### PR TITLE
TASK-530.11 Skills version-aware bulk delete

### DIFF
--- a/Docs/superpowers/plans/2026-06-28-skills-version-aware-bulk-delete.md
+++ b/Docs/superpowers/plans/2026-06-28-skills-version-aware-bulk-delete.md
@@ -73,4 +73,6 @@ Out of scope:
 - [x] Run Bandit touched backend scope: `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_11.json`
 - [x] Run `git diff --check`.
 - [x] Update TASK-530.11 acceptance criteria, implementation notes, final summary, modified files, verification, and known skips.
-- [ ] Commit and open PR against `dev`.
+- [x] Commit and open PR against `dev`.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2545

--- a/Docs/superpowers/plans/2026-06-28-skills-version-aware-bulk-delete.md
+++ b/Docs/superpowers/plans/2026-06-28-skills-version-aware-bulk-delete.md
@@ -1,0 +1,76 @@
+# Skills Version-Aware Bulk Delete Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a selected-row bulk delete flow for Skills that sends optimistic versions and refuses stale destructive deletes before removing any selected skill.
+
+**Architecture:** Reuse the existing `SkillSummary.version` contract from TASK-530.10. Add a POST bulk-delete endpoint with an explicit request body instead of relying on DELETE bodies. The backend prevalidates all selected names and expected versions before deletion; the frontend adds table selection, a small selected-action bar, and the same reload-before-delete recovery pattern used by single delete.
+
+**Tech Stack:** FastAPI, Pydantic, SkillsService, ChaChaNotesDB skill registry, React, Ant Design Table row selection, TanStack Query, Vitest, pytest.
+
+---
+
+## Scope
+
+In scope:
+- `POST /api/v1/skills/bulk-delete`
+- Frontend API client `bulkDeleteSkills()`
+- Skills manager row selection and destructive confirmation
+- Stale-version recovery feedback
+- Focused backend and frontend tests
+
+Out of scope:
+- Delete all filtered results across pages
+- Export feedback
+- Permission metadata panels
+- Undo/restore
+- New DB schema
+
+## Files
+
+- Modify: `tldw_Server_API/app/api/v1/schemas/skills_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/skills.py`
+- Modify: `tldw_Server_API/app/core/Skills/skills_service.py`
+- Modify: `tldw_Server_API/tests/Skills/integration/test_skills_api.py`
+- Modify: `apps/packages/ui/src/types/skill.ts`
+- Modify: `apps/packages/ui/src/services/tldw/domains/workspace-api.ts`
+- Modify: `apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts`
+- Modify: `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+- Modify: `backlog/tasks/task-530.11 - Implement-Skills-version-aware-bulk-delete.md`
+
+## Task 1: Backend Bulk Delete Contract
+
+- [ ] Add Pydantic models `SkillBulkDeleteItem`, `SkillBulkDeleteRequest`, and `SkillBulkDeleteResponse`.
+- [ ] Add failing integration tests for successful bulk delete, unknown-version compatibility, stale conflict, and no partial delete on stale conflict.
+- [ ] Add `SkillsService.bulk_delete_skills(items)` that normalizes names, syncs once, validates every selected row/version, then deletes the validated rows.
+- [ ] Add `POST /api/v1/skills/bulk-delete` endpoint that returns deleted names/count and maps `SkillConflictError` to 409, `SkillNotFoundError` to 404, and generic `SkillsError` to sanitized 500.
+- [ ] Run: `python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "bulk_delete or delete_skill" -v`
+
+## Task 2: Frontend API Client
+
+- [ ] Add TypeScript request/response types for bulk delete.
+- [ ] Add `workspaceApiMethods.bulkDeleteSkills(items)` using `POST /api/v1/skills/bulk-delete`.
+- [ ] Send only positive safe integer versions in request items.
+- [ ] Add focused API-client tests for valid versions and unknown/invalid versions.
+- [ ] Run: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot`
+
+## Task 3: Skills Manager Bulk UX
+
+- [ ] Add selected row state keyed by skill name.
+- [ ] Add AntD `rowSelection` to the Skills table.
+- [ ] Add an unframed action bar above the table when rows are selected: `<count> selected`, clear selection, and destructive `Delete selected`.
+- [ ] Confirm bulk deletion with selected count and a short irreversible warning.
+- [ ] On success, clear selection, invalidate `["skills"]`, and show a bulk-delete success notification.
+- [ ] On stale 409 conflict, keep the selection recoverable, invalidate `["skills"]`, and show reload-before-delete guidance.
+- [ ] Add focused manager tests for selected-row bulk delete, unknown-version compatibility, stale conflict recovery, and clearing selection on success.
+- [ ] Run: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
+
+## Task 4: Verification And Closeout
+
+- [ ] Run backend focused pytest from Task 1.
+- [ ] Run frontend focused Vitest from Tasks 2 and 3.
+- [ ] Run Bandit touched backend scope: `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_11.json`
+- [ ] Run `git diff --check`.
+- [ ] Update TASK-530.11 acceptance criteria, implementation notes, final summary, modified files, verification, and known skips.
+- [ ] Commit and open PR against `dev`.

--- a/Docs/superpowers/plans/2026-06-28-skills-version-aware-bulk-delete.md
+++ b/Docs/superpowers/plans/2026-06-28-skills-version-aware-bulk-delete.md
@@ -41,36 +41,36 @@ Out of scope:
 
 ## Task 1: Backend Bulk Delete Contract
 
-- [ ] Add Pydantic models `SkillBulkDeleteItem`, `SkillBulkDeleteRequest`, and `SkillBulkDeleteResponse`.
-- [ ] Add failing integration tests for successful bulk delete, unknown-version compatibility, stale conflict, and no partial delete on stale conflict.
-- [ ] Add `SkillsService.bulk_delete_skills(items)` that normalizes names, syncs once, validates every selected row/version, then deletes the validated rows.
-- [ ] Add `POST /api/v1/skills/bulk-delete` endpoint that returns deleted names/count and maps `SkillConflictError` to 409, `SkillNotFoundError` to 404, and generic `SkillsError` to sanitized 500.
-- [ ] Run: `python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "bulk_delete or delete_skill" -v`
+- [x] Add Pydantic models `SkillBulkDeleteItem`, `SkillBulkDeleteRequest`, and `SkillBulkDeleteResponse`.
+- [x] Add failing integration tests for successful bulk delete, unknown-version compatibility, stale conflict, and no partial delete on stale conflict.
+- [x] Add `SkillsService.bulk_delete_skills(items)` that normalizes names, syncs once, validates every selected row/version, then deletes the validated rows.
+- [x] Add `POST /api/v1/skills/bulk-delete` endpoint that returns deleted names/count and maps `SkillConflictError` to 409, `SkillNotFoundError` to 404, and generic `SkillsError` to sanitized 500.
+- [x] Run: `python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "bulk_delete or delete_skill" -v`
 
 ## Task 2: Frontend API Client
 
-- [ ] Add TypeScript request/response types for bulk delete.
-- [ ] Add `workspaceApiMethods.bulkDeleteSkills(items)` using `POST /api/v1/skills/bulk-delete`.
-- [ ] Send only positive safe integer versions in request items.
-- [ ] Add focused API-client tests for valid versions and unknown/invalid versions.
-- [ ] Run: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot`
+- [x] Add TypeScript request/response types for bulk delete.
+- [x] Add `workspaceApiMethods.bulkDeleteSkills(items)` using `POST /api/v1/skills/bulk-delete`.
+- [x] Send only positive safe integer versions in request items.
+- [x] Add focused API-client tests for valid versions and unknown/invalid versions.
+- [x] Run: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot`
 
 ## Task 3: Skills Manager Bulk UX
 
-- [ ] Add selected row state keyed by skill name.
-- [ ] Add AntD `rowSelection` to the Skills table.
-- [ ] Add an unframed action bar above the table when rows are selected: `<count> selected`, clear selection, and destructive `Delete selected`.
-- [ ] Confirm bulk deletion with selected count and a short irreversible warning.
-- [ ] On success, clear selection, invalidate `["skills"]`, and show a bulk-delete success notification.
-- [ ] On stale 409 conflict, keep the selection recoverable, invalidate `["skills"]`, and show reload-before-delete guidance.
-- [ ] Add focused manager tests for selected-row bulk delete, unknown-version compatibility, stale conflict recovery, and clearing selection on success.
-- [ ] Run: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
+- [x] Add selected row state keyed by skill name.
+- [x] Add AntD `rowSelection` to the Skills table.
+- [x] Add an unframed action bar above the table when rows are selected: `<count> selected`, clear selection, and destructive `Delete selected`.
+- [x] Confirm bulk deletion with selected count and a short irreversible warning.
+- [x] On success, clear selection, invalidate `["skills"]`, and show a bulk-delete success notification.
+- [x] On stale 409 conflict, keep the selection recoverable, invalidate `["skills"]`, and show reload-before-delete guidance.
+- [x] Add focused manager tests for selected-row bulk delete, unknown-version compatibility, stale conflict recovery, and clearing selection on success.
+- [x] Run: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
 
 ## Task 4: Verification And Closeout
 
-- [ ] Run backend focused pytest from Task 1.
-- [ ] Run frontend focused Vitest from Tasks 2 and 3.
-- [ ] Run Bandit touched backend scope: `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_11.json`
-- [ ] Run `git diff --check`.
-- [ ] Update TASK-530.11 acceptance criteria, implementation notes, final summary, modified files, verification, and known skips.
+- [x] Run backend focused pytest from Task 1.
+- [x] Run frontend focused Vitest from Tasks 2 and 3.
+- [x] Run Bandit touched backend scope: `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_11.json`
+- [x] Run `git diff --check`.
+- [x] Update TASK-530.11 acceptance criteria, implementation notes, final summary, modified files, verification, and known skips.
 - [ ] Commit and open PR against `dev`.

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -154,6 +154,11 @@ const isConflictError = (error: unknown): boolean => {
     || hasConflictMessage
 }
 
+const getKnownSkillVersion = (version: unknown): number | undefined =>
+  typeof version === "number" && Number.isSafeInteger(version) && version > 0
+    ? version
+    : undefined
+
 const buildSkillInvocation = (skillName: string) => `/skill ${skillName}`
 
 const isSkillTableSortField = (value: React.Key | undefined): value is SkillListSort =>
@@ -252,6 +257,7 @@ export const SkillsManager: React.FC = () => {
     React.useState<FileImportReview | null>(null)
   const [editingSkill, setEditingSkill] = React.useState<SkillResponse | null>(null)
   const [previewSkill, setPreviewSkill] = React.useState<string | null>(null)
+  const [selectedSkillNames, setSelectedSkillNames] = React.useState<string[]>([])
   const [successAction, setSuccessAction] =
     React.useState<SkillsSuccessAction | null>(null)
   const [importTextForm] = Form.useForm<ImportTextFormValues>()
@@ -341,6 +347,12 @@ export const SkillsManager: React.FC = () => {
   })
 
   const hasLoadedSkills = data != null && !isError
+  const currentSkills = React.useMemo(() => data?.skills ?? [], [data?.skills])
+  const selectedSkills = React.useMemo(() => {
+    const selectedNames = new Set(selectedSkillNames)
+    return currentSkills.filter((skill) => selectedNames.has(skill.name))
+  }, [currentSkills, selectedSkillNames])
+  const selectedSkillCount = selectedSkillNames.length
   const totalSkills = data?.total ?? 0
   const hasSearch = searchQuery.length > 0
   const isLibraryEmpty =
@@ -378,6 +390,16 @@ export const SkillsManager: React.FC = () => {
       setPage(lastPage)
     }
   }, [hasLoadedSkills, page, pageSize, totalSkills])
+
+  React.useEffect(() => {
+    if (!hasLoadedSkills) return
+
+    const currentSkillNames = new Set(currentSkills.map((skill) => skill.name))
+    setSelectedSkillNames((current) => {
+      const next = current.filter((name) => currentSkillNames.has(name))
+      return next.length === current.length ? current : next
+    })
+  }, [currentSkills, hasLoadedSkills])
 
   const handleContextFilterChange = (nextFilter: SkillContextFilter) => {
     setContextFilter(nextFilter)
@@ -469,6 +491,54 @@ export const SkillsManager: React.FC = () => {
       }
       notification.error({
         message: t("option:skills.deleteError", { defaultValue: "Failed to delete skill" }),
+        description: getErrorDescription(err)
+      })
+    }
+  })
+
+  const bulkDeleteMutation = useMutation({
+    mutationFn: (skills: SkillSummary[]) =>
+      tldwClient.bulkDeleteSkills(
+        skills.map((skill) => {
+          const version = getKnownSkillVersion(skill.version)
+          return {
+            name: skill.name,
+            ...(version ? { version } : {})
+          }
+        })
+      ),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["skills"] })
+      setSelectedSkillNames([])
+      setSuccessAction(null)
+      const count = Number(result?.count ?? 0)
+      notification.success({
+        message: t("option:skills.bulkDeleteSuccess", {
+          defaultValue: "Skills deleted"
+        }),
+        description: t("option:skills.bulkDeleteSuccessDesc", {
+          defaultValue: `${count} skill(s) deleted.`,
+          count
+        })
+      })
+    },
+    onError: (err: unknown) => {
+      if (isConflictError(err)) {
+        queryClient.invalidateQueries({ queryKey: ["skills"] })
+        notification.error({
+          message: t("option:skills.bulkDeleteConflict", {
+            defaultValue: "Selected skills changed elsewhere"
+          }),
+          description: t("option:skills.bulkDeleteConflictDesc", {
+            defaultValue: "Reload skills before deleting these versions."
+          })
+        })
+        return
+      }
+      notification.error({
+        message: t("option:skills.bulkDeleteError", {
+          defaultValue: "Failed to delete selected skills"
+        }),
         description: getErrorDescription(err)
       })
     }
@@ -657,10 +727,35 @@ export const SkillsManager: React.FC = () => {
       cancelText: t("common:cancel", { defaultValue: "Cancel" }),
       onOk: () => deleteMutation.mutateAsync({
         name: skill.name,
-        version: Number.isSafeInteger(skill.version) && Number(skill.version) > 0
-          ? skill.version
-          : undefined
+        version: getKnownSkillVersion(skill.version)
       }).catch((err: unknown) => {
+        if (isConflictError(err)) return
+        throw err
+      })
+    })
+  }
+
+  const handleBulkDelete = () => {
+    if (!selectedSkills.length) return
+
+    const count = selectedSkills.length
+    Modal.confirm({
+      title: t("option:skills.bulkDeleteConfirmTitle", {
+        defaultValue: "Delete selected skills?"
+      }),
+      content: t("option:skills.bulkDeleteConfirmContent", {
+        defaultValue: `Delete ${count} selected skill(s)? This cannot be undone.`,
+        count
+      }),
+      okText: t("option:skills.bulkDeleteConfirmOk", {
+        defaultValue: "Delete selected"
+      }),
+      okButtonProps: {
+        danger: true,
+        loading: bulkDeleteMutation.isPending
+      },
+      cancelText: t("common:cancel", { defaultValue: "Cancel" }),
+      onOk: () => bulkDeleteMutation.mutateAsync(selectedSkills).catch((err: unknown) => {
         if (isConflictError(err)) return
         throw err
       })
@@ -1466,12 +1561,58 @@ export const SkillsManager: React.FC = () => {
         </DesignSystemAlert>
       )}
 
+      {selectedSkillCount > 0 && (
+        <div
+          data-testid="skills-selection-actions"
+          className="flex flex-wrap items-center justify-between gap-2 border-y border-border py-2"
+        >
+          <span className="text-sm font-medium text-text" aria-live="polite">
+            {t("option:skills.selectedCount", {
+              defaultValue: `${selectedSkillCount} selected`,
+              count: selectedSkillCount
+            })}
+          </span>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="small"
+              onClick={() => setSelectedSkillNames([])}
+            >
+              {t("option:skills.clearSelection", {
+                defaultValue: "Clear selection"
+              })}
+            </Button>
+            <Button
+              size="small"
+              danger
+              icon={<Trash2 size={14} />}
+              loading={bulkDeleteMutation.isPending}
+              onClick={handleBulkDelete}
+            >
+              {t("option:skills.bulkDeleteAction", {
+                defaultValue: "Delete selected"
+              })}
+            </Button>
+          </div>
+        </div>
+      )}
+
       <Table
         data-testid="skills-table"
         data-density={tableDensity}
-        dataSource={data?.skills ?? []}
+        dataSource={currentSkills}
         columns={columns}
         rowKey="name"
+        rowSelection={{
+          selectedRowKeys: selectedSkillNames,
+          onChange: (selectedRowKeys) =>
+            setSelectedSkillNames(selectedRowKeys.map((key) => String(key))),
+          getCheckboxProps: (record) => ({
+            "aria-label": t("option:skills.selectSkillRow", {
+              defaultValue: `Select ${record.name}`,
+              name: record.name
+            })
+          })
+        }}
         loading={isLoading}
         onChange={handleTableChange}
         pagination={false}

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -8,6 +8,7 @@ const tldwClientMock = vi.hoisted(() => ({
   listSkills: vi.fn(),
   getSkill: vi.fn(),
   deleteSkill: vi.fn(),
+  bulkDeleteSkills: vi.fn(),
   exportSkill: vi.fn(),
   previewSkillImport: vi.fn(),
   previewSkillImportFile: vi.fn(),
@@ -202,6 +203,12 @@ describe("SkillsManager imports", () => {
 
   const getColumnVisibilityOption = async (name: string) =>
     within(await openColumnVisibilityMenu()).findByRole("menuitem", { name })
+
+  const selectSkillRow = (name: string) => {
+    const row = screen.getByText(name).closest("tr")
+    expect(row).not.toBeNull()
+    fireEvent.click(within(row as HTMLTableRowElement).getByRole("checkbox"))
+  }
 
   it("orients users with a page summary and library count", async () => {
     tldwClientMock.listSkills.mockResolvedValueOnce({
@@ -741,7 +748,7 @@ describe("SkillsManager imports", () => {
       await waitFor(() => {
         expect(confirmConfig?.onOk).toBeTypeOf("function")
       })
-      await expect(confirmConfig?.onOk?.()).resolves.toBeUndefined()
+      await confirmConfig?.onOk?.()
 
       await waitFor(() => {
         expect(notificationMock.error).toHaveBeenCalledWith(
@@ -754,6 +761,152 @@ describe("SkillsManager imports", () => {
       expect(invalidateSpy).toHaveBeenCalledWith(
         expect.objectContaining({ queryKey: ["skills"] })
       )
+    } finally {
+      confirmSpy.mockRestore()
+      invalidateSpy.mockRestore()
+    }
+  })
+
+  it("bulk deletes selected rows with their current versions", async () => {
+    let confirmConfig: { onOk?: () => void | Promise<void> } | undefined
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      (config) => {
+        confirmConfig = config as { onOk?: () => void | Promise<void> }
+        return { destroy: vi.fn(), update: vi.fn() } as any
+      }
+    )
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [makeSkill(1), makeSkill(2)],
+      count: 2,
+      total: 2,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.bulkDeleteSkills.mockResolvedValueOnce({
+      deleted: ["skill-1", "skill-2"],
+      count: 2
+    })
+
+    try {
+      renderManager()
+      await screen.findByText("skill-1")
+      selectSkillRow("skill-1")
+      selectSkillRow("skill-2")
+
+      expect(screen.getByTestId("skills-selection-actions")).toHaveTextContent("2 selected")
+      fireEvent.click(screen.getByRole("button", { name: "Delete selected" }))
+
+      await waitFor(() => {
+        expect(confirmConfig?.onOk).toBeTypeOf("function")
+      })
+      await confirmConfig?.onOk?.()
+
+      await waitFor(() => {
+        expect(tldwClientMock.bulkDeleteSkills).toHaveBeenCalledWith([
+          { name: "skill-1", version: 2 },
+          { name: "skill-2", version: 3 }
+        ])
+      })
+      expect(notificationMock.success).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Skills deleted",
+          description: "2 skill(s) deleted."
+        })
+      )
+      await waitFor(() => {
+        expect(screen.queryByTestId("skills-selection-actions")).not.toBeInTheDocument()
+      })
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it("bulk delete stays compatible when selected rows have no known version", async () => {
+    let confirmConfig: { onOk?: () => void | Promise<void> } | undefined
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      (config) => {
+        confirmConfig = config as { onOk?: () => void | Promise<void> }
+        return { destroy: vi.fn(), update: vi.fn() } as any
+      }
+    )
+    const legacySkill = { ...makeSkill(4) } as Partial<ReturnType<typeof makeSkill>>
+    delete legacySkill.version
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [legacySkill] as any,
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.bulkDeleteSkills.mockResolvedValueOnce({
+      deleted: ["skill-4"],
+      count: 1
+    })
+
+    try {
+      renderManager()
+      await screen.findByText("skill-4")
+      selectSkillRow("skill-4")
+      fireEvent.click(screen.getByRole("button", { name: "Delete selected" }))
+
+      await waitFor(() => {
+        expect(confirmConfig?.onOk).toBeTypeOf("function")
+      })
+      await confirmConfig?.onOk?.()
+
+      await waitFor(() => {
+        expect(tldwClientMock.bulkDeleteSkills).toHaveBeenCalledWith([
+          { name: "skill-4" }
+        ])
+      })
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it("keeps selected rows recoverable on stale bulk delete conflict", async () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+    let confirmConfig: { onOk?: () => void | Promise<void> } | undefined
+    const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(
+      (config) => {
+        confirmConfig = config as { onOk?: () => void | Promise<void> }
+        return { destroy: vi.fn(), update: vi.fn() } as any
+      }
+    )
+    const conflict = Object.assign(new Error("409 version conflict"), { status: 409 })
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [makeSkill(1), makeSkill(2)],
+      count: 2,
+      total: 2,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.bulkDeleteSkills.mockRejectedValueOnce(conflict)
+
+    try {
+      renderManager()
+      await screen.findByText("skill-1")
+      selectSkillRow("skill-1")
+      selectSkillRow("skill-2")
+      fireEvent.click(screen.getByRole("button", { name: "Delete selected" }))
+
+      await waitFor(() => {
+        expect(confirmConfig?.onOk).toBeTypeOf("function")
+      })
+      await expect(confirmConfig?.onOk?.()).resolves.toBeUndefined()
+
+      await waitFor(() => {
+        expect(notificationMock.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Selected skills changed elsewhere",
+            description: "Reload skills before deleting these versions."
+          })
+        )
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["skills"] })
+      )
+      expect(screen.getByTestId("skills-selection-actions")).toHaveTextContent("2 selected")
     } finally {
       confirmSpy.mockRestore()
       invalidateSpy.mockRestore()

--- a/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
+++ b/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
@@ -90,4 +90,58 @@ describe("workspace API skill methods", () => {
       })
     }
   )
+
+  it("posts selected skills and valid row versions for bulk delete", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce({
+      deleted: ["skill-a", "skill-b"],
+      count: 2
+    })
+    const clientCore = {
+      resolveApiPath: vi.fn().mockResolvedValue("/api/v1/skills/bulk-delete")
+    }
+
+    await workspaceApiMethods.bulkDeleteSkills.call(clientCore as any, [
+      { name: "skill-a", version: 2 },
+      { name: "skill-b", version: 3 }
+    ])
+
+    expect(bgRequest).toHaveBeenCalledWith({
+      path: "/api/v1/skills/bulk-delete",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: {
+        skills: [
+          { name: "skill-a", version: 2 },
+          { name: "skill-b", version: 3 }
+        ]
+      }
+    })
+  })
+
+  it("omits invalid bulk delete versions while preserving selected names", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce({
+      deleted: ["legacy-skill", "invalid-version"],
+      count: 2
+    })
+    const clientCore = {
+      resolveApiPath: vi.fn().mockResolvedValue("/api/v1/skills/bulk-delete")
+    }
+
+    await workspaceApiMethods.bulkDeleteSkills.call(clientCore as any, [
+      { name: "legacy-skill" },
+      { name: "invalid-version", version: Number.NaN }
+    ])
+
+    expect(bgRequest).toHaveBeenCalledWith({
+      path: "/api/v1/skills/bulk-delete",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: {
+        skills: [
+          { name: "legacy-skill" },
+          { name: "invalid-version" }
+        ]
+      }
+    })
+  })
 })

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -4,6 +4,8 @@ import { appendPathQuery } from "../path-utils"
 import type { AllowedPath } from "@/services/tldw/openapi-guard"
 import type { OffsetPaginationMeta } from "@/services/response-envelope"
 import type {
+  SkillBulkDeleteItem,
+  SkillBulkDeleteResponse,
   SkillExecutionResult,
   SkillImportPreviewResponse,
   SkillsListParams,
@@ -720,6 +722,9 @@ const trimmedOptionalString = (value: string | undefined): string | undefined =>
   return trimmed.length > 0 ? trimmed : undefined
 }
 
+const isValidSkillVersion = (version: number | undefined): version is number =>
+  Number.isSafeInteger(version) && Number(version) > 0
+
 export const workspaceApiMethods = {
   // ── Skills API ──
 
@@ -819,14 +824,34 @@ export const workspaceApiMethods = {
       "/api/v1/skills/{name}/"
     ])
     const path = this.fillPathParams(base, name)
-    const headers =
-      Number.isSafeInteger(version) && Number(version) > 0
-        ? { "If-Match": String(version) }
-        : undefined
+    const headers = isValidSkillVersion(version)
+      ? { "If-Match": String(version) }
+      : undefined
     await bgRequest<any>({
       path,
       method: "DELETE",
       ...(headers ? { headers } : {})
+    })
+  },
+
+  async bulkDeleteSkills(
+    this: TldwApiClientCore,
+    skills: SkillBulkDeleteItem[]
+  ): Promise<SkillBulkDeleteResponse> {
+    const base = await this.resolveApiPath("skills.bulkDelete", [
+      "/api/v1/skills/bulk-delete",
+      "/api/v1/skills/bulk-delete/"
+    ])
+    return await bgRequest<SkillBulkDeleteResponse>({
+      path: base,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: {
+        skills: skills.map(({ name, version }) => ({
+          name,
+          ...(isValidSkillVersion(version) ? { version } : {})
+        }))
+      }
     })
   },
 

--- a/apps/packages/ui/src/types/skill.ts
+++ b/apps/packages/ui/src/types/skill.ts
@@ -58,6 +58,16 @@ export interface SkillsListResponse {
   offset: number
 }
 
+export interface SkillBulkDeleteItem {
+  name: string
+  version?: number
+}
+
+export interface SkillBulkDeleteResponse {
+  deleted: string[]
+  count: number
+}
+
 export interface SkillCreate {
   name: string
   content: string

--- a/backlog/tasks/task-530.11 - Implement-Skills-version-aware-bulk-delete.md
+++ b/backlog/tasks/task-530.11 - Implement-Skills-version-aware-bulk-delete.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-530.11
 title: Implement Skills version-aware bulk delete
-status: In Progress
+status: Done
 labels:
 - skills
 - webui
@@ -64,6 +64,7 @@ Continue TASK-530 Safe Operations after TASK-530.10 by adding version-aware bulk
 - Implemented version-aware bulk deletion for Skills across backend, frontend API, and manager UI.
 - The backend prevalidates all selected names and optimistic versions before deleting any skill, so a stale selected row returns a recoverable conflict without partial deletion.
 - The UI now supports row selection, a selected-action bar, destructive confirmation, version-aware request payloads, success clearing, and reload-before-delete conflict guidance.
+- PR: https://github.com/rmusser01/tldw_server/pull/2545
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-530.11 - Implement-Skills-version-aware-bulk-delete.md
+++ b/backlog/tasks/task-530.11 - Implement-Skills-version-aware-bulk-delete.md
@@ -1,0 +1,51 @@
+---
+id: TASK-530.11
+title: Implement Skills version-aware bulk delete
+status: In Progress
+labels:
+- skills
+- webui
+- safe-operations
+- backend
+priority: high
+parent_task_id: TASK-530
+documentation:
+- Docs/superpowers/plans/2026-06-28-skills-version-aware-bulk-delete.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-530 Safe Operations after TASK-530.10 by adding version-aware bulk delete for selected Skills rows. Preserve single-delete compatibility, block stale destructive bulk deletes with recoverable conflict feedback, and keep export feedback and permission metadata panels out of scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Bulk delete sends per-skill versions when known and omits versions only for unknown legacy rows.
+- [ ] #2 Backend bulk delete validates expected versions atomically enough to avoid partial stale deletes and returns a recoverable conflict when any selected skill is stale.
+- [ ] #3 The Skills manager exposes a clear selected-row bulk delete action with destructive confirmation and stale-conflict recovery copy.
+- [ ] #4 Existing single delete behavior and unversioned compatibility remain unchanged.
+- [ ] #5 Focused frontend and backend tests cover successful bulk delete, unknown-version compatibility, and stale-version conflict handling.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-530.11 - Implement-Skills-version-aware-bulk-delete.md
+++ b/backlog/tasks/task-530.11 - Implement-Skills-version-aware-bulk-delete.md
@@ -33,14 +33,20 @@ Continue TASK-530 Safe Operations after TASK-530.10 by adding version-aware bulk
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Added `POST /api/v1/skills/bulk-delete` with Pydantic request/response schemas and service-level prevalidation before any selected skill is deleted.
 - Backend validation rejects duplicate/invalid selection items, preserves legacy unknown-version compatibility, and returns 409 conflicts when a known selected version is stale.
+- PR review follow-up moved bulk registry validation and soft-delete into one `CharactersRAGDB.bulk_mark_skill_registry_deleted()` transaction, so stale selections roll back without partially deleting earlier rows.
+- `SkillsService.bulk_delete_skills()` now performs one forced registry sync, calls the DB bulk helper through `asyncio.to_thread()`, preserves omitted versions as unknown-version deletes, and retains directory-delete rollback for storage failures.
+- Bulk-delete 500 logging now includes sanitized request context (`user_id`, selected count, error type) without logging backend exception details or filesystem paths.
 - Added `workspaceApiMethods.bulkDeleteSkills()` and shared frontend bulk-delete request/response types; unsafe versions are omitted from request items.
 - Added Skills manager row selection, selected-action bar, destructive confirmation, success clearing, and stale-conflict recovery feedback that keeps selection recoverable.
 
 ## Modified Files
 - `tldw_Server_API/app/api/v1/endpoints/skills.py`
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
 - `tldw_Server_API/app/api/v1/schemas/skills_schemas.py`
 - `tldw_Server_API/app/core/Skills/skills_service.py`
 - `tldw_Server_API/tests/Skills/integration/test_skills_api.py`
+- `tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py`
+- `tldw_Server_API/tests/Skills/unit/test_skills_service.py`
 - `apps/packages/ui/src/types/skill.ts`
 - `apps/packages/ui/src/services/tldw/domains/workspace-api.ts`
 - `apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts`
@@ -52,6 +58,10 @@ Continue TASK-530 Safe Operations after TASK-530.10 by adding version-aware bulk
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "bulk_delete or delete_skill" -v` - 8 passed, 59 deselected.
 - `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot` - 2 files passed, 44 tests passed.
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_11.json` - 0 findings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py tldw_Server_API/tests/Skills/unit/test_skills_service.py -k "bulk_mark or bulk_delete_syncs_registry_once or delete_skill" -v` - 8 passed, 68 deselected.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "bulk_delete or delete_skill" -v` - 9 passed, 59 deselected.
+- `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot` - 2 files passed, 44 tests passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_task_530_11_review.json` - 0 findings.
 
 ## Known Skips Or Blockers
 - None.
@@ -62,8 +72,9 @@ Continue TASK-530 Safe Operations after TASK-530.10 by adding version-aware bulk
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 - Implemented version-aware bulk deletion for Skills across backend, frontend API, and manager UI.
-- The backend prevalidates all selected names and optimistic versions before deleting any skill, so a stale selected row returns a recoverable conflict without partial deletion.
+- The backend validates and marks selected registry rows deleted inside one transaction, so a stale selected row returns a recoverable conflict without partial deletion.
 - The UI now supports row selection, a selected-action bar, destructive confirmation, version-aware request payloads, success clearing, and reload-before-delete conflict guidance.
+- Addressed PR review by preserving unknown-version deletes, eliminating repeated registry syncs, moving synchronous DB work off the event loop, and adding sanitized bulk-delete failure log context.
 - PR: https://github.com/rmusser01/tldw_server/pull/2545
 
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-530.11 - Implement-Skills-version-aware-bulk-delete.md
+++ b/backlog/tasks/task-530.11 - Implement-Skills-version-aware-bulk-delete.md
@@ -21,31 +21,58 @@ Continue TASK-530 Safe Operations after TASK-530.10 by adding version-aware bulk
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Bulk delete sends per-skill versions when known and omits versions only for unknown legacy rows.
-- [ ] #2 Backend bulk delete validates expected versions atomically enough to avoid partial stale deletes and returns a recoverable conflict when any selected skill is stale.
-- [ ] #3 The Skills manager exposes a clear selected-row bulk delete action with destructive confirmation and stale-conflict recovery copy.
-- [ ] #4 Existing single delete behavior and unversioned compatibility remain unchanged.
-- [ ] #5 Focused frontend and backend tests cover successful bulk delete, unknown-version compatibility, and stale-version conflict handling.
+- [x] #1 Bulk delete sends per-skill versions when known and omits versions only for unknown legacy rows.
+- [x] #2 Backend bulk delete validates expected versions atomically enough to avoid partial stale deletes and returns a recoverable conflict when any selected skill is stale.
+- [x] #3 The Skills manager exposes a clear selected-row bulk delete action with destructive confirmation and stale-conflict recovery copy.
+- [x] #4 Existing single delete behavior and unversioned compatibility remain unchanged.
+- [x] #5 Focused frontend and backend tests cover successful bulk delete, unknown-version compatibility, and stale-version conflict handling.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `POST /api/v1/skills/bulk-delete` with Pydantic request/response schemas and service-level prevalidation before any selected skill is deleted.
+- Backend validation rejects duplicate/invalid selection items, preserves legacy unknown-version compatibility, and returns 409 conflicts when a known selected version is stale.
+- Added `workspaceApiMethods.bulkDeleteSkills()` and shared frontend bulk-delete request/response types; unsafe versions are omitted from request items.
+- Added Skills manager row selection, selected-action bar, destructive confirmation, success clearing, and stale-conflict recovery feedback that keeps selection recoverable.
+
+## Modified Files
+- `tldw_Server_API/app/api/v1/endpoints/skills.py`
+- `tldw_Server_API/app/api/v1/schemas/skills_schemas.py`
+- `tldw_Server_API/app/core/Skills/skills_service.py`
+- `tldw_Server_API/tests/Skills/integration/test_skills_api.py`
+- `apps/packages/ui/src/types/skill.ts`
+- `apps/packages/ui/src/services/tldw/domains/workspace-api.ts`
+- `apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts`
+- `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+- `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+- `Docs/superpowers/plans/2026-06-28-skills-version-aware-bulk-delete.md`
+
+## Verification
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "bulk_delete or delete_skill" -v` - 8 passed, 59 deselected.
+- `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot` - 2 files passed, 44 tests passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_11.json` - 0 findings.
+
+## Known Skips Or Blockers
+- None.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Implemented version-aware bulk deletion for Skills across backend, frontend API, and manager UI.
+- The backend prevalidates all selected names and optimistic versions before deleting any skill, so a stale selected row returns a recoverable conflict without partial deletion.
+- The UI now supports row selection, a selected-action bar, destructive confirmation, version-aware request payloads, success clearing, and reload-before-delete conflict guidance.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -294,7 +294,12 @@ async def bulk_delete_skills(
             detail=str(e),
         ) from e
     except SkillsError as e:
-        logger.error("Error bulk deleting skills")
+        logger.error(
+            "Error bulk deleting skills user_id={} selected_count={} error_type={}",
+            service.user_id,
+            len(request.skills),
+            type(e).__name__,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to bulk delete skills",

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -36,6 +36,8 @@ from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_
 from tldw_Server_API.app.api.v1.schemas.skills_schemas import (
     SkillContext,
     SkillContextPayload,
+    SkillBulkDeleteRequest,
+    SkillBulkDeleteResponse,
     SkillCreate,
     SkillExecuteRequest,
     SkillExecutionResult,
@@ -258,6 +260,44 @@ async def get_skills_context(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to get skills context",
+        ) from e
+
+
+@router.post("/bulk-delete", response_model=SkillBulkDeleteResponse)
+async def bulk_delete_skills(
+    request: SkillBulkDeleteRequest,
+    service: SkillsService = Depends(get_skills_service),
+) -> SkillBulkDeleteResponse:
+    """
+    Delete multiple selected skills.
+
+    Validates every supplied version before deleting any selected skill.
+    """
+    try:
+        deleted = await service.bulk_delete_skills(
+            [item.model_dump() for item in request.skills]
+        )
+        return SkillBulkDeleteResponse(deleted=deleted, count=len(deleted))
+    except SkillNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
+    except SkillConflictError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(e),
+        ) from e
+    except SkillValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except SkillsError as e:
+        logger.error("Error bulk deleting skills")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to bulk delete skills",
         ) from e
 
 

--- a/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
@@ -199,6 +199,37 @@ class SkillSummary(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class SkillBulkDeleteItem(BaseModel):
+    """One skill selected for bulk deletion."""
+    name: str = Field(..., min_length=1, max_length=64, description="Skill identifier")
+    version: int | None = Field(
+        None,
+        ge=1,
+        description="Optional optimistic-lock version from the selected row",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return _normalize_and_validate_skill_name(value)
+
+
+class SkillBulkDeleteRequest(BaseModel):
+    """Request to delete multiple selected skills."""
+    skills: list[SkillBulkDeleteItem] = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Selected skills to delete",
+    )
+
+
+class SkillBulkDeleteResponse(BaseModel):
+    """Response for a successful bulk delete."""
+    deleted: list[str] = Field(..., description="Names deleted in request order")
+    count: int = Field(..., ge=0, description="Number of deleted skills")
+
+
 class SkillsListResponse(BaseModel):
     """Response for listing skills."""
     skills: list[SkillSummary] = Field(..., description="List of skill summaries")

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -16638,6 +16638,77 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             logger.error(f"Database error deleting skill '{name}': {exc}")
             raise
 
+    def bulk_mark_skill_registry_deleted(
+        self,
+        items: list[tuple[str, int | None]],
+    ) -> list[dict[str, Any]]:
+        """Soft-delete multiple skill registry rows in one atomic transaction."""
+        if not items:
+            return []
+
+        self._ensure_skill_registry_table()
+        now = self._get_current_utc_timestamp_iso()
+        deleted_value = self._skill_bool_value(True)
+        active_value = self._skill_bool_value(False)
+        select_query = "SELECT * FROM skill_registry WHERE name = ?"
+        update_query = (
+            "UPDATE skill_registry SET deleted = ?, last_modified = ?, version = ? "
+            "WHERE name = ? AND version = ? AND deleted = ?"
+        )
+
+        try:
+            with self.transaction() as conn:
+                validated_rows: list[dict[str, Any]] = []
+                for name, expected_version in items:
+                    prepared_query, prepared_params = self._prepare_backend_statement(select_query, (name,))
+                    row = self._skill_row_to_dict(conn.execute(prepared_query, prepared_params).fetchone())
+                    if not row:
+                        raise InputError(f"Skill not found: {name}")  # noqa: TRY003
+
+                    current_version = int(row.get("version") or 1)
+                    if expected_version is not None and current_version != expected_version:
+                        raise ConflictError(
+                            f"Skill '{name}' version mismatch (db has {current_version}, expected {expected_version}).",
+                            entity="skill_registry",
+                            entity_id=name,
+                        )
+
+                    row["previous_version"] = current_version
+                    row["was_deleted"] = bool(row.get("deleted", False))
+                    validated_rows.append(row)
+
+                for row in validated_rows:
+                    if row["was_deleted"]:
+                        continue
+
+                    current_version = int(row["previous_version"])
+                    next_version = current_version + 1
+                    params = (
+                        deleted_value,
+                        now,
+                        next_version,
+                        row["name"],
+                        current_version,
+                        active_value,
+                    )
+                    prepared_query, prepared_params = self._prepare_backend_statement(update_query, params)
+                    cursor = conn.execute(prepared_query, prepared_params)
+                    if cursor.rowcount == 0:
+                        raise ConflictError(
+                            f"Skill '{row['name']}' delete affected 0 rows.",
+                            entity="skill_registry",
+                            entity_id=row["name"],
+                        )
+                    row["version"] = next_version
+                    row["deleted"] = True
+
+                return validated_rows
+        except (ConflictError, InputError):
+            raise
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error bulk deleting skills: {exc}")
+            raise
+
     def restore_skill_registry(
         self,
         name: str,

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -1267,25 +1267,39 @@ class SkillsService:
         await self._sync_registry_async(force=True)
         db = self._get_db()
 
-        validated_items: list[tuple[str, int]] = []
-        for name, expected_version in normalized_items:
-            row = db.get_skill_registry(name, include_deleted=True)
-            if not row:
-                raise SkillNotFoundError(name)
-
-            current_version = int(row.get("version") or 1)
-            if expected_version is not None and current_version != expected_version:
-                raise SkillConflictError(
-                    f"Skill '{name}' was modified (expected version {expected_version}, got {current_version})",
-                    skill_name=name,
-                    expected_version=expected_version,
-                    actual_version=current_version,
-                )
-            validated_items.append((name, current_version))
+        try:
+            deleted_rows = await asyncio.to_thread(db.bulk_mark_skill_registry_deleted, normalized_items)
+        except InputError as e:
+            message = str(e)
+            missing_name = (
+                message.removeprefix("Skill not found: ").strip()
+                if message.startswith("Skill not found: ")
+                else message
+            )
+            raise SkillNotFoundError(missing_name) from e
+        except ConflictError as e:
+            raise SkillConflictError(str(e)) from e
+        except CharactersRAGDBError as e:
+            raise SkillsError(f"Failed to bulk delete skills in registry: {e}") from e
 
         deleted: list[str] = []
-        for name, current_version in validated_items:
-            await self.delete_skill(name, expected_version=current_version)
+        for row in deleted_rows:
+            name = str(row["name"])
+            skill_dir = self._get_skill_dir(name)
+            if await asyncio.to_thread(skill_dir.exists):
+                try:
+                    await asyncio.to_thread(shutil.rmtree, skill_dir)
+                except OSError as e:
+                    if not row.get("was_deleted"):
+                        try:
+                            db.restore_skill_registry(
+                                name,
+                                {"directory_path": str(skill_dir)},
+                                expected_version=int(row["version"]),
+                            )
+                        except Exception as restore_error:
+                            logger.error(f"Failed to restore skill registry after bulk delete failure: {restore_error}")
+                    raise SkillStorageError(f"Failed to delete skill directory: {e}", path=str(skill_dir)) from e
             deleted.append(name)
 
         logger.info(f"Bulk deleted {len(deleted)} skills for user {self.user_id}")

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -1229,6 +1229,68 @@ class SkillsService:
 
         logger.info(f"Deleted skill '{name}' for user {self.user_id}")
 
+    async def bulk_delete_skills(self, items: list[dict[str, Any]]) -> list[str]:
+        """
+        Delete multiple skills after validating all selected versions.
+
+        Args:
+            items: Skill name/version mappings. Version may be omitted for legacy rows.
+
+        Returns:
+            Deleted skill names in request order.
+
+        Raises:
+            SkillValidationError: If the selection is invalid
+            SkillNotFoundError: If any selected skill doesn't exist
+            SkillConflictError: If any selected version is stale
+        """
+        if not items:
+            raise SkillValidationError("At least one skill is required for bulk delete")
+
+        normalized_items: list[tuple[str, int | None]] = []
+        seen_names: set[str] = set()
+        for item in items:
+            name = self._normalize_and_validate_skill_name(str(item.get("name") or ""))
+            if name in seen_names:
+                raise SkillValidationError(f"Duplicate skill selected for bulk delete: {name}")
+            seen_names.add(name)
+
+            expected_version = item.get("version")
+            if expected_version is not None:
+                if isinstance(expected_version, bool) or not isinstance(expected_version, int) or expected_version < 1:
+                    raise SkillValidationError(
+                        f"Invalid version for skill '{name}'",
+                        field="version",
+                    )
+            normalized_items.append((name, expected_version))
+
+        await self._sync_registry_async(force=True)
+        db = self._get_db()
+
+        validated_items: list[tuple[str, int]] = []
+        for name, expected_version in normalized_items:
+            row = db.get_skill_registry(name, include_deleted=True)
+            if not row:
+                raise SkillNotFoundError(name)
+
+            current_version = int(row.get("version") or 1)
+            if expected_version is not None and current_version != expected_version:
+                raise SkillConflictError(
+                    f"Skill '{name}' was modified (expected version {expected_version}, got {current_version})",
+                    skill_name=name,
+                    expected_version=expected_version,
+                    actual_version=current_version,
+                )
+            validated_items.append((name, current_version))
+
+        deleted: list[str] = []
+        for name, current_version in validated_items:
+            await self.delete_skill(name, expected_version=current_version)
+            deleted.append(name)
+
+        logger.info(f"Bulk deleted {len(deleted)} skills for user {self.user_id}")
+        return deleted
+
     async def import_skill(
         self,
         content: str,

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -701,6 +701,95 @@ class TestDeleteSkill:
         assert "/private/" not in joined
 
 
+class TestBulkDeleteSkills:
+    def test_bulk_delete_accepts_matching_versions(self, client: TestClient) -> None:
+        """Bulk delete removes all selected skills when versions match."""
+        first = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "bulk-delete-a", "content": "content a"},
+        )
+        second = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "bulk-delete-b", "content": "content b"},
+        )
+        assert first.status_code == 201, first.text
+        assert second.status_code == 201, second.text
+
+        r = client.post(
+            f"{SKILLS_PREFIX}/bulk-delete",
+            json={
+                "skills": [
+                    {"name": "bulk-delete-a", "version": first.json()["version"]},
+                    {"name": "bulk-delete-b", "version": second.json()["version"]},
+                ],
+            },
+        )
+
+        assert r.status_code == 200, r.text
+        assert r.json() == {
+            "deleted": ["bulk-delete-a", "bulk-delete-b"],
+            "count": 2,
+        }
+        assert client.get(f"{SKILLS_PREFIX}/bulk-delete-a").status_code == 404
+        assert client.get(f"{SKILLS_PREFIX}/bulk-delete-b").status_code == 404
+
+    def test_bulk_delete_keeps_unknown_version_compatible(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Bulk delete remains compatible for legacy rows without known versions."""
+        created = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "bulk-delete-legacy", "content": "content"},
+        )
+        assert created.status_code == 201, created.text
+
+        r = client.post(
+            f"{SKILLS_PREFIX}/bulk-delete",
+            json={"skills": [{"name": "bulk-delete-legacy"}]},
+        )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["deleted"] == ["bulk-delete-legacy"]
+        assert client.get(f"{SKILLS_PREFIX}/bulk-delete-legacy").status_code == 404
+
+    def test_bulk_delete_stale_version_returns_409_without_partial_delete(
+        self,
+        client: TestClient,
+    ) -> None:
+        """A stale bulk delete conflicts before deleting any selected skill."""
+        stale = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "bulk-stale", "content": "v1"},
+        )
+        fresh = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "bulk-fresh", "content": "content"},
+        )
+        assert stale.status_code == 201, stale.text
+        assert fresh.status_code == 201, fresh.text
+
+        updated = client.put(
+            f"{SKILLS_PREFIX}/bulk-stale",
+            json={"content": "v2"},
+        )
+        assert updated.status_code == 200, updated.text
+
+        r = client.post(
+            f"{SKILLS_PREFIX}/bulk-delete",
+            json={
+                "skills": [
+                    {"name": "bulk-stale", "version": stale.json()["version"]},
+                    {"name": "bulk-fresh", "version": fresh.json()["version"]},
+                ],
+            },
+        )
+
+        assert r.status_code == 409
+        assert client.get(f"{SKILLS_PREFIX}/bulk-stale").status_code == 200
+        assert client.get(f"{SKILLS_PREFIX}/bulk-fresh").status_code == 200
+
+
 class TestImportExport:
     def test_import_skill_preview_json_returns_metadata_and_conflict(self, client):
         client.post(

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -789,6 +789,33 @@ class TestBulkDeleteSkills:
         assert client.get(f"{SKILLS_PREFIX}/bulk-stale").status_code == 200
         assert client.get(f"{SKILLS_PREFIX}/bulk-fresh").status_code == 200
 
+    def test_bulk_delete_sanitized_error_log_has_request_context(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Bulk delete 500 logs should include request context without leaking details."""
+
+        async def _boom(self, items):  # noqa: ANN001, ANN202
+            raise SkillsError("bulk backend exploded at /private/bulk-delete")
+
+        monkeypatch.setattr(SkillsService, "bulk_delete_skills", _boom)
+
+        with _capture_skills_endpoint_errors() as messages:
+            r = client.post(
+                f"{SKILLS_PREFIX}/bulk-delete",
+                json={"skills": [{"name": "bulk-log", "version": 1}]},
+            )
+
+        joined = "\n".join(messages)
+        assert r.status_code == 500
+        assert r.json()["detail"] == "Failed to bulk delete skills"
+        assert "Error bulk deleting skills" in joined
+        assert "selected_count=1" in joined
+        assert f"user_id={TEST_USER_ID}" in joined
+        assert "bulk backend exploded" not in joined
+        assert "/private/" not in joined
+
 
 class TestImportExport:
     def test_import_skill_preview_json_returns_metadata_and_conflict(self, client):

--- a/tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    ConflictError,
+    InputError,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -113,3 +117,47 @@ def test_restore_skill_registry_reactivates_soft_deleted_row(skills_db: Characte
     assert restored["description"] == "After"
     assert not restored["deleted"]
     assert restored["version"] == 3
+
+
+def test_bulk_mark_skill_registry_deleted_rolls_back_on_version_conflict(
+    skills_db: CharactersRAGDB,
+) -> None:
+    """A stale item in a bulk delete must not soft-delete earlier rows."""
+    _insert_skill(skills_db, "bulk-atomic-a")
+    _insert_skill(skills_db, "bulk-atomic-b")
+    skills_db.update_skill_registry(
+        "bulk-atomic-b",
+        {"description": "newer"},
+        expected_version=1,
+    )
+
+    with pytest.raises(ConflictError):
+        skills_db.bulk_mark_skill_registry_deleted(
+            [
+                ("bulk-atomic-a", 1),
+                ("bulk-atomic-b", 1),
+            ]
+        )
+
+    assert skills_db.get_skill_registry("bulk-atomic-a", include_deleted=False) is not None
+    assert skills_db.get_skill_registry("bulk-atomic-b", include_deleted=False) is not None
+
+
+def test_bulk_mark_skill_registry_deleted_allows_unknown_versions(
+    skills_db: CharactersRAGDB,
+) -> None:
+    """Rows with omitted versions remain compatible with unversioned deletes."""
+    _insert_skill(skills_db, "bulk-unversioned")
+    skills_db.update_skill_registry(
+        "bulk-unversioned",
+        {"description": "changed after list"},
+        expected_version=1,
+    )
+
+    deleted = skills_db.bulk_mark_skill_registry_deleted([("bulk-unversioned", None)])
+
+    assert [item["name"] for item in deleted] == ["bulk-unversioned"]
+    assert skills_db.get_skill_registry("bulk-unversioned", include_deleted=False) is None
+    deleted_row = skills_db.get_skill_registry("bulk-unversioned", include_deleted=True)
+    assert deleted_row is not None
+    assert deleted_row["version"] == 3

--- a/tldw_Server_API/tests/Skills/unit/test_skills_service.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skills_service.py
@@ -521,6 +521,30 @@ New content here.
         assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == "Content"
 
     @pytest.mark.asyncio
+    async def test_bulk_delete_syncs_registry_once(self, service, monkeypatch):
+        """Bulk delete should reuse one forced registry sync for the whole request."""
+        first = await service.create_skill("bulk-sync-a", "Content A")
+        second = await service.create_skill("bulk-sync-b", "Content B")
+        sync_calls = 0
+        original_sync = service._sync_registry_async
+
+        async def _counted_sync(*args, **kwargs):
+            nonlocal sync_calls
+            sync_calls += 1
+            return await original_sync(*args, **kwargs)
+
+        monkeypatch.setattr(service, "_sync_registry_async", _counted_sync)
+
+        await service.bulk_delete_skills(
+            [
+                {"name": "bulk-sync-a", "version": first["version"]},
+                {"name": "bulk-sync-b", "version": second["version"]},
+            ]
+        )
+
+        assert sync_calls == 1
+
+    @pytest.mark.asyncio
     async def test_update_skill_supporting_files_only_bumps_version(self, service):
         """Supporting-file-only changes are skill bundle mutations and must be versioned."""
         created = await service.create_skill(


### PR DESCRIPTION
## Summary
- Add a version-aware `POST /api/v1/skills/bulk-delete` endpoint that prevalidates selected skill names and optimistic versions before deleting anything.
- Add frontend API support plus Skills manager row selection, selected-action bar, destructive confirmation, success clearing, and stale-conflict recovery copy.
- Update TASK-530.11 plan and Backlog records with scope, verification, and closeout notes.

## Change summary
AI-authored implementation. Per repo policy, the human requester must replace this with a human-written change summary explaining what changed and why these implementation choices were made before merge.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "bulk_delete or delete_skill" -v`
- [x] `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_task_530_11.json`
- [x] `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds version-aware bulk delete for Skills with atomic registry deletion to prevent partial deletes and clear conflict recovery across backend and UI. Meets TASK-530.11 safe-operations requirements.

- **New Features**
  - Backend: `POST /api/v1/skills/bulk-delete` with full prevalidation and transactional delete; returns `deleted` and `count`; maps 404/409/400; logs sanitized context and returns 500 on internal errors.
  - Schemas/Service: `SkillBulkDeleteItem`, `SkillBulkDeleteRequest`, `SkillBulkDeleteResponse`; `SkillsService.bulk_delete_skills` checks duplicates, validates versions, forces one registry sync, uses `asyncio.to_thread` for DB calls, preserves unknown-version compatibility, and restores registry on storage failures.
  - Frontend API: `workspaceApiMethods.bulkDeleteSkills` posts selected skills, sending only valid versions; adds TS types in `apps/packages/ui/src/types/skill.ts`.
  - UI: Skills Manager adds row selection, a selected-action bar, destructive “Delete selected” with confirm, success clearing, and 409 conflict recovery that keeps selection and invalidates `["skills"]`.
  - Tests/Docs: Integration/unit tests cover atomic rollback, unknown-version compatibility, stale-version conflicts, and single-sync behavior; plan/backlog updated with acceptance criteria and verification.

<sup>Written for commit a33f8397d9a92a4fcd3386807edb33a5a8dc8c58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

