### PR TITLE
feat(tts): add Fish Audio S2 provider and managed references

### DIFF
--- a/Docs/STT-TTS/TTS-SETUP-GUIDE.md
+++ b/Docs/STT-TTS/TTS-SETUP-GUIDE.md
@@ -22,6 +22,54 @@ OPENAI_API_KEY=your-api-key-here
 ELEVENLABS_API_KEY=your-api-key-here
 ```
 
+### Fish Audio S2
+
+Fish Audio S2 is currently supported through the upstream Fish HTTP server.
+The tldw provider key is `fish_s2`, and v1 expects the `native_http` backend.
+
+#### Upstream Server
+
+Start Fish Speech's API server separately and expose its `/v1/tts` and
+`/v1/references/*` routes. A typical local deployment uses:
+
+```bash
+python tools/api_server.py --host 127.0.0.1 --port 8080
+```
+
+#### Configuration (YAML)
+
+Enable `fish_s2` in `tldw_Server_API/Config_Files/tts_providers_config.yaml`:
+
+```yaml
+providers:
+  fish_s2:
+    enabled: true
+    backend: "native_http"
+    base_url: "http://127.0.0.1:8080"
+    api_key: null
+    timeout: 120
+    model: "s2-pro"
+    sample_rate: 24000
+    max_text_length: 5000
+    extra_params:
+      default_chunk_length: 200
+      default_normalize: true
+      default_use_memory_cache: "off"
+```
+
+#### Request Notes
+
+- Model aliases include `fish_s2`, `fish-s2-pro`, `s2-pro`, and `fishaudio/s2-pro`.
+- Streaming is WAV-only for the native Fish server path.
+- Managed references are user-scoped through:
+  - `POST /api/v1/audio/providers/fish_s2/references`
+  - `GET /api/v1/audio/providers/fish_s2/references`
+  - `DELETE /api/v1/audio/providers/fish_s2/references/{reference_id}`
+- `extra_params.reference_id` uses the local stored `voice_id`, not the backend
+  Fish reference ID.
+- `voice=custom:<voice_id>` reuses existing Fish metadata when present and falls
+  back to an inline reference payload built from the stored voice sample.
+
 ## Local Model Providers
 
 ### One-Command Installers (Recommended)

--- a/Docs/STT-TTS/TTS-SETUP-GUIDE.md
+++ b/Docs/STT-TTS/TTS-SETUP-GUIDE.md
@@ -24,10 +24,45 @@ ELEVENLABS_API_KEY=your-api-key-here
 
 ### Fish Audio S2
 
-Fish Audio S2 is currently supported through the upstream Fish HTTP server.
-The tldw provider key is `fish_s2`, and v1 expects the `native_http` backend.
+Fish Audio S2 is available under the tldw provider key `fish_s2`. The provider
+supports two backend modes:
 
-#### Upstream Server
+- `commercial_api` for the hosted Fish Audio API at `https://api.fish.audio`
+- `native_http` for a self-hosted Fish Speech HTTP server
+
+#### Hosted Commercial API
+
+Set `FISH_AUDIO_API_KEY` in the environment. `FISH_API_KEY` is also accepted as
+an alias.
+
+```bash
+FISH_AUDIO_API_KEY=your-fish-audio-api-key
+```
+
+Enable `fish_s2` in `tldw_Server_API/Config_Files/tts_providers_config.yaml`:
+
+```yaml
+providers:
+  fish_s2:
+    enabled: true
+    backend: "commercial_api"
+    base_url: "https://api.fish.audio"
+    api_key: ${FISH_AUDIO_API_KEY}
+    timeout: 120
+    model: "s2-pro"
+    sample_rate: 24000
+    max_text_length: 5000
+    extra_params:
+      default_chunk_length: 200
+      default_normalize: true
+```
+
+The hosted backend sends `POST /v1/tts` with the Fish `model` request header and
+creates reusable private voices through `POST /model`. Fish returns a hosted
+model ID for managed voices; tldw stores that ID in the local voice metadata and
+uses it as `reference_id` for later speech requests.
+
+#### Self-Hosted Native HTTP
 
 Start Fish Speech's API server separately and expose its `/v1/tts` and
 `/v1/references/*` routes. A typical local deployment uses:
@@ -36,9 +71,7 @@ Start Fish Speech's API server separately and expose its `/v1/tts` and
 python tools/api_server.py --host 127.0.0.1 --port 8080
 ```
 
-#### Configuration (YAML)
-
-Enable `fish_s2` in `tldw_Server_API/Config_Files/tts_providers_config.yaml`:
+Then configure `native_http`:
 
 ```yaml
 providers:
@@ -60,13 +93,17 @@ providers:
 #### Request Notes
 
 - Model aliases include `fish_s2`, `fish-s2-pro`, `s2-pro`, and `fishaudio/s2-pro`.
-- Streaming is WAV-only for the native Fish server path.
+- Supported response formats include `wav`, `mp3`, `opus`, and `pcm`.
+- Hosted commercial requests may pass Fish-specific fields through `extra_params`,
+  including `reference_id`, `references`, `sample_rate`, `mp3_bitrate`,
+  `opus_bitrate`, `latency`, `prosody`, `chunk_length`, `normalize`,
+  `max_new_tokens`, `repetition_penalty`, and chunk-control options.
 - Managed references are user-scoped through:
   - `POST /api/v1/audio/providers/fish_s2/references`
   - `GET /api/v1/audio/providers/fish_s2/references`
   - `DELETE /api/v1/audio/providers/fish_s2/references/{reference_id}`
 - `extra_params.reference_id` uses the local stored `voice_id`, not the backend
-  Fish reference ID.
+  Fish reference/model ID; tldw resolves it to the stored remote ID when present.
 - `voice=custom:<voice_id>` reuses existing Fish metadata when present and falls
   back to an inline reference payload built from the stored voice sample.
 

--- a/Docs/STT-TTS/TTS-SETUP-GUIDE.md
+++ b/Docs/STT-TTS/TTS-SETUP-GUIDE.md
@@ -100,12 +100,54 @@ providers:
   `max_new_tokens`, `repetition_penalty`, and chunk-control options.
 - Managed references are user-scoped through:
   - `POST /api/v1/audio/providers/fish_s2/references`
+  - `POST /api/v1/audio/providers/fish_s2/references/import`
   - `GET /api/v1/audio/providers/fish_s2/references`
   - `DELETE /api/v1/audio/providers/fish_s2/references/{reference_id}`
 - `extra_params.reference_id` uses the local stored `voice_id`, not the backend
   Fish reference/model ID; tldw resolves it to the stored remote ID when present.
 - `voice=custom:<voice_id>` reuses existing Fish metadata when present and falls
   back to an inline reference payload built from the stored voice sample.
+
+#### Reference Imports
+
+`POST /api/v1/audio/providers/fish_s2/references/import` accepts `.json`,
+`.md`, and `.markdown` files. Each imported item must either reference an
+existing stored voice with `voice_id` or include embedded base64 audio with
+`audio_base64`, `filename`, `name`, and `reference_text`.
+
+JSON imports may be a single object, an array, or an object with a `references`
+array:
+
+```json
+{
+  "references": [
+    {
+      "voice_id": "local-voice-id",
+      "reference_text": "Transcript for the stored voice.",
+      "force": false
+    },
+    {
+      "audio_base64": "UklGR...",
+      "filename": "speaker.wav",
+      "name": "Speaker One",
+      "description": "Private Fish S2 voice",
+      "reference_text": "Transcript for the embedded audio."
+    }
+  ]
+}
+```
+
+Markdown imports use YAML frontmatter for metadata and the Markdown body as the
+reference transcript when `reference_text` is omitted:
+
+```markdown
+---
+voice_id: local-voice-id
+name: Speaker One
+description: Private Fish S2 voice
+---
+Transcript for the stored voice.
+```
 
 ## Local Model Providers
 

--- a/Docs/STT-TTS/TTS-SETUP-GUIDE.md
+++ b/Docs/STT-TTS/TTS-SETUP-GUIDE.md
@@ -94,6 +94,8 @@ providers:
 
 - Model aliases include `fish_s2`, `fish-s2-pro`, `s2-pro`, and `fishaudio/s2-pro`.
 - Supported response formats include `wav`, `mp3`, `opus`, and `pcm`.
+- Self-hosted `native_http` streaming currently requires `wav`; hosted
+  `commercial_api` streaming can use broader Fish formats such as `opus`.
 - Hosted commercial requests may pass Fish-specific fields through `extra_params`,
   including `reference_id`, `references`, `sample_rate`, `mp3_bitrate`,
   `opus_bitrate`, `latency`, `prosody`, `chunk_length`, `normalize`,
@@ -114,6 +116,12 @@ providers:
 `.md`, and `.markdown` files. Each imported item must either reference an
 existing stored voice with `voice_id` or include embedded base64 audio with
 `audio_base64`, `filename`, `name`, and `reference_text`.
+
+Imports are bounded to protect local storage and hosted Fish model-creation
+costs: files are limited to 75 MB, each file may contain up to 25 references,
+and embedded base64 audio may decode to at most 50 MB per item. Bulk JSON
+imports return indexed `results` and `errors`; valid items can succeed even when
+other items fail validation or provider-side creation.
 
 JSON imports may be a single object, an array, or an object with a `references`
 array:

--- a/Docs/superpowers/plans/2026-06-27-fish-s2-commercial-api-plan.md
+++ b/Docs/superpowers/plans/2026-06-27-fish-s2-commercial-api-plan.md
@@ -1,0 +1,262 @@
+# Fish S2 Commercial API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add hosted Fish Audio commercial S2 support behind the existing `fish_s2` TTS provider.
+
+**Architecture:** Keep `fish_s2` as the public provider key and add a `commercial_api` backend alongside the existing `native_http` backend. The adapter delegates backend-specific HTTP contracts while `TTSServiceV2` preserves user-scoped local voice metadata and remote Fish model IDs.
+
+**Tech Stack:** FastAPI, pytest, existing `tldw_Server_API.app.core.http_client` helpers, Loguru, existing TTS adapter/service abstractions.
+
+---
+
+### Task 1: Commercial Backend TTS Contract
+
+**Files:**
+- Create: `tldw_Server_API/app/core/TTS/backends/fish_s2_commercial_api.py`
+- Modify: `tldw_Server_API/app/core/TTS/backends/fish_s2_base.py`
+- Test: `tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_commercial_api_backend.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add tests that assert `FishS2CommercialApiBackend.synthesize()`:
+
+```python
+backend = FishS2CommercialApiBackend({
+    "base_url": "https://api.fish.audio",
+    "api_key": "secret",
+    "model": "s2-pro",
+    "timeout": 30,
+})
+
+audio = await backend.synthesize(
+    text="hello",
+    response_format="mp3",
+    streaming=False,
+    reference_id="voice-model-id",
+    extra_params={
+        "sample_rate": 44100,
+        "mp3_bitrate": 128,
+        "latency": "balanced",
+        "prosody": {"speed": 1.2, "volume": 0},
+    },
+)
+```
+
+Expected request:
+
+```python
+method == "POST"
+url == "https://api.fish.audio/v1/tts"
+headers == {
+    "Authorization": "Bearer secret",
+    "Content-Type": "application/json",
+    "model": "s2-pro",
+}
+json == {
+    "text": "hello",
+    "format": "mp3",
+    "reference_id": "voice-model-id",
+    "sample_rate": 44100,
+    "mp3_bitrate": 128,
+    "latency": "balanced",
+    "prosody": {"speed": 1.2, "volume": 0},
+}
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_commercial_api_backend.py
+```
+
+Expected: import failure for missing `fish_s2_commercial_api.py`.
+
+- [x] **Step 3: Implement minimal backend**
+
+Implement:
+
+- config normalization for `base_url`, `api_key`, `model`, `timeout`
+- `health_check()` requiring configured base URL and API key
+- `_headers()`
+- `_build_tts_payload()`
+- `synthesize()` using `afetch` and `astream_bytes`
+- status/error mapping using existing TTS exceptions
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run the same test file and expect pass.
+
+### Task 2: Commercial Voice Model Creation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/TTS/backends/fish_s2_commercial_api.py`
+- Modify: `tldw_Server_API/app/core/TTS/backends/fish_s2_base.py`
+- Test: `tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_commercial_api_backend.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add tests for `add_reference()` that assert it posts multipart data to `/model`:
+
+```python
+await backend.add_reference(
+    reference_id="tldw_u1_voice-1",
+    audio_b64="QUJD",
+    reference_text="hello there",
+    title="Voice One",
+    description="private clone",
+)
+```
+
+Expected:
+
+```python
+url == "https://api.fish.audio/model"
+data includes type="tts", title="Voice One", train_mode="fast", visibility="private", texts="hello there"
+files includes voices=("reference.wav", b"ABC", "audio/wav")
+result["reference_id"] == returned["_id"]
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Expected: method signature or behavior mismatch.
+
+- [x] **Step 3: Implement minimal creation support**
+
+Update protocol and both backends to accept optional metadata. Commercial backend returns `{"reference_id": remote_id, "remote_reference_id": remote_id, ...}`.
+
+- [x] **Step 4: Run backend tests**
+
+Expected: commercial backend tests pass and native backend tests still pass.
+
+### Task 3: Adapter Backend Selection And Format Capabilities
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py`
+- Modify: `tldw_Server_API/app/core/TTS/tts_validation.py`
+- Test: `tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py`
+- Test: `tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_fish_s2.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add tests that:
+
+- `backend="commercial_api"` builds `FishS2CommercialApiBackend`
+- Fish capabilities include `opus`
+- commercial pass-through includes `sample_rate`, `mp3_bitrate`, `opus_bitrate`, `latency`, `max_new_tokens`, `min_chunk_length`, `condition_on_previous_chunks`, `early_stop_threshold`, and `prosody`
+
+- [x] **Step 2: Run tests to verify failure**
+
+Expected: unknown backend or missing pass-through fields.
+
+- [x] **Step 3: Implement adapter updates**
+
+Update `_build_backend()`, supported formats, capabilities, and pass-through list.
+
+- [x] **Step 4: Run adapter/validation tests**
+
+Expected: Fish adapter/validation tests pass.
+
+### Task 4: Service Metadata Flow
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/TTS/tts_service_v2.py`
+- Test: `tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add a test where adapter `add_reference()` returns a hosted ID different from the deterministic local ID:
+
+```python
+return {"reference_id": "fish-hosted-model-id", "remote_reference_id": "fish-hosted-model-id"}
+```
+
+Expected stored metadata:
+
+```python
+metadata.provider_artifacts["fish_s2"]["remote_reference_id"] == "fish-hosted-model-id"
+```
+
+- [x] **Step 2: Run test to verify failure**
+
+Expected: current code stores deterministic `tldw_u...` instead of returned hosted ID.
+
+- [x] **Step 3: Implement service update**
+
+Use backend return payload when present; fall back to deterministic ID for `native_http`.
+
+- [x] **Step 4: Run service Fish tests**
+
+Run:
+
+```bash
+python -m pytest -q tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py -k fish
+```
+
+Expected: pass.
+
+### Task 5: Config And Docs
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/TTS/tts_config.py`
+- Modify: `tldw_Server_API/Config_Files/tts_providers_config.yaml`
+- Modify: `Docs/STT-TTS/TTS-SETUP-GUIDE.md`
+- Test: focused config test if existing pattern is present, otherwise backend config tests cover env use.
+
+- [x] **Step 1: Write/update tests**
+
+Add coverage that `FISH_AUDIO_API_KEY` and `FISH_API_KEY` map to `providers.fish_s2.api_key`.
+
+- [x] **Step 2: Run test to verify failure**
+
+Expected: env var is ignored before implementation.
+
+- [x] **Step 3: Implement config/docs**
+
+Document both modes:
+
+- `backend: commercial_api` for hosted Fish Audio
+- `backend: native_http` for self-hosted Fish Speech
+
+- [x] **Step 4: Run config/docs-adjacent tests**
+
+Run focused backend/config tests.
+
+### Task 6: Final Verification
+
+**Files:**
+- All touched files.
+
+- [x] **Step 1: Run focused tests**
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py \
+  tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py \
+  tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_commercial_api_backend.py \
+  tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_registry.py \
+  tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_fish_s2.py \
+  tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py -k fish \
+  tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
+```
+
+- [x] **Step 2: Run Bandit on touched Python scope**
+
+```bash
+python -m bandit -r \
+  tldw_Server_API/app/core/TTS/backends \
+  tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py \
+  tldw_Server_API/app/core/TTS/tts_service_v2.py \
+  tldw_Server_API/app/core/TTS/tts_config.py \
+  tldw_Server_API/app/core/TTS/tts_validation.py \
+  tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py \
+  -f json -o /tmp/bandit_fish_s2_commercial_api.json
+```
+
+- [x] **Step 3: Update Backlog task**
+
+Record tests, Bandit result, final summary, and known limitations.

--- a/Docs/superpowers/plans/2026-06-27-fish-s2-reference-imports-plan.md
+++ b/Docs/superpowers/plans/2026-06-27-fish-s2-reference-imports-plan.md
@@ -1,0 +1,25 @@
+# Fish S2 Reference Import Implementation Plan
+
+**Goal:** Extend the existing Fish S2 commercial TTS PR with JSON and Markdown import support for managed Fish S2 voice references.
+
+**Architecture:** Add a parser for import files that normalizes JSON objects, JSON arrays, and Markdown files with optional frontmatter into the existing `create_fish_s2_reference` service flow. Keep Fish reference persistence in local voice metadata and reuse the current remote-reference sync path.
+
+**Tech Stack:** FastAPI multipart uploads, pytest, existing TTS service and voice manager abstractions.
+
+## Stage 1: Import File Contract
+**Goal**: Define the supported JSON and Markdown shapes for Fish S2 reference imports.
+**Success Criteria**: JSON object/array imports and Markdown frontmatter/body imports normalize into the same internal item shape.
+**Tests**: Parser tests for object, array, embedded audio, Markdown frontmatter, and invalid payloads.
+**Status**: Complete
+
+## Stage 2: API Endpoint
+**Goal**: Add a Fish S2 reference import endpoint to the existing audio voice router.
+**Success Criteria**: Endpoint accepts `.json`, `.md`, and `.markdown` uploads, forwards normalized items to `create_fish_s2_reference`, and returns per-item results.
+**Tests**: Integration tests for JSON and Markdown imports using fake TTS service overrides.
+**Status**: Complete
+
+## Stage 3: Documentation And Verification
+**Goal**: Document the import file format and verify touched code.
+**Success Criteria**: TTS setup docs mention JSON and Markdown import examples; focused pytest and Bandit checks pass.
+**Tests**: Focused TTS endpoint/parser tests plus Bandit on touched production Python files.
+**Status**: Complete

--- a/Docs/superpowers/plans/2026-06-27-fish-s2-reference-imports-plan.md
+++ b/Docs/superpowers/plans/2026-06-27-fish-s2-reference-imports-plan.md
@@ -23,3 +23,9 @@
 **Success Criteria**: TTS setup docs mention JSON and Markdown import examples; focused pytest and Bandit checks pass.
 **Tests**: Focused TTS endpoint/parser tests plus Bandit on touched production Python files.
 **Status**: Complete
+
+## Stage 4: Code Review Fixes
+**Goal**: Address code-review findings before merge.
+**Success Criteria**: Native Fish streaming rejects non-WAV formats while hosted commercial streaming keeps broader formats; imports return indexed partial errors/results; file/item/audio limits are enforced.
+**Tests**: Adapter regression tests plus parser/endpoint tests for partial parse errors, provider errors, oversized files, too many items, and oversized embedded audio.
+**Status**: Complete

--- a/Docs/superpowers/specs/2026-06-27-fish-s2-commercial-api-design.md
+++ b/Docs/superpowers/specs/2026-06-27-fish-s2-commercial-api-design.md
@@ -1,0 +1,84 @@
+# Fish S2 Commercial API Design
+
+## Context
+
+The existing `codex/fish-s2-pro-tts` worktree adds a `fish_s2` TTS provider that targets a self-hosted Fish Speech HTTP server. That branch is internally consistent and its Fish-focused tests pass, but the hosted Fish Audio commercial API has a different contract:
+
+- `POST https://api.fish.audio/v1/tts`
+- `Authorization: Bearer <token>`
+- required `model` request header, such as `s2-pro`
+- JSON/MessagePack TTS body fields including `reference_id`, `references`, `prosody`, `sample_rate`, `mp3_bitrate`, `opus_bitrate`, `latency`, `max_new_tokens`, `min_chunk_length`, `condition_on_previous_chunks`, and `early_stop_threshold`
+- reusable voice creation through `POST /model`, not `/v1/references/add`
+
+## Goal
+
+Add hosted Fish Audio commercial S2 TTS support without removing or weakening the existing self-hosted `native_http` backend.
+
+## Recommended Approach
+
+Add a second Fish backend named `commercial_api` behind the existing `FishS2Adapter`. The provider key remains `fish_s2`; configuration selects the backend:
+
+```yaml
+providers:
+  fish_s2:
+    enabled: true
+    backend: "commercial_api"
+    base_url: "https://api.fish.audio"
+    api_key: ${FISH_AUDIO_API_KEY}
+    model: "s2-pro"
+```
+
+This keeps existing API clients on one provider name and lets operators choose self-hosted or hosted Fish by config. It also keeps the adapter-level model aliases (`fish_s2`, `fish-s2-pro`, `s2-pro`, `fishaudio/s2-pro`) intact.
+
+## Components
+
+- `fish_s2_base.py`: extend the backend protocol so reference creation can accept voice metadata and return a hosted model ID.
+- `fish_s2_commercial_api.py`: new HTTP backend for Fish Audio hosted API.
+- `fish_s2_native_http.py`: retain existing behavior for self-hosted Fish Speech.
+- `fish_s2_adapter.py`: instantiate `commercial_api` when configured and pass commercial generation fields through.
+- `tts_service_v2.py`: keep local `voice_id` to remote Fish model ID mapping, but allow the backend to choose the remote ID returned by `/model`.
+- `tts_config.py`: add Fish API key environment override support.
+- `tts_validation.py`: allow Fish-supported hosted output formats such as `opus`; backend-specific constraints stay in the backend layer.
+- `audio_voices.py`: keep the existing user-scoped Fish reference endpoints, but document that commercial mode creates Fish hosted models.
+
+## Data Flow
+
+1. A normal `/api/v1/audio/speech` request resolves to provider `fish_s2`.
+2. The adapter builds a provider request and delegates to the configured backend.
+3. In `commercial_api` mode, the backend sends JSON to `/v1/tts`, sets `Authorization` and `model` headers, and returns audio bytes or an async stream.
+4. For `voice=custom:<voice_id>` or local `extra_params.reference_id`, `TTSServiceV2` resolves local voice metadata first.
+5. If metadata has `provider_artifacts.fish_s2.remote_reference_id`, that hosted model ID is sent as Fish `reference_id`.
+6. If no hosted ID exists and a user explicitly syncs the voice, the service calls backend reference creation, stores the returned Fish model `_id`, and reuses it on later TTS requests.
+
+## Error Handling
+
+Commercial API status mapping follows existing TTS exceptions:
+
+- `401` and `403`: `TTSAuthenticationError`
+- `402`: `TTSProviderError` with payment/quota context
+- `429`: `TTSRateLimitError`
+- `400`, `404`, and `422`: `TTSValidationError`
+- `408` and `504`: `TTSTimeoutError`
+- `5xx`: `TTSProviderError`
+- transport failures: `TTSNetworkError`
+
+The implementation must not log API keys or uploaded audio.
+
+## Testing
+
+Use TDD:
+
+- backend tests for `/v1/tts` commercial payload/header construction
+- backend tests for streaming helper use
+- backend tests for `/model` multipart creation and returned `_id`
+- backend tests for auth/payment/rate-limit/validation error mapping
+- adapter tests for selecting `commercial_api`
+- service tests for persisting a remote Fish `_id` returned by the commercial backend
+- endpoint tests to keep user-scoped Fish reference routes stable
+
+## Non-Goals
+
+- Do not implement Fish WebSocket realtime streaming in this slice.
+- Do not remove the self-hosted Fish Speech backend.
+- Do not add a frontend provider management UI in this slice.
+- Do not perform live Fish API calls in automated tests.

--- a/backlog/tasks/task-2370 - Add-commercial-Fish-Audio-S2-TTS-API-backend.md
+++ b/backlog/tasks/task-2370 - Add-commercial-Fish-Audio-S2-TTS-API-backend.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2370
+title: Add commercial Fish Audio S2 TTS API backend
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-28 01:07'
+labels:
+  - tts
+  - audio
+  - provider
+  - fish-audio
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add hosted Fish Audio S2 commercial API support to the existing fish_s2 TTS provider without replacing the self-hosted Fish Speech native_http backend. The backend should call https://api.fish.audio/v1/tts with the required model header, support hosted /model voice creation, preserve local voice metadata mappings, and keep tests/docs/config aligned.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 fish_s2 can be configured with backend: commercial_api and FISH_AUDIO_API_KEY/FISH_API_KEY
+- [x] #2 Commercial TTS payload sends the model header and Fish-compatible JSON fields including prosody, sample rate, bitrates, latency, and multi-speaker reference IDs
+- [x] #3 Commercial voice/model creation uses Fish /model and stores returned remote model IDs in local voice metadata
+- [x] #4 Existing native_http Fish Speech behavior remains covered and unchanged except for shared adapter plumbing
+- [x] #5 Focused unit and endpoint tests pass
+- [x] #6 Bandit runs on touched backend/API TTS scope with no new findings
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented hosted Fish Audio commercial_api support behind the existing fish_s2 provider while preserving native_http.
+
+Verification:
+- Fish-focused pytest suite: 34 passed.
+- Service Fish subset: 8 passed.
+- Bandit touched production TTS scope: 0 findings, report at /tmp/bandit_fish_s2_commercial_api.json.
+
+Known skips/blockers: no live Fish API call was run; automated coverage uses mocked HTTP transports.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fish Audio S2 now supports a hosted commercial API backend via `backend: commercial_api` under the existing `fish_s2` provider key. The implementation covers hosted TTS payload/header construction, streaming, private hosted voice model creation/deletion, local-to-remote voice metadata mapping, Fish OPUS validation, env-based API key configuration, and updated setup documentation. Verification: Fish-focused pytest suite passed (34 tests), service Fish subset passed (8 tests), and Bandit on touched production TTS files reported zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2370 - Add-commercial-Fish-Audio-S2-TTS-API-backend.md
+++ b/backlog/tasks/task-2370 - Add-commercial-Fish-Audio-S2-TTS-API-backend.md
@@ -4,12 +4,12 @@ title: Add commercial Fish Audio S2 TTS API backend
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-28 01:07'
+updated_date: 2026-06-28 01:07
 labels:
-  - tts
-  - audio
-  - provider
-  - fish-audio
+- tts
+- audio
+- provider
+- fish-audio
 dependencies: []
 priority: high
 ---
@@ -58,3 +58,9 @@ Fish Audio S2 now supports a hosted commercial API backend via `backend: commerc
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR #2540 rebase/review pass: rebased Fish S2 branch onto latest origin/dev and addressed review comments for native retry-after parsing, response JSON logging, aggregate audio route mounting, BYOK fallback logging, and Fish S2 endpoint response models. Verification so far: Fish S2 focused pytest selection passed (69 selected), aggregate/route tests passed (22), audio OAuth retry tests passed (18), presets/voice-conversion selection passed (13), Bandit touched production scope reported zero findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-2370 - Add-commercial-Fish-Audio-S2-TTS-API-backend.md
+++ b/backlog/tasks/task-2370 - Add-commercial-Fish-Audio-S2-TTS-API-backend.md
@@ -62,5 +62,5 @@ Fish Audio S2 now supports a hosted commercial API backend via `backend: commerc
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-PR #2540 rebase/review pass: rebased Fish S2 branch onto latest origin/dev and addressed review comments for native retry-after parsing, response JSON logging, aggregate audio route mounting, BYOK fallback logging, and Fish S2 endpoint response models. Verification so far: Fish S2 focused pytest selection passed (69 selected), aggregate/route tests passed (22), audio OAuth retry tests passed (18), presets/voice-conversion selection passed (13), Bandit touched production scope reported zero findings.
+Review follow-up complete after latest CodeRabbit pass. Addressed blank BYOK API key fail-closed behavior for Fish S2/OpenAI/ElevenLabs TTS paths, Fish S2 direct-dict/env API key initialization, adapter ERROR status on initialization exceptions, sanitized native HTTP upstream error logging, and forced managed-reference metadata cleanup after deleting stale Fish remote IDs. Verification: 7 red-step regressions now pass; 75 Fish/reference/audio selected tests passed; 54 route/OAuth selected tests passed; git diff --check clean; Bandit on touched production files reported zero findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-2371 - Add-Fish-S2-reference-imports-from-JSON-and-Markdown-files.md
+++ b/backlog/tasks/task-2371 - Add-Fish-S2-reference-imports-from-JSON-and-Markdown-files.md
@@ -33,12 +33,16 @@ Extend the existing Fish Audio S2 TTS PR with an import endpoint for managed Fis
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Implemented a core parser for `.json`, `.md`, and `.markdown` Fish S2 reference import files. Added `POST /api/v1/audio/providers/fish_s2/references/import`, with coverage for existing-voice JSON, bulk JSON, embedded base64 audio JSON, Markdown frontmatter, and invalid imports. The endpoint returns per-item results/errors and preserves the existing voice upload scope/rate-limit path.
+
+Reopened for code-review fixes: restore native Fish streaming format constraints, harden import partial-error behavior, and add import size/item/audio limits.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added Fish S2 reference imports from JSON and Markdown files on the existing Fish S2 commercial API branch/PR. Verification: pytest Fish S2 focused suite passed with 57 selected tests and 32 deselected; Bandit on touched production Python files reported zero findings; `git diff --check` passed.
+
+Code-review fixes added native Fish streaming format enforcement, indexed partial import errors/results, and file/item/decoded-audio limits. Verification: pytest Fish S2 focused suite passed with 66 selected tests and 32 deselected; Bandit on touched production Python files reported zero findings; `git diff --check` passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2371 - Add-Fish-S2-reference-imports-from-JSON-and-Markdown-files.md
+++ b/backlog/tasks/task-2371 - Add-Fish-S2-reference-imports-from-JSON-and-Markdown-files.md
@@ -1,0 +1,52 @@
+---
+id: TASK-2371
+title: Add Fish S2 reference imports from JSON and Markdown files
+status: Done
+labels:
+  - tts
+  - fish-s2
+  - api
+modified_files:
+  - tldw_Server_API/app/core/TTS/fish_s2_reference_imports.py
+  - tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+  - tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_reference_imports.py
+  - tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
+  - Docs/STT-TTS/TTS-SETUP-GUIDE.md
+  - Docs/superpowers/plans/2026-06-27-fish-s2-reference-imports-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extend the existing Fish Audio S2 TTS PR with an import endpoint for managed Fish S2 references from JSON and Markdown files that match the reference metadata format. Reuse the existing `create_fish_s2_reference` service path so local voice metadata and remote Fish references remain consistent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Add JSON and Markdown import support for Fish S2 managed references.
+- [x] Reuse the existing `create_fish_s2_reference` service path for imported items.
+- [x] Document accepted JSON and Markdown file shapes.
+- [x] Focused Fish S2 tests and Bandit pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented a core parser for `.json`, `.md`, and `.markdown` Fish S2 reference import files. Added `POST /api/v1/audio/providers/fish_s2/references/import`, with coverage for existing-voice JSON, bulk JSON, embedded base64 audio JSON, Markdown frontmatter, and invalid imports. The endpoint returns per-item results/errors and preserves the existing voice upload scope/rate-limit path.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Fish S2 reference imports from JSON and Markdown files on the existing Fish S2 commercial API branch/PR. Verification: pytest Fish S2 focused suite passed with 57 selected tests and 32 deselected; Bandit on touched production Python files reported zero findings; `git diff --check` passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2371 - Add-Fish-S2-reference-imports-from-JSON-and-Markdown-files.md
+++ b/backlog/tasks/task-2371 - Add-Fish-S2-reference-imports-from-JSON-and-Markdown-files.md
@@ -32,7 +32,7 @@ Extend the existing Fish Audio S2 TTS PR with an import endpoint for managed Fis
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-PR #2540 rebase/review pass: Fish S2 import endpoint now has explicit response models and preserves absent optional fields via response_model_exclude_none. Import regression coverage updated alongside retry-after/logging/router fixes. Verification so far: Fish S2 focused pytest selection passed (69 selected), aggregate/route tests passed (22), audio OAuth retry tests passed (18), presets/voice-conversion selection passed (13), Bandit touched production scope reported zero findings.
+Review follow-up complete after latest CodeRabbit pass. Added bounded direct Fish S2 reference upload reads using the existing 50MB decoded-audio cap, fixture teardown reset for cached auth settings, native HTTP streaming/delete request contract assertions, and forced recreation coverage for stale managed-reference metadata. Verification: 7 red-step regressions now pass; 75 Fish/reference/audio selected tests passed; 54 route/OAuth selected tests passed; git diff --check clean; Bandit on touched production files reported zero findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2371 - Add-Fish-S2-reference-imports-from-JSON-and-Markdown-files.md
+++ b/backlog/tasks/task-2371 - Add-Fish-S2-reference-imports-from-JSON-and-Markdown-files.md
@@ -3,16 +3,16 @@ id: TASK-2371
 title: Add Fish S2 reference imports from JSON and Markdown files
 status: Done
 labels:
-  - tts
-  - fish-s2
-  - api
+- tts
+- fish-s2
+- api
 modified_files:
-  - tldw_Server_API/app/core/TTS/fish_s2_reference_imports.py
-  - tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
-  - tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_reference_imports.py
-  - tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
-  - Docs/STT-TTS/TTS-SETUP-GUIDE.md
-  - Docs/superpowers/plans/2026-06-27-fish-s2-reference-imports-plan.md
+- tldw_Server_API/app/core/TTS/fish_s2_reference_imports.py
+- tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+- tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_reference_imports.py
+- tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
+- Docs/STT-TTS/TTS-SETUP-GUIDE.md
+- Docs/superpowers/plans/2026-06-27-fish-s2-reference-imports-plan.md
 ---
 
 ## Description
@@ -32,9 +32,7 @@ Extend the existing Fish Audio S2 TTS PR with an import endpoint for managed Fis
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Implemented a core parser for `.json`, `.md`, and `.markdown` Fish S2 reference import files. Added `POST /api/v1/audio/providers/fish_s2/references/import`, with coverage for existing-voice JSON, bulk JSON, embedded base64 audio JSON, Markdown frontmatter, and invalid imports. The endpoint returns per-item results/errors and preserves the existing voice upload scope/rate-limit path.
-
-Reopened for code-review fixes: restore native Fish streaming format constraints, harden import partial-error behavior, and add import size/item/audio limits.
+PR #2540 rebase/review pass: Fish S2 import endpoint now has explicit response models and preserves absent optional fields via response_model_exclude_none. Import regression coverage updated alongside retry-after/logging/router fixes. Verification so far: Fish S2 focused pytest selection passed (69 selected), aggregate/route tests passed (22), audio OAuth retry tests passed (18), presets/voice-conversion selection passed (13), Bandit touched production scope reported zero findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/Config_Files/tts_providers_config.yaml
+++ b/tldw_Server_API/Config_Files/tts_providers_config.yaml
@@ -17,7 +17,7 @@ provider_priority:
   - higgs       # Advanced multi-lingual
   - index_tts   # IndexTTS2 (local, expressive zero-shot)
   - qwen3_tts   # Qwen3-TTS (local, multilingual; disabled by default)
-  - fish_s2     # Fish Audio S2 via upstream HTTP server (disabled by default)
+  - fish_s2     # Fish Audio S2 hosted API or self-hosted HTTP server (disabled by default)
 
 # Provider-specific configurations
 providers:
@@ -322,12 +322,16 @@ providers:
       idle_shutdown_seconds: 900
       resident_mode: false
 
-  # Fish Audio S2 Configuration (remote Fish HTTP server)
+  # Fish Audio S2 Configuration
+  # Hosted commercial API: set backend to "commercial_api" and provide
+  # FISH_AUDIO_API_KEY (or FISH_API_KEY) in the environment.
+  # Self-hosted Fish Speech server: set backend to "native_http" and base_url
+  # to your local server, for example "http://127.0.0.1:8080".
   fish_s2:
     enabled: false
-    backend: "native_http"
-    base_url: "http://127.0.0.1:8080"
-    api_key: null
+    backend: "commercial_api"
+    base_url: "https://api.fish.audio"
+    api_key: ${FISH_AUDIO_API_KEY}
     timeout: 120
     verify_api_key_on_init: false
     model: "s2-pro"

--- a/tldw_Server_API/Config_Files/tts_providers_config.yaml
+++ b/tldw_Server_API/Config_Files/tts_providers_config.yaml
@@ -17,6 +17,7 @@ provider_priority:
   - higgs       # Advanced multi-lingual
   - index_tts   # IndexTTS2 (local, expressive zero-shot)
   - qwen3_tts   # Qwen3-TTS (local, multilingual; disabled by default)
+  - fish_s2     # Fish Audio S2 via upstream HTTP server (disabled by default)
 
 # Provider-specific configurations
 providers:
@@ -320,6 +321,22 @@ providers:
       warmup_on_startup: false
       idle_shutdown_seconds: 900
       resident_mode: false
+
+  # Fish Audio S2 Configuration (remote Fish HTTP server)
+  fish_s2:
+    enabled: false
+    backend: "native_http"
+    base_url: "http://127.0.0.1:8080"
+    api_key: null
+    timeout: 120
+    verify_api_key_on_init: false
+    model: "s2-pro"
+    sample_rate: 24000
+    max_text_length: 5000
+    extra_params:
+      default_chunk_length: 200
+      default_normalize: true
+      default_use_memory_cache: "off"
 
 # Voice mappings for cross-provider compatibility
 # NOTE: Providers like index_tts rely on uploaded reference audio; the

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
@@ -5,8 +5,9 @@ import importlib
 import os
 from typing import Any, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from loguru import logger
+from starlette import status
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import get_usage_event_logger
@@ -26,11 +27,9 @@ from tldw_Server_API.app.core.Metrics.metrics_manager import (
 from . import (
     audio_health,
     audio_history,
-    audio_presets,
     audio_tokenizer,
     audio_transcriptions,
     audio_tts,
-    audio_voice_conversion,
     audio_voices,
 )
 
@@ -46,12 +45,10 @@ router = APIRouter(
 # Include HTTP routers
 router.include_router(audio_tts.router)
 router.include_router(audio_history.router)
-router.include_router(audio_presets.router)
 router.include_router(audio_tokenizer.router)
 router.include_router(audio_transcriptions.router)
 router.include_router(audio_health.router)
 router.include_router(audio_voices.router)
-router.include_router(audio_voice_conversion.router)
 
 _AUDIO_STREAMING_MODULE = f"{__package__}.audio_streaming"
 
@@ -69,8 +66,8 @@ def _mount_streaming_routes() -> APIRouter:
         streaming_module = _load_audio_streaming()
         router.include_router(streaming_module.router)
         return streaming_module.ws_router
-    except Exception:
-        logger.warning("Audio streaming routes unavailable; skipping import")
+    except Exception as exc:
+        logger.warning(f"Audio streaming routes unavailable; skipping import: {exc}")
         return APIRouter()
 
 
@@ -83,8 +80,6 @@ create_speech_metadata = audio_tts.create_speech_metadata
 list_tts_providers = audio_tts.list_tts_providers
 list_tts_voices = audio_tts.list_tts_voices
 reset_tts_metrics = audio_tts.reset_tts_metrics
-get_tts_provider_model_info = audio_tts.get_tts_provider_model_info
-unload_tts_provider = audio_tts.unload_tts_provider
 encode_audio_tokenizer = audio_tokenizer.encode_audio_tokenizer
 decode_audio_tokenizer = audio_tokenizer.decode_audio_tokenizer
 create_transcription = audio_transcriptions.create_transcription
@@ -98,13 +93,23 @@ list_voices = audio_voices.list_voices
 get_voice_details = audio_voices.get_voice_details
 delete_voice = audio_voices.delete_voice
 preview_voice = audio_voices.preview_voice
-create_voice_conversion = audio_voice_conversion.create_voice_conversion
+create_fish_s2_reference = audio_voices.create_fish_s2_reference
+list_fish_s2_references = audio_voices.list_fish_s2_references
+delete_fish_s2_reference = audio_voices.delete_fish_s2_reference
 
 # Dependency helpers (for FastAPI overrides in tests)
 get_tts_service = audio_tts.get_tts_service
 get_usage_event_logger = get_usage_event_logger
 check_rate_limit = check_rate_limit
 
+# Shared helper re-exports used in tests
+from tldw_Server_API.app.core.Audio.tts_service import (
+    _tts_fallback_resolver,
+)
+from tldw_Server_API.app.core.AuthNZ.byok_runtime import (
+    record_byok_missing_credentials,
+    resolve_byok_credentials,
+)
 from tldw_Server_API.app.core.config import load_comprehensive_config as _load_comprehensive_config
 
 # Re-export config loader for tests to monkeypatch
@@ -119,14 +124,51 @@ async def _resolve_tts_byok(
     force_oauth_refresh: bool = False,
 ):
     """Wrapper to preserve audio.py patch points for BYOK resolution."""
-    from tldw_Server_API.app.core.Audio import tts_service as core_tts_service
+    user_id_int = None
+    try:
+        user_id_int = getattr(current_user, "id_int", None)
+        if user_id_int is None:
+            raw_id = getattr(current_user, "id", None)
+            if raw_id is not None:
+                user_id_int = int(raw_id)
+    except (AttributeError, TypeError, ValueError) as exc:
+        logger.debug(f"Failed to extract user_id from current_user: {exc}")
+        user_id_int = None
 
-    return await core_tts_service._resolve_tts_byok(
-        provider_hint=provider_hint,
-        current_user=current_user,
-        request=request,
-        force_oauth_refresh=force_oauth_refresh,
-    )
+    tts_overrides = None
+    byok_tts_resolution = None
+    if provider_hint:
+        resolver = resolve_byok_credentials
+        try:
+            from tldw_Server_API.app.api.v1.endpoints import audio as _audio_pkg
+
+            resolver = getattr(_audio_pkg, "resolve_byok_credentials", resolve_byok_credentials)
+        except Exception:
+            resolver = resolve_byok_credentials
+        byok_tts_resolution = await resolver(
+            provider_hint,
+            user_id=user_id_int,
+            request=request,
+            fallback_resolver=_tts_fallback_resolver,
+            force_oauth_refresh=force_oauth_refresh,
+        )
+        if byok_tts_resolution.uses_byok:
+            tts_overrides = {"api_key": byok_tts_resolution.api_key}
+            base_url = byok_tts_resolution.credential_fields.get("base_url")
+            if isinstance(base_url, str) and base_url.strip():
+                tts_overrides["base_url"] = base_url.strip()
+        elif not byok_tts_resolution.api_key:
+            if provider_hint in {"openai", "elevenlabs"}:
+                record_byok_missing_credentials(provider_hint, operation="audio_tts")
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail={
+                        "error_code": "missing_provider_credentials",
+                        "message": f"TTS provider '{provider_hint}' requires an API key.",
+                    },
+                )
+
+    return user_id_int, tts_overrides, byok_tts_resolution
 
 
 def _get_failopen_cap_minutes() -> float:
@@ -144,8 +186,8 @@ def _get_failopen_cap_minutes() -> float:
             f = float(v)
             if f > 0:
                 return f
-        except (ValueError, TypeError):
-            logger.debug("AUDIO_FAILOPEN_CAP_MINUTES parse failed")
+        except (ValueError, TypeError) as exc:
+            logger.debug(f"AUDIO_FAILOPEN_CAP_MINUTES parse failed: {exc}")
     try:
         try:
             from tldw_Server_API.app.api.v1.endpoints import audio as _audio_pkg
@@ -160,17 +202,17 @@ def _get_failopen_cap_minutes() -> float:
                     f = float(cfg.get("Audio-Quota", "failopen_cap_minutes", fallback=""))
                     if f > 0:
                         return f
-                except (ValueError, TypeError):
-                    logger.debug("[Audio-Quota].failopen_cap_minutes parse failed")
+                except (ValueError, TypeError) as exc:
+                    logger.debug(f"[Audio-Quota].failopen_cap_minutes parse failed: {exc}")
             if cfg.has_section("Audio"):
                 try:
                     f = float(cfg.get("Audio", "failopen_cap_minutes", fallback=""))
                     if f > 0:
                         return f
-                except (ValueError, TypeError):
-                    logger.debug("[Audio].failopen_cap_minutes parse failed")
-    except Exception:
-        logger.debug("Config read for failopen cap failed")
+                except (ValueError, TypeError) as exc:
+                    logger.debug(f"[Audio].failopen_cap_minutes parse failed: {exc}")
+    except Exception as exc:
+        logger.debug(f"Config read for failopen cap failed: {exc}")
     return 5.0
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
@@ -27,9 +27,11 @@ from tldw_Server_API.app.core.Metrics.metrics_manager import (
 from . import (
     audio_health,
     audio_history,
+    audio_presets,
     audio_tokenizer,
     audio_transcriptions,
     audio_tts,
+    audio_voice_conversion,
     audio_voices,
 )
 
@@ -49,6 +51,8 @@ router.include_router(audio_tokenizer.router)
 router.include_router(audio_transcriptions.router)
 router.include_router(audio_health.router)
 router.include_router(audio_voices.router)
+router.include_router(audio_presets.router)
+router.include_router(audio_voice_conversion.router)
 
 _AUDIO_STREAMING_MODULE = f"{__package__}.audio_streaming"
 
@@ -66,8 +70,8 @@ def _mount_streaming_routes() -> APIRouter:
         streaming_module = _load_audio_streaming()
         router.include_router(streaming_module.router)
         return streaming_module.ws_router
-    except Exception as exc:
-        logger.warning(f"Audio streaming routes unavailable; skipping import: {exc}")
+    except Exception:
+        logger.warning("Audio streaming routes unavailable; skipping import")
         return APIRouter()
 
 
@@ -124,6 +128,16 @@ async def _resolve_tts_byok(
     force_oauth_refresh: bool = False,
 ):
     """Wrapper to preserve audio.py patch points for BYOK resolution."""
+    if not provider_hint:
+        from tldw_Server_API.app.core.Audio import tts_service as core_tts_service
+
+        return await core_tts_service._resolve_tts_byok(
+            provider_hint=provider_hint,
+            current_user=current_user,
+            request=request,
+            force_oauth_refresh=force_oauth_refresh,
+        )
+
     user_id_int = None
     try:
         user_id_int = getattr(current_user, "id_int", None)
@@ -131,8 +145,8 @@ async def _resolve_tts_byok(
             raw_id = getattr(current_user, "id", None)
             if raw_id is not None:
                 user_id_int = int(raw_id)
-    except (AttributeError, TypeError, ValueError) as exc:
-        logger.debug(f"Failed to extract user_id from current_user: {exc}")
+    except (AttributeError, TypeError, ValueError):
+        logger.debug("Failed to extract user_id from current_user")
         user_id_int = None
 
     tts_overrides = None
@@ -143,7 +157,8 @@ async def _resolve_tts_byok(
             from tldw_Server_API.app.api.v1.endpoints import audio as _audio_pkg
 
             resolver = getattr(_audio_pkg, "resolve_byok_credentials", resolve_byok_credentials)
-        except Exception:
+        except (AttributeError, ImportError):
+            logger.debug("Falling back to default BYOK resolver after audio package resolver lookup failed")
             resolver = resolve_byok_credentials
         byok_tts_resolution = await resolver(
             provider_hint,
@@ -186,8 +201,8 @@ def _get_failopen_cap_minutes() -> float:
             f = float(v)
             if f > 0:
                 return f
-        except (ValueError, TypeError) as exc:
-            logger.debug(f"AUDIO_FAILOPEN_CAP_MINUTES parse failed: {exc}")
+        except (ValueError, TypeError):
+            logger.debug("AUDIO_FAILOPEN_CAP_MINUTES parse failed")
     try:
         try:
             from tldw_Server_API.app.api.v1.endpoints import audio as _audio_pkg
@@ -202,17 +217,17 @@ def _get_failopen_cap_minutes() -> float:
                     f = float(cfg.get("Audio-Quota", "failopen_cap_minutes", fallback=""))
                     if f > 0:
                         return f
-                except (ValueError, TypeError) as exc:
-                    logger.debug(f"[Audio-Quota].failopen_cap_minutes parse failed: {exc}")
+                except (ValueError, TypeError):
+                    logger.debug("[Audio-Quota].failopen_cap_minutes parse failed")
             if cfg.has_section("Audio"):
                 try:
                     f = float(cfg.get("Audio", "failopen_cap_minutes", fallback=""))
                     if f > 0:
                         return f
-                except (ValueError, TypeError) as exc:
-                    logger.debug(f"[Audio].failopen_cap_minutes parse failed: {exc}")
-    except Exception as exc:
-        logger.debug(f"Config read for failopen cap failed: {exc}")
+                except (ValueError, TypeError):
+                    logger.debug("[Audio].failopen_cap_minutes parse failed")
+    except Exception:
+        logger.debug("Config read for failopen cap failed")
     return 5.0
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
@@ -119,6 +119,32 @@ from tldw_Server_API.app.core.config import load_comprehensive_config as _load_c
 # Re-export config loader for tests to monkeypatch
 load_comprehensive_config = _load_comprehensive_config
 
+_TTS_API_KEY_REQUIRED_PROVIDERS = {"openai", "elevenlabs", "fish_s2"}
+
+
+def _normalize_tts_provider_hint(provider_hint: Optional[str]) -> str:
+    """Normalize TTS provider hints for credential requirement checks."""
+    return str(provider_hint or "").strip().lower().replace("-", "_")
+
+
+def _resolved_api_key(value: object) -> Optional[str]:
+    """Return a non-empty API key string, or None for blank/missing values."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _raise_missing_tts_credentials(provider_hint: str) -> None:
+    record_byok_missing_credentials(provider_hint, operation="audio_tts")
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail={
+            "error_code": "missing_provider_credentials",
+            "message": f"TTS provider '{provider_hint}' requires an API key.",
+        },
+    )
+
 
 async def _resolve_tts_byok(
     *,
@@ -167,21 +193,19 @@ async def _resolve_tts_byok(
             fallback_resolver=_tts_fallback_resolver,
             force_oauth_refresh=force_oauth_refresh,
         )
+        provider_key = _normalize_tts_provider_hint(provider_hint)
+        resolved_api_key = _resolved_api_key(byok_tts_resolution.api_key)
+        requires_api_key = provider_key in _TTS_API_KEY_REQUIRED_PROVIDERS
         if byok_tts_resolution.uses_byok:
-            tts_overrides = {"api_key": byok_tts_resolution.api_key}
+            if not resolved_api_key and requires_api_key:
+                _raise_missing_tts_credentials(provider_hint)
+            if resolved_api_key:
+                tts_overrides = {"api_key": resolved_api_key}
             base_url = byok_tts_resolution.credential_fields.get("base_url")
-            if isinstance(base_url, str) and base_url.strip():
+            if tts_overrides is not None and isinstance(base_url, str) and base_url.strip():
                 tts_overrides["base_url"] = base_url.strip()
-        elif not byok_tts_resolution.api_key:
-            if provider_hint in {"openai", "elevenlabs"}:
-                record_byok_missing_credentials(provider_hint, operation="audio_tts")
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail={
-                        "error_code": "missing_provider_credentials",
-                        "message": f"TTS provider '{provider_hint}' requires an API key.",
-                    },
-                )
+        elif not resolved_api_key and requires_api_key:
+            _raise_missing_tts_credentials(provider_hint)
 
     return user_id_int, tts_overrides, byok_tts_resolution
 

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -436,7 +436,12 @@ async def create_fish_s2_reference(
                     request_id,
                 ),
             )
-        file_content = await file.read()
+        file_content = await file.read(FISH_S2_REFERENCE_IMPORT_MAX_DECODED_AUDIO_BYTES + 1)
+        if len(file_content) > FISH_S2_REFERENCE_IMPORT_MAX_DECODED_AUDIO_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail("Fish S2 reference audio is too large", request_id),
+            )
         filename = file.filename
 
     try:

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -1,5 +1,7 @@
 # audio_voices.py
 # Description: Custom voice management endpoints.
+import base64
+import binascii
 from typing import Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Path, Request, UploadFile
@@ -22,6 +24,10 @@ from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
 )
 from tldw_Server_API.app.core.Audio.error_payloads import _http_error_detail
 from tldw_Server_API.app.core.Logging.log_context import ensure_request_id
+from tldw_Server_API.app.core.TTS.fish_s2_reference_imports import (
+    FishS2ReferenceImportError,
+    parse_fish_s2_reference_import,
+)
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 
 router = APIRouter(
@@ -466,6 +472,96 @@ async def list_fish_s2_references(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list Fish S2 references",
         ) from e
+
+
+@router.post(
+    "/providers/fish_s2/references/import",
+    summary="Import managed Fish S2 references from JSON or Markdown",
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(
+            require_token_scope(
+                "any",
+                require_if_present=True,
+                endpoint_id=VOICE_SCOPE_UPLOAD,
+                count_as=VOICE_COUNTER_TYPE,
+            )
+        ),
+    ],
+)
+async def import_fish_s2_references(
+    request: Request,
+    file: UploadFile = File(..., description="Fish S2 reference import file (.json, .md, .markdown)"),
+    force: bool = Form(default=False, description="Recreate remote Fish references unless an item overrides force"),
+    current_user: User = Depends(get_request_user),
+    tts_service: TTSServiceV2 = Depends(get_tts_service),
+):
+    """Import one or more Fish S2 managed references from JSON or Markdown."""
+    request_id = ensure_request_id(request)
+    try:
+        content = await file.read()
+        items = parse_fish_s2_reference_import(filename=file.filename or "", content=content)
+    except FishS2ReferenceImportError as e:
+        logger.warning(f"Fish S2 reference import parse failed: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_http_error_detail("Fish S2 reference import file is invalid", request_id, exc=e),
+        ) from e
+
+    results = []
+    errors = []
+    for item in items:
+        file_content = None
+        filename = None
+        if item.audio_base64:
+            try:
+                file_content = base64.b64decode(item.audio_base64, validate=True)
+            except (binascii.Error, ValueError) as e:
+                errors.append(
+                    {
+                        "index": item.source_index,
+                        "message": "audio_base64 must be valid base64",
+                    }
+                )
+                logger.warning(f"Fish S2 reference import item {item.source_index} has invalid audio_base64: {e}")
+                continue
+            filename = item.filename
+
+        try:
+            results.append(
+                await tts_service.create_fish_s2_reference(
+                    user_id=current_user.id,
+                    voice_id=item.voice_id,
+                    file_content=file_content,
+                    filename=filename,
+                    name=item.name,
+                    description=item.description,
+                    reference_text=item.reference_text,
+                    force=item.force if item.force is not None else force,
+                )
+            )
+        except Exception as e:
+            if e.__class__.__name__ == "VoiceProcessingError":
+                logger.warning(f"Fish S2 reference import item {item.source_index} failed: {e}", exc_info=True)
+                errors.append({"index": item.source_index, "message": str(e)})
+                continue
+            logger.error(f"Fish S2 reference import error: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to import Fish S2 references",
+            ) from e
+
+    response = {
+        "results": results,
+        "errors": errors,
+        "imported": len(results),
+        "failed": len(errors),
+    }
+    if not results and errors:
+        detail = _http_error_detail("Fish S2 reference import failed", request_id)
+        detail["errors"] = errors
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+    return response
 
 
 @router.delete(

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -354,3 +354,151 @@ async def preview_voice(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to generate voice preview"
         ) from e
+
+
+@router.post(
+    "/providers/fish_s2/references",
+    summary="Create or sync a managed Fish S2 reference",
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(
+            require_token_scope(
+                "any",
+                require_if_present=True,
+                endpoint_id=VOICE_SCOPE_UPLOAD,
+                count_as=VOICE_COUNTER_TYPE,
+            )
+        ),
+    ],
+)
+async def create_fish_s2_reference(
+    request: Request,
+    voice_id: Optional[str] = Form(default=None, description="Existing stored voice ID to sync"),
+    reference_text: Optional[str] = Form(default=None, description="Transcript of the reference audio"),
+    name: Optional[str] = Form(default=None, description="Name when creating from a new upload"),
+    description: Optional[str] = Form(default=None, description="Description when creating from a new upload"),
+    force: bool = Form(default=False, description="Recreate the remote Fish reference even if already cached"),
+    file: Optional[UploadFile] = File(default=None, description="Optional audio upload when creating a new managed reference"),
+    current_user: User = Depends(get_request_user),
+    tts_service: TTSServiceV2 = Depends(get_tts_service),
+):
+    """Create a managed Fish S2 reference from an existing stored voice or a new upload."""
+    request_id = ensure_request_id(request)
+    if voice_id:
+        if file is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail("Provide either voice_id or file, not both", request_id),
+            )
+        file_content = None
+        filename = None
+    else:
+        if file is None or not name or not reference_text:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail(
+                    "file, name, and reference_text are required when voice_id is not provided",
+                    request_id,
+                ),
+            )
+        file_content = await file.read()
+        filename = file.filename
+
+    try:
+        return await tts_service.create_fish_s2_reference(
+            user_id=current_user.id,
+            voice_id=voice_id,
+            file_content=file_content,
+            filename=filename,
+            name=name,
+            description=description,
+            reference_text=reference_text,
+            force=force,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        if e.__class__.__name__ == "VoiceProcessingError":
+            logger.warning(f"Fish S2 reference creation failed: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail("Fish S2 reference creation failed", request_id, exc=e),
+            ) from e
+        logger.error(f"Fish S2 reference creation error: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create Fish S2 reference",
+        ) from e
+
+
+@router.get(
+    "/providers/fish_s2/references",
+    summary="List managed Fish S2 references for the current user",
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(
+            require_token_scope(
+                "any",
+                require_if_present=True,
+                endpoint_id=VOICE_SCOPE_LIST,
+                count_as=VOICE_COUNTER_TYPE,
+            )
+        ),
+    ],
+)
+async def list_fish_s2_references(
+    current_user: User = Depends(get_request_user),
+    tts_service: TTSServiceV2 = Depends(get_tts_service),
+):
+    """List Fish S2 managed references from local user-scoped metadata."""
+    try:
+        references = await tts_service.list_fish_s2_references(user_id=current_user.id)
+        return {"references": references, "count": len(references)}
+    except Exception as e:
+        logger.error(f"Fish S2 reference listing error: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list Fish S2 references",
+        ) from e
+
+
+@router.delete(
+    "/providers/fish_s2/references/{reference_id}",
+    summary="Delete a managed Fish S2 reference",
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(
+            require_token_scope(
+                "any",
+                require_if_present=True,
+                endpoint_id=VOICE_SCOPE_DELETE,
+                count_as=VOICE_COUNTER_TYPE,
+            )
+        ),
+    ],
+)
+async def delete_fish_s2_reference(
+    request: Request,
+    reference_id: str = Path(..., description="Local Fish S2 reference ID"),
+    current_user: User = Depends(get_request_user),
+    tts_service: TTSServiceV2 = Depends(get_tts_service),
+):
+    """Delete the remote Fish S2 reference while preserving the local voice asset."""
+    request_id = ensure_request_id(request)
+    try:
+        return await tts_service.delete_fish_s2_reference(
+            user_id=current_user.id,
+            reference_id=reference_id,
+        )
+    except Exception as e:
+        if e.__class__.__name__ == "VoiceProcessingError":
+            logger.warning(f"Fish S2 reference deletion failed: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=_http_error_detail("Fish S2 reference not found", request_id, exc=e),
+            ) from e
+        logger.error(f"Fish S2 reference deletion error: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete Fish S2 reference",
+        ) from e

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -25,9 +25,13 @@ from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
 from tldw_Server_API.app.core.Audio.error_payloads import _http_error_detail
 from tldw_Server_API.app.core.Logging.log_context import ensure_request_id
 from tldw_Server_API.app.core.TTS.fish_s2_reference_imports import (
+    FISH_S2_REFERENCE_IMPORT_MAX_BYTES,
+    FISH_S2_REFERENCE_IMPORT_MAX_DECODED_AUDIO_BYTES,
+    FISH_S2_REFERENCE_IMPORT_MAX_ITEMS,
     FishS2ReferenceImportError,
-    parse_fish_s2_reference_import,
+    parse_fish_s2_reference_import_result,
 )
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSError
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 
 router = APIRouter(
@@ -46,6 +50,19 @@ VOICE_SCOPE_GET = "audio.voices.get"
 VOICE_SCOPE_DELETE = "audio.voices.delete"
 VOICE_SCOPE_PREVIEW = "audio.voices.preview"
 VOICE_COUNTER_TYPE = "voice_call"
+
+
+def _fish_s2_import_error(index: int, message: str, code: Optional[str] = None) -> dict[str, object]:
+    payload: dict[str, object] = {"index": index, "message": message}
+    if code:
+        payload["code"] = code
+    return payload
+
+
+def _estimated_base64_decoded_size(value: str) -> int:
+    encoded = value.strip()
+    padding = len(encoded) - len(encoded.rstrip("="))
+    return max(0, (len(encoded) * 3 // 4) - padding)
 
 
 @router.post(
@@ -499,51 +516,78 @@ async def import_fish_s2_references(
     """Import one or more Fish S2 managed references from JSON or Markdown."""
     request_id = ensure_request_id(request)
     try:
-        content = await file.read()
-        items = parse_fish_s2_reference_import(filename=file.filename or "", content=content)
+        content = await file.read(FISH_S2_REFERENCE_IMPORT_MAX_BYTES + 1)
+        if len(content) > FISH_S2_REFERENCE_IMPORT_MAX_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail("Fish S2 reference import file is too large", request_id),
+            )
+        parsed = parse_fish_s2_reference_import_result(
+            filename=file.filename or "",
+            content=content,
+            max_items=FISH_S2_REFERENCE_IMPORT_MAX_ITEMS,
+            max_bytes=FISH_S2_REFERENCE_IMPORT_MAX_BYTES,
+        )
     except FishS2ReferenceImportError as e:
         logger.warning(f"Fish S2 reference import parse failed: {e}")
+        detail = _http_error_detail("Fish S2 reference import file is invalid", request_id, exc=e)
+        detail["details"] = str(e)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=_http_error_detail("Fish S2 reference import file is invalid", request_id, exc=e),
+            detail=detail,
         ) from e
 
     results = []
-    errors = []
-    for item in items:
+    errors = [_fish_s2_import_error(error.index, error.message) for error in parsed.errors]
+    for item in parsed.items:
         file_content = None
         filename = None
         if item.audio_base64:
+            if _estimated_base64_decoded_size(item.audio_base64) > FISH_S2_REFERENCE_IMPORT_MAX_DECODED_AUDIO_BYTES:
+                errors.append(
+                    _fish_s2_import_error(
+                        item.source_index,
+                        "audio_base64 decoded audio exceeds the maximum size",
+                    )
+                )
+                continue
             try:
                 file_content = base64.b64decode(item.audio_base64, validate=True)
             except (binascii.Error, ValueError) as e:
-                errors.append(
-                    {
-                        "index": item.source_index,
-                        "message": "audio_base64 must be valid base64",
-                    }
-                )
+                errors.append(_fish_s2_import_error(item.source_index, "audio_base64 must be valid base64"))
                 logger.warning(f"Fish S2 reference import item {item.source_index} has invalid audio_base64: {e}")
+                continue
+            if len(file_content) > FISH_S2_REFERENCE_IMPORT_MAX_DECODED_AUDIO_BYTES:
+                errors.append(
+                    _fish_s2_import_error(
+                        item.source_index,
+                        "audio_base64 decoded audio exceeds the maximum size",
+                    )
+                )
                 continue
             filename = item.filename
 
         try:
-            results.append(
-                await tts_service.create_fish_s2_reference(
-                    user_id=current_user.id,
-                    voice_id=item.voice_id,
-                    file_content=file_content,
-                    filename=filename,
-                    name=item.name,
-                    description=item.description,
-                    reference_text=item.reference_text,
-                    force=item.force if item.force is not None else force,
-                )
+            item_result = await tts_service.create_fish_s2_reference(
+                user_id=current_user.id,
+                voice_id=item.voice_id,
+                file_content=file_content,
+                filename=filename,
+                name=item.name,
+                description=item.description,
+                reference_text=item.reference_text,
+                force=item.force if item.force is not None else force,
             )
+            result_payload = dict(item_result) if isinstance(item_result, dict) else {"result": item_result}
+            results.append({"index": item.source_index, **result_payload})
+        except TTSError as e:
+            logger.warning(f"Fish S2 reference import item {item.source_index} failed: {e}", exc_info=True)
+            errors.append(_fish_s2_import_error(item.source_index, str(e), getattr(e, "error_code", None)))
+            continue
         except Exception as e:
             if e.__class__.__name__ == "VoiceProcessingError":
                 logger.warning(f"Fish S2 reference import item {item.source_index} failed: {e}", exc_info=True)
-                errors.append({"index": item.source_index, "message": str(e)})
+                errors.append(_fish_s2_import_error(item.source_index, str(e), getattr(e, "error_code", None)))
                 continue
             logger.error(f"Fish S2 reference import error: {e}")
             raise HTTPException(

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -18,6 +18,10 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
 
 from tldw_Server_API.app.api.v1.endpoints.audio.audio_tts import get_tts_service
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
+    FishS2ReferenceDeleteResponse,
+    FishS2ReferenceImportResponse,
+    FishS2ReferenceListResponse,
+    FishS2ReferenceResponse,
     OpenAISpeechRequest,
     VoiceEncodeRequest,
     VoiceEncodeResponse,
@@ -387,6 +391,8 @@ async def preview_voice(
 
 @router.post(
     "/providers/fish_s2/references",
+    response_model=FishS2ReferenceResponse,
+    response_model_exclude_none=True,
     summary="Create or sync a managed Fish S2 reference",
     dependencies=[
         Depends(check_rate_limit),
@@ -462,6 +468,8 @@ async def create_fish_s2_reference(
 
 @router.get(
     "/providers/fish_s2/references",
+    response_model=FishS2ReferenceListResponse,
+    response_model_exclude_none=True,
     summary="List managed Fish S2 references for the current user",
     dependencies=[
         Depends(check_rate_limit),
@@ -493,6 +501,8 @@ async def list_fish_s2_references(
 
 @router.post(
     "/providers/fish_s2/references/import",
+    response_model=FishS2ReferenceImportResponse,
+    response_model_exclude_none=True,
     summary="Import managed Fish S2 references from JSON or Markdown",
     dependencies=[
         Depends(check_rate_limit),
@@ -610,6 +620,8 @@ async def import_fish_s2_references(
 
 @router.delete(
     "/providers/fish_s2/references/{reference_id}",
+    response_model=FishS2ReferenceDeleteResponse,
+    response_model_exclude_none=True,
     summary="Delete a managed Fish S2 reference",
     dependencies=[
         Depends(check_rate_limit),

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -6,7 +6,13 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Path, Request
 from fastapi.responses import StreamingResponse
 from loguru import logger
 from starlette import status
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, TokenScopeGuard, User
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    TokenScopeGuard,
+    User,
+    check_rate_limit,
+    get_request_user,
+    require_token_scope,
+)
 
 from tldw_Server_API.app.api.v1.endpoints.audio.audio_tts import get_tts_service
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (

--- a/tldw_Server_API/app/api/v1/schemas/audio_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/audio_schemas.py
@@ -172,6 +172,63 @@ class VoiceEncodeResponse(BaseModel):
     reference_text: Optional[str] = None
 
 
+class FishS2ReferenceResponse(BaseModel):
+    """Response schema for one managed Fish S2 reference."""
+    model_config = ConfigDict(extra="allow")
+
+    reference_id: str = Field(..., description="Local managed reference identifier")
+    voice_id: Optional[str] = Field(default=None, description="Stored voice ID backing the reference")
+    remote_reference_id: Optional[str] = Field(default=None, description="Fish-hosted reference/model ID")
+    reference_text: Optional[str] = Field(default=None, description="Transcript associated with the reference")
+    name: Optional[str] = Field(default=None, description="Display name for the reference")
+    description: Optional[str] = Field(default=None, description="Optional reference description")
+    cached: Optional[bool] = Field(default=None, description="Whether an existing remote reference was reused")
+
+
+class FishS2ReferenceDeleteResponse(BaseModel):
+    """Response schema for deleting one managed Fish S2 reference."""
+    model_config = ConfigDict(extra="allow")
+
+    reference_id: str = Field(..., description="Deleted local managed reference identifier")
+    deleted: bool = Field(..., description="Whether the managed reference was deleted")
+
+
+class FishS2ReferenceListResponse(BaseModel):
+    """Response schema for listing managed Fish S2 references."""
+    references: list[FishS2ReferenceResponse] = Field(default_factory=list)
+    count: int = Field(..., ge=0)
+
+
+class FishS2ReferenceImportErrorItem(BaseModel):
+    """Per-item import failure for Fish S2 reference imports."""
+    index: int = Field(..., ge=0)
+    message: str = Field(..., min_length=1)
+    code: Optional[str] = None
+
+
+class FishS2ReferenceImportResult(BaseModel):
+    """Per-item success payload for Fish S2 reference imports."""
+    model_config = ConfigDict(extra="allow")
+
+    index: int = Field(..., ge=0)
+    reference_id: Optional[str] = Field(default=None, description="Local managed reference identifier")
+    voice_id: Optional[str] = Field(default=None, description="Stored voice ID backing the reference")
+    remote_reference_id: Optional[str] = Field(default=None, description="Fish-hosted reference/model ID")
+    reference_text: Optional[str] = Field(default=None, description="Transcript associated with the reference")
+    name: Optional[str] = Field(default=None, description="Display name for the reference")
+    description: Optional[str] = Field(default=None, description="Optional reference description")
+    cached: Optional[bool] = Field(default=None, description="Whether an existing remote reference was reused")
+    result: Optional[Any] = Field(default=None, description="Fallback result payload for non-dict service responses")
+
+
+class FishS2ReferenceImportResponse(BaseModel):
+    """Response schema for Fish S2 reference imports."""
+    results: list[FishS2ReferenceImportResult] = Field(default_factory=list)
+    errors: list[FishS2ReferenceImportErrorItem] = Field(default_factory=list)
+    imported: int = Field(..., ge=0)
+    failed: int = Field(..., ge=0)
+
+
 class AudioTokenizerEncodeRequest(BaseModel):
     """Request schema for audio tokenizer encode endpoint (JSON body)."""
     audio_base64: str = Field(

--- a/tldw_Server_API/app/core/Audio/tts_service.py
+++ b/tldw_Server_API/app/core/Audio/tts_service.py
@@ -30,6 +30,32 @@ from tldw_Server_API.app.core.TTS.tts_exceptions import (
 )
 from tldw_Server_API.app.core.TTS.tts_validation import TTSInputValidator
 
+_TTS_API_KEY_REQUIRED_PROVIDERS = {"openai", "elevenlabs", "fish_s2"}
+
+
+def _normalize_tts_provider_hint(provider_hint: Optional[str]) -> str:
+    """Normalize TTS provider hints for credential requirement checks."""
+    return str(provider_hint or "").strip().lower().replace("-", "_")
+
+
+def _resolved_api_key(value: object) -> Optional[str]:
+    """Return a non-empty API key string, or None for blank/missing values."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _raise_missing_tts_credentials(provider_hint: str) -> None:
+    record_byok_missing_credentials(provider_hint, operation="audio_tts")
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail={
+            "error_code": "missing_provider_credentials",
+            "message": f"TTS provider '{provider_hint}' requires an API key.",
+        },
+    )
+
 
 def _infer_tts_provider_from_model(model: Optional[str]) -> Optional[str]:
     """Best-effort mapping from model id to provider key for sanitization."""
@@ -248,20 +274,18 @@ async def _resolve_tts_byok(
             fallback_resolver=_tts_fallback_resolver,
             force_oauth_refresh=force_oauth_refresh,
         )
+        provider_key = _normalize_tts_provider_hint(provider_hint)
+        resolved_api_key = _resolved_api_key(byok_tts_resolution.api_key)
+        requires_api_key = provider_key in _TTS_API_KEY_REQUIRED_PROVIDERS
         if byok_tts_resolution.uses_byok:
-            tts_overrides = {"api_key": byok_tts_resolution.api_key}
+            if not resolved_api_key and requires_api_key:
+                _raise_missing_tts_credentials(provider_hint)
+            if resolved_api_key:
+                tts_overrides = {"api_key": resolved_api_key}
             base_url = byok_tts_resolution.credential_fields.get("base_url")
-            if isinstance(base_url, str) and base_url.strip():
+            if tts_overrides is not None and isinstance(base_url, str) and base_url.strip():
                 tts_overrides["base_url"] = base_url.strip()
-        elif not byok_tts_resolution.api_key:
-            if provider_hint in {"openai", "elevenlabs"}:
-                record_byok_missing_credentials(provider_hint, operation="audio_tts")
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail={
-                        "error_code": "missing_provider_credentials",
-                        "message": f"TTS provider '{provider_hint}' requires an API key.",
-                    },
-                )
+        elif not resolved_api_key and requires_api_key:
+            _raise_missing_tts_credentials(provider_hint)
 
     return user_id_int, tts_overrides, byok_tts_resolution

--- a/tldw_Server_API/app/core/TTS/TTS-README.md
+++ b/tldw_Server_API/app/core/TTS/TTS-README.md
@@ -9,9 +9,9 @@ Developer-oriented details (architecture, provider matrix, configuration, and te
 ## Features
 
 ### Core Capabilities
-- **Multi-Provider Support**: OpenAI, ElevenLabs, and local adapters (Kokoro, KittenTTS, PocketTTS, LuxTTS, Higgs, Chatterbox, Dia, VibeVoice, VibeVoice Realtime, Qwen3-TTS, IndexTTS2, NeuTTS, Supertonic, Supertonic2, EchoTTS) with a mock adapter for testing.
+- **Multi-Provider Support**: OpenAI, ElevenLabs, Fish Audio S2, and local adapters (Kokoro, KittenTTS, PocketTTS, LuxTTS, Higgs, Chatterbox, Dia, VibeVoice, VibeVoice Realtime, Qwen3-TTS, IndexTTS2, NeuTTS, Supertonic, Supertonic2, EchoTTS) with a mock adapter for testing.
 - **Managed Sidecars**: OmniVoice runs behind a dedicated loopback sidecar runtime instead of sharing the main server interpreter.
-- **Voice Cloning**: Voice reference audio accepted by PocketTTS, LuxTTS, Higgs, Chatterbox, Dia, VibeVoice, Qwen3-TTS, NeuTTS, IndexTTS2, and EchoTTS (ElevenLabs supports user voices via API).
+- **Voice Cloning**: Voice reference audio accepted by Fish Audio S2, PocketTTS, LuxTTS, Higgs, Chatterbox, Dia, VibeVoice, Qwen3-TTS, NeuTTS, IndexTTS2, and EchoTTS (ElevenLabs supports user voices via API).
 - **Streaming Audio**: Real-time chunked streaming across adapters; NeuTTS enables streaming when a quantized (GGUF) backbone is loaded; VibeVoice Realtime uses a WS backend.
 - **Format Support**: Adapter-specific coverage spanning MP3, WAV, OPUS, FLAC, PCM, AAC, and OGG via the shared `AudioFormat` enum.
 - **OpenAI Compatibility**: Drop-in replacement for OpenAI TTS API
@@ -26,6 +26,7 @@ Developer-oriented details (architecture, provider matrix, configuration, and te
 |----------|------|-----------|---------------|--------------|
 | **OpenAI** | Commercial API | EN* | ❌ | Industry standard, HD quality |
 | **ElevenLabs** | Commercial API | 29 | ✅ (Pro/user voices) | Premium quality, emotion control |
+| **Fish Audio S2** | Remote HTTP server | Multi | ✅ (managed refs) | S2 Pro via upstream Fish server, user-scoped reference routing |
 | **Kokoro** | Local ONNX | EN (US/GB) | ❌ | Lightweight, CPU-friendly, offline |
 | **KittenTTS** | Local ONNX | EN | ❌ | Small local ONNX voices, first-use download, pinned HF revisions |
 | **PocketTTS** | Local ONNX | EN | ✅ (reference) | Zero-shot cloning, streaming ONNX |

--- a/tldw_Server_API/app/core/TTS/adapter_registry.py
+++ b/tldw_Server_API/app/core/TTS/adapter_registry.py
@@ -82,6 +82,7 @@ class TTSProvider(Enum):
     OMNIVOICE = "omnivoice"
     LUX_TTS = "lux_tts"
     KITTEN_TTS = "kitten_tts"
+    FISH_S2 = "fish_s2"
     # Additional providers
     ALLTALK = "alltalk"  # TODO: Implement AllTalk adapter
     MOCK = "mock"  # Mock provider for testing
@@ -118,6 +119,9 @@ def _build_tts_provider_aliases() -> dict[str, TTSProvider]:
         "echotts": TTSProvider.ECHO_TTS,
         "kittentts": TTSProvider.KITTEN_TTS,
         "vibevoice-asr": TTSProvider.VIBEVOICE,
+        "fish-s2-pro": TTSProvider.FISH_S2,
+        "s2-pro": TTSProvider.FISH_S2,
+        "fishaudio/s2-pro": TTSProvider.FISH_S2,
     }
     for alias, provider in explicit_aliases.items():
         for token in _provider_alias_tokens(alias):
@@ -294,6 +298,7 @@ class TTSAdapterRegistry:
         TTSProvider.OMNIVOICE: "tldw_Server_API.app.core.TTS.adapters.omnivoice_adapter.OmniVoiceAdapter",
         TTSProvider.LUX_TTS: "tldw_Server_API.app.core.TTS.adapters.luxtts_adapter.LuxTTSAdapter",
         TTSProvider.KITTEN_TTS: "tldw_Server_API.app.core.TTS.adapters.kitten_tts_adapter.KittenTTSAdapter",
+        TTSProvider.FISH_S2: "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter.FishS2Adapter",
     }
 
     @classmethod
@@ -1204,6 +1209,13 @@ class TTSAdapterFactory:
         "kittenml/kitten-tts-nano-0.8": TTSProvider.KITTEN_TTS,
         "kittenml/kitten-tts-nano-0.8-fp32": TTSProvider.KITTEN_TTS,
         "kittenml/kitten-tts-nano-0.8-int8": TTSProvider.KITTEN_TTS,
+
+        # Fish Audio S2 models
+        "fish_s2": TTSProvider.FISH_S2,
+        "fish-s2": TTSProvider.FISH_S2,
+        "fish-s2-pro": TTSProvider.FISH_S2,
+        "s2-pro": TTSProvider.FISH_S2,
+        "fishaudio/s2-pro": TTSProvider.FISH_S2,
     }
 
     def __init__(self, config: Optional[dict[str, Any]] = None):

--- a/tldw_Server_API/app/core/TTS/adapter_registry.py
+++ b/tldw_Server_API/app/core/TTS/adapter_registry.py
@@ -54,6 +54,14 @@ def _safe_exception_label(exc: BaseException) -> str:
     return type(exc).__name__
 
 
+def _non_empty_str(value: object) -> Optional[str]:
+    """Return stripped text for non-empty strings."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 class TTSProvider(Enum):
     """
     Enumeration of TTS providers known to the service.
@@ -645,16 +653,32 @@ class TTSAdapterRegistry:
                     logger.info(f"Provider {provider.value} is disabled in configuration")
                     return False
                 if explicit_enabled is None:
-                    remote_providers = {TTSProvider.OPENAI, TTSProvider.ELEVENLABS}
+                    remote_providers = {
+                        TTSProvider.OPENAI,
+                        TTSProvider.ELEVENLABS,
+                        TTSProvider.FISH_S2,
+                    }
                     if provider in remote_providers:
                         # Consider provider enabled if API key is supplied via config or env
                         api_key: Optional[str] = None
                         if provider == TTSProvider.OPENAI:
-                            api_key = (self.config.get("openai_api_key")
-                                       or os.getenv("OPENAI_API_KEY"))
+                            api_key = (
+                                _non_empty_str(provider_config.get("api_key"))
+                                or _non_empty_str(provider_config.get("openai_api_key"))
+                                or _non_empty_str(os.getenv("OPENAI_API_KEY"))
+                            )
                         elif provider == TTSProvider.ELEVENLABS:
-                            api_key = (self.config.get("elevenlabs_api_key")
-                                       or os.getenv("ELEVENLABS_API_KEY"))
+                            api_key = (
+                                _non_empty_str(provider_config.get("api_key"))
+                                or _non_empty_str(provider_config.get("elevenlabs_api_key"))
+                                or _non_empty_str(os.getenv("ELEVENLABS_API_KEY"))
+                            )
+                        elif provider == TTSProvider.FISH_S2:
+                            api_key = (
+                                _non_empty_str(provider_config.get("api_key"))
+                                or _non_empty_str(os.getenv("FISH_AUDIO_API_KEY"))
+                                or _non_empty_str(os.getenv("FISH_API_KEY"))
+                            )
                         if not api_key:
                             logger.info(
                                 f"Provider {provider.value} is disabled (no credentials found)"
@@ -728,13 +752,34 @@ class TTSAdapterRegistry:
                 cfg = model_dump_compat(provider_cfg)
                 return _apply_provider_aliases(provider.value, cfg)
 
-        # Fallback to legacy config
+        # Fallback to legacy/direct dict config
         provider_config = self.config.copy()
+
+        providers_cfg = self.config.get("providers")
+        if isinstance(providers_cfg, dict):
+            nested_provider_config = providers_cfg.get(provider.value)
+            if nested_provider_config is not None and not isinstance(nested_provider_config, dict):
+                nested_provider_config = model_dump_compat(nested_provider_config)
+            if isinstance(nested_provider_config, dict):
+                provider_config.update(nested_provider_config)
 
         # Add provider-specific overrides
         provider_key = f"{provider.value}_config"
         if provider_key in self.config:
             provider_config.update(self.config[provider_key])
+
+        if provider == TTSProvider.OPENAI:
+            env_api_key = _non_empty_str(os.getenv("OPENAI_API_KEY"))
+        elif provider == TTSProvider.ELEVENLABS:
+            env_api_key = _non_empty_str(os.getenv("ELEVENLABS_API_KEY"))
+        elif provider == TTSProvider.FISH_S2:
+            env_api_key = _non_empty_str(os.getenv("FISH_AUDIO_API_KEY")) or _non_empty_str(
+                os.getenv("FISH_API_KEY")
+            )
+        else:
+            env_api_key = None
+        if env_api_key and not _non_empty_str(provider_config.get("api_key")):
+            provider_config["api_key"] = env_api_key
 
         return _apply_provider_aliases(provider.value, provider_config)
 

--- a/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 from loguru import logger
 
 from ..backends.fish_s2_base import FishS2Backend
+from ..backends.fish_s2_commercial_api import FishS2CommercialApiBackend
 from ..backends.fish_s2_native_http import FishS2NativeHttpBackend
 from ..tts_exceptions import (
     TTSProviderInitializationError,
@@ -61,6 +62,8 @@ _SUPPORTED_LANGUAGES = {
 
 def _build_backend(config: dict[str, Any]) -> FishS2Backend:
     backend_name = str(config.get("backend", "native_http")).strip().lower()
+    if backend_name in {"commercial_api", "hosted", "fish_audio"}:
+        return FishS2CommercialApiBackend(config)
     if backend_name == "native_http":
         return FishS2NativeHttpBackend(config)
     if backend_name == "local_runtime":
@@ -79,7 +82,7 @@ class FishS2Adapter(TTSAdapter):
     """Registry-facing adapter for Fish Audio S2."""
 
     PROVIDER_KEY = "fish_s2"
-    SUPPORTED_FORMATS = {AudioFormat.WAV, AudioFormat.MP3, AudioFormat.PCM}
+    SUPPORTED_FORMATS = {AudioFormat.WAV, AudioFormat.MP3, AudioFormat.OPUS, AudioFormat.PCM}
 
     def __init__(self, config: Optional[dict[str, Any]] = None):
         super().__init__(config)
@@ -200,6 +203,8 @@ class FishS2Adapter(TTSAdapter):
         reference_id: str,
         audio_b64: str,
         reference_text: str,
+        title: str | None = None,
+        description: str | None = None,
     ) -> dict[str, Any]:
         if not await self.ensure_initialized():
             raise TTSProviderNotConfiguredError(
@@ -215,6 +220,8 @@ class FishS2Adapter(TTSAdapter):
             reference_id=reference_id,
             audio_b64=audio_b64,
             reference_text=reference_text,
+            title=title,
+            description=description,
         )
 
     async def delete_reference(self, *, reference_id: str) -> bool:
@@ -242,9 +249,12 @@ class FishS2Adapter(TTSAdapter):
 
         return replace(request, voice=voice, extra_params=extras)
 
-    def _resolve_reference_id(self, request: TTSRequest) -> str | None:
+    def _resolve_reference_id(self, request: TTSRequest) -> str | list[str] | None:
         extras = request.extra_params if isinstance(request.extra_params, dict) else {}
         explicit_reference_id = extras.get("reference_id")
+        if isinstance(explicit_reference_id, list):
+            reference_ids = [str(value).strip() for value in explicit_reference_id if str(value).strip()]
+            return reference_ids or None
         if explicit_reference_id:
             return str(explicit_reference_id)
 
@@ -267,8 +277,17 @@ class FishS2Adapter(TTSAdapter):
             backend_extra_params["use_memory_cache"] = self.default_use_memory_cache
 
         for key in (
+            "condition_on_previous_chunks",
             "chunk_length",
+            "early_stop_threshold",
+            "latency",
+            "max_new_tokens",
+            "min_chunk_length",
+            "mp3_bitrate",
             "normalize",
+            "opus_bitrate",
+            "prosody",
+            "sample_rate",
             "seed",
             "top_p",
             "temperature",

--- a/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
@@ -108,14 +108,18 @@ class FishS2Adapter(TTSAdapter):
                 return True
 
             self._status = ProviderStatus.INITIALIZING
-            success = await self.initialize()
-            if success:
-                self._capabilities = await self.get_capabilities()
-                self._status = ProviderStatus.AVAILABLE
-                self._initialized = True
-            else:
+            try:
+                success = await self.initialize()
+                if success:
+                    self._capabilities = await self.get_capabilities()
+                    self._status = ProviderStatus.AVAILABLE
+                    self._initialized = True
+                else:
+                    self._status = ProviderStatus.ERROR
+                return success
+            except Exception:
                 self._status = ProviderStatus.ERROR
-            return success
+                raise
 
     async def initialize(self) -> bool:
         self._backend = _build_backend(self.config)

--- a/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
@@ -194,6 +194,42 @@ class FishS2Adapter(TTSAdapter):
             model=normalized_request.model,
         )
 
+    async def add_reference(
+        self,
+        *,
+        reference_id: str,
+        audio_b64: str,
+        reference_text: str,
+    ) -> dict[str, Any]:
+        if not await self.ensure_initialized():
+            raise TTSProviderNotConfiguredError(
+                "Fish S2 adapter not initialized",
+                provider=self.PROVIDER_KEY,
+            )
+        if self._backend is None:
+            raise TTSProviderInitializationError(
+                "Fish S2 backend is not available",
+                provider=self.PROVIDER_KEY,
+            )
+        return await self._backend.add_reference(
+            reference_id=reference_id,
+            audio_b64=audio_b64,
+            reference_text=reference_text,
+        )
+
+    async def delete_reference(self, *, reference_id: str) -> bool:
+        if not await self.ensure_initialized():
+            raise TTSProviderNotConfiguredError(
+                "Fish S2 adapter not initialized",
+                provider=self.PROVIDER_KEY,
+            )
+        if self._backend is None:
+            raise TTSProviderInitializationError(
+                "Fish S2 backend is not available",
+                provider=self.PROVIDER_KEY,
+            )
+        return await self._backend.delete_reference(reference_id=reference_id)
+
     def _normalize_request(self, request: TTSRequest) -> TTSRequest:
         extras = dict(request.extra_params or {})
         voice = request.voice

--- a/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
@@ -14,6 +14,7 @@ from ..backends.fish_s2_native_http import FishS2NativeHttpBackend
 from ..tts_exceptions import (
     TTSProviderInitializationError,
     TTSProviderNotConfiguredError,
+    TTSValidationError,
 )
 from ..tts_validation import validate_tts_request
 from .base import (
@@ -165,6 +166,7 @@ class FishS2Adapter(TTSAdapter):
 
         normalized_request = self._normalize_request(request)
         validate_tts_request(normalized_request, provider=self.provider_key)
+        self._validate_backend_request(normalized_request)
 
         reference_id = self._resolve_reference_id(normalized_request)
         backend_extra_params = self._build_backend_extra_params(normalized_request.extra_params)
@@ -196,6 +198,20 @@ class FishS2Adapter(TTSAdapter):
             provider=self.PROVIDER_KEY,
             model=normalized_request.model,
         )
+
+    def _validate_backend_request(self, request: TTSRequest) -> None:
+        """Apply backend-specific constraints that global provider validation cannot know."""
+        if (
+            self.backend_name == "native_http"
+            and request.stream
+            and request.format != AudioFormat.WAV
+        ):
+            raise TTSValidationError(
+                "Fish S2 native_http streaming currently supports wav format only",
+                provider=self.PROVIDER_KEY,
+                error_code="unsupported_streaming_format",
+                details={"backend": self.backend_name, "format": request.format.value},
+            )
 
     async def add_reference(
         self,

--- a/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
@@ -1,0 +1,247 @@
+"""Fish Audio S2 provider adapter."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import replace
+from typing import Any, Optional
+
+from loguru import logger
+
+from ..backends.fish_s2_base import FishS2Backend
+from ..backends.fish_s2_native_http import FishS2NativeHttpBackend
+from ..tts_exceptions import (
+    TTSProviderInitializationError,
+    TTSProviderNotConfiguredError,
+)
+from ..tts_validation import validate_tts_request
+from .base import (
+    AudioFormat,
+    ProviderStatus,
+    TTSAdapter,
+    TTSCapabilities,
+    TTSRequest,
+    TTSResponse,
+)
+
+
+_SUPPORTED_LANGUAGES = {
+    "ar",
+    "auto",
+    "cs",
+    "da",
+    "de",
+    "el",
+    "en",
+    "es",
+    "fi",
+    "fr",
+    "he",
+    "hi",
+    "hu",
+    "id",
+    "it",
+    "ja",
+    "ko",
+    "ms",
+    "nl",
+    "no",
+    "pl",
+    "pt",
+    "ro",
+    "ru",
+    "sv",
+    "th",
+    "tr",
+    "uk",
+    "vi",
+    "zh",
+}
+
+
+def _build_backend(config: dict[str, Any]) -> FishS2Backend:
+    backend_name = str(config.get("backend", "native_http")).strip().lower()
+    if backend_name == "native_http":
+        return FishS2NativeHttpBackend(config)
+    if backend_name == "local_runtime":
+        raise TTSProviderInitializationError(
+            "Fish S2 local_runtime backend is not implemented yet",
+            provider="fish_s2",
+        )
+    raise TTSProviderInitializationError(
+        f"Unknown Fish S2 backend '{backend_name}'",
+        provider="fish_s2",
+        details={"backend": backend_name},
+    )
+
+
+class FishS2Adapter(TTSAdapter):
+    """Registry-facing adapter for Fish Audio S2."""
+
+    PROVIDER_KEY = "fish_s2"
+    SUPPORTED_FORMATS = {AudioFormat.WAV, AudioFormat.MP3, AudioFormat.PCM}
+
+    def __init__(self, config: Optional[dict[str, Any]] = None):
+        super().__init__(config)
+        cfg = config or {}
+        extras = cfg.get("extra_params", {}) or {}
+
+        self.backend_name = str(cfg.get("backend", "native_http")).strip().lower()
+        self.sample_rate = int(cfg.get("sample_rate", 24000))
+        self.max_text_length = int(cfg.get("max_text_length", 5000))
+        self.default_chunk_length = extras.get("default_chunk_length")
+        self.default_normalize = extras.get("default_normalize")
+        self.default_use_memory_cache = extras.get("default_use_memory_cache")
+        self._backend: FishS2Backend | None = None
+
+    async def ensure_initialized(self) -> bool:
+        """Propagate initialization errors for clearer operator feedback."""
+        if self._initialized:
+            return True
+
+        async with self._init_lock:
+            if self._initialized:
+                return True
+
+            self._status = ProviderStatus.INITIALIZING
+            success = await self.initialize()
+            if success:
+                self._capabilities = await self.get_capabilities()
+                self._status = ProviderStatus.AVAILABLE
+                self._initialized = True
+            else:
+                self._status = ProviderStatus.ERROR
+            return success
+
+    async def initialize(self) -> bool:
+        self._backend = _build_backend(self.config)
+
+        is_healthy = await self._backend.health_check()
+        if not is_healthy:
+            raise TTSProviderInitializationError(
+                "Fish S2 backend health check failed",
+                provider=self.PROVIDER_KEY,
+            )
+
+        logger.info("Fish S2 adapter initialized with backend={}", self.backend_name)
+        return True
+
+    async def get_capabilities(self) -> TTSCapabilities:
+        return TTSCapabilities(
+            provider_name="Fish Audio S2",
+            supported_languages=_SUPPORTED_LANGUAGES,
+            supported_voices=[],
+            supported_formats=self.SUPPORTED_FORMATS,
+            max_text_length=self.max_text_length,
+            supports_streaming=True,
+            supports_voice_cloning=True,
+            supports_emotion_control=False,
+            supports_speech_rate=False,
+            supports_pitch_control=False,
+            supports_volume_control=False,
+            supports_ssml=False,
+            supports_phonemes=False,
+            supports_multi_speaker=False,
+            supports_background_audio=False,
+            latency_ms=250,
+            sample_rate=self.sample_rate,
+            default_format=AudioFormat.WAV,
+        )
+
+    async def generate(self, request: TTSRequest) -> TTSResponse:
+        if not await self.ensure_initialized():
+            raise TTSProviderNotConfiguredError(
+                "Fish S2 adapter not initialized",
+                provider=self.PROVIDER_KEY,
+            )
+        if self._backend is None:
+            raise TTSProviderInitializationError(
+                "Fish S2 backend is not available",
+                provider=self.PROVIDER_KEY,
+            )
+
+        normalized_request = self._normalize_request(request)
+        validate_tts_request(normalized_request, provider=self.provider_key)
+
+        reference_id = self._resolve_reference_id(normalized_request)
+        backend_extra_params = self._build_backend_extra_params(normalized_request.extra_params)
+        result = await self._backend.synthesize(
+            text=self.preprocess_text(normalized_request.text),
+            response_format=normalized_request.format.value,
+            streaming=normalized_request.stream,
+            reference_id=reference_id,
+            extra_params=backend_extra_params or None,
+        )
+
+        if normalized_request.stream:
+            return TTSResponse(
+                audio_stream=result,  # type: ignore[arg-type]
+                format=normalized_request.format,
+                sample_rate=self.sample_rate,
+                channels=1,
+                voice_used=reference_id or normalized_request.voice,
+                provider=self.PROVIDER_KEY,
+                model=normalized_request.model,
+            )
+
+        return TTSResponse(
+            audio_data=result,  # type: ignore[arg-type]
+            format=normalized_request.format,
+            sample_rate=self.sample_rate,
+            channels=1,
+            voice_used=reference_id or normalized_request.voice,
+            provider=self.PROVIDER_KEY,
+            model=normalized_request.model,
+        )
+
+    def _normalize_request(self, request: TTSRequest) -> TTSRequest:
+        extras = dict(request.extra_params or {})
+        voice = request.voice
+
+        if isinstance(voice, str) and voice.startswith("fishref:"):
+            logical_id = voice.split("fishref:", 1)[-1].strip()
+            if logical_id and "reference_id" not in extras:
+                extras["reference_id"] = logical_id
+            voice = None
+
+        return replace(request, voice=voice, extra_params=extras)
+
+    def _resolve_reference_id(self, request: TTSRequest) -> str | None:
+        extras = request.extra_params if isinstance(request.extra_params, dict) else {}
+        explicit_reference_id = extras.get("reference_id")
+        if explicit_reference_id:
+            return str(explicit_reference_id)
+
+        voice = request.voice or ""
+        if isinstance(voice, str) and voice.startswith("fishref:"):
+            logical_id = voice.split("fishref:", 1)[-1].strip()
+            return logical_id or None
+        return None
+
+    def _build_backend_extra_params(self, extra_params: dict[str, Any] | None) -> dict[str, Any]:
+        extras = dict(extra_params or {})
+        extras.pop("reference_id", None)
+
+        backend_extra_params: dict[str, Any] = {}
+        if self.default_chunk_length is not None and "chunk_length" not in extras:
+            backend_extra_params["chunk_length"] = self.default_chunk_length
+        if self.default_normalize is not None and "normalize" not in extras:
+            backend_extra_params["normalize"] = self.default_normalize
+        if self.default_use_memory_cache is not None and "use_memory_cache" not in extras:
+            backend_extra_params["use_memory_cache"] = self.default_use_memory_cache
+
+        for key in (
+            "chunk_length",
+            "normalize",
+            "seed",
+            "top_p",
+            "temperature",
+            "repetition_penalty",
+            "use_memory_cache",
+            "references",
+        ):
+            value = extras.get(key)
+            if value is not None:
+                backend_extra_params[key] = value
+
+        return backend_extra_params

--- a/tldw_Server_API/app/core/TTS/backends/__init__.py
+++ b/tldw_Server_API/app/core/TTS/backends/__init__.py
@@ -1,6 +1,7 @@
 """Backend implementations for TTS providers that need transport indirection."""
 
 from .fish_s2_base import FishS2Backend
+from .fish_s2_commercial_api import FishS2CommercialApiBackend
 from .fish_s2_native_http import FishS2NativeHttpBackend
 
-__all__ = ["FishS2Backend", "FishS2NativeHttpBackend"]
+__all__ = ["FishS2Backend", "FishS2CommercialApiBackend", "FishS2NativeHttpBackend"]

--- a/tldw_Server_API/app/core/TTS/backends/__init__.py
+++ b/tldw_Server_API/app/core/TTS/backends/__init__.py
@@ -1,0 +1,6 @@
+"""Backend implementations for TTS providers that need transport indirection."""
+
+from .fish_s2_base import FishS2Backend
+from .fish_s2_native_http import FishS2NativeHttpBackend
+
+__all__ = ["FishS2Backend", "FishS2NativeHttpBackend"]

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_base.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_base.py
@@ -1,0 +1,28 @@
+"""Shared interfaces for Fish S2 backend implementations."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any, Protocol, runtime_checkable
+
+
+FishS2SynthesisResult = bytes | AsyncIterator[bytes]
+
+
+@runtime_checkable
+class FishS2Backend(Protocol):
+    """Transport/backend contract for the Fish S2 provider."""
+
+    async def health_check(self) -> bool:
+        """Return whether the backend appears reachable/usable."""
+
+    async def synthesize(
+        self,
+        *,
+        text: str,
+        response_format: str,
+        streaming: bool,
+        reference_id: str | None,
+        extra_params: dict[str, Any] | None,
+    ) -> FishS2SynthesisResult:
+        """Generate speech or return a byte stream for a request."""

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_base.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_base.py
@@ -26,3 +26,15 @@ class FishS2Backend(Protocol):
         extra_params: dict[str, Any] | None,
     ) -> FishS2SynthesisResult:
         """Generate speech or return a byte stream for a request."""
+
+    async def add_reference(
+        self,
+        *,
+        reference_id: str,
+        audio_b64: str,
+        reference_text: str,
+    ) -> dict[str, Any]:
+        """Create or update a managed Fish reference."""
+
+    async def delete_reference(self, *, reference_id: str) -> bool:
+        """Delete a managed Fish reference."""

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_base.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_base.py
@@ -22,7 +22,7 @@ class FishS2Backend(Protocol):
         text: str,
         response_format: str,
         streaming: bool,
-        reference_id: str | None,
+        reference_id: str | list[str] | None,
         extra_params: dict[str, Any] | None,
     ) -> FishS2SynthesisResult:
         """Generate speech or return a byte stream for a request."""
@@ -33,6 +33,8 @@ class FishS2Backend(Protocol):
         reference_id: str,
         audio_b64: str,
         reference_text: str,
+        title: str | None = None,
+        description: str | None = None,
     ) -> dict[str, Any]:
         """Create or update a managed Fish reference."""
 

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_commercial_api.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_commercial_api.py
@@ -1,0 +1,303 @@
+"""Commercial Fish Audio HTTP backend for the Fish S2 provider."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+from typing import Any
+
+from tldw_Server_API.app.core.http_client import afetch, astream_bytes
+
+from ..tts_exceptions import (
+    TTSAuthenticationError,
+    TTSNetworkError,
+    TTSProviderError,
+    TTSRateLimitError,
+    TTSTimeoutError,
+    TTSValidationError,
+    auth_error,
+    network_error,
+    provider_error,
+    rate_limit_error,
+    timeout_error,
+)
+from .fish_s2_base import FishS2SynthesisResult
+
+
+_PASSTHROUGH_PARAMS = {
+    "chunk_length",
+    "condition_on_previous_chunks",
+    "early_stop_threshold",
+    "latency",
+    "max_new_tokens",
+    "min_chunk_length",
+    "mp3_bitrate",
+    "normalize",
+    "opus_bitrate",
+    "prosody",
+    "reference_id",
+    "references",
+    "repetition_penalty",
+    "sample_rate",
+    "temperature",
+    "top_p",
+}
+
+
+class FishS2CommercialApiBackend:
+    """HTTP transport wrapper for Fish Audio's hosted `/v1/tts` API."""
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        self.config = config or {}
+        self.base_url = str(self.config.get("base_url") or "https://api.fish.audio").rstrip("/")
+        self.api_key = self._normalize_api_key(self.config.get("api_key"))
+        self.model = str(self.config.get("model") or "s2-pro").strip() or "s2-pro"
+        self.timeout = self.config.get("timeout", 60)
+
+    async def health_check(self) -> bool:
+        return bool(self.base_url and self.api_key)
+
+    async def synthesize(
+        self,
+        *,
+        text: str,
+        response_format: str,
+        streaming: bool,
+        reference_id: str | list[str] | None,
+        extra_params: dict[str, Any] | None,
+    ) -> FishS2SynthesisResult:
+        payload = self._build_tts_payload(
+            text=text,
+            response_format=response_format,
+            reference_id=reference_id,
+            extra_params=extra_params,
+        )
+        if streaming:
+            return self._stream_audio(payload)
+
+        try:
+            response = await afetch(
+                method="POST",
+                url=f"{self.base_url}/v1/tts",
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+        self._raise_for_response_error(response)
+        return getattr(response, "content", b"") or b""
+
+    async def _stream_audio(self, payload: dict[str, Any]):
+        try:
+            async for chunk in astream_bytes(
+                method="POST",
+                url=f"{self.base_url}/v1/tts",
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            ):
+                if chunk:
+                    yield chunk
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+    async def add_reference(
+        self,
+        *,
+        reference_id: str,
+        audio_b64: str,
+        reference_text: str,
+        title: str | None = None,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        try:
+            audio_bytes = base64.b64decode(audio_b64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise TTSValidationError(
+                "Fish Audio reference audio must be valid base64",
+                provider="fish_s2",
+                details={"reference_id": reference_id},
+            ) from exc
+
+        try:
+            response = await afetch(
+                method="POST",
+                url=f"{self.base_url}/model",
+                headers=self._auth_headers(),
+                data={
+                    "type": "tts",
+                    "title": title or reference_id,
+                    "description": description or "",
+                    "train_mode": "fast",
+                    "visibility": "private",
+                    "texts": reference_text,
+                    "enhance_audio_quality": "true",
+                    "generate_sample": "false",
+                },
+                files={
+                    "voices": ("reference.wav", audio_bytes, "audio/wav"),
+                },
+                timeout=self.timeout,
+            )
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+        self._raise_for_response_error(response)
+        data = self._response_json(response)
+        remote_id = data.get("_id") if isinstance(data, dict) else None
+        return {
+            "reference_id": remote_id or reference_id,
+            "remote_reference_id": remote_id or reference_id,
+            "state": data.get("state") if isinstance(data, dict) else None,
+        }
+
+    async def delete_reference(self, *, reference_id: str) -> bool:
+        try:
+            response = await afetch(
+                method="DELETE",
+                url=f"{self.base_url}/model/{reference_id}",
+                headers=self._auth_headers(),
+                timeout=self.timeout,
+            )
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+        self._raise_for_response_error(response)
+        return True
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "Content-Type": "application/json",
+            "model": self.model,
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _auth_headers(self) -> dict[str, str]:
+        if not self.api_key:
+            return {}
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def _raise_for_response_error(self, response: Any) -> None:
+        status_code = getattr(response, "status_code", None)
+        if status_code is None or status_code < 400:
+            return
+
+        body = getattr(response, "text", "") or ""
+        headers = getattr(response, "headers", {}) or {}
+        if status_code in (401, 403):
+            raise auth_error("fish_s2", "Fish Audio authentication failed")
+        if status_code == 429:
+            retry_after = headers.get("retry-after") if isinstance(headers, dict) else None
+            raise rate_limit_error(
+                "fish_s2",
+                retry_after=self._parse_retry_after(retry_after),
+            )
+        if status_code in (400, 404, 422):
+            raise TTSValidationError(
+                f"Fish Audio request failed ({status_code})",
+                provider="fish_s2",
+                details={"status": status_code, "body": body},
+            )
+        if status_code in (408, 504):
+            raise timeout_error("fish_s2", timeout_seconds=self.timeout)
+        if status_code == 402:
+            raise TTSProviderError(
+                "Fish Audio payment required",
+                provider="fish_s2",
+                error_code=str(status_code),
+                details={"status": status_code, "body": body},
+            )
+        if 500 <= status_code < 600:
+            raise provider_error(
+                "Fish Audio upstream error",
+                provider="fish_s2",
+                error_code=str(status_code),
+                details={"status": status_code, "body": body},
+            )
+        raise TTSProviderError(
+            f"Fish Audio request failed ({status_code})",
+            provider="fish_s2",
+            details={"status": status_code, "body": body},
+        )
+
+    def _raise_transport_error(self, exc: Exception) -> None:
+        if isinstance(
+            exc,
+            (
+                TTSAuthenticationError,
+                TTSNetworkError,
+                TTSProviderError,
+                TTSRateLimitError,
+                TTSTimeoutError,
+                TTSValidationError,
+            ),
+        ):
+            raise exc
+        if self._is_timeout_error(exc):
+            raise timeout_error("fish_s2", timeout_seconds=self.timeout) from exc
+        raise network_error("fish_s2", exc) from exc
+
+    def _build_tts_payload(
+        self,
+        *,
+        text: str,
+        response_format: str,
+        reference_id: str | list[str] | None,
+        extra_params: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "text": text,
+            "format": self._normalize_format(response_format),
+        }
+        if reference_id:
+            payload["reference_id"] = reference_id
+        if extra_params:
+            for key, value in extra_params.items():
+                if key in _PASSTHROUGH_PARAMS and value is not None:
+                    payload[key] = value
+        return payload
+
+    @staticmethod
+    def _normalize_api_key(value: Any) -> str | None:
+        if value is None:
+            return None
+        raw = str(value).strip()
+        if not raw or raw.lower() in {"none", "null"}:
+            return None
+        return raw
+
+    @staticmethod
+    def _normalize_format(response_format: Any) -> str:
+        value = getattr(response_format, "value", response_format)
+        return str(value).lower()
+
+    @staticmethod
+    def _response_json(response: Any) -> dict[str, Any]:
+        try:
+            json_fn = getattr(response, "json", None)
+            if callable(json_fn):
+                data = json_fn()
+                if isinstance(data, dict):
+                    return data
+        except Exception:
+            return {}
+        return {}
+
+    @staticmethod
+    def _parse_retry_after(value: Any) -> int | None:
+        try:
+            return int(value) if value else None
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _is_timeout_error(exc: Exception) -> bool:
+        if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+            return True
+        exc_name = exc.__class__.__name__.lower()
+        return "timeout" in exc_name or "timeout" in str(exc).lower()

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
@@ -60,7 +60,7 @@ class FishS2NativeHttpBackend(FishS2Backend):
         text: str,
         response_format: str,
         streaming: bool,
-        reference_id: str | None,
+        reference_id: str | list[str] | None,
         extra_params: dict[str, Any] | None,
     ) -> FishS2SynthesisResult:
         payload = self._build_tts_payload(
@@ -94,6 +94,8 @@ class FishS2NativeHttpBackend(FishS2Backend):
         reference_id: str,
         audio_b64: str,
         reference_text: str,
+        title: str | None = None,
+        description: str | None = None,
     ) -> dict[str, Any]:
         try:
             audio_bytes = base64.b64decode(audio_b64, validate=True)
@@ -159,7 +161,7 @@ class FishS2NativeHttpBackend(FishS2Backend):
         text: str,
         response_format: str,
         streaming: bool,
-        reference_id: str | None,
+        reference_id: str | list[str] | None,
         extra_params: dict[str, Any] | None,
     ) -> dict[str, Any]:
         payload: dict[str, Any] = {

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
@@ -86,6 +86,50 @@ class FishS2NativeHttpBackend(FishS2Backend):
         self._raise_for_response_error(response)
         return getattr(response, "content", b"") or b""
 
+    async def add_reference(
+        self,
+        *,
+        reference_id: str,
+        audio_b64: str,
+        reference_text: str,
+    ) -> dict[str, Any]:
+        payload = {
+            "reference_id": reference_id,
+            "audio_b64": audio_b64,
+            "text": reference_text,
+        }
+        try:
+            response = await afetch(
+                method="POST",
+                url=f"{self.base_url}/v1/references/add",
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+        self._raise_for_response_error(response)
+        data = self._response_json(response)
+        if isinstance(data, dict):
+            return data
+        return {"reference_id": reference_id}
+
+    async def delete_reference(self, *, reference_id: str) -> bool:
+        try:
+            response = await afetch(
+                method="DELETE",
+                url=f"{self.base_url}/v1/references/delete",
+                headers=self._headers(),
+                json={"reference_id": reference_id},
+                timeout=self.timeout,
+            )
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+        self._raise_for_response_error(response)
+        return True
+
     @property
     def _tts_url(self) -> str:
         return f"{self.base_url}/v1/tts"
@@ -189,6 +233,16 @@ class FishS2NativeHttpBackend(FishS2Backend):
         if self._is_timeout_error(exc):
             raise timeout_error(self.PROVIDER_KEY, timeout_seconds=self.timeout) from exc
         raise network_error(self.PROVIDER_KEY, exc) from exc
+
+    @staticmethod
+    def _response_json(response: Any) -> Any:
+        try:
+            json_fn = getattr(response, "json", None)
+            if callable(json_fn):
+                return json_fn()
+        except Exception:
+            return None
+        return None
 
     @staticmethod
     def _normalize_api_key(value: Any) -> str | None:

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -93,17 +95,29 @@ class FishS2NativeHttpBackend(FishS2Backend):
         audio_b64: str,
         reference_text: str,
     ) -> dict[str, Any]:
-        payload = {
-            "reference_id": reference_id,
-            "audio_b64": audio_b64,
+        try:
+            audio_bytes = base64.b64decode(audio_b64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise TTSValidationError(
+                "Fish S2 reference audio must be valid base64",
+                provider=self.PROVIDER_KEY,
+                details={"reference_id": reference_id},
+            ) from exc
+
+        form_data = {
+            "id": reference_id,
             "text": reference_text,
+        }
+        files = {
+            "audio": ("reference.wav", audio_bytes, "audio/wav"),
         }
         try:
             response = await afetch(
                 method="POST",
                 url=f"{self.base_url}/v1/references/add",
                 headers=self._headers(),
-                json=payload,
+                data=form_data,
+                files=files,
                 timeout=self.timeout,
             )
         except Exception as exc:

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
@@ -220,7 +220,7 @@ class FishS2NativeHttpBackend(FishS2Backend):
             retry_after = headers.get("retry-after") if isinstance(headers, dict) else None
             raise rate_limit_error(
                 self.PROVIDER_KEY,
-                retry_after=int(retry_after) if retry_after else None,
+                retry_after=self._parse_retry_after(retry_after),
             )
         if status_code in (400, 404):
             raise TTSValidationError(
@@ -256,9 +256,23 @@ class FishS2NativeHttpBackend(FishS2Backend):
             json_fn = getattr(response, "json", None)
             if callable(json_fn):
                 return json_fn()
-        except Exception:
+        except (TypeError, ValueError) as exc:
+            logger.debug("Fish S2 response JSON parse failed: {}", type(exc).__name__)
             return None
         return None
+
+    @staticmethod
+    def _parse_retry_after(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            pass
+        try:
+            return int(float(str(value).strip()))
+        except (TypeError, ValueError):
+            return None
 
     @staticmethod
     def _normalize_api_key(value: Any) -> str | None:

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
@@ -200,10 +200,9 @@ class FishS2NativeHttpBackend(FishS2Backend):
         headers = getattr(response, "headers", {}) or {}
 
         logger.error(
-            "%s upstream returned %s: %s",
+            "{} upstream returned status={}",
             self.PROVIDER_KEY,
             status_code,
-            body,
         )
         self._raise_status_error(status_code=status_code, body=body, headers=headers)
 

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
@@ -1,0 +1,212 @@
+"""Native Fish Audio HTTP backend for the Fish S2 provider."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.http_client import afetch, astream_bytes
+
+from ..tts_exceptions import (
+    TTSAuthenticationError,
+    TTSNetworkError,
+    TTSProviderError,
+    TTSRateLimitError,
+    TTSTimeoutError,
+    TTSValidationError,
+    auth_error,
+    network_error,
+    provider_error,
+    rate_limit_error,
+    timeout_error,
+)
+from .fish_s2_base import FishS2Backend, FishS2SynthesisResult
+
+
+_PASSTHROUGH_PARAMS = {
+    "chunk_length",
+    "normalize",
+    "seed",
+    "top_p",
+    "temperature",
+    "repetition_penalty",
+    "use_memory_cache",
+    "references",
+}
+
+
+class FishS2NativeHttpBackend(FishS2Backend):
+    """HTTP transport wrapper for Fish Speech's `/v1/tts` API."""
+
+    PROVIDER_KEY = "fish_s2"
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        self.config = config or {}
+        self.base_url = str(self.config.get("base_url", "")).rstrip("/")
+        self.api_key = self._normalize_api_key(self.config.get("api_key"))
+        self.timeout = self.config.get("timeout", 60)
+
+    async def health_check(self) -> bool:
+        return bool(self.base_url)
+
+    async def synthesize(
+        self,
+        *,
+        text: str,
+        response_format: str,
+        streaming: bool,
+        reference_id: str | None,
+        extra_params: dict[str, Any] | None,
+    ) -> FishS2SynthesisResult:
+        payload = self._build_tts_payload(
+            text=text,
+            response_format=response_format,
+            streaming=streaming,
+            reference_id=reference_id,
+            extra_params=extra_params,
+        )
+
+        if streaming:
+            return self._stream_audio(payload)
+
+        try:
+            response = await afetch(
+                method="POST",
+                url=self._tts_url,
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+        self._raise_for_response_error(response)
+        return getattr(response, "content", b"") or b""
+
+    @property
+    def _tts_url(self) -> str:
+        return f"{self.base_url}/v1/tts"
+
+    def _headers(self) -> dict[str, str]:
+        if not self.api_key:
+            return {}
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def _build_tts_payload(
+        self,
+        *,
+        text: str,
+        response_format: str,
+        streaming: bool,
+        reference_id: str | None,
+        extra_params: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "text": text,
+            "format": self._normalize_format(response_format),
+            "streaming": streaming,
+        }
+        if reference_id:
+            payload["reference_id"] = reference_id
+        if extra_params:
+            for key, value in extra_params.items():
+                if key in _PASSTHROUGH_PARAMS and value is not None:
+                    payload[key] = value
+        return payload
+
+    async def _stream_audio(self, payload: dict[str, Any]) -> AsyncIterator[bytes]:
+        try:
+            async for chunk in astream_bytes(
+                method="POST",
+                url=self._tts_url,
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            ):
+                if chunk:
+                    yield chunk
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+    def _raise_for_response_error(self, response: Any) -> None:
+        status_code = getattr(response, "status_code", None)
+        if status_code is None or status_code < 400:
+            return
+
+        body = getattr(response, "text", "") or ""
+        headers = getattr(response, "headers", {}) or {}
+
+        logger.error(
+            "%s upstream returned %s: %s",
+            self.PROVIDER_KEY,
+            status_code,
+            body,
+        )
+        self._raise_status_error(status_code=status_code, body=body, headers=headers)
+
+    def _raise_status_error(
+        self,
+        *,
+        status_code: int,
+        body: str,
+        headers: dict[str, Any],
+    ) -> None:
+        if status_code in (401, 403):
+            raise auth_error(self.PROVIDER_KEY, "Fish S2 authentication failed")
+        if status_code == 429:
+            retry_after = headers.get("retry-after") if isinstance(headers, dict) else None
+            raise rate_limit_error(
+                self.PROVIDER_KEY,
+                retry_after=int(retry_after) if retry_after else None,
+            )
+        if status_code in (400, 404):
+            raise TTSValidationError(
+                f"Fish S2 request failed ({status_code})",
+                provider=self.PROVIDER_KEY,
+                details={"status": status_code, "body": body},
+            )
+        if status_code in (408, 504):
+            raise timeout_error(self.PROVIDER_KEY, timeout_seconds=self.timeout)
+        if 500 <= status_code < 600:
+            raise provider_error(
+                "Fish S2 upstream error",
+                provider=self.PROVIDER_KEY,
+                error_code=str(status_code),
+                details={"status": status_code, "body": body},
+            )
+        raise TTSProviderError(
+            f"Fish S2 request failed ({status_code})",
+            provider=self.PROVIDER_KEY,
+            details={"status": status_code, "body": body},
+        )
+
+    def _raise_transport_error(self, exc: Exception) -> None:
+        if isinstance(exc, (TTSAuthenticationError, TTSRateLimitError, TTSTimeoutError, TTSValidationError, TTSProviderError)):
+            raise exc
+        if self._is_timeout_error(exc):
+            raise timeout_error(self.PROVIDER_KEY, timeout_seconds=self.timeout) from exc
+        raise network_error(self.PROVIDER_KEY, exc) from exc
+
+    @staticmethod
+    def _normalize_api_key(value: Any) -> str | None:
+        if value is None:
+            return None
+        raw = str(value).strip()
+        if not raw or raw.lower() in {"none", "null"}:
+            return None
+        return raw
+
+    @staticmethod
+    def _normalize_format(response_format: Any) -> str:
+        value = getattr(response_format, "value", response_format)
+        return str(value).lower()
+
+    @staticmethod
+    def _is_timeout_error(exc: Exception) -> bool:
+        if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+            return True
+        exc_name = exc.__class__.__name__.lower()
+        return "timeout" in exc_name or "timeout" in str(exc).lower()

--- a/tldw_Server_API/app/core/TTS/fish_s2_reference_imports.py
+++ b/tldw_Server_API/app/core/TTS/fish_s2_reference_imports.py
@@ -26,7 +26,26 @@ class FishS2ReferenceImportItem:
     source_index: int = 0
 
 
+@dataclass(frozen=True)
+class FishS2ReferenceImportIssue:
+    """Indexed validation issue for an import item."""
+
+    index: int
+    message: str
+
+
+@dataclass(frozen=True)
+class FishS2ReferenceImportParseResult:
+    """Detailed Fish S2 reference import parse result."""
+
+    items: list[FishS2ReferenceImportItem]
+    errors: list[FishS2ReferenceImportIssue]
+
+
 SUPPORTED_FISH_S2_IMPORT_EXTENSIONS = {".json", ".md", ".markdown"}
+FISH_S2_REFERENCE_IMPORT_MAX_BYTES = 75 * 1024 * 1024
+FISH_S2_REFERENCE_IMPORT_MAX_ITEMS = 25
+FISH_S2_REFERENCE_IMPORT_MAX_DECODED_AUDIO_BYTES = 50 * 1024 * 1024
 
 
 def parse_fish_s2_reference_import(
@@ -35,6 +54,26 @@ def parse_fish_s2_reference_import(
     content: bytes,
 ) -> list[FishS2ReferenceImportItem]:
     """Parse JSON or Markdown Fish S2 reference imports into normalized items."""
+    result = parse_fish_s2_reference_import_result(filename=filename, content=content)
+    if result.errors:
+        first_error = result.errors[0]
+        raise FishS2ReferenceImportError(first_error.message)
+    return result.items
+
+
+def parse_fish_s2_reference_import_result(
+    *,
+    filename: str,
+    content: bytes,
+    max_items: int = FISH_S2_REFERENCE_IMPORT_MAX_ITEMS,
+    max_bytes: int = FISH_S2_REFERENCE_IMPORT_MAX_BYTES,
+) -> FishS2ReferenceImportParseResult:
+    """Parse a Fish S2 reference import and collect indexed item errors."""
+    if len(content) > max_bytes:
+        raise FishS2ReferenceImportError(
+            f"Fish S2 import file exceeds the maximum size of {max_bytes} bytes"
+        )
+
     suffix = Path(filename or "").suffix.lower()
     if suffix not in SUPPORTED_FISH_S2_IMPORT_EXTENSIONS:
         raise FishS2ReferenceImportError(
@@ -53,8 +92,22 @@ def parse_fish_s2_reference_import(
 
     if not records:
         raise FishS2ReferenceImportError("Fish S2 import file contains no references")
+    if len(records) > max_items:
+        raise FishS2ReferenceImportError(
+            f"Fish S2 import file contains {len(records)} references; at most {max_items} are allowed"
+        )
 
-    return [_normalize_record(record, index) for index, record in enumerate(records)]
+    items: list[FishS2ReferenceImportItem] = []
+    errors: list[FishS2ReferenceImportIssue] = []
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            errors.append(FishS2ReferenceImportIssue(index=index, message="Each Fish S2 JSON import item must be an object"))
+            continue
+        try:
+            items.append(_normalize_record(record, index))
+        except FishS2ReferenceImportError as exc:
+            errors.append(FishS2ReferenceImportIssue(index=index, message=str(exc)))
+    return FishS2ReferenceImportParseResult(items=items, errors=errors)
 
 
 def _load_json_records(text: str) -> list[dict[str, Any]]:
@@ -71,9 +124,6 @@ def _load_json_records(text: str) -> list[dict[str, Any]]:
     else:
         raise FishS2ReferenceImportError("Fish S2 JSON import must be an object or array")
 
-    for record in records:
-        if not isinstance(record, dict):
-            raise FishS2ReferenceImportError("Each Fish S2 JSON import item must be an object")
     return records
 
 

--- a/tldw_Server_API/app/core/TTS/fish_s2_reference_imports.py
+++ b/tldw_Server_API/app/core/TTS/fish_s2_reference_imports.py
@@ -1,0 +1,166 @@
+"""Import helpers for Fish S2 managed reference files."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class FishS2ReferenceImportError(ValueError):
+    """Raised when a Fish S2 reference import file cannot be parsed."""
+
+
+@dataclass(frozen=True)
+class FishS2ReferenceImportItem:
+    """Normalized Fish S2 reference import item."""
+
+    voice_id: str | None = None
+    reference_text: str | None = None
+    name: str | None = None
+    description: str | None = None
+    filename: str | None = None
+    audio_base64: str | None = None
+    force: bool | None = None
+    source_index: int = 0
+
+
+SUPPORTED_FISH_S2_IMPORT_EXTENSIONS = {".json", ".md", ".markdown"}
+
+
+def parse_fish_s2_reference_import(
+    *,
+    filename: str,
+    content: bytes,
+) -> list[FishS2ReferenceImportItem]:
+    """Parse JSON or Markdown Fish S2 reference imports into normalized items."""
+    suffix = Path(filename or "").suffix.lower()
+    if suffix not in SUPPORTED_FISH_S2_IMPORT_EXTENSIONS:
+        raise FishS2ReferenceImportError(
+            "Unsupported Fish S2 import file type. Use .json, .md, or .markdown."
+        )
+
+    try:
+        text = content.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise FishS2ReferenceImportError("Fish S2 import file must be UTF-8 text") from exc
+
+    if suffix == ".json":
+        records = _load_json_records(text)
+    else:
+        records = [_load_markdown_record(text)]
+
+    if not records:
+        raise FishS2ReferenceImportError("Fish S2 import file contains no references")
+
+    return [_normalize_record(record, index) for index, record in enumerate(records)]
+
+
+def _load_json_records(text: str) -> list[dict[str, Any]]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise FishS2ReferenceImportError(f"Invalid Fish S2 JSON import: {exc.msg}") from exc
+
+    if isinstance(payload, list):
+        records = payload
+    elif isinstance(payload, dict):
+        nested = payload.get("references")
+        records = nested if isinstance(nested, list) else [payload]
+    else:
+        raise FishS2ReferenceImportError("Fish S2 JSON import must be an object or array")
+
+    for record in records:
+        if not isinstance(record, dict):
+            raise FishS2ReferenceImportError("Each Fish S2 JSON import item must be an object")
+    return records
+
+
+def _load_markdown_record(text: str) -> dict[str, Any]:
+    metadata, body = _split_markdown_frontmatter(text)
+    record = dict(metadata)
+    if body and not _first_text(record, "reference_text", "text", "transcript"):
+        record["reference_text"] = body
+    return record
+
+
+def _split_markdown_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    lines = text.splitlines(keepends=True)
+    if lines and lines[0].strip() == "---":
+        closing_index = None
+        for index, line in enumerate(lines[1:], start=1):
+            if line.strip() == "---":
+                closing_index = index
+                break
+        if closing_index is None:
+            raise FishS2ReferenceImportError("Markdown frontmatter is missing a closing --- marker")
+
+        frontmatter = "".join(lines[1:closing_index])
+        body = "".join(lines[closing_index + 1 :]).strip()
+        try:
+            metadata = yaml.safe_load(frontmatter) or {}
+        except yaml.YAMLError as exc:
+            raise FishS2ReferenceImportError("Invalid Markdown frontmatter for Fish S2 import") from exc
+        if not isinstance(metadata, dict):
+            raise FishS2ReferenceImportError("Markdown frontmatter must be a mapping")
+        return metadata, body
+
+    return {}, text.strip()
+
+
+def _normalize_record(record: dict[str, Any], source_index: int) -> FishS2ReferenceImportItem:
+    voice_id = _first_text(record, "voice_id", "reference_id")
+    audio_base64 = _first_text(record, "audio_base64", "audio_b64")
+    reference_text = _first_text(record, "reference_text", "text", "transcript")
+    filename = _first_text(record, "filename", "audio_filename")
+    name = _first_text(record, "name", "title")
+    description = _first_text(record, "description")
+    force = _optional_bool(record.get("force"))
+
+    if voice_id and audio_base64:
+        raise FishS2ReferenceImportError("Provide either voice_id or audio_base64, not both")
+    if not voice_id and not audio_base64:
+        raise FishS2ReferenceImportError("voice_id or audio_base64 is required for Fish S2 imports")
+    if audio_base64 and not (filename and name and reference_text):
+        raise FishS2ReferenceImportError(
+            "filename, name, and reference_text are required when audio_base64 is provided"
+        )
+
+    return FishS2ReferenceImportItem(
+        voice_id=voice_id,
+        reference_text=reference_text,
+        name=name,
+        description=description,
+        filename=filename,
+        audio_base64=audio_base64,
+        force=force,
+        source_index=source_index,
+    )
+
+
+def _first_text(record: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = record.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise FishS2ReferenceImportError("force must be a boolean when provided")

--- a/tldw_Server_API/app/core/TTS/tts_config.py
+++ b/tldw_Server_API/app/core/TTS/tts_config.py
@@ -42,6 +42,7 @@ REDACTED_SECRET = "********"  # nosec B105
 class ProviderConfig(BaseModel):
     """Configuration for a single TTS provider"""
     enabled: bool = False
+    backend: Optional[str] = None
     api_key: Optional[str] = None
     base_url: Optional[str] = None
     runtime: Optional[str] = None
@@ -408,12 +409,15 @@ class TTSConfigManager:
         config_dict = {}
 
         # Check for provider API keys
-        api_key_env_vars = {
-            'OPENAI_API_KEY': ('openai', 'api_key'),
-            'ELEVENLABS_API_KEY': ('elevenlabs', 'api_key'),
-        }
+        api_key_env_vars = (
+            ('OPENAI_API_KEY', ('openai', 'api_key')),
+            ('ELEVENLABS_API_KEY', ('elevenlabs', 'api_key')),
+            ('ANTHROPIC_API_KEY', ('anthropic', 'api_key')),
+            ('FISH_API_KEY', ('fish_s2', 'api_key')),
+            ('FISH_AUDIO_API_KEY', ('fish_s2', 'api_key')),
+        )
 
-        for env_var, (provider, field) in api_key_env_vars.items():
+        for env_var, (provider, field) in api_key_env_vars:
             value = os.getenv(env_var)
             if value:
                 if 'providers' not in config_dict:

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -2767,6 +2767,156 @@ class TTSServiceV2:
                 exc,
             )
 
+    async def create_fish_s2_reference(
+        self,
+        *,
+        user_id: int,
+        voice_id: Optional[str] = None,
+        file_content: Optional[bytes] = None,
+        filename: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        reference_text: Optional[str] = None,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        """Create or reuse a managed Fish S2 reference backed by local voice metadata."""
+        from tldw_Server_API.app.core.TTS.voice_manager import (
+            VoiceProcessingError,
+            VoiceReferenceMetadata,
+            VoiceUploadRequest,
+            get_voice_manager,
+        )
+
+        voice_manager = get_voice_manager()
+
+        resolved_voice_id = voice_id
+        if not resolved_voice_id:
+            if not file_content or not filename or not name or not reference_text:
+                raise VoiceProcessingError(
+                    "file, filename, name, and reference_text are required when voice_id is not provided"
+                )
+            upload_request = VoiceUploadRequest(
+                name=name,
+                description=description,
+                provider="fish_s2",
+                reference_text=reference_text,
+            )
+            upload_result = await voice_manager.upload_voice(
+                user_id=user_id,
+                file_content=file_content,
+                filename=filename,
+                request=upload_request,
+            )
+            resolved_voice_id = upload_result.voice_id
+
+        metadata = await voice_manager.load_reference_metadata(user_id, resolved_voice_id)
+        if metadata is None:
+            metadata = VoiceReferenceMetadata(voice_id=resolved_voice_id)
+        if reference_text:
+            metadata.reference_text = reference_text.strip() or None
+
+        fish_artifacts = metadata.provider_artifacts.get("fish_s2") or {}
+        existing_remote_reference_id = fish_artifacts.get("remote_reference_id")
+        if existing_remote_reference_id and not force:
+            return {
+                "reference_id": resolved_voice_id,
+                "voice_id": resolved_voice_id,
+                "remote_reference_id": existing_remote_reference_id,
+                "reference_text": fish_artifacts.get("reference_text") or metadata.reference_text,
+                "cached": True,
+            }
+
+        voice_bytes = await voice_manager.load_voice_reference_audio(user_id, resolved_voice_id)
+        resolved_reference_text = metadata.reference_text
+        if not resolved_reference_text:
+            raise VoiceProcessingError("reference_text is required for Fish S2 references")
+
+        adapter = await self._get_adapter("fish_s2", provider="fish_s2")
+        if adapter is None or not hasattr(adapter, "add_reference"):
+            raise TTSProviderNotConfiguredError("Fish S2 adapter is not available", provider="fish_s2")
+
+        remote_reference_id = self._build_fish_s2_remote_reference_id(user_id, resolved_voice_id)
+        if force and existing_remote_reference_id and hasattr(adapter, "delete_reference"):
+            with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
+                await adapter.delete_reference(reference_id=str(existing_remote_reference_id))
+
+        await adapter.add_reference(
+            reference_id=remote_reference_id,
+            audio_b64=base64.b64encode(voice_bytes).decode("ascii"),
+            reference_text=resolved_reference_text,
+        )
+
+        metadata.provider_artifacts["fish_s2"] = {
+            "remote_reference_id": remote_reference_id,
+            "reference_text": resolved_reference_text,
+        }
+        await voice_manager.save_reference_metadata(user_id, metadata)
+        return {
+            "reference_id": resolved_voice_id,
+            "voice_id": resolved_voice_id,
+            "remote_reference_id": remote_reference_id,
+            "reference_text": resolved_reference_text,
+            "cached": False,
+        }
+
+    async def list_fish_s2_references(self, *, user_id: int) -> list[dict[str, Any]]:
+        """List Fish S2 managed references from local voice metadata."""
+        from tldw_Server_API.app.core.TTS.voice_manager import get_voice_manager
+
+        voice_manager = get_voice_manager()
+        voices = await voice_manager.list_user_voices(user_id, refresh=True)
+        references: list[dict[str, Any]] = []
+
+        for voice in voices:
+            voice_id = getattr(voice, "voice_id", None)
+            if not voice_id:
+                continue
+            metadata = await voice_manager.load_reference_metadata(user_id, voice_id)
+            if metadata is None:
+                continue
+            fish_artifacts = metadata.provider_artifacts.get("fish_s2") or {}
+            remote_reference_id = fish_artifacts.get("remote_reference_id")
+            if not remote_reference_id:
+                continue
+            references.append(
+                {
+                    "reference_id": voice_id,
+                    "voice_id": voice_id,
+                    "name": getattr(voice, "name", voice_id),
+                    "reference_text": fish_artifacts.get("reference_text") or metadata.reference_text,
+                    "remote_reference_id": remote_reference_id,
+                }
+            )
+
+        return references
+
+    async def delete_fish_s2_reference(self, *, user_id: int, reference_id: str) -> dict[str, Any]:
+        """Delete a Fish S2 managed reference while preserving the local voice record."""
+        from tldw_Server_API.app.core.TTS.voice_manager import VoiceProcessingError, get_voice_manager
+
+        voice_manager = get_voice_manager()
+        metadata = await voice_manager.load_reference_metadata(user_id, reference_id)
+        if metadata is None:
+            raise VoiceProcessingError(f"Fish S2 reference not found: {reference_id}")
+
+        fish_artifacts = metadata.provider_artifacts.get("fish_s2") or {}
+        remote_reference_id = fish_artifacts.get("remote_reference_id")
+        if not remote_reference_id:
+            raise VoiceProcessingError(f"Fish S2 reference not found: {reference_id}")
+
+        adapter = await self._get_adapter("fish_s2", provider="fish_s2")
+        if adapter is None or not hasattr(adapter, "delete_reference"):
+            raise TTSProviderNotConfiguredError("Fish S2 adapter is not available", provider="fish_s2")
+
+        await adapter.delete_reference(reference_id=str(remote_reference_id))
+        metadata.provider_artifacts.pop("fish_s2", None)
+        await voice_manager.save_reference_metadata(user_id, metadata)
+        return {"reference_id": reference_id, "deleted": True}
+
+    @staticmethod
+    def _build_fish_s2_remote_reference_id(user_id: int, voice_id: str) -> str:
+        return f"tldw_u{user_id}_{voice_id}"
+
     async def _get_adapter(
         self,
         model: str,

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -2835,19 +2835,29 @@ class TTSServiceV2:
         if adapter is None or not hasattr(adapter, "add_reference"):
             raise TTSProviderNotConfiguredError("Fish S2 adapter is not available", provider="fish_s2")
 
-        remote_reference_id = self._build_fish_s2_remote_reference_id(user_id, resolved_voice_id)
+        local_reference_id = self._build_fish_s2_remote_reference_id(user_id, resolved_voice_id)
         if force and existing_remote_reference_id and hasattr(adapter, "delete_reference"):
             with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
                 await adapter.delete_reference(reference_id=str(existing_remote_reference_id))
 
-        await adapter.add_reference(
-            reference_id=remote_reference_id,
+        adapter_result = await adapter.add_reference(
+            reference_id=local_reference_id,
             audio_b64=base64.b64encode(voice_bytes).decode("ascii"),
             reference_text=resolved_reference_text,
+            title=name or resolved_voice_id,
+            description=description,
         )
+        remote_reference_id = local_reference_id
+        if isinstance(adapter_result, dict):
+            remote_reference_id = str(
+                adapter_result.get("remote_reference_id")
+                or adapter_result.get("reference_id")
+                or local_reference_id
+            )
 
         metadata.provider_artifacts["fish_s2"] = {
             "remote_reference_id": remote_reference_id,
+            "local_reference_id": local_reference_id,
             "reference_text": resolved_reference_text,
         }
         await voice_manager.save_reference_metadata(user_id, metadata)

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -2837,8 +2837,14 @@ class TTSServiceV2:
 
         local_reference_id = self._build_fish_s2_remote_reference_id(user_id, resolved_voice_id)
         if force and existing_remote_reference_id and hasattr(adapter, "delete_reference"):
-            with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
-                await adapter.delete_reference(reference_id=str(existing_remote_reference_id))
+            try:
+                delete_result = await adapter.delete_reference(reference_id=str(existing_remote_reference_id))
+            except _TTS_NONCRITICAL_EXCEPTIONS:
+                logger.debug("Fish S2 remote reference delete failed before recreation")
+            else:
+                if delete_result is not False:
+                    metadata.provider_artifacts.pop("fish_s2", None)
+                    await voice_manager.save_reference_metadata(user_id, metadata)
 
         adapter_result = await adapter.add_reference(
             reference_id=local_reference_id,

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -466,6 +466,7 @@ class TTSServiceV2:
                 config=self._get_validation_config(),
             )
             await self._apply_custom_voice_reference(tts_request, user_id, provider_hint)
+            await self._apply_fish_s2_reference_context(tts_request, user_id, provider_hint)
 
             adapter = await self._get_adapter(request.model, provider, overrides=provider_overrides)
             if not adapter and fallback:
@@ -2682,6 +2683,86 @@ class TTSServiceV2:
             logger.debug(
                 "Failed to persist Qwen3 voice_clone_prompt for {} (request_id={}): {}",
                 raw_id,
+                request_id or "unknown",
+                exc,
+            )
+
+    async def _apply_fish_s2_reference_context(
+        self,
+        request: TTSRequest,
+        user_id: Optional[int],
+        provider_hint: Optional[str],
+    ) -> None:
+        """Resolve Fish S2 logical references into backend-ready request fields."""
+        if not user_id or (provider_hint or "").lower() != "fish_s2":
+            return
+
+        extras = request.extra_params or {}
+        if not isinstance(extras, dict):
+            extras = {}
+
+        explicit_reference_id = extras.get("reference_id")
+        local_voice_id: Optional[str] = None
+        if isinstance(explicit_reference_id, str) and explicit_reference_id.strip():
+            local_voice_id = explicit_reference_id.strip()
+        elif isinstance(request.voice, str) and request.voice.startswith("custom:"):
+            local_voice_id = request.voice.split("custom:", 1)[-1].strip() or None
+
+        if not local_voice_id:
+            request.extra_params = extras
+            return
+
+        try:
+            from tldw_Server_API.app.core.TTS.voice_manager import VoiceProcessingError, get_voice_manager
+
+            voice_manager = get_voice_manager()
+            metadata = await voice_manager.load_reference_metadata(user_id, local_voice_id)
+
+            fish_artifacts = {}
+            if metadata and isinstance(metadata.provider_artifacts, dict):
+                fish_artifacts = metadata.provider_artifacts.get("fish_s2") or {}
+
+            remote_reference_id = None
+            if isinstance(fish_artifacts, dict):
+                remote_reference_id = fish_artifacts.get("remote_reference_id") or fish_artifacts.get("reference_id")
+
+            if remote_reference_id:
+                extras["reference_id"] = str(remote_reference_id)
+                extras.pop("references", None)
+                request.extra_params = extras
+                return
+
+            reference_text = (
+                extras.get("reference_text")
+                or extras.get("ref_text")
+                or extras.get("voice_reference_text")
+                or (fish_artifacts.get("reference_text") if isinstance(fish_artifacts, dict) else None)
+                or (metadata.reference_text if metadata else None)
+            )
+
+            voice_bytes = request.voice_reference
+            if voice_bytes is None:
+                try:
+                    voice_bytes = await voice_manager.load_voice_reference_audio(user_id, local_voice_id)
+                    request.voice_reference = voice_bytes
+                except VoiceProcessingError:
+                    voice_bytes = None
+
+            if isinstance(voice_bytes, (bytes, bytearray)) and reference_text:
+                extras.pop("reference_id", None)
+                extras["references"] = [
+                    {
+                        "audio_b64": base64.b64encode(bytes(voice_bytes)).decode("ascii"),
+                        "text": str(reference_text),
+                    }
+                ]
+
+            request.extra_params = extras
+        except _TTS_NONCRITICAL_EXCEPTIONS as exc:
+            request_id, _ = self._get_tts_request_observability(request)
+            logger.debug(
+                "Fish S2 reference resolution failed for {} (request_id={}): {}",
+                local_voice_id,
                 request_id or "unknown",
                 exc,
             )

--- a/tldw_Server_API/app/core/TTS/tts_validation.py
+++ b/tldw_Server_API/app/core/TTS/tts_validation.py
@@ -608,16 +608,6 @@ class TTSInputValidator:
             if request.format:
                 self._validate_format(request.format, provider)
 
-            if provider == "fish_s2" and request.stream and request.format != AudioFormat.WAV:
-                raise TTSUnsupportedFormatError(
-                    "Fish S2 streaming only supports WAV format",
-                    provider=provider,
-                    details={
-                        "requested_format": request.format.value,
-                        "supported_streaming_formats": [AudioFormat.WAV.value],
-                    },
-                )
-
             # Validate language (allow extra_params.language override)
             language = request.language
             extras = request.extra_params or {}

--- a/tldw_Server_API/app/core/TTS/tts_validation.py
+++ b/tldw_Server_API/app/core/TTS/tts_validation.py
@@ -194,12 +194,12 @@ class ProviderLimits:
             "max_text_length": 5000,
             "languages": ["en"],
             "valid_formats": {"mp3", "opus", "aac", "flac", "wav", "pcm"},
+            "min_speed": 0.25,
+            "max_speed": 4.0,
         },
         "fish_s2": {
             "max_text_length": 5000,
             "valid_formats": {"wav", "mp3", "opus", "pcm"},
-            "min_speed": 0.25,
-            "max_speed": 4.0,
         }
     }
 

--- a/tldw_Server_API/app/core/TTS/tts_validation.py
+++ b/tldw_Server_API/app/core/TTS/tts_validation.py
@@ -194,6 +194,10 @@ class ProviderLimits:
             "max_text_length": 5000,
             "languages": ["en"],
             "valid_formats": {"mp3", "opus", "aac", "flac", "wav", "pcm"},
+        },
+        "fish_s2": {
+            "max_text_length": 5000,
+            "valid_formats": {"wav", "mp3", "opus", "pcm"},
             "min_speed": 0.25,
             "max_speed": 4.0,
         }
@@ -300,6 +304,7 @@ class TTSInputValidator:
         "lux_tts": 5000,
         "qwen3_tts": 5000,
         "omnivoice": 5000,
+        "fish_s2": 5000,
         "default": 5000,
     }
 
@@ -357,6 +362,7 @@ class TTSInputValidator:
         "lux_tts": {AudioFormat.MP3, AudioFormat.WAV, AudioFormat.FLAC, AudioFormat.OPUS, AudioFormat.AAC, AudioFormat.PCM},
         "qwen3_tts": {AudioFormat.MP3, AudioFormat.OPUS, AudioFormat.AAC, AudioFormat.WAV, AudioFormat.PCM},
         "omnivoice": {AudioFormat.MP3, AudioFormat.OPUS, AudioFormat.AAC, AudioFormat.FLAC, AudioFormat.WAV, AudioFormat.PCM},
+        "fish_s2": {AudioFormat.WAV, AudioFormat.MP3, AudioFormat.OPUS, AudioFormat.PCM},
     }
 
     # Voice reference file validation
@@ -601,6 +607,16 @@ class TTSInputValidator:
             # Validate format
             if request.format:
                 self._validate_format(request.format, provider)
+
+            if provider == "fish_s2" and request.stream and request.format != AudioFormat.WAV:
+                raise TTSUnsupportedFormatError(
+                    "Fish S2 streaming only supports WAV format",
+                    provider=provider,
+                    details={
+                        "requested_format": request.format.value,
+                        "supported_streaming_formats": [AudioFormat.WAV.value],
+                    },
+                )
 
             # Validate language (allow extra_params.language override)
             language = request.language

--- a/tldw_Server_API/app/core/TTS/voice_manager.py
+++ b/tldw_Server_API/app/core/TTS/voice_manager.py
@@ -111,6 +111,13 @@ PROVIDER_REQUIREMENTS = {
         "duration": {"min": 3, "max": 30},
         "sample_rate": 24000,
         "convert_to": "wav",
+    },
+    "fish_s2": {
+        "formats": [".wav", ".mp3", ".flac", ".ogg", ".m4a", ".opus"],
+        "max_size_mb": 50,
+        "duration": {"min": 3, "max": 60},
+        "sample_rate": 24000,
+        "convert_to": "wav"
     }
 }
 

--- a/tldw_Server_API/tests/Audio/test_failopen_cap_minutes.py
+++ b/tldw_Server_API/tests/Audio/test_failopen_cap_minutes.py
@@ -1,4 +1,5 @@
 import importlib
+import builtins
 import os
 import types
 
@@ -331,6 +332,40 @@ async def test_aggregate_resolve_tts_byok_delegates_to_core(monkeypatch):
             "force_oauth_refresh": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_resolve_tts_byok_logs_resolver_lookup_fallback(monkeypatch):
+    mod = _import_audio_aggregate_module(monkeypatch, cfg=_fake_cfg({}))
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(mod, "logger", logger_stub, raising=True)
+    original_import = builtins.__import__
+
+    class _ByokResolution:
+        uses_byok = False
+        api_key = "configured"
+        credential_fields = {}
+
+    async def _fallback_resolver(*_args, **_kwargs):
+        return _ByokResolution()
+
+    def _guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tldw_Server_API.app.api.v1.endpoints" and "audio" in fromlist:
+            raise ImportError("audio package resolver unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(mod, "resolve_byok_credentials", _fallback_resolver, raising=True)
+    monkeypatch.setattr(builtins, "__import__", _guarded_import)
+
+    result = await mod._resolve_tts_byok(
+        provider_hint="fish_s2",
+        current_user=types.SimpleNamespace(id=1),
+        request=object(),
+    )
+
+    assert result[0] == 1
+    assert result[1] is None
+    _assert_sanitized_debug_log(logger_stub, "Falling back to default BYOK resolver after audio package resolver lookup failed")
 
 
 def test_aggregate_quota_helper_import_logs_are_sanitized(monkeypatch):

--- a/tldw_Server_API/tests/Audio/test_failopen_cap_minutes.py
+++ b/tldw_Server_API/tests/Audio/test_failopen_cap_minutes.py
@@ -6,6 +6,7 @@ import types
 import loguru
 import pytest
 from fastapi import APIRouter
+from fastapi import HTTPException
 
 
 pytestmark = pytest.mark.unit
@@ -366,6 +367,31 @@ async def test_aggregate_resolve_tts_byok_logs_resolver_lookup_fallback(monkeypa
     assert result[0] == 1
     assert result[1] is None
     _assert_sanitized_debug_log(logger_stub, "Falling back to default BYOK resolver after audio package resolver lookup failed")
+
+
+@pytest.mark.asyncio
+async def test_aggregate_resolve_tts_byok_rejects_blank_byok_api_key(monkeypatch):
+    mod = _import_audio_aggregate_module(monkeypatch, cfg=_fake_cfg({}))
+
+    class _ByokResolution:
+        uses_byok = True
+        api_key = "   "
+        credential_fields = {}
+
+    async def _blank_byok_resolver(*_args, **_kwargs):
+        return _ByokResolution()
+
+    monkeypatch.setattr(mod, "resolve_byok_credentials", _blank_byok_resolver, raising=True)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await mod._resolve_tts_byok(
+            provider_hint="fish_s2",
+            current_user=types.SimpleNamespace(id=1),
+            request=object(),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail["error_code"] == "missing_provider_credentials"
 
 
 def test_aggregate_quota_helper_import_logs_are_sanitized(monkeypatch):

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
@@ -1,0 +1,123 @@
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.endpoints.audio import audio_voices
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "test-api-key-1234567890")
+    monkeypatch.setenv("SINGLE_USER_FIXED_ID", "1")
+    reset_settings()
+    app = FastAPI()
+    app.include_router(audio_voices.router, prefix="/api/v1/audio")
+    with TestClient(app) as c:
+        yield c, app
+
+
+def test_create_fish_s2_reference_from_existing_voice(client):
+    client_obj, app = client
+    called = {}
+
+    class _FakeTTSService:
+        async def create_fish_s2_reference(self, **kwargs):
+            called.update(kwargs)
+            return {
+                "reference_id": kwargs["voice_id"],
+                "voice_id": kwargs["voice_id"],
+                "remote_reference_id": "tldw_u1_voice-1",
+                "reference_text": kwargs["reference_text"],
+                "cached": False,
+            }
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references",
+            data={"voice_id": "voice-1", "reference_text": "stored text"},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["reference_id"] == "voice-1"
+    assert body["remote_reference_id"] == "tldw_u1_voice-1"
+    assert str(called["user_id"]) == "1"
+    assert called["voice_id"] == "voice-1"
+
+
+def test_create_fish_s2_reference_requires_upload_fields_when_voice_missing(client):
+    client_obj, app = client
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: object()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references",
+            data={},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 400
+
+
+def test_list_fish_s2_references(client):
+    client_obj, app = client
+
+    class _FakeTTSService:
+        async def list_fish_s2_references(self, **kwargs):
+            return [
+                {
+                    "reference_id": "voice-1",
+                    "voice_id": "voice-1",
+                    "name": "Voice One",
+                    "reference_text": "stored text",
+                    "remote_reference_id": "tldw_u1_voice-1",
+                }
+            ]
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.get(
+            "/api/v1/audio/providers/fish_s2/references",
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["count"] == 1
+    assert body["references"][0]["reference_id"] == "voice-1"
+
+
+def test_delete_fish_s2_reference(client):
+    client_obj, app = client
+    called = {}
+
+    class _FakeTTSService:
+        async def delete_fish_s2_reference(self, **kwargs):
+            called.update(kwargs)
+            return {"reference_id": kwargs["reference_id"], "deleted": True}
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.delete(
+            "/api/v1/audio/providers/fish_s2/references/voice-1",
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"reference_id": "voice-1", "deleted": True}
+    assert str(called["user_id"]) == "1"
+    assert called["reference_id"] == "voice-1"

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
@@ -3,9 +3,16 @@ import json
 
 import pytest
 from fastapi import FastAPI
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.api.v1.endpoints.audio import audio_voices
+from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
+    FishS2ReferenceDeleteResponse,
+    FishS2ReferenceImportResponse,
+    FishS2ReferenceListResponse,
+    FishS2ReferenceResponse,
+)
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 from tldw_Server_API.app.core.TTS.tts_exceptions import TTSProviderError
 
@@ -21,6 +28,27 @@ def client(monkeypatch):
     app.include_router(audio_voices.router, prefix="/api/v1/audio")
     with TestClient(app) as c:
         yield c, app
+
+
+def _find_route(app: FastAPI, method: str, path: str) -> APIRoute:
+    for route in app.routes:
+        if isinstance(route, APIRoute) and route.path == path and method.upper() in route.methods:
+            return route
+    raise AssertionError(f"Route not found: {method} {path}")
+
+
+def test_fish_s2_reference_routes_declare_response_models(client):
+    _client_obj, app = client
+
+    expectations = [
+        ("POST", "/api/v1/audio/providers/fish_s2/references", FishS2ReferenceResponse),
+        ("GET", "/api/v1/audio/providers/fish_s2/references", FishS2ReferenceListResponse),
+        ("POST", "/api/v1/audio/providers/fish_s2/references/import", FishS2ReferenceImportResponse),
+        ("DELETE", "/api/v1/audio/providers/fish_s2/references/{reference_id}", FishS2ReferenceDeleteResponse),
+    ]
+
+    for method, path, response_model in expectations:
+        assert _find_route(app, method, path).response_model is response_model
 
 
 def test_create_fish_s2_reference_from_existing_voice(client):

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.api.v1.endpoints.audio import audio_voices
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSProviderError
 
 
 @pytest.fixture
@@ -251,6 +252,176 @@ def test_import_fish_s2_reference_from_json_embedded_audio(client):
     assert called["name"] == "Voice One"
     assert called["description"] == "Embedded audio import"
     assert called["reference_text"] == "embedded transcript"
+
+
+def test_import_fish_s2_references_returns_partial_parse_errors(client):
+    client_obj, app = client
+    calls = []
+
+    class _FakeTTSService:
+        async def create_fish_s2_reference(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "reference_id": kwargs["voice_id"],
+                "voice_id": kwargs["voice_id"],
+                "remote_reference_id": f"remote-{kwargs['voice_id']}",
+                "reference_text": kwargs["reference_text"],
+                "cached": False,
+            }
+
+    payload = {
+        "references": [
+            {"voice_id": "voice-1", "reference_text": "one"},
+            {"reference_text": "missing voice"},
+        ]
+    }
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references/import",
+            files={"file": ("refs.json", json.dumps(payload), "application/json")},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["imported"] == 1
+    assert body["failed"] == 1
+    assert body["results"][0]["index"] == 0
+    assert body["errors"] == [
+        {
+            "index": 1,
+            "message": "voice_id or audio_base64 is required for Fish S2 imports",
+        }
+    ]
+    assert [call["voice_id"] for call in calls] == ["voice-1"]
+
+
+def test_import_fish_s2_references_returns_partial_provider_errors(client):
+    client_obj, app = client
+
+    class _FakeTTSService:
+        async def create_fish_s2_reference(self, **kwargs):
+            if kwargs["voice_id"] == "voice-2":
+                raise TTSProviderError("Fish upstream unavailable", provider="fish_s2", error_code="provider_error")
+            return {
+                "reference_id": kwargs["voice_id"],
+                "voice_id": kwargs["voice_id"],
+                "remote_reference_id": f"remote-{kwargs['voice_id']}",
+                "reference_text": kwargs["reference_text"],
+                "cached": False,
+            }
+
+    payload = {
+        "references": [
+            {"voice_id": "voice-1", "reference_text": "one"},
+            {"voice_id": "voice-2", "reference_text": "two"},
+        ]
+    }
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references/import",
+            files={"file": ("refs.json", json.dumps(payload), "application/json")},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["imported"] == 1
+    assert body["failed"] == 1
+    assert body["results"][0]["index"] == 0
+    assert body["errors"] == [
+        {
+            "index": 1,
+            "message": "Fish upstream unavailable",
+            "code": "provider_error",
+        }
+    ]
+
+
+def test_import_fish_s2_references_rejects_oversized_file(client, monkeypatch):
+    client_obj, app = client
+    monkeypatch.setattr(audio_voices, "FISH_S2_REFERENCE_IMPORT_MAX_BYTES", 5)
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: object()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references/import",
+            files={"file": ("refs.json", '{"voice_id":"voice-1"}', "application/json")},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["message"] == "Fish S2 reference import file is too large"
+
+
+def test_import_fish_s2_references_rejects_too_many_items(client, monkeypatch):
+    client_obj, app = client
+    monkeypatch.setattr(audio_voices, "FISH_S2_REFERENCE_IMPORT_MAX_ITEMS", 1)
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: object()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references/import",
+            files={
+                "file": (
+                    "refs.json",
+                    '[{"voice_id":"voice-1"}, {"voice_id":"voice-2"}]',
+                    "application/json",
+                )
+            },
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 400
+    assert "at most 1" in response.json()["detail"]["details"]
+
+
+def test_import_fish_s2_references_rejects_oversized_embedded_audio(client, monkeypatch):
+    client_obj, app = client
+    monkeypatch.setattr(audio_voices, "FISH_S2_REFERENCE_IMPORT_MAX_DECODED_AUDIO_BYTES", 2)
+    called = False
+
+    class _FakeTTSService:
+        async def create_fish_s2_reference(self, **kwargs):
+            nonlocal called
+            called = True
+            return {}
+
+    payload = {
+        "audio_base64": "QUJD",
+        "filename": "voice.wav",
+        "name": "Voice One",
+        "reference_text": "embedded transcript",
+    }
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references/import",
+            files={"file": ("voice.json", json.dumps(payload), "application/json")},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["errors"] == [
+        {
+            "index": 0,
+            "message": "audio_base64 decoded audio exceeds the maximum size",
+        }
+    ]
+    assert called is False
 
 
 def test_import_fish_s2_references_rejects_unsupported_file_type(client):

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 import pytest
 from fastapi import FastAPI
@@ -121,3 +122,147 @@ def test_delete_fish_s2_reference(client):
     assert response.json() == {"reference_id": "voice-1", "deleted": True}
     assert str(called["user_id"]) == "1"
     assert called["reference_id"] == "voice-1"
+
+
+def test_import_fish_s2_references_from_json(client):
+    client_obj, app = client
+    calls = []
+
+    class _FakeTTSService:
+        async def create_fish_s2_reference(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "reference_id": kwargs["voice_id"],
+                "voice_id": kwargs["voice_id"],
+                "remote_reference_id": f"remote-{kwargs['voice_id']}",
+                "reference_text": kwargs["reference_text"],
+                "cached": False,
+            }
+
+    payload = {
+        "references": [
+            {"voice_id": "voice-1", "reference_text": "one"},
+            {"voice_id": "voice-2", "text": "two", "force": True},
+        ]
+    }
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references/import",
+            data={"force": "false"},
+            files={"file": ("refs.json", json.dumps(payload), "application/json")},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["imported"] == 2
+    assert body["failed"] == 0
+    assert body["results"][0]["reference_id"] == "voice-1"
+    assert body["results"][1]["reference_id"] == "voice-2"
+    assert [call["voice_id"] for call in calls] == ["voice-1", "voice-2"]
+    assert [call["reference_text"] for call in calls] == ["one", "two"]
+    assert [call["force"] for call in calls] == [False, True]
+
+
+def test_import_fish_s2_reference_from_markdown(client):
+    client_obj, app = client
+    called = {}
+
+    class _FakeTTSService:
+        async def create_fish_s2_reference(self, **kwargs):
+            called.update(kwargs)
+            return {
+                "reference_id": kwargs["voice_id"],
+                "voice_id": kwargs["voice_id"],
+                "remote_reference_id": "remote-voice-1",
+                "reference_text": kwargs["reference_text"],
+                "cached": False,
+            }
+
+    md_payload = (
+        "---\n"
+        "voice_id: voice-1\n"
+        "name: Voice One\n"
+        "description: Imported from markdown\n"
+        "---\n"
+        "Markdown transcript text.\n"
+    )
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references/import",
+            files={"file": ("voice.md", md_payload, "text/markdown")},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["imported"] == 1
+    assert called["voice_id"] == "voice-1"
+    assert called["name"] == "Voice One"
+    assert called["description"] == "Imported from markdown"
+    assert called["reference_text"] == "Markdown transcript text."
+
+
+def test_import_fish_s2_reference_from_json_embedded_audio(client):
+    client_obj, app = client
+    called = {}
+
+    class _FakeTTSService:
+        async def create_fish_s2_reference(self, **kwargs):
+            called.update(kwargs)
+            return {
+                "reference_id": "new-voice",
+                "voice_id": "new-voice",
+                "remote_reference_id": "remote-new-voice",
+                "reference_text": kwargs["reference_text"],
+                "cached": False,
+            }
+
+    payload = {
+        "audio_base64": "QUJD",
+        "filename": "voice.wav",
+        "name": "Voice One",
+        "description": "Embedded audio import",
+        "reference_text": "embedded transcript",
+    }
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references/import",
+            files={"file": ("voice.json", json.dumps(payload), "application/json")},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["imported"] == 1
+    assert called["voice_id"] is None
+    assert called["file_content"] == b"ABC"
+    assert called["filename"] == "voice.wav"
+    assert called["name"] == "Voice One"
+    assert called["description"] == "Embedded audio import"
+    assert called["reference_text"] == "embedded transcript"
+
+
+def test_import_fish_s2_references_rejects_unsupported_file_type(client):
+    client_obj, app = client
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: object()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references/import",
+            files={"file": ("voice.txt", "text", "text/plain")},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 400

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
@@ -26,8 +26,11 @@ def client(monkeypatch):
     reset_settings()
     app = FastAPI()
     app.include_router(audio_voices.router, prefix="/api/v1/audio")
-    with TestClient(app) as c:
-        yield c, app
+    try:
+        with TestClient(app) as c:
+            yield c, app
+    finally:
+        reset_settings()
 
 
 def _find_route(app: FastAPI, method: str, path: str) -> APIRoute:
@@ -97,6 +100,39 @@ def test_create_fish_s2_reference_requires_upload_fields_when_voice_missing(clie
         app.dependency_overrides.pop(audio_voices.get_tts_service, None)
 
     assert response.status_code == 400
+
+
+def test_create_fish_s2_reference_rejects_oversized_upload_before_service(client, monkeypatch):
+    client_obj, app = client
+    monkeypatch.setattr(audio_voices, "FISH_S2_REFERENCE_IMPORT_MAX_DECODED_AUDIO_BYTES", 2)
+    called = False
+
+    class _FakeTTSService:
+        async def create_fish_s2_reference(self, **kwargs):
+            nonlocal called
+            called = True
+            return {
+                "reference_id": "voice-1",
+                "voice_id": "voice-1",
+                "remote_reference_id": "fish-remote",
+                "reference_text": kwargs["reference_text"],
+                "cached": False,
+            }
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references",
+            data={"name": "Voice One", "reference_text": "uploaded text"},
+            files={"file": ("voice.wav", b"ABC", "audio/wav")},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["message"] == "Fish S2 reference audio is too large"
+    assert called is False
 
 
 def test_list_fish_s2_references(client):

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_voice_routes_rate_limit.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_voice_routes_rate_limit.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.api.v1.endpoints.audio import audio
 from tldw_Server_API.app.api.v1.endpoints.audio import audio_voices
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 
@@ -72,3 +73,11 @@ def test_voice_routes_use_granular_endpoint_ids_and_voice_counter():
         scope_dep = _extract_token_scope_dependency(route)
         assert getattr(scope_dep, "_tldw_endpoint_id", None) == endpoint_id
         assert getattr(scope_dep, "_tldw_count_as", None) == "voice_call"
+
+
+def test_audio_aggregate_mounts_presets_and_voice_conversion_routes():
+    app = FastAPI()
+    app.include_router(audio.router, prefix="/api/v1/audio")
+
+    assert _find_route(app, "GET", "/api/v1/audio/presets")
+    assert _find_route(app, "POST", "/api/v1/audio/voice-conversion")

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_voice_routes_rate_limit.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_voice_routes_rate_limit.py
@@ -3,7 +3,6 @@ from fastapi import FastAPI, HTTPException
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
-from tldw_Server_API.app.api.v1.endpoints.audio.audio import router as audio_router
 from tldw_Server_API.app.api.v1.endpoints.audio import audio_voices
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 
@@ -16,7 +15,7 @@ def client(monkeypatch):
     monkeypatch.setenv("SINGLE_USER_FIXED_ID", "1")
     reset_settings()
     app = FastAPI()
-    app.include_router(audio_router, prefix="/api/v1/audio")
+    app.include_router(audio_voices.router, prefix="/api/v1/audio")
 
     async def _deny_rate_limit():
         raise HTTPException(status_code=429, detail="rate limited in test")
@@ -54,7 +53,7 @@ def _extract_token_scope_dependency(route: APIRoute):
 
 def test_voice_routes_use_granular_endpoint_ids_and_voice_counter():
     app = FastAPI()
-    app.include_router(audio_router, prefix="/api/v1/audio")
+    app.include_router(audio_voices.router, prefix="/api/v1/audio")
 
     expectations = [
         ("POST", "/api/v1/audio/voices/upload", "audio.voices.upload"),
@@ -63,6 +62,9 @@ def test_voice_routes_use_granular_endpoint_ids_and_voice_counter():
         ("GET", "/api/v1/audio/voices/{voice_id}", "audio.voices.get"),
         ("DELETE", "/api/v1/audio/voices/{voice_id}", "audio.voices.delete"),
         ("POST", "/api/v1/audio/voices/{voice_id}/preview", "audio.voices.preview"),
+        ("POST", "/api/v1/audio/providers/fish_s2/references", "audio.voices.upload"),
+        ("GET", "/api/v1/audio/providers/fish_s2/references", "audio.voices.list"),
+        ("DELETE", "/api/v1/audio/providers/fish_s2/references/{reference_id}", "audio.voices.delete"),
     ]
 
     for method, path, endpoint_id in expectations:

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator
 
 import pytest
 
-from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, ProviderStatus, TTSRequest
 from tldw_Server_API.app.core.TTS.tts_exceptions import TTSProviderInitializationError, TTSValidationError
 
 
@@ -109,6 +109,26 @@ async def test_adapter_rejects_unimplemented_local_runtime():
 
     with pytest.raises(TTSProviderInitializationError):
         await adapter.ensure_initialized()
+
+
+@pytest.mark.asyncio
+async def test_adapter_sets_error_status_when_initialization_raises(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    def _raise_backend(_config):
+        raise TTSProviderInitializationError("backend unavailable", provider="fish_s2")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        _raise_backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "native_http"})
+
+    with pytest.raises(TTSProviderInitializationError):
+        await adapter.ensure_initialized()
+
+    assert adapter.status == ProviderStatus.ERROR
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
@@ -151,3 +151,55 @@ async def test_adapter_returns_streaming_response(monkeypatch):
     assert response.audio_stream is not None
     chunks = [chunk async for chunk in response.audio_stream]
     assert chunks == [b"a", b"b", b"c"]
+
+
+@pytest.mark.asyncio
+async def test_adapter_add_and_delete_reference_delegate_to_backend(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    class _BackendWithRefs(_FakeBackend):
+        def __init__(self):
+            super().__init__()
+            self.add_calls = []
+            self.delete_calls = []
+
+        async def add_reference(self, *, reference_id, audio_b64, reference_text):
+            self.add_calls.append(
+                {
+                    "reference_id": reference_id,
+                    "audio_b64": audio_b64,
+                    "reference_text": reference_text,
+                }
+            )
+            return {"reference_id": reference_id}
+
+        async def delete_reference(self, *, reference_id):
+            self.delete_calls.append(reference_id)
+            return True
+
+    backend = _BackendWithRefs()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "native_http", "base_url": "http://fish.local"})
+    await adapter.ensure_initialized()
+
+    created = await adapter.add_reference(
+        reference_id="tldw_u1_voice-1",
+        audio_b64="QUJD",
+        reference_text="hello there",
+    )
+    deleted = await adapter.delete_reference(reference_id="tldw_u1_voice-1")
+
+    assert created == {"reference_id": "tldw_u1_voice-1"}
+    assert deleted is True
+    assert backend.add_calls == [
+        {
+            "reference_id": "tldw_u1_voice-1",
+            "audio_b64": "QUJD",
+            "reference_text": "hello there",
+        }
+    ]
+    assert backend.delete_calls == ["tldw_u1_voice-1"]

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
@@ -23,7 +23,7 @@ class _FakeBackend:
         text: str,
         response_format: str,
         streaming: bool,
-        reference_id: str | None,
+        reference_id: str | list[str] | None,
         extra_params: dict[str, object] | None,
     ) -> bytes | AsyncIterator[bytes]:
         self.calls.append(
@@ -44,6 +44,25 @@ class _FakeBackend:
         return self._response
 
 
+def test_build_backend_supports_commercial_api():
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import _build_backend
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api import FishS2CommercialApiBackend
+
+    backend = _build_backend(
+        {
+            "backend": "commercial_api",
+            "base_url": "https://api.fish.audio",
+            "api_key": "secret",
+            "model": "s2-pro",
+        }
+    )
+
+    assert isinstance(backend, FishS2CommercialApiBackend)
+    assert backend.base_url == "https://api.fish.audio"
+    assert backend.api_key == "secret"
+    assert backend.model == "s2-pro"
+
+
 @pytest.mark.asyncio
 async def test_adapter_initializes_native_http_backend(monkeypatch):
     from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
@@ -62,6 +81,24 @@ async def test_adapter_initializes_native_http_backend(monkeypatch):
     assert adapter.capabilities.supports_streaming is True
     assert adapter.capabilities.supports_voice_cloning is True
     assert adapter.capabilities.supports_multi_speaker is False
+
+
+@pytest.mark.asyncio
+async def test_adapter_capabilities_include_fish_audio_formats(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    backend = _FakeBackend()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "commercial_api", "api_key": "secret"})
+
+    assert await adapter.ensure_initialized() is True
+    assert adapter.capabilities is not None
+    assert AudioFormat.OPUS in adapter.capabilities.supported_formats
+    assert adapter.capabilities.default_format == AudioFormat.WAV
 
 
 @pytest.mark.asyncio
@@ -127,6 +164,57 @@ async def test_adapter_maps_request_and_merges_defaults(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_adapter_preserves_reference_lists_and_commercial_params(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    backend = _FakeBackend(response=b"fish-audio")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "commercial_api", "api_key": "secret"})
+    await adapter.ensure_initialized()
+
+    await adapter.generate(
+        TTSRequest(
+            text="hello",
+            format=AudioFormat.OPUS,
+            stream=False,
+            extra_params={
+                "reference_id": ["voice-a", "voice-b"],
+                "sample_rate": 44100,
+                "opus_bitrate": 32000,
+                "latency": "balanced",
+                "prosody": {"speed": 1.1},
+                "condition_on_previous_chunks": False,
+                "early_stop_threshold": 0.7,
+                "max_new_tokens": 1024,
+                "min_chunk_length": 80,
+                "ignored": "value",
+            },
+        )
+    )
+
+    assert backend.calls[-1] == {
+        "text": "hello",
+        "response_format": "opus",
+        "streaming": False,
+        "reference_id": ["voice-a", "voice-b"],
+        "extra_params": {
+            "sample_rate": 44100,
+            "opus_bitrate": 32000,
+            "latency": "balanced",
+            "prosody": {"speed": 1.1},
+            "condition_on_previous_chunks": False,
+            "early_stop_threshold": 0.7,
+            "max_new_tokens": 1024,
+            "min_chunk_length": 80,
+        },
+    }
+
+
+@pytest.mark.asyncio
 async def test_adapter_returns_streaming_response(monkeypatch):
     from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
 
@@ -163,12 +251,14 @@ async def test_adapter_add_and_delete_reference_delegate_to_backend(monkeypatch)
             self.add_calls = []
             self.delete_calls = []
 
-        async def add_reference(self, *, reference_id, audio_b64, reference_text):
+        async def add_reference(self, *, reference_id, audio_b64, reference_text, title=None, description=None):
             self.add_calls.append(
                 {
                     "reference_id": reference_id,
                     "audio_b64": audio_b64,
                     "reference_text": reference_text,
+                    "title": title,
+                    "description": description,
                 }
             )
             return {"reference_id": reference_id}
@@ -190,6 +280,8 @@ async def test_adapter_add_and_delete_reference_delegate_to_backend(monkeypatch)
         reference_id="tldw_u1_voice-1",
         audio_b64="QUJD",
         reference_text="hello there",
+        title="Voice One",
+        description="private clone",
     )
     deleted = await adapter.delete_reference(reference_id="tldw_u1_voice-1")
 
@@ -200,6 +292,8 @@ async def test_adapter_add_and_delete_reference_delegate_to_backend(monkeypatch)
             "reference_id": "tldw_u1_voice-1",
             "audio_b64": "QUJD",
             "reference_text": "hello there",
+            "title": "Voice One",
+            "description": "private clone",
         }
     ]
     assert backend.delete_calls == ["tldw_u1_voice-1"]

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSProviderInitializationError
+
+
+class _FakeBackend:
+    def __init__(self, *, response: bytes = b"audio", stream_chunks: list[bytes] | None = None) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._response = response
+        self._stream_chunks = stream_chunks or [b"chunk1", b"chunk2"]
+
+    async def health_check(self) -> bool:
+        return True
+
+    async def synthesize(
+        self,
+        *,
+        text: str,
+        response_format: str,
+        streaming: bool,
+        reference_id: str | None,
+        extra_params: dict[str, object] | None,
+    ) -> bytes | AsyncIterator[bytes]:
+        self.calls.append(
+            {
+                "text": text,
+                "response_format": response_format,
+                "streaming": streaming,
+                "reference_id": reference_id,
+                "extra_params": extra_params,
+            }
+        )
+        if streaming:
+            async def _gen() -> AsyncIterator[bytes]:
+                for chunk in self._stream_chunks:
+                    yield chunk
+
+            return _gen()
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_adapter_initializes_native_http_backend(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    backend = _FakeBackend()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "native_http", "base_url": "http://fish.local"})
+
+    assert await adapter.ensure_initialized() is True
+    assert adapter.capabilities is not None
+    assert adapter.capabilities.provider_name == "Fish Audio S2"
+    assert adapter.capabilities.supports_streaming is True
+    assert adapter.capabilities.supports_voice_cloning is True
+    assert adapter.capabilities.supports_multi_speaker is False
+
+
+@pytest.mark.asyncio
+async def test_adapter_rejects_unimplemented_local_runtime():
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    adapter = FishS2Adapter({"backend": "local_runtime"})
+
+    with pytest.raises(TTSProviderInitializationError):
+        await adapter.ensure_initialized()
+
+
+@pytest.mark.asyncio
+async def test_adapter_maps_request_and_merges_defaults(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    backend = _FakeBackend(response=b"fish-audio")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter(
+        {
+            "backend": "native_http",
+            "base_url": "http://fish.local",
+            "sample_rate": 24000,
+            "extra_params": {
+                "default_chunk_length": 180,
+                "default_normalize": False,
+            },
+        }
+    )
+    await adapter.ensure_initialized()
+
+    response = await adapter.generate(
+        TTSRequest(
+            text="hello",
+            voice="fishref:voice-from-voice",
+            format=AudioFormat.WAV,
+            stream=False,
+            extra_params={
+                "reference_id": "voice-explicit",
+                "seed": 7,
+            },
+        )
+    )
+
+    assert response.audio_content == b"fish-audio"
+    assert response.format == AudioFormat.WAV
+    assert response.sample_rate == 24000
+    assert backend.calls[-1] == {
+        "text": "hello",
+        "response_format": "wav",
+        "streaming": False,
+        "reference_id": "voice-explicit",
+        "extra_params": {
+            "chunk_length": 180,
+            "normalize": False,
+            "seed": 7,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_adapter_returns_streaming_response(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    backend = _FakeBackend(stream_chunks=[b"a", b"b", b"c"])
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "native_http", "base_url": "http://fish.local"})
+    await adapter.ensure_initialized()
+
+    response = await adapter.generate(
+        TTSRequest(
+            text="hello",
+            format=AudioFormat.WAV,
+            stream=True,
+            extra_params={"reference_id": "voice-123"},
+        )
+    )
+
+    assert response.audio_stream is not None
+    chunks = [chunk async for chunk in response.audio_stream]
+    assert chunks == [b"a", b"b", b"c"]

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator
 import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
-from tldw_Server_API.app.core.TTS.tts_exceptions import TTSProviderInitializationError
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSProviderInitializationError, TTSValidationError
 
 
 class _FakeBackend:
@@ -239,6 +239,59 @@ async def test_adapter_returns_streaming_response(monkeypatch):
     assert response.audio_stream is not None
     chunks = [chunk async for chunk in response.audio_stream]
     assert chunks == [b"a", b"b", b"c"]
+
+
+@pytest.mark.asyncio
+async def test_adapter_rejects_native_http_streaming_non_wav(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    backend = _FakeBackend()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "native_http", "base_url": "http://fish.local"})
+    await adapter.ensure_initialized()
+
+    with pytest.raises(TTSValidationError, match="native_http.*streaming.*wav"):
+        await adapter.generate(
+            TTSRequest(
+                text="hello",
+                format=AudioFormat.OPUS,
+                stream=True,
+                extra_params={"reference_id": "voice-123"},
+            )
+        )
+
+    assert backend.calls == []
+
+
+@pytest.mark.asyncio
+async def test_adapter_allows_commercial_api_streaming_opus(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    backend = _FakeBackend(stream_chunks=[b"opus"])
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "commercial_api", "api_key": "secret"})
+    await adapter.ensure_initialized()
+
+    response = await adapter.generate(
+        TTSRequest(
+            text="hello",
+            format=AudioFormat.OPUS,
+            stream=True,
+            extra_params={"reference_id": "voice-123"},
+        )
+    )
+
+    assert response.audio_stream is not None
+    assert [chunk async for chunk in response.audio_stream] == [b"opus"]
+    assert backend.calls[-1]["response_format"] == "opus"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_commercial_api_backend.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_commercial_api_backend.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.tts_exceptions import (
+    TTSAuthenticationError,
+    TTSNetworkError,
+    TTSProviderError,
+    TTSRateLimitError,
+    TTSTimeoutError,
+    TTSValidationError,
+)
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status_code: int = 200,
+        content: bytes = b"audio",
+        text: str = "ok",
+        json_data=None,
+        headers=None,
+    ):
+        self.status_code = status_code
+        self.content = content
+        self.text = text
+        self.headers = headers or {}
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.mark.asyncio
+async def test_commercial_backend_builds_tts_payload_with_model_header(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api import FishS2CommercialApiBackend
+
+    backend = FishS2CommercialApiBackend(
+        {
+            "base_url": "https://api.fish.audio",
+            "api_key": "secret",
+            "model": "s2-pro",
+            "timeout": 30,
+        }
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_fetch(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _FakeResponse()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api.afetch",
+        fake_fetch,
+    )
+
+    audio = await backend.synthesize(
+        text="hello",
+        response_format="mp3",
+        streaming=False,
+        reference_id="voice-model-id",
+        extra_params={
+            "sample_rate": 44100,
+            "mp3_bitrate": 128,
+            "latency": "balanced",
+            "prosody": {"speed": 1.2, "volume": 0},
+            "ignored": "value",
+        },
+    )
+
+    assert audio == b"audio"
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.fish.audio/v1/tts"
+    assert captured["headers"] == {
+        "Authorization": "Bearer secret",
+        "Content-Type": "application/json",
+        "model": "s2-pro",
+    }
+    assert captured["json"] == {
+        "text": "hello",
+        "format": "mp3",
+        "reference_id": "voice-model-id",
+        "sample_rate": 44100,
+        "mp3_bitrate": 128,
+        "latency": "balanced",
+        "prosody": {"speed": 1.2, "volume": 0},
+    }
+    assert captured["timeout"] == 30
+
+
+@pytest.mark.asyncio
+async def test_commercial_backend_uses_streaming_helper(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api import FishS2CommercialApiBackend
+
+    backend = FishS2CommercialApiBackend(
+        {
+            "base_url": "https://api.fish.audio",
+            "api_key": "secret",
+            "model": "s2-pro",
+        }
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_stream(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        yield b"chunk-1"
+        yield b"chunk-2"
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api.astream_bytes",
+        fake_stream,
+    )
+
+    stream = await backend.synthesize(
+        text="hello",
+        response_format="opus",
+        streaming=True,
+        reference_id=None,
+        extra_params={"opus_bitrate": 32000},
+    )
+    chunks = [chunk async for chunk in stream]
+
+    assert chunks == [b"chunk-1", b"chunk-2"]
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.fish.audio/v1/tts"
+    assert captured["json"] == {"text": "hello", "format": "opus", "opus_bitrate": 32000}
+    assert captured["headers"] == {
+        "Authorization": "Bearer secret",
+        "Content-Type": "application/json",
+        "model": "s2-pro",
+    }
+
+
+@pytest.mark.asyncio
+async def test_commercial_backend_creates_hosted_voice_model(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api import FishS2CommercialApiBackend
+
+    backend = FishS2CommercialApiBackend(
+        {
+            "base_url": "https://api.fish.audio",
+            "api_key": "secret",
+            "timeout": 45,
+        }
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_fetch(*, method, url, data=None, files=None, headers=None, timeout=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["data"] = data
+        captured["files"] = files
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _FakeResponse(status_code=201, json_data={"_id": "fish-hosted-model-id", "state": "trained"})
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api.afetch",
+        fake_fetch,
+    )
+
+    result = await backend.add_reference(
+        reference_id="tldw_u1_voice-1",
+        audio_b64="QUJD",
+        reference_text="hello there",
+        title="Voice One",
+        description="private clone",
+    )
+
+    assert result == {
+        "reference_id": "fish-hosted-model-id",
+        "remote_reference_id": "fish-hosted-model-id",
+        "state": "trained",
+    }
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.fish.audio/model"
+    assert captured["data"] == {
+        "type": "tts",
+        "title": "Voice One",
+        "description": "private clone",
+        "train_mode": "fast",
+        "visibility": "private",
+        "texts": "hello there",
+        "enhance_audio_quality": "true",
+        "generate_sample": "false",
+    }
+    assert captured["files"] == {
+        "voices": ("reference.wav", b"ABC", "audio/wav"),
+    }
+    assert captured["headers"] == {"Authorization": "Bearer secret"}
+    assert captured["timeout"] == 45
+
+
+@pytest.mark.asyncio
+async def test_commercial_backend_rejects_invalid_reference_audio():
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api import FishS2CommercialApiBackend
+
+    backend = FishS2CommercialApiBackend({"api_key": "secret"})
+
+    with pytest.raises(TTSValidationError) as exc:
+        await backend.add_reference(
+            reference_id="voice-1",
+            audio_b64="not base64",
+            reference_text="hello there",
+        )
+
+    assert "base64" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_commercial_backend_deletes_hosted_voice_model(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api import FishS2CommercialApiBackend
+
+    backend = FishS2CommercialApiBackend({"base_url": "https://api.fish.audio", "api_key": "secret"})
+    captured: dict[str, object] = {}
+
+    async def fake_fetch(*, method, url, headers=None, timeout=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _FakeResponse(status_code=204, content=b"")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api.afetch",
+        fake_fetch,
+    )
+
+    assert await backend.delete_reference(reference_id="fish-hosted-model-id") is True
+    assert captured == {
+        "method": "DELETE",
+        "url": "https://api.fish.audio/model/fish-hosted-model-id",
+        "headers": {"Authorization": "Bearer secret"},
+        "timeout": 60,
+    }
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_exception"),
+    [
+        (401, TTSAuthenticationError),
+        (402, TTSProviderError),
+        (429, TTSRateLimitError),
+        (422, TTSValidationError),
+        (500, TTSProviderError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_commercial_backend_maps_error_responses(monkeypatch, status_code, expected_exception):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api import FishS2CommercialApiBackend
+
+    backend = FishS2CommercialApiBackend({"base_url": "https://api.fish.audio", "api_key": "secret"})
+
+    async def fake_fetch(**_kwargs):
+        return _FakeResponse(
+            status_code=status_code,
+            text='{"message":"upstream failed"}',
+            headers={"retry-after": "12"},
+        )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api.afetch",
+        fake_fetch,
+    )
+
+    with pytest.raises(expected_exception):
+        await backend.synthesize(
+            text="hello",
+            response_format="mp3",
+            streaming=False,
+            reference_id=None,
+            extra_params=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_commercial_backend_maps_fetch_timeout(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api import FishS2CommercialApiBackend
+
+    backend = FishS2CommercialApiBackend({"base_url": "https://api.fish.audio", "api_key": "secret"})
+
+    async def fake_fetch(**_kwargs):
+        raise TimeoutError("request timed out")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api.afetch",
+        fake_fetch,
+    )
+
+    with pytest.raises(TTSTimeoutError):
+        await backend.synthesize(
+            text="hello",
+            response_format="mp3",
+            streaming=False,
+            reference_id=None,
+            extra_params=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_commercial_backend_maps_fetch_network_errors(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api import FishS2CommercialApiBackend
+
+    backend = FishS2CommercialApiBackend({"base_url": "https://api.fish.audio", "api_key": "secret"})
+
+    async def fake_fetch(**_kwargs):
+        raise OSError("connection failed")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_commercial_api.afetch",
+        fake_fetch,
+    )
+
+    with pytest.raises(TTSNetworkError):
+        await backend.synthesize(
+            text="hello",
+            response_format="mp3",
+            streaming=False,
+            reference_id=None,
+            extra_params=None,
+        )

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSAuthenticationError
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, content: bytes = b"audio", text: str = "ok"):
+        self.status_code = status_code
+        self.content = content
+        self.text = text
+
+
+@pytest.mark.asyncio
+async def test_backend_builds_tts_payload_from_request(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend(
+        {"base_url": "http://fish.local", "api_key": "secret", "timeout": 30}
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_fetch(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _FakeResponse()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.afetch",
+        fake_fetch,
+    )
+
+    audio = await backend.synthesize(
+        text="hello",
+        response_format="wav",
+        streaming=False,
+        reference_id="tldw_u1_vabc",
+        extra_params={"chunk_length": 200, "normalize": True},
+    )
+
+    assert audio == b"audio"
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://fish.local/v1/tts"
+    assert captured["json"] == {
+        "text": "hello",
+        "format": "wav",
+        "streaming": False,
+        "reference_id": "tldw_u1_vabc",
+        "chunk_length": 200,
+        "normalize": True,
+    }
+    assert captured["headers"] == {"Authorization": "Bearer secret"}
+    assert captured["timeout"] == 30
+
+
+@pytest.mark.asyncio
+async def test_backend_uses_streaming_helper_for_streaming_requests(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local"})
+
+    async def fake_stream(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+        yield b"chunk1"
+        yield b"chunk2"
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.astream_bytes",
+        fake_stream,
+    )
+
+    stream = await backend.synthesize(
+        text="hello",
+        response_format="wav",
+        streaming=True,
+        reference_id=None,
+        extra_params=None,
+    )
+
+    chunks = [chunk async for chunk in stream]
+    assert chunks == [b"chunk1", b"chunk2"]
+
+
+@pytest.mark.asyncio
+async def test_backend_maps_401_to_authentication_error(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local", "api_key": "secret"})
+
+    async def fake_fetch(**_kwargs):
+        return _FakeResponse(status_code=401, text="invalid token")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.afetch",
+        fake_fetch,
+    )
+
+    with pytest.raises(TTSAuthenticationError):
+        await backend.synthesize(
+            text="hello",
+            response_format="wav",
+            streaming=False,
+            reference_id=None,
+            extra_params=None,
+        )

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from tldw_Server_API.app.core.TTS.tts_exceptions import TTSAuthenticationError, TTSRateLimitError
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSAuthenticationError, TTSProviderError, TTSRateLimitError
 
 
 class _FakeResponse:
@@ -74,9 +74,15 @@ async def test_backend_builds_tts_payload_from_request(monkeypatch):
 async def test_backend_uses_streaming_helper_for_streaming_requests(monkeypatch):
     from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
 
-    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local"})
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local", "api_key": "secret", "timeout": 12})
+    captured: dict[str, object] = {}
 
     async def fake_stream(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
         yield b"chunk1"
         yield b"chunk2"
 
@@ -95,6 +101,15 @@ async def test_backend_uses_streaming_helper_for_streaming_requests(monkeypatch)
 
     chunks = [chunk async for chunk in stream]
     assert chunks == [b"chunk1", b"chunk2"]
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://fish.local/v1/tts"
+    assert captured["json"] == {
+        "text": "hello",
+        "format": "wav",
+        "streaming": True,
+    }
+    assert captured["headers"] == {"Authorization": "Bearer secret"}
+    assert captured["timeout"] == 12
 
 
 @pytest.mark.asyncio
@@ -174,6 +189,46 @@ def test_backend_response_json_logs_parse_failures(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_backend_error_log_omits_upstream_body(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends import fish_s2_native_http
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    class _LoggerStub:
+        def __init__(self):
+            self.error_calls = []
+
+        def error(self, *args, **kwargs):
+            self.error_calls.append((args, kwargs))
+
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(fish_s2_native_http, "logger", logger_stub)
+
+    async def fake_fetch(**_kwargs):
+        return _FakeResponse(status_code=500, text="token leaked /private/fish-body.txt")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.afetch",
+        fake_fetch,
+    )
+
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local"})
+
+    with pytest.raises(TTSProviderError):
+        await backend.synthesize(
+            text="hello",
+            response_format="wav",
+            streaming=False,
+            reference_id=None,
+            extra_params=None,
+        )
+
+    assert logger_stub.error_calls
+    rendered_calls = repr(logger_stub.error_calls)
+    assert "token leaked" not in rendered_calls
+    assert "/private/fish-body.txt" not in rendered_calls
+
+
+@pytest.mark.asyncio
 async def test_backend_add_reference_posts_expected_payload(monkeypatch):
     from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
 
@@ -221,14 +276,16 @@ async def test_backend_add_reference_posts_expected_payload(monkeypatch):
 async def test_backend_delete_reference_posts_expected_payload(monkeypatch):
     from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
 
-    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local"})
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local", "api_key": "secret", "timeout": 12})
 
     captured = {}
 
-    async def fake_fetch(*, method, url, json=None, **_kwargs):
+    async def fake_fetch(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
         captured["method"] = method
         captured["url"] = url
         captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
         return _FakeResponse(status_code=204)
 
     monkeypatch.setattr(
@@ -242,3 +299,5 @@ async def test_backend_delete_reference_posts_expected_payload(monkeypatch):
     assert captured["method"] == "DELETE"
     assert captured["url"] == "http://fish.local/v1/references/delete"
     assert captured["json"] == {"reference_id": "tldw_u1_voice-1"}
+    assert captured["headers"] == {"Authorization": "Bearer secret"}
+    assert captured["timeout"] == 12

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
@@ -121,10 +121,12 @@ async def test_backend_add_reference_posts_expected_payload(monkeypatch):
 
     captured = {}
 
-    async def fake_fetch(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+    async def fake_fetch(*, method, url, json=None, data=None, files=None, headers=None, timeout=None, **_kwargs):
         captured["method"] = method
         captured["url"] = url
         captured["json"] = json
+        captured["data"] = data
+        captured["files"] = files
         captured["headers"] = headers
         captured["timeout"] = timeout
         return _FakeResponse(json_data={"reference_id": "tldw_u1_voice-1"})
@@ -143,11 +145,16 @@ async def test_backend_add_reference_posts_expected_payload(monkeypatch):
     assert result == {"reference_id": "tldw_u1_voice-1"}
     assert captured["method"] == "POST"
     assert captured["url"] == "http://fish.local/v1/references/add"
-    assert captured["json"] == {
-        "reference_id": "tldw_u1_voice-1",
-        "audio_b64": "QUJD",
+    assert captured["json"] is None
+    assert captured["data"] == {
+        "id": "tldw_u1_voice-1",
         "text": "hello there",
     }
+    assert captured["files"] == {
+        "audio": ("reference.wav", b"ABC", "audio/wav"),
+    }
+    assert captured["headers"] == {"Authorization": "Bearer secret"}
+    assert captured["timeout"] == backend.timeout
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
@@ -2,15 +2,23 @@ from __future__ import annotations
 
 import pytest
 
-from tldw_Server_API.app.core.TTS.tts_exceptions import TTSAuthenticationError
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSAuthenticationError, TTSRateLimitError
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int = 200, content: bytes = b"audio", text: str = "ok", json_data=None):
+    def __init__(
+        self,
+        status_code: int = 200,
+        content: bytes = b"audio",
+        text: str = "ok",
+        json_data=None,
+        headers=None,
+    ):
         self.status_code = status_code
         self.content = content
         self.text = text
         self._json_data = json_data
+        self.headers = headers or {}
 
     def json(self):
         return self._json_data
@@ -111,6 +119,58 @@ async def test_backend_maps_401_to_authentication_error(monkeypatch):
             reference_id=None,
             extra_params=None,
         )
+
+
+@pytest.mark.asyncio
+async def test_backend_maps_non_integer_retry_after_to_rate_limit_error(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local", "api_key": "secret"})
+
+    async def fake_fetch(**_kwargs):
+        return _FakeResponse(
+            status_code=429,
+            text="rate limited",
+            headers={"retry-after": "Wed, 21 Oct 2015 07:28:00 GMT"},
+        )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.afetch",
+        fake_fetch,
+    )
+
+    with pytest.raises(TTSRateLimitError) as exc_info:
+        await backend.synthesize(
+            text="hello",
+            response_format="wav",
+            streaming=False,
+            reference_id=None,
+            extra_params=None,
+        )
+
+    assert exc_info.value.retry_after is None
+
+
+def test_backend_response_json_logs_parse_failures(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends import fish_s2_native_http
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    class _LoggerStub:
+        def __init__(self):
+            self.debug_calls = []
+
+        def debug(self, *args, **kwargs):
+            self.debug_calls.append((args, kwargs))
+
+    class _InvalidJsonResponse:
+        def json(self):
+            raise ValueError("not json")
+
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(fish_s2_native_http, "logger", logger_stub)
+
+    assert FishS2NativeHttpBackend._response_json(_InvalidJsonResponse()) is None
+    assert logger_stub.debug_calls
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
@@ -6,10 +6,14 @@ from tldw_Server_API.app.core.TTS.tts_exceptions import TTSAuthenticationError
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int = 200, content: bytes = b"audio", text: str = "ok"):
+    def __init__(self, status_code: int = 200, content: bytes = b"audio", text: str = "ok", json_data=None):
         self.status_code = status_code
         self.content = content
         self.text = text
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
 
 
 @pytest.mark.asyncio
@@ -107,3 +111,67 @@ async def test_backend_maps_401_to_authentication_error(monkeypatch):
             reference_id=None,
             extra_params=None,
         )
+
+
+@pytest.mark.asyncio
+async def test_backend_add_reference_posts_expected_payload(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local", "api_key": "secret"})
+
+    captured = {}
+
+    async def fake_fetch(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _FakeResponse(json_data={"reference_id": "tldw_u1_voice-1"})
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.afetch",
+        fake_fetch,
+    )
+
+    result = await backend.add_reference(
+        reference_id="tldw_u1_voice-1",
+        audio_b64="QUJD",
+        reference_text="hello there",
+    )
+
+    assert result == {"reference_id": "tldw_u1_voice-1"}
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://fish.local/v1/references/add"
+    assert captured["json"] == {
+        "reference_id": "tldw_u1_voice-1",
+        "audio_b64": "QUJD",
+        "text": "hello there",
+    }
+
+
+@pytest.mark.asyncio
+async def test_backend_delete_reference_posts_expected_payload(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local"})
+
+    captured = {}
+
+    async def fake_fetch(*, method, url, json=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeResponse(status_code=204)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.afetch",
+        fake_fetch,
+    )
+
+    deleted = await backend.delete_reference(reference_id="tldw_u1_voice-1")
+
+    assert deleted is True
+    assert captured["method"] == "DELETE"
+    assert captured["url"] == "http://fish.local/v1/references/delete"
+    assert captured["json"] == {"reference_id": "tldw_u1_voice-1"}

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_reference_imports.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_reference_imports.py
@@ -3,6 +3,7 @@ import pytest
 from tldw_Server_API.app.core.TTS.fish_s2_reference_imports import (
     FishS2ReferenceImportError,
     parse_fish_s2_reference_import,
+    parse_fish_s2_reference_import_result,
 )
 
 
@@ -32,6 +33,34 @@ def test_parse_json_references_array_import():
 
     assert [item.voice_id for item in items] == ["voice-1", "voice-2"]
     assert [item.reference_text for item in items] == ["one", "two"]
+
+
+def test_parse_json_result_collects_item_errors_without_dropping_valid_items():
+    result = parse_fish_s2_reference_import_result(
+        filename="voices.json",
+        content=(
+            b'{"references": ['
+            b'{"voice_id": "voice-1", "reference_text": "one"},'
+            b'{"reference_text": "missing voice"},'
+            b'{"voice_id": "voice-2", "audio_base64": "QUJD", "reference_text": "bad"}'
+            b"]}"
+        ),
+    )
+
+    assert [item.voice_id for item in result.items] == ["voice-1"]
+    assert [(error.index, error.message) for error in result.errors] == [
+        (1, "voice_id or audio_base64 is required for Fish S2 imports"),
+        (2, "Provide either voice_id or audio_base64, not both"),
+    ]
+
+
+def test_parse_json_result_rejects_too_many_items():
+    with pytest.raises(FishS2ReferenceImportError, match="at most 1"):
+        parse_fish_s2_reference_import_result(
+            filename="voices.json",
+            content=b'[{"voice_id": "voice-1"}, {"voice_id": "voice-2"}]',
+            max_items=1,
+        )
 
 
 def test_parse_json_embedded_audio_import():

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_reference_imports.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_reference_imports.py
@@ -1,0 +1,118 @@
+import pytest
+
+from tldw_Server_API.app.core.TTS.fish_s2_reference_imports import (
+    FishS2ReferenceImportError,
+    parse_fish_s2_reference_import,
+)
+
+
+def test_parse_json_single_existing_voice_import():
+    items = parse_fish_s2_reference_import(
+        filename="voice.json",
+        content=b'{"voice_id": "voice-1", "reference_text": "hello there", "force": true}',
+    )
+
+    assert len(items) == 1
+    item = items[0]
+    assert item.voice_id == "voice-1"
+    assert item.reference_text == "hello there"
+    assert item.force is True
+
+
+def test_parse_json_references_array_import():
+    items = parse_fish_s2_reference_import(
+        filename="voices.json",
+        content=(
+            b'{"references": ['
+            b'{"voice_id": "voice-1", "reference_text": "one"},'
+            b'{"voice_id": "voice-2", "text": "two"}'
+            b"]}"
+        ),
+    )
+
+    assert [item.voice_id for item in items] == ["voice-1", "voice-2"]
+    assert [item.reference_text for item in items] == ["one", "two"]
+
+
+def test_parse_json_embedded_audio_import():
+    items = parse_fish_s2_reference_import(
+        filename="voice.json",
+        content=(
+            b"{"
+            b'"audio_b64": "QUJD",'
+            b'"filename": "voice.wav",'
+            b'"name": "Voice One",'
+            b'"reference_text": "hello there"'
+            b"}"
+        ),
+    )
+
+    item = items[0]
+    assert item.audio_base64 == "QUJD"
+    assert item.filename == "voice.wav"
+    assert item.name == "Voice One"
+
+
+def test_parse_markdown_frontmatter_uses_body_as_reference_text():
+    items = parse_fish_s2_reference_import(
+        filename="voice.md",
+        content=(
+            b"---\n"
+            b"voice_id: voice-1\n"
+            b"name: Voice One\n"
+            b"description: Private clone\n"
+            b"---\n"
+            b"Hello from the transcript.\n"
+        ),
+    )
+
+    item = items[0]
+    assert item.voice_id == "voice-1"
+    assert item.name == "Voice One"
+    assert item.description == "Private clone"
+    assert item.reference_text == "Hello from the transcript."
+
+
+def test_parse_markdown_frontmatter_can_override_body_text():
+    items = parse_fish_s2_reference_import(
+        filename="voice.markdown",
+        content=(
+            b"---\n"
+            b"voice_id: voice-1\n"
+            b"reference_text: Frontmatter transcript\n"
+            b"---\n"
+            b"Body transcript.\n"
+        ),
+    )
+
+    assert items[0].reference_text == "Frontmatter transcript"
+
+
+@pytest.mark.parametrize("filename", ["voice.txt", "voice.yaml", "voice"])
+def test_parse_rejects_unsupported_extensions(filename):
+    with pytest.raises(FishS2ReferenceImportError, match="Unsupported Fish S2 import file type"):
+        parse_fish_s2_reference_import(filename=filename, content=b"{}")
+
+
+def test_parse_rejects_markdown_without_voice_or_audio():
+    with pytest.raises(FishS2ReferenceImportError, match="voice_id or audio_base64 is required"):
+        parse_fish_s2_reference_import(
+            filename="voice.md",
+            content=b"Transcript only is not enough.\n",
+        )
+
+
+def test_parse_rejects_item_with_voice_and_audio():
+    with pytest.raises(FishS2ReferenceImportError, match="Provide either voice_id or audio_base64"):
+        parse_fish_s2_reference_import(
+            filename="voice.json",
+            content=b'{"voice_id": "voice-1", "audio_base64": "QUJD", "reference_text": "text"}',
+        )
+
+
+def test_parse_rejects_embedded_audio_without_required_fields():
+    with pytest.raises(FishS2ReferenceImportError, match="filename, name, and reference_text"):
+        parse_fish_s2_reference_import(
+            filename="voice.json",
+            content=b'{"audio_base64": "QUJD"}',
+        )

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_registry.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_registry.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tldw_Server_API.app.core.TTS.adapter_registry import TTSAdapterFactory, TTSProvider
+from tldw_Server_API.app.core.TTS.adapters.base import ProviderStatus
 
 
 @pytest.mark.unit
@@ -11,3 +12,41 @@ def test_fish_s2_aliases_resolve_to_provider():
     assert factory.get_provider_for_model("fish-s2-pro") == TTSProvider.FISH_S2
     assert factory.get_provider_for_model("s2-pro") == TTSProvider.FISH_S2
     assert factory.get_provider_for_model("fishaudio/s2-pro") == TTSProvider.FISH_S2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fish_s2_direct_dict_env_key_initializes_commercial_backend(monkeypatch):
+    monkeypatch.setenv("FISH_AUDIO_API_KEY", "fish-secret")
+
+    class _MemoryMonitor:
+        def is_memory_critical(self):
+            return False
+
+    class _ResourceManager:
+        memory_monitor = _MemoryMonitor()
+
+    async def _resource_manager():
+        return _ResourceManager()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapter_registry.get_resource_manager",
+        _resource_manager,
+        raising=True,
+    )
+
+    factory = TTSAdapterFactory(
+        config={
+            "providers": {
+                "fish_s2": {
+                    "enabled": True,
+                    "backend": "commercial_api",
+                }
+            }
+        }
+    )
+
+    adapter = await factory.registry.get_adapter("fish_s2")
+
+    assert adapter is not None
+    assert adapter.status == ProviderStatus.AVAILABLE

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_registry.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_registry.py
@@ -1,0 +1,13 @@
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapter_registry import TTSAdapterFactory, TTSProvider
+
+
+@pytest.mark.unit
+def test_fish_s2_aliases_resolve_to_provider():
+    factory = TTSAdapterFactory(config={"providers": {"fish_s2": {"enabled": True}}})
+
+    assert factory.get_provider_for_model("fish_s2") == TTSProvider.FISH_S2
+    assert factory.get_provider_for_model("fish-s2-pro") == TTSProvider.FISH_S2
+    assert factory.get_provider_for_model("s2-pro") == TTSProvider.FISH_S2
+    assert factory.get_provider_for_model("fishaudio/s2-pro") == TTSProvider.FISH_S2

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_config_fish_s2.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_config_fish_s2.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.tts_config import TTSConfigManager
+
+
+@pytest.mark.unit
+def test_fish_audio_api_key_env_overrides_provider_config(tmp_path, monkeypatch):
+    yaml_path = tmp_path / "tts.yaml"
+    yaml_path.write_text(
+        """
+providers:
+  fish_s2:
+    enabled: true
+    backend: commercial_api
+    api_key: null
+""".strip(),
+        encoding="utf-8",
+    )
+    config_txt_path = tmp_path / "config.txt"
+    config_txt_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("FISH_AUDIO_API_KEY", "fish-audio-secret")
+    monkeypatch.delenv("FISH_API_KEY", raising=False)
+
+    manager = TTSConfigManager(yaml_path=yaml_path, config_txt_path=config_txt_path)
+
+    provider_config = manager.get_provider_config("fish_s2")
+    assert provider_config is not None
+    assert provider_config.backend == "commercial_api"
+    assert provider_config.api_key == "fish-audio-secret"
+
+
+@pytest.mark.unit
+def test_fish_api_key_env_alias_is_supported(tmp_path, monkeypatch):
+    yaml_path = tmp_path / "tts.yaml"
+    yaml_path.write_text(
+        """
+providers:
+  fish_s2:
+    enabled: true
+    backend: commercial_api
+    api_key: null
+""".strip(),
+        encoding="utf-8",
+    )
+    config_txt_path = tmp_path / "config.txt"
+    config_txt_path.write_text("", encoding="utf-8")
+
+    monkeypatch.delenv("FISH_AUDIO_API_KEY", raising=False)
+    monkeypatch.setenv("FISH_API_KEY", "fish-secret")
+
+    manager = TTSConfigManager(yaml_path=yaml_path, config_txt_path=config_txt_path)
+
+    provider_config = manager.get_provider_config("fish_s2")
+    assert provider_config is not None
+    assert provider_config.backend == "commercial_api"
+    assert provider_config.api_key == "fish-secret"

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
@@ -1064,6 +1064,62 @@ async def test_create_fish_s2_reference_returns_cached_mapping(tts_service, monk
 
 
 @pytest.mark.unit
+async def test_create_fish_s2_reference_force_clears_stale_mapping_when_recreate_fails(tts_service, monkeypatch):
+    saved = []
+    metadata = VoiceReferenceMetadata(
+        voice_id="voice-1",
+        reference_text="stored text",
+        provider_artifacts={
+            "fish_s2": {
+                "remote_reference_id": "old-fish-model",
+                "reference_text": "stored text",
+            }
+        },
+    )
+
+    class _FakeVoiceManager:
+        async def load_reference_metadata(self, user_id, voice_id):
+            return metadata
+
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            return b"audio-bytes"
+
+        async def save_reference_metadata(self, user_id, metadata_arg):
+            saved.append(dict(metadata_arg.provider_artifacts))
+
+    class _FakeAdapter:
+        def __init__(self):
+            self.deleted = []
+
+        async def delete_reference(self, *, reference_id):
+            self.deleted.append(reference_id)
+            return True
+
+        async def add_reference(self, **_kwargs):
+            raise TTSProviderError("Fish upstream unavailable", provider="fish_s2")
+
+    adapter = _FakeAdapter()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+    monkeypatch.setattr(tts_service, "_get_adapter", AsyncMock(return_value=adapter))
+
+    with pytest.raises(TTSProviderError):
+        await tts_service.create_fish_s2_reference(
+            user_id=1,
+            voice_id="voice-1",
+            force=True,
+        )
+
+    assert adapter.deleted == ["old-fish-model"]
+    assert saved
+    assert "fish_s2" not in saved[-1]
+    assert "fish_s2" not in metadata.provider_artifacts
+
+
+@pytest.mark.unit
 async def test_delete_fish_s2_reference_clears_remote_mapping(tts_service, monkeypatch):
     saved = {}
 

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
@@ -5,6 +5,7 @@ Tests the main service logic, adapter selection, and request processing
 with mocked dependencies.
 """
 
+import base64
 import pytest
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 import asyncio
@@ -805,6 +806,124 @@ async def test_custom_voice_stores_qwen3_prompt_metadata(tts_service, monkeypatc
     assert metadata is not None
     assert metadata.voice_clone_prompt_b64 == "PROMPTDATA"
     assert metadata.voice_clone_prompt_format == "qwen3_tts_prompt_v1"
+
+
+@pytest.mark.unit
+async def test_fish_custom_voice_reuses_remote_reference_metadata(tts_service, monkeypatch):
+    class _FakeVoiceManager:
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            return b"audio-bytes"
+
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+                provider_artifacts={
+                    "fish_s2": {
+                        "remote_reference_id": "tldw_u1_voice-1",
+                        "reference_text": "stored text",
+                    }
+                },
+            )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+
+    req = OpenAISpeechRequest(
+        model="fish_s2",
+        input="hello",
+        voice="custom:voice-1",
+        response_format="wav",
+        stream=False,
+    )
+    tts_request = tts_service._convert_request(req)
+
+    await tts_service._apply_custom_voice_reference(tts_request, user_id=1, provider_hint="fish_s2")
+    await tts_service._apply_fish_s2_reference_context(tts_request, user_id=1, provider_hint="fish_s2")
+
+    assert tts_request.extra_params.get("reference_id") == "tldw_u1_voice-1"
+    assert "references" not in tts_request.extra_params
+
+
+@pytest.mark.unit
+async def test_fish_custom_voice_falls_back_to_inline_reference(tts_service, monkeypatch):
+    class _FakeVoiceManager:
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            return b"audio-bytes"
+
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+                provider_artifacts={},
+            )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+
+    req = OpenAISpeechRequest(
+        model="fish_s2",
+        input="hello",
+        voice="custom:voice-1",
+        response_format="wav",
+        stream=False,
+    )
+    tts_request = tts_service._convert_request(req)
+
+    await tts_service._apply_custom_voice_reference(tts_request, user_id=1, provider_hint="fish_s2")
+    await tts_service._apply_fish_s2_reference_context(tts_request, user_id=1, provider_hint="fish_s2")
+
+    assert tts_request.extra_params.get("reference_id") is None
+    assert tts_request.extra_params.get("references") == [
+        {
+            "audio_b64": base64.b64encode(b"audio-bytes").decode("ascii"),
+            "text": "stored text",
+        }
+    ]
+
+
+@pytest.mark.unit
+async def test_fish_reference_id_resolves_local_voice_id(tts_service, monkeypatch):
+    class _FakeVoiceManager:
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            return b"audio-bytes"
+
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+                provider_artifacts={
+                    "fish_s2": {
+                        "remote_reference_id": "tldw_u1_voice-1",
+                    }
+                },
+            )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+
+    req = OpenAISpeechRequest(
+        model="fish_s2",
+        input="hello",
+        voice="alloy",
+        response_format="wav",
+        stream=False,
+        extra_params={"reference_id": "voice-1"},
+    )
+    tts_request = tts_service._convert_request(req)
+
+    await tts_service._apply_fish_s2_reference_context(tts_request, user_id=1, provider_hint="fish_s2")
+
+    assert tts_request.extra_params.get("reference_id") == "tldw_u1_voice-1"
 
 # ========================================================================
 # Caching Tests

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
@@ -925,6 +925,164 @@ async def test_fish_reference_id_resolves_local_voice_id(tts_service, monkeypatc
 
     assert tts_request.extra_params.get("reference_id") == "tldw_u1_voice-1"
 
+
+@pytest.mark.unit
+async def test_create_fish_s2_reference_persists_remote_mapping(tts_service, monkeypatch):
+    saved = {}
+
+    class _FakeVoiceManager:
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(voice_id=voice_id, reference_text="stored text")
+
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            return b"audio-bytes"
+
+        async def save_reference_metadata(self, user_id, metadata):
+            saved["metadata"] = metadata
+
+    class _FakeAdapter:
+        async def add_reference(self, *, reference_id, audio_b64, reference_text):
+            return {"reference_id": reference_id}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+    monkeypatch.setattr(tts_service, "_get_adapter", AsyncMock(return_value=_FakeAdapter()))
+
+    result = await tts_service.create_fish_s2_reference(
+        user_id=1,
+        voice_id="voice-1",
+        reference_text="stored text",
+    )
+
+    assert result["reference_id"] == "voice-1"
+    assert result["remote_reference_id"] == "tldw_u1_voice-1"
+    metadata = saved["metadata"]
+    assert metadata.provider_artifacts["fish_s2"]["remote_reference_id"] == "tldw_u1_voice-1"
+    assert metadata.provider_artifacts["fish_s2"]["reference_text"] == "stored text"
+
+
+@pytest.mark.unit
+async def test_create_fish_s2_reference_returns_cached_mapping(tts_service, monkeypatch):
+    class _FakeVoiceManager:
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+                provider_artifacts={
+                    "fish_s2": {
+                        "remote_reference_id": "tldw_u1_voice-1",
+                        "reference_text": "stored text",
+                    }
+                },
+            )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+    get_adapter = AsyncMock()
+    monkeypatch.setattr(tts_service, "_get_adapter", get_adapter)
+
+    result = await tts_service.create_fish_s2_reference(
+        user_id=1,
+        voice_id="voice-1",
+    )
+
+    assert result["cached"] is True
+    assert result["remote_reference_id"] == "tldw_u1_voice-1"
+    get_adapter.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_delete_fish_s2_reference_clears_remote_mapping(tts_service, monkeypatch):
+    saved = {}
+
+    class _FakeVoiceManager:
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+                provider_artifacts={
+                    "fish_s2": {
+                        "remote_reference_id": "tldw_u1_voice-1",
+                        "reference_text": "stored text",
+                    }
+                },
+            )
+
+        async def save_reference_metadata(self, user_id, metadata):
+            saved["metadata"] = metadata
+
+    class _FakeAdapter:
+        def __init__(self):
+            self.calls = []
+
+        async def delete_reference(self, *, reference_id):
+            self.calls.append(reference_id)
+            return True
+
+    adapter = _FakeAdapter()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+    monkeypatch.setattr(tts_service, "_get_adapter", AsyncMock(return_value=adapter))
+
+    result = await tts_service.delete_fish_s2_reference(user_id=1, reference_id="voice-1")
+
+    assert result["deleted"] is True
+    assert adapter.calls == ["tldw_u1_voice-1"]
+    assert saved["metadata"].provider_artifacts == {}
+
+
+@pytest.mark.unit
+async def test_list_fish_s2_references_reads_local_metadata(tts_service, monkeypatch):
+    class _Voice:
+        def __init__(self, voice_id, name):
+            self.voice_id = voice_id
+            self.name = name
+
+    class _FakeVoiceManager:
+        async def list_user_voices(self, user_id, refresh=False):
+            return [_Voice("voice-1", "Voice One"), _Voice("voice-2", "Voice Two")]
+
+        async def load_reference_metadata(self, user_id, voice_id):
+            if voice_id == "voice-1":
+                return VoiceReferenceMetadata(
+                    voice_id=voice_id,
+                    reference_text="stored text",
+                    provider_artifacts={
+                        "fish_s2": {
+                            "remote_reference_id": "tldw_u1_voice-1",
+                            "reference_text": "stored text",
+                        }
+                    },
+                )
+            return VoiceReferenceMetadata(voice_id=voice_id, reference_text="other text")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+
+    result = await tts_service.list_fish_s2_references(user_id=1)
+
+    assert result == [
+        {
+            "reference_id": "voice-1",
+            "voice_id": "voice-1",
+            "name": "Voice One",
+            "reference_text": "stored text",
+            "remote_reference_id": "tldw_u1_voice-1",
+        }
+    ]
+
 # ========================================================================
 # Caching Tests
 # ========================================================================

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
@@ -941,7 +941,7 @@ async def test_create_fish_s2_reference_persists_remote_mapping(tts_service, mon
             saved["metadata"] = metadata
 
     class _FakeAdapter:
-        async def add_reference(self, *, reference_id, audio_b64, reference_text):
+        async def add_reference(self, *, reference_id, audio_b64, reference_text, title=None, description=None):
             return {"reference_id": reference_id}
 
     monkeypatch.setattr(
@@ -961,6 +961,72 @@ async def test_create_fish_s2_reference_persists_remote_mapping(tts_service, mon
     assert result["remote_reference_id"] == "tldw_u1_voice-1"
     metadata = saved["metadata"]
     assert metadata.provider_artifacts["fish_s2"]["remote_reference_id"] == "tldw_u1_voice-1"
+    assert metadata.provider_artifacts["fish_s2"]["reference_text"] == "stored text"
+
+
+@pytest.mark.unit
+async def test_create_fish_s2_reference_uses_hosted_remote_id(tts_service, monkeypatch):
+    saved = {}
+
+    class _FakeVoiceManager:
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(voice_id=voice_id, reference_text="stored text")
+
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            return b"audio-bytes"
+
+        async def save_reference_metadata(self, user_id, metadata):
+            saved["metadata"] = metadata
+
+    class _FakeAdapter:
+        def __init__(self):
+            self.add_calls = []
+
+        async def add_reference(self, *, reference_id, audio_b64, reference_text, title=None, description=None):
+            self.add_calls.append(
+                {
+                    "reference_id": reference_id,
+                    "audio_b64": audio_b64,
+                    "reference_text": reference_text,
+                    "title": title,
+                    "description": description,
+                }
+            )
+            return {
+                "reference_id": "fish-hosted-model-id",
+                "remote_reference_id": "fish-hosted-model-id",
+            }
+
+    adapter = _FakeAdapter()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+    monkeypatch.setattr(tts_service, "_get_adapter", AsyncMock(return_value=adapter))
+
+    result = await tts_service.create_fish_s2_reference(
+        user_id=1,
+        voice_id="voice-1",
+        name="Voice One",
+        description="private clone",
+        reference_text="stored text",
+    )
+
+    assert result["reference_id"] == "voice-1"
+    assert result["remote_reference_id"] == "fish-hosted-model-id"
+    assert adapter.add_calls == [
+        {
+            "reference_id": "tldw_u1_voice-1",
+            "audio_b64": base64.b64encode(b"audio-bytes").decode("ascii"),
+            "reference_text": "stored text",
+            "title": "Voice One",
+            "description": "private clone",
+        }
+    ]
+    metadata = saved["metadata"]
+    assert metadata.provider_artifacts["fish_s2"]["remote_reference_id"] == "fish-hosted-model-id"
+    assert metadata.provider_artifacts["fish_s2"]["local_reference_id"] == "tldw_u1_voice-1"
     assert metadata.provider_artifacts["fish_s2"]["reference_text"] == "stored text"
 
 

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_fish_s2.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_fish_s2.py
@@ -2,7 +2,7 @@ import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
-from tldw_Server_API.app.core.TTS.tts_validation import validate_tts_request
+from tldw_Server_API.app.core.TTS.tts_validation import ProviderLimits, validate_tts_request
 
 
 @pytest.mark.unit
@@ -29,3 +29,14 @@ def test_fish_s2_rejects_unsupported_format():
 
     with pytest.raises(TTSValidationError):
         validate_tts_request(request, provider="fish_s2")
+
+
+@pytest.mark.unit
+def test_fish_s2_does_not_inherit_omnivoice_speed_limits():
+    fish_limits = ProviderLimits.get_limits("fish_s2")
+    omni_limits = ProviderLimits.get_limits("omnivoice")
+
+    assert "min_speed" not in fish_limits
+    assert "max_speed" not in fish_limits
+    assert omni_limits["min_speed"] == 0.25
+    assert omni_limits["max_speed"] == 4.0

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_fish_s2.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_fish_s2.py
@@ -6,16 +6,26 @@ from tldw_Server_API.app.core.TTS.tts_validation import validate_tts_request
 
 
 @pytest.mark.unit
-def test_fish_s2_streaming_requires_wav():
+def test_fish_s2_accepts_hosted_api_opus_format():
     request = TTSRequest(
         text="hello",
         provider="fish_s2",
-        format=AudioFormat.MP3,
+        format=AudioFormat.OPUS,
         stream=True,
         extra_params={"reference_id": "voice-123"},
     )
 
-    with pytest.raises(TTSValidationError) as exc:
-        validate_tts_request(request, provider="fish_s2")
+    validate_tts_request(request, provider="fish_s2")
 
-    assert "wav" in str(exc.value).lower()
+
+@pytest.mark.unit
+def test_fish_s2_rejects_unsupported_format():
+    request = TTSRequest(
+        text="hello",
+        provider="fish_s2",
+        format=AudioFormat.FLAC,
+        stream=False,
+    )
+
+    with pytest.raises(TTSValidationError):
+        validate_tts_request(request, provider="fish_s2")

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_fish_s2.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_fish_s2.py
@@ -1,0 +1,21 @@
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
+from tldw_Server_API.app.core.TTS.tts_validation import validate_tts_request
+
+
+@pytest.mark.unit
+def test_fish_s2_streaming_requires_wav():
+    request = TTSRequest(
+        text="hello",
+        provider="fish_s2",
+        format=AudioFormat.MP3,
+        stream=True,
+        extra_params={"reference_id": "voice-123"},
+    )
+
+    with pytest.raises(TTSValidationError) as exc:
+        validate_tts_request(request, provider="fish_s2")
+
+    assert "wav" in str(exc.value).lower()


### PR DESCRIPTION
## Summary

- add a canonical `fish_s2` TTS provider with registry/config wiring and a native HTTP backend for upstream Fish `s2-pro`
- add Fish-managed reference support across the service and new provider routes for add/list/delete
- document setup, align the reference upload client to the current upstream multipart contract, and fix the small `dev` rebase integration drift in `audio_voices.py`

## Test Plan

- [x] `source .venv/bin/activate && python -m pytest -q tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py -k "fish_" tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py`
- [x] `source .venv/bin/activate && python -m bandit -f json -o /tmp/bandit_fish_s2_rebased_dev_postfix.json tldw_Server_API/app/api/v1/endpoints/audio/audio.py tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py tldw_Server_API/app/core/TTS/backends/fish_s2_base.py tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py tldw_Server_API/app/core/TTS/tts_service_v2.py`
- [x] `git diff --check`

## Change Summary

Human maintainer: please replace this section with a human-written change summary before marking the PR ready for review, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Notes

- This branch is rebased onto the latest `origin/dev`.
- Live remote validation against a running Fish server is still pending and is tracked in #1339.