### PR TITLE
Add local CATS API fuzzing harness

### DIFF
--- a/Docs/Development/CATS_Fuzzing.md
+++ b/Docs/Development/CATS_Fuzzing.md
@@ -42,18 +42,27 @@ The default harness is local-only by design.
 - Uses a deterministic long test API key for single-user auth.
 - Writes AuthNZ and user SQLite databases under the artifact runtime directory.
 - Generates `runtime/.env` for OpenAPI export and CATS subprocesses.
+- Generates `runtime/config.txt` and forces `TLDW_CONFIG_FILE`,
+  `TLDW_CONFIG_PATH`, and `TLDW_CONFIG_DIR` to that file/directory so the
+  harness does not read a contributor's normal `Config_Files/config.txt`.
 - Generates `runtime/cats-server.env` for uvicorn without guarded test-mode
   flags that would make server startup unsafe.
-- Scrubs known sensitive values from the child environment.
+- Scrubs known sensitive values and provider endpoint overrides from the child
+  environment.
+- Sets `PYTHON_DOTENV_DISABLED=true` in child processes; the generated env file
+  remains as an audit artifact, while the subprocess environment carries the
+  actual test settings.
 - Refuses to run when real provider or webhook credentials are detected unless
   `--allow-external` is passed.
+- Rejects non-loopback `--server-url` values for built-in local-only blocks.
 - Passes `--maskHeaders X-API-KEY,Authorization` to CATS and masks those header
   values again in `summary.json`.
 - Uses CATS blackbox mode for runtime blocks, so the harness gate focuses on 5xx
   responses rather than normal validation mismatches.
 
-Do not point `--server-url` at production or a server with real user data. CATS
-intentionally sends malformed, oversized, and adversarial inputs.
+Do not point CATS at production or a server with real user data. CATS
+intentionally sends malformed, oversized, and adversarial inputs. The built-in
+blocks accept existing servers only on `localhost`, `127.0.0.0/8`, or `::1`.
 
 ## Prerequisites
 
@@ -190,7 +199,7 @@ Options:
   run multiple blocks. Defaults to `contract` and `public-read`.
 - `--output PATH`: Artifact directory. Defaults to `artifacts/cats-fuzz`.
 - `--cats-bin PATH_OR_NAME`: CATS executable. Defaults to `cats`.
-- `--server-url URL`: Use an already running server for runtime blocks.
+- `--server-url URL`: Use an already running loopback server for runtime blocks.
 - `--no-start-server`: Do not start uvicorn. Requires `--server-url` for runtime
   blocks.
 - `--start-server`: Explicitly start the isolated loopback uvicorn server.
@@ -241,6 +250,7 @@ For `--output /tmp/tldw-cats-run`, expect:
 +-- runtime/
 |   +-- .env
 |   +-- cats-server.env
+|   +-- config.txt
 |   +-- users.db
 |   +-- user_databases/
 +-- server/
@@ -352,7 +362,8 @@ python -m Helper_Scripts.cats_fuzz \
 ```
 
 The harness cannot isolate databases, env files, or credentials for a server you
-started yourself. Do not use this mode with production-like data.
+started yourself. Existing-server mode is still restricted to loopback hosts for
+built-in local-only blocks. Do not use this mode with production-like data.
 
 ## Cleanup
 

--- a/Docs/Development/CATS_Fuzzing.md
+++ b/Docs/Development/CATS_Fuzzing.md
@@ -1,46 +1,105 @@
-# CATS Fuzzing
+# CATS Fuzzing Setup and Operations Guide
 
-This harness runs local OpenAPI-driven negative fuzzing against `tldw_server` with
-CATS. It is intended for contract validation and first-slice runtime coverage, not
-for production traffic.
+This guide is for contributors who want to validate `tldw_server` API changes
+with the local CATS fuzzing harness.
 
-## Safety
+CATS is a REST API fuzzer and negative testing tool for OpenAPI endpoints. The
+project harness wraps CATS with local-only safety defaults, OpenAPI export,
+isolated runtime configuration, repeatable block definitions, and summary files
+that are easier to review in PRs.
 
-Do not run the default harness against production deployments or real provider
-credentials. The default runtime starts loopback uvicorn, uses deterministic long
-test API keys, isolates SQLite databases under the artifact runtime directory,
-generates a dedicated `TLDW_ENV_FILE`, and rejects inherited provider/webhook
-credentials unless `--allow-external` is passed. That flag permits the parent
-environment to contain real credentials, but known sensitive values are still
-scrubbed from the child environment and harness auth is overwritten with the
-deterministic test key. Runtime blocks use CATS blackbox mode and gate failures
-on 5xx responses.
+Reference docs:
 
-## Setup
+- [CATS introduction](https://endava.github.io/cats/docs/intro/)
+- [CATS installation](https://endava.github.io/cats/docs/getting-started/installation/)
+- [Running CATS](https://endava.github.io/cats/docs/getting-started/running-cats/)
+- [Interpreting CATS results](https://endava.github.io/cats/docs/getting-started/interpreting-results/)
+- [CATS exit codes](https://endava.github.io/cats/docs/getting-started/exit-codes/)
+- [CATS authentication header masking](https://endava.github.io/cats/docs/getting-started/masking-headers/)
 
-Activate the shared project environment and confirm CATS is installed:
+## Scope
+
+Use this harness for:
+
+- Contract validation of the generated OpenAPI document.
+- Local blackbox fuzzing of selected read-only API surfaces.
+- Smoke-level detection of unexpected 5xx responses.
+- Producing artifact bundles for PR review and debugging.
+
+Do not use this first-slice harness as:
+
+- A production scanner.
+- A broad authenticated mutation fuzzer.
+- A hard CI gate for the full public-read surface.
+- A substitute for endpoint-specific integration tests.
+
+## Safety Model
+
+The default harness is local-only by design.
+
+- Starts uvicorn on `127.0.0.1` for runtime blocks unless `--no-start-server`
+  is used.
+- Uses a deterministic long test API key for single-user auth.
+- Writes AuthNZ and user SQLite databases under the artifact runtime directory.
+- Generates `runtime/.env` for OpenAPI export and CATS subprocesses.
+- Generates `runtime/cats-server.env` for uvicorn without guarded test-mode
+  flags that would make server startup unsafe.
+- Scrubs known sensitive values from the child environment.
+- Refuses to run when real provider or webhook credentials are detected unless
+  `--allow-external` is passed.
+- Passes `--maskHeaders X-API-KEY,Authorization` to CATS and masks those header
+  values again in `summary.json`.
+- Uses CATS blackbox mode for runtime blocks, so the harness gate focuses on 5xx
+  responses rather than normal validation mismatches.
+
+Do not point `--server-url` at production or a server with real user data. CATS
+intentionally sends malformed, oversized, and adversarial inputs.
+
+## Prerequisites
+
+From a normal checkout:
 
 ```bash
+make tooling-install
 source .venv/bin/activate
+```
+
+From a worktree that does not have its own `.venv`, either create one or
+deliberately activate the main checkout environment:
+
+```bash
+source /path/to/tldw_server2/.venv/bin/activate
+```
+
+Install CATS and verify it is on `PATH`:
+
+```bash
 cats --version
 ```
 
-Run the contract-only block:
+The local harness has been verified with CATS `13.8.0`. CATS can be installed
+with Homebrew on macOS:
+
+```bash
+brew tap endava/tap
+brew install cats
+```
+
+The upstream project also publishes native binaries and an uberjar. The native
+binary does not require Java; the uberjar requires Java 17 or newer.
+
+## Quick Start
+
+Run the contract-only block first. It does not start the API server.
 
 ```bash
 python -m Helper_Scripts.cats_fuzz --block contract
 ```
 
-Run the default first-slice blocks explicitly:
+Run the default first-slice local validation:
 
 ```bash
 python -m Helper_Scripts.cats_fuzz --block contract --block public-read
-```
-
-Run a runtime block against an already-started local server:
-
-```bash
-python -m Helper_Scripts.cats_fuzz --block public-read --no-start-server --server-url http://127.0.0.1:8000
 ```
 
 Or use the Makefile target:
@@ -49,32 +108,286 @@ Or use the Makefile target:
 make cats-fuzz
 ```
 
-## Blocks
+Artifacts default to `artifacts/cats-fuzz/`. Use a unique output directory when
+comparing runs:
 
-- `contract`: exports and validates `openapi.json` without calling the API.
-- `public-read`: starts or uses a local server and fuzzes public read-only
-  endpoints.
-- `auth-read`: exists in the manifest for authenticated read-only fuzzing, but is
-  not part of the default first slice unless explicitly selected.
+```bash
+python -m Helper_Scripts.cats_fuzz \
+  --block contract \
+  --block public-read \
+  --output /tmp/tldw-cats-public-read
+```
 
-## Artifacts
+## Recommended PR Validation Workflow
 
-Artifacts are written under `artifacts/cats-fuzz/` by default:
+Run these before asking reviewers to trust a fuzzing-related change:
 
-- `openapi.json`
-- per-block `summary.json`
-- per-block stdout/stderr logs
-- CATS reports
-- local server logs under `server/`
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py \
+  -q
+```
 
-## Failure Interpretation
+Then run contract validation:
 
-Block summaries classify results with `failure_class`:
+```bash
+python -m Helper_Scripts.cats_fuzz --block contract --output /tmp/tldw-cats-contract
+```
 
-- `usage`: invalid command/options or harness invocation problem
-- `tool`: CATS/tooling execution failure
-- `api`: API behavior failed the block gate
-- `ok`: block exited successfully
+Check:
 
-A nonzero `public-read` summary means inspect that block's logs and CATS report
-before treating the result as an API regression.
+```bash
+cat /tmp/tldw-cats-contract/contract/summary.json
+```
+
+Expected contract result:
+
+- `exit_code` is `0`.
+- `failure_class` is `ok`.
+- `cats_version` is populated.
+- `openapi_sha256` is populated.
+
+For runtime validation, run:
+
+```bash
+python -m Helper_Scripts.cats_fuzz \
+  --block contract \
+  --block public-read \
+  --output /tmp/tldw-cats-public-read
+```
+
+The current broad `public-read` block is operational but may time out before
+finishing all selected paths. A timeout is acceptable for this first slice when
+it is captured as a structured tool failure:
+
+- `public-read/summary.json` exists.
+- `failure_class` is `tool`.
+- `exit_code` is `124`.
+- `public-read/stderr.log` says `Command timed out after 300 seconds`.
+- CATS reports exist under `public-read/cats-report/`.
+
+Do not hide this result in a PR. Record it as "public-read timed out after
+300s; artifacts were written" and include the output directory.
+
+## CLI Reference
+
+Entrypoint:
+
+```bash
+python -m Helper_Scripts.cats_fuzz [options]
+```
+
+Options:
+
+- `--block {contract,public-read,auth-read}`: Select a block. Repeat the flag to
+  run multiple blocks. Defaults to `contract` and `public-read`.
+- `--output PATH`: Artifact directory. Defaults to `artifacts/cats-fuzz`.
+- `--cats-bin PATH_OR_NAME`: CATS executable. Defaults to `cats`.
+- `--server-url URL`: Use an already running server for runtime blocks.
+- `--no-start-server`: Do not start uvicorn. Requires `--server-url` for runtime
+  blocks.
+- `--start-server`: Explicitly start the isolated loopback uvicorn server.
+- `--dry-run`: Pass CATS dry-run mode to runtime blocks.
+- `--allow-external`: Allow the parent environment to contain real credentials.
+  Known sensitive values are still scrubbed from the child env, and harness auth
+  is overwritten with the deterministic test key.
+
+Examples:
+
+```bash
+# Contract only, no server.
+python -m Helper_Scripts.cats_fuzz --block contract
+
+# Isolated local server plus public-read fuzzing.
+python -m Helper_Scripts.cats_fuzz --block contract --block public-read
+
+# Public-read against an existing local server.
+python -m Helper_Scripts.cats_fuzz \
+  --block public-read \
+  --no-start-server \
+  --server-url http://127.0.0.1:8000
+
+# Use a non-default CATS binary.
+python -m Helper_Scripts.cats_fuzz --block contract --cats-bin /usr/local/bin/cats
+```
+
+## Built-In Blocks
+
+| Block | Purpose | Server | Scope | Timeout |
+| --- | --- | --- | --- | --- |
+| `contract` | Export, validate, and summarize `openapi.json`. | No | Full OpenAPI contract. | 60s per CATS validate/stats command |
+| `public-read` | Blackbox fuzz public metadata and health endpoints. | Yes | `GET`/`HEAD` on `/`, `/health`, `/ready`, `/health/ready`, `/api/v1/health`, `/api/v1/health/live`, `/api/v1/health/ready`, `/api/v1/config/docs-info`, `/api/v1/config/quickstart`. | 300s |
+| `auth-read` | Authenticated read-only smoke fuzzing. | Yes | `GET`/`HEAD` on `/api/v1/llm/providers`, `/api/v1/mcp/status`, `/api/v1/rag/health/simple`. | 180s |
+
+The runtime blocks skip `POST`, `PUT`, `PATCH`, `DELETE`, and `TRACE`. Mutating
+blocks are intentionally not included in this first slice.
+
+## Artifact Layout
+
+For `--output /tmp/tldw-cats-run`, expect:
+
+```text
+/tmp/tldw-cats-run/
++-- openapi.json
++-- openapi-export.stdout.log
++-- openapi-export.stderr.log
++-- runtime/
+|   +-- .env
+|   +-- cats-server.env
+|   +-- users.db
+|   +-- user_databases/
++-- server/
+|   +-- uvicorn.stdout.log
+|   +-- uvicorn.stderr.log
++-- contract/
+|   +-- summary.json
+|   +-- stdout.log
+|   +-- stderr.log
++-- public-read/
+    +-- summary.json
+    +-- stdout.log
+    +-- stderr.log
+    +-- cats-report/
+        +-- junit.xml
+        +-- Test*.html
+        +-- Test*.json
+```
+
+Keep `summary.json`, CATS reports, and relevant logs when filing an issue or PR.
+Do not publish `runtime/` artifacts from a run where you used `--allow-external`
+or pointed at a manually started server with real data.
+
+## Interpreting Results
+
+Every block writes `summary.json` with:
+
+- `block`: block name.
+- `cats_version`: detected CATS version or `unknown`.
+- `openapi_sha256`: checksum of the generated OpenAPI file.
+- `command` and `masked_command`: the command with auth header values masked.
+- `exit_code`: CATS or harness subprocess exit code.
+- `failure_class`: normalized result class.
+- `stdout_path`, `stderr_path`, `report_dir`: artifact pointers.
+
+Failure classes:
+
+- `ok`: command exited successfully.
+- `usage`: invalid CATS options, invalid harness invocation, or command-line
+  usage failure.
+- `tool`: CATS/tooling/runtime execution issue, including harness timeouts.
+- `api`: CATS completed and reported API behavior that failed the block gate.
+
+CATS itself can return invalid-input and unexpected-execution exit codes, or the
+number of fuzzing errors found. The harness maps those raw exits into the
+classes above so PR reviewers can triage consistently.
+
+Runtime blocks use blackbox mode. In CATS blackbox mode, 2xx and 4xx mismatches
+are ignored for the gate; unexpected 5xx responses are the important API signal.
+
+## Triage Playbooks
+
+### Contract Block Fails
+
+1. Open `contract/summary.json`.
+2. Check `failure_class`.
+3. Read `contract/stderr.log`.
+4. If CATS validation reports an OpenAPI problem, inspect `openapi.json` around
+   the failing path/schema.
+5. Add or adjust focused OpenAPI shape tests before changing endpoint schemas.
+
+### Runtime Block Reports `api`
+
+1. Open the block `summary.json` and confirm `failure_class` is `api`.
+2. Open `cats-report/index.html` or the relevant `Test*.html` files.
+3. Identify the path, method, fuzzer, request, and response.
+4. Check `server/uvicorn.stderr.log` for the matching stack trace or 5xx log.
+5. Reproduce with the `curl` command in the CATS test detail, after replacing
+   masked header environment variables with test credentials only.
+6. Fix the endpoint or contract mismatch, then rerun the same block.
+
+### Runtime Block Reports `tool`
+
+1. Read the block `stderr.log`.
+2. If it says `Command timed out after 300 seconds`, inspect `stdout.log` to see
+   which path/fuzzer was active when time expired.
+3. Check whether CATS produced partial `cats-report/` files.
+4. Split the block or narrow paths/fuzzers in a follow-up task if the timeout is
+   due to broad coverage rather than a server hang.
+5. If CATS reports an internal exception, capture the CATS version, command, and
+   the smallest reproducing OpenAPI path.
+
+### Server Fails To Start
+
+1. Read `server/uvicorn.stderr.log`.
+2. Confirm the harness wrote `runtime/cats-server.env`.
+3. Confirm no real provider credentials are inherited unless
+   `--allow-external` was intentional.
+4. Confirm local port binding is allowed in the execution environment.
+
+### Sensitive Credential Detection Blocks A Run
+
+By default, the harness refuses to build its child environment when real provider
+or webhook credentials are present. Prefer unsetting those values in the shell.
+Use `--allow-external` only when you understand the local risk. The harness still
+scrubs known sensitive child variables and overwrites its auth keys.
+
+## Existing Server Mode
+
+Use existing-server mode only for local throwaway servers:
+
+```bash
+python -m uvicorn tldw_Server_API.app.main:app --host 127.0.0.1 --port 8000
+python -m Helper_Scripts.cats_fuzz \
+  --block public-read \
+  --no-start-server \
+  --server-url http://127.0.0.1:8000 \
+  --output /tmp/tldw-cats-existing-server
+```
+
+The harness cannot isolate databases, env files, or credentials for a server you
+started yourself. Do not use this mode with production-like data.
+
+## Cleanup
+
+Artifact directories can be large because CATS writes individual HTML and JSON
+test files. After preserving anything needed for review, remove old local output
+directories:
+
+```bash
+rm -rf artifacts/cats-fuzz /tmp/tldw-cats-*
+```
+
+Do not remove artifacts referenced by an active issue, PR, or Backlog task.
+
+## Contributor Checklist
+
+Before posting CATS validation results in a PR:
+
+- Record the exact command.
+- Record the CATS version.
+- Record the output directory.
+- Include each block's `exit_code` and `failure_class`.
+- Include whether `public-read` completed or timed out.
+- Attach or point to relevant `summary.json`, `stderr.log`, and CATS report
+  files when a block is nonzero.
+- Confirm no real secrets appear in copied command lines, logs, summaries, or
+  reports.
+- Run `git diff --check` after editing docs or harness files.
+
+## Known Limitations
+
+- `public-read` currently covers enough of the generated OpenAPI surface that it
+  may time out after 300s while still writing useful partial reports.
+- `auth-read` is scaffolded and selectable, but it is not the default block.
+- CATS `--dry-run` has reached command parsing locally but has shown tool-level
+  instability against the large generated tldw OpenAPI; treat it as diagnostic,
+  not a required preflight.
+- This harness is not wired as a hard CI gate yet. Start with manual local runs
+  and make later CI jobs narrower than the broad local exploration block.

--- a/Docs/Development/CATS_Fuzzing.md
+++ b/Docs/Development/CATS_Fuzzing.md
@@ -1,0 +1,71 @@
+# CATS Fuzzing
+
+This harness runs local OpenAPI-driven negative fuzzing against `tldw_server` with
+CATS. It is intended for contract validation and first-slice runtime coverage, not
+for production traffic.
+
+## Safety
+
+Do not run the default harness against production deployments or real provider
+credentials. The default runtime starts loopback uvicorn, uses deterministic long
+test API keys, isolates SQLite databases under the artifact runtime directory,
+generates a dedicated `TLDW_ENV_FILE`, and rejects inherited provider/webhook
+credentials unless `--allow-external` is passed. Runtime blocks use CATS blackbox
+mode and gate failures on 5xx responses.
+
+## Setup
+
+Activate the shared project environment and confirm CATS is installed:
+
+```bash
+source .venv/bin/activate
+cats --version
+```
+
+Run the contract-only block:
+
+```bash
+python -m Helper_Scripts.cats_fuzz --block contract
+```
+
+Run the default first-slice blocks explicitly:
+
+```bash
+python -m Helper_Scripts.cats_fuzz --block contract --block public-read
+```
+
+Or use the Makefile target:
+
+```bash
+make cats-fuzz
+```
+
+## Blocks
+
+- `contract`: exports and validates `openapi.json` without calling the API.
+- `public-read`: starts or uses a local server and fuzzes public read-only
+  endpoints.
+- `auth-read`: exists in the manifest for authenticated read-only fuzzing, but is
+  not part of the default first slice unless explicitly selected.
+
+## Artifacts
+
+Artifacts are written under `artifacts/cats-fuzz/` by default:
+
+- `openapi.json`
+- per-block `summary.json`
+- per-block stdout/stderr logs
+- CATS reports
+- local server logs under `server/`
+
+## Failure Interpretation
+
+Block summaries classify results with `failure_class`:
+
+- `usage`: invalid command/options or harness invocation problem
+- `tool`: CATS/tooling execution failure
+- `api`: API behavior failed the block gate
+- `ok`: block exited successfully
+
+A nonzero `public-read` summary means inspect that block's logs and CATS report
+before treating the result as an API regression.

--- a/Docs/Development/CATS_Fuzzing.md
+++ b/Docs/Development/CATS_Fuzzing.md
@@ -10,8 +10,11 @@ Do not run the default harness against production deployments or real provider
 credentials. The default runtime starts loopback uvicorn, uses deterministic long
 test API keys, isolates SQLite databases under the artifact runtime directory,
 generates a dedicated `TLDW_ENV_FILE`, and rejects inherited provider/webhook
-credentials unless `--allow-external` is passed. Runtime blocks use CATS blackbox
-mode and gate failures on 5xx responses.
+credentials unless `--allow-external` is passed. That flag permits the parent
+environment to contain real credentials, but known sensitive values are still
+scrubbed from the child environment and harness auth is overwritten with the
+deterministic test key. Runtime blocks use CATS blackbox mode and gate failures
+on 5xx responses.
 
 ## Setup
 
@@ -32,6 +35,12 @@ Run the default first-slice blocks explicitly:
 
 ```bash
 python -m Helper_Scripts.cats_fuzz --block contract --block public-read
+```
+
+Run a runtime block against an already-started local server:
+
+```bash
+python -m Helper_Scripts.cats_fuzz --block public-read --no-start-server --server-url http://127.0.0.1:8000
 ```
 
 Or use the Makefile target:

--- a/Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md
@@ -85,7 +85,7 @@ When a command below starts with `source .venv/bin/activate`, run it from the wo
 - Modify: `tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py:1144-1161`
 - Create: `tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py`
 
-- [ ] **Step 1: Write the failing OpenAPI example-shape test**
+- [x] **Step 1: Write the failing OpenAPI example-shape test**
 
 Create `tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py`:
 
@@ -128,7 +128,7 @@ def test_vector_list_query_examples_are_cats_validate_compatible(monkeypatch: py
         assert "examples" in params[name] or isinstance(schema.get("examples"), list), name
 ```
 
-- [ ] **Step 2: Run the focused test to verify it fails**
+- [x] **Step 2: Run the focused test to verify it fails**
 
 Run:
 
@@ -139,7 +139,7 @@ python -m pytest tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_e
 
 Expected: FAIL because `schema.examples` is currently a dict for `filter`, `order_by`, and `order_dir`.
 
-- [ ] **Step 3: Move the examples to OpenAPI parameter examples**
+- [x] **Step 3: Move the examples to OpenAPI parameter examples**
 
 In `tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py`, replace the three `examples=` arguments with `openapi_examples=`:
 
@@ -171,7 +171,7 @@ order_dir: str = Query(
 ),
 ```
 
-- [ ] **Step 4: Run the focused test to verify it passes**
+- [x] **Step 4: Run the focused test to verify it passes**
 
 Run:
 
@@ -182,7 +182,7 @@ python -m pytest tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_e
 
 Expected: PASS.
 
-- [ ] **Step 5: Generate a temporary OpenAPI file and run CATS validation**
+- [x] **Step 5: Generate a temporary OpenAPI file and run CATS validation**
 
 Run:
 
@@ -201,7 +201,7 @@ cats validate -c /tmp/tldw_openapi_cats_fixed.json -j
 
 Expected: `cats validate` exits `0`. If unrelated validation issues remain, record them in `TASK-2370` and continue with the known-issues path rather than hiding them.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
@@ -215,7 +215,7 @@ git commit -m "fix: make vector store OpenAPI examples CATS compatible"
 - Create: `Helper_Scripts/cats_fuzz/manifest.py`
 - Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py`
 
-- [ ] **Step 1: Write manifest unit tests**
+- [x] **Step 1: Write manifest unit tests**
 
 Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py`:
 
@@ -261,7 +261,7 @@ def test_unknown_builtin_block_fails() -> None:
         get_builtin_block("missing")
 ```
 
-- [ ] **Step 2: Run tests to verify import failure**
+- [x] **Step 2: Run tests to verify import failure**
 
 Run:
 
@@ -272,7 +272,7 @@ python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
 
 Expected: FAIL because `Helper_Scripts.cats_fuzz` does not exist yet.
 
-- [ ] **Step 3: Implement the manifest module**
+- [x] **Step 3: Implement the manifest module**
 
 Create `Helper_Scripts/cats_fuzz/__init__.py`:
 
@@ -390,7 +390,7 @@ def get_builtin_block(name: str) -> CatsBlock:
     return get_builtin_manifest()[name]
 ```
 
-- [ ] **Step 4: Run manifest tests**
+- [x] **Step 4: Run manifest tests**
 
 Run:
 
@@ -401,7 +401,7 @@ python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add Helper_Scripts/cats_fuzz/__init__.py Helper_Scripts/cats_fuzz/manifest.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
@@ -415,7 +415,7 @@ git commit -m "feat: add CATS fuzz block manifest"
 - Create: `Helper_Scripts/cats_fuzz/openapi_export.py`
 - Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py`
 
-- [ ] **Step 1: Write env and OpenAPI command tests**
+- [x] **Step 1: Write env and OpenAPI command tests**
 
 Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py`:
 
@@ -465,7 +465,7 @@ def test_openapi_export_command_uses_module_and_output_path(tmp_path: Path) -> N
     assert str(output) in command
 ```
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run:
 
@@ -476,7 +476,7 @@ python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py -q
 
 Expected: FAIL because the modules do not exist yet.
 
-- [ ] **Step 3: Implement `env.py`**
+- [x] **Step 3: Implement `env.py`**
 
 Create `Helper_Scripts/cats_fuzz/env.py`:
 
@@ -576,7 +576,7 @@ def build_child_env(
     return child
 ```
 
-- [ ] **Step 4: Implement `openapi_export.py`**
+- [x] **Step 4: Implement `openapi_export.py`**
 
 Create `Helper_Scripts/cats_fuzz/openapi_export.py`:
 
@@ -622,7 +622,7 @@ if __name__ == "__main__":
     raise SystemExit(main())
 ```
 
-- [ ] **Step 5: Run env tests**
+- [x] **Step 5: Run env tests**
 
 Run:
 
@@ -633,7 +633,7 @@ python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py -q
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add Helper_Scripts/cats_fuzz/env.py Helper_Scripts/cats_fuzz/openapi_export.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
@@ -648,7 +648,7 @@ git commit -m "feat: isolate CATS fuzz runtime environment"
 - Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py`
 - Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py`
 
-- [ ] **Step 1: Write command and summary tests**
+- [x] **Step 1: Write command and summary tests**
 
 Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py`:
 
@@ -737,7 +737,7 @@ def test_write_summary_persists_expected_shape(tmp_path: Path) -> None:
     assert data["command"] == ["cats", "--blackbox"]
 ```
 
-- [ ] **Step 2: Run tests to verify failure**
+- [x] **Step 2: Run tests to verify failure**
 
 Run:
 
@@ -748,7 +748,7 @@ python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
 
 Expected: FAIL because modules do not exist.
 
-- [ ] **Step 3: Implement command builder**
+- [x] **Step 3: Implement command builder**
 
 Create `Helper_Scripts/cats_fuzz/cats_cli.py`:
 
@@ -857,7 +857,7 @@ def run_command(command: list[str], *, timeout_seconds: int, env: dict[str, str]
     return CatsProcessResult(command=command, exit_code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
 ```
 
-- [ ] **Step 4: Implement summary writer**
+- [x] **Step 4: Implement summary writer**
 
 Create `Helper_Scripts/cats_fuzz/summary.py`:
 
@@ -903,7 +903,7 @@ def write_summary(summary: CatsRunSummary, output_path: Path) -> Path:
     return output_path
 ```
 
-- [ ] **Step 5: Run command and summary tests**
+- [x] **Step 5: Run command and summary tests**
 
 Run:
 
@@ -914,7 +914,7 @@ python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add Helper_Scripts/cats_fuzz/cats_cli.py Helper_Scripts/cats_fuzz/summary.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py
@@ -928,7 +928,7 @@ git commit -m "feat: build CATS commands and run summaries"
 - Create: `Helper_Scripts/cats_fuzz/runner.py`
 - Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py`
 
-- [ ] **Step 1: Write mocked runner tests**
+- [x] **Step 1: Write mocked runner tests**
 
 Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py`:
 
@@ -969,7 +969,7 @@ def test_contract_block_writes_summary_for_validate_and_stats(tmp_path: Path, mo
     assert (tmp_path / "out" / "contract" / "summary.json").exists()
 ```
 
-- [ ] **Step 2: Run test to verify failure**
+- [x] **Step 2: Run test to verify failure**
 
 Run:
 
@@ -980,7 +980,7 @@ python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py -
 
 Expected: FAIL because `runner.py` and `server.py` do not exist yet.
 
-- [ ] **Step 3: Implement server lifecycle**
+- [x] **Step 3: Implement server lifecycle**
 
 Create `Helper_Scripts/cats_fuzz/server.py`:
 
@@ -1053,7 +1053,7 @@ def stop_server(server: UvicornServer) -> None:
         server.process.wait(timeout=5)
 ```
 
-- [ ] **Step 4: Implement runner orchestration**
+- [x] **Step 4: Implement runner orchestration**
 
 Create `Helper_Scripts/cats_fuzz/runner.py`:
 
@@ -1186,7 +1186,7 @@ def get_default_runtime_block() -> CatsBlock:
     return get_builtin_block("public-read")
 ```
 
-- [ ] **Step 5: Run runner tests**
+- [x] **Step 5: Run runner tests**
 
 Run:
 
@@ -1197,7 +1197,7 @@ python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py -
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add Helper_Scripts/cats_fuzz/server.py Helper_Scripts/cats_fuzz/runner.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
@@ -1212,7 +1212,7 @@ git commit -m "feat: orchestrate CATS fuzz runs"
 - Create: `Docs/Development/CATS_Fuzzing.md`
 - Modify: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py` or create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py`
 
-- [ ] **Step 1: Write CLI parser tests**
+- [x] **Step 1: Write CLI parser tests**
 
 Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py`:
 
@@ -1241,7 +1241,7 @@ def test_cli_accepts_existing_server_url() -> None:
     assert args.start_server is False
 ```
 
-- [ ] **Step 2: Run CLI tests to verify failure**
+- [x] **Step 2: Run CLI tests to verify failure**
 
 Run:
 
@@ -1252,7 +1252,7 @@ python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py -q
 
 Expected: FAIL because `cli.py` does not exist.
 
-- [ ] **Step 3: Implement CLI**
+- [x] **Step 3: Implement CLI**
 
 Create `Helper_Scripts/cats_fuzz/cli.py`:
 
@@ -1353,7 +1353,7 @@ if __name__ == "__main__":
     raise SystemExit(main())
 ```
 
-- [ ] **Step 4: Write usage docs**
+- [x] **Step 4: Write usage docs**
 
 Create `Docs/Development/CATS_Fuzzing.md`:
 
@@ -1387,7 +1387,7 @@ Artifacts are written under `artifacts/cats-fuzz/` by default:
 - Uses CATS blackbox mode so only `5xx` responses are gate failures for runtime blocks.
 ````
 
-- [ ] **Step 5: Run CLI tests**
+- [x] **Step 5: Run CLI tests**
 
 Run:
 
@@ -1398,7 +1398,7 @@ python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py -q
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add Helper_Scripts/cats_fuzz/cli.py Helper_Scripts/cats_fuzz/__main__.py Docs/Development/CATS_Fuzzing.md tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
@@ -1410,7 +1410,7 @@ git commit -m "feat: add CATS fuzzing CLI"
 **Files:**
 - Modify: `backlog/tasks/task-2370 - Plan-CATS-API-fuzzing-harness-implementation.md` only for final notes if this plan task is still open, or the implementation task that owns execution.
 
-- [ ] **Step 1: Run all focused Python tests**
+- [x] **Step 1: Run all focused Python tests**
 
 Run:
 
@@ -1429,7 +1429,7 @@ python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 2: Run CATS contract block**
+- [x] **Step 2: Run CATS contract block**
 
 Run:
 
@@ -1440,7 +1440,7 @@ python -m Helper_Scripts.cats_fuzz --block contract --output /tmp/tldw-cats-cont
 
 Expected: exit `0`, `/tmp/tldw-cats-contract/contract/summary.json` has `"failure_class": "ok"`.
 
-- [ ] **Step 3: Run CATS public-read live block**
+- [x] **Step 3: Run CATS public-read live block**
 
 Run:
 
@@ -1451,7 +1451,7 @@ python -m Helper_Scripts.cats_fuzz --block contract --block public-read --output
 
 Expected: exit `0` or a non-zero exit only when `summary.json` clearly classifies an API `5xx` issue worth fixing. If CATS itself throws a tool/internal error, record stderr and either adjust command construction or add a documented fallback.
 
-- [ ] **Step 4: Run Bandit on touched executable harness scope**
+- [x] **Step 4: Run Bandit on touched executable harness scope**
 
 Run:
 
@@ -1462,7 +1462,7 @@ python -m bandit -r Helper_Scripts/cats_fuzz tldw_Server_API/app/api/v1/endpoint
 
 Expected: no new findings in touched code. If Bandit flags the deliberate local subprocess/urlopen calls, add tight `# nosec` comments with a local-only justification only where needed.
 
-- [ ] **Step 5: Run whitespace check**
+- [x] **Step 5: Run whitespace check**
 
 Run:
 
@@ -1472,7 +1472,7 @@ git diff --check
 
 Expected: no output.
 
-- [ ] **Step 6: Commit final verification notes if needed**
+- [x] **Step 6: Commit final verification notes if needed**
 
 If verification notes or docs changed:
 
@@ -1483,6 +1483,7 @@ git commit -m "docs: record CATS fuzzing verification"
 
 ## Known Risks And Follow-Ups
 
+- 2026-06-27 live verification: `contract` passed with `failure_class: ok` under `/tmp/tldw-cats-public-read-v4/contract/summary.json`; `public-read` started the isolated server and wrote `/tmp/tldw-cats-public-read-v4/public-read/summary.json` with `exit_code: 124`, `failure_class: tool`, and `stderr.log` recording `Command timed out after 300 seconds`. Split or narrow public-read before using it as a hard CI gate.
 - CATS `--dryRun` reached command parsing locally but threw a Java `ClassCastException` against the large tldw OpenAPI shape. Treat dry-run as helpful but not a hard preflight until proven stable with the finalized command.
 - The first implementation should not add broad CI yet. Start with local/manual usage and a small contract/public-read command that can later be wired into CI.
 - The worktree has no `.venv`; implementation must set up dependencies before running Python tests.

--- a/Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md
@@ -1,0 +1,1498 @@
+# CATS API Fuzzing Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first safe, local-only CATS fuzzing harness slice for the tldw_server API.
+
+**Architecture:** Fix the known OpenAPI validation issue first, then add an importable Python harness under `Helper_Scripts/cats_fuzz/`. Keep block definitions, environment isolation, OpenAPI generation, CATS command construction, uvicorn lifecycle, and report summarization in small modules so most behavior is covered by unit tests without launching CATS or the server. The first live path should support `contract` and `public-read`; `auth-read` is scaffolded in the manifest but can remain non-default until the isolated server run is stable.
+
+**Tech Stack:** Python 3.10+, FastAPI OpenAPI generation, pytest, uvicorn, CATS 13.8.0 CLI.
+
+---
+
+## References
+
+- Design spec: `Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md`
+- Backlog task: `TASK-2370`
+- CATS docs: `https://endava.github.io/cats/docs/intro/`
+- Local CATS version: `cats --version` reports `13.8.0`.
+- Local CATS help confirms:
+  - `--blackbox` ignores all response codes except `5xx`.
+  - `--skipReportingForIgnored` suppresses ignored response reports.
+  - `--reportFormat` supports HTML/JUnit report families, not JSON.
+  - `--path`, `--skipPath`, `-H`, `--refData`, `--urlParams`, and `--dryRun` are available.
+
+## File Structure
+
+- Modify: `tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py`
+  - Move query parameter examples off invalid schema-level dicts so CATS strict validation can pass.
+- Create: `Helper_Scripts/cats_fuzz/__init__.py`
+  - Package marker and public constants.
+- Create: `Helper_Scripts/cats_fuzz/__main__.py`
+  - Thin `python -m Helper_Scripts.cats_fuzz` entrypoint.
+- Create: `Helper_Scripts/cats_fuzz/manifest.py`
+  - Built-in block definitions and manifest validation.
+- Create: `Helper_Scripts/cats_fuzz/env.py`
+  - Local-only child environment construction and credential detection.
+- Create: `Helper_Scripts/cats_fuzz/openapi_export.py`
+  - Subprocess-safe OpenAPI generation command and generated spec hashing.
+- Create: `Helper_Scripts/cats_fuzz/cats_cli.py`
+  - CATS argv construction, subprocess execution wrapper, and failure classification.
+- Create: `Helper_Scripts/cats_fuzz/server.py`
+  - Isolated uvicorn process lifecycle and health wait loop.
+- Create: `Helper_Scripts/cats_fuzz/summary.py`
+  - Runner summary JSON schema and masked command rendering.
+- Create: `Helper_Scripts/cats_fuzz/runner.py`
+  - Block orchestration for `contract`, `public-read`, and scaffolded `auth-read`.
+- Create: `Helper_Scripts/cats_fuzz/cli.py`
+  - argparse CLI that wires manifest, env, server, CATS, and summaries.
+- Create: `tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py`
+  - Regression tests for the vector store OpenAPI example shape.
+- Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py`
+  - Unit tests for block manifest validation.
+- Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py`
+  - Unit tests for credential detection and child env construction.
+- Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py`
+  - Unit tests for CATS command construction and failure classification.
+- Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py`
+  - Unit tests for summary JSON output and secret masking.
+- Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py`
+  - Unit tests for orchestration with subprocess/server calls mocked.
+- Create: `Docs/Development/CATS_Fuzzing.md`
+  - Usage, safety defaults, block descriptions, and local verification commands.
+
+## Setup Notes
+
+This plan was written in the clean worktree:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/cats-api-fuzzing-harness
+```
+
+The worktree was clean at creation but did not include a `.venv`. Before running Python tests in that worktree, either create a new venv or point to the main repo venv deliberately. Prefer a worktree-local venv for implementation:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+When a command below starts with `source .venv/bin/activate`, run it from the worktree root after creating/installing that venv.
+
+## Task 1: Fix Vector Store OpenAPI Examples
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py:1144-1161`
+- Create: `tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py`
+
+- [ ] **Step 1: Write the failing OpenAPI example-shape test**
+
+Create `tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py`:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+VECTOR_LIST_PATH = "/api/v1/vector_stores/{store_id}/vectors"
+
+
+def _openapi_spec(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "THIS-IS-A-SECURE-KEY-123-FAKE-KEY")
+    monkeypatch.setenv("SINGLE_USER_TEST_API_KEY", "THIS-IS-A-SECURE-KEY-123-FAKE-KEY")
+    monkeypatch.setenv("MINIMAL_TEST_APP", "1")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO", "1")
+    monkeypatch.setenv("PYTHONWARNINGS", "ignore")
+
+    from tldw_Server_API.app.main import app
+
+    app.openapi_schema = None
+    return app.openapi()
+
+
+@pytest.mark.unit
+def test_vector_list_query_examples_are_cats_validate_compatible(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec = _openapi_spec(monkeypatch)
+    params = {
+        param["name"]: param
+        for param in spec["paths"][VECTOR_LIST_PATH]["get"]["parameters"]
+    }
+
+    for name in ("filter", "order_by", "order_dir"):
+        schema = params[name].get("schema", {})
+        assert not isinstance(schema.get("examples"), dict), name
+        assert "examples" in params[name] or isinstance(schema.get("examples"), list), name
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py -q
+```
+
+Expected: FAIL because `schema.examples` is currently a dict for `filter`, `order_by`, and `order_dir`.
+
+- [ ] **Step 3: Move the examples to OpenAPI parameter examples**
+
+In `tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py`, replace the three `examples=` arguments with `openapi_examples=`:
+
+```python
+filter: str | None = Query(
+    None,
+    description="Optional JSON metadata filter",
+    openapi_examples={
+        "simple": {"summary": "Simple equality", "value": "{\"genre\":\"a\"}"},
+        "and_numeric": {
+            "summary": "AND with numeric",
+            "value": "{\"$and\":[{\"genre\":\"a\"},{\"score\":{\"$gte\":0.8}}]}",
+        },
+    },
+),
+order_by: str | None = Query(
+    "id",
+    description="Order field: 'id' or 'metadata.<key>'",
+    openapi_examples={
+        "metadata": {"summary": "Order by metadata.score desc", "value": "metadata.score"},
+    },
+),
+order_dir: str = Query(
+    "asc",
+    pattern="^(?i)(asc|desc)$",
+    openapi_examples={
+        "desc": {"summary": "Descending", "value": "desc"},
+    },
+),
+```
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Generate a temporary OpenAPI file and run CATS validation**
+
+Run:
+
+```bash
+source .venv/bin/activate
+AUTH_MODE=single_user \
+SINGLE_USER_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY \
+SINGLE_USER_TEST_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY \
+MINIMAL_TEST_APP=1 \
+MINIMAL_TEST_INCLUDE_AUDIO=1 \
+PYTHONWARNINGS=ignore \
+LOGURU_LEVEL=ERROR \
+python -c 'import json; from pathlib import Path; from tldw_Server_API.app.main import app; app.openapi_schema = None; Path("/tmp/tldw_openapi_cats_fixed.json").write_text(json.dumps(app.openapi()), encoding="utf-8")'
+cats validate -c /tmp/tldw_openapi_cats_fixed.json -j
+```
+
+Expected: `cats validate` exits `0`. If unrelated validation issues remain, record them in `TASK-2370` and continue with the known-issues path rather than hiding them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
+git commit -m "fix: make vector store OpenAPI examples CATS compatible"
+```
+
+## Task 2: Add Block Manifest Models
+
+**Files:**
+- Create: `Helper_Scripts/cats_fuzz/__init__.py`
+- Create: `Helper_Scripts/cats_fuzz/manifest.py`
+- Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py`
+
+- [ ] **Step 1: Write manifest unit tests**
+
+Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from Helper_Scripts.cats_fuzz.manifest import (
+    BlockRisk,
+    ExpectedGate,
+    get_builtin_block,
+    get_builtin_manifest,
+    validate_block,
+)
+
+
+@pytest.mark.unit
+def test_builtin_manifest_contains_initial_blocks() -> None:
+    manifest = get_builtin_manifest()
+
+    assert {"contract", "public-read", "auth-read"}.issubset(manifest)
+    assert manifest["contract"].risk is BlockRisk.CONTRACT
+    assert manifest["public-read"].expected_gate is ExpectedGate.NO_5XX
+    assert manifest["public-read"].allows_network is False
+    assert "/" in manifest["public-read"].paths
+
+
+@pytest.mark.unit
+def test_mutating_blocks_must_require_seed_or_be_manual() -> None:
+    block = get_builtin_block("public-read")
+    unsafe = block.__class__(
+        **{**block.__dict__, "name": "unsafe", "allows_mutation": True, "requires_seed": False}
+    )
+
+    with pytest.raises(ValueError, match="requires_seed"):
+        validate_block(unsafe)
+
+
+@pytest.mark.unit
+def test_unknown_builtin_block_fails() -> None:
+    with pytest.raises(KeyError):
+        get_builtin_block("missing")
+```
+
+- [ ] **Step 2: Run tests to verify import failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py -q
+```
+
+Expected: FAIL because `Helper_Scripts.cats_fuzz` does not exist yet.
+
+- [ ] **Step 3: Implement the manifest module**
+
+Create `Helper_Scripts/cats_fuzz/__init__.py`:
+
+```python
+from __future__ import annotations
+
+DEFAULT_TEST_API_KEY = "THIS-IS-A-SECURE-KEY-123-FAKE-KEY"
+```
+
+Create `Helper_Scripts/cats_fuzz/manifest.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class BlockRisk(str, Enum):
+    CONTRACT = "contract"
+    PUBLIC_READ = "public-read"
+    AUTH_READ = "auth-read"
+    ISOLATED_MUTATION = "isolated-mutation"
+    EXTERNAL_RISK = "external-risk"
+    MANUAL = "manual"
+
+
+class ExpectedGate(str, Enum):
+    NO_5XX = "no_5xx"
+    CONTRACT_ONLY = "contract_only"
+
+
+@dataclass(frozen=True)
+class CatsBlock:
+    name: str
+    description: str
+    risk: BlockRisk
+    paths: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    skip_paths: tuple[str, ...] = ()
+    skip_tags: tuple[str, ...] = ()
+    skip_methods: tuple[str, ...] = ()
+    requires_seed: bool = False
+    allows_mutation: bool = False
+    allows_network: bool = False
+    timeout_seconds: int = 120
+    read_timeout: int = 5
+    connection_timeout: int = 5
+    write_timeout: int = 5
+    max_requests_per_minute: int = 120
+    expected_gate: ExpectedGate = ExpectedGate.NO_5XX
+    skip_reason: str | None = None
+    report_formats: tuple[str, ...] = ("HTML_ONLY", "JUNIT")
+
+
+def validate_block(block: CatsBlock) -> None:
+    if not block.name:
+        raise ValueError("block name is required")
+    if not block.paths and not block.tags and block.risk is not BlockRisk.CONTRACT:
+        raise ValueError(f"{block.name}: paths or tags are required")
+    if block.allows_mutation and not block.requires_seed and block.risk is not BlockRisk.MANUAL:
+        raise ValueError(f"{block.name}: mutating blocks must set requires_seed")
+    if block.allows_network and block.risk is not BlockRisk.EXTERNAL_RISK:
+        raise ValueError(f"{block.name}: allows_network requires external-risk")
+
+
+def get_builtin_manifest() -> dict[str, CatsBlock]:
+    blocks = {
+        "contract": CatsBlock(
+            name="contract",
+            description="Validate and summarize generated OpenAPI without calling the API.",
+            risk=BlockRisk.CONTRACT,
+            expected_gate=ExpectedGate.CONTRACT_ONLY,
+            timeout_seconds=60,
+        ),
+        "public-read": CatsBlock(
+            name="public-read",
+            description="Fuzz public metadata and health endpoints in blackbox mode.",
+            risk=BlockRisk.PUBLIC_READ,
+            paths=(
+                "/",
+                "/health",
+                "/ready",
+                "/health/ready",
+                "/api/v1/health",
+                "/api/v1/health/live",
+                "/api/v1/health/ready",
+                "/api/v1/config/docs-info",
+                "/api/v1/config/quickstart",
+            ),
+            skip_methods=("POST", "PUT", "PATCH", "DELETE", "TRACE"),
+            max_requests_per_minute=60,
+            timeout_seconds=120,
+        ),
+        "auth-read": CatsBlock(
+            name="auth-read",
+            description="Authenticated read-only smoke fuzzing with X-API-KEY.",
+            risk=BlockRisk.AUTH_READ,
+            paths=(
+                "/api/v1/llm/providers",
+                "/api/v1/mcp/status",
+                "/api/v1/rag/health/simple",
+            ),
+            skip_methods=("POST", "PUT", "PATCH", "DELETE", "TRACE"),
+            max_requests_per_minute=60,
+            timeout_seconds=180,
+        ),
+    }
+    for block in blocks.values():
+        validate_block(block)
+    return blocks
+
+
+def get_builtin_block(name: str) -> CatsBlock:
+    return get_builtin_manifest()[name]
+```
+
+- [ ] **Step 4: Run manifest tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Helper_Scripts/cats_fuzz/__init__.py Helper_Scripts/cats_fuzz/manifest.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
+git commit -m "feat: add CATS fuzz block manifest"
+```
+
+## Task 3: Add Local-Only Environment Builder And OpenAPI Export
+
+**Files:**
+- Create: `Helper_Scripts/cats_fuzz/env.py`
+- Create: `Helper_Scripts/cats_fuzz/openapi_export.py`
+- Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py`
+
+- [ ] **Step 1: Write env and OpenAPI command tests**
+
+Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
+from Helper_Scripts.cats_fuzz.env import build_child_env, find_sensitive_values
+from Helper_Scripts.cats_fuzz.openapi_export import build_openapi_export_command
+
+
+@pytest.mark.unit
+def test_find_sensitive_values_detects_provider_keys() -> None:
+    found = find_sensitive_values({"OPENAI_API_KEY": "sk-real", "SAFE": "value"})
+
+    assert found == {"OPENAI_API_KEY": "set"}
+
+
+@pytest.mark.unit
+def test_build_child_env_rejects_real_credentials_by_default(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="real credentials"):
+        build_child_env(tmp_path, parent_env={"OPENAI_API_KEY": "sk-real"})
+
+
+@pytest.mark.unit
+def test_build_child_env_sets_test_paths_and_sentinels(tmp_path: Path) -> None:
+    env = build_child_env(tmp_path, parent_env={}, allow_external=False)
+
+    assert env["AUTH_MODE"] == "single_user"
+    assert env["SINGLE_USER_API_KEY"] == DEFAULT_TEST_API_KEY
+    assert env["SINGLE_USER_TEST_API_KEY"] == DEFAULT_TEST_API_KEY
+    assert env["DATABASE_URL"].startswith("sqlite:///")
+    assert Path(env["TLDW_ENV_FILE"]).exists()
+    assert env["OPENAI_API_KEY"] == ""
+
+
+@pytest.mark.unit
+def test_openapi_export_command_uses_module_and_output_path(tmp_path: Path) -> None:
+    output = tmp_path / "openapi.json"
+    command = build_openapi_export_command(output)
+
+    assert command[:3] == ["python", "-m", "Helper_Scripts.cats_fuzz.openapi_export"]
+    assert str(output) in command
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py -q
+```
+
+Expected: FAIL because the modules do not exist yet.
+
+- [ ] **Step 3: Implement `env.py`**
+
+Create `Helper_Scripts/cats_fuzz/env.py`:
+
+```python
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Mapping
+
+from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
+
+
+SENSITIVE_ENV_NAMES = {
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "COHERE_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GOOGLE_API_KEY",
+    "GROQ_API_KEY",
+    "HUGGINGFACE_API_KEY",
+    "MISTRAL_API_KEY",
+    "OPENROUTER_API_KEY",
+    "QWEN_API_KEY",
+    "SLACK_BOT_TOKEN",
+    "DISCORD_BOT_TOKEN",
+    "TELEGRAM_BOT_TOKEN",
+    "WEBHOOK_URL",
+}
+
+SENSITIVE_ENV_SUBSTRINGS = ("API_KEY", "TOKEN", "WEBHOOK", "SECRET")
+
+
+def find_sensitive_values(env: Mapping[str, str]) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for name, value in env.items():
+        if not value or not value.strip():
+            continue
+        upper_name = name.upper()
+        if name in SENSITIVE_ENV_NAMES or any(part in upper_name for part in SENSITIVE_ENV_SUBSTRINGS):
+            found[name] = "set"
+    return found
+
+
+def _write_minimal_env_file(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "AUTH_MODE=single_user",
+                f"SINGLE_USER_API_KEY={DEFAULT_TEST_API_KEY}",
+                f"SINGLE_USER_TEST_API_KEY={DEFAULT_TEST_API_KEY}",
+                "MINIMAL_TEST_APP=1",
+                "MINIMAL_TEST_INCLUDE_AUDIO=1",
+                "TEST_MODE=true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def build_child_env(
+    work_dir: Path,
+    *,
+    parent_env: Mapping[str, str] | None = None,
+    allow_external: bool = False,
+) -> dict[str, str]:
+    source = dict(parent_env or os.environ)
+    sensitive = find_sensitive_values(source)
+    if sensitive and not allow_external:
+        names = ", ".join(sorted(sensitive))
+        raise ValueError(f"Refusing to run with real credentials in environment: {names}")
+
+    runtime_dir = work_dir / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    env_file = runtime_dir / "cats-fuzz.env"
+    _write_minimal_env_file(env_file)
+
+    child = dict(source)
+    for name in SENSITIVE_ENV_NAMES:
+        child[name] = ""
+    child.update(
+        {
+            "AUTH_MODE": "single_user",
+            "SINGLE_USER_API_KEY": DEFAULT_TEST_API_KEY,
+            "SINGLE_USER_TEST_API_KEY": DEFAULT_TEST_API_KEY,
+            "DATABASE_URL": f"sqlite:///{runtime_dir / 'users.db'}",
+            "USER_DB_BASE_DIR": str(runtime_dir / "user_databases"),
+            "TLDW_ENV_FILE": str(env_file),
+            "MINIMAL_TEST_APP": "1",
+            "MINIMAL_TEST_INCLUDE_AUDIO": "1",
+            "TEST_MODE": "true",
+            "PYTHONWARNINGS": "ignore",
+            "LOGURU_LEVEL": "ERROR",
+        }
+    )
+    return child
+```
+
+- [ ] **Step 4: Implement `openapi_export.py`**
+
+Create `Helper_Scripts/cats_fuzz/openapi_export.py`:
+
+```python
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def build_openapi_export_command(output_path: Path) -> list[str]:
+    return [
+        "python",
+        "-m",
+        "Helper_Scripts.cats_fuzz.openapi_export",
+        "--output",
+        str(output_path),
+    ]
+
+
+def export_openapi(output_path: Path) -> str:
+    from tldw_Server_API.app.main import app
+
+    app.openapi_schema = None
+    payload = json.dumps(app.openapi(), sort_keys=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(payload, encoding="utf-8")
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Export tldw_server OpenAPI for CATS")
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+    digest = export_openapi(args.output)
+    print(digest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 5: Run env tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Helper_Scripts/cats_fuzz/env.py Helper_Scripts/cats_fuzz/openapi_export.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
+git commit -m "feat: isolate CATS fuzz runtime environment"
+```
+
+## Task 4: Add CATS Command Builder And Summary JSON
+
+**Files:**
+- Create: `Helper_Scripts/cats_fuzz/cats_cli.py`
+- Create: `Helper_Scripts/cats_fuzz/summary.py`
+- Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py`
+- Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py`
+
+- [ ] **Step 1: Write command and summary tests**
+
+Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
+from Helper_Scripts.cats_fuzz.cats_cli import build_cats_run_command, classify_cats_exit
+from Helper_Scripts.cats_fuzz.manifest import get_builtin_block
+
+
+@pytest.mark.unit
+def test_public_read_command_uses_blackbox_and_junit_reports(tmp_path: Path) -> None:
+    block = get_builtin_block("public-read")
+    command = build_cats_run_command(
+        block,
+        contract_path=tmp_path / "openapi.json",
+        server_url="http://127.0.0.1:8000",
+        output_dir=tmp_path / "reports",
+        api_key=DEFAULT_TEST_API_KEY,
+    )
+
+    assert "--blackbox" in command
+    assert "--skipReportingForIgnored" in command
+    assert "--reportFormat" in command
+    assert command[command.index("--reportFormat") + 1] == "HTML_ONLY,JUNIT"
+    assert "-H" in command
+    assert f"X-API-KEY={DEFAULT_TEST_API_KEY}" in command
+    assert "--path" in command
+    assert "/" in command[command.index("--path") + 1].split(",")
+
+
+@pytest.mark.unit
+def test_cats_exit_classification_separates_usage_tool_and_api_failures() -> None:
+    assert classify_cats_exit(0, "") == "ok"
+    assert classify_cats_exit(2, "Invalid value for option") == "usage"
+    assert classify_cats_exit(1, "Internal execution error") == "tool"
+    assert classify_cats_exit(1, "Some tests failed with 500") == "api"
+```
+
+Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from Helper_Scripts.cats_fuzz.summary import CatsRunSummary, mask_command, write_summary
+
+
+@pytest.mark.unit
+def test_mask_command_hides_api_key() -> None:
+    masked = mask_command(["cats", "-H", "X-API-KEY=secret-value"])
+
+    assert "secret-value" not in " ".join(masked)
+    assert "X-API-KEY=$X-API-KEY" in masked
+
+
+@pytest.mark.unit
+def test_write_summary_persists_expected_shape(tmp_path: Path) -> None:
+    summary = CatsRunSummary(
+        block="public-read",
+        cats_version="13.8.0",
+        openapi_sha256="abc",
+        command=["cats", "--blackbox"],
+        masked_command=["cats", "--blackbox"],
+        exit_code=0,
+        failure_class="ok",
+        stdout_path="stdout.log",
+        stderr_path="stderr.log",
+        report_dir="report",
+    )
+
+    output = write_summary(summary, tmp_path / "summary.json")
+    data = json.loads(output.read_text(encoding="utf-8"))
+
+    assert data["block"] == "public-read"
+    assert data["failure_class"] == "ok"
+    assert data["command"] == ["cats", "--blackbox"]
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py -q
+```
+
+Expected: FAIL because modules do not exist.
+
+- [ ] **Step 3: Implement command builder**
+
+Create `Helper_Scripts/cats_fuzz/cats_cli.py`:
+
+```python
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from Helper_Scripts.cats_fuzz.manifest import CatsBlock
+
+
+@dataclass(frozen=True)
+class CatsProcessResult:
+    command: list[str]
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+def _join(values: tuple[str, ...]) -> str:
+    return ",".join(values)
+
+
+def build_cats_run_command(
+    block: CatsBlock,
+    *,
+    contract_path: Path,
+    server_url: str,
+    output_dir: Path,
+    api_key: str,
+    cats_bin: str = "cats",
+    dry_run: bool = False,
+) -> list[str]:
+    command = [
+        cats_bin,
+        "-c",
+        str(contract_path),
+        "-s",
+        server_url.rstrip("/"),
+        "-H",
+        f"X-API-KEY={api_key}",
+        "--maskHeaders",
+        "X-API-KEY,Authorization",
+        "--blackbox",
+        "--skipReportingForIgnored",
+        "--maxRequestsPerMinute",
+        str(block.max_requests_per_minute),
+        "--connectionTimeout",
+        str(block.connection_timeout),
+        "--readTimeout",
+        str(block.read_timeout),
+        "--writeTimeout",
+        str(block.write_timeout),
+        "--reportFormat",
+        _join(block.report_formats),
+        "--output",
+        str(output_dir),
+    ]
+    if block.paths:
+        command.extend(["--path", _join(block.paths)])
+    if block.skip_paths:
+        command.extend(["--skipPath", _join(block.skip_paths)])
+    if block.skip_methods:
+        command.extend(["--skipHttpMethod", _join(block.skip_methods)])
+    if dry_run:
+        command.append("--dryRun")
+    return command
+
+
+def build_cats_validate_command(contract_path: Path, *, cats_bin: str = "cats", json_output: bool = True) -> list[str]:
+    command = [cats_bin, "validate", "-c", str(contract_path)]
+    if json_output:
+        command.append("-j")
+    return command
+
+
+def build_cats_stats_command(contract_path: Path, *, cats_bin: str = "cats", json_output: bool = True) -> list[str]:
+    command = [cats_bin, "stats", "-c", str(contract_path)]
+    if json_output:
+        command.append("-j")
+    return command
+
+
+def classify_cats_exit(exit_code: int, stderr: str) -> str:
+    if exit_code == 0:
+        return "ok"
+    lowered = stderr.lower()
+    if exit_code == 2 or "invalid value for option" in lowered:
+        return "usage"
+    if "internal execution error" in lowered or "exception occurred" in lowered:
+        return "tool"
+    return "api"
+
+
+def run_command(command: list[str], *, timeout_seconds: int, env: dict[str, str] | None = None) -> CatsProcessResult:
+    proc = subprocess.run(  # nosec B603 - command is built from trusted harness args
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        env=env,
+    )
+    return CatsProcessResult(command=command, exit_code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+```
+
+- [ ] **Step 4: Implement summary writer**
+
+Create `Helper_Scripts/cats_fuzz/summary.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import json
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CatsRunSummary:
+    block: str
+    cats_version: str
+    openapi_sha256: str
+    command: list[str]
+    masked_command: list[str]
+    exit_code: int
+    failure_class: str
+    stdout_path: str
+    stderr_path: str
+    report_dir: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def mask_command(command: list[str]) -> list[str]:
+    masked: list[str] = []
+    for part in command:
+        if part.startswith("X-API-KEY="):
+            masked.append("X-API-KEY=$X-API-KEY")
+        elif part.startswith("Authorization="):
+            masked.append("Authorization=$AUTHORIZATION")
+        else:
+            masked.append(part)
+    return masked
+
+
+def write_summary(summary: CatsRunSummary, output_path: Path) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return output_path
+```
+
+- [ ] **Step 5: Run command and summary tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Helper_Scripts/cats_fuzz/cats_cli.py Helper_Scripts/cats_fuzz/summary.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py
+git commit -m "feat: build CATS commands and run summaries"
+```
+
+## Task 5: Add Server Lifecycle And Runner Orchestration
+
+**Files:**
+- Create: `Helper_Scripts/cats_fuzz/server.py`
+- Create: `Helper_Scripts/cats_fuzz/runner.py`
+- Create: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py`
+
+- [ ] **Step 1: Write mocked runner tests**
+
+Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from Helper_Scripts.cats_fuzz.cats_cli import CatsProcessResult
+from Helper_Scripts.cats_fuzz.runner import run_contract_block
+
+
+@pytest.mark.unit
+def test_contract_block_writes_summary_for_validate_and_stats(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    openapi = tmp_path / "openapi.json"
+    openapi.write_text("{}", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, timeout_seconds: int, env: dict[str, str] | None = None) -> CatsProcessResult:
+        calls.append(command)
+        return CatsProcessResult(command=command, exit_code=0, stdout="{}", stderr="")
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.run_command", fake_run)
+
+    result = run_contract_block(
+        contract_path=openapi,
+        output_dir=tmp_path / "out",
+        cats_version="13.8.0",
+        openapi_sha256="abc",
+    )
+
+    assert result.exit_code == 0
+    assert any(command[:2] == ["cats", "validate"] for command in calls)
+    assert any(command[:2] == ["cats", "stats"] for command in calls)
+    assert (tmp_path / "out" / "contract" / "summary.json").exists()
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py -q
+```
+
+Expected: FAIL because `runner.py` and `server.py` do not exist yet.
+
+- [ ] **Step 3: Implement server lifecycle**
+
+Create `Helper_Scripts/cats_fuzz/server.py`:
+
+```python
+from __future__ import annotations
+
+import contextlib
+import socket
+import subprocess
+import time
+from dataclasses import dataclass
+from urllib.request import urlopen
+
+
+@dataclass
+class UvicornServer:
+    process: subprocess.Popen[str]
+    url: str
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def start_server(env: dict[str, str], *, port: int | None = None) -> UvicornServer:
+    resolved_port = port or find_free_port()
+    url = f"http://127.0.0.1:{resolved_port}"
+    process = subprocess.Popen(  # nosec B603 - fixed module invocation
+        [
+            "python",
+            "-m",
+            "uvicorn",
+            "tldw_Server_API.app.main:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(resolved_port),
+        ],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    wait_for_health(url)
+    return UvicornServer(process=process, url=url)
+
+
+def wait_for_health(base_url: str, *, timeout_seconds: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(f"{base_url}/health", timeout=2.0) as response:  # nosec B310
+                if int(response.status) < 500:
+                    return
+        except Exception as exc:  # noqa: BLE001 - health polling should retain last failure
+            last_error = exc
+        time.sleep(0.25)
+    raise TimeoutError(f"Server did not become healthy: {last_error}")
+
+
+def stop_server(server: UvicornServer) -> None:
+    server.process.terminate()
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        server.process.wait(timeout=10)
+    if server.process.poll() is None:
+        server.process.kill()
+        server.process.wait(timeout=5)
+```
+
+- [ ] **Step 4: Implement runner orchestration**
+
+Create `Helper_Scripts/cats_fuzz/runner.py`:
+
+```python
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
+from Helper_Scripts.cats_fuzz.cats_cli import (
+    CatsProcessResult,
+    build_cats_run_command,
+    build_cats_stats_command,
+    build_cats_validate_command,
+    classify_cats_exit,
+    run_command,
+)
+from Helper_Scripts.cats_fuzz.manifest import CatsBlock, get_builtin_block
+from Helper_Scripts.cats_fuzz.summary import CatsRunSummary, mask_command, write_summary
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_process_artifacts(result: CatsProcessResult, output_dir: Path) -> tuple[Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = output_dir / "stdout.log"
+    stderr_path = output_dir / "stderr.log"
+    stdout_path.write_text(result.stdout, encoding="utf-8")
+    stderr_path.write_text(result.stderr, encoding="utf-8")
+    return stdout_path, stderr_path
+
+
+def _summarize(
+    *,
+    block: str,
+    result: CatsProcessResult,
+    output_dir: Path,
+    cats_version: str,
+    openapi_sha256: str,
+    report_dir: Path,
+) -> CatsRunSummary:
+    stdout_path, stderr_path = _write_process_artifacts(result, output_dir)
+    summary = CatsRunSummary(
+        block=block,
+        cats_version=cats_version,
+        openapi_sha256=openapi_sha256,
+        command=result.command,
+        masked_command=mask_command(result.command),
+        exit_code=result.exit_code,
+        failure_class=classify_cats_exit(result.exit_code, result.stderr),
+        stdout_path=str(stdout_path),
+        stderr_path=str(stderr_path),
+        report_dir=str(report_dir),
+    )
+    write_summary(summary, output_dir / "summary.json")
+    return summary
+
+
+def run_contract_block(
+    *,
+    contract_path: Path,
+    output_dir: Path,
+    cats_version: str,
+    openapi_sha256: str | None = None,
+    cats_bin: str = "cats",
+) -> CatsRunSummary:
+    block_dir = output_dir / "contract"
+    validate_result = run_command(
+        build_cats_validate_command(contract_path, cats_bin=cats_bin),
+        timeout_seconds=60,
+    )
+    stats_result = run_command(
+        build_cats_stats_command(contract_path, cats_bin=cats_bin),
+        timeout_seconds=60,
+    )
+    merged = CatsProcessResult(
+        command=validate_result.command,
+        exit_code=validate_result.exit_code or stats_result.exit_code,
+        stdout=validate_result.stdout + "\n" + stats_result.stdout,
+        stderr=validate_result.stderr + "\n" + stats_result.stderr,
+    )
+    return _summarize(
+        block="contract",
+        result=merged,
+        output_dir=block_dir,
+        cats_version=cats_version,
+        openapi_sha256=openapi_sha256 or _sha256(contract_path),
+        report_dir=block_dir,
+    )
+
+
+def run_runtime_block(
+    block: CatsBlock,
+    *,
+    contract_path: Path,
+    server_url: str,
+    output_dir: Path,
+    cats_version: str,
+    api_key: str = DEFAULT_TEST_API_KEY,
+    cats_bin: str = "cats",
+    dry_run: bool = False,
+    env: dict[str, str] | None = None,
+) -> CatsRunSummary:
+    block_dir = output_dir / block.name
+    report_dir = block_dir / "cats-report"
+    command = build_cats_run_command(
+        block,
+        contract_path=contract_path,
+        server_url=server_url,
+        output_dir=report_dir,
+        api_key=api_key,
+        cats_bin=cats_bin,
+        dry_run=dry_run,
+    )
+    result = run_command(command, timeout_seconds=block.timeout_seconds, env=env)
+    return _summarize(
+        block=block.name,
+        result=result,
+        output_dir=block_dir,
+        cats_version=cats_version,
+        openapi_sha256=_sha256(contract_path),
+        report_dir=report_dir,
+    )
+
+
+def get_default_runtime_block() -> CatsBlock:
+    return get_builtin_block("public-read")
+```
+
+- [ ] **Step 5: Run runner tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Helper_Scripts/cats_fuzz/server.py Helper_Scripts/cats_fuzz/runner.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
+git commit -m "feat: orchestrate CATS fuzz runs"
+```
+
+## Task 6: Add CLI And Documentation
+
+**Files:**
+- Create: `Helper_Scripts/cats_fuzz/cli.py`
+- Create: `Helper_Scripts/cats_fuzz/__main__.py`
+- Create: `Docs/Development/CATS_Fuzzing.md`
+- Modify: `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py` or create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py`
+
+- [ ] **Step 1: Write CLI parser tests**
+
+Create `tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from Helper_Scripts.cats_fuzz.cli import parse_args
+
+
+@pytest.mark.unit
+def test_cli_defaults_to_contract_and_public_read() -> None:
+    args = parse_args([])
+
+    assert args.block == ["contract", "public-read"]
+    assert args.output == "artifacts/cats-fuzz"
+    assert args.start_server is True
+
+
+@pytest.mark.unit
+def test_cli_accepts_existing_server_url() -> None:
+    args = parse_args(["--server-url", "http://127.0.0.1:8000", "--no-start-server"])
+
+    assert args.server_url == "http://127.0.0.1:8000"
+    assert args.start_server is False
+```
+
+- [ ] **Step 2: Run CLI tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py -q
+```
+
+Expected: FAIL because `cli.py` does not exist.
+
+- [ ] **Step 3: Implement CLI**
+
+Create `Helper_Scripts/cats_fuzz/cli.py`:
+
+```python
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from Helper_Scripts.cats_fuzz.env import build_child_env
+from Helper_Scripts.cats_fuzz.manifest import get_builtin_block
+from Helper_Scripts.cats_fuzz.openapi_export import build_openapi_export_command
+from Helper_Scripts.cats_fuzz.runner import run_contract_block, run_runtime_block
+from Helper_Scripts.cats_fuzz.server import start_server, stop_server
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run local CATS fuzzing blocks for tldw_server")
+    parser.add_argument("--block", action="append", default=None, help="Block to run; may be repeated")
+    parser.add_argument("--output", default="artifacts/cats-fuzz")
+    parser.add_argument("--cats-bin", default="cats")
+    parser.add_argument("--server-url")
+    parser.add_argument("--start-server", dest="start_server", action="store_true", default=True)
+    parser.add_argument("--no-start-server", dest="start_server", action="store_false")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--allow-external", action="store_true")
+    args = parser.parse_args(argv)
+    if args.block is None:
+        args.block = ["contract", "public-read"]
+    return args
+
+
+def _cats_version(cats_bin: str) -> str:
+    proc = subprocess.run([cats_bin, "--version"], check=False, capture_output=True, text=True)  # nosec B603
+    return (proc.stdout or proc.stderr).strip().splitlines()[0] if proc.returncode == 0 else "unknown"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    child_env = build_child_env(output_dir, allow_external=args.allow_external)
+    contract_path = output_dir / "openapi.json"
+
+    subprocess.run(build_openapi_export_command(contract_path), check=True, env=child_env)  # nosec B603
+    cats_version = _cats_version(args.cats_bin)
+
+    server = None
+    server_url = args.server_url
+    try:
+        if any(block != "contract" for block in args.block) and args.start_server:
+            server = start_server(child_env)
+            server_url = server.url
+        exit_code = 0
+        for block_name in args.block:
+            if block_name == "contract":
+                summary = run_contract_block(
+                    contract_path=contract_path,
+                    output_dir=output_dir,
+                    cats_version=cats_version,
+                    cats_bin=args.cats_bin,
+                )
+            else:
+                if not server_url:
+                    raise ValueError(f"{block_name} requires --server-url or --start-server")
+                summary = run_runtime_block(
+                    get_builtin_block(block_name),
+                    contract_path=contract_path,
+                    server_url=server_url,
+                    output_dir=output_dir,
+                    cats_version=cats_version,
+                    cats_bin=args.cats_bin,
+                    dry_run=args.dry_run,
+                    env=child_env,
+                )
+            if summary.exit_code != 0:
+                exit_code = summary.exit_code
+        return exit_code
+    finally:
+        if server is not None:
+            stop_server(server)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+Create `Helper_Scripts/cats_fuzz/__main__.py`:
+
+```python
+from __future__ import annotations
+
+from Helper_Scripts.cats_fuzz.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Write usage docs**
+
+Create `Docs/Development/CATS_Fuzzing.md`:
+
+````markdown
+# CATS API Fuzzing
+
+The CATS harness runs OpenAPI-driven negative fuzzing against an isolated local tldw_server process. Do not run the default harness against production or a server with real provider credentials.
+
+## First Slice
+
+```bash
+source .venv/bin/activate
+python -m Helper_Scripts.cats_fuzz --block contract
+python -m Helper_Scripts.cats_fuzz --block contract --block public-read
+```
+
+Artifacts are written under `artifacts/cats-fuzz/` by default:
+
+- `openapi.json`
+- per-block `summary.json`
+- per-block `stdout.log` and `stderr.log`
+- CATS HTML/JUnit report folders for runtime blocks
+
+## Safety Defaults
+
+- Starts uvicorn on `127.0.0.1` by default.
+- Uses a deterministic long test API key.
+- Writes AuthNZ and user databases under the artifact runtime directory.
+- Sets `TLDW_ENV_FILE` to a generated minimal env file.
+- Rejects real provider or webhook credentials unless `--allow-external` is passed.
+- Uses CATS blackbox mode so only `5xx` responses are gate failures for runtime blocks.
+````
+
+- [ ] **Step 5: Run CLI tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Helper_Scripts/cats_fuzz/cli.py Helper_Scripts/cats_fuzz/__main__.py Docs/Development/CATS_Fuzzing.md tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
+git commit -m "feat: add CATS fuzzing CLI"
+```
+
+## Task 7: Run End-to-End Harness Verification
+
+**Files:**
+- Modify: `backlog/tasks/task-2370 - Plan-CATS-API-fuzzing-harness-implementation.md` only for final notes if this plan task is still open, or the implementation task that owns execution.
+
+- [ ] **Step 1: Run all focused Python tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py \
+  tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run CATS contract block**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m Helper_Scripts.cats_fuzz --block contract --output /tmp/tldw-cats-contract
+```
+
+Expected: exit `0`, `/tmp/tldw-cats-contract/contract/summary.json` has `"failure_class": "ok"`.
+
+- [ ] **Step 3: Run CATS public-read live block**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m Helper_Scripts.cats_fuzz --block contract --block public-read --output /tmp/tldw-cats-public-read
+```
+
+Expected: exit `0` or a non-zero exit only when `summary.json` clearly classifies an API `5xx` issue worth fixing. If CATS itself throws a tool/internal error, record stderr and either adjust command construction or add a documented fallback.
+
+- [ ] **Step 4: Run Bandit on touched executable harness scope**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r Helper_Scripts/cats_fuzz tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py -f json -o /tmp/bandit_cats_fuzz.json
+```
+
+Expected: no new findings in touched code. If Bandit flags the deliberate local subprocess/urlopen calls, add tight `# nosec` comments with a local-only justification only where needed.
+
+- [ ] **Step 5: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Commit final verification notes if needed**
+
+If verification notes or docs changed:
+
+```bash
+git add <changed-files>
+git commit -m "docs: record CATS fuzzing verification"
+```
+
+## Known Risks And Follow-Ups
+
+- CATS `--dryRun` reached command parsing locally but threw a Java `ClassCastException` against the large tldw OpenAPI shape. Treat dry-run as helpful but not a hard preflight until proven stable with the finalized command.
+- The first implementation should not add broad CI yet. Start with local/manual usage and a small contract/public-read command that can later be wired into CI.
+- The worktree has no `.venv`; implementation must set up dependencies before running Python tests.
+- `auth-read`, `auth-crud-isolated`, `media-light`, and broad/nightly blocks remain follow-up work after the first live public-read path is reliable.
+- Subagent plan review was not dispatched while drafting this plan because the current thread policy only permits subagents when the user explicitly requests delegation.
+
+## Success Criteria
+
+- `cats validate` passes against the generated tldw OpenAPI file, or any remaining validation failure is recorded in a known-issues file with an explicit non-blocking contract gate.
+- `python -m Helper_Scripts.cats_fuzz --block contract` writes a summary JSON and exits correctly.
+- `python -m Helper_Scripts.cats_fuzz --block contract --block public-read` can start an isolated local server and run CATS blackbox fuzzing without real credentials.
+- Focused pytest and Bandit commands pass.
+- Reports never expose `X-API-KEY` or provider credentials.

--- a/Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md
+++ b/Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md
@@ -1,0 +1,285 @@
+# CATS API Fuzzing Harness Design
+
+Backlog task: TASK-2369
+
+## Context
+
+tldw_server exposes a large FastAPI OpenAPI surface at `/openapi.json`. A
+minimal-test OpenAPI generation pass produced 1608 paths and 2044 operations,
+which is too broad for a single first-pass fuzzing run. CATS 13.8.0 is already
+available locally and can run OpenAPI-driven negative and security fuzzing
+against a live API server.
+
+The harness should make broad coverage practical by splitting fuzzing into
+explicit blocks. Each block should state its risk level, required seed state,
+mutation behavior, network policy, timeout profile, and skip rationale. The
+initial gate should find server crashes and unsafe runtime behavior without
+turning expected validation, authentication, and missing-resource responses
+into noise.
+
+## Goals
+
+- Provide a repeatable local and CI-friendly CATS fuzzing harness for the
+  tldw_server API.
+- Cover the API broadly through staged blocks instead of one monolithic sweep.
+- Fail on unexpected server errors while preserving detailed reports for
+  warnings and schema mismatches.
+- Keep local developer data, provider credentials, and external networks out of
+  default fuzzing runs.
+- Make stateful coverage possible through seed data and CATS reference data.
+
+## Non-Goals
+
+- Replace pytest integration tests or property tests.
+- Require real LLM, embedding, search, webhook, social, or provider services.
+- Exercise all streaming, WebSocket, media, and background-job behavior in the
+  first implementation slice.
+- Make full broad fuzzing a required PR gate.
+
+## Block Architecture
+
+The harness should use a block manifest rather than hard-coded one-off CATS
+commands. Each block entry should include:
+
+- `name`: stable block id used in reports and CLI selection.
+- `description`: short purpose and coverage summary.
+- `risk`: one of `contract`, `public-read`, `auth-read`, `isolated-mutation`,
+  `external-risk`, or `manual`.
+- `paths` or `tags`: allowlist passed to CATS.
+- `skip_paths`, `skip_tags`, or `skip_methods`: explicit exclusions.
+- `requires_seed`: whether a seed phase must run before CATS.
+- `allows_mutation`: whether the block may create, update, or delete data.
+- `allows_network`: false by default.
+- `timeout_seconds`, `read_timeout`, and `max_requests_per_minute`.
+- `expected_gate`: default `no_5xx`, with stricter gates added later.
+- `skip_reason`: required for risky paths excluded from broad blocks.
+
+### Initial Blocks
+
+1. `contract`
+   - Runs `cats validate` and `cats stats` against a generated OpenAPI file.
+   - Does not call the API service.
+   - Records known OpenAPI validation defects separately from runtime failures.
+
+2. `public-read`
+   - Covers `/`, `/health`, `/ready`, `/health/ready`, `/api/v1/health/*`,
+     `/api/v1/config/docs-info`, `/api/v1/config/quickstart`, and similar
+     public metadata endpoints.
+   - Uses blackbox mode and fails on `5xx`.
+   - Runs in PR CI once stable.
+
+3. `auth-read`
+   - Covers authenticated read-only endpoints such as LLM provider lists,
+     capabilities, metrics JSON, MCP status/catalog lists, RAG health, user
+     profile read paths, and resource-governor diagnostics.
+   - Uses `X-API-KEY` in single-user mode.
+   - Scrubs all provider credentials from the environment.
+
+4. `auth-crud-isolated`
+   - Covers selected create/update/delete flows in temporary SQLite user data.
+   - Requires seeding and CATS `refData` or `urlParams` so IDs reference real
+     rows rather than mostly hitting 404 responses.
+   - Runs nightly or manually first.
+
+5. `media-light`
+   - Covers upload and media-adjacent endpoints only with tiny local fixtures.
+   - Skips remote downloads, transcription, large files, model execution, and
+     provider calls.
+   - Requires strict file-size and timeout controls.
+
+6. `protocol-streaming`
+   - Covers protocol and streaming-adjacent HTTP endpoints only where CATS can
+     complete requests reliably.
+   - Skips WebSocket-only behavior and long-lived SSE streams unless the block
+     has short read timeouts and explicit path exclusions.
+
+7. `broad-nightly`
+   - Expands across larger tags/path groups in blackbox mode.
+   - Excludes external-egress, destructive admin, long-running media, and
+     provider-backed routes by default.
+   - Intended for scheduled CI or local manual use, not mandatory PR gating.
+
+8. `multi-user-auth`
+   - Future block for JWT and RBAC coverage.
+   - Seeds users, roles, and admin/non-admin JWTs.
+   - Exercises invalid, missing, and insufficient-scope auth separately from
+     single-user API key fuzzing.
+
+## Runtime Isolation
+
+The runner should start from an explicit test environment:
+
+- `AUTH_MODE=single_user`.
+- A deterministic long `SINGLE_USER_API_KEY` and `SINGLE_USER_TEST_API_KEY`.
+- Temporary `DATABASE_URL`.
+- Temporary `USER_DB_BASE_DIR`.
+- Temporary output, upload, artifact, and report directories where supported.
+- Disabled schedulers, background workers, webhook delivery, and external
+  provider calls where supported by existing configuration flags.
+- Low request rate and bounded read/write/connect timeouts.
+
+The default runner should fail fast if it detects real provider credentials or
+webhook destinations in the environment. Examples include `OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, provider-specific API keys, Slack/Discord/Telegram tokens,
+and webhook URLs. A deliberate override flag can be added later for controlled
+external-provider fuzzing, but the default behavior must be local-only.
+
+## CATS Invocation Shape
+
+Each block should resolve to a deterministic CATS command similar to:
+
+```bash
+cats \
+  -c <generated-openapi.json> \
+  -s http://127.0.0.1:<port> \
+  -H X-API-KEY=<test-key> \
+  --maskHeaders X-API-KEY,Authorization \
+  --blackbox \
+  --skipReportingForIgnored \
+  --maxRequestsPerMinute <block-limit> \
+  --connectionTimeout <seconds> \
+  --readTimeout <seconds> \
+  --writeTimeout <seconds> \
+  --reportFormat HTML_ONLY,JSON \
+  --output <artifact-dir>/<block-name> \
+  --path <comma-separated-path-allowlist>
+```
+
+The first implementation should prefer path allowlists because the current tag
+set is very large and tag cohesion is uneven. Tag-based blocks can be added
+after individual tags prove stable.
+
+## Stateful Seed Data
+
+Stateful blocks should have an explicit seed phase. The seed phase should:
+
+- Run against the same isolated server and temp DB as the fuzz block.
+- Create minimal valid entities for selected route families.
+- Emit CATS `refData`, `urlParams`, and optional header/query files.
+- Avoid real networks and large media.
+- Record all generated IDs in a manifest for replay and cleanup.
+
+Without seeding, stateful fuzzing would mostly test missing-resource paths and
+would not meaningfully cover authorization, validation, or update logic.
+
+## Failure Policy
+
+Initial runtime blocks use blackbox mode. The gate is:
+
+- fail on any CATS `error` caused by an HTTP `5xx`;
+- report but do not initially fail on warnings, undocumented response codes,
+  content type mismatches, or response schema mismatches;
+- record expected `4xx` validation/auth failures as non-failures;
+- keep full CATS artifacts for replay and manual triage.
+
+Later hardening blocks should add stricter expectations:
+
+- Missing or invalid auth should return `401` or `403`, not `2xx` or `5xx`.
+- Public endpoints should stay public only when intentionally listed.
+- Response schema and content type warnings should become actionable after the
+  OpenAPI contract is stable enough for that block.
+
+## Reporting
+
+Every run should write a compact summary JSON next to the CATS reports. The
+summary should include:
+
+- CATS version.
+- git commit and dirty-state marker when available.
+- OpenAPI spec hash.
+- block name and block manifest hash.
+- server URL and port.
+- paths, tags, and methods covered.
+- skipped paths and reasons.
+- request count, warnings, errors, and `5xx` count.
+- random seed and replay references where CATS provides them.
+
+Failure triage should group results by `method + path + status + fuzzer`, not
+only by raw request count. This keeps broad blocks readable when many payloads
+hit the same underlying issue.
+
+## CI And Scheduling
+
+PR CI:
+
+- `contract`
+- `public-read`
+
+Nightly CI:
+
+- `auth-read`
+- selected `auth-crud-isolated`
+- selected `media-light`
+
+Manual or scheduled security sweeps:
+
+- `protocol-streaming`
+- `broad-nightly`
+- future `multi-user-auth`
+
+Nightly and manual runs should upload CATS HTML/JSON reports as artifacts.
+PR CI should keep reports small and avoid starting provider-backed or
+long-running workers.
+
+## Known Issues
+
+CATS currently reports the generated OpenAPI document as invalid because
+`GET /api/v1/vector_stores/{store_id}/vectors` exposes three query parameter
+`examples` fields in a shape CATS rejects:
+
+- `filter`
+- `order_by`
+- `order_dir`
+
+This is defined in `tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py`.
+The first implementation should either fix those examples before enabling the
+`contract` gate or record the issue in a known-issues file so the gate remains
+transparent. The preferred path is to fix the OpenAPI examples as a small
+pre-harness cleanup task if the file is not owned by another active change.
+
+## Security And Safety
+
+Default fuzzing must be local-only. The runner should:
+
+- scrub sensitive environment variables before starting the server;
+- reject runs with real credentials unless explicitly overridden;
+- default `allows_network` to false;
+- skip web scraping, research provider, social integration, webhook, and LLM
+  provider execution blocks unless deliberately selected;
+- mask auth headers in console and reports;
+- keep generated test keys long enough to satisfy AuthNZ validation;
+- write all mutable data under temporary directories.
+
+## Rollout Plan
+
+1. Implement the block manifest and runner with `contract` and `public-read`.
+2. Add isolated authenticated server startup and `auth-read`.
+3. Add seed helpers and `auth-crud-isolated` for one or two stable route
+   families.
+4. Add `media-light` with tiny fixtures and strict timeout controls.
+5. Add `protocol-streaming` exclusions and short-read checks.
+6. Add `broad-nightly` as a scheduled/manual artifact-producing run.
+7. Add `multi-user-auth` after single-user API key fuzzing is stable.
+
+## Verification Strategy
+
+The design and implementation should be verified with:
+
+- `cats --version`.
+- `cats validate -c <generated-openapi.json>`.
+- `cats stats -c <generated-openapi.json>`.
+- CATS dry-run for each enabled block.
+- One live `public-read` run against an isolated local server.
+- One live `auth-read` run after env scrubbing is implemented.
+- `python -m pytest` for runner/unit helpers when they exist.
+- Bandit over touched executable harness code.
+- `git diff --check`.
+
+## Open Questions
+
+- Which CI workflow should eventually own nightly fuzzing artifacts.
+- Whether the runner should start uvicorn itself or require an existing server
+  for the first implementation slice.
+- Which CRUD route family should be the first seeded stateful block.
+- Whether to fix the vector store OpenAPI examples in the same PR as the first
+  harness slice or as a separate cleanup PR.

--- a/Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md
+++ b/Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md
@@ -124,6 +124,14 @@ webhook destinations in the environment. Examples include `OPENAI_API_KEY`,
 and webhook URLs. A deliberate override flag can be added later for controlled
 external-provider fuzzing, but the default behavior must be local-only.
 
+Credential scrubbing must account for the app configuration loader. The server
+loads `TLDW_ENV_FILE` and canonical repo `.env` files with `override=False`, so
+unsetting a key can allow a real value from `.env` to be loaded later. The
+runner should build an explicit child process environment that pre-sets known
+provider, webhook, and social integration variables to empty or inert sentinel
+values, points `TLDW_ENV_FILE` at a temporary minimal fuzzing env file, and
+verifies the effective child environment before starting uvicorn.
+
 ## CATS Invocation Shape
 
 Each block should resolve to a deterministic CATS command similar to:
@@ -140,10 +148,14 @@ cats \
   --connectionTimeout <seconds> \
   --readTimeout <seconds> \
   --writeTimeout <seconds> \
-  --reportFormat HTML_ONLY,JSON \
+  --reportFormat HTML_ONLY,JUNIT \
   --output <artifact-dir>/<block-name> \
   --path <comma-separated-path-allowlist>
 ```
+
+The compact JSON summary is owned by the runner. CATS 13.8.0 does not expose a
+JSON report format; supported report formats include `HTML_ONLY`, `HTML_JS`,
+`HTML_JS_CLUSTERS`, and `JUNIT`.
 
 The first implementation should prefer path allowlists because the current tag
 set is very large and tag cohesion is uneven. Tag-based blocks can be added
@@ -193,6 +205,9 @@ summary should include:
 - skipped paths and reasons.
 - request count, warnings, errors, and `5xx` count.
 - random seed and replay references where CATS provides them.
+- CATS exit code and failure class, separating API failures from CATS/tooling
+  failures.
+- masked command arguments plus stdout and stderr artifact paths.
 
 Failure triage should group results by `method + path + status + fuzzer`, not
 only by raw request count. This keeps broad blocks readable when many payloads
@@ -200,10 +215,14 @@ hit the same underlying issue.
 
 ## CI And Scheduling
 
-PR CI:
+PR CI after OpenAPI validation is clean:
 
 - `contract`
 - `public-read`
+
+Until the known vector store OpenAPI examples issue is fixed, `contract` should
+run only as an advisory local/manual check or use an explicit known-issues file
+that keeps the non-blocking failure visible.
 
 Nightly CI:
 
@@ -217,9 +236,9 @@ Manual or scheduled security sweeps:
 - `broad-nightly`
 - future `multi-user-auth`
 
-Nightly and manual runs should upload CATS HTML/JSON reports as artifacts.
-PR CI should keep reports small and avoid starting provider-backed or
-long-running workers.
+Nightly and manual runs should upload CATS HTML/JUnit reports plus the
+runner-owned summary JSON as artifacts. PR CI should keep reports small and
+avoid starting provider-backed or long-running workers.
 
 ## Known Issues
 
@@ -236,12 +255,18 @@ The first implementation should either fix those examples before enabling the
 `contract` gate or record the issue in a known-issues file so the gate remains
 transparent. The preferred path is to fix the OpenAPI examples as a small
 pre-harness cleanup task if the file is not owned by another active change.
+Until one of those paths is complete, `contract` must not be a blocking PR gate.
 
 ## Security And Safety
 
 Default fuzzing must be local-only. The runner should:
 
-- scrub sensitive environment variables before starting the server;
+- pre-set sensitive environment variables to empty or inert sentinel values
+  before starting the server so dotenv fallback files cannot reintroduce real
+  credentials;
+- set `TLDW_ENV_FILE` to a temporary minimal fuzzing env file;
+- verify the effective child process environment before importing or starting
+  the app;
 - reject runs with real credentials unless explicitly overridden;
 - default `allows_network` to false;
 - skip web scraping, research provider, social integration, webhook, and LLM
@@ -252,7 +277,8 @@ Default fuzzing must be local-only. The runner should:
 
 ## Rollout Plan
 
-1. Implement the block manifest and runner with `contract` and `public-read`.
+1. Fix or explicitly known-issue the vector store OpenAPI examples, then
+   implement the block manifest and runner with `contract` and `public-read`.
 2. Add isolated authenticated server startup and `auth-read`.
 3. Add seed helpers and `auth-crud-isolated` for one or two stable route
    families.
@@ -268,7 +294,9 @@ The design and implementation should be verified with:
 - `cats --version`.
 - `cats validate -c <generated-openapi.json>`.
 - `cats stats -c <generated-openapi.json>`.
-- CATS dry-run for each enabled block.
+- CATS dry-run for each enabled block where stable. If a CATS dry-run fails due
+  to a tool-level error, capture the exit code and stderr, then fall back to
+  command-construction tests plus a tiny live run against the isolated server.
 - One live `public-read` run against an isolated local server.
 - One live `auth-read` run after env scrubbing is implemented.
 - `python -m pytest` for runner/unit helpers when they exist.
@@ -278,8 +306,14 @@ The design and implementation should be verified with:
 ## Open Questions
 
 - Which CI workflow should eventually own nightly fuzzing artifacts.
-- Whether the runner should start uvicorn itself or require an existing server
-  for the first implementation slice.
 - Which CRUD route family should be the first seeded stateful block.
 - Whether to fix the vector store OpenAPI examples in the same PR as the first
   harness slice or as a separate cleanup PR.
+
+## Implementation Decision
+
+The first implementation slice should start uvicorn itself by default. This
+keeps credential isolation, temporary database paths, port allocation, and
+cleanup under the runner's control. A later `--server-url` mode can support
+manual runs against an already-started server, but it should be opt-in because
+the runner cannot fully verify an external server's environment.

--- a/Helper_Scripts/cats_fuzz/__init__.py
+++ b/Helper_Scripts/cats_fuzz/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+DEFAULT_TEST_API_KEY = "THIS-IS-A-SECURE-KEY-123-FAKE-KEY"
+
+__all__ = ["DEFAULT_TEST_API_KEY"]

--- a/Helper_Scripts/cats_fuzz/__init__.py
+++ b/Helper_Scripts/cats_fuzz/__init__.py
@@ -1,3 +1,5 @@
+"""Shared constants for the local CATS fuzzing harness."""
+
 from __future__ import annotations
 
 DEFAULT_TEST_API_KEY = "THIS-IS-A-SECURE-KEY-123-FAKE-KEY"

--- a/Helper_Scripts/cats_fuzz/__main__.py
+++ b/Helper_Scripts/cats_fuzz/__main__.py
@@ -1,3 +1,5 @@
+"""Module entrypoint for running the CATS fuzzing harness with python -m."""
+
 from __future__ import annotations
 
 from Helper_Scripts.cats_fuzz.cli import main

--- a/Helper_Scripts/cats_fuzz/__main__.py
+++ b/Helper_Scripts/cats_fuzz/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from Helper_Scripts.cats_fuzz.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Helper_Scripts/cats_fuzz/cats_cli.py
+++ b/Helper_Scripts/cats_fuzz/cats_cli.py
@@ -32,7 +32,6 @@ def build_cats_run_command(
 ) -> list[str]:
     command = [
         cats_bin,
-        "run",
         "-c",
         str(contract_path),
         "-s",

--- a/Helper_Scripts/cats_fuzz/cats_cli.py
+++ b/Helper_Scripts/cats_fuzz/cats_cli.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import subprocess  # nosec B404
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from Helper_Scripts.cats_fuzz.manifest import CatsBlock
+
+
+@dataclass(frozen=True)
+class CatsProcessResult:
+    command: list[str]
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+def _append_csv_option(command: list[str], option: str, values: Sequence[str]) -> None:
+    if values:
+        command.extend([option, ",".join(values)])
+
+
+def build_cats_run_command(
+    block: CatsBlock,
+    contract_path: Path,
+    server_url: str,
+    output_dir: Path,
+    api_key: str,
+    cats_bin: str = "cats",
+    dry_run: bool = False,
+) -> list[str]:
+    command = [
+        cats_bin,
+        "run",
+        "-c",
+        str(contract_path),
+        "-s",
+        server_url,
+        "-H",
+        f"X-API-KEY={api_key}",
+        "--maskHeaders",
+        "X-API-KEY,Authorization",
+        "--skipReportingForIgnored",
+        "--maxRequestsPerMinute",
+        str(block.max_requests_per_minute),
+        "--connectionTimeout",
+        str(block.connection_timeout),
+        "--readTimeout",
+        str(block.read_timeout),
+        "--writeTimeout",
+        str(block.write_timeout),
+        "--reportFormat",
+        ",".join(block.report_formats),
+        "--output",
+        str(output_dir),
+    ]
+    if block.blackbox:
+        command.append("--blackbox")
+    _append_csv_option(command, "--path", block.paths)
+    _append_csv_option(command, "--tag", block.tags)
+    _append_csv_option(command, "--skipPath", block.skip_paths)
+    _append_csv_option(command, "--skipTag", block.skip_tags)
+    _append_csv_option(command, "--skipHttpMethod", block.skip_methods)
+    if dry_run:
+        command.append("--dryRun")
+    return command
+
+
+def build_cats_validate_command(
+    contract_path: Path,
+    cats_bin: str = "cats",
+    json_output: bool = True,
+) -> list[str]:
+    command = [cats_bin, "validate", "-c", str(contract_path)]
+    if json_output:
+        command.append("-j")
+    return command
+
+
+def build_cats_stats_command(
+    contract_path: Path,
+    cats_bin: str = "cats",
+    json_output: bool = True,
+) -> list[str]:
+    command = [cats_bin, "stats", "-c", str(contract_path)]
+    if json_output:
+        command.append("-j")
+    return command
+
+
+def classify_cats_exit(exit_code: int, stderr: str) -> str:
+    if exit_code == 0:
+        return "ok"
+
+    normalized_stderr = stderr.lower()
+    usage_markers = (
+        "invalid value",
+        "unknown option",
+        "missing required",
+        "unmatched argument",
+        "usage:",
+    )
+    if exit_code == 2 or any(marker in normalized_stderr for marker in usage_markers):
+        return "usage"
+
+    tool_markers = (
+        "internal execution error",
+        "exception",
+        "stacktrace",
+        "stack trace",
+    )
+    if any(marker in normalized_stderr for marker in tool_markers):
+        return "tool"
+
+    return "api"
+
+
+def run_command(
+    command: Sequence[str],
+    timeout_seconds: int,
+    env: Mapping[str, str] | None = None,
+) -> CatsProcessResult:
+    # Command arguments are built by the local harness from controlled values.
+    completed = subprocess.run(  # nosec B603
+        list(command),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        env=dict(env) if env is not None else None,
+    )
+    return CatsProcessResult(
+        command=list(command),
+        exit_code=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+__all__ = [
+    "CatsProcessResult",
+    "build_cats_run_command",
+    "build_cats_stats_command",
+    "build_cats_validate_command",
+    "classify_cats_exit",
+    "run_command",
+]

--- a/Helper_Scripts/cats_fuzz/cats_cli.py
+++ b/Helper_Scripts/cats_fuzz/cats_cli.py
@@ -47,8 +47,6 @@ def build_cats_run_command(
         str(contract_path),
         "-s",
         server_url,
-        "-H",
-        f"X-API-KEY={api_key}",
         "--maskHeaders",
         "X-API-KEY,Authorization",
         "--skipReportingForIgnored",
@@ -65,6 +63,8 @@ def build_cats_run_command(
         "--output",
         str(output_dir),
     ]
+    if block.include_api_key:
+        command[5:5] = ["-H", f"X-API-KEY={api_key}"]
     if block.blackbox:
         command.append("--blackbox")
     _append_csv_option(command, "--path", block.paths)
@@ -115,6 +115,7 @@ def classify_cats_exit(exit_code: int, stderr: str) -> str:
         return "usage"
 
     tool_markers = (
+        "failed to execute command",
         "internal execution error",
         "exception",
         "stacktrace",
@@ -153,6 +154,13 @@ def run_command(
             exit_code=_TIMEOUT_EXIT_CODE,
             stdout=stdout,
             stderr=stderr,
+        )
+    except OSError as exc:
+        return CatsProcessResult(
+            command=list(command),
+            exit_code=127,
+            stdout="",
+            stderr=f"Failed to execute command: {exc}",
         )
     return CatsProcessResult(
         command=list(command),

--- a/Helper_Scripts/cats_fuzz/cats_cli.py
+++ b/Helper_Scripts/cats_fuzz/cats_cli.py
@@ -1,3 +1,5 @@
+"""CATS command builders, subprocess execution, and exit classification."""
+
 from __future__ import annotations
 
 import subprocess  # nosec B404
@@ -10,6 +12,8 @@ from Helper_Scripts.cats_fuzz.manifest import CatsBlock
 
 @dataclass(frozen=True)
 class CatsProcessResult:
+    """Captured result for one CATS or harness subprocess invocation."""
+
     command: list[str]
     exit_code: int
     stdout: str
@@ -20,6 +24,7 @@ _TIMEOUT_EXIT_CODE = 124
 
 
 def _normalize_timeout_output(value: str | bytes | None) -> str:
+    """Convert partial timeout output to text for artifact persistence."""
     if value is None:
         return ""
     if isinstance(value, bytes):
@@ -28,6 +33,7 @@ def _normalize_timeout_output(value: str | bytes | None) -> str:
 
 
 def _append_csv_option(command: list[str], option: str, values: Sequence[str]) -> None:
+    """Append a comma-separated CATS option when values are configured."""
     if values:
         command.extend([option, ",".join(values)])
 
@@ -41,6 +47,7 @@ def build_cats_run_command(
     cats_bin: str = "cats",
     dry_run: bool = False,
 ) -> list[str]:
+    """Build a runtime CATS fuzzing command for one manifest block."""
     command = [
         cats_bin,
         "-c",
@@ -82,6 +89,7 @@ def build_cats_validate_command(
     cats_bin: str = "cats",
     json_output: bool = True,
 ) -> list[str]:
+    """Build a CATS OpenAPI validation command."""
     command = [cats_bin, "validate", "-c", str(contract_path)]
     if json_output:
         command.append("-j")
@@ -93,6 +101,7 @@ def build_cats_stats_command(
     cats_bin: str = "cats",
     json_output: bool = True,
 ) -> list[str]:
+    """Build a CATS OpenAPI statistics command."""
     command = [cats_bin, "stats", "-c", str(contract_path)]
     if json_output:
         command.append("-j")
@@ -100,6 +109,7 @@ def build_cats_stats_command(
 
 
 def classify_cats_exit(exit_code: int, stderr: str) -> str:
+    """Classify a CATS exit as ok, usage, tool, or API behavior."""
     if exit_code == 0:
         return "ok"
 
@@ -134,6 +144,7 @@ def run_command(
     timeout_seconds: int,
     env: Mapping[str, str] | None = None,
 ) -> CatsProcessResult:
+    """Run a CATS subprocess with timeout and structured failure capture."""
     # Command arguments are built by the local harness from controlled values.
     try:
         completed = subprocess.run(  # nosec B603

--- a/Helper_Scripts/cats_fuzz/cats_cli.py
+++ b/Helper_Scripts/cats_fuzz/cats_cli.py
@@ -16,6 +16,17 @@ class CatsProcessResult:
     stderr: str
 
 
+_TIMEOUT_EXIT_CODE = 124
+
+
+def _normalize_timeout_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
 def _append_csv_option(command: list[str], option: str, values: Sequence[str]) -> None:
     if values:
         command.extend([option, ",".join(values)])
@@ -108,8 +119,10 @@ def classify_cats_exit(exit_code: int, stderr: str) -> str:
         "exception",
         "stacktrace",
         "stack trace",
+        "timed out",
+        "timeout",
     )
-    if any(marker in normalized_stderr for marker in tool_markers):
+    if exit_code == _TIMEOUT_EXIT_CODE or any(marker in normalized_stderr for marker in tool_markers):
         return "tool"
 
     return "api"
@@ -121,14 +134,26 @@ def run_command(
     env: Mapping[str, str] | None = None,
 ) -> CatsProcessResult:
     # Command arguments are built by the local harness from controlled values.
-    completed = subprocess.run(  # nosec B603
-        list(command),
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=timeout_seconds,
-        env=dict(env) if env is not None else None,
-    )
+    try:
+        completed = subprocess.run(  # nosec B603
+            list(command),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env=dict(env) if env is not None else None,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = _normalize_timeout_output(exc.output)
+        partial_stderr = _normalize_timeout_output(exc.stderr)
+        timeout_message = f"Command timed out after {timeout_seconds} seconds"
+        stderr = timeout_message if not partial_stderr else f"{timeout_message}\n{partial_stderr}"
+        return CatsProcessResult(
+            command=list(command),
+            exit_code=_TIMEOUT_EXIT_CODE,
+            stdout=stdout,
+            stderr=stderr,
+        )
     return CatsProcessResult(
         command=list(command),
         exit_code=completed.returncode,

--- a/Helper_Scripts/cats_fuzz/cli.py
+++ b/Helper_Scripts/cats_fuzz/cli.py
@@ -31,7 +31,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--start-server",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=None,
         help="Start a local loopback uvicorn server for runtime blocks.",
     )
     parser.add_argument("--dry-run", action="store_true", help="Pass dry-run mode to runtime CATS blocks.")
@@ -46,6 +46,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     if args.block is None:
         args.block = ["contract", "public-read"]
+    if args.start_server is None:
+        args.start_server = args.server_url is None
     first_runtime_block = _first_runtime_block(args.block)
     if first_runtime_block is not None and not args.start_server and not args.server_url:
         parser.error(f"{first_runtime_block} requires --server-url or --start-server")

--- a/Helper_Scripts/cats_fuzz/cli.py
+++ b/Helper_Scripts/cats_fuzz/cli.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import argparse
+
+# This wrapper invokes fixed local CLI argv with shell=False.
+import subprocess  # nosec B404
+from pathlib import Path
+
+from Helper_Scripts.cats_fuzz.env import build_child_env
+from Helper_Scripts.cats_fuzz.manifest import get_builtin_block
+from Helper_Scripts.cats_fuzz.openapi_export import build_openapi_export_command
+from Helper_Scripts.cats_fuzz.runner import run_contract_block, run_runtime_block
+from Helper_Scripts.cats_fuzz.server import start_server, stop_server
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run local CATS OpenAPI fuzzing blocks.")
+    parser.add_argument(
+        "--block",
+        action="append",
+        choices=("contract", "public-read", "auth-read"),
+        help="CATS harness block to run; repeat to select multiple blocks.",
+    )
+    parser.add_argument("--output", default="artifacts/cats-fuzz", help="Artifact output directory.")
+    parser.add_argument("--cats-bin", default="cats", help="CATS executable to invoke.")
+    parser.add_argument("--server-url", help="Existing server URL for runtime blocks.")
+    parser.add_argument(
+        "--start-server",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Start a local loopback uvicorn server for runtime blocks.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Pass dry-run mode to runtime CATS blocks.")
+    parser.add_argument(
+        "--allow-external",
+        action="store_true",
+        help="Allow inherited provider/webhook credentials in the child environment.",
+    )
+    args = parser.parse_args(argv)
+    if args.block is None:
+        args.block = ["contract", "public-read"]
+    return args
+
+
+def _first_output_line(value: str) -> str | None:
+    for line in value.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def _cats_version(cats_bin: str) -> str:
+    try:
+        # Fixed argv, shell=False; cats_bin selects the local CATS executable.
+        result = subprocess.run(  # nosec B603
+            [cats_bin, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return "unknown"
+
+    return _first_output_line(result.stdout) or _first_output_line(result.stderr) or "unknown"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    child_env = build_child_env(output_dir, allow_external=args.allow_external)
+    contract_path = output_dir / "openapi.json"
+
+    # Local helper argv, shell=False, executed with an isolated child env.
+    subprocess.run(  # nosec B603
+        build_openapi_export_command(contract_path),
+        check=True,
+        env=child_env,
+    )
+
+    cats_version = _cats_version(args.cats_bin)
+    selected_blocks = list(args.block)
+    needs_runtime = any(block_name != "contract" for block_name in selected_blocks)
+    started_server = None
+    exit_code = 0
+
+    try:
+        if needs_runtime and args.start_server:
+            started_server = start_server(child_env, log_dir=output_dir / "server")
+
+        for block_name in selected_blocks:
+            if block_name == "contract":
+                summary = run_contract_block(
+                    contract_path,
+                    output_dir,
+                    cats_version,
+                    cats_bin=args.cats_bin,
+                )
+            else:
+                server_url = started_server.url if started_server is not None else args.server_url
+                if not server_url:
+                    raise ValueError(f"{block_name} requires --server-url or --start-server")
+                summary = run_runtime_block(
+                    get_builtin_block(block_name),
+                    contract_path,
+                    server_url,
+                    output_dir,
+                    cats_version,
+                    cats_bin=args.cats_bin,
+                    dry_run=args.dry_run,
+                    env=child_env,
+                )
+
+            if exit_code == 0 and summary.exit_code != 0:
+                exit_code = summary.exit_code
+    finally:
+        if started_server is not None:
+            stop_server(started_server)
+
+    return exit_code
+
+
+__all__ = ["_cats_version", "main", "parse_args"]

--- a/Helper_Scripts/cats_fuzz/cli.py
+++ b/Helper_Scripts/cats_fuzz/cli.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 # This wrapper invokes fixed local CLI argv with shell=False.
 import subprocess  # nosec B404
 from pathlib import Path
+from collections.abc import Mapping
 
 from Helper_Scripts.cats_fuzz.env import build_child_env
 from Helper_Scripts.cats_fuzz.manifest import get_builtin_block
@@ -34,7 +36,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--allow-external",
         action="store_true",
-        help="Allow inherited provider/webhook credentials in the child environment.",
+        help=(
+            "Permit parent env to contain real credentials; known sensitive values are "
+            "still scrubbed from the child env."
+        ),
     )
     args = parser.parse_args(argv)
     if args.block is None:
@@ -62,26 +67,54 @@ def _cats_version(cats_bin: str) -> str:
     except OSError:
         return "unknown"
 
+    if result.returncode != 0:
+        return "unknown"
     return _first_output_line(result.stdout) or _first_output_line(result.stderr) or "unknown"
+
+
+def _first_runtime_block(selected_blocks: list[str]) -> str | None:
+    for block_name in selected_blocks:
+        if block_name != "contract":
+            return block_name
+    return None
+
+
+def _export_openapi_contract(contract_path: Path, child_env: Mapping[str, str], output_dir: Path) -> int:
+    # Local helper argv, shell=False, executed with an isolated child env.
+    result = subprocess.run(  # nosec B603
+        build_openapi_export_command(contract_path),
+        check=False,
+        capture_output=True,
+        text=True,
+        env=dict(child_env),
+    )
+    stdout_path = output_dir / "openapi-export.stdout.log"
+    stderr_path = output_dir / "openapi-export.stderr.log"
+    stdout_path.write_text(result.stdout, encoding="utf-8")
+    stderr_path.write_text(result.stderr, encoding="utf-8")
+    if result.returncode != 0:
+        print(f"OpenAPI export failed; see {stderr_path}", file=sys.stderr)
+    return result.returncode
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    selected_blocks = list(args.block)
+    first_runtime_block = _first_runtime_block(selected_blocks)
+    needs_runtime = first_runtime_block is not None
+    if needs_runtime and not args.start_server and not args.server_url:
+        raise ValueError(f"{first_runtime_block} requires --server-url or --start-server")
+
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
     child_env = build_child_env(output_dir, allow_external=args.allow_external)
     contract_path = output_dir / "openapi.json"
 
-    # Local helper argv, shell=False, executed with an isolated child env.
-    subprocess.run(  # nosec B603
-        build_openapi_export_command(contract_path),
-        check=True,
-        env=child_env,
-    )
+    export_exit_code = _export_openapi_contract(contract_path, child_env, output_dir)
+    if export_exit_code != 0:
+        return export_exit_code
 
     cats_version = _cats_version(args.cats_bin)
-    selected_blocks = list(args.block)
-    needs_runtime = any(block_name != "contract" for block_name in selected_blocks)
     started_server = None
     exit_code = 0
 
@@ -99,8 +132,6 @@ def main(argv: list[str] | None = None) -> int:
                 )
             else:
                 server_url = started_server.url if started_server is not None else args.server_url
-                if not server_url:
-                    raise ValueError(f"{block_name} requires --server-url or --start-server")
                 summary = run_runtime_block(
                     get_builtin_block(block_name),
                     contract_path,
@@ -121,4 +152,4 @@ def main(argv: list[str] | None = None) -> int:
     return exit_code
 
 
-__all__ = ["_cats_version", "main", "parse_args"]
+__all__ = ["_cats_version", "_export_openapi_contract", "main", "parse_args"]

--- a/Helper_Scripts/cats_fuzz/cli.py
+++ b/Helper_Scripts/cats_fuzz/cli.py
@@ -55,6 +55,14 @@ def _first_output_line(value: str) -> str | None:
     return None
 
 
+def _cats_version_line(value: str) -> str | None:
+    for line in value.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("CATS version "):
+            return stripped
+    return None
+
+
 def _cats_version(cats_bin: str) -> str:
     try:
         # Fixed argv, shell=False; cats_bin selects the local CATS executable.
@@ -69,7 +77,13 @@ def _cats_version(cats_bin: str) -> str:
 
     if result.returncode != 0:
         return "unknown"
-    return _first_output_line(result.stdout) or _first_output_line(result.stderr) or "unknown"
+    return (
+        _cats_version_line(result.stdout)
+        or _cats_version_line(result.stderr)
+        or _first_output_line(result.stdout)
+        or _first_output_line(result.stderr)
+        or "unknown"
+    )
 
 
 def _first_runtime_block(selected_blocks: list[str]) -> str | None:

--- a/Helper_Scripts/cats_fuzz/cli.py
+++ b/Helper_Scripts/cats_fuzz/cli.py
@@ -1,14 +1,17 @@
+"""Command-line orchestration for the local CATS OpenAPI fuzzing harness."""
+
 from __future__ import annotations
 
 import argparse
 import ipaddress
-import sys
 
 # This wrapper invokes fixed local CLI argv with shell=False.
 import subprocess  # nosec B404
-from pathlib import Path
 from collections.abc import Mapping
+from pathlib import Path
 from urllib.parse import urlparse
+
+from loguru import logger
 
 from Helper_Scripts.cats_fuzz.env import build_child_env, build_server_env
 from Helper_Scripts.cats_fuzz.manifest import get_builtin_block
@@ -16,8 +19,12 @@ from Helper_Scripts.cats_fuzz.openapi_export import build_openapi_export_command
 from Helper_Scripts.cats_fuzz.runner import run_contract_block, run_runtime_block
 from Helper_Scripts.cats_fuzz.server import start_server, stop_server
 
+OPENAPI_EXPORT_TIMEOUT_SECONDS = 120
+_TIMEOUT_EXIT_CODE = 124
+
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse and validate harness CLI arguments."""
     parser = argparse.ArgumentParser(description="Run local CATS OpenAPI fuzzing blocks.")
     parser.add_argument(
         "--block",
@@ -57,6 +64,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def _first_output_line(value: str) -> str | None:
+    """Return the first non-empty line from command output."""
     for line in value.splitlines():
         stripped = line.strip()
         if stripped:
@@ -65,6 +73,7 @@ def _first_output_line(value: str) -> str | None:
 
 
 def _cats_version_line(value: str) -> str | None:
+    """Return the first CATS version banner line from command output."""
     for line in value.splitlines():
         stripped = line.strip()
         if stripped.startswith("CATS version "):
@@ -73,6 +82,7 @@ def _cats_version_line(value: str) -> str | None:
 
 
 def _cats_version(cats_bin: str) -> str:
+    """Read the installed CATS version without failing the harness on lookup errors."""
     try:
         # Fixed argv, shell=False; cats_bin selects the local CATS executable.
         result = subprocess.run(  # nosec B603
@@ -96,6 +106,7 @@ def _cats_version(cats_bin: str) -> str:
 
 
 def _first_runtime_block(selected_blocks: list[str]) -> str | None:
+    """Return the first selected block that requires a running API server."""
     for block_name in selected_blocks:
         if block_name != "contract":
             return block_name
@@ -103,6 +114,7 @@ def _first_runtime_block(selected_blocks: list[str]) -> str | None:
 
 
 def _is_loopback_server_url(server_url: str) -> bool:
+    """Return True when a server URL points at localhost or a loopback IP."""
     parsed = urlparse(server_url)
     if parsed.scheme not in {"http", "https"}:
         return False
@@ -118,6 +130,11 @@ def _is_loopback_server_url(server_url: str) -> bool:
 
 
 def _validate_server_url(parser: argparse.ArgumentParser, server_url: str, selected_blocks: list[str]) -> None:
+    """Reject runtime server URLs that could send fuzzing traffic outside loopback or path roots."""
+    parsed = urlparse(server_url)
+    if parsed.path not in {"", "/"} or parsed.params or parsed.query or parsed.fragment:
+        parser.error("--server-url must be an origin URL without a path, query, or fragment")
+
     for block_name in selected_blocks:
         if block_name == "contract":
             continue
@@ -126,25 +143,44 @@ def _validate_server_url(parser: argparse.ArgumentParser, server_url: str, selec
             parser.error(f"{block_name} only allows loopback --server-url values")
 
 
+def _normalize_subprocess_output(value: str | bytes | None) -> str:
+    """Convert partial subprocess output to text for artifact logs."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
 def _export_openapi_contract(contract_path: Path, child_env: Mapping[str, str], output_dir: Path) -> int:
-    # Local helper argv, shell=False, executed with an isolated child env.
-    result = subprocess.run(  # nosec B603
-        build_openapi_export_command(contract_path),
-        check=False,
-        capture_output=True,
-        text=True,
-        env=dict(child_env),
-    )
+    """Run OpenAPI export in an isolated subprocess and persist diagnostic logs."""
     stdout_path = output_dir / "openapi-export.stdout.log"
     stderr_path = output_dir / "openapi-export.stderr.log"
+    # Local helper argv, shell=False, executed with an isolated child env.
+    try:
+        result = subprocess.run(  # nosec B603
+            build_openapi_export_command(contract_path),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=OPENAPI_EXPORT_TIMEOUT_SECONDS,
+            env=dict(child_env),
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout_path.write_text(_normalize_subprocess_output(exc.output), encoding="utf-8")
+        stderr_path.write_text(_normalize_subprocess_output(exc.stderr), encoding="utf-8")
+        logger.error("OpenAPI export timed out after {} seconds; see {}", OPENAPI_EXPORT_TIMEOUT_SECONDS, stderr_path)
+        return _TIMEOUT_EXIT_CODE
+
     stdout_path.write_text(result.stdout, encoding="utf-8")
     stderr_path.write_text(result.stderr, encoding="utf-8")
     if result.returncode != 0:
-        print(f"OpenAPI export failed; see {stderr_path}", file=sys.stderr)
+        logger.error("OpenAPI export failed; see {}", stderr_path)
     return result.returncode
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run selected harness blocks and return the first non-zero block exit code."""
     args = parse_args(argv)
     selected_blocks = list(args.block)
     first_runtime_block = _first_runtime_block(selected_blocks)

--- a/Helper_Scripts/cats_fuzz/cli.py
+++ b/Helper_Scripts/cats_fuzz/cli.py
@@ -8,7 +8,7 @@ import subprocess  # nosec B404
 from pathlib import Path
 from collections.abc import Mapping
 
-from Helper_Scripts.cats_fuzz.env import build_child_env
+from Helper_Scripts.cats_fuzz.env import build_child_env, build_server_env
 from Helper_Scripts.cats_fuzz.manifest import get_builtin_block
 from Helper_Scripts.cats_fuzz.openapi_export import build_openapi_export_command
 from Helper_Scripts.cats_fuzz.runner import run_contract_block, run_runtime_block
@@ -134,7 +134,8 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         if needs_runtime and args.start_server:
-            started_server = start_server(child_env, log_dir=output_dir / "server")
+            server_env = build_server_env(output_dir, child_env)
+            started_server = start_server(server_env, log_dir=output_dir / "server")
 
         for block_name in selected_blocks:
             if block_name == "contract":

--- a/Helper_Scripts/cats_fuzz/cli.py
+++ b/Helper_Scripts/cats_fuzz/cli.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import sys
 
 # This wrapper invokes fixed local CLI argv with shell=False.
 import subprocess  # nosec B404
 from pathlib import Path
 from collections.abc import Mapping
+from urllib.parse import urlparse
 
 from Helper_Scripts.cats_fuzz.env import build_child_env, build_server_env
 from Helper_Scripts.cats_fuzz.manifest import get_builtin_block
@@ -44,6 +46,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     if args.block is None:
         args.block = ["contract", "public-read"]
+    first_runtime_block = _first_runtime_block(args.block)
+    if first_runtime_block is not None and not args.start_server and not args.server_url:
+        parser.error(f"{first_runtime_block} requires --server-url or --start-server")
+    if args.server_url:
+        _validate_server_url(parser, args.server_url, args.block)
     return args
 
 
@@ -93,6 +100,30 @@ def _first_runtime_block(selected_blocks: list[str]) -> str | None:
     return None
 
 
+def _is_loopback_server_url(server_url: str) -> bool:
+    parsed = urlparse(server_url)
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    if not parsed.hostname:
+        return False
+    hostname = parsed.hostname.lower()
+    if hostname == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _validate_server_url(parser: argparse.ArgumentParser, server_url: str, selected_blocks: list[str]) -> None:
+    for block_name in selected_blocks:
+        if block_name == "contract":
+            continue
+        block = get_builtin_block(block_name)
+        if not block.allows_network and not _is_loopback_server_url(server_url):
+            parser.error(f"{block_name} only allows loopback --server-url values")
+
+
 def _export_openapi_contract(contract_path: Path, child_env: Mapping[str, str], output_dir: Path) -> int:
     # Local helper argv, shell=False, executed with an isolated child env.
     result = subprocess.run(  # nosec B603
@@ -116,8 +147,6 @@ def main(argv: list[str] | None = None) -> int:
     selected_blocks = list(args.block)
     first_runtime_block = _first_runtime_block(selected_blocks)
     needs_runtime = first_runtime_block is not None
-    if needs_runtime and not args.start_server and not args.server_url:
-        raise ValueError(f"{first_runtime_block} requires --server-url or --start-server")
 
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/Helper_Scripts/cats_fuzz/env.py
+++ b/Helper_Scripts/cats_fuzz/env.py
@@ -1,3 +1,5 @@
+"""Environment isolation helpers for deterministic local CATS fuzzing runs."""
+
 from __future__ import annotations
 
 import os
@@ -121,19 +123,30 @@ SANITIZE_ONLY_ENV_NAMES = frozenset(
 
 SERVER_GUARDED_TEST_FLAGS = ("TEST_MODE", "TESTING", "TLDW_TEST_MODE")
 CONFIG_ENV_NAMES = ("TLDW_CONFIG_FILE", "TLDW_CONFIG_PATH", "TLDW_CONFIG_DIR")
+ROUTE_POLICY_ENV_NAMES = frozenset(
+    {
+        "ROUTES_STABLE_ONLY",
+        "ROUTES_DISABLE",
+        "ROUTES_ENABLE",
+        "ROUTES_EXPERIMENTAL",
+    }
+)
 
 
 def _is_sensitive_name(name: str) -> bool:
+    """Return True when an environment name is known or shaped like a secret."""
     upper_name = name.upper()
     return upper_name in SENSITIVE_ENV_NAMES or any(substring in upper_name for substring in SENSITIVE_NAME_SUBSTRINGS)
 
 
 def _should_blank_name(name: str) -> bool:
+    """Return True when a name should be scrubbed from the child process environment."""
     upper_name = name.upper()
     return _is_sensitive_name(upper_name) or _is_provider_runtime_name(upper_name)
 
 
 def _is_provider_runtime_name(name: str) -> bool:
+    """Return True when a name can route requests to an external provider endpoint."""
     upper_name = name.upper()
     if upper_name in PROVIDER_RUNTIME_ENV_NAMES:
         return True
@@ -145,10 +158,12 @@ def _is_provider_runtime_name(name: str) -> bool:
 
 
 def find_sensitive_values(env: Mapping[str, str]) -> dict[str, str]:
+    """Return a redacted map of populated sensitive environment names."""
     return {name: "set" for name, value in env.items() if value and _is_sensitive_name(name)}
 
 
 def _find_blocking_sensitive_values(env: Mapping[str, str]) -> dict[str, str]:
+    """Return populated sensitive names that should block harness startup."""
     return {
         name: "set"
         for name, value in env.items()
@@ -157,6 +172,7 @@ def _find_blocking_sensitive_values(env: Mapping[str, str]) -> dict[str, str]:
 
 
 def _write_minimal_env_file(env_file: Path, runtime_dir: Path, user_db_dir: Path) -> None:
+    """Write the minimal .env consumed by the OpenAPI export subprocess."""
     config_file = runtime_dir / "config.txt"
     lines = [
         "AUTH_MODE=single_user",
@@ -178,6 +194,7 @@ def _write_minimal_env_file(env_file: Path, runtime_dir: Path, user_db_dir: Path
 
 
 def _write_minimal_config_file(config_file: Path, runtime_dir: Path, user_db_dir: Path) -> None:
+    """Write an inert config.txt that keeps the harness route surface stable."""
     lines = [
         "[Authentication]",
         "auth_mode = single_user",
@@ -218,6 +235,7 @@ def _write_minimal_config_file(config_file: Path, runtime_dir: Path, user_db_dir
 
 
 def _write_server_env_file(env_file: Path, server_env: Mapping[str, str]) -> None:
+    """Write the server-side environment file used by the spawned uvicorn process."""
     names = (
         "AUTH_MODE",
         "SINGLE_USER_API_KEY",
@@ -242,6 +260,7 @@ def build_child_env(
     parent_env: Mapping[str, str] | None = None,
     allow_external: bool = False,
 ) -> dict[str, str]:
+    """Build a scrubbed environment for OpenAPI export and CATS child processes."""
     source_env = dict(os.environ if parent_env is None else parent_env)
     detected = _find_blocking_sensitive_values(source_env)
     if detected and not allow_external:
@@ -257,7 +276,7 @@ def build_child_env(
 
     child_env = dict(source_env)
     for name in set(child_env).union(SENSITIVE_ENV_NAMES, SANITIZE_ONLY_ENV_NAMES, PROVIDER_RUNTIME_ENV_NAMES):
-        if _should_blank_name(name):
+        if _should_blank_name(name) or name.upper() in ROUTE_POLICY_ENV_NAMES:
             child_env[name] = ""
 
     child_env.update(
@@ -285,6 +304,7 @@ def build_child_env(
 
 
 def build_server_env(work_dir: Path, child_env: Mapping[str, str]) -> dict[str, str]:
+    """Build the uvicorn server environment from the already-scrubbed child environment."""
     runtime_dir = work_dir / "runtime"
     runtime_dir.mkdir(parents=True, exist_ok=True)
     user_db_dir = runtime_dir / "user_databases"

--- a/Helper_Scripts/cats_fuzz/env.py
+++ b/Helper_Scripts/cats_fuzz/env.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
+
+SENSITIVE_NAME_SUBSTRINGS = (
+    "API_KEY",
+    "TOKEN",
+    "WEBHOOK",
+    "SECRET",
+)
+
+SENSITIVE_ENV_NAMES = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "APIFY_API_TOKEN",
+        "BRAVE_SEARCH_API_KEY",
+        "COHERE_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "DISCORD_BOT_TOKEN",
+        "DISCORD_WEBHOOK_URL",
+        "GOOGLE_API_KEY",
+        "GROQ_API_KEY",
+        "HUGGINGFACE_API_KEY",
+        "HUGGINGFACEHUB_API_TOKEN",
+        "HF_TOKEN",
+        "LLAMA_CLOUD_API_KEY",
+        "MISTRAL_API_KEY",
+        "MOONSHOT_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "QWEN_API_KEY",
+        "SERPAPI_API_KEY",
+        "SLACK_BOT_TOKEN",
+        "SLACK_WEBHOOK_URL",
+        "TAVILY_API_KEY",
+        "TELEGRAM_BOT_TOKEN",
+        "VOYAGE_API_KEY",
+        "XAI_API_KEY",
+        "ZAI_API_KEY",
+    }
+)
+
+
+def _is_sensitive_name(name: str) -> bool:
+    upper_name = name.upper()
+    return upper_name in SENSITIVE_ENV_NAMES or any(substring in upper_name for substring in SENSITIVE_NAME_SUBSTRINGS)
+
+
+def find_sensitive_values(env: Mapping[str, str]) -> dict[str, str]:
+    return {name: "set" for name, value in env.items() if value and _is_sensitive_name(name)}
+
+
+def _write_minimal_env_file(env_file: Path, runtime_dir: Path, user_db_dir: Path) -> None:
+    lines = [
+        "AUTH_MODE=single_user",
+        f"SINGLE_USER_API_KEY={DEFAULT_TEST_API_KEY}",
+        f"SINGLE_USER_TEST_API_KEY={DEFAULT_TEST_API_KEY}",
+        f"DATABASE_URL=sqlite:///{runtime_dir / 'users.db'}",
+        f"USER_DB_BASE_DIR={user_db_dir}",
+        "MINIMAL_TEST_APP=1",
+        "MINIMAL_TEST_INCLUDE_AUDIO=1",
+        "TEST_MODE=true",
+        "PYTHONWARNINGS=ignore",
+        "LOGURU_LEVEL=ERROR",
+    ]
+    env_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_child_env(
+    work_dir: Path,
+    parent_env: Mapping[str, str] | None = None,
+    allow_external: bool = False,
+) -> dict[str, str]:
+    source_env = dict(os.environ if parent_env is None else parent_env)
+    detected = find_sensitive_values(source_env)
+    if detected and not allow_external:
+        names = ", ".join(sorted(detected))
+        raise ValueError(f"Refusing to build CATS fuzz env with real credentials: {names}")
+
+    runtime_dir = work_dir / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    user_db_dir = runtime_dir / "user_databases"
+    user_db_dir.mkdir(parents=True, exist_ok=True)
+    env_file = runtime_dir / ".env"
+
+    child_env = dict(source_env)
+    for name in set(child_env).union(SENSITIVE_ENV_NAMES):
+        if _is_sensitive_name(name):
+            child_env[name] = ""
+
+    child_env.update(
+        {
+            "AUTH_MODE": "single_user",
+            "SINGLE_USER_API_KEY": DEFAULT_TEST_API_KEY,
+            "SINGLE_USER_TEST_API_KEY": DEFAULT_TEST_API_KEY,
+            "DATABASE_URL": f"sqlite:///{runtime_dir / 'users.db'}",
+            "USER_DB_BASE_DIR": str(user_db_dir),
+            "TLDW_ENV_FILE": str(env_file),
+            "MINIMAL_TEST_APP": "1",
+            "MINIMAL_TEST_INCLUDE_AUDIO": "1",
+            "TEST_MODE": "true",
+            "PYTHONWARNINGS": "ignore",
+            "LOGURU_LEVEL": "ERROR",
+        }
+    )
+    _write_minimal_env_file(env_file, runtime_dir, user_db_dir)
+    return child_env
+
+
+__all__ = [
+    "SENSITIVE_ENV_NAMES",
+    "SENSITIVE_NAME_SUBSTRINGS",
+    "build_child_env",
+    "find_sensitive_values",
+]

--- a/Helper_Scripts/cats_fuzz/env.py
+++ b/Helper_Scripts/cats_fuzz/env.py
@@ -55,6 +55,8 @@ SANITIZE_ONLY_ENV_NAMES = frozenset(
     }
 )
 
+SERVER_GUARDED_TEST_FLAGS = ("TEST_MODE", "TESTING", "TLDW_TEST_MODE")
+
 
 def _is_sensitive_name(name: str) -> bool:
     upper_name = name.upper()
@@ -86,6 +88,22 @@ def _write_minimal_env_file(env_file: Path, runtime_dir: Path, user_db_dir: Path
         "PYTHONWARNINGS=ignore",
         "LOGURU_LEVEL=ERROR",
     ]
+    env_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_server_env_file(env_file: Path, server_env: Mapping[str, str]) -> None:
+    names = (
+        "AUTH_MODE",
+        "SINGLE_USER_API_KEY",
+        "SINGLE_USER_TEST_API_KEY",
+        "DATABASE_URL",
+        "USER_DB_BASE_DIR",
+        "MINIMAL_TEST_APP",
+        "MINIMAL_TEST_INCLUDE_AUDIO",
+        "PYTHONWARNINGS",
+        "LOGURU_LEVEL",
+    )
+    lines = [f"{name}={server_env[name]}" for name in names]
     env_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
@@ -130,10 +148,41 @@ def build_child_env(
     return child_env
 
 
+def build_server_env(work_dir: Path, child_env: Mapping[str, str]) -> dict[str, str]:
+    runtime_dir = work_dir / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    user_db_dir = runtime_dir / "user_databases"
+    user_db_dir.mkdir(parents=True, exist_ok=True)
+    env_file = runtime_dir / "cats-server.env"
+
+    server_env = dict(child_env)
+    for name in SERVER_GUARDED_TEST_FLAGS:
+        server_env.pop(name, None)
+
+    server_env.update(
+        {
+            "AUTH_MODE": child_env.get("AUTH_MODE", "single_user"),
+            "SINGLE_USER_API_KEY": child_env.get("SINGLE_USER_API_KEY", DEFAULT_TEST_API_KEY),
+            "SINGLE_USER_TEST_API_KEY": child_env.get("SINGLE_USER_TEST_API_KEY", DEFAULT_TEST_API_KEY),
+            "DATABASE_URL": child_env.get("DATABASE_URL", f"sqlite:///{runtime_dir / 'users.db'}"),
+            "USER_DB_BASE_DIR": child_env.get("USER_DB_BASE_DIR", str(user_db_dir)),
+            "TLDW_ENV_FILE": str(env_file),
+            "MINIMAL_TEST_APP": "1",
+            "MINIMAL_TEST_INCLUDE_AUDIO": "1",
+            "PYTHONWARNINGS": "ignore",
+            "LOGURU_LEVEL": "ERROR",
+        }
+    )
+    _write_server_env_file(env_file, server_env)
+    return server_env
+
+
 __all__ = [
     "SANITIZE_ONLY_ENV_NAMES",
+    "SERVER_GUARDED_TEST_FLAGS",
     "SENSITIVE_ENV_NAMES",
     "SENSITIVE_NAME_SUBSTRINGS",
     "build_child_env",
+    "build_server_env",
     "find_sensitive_values",
 ]

--- a/Helper_Scripts/cats_fuzz/env.py
+++ b/Helper_Scripts/cats_fuzz/env.py
@@ -8,6 +8,9 @@ from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
 
 SENSITIVE_NAME_SUBSTRINGS = (
     "API_KEY",
+    "ENCRYPTION_KEY",
+    "PASSWORD",
+    "SALT",
     "TOKEN",
     "WEBHOOK",
     "SECRET",
@@ -17,32 +20,93 @@ SENSITIVE_ENV_NAMES = frozenset(
     {
         "ANTHROPIC_API_KEY",
         "APIFY_API_TOKEN",
+        "APHRODITE_API_KEY",
+        "AUDIO_STUDIO_ACE_STEP_API_KEY",
+        "BAIDU_API_KEY",
+        "BEDROCK_API_KEY",
+        "BING_SEARCH_API_KEY",
         "BRAVE_SEARCH_API_KEY",
+        "BRAVE_AI_API_KEY",
+        "BYOK_ENCRYPTION_KEY",
+        "BYOK_SECONDARY_ENCRYPTION_KEY",
         "COHERE_API_KEY",
+        "CUSTOM_OPENAI_API_2_API_KEY",
+        "CUSTOM_OPENAI2_API_KEY",
+        "CUSTOM_OPENAI_API_KEY",
         "DEEPSEEK_API_KEY",
         "DISCORD_BOT_TOKEN",
         "DISCORD_WEBHOOK_URL",
+        "ELEVENLABS_API_KEY",
+        "EMBEDDING_API_KEY",
         "GOOGLE_API_KEY",
+        "GOOGLE_SEARCH_API_KEY",
         "GROQ_API_KEY",
         "HUGGINGFACE_API_KEY",
         "HUGGINGFACEHUB_API_TOKEN",
         "HF_TOKEN",
+        "KAGI_API_KEY",
+        "KOBOLD_API_KEY",
         "LLAMA_CLOUD_API_KEY",
+        "LLAMA_API_KEY",
         "MISTRAL_API_KEY",
+        "MCP_API_KEY_SALT",
+        "MCP_JWT_SECRET",
         "MOONSHOT_API_KEY",
+        "NEXT_PUBLIC_X_API_KEY",
+        "OLLAMA_API_KEY",
+        "OOBA_API_KEY",
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
         "QWEN_API_KEY",
+        "SERPER_API_KEY",
         "SERPAPI_API_KEY",
+        "SESSION_ENCRYPTION_KEY",
         "SLACK_BOT_TOKEN",
         "SLACK_WEBHOOK_URL",
+        "TABBY_API_KEY",
         "TAVILY_API_KEY",
         "TELEGRAM_BOT_TOKEN",
+        "VECTOR_DB_API_KEY",
+        "VLLM_API_KEY",
         "VOYAGE_API_KEY",
+        "WEB_SCRAPER_API_KEY",
         "XAI_API_KEY",
+        "YANDEX_API_KEY",
         "ZAI_API_KEY",
     }
 )
+
+PROVIDER_RUNTIME_ENV_NAMES = frozenset(
+    {
+        "AUDIO_STUDIO_ACE_STEP_BASE_URL",
+        "AUDIO_STUDIO_EXTERNAL_ENDPOINT_ALLOWLIST",
+        "BEDROCK_API_BASE_URL",
+        "CUSTOM_OPENAI2_API_BASE",
+        "CUSTOM_OPENAI2_API_BASE_URL",
+        "CUSTOM_OPENAI2_API_IP",
+        "CUSTOM_OPENAI2_API_URL",
+        "CUSTOM_OPENAI_API_BASE",
+        "CUSTOM_OPENAI_API_BASE_2",
+        "CUSTOM_OPENAI_API_BASE_URL_2",
+        "CUSTOM_OPENAI_API_IP",
+        "CUSTOM_OPENAI_API_IP_1",
+        "CUSTOM_OPENAI_API_IP_2",
+        "CUSTOM_OPENAI_API_MODEL_37",
+        "CUSTOM_OPENAI_API_URL",
+        "CUSTOM_OPENAI_API_URL_2",
+        "EMBEDDING_API_URL",
+        "MLX_MODEL_PATH",
+    }
+)
+PROVIDER_RUNTIME_NAME_SUFFIXES = (
+    "_API_BASE",
+    "_API_BASE_URL",
+    "_API_IP",
+    "_API_URL",
+    "_BASE_URL",
+    "_RUNTIME_ENDPOINT",
+)
+CUSTOM_OPENAI_RUNTIME_NAME_SUFFIXES = ("_BASE", "_IP", "_URL")
 
 SANITIZE_ONLY_ENV_NAMES = frozenset(
     {
@@ -56,11 +120,28 @@ SANITIZE_ONLY_ENV_NAMES = frozenset(
 )
 
 SERVER_GUARDED_TEST_FLAGS = ("TEST_MODE", "TESTING", "TLDW_TEST_MODE")
+CONFIG_ENV_NAMES = ("TLDW_CONFIG_FILE", "TLDW_CONFIG_PATH", "TLDW_CONFIG_DIR")
 
 
 def _is_sensitive_name(name: str) -> bool:
     upper_name = name.upper()
     return upper_name in SENSITIVE_ENV_NAMES or any(substring in upper_name for substring in SENSITIVE_NAME_SUBSTRINGS)
+
+
+def _should_blank_name(name: str) -> bool:
+    upper_name = name.upper()
+    return _is_sensitive_name(upper_name) or _is_provider_runtime_name(upper_name)
+
+
+def _is_provider_runtime_name(name: str) -> bool:
+    upper_name = name.upper()
+    if upper_name in PROVIDER_RUNTIME_ENV_NAMES:
+        return True
+    if upper_name == "BASE_URL":
+        return True
+    if upper_name.endswith(PROVIDER_RUNTIME_NAME_SUFFIXES):
+        return True
+    return upper_name.startswith("CUSTOM_OPENAI") and upper_name.endswith(CUSTOM_OPENAI_RUNTIME_NAME_SUFFIXES)
 
 
 def find_sensitive_values(env: Mapping[str, str]) -> dict[str, str]:
@@ -76,19 +157,64 @@ def _find_blocking_sensitive_values(env: Mapping[str, str]) -> dict[str, str]:
 
 
 def _write_minimal_env_file(env_file: Path, runtime_dir: Path, user_db_dir: Path) -> None:
+    config_file = runtime_dir / "config.txt"
     lines = [
         "AUTH_MODE=single_user",
         f"SINGLE_USER_API_KEY={DEFAULT_TEST_API_KEY}",
         f"SINGLE_USER_TEST_API_KEY={DEFAULT_TEST_API_KEY}",
         f"DATABASE_URL=sqlite:///{runtime_dir / 'users.db'}",
         f"USER_DB_BASE_DIR={user_db_dir}",
+        f"TLDW_CONFIG_FILE={config_file}",
+        f"TLDW_CONFIG_PATH={config_file}",
+        f"TLDW_CONFIG_DIR={runtime_dir}",
         "MINIMAL_TEST_APP=1",
         "MINIMAL_TEST_INCLUDE_AUDIO=1",
         "TEST_MODE=true",
         "PYTHONWARNINGS=ignore",
         "LOGURU_LEVEL=ERROR",
+        "PYTHON_DOTENV_DISABLED=true",
     ]
     env_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_minimal_config_file(config_file: Path, runtime_dir: Path, user_db_dir: Path) -> None:
+    lines = [
+        "[Authentication]",
+        "auth_mode = single_user",
+        f"single_user_api_key = {DEFAULT_TEST_API_KEY}",
+        "",
+        "[AuthNZ]",
+        "auth_mode = single_user",
+        "",
+        "[Server]",
+        "host = 127.0.0.1",
+        "port = 0",
+        "",
+        "[Database]",
+        f"database_url = sqlite:///{runtime_dir / 'users.db'}",
+        f"user_db_base_dir = {user_db_dir}",
+        "",
+        "[API-Routes]",
+        "stable_only = false",
+        "disable = setup",
+        "enable =",
+        "",
+        "[API]",
+        "",
+        "[Local-API]",
+        "",
+        "[external_providers]",
+        "",
+        "[Embeddings]",
+        "",
+        "[RAG]",
+        "",
+        "[Search-Engines]",
+        "",
+        "[Web-Scraper]",
+        "",
+    ]
+    config_file.write_text("\n".join(lines), encoding="utf-8")
 
 
 def _write_server_env_file(env_file: Path, server_env: Mapping[str, str]) -> None:
@@ -98,10 +224,14 @@ def _write_server_env_file(env_file: Path, server_env: Mapping[str, str]) -> Non
         "SINGLE_USER_TEST_API_KEY",
         "DATABASE_URL",
         "USER_DB_BASE_DIR",
+        "TLDW_CONFIG_FILE",
+        "TLDW_CONFIG_PATH",
+        "TLDW_CONFIG_DIR",
         "MINIMAL_TEST_APP",
         "MINIMAL_TEST_INCLUDE_AUDIO",
         "PYTHONWARNINGS",
         "LOGURU_LEVEL",
+        "PYTHON_DOTENV_DISABLED",
     )
     lines = [f"{name}={server_env[name]}" for name in names]
     env_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -123,10 +253,11 @@ def build_child_env(
     user_db_dir = runtime_dir / "user_databases"
     user_db_dir.mkdir(parents=True, exist_ok=True)
     env_file = runtime_dir / ".env"
+    config_file = runtime_dir / "config.txt"
 
     child_env = dict(source_env)
-    for name in set(child_env).union(SENSITIVE_ENV_NAMES, SANITIZE_ONLY_ENV_NAMES):
-        if _is_sensitive_name(name):
+    for name in set(child_env).union(SENSITIVE_ENV_NAMES, SANITIZE_ONLY_ENV_NAMES, PROVIDER_RUNTIME_ENV_NAMES):
+        if _should_blank_name(name):
             child_env[name] = ""
 
     child_env.update(
@@ -137,13 +268,18 @@ def build_child_env(
             "DATABASE_URL": f"sqlite:///{runtime_dir / 'users.db'}",
             "USER_DB_BASE_DIR": str(user_db_dir),
             "TLDW_ENV_FILE": str(env_file),
+            "TLDW_CONFIG_FILE": str(config_file),
+            "TLDW_CONFIG_PATH": str(config_file),
+            "TLDW_CONFIG_DIR": str(runtime_dir),
             "MINIMAL_TEST_APP": "1",
             "MINIMAL_TEST_INCLUDE_AUDIO": "1",
             "TEST_MODE": "true",
             "PYTHONWARNINGS": "ignore",
             "LOGURU_LEVEL": "ERROR",
+            "PYTHON_DOTENV_DISABLED": "true",
         }
     )
+    _write_minimal_config_file(config_file, runtime_dir, user_db_dir)
     _write_minimal_env_file(env_file, runtime_dir, user_db_dir)
     return child_env
 
@@ -167,10 +303,14 @@ def build_server_env(work_dir: Path, child_env: Mapping[str, str]) -> dict[str, 
             "DATABASE_URL": child_env.get("DATABASE_URL", f"sqlite:///{runtime_dir / 'users.db'}"),
             "USER_DB_BASE_DIR": child_env.get("USER_DB_BASE_DIR", str(user_db_dir)),
             "TLDW_ENV_FILE": str(env_file),
+            "TLDW_CONFIG_FILE": child_env["TLDW_CONFIG_FILE"],
+            "TLDW_CONFIG_PATH": child_env["TLDW_CONFIG_PATH"],
+            "TLDW_CONFIG_DIR": child_env["TLDW_CONFIG_DIR"],
             "MINIMAL_TEST_APP": "1",
             "MINIMAL_TEST_INCLUDE_AUDIO": "1",
             "PYTHONWARNINGS": "ignore",
             "LOGURU_LEVEL": "ERROR",
+            "PYTHON_DOTENV_DISABLED": "true",
         }
     )
     _write_server_env_file(env_file, server_env)
@@ -182,6 +322,7 @@ __all__ = [
     "SERVER_GUARDED_TEST_FLAGS",
     "SENSITIVE_ENV_NAMES",
     "SENSITIVE_NAME_SUBSTRINGS",
+    "PROVIDER_RUNTIME_ENV_NAMES",
     "build_child_env",
     "build_server_env",
     "find_sensitive_values",

--- a/Helper_Scripts/cats_fuzz/env.py
+++ b/Helper_Scripts/cats_fuzz/env.py
@@ -44,6 +44,17 @@ SENSITIVE_ENV_NAMES = frozenset(
     }
 )
 
+SANITIZE_ONLY_ENV_NAMES = frozenset(
+    {
+        "CODEX_API_KEY",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "NPM_TOKEN",
+        "SINGLE_USER_API_KEY",
+        "SINGLE_USER_TEST_API_KEY",
+    }
+)
+
 
 def _is_sensitive_name(name: str) -> bool:
     upper_name = name.upper()
@@ -52,6 +63,14 @@ def _is_sensitive_name(name: str) -> bool:
 
 def find_sensitive_values(env: Mapping[str, str]) -> dict[str, str]:
     return {name: "set" for name, value in env.items() if value and _is_sensitive_name(name)}
+
+
+def _find_blocking_sensitive_values(env: Mapping[str, str]) -> dict[str, str]:
+    return {
+        name: "set"
+        for name, value in env.items()
+        if value and _is_sensitive_name(name) and name.upper() not in SANITIZE_ONLY_ENV_NAMES
+    }
 
 
 def _write_minimal_env_file(env_file: Path, runtime_dir: Path, user_db_dir: Path) -> None:
@@ -76,7 +95,7 @@ def build_child_env(
     allow_external: bool = False,
 ) -> dict[str, str]:
     source_env = dict(os.environ if parent_env is None else parent_env)
-    detected = find_sensitive_values(source_env)
+    detected = _find_blocking_sensitive_values(source_env)
     if detected and not allow_external:
         names = ", ".join(sorted(detected))
         raise ValueError(f"Refusing to build CATS fuzz env with real credentials: {names}")
@@ -88,7 +107,7 @@ def build_child_env(
     env_file = runtime_dir / ".env"
 
     child_env = dict(source_env)
-    for name in set(child_env).union(SENSITIVE_ENV_NAMES):
+    for name in set(child_env).union(SENSITIVE_ENV_NAMES, SANITIZE_ONLY_ENV_NAMES):
         if _is_sensitive_name(name):
             child_env[name] = ""
 
@@ -112,6 +131,7 @@ def build_child_env(
 
 
 __all__ = [
+    "SANITIZE_ONLY_ENV_NAMES",
     "SENSITIVE_ENV_NAMES",
     "SENSITIVE_NAME_SUBSTRINGS",
     "build_child_env",

--- a/Helper_Scripts/cats_fuzz/manifest.py
+++ b/Helper_Scripts/cats_fuzz/manifest.py
@@ -88,7 +88,7 @@ def get_builtin_manifest() -> dict[str, CatsBlock]:
             requires_readiness=True,
             expected_gate=ExpectedGate.NO_5XX,
             max_requests_per_minute=60,
-            timeout_seconds=120,
+            timeout_seconds=300,
         ),
         "auth-read": CatsBlock(
             name="auth-read",

--- a/Helper_Scripts/cats_fuzz/manifest.py
+++ b/Helper_Scripts/cats_fuzz/manifest.py
@@ -33,6 +33,7 @@ class CatsBlock:
     allows_network: bool = False
     calls_api_service: bool = True
     blackbox: bool = True
+    requires_readiness: bool = False
     timeout_seconds: int = 120
     read_timeout: int = 5
     connection_timeout: int = 5
@@ -84,6 +85,7 @@ def get_builtin_manifest() -> dict[str, CatsBlock]:
             allows_mutation=False,
             allows_network=False,
             blackbox=True,
+            requires_readiness=True,
             expected_gate=ExpectedGate.NO_5XX,
             max_requests_per_minute=60,
             timeout_seconds=120,

--- a/Helper_Scripts/cats_fuzz/manifest.py
+++ b/Helper_Scripts/cats_fuzz/manifest.py
@@ -32,6 +32,7 @@ class CatsBlock:
     allows_mutation: bool = False
     allows_network: bool = False
     calls_api_service: bool = True
+    include_api_key: bool = True
     blackbox: bool = True
     requires_readiness: bool = False
     timeout_seconds: int = 120
@@ -84,6 +85,7 @@ def get_builtin_manifest() -> dict[str, CatsBlock]:
             skip_methods=("POST", "PUT", "PATCH", "DELETE", "TRACE"),
             allows_mutation=False,
             allows_network=False,
+            include_api_key=False,
             blackbox=True,
             requires_readiness=True,
             expected_gate=ExpectedGate.NO_5XX,

--- a/Helper_Scripts/cats_fuzz/manifest.py
+++ b/Helper_Scripts/cats_fuzz/manifest.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class BlockRisk(str, Enum):
+    CONTRACT = "contract"
+    PUBLIC_READ = "public-read"
+    AUTH_READ = "auth-read"
+    ISOLATED_MUTATION = "isolated-mutation"
+    EXTERNAL_RISK = "external-risk"
+    MANUAL = "manual"
+
+
+class ExpectedGate(str, Enum):
+    NO_5XX = "no_5xx"
+    CONTRACT_ONLY = "contract_only"
+
+
+@dataclass(frozen=True)
+class CatsBlock:
+    name: str
+    description: str
+    risk: BlockRisk
+    paths: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    skip_paths: tuple[str, ...] = ()
+    skip_tags: tuple[str, ...] = ()
+    skip_methods: tuple[str, ...] = ()
+    requires_seed: bool = False
+    allows_mutation: bool = False
+    allows_network: bool = False
+    calls_api_service: bool = True
+    blackbox: bool = True
+    timeout_seconds: int = 120
+    read_timeout: int = 5
+    connection_timeout: int = 5
+    write_timeout: int = 5
+    max_requests_per_minute: int = 120
+    expected_gate: ExpectedGate = ExpectedGate.NO_5XX
+    skip_reason: str | None = None
+    report_formats: tuple[str, ...] = ("HTML_ONLY", "JUNIT")
+
+
+def validate_block(block: CatsBlock) -> None:
+    if not block.name:
+        raise ValueError("block name is required")
+    if not block.paths and not block.tags and block.risk is not BlockRisk.CONTRACT:
+        raise ValueError(f"{block.name}: paths or tags are required")
+    if block.allows_mutation and not block.requires_seed and block.risk is not BlockRisk.MANUAL:
+        raise ValueError(f"{block.name}: mutating blocks must set requires_seed")
+    if block.allows_network and block.risk is not BlockRisk.EXTERNAL_RISK:
+        raise ValueError(f"{block.name}: allows_network requires external-risk")
+
+
+def get_builtin_manifest() -> dict[str, CatsBlock]:
+    blocks = {
+        "contract": CatsBlock(
+            name="contract",
+            description="Validate and summarize generated OpenAPI without calling the API.",
+            risk=BlockRisk.CONTRACT,
+            calls_api_service=False,
+            blackbox=False,
+            expected_gate=ExpectedGate.CONTRACT_ONLY,
+            timeout_seconds=60,
+        ),
+        "public-read": CatsBlock(
+            name="public-read",
+            description="Fuzz public metadata and health endpoints in blackbox mode.",
+            risk=BlockRisk.PUBLIC_READ,
+            paths=(
+                "/",
+                "/health",
+                "/ready",
+                "/health/ready",
+                "/api/v1/health",
+                "/api/v1/health/live",
+                "/api/v1/health/ready",
+                "/api/v1/config/docs-info",
+                "/api/v1/config/quickstart",
+            ),
+            skip_methods=("POST", "PUT", "PATCH", "DELETE", "TRACE"),
+            allows_mutation=False,
+            allows_network=False,
+            blackbox=True,
+            expected_gate=ExpectedGate.NO_5XX,
+            max_requests_per_minute=60,
+            timeout_seconds=120,
+        ),
+        "auth-read": CatsBlock(
+            name="auth-read",
+            description="Authenticated read-only smoke fuzzing with X-API-KEY.",
+            risk=BlockRisk.AUTH_READ,
+            paths=(
+                "/api/v1/llm/providers",
+                "/api/v1/mcp/status",
+                "/api/v1/rag/health/simple",
+            ),
+            skip_methods=("POST", "PUT", "PATCH", "DELETE", "TRACE"),
+            allows_mutation=False,
+            allows_network=False,
+            blackbox=True,
+            expected_gate=ExpectedGate.NO_5XX,
+            max_requests_per_minute=60,
+            timeout_seconds=180,
+        ),
+    }
+    for block in blocks.values():
+        validate_block(block)
+    return blocks
+
+
+def get_builtin_block(name: str) -> CatsBlock:
+    return get_builtin_manifest()[name]
+
+
+__all__ = [
+    "BlockRisk",
+    "CatsBlock",
+    "ExpectedGate",
+    "get_builtin_block",
+    "get_builtin_manifest",
+    "validate_block",
+]

--- a/Helper_Scripts/cats_fuzz/manifest.py
+++ b/Helper_Scripts/cats_fuzz/manifest.py
@@ -1,3 +1,5 @@
+"""Built-in CATS fuzzing block manifest and validation rules."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -5,6 +7,8 @@ from enum import Enum
 
 
 class BlockRisk(str, Enum):
+    """Risk categories used to group harness blocks by allowed behavior."""
+
     CONTRACT = "contract"
     PUBLIC_READ = "public-read"
     AUTH_READ = "auth-read"
@@ -14,12 +18,16 @@ class BlockRisk(str, Enum):
 
 
 class ExpectedGate(str, Enum):
+    """Expected CI gate semantics for a harness block."""
+
     NO_5XX = "no_5xx"
     CONTRACT_ONLY = "contract_only"
 
 
 @dataclass(frozen=True)
 class CatsBlock:
+    """Declarative configuration for one CATS fuzzing block."""
+
     name: str
     description: str
     risk: BlockRisk
@@ -46,6 +54,7 @@ class CatsBlock:
 
 
 def validate_block(block: CatsBlock) -> None:
+    """Validate that a CATS block obeys the harness safety constraints."""
     if not block.name:
         raise ValueError("block name is required")
     if not block.paths and not block.tags and block.risk is not BlockRisk.CONTRACT:
@@ -57,6 +66,7 @@ def validate_block(block: CatsBlock) -> None:
 
 
 def get_builtin_manifest() -> dict[str, CatsBlock]:
+    """Return the built-in CATS block manifest keyed by block name."""
     blocks = {
         "contract": CatsBlock(
             name="contract",
@@ -116,6 +126,7 @@ def get_builtin_manifest() -> dict[str, CatsBlock]:
 
 
 def get_builtin_block(name: str) -> CatsBlock:
+    """Return one built-in CATS block by name."""
     return get_builtin_manifest()[name]
 
 

--- a/Helper_Scripts/cats_fuzz/openapi_export.py
+++ b/Helper_Scripts/cats_fuzz/openapi_export.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import sys
 from pathlib import Path
 
 
 def build_openapi_export_command(output_path: Path) -> list[str]:
     return [
-        "python",
+        sys.executable,
         "-m",
         "Helper_Scripts.cats_fuzz.openapi_export",
         "--output",

--- a/Helper_Scripts/cats_fuzz/openapi_export.py
+++ b/Helper_Scripts/cats_fuzz/openapi_export.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def build_openapi_export_command(output_path: Path) -> list[str]:
+    return [
+        "python",
+        "-m",
+        "Helper_Scripts.cats_fuzz.openapi_export",
+        "--output",
+        str(output_path),
+    ]
+
+
+def export_openapi(output_path: Path) -> str:
+    from tldw_Server_API.app.main import app
+
+    app.openapi_schema = None
+    openapi_schema = app.openapi()
+    json_bytes = json.dumps(
+        openapi_schema,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(json_bytes)
+    return hashlib.sha256(json_bytes).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Export deterministic OpenAPI JSON.")
+    parser.add_argument("--output", required=True, type=Path, help="Output OpenAPI JSON path.")
+    args = parser.parse_args(argv)
+
+    digest = export_openapi(args.output)
+    print(digest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["build_openapi_export_command", "export_openapi", "main"]

--- a/Helper_Scripts/cats_fuzz/openapi_export.py
+++ b/Helper_Scripts/cats_fuzz/openapi_export.py
@@ -1,3 +1,5 @@
+"""Deterministic OpenAPI export helper for the CATS fuzzing harness."""
+
 from __future__ import annotations
 
 import argparse
@@ -8,6 +10,7 @@ from pathlib import Path
 
 
 def build_openapi_export_command(output_path: Path) -> list[str]:
+    """Build the Python module command used to export OpenAPI in a subprocess."""
     return [
         sys.executable,
         "-m",
@@ -18,6 +21,7 @@ def build_openapi_export_command(output_path: Path) -> list[str]:
 
 
 def export_openapi(output_path: Path) -> str:
+    """Export the FastAPI OpenAPI schema to JSON and return its SHA-256 digest."""
     from tldw_Server_API.app.main import app
 
     app.openapi_schema = None
@@ -34,6 +38,7 @@ def export_openapi(output_path: Path) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint for deterministic OpenAPI export."""
     parser = argparse.ArgumentParser(description="Export deterministic OpenAPI JSON.")
     parser.add_argument("--output", required=True, type=Path, help="Output OpenAPI JSON path.")
     args = parser.parse_args(argv)

--- a/Helper_Scripts/cats_fuzz/runner.py
+++ b/Helper_Scripts/cats_fuzz/runner.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from pathlib import Path
+
+from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
+from Helper_Scripts.cats_fuzz.cats_cli import (
+    CatsProcessResult,
+    build_cats_run_command,
+    build_cats_stats_command,
+    build_cats_validate_command,
+    classify_cats_exit,
+    run_command,
+)
+from Helper_Scripts.cats_fuzz.manifest import CatsBlock, get_builtin_block
+from Helper_Scripts.cats_fuzz.server import wait_for_readiness
+from Helper_Scripts.cats_fuzz.summary import CatsRunSummary, mask_command, write_summary
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_obj:
+        for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_process_artifacts(result: CatsProcessResult, output_dir: Path) -> tuple[Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = output_dir / "stdout.log"
+    stderr_path = output_dir / "stderr.log"
+    stdout_path.write_text(result.stdout, encoding="utf-8")
+    stderr_path.write_text(result.stderr, encoding="utf-8")
+    return stdout_path, stderr_path
+
+
+def _summarize(
+    *,
+    block_name: str,
+    cats_version: str,
+    openapi_sha256: str,
+    result: CatsProcessResult,
+    output_dir: Path,
+    report_dir: Path,
+) -> CatsRunSummary:
+    stdout_path, stderr_path = _write_process_artifacts(result, output_dir)
+    masked_command = mask_command(result.command)
+    summary = CatsRunSummary(
+        block=block_name,
+        cats_version=cats_version,
+        openapi_sha256=openapi_sha256,
+        command=masked_command,
+        masked_command=masked_command,
+        exit_code=result.exit_code,
+        failure_class=classify_cats_exit(result.exit_code, result.stderr),
+        stdout_path=str(stdout_path),
+        stderr_path=str(stderr_path),
+        report_dir=str(report_dir),
+    )
+    write_summary(summary, output_dir / "summary.json")
+    return summary
+
+
+def _merge_contract_results(
+    validate_result: CatsProcessResult,
+    stats_result: CatsProcessResult,
+) -> CatsProcessResult:
+    exit_code = validate_result.exit_code or stats_result.exit_code
+    return CatsProcessResult(
+        command=validate_result.command + [";"] + stats_result.command,
+        exit_code=exit_code,
+        stdout="\n".join(part for part in (validate_result.stdout, stats_result.stdout) if part),
+        stderr="\n".join(part for part in (validate_result.stderr, stats_result.stderr) if part),
+    )
+
+
+def run_contract_block(
+    contract_path: Path,
+    output_dir: Path,
+    cats_version: str,
+    openapi_sha256: str | None = None,
+    cats_bin: str = "cats",
+) -> CatsRunSummary:
+    validate_result = run_command(
+        build_cats_validate_command(contract_path, cats_bin=cats_bin),
+        timeout_seconds=60,
+    )
+    stats_result = run_command(
+        build_cats_stats_command(contract_path, cats_bin=cats_bin),
+        timeout_seconds=60,
+    )
+    result = _merge_contract_results(validate_result, stats_result)
+    block_dir = output_dir / "contract"
+    return _summarize(
+        block_name="contract",
+        cats_version=cats_version,
+        openapi_sha256=openapi_sha256 or _sha256(contract_path),
+        result=result,
+        output_dir=block_dir,
+        report_dir=block_dir,
+    )
+
+
+def run_runtime_block(
+    block: CatsBlock,
+    contract_path: Path,
+    server_url: str,
+    output_dir: Path,
+    cats_version: str,
+    api_key: str = DEFAULT_TEST_API_KEY,
+    cats_bin: str = "cats",
+    dry_run: bool = False,
+    env: Mapping[str, str] | None = None,
+) -> CatsRunSummary:
+    if block.requires_readiness:
+        wait_for_readiness(server_url)
+
+    block_dir = output_dir / block.name
+    report_dir = block_dir / "cats-report"
+    command = build_cats_run_command(
+        block=block,
+        contract_path=contract_path,
+        server_url=server_url,
+        output_dir=report_dir,
+        api_key=api_key,
+        cats_bin=cats_bin,
+        dry_run=dry_run,
+    )
+    result = run_command(command, timeout_seconds=block.timeout_seconds, env=env)
+    return _summarize(
+        block_name=block.name,
+        cats_version=cats_version,
+        openapi_sha256=_sha256(contract_path),
+        result=result,
+        output_dir=block_dir,
+        report_dir=report_dir,
+    )
+
+
+def get_default_runtime_block() -> CatsBlock:
+    return get_builtin_block("public-read")
+
+
+__all__ = [
+    "get_default_runtime_block",
+    "run_contract_block",
+    "run_runtime_block",
+]

--- a/Helper_Scripts/cats_fuzz/runner.py
+++ b/Helper_Scripts/cats_fuzz/runner.py
@@ -1,3 +1,5 @@
+"""Runner orchestration for contract and runtime CATS fuzzing blocks."""
+
 from __future__ import annotations
 
 import hashlib
@@ -19,6 +21,7 @@ from Helper_Scripts.cats_fuzz.summary import CatsRunSummary, mask_command, write
 
 
 def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest for a file."""
     digest = hashlib.sha256()
     with path.open("rb") as file_obj:
         for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
@@ -27,6 +30,7 @@ def _sha256(path: Path) -> str:
 
 
 def _write_process_artifacts(result: CatsProcessResult, output_dir: Path) -> tuple[Path, Path]:
+    """Write stdout and stderr logs for a CATS process result."""
     output_dir.mkdir(parents=True, exist_ok=True)
     stdout_path = output_dir / "stdout.log"
     stderr_path = output_dir / "stderr.log"
@@ -44,6 +48,7 @@ def _summarize(
     output_dir: Path,
     report_dir: Path,
 ) -> CatsRunSummary:
+    """Write artifacts and return a redacted run summary."""
     stdout_path, stderr_path = _write_process_artifacts(result, output_dir)
     masked_command = mask_command(result.command)
     summary = CatsRunSummary(
@@ -66,6 +71,7 @@ def _merge_contract_results(
     validate_result: CatsProcessResult,
     stats_result: CatsProcessResult,
 ) -> CatsProcessResult:
+    """Combine validate and stats command results into one contract result."""
     exit_code = validate_result.exit_code or stats_result.exit_code
     return CatsProcessResult(
         command=validate_result.command + [";"] + stats_result.command,
@@ -82,6 +88,7 @@ def run_contract_block(
     openapi_sha256: str | None = None,
     cats_bin: str = "cats",
 ) -> CatsRunSummary:
+    """Run contract-only CATS validation and statistics commands."""
     validate_result = run_command(
         build_cats_validate_command(contract_path, cats_bin=cats_bin),
         timeout_seconds=60,
@@ -113,6 +120,7 @@ def run_runtime_block(
     dry_run: bool = False,
     env: Mapping[str, str] | None = None,
 ) -> CatsRunSummary:
+    """Run one runtime CATS block and always emit block artifacts on failure."""
     block_dir = output_dir / block.name
     report_dir = block_dir / "cats-report"
     if block.requires_readiness:
@@ -155,6 +163,7 @@ def run_runtime_block(
 
 
 def get_default_runtime_block() -> CatsBlock:
+    """Return the default runtime block used by the harness CLI."""
     return get_builtin_block("public-read")
 
 

--- a/Helper_Scripts/cats_fuzz/runner.py
+++ b/Helper_Scripts/cats_fuzz/runner.py
@@ -113,11 +113,27 @@ def run_runtime_block(
     dry_run: bool = False,
     env: Mapping[str, str] | None = None,
 ) -> CatsRunSummary:
-    if block.requires_readiness:
-        wait_for_readiness(server_url)
-
     block_dir = output_dir / block.name
     report_dir = block_dir / "cats-report"
+    if block.requires_readiness:
+        try:
+            wait_for_readiness(server_url)
+        except Exception as exc:  # noqa: BLE001 - preserve artifact output for preflight failures.
+            result = CatsProcessResult(
+                command=["readiness", server_url],
+                exit_code=124,
+                stdout="",
+                stderr=f"readiness preflight failed: {exc}",
+            )
+            return _summarize(
+                block_name=block.name,
+                cats_version=cats_version,
+                openapi_sha256=_sha256(contract_path),
+                result=result,
+                output_dir=block_dir,
+                report_dir=report_dir,
+            )
+
     command = build_cats_run_command(
         block=block,
         contract_path=contract_path,

--- a/Helper_Scripts/cats_fuzz/server.py
+++ b/Helper_Scripts/cats_fuzz/server.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import socket
+
+# This module owns the local uvicorn subprocess lifecycle for the harness.
+import subprocess  # nosec B404
+import sys
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class UvicornServer:
+    process: subprocess.Popen[str]
+    url: str
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _poll_url(url: str, timeout: float = 2.0) -> int:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"Unsupported health check URL scheme: {parsed.scheme}")
+
+    request = Request(url, method="GET")
+    try:
+        # URL scheme is constrained to HTTP(S) above before opening.
+        with urlopen(request, timeout=timeout) as response:  # nosec B310
+            return int(response.status)
+    except HTTPError as exc:
+        return int(exc.code)
+    except URLError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+
+def wait_for_health(base_url: str, timeout_seconds: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    health_url = f"{base_url.rstrip('/')}/health"
+    last_error: Exception | str | None = None
+
+    while time.monotonic() <= deadline:
+        try:
+            status = _poll_url(health_url)
+            if status < 500:
+                return
+            last_error = f"{health_url} returned HTTP {status}"
+        except Exception as exc:  # noqa: BLE001 - retain last transient startup error.
+            last_error = exc
+        time.sleep(0.25)
+
+    raise TimeoutError(f"Timed out waiting for {health_url}; last error: {last_error}")
+
+
+def wait_for_readiness(base_url: str, timeout_seconds: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    readiness_urls = (
+        f"{base_url.rstrip('/')}/ready",
+        f"{base_url.rstrip('/')}/health/ready",
+    )
+    last_error: Exception | str | None = None
+
+    while time.monotonic() <= deadline:
+        for readiness_url in readiness_urls:
+            try:
+                status = _poll_url(readiness_url)
+                if status < 500:
+                    return
+                last_error = f"{readiness_url} returned HTTP {status}"
+            except Exception as exc:  # noqa: BLE001 - retain last transient startup error.
+                last_error = exc
+        time.sleep(0.25)
+
+    raise TimeoutError(
+        f"Timed out waiting for readiness endpoints {', '.join(readiness_urls)}; " f"last error: {last_error}"
+    )
+
+
+def start_server(env: Mapping[str, str], port: int | None = None) -> UvicornServer:
+    selected_port = port if port is not None else find_free_port()
+    url = f"http://127.0.0.1:{selected_port}"
+    command = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "tldw_Server_API.app.main:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(selected_port),
+    ]
+    # Fixed argv, shell=False, local harness only.
+    process = subprocess.Popen(  # nosec B603
+        command,
+        env=dict(env),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    server = UvicornServer(process=process, url=url)
+    try:
+        wait_for_health(url)
+    except Exception:
+        stop_server(server)
+        raise
+    return server
+
+
+def stop_server(server: UvicornServer) -> None:
+    if server.process.poll() is not None:
+        return
+
+    server.process.terminate()
+    try:
+        server.process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        server.process.kill()
+        server.process.wait(timeout=10)
+
+
+__all__ = [
+    "UvicornServer",
+    "find_free_port",
+    "start_server",
+    "stop_server",
+    "wait_for_health",
+    "wait_for_readiness",
+]

--- a/Helper_Scripts/cats_fuzz/server.py
+++ b/Helper_Scripts/cats_fuzz/server.py
@@ -45,12 +45,29 @@ def _poll_url(url: str, timeout: float = 2.0) -> int:
         raise RuntimeError(str(exc)) from exc
 
 
-def wait_for_health(base_url: str, timeout_seconds: float = 30.0) -> None:
+def _startup_exit_message(return_code: int, stderr_path: Path | None) -> str:
+    message = f"uvicorn exited during startup with code {return_code}"
+    if stderr_path is not None:
+        return f"{message}; stderr log: {stderr_path}"
+    return f"{message}; stderr was not captured"
+
+
+def wait_for_health(
+    base_url: str,
+    timeout_seconds: float = 30.0,
+    *,
+    process: subprocess.Popen[str] | None = None,
+    stderr_path: Path | None = None,
+) -> None:
     deadline = time.monotonic() + timeout_seconds
     health_url = f"{base_url.rstrip('/')}/health"
     last_error: Exception | str | None = None
 
     while time.monotonic() <= deadline:
+        if process is not None:
+            return_code = process.poll()
+            if return_code is not None:
+                raise RuntimeError(_startup_exit_message(return_code, stderr_path))
         try:
             status = _poll_url(health_url)
             if 200 <= status < 300:
@@ -114,14 +131,16 @@ def start_server(
     stderr_target: int | TextIO
     stdout_stream: TextIO | None = None
     stderr_stream: TextIO | None = None
+    stderr_path: Path | None = None
     if log_dir is None:
         stdout_target = subprocess.DEVNULL
         stderr_target = subprocess.DEVNULL
     else:
         log_dir.mkdir(parents=True, exist_ok=True)
         stdout_stream = (log_dir / "uvicorn.stdout.log").open("w", encoding="utf-8")
+        stderr_path = log_dir / "uvicorn.stderr.log"
         try:
-            stderr_stream = (log_dir / "uvicorn.stderr.log").open("w", encoding="utf-8")
+            stderr_stream = stderr_path.open("w", encoding="utf-8")
         except Exception:
             stdout_stream.close()
             raise
@@ -149,7 +168,7 @@ def start_server(
         stderr_stream=stderr_stream,
     )
     try:
-        wait_for_health(url)
+        wait_for_health(url, process=process, stderr_path=stderr_path)
     except Exception:
         stop_server(server)
         raise

--- a/Helper_Scripts/cats_fuzz/server.py
+++ b/Helper_Scripts/cats_fuzz/server.py
@@ -1,3 +1,5 @@
+"""Local uvicorn lifecycle and readiness helpers for CATS runtime blocks."""
+
 from __future__ import annotations
 
 import socket
@@ -17,6 +19,8 @@ from urllib.request import Request, urlopen
 
 @dataclass(frozen=True)
 class UvicornServer:
+    """Handle for a spawned uvicorn process and its optional log streams."""
+
     process: subprocess.Popen[str]
     url: str
     stdout_stream: TextIO | None = None
@@ -24,12 +28,14 @@ class UvicornServer:
 
 
 def find_free_port() -> int:
+    """Reserve and return an available loopback TCP port."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
 
 
 def _poll_url(url: str, timeout: float = 2.0) -> int:
+    """Return one HTTP status code for a constrained HTTP(S) health URL."""
     parsed = urlparse(url)
     if parsed.scheme not in {"http", "https"}:
         raise ValueError(f"Unsupported health check URL scheme: {parsed.scheme}")
@@ -46,6 +52,7 @@ def _poll_url(url: str, timeout: float = 2.0) -> int:
 
 
 def _startup_exit_message(return_code: int, stderr_path: Path | None) -> str:
+    """Build an actionable startup failure message for an exited uvicorn child."""
     message = f"uvicorn exited during startup with code {return_code}"
     if stderr_path is not None:
         return f"{message}; stderr log: {stderr_path}"
@@ -59,6 +66,7 @@ def wait_for_health(
     process: subprocess.Popen[str] | None = None,
     stderr_path: Path | None = None,
 ) -> None:
+    """Wait for the local server health endpoint and fail fast if uvicorn exits."""
     deadline = time.monotonic() + timeout_seconds
     health_url = f"{base_url.rstrip('/')}/health"
     last_error: Exception | str | None = None
@@ -81,6 +89,7 @@ def wait_for_health(
 
 
 def wait_for_readiness(base_url: str, timeout_seconds: float = 30.0) -> None:
+    """Wait for one of the supported readiness endpoints to return HTTP 2xx."""
     deadline = time.monotonic() + timeout_seconds
     readiness_urls = (
         f"{base_url.rstrip('/')}/ready",
@@ -105,6 +114,7 @@ def wait_for_readiness(base_url: str, timeout_seconds: float = 30.0) -> None:
 
 
 def _close_server_streams(server: UvicornServer) -> None:
+    """Close any log streams attached to a server handle."""
     for stream in (server.stdout_stream, server.stderr_stream):
         if stream is not None and not stream.closed:
             stream.close()
@@ -115,6 +125,7 @@ def start_server(
     port: int | None = None,
     log_dir: Path | None = None,
 ) -> UvicornServer:
+    """Start a loopback uvicorn server and wait until it is healthy."""
     selected_port = port if port is not None else find_free_port()
     url = f"http://127.0.0.1:{selected_port}"
     command = [
@@ -176,6 +187,7 @@ def start_server(
 
 
 def stop_server(server: UvicornServer) -> None:
+    """Terminate a spawned uvicorn server and close any attached streams."""
     try:
         if server.process.poll() is not None:
             return

--- a/Helper_Scripts/cats_fuzz/server.py
+++ b/Helper_Scripts/cats_fuzz/server.py
@@ -8,6 +8,8 @@ import sys
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
@@ -17,6 +19,8 @@ from urllib.request import Request, urlopen
 class UvicornServer:
     process: subprocess.Popen[str]
     url: str
+    stdout_stream: TextIO | None = None
+    stderr_stream: TextIO | None = None
 
 
 def find_free_port() -> int:
@@ -49,7 +53,7 @@ def wait_for_health(base_url: str, timeout_seconds: float = 30.0) -> None:
     while time.monotonic() <= deadline:
         try:
             status = _poll_url(health_url)
-            if status < 500:
+            if 200 <= status < 300:
                 return
             last_error = f"{health_url} returned HTTP {status}"
         except Exception as exc:  # noqa: BLE001 - retain last transient startup error.
@@ -71,7 +75,7 @@ def wait_for_readiness(base_url: str, timeout_seconds: float = 30.0) -> None:
         for readiness_url in readiness_urls:
             try:
                 status = _poll_url(readiness_url)
-                if status < 500:
+                if 200 <= status < 300:
                     return
                 last_error = f"{readiness_url} returned HTTP {status}"
             except Exception as exc:  # noqa: BLE001 - retain last transient startup error.
@@ -83,7 +87,17 @@ def wait_for_readiness(base_url: str, timeout_seconds: float = 30.0) -> None:
     )
 
 
-def start_server(env: Mapping[str, str], port: int | None = None) -> UvicornServer:
+def _close_server_streams(server: UvicornServer) -> None:
+    for stream in (server.stdout_stream, server.stderr_stream):
+        if stream is not None and not stream.closed:
+            stream.close()
+
+
+def start_server(
+    env: Mapping[str, str],
+    port: int | None = None,
+    log_dir: Path | None = None,
+) -> UvicornServer:
     selected_port = port if port is not None else find_free_port()
     url = f"http://127.0.0.1:{selected_port}"
     command = [
@@ -96,15 +110,44 @@ def start_server(env: Mapping[str, str], port: int | None = None) -> UvicornServ
         "--port",
         str(selected_port),
     ]
+    stdout_target: int | TextIO
+    stderr_target: int | TextIO
+    stdout_stream: TextIO | None = None
+    stderr_stream: TextIO | None = None
+    if log_dir is None:
+        stdout_target = subprocess.DEVNULL
+        stderr_target = subprocess.DEVNULL
+    else:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stdout_stream = (log_dir / "uvicorn.stdout.log").open("w", encoding="utf-8")
+        try:
+            stderr_stream = (log_dir / "uvicorn.stderr.log").open("w", encoding="utf-8")
+        except Exception:
+            stdout_stream.close()
+            raise
+        stdout_target = stdout_stream
+        stderr_target = stderr_stream
+
     # Fixed argv, shell=False, local harness only.
-    process = subprocess.Popen(  # nosec B603
-        command,
-        env=dict(env),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+    try:
+        process = subprocess.Popen(  # nosec B603
+            command,
+            env=dict(env),
+            stdout=stdout_target,
+            stderr=stderr_target,
+            text=True,
+        )
+    except Exception:
+        for stream in (stdout_stream, stderr_stream):
+            if stream is not None and not stream.closed:
+                stream.close()
+        raise
+    server = UvicornServer(
+        process=process,
+        url=url,
+        stdout_stream=stdout_stream,
+        stderr_stream=stderr_stream,
     )
-    server = UvicornServer(process=process, url=url)
     try:
         wait_for_health(url)
     except Exception:
@@ -114,15 +157,18 @@ def start_server(env: Mapping[str, str], port: int | None = None) -> UvicornServ
 
 
 def stop_server(server: UvicornServer) -> None:
-    if server.process.poll() is not None:
-        return
-
-    server.process.terminate()
     try:
-        server.process.wait(timeout=10)
-    except subprocess.TimeoutExpired:
-        server.process.kill()
-        server.process.wait(timeout=10)
+        if server.process.poll() is not None:
+            return
+
+        server.process.terminate()
+        try:
+            server.process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            server.process.kill()
+            server.process.wait(timeout=10)
+    finally:
+        _close_server_streams(server)
 
 
 __all__ = [

--- a/Helper_Scripts/cats_fuzz/summary.py
+++ b/Helper_Scripts/cats_fuzz/summary.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CatsRunSummary:
+    block: str
+    cats_version: str
+    openapi_sha256: str
+    command: list[str]
+    masked_command: list[str]
+    exit_code: int
+    failure_class: str
+    stdout_path: str
+    stderr_path: str
+    report_dir: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def _mask_header_arg(value: str) -> str:
+    for header_name in ("X-API-KEY", "Authorization"):
+        prefix = f"{header_name}="
+        if value.startswith(prefix):
+            return f"{prefix}${header_name}"
+    return value
+
+
+def mask_command(command: list[str]) -> list[str]:
+    return [_mask_header_arg(value) for value in command]
+
+
+def write_summary(summary: CatsRunSummary, output_path: Path) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    data = asdict(summary)
+    data["command"] = mask_command(summary.command)
+    data["masked_command"] = mask_command(summary.masked_command)
+    output_path.write_text(
+        json.dumps(data, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+__all__ = ["CatsRunSummary", "mask_command", "write_summary"]

--- a/Helper_Scripts/cats_fuzz/summary.py
+++ b/Helper_Scripts/cats_fuzz/summary.py
@@ -1,3 +1,5 @@
+"""Run-summary data model and redaction helpers for CATS artifacts."""
+
 from __future__ import annotations
 
 import json
@@ -8,6 +10,8 @@ from typing import Any
 
 @dataclass(frozen=True)
 class CatsRunSummary:
+    """Serializable summary for one CATS harness block."""
+
     block: str
     cats_version: str
     openapi_sha256: str
@@ -22,6 +26,7 @@ class CatsRunSummary:
 
 
 def _mask_header_arg(value: str) -> str:
+    """Mask sensitive header arguments embedded in CATS command argv."""
     for header_name in ("X-API-KEY", "Authorization"):
         prefix = f"{header_name}="
         if value.startswith(prefix):
@@ -30,10 +35,12 @@ def _mask_header_arg(value: str) -> str:
 
 
 def mask_command(command: list[str]) -> list[str]:
+    """Return a copy of command argv with supported credential headers redacted."""
     return [_mask_header_arg(value) for value in command]
 
 
 def write_summary(summary: CatsRunSummary, output_path: Path) -> Path:
+    """Write a redacted JSON summary artifact and return its path."""
     output_path.parent.mkdir(parents=True, exist_ok=True)
     data = asdict(summary)
     data["command"] = mask_command(summary.command)

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ help:
 	@echo "Testing:"
 	@echo "  make tooling-install         Install test/smoke extras"
 	@echo "  make tooling-smoke           Run unified smoke checks"
+	@echo "  make cats-fuzz               Run local CATS contract/public-read fuzz blocks"
 	@echo "  make mcp-unified-build       Build MCP Unified standalone RC artifacts"
 	@echo "  make mcp-unified-check       Run MCP Unified RC artifact gates"
 	@echo "  make mcp-unified-uat         Run MCP Unified RC UAT checks"
@@ -59,7 +60,7 @@ help:
 # -----------------------------------------------------------------------------
 # Quickstart targets (first-time setup)
 # -----------------------------------------------------------------------------
-.PHONY: setup-wizard-tools setup-docker-single start-docker-single verify-docker-single setup-docker-multi start-docker-multi verify-docker-multi install-local setup-local-single start-local-single verify-local-single quickstart quickstart-install quickstart-prereqs quickstart-local quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check pypi-check-contents tooling-install tooling-smoke show-api-key release release-patch release-minor mcp-unified-build mcp-unified-check mcp-unified-uat mcp-unified-rc mcp-unified-publish-dry-run
+.PHONY: setup-wizard-tools setup-docker-single start-docker-single verify-docker-single setup-docker-multi start-docker-multi verify-docker-multi install-local setup-local-single start-local-single verify-local-single quickstart quickstart-install quickstart-prereqs quickstart-local quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check pypi-check-contents tooling-install tooling-smoke cats-fuzz show-api-key release release-patch release-minor mcp-unified-build mcp-unified-check mcp-unified-uat mcp-unified-rc mcp-unified-publish-dry-run
 
 PYTHON ?= python3
 VENV_DIR ?= .venv
@@ -207,6 +208,9 @@ tooling-install:
 	@echo "[tooling-install] Installing tooling extras into $(VENV_DIR)..."
 	@$(VENV_PYTHON) -m pip install --upgrade pip setuptools wheel
 	@$(VENV_PYTHON) -m pip install -e ".[tooling]"
+
+cats-fuzz:
+	$(VENV_PYTHON) -m Helper_Scripts.cats_fuzz --block contract --block public-read
 
 release:
 	@$(MAKE) release-patch RELEASE_DRY_RUN=$(RELEASE_DRY_RUN)

--- a/backlog/tasks/task-12054 - Address-CATS-fuzzing-code-review-findings.md
+++ b/backlog/tasks/task-12054 - Address-CATS-fuzzing-code-review-findings.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12054
+title: Address CATS fuzzing code review findings
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-27 20:48'
+labels:
+  - testing
+  - security
+  - api
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2538'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the blocking and important findings from the CATS fuzzing PR review: harden runtime config/credential isolation, keep OpenAPI export on the selected Python interpreter, reject non-loopback existing-server URLs for local-only blocks, and return clean CLI usage errors for invalid no-start-server combinations.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 CATS child/server environments use generated inert config and do not inherit local credentials or provider endpoint overrides.
+- [x] #2 OpenAPI export uses the current Python interpreter and invalid runtime CLI combinations fail with usage errors before subprocess work.
+- [x] #3 Built-in local-only runtime blocks reject non-loopback existing-server URLs.
+- [x] #4 Live CATS contract block exports OpenAPI and reports failure_class=ok.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Generated an inert runtime config/env for CATS subprocesses, forced TLDW_CONFIG_FILE/TLDW_CONFIG_PATH/TLDW_CONFIG_DIR, set PYTHON_DOTENV_DISABLED=true, blanked known secrets plus provider endpoint/base-url overrides, used sys.executable for OpenAPI export, rejected non-loopback --server-url values for local-only runtime blocks, and moved invalid --no-start-server usage to argparse errors. Added route_key=setup to the minimal optional setup router spec so generated CATS configs can disable setup API routes before OpenAPI export.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed CATS fuzzing review findings and validated the harness. Focused tests pass, production-path Bandit reports zero findings, and a live contract block now exports OpenAPI and reports failure_class=ok with setup UI and setup API routes disabled by policy. Verification: python -m pytest tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py tldw_Server_API/tests/Services/test_router_groups_contract.py::test_minimal_optional_setup_router_participates_in_route_policy -q (60 passed); python -m Helper_Scripts.cats_fuzz --block contract --output /tmp/tldw-cats-review-fix-contract-v4 (exit 0, failure_class ok); python -m bandit -r Helper_Scripts/cats_fuzz tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_cats_fuzz_review_fix_prod_final.json (0 findings); git diff --check (clean).
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12055 - Rebase-CATS-fuzzing-PR-and-address-review-comments.md
+++ b/backlog/tasks/task-12055 - Rebase-CATS-fuzzing-PR-and-address-review-comments.md
@@ -9,13 +9,19 @@ labels:
 references:
 - https://github.com/rmusser01/tldw_server/pull/2538
 modified_files:
+- Helper_Scripts/cats_fuzz/__init__.py
+- Helper_Scripts/cats_fuzz/__main__.py
 - Helper_Scripts/cats_fuzz/cli.py
 - Helper_Scripts/cats_fuzz/cats_cli.py
+- Helper_Scripts/cats_fuzz/env.py
 - Helper_Scripts/cats_fuzz/manifest.py
+- Helper_Scripts/cats_fuzz/openapi_export.py
 - Helper_Scripts/cats_fuzz/runner.py
 - Helper_Scripts/cats_fuzz/server.py
+- Helper_Scripts/cats_fuzz/summary.py
 - tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
 - tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
 - tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
 - tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
 - tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
@@ -38,13 +44,15 @@ Rebase PR #2538 on the latest dev branch, inspect all GitHub review comments and
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Rebased PR #2538 branch codex/cats-api-fuzzing-harness-dev-pr on origin/dev and addressed the unresolved review comments. Fixed --server-url default behavior so existing-server mode does not require --no-start-server, made public-read omit X-API-KEY while auth-read still includes it, added structured missing-CATS-binary failures, made readiness preflight failures write artifacts and summary.json, made uvicorn startup fail fast if the child exits, tightened OpenAPI example-shape assertions, and normalized duplicate Backlog section markers on the CATS Task 5 record.
 
-Verification: focused pytest suite passed 66 tests; live CATS contract block exited 0 and produced summary.json with failure_class=ok; git diff --check passed; Bandit over Helper_Scripts/cats_fuzz and router_groups/minimal.py reported 0 results in /tmp/bandit_cats_fuzz_rebase_comments.json.
+Additional Qodo follow-up: added module/class/function docstrings across Helper_Scripts/cats_fuzz, replaced CLI diagnostic print output with Loguru, blanked ROUTES_* route-policy overrides from the harness child env, rejected --server-url values with path/query/fragment so readiness probes stay rooted at the server origin, and added a 120 second OpenAPI export subprocess timeout that writes partial stdout/stderr logs and returns 124.
+
+Verification: focused pytest suite passed 71 tests; live CATS contract block exited 0 and produced summary.json with failure_class=ok; black --check passed over the harness and touched tests; AST docstring scan over Helper_Scripts/cats_fuzz passed; cli.py print scan returned no diagnostic print calls; git diff --check passed; Bandit over Helper_Scripts/cats_fuzz and router_groups/minimal.py reported 0 results in /tmp/bandit_cats_fuzz_rebase_comments_qodo.json.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Rebased the CATS fuzzing harness PR on latest dev and addressed all actionable review comments with focused regression coverage and validation artifacts.
+Rebased the CATS fuzzing harness PR on latest dev and addressed all actionable review comments, including Qodo follow-up items, with focused regression coverage and validation artifacts.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12055 - Rebase-CATS-fuzzing-PR-and-address-review-comments.md
+++ b/backlog/tasks/task-12055 - Rebase-CATS-fuzzing-PR-and-address-review-comments.md
@@ -1,0 +1,58 @@
+---
+id: TASK-12055
+title: Rebase CATS fuzzing PR and address review comments
+status: Done
+labels:
+- testing
+- api
+- pr-maintenance
+references:
+- https://github.com/rmusser01/tldw_server/pull/2538
+modified_files:
+- Helper_Scripts/cats_fuzz/cli.py
+- Helper_Scripts/cats_fuzz/cats_cli.py
+- Helper_Scripts/cats_fuzz/manifest.py
+- Helper_Scripts/cats_fuzz/runner.py
+- Helper_Scripts/cats_fuzz/server.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
+- tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
+- backlog/tasks/task-2374 - Task-5-Add-Server-Lifecycle-And-Runner-Orchestration.md
+- backlog/tasks/task-12055 - Rebase-CATS-fuzzing-PR-and-address-review-comments.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2538 on the latest dev branch, inspect all GitHub review comments and check results, address any technically valid issues, and push the updated branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Rebased PR #2538 branch codex/cats-api-fuzzing-harness-dev-pr on origin/dev and addressed the unresolved review comments. Fixed --server-url default behavior so existing-server mode does not require --no-start-server, made public-read omit X-API-KEY while auth-read still includes it, added structured missing-CATS-binary failures, made readiness preflight failures write artifacts and summary.json, made uvicorn startup fail fast if the child exits, tightened OpenAPI example-shape assertions, and normalized duplicate Backlog section markers on the CATS Task 5 record.
+
+Verification: focused pytest suite passed 66 tests; live CATS contract block exited 0 and produced summary.json with failure_class=ok; git diff --check passed; Bandit over Helper_Scripts/cats_fuzz and router_groups/minimal.py reported 0 results in /tmp/bandit_cats_fuzz_rebase_comments.json.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased the CATS fuzzing harness PR on latest dev and addressed all actionable review comments with focused regression coverage and validation artifacts.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2369 - Design-CATS-API-fuzzing-harness.md
+++ b/backlog/tasks/task-2369 - Design-CATS-API-fuzzing-harness.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2369
 title: Design CATS API fuzzing harness
-status: In Progress
+status: Done
 labels:
 - testing
 - security
@@ -31,12 +31,14 @@ Create the approved design spec for a broad-in-blocks CATS OpenAPI fuzzing harne
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 2026-06-27: Wrote design spec at Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md. Local self-review covered block architecture, egress controls, seeded state, failure policy, reporting, CI policy, and known CATS OpenAPI validation issue. Formal spec-review subagent was not dispatched because the available multi-agent tool requires explicit user request for subagents/delegation. Verification: git diff --check passed for the spec and task paths. Bandit skipped because this stage touched only Markdown/Backlog task documentation.
+
+2026-06-27: Applied review corrections before implementation planning. Updated the design to replace the invalid CATS JSON report format with HTML/JUnit plus runner-owned summary JSON, strengthen dotenv-safe credential isolation, keep the contract gate non-blocking until the vector store OpenAPI examples are fixed or known-issued, record CATS dry-run fallback behavior, capture tool/process diagnostics in summary output, and choose runner-owned uvicorn startup for the first implementation slice.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Completed the CATS fuzzing harness design and review-fix pass. The final design uses broad staged blocks, local-only runtime isolation, dotenv-safe credential handling, valid CATS HTML/JUnit reports plus runner-owned summary JSON, non-blocking contract handling until the vector store OpenAPI examples are fixed or known-issued, dry-run fallback behavior, and runner-owned uvicorn startup for the first implementation slice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -45,6 +47,6 @@ Create the approved design spec for a broad-in-blocks CATS OpenAPI fuzzing harne
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2369 - Design-CATS-API-fuzzing-harness.md
+++ b/backlog/tasks/task-2369 - Design-CATS-API-fuzzing-harness.md
@@ -1,0 +1,50 @@
+---
+id: TASK-2369
+title: Design CATS API fuzzing harness
+status: In Progress
+labels:
+- testing
+- security
+- api
+documentation:
+- Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md
+modified_files:
+- Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the approved design spec for a broad-in-blocks CATS OpenAPI fuzzing harness for the tldw_server API. The spec should cover staged block architecture, isolation and egress controls, CATS command shape, reporting, triage, CI/nightly policy, and known OpenAPI validation issues discovered during exploration.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec documents broad staged fuzzing blocks and risk metadata.
+- [x] #2 Spec requires isolated runtime env, credential scrubbing, and external egress safeguards.
+- [x] #3 Spec covers seeded state/refData needs for stateful blocks.
+- [x] #4 Spec defines CATS failure policy, reporting artifacts, and CI/nightly/manual scope.
+- [x] #5 Spec records the current vector store OpenAPI validation issue and rollout path.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-06-27: Wrote design spec at Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md. Local self-review covered block architecture, egress controls, seeded state, failure policy, reporting, CI policy, and known CATS OpenAPI validation issue. Formal spec-review subagent was not dispatched because the available multi-agent tool requires explicit user request for subagents/delegation. Verification: git diff --check passed for the spec and task paths. Bandit skipped because this stage touched only Markdown/Backlog task documentation.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2370 - Plan-CATS-API-fuzzing-harness-implementation.md
+++ b/backlog/tasks/task-2370 - Plan-CATS-API-fuzzing-harness-implementation.md
@@ -1,0 +1,50 @@
+---
+id: TASK-2370
+title: Plan CATS API fuzzing harness implementation
+status: Done
+labels:
+- testing
+- security
+- api
+documentation:
+- Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md
+- Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md
+modified_files:
+- Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a staged implementation plan for the first CATS API fuzzing harness slice, based on the approved broad-in-blocks design. The plan should be detailed enough for agentic execution with TDD steps, exact files, verification commands, commits, and known setup constraints.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan follows the approved CATS fuzzing harness design spec.
+- [x] #2 Plan decomposes the first implementation slice into TDD-friendly tasks with exact files and commands.
+- [x] #3 Plan covers OpenAPI validation cleanup, runner/env isolation, block manifest, reporting, and verification.
+- [x] #4 Plan records known skips and setup constraints for the isolated worktree.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the CATS fuzzing harness implementation plan at Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md. The plan follows the approved design, starts with the vector store OpenAPI validation cleanup, decomposes the harness into TDD-friendly modules under Helper_Scripts/cats_fuzz, covers local-only env isolation, CATS command construction, summary reporting, uvicorn lifecycle, CLI/docs, focused pytest, live CATS verification, and Bandit. Verification for this planning task: git diff --check passed; stale invalid report-format and Python 3.11-only StrEnum wording were removed. Bandit is deferred to implementation because this task only added Markdown/Backlog planning docs.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
+++ b/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
@@ -47,6 +47,8 @@ Implement the first local-only CATS API fuzzing harness slice from the approved 
 2026-06-27 Task 7 verification fix: added a regression for `cats --version` banner output before changing `_cats_version()` to prefer `CATS version ...` lines ahead of generic first-line fallback. Red run failed on the banner border being returned; green run passed focused CLI tests. Verification: focused pytest, Black check, Bandit on cli.py, and git diff --check passed.
 
 2026-06-27 Task 7 live verification env fix: added failing regressions for server-safe CATS harness env generation and CLI uvicorn startup env selection. Red run failed on missing `build_server_env`; green run passed focused env/CLI tests after adding `runtime/cats-server.env` without guarded test flags (`TEST_MODE`, `TESTING`, `TLDW_TEST_MODE`) and routing only `start_server()` through that env while OpenAPI export/runtime CATS still use the raw child env.
+
+2026-06-27 Task 7 live verification timeout fix: added failing regressions for CATS subprocess timeouts returning structured results, timeout classification as tool failure, and a >=300s public-read budget. Red run failed on uncaught `TimeoutExpired`, `api` classification, and 120s public-read timeout; green run passed focused cats_cli/manifest tests. Verification: focused pytest, Black check, Bandit on cats_cli.py/manifest.py, and git diff --check passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
+++ b/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
@@ -45,6 +45,8 @@ Implement the first local-only CATS API fuzzing harness slice from the approved 
 2026-06-27 Task 6: added the CATS fuzzing CLI/module entrypoint, focused CLI parser/orchestration tests, developer documentation, and Makefile cats-fuzz target. Initial red test run failed on missing Helper_Scripts.cats_fuzz.cli as expected; final focused pytest, Black check, Bandit on cli.py, and git diff --check passed.
 
 2026-06-27 Task 7 verification fix: added a regression for `cats --version` banner output before changing `_cats_version()` to prefer `CATS version ...` lines ahead of generic first-line fallback. Red run failed on the banner border being returned; green run passed focused CLI tests. Verification: focused pytest, Black check, Bandit on cli.py, and git diff --check passed.
+
+2026-06-27 Task 7 live verification env fix: added failing regressions for server-safe CATS harness env generation and CLI uvicorn startup env selection. Red run failed on missing `build_server_env`; green run passed focused env/CLI tests after adding `runtime/cats-server.env` without guarded test flags (`TEST_MODE`, `TESTING`, `TLDW_TEST_MODE`) and routing only `start_server()` through that env while OpenAPI export/runtime CATS still use the raw child env.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
+++ b/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
@@ -20,6 +20,8 @@ modified_files:
 - tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
 - tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
 - Docs/Development/CATS_Fuzzing.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2538
 ---
 
 ## Description

--- a/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
+++ b/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
@@ -43,6 +43,8 @@ Implement the first local-only CATS API fuzzing harness slice from the approved 
 2026-06-27: Starting subagent-driven execution from Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md in worktree codex/cats-api-fuzzing-harness.
 
 2026-06-27 Task 6: added the CATS fuzzing CLI/module entrypoint, focused CLI parser/orchestration tests, developer documentation, and Makefile cats-fuzz target. Initial red test run failed on missing Helper_Scripts.cats_fuzz.cli as expected; final focused pytest, Black check, Bandit on cli.py, and git diff --check passed.
+
+2026-06-27 Task 7 verification fix: added a regression for `cats --version` banner output before changing `_cats_version()` to prefer `CATS version ...` lines ahead of generic first-line fallback. Red run failed on the banner border being returned; green run passed focused CLI tests. Verification: focused pytest, Black check, Bandit on cli.py, and git diff --check passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
+++ b/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
@@ -41,6 +41,8 @@ Implement the first local-only CATS API fuzzing harness slice from the approved 
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 2026-06-27: Starting subagent-driven execution from Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md in worktree codex/cats-api-fuzzing-harness.
+
+2026-06-27 Task 6: added the CATS fuzzing CLI/module entrypoint, focused CLI parser/orchestration tests, developer documentation, and Makefile cats-fuzz target. Initial red test run failed on missing Helper_Scripts.cats_fuzz.cli as expected; final focused pytest, Black check, Bandit on cli.py, and git diff --check passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
+++ b/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2371
 title: Implement CATS API fuzzing harness first slice
-status: In Progress
+status: Done
 labels:
 - testing
 - security
@@ -30,11 +30,11 @@ Implement the first local-only CATS API fuzzing harness slice from the approved 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Vector store OpenAPI query examples are compatible with CATS strict validation.
-- [ ] #2 Helper_Scripts/cats_fuzz supports manifest blocks, local-only env isolation, OpenAPI export, CATS command construction, summary JSON, uvicorn lifecycle, and CLI execution for contract/public-read.
-- [ ] #3 Focused pytest coverage passes for the new harness modules and OpenAPI cleanup.
-- [ ] #4 Live local CATS contract and public-read commands either pass or record actionable tool/API failure summaries.
-- [ ] #5 Bandit runs on touched executable scope with no unresolved new findings.
+- [x] #1 Vector store OpenAPI query examples are compatible with CATS strict validation.
+- [x] #2 Helper_Scripts/cats_fuzz supports manifest blocks, local-only env isolation, OpenAPI export, CATS command construction, summary JSON, uvicorn lifecycle, and CLI execution for contract/public-read.
+- [x] #3 Focused pytest coverage passes for the new harness modules and OpenAPI cleanup.
+- [x] #4 Live local CATS contract and public-read commands either pass or record actionable tool/API failure summaries.
+- [x] #5 Bandit runs on touched executable scope with no unresolved new findings.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -54,15 +54,24 @@ Implement the first local-only CATS API fuzzing harness slice from the approved 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the first local-only CATS fuzzing harness slice. The harness now exports an isolated OpenAPI contract, constructs CATS contract/runtime commands, starts a sandboxed uvicorn server with generated test-only env files, masks sensitive headers in summaries, writes per-block `summary.json`/stdout/stderr/report artifacts, and exposes CLI/docs/Makefile entrypoints for `contract`, `public-read`, and scaffolded `auth-read` blocks.
 
+Verification completed on 2026-06-27:
+- Focused pytest: `57 passed, 6 warnings`.
+- Live CATS contract: `/tmp/tldw-cats-public-read-v4/contract/summary.json` has `exit_code: 0`, `failure_class: ok`, CATS `13.8.0`.
+- Live CATS public-read: `/tmp/tldw-cats-public-read-v4/public-read/summary.json` has `exit_code: 124`, `failure_class: tool`; stderr records `Command timed out after 300 seconds`, with partial CATS HTML/JUnit reports under `/tmp/tldw-cats-public-read-v4/public-read/cats-report`.
+- Final Bandit touched executable scope: `/tmp/bandit_cats_fuzz_final.json` has zero findings.
+- `git diff --check` passed.
+
+Known follow-up: the broad first-slice public-read surface starts correctly and records an actionable summary, but it does not complete within the current 300s budget on the full generated tldw OpenAPI. Narrowing fuzzers/paths or splitting public-read into smaller blocks should be handled in a later task before making this a hard CI gate.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
+++ b/backlog/tasks/task-2371 - Implement-CATS-API-fuzzing-harness-first-slice.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2371
+title: Implement CATS API fuzzing harness first slice
+status: In Progress
+labels:
+- testing
+- security
+- api
+documentation:
+- Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md
+- Docs/superpowers/specs/2026-06-27-cats-api-fuzzing-harness-design.md
+modified_files:
+- tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py
+- Helper_Scripts/cats_fuzz/
+- tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
+- Docs/Development/CATS_Fuzzing.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first local-only CATS API fuzzing harness slice from the approved implementation plan. Scope includes the vector store OpenAPI examples cleanup, importable Helper_Scripts/cats_fuzz modules, focused unit tests, CLI/docs, live contract/public-read verification, and touched-scope Bandit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Vector store OpenAPI query examples are compatible with CATS strict validation.
+- [ ] #2 Helper_Scripts/cats_fuzz supports manifest blocks, local-only env isolation, OpenAPI export, CATS command construction, summary JSON, uvicorn lifecycle, and CLI execution for contract/public-read.
+- [ ] #3 Focused pytest coverage passes for the new harness modules and OpenAPI cleanup.
+- [ ] #4 Live local CATS contract and public-read commands either pass or record actionable tool/API failure summaries.
+- [ ] #5 Bandit runs on touched executable scope with no unresolved new findings.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-06-27: Starting subagent-driven execution from Docs/superpowers/plans/2026-06-27-cats-api-fuzzing-harness-implementation-plan.md in worktree codex/cats-api-fuzzing-harness.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2372 - Task-3-Add-local-only-CATS-fuzz-environment-builder-and-OpenAPI-export.md
+++ b/backlog/tasks/task-2372 - Task-3-Add-local-only-CATS-fuzz-environment-builder-and-OpenAPI-export.md
@@ -4,7 +4,7 @@ title: 'Task 3: Add local-only CATS fuzz environment builder and OpenAPI export'
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-27 17:52'
+updated_date: '2026-06-27 17:58'
 labels:
   - cats
   - fuzzing
@@ -29,6 +29,8 @@ Implement Task 3 for the CATS API fuzzing harness: tests for local-only environm
 
 <!-- SECTION:NOTES:BEGIN -->
 TDD flow: added test_cats_fuzz_env.py first, then captured the initial red pytest collection failure before implementing env.py and openapi_export.py. Verification after implementation: focused pytest passed 6 tests; Black check passed; Bandit reported zero findings; OpenAPI export CLI smoke run exited 0 with digest 50653ad9c3414b434eba48de360b9e18c2e3b5d4820b0b831a011577656e0b2c.
+
+Review fix: split broad sensitive detection from default blocking so known local/tool variables (SINGLE_USER_API_KEY, SINGLE_USER_TEST_API_KEY, GITHUB_TOKEN, GH_TOKEN, NPM_TOKEN, CODEX_API_KEY) are sanitized or overwritten instead of rejecting normal developer shells. Added fake-FastAPI unit coverage for export_openapi cache clearing, deterministic bytes/digest, parent directory creation, and main() digest printing. Verification for fix: focused pytest passed 10 tests; Black check passed; Bandit reported zero findings in /tmp/bandit_cats_fuzz_env_export_fix.json.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2372 - Task-3-Add-local-only-CATS-fuzz-environment-builder-and-OpenAPI-export.md
+++ b/backlog/tasks/task-2372 - Task-3-Add-local-only-CATS-fuzz-environment-builder-and-OpenAPI-export.md
@@ -1,0 +1,48 @@
+---
+id: TASK-2372
+title: 'Task 3: Add local-only CATS fuzz environment builder and OpenAPI export'
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-27 17:52'
+labels:
+  - cats
+  - fuzzing
+  - tests
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 3 for the CATS API fuzzing harness: tests for local-only environment safety and OpenAPI export command construction; add Helper_Scripts/cats_fuzz/env.py and openapi_export.py; verify focused pytest, black, and Bandit; commit with the requested message.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused env/OpenAPI tests cover sensitive detection, credential rejection, local sentinels, child env blanking, and OpenAPI command construction.
+- [x] #2 env.py creates a local single-user runtime environment and rejects real credentials by default.
+- [x] #3 openapi_export.py builds the module command and exports deterministic sorted OpenAPI JSON with a SHA-256 digest.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TDD flow: added test_cats_fuzz_env.py first, then captured the initial red pytest collection failure before implementing env.py and openapi_export.py. Verification after implementation: focused pytest passed 6 tests; Black check passed; Bandit reported zero findings; OpenAPI export CLI smoke run exited 0 with digest 50653ad9c3414b434eba48de360b9e18c2e3b5d4820b0b831a011577656e0b2c.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 3 implemented and verified. Initial red focused pytest failed during collection before env.py/openapi_export.py existed. Final focused pytest passed 6 tests. Black check passed. Bandit completed with zero findings. OpenAPI export CLI smoke run exited 0 and printed digest 50653ad9c3414b434eba48de360b9e18c2e3b5d4820b0b831a011577656e0b2c.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2373 - Task-4-Add-CATS-command-builder-and-summary-JSON.md
+++ b/backlog/tasks/task-2373 - Task-4-Add-CATS-command-builder-and-summary-JSON.md
@@ -28,6 +28,8 @@ Implement Task 4 for the CATS API fuzzing harness: add CATS command construction
 - Verification: `python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py -q` passed with 8 tests.
 - Formatting: `python -m black --check Helper_Scripts/cats_fuzz/cats_cli.py Helper_Scripts/cats_fuzz/summary.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py` passed.
 - Security: `python -m bandit -r Helper_Scripts/cats_fuzz/cats_cli.py Helper_Scripts/cats_fuzz/summary.py -f json -o /tmp/bandit_cats_fuzz_cli_summary.json` passed with no findings.
+- Review fix: added red regression coverage for the top-level CATS fuzz command prefix and dry-run flag, then removed the incorrect `run` subcommand from `build_cats_run_command()`.
+- Review-fix verification: `python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py -q` passed with 10 tests; `python -m black --check Helper_Scripts/cats_fuzz/cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py` passed; `python -m bandit -r Helper_Scripts/cats_fuzz/cats_cli.py -f json -o /tmp/bandit_cats_fuzz_cli_fix.json` passed with no findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2373 - Task-4-Add-CATS-command-builder-and-summary-JSON.md
+++ b/backlog/tasks/task-2373 - Task-4-Add-CATS-command-builder-and-summary-JSON.md
@@ -1,0 +1,49 @@
+---
+id: TASK-2373
+title: 'Task 4: Add CATS command builder and summary JSON'
+status: Done
+references:
+- TASK-2371
+modified_files:
+- Helper_Scripts/cats_fuzz/cats_cli.py
+- Helper_Scripts/cats_fuzz/summary.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
+- tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 4 for the CATS API fuzzing harness: add CATS command construction helpers, exit classification, safe subprocess runner, run summary dataclass, secret-masking summary writer, focused unit tests, verification, and commit with the requested message.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- TDD red run: focused pytest failed during collection because `Helper_Scripts.cats_fuzz.cats_cli` and `Helper_Scripts.cats_fuzz.summary` did not exist.
+- Verification: `python -m pytest tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py -q` passed with 8 tests.
+- Formatting: `python -m black --check Helper_Scripts/cats_fuzz/cats_cli.py Helper_Scripts/cats_fuzz/summary.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py` passed.
+- Security: `python -m bandit -r Helper_Scripts/cats_fuzz/cats_cli.py Helper_Scripts/cats_fuzz/summary.py -f json -o /tmp/bandit_cats_fuzz_cli_summary.json` passed with no findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Added CATS run/validate/stats command builders, exit classification, and a captured-output subprocess runner.
+- Added CATS run summary JSON writing with command masking at the persistence boundary so raw `X-API-KEY` and `Authorization` header values are not written.
+- Added focused unit coverage for command construction, exit classification, summary shape, and API-key masking regression behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2374 - Task-5-Add-Server-Lifecycle-And-Runner-Orchestration.md
+++ b/backlog/tasks/task-2374 - Task-5-Add-Server-Lifecycle-And-Runner-Orchestration.md
@@ -4,7 +4,7 @@ title: 'Task 5: Add Server Lifecycle And Runner Orchestration'
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-27 18:18'
+updated_date: '2026-06-27 18:23'
 labels:
   - cats-fuzz
   - task-5
@@ -31,6 +31,8 @@ dependencies: []
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 Implemented Task 5 server lifecycle and CATS runner orchestration with TDD. Initial red run failed on missing Helper_Scripts.cats_fuzz.runner import before implementation. Verification: pytest test_cats_fuzz_runner.py passed 13 tests; black --check passed; bandit JSON report passed at /tmp/bandit_cats_fuzz_runner.json.
+
+Code-quality review fix: tightened health/readiness success to 2xx-only, added readiness fallback coverage for 404/503, and changed uvicorn output handling to DEVNULL by default or explicit log files closed by stop_server. Verification: pytest test_cats_fuzz_runner.py passed 19 tests; black --check passed; bandit server report passed at /tmp/bandit_cats_fuzz_server_fix.json.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2374 - Task-5-Add-Server-Lifecycle-And-Runner-Orchestration.md
+++ b/backlog/tasks/task-2374 - Task-5-Add-Server-Lifecycle-And-Runner-Orchestration.md
@@ -1,0 +1,52 @@
+---
+id: TASK-2374
+title: 'Task 5: Add Server Lifecycle And Runner Orchestration'
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-27 18:18'
+labels:
+  - cats-fuzz
+  - task-5
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:END -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Implemented Task 5 server lifecycle and CATS runner orchestration with TDD. Initial red run failed on missing Helper_Scripts.cats_fuzz.runner import before implementation. Verification: pytest test_cats_fuzz_runner.py passed 13 tests; black --check passed; bandit JSON report passed at /tmp/bandit_cats_fuzz_runner.json.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added CATS server lifecycle helpers, runner orchestration, artifact/summary writing, readiness gating, and focused unit coverage for Task 5.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2374 - Task-5-Add-Server-Lifecycle-And-Runner-Orchestration.md
+++ b/backlog/tasks/task-2374 - Task-5-Add-Server-Lifecycle-And-Runner-Orchestration.md
@@ -14,9 +14,6 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-<!-- SECTION:DESCRIPTION:BEGIN -->
-<!-- SECTION:DESCRIPTION:END -->
-
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -26,10 +23,6 @@ dependencies: []
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 Implemented Task 5 server lifecycle and CATS runner orchestration with TDD. Initial red run failed on missing Helper_Scripts.cats_fuzz.runner import before implementation. Verification: pytest test_cats_fuzz_runner.py passed 13 tests; black --check passed; bandit JSON report passed at /tmp/bandit_cats_fuzz_runner.json.
 
 Code-quality review fix: tightened health/readiness success to 2xx-only, added readiness fallback coverage for 404/503, and changed uvicorn output handling to DEVNULL by default or explicit log files closed by stop_server. Verification: pytest test_cats_fuzz_runner.py passed 19 tests; black --check passed; bandit server report passed at /tmp/bandit_cats_fuzz_server_fix.json.
@@ -39,8 +32,6 @@ Code-quality review fix: tightened health/readiness success to 2xx-only, added r
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added CATS server lifecycle helpers, runner orchestration, artifact/summary writing, readiness gating, and focused unit coverage for Task 5.
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2375 - Document-CATS-fuzzing-setup-and-operations-guide.md
+++ b/backlog/tasks/task-2375 - Document-CATS-fuzzing-setup-and-operations-guide.md
@@ -1,0 +1,47 @@
+---
+id: TASK-2375
+title: Document CATS fuzzing setup and operations guide
+status: Done
+labels:
+- docs
+- testing
+- security
+modified_files:
+- Docs/Development/CATS_Fuzzing.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create contributor-facing setup and operations guidance for running and interpreting the CATS API fuzzing harness during testing and validation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Guide explains contributor setup prerequisites, including venv and CATS installation checks.
+- [x] #2 Guide documents safe operating modes, CLI options, blocks, artifacts, and result interpretation.
+- [x] #3 Guide includes triage playbooks for contract, API, tool, timeout, startup, and credential-detection failures.
+- [x] #4 Guide records known limitations and PR reporting expectations for validation results.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-06-27: Expanded `Docs/Development/CATS_Fuzzing.md` from a short usage note into a contributor setup and operations guide. Verified against the implemented harness modules and current CATS docs links. Documentation-only change; Bandit not applicable.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created a contributor-facing CATS fuzzing setup and operations guide covering prerequisites, safe local operation, CLI usage, built-in block behavior, artifact layout, summary interpretation, triage playbooks, cleanup, PR checklist, and known limitations.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py
@@ -1147,7 +1147,7 @@ async def list_vectors(
     filter: str | None = Query(
         None,
         description="Optional JSON metadata filter",
-        examples={
+        openapi_examples={
             "simple": {"summary": "Simple equality", "value": "{\"genre\":\"a\"}"},
             "and_numeric": {"summary": "AND with numeric", "value": "{\"$and\":[{\"genre\":\"a\"},{\"score\":{\"$gte\":0.8}}]}"}
         }
@@ -1155,12 +1155,12 @@ async def list_vectors(
     order_by: str | None = Query(
         "id",
         description="Order field: 'id' or 'metadata.<key>'",
-        examples={"metadata": {"summary": "Order by metadata.score desc", "value": "metadata.score"}}
+        openapi_examples={"metadata": {"summary": "Order by metadata.score desc", "value": "metadata.score"}}
     ),
     order_dir: str = Query(
         "asc",
         pattern="^(?i)(asc|desc)$",
-        examples={"desc": {"summary": "Descending", "value": "desc"}}
+        openapi_examples={"desc": {"summary": "Descending", "value": "desc"}}
     ),
     current_user: User = Depends(get_request_user)
 ):

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -880,6 +880,7 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             log_name="setup",
             prefix=f"{API_V1_PREFIX}",
             tags=("setup",),
+            route_key="setup",
             skip_context=minimal_skip_context,
         ),
         ImportedRouterSpec(

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -86,6 +87,7 @@ def test_cats_exit_classification_separates_usage_tool_and_api_failures() -> Non
     assert classify_cats_exit(0, "") == "ok"
     assert classify_cats_exit(2, "Invalid value for option") == "usage"
     assert classify_cats_exit(1, "Internal execution error") == "tool"
+    assert classify_cats_exit(124, "Command timed out after 10 seconds") == "tool"
     assert classify_cats_exit(1, "Some tests failed with 500") == "api"
 
 
@@ -123,3 +125,27 @@ def test_run_command_captures_stdout_stderr_and_exit_code() -> None:
     assert result.exit_code == 3
     assert result.stdout == "out\n"
     assert result.stderr == "err\n"
+
+
+@pytest.mark.unit
+def test_run_command_returns_structured_result_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    command = ["cats", "-c", "openapi.json"]
+
+    def raise_timeout(*_args: object, **kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(
+            cmd=command,
+            timeout=kwargs["timeout"],
+            output=b"partial stdout",
+            stderr=b"partial stderr",
+        )
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.cats_cli.subprocess.run", raise_timeout)
+
+    result = run_command(command, timeout_seconds=10)
+
+    assert result.command == command
+    assert result.exit_code == 124
+    assert result.stdout == "partial stdout"
+    assert "Command timed out after 10 seconds" in result.stderr
+    assert "partial stderr" in result.stderr
+    assert classify_cats_exit(result.exit_code, result.stderr) == "tool"

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
@@ -32,10 +32,26 @@ def test_public_read_command_uses_blackbox_and_junit_reports(tmp_path: Path) -> 
     assert "--skipReportingForIgnored" in command
     assert "--reportFormat" in command
     assert command[command.index("--reportFormat") + 1] == "HTML_ONLY,JUNIT"
-    assert "-H" in command
-    assert f"X-API-KEY={DEFAULT_TEST_API_KEY}" in command
+    assert "-H" not in command
+    assert f"X-API-KEY={DEFAULT_TEST_API_KEY}" not in command
     assert "--path" in command
     assert "/" in command[command.index("--path") + 1].split(",")
+
+
+@pytest.mark.unit
+def test_auth_read_command_includes_api_key_header(tmp_path: Path) -> None:
+    block = get_builtin_block("auth-read")
+    command = build_cats_run_command(
+        block,
+        contract_path=tmp_path / "openapi.json",
+        server_url="http://127.0.0.1:8000",
+        output_dir=tmp_path / "reports",
+        api_key=DEFAULT_TEST_API_KEY,
+    )
+
+    assert "-H" in command
+    assert f"X-API-KEY={DEFAULT_TEST_API_KEY}" in command
+    assert command.index("-H") < command.index("--maskHeaders")
 
 
 @pytest.mark.unit
@@ -149,4 +165,23 @@ def test_run_command_returns_structured_result_on_timeout(monkeypatch: pytest.Mo
     assert result.stdout == "partial stdout"
     assert "Command timed out after 10 seconds" in result.stderr
     assert "partial stderr" in result.stderr
+    assert classify_cats_exit(result.exit_code, result.stderr) == "tool"
+
+
+@pytest.mark.unit
+def test_run_command_returns_structured_result_when_binary_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    command = ["missing-cats", "-c", "openapi.json"]
+
+    def raise_missing_binary(*_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError("missing-cats")
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.cats_cli.subprocess.run", raise_missing_binary)
+
+    result = run_command(command, timeout_seconds=10)
+
+    assert result.command == command
+    assert result.exit_code == 127
+    assert result.stdout == ""
+    assert "Failed to execute command" in result.stderr
+    assert "missing-cats" in result.stderr
     assert classify_cats_exit(result.exit_code, result.stderr) == "tool"

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
+from Helper_Scripts.cats_fuzz.cats_cli import (
+    build_cats_run_command,
+    build_cats_stats_command,
+    build_cats_validate_command,
+    classify_cats_exit,
+    run_command,
+)
+from Helper_Scripts.cats_fuzz.manifest import get_builtin_block
+
+
+@pytest.mark.unit
+def test_public_read_command_uses_blackbox_and_junit_reports(tmp_path: Path) -> None:
+    block = get_builtin_block("public-read")
+    command = build_cats_run_command(
+        block,
+        contract_path=tmp_path / "openapi.json",
+        server_url="http://127.0.0.1:8000",
+        output_dir=tmp_path / "reports",
+        api_key=DEFAULT_TEST_API_KEY,
+    )
+
+    assert "--blackbox" in command
+    assert "--skipReportingForIgnored" in command
+    assert "--reportFormat" in command
+    assert command[command.index("--reportFormat") + 1] == "HTML_ONLY,JUNIT"
+    assert "-H" in command
+    assert f"X-API-KEY={DEFAULT_TEST_API_KEY}" in command
+    assert "--path" in command
+    assert "/" in command[command.index("--path") + 1].split(",")
+
+
+@pytest.mark.unit
+def test_cats_exit_classification_separates_usage_tool_and_api_failures() -> None:
+    assert classify_cats_exit(0, "") == "ok"
+    assert classify_cats_exit(2, "Invalid value for option") == "usage"
+    assert classify_cats_exit(1, "Internal execution error") == "tool"
+    assert classify_cats_exit(1, "Some tests failed with 500") == "api"
+
+
+@pytest.mark.unit
+def test_validate_and_stats_commands_default_to_json_output(tmp_path: Path) -> None:
+    contract_path = tmp_path / "openapi.json"
+
+    assert build_cats_validate_command(contract_path) == [
+        "cats",
+        "validate",
+        "-c",
+        str(contract_path),
+        "-j",
+    ]
+    assert build_cats_stats_command(contract_path) == [
+        "cats",
+        "stats",
+        "-c",
+        str(contract_path),
+        "-j",
+    ]
+
+
+@pytest.mark.unit
+def test_run_command_captures_stdout_stderr_and_exit_code() -> None:
+    command = [
+        "python",
+        "-c",
+        "import sys; print('out'); print('err', file=sys.stderr); raise SystemExit(3)",
+    ]
+
+    result = run_command(command, timeout_seconds=10)
+
+    assert result.command == command
+    assert result.exit_code == 3
+    assert result.stdout == "out\n"
+    assert result.stderr == "err\n"

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -114,7 +115,7 @@ def test_validate_and_stats_commands_default_to_json_output(tmp_path: Path) -> N
 @pytest.mark.unit
 def test_run_command_captures_stdout_stderr_and_exit_code() -> None:
     command = [
-        "python",
+        sys.executable,
         "-c",
         "import sys; print('out'); print('err', file=sys.stderr); raise SystemExit(3)",
     ]

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py
@@ -37,6 +37,51 @@ def test_public_read_command_uses_blackbox_and_junit_reports(tmp_path: Path) -> 
 
 
 @pytest.mark.unit
+def test_run_command_uses_top_level_cats_fuzz_command(tmp_path: Path) -> None:
+    block = get_builtin_block("public-read")
+    contract_path = tmp_path / "openapi.json"
+    command = build_cats_run_command(
+        block,
+        contract_path=contract_path,
+        server_url="http://127.0.0.1:8000",
+        output_dir=tmp_path / "reports",
+        api_key=DEFAULT_TEST_API_KEY,
+    )
+
+    assert command[:5] == [
+        "cats",
+        "-c",
+        str(contract_path),
+        "-s",
+        "http://127.0.0.1:8000",
+    ]
+    assert command[1] != "run"
+
+
+@pytest.mark.unit
+def test_dry_run_stays_on_top_level_cats_fuzz_command(tmp_path: Path) -> None:
+    block = get_builtin_block("public-read")
+    contract_path = tmp_path / "openapi.json"
+    command = build_cats_run_command(
+        block,
+        contract_path=contract_path,
+        server_url="http://127.0.0.1:8000",
+        output_dir=tmp_path / "reports",
+        api_key=DEFAULT_TEST_API_KEY,
+        dry_run=True,
+    )
+
+    assert command[:5] == [
+        "cats",
+        "-c",
+        str(contract_path),
+        "-s",
+        "http://127.0.0.1:8000",
+    ]
+    assert "--dryRun" in command
+
+
+@pytest.mark.unit
 def test_cats_exit_classification_separates_usage_tool_and_api_failures() -> None:
     assert classify_cats_exit(0, "") == "ok"
     assert classify_cats_exit(2, "Invalid value for option") == "usage"

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
@@ -292,6 +292,14 @@ def test_openapi_export_failure_writes_logs_and_stops_before_blocks(
 def test_cats_version_uses_first_output_line(monkeypatch: pytest.MonkeyPatch) -> None:
     from Helper_Scripts.cats_fuzz import cli
 
+    cats_banner_output = """# # # # # # # # # # # # # # # # # # # # # # # # # #
+#             _____   ___ _____ _____             #
+# # # # # # # # # # # # # # # # # # # # # # # # # #
+
+CATS version 13.8.0
+Built on: 2026-04-01 17:42:27 UTC
+"""
+
     def fake_run(
         command: list[str],
         *,
@@ -303,11 +311,11 @@ def test_cats_version_uses_first_output_line(monkeypatch: pytest.MonkeyPatch) ->
         assert check is False
         assert capture_output is True
         assert text is True
-        return subprocess.CompletedProcess(command, 0, stdout="cats 13.8.0\nextra\n", stderr="")
+        return subprocess.CompletedProcess(command, 0, stdout=cats_banner_output, stderr="")
 
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
 
-    assert cli._cats_version("cats") == "cats 13.8.0"
+    assert cli._cats_version("cats") == "CATS version 13.8.0"
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
@@ -102,6 +102,15 @@ def test_runtime_default_blocks_start_server_use_started_url_and_stop_finally(
 
     events: list[tuple[str, object]] = []
     server = SimpleNamespace(url="http://127.0.0.1:9123")
+    child_env = {
+        "SAFE": "1",
+        "TEST_MODE": "true",
+        "TLDW_ENV_FILE": str(tmp_path / "runtime" / ".env"),
+    }
+    server_env = {
+        "SAFE": "1",
+        "TLDW_ENV_FILE": str(tmp_path / "runtime" / "cats-server.env"),
+    }
 
     def fake_run(
         command: list[str],
@@ -150,7 +159,13 @@ def test_runtime_default_blocks_start_server_use_started_url_and_stop_finally(
         )
         return _summary(getattr(block, "name"), 5)
 
-    monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: {"SAFE": "1"})
+    def fake_build_server_env(output_dir: Path, env: dict[str, str]) -> dict[str, str]:
+        assert output_dir == tmp_path
+        assert env is child_env
+        return server_env
+
+    monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: child_env)
+    monkeypatch.setattr(cli, "build_server_env", fake_build_server_env)
     monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
     monkeypatch.setattr(cli, "_cats_version", lambda cats_bin: "cats 13.8.0")
@@ -162,7 +177,15 @@ def test_runtime_default_blocks_start_server_use_started_url_and_stop_finally(
     result = cli.main(["--output", str(tmp_path)])
 
     assert result == 5
-    assert events[1] == ("start", ({"SAFE": "1"}, tmp_path / "server"))
+    assert events[0] == (
+        "export",
+        (["python", "export", str(tmp_path / "openapi.json")], False, child_env),
+    )
+    assert events[1] == ("start", (server_env, tmp_path / "server"))
+    started_env = events[1][1][0]
+    assert started_env is server_env
+    assert started_env.get("TEST_MODE", "") == ""
+    assert started_env["TLDW_ENV_FILE"] != child_env["TLDW_ENV_FILE"]
     assert events[2][0] == "contract"
     assert events[3] == (
         "runtime",
@@ -174,7 +197,7 @@ def test_runtime_default_blocks_start_server_use_started_url_and_stop_finally(
             "cats 13.8.0",
             "cats",
             False,
-            {"SAFE": "1"},
+            child_env,
         ),
     )
     assert events[-1] == ("stop", server)

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
@@ -255,7 +255,7 @@ def test_runtime_run_with_existing_server_url_does_not_start_server(
 
 @pytest.mark.unit
 def test_runtime_without_server_url_and_no_start_server_raises_before_env_or_export(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     from Helper_Scripts.cats_fuzz import cli
 
@@ -268,8 +268,41 @@ def test_runtime_without_server_url_and_no_start_server_raises_before_env_or_exp
     monkeypatch.setattr(cli, "build_child_env", fail_build_child_env)
     monkeypatch.setattr(cli.subprocess, "run", fail_run)
 
-    with pytest.raises(ValueError, match="public-read requires --server-url or --start-server"):
+    with pytest.raises(SystemExit) as exc_info:
         cli.main(["--block", "public-read", "--no-start-server", "--output", str(tmp_path)])
+    assert exc_info.value.code == 2
+    assert "public-read requires --server-url or --start-server" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_runtime_rejects_non_loopback_existing_server_url_before_env_or_export(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from Helper_Scripts.cats_fuzz import cli
+
+    def fail_build_child_env(*args: object, **kwargs: object) -> None:
+        raise AssertionError("child env should not be built for remote runtime invocation")
+
+    def fail_run(*args: object, **kwargs: object) -> None:
+        raise AssertionError("OpenAPI export should not run for remote runtime invocation")
+
+    monkeypatch.setattr(cli, "build_child_env", fail_build_child_env)
+    monkeypatch.setattr(cli.subprocess, "run", fail_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "--block",
+                "public-read",
+                "--server-url",
+                "https://prod.example",
+                "--no-start-server",
+                "--output",
+                str(tmp_path),
+            ]
+        )
+    assert exc_info.value.code == 2
+    assert "public-read only allows loopback --server-url values" in capsys.readouterr().err
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
@@ -30,6 +30,16 @@ def test_cli_accepts_existing_server_url() -> None:
     assert args.start_server is False
 
 
+@pytest.mark.unit
+def test_cli_server_url_without_start_flag_uses_existing_server() -> None:
+    from Helper_Scripts.cats_fuzz.cli import parse_args
+
+    args = parse_args(["--server-url", "http://127.0.0.1:8000"])
+
+    assert args.server_url == "http://127.0.0.1:8000"
+    assert args.start_server is False
+
+
 def _summary(block: str, exit_code: int) -> CatsRunSummary:
     return CatsRunSummary(
         block=block,
@@ -244,6 +254,55 @@ def test_runtime_run_with_existing_server_url_does_not_start_server(
             "--server-url",
             "http://127.0.0.1:8000",
             "--no-start-server",
+            "--output",
+            str(tmp_path),
+        ]
+    )
+
+    assert result == 0
+    assert runtime_calls == [("public-read", "http://127.0.0.1:8000")]
+
+
+@pytest.mark.unit
+def test_runtime_run_with_server_url_only_does_not_start_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from Helper_Scripts.cats_fuzz import cli
+
+    runtime_calls: list[tuple[str, str]] = []
+
+    def fail_start_server(*args: object, **kwargs: object) -> None:
+        raise AssertionError("server URL should skip server startup unless --start-server is explicit")
+
+    def fake_run_runtime_block(
+        block: object,
+        contract_path: Path,
+        server_url: str,
+        output_dir: Path,
+        cats_version: str,
+        *,
+        cats_bin: str,
+        dry_run: bool,
+        env: dict[str, str],
+    ) -> CatsRunSummary:
+        runtime_calls.append((getattr(block, "name"), server_url))
+        return _summary(getattr(block, "name"), 0)
+
+    monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: {"SAFE": "1"})
+    monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
+    monkeypatch.setattr(
+        cli.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr="")
+    )
+    monkeypatch.setattr(cli, "_cats_version", lambda cats_bin: "cats 13.8.0")
+    monkeypatch.setattr(cli, "start_server", fail_start_server)
+    monkeypatch.setattr(cli, "run_runtime_block", fake_run_runtime_block)
+
+    result = cli.main(
+        [
+            "--block",
+            "public-read",
+            "--server-url",
+            "http://127.0.0.1:8000",
             "--output",
             str(tmp_path),
         ]

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from Helper_Scripts.cats_fuzz.summary import CatsRunSummary
+
+
+@pytest.mark.unit
+def test_cli_defaults_to_contract_and_public_read() -> None:
+    from Helper_Scripts.cats_fuzz.cli import parse_args
+
+    args = parse_args([])
+
+    assert args.block == ["contract", "public-read"]
+    assert args.output == "artifacts/cats-fuzz"
+    assert args.start_server is True
+
+
+@pytest.mark.unit
+def test_cli_accepts_existing_server_url() -> None:
+    from Helper_Scripts.cats_fuzz.cli import parse_args
+
+    args = parse_args(["--server-url", "http://127.0.0.1:8000", "--no-start-server"])
+
+    assert args.server_url == "http://127.0.0.1:8000"
+    assert args.start_server is False
+
+
+def _summary(block: str, exit_code: int) -> CatsRunSummary:
+    return CatsRunSummary(
+        block=block,
+        cats_version="cats 13.8.0",
+        openapi_sha256="abc123",
+        command=["cats"],
+        masked_command=["cats"],
+        exit_code=exit_code,
+        failure_class="ok" if exit_code == 0 else "api",
+        stdout_path=f"{block}/stdout.log",
+        stderr_path=f"{block}/stderr.log",
+        report_dir=f"{block}/cats-report",
+    )
+
+
+@pytest.mark.unit
+def test_contract_only_run_exports_openapi_and_returns_contract_exit_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from Helper_Scripts.cats_fuzz import cli
+
+    calls: list[tuple[str, object]] = []
+
+    def fake_run(command: list[str], *, check: bool = False, env: dict[str, str] | None = None) -> object:
+        calls.append(("subprocess", (command, check, env)))
+        return SimpleNamespace(stdout="", stderr="")
+
+    def fail_start_server(*args: object, **kwargs: object) -> None:
+        raise AssertionError("contract-only run should not start a server")
+
+    def fake_run_contract_block(
+        contract_path: Path,
+        output_dir: Path,
+        cats_version: str,
+        *,
+        cats_bin: str,
+    ) -> CatsRunSummary:
+        calls.append(("contract", (contract_path, output_dir, cats_version, cats_bin)))
+        return _summary("contract", 7)
+
+    monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: {"SAFE": "1"})
+    monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli, "_cats_version", lambda cats_bin: "cats 13.8.0")
+    monkeypatch.setattr(cli, "start_server", fail_start_server)
+    monkeypatch.setattr(cli, "run_contract_block", fake_run_contract_block)
+
+    result = cli.main(["--block", "contract", "--output", str(tmp_path)])
+
+    assert result == 7
+    assert calls[0] == ("subprocess", (["python", "export", str(tmp_path / "openapi.json")], True, {"SAFE": "1"}))
+    assert calls[1] == ("contract", (tmp_path / "openapi.json", tmp_path, "cats 13.8.0", "cats"))
+
+
+@pytest.mark.unit
+def test_runtime_default_blocks_start_server_use_started_url_and_stop_finally(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from Helper_Scripts.cats_fuzz import cli
+
+    events: list[tuple[str, object]] = []
+    server = SimpleNamespace(url="http://127.0.0.1:9123")
+
+    def fake_run(command: list[str], *, check: bool = False, env: dict[str, str] | None = None) -> object:
+        events.append(("export", (command, check, env)))
+        return SimpleNamespace(stdout="", stderr="")
+
+    def fake_start_server(env: dict[str, str], *, log_dir: Path) -> SimpleNamespace:
+        events.append(("start", (env, log_dir)))
+        return server
+
+    def fake_stop_server(started_server: SimpleNamespace) -> None:
+        events.append(("stop", started_server))
+
+    def fake_run_contract_block(
+        contract_path: Path,
+        output_dir: Path,
+        cats_version: str,
+        *,
+        cats_bin: str,
+    ) -> CatsRunSummary:
+        events.append(("contract", (contract_path, output_dir, cats_version, cats_bin)))
+        return _summary("contract", 0)
+
+    def fake_run_runtime_block(
+        block: object,
+        contract_path: Path,
+        server_url: str,
+        output_dir: Path,
+        cats_version: str,
+        *,
+        cats_bin: str,
+        dry_run: bool,
+        env: dict[str, str],
+    ) -> CatsRunSummary:
+        events.append(
+            (
+                "runtime",
+                (getattr(block, "name"), contract_path, server_url, output_dir, cats_version, cats_bin, dry_run, env),
+            )
+        )
+        return _summary(getattr(block, "name"), 5)
+
+    monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: {"SAFE": "1"})
+    monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli, "_cats_version", lambda cats_bin: "cats 13.8.0")
+    monkeypatch.setattr(cli, "start_server", fake_start_server)
+    monkeypatch.setattr(cli, "stop_server", fake_stop_server)
+    monkeypatch.setattr(cli, "run_contract_block", fake_run_contract_block)
+    monkeypatch.setattr(cli, "run_runtime_block", fake_run_runtime_block)
+
+    result = cli.main(["--output", str(tmp_path)])
+
+    assert result == 5
+    assert events[1] == ("start", ({"SAFE": "1"}, tmp_path / "server"))
+    assert events[2][0] == "contract"
+    assert events[3] == (
+        "runtime",
+        (
+            "public-read",
+            tmp_path / "openapi.json",
+            "http://127.0.0.1:9123",
+            tmp_path,
+            "cats 13.8.0",
+            "cats",
+            False,
+            {"SAFE": "1"},
+        ),
+    )
+    assert events[-1] == ("stop", server)
+
+
+@pytest.mark.unit
+def test_runtime_run_with_existing_server_url_does_not_start_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from Helper_Scripts.cats_fuzz import cli
+
+    runtime_calls: list[tuple[str, str]] = []
+
+    def fail_start_server(*args: object, **kwargs: object) -> None:
+        raise AssertionError("existing server URL should skip server startup")
+
+    def fake_run_runtime_block(
+        block: object,
+        contract_path: Path,
+        server_url: str,
+        output_dir: Path,
+        cats_version: str,
+        *,
+        cats_bin: str,
+        dry_run: bool,
+        env: dict[str, str],
+    ) -> CatsRunSummary:
+        runtime_calls.append((getattr(block, "name"), server_url))
+        return _summary(getattr(block, "name"), 0)
+
+    monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: {"SAFE": "1"})
+    monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
+    monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(stdout="", stderr=""))
+    monkeypatch.setattr(cli, "_cats_version", lambda cats_bin: "cats 13.8.0")
+    monkeypatch.setattr(cli, "start_server", fail_start_server)
+    monkeypatch.setattr(cli, "run_runtime_block", fake_run_runtime_block)
+
+    result = cli.main(
+        [
+            "--block",
+            "public-read",
+            "--server-url",
+            "http://127.0.0.1:8000",
+            "--no-start-server",
+            "--output",
+            str(tmp_path),
+        ]
+    )
+
+    assert result == 0
+    assert runtime_calls == [("public-read", "http://127.0.0.1:8000")]
+
+
+@pytest.mark.unit
+def test_runtime_without_server_url_and_no_start_server_raises_clear_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from Helper_Scripts.cats_fuzz import cli
+
+    monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: {"SAFE": "1"})
+    monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
+    monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(stdout="", stderr=""))
+    monkeypatch.setattr(cli, "_cats_version", lambda cats_bin: "cats 13.8.0")
+
+    with pytest.raises(ValueError, match="public-read requires --server-url or --start-server"):
+        cli.main(["--block", "public-read", "--no-start-server", "--output", str(tmp_path)])
+
+
+@pytest.mark.unit
+def test_cats_version_uses_first_output_line(monkeypatch: pytest.MonkeyPatch) -> None:
+    from Helper_Scripts.cats_fuzz import cli
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool = False,
+        capture_output: bool = False,
+        text: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        assert command == ["cats", "--version"]
+        assert check is False
+        assert capture_output is True
+        assert text is True
+        return subprocess.CompletedProcess(command, 0, stdout="cats 13.8.0\nextra\n", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    assert cli._cats_version("cats") == "cats 13.8.0"
+
+
+@pytest.mark.unit
+def test_cats_version_falls_back_to_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    from Helper_Scripts.cats_fuzz import cli
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["cats", "--version"], 127, stdout="", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    assert cli._cats_version("cats") == "unknown"

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
@@ -40,6 +40,28 @@ def test_cli_server_url_without_start_flag_uses_existing_server() -> None:
     assert args.start_server is False
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "server_url",
+    [
+        "http://127.0.0.1:8000/prefix",
+        "http://127.0.0.1:8000?debug=1",
+        "http://127.0.0.1:8000#fragment",
+    ],
+)
+def test_cli_rejects_existing_server_url_with_path_query_or_fragment(
+    server_url: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from Helper_Scripts.cats_fuzz.cli import parse_args
+
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--block", "public-read", "--server-url", server_url])
+
+    assert exc_info.value.code == 2
+    assert "must be an origin URL without a path, query, or fragment" in capsys.readouterr().err
+
+
 def _summary(block: str, exit_code: int) -> CatsRunSummary:
     return CatsRunSummary(
         block=block,
@@ -69,9 +91,10 @@ def test_contract_only_run_exports_openapi_and_returns_contract_exit_code(
         check: bool = False,
         capture_output: bool = False,
         text: bool = False,
+        timeout: int | None = None,
         env: dict[str, str] | None = None,
     ) -> object:
-        calls.append(("subprocess", (command, check, capture_output, text, env)))
+        calls.append(("subprocess", (command, check, capture_output, text, timeout, env)))
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     def fail_start_server(*args: object, **kwargs: object) -> None:
@@ -99,7 +122,7 @@ def test_contract_only_run_exports_openapi_and_returns_contract_exit_code(
     assert result == 7
     assert calls[0] == (
         "subprocess",
-        (["python", "export", str(tmp_path / "openapi.json")], False, True, True, {"SAFE": "1"}),
+        (["python", "export", str(tmp_path / "openapi.json")], False, True, True, 120, {"SAFE": "1"}),
     )
     assert calls[1] == ("contract", (tmp_path / "openapi.json", tmp_path, "cats 13.8.0", "cats"))
 
@@ -128,9 +151,10 @@ def test_runtime_default_blocks_start_server_use_started_url_and_stop_finally(
         check: bool = False,
         capture_output: bool = False,
         text: bool = False,
+        timeout: int | None = None,
         env: dict[str, str] | None = None,
     ) -> object:
-        events.append(("export", (command, check, env)))
+        events.append(("export", (command, check, timeout, env)))
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     def fake_start_server(env: dict[str, str], *, log_dir: Path) -> SimpleNamespace:
@@ -189,7 +213,7 @@ def test_runtime_default_blocks_start_server_use_started_url_and_stop_finally(
     assert result == 5
     assert events[0] == (
         "export",
-        (["python", "export", str(tmp_path / "openapi.json")], False, child_env),
+        (["python", "export", str(tmp_path / "openapi.json")], False, 120, child_env),
     )
     assert events[1] == ("start", (server_env, tmp_path / "server"))
     started_env = events[1][1][0]
@@ -366,9 +390,11 @@ def test_runtime_rejects_non_loopback_existing_server_url_before_env_or_export(
 
 @pytest.mark.unit
 def test_openapi_export_failure_writes_logs_and_stops_before_blocks(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from Helper_Scripts.cats_fuzz import cli
+
+    errors: list[str] = []
 
     def fake_run(
         command: list[str],
@@ -376,12 +402,14 @@ def test_openapi_export_failure_writes_logs_and_stops_before_blocks(
         check: bool = False,
         capture_output: bool = False,
         text: bool = False,
+        timeout: int | None = None,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         assert command == ["python", "export", str(tmp_path / "openapi.json")]
         assert check is False
         assert capture_output is True
         assert text is True
+        assert timeout == 120
         assert env == {"SAFE": "1"}
         return subprocess.CompletedProcess(command, 9, stdout="export out", stderr="export err")
 
@@ -391,6 +419,9 @@ def test_openapi_export_failure_writes_logs_and_stops_before_blocks(
     monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: {"SAFE": "1"})
     monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        cli, "logger", SimpleNamespace(error=lambda message, *args: errors.append(message.format(*args)))
+    )
     monkeypatch.setattr(cli, "start_server", fail_start_or_run)
     monkeypatch.setattr(cli, "run_contract_block", fail_start_or_run)
     monkeypatch.setattr(cli, "run_runtime_block", fail_start_or_run)
@@ -400,7 +431,41 @@ def test_openapi_export_failure_writes_logs_and_stops_before_blocks(
     assert result == 9
     assert (tmp_path / "openapi-export.stdout.log").read_text(encoding="utf-8") == "export out"
     assert (tmp_path / "openapi-export.stderr.log").read_text(encoding="utf-8") == "export err"
-    assert f"OpenAPI export failed; see {tmp_path / 'openapi-export.stderr.log'}" in capsys.readouterr().err
+    assert errors == [f"OpenAPI export failed; see {tmp_path / 'openapi-export.stderr.log'}"]
+
+
+@pytest.mark.unit
+def test_openapi_export_timeout_writes_partial_logs_and_returns_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from Helper_Scripts.cats_fuzz import cli
+
+    errors: list[str] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool = False,
+        capture_output: bool = False,
+        text: bool = False,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, timeout or 0, output="partial stdout", stderr=b"partial stderr")
+
+    monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        cli, "logger", SimpleNamespace(error=lambda message, *args: errors.append(message.format(*args)))
+    )
+
+    result = cli._export_openapi_contract(tmp_path / "openapi.json", {"SAFE": "1"}, tmp_path)
+
+    assert result == 124
+    assert (tmp_path / "openapi-export.stdout.log").read_text(encoding="utf-8") == "partial stdout"
+    assert (tmp_path / "openapi-export.stderr.log").read_text(encoding="utf-8") == "partial stderr"
+    assert errors == [f"OpenAPI export timed out after 120 seconds; see {tmp_path / 'openapi-export.stderr.log'}"]
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py
@@ -53,9 +53,16 @@ def test_contract_only_run_exports_openapi_and_returns_contract_exit_code(
 
     calls: list[tuple[str, object]] = []
 
-    def fake_run(command: list[str], *, check: bool = False, env: dict[str, str] | None = None) -> object:
-        calls.append(("subprocess", (command, check, env)))
-        return SimpleNamespace(stdout="", stderr="")
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool = False,
+        capture_output: bool = False,
+        text: bool = False,
+        env: dict[str, str] | None = None,
+    ) -> object:
+        calls.append(("subprocess", (command, check, capture_output, text, env)))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     def fail_start_server(*args: object, **kwargs: object) -> None:
         raise AssertionError("contract-only run should not start a server")
@@ -80,7 +87,10 @@ def test_contract_only_run_exports_openapi_and_returns_contract_exit_code(
     result = cli.main(["--block", "contract", "--output", str(tmp_path)])
 
     assert result == 7
-    assert calls[0] == ("subprocess", (["python", "export", str(tmp_path / "openapi.json")], True, {"SAFE": "1"}))
+    assert calls[0] == (
+        "subprocess",
+        (["python", "export", str(tmp_path / "openapi.json")], False, True, True, {"SAFE": "1"}),
+    )
     assert calls[1] == ("contract", (tmp_path / "openapi.json", tmp_path, "cats 13.8.0", "cats"))
 
 
@@ -93,9 +103,16 @@ def test_runtime_default_blocks_start_server_use_started_url_and_stop_finally(
     events: list[tuple[str, object]] = []
     server = SimpleNamespace(url="http://127.0.0.1:9123")
 
-    def fake_run(command: list[str], *, check: bool = False, env: dict[str, str] | None = None) -> object:
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool = False,
+        capture_output: bool = False,
+        text: bool = False,
+        env: dict[str, str] | None = None,
+    ) -> object:
         events.append(("export", (command, check, env)))
-        return SimpleNamespace(stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     def fake_start_server(env: dict[str, str], *, log_dir: Path) -> SimpleNamespace:
         events.append(("start", (env, log_dir)))
@@ -190,7 +207,9 @@ def test_runtime_run_with_existing_server_url_does_not_start_server(
 
     monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: {"SAFE": "1"})
     monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
-    monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(stdout="", stderr=""))
+    monkeypatch.setattr(
+        cli.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr="")
+    )
     monkeypatch.setattr(cli, "_cats_version", lambda cats_bin: "cats 13.8.0")
     monkeypatch.setattr(cli, "start_server", fail_start_server)
     monkeypatch.setattr(cli, "run_runtime_block", fake_run_runtime_block)
@@ -212,18 +231,61 @@ def test_runtime_run_with_existing_server_url_does_not_start_server(
 
 
 @pytest.mark.unit
-def test_runtime_without_server_url_and_no_start_server_raises_clear_error(
+def test_runtime_without_server_url_and_no_start_server_raises_before_env_or_export(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from Helper_Scripts.cats_fuzz import cli
 
-    monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: {"SAFE": "1"})
-    monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
-    monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(stdout="", stderr=""))
-    monkeypatch.setattr(cli, "_cats_version", lambda cats_bin: "cats 13.8.0")
+    def fail_build_child_env(*args: object, **kwargs: object) -> None:
+        raise AssertionError("child env should not be built for invalid runtime invocation")
+
+    def fail_run(*args: object, **kwargs: object) -> None:
+        raise AssertionError("OpenAPI export should not run for invalid runtime invocation")
+
+    monkeypatch.setattr(cli, "build_child_env", fail_build_child_env)
+    monkeypatch.setattr(cli.subprocess, "run", fail_run)
 
     with pytest.raises(ValueError, match="public-read requires --server-url or --start-server"):
         cli.main(["--block", "public-read", "--no-start-server", "--output", str(tmp_path)])
+
+
+@pytest.mark.unit
+def test_openapi_export_failure_writes_logs_and_stops_before_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from Helper_Scripts.cats_fuzz import cli
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool = False,
+        capture_output: bool = False,
+        text: bool = False,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        assert command == ["python", "export", str(tmp_path / "openapi.json")]
+        assert check is False
+        assert capture_output is True
+        assert text is True
+        assert env == {"SAFE": "1"}
+        return subprocess.CompletedProcess(command, 9, stdout="export out", stderr="export err")
+
+    def fail_start_or_run(*args: object, **kwargs: object) -> None:
+        raise AssertionError("server and CATS blocks should not run after export failure")
+
+    monkeypatch.setattr(cli, "build_child_env", lambda output_dir, allow_external=False: {"SAFE": "1"})
+    monkeypatch.setattr(cli, "build_openapi_export_command", lambda path: ["python", "export", str(path)])
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli, "start_server", fail_start_or_run)
+    monkeypatch.setattr(cli, "run_contract_block", fail_start_or_run)
+    monkeypatch.setattr(cli, "run_runtime_block", fail_start_or_run)
+
+    result = cli.main(["--output", str(tmp_path)])
+
+    assert result == 9
+    assert (tmp_path / "openapi-export.stdout.log").read_text(encoding="utf-8") == "export out"
+    assert (tmp_path / "openapi-export.stderr.log").read_text(encoding="utf-8") == "export err"
+    assert f"OpenAPI export failed; see {tmp_path / 'openapi-export.stderr.log'}" in capsys.readouterr().err
 
 
 @pytest.mark.unit
@@ -253,7 +315,7 @@ def test_cats_version_falls_back_to_unknown(monkeypatch: pytest.MonkeyPatch) -> 
     from Helper_Scripts.cats_fuzz import cli
 
     def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(["cats", "--version"], 127, stdout="", stderr="")
+        return subprocess.CompletedProcess(["cats", "--version"], 127, stdout="", stderr="cats error")
 
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
 

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
+import hashlib
+import json
+import sys
+import types
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
 
 from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
 from Helper_Scripts.cats_fuzz.env import build_child_env, find_sensitive_values
-from Helper_Scripts.cats_fuzz.openapi_export import build_openapi_export_command
+from Helper_Scripts.cats_fuzz.openapi_export import (
+    build_openapi_export_command,
+    export_openapi,
+    main,
+)
 
 
 @pytest.mark.unit
@@ -27,6 +36,24 @@ def test_find_sensitive_values_ignores_empty_sensitive_values() -> None:
 def test_build_child_env_rejects_real_credentials_by_default(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="real credentials"):
         build_child_env(tmp_path, parent_env={"OPENAI_API_KEY": "sk-real"})
+
+
+@pytest.mark.unit
+def test_build_child_env_overwrites_single_user_key_without_rejecting(tmp_path: Path) -> None:
+    env = build_child_env(tmp_path, parent_env={"SINGLE_USER_API_KEY": "dev-key"})
+
+    assert env["SINGLE_USER_API_KEY"] == DEFAULT_TEST_API_KEY
+
+
+@pytest.mark.unit
+def test_build_child_env_blanks_tool_tokens_without_rejecting(tmp_path: Path) -> None:
+    env = build_child_env(
+        tmp_path,
+        parent_env={"GITHUB_TOKEN": "gh-real", "SAFE": "value"},
+    )
+
+    assert env["SAFE"] == "value"
+    assert env["GITHUB_TOKEN"] == ""
 
 
 @pytest.mark.unit
@@ -60,3 +87,51 @@ def test_openapi_export_command_uses_module_and_output_path(tmp_path: Path) -> N
 
     assert command[:3] == ["python", "-m", "Helper_Scripts.cats_fuzz.openapi_export"]
     assert str(output) in command
+
+
+@pytest.mark.unit
+def test_export_openapi_clears_cache_creates_parent_and_writes_deterministic_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_app = FastAPI(title="CATS Test")
+    fake_app.openapi_schema = {"stale": True}
+    fake_module = types.ModuleType("tldw_Server_API.app.main")
+    fake_module.app = fake_app
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.main", fake_module)
+    output = tmp_path / "nested" / "openapi.json"
+
+    digest = export_openapi(output)
+    first_bytes = output.read_bytes()
+    second_digest = export_openapi(output)
+    second_bytes = output.read_bytes()
+
+    assert output.parent.exists()
+    assert digest == hashlib.sha256(first_bytes).hexdigest()
+    assert second_digest == digest
+    assert second_bytes == first_bytes
+    schema = json.loads(first_bytes)
+    assert schema["info"]["title"] == "CATS Test"
+    assert "stale" not in schema
+
+
+@pytest.mark.unit
+def test_openapi_export_main_prints_digest_and_returns_zero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "openapi.json"
+    calls: list[Path] = []
+
+    def fake_export(path: Path) -> str:
+        calls.append(path)
+        return "abc123"
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.openapi_export.export_openapi", fake_export)
+
+    result = main(["--output", str(output)])
+
+    assert result == 0
+    assert calls == [output]
+    assert capsys.readouterr().out == "abc123\n"

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi import FastAPI
 
 from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
+from Helper_Scripts.cats_fuzz import env as cats_env
 from Helper_Scripts.cats_fuzz.env import build_child_env, find_sensitive_values
 from Helper_Scripts.cats_fuzz.openapi_export import (
     build_openapi_export_command,
@@ -78,6 +79,41 @@ def test_build_child_env_blanks_sensitive_parent_values_when_external_allowed(tm
 
     assert env["SAFE"] == "value"
     assert env["OPENAI_API_KEY"] == ""
+
+
+@pytest.mark.unit
+def test_build_server_env_removes_guarded_test_flags_and_writes_safe_env_file(tmp_path: Path) -> None:
+    child_env = build_child_env(
+        tmp_path,
+        parent_env={
+            "SAFE": "value",
+            "TESTING": "true",
+            "TLDW_TEST_MODE": "1",
+        },
+    )
+    assert child_env["TEST_MODE"] == "true"
+
+    server_env = cats_env.build_server_env(tmp_path, child_env)
+
+    for flag in ("TEST_MODE", "TESTING", "TLDW_TEST_MODE"):
+        assert server_env.get(flag, "") == ""
+
+    assert server_env["SAFE"] == "value"
+    assert server_env["AUTH_MODE"] == "single_user"
+    assert server_env["SINGLE_USER_API_KEY"] == DEFAULT_TEST_API_KEY
+    assert server_env["SINGLE_USER_TEST_API_KEY"] == DEFAULT_TEST_API_KEY
+    assert server_env["DATABASE_URL"].startswith("sqlite:///")
+    assert server_env["USER_DB_BASE_DIR"] == child_env["USER_DB_BASE_DIR"]
+    assert server_env["MINIMAL_TEST_APP"] == "1"
+    assert server_env["MINIMAL_TEST_INCLUDE_AUDIO"] == "1"
+    assert server_env["TLDW_ENV_FILE"] != child_env["TLDW_ENV_FILE"]
+
+    server_env_file = Path(server_env["TLDW_ENV_FILE"])
+    assert server_env_file.exists()
+    server_env_text = server_env_file.read_text(encoding="utf-8")
+    assert "TEST_MODE" not in server_env_text
+    assert "TESTING" not in server_env_text
+    assert "TLDW_TEST_MODE" not in server_env_text
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
@@ -66,6 +66,9 @@ def test_build_child_env_sets_test_paths_and_sentinels(tmp_path: Path) -> None:
     assert env["SINGLE_USER_TEST_API_KEY"] == DEFAULT_TEST_API_KEY
     assert env["DATABASE_URL"].startswith("sqlite:///")
     assert Path(env["TLDW_ENV_FILE"]).exists()
+    assert Path(env["TLDW_CONFIG_FILE"]).exists()
+    assert env["TLDW_CONFIG_PATH"] == env["TLDW_CONFIG_FILE"]
+    assert Path(env["TLDW_CONFIG_DIR"]).exists()
     assert env["OPENAI_API_KEY"] == ""
 
 
@@ -79,6 +82,36 @@ def test_build_child_env_blanks_sensitive_parent_values_when_external_allowed(tm
 
     assert env["SAFE"] == "value"
     assert env["OPENAI_API_KEY"] == ""
+
+
+@pytest.mark.unit
+def test_build_child_env_writes_inert_runtime_config_and_env_files(tmp_path: Path) -> None:
+    external_values = {
+        "OPENAI_API_KEY": "sk-real",
+        "CUSTOM_OPENAI_API_URL": "https://prod-llm.example/v1",
+        "CUSTOM_OPENAI_API_BASE_URL": "https://prod-base.example/v1",
+        "CUSTOM_OPENAI_API_2_BASE": "https://prod-second.example/v1",
+        "CUSTOM_OPENAI37_API_URL": "https://prod-dynamic.example/v1",
+        "OPENAI_API_BASE_URL": "https://prod-openai-proxy.example/v1",
+        "BEDROCK_API_BASE_URL": "https://bedrock.example",
+        "BEDROCK_OPENAI_BASE_URL": "https://bedrock-openai.example/v1",
+        "BEDROCK_RUNTIME_ENDPOINT": "https://bedrock-runtime.example",
+    }
+    env = build_child_env(
+        tmp_path,
+        parent_env=external_values,
+        allow_external=True,
+    )
+
+    for name in external_values:
+        assert env[name] == ""
+
+    config_text = Path(env["TLDW_CONFIG_FILE"]).read_text(encoding="utf-8")
+    env_text = Path(env["TLDW_ENV_FILE"]).read_text(encoding="utf-8")
+    combined_text = config_text + env_text
+    for value in external_values.values():
+        assert value not in combined_text
+    assert "disable = setup" in config_text
 
 
 @pytest.mark.unit
@@ -106,6 +139,9 @@ def test_build_server_env_removes_guarded_test_flags_and_writes_safe_env_file(tm
     assert server_env["USER_DB_BASE_DIR"] == child_env["USER_DB_BASE_DIR"]
     assert server_env["MINIMAL_TEST_APP"] == "1"
     assert server_env["MINIMAL_TEST_INCLUDE_AUDIO"] == "1"
+    assert server_env["TLDW_CONFIG_FILE"] == child_env["TLDW_CONFIG_FILE"]
+    assert server_env["TLDW_CONFIG_PATH"] == child_env["TLDW_CONFIG_PATH"]
+    assert server_env["TLDW_CONFIG_DIR"] == child_env["TLDW_CONFIG_DIR"]
     assert server_env["TLDW_ENV_FILE"] != child_env["TLDW_ENV_FILE"]
 
     server_env_file = Path(server_env["TLDW_ENV_FILE"])
@@ -121,7 +157,7 @@ def test_openapi_export_command_uses_module_and_output_path(tmp_path: Path) -> N
     output = tmp_path / "openapi.json"
     command = build_openapi_export_command(output)
 
-    assert command[:3] == ["python", "-m", "Helper_Scripts.cats_fuzz.openapi_export"]
+    assert command[:3] == [sys.executable, "-m", "Helper_Scripts.cats_fuzz.openapi_export"]
     assert str(output) in command
 
 

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
@@ -115,6 +115,27 @@ def test_build_child_env_writes_inert_runtime_config_and_env_files(tmp_path: Pat
 
 
 @pytest.mark.unit
+def test_build_child_env_blanks_route_policy_overrides_for_deterministic_export(tmp_path: Path) -> None:
+    env = build_child_env(
+        tmp_path,
+        parent_env={
+            "ROUTES_STABLE_ONLY": "1",
+            "ROUTES_DISABLE": "chat,rag",
+            "ROUTES_ENABLE": "setup",
+            "ROUTES_EXPERIMENTAL": "labs",
+        },
+    )
+
+    for name in ("ROUTES_STABLE_ONLY", "ROUTES_DISABLE", "ROUTES_ENABLE", "ROUTES_EXPERIMENTAL"):
+        assert env[name] == ""
+
+    config_text = Path(env["TLDW_CONFIG_FILE"]).read_text(encoding="utf-8")
+    assert "disable = setup" in config_text
+    assert "chat,rag" not in config_text
+    assert "labs" not in config_text
+
+
+@pytest.mark.unit
 def test_build_server_env_removes_guarded_test_flags_and_writes_safe_env_file(tmp_path: Path) -> None:
     child_env = build_child_env(
         tmp_path,

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
+from Helper_Scripts.cats_fuzz.env import build_child_env, find_sensitive_values
+from Helper_Scripts.cats_fuzz.openapi_export import build_openapi_export_command
+
+
+@pytest.mark.unit
+def test_find_sensitive_values_detects_provider_keys() -> None:
+    found = find_sensitive_values({"OPENAI_API_KEY": "sk-real", "SAFE": "value"})
+
+    assert found == {"OPENAI_API_KEY": "set"}
+
+
+@pytest.mark.unit
+def test_find_sensitive_values_ignores_empty_sensitive_values() -> None:
+    found = find_sensitive_values({"ANTHROPIC_API_KEY": "", "SAFE": "value"})
+
+    assert found == {}
+
+
+@pytest.mark.unit
+def test_build_child_env_rejects_real_credentials_by_default(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="real credentials"):
+        build_child_env(tmp_path, parent_env={"OPENAI_API_KEY": "sk-real"})
+
+
+@pytest.mark.unit
+def test_build_child_env_sets_test_paths_and_sentinels(tmp_path: Path) -> None:
+    env = build_child_env(tmp_path, parent_env={}, allow_external=False)
+
+    assert env["AUTH_MODE"] == "single_user"
+    assert env["SINGLE_USER_API_KEY"] == DEFAULT_TEST_API_KEY
+    assert env["SINGLE_USER_TEST_API_KEY"] == DEFAULT_TEST_API_KEY
+    assert env["DATABASE_URL"].startswith("sqlite:///")
+    assert Path(env["TLDW_ENV_FILE"]).exists()
+    assert env["OPENAI_API_KEY"] == ""
+
+
+@pytest.mark.unit
+def test_build_child_env_blanks_sensitive_parent_values_when_external_allowed(tmp_path: Path) -> None:
+    env = build_child_env(
+        tmp_path,
+        parent_env={"OPENAI_API_KEY": "sk-real", "SAFE": "value"},
+        allow_external=True,
+    )
+
+    assert env["SAFE"] == "value"
+    assert env["OPENAI_API_KEY"] == ""
+
+
+@pytest.mark.unit
+def test_openapi_export_command_uses_module_and_output_path(tmp_path: Path) -> None:
+    output = tmp_path / "openapi.json"
+    command = build_openapi_export_command(output)
+
+    assert command[:3] == ["python", "-m", "Helper_Scripts.cats_fuzz.openapi_export"]
+    assert str(output) in command

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
@@ -23,6 +23,7 @@ def test_builtin_manifest_contains_initial_blocks() -> None:
     assert manifest["public-read"].expected_gate is ExpectedGate.NO_5XX
     assert manifest["public-read"].blackbox is True
     assert manifest["public-read"].requires_readiness is True
+    assert manifest["public-read"].timeout_seconds >= 300
     assert manifest["public-read"].allows_mutation is False
     assert manifest["public-read"].allows_network is False
     assert "/" in manifest["public-read"].paths

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
@@ -26,9 +26,11 @@ def test_builtin_manifest_contains_initial_blocks() -> None:
     assert manifest["public-read"].timeout_seconds >= 300
     assert manifest["public-read"].allows_mutation is False
     assert manifest["public-read"].allows_network is False
+    assert manifest["public-read"].include_api_key is False
     assert "/" in manifest["public-read"].paths
     assert manifest["auth-read"].allows_mutation is False
     assert manifest["auth-read"].allows_network is False
+    assert manifest["auth-read"].include_api_key is True
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pytest
+
+from Helper_Scripts.cats_fuzz.manifest import (
+    BlockRisk,
+    ExpectedGate,
+    get_builtin_block,
+    get_builtin_manifest,
+    validate_block,
+)
+
+
+@pytest.mark.unit
+def test_builtin_manifest_contains_initial_blocks() -> None:
+    manifest = get_builtin_manifest()
+
+    assert {"contract", "public-read", "auth-read"}.issubset(manifest)
+    assert manifest["contract"].risk is BlockRisk.CONTRACT
+    assert manifest["contract"].expected_gate is ExpectedGate.CONTRACT_ONLY
+    assert manifest["contract"].calls_api_service is False
+    assert manifest["contract"].paths == ()
+    assert manifest["public-read"].expected_gate is ExpectedGate.NO_5XX
+    assert manifest["public-read"].blackbox is True
+    assert manifest["public-read"].allows_mutation is False
+    assert manifest["public-read"].allows_network is False
+    assert "/" in manifest["public-read"].paths
+    assert manifest["auth-read"].allows_mutation is False
+    assert manifest["auth-read"].allows_network is False
+
+
+@pytest.mark.unit
+def test_mutating_blocks_must_require_seed_or_be_manual() -> None:
+    block = get_builtin_block("public-read")
+    unsafe = block.__class__(
+        **{
+            **block.__dict__,
+            "name": "unsafe",
+            "allows_mutation": True,
+            "requires_seed": False,
+        }
+    )
+
+    with pytest.raises(ValueError, match="requires_seed"):
+        validate_block(unsafe)
+
+
+@pytest.mark.unit
+def test_manual_blocks_may_mutate_without_seed() -> None:
+    block = get_builtin_block("public-read")
+    manual = block.__class__(
+        **{
+            **block.__dict__,
+            "name": "manual-check",
+            "risk": BlockRisk.MANUAL,
+            "allows_mutation": True,
+            "requires_seed": False,
+        }
+    )
+
+    validate_block(manual)
+
+
+@pytest.mark.unit
+def test_network_enabled_blocks_must_be_external_risk() -> None:
+    block = get_builtin_block("public-read")
+    unsafe = block.__class__(**{**block.__dict__, "name": "unsafe-network", "allows_network": True})
+
+    with pytest.raises(ValueError, match="external-risk"):
+        validate_block(unsafe)
+
+
+@pytest.mark.unit
+def test_unknown_builtin_block_fails() -> None:
+    with pytest.raises(KeyError):
+        get_builtin_block("missing")

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py
@@ -22,11 +22,23 @@ def test_builtin_manifest_contains_initial_blocks() -> None:
     assert manifest["contract"].paths == ()
     assert manifest["public-read"].expected_gate is ExpectedGate.NO_5XX
     assert manifest["public-read"].blackbox is True
+    assert manifest["public-read"].requires_readiness is True
     assert manifest["public-read"].allows_mutation is False
     assert manifest["public-read"].allows_network is False
     assert "/" in manifest["public-read"].paths
     assert manifest["auth-read"].allows_mutation is False
     assert manifest["auth-read"].allows_network is False
+
+
+@pytest.mark.unit
+def test_public_read_readiness_paths_require_readiness_metadata() -> None:
+    manifest = get_builtin_manifest()
+    readiness_paths = {"/ready", "/health/ready", "/api/v1/health/ready"}
+
+    for block in manifest.values():
+        covered_readiness_paths = readiness_paths.intersection(block.paths)
+        if covered_readiness_paths:
+            assert block.requires_readiness is True, block.name
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -15,7 +16,13 @@ from Helper_Scripts.cats_fuzz.runner import (
     run_contract_block,
     run_runtime_block,
 )
-from Helper_Scripts.cats_fuzz.server import wait_for_health, wait_for_readiness
+from Helper_Scripts.cats_fuzz.server import (
+    UvicornServer,
+    start_server,
+    stop_server,
+    wait_for_health,
+    wait_for_readiness,
+)
 
 
 @pytest.mark.unit
@@ -213,8 +220,8 @@ class _Response:
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("status", [200, 302, 404])
-def test_wait_for_health_accepts_non_5xx_status(status: int, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("status", [200, 204])
+def test_wait_for_health_accepts_2xx_status(status: int, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "Helper_Scripts.cats_fuzz.server.urlopen",
         lambda request, timeout: _Response(status),
@@ -224,10 +231,11 @@ def test_wait_for_health_accepts_non_5xx_status(status: int, monkeypatch: pytest
 
 
 @pytest.mark.unit
-def test_wait_for_health_rejects_5xx_status(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("status", [404, 503])
+def test_wait_for_health_rejects_non_2xx_status(status: int, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "Helper_Scripts.cats_fuzz.server.urlopen",
-        lambda request, timeout: _Response(503),
+        lambda request, timeout: _Response(status),
     )
     monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.time.sleep", lambda seconds: None)
 
@@ -258,15 +266,127 @@ def test_wait_for_readiness_uses_ready_before_health_ready(
 
 
 @pytest.mark.unit
-def test_wait_for_readiness_rejects_all_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("ready_status", [404, 503])
+def test_wait_for_readiness_falls_back_from_ready_to_health_ready(
+    ready_status: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requested_urls: list[str] = []
+
+    def fake_urlopen(request: Any, timeout: float) -> _Response:
+        requested_urls.append(request.full_url)
+        if request.full_url == "http://127.0.0.1:8000/ready":
+            return _Response(ready_status)
+        return _Response(204)
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.urlopen", fake_urlopen)
+
+    wait_for_readiness("http://127.0.0.1:8000", timeout_seconds=0.01)
+
+    assert requested_urls == [
+        "http://127.0.0.1:8000/ready",
+        "http://127.0.0.1:8000/health/ready",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("status", [404, 500])
+def test_wait_for_readiness_rejects_all_non_2xx_statuses(status: int, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "Helper_Scripts.cats_fuzz.server.urlopen",
-        lambda request, timeout: _Response(500),
+        lambda request, timeout: _Response(status),
     )
     monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.time.sleep", lambda seconds: None)
 
     with pytest.raises(TimeoutError):
         wait_for_readiness("http://127.0.0.1:8000", timeout_seconds=0.01)
+
+
+class _FakeProcess:
+    def __init__(self, exited: bool = False) -> None:
+        self.exited = exited
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return 0 if self.exited else None
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.exited = True
+
+    def kill(self) -> None:
+        self.killed = True
+        self.exited = True
+
+    def wait(self, timeout: int) -> int:
+        self.exited = True
+        return 0
+
+
+@pytest.mark.unit
+def test_start_server_discards_output_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    popen_calls: list[dict[str, Any]] = []
+    fake_process = _FakeProcess()
+
+    def fake_popen(command: list[str], **kwargs: Any) -> _FakeProcess:
+        popen_calls.append(kwargs)
+        return fake_process
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.wait_for_health", lambda url: None)
+
+    server = start_server(env={"AUTH_MODE": "single_user"}, port=1234)
+
+    assert server.process is fake_process
+    assert popen_calls[0]["stdout"] == subprocess.DEVNULL
+    assert popen_calls[0]["stderr"] == subprocess.DEVNULL
+
+
+@pytest.mark.unit
+def test_start_server_with_log_dir_redirects_output_and_stop_closes_streams(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    popen_calls: list[dict[str, Any]] = []
+    fake_process = _FakeProcess()
+
+    def fake_popen(command: list[str], **kwargs: Any) -> _FakeProcess:
+        popen_calls.append(kwargs)
+        return fake_process
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.wait_for_health", lambda url: None)
+
+    server = start_server(env={"AUTH_MODE": "single_user"}, port=1234, log_dir=tmp_path)
+
+    assert (tmp_path / "uvicorn.stdout.log").exists()
+    assert (tmp_path / "uvicorn.stderr.log").exists()
+    assert popen_calls[0]["stdout"] is server.stdout_stream
+    assert popen_calls[0]["stderr"] is server.stderr_stream
+    assert server.stdout_stream is not None
+    assert server.stderr_stream is not None
+
+    stop_server(server)
+
+    assert fake_process.terminated is True
+    assert server.stdout_stream.closed is True
+    assert server.stderr_stream.closed is True
+
+
+@pytest.mark.unit
+def test_stop_server_closes_streams_for_already_exited_process(tmp_path: Path) -> None:
+    stdout_stream = (tmp_path / "stdout.log").open("w", encoding="utf-8")
+    stderr_stream = (tmp_path / "stderr.log").open("w", encoding="utf-8")
+    server = UvicornServer(
+        process=_FakeProcess(exited=True),
+        url="http://127.0.0.1:1234",
+        stdout_stream=stdout_stream,
+        stderr_stream=stderr_stream,
+    )
+
+    stop_server(server)
+
+    assert stdout_stream.closed is True
+    assert stderr_stream.closed is True
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
@@ -113,7 +113,7 @@ def test_runtime_block_writes_artifacts_passes_env_and_uses_top_level_command(
 def test_runtime_summary_masks_api_key_in_memory_and_on_disk(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     openapi = tmp_path / "openapi.json"
     openapi.write_text("{}", encoding="utf-8")
-    block = replace(get_builtin_block("public-read"), requires_readiness=False)
+    block = replace(get_builtin_block("auth-read"), requires_readiness=False)
 
     def fake_run(
         command: list[str],
@@ -134,7 +134,7 @@ def test_runtime_summary_masks_api_key_in_memory_and_on_disk(tmp_path: Path, mon
         api_key=DEFAULT_TEST_API_KEY,
     )
 
-    summary_json = (tmp_path / "out" / "public-read" / "summary.json").read_text(encoding="utf-8")
+    summary_json = (tmp_path / "out" / "auth-read" / "summary.json").read_text(encoding="utf-8")
     assert DEFAULT_TEST_API_KEY not in " ".join(summary.command)
     assert DEFAULT_TEST_API_KEY not in " ".join(summary.masked_command)
     assert DEFAULT_TEST_API_KEY not in summary_json
@@ -170,6 +170,38 @@ def test_runtime_block_waits_for_readiness_when_required(tmp_path: Path, monkeyp
     )
 
     assert ready_urls == ["http://127.0.0.1:8000"]
+
+
+@pytest.mark.unit
+def test_runtime_block_writes_summary_when_readiness_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    openapi = tmp_path / "openapi.json"
+    openapi.write_text("{}", encoding="utf-8")
+    block = get_builtin_block("public-read")
+
+    def fail_wait_for_readiness(server_url: str) -> None:
+        raise TimeoutError(f"{server_url} never became ready")
+
+    def fail_run(*args: object, **kwargs: object) -> CatsProcessResult:
+        raise AssertionError("CATS should not run when readiness preflight fails")
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.wait_for_readiness", fail_wait_for_readiness)
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.run_command", fail_run)
+
+    summary = run_runtime_block(
+        block=block,
+        contract_path=openapi,
+        server_url="http://127.0.0.1:8000",
+        output_dir=tmp_path / "out",
+        cats_version="13.8.0",
+    )
+
+    block_dir = tmp_path / "out" / "public-read"
+    summary_json = json.loads((block_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary.exit_code == 124
+    assert summary.failure_class == "tool"
+    assert summary_json["failure_class"] == "tool"
+    assert "readiness preflight failed" in (block_dir / "stderr.log").read_text(encoding="utf-8")
+    assert (block_dir / "stdout.log").read_text(encoding="utf-8") == ""
 
 
 @pytest.mark.unit
@@ -333,7 +365,7 @@ def test_start_server_discards_output_by_default(monkeypatch: pytest.MonkeyPatch
         return fake_process
 
     monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.subprocess.Popen", fake_popen)
-    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.wait_for_health", lambda url: None)
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.wait_for_health", lambda url, **kwargs: None)
 
     server = start_server(env={"AUTH_MODE": "single_user"}, port=1234)
 
@@ -354,7 +386,7 @@ def test_start_server_with_log_dir_redirects_output_and_stop_closes_streams(
         return fake_process
 
     monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.subprocess.Popen", fake_popen)
-    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.wait_for_health", lambda url: None)
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.wait_for_health", lambda url, **kwargs: None)
 
     server = start_server(env={"AUTH_MODE": "single_user"}, port=1234, log_dir=tmp_path)
 
@@ -370,6 +402,27 @@ def test_start_server_with_log_dir_redirects_output_and_stop_closes_streams(
     assert fake_process.terminated is True
     assert server.stdout_stream.closed is True
     assert server.stderr_stream.closed is True
+
+
+@pytest.mark.unit
+def test_start_server_fails_fast_when_child_exits_during_startup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_process = _FakeProcess(exited=True)
+
+    def fake_popen(command: list[str], **kwargs: Any) -> _FakeProcess:
+        return fake_process
+
+    def fail_poll_url(*args: object, **kwargs: object) -> int:
+        raise AssertionError("health polling should stop once the child has exited")
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server._poll_url", fail_poll_url)
+
+    with pytest.raises(RuntimeError, match="uvicorn exited during startup") as exc_info:
+        start_server(env={"AUTH_MODE": "single_user"}, port=1234, log_dir=tmp_path)
+
+    assert str(tmp_path / "uvicorn.stderr.log") in str(exc_info.value)
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from Helper_Scripts.cats_fuzz import DEFAULT_TEST_API_KEY
+from Helper_Scripts.cats_fuzz.cats_cli import CatsProcessResult
+from Helper_Scripts.cats_fuzz.manifest import get_builtin_block
+from Helper_Scripts.cats_fuzz.runner import (
+    get_default_runtime_block,
+    run_contract_block,
+    run_runtime_block,
+)
+from Helper_Scripts.cats_fuzz.server import wait_for_health, wait_for_readiness
+
+
+@pytest.mark.unit
+def test_contract_block_writes_summary_for_validate_and_stats(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    openapi = tmp_path / "openapi.json"
+    openapi.write_text("{}", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: int,
+        env: dict[str, str] | None = None,
+    ) -> CatsProcessResult:
+        calls.append(command)
+        return CatsProcessResult(command=command, exit_code=0, stdout="{}", stderr="")
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.run_command", fake_run)
+
+    result = run_contract_block(
+        contract_path=openapi,
+        output_dir=tmp_path / "out",
+        cats_version="13.8.0",
+        openapi_sha256="abc",
+    )
+
+    assert result.exit_code == 0
+    assert any(command[:2] == ["cats", "validate"] for command in calls)
+    assert any(command[:2] == ["cats", "stats"] for command in calls)
+    assert (tmp_path / "out" / "contract" / "summary.json").exists()
+
+
+@pytest.mark.unit
+def test_runtime_block_writes_artifacts_passes_env_and_uses_top_level_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    openapi = tmp_path / "openapi.json"
+    openapi.write_text("{}", encoding="utf-8")
+    block = replace(get_builtin_block("public-read"), requires_readiness=False)
+    process_env = {"CATS_HOME": str(tmp_path / "cats-home")}
+    calls: list[tuple[list[str], dict[str, str] | None]] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: int,
+        env: dict[str, str] | None = None,
+    ) -> CatsProcessResult:
+        calls.append((command, env))
+        return CatsProcessResult(
+            command=command,
+            exit_code=0,
+            stdout="runtime stdout",
+            stderr="runtime stderr",
+        )
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.run_command", fake_run)
+
+    summary = run_runtime_block(
+        block=block,
+        contract_path=openapi,
+        server_url="http://127.0.0.1:8000",
+        output_dir=tmp_path / "out",
+        cats_version="13.8.0",
+        env=process_env,
+    )
+
+    block_dir = tmp_path / "out" / "public-read"
+    command = calls[0][0]
+    assert command[:5] == [
+        "cats",
+        "-c",
+        str(openapi),
+        "-s",
+        "http://127.0.0.1:8000",
+    ]
+    assert command[1] != "run"
+    assert command[command.index("--output") + 1] == str(block_dir / "cats-report")
+    assert calls == [(command, process_env)]
+    assert (block_dir / "stdout.log").read_text(encoding="utf-8") == "runtime stdout"
+    assert (block_dir / "stderr.log").read_text(encoding="utf-8") == "runtime stderr"
+    assert (block_dir / "summary.json").exists()
+    assert summary.report_dir == str(block_dir / "cats-report")
+
+
+@pytest.mark.unit
+def test_runtime_summary_masks_api_key_in_memory_and_on_disk(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    openapi = tmp_path / "openapi.json"
+    openapi.write_text("{}", encoding="utf-8")
+    block = replace(get_builtin_block("public-read"), requires_readiness=False)
+
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: int,
+        env: dict[str, str] | None = None,
+    ) -> CatsProcessResult:
+        return CatsProcessResult(command=command, exit_code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.run_command", fake_run)
+
+    summary = run_runtime_block(
+        block=block,
+        contract_path=openapi,
+        server_url="http://127.0.0.1:8000",
+        output_dir=tmp_path / "out",
+        cats_version="13.8.0",
+        api_key=DEFAULT_TEST_API_KEY,
+    )
+
+    summary_json = (tmp_path / "out" / "public-read" / "summary.json").read_text(encoding="utf-8")
+    assert DEFAULT_TEST_API_KEY not in " ".join(summary.command)
+    assert DEFAULT_TEST_API_KEY not in " ".join(summary.masked_command)
+    assert DEFAULT_TEST_API_KEY not in summary_json
+    assert "X-API-KEY=$X-API-KEY" in summary_json
+
+
+@pytest.mark.unit
+def test_runtime_block_waits_for_readiness_when_required(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    openapi = tmp_path / "openapi.json"
+    openapi.write_text("{}", encoding="utf-8")
+    ready_urls: list[str] = []
+
+    def fake_wait_for_readiness(server_url: str) -> None:
+        ready_urls.append(server_url)
+
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: int,
+        env: dict[str, str] | None = None,
+    ) -> CatsProcessResult:
+        return CatsProcessResult(command=command, exit_code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.wait_for_readiness", fake_wait_for_readiness)
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.run_command", fake_run)
+
+    run_runtime_block(
+        block=get_builtin_block("public-read"),
+        contract_path=openapi,
+        server_url="http://127.0.0.1:8000",
+        output_dir=tmp_path / "out",
+        cats_version="13.8.0",
+    )
+
+    assert ready_urls == ["http://127.0.0.1:8000"]
+
+
+@pytest.mark.unit
+def test_runtime_block_skips_readiness_when_not_required(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    openapi = tmp_path / "openapi.json"
+    openapi.write_text("{}", encoding="utf-8")
+    block = replace(get_builtin_block("public-read"), requires_readiness=False, name="no-ready")
+
+    def fail_wait_for_readiness(server_url: str) -> None:
+        raise AssertionError("readiness wait should not be called")
+
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: int,
+        env: dict[str, str] | None = None,
+    ) -> CatsProcessResult:
+        return CatsProcessResult(command=command, exit_code=0, stdout="", stderr="")
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.wait_for_readiness", fail_wait_for_readiness)
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.run_command", fake_run)
+
+    summary = run_runtime_block(
+        block=block,
+        contract_path=openapi,
+        server_url="http://127.0.0.1:8000",
+        output_dir=tmp_path / "out",
+        cats_version="13.8.0",
+    )
+
+    assert summary.block == "no-ready"
+
+
+@pytest.mark.unit
+def test_get_default_runtime_block_is_public_read() -> None:
+    assert get_default_runtime_block() == get_builtin_block("public-read")
+
+
+class _Response:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        return None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("status", [200, 302, 404])
+def test_wait_for_health_accepts_non_5xx_status(status: int, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "Helper_Scripts.cats_fuzz.server.urlopen",
+        lambda request, timeout: _Response(status),
+    )
+
+    wait_for_health("http://127.0.0.1:8000", timeout_seconds=0.01)
+
+
+@pytest.mark.unit
+def test_wait_for_health_rejects_5xx_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "Helper_Scripts.cats_fuzz.server.urlopen",
+        lambda request, timeout: _Response(503),
+    )
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.time.sleep", lambda seconds: None)
+
+    with pytest.raises(TimeoutError):
+        wait_for_health("http://127.0.0.1:8000", timeout_seconds=0.01)
+
+
+@pytest.mark.unit
+def test_wait_for_readiness_uses_ready_before_health_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_urls: list[str] = []
+
+    def fake_urlopen(request: Any, timeout: float) -> _Response:
+        requested_urls.append(request.full_url)
+        if request.full_url == "http://127.0.0.1:8000/ready":
+            return _Response(503)
+        return _Response(204)
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.urlopen", fake_urlopen)
+
+    wait_for_readiness("http://127.0.0.1:8000", timeout_seconds=0.01)
+
+    assert requested_urls == [
+        "http://127.0.0.1:8000/ready",
+        "http://127.0.0.1:8000/health/ready",
+    ]
+
+
+@pytest.mark.unit
+def test_wait_for_readiness_rejects_all_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "Helper_Scripts.cats_fuzz.server.urlopen",
+        lambda request, timeout: _Response(500),
+    )
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.server.time.sleep", lambda seconds: None)
+
+    with pytest.raises(TimeoutError):
+        wait_for_readiness("http://127.0.0.1:8000", timeout_seconds=0.01)
+
+
+@pytest.mark.unit
+def test_contract_block_summary_combines_validate_and_stats_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    openapi = tmp_path / "openapi.json"
+    openapi.write_text("{}", encoding="utf-8")
+
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: int,
+        env: dict[str, str] | None = None,
+    ) -> CatsProcessResult:
+        stdout = '{"command": "%s"}' % command[1]
+        return CatsProcessResult(command=command, exit_code=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("Helper_Scripts.cats_fuzz.runner.run_command", fake_run)
+
+    summary = run_contract_block(
+        contract_path=openapi,
+        output_dir=tmp_path / "out",
+        cats_version="13.8.0",
+    )
+    data = json.loads((tmp_path / "out" / "contract" / "summary.json").read_text())
+
+    assert summary.openapi_sha256
+    assert "validate" in (tmp_path / "out" / "contract" / "stdout.log").read_text()
+    assert "stats" in (tmp_path / "out" / "contract" / "stdout.log").read_text()
+    assert data["block"] == "contract"

--- a/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from Helper_Scripts.cats_fuzz.summary import CatsRunSummary, mask_command, write_summary
+
+
+@pytest.mark.unit
+def test_mask_command_hides_api_key() -> None:
+    masked = mask_command(["cats", "-H", "X-API-KEY=secret-value"])
+
+    assert "secret-value" not in " ".join(masked)
+    assert "X-API-KEY=$X-API-KEY" in masked
+
+
+@pytest.mark.unit
+def test_mask_command_hides_authorization_header() -> None:
+    masked = mask_command(["cats", "-H", "Authorization=Bearer secret-value"])
+
+    assert "secret-value" not in " ".join(masked)
+    assert "Authorization=$Authorization" in masked
+
+
+@pytest.mark.unit
+def test_write_summary_persists_expected_shape(tmp_path: Path) -> None:
+    summary = CatsRunSummary(
+        block="public-read",
+        cats_version="13.8.0",
+        openapi_sha256="abc",
+        command=["cats", "--blackbox"],
+        masked_command=["cats", "--blackbox"],
+        exit_code=0,
+        failure_class="ok",
+        stdout_path="stdout.log",
+        stderr_path="stderr.log",
+        report_dir="report",
+    )
+
+    output = write_summary(summary, tmp_path / "summary.json")
+    data = json.loads(output.read_text(encoding="utf-8"))
+
+    assert data["block"] == "public-read"
+    assert data["failure_class"] == "ok"
+    assert data["command"] == ["cats", "--blackbox"]
+
+
+@pytest.mark.unit
+def test_write_summary_never_persists_raw_api_key(tmp_path: Path) -> None:
+    summary = CatsRunSummary(
+        block="public-read",
+        cats_version="13.8.0",
+        openapi_sha256="abc",
+        command=["cats", "-H", "X-API-KEY=secret-value"],
+        masked_command=["cats", "-H", "X-API-KEY=secret-value"],
+        exit_code=1,
+        failure_class="api",
+        stdout_path="stdout.log",
+        stderr_path="stderr.log",
+        report_dir="report",
+    )
+
+    output = write_summary(summary, tmp_path / "summary.json")
+    raw_json = output.read_text(encoding="utf-8")
+    data = json.loads(raw_json)
+
+    assert "secret-value" not in raw_json
+    assert data["command"] == ["cats", "-H", "X-API-KEY=$X-API-KEY"]
+    assert data["masked_command"] == ["cats", "-H", "X-API-KEY=$X-API-KEY"]

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -4361,6 +4361,15 @@ def test_minimal_test_router_specs_participate_in_route_policy(
     assert set(actual_counts) - set(expected_counts) == set()
 
 
+def test_minimal_optional_setup_router_participates_in_route_policy() -> None:
+    """Verify setup API routes can be disabled by generated runtime configs."""
+    from tldw_Server_API.app.api.v1.router_groups.minimal import iter_minimal_optional_router_specs
+
+    setup_spec = next(spec for spec in iter_minimal_optional_router_specs() if spec.name == "setup")
+
+    assert setup_spec.route_key == "setup"
+
+
 def test_minimal_source_delegates_always_included_routers_to_imported_specs() -> None:
     """Verify minimal always-included router specs no longer direct-import endpoints."""
     source = _minimal_group_source_text()

--- a/tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
+++ b/tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
@@ -30,14 +30,15 @@ def test_vector_list_query_examples_are_cats_validate_compatible(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     spec = _openapi_spec(monkeypatch)
-    params = {
-        param["name"]: param
-        for param in spec["paths"][VECTOR_LIST_PATH]["get"]["parameters"]
-    }
+    params = {param["name"]: param for param in spec["paths"][VECTOR_LIST_PATH]["get"]["parameters"]}
 
     for name in ("filter", "order_by", "order_dir"):
         schema = params[name].get("schema", {})
-        if isinstance(schema.get("examples"), dict):
-            pytest.fail(f"{name} has schema-level dict examples")
-        if "examples" not in params[name] and not isinstance(schema.get("examples"), list):
-            pytest.fail(f"{name} is missing CATS-compatible examples")
+        assert "examples" not in schema, f"{name} must use parameter-level examples"
+        examples = params[name].get("examples")
+        assert isinstance(examples, dict), f"{name} must expose parameter-level examples"
+        assert examples, f"{name} must expose non-empty parameter-level examples"
+        for example_name, example in examples.items():
+            assert isinstance(example_name, str)
+            assert isinstance(example, dict)
+            assert "value" in example

--- a/tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
+++ b/tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
@@ -16,8 +16,11 @@ def _openapi_spec(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO", "1")
     monkeypatch.setenv("PYTHONWARNINGS", "ignore")
 
-    from tldw_Server_API.app.main import app
+    from fastapi import FastAPI
+    from tldw_Server_API.app.api.v1.endpoints.vector_stores_openai import router
 
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
     app.openapi_schema = None
     return app.openapi()
 

--- a/tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
+++ b/tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+VECTOR_LIST_PATH = "/api/v1/vector_stores/{store_id}/vectors"
+
+
+def _openapi_spec(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "THIS-IS-A-SECURE-KEY-123-FAKE-KEY")
+    monkeypatch.setenv("SINGLE_USER_TEST_API_KEY", "THIS-IS-A-SECURE-KEY-123-FAKE-KEY")
+    monkeypatch.setenv("MINIMAL_TEST_APP", "1")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO", "1")
+    monkeypatch.setenv("PYTHONWARNINGS", "ignore")
+
+    from tldw_Server_API.app.main import app
+
+    app.openapi_schema = None
+    return app.openapi()
+
+
+@pytest.mark.unit
+def test_vector_list_query_examples_are_cats_validate_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = _openapi_spec(monkeypatch)
+    params = {
+        param["name"]: param
+        for param in spec["paths"][VECTOR_LIST_PATH]["get"]["parameters"]
+    }
+
+    for name in ("filter", "order_by", "order_dir"):
+        schema = params[name].get("schema", {})
+        if isinstance(schema.get("examples"), dict):
+            pytest.fail(f"{name} has schema-level dict examples")
+        if "examples" not in params[name] and not isinstance(schema.get("examples"), list):
+            pytest.fail(f"{name} is missing CATS-compatible examples")


### PR DESCRIPTION
## Summary
- Adds a local-only CATS fuzzing harness under `Helper_Scripts/cats_fuzz` with manifest blocks, environment isolation, OpenAPI export, CATS command construction, server lifecycle management, summaries, and CLI entrypoints.
- Fixes vector-store OpenAPI query examples so strict CATS validation accepts them.
- Adds contributor setup/operations documentation, Backlog records, and validation notes for running and interpreting the harness.

## Human Change Summary Required Before Merge
This PR is materially AI-authored. Per repo policy, a human maintainer must replace this section with their own change summary explaining what changed and why before this PR is merge-ready.

## Validation
- [x] `python -m pytest tldw_Server_API/tests/VectorStores/test_vector_stores_openapi_examples.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_manifest.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_env.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cats_cli.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_summary.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_runner.py tldw_Server_API/tests/Helper_Scripts/test_cats_fuzz_cli.py -q`: 57 passed, 3 warnings.
- [x] `python -m bandit -r Helper_Scripts/cats_fuzz tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py -f json -o /tmp/bandit_cats_fuzz_dev_pr.json`: 0 findings.
- [x] `git diff --check origin/dev...HEAD`.
- [x] Live CATS `contract` block on the original implementation branch: `exit_code: 0`, `failure_class: ok`.
- [x] Live CATS `public-read` block on the original implementation branch: produced structured reports and summary, but timed out at 300 seconds with `exit_code: 124`, `failure_class: tool`.

## Known Follow-up
- The broad `public-read` block starts correctly and writes CATS reports/summaries, but currently times out at 300 seconds on the large OpenAPI surface. Split or narrow this block before using it as a hard CI gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe, local-only CATS fuzzing harness with manifest-driven blocks, an isolated runtime, deterministic OpenAPI export, and PR-friendly run summaries. Adds loopback-origin URL validation, route-policy env scrubbing, Loguru diagnostics, OpenAPI export timeout handling, and keeps CLI defaulting to existing-server when `--server-url` is set; preserves artifacts on preflight failures and fails fast on uvicorn startup; also fixes vector-store OpenAPI examples for strict CATS validation.

- **New Features**
  - Local harness under `Helper_Scripts/cats_fuzz` with blocks: `contract`, `public-read` (default), scaffolded `auth-read`.
  - Isolated runtime scrubs provider keys, uses test `SINGLE_USER_API_KEY`, scrubs route-policy env, and rejects non-loopback/non-origin URLs.
  - Deterministic OpenAPI export with SHA; CATS validate/stats and blackbox runs with JUnit/JSON reports.
  - Server lifecycle via `uvicorn` with 2xx health/readiness checks, free-port selection, and fail-fast on early exit.
  - CLI: `python -m Helper_Scripts.cats_fuzz ...` and `make cats-fuzz`; loopback-origin URL validation; `--server-url` implies existing-server; clear `--no-start-server` usage errors; Loguru diagnostics; OpenAPI export timeout; artifacts in `artifacts/cats-fuzz/` (preserved on preflight failures).

- **Bug Fixes**
  - Vector-store query param `examples` → `openapi_examples` for FastAPI/CATS compatibility; tests added.
  - `public-read` no longer sends auth headers; header values masked in summaries.
  - Set `route_key` for the minimal “setup” router so route policy can disable it in isolated runs.

<sup>Written for commit a44f8f304bb77af72f66da2e285a1bb7a717f710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

