### PR TITLE
TASK-530.10 version-aware Skills delete

### DIFF
--- a/Docs/superpowers/plans/2026-06-28-skills-version-aware-delete.md
+++ b/Docs/superpowers/plans/2026-06-28-skills-version-aware-delete.md
@@ -1,0 +1,658 @@
+# Skills Version-Aware Delete Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/skills` single-skill deletion send and enforce optimistic versions when the UI has a known skill version, while preserving unversioned delete compatibility.
+
+**Architecture:** The backend already accepts `If-Match` for deletes and the service already enforces optimistic locking, so backend work is mostly response-contract exposure and API-level coverage. The frontend will carry `SkillSummary.version` from list rows into the existing delete confirmation flow, and the API client will include `If-Match` only for positive safe integer versions. Stale deletes get recovery-specific copy and refresh the existing React Query `["skills"]` cache prefix.
+
+**Tech Stack:** FastAPI, Pydantic, pytest, React 18, TypeScript, TanStack Query, Ant Design `Modal.confirm`, Vitest, Testing Library.
+
+**Spec:** `Docs/superpowers/specs/2026-06-28-skills-version-aware-delete-design.md`
+
+---
+
+## File Structure
+
+- Modify `tldw_Server_API/app/api/v1/schemas/skills_schemas.py`
+  - Add `version: int` to `SkillSummary`.
+- Modify `tldw_Server_API/app/api/v1/endpoints/skills.py`
+  - Include `metadata.version` in `_metadata_to_summary()`.
+- Modify `tldw_Server_API/app/core/Skills/skills_service.py`
+  - Include `version` in `_build_context_payload()` `available_skills` dictionaries.
+  - Keep `context_text` unchanged.
+- Modify `tldw_Server_API/tests/Skills/integration/test_skills_api.py`
+  - Add list-summary version, delete `If-Match`, stale conflict, and context-summary version coverage.
+- Modify `tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py` only if the focused MCP context tests fail after the schema change.
+  - Keep any changes limited to test fixture summary dictionaries.
+- Modify `apps/packages/ui/src/types/skill.ts`
+  - Add `version: number` to `SkillSummary`.
+- Modify `apps/packages/ui/src/services/tldw/domains/workspace-api.ts`
+  - Extend `deleteSkill(name, version?)`.
+  - Send `If-Match` only when `Number.isSafeInteger(version) && version > 0`.
+- Modify `apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts`
+  - Add API client delete header and invalid-version tests.
+- Modify `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+  - Pass row versions to delete.
+  - Add local conflict detection helper.
+  - Show conflict-specific notification and invalidate `["skills"]` on stale delete conflicts.
+- Modify `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+  - Update `makeSkill()` and focused fixtures with `version`.
+  - Add versioned delete, unknown-version compatibility, and stale conflict recovery tests.
+- Modify `backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md`
+  - Record plan link, implementation notes, verification results, and final summary.
+
+## Task 1: Backend Summary Contract And Delete API Coverage
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Skills/integration/test_skills_api.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/skills_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/skills.py`
+- Modify: `tldw_Server_API/app/core/Skills/skills_service.py`
+- Maybe modify: `tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py`
+
+- [ ] **Step 1: Add failing list-summary version test**
+
+In `TestListSkills`, add a test near `test_list_skills_pagination`:
+
+```python
+    def test_list_skills_includes_version(self, client):
+        create_resp = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "listed-version", "content": "content"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        r = client.get(f"{SKILLS_PREFIX}/?limit=50&offset=0")
+        assert r.status_code == 200, r.text
+        listed = {skill["name"]: skill for skill in r.json()["skills"]}
+        assert listed["listed-version"]["version"] == create_resp.json()["version"]
+```
+
+- [ ] **Step 2: Add failing delete `If-Match` tests**
+
+In `TestDeleteSkill`, keep `test_delete_skill_204` as the unversioned compatibility test and add:
+
+```python
+    def test_delete_skill_accepts_matching_if_match(self, client):
+        create_resp = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "del-versioned", "content": "content"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        version = create_resp.json()["version"]
+
+        r = client.delete(
+            f"{SKILLS_PREFIX}/del-versioned",
+            headers={"If-Match": str(version)},
+        )
+        assert r.status_code == 204, r.text
+
+        missing = client.get(f"{SKILLS_PREFIX}/del-versioned")
+        assert missing.status_code == 404
+
+    def test_delete_skill_stale_if_match_returns_409_and_keeps_skill(self, client):
+        create_resp = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "del-stale", "content": "v1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        update_resp = client.put(
+            f"{SKILLS_PREFIX}/del-stale",
+            json={"content": "v2"},
+        )
+        assert update_resp.status_code == 200, update_resp.text
+        assert update_resp.json()["version"] == create_resp.json()["version"] + 1
+
+        r = client.delete(
+            f"{SKILLS_PREFIX}/del-stale",
+            headers={"If-Match": str(create_resp.json()["version"])},
+        )
+        assert r.status_code == 409
+
+        still_there = client.get(f"{SKILLS_PREFIX}/del-stale")
+        assert still_there.status_code == 200, still_there.text
+        assert still_there.json()["version"] == update_resp.json()["version"]
+```
+
+- [ ] **Step 3: Add failing context-summary version assertion**
+
+Update `TestContextPayload.test_get_context_payload`:
+
+```python
+        listed = {skill["name"]: skill for skill in data["available_skills"]}
+        assert listed["ctx-skill"]["version"] == 1
+        assert "version" not in data["context_text"].lower()
+```
+
+If another existing context skill includes the word `version`, narrow the prompt assertion to the test skill line:
+
+```python
+        ctx_line = next(line for line in data["context_text"].splitlines() if "ctx-skill" in line)
+        assert "version" not in ctx_line.lower()
+```
+
+- [ ] **Step 4: Run backend tests to verify failures**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py \
+  -k "list_skills_includes_version or delete_skill_accepts_matching_if_match or delete_skill_stale_if_match_returns_409_and_keeps_skill or get_context_payload" -v
+```
+
+Expected before implementation: list/context version assertions fail because `SkillSummary` omits `version`. Delete tests may already pass because endpoint/service enforcement exists; keep them as API contract coverage.
+
+- [ ] **Step 5: Add backend schema and endpoint implementation**
+
+In `SkillSummary`, add:
+
+```python
+    version: int = Field(..., description="Version for optimistic locking")
+```
+
+In `_metadata_to_summary()`, add:
+
+```python
+        version=metadata.version,
+```
+
+In `_build_context_payload()`, add:
+
+```python
+                    "version": int(s.get("version") or 1),
+```
+
+Do not add version text to `context_text`.
+
+- [ ] **Step 6: Run focused backend tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py \
+  tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py \
+  -k "list_skills or delete_skill or get_context_payload or async_variant_uses_async_context_payload" -v
+```
+
+Expected: PASS. If `test_skill_mcp_integration.py` fails because a mocked `available_skills` item is now treated as a `SkillSummary`, update the mock item with the required fields and `version: 1`; do not broaden production schema optionality.
+
+- [ ] **Step 7: Commit backend contract**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/schemas/skills_schemas.py \
+  tldw_Server_API/app/api/v1/endpoints/skills.py \
+  tldw_Server_API/app/core/Skills/skills_service.py \
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py \
+  tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py
+git commit -m "TASK-530.10 add skills delete version API coverage"
+```
+
+If `test_skill_mcp_integration.py` is unchanged, omit it from `git add`.
+
+## Task 2: Frontend API Client Version Header
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/skill.ts`
+- Modify: `apps/packages/ui/src/services/tldw/domains/workspace-api.ts`
+- Modify: `apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts`
+
+- [ ] **Step 1: Add failing API client tests**
+
+Add tests in `workspace-api.skills.test.ts`:
+
+```ts
+  it("sends If-Match when deleting a skill with a valid version", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce(undefined)
+    const clientCore = {
+      resolveApiPath: vi.fn().mockResolvedValue("/api/v1/skills/{name}"),
+      fillPathParams: vi.fn().mockReturnValue("/api/v1/skills/summarize")
+    }
+
+    await workspaceApiMethods.deleteSkill.call(clientCore as any, "summarize", 3)
+
+    expect(bgRequest).toHaveBeenCalledWith({
+      path: "/api/v1/skills/summarize",
+      method: "DELETE",
+      headers: { "If-Match": "3" }
+    })
+  })
+
+  it("omits If-Match when deleting a skill without a known version", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce(undefined)
+    const clientCore = {
+      resolveApiPath: vi.fn().mockResolvedValue("/api/v1/skills/{name}"),
+      fillPathParams: vi.fn().mockReturnValue("/api/v1/skills/summarize")
+    }
+
+    await workspaceApiMethods.deleteSkill.call(clientCore as any, "summarize")
+
+    expect(bgRequest).toHaveBeenCalledWith({
+      path: "/api/v1/skills/summarize",
+      method: "DELETE"
+    })
+  })
+
+  it.each([Number.NaN, 0, -1, 1.5, Number.POSITIVE_INFINITY])(
+    "omits If-Match for invalid delete version %s",
+    async (version) => {
+      vi.mocked(bgRequest).mockResolvedValueOnce(undefined)
+      const clientCore = {
+        resolveApiPath: vi.fn().mockResolvedValue("/api/v1/skills/{name}"),
+        fillPathParams: vi.fn().mockReturnValue("/api/v1/skills/summarize")
+      }
+
+      await workspaceApiMethods.deleteSkill.call(clientCore as any, "summarize", version)
+
+      expect(bgRequest).toHaveBeenCalledWith({
+        path: "/api/v1/skills/summarize",
+        method: "DELETE"
+      })
+    }
+  )
+```
+
+- [ ] **Step 2: Run API client tests to verify failure**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot
+```
+
+Expected before implementation: FAIL because `deleteSkill` does not accept/send versions.
+
+- [ ] **Step 3: Implement API client header guard**
+
+In `SkillSummary`, add:
+
+```ts
+  version: number
+```
+
+In `workspace-api.ts`, change `deleteSkill` to:
+
+```ts
+  async deleteSkill(
+    this: TldwApiClientCore,
+    name: string,
+    version?: number
+  ): Promise<void> {
+    const base = await this.resolveApiPath("skills.delete", [
+      "/api/v1/skills/{name}",
+      "/api/v1/skills/{name}/"
+    ])
+    const path = this.fillPathParams(base, name)
+    const headers =
+      Number.isSafeInteger(version) && Number(version) > 0
+        ? { "If-Match": String(version) }
+        : undefined
+    await bgRequest<any>({
+      path,
+      method: "DELETE",
+      ...(headers ? { headers } : {})
+    })
+  },
+```
+
+- [ ] **Step 4: Run API client tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit API client contract**
+
+```bash
+git add \
+  apps/packages/ui/src/types/skill.ts \
+  apps/packages/ui/src/services/tldw/domains/workspace-api.ts \
+  apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
+git commit -m "TASK-530.10 send skill delete If-Match header"
+```
+
+## Task 3: Skills Manager Versioned Delete UX
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+
+- [ ] **Step 1: Update test fixture helper with versions**
+
+In `makeSkill`, add:
+
+```ts
+  version: index + 1
+```
+
+For existing inline skill fixtures in this file, add `version` when TypeScript or assertions require it. Keep one delete test using a local cast to exercise unknown-version compatibility.
+
+- [ ] **Step 2: Add failing versioned delete test**
+
+Add a test near the seed/delete action tests:
+
+```ts
+  it("passes the row version when deleting a skill", async () => {
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      (config) => {
+        void config.onOk?.()
+        return { destroy: vi.fn(), update: vi.fn() } as any
+      }
+    )
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [makeSkill(2)],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.deleteSkill.mockResolvedValueOnce(undefined)
+
+    try {
+      renderManager()
+      await screen.findByText("skill-2")
+      fireEvent.click(screen.getByRole("button", { name: "Delete skill-2" }))
+
+      await waitFor(() => {
+        expect(tldwClientMock.deleteSkill).toHaveBeenCalledWith("skill-2", 3)
+      })
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+```
+
+- [ ] **Step 3: Add failing unknown-version compatibility test**
+
+```ts
+  it("keeps delete compatible when a row has no known version", async () => {
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      (config) => {
+        void config.onOk?.()
+        return { destroy: vi.fn(), update: vi.fn() } as any
+      }
+    )
+    const legacySkill = { ...makeSkill(4) } as Partial<ReturnType<typeof makeSkill>>
+    delete legacySkill.version
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [legacySkill],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.deleteSkill.mockResolvedValueOnce(undefined)
+
+    try {
+      renderManager()
+      await screen.findByText("skill-4")
+      fireEvent.click(screen.getByRole("button", { name: "Delete skill-4" }))
+
+      await waitFor(() => {
+        expect(tldwClientMock.deleteSkill).toHaveBeenCalledWith("skill-4", undefined)
+      })
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+```
+
+If TypeScript rejects the partial row in `mockResolvedValueOnce`, cast only that `skills` value to `any` in the test. Do not make production `SkillSummary.version` optional.
+
+- [ ] **Step 4: Add failing stale conflict recovery test**
+
+```ts
+  it("shows reload-before-delete guidance on stale delete conflict", async () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      (config) => {
+        void config.onOk?.()
+        return { destroy: vi.fn(), update: vi.fn() } as any
+      }
+    )
+    const conflict = Object.assign(new Error("409 version conflict"), { status: 409 })
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [makeSkill(1)],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.deleteSkill.mockRejectedValueOnce(conflict)
+
+    try {
+      renderManager()
+      await screen.findByText("skill-1")
+      fireEvent.click(screen.getByRole("button", { name: "Delete skill-1" }))
+
+      await waitFor(() => {
+        expect(notificationMock.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Skill changed elsewhere",
+            description: "Reload skills before deleting this version."
+          })
+        )
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["skills"] })
+      )
+    } finally {
+      confirmSpy.mockRestore()
+      invalidateSpy.mockRestore()
+    }
+  })
+```
+
+- [ ] **Step 5: Run manager tests to verify failure**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot
+```
+
+Expected before implementation: FAIL because delete calls omit version and stale conflicts use generic copy.
+
+- [ ] **Step 6: Implement local conflict helper**
+
+Near `getErrorDescription`, add:
+
+```ts
+const isConflictError = (error: unknown): boolean => {
+  const candidate = error as {
+    status?: unknown
+    statusCode?: unknown
+    response?: { status?: unknown }
+    message?: unknown
+  } | null
+  if (!candidate) return false
+  return candidate.status === 409
+    || candidate.statusCode === 409
+    || candidate.response?.status === 409
+    || (typeof candidate.message === "string" && candidate.message.includes("409"))
+}
+```
+
+- [ ] **Step 7: Implement mutation payload and conflict feedback**
+
+Add:
+
+```ts
+interface DeleteSkillPayload {
+  name: string
+  version?: number
+}
+```
+
+Change delete mutation:
+
+```ts
+  const deleteMutation = useMutation({
+    mutationFn: ({ name, version }: DeleteSkillPayload) =>
+      tldwClient.deleteSkill(name, version),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["skills"] })
+      setSuccessAction(null)
+      notification.success({
+        message: t("option:skills.deleteSuccess", { defaultValue: "Skill deleted" })
+      })
+    },
+    onError: (err: unknown) => {
+      if (isConflictError(err)) {
+        queryClient.invalidateQueries({ queryKey: ["skills"] })
+        notification.error({
+          message: t("option:skills.deleteConflict", {
+            defaultValue: "Skill changed elsewhere"
+          }),
+          description: t("option:skills.deleteConflictDesc", {
+            defaultValue: "Reload skills before deleting this version."
+          })
+        })
+        return
+      }
+      notification.error({
+        message: t("option:skills.deleteError", { defaultValue: "Failed to delete skill" }),
+        description: getErrorDescription(err)
+      })
+    }
+  })
+```
+
+The reviewer advisory is satisfied because the component already uses `queryClient.invalidateQueries({ queryKey: ["skills"] })` for create/import/delete success paths, and TanStack Query prefix matching invalidates the paginated/filter-specific skills query keys.
+
+- [ ] **Step 8: Pass row version through the confirmation**
+
+Change `handleDelete`:
+
+```ts
+  const handleDelete = (skill: Pick<SkillSummary, "name"> & Partial<Pick<SkillSummary, "version">>) => {
+    Modal.confirm({
+      title: t("option:skills.deleteConfirmTitle", {
+        defaultValue: "Delete skill?"
+      }),
+      content: t("option:skills.deleteConfirmContent", {
+        defaultValue: `Are you sure you want to delete "${skill.name}"? This cannot be undone.`,
+        name: skill.name
+      }),
+      okText: t("common:delete", { defaultValue: "Delete" }),
+      okButtonProps: { danger: true },
+      cancelText: t("common:cancel", { defaultValue: "Cancel" }),
+      onOk: () => deleteMutation.mutateAsync({
+        name: skill.name,
+        version: Number.isSafeInteger(skill.version) && Number(skill.version) > 0
+          ? skill.version
+          : undefined
+      })
+    })
+  }
+```
+
+Change row action:
+
+```ts
+onClick={() => handleDelete(record)}
+```
+
+- [ ] **Step 9: Run manager tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit manager UX**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/Skills/Manager.tsx \
+  apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+git commit -m "TASK-530.10 add skills delete conflict recovery"
+```
+
+## Task 4: Full Verification And Task Finalization
+
+**Files:**
+- Modify: `backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md`
+
+- [ ] **Step 1: Run full focused backend verification**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py \
+  tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py \
+  -k "list_skills or delete_skill or get_context_payload or async_variant_uses_async_context_payload" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full focused frontend verification**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run \
+  src/services/tldw/domains/__tests__/workspace-api.skills.test.ts \
+  src/components/Option/Skills/__tests__/Manager.test.tsx \
+  --reporter=dot
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Bandit on touched backend Python files**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/api/v1/endpoints/skills.py \
+  tldw_Server_API/app/api/v1/schemas/skills_schemas.py \
+  tldw_Server_API/app/core/Skills/skills_service.py \
+  -f json -o /tmp/bandit_task_530_10.json
+```
+
+Expected: command completes. Review `/tmp/bandit_task_530_10.json`; fix any new findings in touched code before proceeding.
+
+- [ ] **Step 4: Update Backlog task through MCP**
+
+Record:
+
+- Plan link: `Docs/superpowers/plans/2026-06-28-skills-version-aware-delete.md`
+- Files changed.
+- Verification command results.
+- Bandit output path.
+- Any known skips or blockers.
+- Final summary.
+
+- [ ] **Step 5: Commit final task note**
+
+```bash
+git add "backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md"
+git commit -m "TASK-530.10 record skills delete verification"
+```
+
+- [ ] **Step 6: Final self-check before PR**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -8
+```
+
+Expected: clean worktree, commits are scoped to `TASK-530.10`.

--- a/Docs/superpowers/specs/2026-06-28-skills-version-aware-delete-design.md
+++ b/Docs/superpowers/specs/2026-06-28-skills-version-aware-delete-design.md
@@ -1,0 +1,178 @@
+# Skills Version-Aware Delete Design
+
+## Context
+
+`TASK-530.10` continues the `/skills` Safe Operations sequence after import review and seed overwrite confirmation. The backend already has most of the destructive-delete protection:
+
+- `DELETE /api/v1/skills/{skill_name}` accepts `If-Match`.
+- `SkillsService.delete_skill()` checks the current registry version when `expected_version` is provided.
+- Service unit tests cover stale delete conflicts and rollback behavior.
+
+The gap is the end-to-end product path. The Skills manager only passes a skill name to `tldwClient.deleteSkill(name)`, and the client sends an unversioned `DELETE`. The list summary contract also omits `version`, so the table row cannot send `If-Match` even though the registry has a version.
+
+## Goal
+
+Make single-skill delete version-aware when the frontend has a known row version, while preserving existing unversioned delete compatibility for older callers and unknown-version rows.
+
+## Non-Goals
+
+- No bulk delete.
+- No undo/restore workflow.
+- No delete preview endpoint.
+- No permissions/model/tool metadata panel work.
+- No export feedback work.
+- No broader Skills manager redesign.
+- No change to update semantics beyond any type sharing needed for the list summary.
+
+## UX Design
+
+The visible delete workflow stays the same for a current row:
+
+1. User clicks the row delete icon.
+2. The manager opens the existing destructive confirmation dialog.
+3. User confirms.
+4. The frontend sends `DELETE` with `If-Match: <row.version>`.
+5. On success, the list refreshes and the existing `Skill deleted` notification appears.
+
+If the delete receives a stale-version conflict, the manager shows recovery-specific feedback instead of the generic server error:
+
+- Message: `Skill changed elsewhere`
+- Description: `Reload skills before deleting this version.`
+
+After a conflict, the manager invalidates the skills query so the table refreshes to the latest version. The skill is not deleted. The user can review the refreshed row and choose delete again if it is still intended.
+
+If a row or caller has no known version, deletion remains compatible and sends no `If-Match` header. This path is intentionally preserved for older UI state, direct API consumers, and any compatibility caller that has only the skill name.
+
+## Technical Design
+
+### Backend Contract
+
+Extend `SkillSummary` with:
+
+```python
+version: int = Field(..., description="Version for optimistic locking")
+```
+
+Update `_metadata_to_summary()` to include `metadata.version`. This exposes a value already present in `SkillMetadata` and the skill registry; it does not require a schema migration.
+
+Keep the existing delete endpoint signature:
+
+```python
+expected_version: Optional[int] = Header(None, alias="If-Match")
+```
+
+Keep existing compatibility behavior: `expected_version=None` does not reject the delete.
+
+Add API integration tests for:
+
+- list summaries include `version`.
+- delete with matching `If-Match` returns `204`.
+- delete without `If-Match` still returns `204`.
+- delete with stale `If-Match` returns `409` and leaves the skill available.
+
+### Frontend Types And Client
+
+Add `version: number` to `SkillSummary` in `apps/packages/ui/src/types/skill.ts`.
+
+Update `tldwClient.deleteSkill` in `workspace-api.ts`:
+
+```ts
+async deleteSkill(name: string, version?: number): Promise<void>
+```
+
+When `version` is a finite number, send:
+
+```ts
+headers: { "If-Match": String(version) }
+```
+
+When no valid version is supplied, keep the existing unversioned request shape.
+
+### Skills Manager
+
+Change the delete mutation input from `name: string` to a small payload:
+
+```ts
+{ name: string; version?: number }
+```
+
+Change `handleDelete` to accept the `SkillSummary` row or `{ name, version }`, and update the row action from:
+
+```ts
+onClick={() => handleDelete(record.name)}
+```
+
+to pass the row version.
+
+In `onError`, detect conflict via `err?.status === 409` or a message containing `409`. For conflicts:
+
+- invalidate `["skills"]`
+- show the conflict-specific message and description
+
+For non-conflict errors, keep the existing generic delete error behavior and sanitized description.
+
+## Accessibility And Interaction Notes
+
+- The destructive confirmation remains explicit and keyboard-accessible through Ant Design `Modal.confirm`.
+- The row delete button keeps its current accessible label: `Delete {skillName}`.
+- Conflict copy should name the recovery action in plain language: reload the list before deleting.
+- Do not add a second confirmation after conflict; the refreshed row plus existing confirmation is enough for this slice.
+
+## Testing
+
+Backend focused tests:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py \
+  -k "list_skills or delete_skill" -v
+```
+
+Frontend focused tests:
+
+```bash
+cd apps/packages/ui
+bunx vitest run \
+  src/services/tldw/domains/__tests__/workspace-api.skills.test.ts \
+  src/components/Option/Skills/__tests__/Manager.test.tsx \
+  --reporter=dot
+```
+
+Add or update tests for:
+
+- `workspaceApiMethods.deleteSkill` sends `If-Match` when version is provided.
+- `workspaceApiMethods.deleteSkill` omits headers when version is not provided.
+- `SkillsManager` calls `deleteSkill(name, version)` from a versioned row.
+- `SkillsManager` still calls `deleteSkill(name, undefined)` or equivalent for an unknown-version row.
+- `SkillsManager` shows `Skill changed elsewhere` and `Reload skills before deleting this version.` on a `409`.
+
+Run Bandit on touched backend Python files before completion:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/api/v1/endpoints/skills.py \
+  tldw_Server_API/app/api/v1/schemas/skills_schemas.py \
+  -f json -o /tmp/bandit_task_530_10.json
+```
+
+## Risks And Mitigations
+
+- **Risk:** Adding `version` to `SkillSummary` could expose an extra field to older clients.
+  **Mitigation:** This is additive JSON. Existing consumers should ignore unknown fields, and the frontend type will be updated.
+
+- **Risk:** Some test fixtures create skill summaries without versions.
+  **Mitigation:** Update focused Skills test fixtures. Where intentionally testing unknown-version compatibility, use a type cast or partial object locally rather than weakening the production type.
+
+- **Risk:** Conflict detection based only on status may miss errors wrapped by the browser proxy.
+  **Mitigation:** Check both `err.status === 409` and a sanitized/raw message containing `409`, matching existing Skills drawer conflict handling style.
+
+- **Risk:** Invalidating the query after conflict could briefly leave stale row state visible.
+  **Mitigation:** React Query invalidation matches existing manager cache patterns and is sufficient for this focused safety slice.
+
+## Acceptance Criteria Mapping
+
+- AC1: `SkillSummary.version` is exposed; row delete passes version; `deleteSkill` sends `If-Match` when valid.
+- AC2: Existing backend endpoint/service behavior remains enforced and gains API-level stale conflict coverage.
+- AC3: Manager conflict handling shows reload-before-delete recovery copy and refreshes the list.
+- AC4: `deleteSkill(name)` without version keeps unversioned compatibility and has explicit test coverage.
+- AC5: Focused backend API, frontend API-client, and manager tests cover success, compatibility, and stale conflict paths.

--- a/Docs/superpowers/specs/2026-06-28-skills-version-aware-delete-design.md
+++ b/Docs/superpowers/specs/2026-06-28-skills-version-aware-delete-design.md
@@ -10,6 +10,8 @@
 
 The gap is the end-to-end product path. The Skills manager only passes a skill name to `tldwClient.deleteSkill(name)`, and the client sends an unversioned `DELETE`. The list summary contract also omits `version`, so the table row cannot send `If-Match` even though the registry has a version.
 
+`SkillSummary` is also reused by the `/skills/context` response. Any required summary-field change must keep that endpoint valid by either adding `version` to context summaries or by introducing a separate context summary schema. This slice should prefer adding `version` to context summaries because the service already has registry versions and the `context_text` prompt body can remain unchanged.
+
 ## Goal
 
 Make single-skill delete version-aware when the frontend has a known row version, while preserving existing unversioned delete compatibility for older callers and unknown-version rows.
@@ -55,6 +57,8 @@ version: int = Field(..., description="Version for optimistic locking")
 
 Update `_metadata_to_summary()` to include `metadata.version`. This exposes a value already present in `SkillMetadata` and the skill registry; it does not require a schema migration.
 
+Because `SkillSummary` is reused by `SkillContextPayload.available_skills`, update `SkillsService._build_context_payload()` to include `version` in each `available_skills` item. Do not add version text to `context_text`; this is API metadata for optimistic operations, not model prompt content.
+
 Keep the existing delete endpoint signature:
 
 ```python
@@ -69,6 +73,7 @@ Add API integration tests for:
 - delete with matching `If-Match` returns `204`.
 - delete without `If-Match` still returns `204`.
 - delete with stale `If-Match` returns `409` and leaves the skill available.
+- context payload still returns `200` and includes `version` in `available_skills` without changing the prompt-oriented `context_text`.
 
 ### Frontend Types And Client
 
@@ -104,7 +109,14 @@ onClick={() => handleDelete(record.name)}
 
 to pass the row version.
 
-In `onError`, detect conflict via `err?.status === 409` or a message containing `409`. For conflicts:
+In `onError`, detect conflicts through a small local helper rather than inline checks. It should handle the error shapes used elsewhere in the UI:
+
+- `err.status === 409`
+- `err.statusCode === 409`
+- `err.response?.status === 409`
+- stringified message containing `409`
+
+For conflicts:
 
 - invalidate `["skills"]`
 - show the conflict-specific message and description
@@ -145,6 +157,7 @@ Add or update tests for:
 - `SkillsManager` calls `deleteSkill(name, version)` from a versioned row.
 - `SkillsManager` still calls `deleteSkill(name, undefined)` or equivalent for an unknown-version row.
 - `SkillsManager` shows `Skill changed elsewhere` and `Reload skills before deleting this version.` on a `409`.
+- existing context endpoint tests, MCP integration tests, and fixtures remain valid after `SkillSummary.version` becomes required.
 
 Run Bandit on touched backend Python files before completion:
 
@@ -152,6 +165,7 @@ Run Bandit on touched backend Python files before completion:
 source .venv/bin/activate && python -m bandit -r \
   tldw_Server_API/app/api/v1/endpoints/skills.py \
   tldw_Server_API/app/api/v1/schemas/skills_schemas.py \
+  tldw_Server_API/app/core/Skills/skills_service.py \
   -f json -o /tmp/bandit_task_530_10.json
 ```
 
@@ -163,8 +177,11 @@ source .venv/bin/activate && python -m bandit -r \
 - **Risk:** Some test fixtures create skill summaries without versions.
   **Mitigation:** Update focused Skills test fixtures. Where intentionally testing unknown-version compatibility, use a type cast or partial object locally rather than weakening the production type.
 
+- **Risk:** Requiring `SkillSummary.version` could break `/skills/context` and async context integration tests, because those paths build or mock summaries from service dictionaries rather than `_metadata_to_summary()`.
+  **Mitigation:** Include `version` in `_build_context_payload()` `available_skills` items, keep `context_text` unchanged, and update context endpoint/MCP integration tests or mocks that construct summary dictionaries.
+
 - **Risk:** Conflict detection based only on status may miss errors wrapped by the browser proxy.
-  **Mitigation:** Check both `err.status === 409` and a sanitized/raw message containing `409`, matching existing Skills drawer conflict handling style.
+  **Mitigation:** Use a focused helper that checks common status locations plus the stringified message, matching existing Skills drawer conflict handling style while keeping the behavior local to delete handling.
 
 - **Risk:** Invalidating the query after conflict could briefly leave stale row state visible.
   **Mitigation:** React Query invalidation matches existing manager cache patterns and is sufficient for this focused safety slice.

--- a/Docs/superpowers/specs/2026-06-28-skills-version-aware-delete-design.md
+++ b/Docs/superpowers/specs/2026-06-28-skills-version-aware-delete-design.md
@@ -85,7 +85,7 @@ Update `tldwClient.deleteSkill` in `workspace-api.ts`:
 async deleteSkill(name: string, version?: number): Promise<void>
 ```
 
-When `version` is a finite number, send:
+When `version` is a positive safe integer, send:
 
 ```ts
 headers: { "If-Match": String(version) }
@@ -137,7 +137,8 @@ Backend focused tests:
 ```bash
 source .venv/bin/activate && python -m pytest \
   tldw_Server_API/tests/Skills/integration/test_skills_api.py \
-  -k "list_skills or delete_skill" -v
+  tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py \
+  -k "list_skills or delete_skill or get_context_payload or async_variant_uses_async_context_payload" -v
 ```
 
 Frontend focused tests:
@@ -153,6 +154,7 @@ bunx vitest run \
 Add or update tests for:
 
 - `workspaceApiMethods.deleteSkill` sends `If-Match` when version is provided.
+- `workspaceApiMethods.deleteSkill` treats invalid versions such as `NaN`, decimal values, zero, or negative values as unknown and omits `If-Match`.
 - `workspaceApiMethods.deleteSkill` omits headers when version is not provided.
 - `SkillsManager` calls `deleteSkill(name, version)` from a versioned row.
 - `SkillsManager` still calls `deleteSkill(name, undefined)` or equivalent for an unknown-version row.

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -657,7 +657,7 @@ export const SkillsManager: React.FC = () => {
         version: Number.isSafeInteger(skill.version) && Number(skill.version) > 0
           ? skill.version
           : undefined
-      }).catch(() => undefined)
+      })
     })
   }
 

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -145,10 +145,13 @@ const isConflictError = (error: unknown): boolean => {
     message?: unknown
   } | null
   if (!candidate) return false
+  const message = typeof candidate.message === "string" ? candidate.message : ""
+  const hasConflictMessage = /\b(?:http|status(?:\s+code)?)\s*[:=]?\s*409\b/i.test(message)
+    || /\b409\b\s*(?:[:=-]\s*)?(?:version\s+)?conflict\b/i.test(message)
   return candidate.status === 409
     || candidate.statusCode === 409
     || candidate.response?.status === 409
-    || (typeof candidate.message === "string" && candidate.message.includes("409"))
+    || hasConflictMessage
 }
 
 const buildSkillInvocation = (skillName: string) => `/skill ${skillName}`

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -79,6 +79,11 @@ interface FileImportReview {
   overwrite: boolean
 }
 
+interface DeleteSkillPayload {
+  name: string
+  version?: number
+}
+
 type SkillContextFilter = "all" | SkillContext
 type SkillVisibilityFilter = "visible" | "hidden" | "all"
 type SkillToolsFilter = "any" | "with-tools" | "without-tools"
@@ -130,6 +135,20 @@ const getSeededSkillNames = (result: SeedSkillsResult | undefined): string[] => 
 const getErrorDescription = (error: unknown): string | undefined => {
   if (!error) return undefined
   return sanitizeServerErrorMessage(error, "") || undefined
+}
+
+const isConflictError = (error: unknown): boolean => {
+  const candidate = error as {
+    status?: unknown
+    statusCode?: unknown
+    response?: { status?: unknown }
+    message?: unknown
+  } | null
+  if (!candidate) return false
+  return candidate.status === 409
+    || candidate.statusCode === 409
+    || candidate.response?.status === 409
+    || (typeof candidate.message === "string" && candidate.message.includes("409"))
 }
 
 const buildSkillInvocation = (skillName: string) => `/skill ${skillName}`
@@ -423,7 +442,8 @@ export const SkillsManager: React.FC = () => {
   }
 
   const deleteMutation = useMutation({
-    mutationFn: (name: string) => tldwClient.deleteSkill(name),
+    mutationFn: ({ name, version }: DeleteSkillPayload) =>
+      tldwClient.deleteSkill(name, version),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["skills"] })
       setSuccessAction(null)
@@ -432,6 +452,18 @@ export const SkillsManager: React.FC = () => {
       })
     },
     onError: (err: unknown) => {
+      if (isConflictError(err)) {
+        queryClient.invalidateQueries({ queryKey: ["skills"] })
+        notification.error({
+          message: t("option:skills.deleteConflict", {
+            defaultValue: "Skill changed elsewhere"
+          }),
+          description: t("option:skills.deleteConflictDesc", {
+            defaultValue: "Reload skills before deleting this version."
+          })
+        })
+        return
+      }
       notification.error({
         message: t("option:skills.deleteError", { defaultValue: "Failed to delete skill" }),
         description: getErrorDescription(err)
@@ -606,19 +638,26 @@ export const SkillsManager: React.FC = () => {
     }
   }
 
-  const handleDelete = (name: string) => {
+  const handleDelete = (
+    skill: Pick<SkillSummary, "name"> & Partial<Pick<SkillSummary, "version">>
+  ) => {
     Modal.confirm({
       title: t("option:skills.deleteConfirmTitle", {
         defaultValue: "Delete skill?"
       }),
       content: t("option:skills.deleteConfirmContent", {
-        defaultValue: `Are you sure you want to delete "${name}"? This cannot be undone.`,
-        name
+        defaultValue: `Are you sure you want to delete "${skill.name}"? This cannot be undone.`,
+        name: skill.name
       }),
       okText: t("common:delete", { defaultValue: "Delete" }),
       okButtonProps: { danger: true },
       cancelText: t("common:cancel", { defaultValue: "Cancel" }),
-      onOk: () => deleteMutation.mutateAsync(name)
+      onOk: () => deleteMutation.mutateAsync({
+        name: skill.name,
+        version: Number.isSafeInteger(skill.version) && Number(skill.version) > 0
+          ? skill.version
+          : undefined
+      }).catch(() => undefined)
     })
   }
 
@@ -881,7 +920,7 @@ export const SkillsManager: React.FC = () => {
               size="small"
               danger
               icon={<Trash2 size={14} />}
-              onClick={() => handleDelete(record.name)}
+              onClick={() => handleDelete(record)}
             />
           </Tooltip>
         </div>

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -660,6 +660,9 @@ export const SkillsManager: React.FC = () => {
         version: Number.isSafeInteger(skill.version) && Number(skill.version) > 0
           ? skill.version
           : undefined
+      }).catch((err: unknown) => {
+        if (isConflictError(err)) return
+        throw err
       })
     })
   }

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -741,7 +741,7 @@ describe("SkillsManager imports", () => {
       await waitFor(() => {
         expect(confirmConfig?.onOk).toBeTypeOf("function")
       })
-      await expect(confirmConfig?.onOk?.()).rejects.toMatchObject({ status: 409 })
+      await expect(confirmConfig?.onOk?.()).resolves.toBeUndefined()
 
       await waitFor(() => {
         expect(notificationMock.error).toHaveBeenCalledWith(

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -760,6 +760,55 @@ describe("SkillsManager imports", () => {
     }
   })
 
+  it("uses generic delete errors when a non-conflict message mentions 409", async () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+    let confirmConfig: { onOk?: () => void | Promise<void> } | undefined
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      (config) => {
+        confirmConfig = config as { onOk?: () => void | Promise<void> }
+        return { destroy: vi.fn(), update: vi.fn() } as any
+      }
+    )
+    const failure = new Error("Failed after processing 409 skills")
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [makeSkill(1)],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.deleteSkill.mockRejectedValueOnce(failure)
+
+    try {
+      renderManager()
+      await screen.findByText("skill-1")
+      fireEvent.click(screen.getByRole("button", { name: "Delete skill-1" }))
+
+      await waitFor(() => {
+        expect(confirmConfig?.onOk).toBeTypeOf("function")
+      })
+      await expect(confirmConfig?.onOk?.()).rejects.toThrow(
+        "Failed after processing 409 skills"
+      )
+
+      await waitFor(() => {
+        expect(notificationMock.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Failed to delete skill",
+            description: expect.stringContaining("Failed after processing 409 skills")
+          })
+        )
+      })
+      expect(notificationMock.error).not.toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Skill changed elsewhere" })
+      )
+      expect(invalidateSpy).not.toHaveBeenCalled()
+    } finally {
+      confirmSpy.mockRestore()
+      invalidateSpy.mockRestore()
+    }
+  })
+
   it("clears server-backed mode sorting when the mode column is hidden", async () => {
     tldwClientMock.listSkills.mockResolvedValue({
       skills: [

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -716,9 +716,10 @@ describe("SkillsManager imports", () => {
 
   it("shows reload-before-delete guidance on stale delete conflict", async () => {
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+    let confirmConfig: { onOk?: () => void | Promise<void> } | undefined
     const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
       (config) => {
-        void config.onOk?.()
+        confirmConfig = config as { onOk?: () => void | Promise<void> }
         return { destroy: vi.fn(), update: vi.fn() } as any
       }
     )
@@ -736,6 +737,11 @@ describe("SkillsManager imports", () => {
       renderManager()
       await screen.findByText("skill-1")
       fireEvent.click(screen.getByRole("button", { name: "Delete skill-1" }))
+
+      await waitFor(() => {
+        expect(confirmConfig?.onOk).toBeTypeOf("function")
+      })
+      await expect(confirmConfig?.onOk?.()).rejects.toMatchObject({ status: 409 })
 
       await waitFor(() => {
         expect(notificationMock.error).toHaveBeenCalledWith(

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -76,7 +76,8 @@ const makeSkill = (index: number) => ({
   argument_hint: null,
   user_invocable: true,
   disable_model_invocation: false,
-  context: "inline" as const
+  context: "inline" as const,
+  version: index + 1
 })
 
 describe("SkillsManager imports", () => {
@@ -651,6 +652,106 @@ describe("SkillsManager imports", () => {
 
     fireEvent.click(testRunButton)
     expect(screen.getByTestId("skill-preview-open")).toHaveTextContent("skill-1")
+  })
+
+  it("passes the row version when deleting a skill", async () => {
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      (config) => {
+        void config.onOk?.()
+        return { destroy: vi.fn(), update: vi.fn() } as any
+      }
+    )
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [makeSkill(2)],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.deleteSkill.mockResolvedValueOnce(undefined)
+
+    try {
+      renderManager()
+      await screen.findByText("skill-2")
+      fireEvent.click(screen.getByRole("button", { name: "Delete skill-2" }))
+
+      await waitFor(() => {
+        expect(tldwClientMock.deleteSkill).toHaveBeenCalledWith("skill-2", 3)
+      })
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it("keeps delete compatible when a row has no known version", async () => {
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      (config) => {
+        void config.onOk?.()
+        return { destroy: vi.fn(), update: vi.fn() } as any
+      }
+    )
+    const legacySkill = { ...makeSkill(4) } as Partial<ReturnType<typeof makeSkill>>
+    delete legacySkill.version
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [legacySkill] as any,
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.deleteSkill.mockResolvedValueOnce(undefined)
+
+    try {
+      renderManager()
+      await screen.findByText("skill-4")
+      fireEvent.click(screen.getByRole("button", { name: "Delete skill-4" }))
+
+      await waitFor(() => {
+        expect(tldwClientMock.deleteSkill).toHaveBeenCalledWith("skill-4", undefined)
+      })
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it("shows reload-before-delete guidance on stale delete conflict", async () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      (config) => {
+        void config.onOk?.()
+        return { destroy: vi.fn(), update: vi.fn() } as any
+      }
+    )
+    const conflict = Object.assign(new Error("409 version conflict"), { status: 409 })
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [makeSkill(1)],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.deleteSkill.mockRejectedValueOnce(conflict)
+
+    try {
+      renderManager()
+      await screen.findByText("skill-1")
+      fireEvent.click(screen.getByRole("button", { name: "Delete skill-1" }))
+
+      await waitFor(() => {
+        expect(notificationMock.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Skill changed elsewhere",
+            description: "Reload skills before deleting this version."
+          })
+        )
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["skills"] })
+      )
+    } finally {
+      confirmSpy.mockRestore()
+      invalidateSpy.mockRestore()
+    }
   })
 
   it("clears server-backed mode sorting when the mode column is hidden", async () => {

--- a/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
+++ b/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
@@ -41,4 +41,53 @@ describe("workspace API skill methods", () => {
       body: { args: "chapter 1", dry_run: true }
     })
   })
+
+  it("sends If-Match when deleting a skill with a valid version", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce(undefined)
+    const clientCore = {
+      resolveApiPath: vi.fn().mockResolvedValue("/api/v1/skills/{name}"),
+      fillPathParams: vi.fn().mockReturnValue("/api/v1/skills/summarize")
+    }
+
+    await workspaceApiMethods.deleteSkill.call(clientCore as any, "summarize", 3)
+
+    expect(bgRequest).toHaveBeenCalledWith({
+      path: "/api/v1/skills/summarize",
+      method: "DELETE",
+      headers: { "If-Match": "3" }
+    })
+  })
+
+  it("omits If-Match when deleting a skill without a known version", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce(undefined)
+    const clientCore = {
+      resolveApiPath: vi.fn().mockResolvedValue("/api/v1/skills/{name}"),
+      fillPathParams: vi.fn().mockReturnValue("/api/v1/skills/summarize")
+    }
+
+    await workspaceApiMethods.deleteSkill.call(clientCore as any, "summarize")
+
+    expect(bgRequest).toHaveBeenCalledWith({
+      path: "/api/v1/skills/summarize",
+      method: "DELETE"
+    })
+  })
+
+  it.each([Number.NaN, 0, -1, 1.5, Number.POSITIVE_INFINITY])(
+    "omits If-Match for invalid delete version %s",
+    async (version) => {
+      vi.mocked(bgRequest).mockResolvedValueOnce(undefined)
+      const clientCore = {
+        resolveApiPath: vi.fn().mockResolvedValue("/api/v1/skills/{name}"),
+        fillPathParams: vi.fn().mockReturnValue("/api/v1/skills/summarize")
+      }
+
+      await workspaceApiMethods.deleteSkill.call(clientCore as any, "summarize", version)
+
+      expect(bgRequest).toHaveBeenCalledWith({
+        path: "/api/v1/skills/summarize",
+        method: "DELETE"
+      })
+    }
+  )
 })

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -811,14 +811,23 @@ export const workspaceApiMethods = {
 
   async deleteSkill(
     this: TldwApiClientCore,
-    name: string
+    name: string,
+    version?: number
   ): Promise<void> {
     const base = await this.resolveApiPath("skills.delete", [
       "/api/v1/skills/{name}",
       "/api/v1/skills/{name}/"
     ])
     const path = this.fillPathParams(base, name)
-    await bgRequest<any>({ path, method: "DELETE" })
+    const headers =
+      Number.isSafeInteger(version) && Number(version) > 0
+        ? { "If-Match": String(version) }
+        : undefined
+    await bgRequest<any>({
+      path,
+      method: "DELETE",
+      ...(headers ? { headers } : {})
+    })
   },
 
   async importSkill(

--- a/apps/packages/ui/src/types/skill.ts
+++ b/apps/packages/ui/src/types/skill.ts
@@ -28,6 +28,7 @@ export interface SkillSummary {
   user_invocable: boolean
   disable_model_invocation: boolean
   context: SkillContext
+  version: number
 }
 
 export interface SkillResponse {

--- a/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
+++ b/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
@@ -35,6 +35,8 @@ Spec approved by user and written at `Docs/superpowers/specs/2026-06-28-skills-v
 Self-review completed before implementation planning. Found and patched a spec gap: `SkillSummary` is reused by `/skills/context` and async context integration paths, so requiring `version` must also update `_build_context_payload()` and context/MCP fixtures while keeping `context_text` unchanged. Also tightened delete conflict detection guidance to use a helper covering common wrapped error shapes.
 
 Spec review loop completed: reviewer approved with no blocking issues. Advisory for planning: confirm the actual React Query skills query key/invalidation behavior or use an existing shared key helper if one exists.
+
+Final pre-plan review completed. Confirmed React Query invalidation uses the existing `['skills']` prefix. Patched two planning issues: `If-Match` should only be sent for positive safe integer versions, and backend verification must include context/MCP paths affected by the shared `SkillSummary` schema.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
+++ b/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
@@ -39,6 +39,8 @@ Spec review loop completed: reviewer approved with no blocking issues. Advisory 
 Final pre-plan review completed. Confirmed React Query invalidation uses the existing `['skills']` prefix. Patched two planning issues: `If-Match` should only be sent for positive safe integer versions, and backend verification must include context/MCP paths affected by the shared `SkillSummary` schema.
 
 Implementation plan written at `Docs/superpowers/plans/2026-06-28-skills-version-aware-delete.md`. Plan splits work into backend contract/API coverage, frontend API-client header handling, Skills manager UX recovery, and final verification/bookkeeping.
+
+Plan review loop completed: reviewer approved with no blocking issues or recommendations.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
+++ b/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
@@ -31,6 +31,8 @@ Continue TASK-530 Safe Operations after TASK-530.9 by adding version-aware singl
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Spec approved by user and written at `Docs/superpowers/specs/2026-06-28-skills-version-aware-delete-design.md`. Design scope: expose row versions in Skills list summaries, send `If-Match` from frontend deletes when known, preserve unversioned delete compatibility, and show reload-before-delete recovery copy on stale conflicts.
+
+Self-review completed before implementation planning. Found and patched a spec gap: `SkillSummary` is reused by `/skills/context` and async context integration paths, so requiring `version` must also update `_build_context_payload()` and context/MCP fixtures while keeping `context_text` unchanged. Also tightened delete conflict detection guidance to use a helper covering common wrapped error shapes.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
+++ b/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-530.10
 title: Implement Skills version-aware delete path
-status: In Progress
+status: Done
 labels:
 - skills
 - webui
@@ -54,7 +54,7 @@ Implementation plan written at `Docs/superpowers/plans/2026-06-28-skills-version
 
 Plan review loop completed: reviewer approved with no blocking issues or recommendations.
 
-Implementation completed in staged commits. Task 1 added backend summary/context version exposure and delete API coverage. Task 2 added the frontend API client `If-Match` header guard. Task 3 wired row versions through the Skills manager delete confirmation, added stale-conflict recovery copy, and tightened conflict detection after review to avoid treating arbitrary messages containing `409` as conflicts.
+Implementation completed in staged commits. Task 1 added backend summary/context version exposure and delete API coverage. Task 2 added the frontend API client `If-Match` header guard. Task 3 wired row versions through the Skills manager delete confirmation, added stale-conflict recovery copy, and tightened conflict detection after review to avoid treating arbitrary messages containing `409` as conflicts. Final branch review follow-up made handled stale conflicts resolve the confirmation flow so users are not left in a stale delete modal after recovery feedback, while generic delete failures still reject.
 
 Verification completed:
 - Backend focused pytest: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py -k "list_skills or delete_skill or get_context_payload or async_variant_uses_async_context_payload" -v` -> 21 passed, 55 deselected.

--- a/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
+++ b/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
@@ -22,6 +22,8 @@ modified_files:
 - apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
 - apps/packages/ui/src/components/Option/Skills/Manager.tsx
 - apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+references:
+- https://github.com/rmusser01/tldw_server/pull/2544
 ---
 
 ## Description

--- a/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
+++ b/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
@@ -37,6 +37,8 @@ Self-review completed before implementation planning. Found and patched a spec g
 Spec review loop completed: reviewer approved with no blocking issues. Advisory for planning: confirm the actual React Query skills query key/invalidation behavior or use an existing shared key helper if one exists.
 
 Final pre-plan review completed. Confirmed React Query invalidation uses the existing `['skills']` prefix. Patched two planning issues: `If-Match` should only be sent for positive safe integer versions, and backend verification must include context/MCP paths affected by the shared `SkillSummary` schema.
+
+Implementation plan written at `Docs/superpowers/plans/2026-06-28-skills-version-aware-delete.md`. Plan splits work into backend contract/API coverage, frontend API-client header handling, Skills manager UX recovery, and final verification/bookkeeping.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
+++ b/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
@@ -1,0 +1,50 @@
+---
+id: TASK-530.10
+title: Implement Skills version-aware delete path
+status: In Progress
+labels:
+- skills
+- webui
+- safe-operations
+- backend
+priority: high
+ordinal: 530.1
+parent_task_id: TASK-530
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-530 Safe Operations after TASK-530.9 by adding version-aware single-skill delete behavior. Extend the frontend/API path so stale destructive deletes can be blocked and recovered before any bulk-delete work. Keep bulk delete, export feedback, and permission metadata panels out of scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Delete requests send an If-Match version when the frontend has a known skill version.
+- [ ] #2 Backend delete validates If-Match consistently and returns a recoverable conflict for stale versions.
+- [ ] #3 The Skills manager shows a clear reload-before-delete recovery message on stale delete conflicts.
+- [ ] #4 Existing delete behavior remains compatible when no version is known.
+- [ ] #5 Focused frontend and backend tests cover successful delete, no-version compatibility, and stale-version conflict handling.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Spec approved by user and written at `Docs/superpowers/specs/2026-06-28-skills-version-aware-delete-design.md`. Design scope: expose row versions in Skills list summaries, send `If-Match` from frontend deletes when known, preserve unversioned delete compatibility, and show reload-before-delete recovery copy on stale conflicts.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
+++ b/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
@@ -33,6 +33,8 @@ Continue TASK-530 Safe Operations after TASK-530.9 by adding version-aware singl
 Spec approved by user and written at `Docs/superpowers/specs/2026-06-28-skills-version-aware-delete-design.md`. Design scope: expose row versions in Skills list summaries, send `If-Match` from frontend deletes when known, preserve unversioned delete compatibility, and show reload-before-delete recovery copy on stale conflicts.
 
 Self-review completed before implementation planning. Found and patched a spec gap: `SkillSummary` is reused by `/skills/context` and async context integration paths, so requiring `version` must also update `_build_context_payload()` and context/MCP fixtures while keeping `context_text` unchanged. Also tightened delete conflict detection guidance to use a helper covering common wrapped error shapes.
+
+Spec review loop completed: reviewer approved with no blocking issues. Advisory for planning: confirm the actual React Query skills query key/invalidation behavior or use an existing shared key helper if one exists.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
+++ b/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
@@ -10,6 +10,18 @@ labels:
 priority: high
 ordinal: 530.1
 parent_task_id: TASK-530
+documentation:
+- Docs/superpowers/plans/2026-06-28-skills-version-aware-delete.md
+modified_files:
+- tldw_Server_API/app/api/v1/endpoints/skills.py
+- tldw_Server_API/app/api/v1/schemas/skills_schemas.py
+- tldw_Server_API/app/core/Skills/skills_service.py
+- tldw_Server_API/tests/Skills/integration/test_skills_api.py
+- apps/packages/ui/src/types/skill.ts
+- apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+- apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
+- apps/packages/ui/src/components/Option/Skills/Manager.tsx
+- apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
 ---
 
 ## Description
@@ -20,11 +32,11 @@ Continue TASK-530 Safe Operations after TASK-530.9 by adding version-aware singl
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Delete requests send an If-Match version when the frontend has a known skill version.
-- [ ] #2 Backend delete validates If-Match consistently and returns a recoverable conflict for stale versions.
-- [ ] #3 The Skills manager shows a clear reload-before-delete recovery message on stale delete conflicts.
-- [ ] #4 Existing delete behavior remains compatible when no version is known.
-- [ ] #5 Focused frontend and backend tests cover successful delete, no-version compatibility, and stale-version conflict handling.
+- [x] #1 Delete requests send an If-Match version when the frontend has a known skill version.
+- [x] #2 Backend delete validates If-Match consistently and returns a recoverable conflict for stale versions.
+- [x] #3 The Skills manager shows a clear reload-before-delete recovery message on stale delete conflicts.
+- [x] #4 Existing delete behavior remains compatible when no version is known.
+- [x] #5 Focused frontend and backend tests cover successful delete, no-version compatibility, and stale-version conflict handling.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -41,20 +53,29 @@ Final pre-plan review completed. Confirmed React Query invalidation uses the exi
 Implementation plan written at `Docs/superpowers/plans/2026-06-28-skills-version-aware-delete.md`. Plan splits work into backend contract/API coverage, frontend API-client header handling, Skills manager UX recovery, and final verification/bookkeeping.
 
 Plan review loop completed: reviewer approved with no blocking issues or recommendations.
+
+Implementation completed in staged commits. Task 1 added backend summary/context version exposure and delete API coverage. Task 2 added the frontend API client `If-Match` header guard. Task 3 wired row versions through the Skills manager delete confirmation, added stale-conflict recovery copy, and tightened conflict detection after review to avoid treating arbitrary messages containing `409` as conflicts.
+
+Verification completed:
+- Backend focused pytest: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py -k "list_skills or delete_skill or get_context_payload or async_variant_uses_async_context_payload" -v` -> 21 passed, 55 deselected.
+- Frontend focused Vitest: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot` -> 2 files passed, 39 tests passed.
+- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_10.json` -> 0 results.
+
+Known skip: no full frontend build/typecheck was run; focused backend/API-client/manager suites cover this task slice.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented version-aware single-skill delete across backend and WebUI. Skill summaries now expose `version`, context payload summaries include version metadata without changing prompt text, and delete API integration tests cover matching and stale `If-Match` behavior. The frontend API client now accepts an optional delete version and sends `If-Match` only for positive safe integers. The Skills manager passes row versions through the existing destructive confirmation, preserves unknown-version compatibility, refreshes the skills list on stale 409 conflicts, and shows reload-before-delete recovery copy. Verification: backend focused pytest selected 21 tests passed; frontend focused Vitest selected 39 tests passed; Bandit on touched backend files wrote `/tmp/bandit_task_530_10.json` with 0 findings. Known skip: no full frontend build/typecheck was run; focused suites cover this slice.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
+++ b/backlog/tasks/task-530.10 - Implement-Skills-version-aware-delete-path.md
@@ -59,9 +59,9 @@ Plan review loop completed: reviewer approved with no blocking issues or recomme
 Implementation completed in staged commits. Task 1 added backend summary/context version exposure and delete API coverage. Task 2 added the frontend API client `If-Match` header guard. Task 3 wired row versions through the Skills manager delete confirmation, added stale-conflict recovery copy, and tightened conflict detection after review to avoid treating arbitrary messages containing `409` as conflicts. Final branch review follow-up made handled stale conflicts resolve the confirmation flow so users are not left in a stale delete modal after recovery feedback, while generic delete failures still reject.
 
 Verification completed:
-- Backend focused pytest: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py -k "list_skills or delete_skill or get_context_payload or async_variant_uses_async_context_payload" -v` -> 21 passed, 55 deselected.
+- Backend focused pytest: `python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py -k "list_skills or delete_skill or get_context_payload or async_variant_uses_async_context_payload" -v` -> 21 passed, 55 deselected.
 - Frontend focused Vitest: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot` -> 2 files passed, 39 tests passed.
-- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_10.json` -> 0 results.
+- Bandit: `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_10.json` -> 0 results.
 
 Known skip: no full frontend build/typecheck was run; focused backend/API-client/manager suites cover this task slice.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -142,7 +142,7 @@ def _metadata_to_summary(metadata) -> SkillSummary:
         user_invocable=metadata.user_invocable,
         disable_model_invocation=metadata.disable_model_invocation,
         context=metadata.context,
-        version=metadata.version,
+        version=metadata.version or 1,
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -142,6 +142,7 @@ def _metadata_to_summary(metadata) -> SkillSummary:
         user_invocable=metadata.user_invocable,
         disable_model_invocation=metadata.disable_model_invocation,
         context=metadata.context,
+        version=metadata.version,
     )
 
 

--- a/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
@@ -194,6 +194,7 @@ class SkillSummary(BaseModel):
     user_invocable: bool = Field(..., description="If false, hidden from user UI")
     disable_model_invocation: bool = Field(..., description="If true, only user can invoke")
     context: SkillContext = Field(..., description="Execution context mode")
+    version: int = Field(..., description="Version for optimistic locking")
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -1596,6 +1596,7 @@ class SkillsService:
                     "user_invocable": bool(s.get("user_invocable")),
                     "disable_model_invocation": bool(s.get("disable_model_invocation")),
                     "context": s.get("context", "inline"),
+                    "version": int(s.get("version") or 1),
                 }
                 for s in skills
             ],

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -342,6 +342,18 @@ class TestListSkills:
         assert data["has_more"] is False
         assert data["next_offset"] is None
 
+    def test_list_skills_includes_version(self, client):
+        create_resp = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "listed-version", "content": "content"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        r = client.get(f"{SKILLS_PREFIX}/?limit=50&offset=0")
+        assert r.status_code == 200, r.text
+        listed = {skill["name"]: skill for skill in r.json()["skills"]}
+        assert listed["listed-version"]["version"] == create_resp.json()["version"]
+
     def test_list_skills_search_filters_before_pagination(self, client):
         for i in range(12):
             r = client.post(
@@ -601,6 +613,47 @@ class TestDeleteSkill:
 
         r = client.get(f"{SKILLS_PREFIX}/del-skill")
         assert r.status_code == 404
+
+    def test_delete_skill_accepts_matching_if_match(self, client):
+        create_resp = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "del-versioned", "content": "content"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        version = create_resp.json()["version"]
+
+        r = client.delete(
+            f"{SKILLS_PREFIX}/del-versioned",
+            headers={"If-Match": str(version)},
+        )
+        assert r.status_code == 204, r.text
+
+        missing = client.get(f"{SKILLS_PREFIX}/del-versioned")
+        assert missing.status_code == 404
+
+    def test_delete_skill_stale_if_match_returns_409_and_keeps_skill(self, client):
+        create_resp = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "del-stale", "content": "v1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        update_resp = client.put(
+            f"{SKILLS_PREFIX}/del-stale",
+            json={"content": "v2"},
+        )
+        assert update_resp.status_code == 200, update_resp.text
+        assert update_resp.json()["version"] == create_resp.json()["version"] + 1
+
+        r = client.delete(
+            f"{SKILLS_PREFIX}/del-stale",
+            headers={"If-Match": str(create_resp.json()["version"])},
+        )
+        assert r.status_code == 409
+
+        still_there = client.get(f"{SKILLS_PREFIX}/del-stale")
+        assert still_there.status_code == 200, still_there.text
+        assert still_there.json()["version"] == update_resp.json()["version"]
 
     def test_delete_skill_not_found_404(self, client):
         r = client.delete(f"{SKILLS_PREFIX}/nonexistent")
@@ -1217,6 +1270,10 @@ class TestContextPayload:
         data = r.json()
         assert len(data["available_skills"]) >= 1
         assert "ctx-skill" in data["context_text"]
+        listed = {skill["name"]: skill for skill in data["available_skills"]}
+        assert listed["ctx-skill"]["version"] == 1
+        ctx_line = next(line for line in data["context_text"].splitlines() if "ctx-skill" in line)
+        assert "version" not in ctx_line.lower()
 
     def test_get_context_payload_uses_async_service_method(self, client, monkeypatch):
         calls = {"async": 0}

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -27,7 +27,10 @@ os.environ["ROUTES_DISABLE"] = ",".join(sorted(_routes_disable))
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps import auth_deps
-from tldw_Server_API.app.api.v1.endpoints.skills import MAX_SKILL_IMPORT_PREVIEW_UPLOAD_BYTES
+from tldw_Server_API.app.api.v1.endpoints.skills import (
+    MAX_SKILL_IMPORT_PREVIEW_UPLOAD_BYTES,
+    _metadata_to_summary,
+)
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 from tldw_Server_API.app.core.Context_Integrity.resolver import clear_global_context_integrity_resolver
@@ -342,7 +345,8 @@ class TestListSkills:
         assert data["has_more"] is False
         assert data["next_offset"] is None
 
-    def test_list_skills_includes_version(self, client):
+    def test_list_skills_includes_version(self, client: TestClient) -> None:
+        """List summaries expose the registry version for optimistic deletes."""
         create_resp = client.post(
             f"{SKILLS_PREFIX}/",
             json={"name": "listed-version", "content": "content"},
@@ -353,6 +357,22 @@ class TestListSkills:
         assert r.status_code == 200, r.text
         listed = {skill["name"]: skill for skill in r.json()["skills"]}
         assert listed["listed-version"]["version"] == create_resp.json()["version"]
+
+    def test_metadata_summary_defaults_missing_version(self) -> None:
+        """Legacy metadata without a version still produces a valid summary."""
+        metadata = SimpleNamespace(
+            name="legacy-version",
+            description=None,
+            argument_hint=None,
+            user_invocable=True,
+            disable_model_invocation=False,
+            context="inline",
+            version=None,
+        )
+
+        summary = _metadata_to_summary(metadata)
+
+        assert summary.version == 1
 
     def test_list_skills_search_filters_before_pagination(self, client):
         for i in range(12):
@@ -614,7 +634,8 @@ class TestDeleteSkill:
         r = client.get(f"{SKILLS_PREFIX}/del-skill")
         assert r.status_code == 404
 
-    def test_delete_skill_accepts_matching_if_match(self, client):
+    def test_delete_skill_accepts_matching_if_match(self, client: TestClient) -> None:
+        """Deletes with a matching If-Match version remove the skill."""
         create_resp = client.post(
             f"{SKILLS_PREFIX}/",
             json={"name": "del-versioned", "content": "content"},
@@ -631,7 +652,11 @@ class TestDeleteSkill:
         missing = client.get(f"{SKILLS_PREFIX}/del-versioned")
         assert missing.status_code == 404
 
-    def test_delete_skill_stale_if_match_returns_409_and_keeps_skill(self, client):
+    def test_delete_skill_stale_if_match_returns_409_and_keeps_skill(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Stale If-Match deletes return 409 without deleting the current skill."""
         create_resp = client.post(
             f"{SKILLS_PREFIX}/",
             json={"name": "del-stale", "content": "v1"},


### PR DESCRIPTION
## Summary

- Exposes skill summary versions in the backend list/context contracts and adds API coverage for versioned/stale deletes.
- Sends `If-Match` from the frontend delete client only for valid known versions while preserving unversioned compatibility.
- Wires Skills Manager row versions into delete confirmation and adds stale-conflict recovery copy, refresh behavior, and regression coverage.

## Test Plan

- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py -k "list_skills or delete_skill or get_context_payload or async_variant_uses_async_context_payload" -v`
- [x] `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_10.json`

## Change summary

This implements TASK-530.10 as an optimistic-delete safety slice. The backend already had service-level version checks, so the change exposes existing registry versions through list/context metadata and adds API-level coverage rather than introducing new storage behavior. The frontend keeps older callers compatible by treating missing or invalid versions as unknown, while current table rows send `If-Match` so stale destructive actions can be blocked and recovered with a clear reload-before-delete message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds version-aware skill deletion with optimistic locking, precise 409 detection, and clear conflict recovery, while keeping unversioned deletes compatible. Implements TASK-530.10 by exposing row versions, sending `If-Match` when valid, and refreshing the list on conflicts.

- **New Features**
  - Backend: exposes `version` in `SkillSummary` for list and context payloads (keeps `context_text` unchanged), defaults missing versions to `1`, and adds API tests for matching and stale `If-Match`.
  - Frontend API: `deleteSkill(name, version?)` sends `If-Match` only for positive safe integers.
  - Skills Manager: passes row `version` through delete confirm, detects 409s without false positives, shows “Skill changed elsewhere” with “Reload skills before deleting this version.”, invalidates `["skills"]`, and resolves the confirm flow on conflict.
  - Compatibility: unversioned deletes remain supported for older callers and unknown-version rows.

<sup>Written for commit e9e23f66b12862641c2f6b8d54bcf1bd4de92825. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

