### PR TITLE
TASK-530.9 add Skills seed overwrite confirmation

### DIFF
--- a/Docs/superpowers/plans/2026-06-28-skills-seed-overwrite-confirmation.md
+++ b/Docs/superpowers/plans/2026-06-28-skills-seed-overwrite-confirmation.md
@@ -1,0 +1,306 @@
+# Skills Seed Overwrite Confirmation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a confirmation step before the Skills manager overwrites existing built-in skills.
+
+**Architecture:** This is a frontend-only safety affordance in the existing Skills manager. The overwrite menu item will open Ant Design `Modal.confirm`; the existing React Query seed mutation remains responsible for API calls, success UI, cache invalidation, and error handling.
+
+**Tech Stack:** React 18, TypeScript, Ant Design `Modal.confirm`, TanStack Query, Vitest, Testing Library.
+
+**Spec:** `Docs/superpowers/specs/2026-06-28-skills-seed-overwrite-confirmation-design.md`
+
+---
+
+## File Structure
+
+- Modify `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+  - Add `confirmSeedOverwrite()` near the existing mutation/action handlers.
+  - Update only the `Seed and Overwrite Existing` dropdown item to use that handler.
+  - Leave `Seed Missing Only` and the empty-state `Seed built-ins` button as immediate missing-only seed actions.
+- Modify `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+  - Keep existing missing-only coverage.
+  - Replace the immediate-overwrite expectation with confirmation-first coverage.
+  - Spy on `Modal.confirm` instead of relying on Ant Design static modal portal DOM.
+- Update `backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md`
+  - Record plan link, verification results, and final summary through Backlog MCP.
+
+## Stage 1: Confirmation Tests
+
+**Goal:** Lock the new behavior before changing the component.
+
+**Success Criteria:** The new overwrite-confirmation tests fail against the current implementation because confirmation is missing, and the updated tests describe the confirmation contract.
+
+**Tests:** `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
+
+**Status:** Not Started
+
+### Task 1: Write Failing Confirmation Coverage
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+
+- [ ] **Step 1: Keep existing test imports unless the implementation requires otherwise**
+
+The file already imports `Modal` from `antd` and uses Testing Library utilities. Follow existing repo patterns for `Modal.confirm` tests; do not add `act` unless Vitest reports a React state-update warning that is fixed by wrapping the handler call.
+
+- [ ] **Step 2: Keep missing-only behavior unchanged**
+
+Do not weaken the existing test named `seeds built-in skills via seedSkills action`. It must still click `Seed Missing Only` and assert:
+
+```ts
+expect(tldwClientMock.seedSkills).toHaveBeenCalledWith({ overwrite: false })
+```
+
+- [ ] **Step 3: Replace the immediate-overwrite test**
+
+Replace `seeds built-in skills with overwrite via seedSkills action` with confirmation-first coverage:
+
+```ts
+it("opens a destructive confirmation before seeding built-in skills with overwrite", async () => {
+  const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementation(
+    () =>
+      ({
+        destroy: vi.fn(),
+        update: vi.fn()
+      }) as any
+  )
+
+  renderManager()
+
+  await waitFor(() => {
+    expect(tldwClientMock.listSkills).toHaveBeenCalled()
+  })
+
+  fireEvent.click(screen.getByRole("button", { name: "Seed Built-ins" }))
+  fireEvent.click(await screen.findByText("Seed and Overwrite Existing"))
+
+  expect(tldwClientMock.seedSkills).not.toHaveBeenCalled()
+  expect(confirmSpy).toHaveBeenCalledTimes(1)
+
+  const confirmConfig = confirmSpy.mock.calls[0][0]
+  expect(confirmConfig.title).toBe("Overwrite existing built-in skills?")
+  expect(confirmConfig.content).toBe(
+    "This replaces existing skill copies that match built-in skill names. Custom skills with other names are not changed."
+  )
+  expect(confirmConfig.okText).toBe("Overwrite built-ins")
+  expect(confirmConfig.cancelText).toBe("Cancel")
+  expect(confirmConfig.okButtonProps).toMatchObject({ danger: true })
+})
+```
+
+- [ ] **Step 4: Add cancel-path coverage**
+
+Use the captured confirm config. Because the implementation does not need a custom `onCancel`, this unit test represents cancellation by opening the confirmation and not invoking `onOk`; that path must not call the seed endpoint:
+
+```ts
+it("does not seed built-in skills when overwrite confirmation is cancelled", async () => {
+  const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementation(
+    () =>
+      ({
+        destroy: vi.fn(),
+        update: vi.fn()
+      }) as any
+  )
+
+  renderManager()
+
+  await waitFor(() => {
+    expect(tldwClientMock.listSkills).toHaveBeenCalled()
+  })
+
+  fireEvent.click(screen.getByRole("button", { name: "Seed Built-ins" }))
+  fireEvent.click(await screen.findByText("Seed and Overwrite Existing"))
+
+  const confirmConfig = confirmSpy.mock.calls[0][0]
+  expect(confirmConfig.onOk).toEqual(expect.any(Function))
+
+  expect(tldwClientMock.seedSkills).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 5: Add confirm-path coverage**
+
+Invoke `onOk` and assert one overwrite call:
+
+```ts
+it("seeds built-in skills with overwrite after confirmation", async () => {
+  const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementation(
+    () =>
+      ({
+        destroy: vi.fn(),
+        update: vi.fn()
+      }) as any
+  )
+
+  renderManager()
+
+  await waitFor(() => {
+    expect(tldwClientMock.listSkills).toHaveBeenCalled()
+  })
+
+  fireEvent.click(screen.getByRole("button", { name: "Seed Built-ins" }))
+  fireEvent.click(await screen.findByText("Seed and Overwrite Existing"))
+
+  const confirmConfig = confirmSpy.mock.calls[0][0]
+  await confirmConfig.onOk?.()
+
+  await waitFor(() => {
+    expect(tldwClientMock.seedSkills).toHaveBeenCalledTimes(1)
+  })
+  expect(tldwClientMock.seedSkills).toHaveBeenCalledWith({ overwrite: true })
+})
+```
+
+- [ ] **Step 6: Run the focused test and verify failure**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot
+```
+
+Expected before implementation: FAIL because `Modal.confirm` is not called and overwrite still calls `seedSkills({ overwrite: true })` immediately.
+
+## Stage 2: Component Implementation
+
+**Goal:** Add the confirmation without changing seed endpoint semantics.
+
+**Success Criteria:** Overwrite opens a destructive confirmation; confirming calls the existing mutation exactly once; missing-only seed paths are unchanged.
+
+**Tests:** Same focused Manager Vitest file.
+
+**Status:** Not Started
+
+### Task 2: Add Confirm Handler And Wire Dropdown
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+
+- [ ] **Step 1: Add `confirmSeedOverwrite()` after `seedBuiltinsMutation`**
+
+Add the handler near the existing action handlers:
+
+```ts
+const confirmSeedOverwrite = () => {
+  Modal.confirm({
+    title: t("option:skills.seedOverwriteConfirmTitle", {
+      defaultValue: "Overwrite existing built-in skills?"
+    }),
+    content: t("option:skills.seedOverwriteConfirmContent", {
+      defaultValue:
+        "This replaces existing skill copies that match built-in skill names. Custom skills with other names are not changed."
+    }),
+    okText: t("option:skills.seedOverwriteConfirmOk", {
+      defaultValue: "Overwrite built-ins"
+    }),
+    okButtonProps: { danger: true },
+    cancelText: t("common:cancel", { defaultValue: "Cancel" }),
+    onOk: () => seedBuiltinsMutation.mutateAsync(true)
+  })
+}
+```
+
+- [ ] **Step 2: Wire only the overwrite dropdown item**
+
+Change only this menu item:
+
+```ts
+{
+  key: "seed-overwrite-existing",
+  label: t("option:skills.seedBuiltinsOverwrite", {
+    defaultValue: "Seed and Overwrite Existing"
+  }),
+  onClick: confirmSeedOverwrite
+}
+```
+
+- [ ] **Step 3: Confirm missing-only paths were not changed**
+
+Leave both of these paths as-is:
+
+```ts
+onClick: () => seedBuiltinsMutation.mutate(false)
+```
+
+This applies to the dropdown `Seed Missing Only` item and the empty-state `Seed built-ins` button.
+
+- [ ] **Step 4: Run focused test and verify pass**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot
+```
+
+Expected after implementation: PASS.
+
+## Stage 3: Verification And Finalization
+
+**Goal:** Verify the touched scope, update tracking, and commit a clean implementation.
+
+**Success Criteria:** Focused tests pass, frontend-only Bandit skip is recorded, task metadata is current, and the worktree is clean.
+
+**Tests:** Focused Manager Vitest file.
+
+**Status:** Not Started
+
+### Task 3: Verify, Update Backlog, Commit
+
+**Files:**
+- Modify through Backlog MCP: `backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md`
+- Commit touched files.
+
+- [ ] **Step 1: Run focused verification**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Record Bandit skip**
+
+Do not run Bandit if the implementation remains frontend-only. Record: `Bandit skipped; touched scope is TypeScript/React only.`
+
+- [ ] **Step 3: Review diff**
+
+Run from repo root:
+
+```bash
+git diff -- apps/packages/ui/src/components/Option/Skills/Manager.tsx apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx Docs/superpowers/plans/2026-06-28-skills-seed-overwrite-confirmation.md
+```
+
+Expected: only planned files changed.
+
+- [ ] **Step 4: Update task tracking**
+
+Use Backlog MCP to add:
+
+- Plan link: `Docs/superpowers/plans/2026-06-28-skills-seed-overwrite-confirmation.md`
+- Verification result for the focused Vitest command.
+- Bandit skip note for frontend-only scope.
+- Final summary of behavior change.
+
+- [ ] **Step 5: Commit implementation**
+
+Run from repo root:
+
+```bash
+git add Docs/superpowers/plans/2026-06-28-skills-seed-overwrite-confirmation.md apps/packages/ui/src/components/Option/Skills/Manager.tsx apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx "backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md"
+git commit -m "TASK-530.9 add skills seed overwrite confirmation"
+```
+
+Expected: commit succeeds without unrelated files.
+
+- [ ] **Step 6: Confirm clean worktree**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: branch ahead of `origin/dev`; no unstaged or staged changes.

--- a/Docs/superpowers/specs/2026-06-28-skills-seed-overwrite-confirmation-design.md
+++ b/Docs/superpowers/specs/2026-06-28-skills-seed-overwrite-confirmation-design.md
@@ -1,0 +1,110 @@
+# Skills Seed Overwrite Confirmation Design
+
+## Context
+
+`TASK-530.9` continues the `/skills` Safe Operations sequence after import review. The current Skills manager exposes a `Seed Built-ins` dropdown with two choices:
+
+- `Seed Missing Only`, which calls `seedSkills({ overwrite: false })`
+- `Seed and Overwrite Existing`, which immediately calls `seedSkills({ overwrite: true })`
+
+The backend overwrite behavior already exists and has service/API coverage. The UX gap is that the destructive overwrite path is one menu click with no confirmation, while the page already treats delete and import overwrite as explicit safe-operation moments.
+
+## Goal
+
+Add a frontend confirmation before built-in skill overwrite seeding runs, without changing backend seed semantics or broader Skills workflows.
+
+## Non-Goals
+
+- No backend API changes.
+- No preflight endpoint for counting overwritten skills.
+- No version-aware delete.
+- No bulk delete.
+- No export feedback work.
+- No permission/model/tool metadata panel work.
+- No redesign of the Skills action bar or dropdown.
+
+## UX Design
+
+`Seed Missing Only` remains one click because it is additive and does not replace existing skills.
+
+When the user chooses `Seed and Overwrite Existing`, the manager opens a confirmation dialog instead of firing the mutation immediately.
+
+Dialog content:
+
+- Title: `Overwrite existing built-in skills?`
+- Body: `This replaces existing skill copies that match built-in skill names. Custom skills with other names are not changed.`
+- Confirm action: `Overwrite built-ins`
+- Cancel action: `Cancel`
+
+The confirm action uses a destructive affordance. The dialog is appropriate here because this is a blocking destructive action, and the component already uses Ant Design `Modal.confirm` for delete confirmation. Avoid `Popconfirm` because dropdown-contained popovers are more fragile for focus, keyboard operation, and tests.
+
+While the overwrite mutation is pending, the confirm action should remain in an async/loading state and must not allow duplicate submissions.
+
+## Technical Design
+
+Add a small handler near existing Skills manager action handlers:
+
+- `confirmSeedOverwrite()`
+- It calls `Modal.confirm(...)`
+- `onOk` returns `seedBuiltinsMutation.mutateAsync(true)`
+
+Update `seedMenuItems` so:
+
+- `Seed Missing Only` keeps `onClick: () => seedBuiltinsMutation.mutate(false)`
+- `Seed and Overwrite Existing` uses `onClick: confirmSeedOverwrite`
+
+Keep the empty-state `Seed built-ins` button unchanged. It is another missing-only entry point and should continue to call `seedBuiltinsMutation.mutate(false)` directly.
+
+Keep the existing `seedBuiltinsMutation` success and error handling. Do not add state unless the static Ant Design confirm path proves insufficient.
+
+All new user-facing strings use `t(...)` with namespaced keys and `defaultValue`, matching the current component pattern.
+
+## Accessibility And Interaction Notes
+
+- The confirmation title should clearly identify the destructive operation.
+- The copy must name the affected scope: existing skills with built-in names.
+- The copy must name what is not affected: custom skills with other names.
+- The confirm button must be visually destructive through `okButtonProps: { danger: true }`.
+- Cancel must be available through the standard Ant Design modal controls.
+
+## Testing
+
+Update `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`.
+
+Required coverage:
+
+- `Seed Missing Only` still calls `seedSkills({ overwrite: false })` immediately.
+- Clicking `Seed and Overwrite Existing` does not call `seedSkills` immediately.
+- The confirmation dialog appears with the destructive title/copy.
+- Cancelling the confirmation does not call `seedSkills`.
+- Confirming the dialog calls `seedSkills({ overwrite: true })` exactly once.
+
+Prefer spying on `Modal.confirm` for the overwrite-confirmation unit tests. Assert the confirm configuration includes the expected title, copy, cancel text, confirm text, and `okButtonProps: { danger: true }`, then invoke the captured `onCancel` and `onOk` handlers directly. Avoid relying on Ant Design's static modal portal DOM unless a role-based assertion is stable in the local test harness.
+
+Focused verification:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot
+```
+
+No Bandit run is required if the implementation remains frontend-only. Record that as a non-Python scope skip in the task final summary.
+
+## Risks And Mitigations
+
+- **Risk:** Static `Modal.confirm` can leave modal state between tests.
+  **Mitigation:** The existing test file already imports `Modal` and calls `Modal.destroyAll()` in cleanup.
+
+- **Risk:** Async confirmation could allow duplicate overwrite submissions.
+  **Mitigation:** Return `seedBuiltinsMutation.mutateAsync(true)` from `onOk` so Ant Design owns confirm loading behavior.
+
+- **Risk:** Confirmation copy becomes vague and users cannot tell what will be overwritten.
+  **Mitigation:** Copy names both affected and unaffected skill groups.
+
+## Acceptance Criteria Mapping
+
+- AC1: Dropdown overwrite item opens `Modal.confirm`.
+- AC2: Cancel path leaves `seedSkills` untouched.
+- AC3: Confirm path calls `seedSkills({ overwrite: true })` once and uses `danger`.
+- AC4: Missing-only item keeps existing immediate mutation.
+- AC5: Focused Manager Vitest coverage validates all of the above.

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -569,6 +569,24 @@ export const SkillsManager: React.FC = () => {
     }
   })
 
+  const confirmSeedOverwrite = () => {
+    Modal.confirm({
+      title: t("option:skills.seedOverwriteConfirmTitle", {
+        defaultValue: "Overwrite existing built-in skills?"
+      }),
+      content: t("option:skills.seedOverwriteConfirmContent", {
+        defaultValue:
+          "This replaces existing skill copies that match built-in skill names. Custom skills with other names are not changed."
+      }),
+      okText: t("option:skills.seedOverwriteConfirmOk", {
+        defaultValue: "Overwrite built-ins"
+      }),
+      okButtonProps: { danger: true },
+      cancelText: t("common:cancel", { defaultValue: "Cancel" }),
+      onOk: () => seedBuiltinsMutation.mutateAsync(true)
+    })
+  }
+
   const handleNew = () => {
     setSuccessAction(null)
     setEditingSkill(null)
@@ -912,7 +930,7 @@ export const SkillsManager: React.FC = () => {
       label: t("option:skills.seedBuiltinsOverwrite", {
         defaultValue: "Seed and Overwrite Existing"
       }),
-      onClick: () => seedBuiltinsMutation.mutate(true)
+      onClick: confirmSeedOverwrite
     }
   ]
 

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -1233,8 +1233,10 @@ describe("SkillsManager imports", () => {
       ]
       await confirmConfig.onOk?.()
 
-      expect(tldwClientMock.seedSkills).toHaveBeenCalledTimes(1)
-      expect(tldwClientMock.seedSkills).toHaveBeenCalledWith({ overwrite: true })
+      await waitFor(() => {
+        expect(tldwClientMock.seedSkills).toHaveBeenCalledTimes(1)
+        expect(tldwClientMock.seedSkills).toHaveBeenCalledWith({ overwrite: true })
+      })
     } finally {
       confirmSpy.mockRestore()
     }

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -1146,19 +1146,98 @@ describe("SkillsManager imports", () => {
     })
   })
 
-  it("seeds built-in skills with overwrite via seedSkills action", async () => {
-    renderManager()
+  it("opens a destructive confirmation before seeding built-in skills with overwrite", async () => {
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      () =>
+        ({
+          destroy: vi.fn(),
+          update: vi.fn()
+        }) as any
+    )
 
-    await waitFor(() => {
-      expect(tldwClientMock.listSkills).toHaveBeenCalled()
-    })
+    try {
+      renderManager()
 
-    fireEvent.click(screen.getByRole("button", { name: "Seed Built-ins" }))
-    fireEvent.click(await screen.findByText("Seed and Overwrite Existing"))
+      await waitFor(() => {
+        expect(tldwClientMock.listSkills).toHaveBeenCalled()
+      })
 
-    await waitFor(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Seed Built-ins" }))
+      fireEvent.click(await screen.findByText("Seed and Overwrite Existing"))
+
+      expect(tldwClientMock.seedSkills).not.toHaveBeenCalled()
+      expect(confirmSpy).toHaveBeenCalledTimes(1)
+      expect(confirmSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Overwrite existing built-in skills?",
+          content:
+            "This replaces existing skill copies that match built-in skill names. Custom skills with other names are not changed.",
+          okText: "Overwrite built-ins",
+          cancelText: "Cancel",
+          okButtonProps: expect.objectContaining({ danger: true })
+        })
+      )
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it("does not seed built-in skills with overwrite unless confirmation is accepted", async () => {
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      () =>
+        ({
+          destroy: vi.fn(),
+          update: vi.fn()
+        }) as any
+    )
+
+    try {
+      renderManager()
+
+      await waitFor(() => {
+        expect(tldwClientMock.listSkills).toHaveBeenCalled()
+      })
+
+      fireEvent.click(screen.getByRole("button", { name: "Seed Built-ins" }))
+      fireEvent.click(await screen.findByText("Seed and Overwrite Existing"))
+
+      expect(confirmSpy).toHaveBeenCalledTimes(1)
+      expect(tldwClientMock.seedSkills).not.toHaveBeenCalled()
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it("seeds built-in skills with overwrite after confirmation", async () => {
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      () =>
+        ({
+          destroy: vi.fn(),
+          update: vi.fn()
+        }) as any
+    )
+
+    try {
+      renderManager()
+
+      await waitFor(() => {
+        expect(tldwClientMock.listSkills).toHaveBeenCalled()
+      })
+
+      fireEvent.click(screen.getByRole("button", { name: "Seed Built-ins" }))
+      fireEvent.click(await screen.findByText("Seed and Overwrite Existing"))
+
+      expect(confirmSpy).toHaveBeenCalledTimes(1)
+      const [confirmConfig] = confirmSpy.mock.calls[0] as [
+        { onOk?: () => void | Promise<void> }
+      ]
+      await confirmConfig.onOk?.()
+
+      expect(tldwClientMock.seedSkills).toHaveBeenCalledTimes(1)
       expect(tldwClientMock.seedSkills).toHaveBeenCalledWith({ overwrite: true })
-    })
+    } finally {
+      confirmSpy.mockRestore()
+    }
   })
 
   it("sanitizes skill action failure notifications", async () => {

--- a/backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md
+++ b/backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md
@@ -3,16 +3,16 @@ id: TASK-530.9
 title: Implement Skills seed overwrite confirmation
 status: In Progress
 assignee: []
-created_date: '2026-06-28 15:38'
-updated_date: '2026-06-28 15:39'
+created_date: 2026-06-28 15:38
+updated_date: 2026-06-28 15:39
 labels:
-  - skills
-  - webui
-  - safe-operations
+- skills
+- webui
+- safe-operations
 dependencies: []
 documentation:
-  - >-
-    Docs/superpowers/specs/2026-06-28-skills-seed-overwrite-confirmation-design.md
+- Docs/superpowers/specs/2026-06-28-skills-seed-overwrite-confirmation-design.md
+- Docs/superpowers/plans/2026-06-28-skills-seed-overwrite-confirmation.md
 parent_task_id: TASK-530
 priority: high
 ---
@@ -36,6 +36,7 @@ Continue TASK-530 Safe Operations after TASK-530.8 by adding an explicit fronten
 
 <!-- SECTION:PLAN:BEGIN -->
 Spec: Docs/superpowers/specs/2026-06-28-skills-seed-overwrite-confirmation-design.md
+Plan: Docs/superpowers/plans/2026-06-28-skills-seed-overwrite-confirmation.md
 <!-- SECTION:PLAN:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md
+++ b/backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md
@@ -1,0 +1,49 @@
+---
+id: TASK-530.9
+title: Implement Skills seed overwrite confirmation
+status: In Progress
+assignee: []
+created_date: '2026-06-28 15:38'
+updated_date: '2026-06-28 15:39'
+labels:
+  - skills
+  - webui
+  - safe-operations
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-06-28-skills-seed-overwrite-confirmation-design.md
+parent_task_id: TASK-530
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-530 Safe Operations after TASK-530.8 by adding an explicit frontend confirmation before Seed and Overwrite Existing calls the Skills seed endpoint with overwrite=true. Keep Seed Missing Only one-click, keep backend seed behavior unchanged, and keep version-aware delete, bulk delete, export feedback, and permission metadata panels out of scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Seed and Overwrite Existing opens a confirmation before calling seedSkills with overwrite=true.
+- [ ] #2 Cancelling the confirmation does not call the seed mutation.
+- [ ] #3 Confirming the modal calls seedSkills({ overwrite: true }) exactly once and uses destructive button affordance.
+- [ ] #4 Seed Missing Only remains one-click and continues to call seedSkills({ overwrite: false }).
+- [ ] #5 Focused Manager Vitest coverage records the safe overwrite workflow.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Spec: Docs/superpowers/specs/2026-06-28-skills-seed-overwrite-confirmation-design.md
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md
+++ b/backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-530.9
 title: Implement Skills seed overwrite confirmation
-status: In Progress
+status: Done
 assignee: []
 created_date: 2026-06-28 15:38
 updated_date: 2026-06-28 15:39
@@ -25,11 +25,11 @@ Continue TASK-530 Safe Operations after TASK-530.8 by adding an explicit fronten
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Seed and Overwrite Existing opens a confirmation before calling seedSkills with overwrite=true.
-- [ ] #2 Cancelling the confirmation does not call the seed mutation.
-- [ ] #3 Confirming the modal calls seedSkills({ overwrite: true }) exactly once and uses destructive button affordance.
-- [ ] #4 Seed Missing Only remains one-click and continues to call seedSkills({ overwrite: false }).
-- [ ] #5 Focused Manager Vitest coverage records the safe overwrite workflow.
+- [x] #1 Seed and Overwrite Existing opens a confirmation before calling seedSkills with overwrite=true.
+- [x] #2 Cancelling the confirmation does not call the seed mutation.
+- [x] #3 Confirming the modal calls seedSkills({ overwrite: true }) exactly once and uses destructive button affordance.
+- [x] #4 Seed Missing Only remains one-click and continues to call seedSkills({ overwrite: false }).
+- [x] #5 Focused Manager Vitest coverage records the safe overwrite workflow.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,14 +37,27 @@ Continue TASK-530 Safe Operations after TASK-530.8 by adding an explicit fronten
 <!-- SECTION:PLAN:BEGIN -->
 Spec: Docs/superpowers/specs/2026-06-28-skills-seed-overwrite-confirmation-design.md
 Plan: Docs/superpowers/plans/2026-06-28-skills-seed-overwrite-confirmation.md
+
+Implementation completed:
+- Added a `Modal.confirm` guard for the Skills manager `Seed and Overwrite Existing` dropdown action.
+- Kept `Seed Missing Only` and the empty-state `Seed built-ins` actions as immediate missing-only seed operations.
+- Added focused Manager tests for confirmation configuration, no mutation before accept, and accepted overwrite mutation.
+
+Verification:
+- `cd apps/packages/ui && bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot` -> PASS, 27 tests passed.
+- `git diff --check` -> PASS.
+- Bandit skipped; touched scope is TypeScript/React only.
+
+Notes:
+- Local `apps/packages/ui/node_modules/antd` symlink target in the tracked worktree points to a missing Bun package hash, so Vitest requires a temporary local symlink to an installed `antd@6.2.1` Bun package hash for execution. The symlink was restored to the tracked target after verification and is not part of this change.
 <!-- SECTION:PLAN:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md
+++ b/backlog/tasks/task-530.9 - Implement-Skills-seed-overwrite-confirmation.md
@@ -15,6 +15,8 @@ documentation:
 - Docs/superpowers/plans/2026-06-28-skills-seed-overwrite-confirmation.md
 parent_task_id: TASK-530
 priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/2543
 ---
 
 ## Description
@@ -37,6 +39,7 @@ Continue TASK-530 Safe Operations after TASK-530.8 by adding an explicit fronten
 <!-- SECTION:PLAN:BEGIN -->
 Spec: Docs/superpowers/specs/2026-06-28-skills-seed-overwrite-confirmation-design.md
 Plan: Docs/superpowers/plans/2026-06-28-skills-seed-overwrite-confirmation.md
+PR: https://github.com/rmusser01/tldw_server/pull/2543
 
 Implementation completed:
 - Added a `Modal.confirm` guard for the Skills manager `Seed and Overwrite Existing` dropdown action.
@@ -50,6 +53,7 @@ Verification:
 
 Notes:
 - Local `apps/packages/ui/node_modules/antd` symlink target in the tracked worktree points to a missing Bun package hash, so Vitest requires a temporary local symlink to an installed `antd@6.2.1` Bun package hash for execution. The symlink was restored to the tracked target after verification and is not part of this change.
+- PR body includes a placeholder noting that a human-written change summary is required before merge per repo policy.
 <!-- SECTION:PLAN:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary

### What changed
- Added a destructive confirmation before Skills `Seed and Overwrite Existing` calls overwrite seeding.
- Kept `Seed Missing Only` and empty-state seeding as immediate missing-only actions.
- Added focused Manager tests for confirmation config, non-acceptance, and accepted overwrite behavior.

### Why
- Prevents one-click replacement of existing built-in skill copies while preserving the fast additive seed workflow.
- Matches the existing Skills safe-operation pattern that uses `Modal.confirm` for destructive actions.

### Change summary
- Human-written change summary is still required before merge per repo policy.

## Validation
- [x] `cd apps/packages/ui && bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot` -> 27 passed
- [x] `git diff --check` -> passed
- [x] Bandit skipped: touched scope is TypeScript/React only

## Risk & Rollback
- Risk: Low; frontend-only confirmation gate on an existing overwrite action. Backend seed behavior is unchanged.
- Rollback: Revert this PR to restore the previous direct overwrite-seed dropdown behavior.