### PR TITLE
Fix Writing Playground annotation UAT polish

### DIFF
--- a/Docs/superpowers/plans/2026-06-29-pr2541-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2541-review-rebase.md
@@ -1,0 +1,35 @@
+# PR 2541 Review Rebase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebase PR #2541 onto latest `origin/dev`, address valid Writing Playground annotation review feedback, and push the verified PR branch.
+
+**Architecture:** Keep changes scoped to the Writing Playground annotation UAT surface and its tests. Verify every review comment against current code before editing, and avoid broad UI rewrites outside the reviewed annotation flow.
+
+**Tech Stack:** React/TypeScript, Vitest, Backlog.md, GitHub CLI.
+
+---
+
+## Stage 1: Rebase And Review Inventory
+**Goal**: Rebase the PR branch onto latest `origin/dev` and map all open review comments.
+**Success Criteria**: Branch is rebased or conflicts are resolved; each GitHub review thread/top-level comment is categorized.
+**Tests**: `git status`, `git rebase`, and GitHub review-thread query.
+**Status**: In Progress
+
+## Stage 2: Review Fixes
+**Goal**: Implement only technically valid fixes from PR comments.
+**Success Criteria**: Each actionable comment has a code/test change or a documented reason it is not applicable.
+**Tests**: Focused Vitest tests for the touched Writing Playground utilities/components.
+**Status**: Not Started
+
+## Stage 3: Verification
+**Goal**: Run focused frontend tests and required quality/security checks for touched scope.
+**Success Criteria**: Focused tests, formatting/lint/type checks where practical, and non-Python security-scope notes are recorded.
+**Tests**: Commands recorded in `TASK-12054`.
+**Status**: Not Started
+
+## Stage 4: Push And Resolve
+**Goal**: Commit, push to the PR head branch, resolve addressed threads, and report CI status.
+**Success Criteria**: PR branch is updated on GitHub; review threads are resolved or documented; final status is reported.
+**Tests**: `gh pr view`, `gh pr checks`, review-thread query.
+**Status**: Not Started

--- a/Docs/superpowers/plans/2026-06-29-pr2541-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2541-review-rebase.md
@@ -14,22 +14,22 @@
 **Goal**: Rebase the PR branch onto latest `origin/dev` and map all open review comments.
 **Success Criteria**: Branch is rebased or conflicts are resolved; each GitHub review thread/top-level comment is categorized.
 **Tests**: `git status`, `git rebase`, and GitHub review-thread query.
-**Status**: In Progress
+**Status**: Complete
 
 ## Stage 2: Review Fixes
 **Goal**: Implement only technically valid fixes from PR comments.
 **Success Criteria**: Each actionable comment has a code/test change or a documented reason it is not applicable.
 **Tests**: Focused Vitest tests for the touched Writing Playground utilities/components.
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 3: Verification
 **Goal**: Run focused frontend tests and required quality/security checks for touched scope.
 **Success Criteria**: Focused tests, formatting/lint/type checks where practical, and non-Python security-scope notes are recorded.
 **Tests**: Commands recorded in `TASK-12054`.
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 4: Push And Resolve
 **Goal**: Commit, push to the PR head branch, resolve addressed threads, and report CI status.
 **Success Criteria**: PR branch is updated on GitHub; review threads are resolved or documented; final status is reported.
 **Tests**: `gh pr view`, `gh pr checks`, review-thread query.
-**Status**: Not Started
+**Status**: In Progress

--- a/Docs/superpowers/plans/2026-06-29-pr2541-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2541-review-rebase.md
@@ -32,4 +32,4 @@
 **Goal**: Commit, push to the PR head branch, resolve addressed threads, and report CI status.
 **Success Criteria**: PR branch is updated on GitHub; review threads are resolved or documented; final status is reported.
 **Tests**: `gh pr view`, `gh pr checks`, review-thread query.
-**Status**: In Progress
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingTipTapEditor.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingTipTapEditor.tsx
@@ -76,6 +76,7 @@ export function WritingTipTapEditor({
     extensions,
     content: content || EMPTY_TIPTAP_DOCUMENT,
     editable,
+    immediatelyRender: false,
     onUpdate: handleUpdate,
     onSelectionUpdate: handleSelectionUpdate,
   })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx
@@ -107,14 +107,14 @@ describe("WritingTipTapEditor external sync", () => {
     })
 
     act(() => {
-      adapterRef.current?.setSelection({ start: 6, end: 10 })
+      adapterRef.current?.setSelection({ start: 7, end: 11 })
     })
 
     await waitFor(() => {
-      expect(adapterRef.current?.getSelectedText("Alpha\nBeta")).toBe("Beta")
+      expect(adapterRef.current?.getSelectedText("Alpha\n\nBeta")).toBe("Beta")
     })
     await waitFor(() => {
-      expect(selectionChanges.at(-1)).toEqual({ start: 6, end: 10 })
+      expect(selectionChanges.at(-1)).toEqual({ start: 7, end: 11 })
     })
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.ssr-options.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.ssr-options.test.tsx
@@ -1,0 +1,66 @@
+import type { JSONContent } from "@tiptap/react"
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { WritingTipTapEditor } from "../WritingTipTapEditor"
+
+const tiptapMock = vi.hoisted(() => {
+  const state = {
+    options: null as Record<string, unknown> | null,
+  }
+  const mockEditor = {
+    isDestroyed: false,
+    commands: {
+      focus: vi.fn(),
+      setContent: vi.fn(),
+      setTextSelection: vi.fn(),
+    },
+    getJSON: vi.fn(() => ({ type: "doc", content: [] })),
+    setEditable: vi.fn(),
+    state: {
+      selection: { from: 0, to: 0 },
+      doc: {
+        content: { size: 0 },
+        forEach: vi.fn(),
+      },
+    },
+    view: {
+      coordsAtPos: vi.fn(() => ({ top: 0, bottom: 0 })),
+      dom: {
+        getBoundingClientRect: vi.fn(() => ({ top: 0 })),
+      },
+    },
+  }
+
+  return {
+    state,
+    mockEditor,
+    useEditor: vi.fn((options: Record<string, unknown>) => {
+      state.options = options
+      return mockEditor
+    }),
+  }
+})
+
+vi.mock("@tiptap/react", () => ({
+  EditorContent: () => null,
+  useEditor: tiptapMock.useEditor,
+}))
+
+const DOC: JSONContent = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "SSR-safe editor" }],
+    },
+  ],
+}
+
+describe("WritingTipTapEditor SSR options", () => {
+  it("opts out of immediate TipTap rendering for Next WebUI hydration", () => {
+    render(<WritingTipTapEditor content={DOC} onContentChange={vi.fn()} />)
+
+    expect(tiptapMock.useEditor).toHaveBeenCalled()
+    expect(tiptapMock.state.options?.immediatelyRender).toBe(false)
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useActiveManuscriptScene.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/useActiveManuscriptScene.test.tsx
@@ -21,6 +21,7 @@ type NodeType = "part" | "chapter" | "scene" | null
 type HookProps = {
   activeNodeId: string | null
   activeNodeType: NodeType
+  editorMode?: "plain" | "tiptap"
   initialEditorText?: string
   initialTipTapContent?: JSONContent | null
 }
@@ -88,7 +89,8 @@ function renderActiveSceneHook(initialProps: HookProps) {
         editorText,
         setEditorText,
         tipTapContent,
-        setTipTapContent
+        setTipTapContent,
+        editorMode: props.editorMode
       })
 
       return {
@@ -132,7 +134,8 @@ describe("useActiveManuscriptScene", () => {
 
     const { result } = renderActiveSceneHook({
       activeNodeId: "scene-1",
-      activeNodeType: "scene"
+      activeNodeType: "scene",
+      editorMode: "plain"
     })
 
     await waitFor(() => {
@@ -268,6 +271,28 @@ describe("useActiveManuscriptScene", () => {
     })
 
     expect(result.current.binding.canCreateRangeAnnotation).toBe(false)
+  })
+
+  it("keeps range annotations enabled in plain mode when only stale rich content differs", async () => {
+    vi.mocked(getManuscriptScene).mockResolvedValue(makeScene())
+
+    const { result } = renderActiveSceneHook({
+      activeNodeId: "scene-1",
+      activeNodeType: "scene",
+      editorMode: "plain"
+    })
+
+    await waitFor(() => {
+      expect(result.current.binding.canCreateRangeAnnotation).toBe(true)
+    })
+
+    act(() => {
+      result.current.setTipTapContent(sceneContent("Stale rich editor state"))
+    })
+
+    expect(result.current.editorText).toBe("Saved scene text")
+    expect(result.current.binding.isSceneDirty).toBe(false)
+    expect(result.current.binding.canCreateRangeAnnotation).toBe(true)
   })
 
   it("preserves dirty editor content when a different active manuscript scene is selected", async () => {

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts
@@ -41,6 +41,91 @@ describe("writing editor adapter", () => {
     editor.destroy()
   })
 
+  it("sets TipTap selections using offsets after empty paragraphs", () => {
+    const editor = new Editor({
+      extensions: [StarterKit],
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Alpha" }]
+          },
+          {
+            type: "paragraph"
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Beta" }]
+          }
+        ]
+      }
+    })
+    const adapter = createTipTapEditorAdapter(editor)
+    const plainText = tipTapJsonToPlainText(editor.getJSON())
+    const start = plainText.indexOf("Beta")
+
+    expect(plainText).toBe("Alpha\n\n\n\nBeta")
+
+    adapter?.setSelection({ start, end: start + "Beta".length })
+
+    const { from, to } = editor.state.selection
+    expect(editor.state.doc.textBetween(from, to, "\n", "\n")).toBe("Beta")
+    expect(adapter?.getSelection()).toEqual({ start, end: start + "Beta".length })
+
+    editor.destroy()
+  })
+
+  it("sets TipTap selections using offsets inside nested list items", () => {
+    const editor = new Editor({
+      extensions: [StarterKit],
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "bulletList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "First item" }]
+                  }
+                ]
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Second item" }]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    })
+    const adapter = createTipTapEditorAdapter(editor)
+    const plainText = tipTapJsonToPlainText(editor.getJSON())
+    const start = plainText.indexOf("Second item")
+
+    expect(plainText).toBe("First item\n\nSecond item")
+
+    adapter?.setSelection({ start, end: start + "Second item".length })
+
+    const { from, to } = editor.state.selection
+    expect(editor.state.doc.textBetween(from, to, "\n", "\n")).toBe("Second item")
+    expect(adapter?.getSelection()).toEqual({
+      start,
+      end: start + "Second item".length
+    })
+
+    editor.destroy()
+  })
+
   it("maps TipTap selections against serialized scene breaks", () => {
     const editor = new Editor({
       extensions: [StarterKit, SceneBreakExtension],

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts
@@ -27,12 +27,16 @@ describe("writing editor adapter", () => {
       }
     })
     const adapter = createTipTapEditorAdapter(editor)
+    const plainText = tipTapJsonToPlainText(editor.getJSON())
+    const start = plainText.indexOf("Beta")
 
-    adapter?.setSelection({ start: 6, end: 10 })
+    expect(plainText).toBe("Alpha\n\nBeta")
+
+    adapter?.setSelection({ start, end: start + "Beta".length })
 
     const { from, to } = editor.state.selection
     expect(editor.state.doc.textBetween(from, to, "\n", "\n")).toBe("Beta")
-    expect(adapter?.getSelection()).toEqual({ start: 6, end: 10 })
+    expect(adapter?.getSelection()).toEqual({ start, end: start + "Beta".length })
 
     editor.destroy()
   })
@@ -59,7 +63,7 @@ describe("writing editor adapter", () => {
     const plainText = tipTapJsonToPlainText(editor.getJSON())
     const start = plainText.indexOf("Beta")
 
-    expect(plainText).toBe("Alpha\n\n***\nBeta")
+    expect(plainText).toBe("Alpha\n\n***\n\nBeta")
 
     adapter?.setSelection({ start, end: start + "Beta".length })
 
@@ -88,8 +92,12 @@ describe("writing editor adapter", () => {
       }
     })
     const adapter = createTipTapEditorAdapter(editor)
+    const plainText = tipTapJsonToPlainText(editor.getJSON())
+    const start = plainText.indexOf("Beta")
 
-    adapter?.setSelection({ start: 6, end: 10 })
+    expect(plainText).toBe("Alpha\n\nBeta")
+
+    adapter?.setSelection({ start, end: start + "Beta".length })
     const { from } = editor.state.selection
     const coordsAtPos = vi
       .spyOn(editor.view, "coordsAtPos")
@@ -107,7 +115,7 @@ describe("writing editor adapter", () => {
       }))
 
     expect(adapter?.measureRange).toBeTypeOf("function")
-    expect(adapter?.measureRange?.({ start: 6, end: 10 })).toEqual({
+    expect(adapter?.measureRange?.({ start, end: start + "Beta".length })).toEqual({
       top: 24,
       bottom: 82,
       height: 58

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts
@@ -45,6 +45,108 @@ describe("writing tiptap utils", () => {
     ).toBe("First paragraph.\n\nSecond paragraph.")
   })
 
+  it("preserves empty rich paragraphs as distinct blank-line blocks", () => {
+    expect(
+      tipTapJsonToPlainText({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "First paragraph." }]
+          },
+          {
+            type: "paragraph"
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Second paragraph." }]
+          }
+        ]
+      })
+    ).toBe("First paragraph.\n\n\n\nSecond paragraph.")
+  })
+
+  it("serializes nested list items with block delimiters", () => {
+    expect(
+      tipTapJsonToPlainText({
+        type: "doc",
+        content: [
+          {
+            type: "bulletList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "First item" }]
+                  }
+                ]
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Second item" }]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      })
+    ).toBe("First item\n\nSecond item")
+  })
+
+  it("serializes nested blockquote paragraphs with block delimiters", () => {
+    expect(
+      tipTapJsonToPlainText({
+        type: "doc",
+        content: [
+          {
+            type: "blockquote",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "First quote" }]
+              },
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Second quote" }]
+              }
+            ]
+          }
+        ]
+      })
+    ).toBe("First quote\n\nSecond quote")
+  })
+
+  it("round-trips single newlines as hard breaks inside a paragraph", () => {
+    const json = plainTextToTipTapJson("First line\nSecond line")
+
+    expect(json).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "First line" },
+            { type: "hardBreak" },
+            { type: "text", text: "Second line" }
+          ]
+        }
+      ]
+    })
+    expect(tipTapJsonToPlainText(json)).toBe("First line\nSecond line")
+  })
+
+  it("round-trips empty paragraphs without collapsing them", () => {
+    const text = "First paragraph.\n\n\n\nSecond paragraph."
+
+    expect(tipTapJsonToPlainText(plainTextToTipTapJson(text))).toBe(text)
+  })
+
   it("serializes scene breaks as standalone manuscript blocks", () => {
     expect(
       tipTapJsonToPlainText({
@@ -62,5 +164,11 @@ describe("writing tiptap utils", () => {
         ]
       })
     ).toBe("Before\n\n***\n\nAfter")
+  })
+
+  it("round-trips scene breaks as standalone manuscript blocks", () => {
+    const text = "Before\n\n***\n\nAfter"
+
+    expect(tipTapJsonToPlainText(plainTextToTipTapJson(text))).toBe(text)
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts
@@ -2,7 +2,8 @@ import type { JSONContent } from "@tiptap/react"
 import { describe, expect, it } from "vitest"
 import {
   plainTextToTipTapJson,
-  resolveTipTapDocument
+  resolveTipTapDocument,
+  tipTapJsonToPlainText
 } from "../writing-tiptap-utils"
 
 const RICH_DOC: JSONContent = {
@@ -24,5 +25,42 @@ describe("writing tiptap utils", () => {
     expect(resolveTipTapDocument("plain fallback", null)).toEqual(
       plainTextToTipTapJson("plain fallback")
     )
+  })
+
+  it("serializes adjacent rich paragraphs with blank-line paragraph delimiters", () => {
+    expect(
+      tipTapJsonToPlainText({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "First paragraph." }]
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Second paragraph." }]
+          }
+        ]
+      })
+    ).toBe("First paragraph.\n\nSecond paragraph.")
+  })
+
+  it("serializes scene breaks as standalone manuscript blocks", () => {
+    expect(
+      tipTapJsonToPlainText({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Before" }]
+          },
+          { type: "sceneBreak" },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "After" }]
+          }
+        ]
+      })
+    ).toBe("Before\n\n***\n\nAfter")
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/hooks/useActiveManuscriptScene.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/hooks/useActiveManuscriptScene.ts
@@ -10,6 +10,7 @@ import {
 import { resolveTipTapDocument } from "../writing-tiptap-utils"
 
 type ManuscriptNodeType = "part" | "chapter" | "scene" | null
+type ManuscriptEditorMode = "plain" | "tiptap"
 
 export type ActiveManuscriptSceneBinding = {
   scene: ManuscriptSceneResponse | null
@@ -30,6 +31,7 @@ type UseActiveManuscriptSceneDeps = {
   setEditorText: (nextText: string) => void
   tipTapContent: JSONContent | null
   setTipTapContent: (nextContent: JSONContent | null) => void
+  editorMode?: ManuscriptEditorMode
   isOnline?: boolean
 }
 
@@ -74,9 +76,11 @@ const getCurrentContentSignature = (
 const resolveSaveContent = (
   binding: SceneBindingState,
   editorText: string,
-  tipTapContent: JSONContent | null
+  tipTapContent: JSONContent | null,
+  trackRichContent: boolean
 ): JSONContent => {
   if (
+    trackRichContent &&
     tipTapContent &&
     serializeTipTapContent(tipTapContent) !== binding.savedContentSignature
   ) {
@@ -88,9 +92,11 @@ const resolveSaveContent = (
 const isBindingDirty = (
   binding: SceneBindingState | null,
   editorText: string,
-  tipTapContent: JSONContent | null
+  tipTapContent: JSONContent | null,
+  trackRichContent: boolean
 ): boolean => {
   if (!binding) return false
+  if (!trackRichContent) return editorText !== binding.savedPlainText
   return (
     editorText !== binding.savedPlainText ||
     getCurrentContentSignature(binding, tipTapContent) !==
@@ -105,6 +111,7 @@ export function useActiveManuscriptScene({
   setEditorText,
   tipTapContent,
   setTipTapContent,
+  editorMode = "tiptap",
   isOnline = true
 }: UseActiveManuscriptSceneDeps): ActiveManuscriptSceneBinding {
   const queryClient = useQueryClient()
@@ -123,15 +130,18 @@ export function useActiveManuscriptScene({
     activeNodeType === "scene" &&
     Boolean(activeNodeId) &&
     binding?.scene.id === activeNodeId
+  const trackRichContent = editorMode === "tiptap"
   const isSceneDirty = bindingMatchesActiveScene
-    ? isBindingDirty(binding, editorText, tipTapContent)
+    ? isBindingDirty(binding, editorText, tipTapContent, trackRichContent)
     : false
 
   React.useEffect(() => {
     if (activeNodeType === "scene" || !binding) return
-    if (isBindingDirty(binding, editorText, tipTapContent)) return
+    if (isBindingDirty(binding, editorText, tipTapContent, trackRichContent)) {
+      return
+    }
     setBinding(null)
-  }, [activeNodeType, binding, editorText, tipTapContent])
+  }, [activeNodeType, binding, editorText, tipTapContent, trackRichContent])
 
   React.useEffect(() => {
     const scene = sceneQuery.data ?? null
@@ -172,7 +182,12 @@ export function useActiveManuscriptScene({
       return null
     }
 
-    const content = resolveSaveContent(binding, editorText, tipTapContent)
+    const content = resolveSaveContent(
+      binding,
+      editorText,
+      tipTapContent,
+      trackRichContent
+    )
     const savedScene = (await updateManuscriptScene(
       binding.scene.id,
       {
@@ -202,7 +217,8 @@ export function useActiveManuscriptScene({
     queryClient,
     setEditorText,
     setTipTapContent,
-    tipTapContent
+    tipTapContent,
+    trackRichContent
   ])
 
   const reloadScene = React.useCallback(() => {

--- a/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
@@ -481,6 +481,7 @@ export const WritingPlayground = () => {
     setEditorText,
     tipTapContent,
     setTipTapContent,
+    editorMode,
     isOnline
   })
   const {

--- a/apps/packages/ui/src/components/Option/WritingPlayground/writing-editor-adapter.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/writing-editor-adapter.ts
@@ -46,7 +46,7 @@ const normalizeUnboundedSelection = (
   return start <= end ? { start, end } : { start: end, end: start }
 }
 
-const TIPTAP_SCENE_BREAK_TEXT = "\n***\n"
+const TIPTAP_SCENE_BREAK_TEXT = "***"
 
 type TipTapNode = Editor["state"]["doc"]
 
@@ -104,6 +104,20 @@ const pushTipTapMappingPoint = (
   points.push({ position, offset })
 }
 
+const isEmptyTipTapTextBlock = (node: TipTapNode): boolean =>
+  (node.type.name === "paragraph" || node.type.name === "heading") &&
+  node.content.size === 0
+
+const getTipTapBlockSeparatorLength = (
+  previousNode: TipTapNode | null,
+  nextNode: TipTapNode,
+): number => {
+  if (!previousNode) return 0
+  return isEmptyTipTapTextBlock(previousNode) || isEmptyTipTapTextBlock(nextNode)
+    ? 1
+    : 2
+}
+
 const appendTipTapNodeMappings = (
   node: TipTapNode,
   position: number,
@@ -148,11 +162,6 @@ const appendTipTapNodeMappings = (
   })
 
   pushTipTapMappingPoint(points, position + node.nodeSize - 1, nextOffset)
-
-  if (node.type.name === "paragraph" || node.type.name === "heading") {
-    nextOffset += 1
-  }
-
   pushTipTapMappingPoint(points, position + node.nodeSize, nextOffset)
   return nextOffset
 }
@@ -162,9 +171,16 @@ const getTipTapPositionOffsetPoints = (
 ): TipTapPositionOffsetPoint[] => {
   const points: TipTapPositionOffsetPoint[] = [{ position: 0, offset: 0 }]
   let offset = 0
+  let previousNode: TipTapNode | null = null
 
   editor.state.doc.forEach((childNode, childOffset) => {
+    const separatorLength = getTipTapBlockSeparatorLength(previousNode, childNode)
+    for (let index = 1; index <= separatorLength; index += 1) {
+      pushTipTapMappingPoint(points, childOffset, offset + index)
+    }
+    offset += separatorLength
     offset = appendTipTapNodeMappings(childNode, childOffset, offset, points)
+    previousNode = childNode
   })
 
   return points.sort((a, b) => a.position - b.position || a.offset - b.offset)

--- a/apps/packages/ui/src/components/Option/WritingPlayground/writing-editor-adapter.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/writing-editor-adapter.ts
@@ -104,19 +104,18 @@ const pushTipTapMappingPoint = (
   points.push({ position, offset })
 }
 
-const isEmptyTipTapTextBlock = (node: TipTapNode): boolean =>
-  (node.type.name === "paragraph" || node.type.name === "heading") &&
-  node.content.size === 0
+const TIPTAP_BLOCK_CONTAINER_TYPES = new Set([
+  "bulletList",
+  "orderedList",
+  "listItem",
+  "blockquote"
+])
 
-const getTipTapBlockSeparatorLength = (
-  previousNode: TipTapNode | null,
-  nextNode: TipTapNode,
-): number => {
-  if (!previousNode) return 0
-  return isEmptyTipTapTextBlock(previousNode) || isEmptyTipTapTextBlock(nextNode)
-    ? 1
-    : 2
-}
+const usesTipTapBlockChildSeparators = (node: TipTapNode): boolean =>
+  TIPTAP_BLOCK_CONTAINER_TYPES.has(node.type.name)
+
+const getTipTapBlockSeparatorLength = (previousNode: TipTapNode | null): number =>
+  previousNode ? 2 : 0
 
 const appendTipTapNodeMappings = (
   node: TipTapNode,
@@ -152,13 +151,24 @@ const appendTipTapNodeMappings = (
   }
 
   let nextOffset = offset
+  let previousChildNode: TipTapNode | null = null
+  const shouldSeparateChildren = usesTipTapBlockChildSeparators(node)
   node.forEach((childNode, childOffset) => {
+    if (shouldSeparateChildren) {
+      const separatorLength = getTipTapBlockSeparatorLength(previousChildNode)
+      const childPosition = position + 1 + childOffset
+      for (let index = 1; index <= separatorLength; index += 1) {
+        pushTipTapMappingPoint(points, childPosition, nextOffset + index)
+      }
+      nextOffset += separatorLength
+    }
     nextOffset = appendTipTapNodeMappings(
       childNode,
       position + 1 + childOffset,
       nextOffset,
       points,
     )
+    previousChildNode = childNode
   })
 
   pushTipTapMappingPoint(points, position + node.nodeSize - 1, nextOffset)
@@ -174,7 +184,7 @@ const getTipTapPositionOffsetPoints = (
   let previousNode: TipTapNode | null = null
 
   editor.state.doc.forEach((childNode, childOffset) => {
-    const separatorLength = getTipTapBlockSeparatorLength(previousNode, childNode)
+    const separatorLength = getTipTapBlockSeparatorLength(previousNode)
     for (let index = 1; index <= separatorLength; index += 1) {
       pushTipTapMappingPoint(points, childOffset, offset + index)
     }

--- a/apps/packages/ui/src/components/Option/WritingPlayground/writing-tiptap-utils.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/writing-tiptap-utils.ts
@@ -1,47 +1,57 @@
 import type { JSONContent } from "@tiptap/react"
 
 const joinTipTapDocumentBlocks = (blocks: string[]): string => {
-  let output = ""
-  blocks.forEach((block, index) => {
-    if (index > 0) {
-      const previousBlock = blocks[index - 1]
-      output += previousBlock === "" || block === "" ? "\n" : "\n\n"
-    }
-    output += block
-  })
-  return output.replace(/\n+$/, "")
+  return blocks.join("\n\n").replace(/\n+$/, "")
 }
+
+const TIPTAP_BLOCK_CONTAINER_TYPES = new Set([
+  "doc",
+  "bulletList",
+  "orderedList",
+  "listItem",
+  "blockquote"
+])
 
 /** Extract plain text from TipTap JSON document */
 export function tipTapJsonToPlainText(json: JSONContent | null | undefined): string {
   if (!json) return ""
   if (json.type === "text") return json.text || ""
-  const childText = json.content?.map(tipTapJsonToPlainText).join("") || ""
-  if (json.type === "doc") {
-    return joinTipTapDocumentBlocks(json.content?.map(tipTapJsonToPlainText) || [])
+  if (json.type === "hardBreak") return "\n"
+
+  const childBlocks = json.content?.map(tipTapJsonToPlainText) || []
+  const childText = childBlocks.join("")
+  if (TIPTAP_BLOCK_CONTAINER_TYPES.has(json.type || "")) {
+    return joinTipTapDocumentBlocks(childBlocks)
   }
   if (json.type === "paragraph") return childText
   if (json.type === "heading") return childText
   if (json.type === "sceneBreak") return "***"
-  if (json.type === "bulletList" || json.type === "orderedList") return childText
-  if (json.type === "listItem") return childText
-  if (json.type === "blockquote") return childText
-  if (json.type === "hardBreak") return "\n"
   return childText
+}
+
+const plainTextBlockToTipTapInlineContent = (block: string): JSONContent[] => {
+  const content: JSONContent[] = []
+
+  block.split("\n").forEach((part, index) => {
+    if (index > 0) content.push({ type: "hardBreak" })
+    if (part) content.push({ type: "text", text: part })
+  })
+
+  return content
 }
 
 /** Convert plain text to a minimal TipTap JSON document */
 export function plainTextToTipTapJson(text: string): JSONContent {
   if (!text) return { type: "doc", content: [{ type: "paragraph" }] }
   const trimmed = text.replace(/\n+$/, '')
-  const lines = trimmed ? trimmed.split('\n') : ['']
-  const content: JSONContent[] = lines.map((line) => {
-    if (line.trim() === "***") {
+  const blocks = trimmed ? trimmed.split("\n\n") : [""]
+  const content: JSONContent[] = blocks.map((block) => {
+    if (block.trim() === "***") {
       return { type: "sceneBreak" }
     }
     return {
       type: "paragraph",
-      content: line ? [{ type: "text", text: line }] : [],
+      content: plainTextBlockToTipTapInlineContent(block),
     }
   })
   return { type: "doc", content }

--- a/apps/packages/ui/src/components/Option/WritingPlayground/writing-tiptap-utils.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/writing-tiptap-utils.ts
@@ -1,18 +1,32 @@
 import type { JSONContent } from "@tiptap/react"
 
+const joinTipTapDocumentBlocks = (blocks: string[]): string => {
+  let output = ""
+  blocks.forEach((block, index) => {
+    if (index > 0) {
+      const previousBlock = blocks[index - 1]
+      output += previousBlock === "" || block === "" ? "\n" : "\n\n"
+    }
+    output += block
+  })
+  return output.replace(/\n+$/, "")
+}
+
 /** Extract plain text from TipTap JSON document */
 export function tipTapJsonToPlainText(json: JSONContent | null | undefined): string {
   if (!json) return ""
   if (json.type === "text") return json.text || ""
   const childText = json.content?.map(tipTapJsonToPlainText).join("") || ""
-  if (json.type === "paragraph") return childText + "\n"
-  if (json.type === "heading") return childText + "\n"
-  if (json.type === "sceneBreak") return "\n***\n"
+  if (json.type === "doc") {
+    return joinTipTapDocumentBlocks(json.content?.map(tipTapJsonToPlainText) || [])
+  }
+  if (json.type === "paragraph") return childText
+  if (json.type === "heading") return childText
+  if (json.type === "sceneBreak") return "***"
   if (json.type === "bulletList" || json.type === "orderedList") return childText
   if (json.type === "listItem") return childText
   if (json.type === "blockquote") return childText
   if (json.type === "hardBreak") return "\n"
-  if (json.type === "doc") return childText.replace(/\n+$/, '')
   return childText
 }
 

--- a/backlog/tasks/task-12019 - UAT-Writing-Playground-manuscript-annotations.md
+++ b/backlog/tasks/task-12019 - UAT-Writing-Playground-manuscript-annotations.md
@@ -23,7 +23,7 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Run a post-merge UAT and polish pass for the Writing Playground manuscript annotations workflow across WebUI and extension surfaces. Capture browser/rendered evidence for saved-scene binding, manual annotations, margin rail behavior, dirty-scene gating, selected-text/scene review affordances, and suggested-fix revision handoff; fix narrow defects found during the pass.
+Run a post-merge UAT and polish pass for the Writing Playground manuscript annotations workflow, using rendered WebUI evidence and explicitly recording the blocked extension harness status. Capture browser/rendered evidence for saved-scene binding, manual annotations, margin rail behavior, dirty-scene gating, selected-text/scene review affordances, and suggested-fix revision handoff; fix narrow defects found during the pass.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -48,7 +48,7 @@ Run a post-merge UAT and polish pass for the Writing Playground manuscript annot
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Completed Writing Playground manuscript annotations UAT/polish. Fixed Rich mode TipTap SSR crash, aligned TipTap paragraph serialization/selection offsets with manuscript blank-line delimiters, and made scene dirty checks respect Plain vs Rich editor authority. Added focused frontend coverage and captured rendered WebUI UAT screenshots for Rich margin rail and Plain inspector fallback. Residual unrelated issues documented: local /openapi.json 500, Ant Design Drawer width deprecation warning, and extension E2E harness service-worker/blank-launch blocker.
+Completed Writing Playground manuscript annotations WebUI UAT/polish and recorded the extension E2E harness as blocked in this environment. Fixed Rich mode TipTap SSR crash, aligned TipTap paragraph serialization/selection offsets with manuscript blank-line delimiters, and made scene dirty checks respect Plain vs Rich editor authority. Added focused frontend coverage and captured rendered WebUI UAT screenshots for Rich margin rail and Plain inspector fallback. Residual unrelated issues documented: local /openapi.json 500, Ant Design Drawer width deprecation warning, and extension E2E harness service-worker/blank-launch blocker.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12019 - UAT-Writing-Playground-manuscript-annotations.md
+++ b/backlog/tasks/task-12019 - UAT-Writing-Playground-manuscript-annotations.md
@@ -1,0 +1,62 @@
+---
+id: TASK-12019
+title: UAT Writing Playground manuscript annotations
+status: Done
+assignee: []
+created_date: '2026-06-26 06:53'
+updated_date: '2026-06-26 18:03'
+labels:
+  - uat
+  - webui
+  - extension
+  - writing-playground
+  - manuscripts
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-05-24-writing-playground-manuscript-annotations-design.md
+  - >-
+    Docs/superpowers/plans/2026-06-23-writing-playground-manuscript-annotations-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run a post-merge UAT and polish pass for the Writing Playground manuscript annotations workflow across WebUI and extension surfaces. Capture browser/rendered evidence for saved-scene binding, manual annotations, margin rail behavior, dirty-scene gating, selected-text/scene review affordances, and suggested-fix revision handoff; fix narrow defects found during the pass.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused annotation backend/frontend regression suites still pass on origin/dev baseline or documented known failures.
+- [x] #2 Rendered WebUI or extension UAT exercises the manuscript annotation flow with screenshots/console evidence.
+- [x] #3 Any found UAT defects are either fixed with focused coverage or recorded as follow-up work.
+- [x] #4 Final task notes include verification commands, browser evidence, residual risks, and dirty/unrelated file notes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-06-26 UAT/polish notes:
+- Found rendered WebUI crash in Rich mode: TipTap raised SSR hydration error before the annotation margin rail could render. Added WritingTipTapEditor SSR option coverage and set immediatelyRender: false.
+- Found Plain/Rich mode switch marking saved scenes dirty and disabling range comments. Root cause was TipTap plain-text serialization and adapter offsets using single-newline paragraph boundaries while manuscript content_plain uses blank-line paragraph delimiters. Updated serializer + TipTap offset mapping and added focused coverage.
+- Rendered Playwright UAT seeds a session/project/chapter/scene plus two annotations, verifies Rich margin rail cards are visible/non-overlapping, switches to Plain, opens the inspector, verifies the annotation list, and asserts no false Scene unsaved/save-before-range-comments state. Evidence: /tmp/writing-annotations-uat/writing-annotations-rich-rail.png and /tmp/writing-annotations-uat/writing-annotations-plain-inspector.png.
+- Residual environment noise during UAT: local API /openapi.json returns 500 independently of writing endpoints; Ant Design Drawer logs a width deprecation warning. Extension E2E harness was blocked earlier by service-worker/blank extension launch in this environment, so WebUI shared-component UAT was used for rendered evidence.
+- Verification: focused backend annotation suite passed earlier (75 passed); focused frontend annotation suite now passes (10 files, 68 tests); git diff --check passes; package tsc needed NODE_OPTIONS=--max-old-space-size=8192 and then failed on unrelated baseline type errors outside WritingPlayground. Bandit is not applicable because this pass changed frontend TypeScript/tests and Backlog metadata only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed Writing Playground manuscript annotations UAT/polish. Fixed Rich mode TipTap SSR crash, aligned TipTap paragraph serialization/selection offsets with manuscript blank-line delimiters, and made scene dirty checks respect Plain vs Rich editor authority. Added focused frontend coverage and captured rendered WebUI UAT screenshots for Rich margin rail and Plain inspector fallback. Residual unrelated issues documented: local /openapi.json 500, Ant Design Drawer width deprecation warning, and extension E2E harness service-worker/blank-launch blocker.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12054 - Rebase-PR-2541-and-address-Writing-annotation-review-feedback.md
+++ b/backlog/tasks/task-12054 - Rebase-PR-2541-and-address-Writing-annotation-review-feedback.md
@@ -38,7 +38,7 @@ Rebase PR #2541 onto latest origin/dev, evaluate all PR review comments, address
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Plan: `Docs/superpowers/plans/2026-06-29-pr2541-review-rebase.md`
-- Rebased PR #2541 onto `origin/dev` at `40d5a2f8db01bc31a4e012de546626389a137a10`.
+- Rebased PR #2541 onto `origin/dev` at `ccd07118855e153780011823155cef6cafa59030`.
 - Addressed actionable review threads:
   - Preserved empty TipTap paragraphs by joining serialized blocks with a consistent `\n\n` separator.
   - Simplified top-level block separator mapping now that every previous block contributes two plain-text separator characters.
@@ -47,13 +47,13 @@ Rebase PR #2541 onto latest origin/dev, evaluate all PR review comments, address
   - Narrowed the prior UAT task summary to WebUI evidence and explicit extension-harness blocked status.
 - Verification:
   - `./node_modules/.bin/vitest run src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts --maxWorkers=1 --no-file-parallelism` passed: 17 tests.
-  - `./node_modules/.bin/vitest run src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.ssr-options.test.tsx src/components/Option/WritingPlayground/__tests__/useActiveManuscriptScene.test.tsx src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts --maxWorkers=1 --no-file-parallelism` passed: 30 tests.
+  - `./node_modules/.bin/vitest run src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.ssr-options.test.tsx src/components/Option/WritingPlayground/__tests__/useActiveManuscriptScene.test.tsx src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts --maxWorkers=1 --no-file-parallelism` passed: 30 tests before and after the final rebase onto `ccd07118855e153780011823155cef6cafa59030`.
   - `git diff --check` passed.
   - `./node_modules/.bin/tsc --noEmit --pretty false` hit Node's default heap limit. Retried as `NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit --pretty false`; after temporarily correcting the local `antd` node_modules symlink for the check, it failed only on existing package-wide diagnostics outside the touched Writing Playground files.
   - Bandit skipped: touched implementation scope is TypeScript/Markdown, not Python.
-- Pushed `0d71a6b1d8b97a81836b5e03fec23721f2e68d14` to `codex/writing-annotations-uat-polish`.
-- Resolved all five actionable inline review threads and posted PR summary comment: https://github.com/rmusser01/tldw_server/pull/2541#issuecomment-4828919427
-- `gh pr view` confirmed PR #2541 remains open against `dev` with head `0d71a6b1d8b97a81836b5e03fec23721f2e68d14`.
+- Pushed the rebased branch to `codex/writing-annotations-uat-polish`.
+- Resolved all five actionable inline review threads and posted a PR summary comment: https://github.com/rmusser01/tldw_server/pull/2541#issuecomment-4828919427
+- `gh pr view` confirmed PR #2541 remains open against `dev`.
 - `gh pr checks` showed newly triggered GitHub checks still pending at handoff.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 

--- a/backlog/tasks/task-12054 - Rebase-PR-2541-and-address-Writing-annotation-review-feedback.md
+++ b/backlog/tasks/task-12054 - Rebase-PR-2541-and-address-Writing-annotation-review-feedback.md
@@ -10,13 +10,12 @@ priority: high
 references:
 - https://github.com/rmusser01/tldw_server/pull/2541
 modified_files:
-- apps/packages/ui/src/components/WritingPlayground/WritingTipTapEditor.tsx
-- apps/packages/ui/src/components/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx
-- apps/packages/ui/src/components/WritingPlayground/__tests__/WritingTipTapEditor.ssr-options.test.tsx
-- apps/packages/ui/src/components/WritingPlayground/hooks/useActiveManuscriptScene.ts
-- apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+- Docs/superpowers/plans/2026-06-29-pr2541-review-rebase.md
+- apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts
+- apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts
 - apps/packages/ui/src/components/Option/WritingPlayground/writing-editor-adapter.ts
 - apps/packages/ui/src/components/Option/WritingPlayground/writing-tiptap-utils.ts
+- backlog/tasks/task-12019 - UAT-Writing-Playground-manuscript-annotations.md
 ---
 
 ## Description
@@ -27,10 +26,10 @@ Rebase PR #2541 onto latest origin/dev, evaluate all PR review comments, address
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 PR branch is rebased onto the latest `origin/dev`.
-- [ ] #2 All PR review comments and review threads are evaluated and addressed or documented as non-actionable.
-- [ ] #3 Focused Writing Playground annotation tests pass after review fixes.
-- [ ] #4 Formatting/lint/type/security checks for the touched scope pass or are documented with rationale.
+- [x] #1 PR branch is rebased onto the latest `origin/dev`.
+- [x] #2 All PR review comments and review threads are evaluated and addressed or documented as non-actionable.
+- [x] #3 Focused Writing Playground annotation tests pass after review fixes.
+- [x] #4 Formatting/lint/type/security checks for the touched scope pass or are documented with rationale.
 - [ ] #5 Updated branch is pushed to PR #2541 and review threads are resolved where applicable.
 <!-- AC:END -->
 
@@ -38,6 +37,19 @@ Rebase PR #2541 onto latest origin/dev, evaluate all PR review comments, address
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Plan: `Docs/superpowers/plans/2026-06-29-pr2541-review-rebase.md`
+- Rebased PR #2541 onto `origin/dev` at `40d5a2f8db01bc31a4e012de546626389a137a10`.
+- Addressed actionable review threads:
+  - Preserved empty TipTap paragraphs by joining serialized blocks with a consistent `\n\n` separator.
+  - Simplified top-level block separator mapping now that every previous block contributes two plain-text separator characters.
+  - Added nested block-container serialization and selection-offset mapping for lists, list items, and blockquotes.
+  - Converted single plain-text newlines to TipTap `hardBreak` nodes while retaining `\n\n` paragraph boundaries.
+  - Narrowed the prior UAT task summary to WebUI evidence and explicit extension-harness blocked status.
+- Verification:
+  - `./node_modules/.bin/vitest run src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts --maxWorkers=1 --no-file-parallelism` passed: 17 tests.
+  - `./node_modules/.bin/vitest run src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.ssr-options.test.tsx src/components/Option/WritingPlayground/__tests__/useActiveManuscriptScene.test.tsx src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts --maxWorkers=1 --no-file-parallelism` passed: 30 tests.
+  - `git diff --check` passed.
+  - `./node_modules/.bin/tsc --noEmit --pretty false` hit Node's default heap limit. Retried as `NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit --pretty false`; after temporarily correcting the local `antd` node_modules symlink for the check, it failed only on existing package-wide diagnostics outside the touched Writing Playground files.
+  - Bandit skipped: touched implementation scope is TypeScript/Markdown, not Python.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -49,9 +61,9 @@ Rebase PR #2541 onto latest origin/dev, evaluate all PR review comments, address
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12054 - Rebase-PR-2541-and-address-Writing-annotation-review-feedback.md
+++ b/backlog/tasks/task-12054 - Rebase-PR-2541-and-address-Writing-annotation-review-feedback.md
@@ -1,0 +1,57 @@
+---
+id: TASK-12054
+title: Rebase PR 2541 and address Writing annotation review feedback
+status: In Progress
+labels:
+- pr
+- review
+- writing
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/2541
+modified_files:
+- apps/packages/ui/src/components/WritingPlayground/WritingTipTapEditor.tsx
+- apps/packages/ui/src/components/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx
+- apps/packages/ui/src/components/WritingPlayground/__tests__/WritingTipTapEditor.ssr-options.test.tsx
+- apps/packages/ui/src/components/WritingPlayground/hooks/useActiveManuscriptScene.ts
+- apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+- apps/packages/ui/src/components/Option/WritingPlayground/writing-editor-adapter.ts
+- apps/packages/ui/src/components/Option/WritingPlayground/writing-tiptap-utils.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2541 onto latest origin/dev, evaluate all PR review comments, address valid Writing Playground annotation UAT feedback, verify the touched frontend scope, and push the updated PR branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 PR branch is rebased onto the latest `origin/dev`.
+- [ ] #2 All PR review comments and review threads are evaluated and addressed or documented as non-actionable.
+- [ ] #3 Focused Writing Playground annotation tests pass after review fixes.
+- [ ] #4 Formatting/lint/type/security checks for the touched scope pass or are documented with rationale.
+- [ ] #5 Updated branch is pushed to PR #2541 and review threads are resolved where applicable.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Plan: `Docs/superpowers/plans/2026-06-29-pr2541-review-rebase.md`
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12054 - Rebase-PR-2541-and-address-Writing-annotation-review-feedback.md
+++ b/backlog/tasks/task-12054 - Rebase-PR-2541-and-address-Writing-annotation-review-feedback.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12054
 title: Rebase PR 2541 and address Writing annotation review feedback
-status: In Progress
+status: Done
 labels:
 - pr
 - review
@@ -16,6 +16,7 @@ modified_files:
 - apps/packages/ui/src/components/Option/WritingPlayground/writing-editor-adapter.ts
 - apps/packages/ui/src/components/Option/WritingPlayground/writing-tiptap-utils.ts
 - backlog/tasks/task-12019 - UAT-Writing-Playground-manuscript-annotations.md
+- backlog/tasks/task-12054 - Rebase-PR-2541-and-address-Writing-annotation-review-feedback.md
 ---
 
 ## Description
@@ -30,7 +31,7 @@ Rebase PR #2541 onto latest origin/dev, evaluate all PR review comments, address
 - [x] #2 All PR review comments and review threads are evaluated and addressed or documented as non-actionable.
 - [x] #3 Focused Writing Playground annotation tests pass after review fixes.
 - [x] #4 Formatting/lint/type/security checks for the touched scope pass or are documented with rationale.
-- [ ] #5 Updated branch is pushed to PR #2541 and review threads are resolved where applicable.
+- [x] #5 Updated branch is pushed to PR #2541 and review threads are resolved where applicable.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -50,20 +51,24 @@ Rebase PR #2541 onto latest origin/dev, evaluate all PR review comments, address
   - `git diff --check` passed.
   - `./node_modules/.bin/tsc --noEmit --pretty false` hit Node's default heap limit. Retried as `NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit --pretty false`; after temporarily correcting the local `antd` node_modules symlink for the check, it failed only on existing package-wide diagnostics outside the touched Writing Playground files.
   - Bandit skipped: touched implementation scope is TypeScript/Markdown, not Python.
+- Pushed `0d71a6b1d8b97a81836b5e03fec23721f2e68d14` to `codex/writing-annotations-uat-polish`.
+- Resolved all five actionable inline review threads and posted PR summary comment: https://github.com/rmusser01/tldw_server/pull/2541#issuecomment-4828919427
+- `gh pr view` confirmed PR #2541 remains open against `dev` with head `0d71a6b1d8b97a81836b5e03fec23721f2e68d14`.
+- `gh pr checks` showed newly triggered GitHub checks still pending at handoff.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Rebased PR #2541 onto latest `dev`, fixed the actionable Writing Playground annotation review feedback, pushed the updated branch, resolved the review threads, and posted the verification summary on the PR. Focused and broader Writing Playground Vitest slices passed; package-wide `tsc` remains blocked by existing unrelated UI diagnostics after the local dependency symlink issue is accounted for.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Fixes the Writing Playground Rich editor crash by making TipTap opt out of immediate SSR rendering.
- Preserves manuscript paragraph delimiters and TipTap selection offsets so annotation anchors stay aligned across Rich and Plain modes.
- Keeps saved manuscript scenes from being falsely marked dirty when switching editor modes, preserving range-comment affordances.

## Test Plan
- [x] Rebased onto latest origin/dev.
- [x] bunx vitest run src/components/Option/WritingPlayground/__tests__/writing-annotation-anchor-utils.test.ts src/components/Option/WritingPlayground/__tests__/useActiveManuscriptScene.test.tsx src/components/Option/WritingPlayground/__tests__/useWritingAnnotations.test.tsx src/components/Option/WritingPlayground/__tests__/WritingAnnotationsTab.test.tsx src/components/Option/WritingPlayground/__tests__/WritingAnnotationMarginRail.test.tsx src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.ssr-options.test.tsx src/components/Option/WritingPlayground/__tests__/WritingTipTapEditor.external-sync.test.tsx src/components/Option/WritingPlayground/__tests__/writing-editor-adapter.test.ts src/components/Option/WritingPlayground/__tests__/writing-tiptap-utils.test.ts src/services/__tests__/writing-playground.annotations.test.ts

## Notes
- Rendered WebUI UAT was captured before rebase with Rich margin rail and Plain inspector screenshots in /tmp/writing-annotations-uat/.
- Package-level tsc still has unrelated baseline failures outside WritingPlayground.
- Bandit is not applicable for this frontend-only TypeScript/test change.
- AI-generated PR merge gate: needs a human-written Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Rich editor SSR hydration crash and fully aligns plain-text serialization and selection offsets so annotation anchors stay consistent across Rich and Plain modes. Prevents false dirty scenes in Plain mode to keep range comments usable.

- **Bug Fixes**
  - Set `immediatelyRender: false` in `WritingTipTapEditor` to stop the `@tiptap/react` hydration crash.
  - Align serialization with manuscripts: blank-line paragraph delimiters, standalone `***` scene breaks, single-newline hard breaks, preserved empty paragraphs, and proper list/blockquote separators.
  - Update TipTap position-to-offset mapping for top-level block separators, empty blocks, and nested lists/blockquote so selections and range measurements match manuscript delimiters.
  - Make `useActiveManuscriptScene` respect editor mode and track rich content only in TipTap mode, avoiding false dirty state and preserving range annotations in Plain mode.

<sup>Written for commit dafe3850fbb782208b31a1c8549217d40dd869ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

