### PR TITLE
Add notebook-safe MCP tools

### DIFF
--- a/Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
+++ b/Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
@@ -1,0 +1,236 @@
+# MCP Notebook Edit Tools Design
+
+## Context
+
+`TASK-2282` adds notebook-safe MCP tools modeled after Claude Code `NotebookEdit`.
+The current MCP filesystem module already provides the trust boundary this work
+needs: workspace-root resolution, path-scope metadata, file-policy action
+grants, preimage checks, read receipts, advisory lock leases, atomic writes, and
+metadata-only tool reporting. Notebook tools should reuse that boundary instead
+of introducing a parallel filesystem policy path.
+
+Baseline note: before this design was written, the existing filesystem module
+test file passed 103 tests and failed
+`test_filesystem_glob_marks_file_size_unavailable` with
+`OSError("metadata unavailable")`. The notebook work will avoid touching the
+glob path and will record this as pre-existing baseline risk unless it becomes
+directly relevant.
+
+## Goals
+
+- Let MCP clients inspect Jupyter notebook structure without reading or writing
+  the whole notebook body by default.
+- Let MCP clients replace, insert, and delete notebook cells by stable Jupyter
+  cell `id`.
+- Require normal MCP filesystem path grants and preimage protection before cell
+  mutation.
+- Preserve JSON validity and minimize avoidable notebook churn.
+- Return bounded, audit-friendly summaries without leaking raw notebook content
+  into telemetry, errors, or eval metadata.
+
+## Non-Goals
+
+- No full notebook overwrite tool.
+- No notebook execution, kernel management, or output generation.
+- No automatic repair or normalization of notebooks with missing or duplicate
+  cell ids.
+- No broad dependency addition such as `nbformat`; this implementation will use
+  the Python standard library and validate the invariants it depends on.
+
+## Architecture
+
+Add focused notebook helpers under
+`tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py`.
+The existing `FilesystemModule` will own MCP tool registration and workspace
+integration, then delegate parsing, validation, cell summarization, and JSON
+mutation to that helper. This avoids expanding the already-large filesystem
+module with notebook-specific mechanics while preserving a single policy and
+execution surface for filesystem-backed MCP tools.
+
+The helper should expose small pure functions or simple dataclasses for:
+
+- parsing a notebook byte payload into validated notebook state;
+- summarizing cell structure with bounded source previews;
+- applying one cell operation in memory;
+- serializing the edited notebook while preserving practical formatting traits
+  such as trailing newline, indentation style, key order, and cell source
+  string/list representation where possible.
+
+## Tool Surface
+
+### `notebook.read`
+
+Reads one `.ipynb` file under the active trusted workspace root.
+
+Arguments:
+
+- `path` string, required.
+- `include_source` boolean, default `false`.
+- `cell_ids` string array, optional filter for source previews.
+- `max_source_chars` positive integer, optional bounded source preview limit.
+- `max_total_source_chars` positive integer, optional total preview budget.
+- `include_receipt` boolean, default `true`.
+
+Returns:
+
+- workspace-relative `path`;
+- `cell_count`;
+- notebook `nbformat` and `nbformat_minor`;
+- `sha256`, byte count, truncation state, and optional `read_receipt`;
+- per-cell summaries: `id`, `cell_type`, index, source line count,
+  source character count, execution/output counts for code cells, and source
+  preview only when explicitly requested.
+
+Default behavior is structure-first and source-sparing. Clients that need cell
+content must request it intentionally, can scope the request to specific cell
+ids, and remain bounded by both per-cell and total source preview budgets.
+
+### `notebook.edit_cell`
+
+Mutates one `.ipynb` cell by Jupyter cell `id`.
+
+Arguments:
+
+- `path` string, required.
+- `cell_id` string, required for `replace`, `insert`, and `delete`.
+- `mode` enum: `replace`, `insert`, `delete`.
+- `insert_position` enum: `before`, `after`; required only for `insert`.
+- `new_cell_id` string, optional for inserted cells and ignored otherwise.
+- `cell_type` enum: `code`, `markdown`, `raw`; required for inserted cells and
+  optional for replace.
+- `source` string, required for replace and insert.
+- `expected_sha256` string or `read_receipt` string, one required.
+- `lock_lease_id` string, optional.
+- `dry_run` boolean, default `false`.
+
+Returns a bounded diff summary:
+
+- workspace-relative `path`;
+- `mode`, `edited`, and `dry_run`;
+- affected cell ids and indexes;
+- cell count before/after;
+- source line and character counts before/after;
+- output count before/after for code cells;
+- `sha256_before` and `sha256_after`;
+- `bytes_before`, `bytes_after`, and `bytes_written` when committed.
+
+Cell deletion is a file-policy `edit`, not filesystem `delete`, because the
+notebook file remains and the mutation is bounded to notebook structure.
+
+## Policy And Permissions
+
+Both tools use existing MCP file-policy metadata:
+
+- `notebook.read`: `uses_filesystem=true`, `path_boundable=true`,
+  `path_scope_action=read`, `file_policy_action=read`, `readOnlyHint=true`.
+- `notebook.edit_cell`: `uses_filesystem=true`, `path_boundable=true`,
+  `path_scope_action=edit`, `file_policy_action=edit`, `write_capable=true`,
+  `readOnlyHint=false`.
+
+Profiles still need the tool allowed and a path grant that covers the requested
+path/action. `NotebookEdit(...)` already exists in permission-rule parsing as a
+path-oriented rule family, so documentation should connect the new tool names to
+that mental model without treating path rules as tool grants.
+
+Preset updates should be conservative:
+
+- add `notebook.read` only to file-read-oriented presets;
+- add `notebook.edit_cell` only where bounded file edit tools such as
+  `fs.patch` are already available;
+- leave explicit allow-list profiles unchanged unless operators opt in.
+
+## Validation And Error Recovery
+
+The tools reject:
+
+- non-`.ipynb` paths;
+- symlinks that cannot be resolved inside the workspace;
+- files exceeding configured notebook read/edit limits;
+- invalid UTF-8 or invalid JSON;
+- notebook JSON without a top-level `cells` list;
+- cells without valid string `id` values;
+- duplicate cell ids;
+- missing target `cell_id`;
+- unsupported `cell_type`, invalid source shape, or invalid mode arguments;
+- stale `expected_sha256` or `read_receipt`;
+- missing required lock lease when the filesystem module requires locks.
+
+Do not synthesize ids for existing notebooks that lack ids. `notebook.read`
+should report missing or duplicate id diagnostics, and `notebook.edit_cell`
+should fail closed. Inserted cells may use caller-provided `new_cell_id` when
+unique and valid; otherwise the tool generates a valid unique id.
+
+Replacing a code cell source clears `outputs` and sets `execution_count` to
+`null` by default. This avoids presenting stale execution results as if they
+belong to the edited source. A future explicit `preserve_outputs` option can be
+considered separately if there is a concrete trusted workflow.
+
+Errors should use stable reason-code-style messages such as
+`notebook_invalid_json`, `notebook_cell_id_not_found`,
+`notebook_duplicate_cell_id`, `notebook_preimage_mismatch`, and
+`notebook_write_too_large`. Error messages must not include raw cell source,
+absolute host paths, or full notebook content.
+
+## Serialization
+
+The helper should use `json.loads`/`json.dumps` with insertion-order preservation
+and no `sort_keys`. It should preserve a trailing newline when the input had one.
+It should keep source representation compatible with the edited cell's original
+shape where practical: if a replaced cell stored `source` as a list of lines,
+write a list; if it stored a string, write a string. Inserted cells can use a
+string source unless the surrounding notebook strongly indicates list-style
+sources.
+
+Whole-file byte output is acceptable internally because `.ipynb` is JSON, but
+the public edit API must remain cell-scoped and must not accept a full notebook
+body.
+
+## Telemetry And Reporting
+
+Tool results can include bounded source previews only when the user explicitly
+requests them from `notebook.read`. Eval metadata, tool-use reporting, policy
+explanations, logs, and exception messages must remain metadata-only. They may
+include tool names, action family, result kind, truncation flags, reason codes,
+workspace-relative paths after existing sanitization, and redacted path-policy
+decisions. They must not include raw cell source, outputs, full diffs, read
+receipt values, or absolute local paths.
+
+## Tests
+
+Use TDD. Add tests before implementation for:
+
+- tool definitions and path-scope metadata;
+- `notebook.read` default structure-only response;
+- explicit bounded source previews and truncation;
+- read receipts on full hashed reads;
+- replace, insert before/after, and delete by cell id;
+- dry-run mutation summaries without writes;
+- preimage mismatch and receipt mismatch;
+- lock-required behavior through existing lock settings;
+- invalid JSON, non-notebook paths, missing cells list, missing ids, duplicate
+  ids, missing target id, and unsupported cell types;
+- code-cell output clearing after source replacement;
+- path-scope extraction/enforcement metadata;
+- preset inclusion for file read/edit profiles;
+- docs examples that show both tool allow-list and path-grant requirements.
+
+Run targeted notebook/filesystem tests, relevant profile preset tests, and
+Bandit on touched Python files before completion.
+
+## Acceptance Criteria
+
+- `notebook.read` and `notebook.edit_cell` are visible through the MCP tool
+  catalog with correct schemas, metadata, and read/write classification.
+- `notebook.read` returns notebook structure by default and only returns bounded
+  source previews when explicitly requested.
+- `notebook.edit_cell` supports replace, insert, and delete by cell id with
+  preimage checks, optional lock leases, dry-run behavior, and atomic writes.
+- Notebook mutations preserve valid JSON and avoid raw whole-notebook overwrite
+  inputs.
+- Invalid notebooks and unsafe/stale edits fail closed with stable reason-code
+  errors that do not leak raw content.
+- File-policy path grants control notebook read/edit access using existing
+  `read` and `edit` actions.
+- Presets, docs, and tests reflect the conservative permission model.
+- Verification results, baseline skips or failures, Bandit output, and final
+  summary are recorded on `TASK-2282`.

--- a/Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
+++ b/Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
@@ -491,3 +491,42 @@ Expected: no whitespace errors, only intended files changed or clean after commi
 git add 'backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md'
 git commit -m "chore: finalize task 2282 notebook tools"
 ```
+
+## Task 7: PR Review Remediation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py`
+- Modify: `backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md`
+
+- [x] **Step 1: Rebase on latest dev**
+
+Run `git fetch origin dev` and `git rebase origin/dev`. Expected: branch is based on current `origin/dev`.
+
+- [x] **Step 2: Verify review comments against code**
+
+Inspect unresolved PR review threads. Valid review items:
+
+- add docstrings to the new notebook test modules and new symbols;
+- map oversized notebook reads/edits to notebook-specific reason codes;
+- validate existing notebook cell types during parsing;
+- strip code-only metadata when a replace changes a cell to markdown/raw;
+- add receipt-authorized notebook edit coverage.
+
+- [x] **Step 3: Write failing tests for behavior changes**
+
+Add tests for oversized notebook reads/edits, invalid existing `cell_type`, non-code replace metadata stripping, and read-receipt-based edits.
+
+- [x] **Step 4: Implement fixes**
+
+Keep changes minimal: normalize notebook-specific oversize errors at notebook call sites, validate canonical existing cell types in parsing, and strip `outputs` / `execution_count` from final non-code cells.
+
+- [x] **Step 5: Verify focused tests and Bandit**
+
+Run the notebook helper/tool tests, preset tests, existing filesystem baseline, and Bandit on touched Python files.
+
+- [x] **Step 6: Update Backlog and push**
+
+Record remediation summary and verification in `TASK-2282`, commit the fixes, force-with-lease push the rebased branch, and resolve or reply to addressed PR threads.

--- a/Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
+++ b/Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
@@ -54,7 +54,7 @@ Use the existing root virtualenv while working in the worktree:
 - Create: `tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py`
 
-- [ ] **Step 1: Write failing helper tests for valid read summaries**
+- [x] **Step 1: Write failing helper tests for valid read summaries**
 
 Add tests that build small notebook JSON payloads as bytes and assert:
 
@@ -68,7 +68,7 @@ assert "source_preview" not in summary["cells"][0]
 
 Also test `include_source=True`, `cell_ids=["code-1"]`, `max_source_chars`, and `max_total_source_chars`.
 
-- [ ] **Step 2: Run tests to verify red**
+- [x] **Step 2: Run tests to verify red**
 
 Run:
 
@@ -78,7 +78,7 @@ Run:
 
 Expected: fail because `notebook_files.py` does not exist.
 
-- [ ] **Step 3: Implement minimal parser and summary helpers**
+- [x] **Step 3: Implement minimal parser and summary helpers**
 
 Implement stdlib-only helpers:
 
@@ -120,11 +120,11 @@ Validation requirements:
 - Missing ids raise `ValueError("notebook_cell_id_required")`.
 - Source may be string, list of strings, or absent.
 
-- [ ] **Step 4: Run tests to verify green**
+- [x] **Step 4: Run tests to verify green**
 
 Run the same pytest command. Expected: all helper read tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py \
@@ -138,7 +138,7 @@ git commit -m "feat: add notebook file read helpers"
 - Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py`
 
-- [ ] **Step 1: Write failing tests for replace, insert, delete, and serialization**
+- [x] **Step 1: Write failing tests for replace, insert, delete, and serialization**
 
 Test behavior:
 
@@ -165,7 +165,7 @@ assert result.summary["output_count_after"] == 0
 assert result.document["cells"][1]["execution_count"] is None
 ```
 
-- [ ] **Step 2: Run tests to verify red**
+- [x] **Step 2: Run tests to verify red**
 
 Run:
 
@@ -175,7 +175,7 @@ Run:
 
 Expected: fail because mutation helpers are missing.
 
-- [ ] **Step 3: Implement mutation helpers**
+- [x] **Step 3: Implement mutation helpers**
 
 Add:
 
@@ -209,11 +209,11 @@ Use `copy.deepcopy()` before mutation. Raise stable `ValueError` reason codes:
 - `notebook_invalid_cell_type`
 - `notebook_duplicate_cell_id`
 
-- [ ] **Step 4: Run tests to verify green**
+- [x] **Step 4: Run tests to verify green**
 
 Run helper tests. Expected: pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py \
@@ -227,7 +227,7 @@ git commit -m "feat: add notebook cell edit helpers"
 - Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py`
 
-- [ ] **Step 1: Write failing tool metadata and validation tests**
+- [x] **Step 1: Write failing tool metadata and validation tests**
 
 Create tests that instantiate `FilesystemModule` and assert:
 
@@ -237,7 +237,7 @@ Create tests that instantiate `FilesystemModule` and assert:
 - `notebook.edit_cell` has `write_capable=True`, `path_scope_action="edit"`, and file-policy `edit`.
 - Validation rejects unknown args, non-string `path`, invalid modes, missing source for replace/insert, missing `insert_position` for insert, invalid booleans, and missing preimage for edit.
 
-- [ ] **Step 2: Run tests to verify red**
+- [x] **Step 2: Run tests to verify red**
 
 Run:
 
@@ -247,7 +247,7 @@ Run:
 
 Expected: fail because tools are not defined.
 
-- [ ] **Step 3: Add tool definitions and validators**
+- [x] **Step 3: Add tool definitions and validators**
 
 In `get_tools()`, add `notebook.read` near `fs.read` and `notebook.edit_cell` near `fs.edit`.
 
@@ -280,11 +280,11 @@ and:
 
 Extend `validate_tool_arguments()` with dedicated branches for both tools.
 
-- [ ] **Step 4: Run tests to verify green**
+- [x] **Step 4: Run tests to verify green**
 
 Run the notebook tool test file. Expected: metadata and validation tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py \
@@ -298,7 +298,7 @@ git commit -m "feat: register notebook mcp tools"
 - Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py`
 
-- [ ] **Step 1: Write failing execution tests**
+- [x] **Step 1: Write failing execution tests**
 
 Use a fake workspace root resolver and temp `.ipynb` files. Assert:
 
@@ -312,7 +312,7 @@ Use a fake workspace root resolver and temp `.ipynb` files. Assert:
 - Invalid JSON raises `ValueError("notebook_invalid_json")`.
 - Code cell replacement clears outputs and execution count.
 
-- [ ] **Step 2: Run tests to verify red**
+- [x] **Step 2: Run tests to verify red**
 
 Run:
 
@@ -322,7 +322,7 @@ Run:
 
 Expected: execution tests fail because dispatch is missing.
 
-- [ ] **Step 3: Implement execution dispatch**
+- [x] **Step 3: Implement execution dispatch**
 
 Add branches in `execute_tool()`:
 
@@ -349,11 +349,11 @@ build_execution_eval_metadata(
 
 and similarly `notebook.edit_cell` / `notebook_edit`.
 
-- [ ] **Step 4: Run tests to verify green**
+- [x] **Step 4: Run tests to verify green**
 
 Run the notebook tool test file. Expected: pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py \
@@ -368,7 +368,7 @@ git commit -m "feat: execute notebook mcp tools"
 - Modify: `apps/mcp-unified/src/mcp_unified/USER_GUIDE.md`
 - Test: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
 
-- [ ] **Step 1: Write failing preset tests**
+- [x] **Step 1: Write failing preset tests**
 
 Update tests to assert:
 
@@ -380,7 +380,7 @@ assert "notebook.edit_cell" in presets._FILES_WRITE_TOOLS
 
 Also assert legacy read/write lists are unchanged.
 
-- [ ] **Step 2: Run tests to verify red**
+- [x] **Step 2: Run tests to verify red**
 
 Run:
 
@@ -390,7 +390,7 @@ Run:
 
 Expected: fail because presets do not include notebook tools.
 
-- [ ] **Step 3: Update presets and user guide**
+- [x] **Step 3: Update presets and user guide**
 
 Add:
 
@@ -407,7 +407,7 @@ Update `USER_GUIDE.md` near the safe file read/patch/write section:
 - state that path grants do not grant the tool itself;
 - state code-cell source replacement clears stale outputs.
 
-- [ ] **Step 4: Run tests to verify green**
+- [x] **Step 4: Run tests to verify green**
 
 Run profile preset tests. Expected: pass.
 

--- a/Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
+++ b/Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
@@ -411,7 +411,7 @@ Update `USER_GUIDE.md` near the safe file read/patch/write section:
 
 Run profile preset tests. Expected: pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/mcp-unified/src/mcp_unified/profiles/presets.py \
@@ -425,7 +425,7 @@ git commit -m "docs: document notebook mcp tools"
 **Files:**
 - Modify: `backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md`
 
-- [ ] **Step 1: Run focused tests**
+- [x] **Step 1: Run focused tests**
 
 Run:
 
@@ -439,7 +439,7 @@ Run:
 
 Expected: pass.
 
-- [ ] **Step 2: Re-run existing filesystem baseline**
+- [x] **Step 2: Re-run existing filesystem baseline**
 
 Run:
 
@@ -449,7 +449,7 @@ Run:
 
 Expected: either the same pre-existing glob failure remains, or the file passes. If a new notebook-related failure appears, fix it before continuing.
 
-- [ ] **Step 3: Run Bandit on touched Python files**
+- [x] **Step 3: Run Bandit on touched Python files**
 
 Run:
 
@@ -463,7 +463,7 @@ Run:
 
 Expected: no new findings in touched code. If Bandit is unavailable, record the environment failure on `TASK-2282`.
 
-- [ ] **Step 4: Update Backlog task**
+- [x] **Step 4: Update Backlog task**
 
 Record:
 
@@ -473,7 +473,7 @@ Record:
 - Bandit result path;
 - known baseline filesystem glob failure if still present.
 
-- [ ] **Step 5: Final self-review**
+- [x] **Step 5: Final self-review**
 
 Run:
 
@@ -485,7 +485,7 @@ git log --oneline --decorate -5
 
 Expected: no whitespace errors, only intended files changed or clean after commit.
 
-- [ ] **Step 6: Commit task finalization**
+- [x] **Step 6: Commit task finalization**
 
 ```bash
 git add 'backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md'

--- a/Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
+++ b/Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
@@ -1,0 +1,493 @@
+# MCP Notebook Edit Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add notebook-safe MCP tools for reading Jupyter notebook structure and editing cells by id without exposing whole-notebook overwrite behavior.
+
+**Architecture:** Keep notebook JSON parsing and cell mutation in a focused helper module, then expose `notebook.read` and `notebook.edit_cell` through the existing `FilesystemModule` so path grants, read receipts, lock leases, and reporting stay on the established MCP filesystem path. Preserve the conservative policy model: read uses file-policy `read`, cell mutation uses file-policy `edit`, and source output is explicit and bounded.
+
+**Tech Stack:** Python 3.11, FastAPI-adjacent MCP module code, stdlib `json`/`hashlib`/`pathlib`, pytest/pytest-asyncio, existing `mcp_unified` package contracts.
+
+---
+
+## Source Documents
+
+- Spec: `Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md`
+- Backlog task: `backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md`
+
+## Baseline
+
+Before implementation, the existing filesystem module test file produced:
+
+- 103 passed
+- 1 failed: `test_filesystem_glob_marks_file_size_unavailable`
+- Failure: `OSError("metadata unavailable")` from the existing glob path
+
+Do not touch or fix this unrelated glob failure unless notebook work directly changes it. Use narrower notebook-focused tests for red/green verification, and record the baseline failure in `TASK-2282`.
+
+## File Structure
+
+- Create: `tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py`
+  - Pure notebook parsing, validation, summary, mutation, and serialization helpers.
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+  - Tool definitions, argument validation, workspace/preimage/lock integration, execution dispatch.
+- Modify: `apps/mcp-unified/src/mcp_unified/profiles/presets.py`
+  - Add notebook tools to existing file read/edit tool preset collections.
+- Modify: `apps/mcp-unified/src/mcp_unified/USER_GUIDE.md`
+  - Document notebook read/edit flow, tool allow-list requirements, and path grants.
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py`
+  - Helper-level unit tests.
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py`
+  - MCP module integration tests for tools, receipts, locks, path metadata, and summaries.
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+  - Preset inclusion tests.
+
+Use the existing root virtualenv while working in the worktree:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest ...
+```
+
+## Task 1: Notebook Helper Read Model
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py`
+
+- [ ] **Step 1: Write failing helper tests for valid read summaries**
+
+Add tests that build small notebook JSON payloads as bytes and assert:
+
+```python
+state = parse_notebook_payload(payload)
+summary = summarize_notebook(state, include_source=False)
+assert summary["cell_count"] == 2
+assert summary["cells"][0]["id"] == "markdown-1"
+assert "source_preview" not in summary["cells"][0]
+```
+
+Also test `include_source=True`, `cell_ids=["code-1"]`, `max_source_chars`, and `max_total_source_chars`.
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py -q
+```
+
+Expected: fail because `notebook_files.py` does not exist.
+
+- [ ] **Step 3: Implement minimal parser and summary helpers**
+
+Implement stdlib-only helpers:
+
+```python
+@dataclass(frozen=True, slots=True)
+class NotebookFormat:
+    trailing_newline: bool
+    indent: int
+
+@dataclass(frozen=True, slots=True)
+class ParsedNotebook:
+    document: dict[str, Any]
+    payload: bytes
+    sha256: str
+    size: int
+    format: NotebookFormat
+```
+
+Functions:
+
+```python
+def parse_notebook_payload(payload: bytes, *, max_bytes: int | None = None) -> ParsedNotebook: ...
+def summarize_notebook(
+    notebook: ParsedNotebook,
+    *,
+    include_source: bool = False,
+    cell_ids: list[str] | None = None,
+    max_source_chars: int = 4_000,
+    max_total_source_chars: int = 20_000,
+) -> dict[str, Any]: ...
+```
+
+Validation requirements:
+
+- UTF-8 JSON object.
+- Top-level `cells` list.
+- Each cell is an object with non-empty string `id`.
+- Duplicate ids raise `ValueError("notebook_duplicate_cell_id")`.
+- Missing ids raise `ValueError("notebook_cell_id_required")`.
+- Source may be string, list of strings, or absent.
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run the same pytest command. Expected: all helper read tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py
+git commit -m "feat: add notebook file read helpers"
+```
+
+## Task 2: Notebook Helper Cell Mutations
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py`
+
+- [ ] **Step 1: Write failing tests for replace, insert, delete, and serialization**
+
+Test behavior:
+
+- `replace` changes only target cell source.
+- Replacing a code cell clears `outputs` and sets `execution_count` to `None`.
+- `insert` supports `insert_position="before"` and `"after"`.
+- Inserted cells receive a unique generated id when `new_cell_id` is omitted.
+- Caller-provided `new_cell_id` must be unique and valid.
+- `delete` removes only the target cell.
+- Serialization preserves trailing newline when input had one.
+- Replaced list-style source remains list-style; string-style remains string-style.
+
+Example assertion:
+
+```python
+result = apply_cell_edit(
+    parsed,
+    mode="replace",
+    cell_id="code-1",
+    source="print('new')\n",
+)
+assert result.summary["output_count_before"] == 1
+assert result.summary["output_count_after"] == 0
+assert result.document["cells"][1]["execution_count"] is None
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py -q
+```
+
+Expected: fail because mutation helpers are missing.
+
+- [ ] **Step 3: Implement mutation helpers**
+
+Add:
+
+```python
+@dataclass(frozen=True, slots=True)
+class NotebookEditResult:
+    document: dict[str, Any]
+    data: bytes
+    sha256_after: str
+    bytes_after: int
+    summary: dict[str, Any]
+
+def apply_cell_edit(
+    notebook: ParsedNotebook,
+    *,
+    mode: str,
+    cell_id: str,
+    source: str | None = None,
+    cell_type: str | None = None,
+    insert_position: str | None = None,
+    new_cell_id: str | None = None,
+) -> NotebookEditResult: ...
+```
+
+Use `copy.deepcopy()` before mutation. Raise stable `ValueError` reason codes:
+
+- `notebook_cell_id_not_found`
+- `notebook_invalid_mode`
+- `notebook_insert_position_required`
+- `notebook_source_required`
+- `notebook_invalid_cell_type`
+- `notebook_duplicate_cell_id`
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run helper tests. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py
+git commit -m "feat: add notebook cell edit helpers"
+```
+
+## Task 3: MCP Tool Definitions And Validation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py`
+
+- [ ] **Step 1: Write failing tool metadata and validation tests**
+
+Create tests that instantiate `FilesystemModule` and assert:
+
+- `notebook.read` and `notebook.edit_cell` appear in `get_tools()`.
+- Both tools have `additionalProperties: False`.
+- `notebook.read` has `readOnlyHint=True`, `path_scope_action="read"`, and file-policy `read`.
+- `notebook.edit_cell` has `write_capable=True`, `path_scope_action="edit"`, and file-policy `edit`.
+- Validation rejects unknown args, non-string `path`, invalid modes, missing source for replace/insert, missing `insert_position` for insert, invalid booleans, and missing preimage for edit.
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py -q
+```
+
+Expected: fail because tools are not defined.
+
+- [ ] **Step 3: Add tool definitions and validators**
+
+In `get_tools()`, add `notebook.read` near `fs.read` and `notebook.edit_cell` near `fs.edit`.
+
+Use metadata:
+
+```python
+{
+    "category": "retrieval",
+    "readOnlyHint": True,
+    "capabilities": ["filesystem.read", "notebook.read"],
+    "path_scope_action": "read",
+    **_file_policy_metadata("read"),
+    **shared_path_metadata,
+}
+```
+
+and:
+
+```python
+{
+    "category": "management",
+    "readOnlyHint": False,
+    "write_capable": True,
+    "capabilities": ["filesystem.edit", "notebook.edit"],
+    "path_scope_action": "edit",
+    **_file_policy_metadata("edit"),
+    **shared_path_metadata,
+}
+```
+
+Extend `validate_tool_arguments()` with dedicated branches for both tools.
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run the notebook tool test file. Expected: metadata and validation tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py
+git commit -m "feat: register notebook mcp tools"
+```
+
+## Task 4: MCP Execution Integration
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py`
+
+- [ ] **Step 1: Write failing execution tests**
+
+Use a fake workspace root resolver and temp `.ipynb` files. Assert:
+
+- `notebook.read` returns structure-only summaries by default.
+- `notebook.read` issues a read receipt when configured and full hash is available.
+- `notebook.edit_cell` requires `expected_sha256` or `read_receipt`.
+- Replace, insert, and delete update the file and return bounded summaries.
+- `dry_run=True` returns `edited=False` and does not write.
+- Stale `expected_sha256` raises `ValueError("edit_preimage_mismatch")` or notebook-specific equivalent.
+- Non-`.ipynb` path raises `ValueError("notebook_path_required")`.
+- Invalid JSON raises `ValueError("notebook_invalid_json")`.
+- Code cell replacement clears outputs and execution count.
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py -q
+```
+
+Expected: execution tests fail because dispatch is missing.
+
+- [ ] **Step 3: Implement execution dispatch**
+
+Add branches in `execute_tool()`:
+
+- Resolve paths with `_resolve_workspace_path_no_follow()`.
+- Reject non-`.ipynb` suffix.
+- Read bytes using existing no-follow regular-file helper.
+- Use helper parser/summarizer for `notebook.read`.
+- Issue read receipts with the same manager and context metadata as `fs.read`.
+- For edits, call `_validate_mutation_lock()`, authorize preimage with existing edit receipt logic, call `apply_cell_edit()`, enforce write-size limit, recheck preimage, and write atomically.
+
+Return eval metadata with:
+
+```python
+build_execution_eval_metadata(
+    tool_name="notebook.read",
+    tool_prompt_id="mcp.notebook.read.v1",
+    tool_prompt_version="2026.06.27",
+    action_family="notebook_read",
+    result_kind="structured_notebook_read",
+    path_filter_used=True,
+    truncated=...,
+)
+```
+
+and similarly `notebook.edit_cell` / `notebook_edit`.
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run the notebook tool test file. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py
+git commit -m "feat: execute notebook mcp tools"
+```
+
+## Task 5: Presets And Documentation
+
+**Files:**
+- Modify: `apps/mcp-unified/src/mcp_unified/profiles/presets.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/USER_GUIDE.md`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+
+- [ ] **Step 1: Write failing preset tests**
+
+Update tests to assert:
+
+```python
+assert "notebook.read" in presets._FILES_READ_TOOLS
+assert "notebook.edit_cell" in presets._FILES_EDIT_TOOLS
+assert "notebook.edit_cell" in presets._FILES_WRITE_TOOLS
+```
+
+Also assert legacy read/write lists are unchanged.
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q
+```
+
+Expected: fail because presets do not include notebook tools.
+
+- [ ] **Step 3: Update presets and user guide**
+
+Add:
+
+```python
+_FILES_READ_TOOLS = ["fs.list", "fs.read", "fs.stat", "fs.glob", "fs.grep", "notebook.read"]
+_FILES_EDIT_TOOLS = [*_FILES_READ_TOOLS, "fs.patch", "notebook.edit_cell"]
+```
+
+Update `USER_GUIDE.md` near the safe file read/patch/write section:
+
+- explain structure-first `notebook.read`;
+- explain `notebook.edit_cell` replace/insert/delete by id;
+- show path grant example using `read` and `edit`;
+- state that path grants do not grant the tool itself;
+- state code-cell source replacement clears stale outputs.
+
+- [ ] **Step 4: Run tests to verify green**
+
+Run profile preset tests. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/profiles/presets.py \
+  apps/mcp-unified/src/mcp_unified/USER_GUIDE.md \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+git commit -m "docs: document notebook mcp tools"
+```
+
+## Task 6: Focused Regression And Security Verification
+
+**Files:**
+- Modify: `backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md`
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  -q
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Re-run existing filesystem baseline**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q
+```
+
+Expected: either the same pre-existing glob failure remains, or the file passes. If a new notebook-related failure appears, fix it before continuing.
+
+- [ ] **Step 3: Run Bandit on touched Python files**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py \
+  apps/mcp-unified/src/mcp_unified/profiles/presets.py \
+  -f json -o /tmp/bandit_mcp_notebook_edit_tools.json
+```
+
+Expected: no new findings in touched code. If Bandit is unavailable, record the environment failure on `TASK-2282`.
+
+- [ ] **Step 4: Update Backlog task**
+
+Record:
+
+- implementation summary;
+- touched files;
+- test commands and results;
+- Bandit result path;
+- known baseline filesystem glob failure if still present.
+
+- [ ] **Step 5: Final self-review**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git log --oneline --decorate -5
+```
+
+Expected: no whitespace errors, only intended files changed or clean after commit.
+
+- [ ] **Step 6: Commit task finalization**
+
+```bash
+git add 'backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md'
+git commit -m "chore: finalize task 2282 notebook tools"
+```

--- a/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+++ b/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
@@ -176,6 +176,14 @@ content plus file size, newline style, SHA-256 when available, truncation state,
 and a short-lived read receipt for complete hashed reads when the filesystem
 module has a stable `read_receipt_secret` configured.
 
+For Jupyter notebooks, use `notebook.read` instead of `fs.read` when the caller
+needs notebook structure rather than raw JSON. It returns notebook metadata,
+cell ids, cell types, execution counts, output counts, byte size, SHA-256, and
+an optional read receipt. Source is omitted by default. Callers can pass
+`include_source=true` for bounded source previews, narrow the response with
+`cell_ids`, and tune `max_source_chars` or `max_total_source_chars` within the
+module limits.
+
 For existing-file edits, prefer `fs.patch` over whole-file replacement. It
 accepts unified diff text, derives affected paths before execution for path
 policy checks, validates context in memory, and only writes after preimage
@@ -187,6 +195,15 @@ and it also requires either `expected_sha256` or a valid `read_receipt` from
 `fs.write` `mode="create"` fails if the file already exists. `mode="replace"`
 requires either `expected_sha256` or a valid `read_receipt` from `fs.read`.
 
+For notebook edits, use `notebook.edit_cell` instead of `fs.write`. It performs
+one cell-scoped operation by stable cell id: `mode="replace"` updates the target
+cell source, `mode="insert"` adds a `code`, `markdown`, or `raw` cell before or
+after the target, and `mode="delete"` removes the target cell. Replacing a code
+cell clears stored outputs and execution count so stale execution artifacts are
+not preserved. Like file edits, notebook edits require either
+`expected_sha256` or a valid read receipt from `notebook.read`, and they can use
+`dry_run=true` before writing.
+
 This read-before-mutate flow protects against stale edits: if a file changes
 after the model read it, the expected hash or receipt no longer matches and the
 write is rejected instead of silently overwriting newer content.
@@ -194,11 +211,12 @@ write is rejected instead of silently overwriting newer content.
 For concurrent editing workflows, `fs.lock_acquire` and `fs.lock_release`
 provide advisory leases for workspace-relative file paths. A successful acquire
 returns a `lease_id` that callers can pass to `fs.edit` and `fs.write` as
-`lock_lease_id`, or to `fs.patch` as `lock_lease_id_by_path`. Leases do not
-replace hashes or read receipts; mutation tools still run their normal preimage
-checks. Operators can set `require_lock_for_mutation=true` on the filesystem
-module when they want mutations to fail with `lock_required` unless the caller
-supplies a matching active lease.
+`lock_lease_id`, to `notebook.edit_cell` as `lock_lease_id`, or to `fs.patch` as
+`lock_lease_id_by_path`. Leases do not replace hashes or read receipts;
+mutation tools still run their normal preimage checks. Operators can set
+`require_lock_for_mutation=true` on the filesystem module when they want
+mutations to fail with `lock_required` unless the caller supplies a matching
+active lease.
 
 The packaged lock manager supports `lock_manager_backend` values of `memory`,
 `in_memory`, or `sqlite`. The memory and in-memory backends are process-local
@@ -232,12 +250,19 @@ profile with `write` can use `fs.write` and patch-created files when policy also
 allows creation. Deny grants take precedence over broader allow grants, so a
 private subtree can remain read-only or blocked under a writable parent.
 
+Tool allow lists and path grants are separate checks. A profile must allow
+`notebook.read` or `notebook.edit_cell` as tools, and the target path must also
+have the matching `read` or `edit` path action. The shorthand mental model is
+`NotebookRead(path)` for a read action and `NotebookEdit(path)` for an edit
+action; these are policy concepts, not extra executable tool names.
+
 The file-policy action vocabulary is broader than the tools currently shipped.
 The executable filesystem actions today are:
 
 - `read`: inspect file content, directory listings, search results, and path
-  metadata.
-- `edit`: bounded existing-file edits through `fs.patch` or `fs.edit`.
+  metadata, including notebook structure through `notebook.read`.
+- `edit`: bounded existing-file edits through `fs.patch`, `fs.edit`, or
+  `notebook.edit_cell`.
 - `write`: deliberate whole-file create or replace through `fs.write`.
 - `lock`: acquire or release advisory path locks through `fs.lock_acquire` and
   `fs.lock_release`.

--- a/apps/mcp-unified/src/mcp_unified/profiles/presets.py
+++ b/apps/mcp-unified/src/mcp_unified/profiles/presets.py
@@ -186,8 +186,8 @@ _TOOL_DISCOVERY_TOOLS = [
     "tool_describe",
     "profile.tools.list",
 ]
-_FILES_READ_TOOLS = ["fs.list", "fs.read", "fs.stat", "fs.glob", "fs.grep"]
-_FILES_EDIT_TOOLS = [*_FILES_READ_TOOLS, "fs.patch"]
+_FILES_READ_TOOLS = ["fs.list", "fs.read", "fs.stat", "fs.glob", "fs.grep", "notebook.read"]
+_FILES_EDIT_TOOLS = [*_FILES_READ_TOOLS, "fs.patch", "notebook.edit_cell"]
 _FILES_WRITE_TOOLS = [*_FILES_EDIT_TOOLS, "fs.write"]
 _LEGACY_FILES_READ_TOOLS = ["fs.read_text"]
 _LEGACY_FILES_WRITE_TOOLS = ["fs.write_text"]
@@ -765,8 +765,8 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
                 "screenshots.capture",
                 "app_state.read",
             ],
-            direct_categories=["files", "code", "tests", "browser", "tool_discovery"],
-            deferred_categories=["git", "safe_test_runner", "issue_tracker"],
+            direct_categories=["files", "tests", "browser", "tool_discovery"],
+            deferred_categories=["code", "git", "safe_test_runner", "issue_tracker"],
             recommended_tools=[
                 recommended_tool(
                     "tests.plan.generate",

--- a/backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md
+++ b/backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md
@@ -1,21 +1,22 @@
 ---
 id: TASK-2282
 title: Add NotebookEdit-style notebook file tools
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-27 20:33'
 labels:
-- mcp
-- filesystem
-- notebooks
-- tools
-- agentic-execution
+  - mcp
+  - filesystem
+  - notebooks
+  - tools
+  - agentic-execution
+dependencies: []
 references:
-- https://code.claude.com/docs/en/tools-reference
+  - 'https://code.claude.com/docs/en/tools-reference'
 documentation:
-- Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
-- Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
-modified_files:
-- Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
-- Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
+  - Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
+  - Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
 ---
 
 ## Description
@@ -36,22 +37,29 @@ Design approved and committed. Implementation plan added at Docs/superpowers/pla
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented notebook-safe MCP file tooling for TASK-2282. Added `notebook.read` for structure-first `.ipynb` inspection with bounded optional source previews and read receipts. Added `notebook.edit_cell` for replace, insert, and delete operations by stable cell id with preimage checks, optional lock leases, dry-run support, write-size limits, and stale code-output clearing on code-cell replacement. Registered both tools in the filesystem module with read/edit file policy metadata, added profile preset coverage, documented the allow-list/path-grant model in the MCP Unified user guide, and kept SDET progressive disclosure within the direct-tool budget by deferring code search while keeping it enabled.
 
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q` -> 74 passed, 4 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q` -> 103 passed, 1 failed. The failure is the known pre-existing `test_filesystem_glob_marks_file_size_unavailable` glob metadata failure recorded before notebook changes.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py apps/mcp-unified/src/mcp_unified/profiles/presets.py -f json -o /tmp/bandit_mcp_notebook_edit_tools.json` -> exit 0, zero findings, output at `/tmp/bandit_mcp_notebook_edit_tools.json`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md
+++ b/backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2282
 title: Add NotebookEdit-style notebook file tools
-status: To Do
+status: In Progress
 labels:
 - mcp
 - filesystem
@@ -10,6 +10,10 @@ labels:
 - agentic-execution
 references:
 - https://code.claude.com/docs/en/tools-reference
+documentation:
+- Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
+modified_files:
+- Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
 ---
 
 ## Description
@@ -21,6 +25,12 @@ Design and implement notebook-safe MCP tools modeled after Claude Code NotebookE
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Design approved with refinements: keep notebook parsing/editing in a focused helper, expose NotebookEdit-style read/edit tools through the MCP filesystem module, require path grants and preimage checks, clear stale code-cell outputs by default, reject missing/duplicate target cell ids, preserve notebook JSON shape where practical, keep source reads bounded and intentional, treat cell deletion as file-policy edit, and keep telemetry/error payloads redaction-safe.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 

--- a/backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md
+++ b/backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md
@@ -12,8 +12,10 @@ references:
 - https://code.claude.com/docs/en/tools-reference
 documentation:
 - Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
+- Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
 modified_files:
 - Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
+- Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
 ---
 
 ## Description
@@ -29,7 +31,7 @@ Design and implement notebook-safe MCP tools modeled after Claude Code NotebookE
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Design approved with refinements: keep notebook parsing/editing in a focused helper, expose NotebookEdit-style read/edit tools through the MCP filesystem module, require path grants and preimage checks, clear stale code-cell outputs by default, reject missing/duplicate target cell ids, preserve notebook JSON shape where practical, keep source reads bounded and intentional, treat cell deletion as file-policy edit, and keep telemetry/error payloads redaction-safe.
+Design approved and committed. Implementation plan added at Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md. Baseline before notebook edits: filesystem module tests had 103 passed and 1 pre-existing glob metadata failure.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md
+++ b/backlog/tasks/task-2282 - Add-NotebookEdit-style-notebook-file-tools.md
@@ -4,19 +4,29 @@ title: Add NotebookEdit-style notebook file tools
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-27 20:33'
+updated_date: 2026-06-27 20:33
 labels:
-  - mcp
-  - filesystem
-  - notebooks
-  - tools
-  - agentic-execution
+- mcp
+- filesystem
+- notebooks
+- tools
+- agentic-execution
 dependencies: []
 references:
-  - 'https://code.claude.com/docs/en/tools-reference'
+- https://code.claude.com/docs/en/tools-reference
 documentation:
-  - Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
-  - Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
+- Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
+- Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
+modified_files:
+- Docs/Design/2026-06-27-mcp-notebook-edit-tools-design.md
+- Docs/superpowers/plans/2026-06-27-mcp-notebook-edit-tools.md
+- apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+- apps/mcp-unified/src/mcp_unified/profiles/presets.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
 ---
 
 ## Description
@@ -46,12 +56,13 @@ Design approved and committed. Implementation plan added at Docs/superpowers/pla
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented notebook-safe MCP file tooling for TASK-2282. Added `notebook.read` for structure-first `.ipynb` inspection with bounded optional source previews and read receipts. Added `notebook.edit_cell` for replace, insert, and delete operations by stable cell id with preimage checks, optional lock leases, dry-run support, write-size limits, and stale code-output clearing on code-cell replacement. Registered both tools in the filesystem module with read/edit file policy metadata, added profile preset coverage, documented the allow-list/path-grant model in the MCP Unified user guide, and kept SDET progressive disclosure within the direct-tool budget by deferring code search while keeping it enabled.
+Implemented notebook-safe MCP file tooling for TASK-2282 and addressed PR review feedback after rebasing on latest `origin/dev`. Original implementation added `notebook.read` for structure-first `.ipynb` inspection with bounded optional source previews and read receipts, plus `notebook.edit_cell` for replace, insert, and delete by stable cell id with preimage checks, optional lock leases, dry-run support, write-size limits, and stale code-output clearing on code-cell replacement. Review remediation added module/class/function docstrings in the new notebook test modules, validates existing notebook cell types during parsing, strips code-only `outputs` and `execution_count` when replacing a code cell with markdown/raw, maps oversized notebook reads/edits to `notebook_too_large`, and adds receipt-authorized edit coverage.
 
 Verification:
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q` -> 74 passed, 4 warnings.
+- Red run before fixes: `pytest test_notebook_files.py test_filesystem_notebook_tools.py -q` failed on invalid existing cell types, code-only field stripping, and oversize reason-code mapping as expected.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q` -> 80 passed, 4 warnings.
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q` -> 103 passed, 1 failed. The failure is the known pre-existing `test_filesystem_glob_marks_file_size_unavailable` glob metadata failure recorded before notebook changes.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py apps/mcp-unified/src/mcp_unified/profiles/presets.py -f json -o /tmp/bandit_mcp_notebook_edit_tools.json` -> exit 0, zero findings, output at `/tmp/bandit_mcp_notebook_edit_tools.json`.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py apps/mcp-unified/src/mcp_unified/profiles/presets.py -f json -o /tmp/bandit_mcp_notebook_edit_tools_review.json` -> exit 0, zero findings, output at `/tmp/bandit_mcp_notebook_edit_tools_review.json`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -2690,7 +2690,12 @@ class FilesystemModule(BaseModule):
 
         if target.suffix.lower() != ".ipynb":
             raise ValueError("notebook_path_required")
-        payload, _file_stat = self._read_existing_regular_file_no_follow(target, max_bytes=max_bytes)
+        try:
+            payload, _file_stat = self._read_existing_regular_file_no_follow(target, max_bytes=max_bytes)
+        except ValueError as exc:
+            if str(exc) == "edit_preimage_too_large":
+                raise ValueError("notebook_too_large") from exc
+            raise
         parsed = parse_notebook_payload(payload, max_bytes=max_bytes)
         rel_path = self._to_workspace_relative_path(workspace_root, target)
         result = {
@@ -2749,7 +2754,12 @@ class FilesystemModule(BaseModule):
             raise ValueError("notebook_path_required")
         rel_path = self._to_workspace_relative_path(workspace_root, target)
         self._validate_mutation_lock(workspace_root, rel_path, lock_lease_id)
-        payload, file_stat = self._read_existing_regular_file_no_follow(target, max_bytes=preimage_max_bytes)
+        try:
+            payload, file_stat = self._read_existing_regular_file_no_follow(target, max_bytes=preimage_max_bytes)
+        except ValueError as exc:
+            if str(exc) == "edit_preimage_too_large":
+                raise ValueError("notebook_too_large") from exc
+            raise
         parsed = parse_notebook_payload(payload, max_bytes=preimage_max_bytes)
         self._authorize_edit_preimage(
             rel_path,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -210,6 +210,36 @@ class FilesystemModule(BaseModule):
         )
         read_tool["inputSchema"]["additionalProperties"] = False
 
+        notebook_read_tool = create_tool_definition(
+            name="notebook.read",
+            description="Read bounded Jupyter notebook structure and optional cell source previews.",
+            parameters={
+                "properties": {
+                    "path": {"type": "string", "description": "Workspace-relative or absolute .ipynb path"},
+                    "include_source": {"type": "boolean", "default": False},
+                    "cell_ids": {"type": "array", "items": {"type": "string"}},
+                    "max_source_chars": {"type": "integer", "minimum": 1},
+                    "max_total_source_chars": {"type": "integer", "minimum": 1},
+                    "include_receipt": {"type": "boolean", "default": True},
+                },
+                "required": ["path"],
+            },
+            metadata={
+                "category": "retrieval",
+                "readOnlyHint": True,
+                "capabilities": ["filesystem.read", "notebook.read"],
+                "path_scope_action": "read",
+                **_file_policy_metadata("read"),
+                "eval": {
+                    "task_families": ["notebook_read"],
+                    "expected_result_kind": "structured_notebook_read",
+                    "success_signals": ["avoided_mutation"],
+                },
+                **shared_path_metadata,
+            },
+        )
+        notebook_read_tool["inputSchema"]["additionalProperties"] = False
+
         edit_tool = create_tool_definition(
             name="fs.edit",
             description="Replace exact UTF-8 text inside an existing workspace file after preimage checks.",
@@ -242,6 +272,42 @@ class FilesystemModule(BaseModule):
             },
         )
         edit_tool["inputSchema"]["additionalProperties"] = False
+
+        notebook_edit_tool = create_tool_definition(
+            name="notebook.edit_cell",
+            description="Replace, insert, or delete one Jupyter notebook cell by cell id after preimage checks.",
+            parameters={
+                "properties": {
+                    "path": {"type": "string", "description": "Workspace-relative or absolute .ipynb path"},
+                    "mode": {"type": "string", "enum": ["replace", "insert", "delete"]},
+                    "cell_id": {"type": "string", "description": "Existing target cell id"},
+                    "insert_position": {"type": "string", "enum": ["before", "after"]},
+                    "new_cell_id": {"type": "string"},
+                    "cell_type": {"type": "string", "enum": ["code", "markdown", "raw"]},
+                    "source": {"type": "string"},
+                    "expected_sha256": {"type": "string"},
+                    "read_receipt": {"type": "string"},
+                    "lock_lease_id": {"type": "string"},
+                    "dry_run": {"type": "boolean", "default": False},
+                },
+                "required": ["path", "mode", "cell_id"],
+            },
+            metadata={
+                "category": "management",
+                "readOnlyHint": False,
+                "write_capable": True,
+                "capabilities": ["filesystem.edit", "notebook.edit"],
+                "path_scope_action": "edit",
+                **_file_policy_metadata("edit"),
+                "eval": {
+                    "task_families": ["notebook_edit"],
+                    "expected_result_kind": "structured_notebook_edit",
+                    "success_signals": ["completed_requested_mutation"],
+                },
+                **shared_path_metadata,
+            },
+        )
+        notebook_edit_tool["inputSchema"]["additionalProperties"] = False
 
         lock_acquire_tool = create_tool_definition(
             name="fs.lock_acquire",
@@ -523,7 +589,9 @@ class FilesystemModule(BaseModule):
         return [
             list_tool,
             read_tool,
+            notebook_read_tool,
             edit_tool,
+            notebook_edit_tool,
             lock_acquire_tool,
             lock_release_tool,
             read_text_tool,
@@ -894,6 +962,30 @@ class FilesystemModule(BaseModule):
             self._validate_bool_argument(arguments, "include_receipt")
             return
 
+        if tool_name == "notebook.read":
+            unknown = sorted(
+                set(arguments)
+                - {
+                    "path",
+                    "include_source",
+                    "cell_ids",
+                    "max_source_chars",
+                    "max_total_source_chars",
+                    "include_receipt",
+                }
+            )
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            path = arguments.get("path")
+            if not isinstance(path, str) or not path.strip():
+                raise ValueError("path is required")
+            self._validate_bool_argument(arguments, "include_source")
+            self._validate_bool_argument(arguments, "include_receipt")
+            self._validate_optional_string_list_argument(arguments, "cell_ids")
+            self._validate_positive_int_argument(arguments, "max_source_chars")
+            self._validate_positive_int_argument(arguments, "max_total_source_chars")
+            return
+
         if tool_name == "fs.lock_acquire":
             unknown = sorted(set(arguments) - {"path", "owner", "ttl_seconds", "lease_id"})
             if unknown:
@@ -956,6 +1048,63 @@ class FilesystemModule(BaseModule):
             self._validate_optional_nonempty_string_argument(arguments, "lock_lease_id")
             self._validate_bool_argument(arguments, "replace_all")
             self._validate_bool_argument(arguments, "dry_run")
+            return
+
+        if tool_name == "notebook.edit_cell":
+            unknown = sorted(
+                set(arguments)
+                - {
+                    "path",
+                    "mode",
+                    "cell_id",
+                    "insert_position",
+                    "new_cell_id",
+                    "cell_type",
+                    "source",
+                    "expected_sha256",
+                    "read_receipt",
+                    "lock_lease_id",
+                    "dry_run",
+                }
+            )
+            if unknown:
+                raise ValueError(f"unknown arguments: {', '.join(unknown)}")
+            path = arguments.get("path")
+            mode = arguments.get("mode")
+            cell_id = arguments.get("cell_id")
+            source = arguments.get("source")
+            cell_type = arguments.get("cell_type")
+            insert_position = arguments.get("insert_position")
+            if not isinstance(path, str) or not path.strip():
+                raise ValueError("path is required")
+            if not isinstance(mode, str) or not mode.strip():
+                raise ValueError("mode is required")
+            if mode not in {"replace", "insert", "delete"}:
+                raise ValueError("mode must be one of: replace, insert, delete")
+            if not isinstance(cell_id, str) or not cell_id.strip():
+                raise ValueError("cell_id is required")
+            if mode in {"replace", "insert"} and not isinstance(source, str):
+                raise ValueError("source is required")
+            if source is not None and not isinstance(source, str):
+                raise ValueError("source must be a string")
+            if mode == "insert":
+                if insert_position not in {"before", "after"}:
+                    raise ValueError("insert_position is required")
+                if cell_type not in {"code", "markdown", "raw"}:
+                    raise ValueError("cell_type is required" if cell_type is None else "cell_type must be one of: code, markdown, raw")
+            elif insert_position is not None and insert_position not in {"before", "after"}:
+                raise ValueError("insert_position must be one of: before, after")
+            if cell_type is not None and cell_type not in {"code", "markdown", "raw"}:
+                raise ValueError("cell_type must be one of: code, markdown, raw")
+            for key in ("new_cell_id", "lock_lease_id"):
+                self._validate_optional_nonempty_string_argument(arguments, key)
+            for key in ("expected_sha256", "read_receipt"):
+                value = arguments.get(key)
+                if value is not None and not isinstance(value, str):
+                    raise ValueError(f"{key} must be a string")
+            self._validate_bool_argument(arguments, "dry_run")
+            if not arguments.get("expected_sha256") and not arguments.get("read_receipt"):
+                raise ValueError("edit_preimage_required")
             return
 
         if tool_name == "fs.patch":
@@ -1180,6 +1329,14 @@ class FilesystemModule(BaseModule):
         value = arguments.get(key)
         if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value <= 0):
             raise ValueError(f"{key} must be a positive integer")
+
+    @staticmethod
+    def _validate_optional_string_list_argument(arguments: dict[str, Any], key: str) -> None:
+        value = arguments.get(key)
+        if value is None:
+            return
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError(f"{key} must be a list of strings")
 
     @staticmethod
     def _validate_optional_string_map_argument(arguments: dict[str, Any], key: str) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -51,6 +51,7 @@ from ...tool_observability import build_execution_eval_metadata
 from ..base import BaseModule, ModuleConfig, create_tool_definition
 from .filesystem_diff import FilesystemPatchError, PatchFile, apply_patch_to_text, parse_unified_diff
 from .filesystem_receipts import ReadReceiptError, ReadReceiptManager
+from .notebook_files import apply_cell_edit, parse_notebook_payload, summarize_notebook
 
 
 def _first_nonempty(*values: Any) -> str | None:
@@ -610,6 +611,11 @@ class FilesystemModule(BaseModule):
                 key: value if key in {"old_string", "new_string"} else self.sanitize_input(value)
                 for key, value in raw_args.items()
             }
+        elif tool_name == "notebook.edit_cell":
+            args = {
+                key: value if key == "source" else self.sanitize_input(value)
+                for key, value in raw_args.items()
+            }
         elif tool_name == "fs.patch":
             args = {
                 key: self._sanitize_patch_diff(value) if key == "diff" else self.sanitize_input(value)
@@ -685,6 +691,29 @@ class FilesystemModule(BaseModule):
             )
             return result
 
+        if tool_name == "notebook.read":
+            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
+            return await asyncio.to_thread(
+                self._read_notebook,
+                workspace_root,
+                target,
+                bool(args.get("include_source", False)),
+                self._string_list_argument(args.get("cell_ids")),
+                self._bounded_positive_int(
+                    args.get("max_source_chars"),
+                    self._setting_positive_int("notebook_default_max_source_chars", 4_000),
+                    maximum=self._setting_positive_int("notebook_max_source_chars", 20_000),
+                ),
+                self._bounded_positive_int(
+                    args.get("max_total_source_chars"),
+                    self._setting_positive_int("notebook_default_max_total_source_chars", 20_000),
+                    maximum=self._setting_positive_int("notebook_max_total_source_chars", 100_000),
+                ),
+                self._setting_positive_int("notebook_read_max_bytes", 5_000_000),
+                bool(args.get("include_receipt", True)),
+                context,
+            )
+
         if tool_name == "fs.lock_acquire":
             return await asyncio.to_thread(
                 self._acquire_lock_for_path,
@@ -719,6 +748,27 @@ class FilesystemModule(BaseModule):
                 bool(args.get("dry_run", False)),
                 self._setting_positive_int("edit_preimage_max_bytes", 5_000_000),
                 self._setting_positive_int("edit_write_max_bytes", 5_000_000),
+                context,
+            )
+
+        if tool_name == "notebook.edit_cell":
+            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
+            return await asyncio.to_thread(
+                self._edit_notebook_cell,
+                workspace_root,
+                target,
+                str(args.get("mode")),
+                str(args.get("cell_id")),
+                args.get("source"),
+                args.get("cell_type"),
+                args.get("insert_position"),
+                args.get("new_cell_id"),
+                args.get("expected_sha256"),
+                args.get("read_receipt"),
+                args.get("lock_lease_id"),
+                bool(args.get("dry_run", False)),
+                self._setting_positive_int("notebook_preimage_max_bytes", 5_000_000),
+                self._setting_positive_int("notebook_write_max_bytes", 5_000_000),
                 context,
             )
 
@@ -1329,6 +1379,14 @@ class FilesystemModule(BaseModule):
         value = arguments.get(key)
         if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value <= 0):
             raise ValueError(f"{key} must be a positive integer")
+
+    @staticmethod
+    def _string_list_argument(value: Any) -> list[str] | None:
+        if value is None:
+            return None
+        if not isinstance(value, list):
+            return None
+        return [str(item) for item in value]
 
     @staticmethod
     def _validate_optional_string_list_argument(arguments: dict[str, Any], key: str) -> None:
@@ -2615,6 +2673,131 @@ class FilesystemModule(BaseModule):
             or hashlib.sha256(payload).hexdigest() != expected_sha256
         ):
             raise ValueError("preimage_changed_during_commit")
+
+    def _read_notebook(
+        self,
+        workspace_root: Path,
+        target: Path,
+        include_source: bool,
+        cell_ids: list[str] | None,
+        max_source_chars: int,
+        max_total_source_chars: int,
+        max_bytes: int,
+        include_receipt: bool,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        """Read a notebook structure summary without exposing full notebook JSON."""
+
+        if target.suffix.lower() != ".ipynb":
+            raise ValueError("notebook_path_required")
+        payload, _file_stat = self._read_existing_regular_file_no_follow(target, max_bytes=max_bytes)
+        parsed = parse_notebook_payload(payload, max_bytes=max_bytes)
+        rel_path = self._to_workspace_relative_path(workspace_root, target)
+        result = {
+            "path": rel_path,
+            **summarize_notebook(
+                parsed,
+                include_source=include_source,
+                cell_ids=cell_ids,
+                max_source_chars=max_source_chars,
+                max_total_source_chars=max_total_source_chars,
+            ),
+        }
+        if include_receipt and self._read_receipts.enabled:
+            result["read_receipt"] = self._read_receipts.issue(
+                path=rel_path,
+                sha256=parsed.sha256,
+                size=parsed.size,
+                workspace_id=self._context_metadata_value(context, "workspace_id"),
+                session_id=_first_nonempty(
+                    getattr(context, "session_id", None),
+                    self._context_metadata_value(context, "session_id"),
+                ),
+            )
+        result["eval"] = build_execution_eval_metadata(
+            tool_name="notebook.read",
+            tool_prompt_id="mcp.notebook.read.v1",
+            tool_prompt_version="2026.06.27",
+            action_family="notebook_read",
+            result_kind="structured_notebook_read",
+            path_filter_used=True,
+            truncated=bool(result.get("source_preview_truncated", False)),
+        )
+        return result
+
+    def _edit_notebook_cell(
+        self,
+        workspace_root: Path,
+        target: Path,
+        mode: str,
+        cell_id: str,
+        source: Any,
+        cell_type: Any,
+        insert_position: Any,
+        new_cell_id: Any,
+        expected_sha256: Any,
+        read_receipt: Any,
+        lock_lease_id: Any,
+        dry_run: bool,
+        preimage_max_bytes: int,
+        write_max_bytes: int,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        """Apply one preimage-protected notebook cell edit."""
+
+        if target.suffix.lower() != ".ipynb":
+            raise ValueError("notebook_path_required")
+        rel_path = self._to_workspace_relative_path(workspace_root, target)
+        self._validate_mutation_lock(workspace_root, rel_path, lock_lease_id)
+        payload, file_stat = self._read_existing_regular_file_no_follow(target, max_bytes=preimage_max_bytes)
+        parsed = parse_notebook_payload(payload, max_bytes=preimage_max_bytes)
+        self._authorize_edit_preimage(
+            rel_path,
+            parsed.sha256,
+            parsed.size,
+            expected_sha256,
+            read_receipt,
+            context,
+        )
+        edit_result = apply_cell_edit(
+            parsed,
+            mode=mode,
+            cell_id=cell_id,
+            source=source,
+            cell_type=cell_type,
+            insert_position=insert_position,
+            new_cell_id=new_cell_id,
+        )
+        if edit_result.bytes_after > write_max_bytes:
+            raise ValueError("notebook_write_too_large")
+
+        if not dry_run:
+            self._validate_mutation_lock(workspace_root, rel_path, lock_lease_id)
+            self._assert_edit_preimage_unchanged_no_follow(target, parsed.sha256, parsed.size, file_stat)
+            self._atomic_write_text_file(target, edit_result.data.decode("utf-8"))
+
+        result: dict[str, Any] = {
+            "path": rel_path,
+            "edited": not dry_run,
+            "dry_run": dry_run,
+            "bytes_before": parsed.size,
+            "bytes_after": edit_result.bytes_after,
+            "sha256_before": parsed.sha256,
+            "sha256_after": edit_result.sha256_after,
+            **edit_result.summary,
+            "eval": build_execution_eval_metadata(
+                tool_name="notebook.edit_cell",
+                tool_prompt_id="mcp.notebook.edit_cell.v1",
+                tool_prompt_version="2026.06.27",
+                action_family="notebook_edit",
+                result_kind="structured_notebook_edit",
+                path_filter_used=True,
+                truncated=False,
+            ),
+        }
+        if not dry_run:
+            result["bytes_written"] = edit_result.bytes_after
+        return result
 
     @staticmethod
     def _find_overlapping_matches(text: str, old_string: str) -> list[int]:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py
@@ -1,0 +1,153 @@
+"""Jupyter notebook parsing and bounded cell-summary helpers for MCP tools."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class NotebookFormat:
+    """Small formatting hints captured from an input notebook."""
+
+    trailing_newline: bool
+    indent: int
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedNotebook:
+    """Validated notebook JSON plus stable preimage metadata."""
+
+    document: dict[str, Any]
+    payload: bytes
+    sha256: str
+    size: int
+    format: NotebookFormat
+
+
+def parse_notebook_payload(payload: bytes, *, max_bytes: int | None = None) -> ParsedNotebook:
+    """Parse and validate a Jupyter notebook byte payload."""
+
+    if max_bytes is not None and len(payload) > max(0, int(max_bytes)):
+        raise ValueError("notebook_too_large")
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("notebook_invalid_utf8") from exc
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError("notebook_invalid_json") from exc
+    if not isinstance(document, dict):
+        raise ValueError("notebook_object_required")
+
+    cells = document.get("cells")
+    if not isinstance(cells, list):
+        raise ValueError("notebook_cells_required")
+
+    seen_ids: set[str] = set()
+    for cell in cells:
+        if not isinstance(cell, dict):
+            raise ValueError("notebook_cell_object_required")
+        cell_id = cell.get("id")
+        if not isinstance(cell_id, str) or not cell_id.strip():
+            raise ValueError("notebook_cell_id_required")
+        if cell_id in seen_ids:
+            raise ValueError("notebook_duplicate_cell_id")
+        seen_ids.add(cell_id)
+        _cell_source_text(cell)
+
+    return ParsedNotebook(
+        document=document,
+        payload=payload,
+        sha256=hashlib.sha256(payload).hexdigest(),
+        size=len(payload),
+        format=NotebookFormat(
+            trailing_newline=text.endswith("\n"),
+            indent=_detect_json_indent(text),
+        ),
+    )
+
+
+def summarize_notebook(
+    notebook: ParsedNotebook,
+    *,
+    include_source: bool = False,
+    cell_ids: list[str] | None = None,
+    max_source_chars: int = 4_000,
+    max_total_source_chars: int = 20_000,
+) -> dict[str, Any]:
+    """Return a bounded notebook structure summary."""
+
+    selected_ids = set(cell_ids or [])
+    per_cell_limit = max(0, int(max_source_chars))
+    total_remaining = max(0, int(max_total_source_chars))
+    any_source_truncated = False
+    cells: list[dict[str, Any]] = []
+
+    for index, cell in enumerate(notebook.document["cells"]):
+        source_text = _cell_source_text(cell)
+        item: dict[str, Any] = {
+            "index": index,
+            "id": str(cell["id"]),
+            "cell_type": str(cell.get("cell_type") or ""),
+            "source_line_count": _source_line_count(source_text),
+            "source_char_count": len(source_text),
+        }
+        if item["cell_type"] == "code":
+            item["execution_count"] = cell.get("execution_count")
+            outputs = cell.get("outputs")
+            item["output_count"] = len(outputs) if isinstance(outputs, list) else 0
+
+        should_include_source = include_source and (not selected_ids or item["id"] in selected_ids)
+        if should_include_source:
+            cell_budget = min(per_cell_limit, total_remaining)
+            preview = source_text[:cell_budget]
+            truncated = len(preview) < len(source_text)
+            item["source_preview"] = preview
+            item["source_preview_truncated"] = truncated
+            any_source_truncated = any_source_truncated or truncated
+            total_remaining -= len(preview)
+
+        cells.append(item)
+
+    return {
+        "nbformat": notebook.document.get("nbformat"),
+        "nbformat_minor": notebook.document.get("nbformat_minor"),
+        "cell_count": len(cells),
+        "sha256": notebook.sha256,
+        "bytes_total": notebook.size,
+        "source_preview_truncated": any_source_truncated,
+        "cells": cells,
+    }
+
+
+def _cell_source_text(cell: dict[str, Any]) -> str:
+    """Return a normalized source string for one notebook cell."""
+
+    source = cell.get("source", "")
+    if isinstance(source, str):
+        return source
+    if isinstance(source, list) and all(isinstance(item, str) for item in source):
+        return "".join(source)
+    raise ValueError("notebook_cell_source_invalid")
+
+
+def _source_line_count(source: str) -> int:
+    """Return a stable human-facing source line count."""
+
+    if not source:
+        return 0
+    return len(source.splitlines())
+
+
+def _detect_json_indent(text: str) -> int:
+    """Infer common JSON indentation from the first indented key line."""
+
+    match = re.search(r"\n( +)\"", text)
+    if match is None:
+        return 2
+    return max(1, len(match.group(1)))

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py
@@ -69,6 +69,7 @@ def parse_notebook_payload(payload: bytes, *, max_bytes: int | None = None) -> P
     for cell in cells:
         if not isinstance(cell, dict):
             raise ValueError("notebook_cell_object_required")
+        cell["cell_type"] = _normalized_cell_type(cell.get("cell_type"))
         cell_id = cell.get("id")
         if not isinstance(cell_id, str) or not cell_id.strip():
             raise ValueError("notebook_cell_id_required")
@@ -188,6 +189,9 @@ def apply_cell_edit(
         if editable_target.get("cell_type") == "code":
             editable_target["outputs"] = []
             editable_target["execution_count"] = None
+        else:
+            editable_target.pop("outputs", None)
+            editable_target.pop("execution_count", None)
         source_after = _cell_source_text(editable_target)
         summary.update(
             {

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import secrets
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
+
+
+_VALID_CELL_TYPES = frozenset({"code", "markdown", "raw"})
+_CELL_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +32,17 @@ class ParsedNotebook:
     sha256: str
     size: int
     format: NotebookFormat
+
+
+@dataclass(frozen=True, slots=True)
+class NotebookEditResult:
+    """Result of one in-memory notebook cell edit."""
+
+    document: dict[str, Any]
+    data: bytes
+    sha256_after: str
+    bytes_after: int
+    summary: dict[str, Any]
 
 
 def parse_notebook_payload(payload: bytes, *, max_bytes: int | None = None) -> ParsedNotebook:
@@ -125,6 +142,109 @@ def summarize_notebook(
     }
 
 
+def apply_cell_edit(
+    notebook: ParsedNotebook,
+    *,
+    mode: str,
+    cell_id: str,
+    source: str | None = None,
+    cell_type: str | None = None,
+    insert_position: str | None = None,
+    new_cell_id: str | None = None,
+) -> NotebookEditResult:
+    """Apply one bounded cell edit to a parsed notebook document."""
+
+    normalized_mode = str(mode or "").strip()
+    if normalized_mode not in {"replace", "insert", "delete"}:
+        raise ValueError("notebook_invalid_mode")
+
+    cells = _notebook_cells(notebook.document)
+    target_index = _find_cell_index(cells, cell_id)
+    target_cell = cells[target_index]
+    document = deepcopy(notebook.document)
+    editable_cells = _notebook_cells(document)
+    editable_target = editable_cells[target_index]
+
+    cell_count_before = len(cells)
+    source_before = _cell_source_text(target_cell)
+    output_count_before = _cell_output_count(target_cell)
+    summary: dict[str, Any] = {
+        "mode": normalized_mode,
+        "cell_id": cell_id,
+        "index_before": target_index,
+        "cell_count_before": cell_count_before,
+        "source_line_count_before": _source_line_count(source_before),
+        "source_char_count_before": len(source_before),
+        "output_count_before": output_count_before,
+    }
+
+    if normalized_mode == "replace":
+        if source is None:
+            raise ValueError("notebook_source_required")
+        replacement_type = _normalized_cell_type(cell_type) if cell_type is not None else None
+        if replacement_type is not None:
+            editable_target["cell_type"] = replacement_type
+        _set_cell_source(editable_target, source, original_cell=target_cell)
+        if editable_target.get("cell_type") == "code":
+            editable_target["outputs"] = []
+            editable_target["execution_count"] = None
+        source_after = _cell_source_text(editable_target)
+        summary.update(
+            {
+                "index_after": target_index,
+                "cell_count_after": len(editable_cells),
+                "source_line_count_after": _source_line_count(source_after),
+                "source_char_count_after": len(source_after),
+                "output_count_after": _cell_output_count(editable_target),
+            }
+        )
+    elif normalized_mode == "insert":
+        if source is None:
+            raise ValueError("notebook_source_required")
+        if insert_position not in {"before", "after"}:
+            raise ValueError("notebook_insert_position_required")
+        inserted_cell_id = _unique_new_cell_id(editable_cells, new_cell_id)
+        inserted_cell_type = _normalized_cell_type(cell_type)
+        insert_index = target_index if insert_position == "before" else target_index + 1
+        inserted_cell = _new_cell(
+            cell_id=inserted_cell_id,
+            cell_type=inserted_cell_type,
+            source=source,
+        )
+        editable_cells.insert(insert_index, inserted_cell)
+        summary.update(
+            {
+                "insert_position": insert_position,
+                "inserted_cell_id": inserted_cell_id,
+                "index_after": insert_index,
+                "cell_count_after": len(editable_cells),
+                "source_line_count_after": _source_line_count(source),
+                "source_char_count_after": len(source),
+                "output_count_after": _cell_output_count(inserted_cell),
+            }
+        )
+    else:
+        del editable_cells[target_index]
+        summary.update(
+            {
+                "index_after": None,
+                "cell_count_after": len(editable_cells),
+                "source_line_count_after": 0,
+                "source_char_count_after": 0,
+                "output_count_after": 0,
+            }
+        )
+
+    data = _serialize_notebook(document, notebook.format)
+    return NotebookEditResult(
+        document=document,
+        data=data,
+        sha256_after=hashlib.sha256(data).hexdigest(),
+        bytes_after=len(data),
+        summary=summary,
+    )
+
+
 def _cell_source_text(cell: dict[str, Any]) -> str:
     """Return a normalized source string for one notebook cell."""
 
@@ -134,6 +254,95 @@ def _cell_source_text(cell: dict[str, Any]) -> str:
     if isinstance(source, list) and all(isinstance(item, str) for item in source):
         return "".join(source)
     raise ValueError("notebook_cell_source_invalid")
+
+
+def _notebook_cells(document: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the validated notebook cell list."""
+
+    cells = document.get("cells")
+    if not isinstance(cells, list) or not all(isinstance(cell, dict) for cell in cells):
+        raise ValueError("notebook_cells_required")
+    return cells
+
+
+def _find_cell_index(cells: list[dict[str, Any]], cell_id: str) -> int:
+    """Find one target cell id or fail closed."""
+
+    for index, cell in enumerate(cells):
+        if cell.get("id") == cell_id:
+            return index
+    raise ValueError("notebook_cell_id_not_found")
+
+
+def _cell_output_count(cell: dict[str, Any]) -> int:
+    """Return code-cell output count metadata."""
+
+    outputs = cell.get("outputs")
+    return len(outputs) if isinstance(outputs, list) else 0
+
+
+def _normalized_cell_type(cell_type: str | None) -> str:
+    """Validate and normalize a notebook cell type."""
+
+    normalized = str(cell_type or "").strip()
+    if normalized not in _VALID_CELL_TYPES:
+        raise ValueError("notebook_invalid_cell_type")
+    return normalized
+
+
+def _unique_new_cell_id(cells: list[dict[str, Any]], requested_cell_id: str | None) -> str:
+    """Return a valid cell id that does not collide with existing ids."""
+
+    existing_ids = {str(cell.get("id") or "") for cell in cells}
+    if requested_cell_id is not None:
+        normalized = str(requested_cell_id).strip()
+        if not _CELL_ID_RE.fullmatch(normalized):
+            raise ValueError("notebook_invalid_cell_id")
+        if normalized in existing_ids:
+            raise ValueError("notebook_duplicate_cell_id")
+        return normalized
+
+    for _attempt in range(100):
+        candidate = f"cell-{secrets.token_hex(8)}"
+        if candidate not in existing_ids:
+            return candidate
+    raise ValueError("notebook_cell_id_generation_failed")
+
+
+def _new_cell(*, cell_id: str, cell_type: str, source: str) -> dict[str, Any]:
+    """Build a minimal Jupyter cell object."""
+
+    cell: dict[str, Any] = {
+        "cell_type": cell_type,
+        "id": cell_id,
+        "metadata": {},
+        "source": source,
+    }
+    if cell_type == "code":
+        cell["execution_count"] = None
+        cell["outputs"] = []
+    return cell
+
+
+def _set_cell_source(cell: dict[str, Any], source: str, *, original_cell: dict[str, Any]) -> None:
+    """Set source while preserving the original source container shape."""
+
+    original_source = original_cell.get("source", "")
+    if isinstance(original_source, list):
+        cell["source"] = source.splitlines(keepends=True)
+        if source and not cell["source"]:
+            cell["source"] = [source]
+        return
+    cell["source"] = source
+
+
+def _serialize_notebook(document: dict[str, Any], notebook_format: NotebookFormat) -> bytes:
+    """Serialize edited notebook JSON while preserving basic input shape."""
+
+    text = json.dumps(document, indent=notebook_format.indent, ensure_ascii=False)
+    if notebook_format.trailing_newline:
+        text += "\n"
+    return text.encode("utf-8")
 
 
 def _source_line_count(source: str) -> int:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py
@@ -1,11 +1,63 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any
+
 import pytest
 
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module import (
     FilesystemModule,
 )
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+
+
+class _FakeWorkspaceRootResolver:
+    def __init__(self, workspace_root: Path) -> None:
+        self.workspace_root = workspace_root
+
+    async def resolve_for_context(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "workspace_root": str(self.workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "test",
+            "reason": None,
+        }
+
+
+def _context() -> RequestContext:
+    return RequestContext(
+        request_id="req-notebook",
+        session_id="session-1",
+        user_id="user-1",
+        metadata={"workspace_id": "workspace-1", "session_id": "session-1", "user_id": "user-1"},
+    )
+
+
+def _module(workspace_root: Path, *, settings: dict[str, object] | None = None) -> FilesystemModule:
+    return FilesystemModule(
+        ModuleConfig(
+            name="filesystem",
+            settings={"read_receipt_secret": "notebook-test-secret", **dict(settings or {})},
+        ),
+        workspace_root_resolver=_FakeWorkspaceRootResolver(workspace_root),
+    )
+
+
+def _write_notebook(path: Path, cells: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "cells": cells,
+        "metadata": {"language_info": {"name": "python"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_notebook(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 @pytest.mark.asyncio
@@ -178,3 +230,219 @@ def test_notebook_edit_argument_validation_rejects_invalid_arguments(
 
     with pytest.raises(ValueError, match=reason):
         mod.validate_tool_arguments("notebook.edit_cell", arguments)
+
+
+@pytest.mark.asyncio
+async def test_notebook_read_returns_structure_and_receipt(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    notebook_path = workspace / "analysis.ipynb"
+    _write_notebook(
+        notebook_path,
+        [
+            {"cell_type": "markdown", "id": "intro", "metadata": {}, "source": "# Intro\n"},
+            {
+                "cell_type": "code",
+                "execution_count": 1,
+                "id": "code-1",
+                "metadata": {},
+                "outputs": [{"output_type": "stream", "text": "old\n"}],
+                "source": "print('old')\n",
+            },
+        ],
+    )
+    mod = _module(workspace)
+
+    result = await mod.execute_tool("notebook.read", {"path": "analysis.ipynb"}, context=_context())
+
+    assert result["path"] == "analysis.ipynb"  # nosec B101
+    assert result["cell_count"] == 2  # nosec B101
+    assert result["cells"][0]["id"] == "intro"  # nosec B101
+    assert "source_preview" not in result["cells"][0]  # nosec B101
+    assert result["cells"][1]["output_count"] == 1  # nosec B101
+    assert isinstance(result["sha256"], str)  # nosec B101
+    assert isinstance(result["read_receipt"], str)  # nosec B101
+    assert result["eval"]["result_kind"] == "structured_notebook_read"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_notebook_read_returns_bounded_source_preview(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    notebook_path = workspace / "analysis.ipynb"
+    _write_notebook(
+        notebook_path,
+        [
+            {"cell_type": "markdown", "id": "intro", "metadata": {}, "source": "alpha beta"},
+            {"cell_type": "markdown", "id": "details", "metadata": {}, "source": "gamma delta"},
+        ],
+    )
+    mod = _module(workspace)
+
+    result = await mod.execute_tool(
+        "notebook.read",
+        {
+            "path": "analysis.ipynb",
+            "include_source": True,
+            "cell_ids": ["details"],
+            "max_source_chars": 5,
+            "max_total_source_chars": 5,
+        },
+        context=_context(),
+    )
+
+    assert "source_preview" not in result["cells"][0]  # nosec B101
+    assert result["cells"][1]["source_preview"] == "gamma"  # nosec B101
+    assert result["cells"][1]["source_preview_truncated"] is True  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_notebook_edit_replace_updates_cell_and_clears_code_outputs(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    notebook_path = workspace / "analysis.ipynb"
+    _write_notebook(
+        notebook_path,
+        [
+            {"cell_type": "markdown", "id": "intro", "metadata": {}, "source": "# Intro\n"},
+            {
+                "cell_type": "code",
+                "execution_count": 3,
+                "id": "code-1",
+                "metadata": {},
+                "outputs": [{"output_type": "stream", "text": "stale\n"}],
+                "source": "print('old')\n",
+            },
+        ],
+    )
+    mod = _module(workspace)
+    read_result = await mod.execute_tool("notebook.read", {"path": "analysis.ipynb"}, context=_context())
+
+    edit_result = await mod.execute_tool(
+        "notebook.edit_cell",
+        {
+            "path": "analysis.ipynb",
+            "mode": "replace",
+            "cell_id": "code-1",
+            "source": "print('new')\n",
+            "expected_sha256": read_result["sha256"],
+        },
+        context=_context(),
+    )
+    stored = _read_notebook(notebook_path)
+
+    assert edit_result["edited"] is True  # nosec B101
+    assert edit_result["mode"] == "replace"  # nosec B101
+    assert edit_result["sha256_before"] == read_result["sha256"]  # nosec B101
+    assert stored["cells"][1]["source"] == "print('new')\n"  # nosec B101
+    assert stored["cells"][1]["outputs"] == []  # nosec B101
+    assert stored["cells"][1]["execution_count"] is None  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_notebook_edit_insert_and_delete_cells(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    notebook_path = workspace / "analysis.ipynb"
+    _write_notebook(
+        notebook_path,
+        [
+            {"cell_type": "markdown", "id": "first", "metadata": {}, "source": "first"},
+            {"cell_type": "markdown", "id": "second", "metadata": {}, "source": "second"},
+        ],
+    )
+    mod = _module(workspace)
+    read_result = await mod.execute_tool("notebook.read", {"path": "analysis.ipynb"}, context=_context())
+
+    insert_result = await mod.execute_tool(
+        "notebook.edit_cell",
+        {
+            "path": "analysis.ipynb",
+            "mode": "insert",
+            "cell_id": "second",
+            "insert_position": "before",
+            "cell_type": "markdown",
+            "source": "inserted",
+            "new_cell_id": "inserted-cell",
+            "expected_sha256": read_result["sha256"],
+        },
+        context=_context(),
+    )
+    delete_result = await mod.execute_tool(
+        "notebook.edit_cell",
+        {
+            "path": "analysis.ipynb",
+            "mode": "delete",
+            "cell_id": "first",
+            "expected_sha256": insert_result["sha256_after"],
+        },
+        context=_context(),
+    )
+    stored = _read_notebook(notebook_path)
+
+    assert insert_result["inserted_cell_id"] == "inserted-cell"  # nosec B101
+    assert delete_result["mode"] == "delete"  # nosec B101
+    assert [cell["id"] for cell in stored["cells"]] == ["inserted-cell", "second"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_notebook_edit_dry_run_does_not_write(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    notebook_path = workspace / "analysis.ipynb"
+    _write_notebook(
+        notebook_path,
+        [{"cell_type": "markdown", "id": "intro", "metadata": {}, "source": "old"}],
+    )
+    before_text = notebook_path.read_text(encoding="utf-8")
+    mod = _module(workspace)
+    read_result = await mod.execute_tool("notebook.read", {"path": "analysis.ipynb"}, context=_context())
+
+    edit_result = await mod.execute_tool(
+        "notebook.edit_cell",
+        {
+            "path": "analysis.ipynb",
+            "mode": "replace",
+            "cell_id": "intro",
+            "source": "new",
+            "expected_sha256": read_result["sha256"],
+            "dry_run": True,
+        },
+        context=_context(),
+    )
+
+    assert edit_result["edited"] is False  # nosec B101
+    assert notebook_path.read_text(encoding="utf-8") == before_text  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_notebook_edit_rejects_stale_preimage(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    notebook_path = workspace / "analysis.ipynb"
+    _write_notebook(
+        notebook_path,
+        [{"cell_type": "markdown", "id": "intro", "metadata": {}, "source": "old"}],
+    )
+    mod = _module(workspace)
+
+    with pytest.raises(ValueError, match="edit_preimage_mismatch"):
+        await mod.execute_tool(
+            "notebook.edit_cell",
+            {
+                "path": "analysis.ipynb",
+                "mode": "replace",
+                "cell_id": "intro",
+                "source": "new",
+                "expected_sha256": "0" * 64,
+            },
+            context=_context(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_notebook_tools_reject_non_notebook_and_invalid_json(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "notes.txt").write_text("hello", encoding="utf-8")
+    (workspace / "bad.ipynb").write_text("{not json", encoding="utf-8")
+    mod = _module(workspace)
+
+    with pytest.raises(ValueError, match="notebook_path_required"):
+        await mod.execute_tool("notebook.read", {"path": "notes.txt"}, context=_context())
+    with pytest.raises(ValueError, match="notebook_invalid_json"):
+        await mod.execute_tool("notebook.read", {"path": "bad.ipynb"}, context=_context())

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module import (
+    FilesystemModule,
+)
+
+
+@pytest.mark.asyncio
+async def test_notebook_tools_include_path_scope_metadata() -> None:
+    mod = FilesystemModule(ModuleConfig(name="filesystem"))
+
+    tools = await mod.get_tools()
+    by_name = {tool["name"]: tool for tool in tools}
+
+    assert {"notebook.read", "notebook.edit_cell"} <= set(by_name)  # nosec B101
+
+    read_tool = by_name["notebook.read"]
+    read_metadata = read_tool["metadata"]
+    assert read_tool["inputSchema"]["additionalProperties"] is False  # nosec B101
+    assert read_metadata["uses_filesystem"] is True  # nosec B101
+    assert read_metadata["path_boundable"] is True  # nosec B101
+    assert read_metadata["path_argument_hints"] == ["path"]  # nosec B101
+    assert read_metadata["readOnlyHint"] is True  # nosec B101
+    assert read_metadata["path_scope_action"] == "read"  # nosec B101
+    assert read_metadata["file_policy_action"] == "read"  # nosec B101
+    assert read_metadata["file_policy_action_family"] == "read"  # nosec B101
+    assert "notebook.read" in read_metadata["capabilities"]  # nosec B101
+    assert read_metadata["eval"]["task_families"] == ["notebook_read"]  # nosec B101
+
+    edit_tool = by_name["notebook.edit_cell"]
+    edit_metadata = edit_tool["metadata"]
+    assert edit_tool["inputSchema"]["additionalProperties"] is False  # nosec B101
+    assert edit_metadata["uses_filesystem"] is True  # nosec B101
+    assert edit_metadata["path_boundable"] is True  # nosec B101
+    assert edit_metadata["path_argument_hints"] == ["path"]  # nosec B101
+    assert edit_metadata["readOnlyHint"] is False  # nosec B101
+    assert edit_metadata["write_capable"] is True  # nosec B101
+    assert edit_metadata["path_scope_action"] == "edit"  # nosec B101
+    assert edit_metadata["file_policy_action"] == "edit"  # nosec B101
+    assert edit_metadata["file_policy_action_family"] == "bounded_edit"  # nosec B101
+    assert "notebook.edit" in edit_metadata["capabilities"]  # nosec B101
+    assert edit_metadata["eval"]["task_families"] == ["notebook_edit"]  # nosec B101
+
+
+def test_notebook_read_argument_validation_accepts_valid_arguments() -> None:
+    mod = FilesystemModule(ModuleConfig(name="filesystem"))
+
+    mod.validate_tool_arguments(
+        "notebook.read",
+        {
+            "path": "analysis/example.ipynb",
+            "include_source": True,
+            "cell_ids": ["cell-1"],
+            "max_source_chars": 100,
+            "max_total_source_chars": 500,
+            "include_receipt": False,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("arguments", "reason"),
+    [
+        ({"path": "analysis/example.ipynb", "unexpected": True}, "unknown arguments"),
+        ({}, "path is required"),
+        ({"path": 12}, "path is required"),
+        ({"path": "analysis/example.ipynb", "include_source": "yes"}, "include_source must be a boolean"),
+        ({"path": "analysis/example.ipynb", "include_receipt": "yes"}, "include_receipt must be a boolean"),
+        ({"path": "analysis/example.ipynb", "cell_ids": "cell-1"}, "cell_ids must be a list of strings"),
+        ({"path": "analysis/example.ipynb", "max_source_chars": 0}, "max_source_chars must be a positive integer"),
+        (
+            {"path": "analysis/example.ipynb", "max_total_source_chars": 0},
+            "max_total_source_chars must be a positive integer",
+        ),
+    ],
+)
+def test_notebook_read_argument_validation_rejects_invalid_arguments(
+    arguments: dict[str, object],
+    reason: str,
+) -> None:
+    mod = FilesystemModule(ModuleConfig(name="filesystem"))
+
+    with pytest.raises(ValueError, match=reason):
+        mod.validate_tool_arguments("notebook.read", arguments)
+
+
+def test_notebook_edit_argument_validation_accepts_valid_arguments() -> None:
+    mod = FilesystemModule(ModuleConfig(name="filesystem"))
+
+    mod.validate_tool_arguments(
+        "notebook.edit_cell",
+        {
+            "path": "analysis/example.ipynb",
+            "mode": "insert",
+            "cell_id": "cell-1",
+            "insert_position": "after",
+            "cell_type": "markdown",
+            "source": "new cell",
+            "new_cell_id": "inserted-cell",
+            "expected_sha256": "a" * 64,
+            "lock_lease_id": "lease-1",
+            "dry_run": True,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("arguments", "reason"),
+    [
+        (
+            {"path": "analysis/example.ipynb", "mode": "replace", "cell_id": "cell-1", "source": "x", "extra": 1},
+            "unknown arguments",
+        ),
+        ({"mode": "replace", "cell_id": "cell-1", "source": "x"}, "path is required"),
+        ({"path": "analysis/example.ipynb", "cell_id": "cell-1", "source": "x"}, "mode is required"),
+        ({"path": "analysis/example.ipynb", "mode": "move", "cell_id": "cell-1"}, "mode must be one of"),
+        ({"path": "analysis/example.ipynb", "mode": "replace", "source": "x"}, "cell_id is required"),
+        ({"path": "analysis/example.ipynb", "mode": "replace", "cell_id": "cell-1"}, "source is required"),
+        (
+            {"path": "analysis/example.ipynb", "mode": "insert", "cell_id": "cell-1", "source": "x"},
+            "insert_position is required",
+        ),
+        (
+            {
+                "path": "analysis/example.ipynb",
+                "mode": "insert",
+                "cell_id": "cell-1",
+                "insert_position": "after",
+                "source": "x",
+            },
+            "cell_type is required",
+        ),
+        (
+            {
+                "path": "analysis/example.ipynb",
+                "mode": "insert",
+                "cell_id": "cell-1",
+                "insert_position": "after",
+                "cell_type": "widget",
+                "source": "x",
+            },
+            "cell_type must be one of",
+        ),
+        (
+            {
+                "path": "analysis/example.ipynb",
+                "mode": "replace",
+                "cell_id": "cell-1",
+                "source": "x",
+                "expected_sha256": 123,
+            },
+            "expected_sha256 must be a string",
+        ),
+        (
+            {
+                "path": "analysis/example.ipynb",
+                "mode": "replace",
+                "cell_id": "cell-1",
+                "source": "x",
+                "dry_run": "false",
+            },
+            "dry_run must be a boolean",
+        ),
+        (
+            {"path": "analysis/example.ipynb", "mode": "replace", "cell_id": "cell-1", "source": "x"},
+            "edit_preimage_required",
+        ),
+    ],
+)
+def test_notebook_edit_argument_validation_rejects_invalid_arguments(
+    arguments: dict[str, object],
+    reason: str,
+) -> None:
+    mod = FilesystemModule(ModuleConfig(name="filesystem"))
+
+    with pytest.raises(ValueError, match=reason):
+        mod.validate_tool_arguments("notebook.edit_cell", arguments)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py
@@ -1,3 +1,5 @@
+"""Integration tests for notebook MCP tools in the filesystem module."""
+
 from __future__ import annotations
 
 import json
@@ -14,10 +16,16 @@ from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
 
 
 class _FakeWorkspaceRootResolver:
+    """Workspace resolver test double returning one fixed root."""
+
     def __init__(self, workspace_root: Path) -> None:
+        """Store the workspace root returned to the filesystem module."""
+
         self.workspace_root = workspace_root
 
     async def resolve_for_context(self, **_kwargs: Any) -> dict[str, Any]:
+        """Resolve every request context to the configured workspace root."""
+
         return {
             "workspace_root": str(self.workspace_root),
             "workspace_id": "workspace-1",
@@ -27,6 +35,8 @@ class _FakeWorkspaceRootResolver:
 
 
 def _context() -> RequestContext:
+    """Return a request context with workspace, session, and user ids."""
+
     return RequestContext(
         request_id="req-notebook",
         session_id="session-1",
@@ -36,6 +46,8 @@ def _context() -> RequestContext:
 
 
 def _module(workspace_root: Path, *, settings: dict[str, object] | None = None) -> FilesystemModule:
+    """Create a filesystem module configured for notebook tool tests."""
+
     return FilesystemModule(
         ModuleConfig(
             name="filesystem",
@@ -46,6 +58,8 @@ def _module(workspace_root: Path, *, settings: dict[str, object] | None = None) 
 
 
 def _write_notebook(path: Path, cells: list[dict[str, object]]) -> None:
+    """Write a minimal Jupyter notebook payload to a test path."""
+
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "cells": cells,
@@ -57,11 +71,15 @@ def _write_notebook(path: Path, cells: list[dict[str, object]]) -> None:
 
 
 def _read_notebook(path: Path) -> dict[str, Any]:
+    """Read a test notebook payload back from disk."""
+
     return json.loads(path.read_text(encoding="utf-8"))
 
 
 @pytest.mark.asyncio
 async def test_notebook_tools_include_path_scope_metadata() -> None:
+    """Notebook tools advertise strict schemas and path-scope metadata."""
+
     mod = FilesystemModule(ModuleConfig(name="filesystem"))
 
     tools = await mod.get_tools()
@@ -98,6 +116,8 @@ async def test_notebook_tools_include_path_scope_metadata() -> None:
 
 
 def test_notebook_read_argument_validation_accepts_valid_arguments() -> None:
+    """The read validator accepts the complete supported argument set."""
+
     mod = FilesystemModule(ModuleConfig(name="filesystem"))
 
     mod.validate_tool_arguments(
@@ -133,6 +153,8 @@ def test_notebook_read_argument_validation_rejects_invalid_arguments(
     arguments: dict[str, object],
     reason: str,
 ) -> None:
+    """The read validator rejects unknown and incorrectly typed arguments."""
+
     mod = FilesystemModule(ModuleConfig(name="filesystem"))
 
     with pytest.raises(ValueError, match=reason):
@@ -140,6 +162,8 @@ def test_notebook_read_argument_validation_rejects_invalid_arguments(
 
 
 def test_notebook_edit_argument_validation_accepts_valid_arguments() -> None:
+    """The edit validator accepts the complete supported argument set."""
+
     mod = FilesystemModule(ModuleConfig(name="filesystem"))
 
     mod.validate_tool_arguments(
@@ -226,6 +250,8 @@ def test_notebook_edit_argument_validation_rejects_invalid_arguments(
     arguments: dict[str, object],
     reason: str,
 ) -> None:
+    """The edit validator rejects unsafe or incomplete mutation arguments."""
+
     mod = FilesystemModule(ModuleConfig(name="filesystem"))
 
     with pytest.raises(ValueError, match=reason):
@@ -234,6 +260,8 @@ def test_notebook_edit_argument_validation_rejects_invalid_arguments(
 
 @pytest.mark.asyncio
 async def test_notebook_read_returns_structure_and_receipt(tmp_path: Path) -> None:
+    """Notebook reads return structure and a read receipt when configured."""
+
     workspace = tmp_path / "workspace"
     notebook_path = workspace / "analysis.ipynb"
     _write_notebook(
@@ -266,6 +294,8 @@ async def test_notebook_read_returns_structure_and_receipt(tmp_path: Path) -> No
 
 @pytest.mark.asyncio
 async def test_notebook_read_returns_bounded_source_preview(tmp_path: Path) -> None:
+    """Notebook reads return bounded source previews only when requested."""
+
     workspace = tmp_path / "workspace"
     notebook_path = workspace / "analysis.ipynb"
     _write_notebook(
@@ -296,6 +326,8 @@ async def test_notebook_read_returns_bounded_source_preview(tmp_path: Path) -> N
 
 @pytest.mark.asyncio
 async def test_notebook_edit_replace_updates_cell_and_clears_code_outputs(tmp_path: Path) -> None:
+    """Replacing a code cell writes new source and clears stale outputs."""
+
     workspace = tmp_path / "workspace"
     notebook_path = workspace / "analysis.ipynb"
     _write_notebook(
@@ -337,7 +369,40 @@ async def test_notebook_edit_replace_updates_cell_and_clears_code_outputs(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_notebook_edit_replace_accepts_read_receipt_without_expected_sha(tmp_path: Path) -> None:
+    """Notebook edits can authorize against a read receipt instead of a raw SHA."""
+
+    workspace = tmp_path / "workspace"
+    notebook_path = workspace / "analysis.ipynb"
+    _write_notebook(
+        notebook_path,
+        [{"cell_type": "markdown", "id": "intro", "metadata": {}, "source": "old"}],
+    )
+    mod = _module(workspace)
+    read_result = await mod.execute_tool("notebook.read", {"path": "analysis.ipynb"}, context=_context())
+
+    edit_result = await mod.execute_tool(
+        "notebook.edit_cell",
+        {
+            "path": "analysis.ipynb",
+            "mode": "replace",
+            "cell_id": "intro",
+            "source": "new",
+            "read_receipt": read_result["read_receipt"],
+        },
+        context=_context(),
+    )
+    stored = _read_notebook(notebook_path)
+
+    assert edit_result["edited"] is True  # nosec B101
+    assert edit_result["sha256_before"] == read_result["sha256"]  # nosec B101
+    assert stored["cells"][0]["source"] == "new"  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_notebook_edit_insert_and_delete_cells(tmp_path: Path) -> None:
+    """Notebook edits can insert and delete cells using SHA preimages."""
+
     workspace = tmp_path / "workspace"
     notebook_path = workspace / "analysis.ipynb"
     _write_notebook(
@@ -383,6 +448,8 @@ async def test_notebook_edit_insert_and_delete_cells(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_notebook_edit_dry_run_does_not_write(tmp_path: Path) -> None:
+    """Dry-run notebook edits return a summary without writing the file."""
+
     workspace = tmp_path / "workspace"
     notebook_path = workspace / "analysis.ipynb"
     _write_notebook(
@@ -412,6 +479,8 @@ async def test_notebook_edit_dry_run_does_not_write(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_notebook_edit_rejects_stale_preimage(tmp_path: Path) -> None:
+    """Notebook edits reject a stale or incorrect expected SHA."""
+
     workspace = tmp_path / "workspace"
     notebook_path = workspace / "analysis.ipynb"
     _write_notebook(
@@ -436,6 +505,8 @@ async def test_notebook_edit_rejects_stale_preimage(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_notebook_tools_reject_non_notebook_and_invalid_json(tmp_path: Path) -> None:
+    """Notebook tools reject non-ipynb paths and invalid notebook JSON."""
+
     workspace = tmp_path / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
     (workspace / "notes.txt").write_text("hello", encoding="utf-8")
@@ -446,3 +517,45 @@ async def test_notebook_tools_reject_non_notebook_and_invalid_json(tmp_path: Pat
         await mod.execute_tool("notebook.read", {"path": "notes.txt"}, context=_context())
     with pytest.raises(ValueError, match="notebook_invalid_json"):
         await mod.execute_tool("notebook.read", {"path": "bad.ipynb"}, context=_context())
+
+
+@pytest.mark.asyncio
+async def test_notebook_read_maps_oversize_file_to_notebook_reason(tmp_path: Path) -> None:
+    """Oversized notebook reads fail with a notebook-specific reason code."""
+
+    workspace = tmp_path / "workspace"
+    notebook_path = workspace / "analysis.ipynb"
+    _write_notebook(
+        notebook_path,
+        [{"cell_type": "markdown", "id": "intro", "metadata": {}, "source": "x" * 100}],
+    )
+    mod = _module(workspace, settings={"notebook_read_max_bytes": 16})
+
+    with pytest.raises(ValueError, match="notebook_too_large"):
+        await mod.execute_tool("notebook.read", {"path": "analysis.ipynb"}, context=_context())
+
+
+@pytest.mark.asyncio
+async def test_notebook_edit_maps_oversize_preimage_to_notebook_reason(tmp_path: Path) -> None:
+    """Oversized notebook edit preimages fail with a notebook-specific reason code."""
+
+    workspace = tmp_path / "workspace"
+    notebook_path = workspace / "analysis.ipynb"
+    _write_notebook(
+        notebook_path,
+        [{"cell_type": "markdown", "id": "intro", "metadata": {}, "source": "x" * 100}],
+    )
+    mod = _module(workspace, settings={"notebook_preimage_max_bytes": 16})
+
+    with pytest.raises(ValueError, match="notebook_too_large"):
+        await mod.execute_tool(
+            "notebook.edit_cell",
+            {
+                "path": "analysis.ipynb",
+                "mode": "replace",
+                "cell_id": "intro",
+                "source": "new",
+                "expected_sha256": "0" * 64,
+            },
+            context=_context(),
+        )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py
@@ -1,3 +1,5 @@
+"""Tests for notebook parsing, summaries, and cell edit helpers."""
+
 from __future__ import annotations
 
 import json
@@ -12,6 +14,8 @@ from tldw_Server_API.app.core.MCP_unified.modules.implementations.notebook_files
 
 
 def _notebook_bytes(cells: list[dict[str, object]], *, trailing_newline: bool = True) -> bytes:
+    """Build a minimal notebook payload for helper tests."""
+
     payload = {
         "cells": cells,
         "metadata": {"language_info": {"name": "python"}},
@@ -25,6 +29,8 @@ def _notebook_bytes(cells: list[dict[str, object]], *, trailing_newline: bool = 
 
 
 def test_summarize_notebook_defaults_to_structure_only() -> None:
+    """Summaries omit source by default while preserving cell metadata."""
+
     parsed = parse_notebook_payload(
         _notebook_bytes(
             [
@@ -67,6 +73,8 @@ def test_summarize_notebook_defaults_to_structure_only() -> None:
 
 
 def test_summarize_notebook_source_previews_are_cell_and_total_bounded() -> None:
+    """Source previews are bounded by both per-cell and total budgets."""
+
     parsed = parse_notebook_payload(
         _notebook_bytes(
             [
@@ -101,6 +109,8 @@ def test_summarize_notebook_source_previews_are_cell_and_total_bounded() -> None
 
 
 def test_summarize_notebook_source_previews_can_filter_to_cell_ids() -> None:
+    """Source previews can be restricted to selected cell ids."""
+
     parsed = parse_notebook_payload(
         _notebook_bytes(
             [
@@ -157,14 +167,34 @@ def test_summarize_notebook_source_previews_can_filter_to_cell_ids() -> None:
             ),
             "notebook_duplicate_cell_id",
         ),
+        (
+            _notebook_bytes(
+                [
+                    {"id": "missing-type", "metadata": {}, "source": "text"},
+                ]
+            ),
+            "notebook_invalid_cell_type",
+        ),
+        (
+            _notebook_bytes(
+                [
+                    {"cell_type": "widget", "id": "widget-1", "metadata": {}, "source": "text"},
+                ]
+            ),
+            "notebook_invalid_cell_type",
+        ),
     ],
 )
 def test_parse_notebook_payload_rejects_invalid_notebooks(payload: bytes, reason: str) -> None:
+    """Malformed or unsupported notebooks fail with stable reason codes."""
+
     with pytest.raises(ValueError, match=reason):
         parse_notebook_payload(payload)
 
 
 def test_apply_cell_edit_replaces_source_and_clears_code_outputs() -> None:
+    """Replacing a code cell resets stale execution artifacts."""
+
     parsed = parse_notebook_payload(
         _notebook_bytes(
             [
@@ -202,6 +232,8 @@ def test_apply_cell_edit_replaces_source_and_clears_code_outputs() -> None:
 
 
 def test_apply_cell_edit_preserves_list_source_shape_on_replace() -> None:
+    """Replacing a list-source cell preserves the source container shape."""
+
     parsed = parse_notebook_payload(
         _notebook_bytes(
             [
@@ -222,7 +254,44 @@ def test_apply_cell_edit_preserves_list_source_shape_on_replace() -> None:
     assert not result.data.endswith(b"\n")  # nosec B101
 
 
+def test_apply_cell_edit_strips_code_only_fields_when_replacing_with_non_code_type() -> None:
+    """Changing a code cell to markdown removes code-only notebook fields."""
+
+    parsed = parse_notebook_payload(
+        _notebook_bytes(
+            [
+                {
+                    "cell_type": "code",
+                    "execution_count": 4,
+                    "id": "code-1",
+                    "metadata": {},
+                    "outputs": [{"output_type": "stream", "text": "old\n"}],
+                    "source": "print('old')\n",
+                },
+            ]
+        )
+    )
+
+    result = apply_cell_edit(
+        parsed,
+        mode="replace",
+        cell_id="code-1",
+        cell_type="markdown",
+        source="converted markdown",
+    )
+    edited_cell = result.document["cells"][0]
+
+    assert edited_cell["cell_type"] == "markdown"  # nosec B101
+    assert edited_cell["source"] == "converted markdown"  # nosec B101
+    assert "outputs" not in edited_cell  # nosec B101
+    assert "execution_count" not in edited_cell  # nosec B101
+    assert result.summary["output_count_before"] == 1  # nosec B101
+    assert result.summary["output_count_after"] == 0  # nosec B101
+
+
 def test_apply_cell_edit_inserts_before_and_after_anchor_cell() -> None:
+    """Insertion supports before and after positions around an anchor cell."""
+
     parsed = parse_notebook_payload(
         _notebook_bytes(
             [
@@ -264,6 +333,8 @@ def test_apply_cell_edit_inserts_before_and_after_anchor_cell() -> None:
 
 
 def test_apply_cell_edit_deletes_target_cell() -> None:
+    """Deleting a cell removes only the requested target cell."""
+
     parsed = parse_notebook_payload(
         _notebook_bytes(
             [
@@ -315,6 +386,8 @@ def test_apply_cell_edit_deletes_target_cell() -> None:
     ],
 )
 def test_apply_cell_edit_rejects_invalid_mutations(kwargs: dict[str, str], reason: str) -> None:
+    """Invalid edit arguments fail before producing a mutated notebook."""
+
     parsed = parse_notebook_payload(
         _notebook_bytes(
             [

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.notebook_files import (
+    parse_notebook_payload,
+    summarize_notebook,
+)
+
+
+def _notebook_bytes(cells: list[dict[str, object]], *, trailing_newline: bool = True) -> bytes:
+    payload = {
+        "cells": cells,
+        "metadata": {"language_info": {"name": "python"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    text = json.dumps(payload, indent=2)
+    if trailing_newline:
+        text += "\n"
+    return text.encode("utf-8")
+
+
+def test_summarize_notebook_defaults_to_structure_only() -> None:
+    parsed = parse_notebook_payload(
+        _notebook_bytes(
+            [
+                {
+                    "cell_type": "markdown",
+                    "id": "markdown-1",
+                    "metadata": {},
+                    "source": "# Title\n\nBody\n",
+                },
+                {
+                    "cell_type": "code",
+                    "execution_count": 1,
+                    "id": "code-1",
+                    "metadata": {},
+                    "outputs": [{"output_type": "stream", "text": "old\n"}],
+                    "source": ["print('old')\n"],
+                },
+            ]
+        )
+    )
+
+    summary = summarize_notebook(parsed)
+
+    assert summary["nbformat"] == 4  # nosec B101
+    assert summary["nbformat_minor"] == 5  # nosec B101
+    assert summary["cell_count"] == 2  # nosec B101
+    assert summary["sha256"] == parsed.sha256  # nosec B101
+    assert summary["bytes_total"] == parsed.size  # nosec B101
+    assert summary["cells"][0] == {  # nosec B101
+        "index": 0,
+        "id": "markdown-1",
+        "cell_type": "markdown",
+        "source_line_count": 3,
+        "source_char_count": 14,
+    }
+    assert summary["cells"][1]["execution_count"] == 1  # nosec B101
+    assert summary["cells"][1]["output_count"] == 1  # nosec B101
+    assert "source_preview" not in summary["cells"][0]  # nosec B101
+    assert "source_preview" not in summary["cells"][1]  # nosec B101
+
+
+def test_summarize_notebook_source_previews_are_cell_and_total_bounded() -> None:
+    parsed = parse_notebook_payload(
+        _notebook_bytes(
+            [
+                {
+                    "cell_type": "markdown",
+                    "id": "markdown-1",
+                    "metadata": {},
+                    "source": "alpha beta",
+                },
+                {
+                    "cell_type": "markdown",
+                    "id": "markdown-2",
+                    "metadata": {},
+                    "source": "gamma delta",
+                },
+            ]
+        )
+    )
+
+    summary = summarize_notebook(
+        parsed,
+        include_source=True,
+        max_source_chars=20,
+        max_total_source_chars=12,
+    )
+
+    assert summary["cells"][0]["source_preview"] == "alpha beta"  # nosec B101
+    assert summary["cells"][0]["source_preview_truncated"] is False  # nosec B101
+    assert summary["cells"][1]["source_preview"] == "ga"  # nosec B101
+    assert summary["cells"][1]["source_preview_truncated"] is True  # nosec B101
+    assert summary["source_preview_truncated"] is True  # nosec B101
+
+
+def test_summarize_notebook_source_previews_can_filter_to_cell_ids() -> None:
+    parsed = parse_notebook_payload(
+        _notebook_bytes(
+            [
+                {
+                    "cell_type": "markdown",
+                    "id": "markdown-1",
+                    "metadata": {},
+                    "source": "alpha beta",
+                },
+                {
+                    "cell_type": "code",
+                    "execution_count": None,
+                    "id": "code-1",
+                    "metadata": {},
+                    "outputs": [],
+                    "source": "print('hello')\n",
+                },
+            ]
+        )
+    )
+
+    summary = summarize_notebook(
+        parsed,
+        include_source=True,
+        cell_ids=["code-1"],
+        max_source_chars=5,
+        max_total_source_chars=5,
+    )
+
+    assert "source_preview" not in summary["cells"][0]  # nosec B101
+    assert summary["cells"][1]["source_preview"] == "print"  # nosec B101
+    assert summary["cells"][1]["source_preview_truncated"] is True  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason"),
+    [
+        (b"{not json", "notebook_invalid_json"),
+        (json.dumps({"cells": {}, "nbformat": 4}).encode("utf-8"), "notebook_cells_required"),
+        (
+            _notebook_bytes(
+                [
+                    {"cell_type": "markdown", "metadata": {}, "source": "missing id"},
+                ]
+            ),
+            "notebook_cell_id_required",
+        ),
+        (
+            _notebook_bytes(
+                [
+                    {"cell_type": "markdown", "id": "same", "metadata": {}, "source": "a"},
+                    {"cell_type": "markdown", "id": "same", "metadata": {}, "source": "b"},
+                ]
+            ),
+            "notebook_duplicate_cell_id",
+        ),
+    ],
+)
+def test_parse_notebook_payload_rejects_invalid_notebooks(payload: bytes, reason: str) -> None:
+    with pytest.raises(ValueError, match=reason):
+        parse_notebook_payload(payload)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.notebook_files import (
+    apply_cell_edit,
     parse_notebook_payload,
     summarize_notebook,
 )
@@ -161,3 +162,166 @@ def test_summarize_notebook_source_previews_can_filter_to_cell_ids() -> None:
 def test_parse_notebook_payload_rejects_invalid_notebooks(payload: bytes, reason: str) -> None:
     with pytest.raises(ValueError, match=reason):
         parse_notebook_payload(payload)
+
+
+def test_apply_cell_edit_replaces_source_and_clears_code_outputs() -> None:
+    parsed = parse_notebook_payload(
+        _notebook_bytes(
+            [
+                {
+                    "cell_type": "markdown",
+                    "id": "markdown-1",
+                    "metadata": {},
+                    "source": "# Title\n",
+                },
+                {
+                    "cell_type": "code",
+                    "execution_count": 7,
+                    "id": "code-1",
+                    "metadata": {},
+                    "outputs": [{"output_type": "stream", "text": "stale\n"}],
+                    "source": "print('old')\n",
+                },
+            ]
+        )
+    )
+
+    result = apply_cell_edit(parsed, mode="replace", cell_id="code-1", source="print('new')\n")
+    edited_cell = result.document["cells"][1]
+
+    assert edited_cell["source"] == "print('new')\n"  # nosec B101
+    assert edited_cell["outputs"] == []  # nosec B101
+    assert edited_cell["execution_count"] is None  # nosec B101
+    assert result.summary["mode"] == "replace"  # nosec B101
+    assert result.summary["cell_id"] == "code-1"  # nosec B101
+    assert result.summary["source_line_count_before"] == 1  # nosec B101
+    assert result.summary["source_line_count_after"] == 1  # nosec B101
+    assert result.summary["output_count_before"] == 1  # nosec B101
+    assert result.summary["output_count_after"] == 0  # nosec B101
+    assert result.data.endswith(b"\n")  # nosec B101
+
+
+def test_apply_cell_edit_preserves_list_source_shape_on_replace() -> None:
+    parsed = parse_notebook_payload(
+        _notebook_bytes(
+            [
+                {
+                    "cell_type": "markdown",
+                    "id": "markdown-1",
+                    "metadata": {},
+                    "source": ["line one\n", "line two\n"],
+                },
+            ],
+            trailing_newline=False,
+        )
+    )
+
+    result = apply_cell_edit(parsed, mode="replace", cell_id="markdown-1", source="new one\nnew two\n")
+
+    assert result.document["cells"][0]["source"] == ["new one\n", "new two\n"]  # nosec B101
+    assert not result.data.endswith(b"\n")  # nosec B101
+
+
+def test_apply_cell_edit_inserts_before_and_after_anchor_cell() -> None:
+    parsed = parse_notebook_payload(
+        _notebook_bytes(
+            [
+                {"cell_type": "markdown", "id": "first", "metadata": {}, "source": "first"},
+                {"cell_type": "markdown", "id": "second", "metadata": {}, "source": "second"},
+            ]
+        )
+    )
+
+    before = apply_cell_edit(
+        parsed,
+        mode="insert",
+        cell_id="second",
+        insert_position="before",
+        cell_type="markdown",
+        source="inserted before",
+        new_cell_id="insert-before",
+    )
+    after = apply_cell_edit(
+        parsed,
+        mode="insert",
+        cell_id="first",
+        insert_position="after",
+        cell_type="code",
+        source="print('after')\n",
+    )
+
+    assert [cell["id"] for cell in before.document["cells"]] == [  # nosec B101
+        "first",
+        "insert-before",
+        "second",
+    ]
+    assert before.summary["cell_count_before"] == 2  # nosec B101
+    assert before.summary["cell_count_after"] == 3  # nosec B101
+    assert before.summary["insert_position"] == "before"  # nosec B101
+    assert after.document["cells"][1]["cell_type"] == "code"  # nosec B101
+    assert after.document["cells"][1]["source"] == "print('after')\n"  # nosec B101
+    assert after.document["cells"][1]["id"] not in {"first", "second"}  # nosec B101
+
+
+def test_apply_cell_edit_deletes_target_cell() -> None:
+    parsed = parse_notebook_payload(
+        _notebook_bytes(
+            [
+                {"cell_type": "markdown", "id": "first", "metadata": {}, "source": "first"},
+                {"cell_type": "markdown", "id": "second", "metadata": {}, "source": "second"},
+            ]
+        )
+    )
+
+    result = apply_cell_edit(parsed, mode="delete", cell_id="first")
+
+    assert [cell["id"] for cell in result.document["cells"]] == ["second"]  # nosec B101
+    assert result.summary["mode"] == "delete"  # nosec B101
+    assert result.summary["cell_count_before"] == 2  # nosec B101
+    assert result.summary["cell_count_after"] == 1  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "reason"),
+    [
+        ({"mode": "replace", "cell_id": "missing", "source": "x"}, "notebook_cell_id_not_found"),
+        ({"mode": "move", "cell_id": "cell-1"}, "notebook_invalid_mode"),
+        ({"mode": "replace", "cell_id": "cell-1"}, "notebook_source_required"),
+        (
+            {"mode": "insert", "cell_id": "cell-1", "cell_type": "markdown", "source": "x"},
+            "notebook_insert_position_required",
+        ),
+        (
+            {
+                "mode": "insert",
+                "cell_id": "cell-1",
+                "insert_position": "before",
+                "cell_type": "widget",
+                "source": "x",
+            },
+            "notebook_invalid_cell_type",
+        ),
+        (
+            {
+                "mode": "insert",
+                "cell_id": "cell-1",
+                "insert_position": "before",
+                "cell_type": "markdown",
+                "source": "x",
+                "new_cell_id": "cell-1",
+            },
+            "notebook_duplicate_cell_id",
+        ),
+    ],
+)
+def test_apply_cell_edit_rejects_invalid_mutations(kwargs: dict[str, str], reason: str) -> None:
+    parsed = parse_notebook_payload(
+        _notebook_bytes(
+            [
+                {"cell_type": "markdown", "id": "cell-1", "metadata": {}, "source": "first"},
+            ]
+        )
+    )
+
+    with pytest.raises(ValueError, match=reason):
+        apply_cell_edit(parsed, **kwargs)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -67,6 +67,7 @@ TOOL_CATEGORY_BY_PREFIX = {
     "kanban": "issues",
     "logs": "logs",
     "memory": "memory",
+    "notebook": "files",
     "profile": "tool_discovery",
     "screenshots": "screenshots",
     "tests": "tests",
@@ -196,7 +197,7 @@ def test_preset_direct_categories_do_not_exceed_max_direct_tools() -> None:
 
 
 def test_filesystem_read_presets_include_helper_tools() -> None:
-    expected = {"fs.read", "fs.stat", "fs.glob", "fs.grep"}
+    expected = {"fs.read", "fs.stat", "fs.glob", "fs.grep", "notebook.read"}
     for preset in presets.list_builtin_presets():
         tooling = preset.profile.metadata.get("tooling")
         if not isinstance(tooling, dict):
@@ -207,8 +208,15 @@ def test_filesystem_read_presets_include_helper_tools() -> None:
 
 
 def test_filesystem_tool_buckets_prefer_canonical_safe_tools() -> None:
-    assert presets._FILES_READ_TOOLS == ["fs.list", "fs.read", "fs.stat", "fs.glob", "fs.grep"]  # nosec B101
-    assert presets._FILES_EDIT_TOOLS == [*presets._FILES_READ_TOOLS, "fs.patch"]  # nosec B101
+    assert presets._FILES_READ_TOOLS == [  # nosec B101
+        "fs.list",
+        "fs.read",
+        "fs.stat",
+        "fs.glob",
+        "fs.grep",
+        "notebook.read",
+    ]
+    assert presets._FILES_EDIT_TOOLS == [*presets._FILES_READ_TOOLS, "fs.patch", "notebook.edit_cell"]  # nosec B101
     assert presets._FILES_WRITE_TOOLS == [*presets._FILES_EDIT_TOOLS, "fs.write"]  # nosec B101
     assert presets._LEGACY_FILES_READ_TOOLS == ["fs.read_text"]  # nosec B101
     assert presets._LEGACY_FILES_WRITE_TOOLS == ["fs.write_text"]  # nosec B101


### PR DESCRIPTION
## Summary
- Add notebook-safe MCP helpers and filesystem tools for `notebook.read` and `notebook.edit_cell`.
- Integrate notebook reads/edits with existing path policy, read receipts, preimage checks, lock leases, dry runs, and eval metadata.
- Expose notebook tools in MCP standalone presets and document the notebook read/edit workflow plus tool allow-list versus path-grant model.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_notebook_files.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_notebook_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q` -> 74 passed, 4 warnings
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/notebook_files.py tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py apps/mcp-unified/src/mcp_unified/profiles/presets.py -f json -o /tmp/bandit_mcp_notebook_edit_tools.json` -> zero findings
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py -q` -> 103 passed, 1 known pre-existing `test_filesystem_glob_marks_file_size_unavailable` failure

## Change summary
AI-generated PR merge gate applies. A human maintainer must add their own Change summary explaining what changed and why these implementation choices were made before this PR is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds notebook-safe MCP tools to read notebook structure and edit cells by id with the same path policy, receipts, locks, and preimage checks as the filesystem module. Completes TASK-2282 and updates presets and docs.

- **New Features**
  - `notebook.read`: returns notebook metadata, cell ids/types/counts, SHA-256, and optional read receipt; source previews are opt-in, filterable by `cell_ids`, and bounded by `max_source_chars` and `max_total_source_chars`.
  - `notebook.edit_cell`: `replace`/`insert`/`delete` by cell `id`; requires `expected_sha256` or `read_receipt`; supports `lock_lease_id`, `dry_run`, and size limits; code-cell replacement clears `outputs` and `execution_count`; atomic writes with eval metadata.
  - Filesystem integration: tool registration, strict arg validation, workspace-root resolution, separate `read`/`edit` grants, read receipts, preimage checks, lock leases, and reason-coded errors.
  - Presets, docs, tests: added `notebook.read` to read presets and `notebook.edit_cell` to edit/write; moved `code` tools to deferred in presets; updated `USER_GUIDE.md`; added design and implementation plan docs; unit/integration tests for helpers/tools/presets; Bandit clean; known unrelated `fs.glob` test remains a baseline failure.

<sup>Written for commit 6e55def26dbe7ddc68e42b493bc1062c0975f68f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

