### PR TITLE
TASK-530.12 add Skills export metadata feedback

### DIFF
--- a/Docs/superpowers/plans/2026-06-29-skills-export-metadata-feedback.md
+++ b/Docs/superpowers/plans/2026-06-29-skills-export-metadata-feedback.md
@@ -1,0 +1,90 @@
+# Skills Export Metadata Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve Skills export filename metadata through the frontend client and show clear export feedback.
+
+**Architecture:** Keep the backend unchanged because it already sends `Content-Disposition`. Update the frontend Skills API helper to return `{ blob, filename }`, then use that filename in the Skills manager download flow and success notification. Add focused Vitest coverage for the client contract and UI feedback.
+
+**Tech Stack:** React, TypeScript, Ant Design notification wrapper, TanStack Query, Vitest, Testing Library, existing `bgRequest` response wrapper.
+
+---
+
+### Task 1: Add Frontend Client Contract Tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts`
+- Modify: `apps/packages/ui/src/services/tldw/domains/workspace-api.ts`
+
+- [ ] **Step 1: Write failing tests for export filename metadata**
+  - Add a test where `bgRequest` returns an arrayBuffer response with
+    `content-disposition: attachment; filename="server-skill.zip"`.
+  - Assert `workspaceApiMethods.exportSkill()` returns a `Blob` and
+    `filename: "server-skill.zip"`.
+
+- [ ] **Step 2: Write failing tests for safe fallback**
+  - Add a test where `Content-Disposition` is missing or path-like.
+  - Assert fallback is `<skill-name>.zip`.
+
+- [ ] **Step 3: Run focused service tests and verify RED**
+  - Run: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot`
+  - Expected: export metadata tests fail because `exportSkill()` currently returns only `Blob`.
+
+- [ ] **Step 4: Implement minimal client contract**
+  - Change `exportSkill()` to call `bgRequest(..., returnResponse: true)`.
+  - Parse `filename*` and `filename` from response headers.
+  - Build `{ blob, filename }` with safe fallback.
+
+- [ ] **Step 5: Run focused service tests and verify GREEN**
+  - Run: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot`
+  - Expected: tests pass.
+
+### Task 2: Add Skills Manager Export Feedback Tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+
+- [ ] **Step 1: Write failing UI test for metadata filename and success feedback**
+  - Mock `tldwClient.exportSkill()` to resolve `{ blob, filename: "server-skill.zip" }`.
+  - Mock `URL.createObjectURL`, `URL.revokeObjectURL`, and anchor click.
+  - Click the row Export action.
+  - Assert anchor download uses `server-skill.zip`.
+  - Assert success notification names `server-skill.zip`.
+
+- [ ] **Step 2: Write failing or confirming UI test for sanitized failure feedback**
+  - Mock `exportSkill()` rejection with sensitive URL/path/token content.
+  - Assert error notification remains sanitized.
+
+- [ ] **Step 3: Run focused manager tests and verify RED**
+  - Run: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
+  - Expected: success-feedback test fails because no success notification exists and current handler expects `Blob`.
+
+- [ ] **Step 4: Implement minimal manager update**
+  - Destructure `{ blob, filename }` from `exportSkill()`.
+  - Use `filename` for `a.download`.
+  - Show success notification after the click is triggered.
+
+- [ ] **Step 5: Run focused manager tests and verify GREEN**
+  - Run: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
+  - Expected: tests pass.
+
+### Task 3: Verify, Document, And Commit
+
+**Files:**
+- Modify: `backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md`
+
+- [ ] **Step 1: Run focused frontend verification**
+  - Run: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
+  - Expected: both files pass.
+
+- [ ] **Step 2: Run static cleanup checks**
+  - Run: `git diff --check`
+  - Expected: no output.
+
+- [ ] **Step 3: Update Backlog task**
+  - Record implementation notes, modified files, verification, known skips, and final summary.
+
+- [ ] **Step 4: Commit**
+  - Stage the task, spec, plan, client, manager, and tests.
+  - Commit message: `TASK-530.12 add skills export metadata feedback`

--- a/Docs/superpowers/plans/2026-06-29-skills-export-metadata-feedback.md
+++ b/Docs/superpowers/plans/2026-06-29-skills-export-metadata-feedback.md
@@ -16,26 +16,26 @@
 - Modify: `apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts`
 - Modify: `apps/packages/ui/src/services/tldw/domains/workspace-api.ts`
 
-- [ ] **Step 1: Write failing tests for export filename metadata**
+- [x] **Step 1: Write failing tests for export filename metadata**
   - Add a test where `bgRequest` returns an arrayBuffer response with
     `content-disposition: attachment; filename="server-skill.zip"`.
   - Assert `workspaceApiMethods.exportSkill()` returns a `Blob` and
     `filename: "server-skill.zip"`.
 
-- [ ] **Step 2: Write failing tests for safe fallback**
+- [x] **Step 2: Write failing tests for safe fallback**
   - Add a test where `Content-Disposition` is missing or path-like.
   - Assert fallback is `<skill-name>.zip`.
 
-- [ ] **Step 3: Run focused service tests and verify RED**
+- [x] **Step 3: Run focused service tests and verify RED**
   - Run: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot`
   - Expected: export metadata tests fail because `exportSkill()` currently returns only `Blob`.
 
-- [ ] **Step 4: Implement minimal client contract**
+- [x] **Step 4: Implement minimal client contract**
   - Change `exportSkill()` to call `bgRequest(..., returnResponse: true)`.
   - Parse `filename*` and `filename` from response headers.
   - Build `{ blob, filename }` with safe fallback.
 
-- [ ] **Step 5: Run focused service tests and verify GREEN**
+- [x] **Step 5: Run focused service tests and verify GREEN**
   - Run: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot`
   - Expected: tests pass.
 
@@ -45,27 +45,27 @@
 - Modify: `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
 - Modify: `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
 
-- [ ] **Step 1: Write failing UI test for metadata filename and success feedback**
+- [x] **Step 1: Write failing UI test for metadata filename and success feedback**
   - Mock `tldwClient.exportSkill()` to resolve `{ blob, filename: "server-skill.zip" }`.
   - Mock `URL.createObjectURL`, `URL.revokeObjectURL`, and anchor click.
   - Click the row Export action.
   - Assert anchor download uses `server-skill.zip`.
   - Assert success notification names `server-skill.zip`.
 
-- [ ] **Step 2: Write failing or confirming UI test for sanitized failure feedback**
+- [x] **Step 2: Write failing or confirming UI test for sanitized failure feedback**
   - Mock `exportSkill()` rejection with sensitive URL/path/token content.
   - Assert error notification remains sanitized.
 
-- [ ] **Step 3: Run focused manager tests and verify RED**
+- [x] **Step 3: Run focused manager tests and verify RED**
   - Run: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
   - Expected: success-feedback test fails because no success notification exists and current handler expects `Blob`.
 
-- [ ] **Step 4: Implement minimal manager update**
+- [x] **Step 4: Implement minimal manager update**
   - Destructure `{ blob, filename }` from `exportSkill()`.
   - Use `filename` for `a.download`.
   - Show success notification after the click is triggered.
 
-- [ ] **Step 5: Run focused manager tests and verify GREEN**
+- [x] **Step 5: Run focused manager tests and verify GREEN**
   - Run: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
   - Expected: tests pass.
 
@@ -74,17 +74,17 @@
 **Files:**
 - Modify: `backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md`
 
-- [ ] **Step 1: Run focused frontend verification**
+- [x] **Step 1: Run focused frontend verification**
   - Run: `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot`
   - Expected: both files pass.
 
-- [ ] **Step 2: Run static cleanup checks**
+- [x] **Step 2: Run static cleanup checks**
   - Run: `git diff --check`
   - Expected: no output.
 
-- [ ] **Step 3: Update Backlog task**
+- [x] **Step 3: Update Backlog task**
   - Record implementation notes, modified files, verification, known skips, and final summary.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
   - Stage the task, spec, plan, client, manager, and tests.
   - Commit message: `TASK-530.12 add skills export metadata feedback`

--- a/Docs/superpowers/specs/2026-06-29-skills-export-metadata-feedback-design.md
+++ b/Docs/superpowers/specs/2026-06-29-skills-export-metadata-feedback-design.md
@@ -1,0 +1,55 @@
+# Skills Export Metadata Feedback Design
+
+## Context
+
+`/api/v1/skills/{skill_name}/export` already returns zip bytes with a
+`Content-Disposition` filename. The frontend currently discards response
+headers, guesses `${name}.zip`, and only notifies users on failure. That works
+for the current simple case, but it makes export behavior brittle if the server
+later changes naming, adds conflict-safe filenames, or returns encoded names.
+
+## Goal
+
+Preserve server-provided export filename metadata through the WebUI client and
+use it for browser downloads and user feedback.
+
+## Scope
+
+- Change the Skills frontend API helper to return `{ blob, filename }`.
+- Parse `filename=` and `filename*=UTF-8''...` from `Content-Disposition`.
+- Fall back to a safe `${skillName}.zip` filename when metadata is absent,
+  invalid, or unsafe.
+- Use the returned filename for the anchor download name.
+- Show a success notification naming the downloaded file.
+- Preserve existing sanitized error feedback.
+
+Out of scope: backend API shape changes, bulk export, import review, permission
+or model metadata panels, visual restyling, and route-level redesign.
+
+## Design
+
+The client contract should mirror existing export helpers in the codebase:
+`exportSkill(name): Promise<{ blob: Blob; filename: string }>`. The helper will
+request `arrayBuffer` with `returnResponse: true`, validate non-OK responses,
+build the blob from `response.data`, and derive the filename from response
+headers.
+
+Filename parsing should prefer `filename*` because it supports encoded UTF-8
+names. Plain `filename` remains supported for the current backend response.
+After parsing, the client should reject path-like or empty filenames and fall
+back to `${skillName}.zip`. This keeps the UI stable even when proxies strip
+headers or a server returns malformed metadata.
+
+`SkillsManager.handleExport()` will use the returned filename for the hidden
+anchor download, then show a compact success notification. The notification is
+post-click feedback that the browser download was initiated, not a guarantee
+that the user saved the file. Failure feedback remains sanitized through the
+existing `getErrorDescription()` path.
+
+## Testing
+
+- Service tests cover header filename parsing and safe fallback behavior.
+- Manager tests cover download filename usage and success notification.
+- Manager tests cover sanitized export failure notification.
+- Existing Skills manager tests remain focused; no browser E2E is required for
+  this contract-only slice.

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -776,7 +776,7 @@ export const SkillsManager: React.FC = () => {
       notification.success({
         message: t("option:skills.exportStarted", { defaultValue: "Export started" }),
         description: t("option:skills.exportStartedDescription", {
-          defaultValue: `${filename} download has started.`,
+          defaultValue: "{{filename}} download has started.",
           filename
         })
       })

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -764,15 +764,22 @@ export const SkillsManager: React.FC = () => {
 
   const handleExport = async (name: string) => {
     try {
-      const blob = await tldwClient.exportSkill(name)
+      const { blob, filename } = await tldwClient.exportSkill(name)
       const url = URL.createObjectURL(blob)
       const a = document.createElement("a")
       a.href = url
-      a.download = `${name}.zip`
+      a.download = filename
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)
       URL.revokeObjectURL(url)
+      notification.success({
+        message: t("option:skills.exportStarted", { defaultValue: "Export started" }),
+        description: t("option:skills.exportStartedDescription", {
+          defaultValue: `${filename} download has started.`,
+          filename
+        })
+      })
     } catch (err: unknown) {
       notification.error({
         message: t("option:skills.exportError", { defaultValue: "Failed to export skill" }),

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -41,7 +41,10 @@ vi.mock("react-i18next", () => ({
     ) => {
       if (typeof fallbackOrOptions === "string") return fallbackOrOptions
       if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
-        return fallbackOrOptions.defaultValue || key
+        const defaultValue = fallbackOrOptions.defaultValue || key
+        return defaultValue.replace(/\{\{(\w+)\}\}/g, (_match, token: string) =>
+          String(fallbackOrOptions[token] ?? "")
+        )
       }
       return key
     }

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -767,6 +767,105 @@ describe("SkillsManager imports", () => {
     }
   })
 
+  it("downloads exported skills with the server filename and success feedback", async () => {
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    let downloadedFilename = ""
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloadedFilename = this.download
+      })
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:skills-export")
+    })
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn()
+    })
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [makeSkill(1)],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.exportSkill.mockResolvedValueOnce({
+      blob: new Blob(["zip"], { type: "application/zip" }),
+      filename: "server-skill.zip"
+    })
+
+    try {
+      renderManager()
+      await screen.findByText("skill-1")
+      fireEvent.click(screen.getByRole("button", { name: "Export skill-1" }))
+
+      await waitFor(() => {
+        expect(tldwClientMock.exportSkill).toHaveBeenCalledWith("skill-1")
+      })
+      expect(downloadedFilename).toBe("server-skill.zip")
+      expect(notificationMock.success).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Export started",
+          description: "server-skill.zip download has started."
+        })
+      )
+    } finally {
+      clickSpy.mockRestore()
+      if (originalCreateObjectURL) {
+        Object.defineProperty(URL, "createObjectURL", {
+          configurable: true,
+          value: originalCreateObjectURL
+        })
+      } else {
+        Reflect.deleteProperty(URL, "createObjectURL")
+      }
+      if (originalRevokeObjectURL) {
+        Object.defineProperty(URL, "revokeObjectURL", {
+          configurable: true,
+          value: originalRevokeObjectURL
+        })
+      } else {
+        Reflect.deleteProperty(URL, "revokeObjectURL")
+      }
+    }
+  })
+
+  it("sanitizes export failure notifications", async () => {
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [makeSkill(1)],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+    tldwClientMock.exportSkill.mockRejectedValueOnce(
+      new Error(
+        "Request failed: GET /api/v1/skills/skill-1/export?token=sk_live_secret from /Users/alice/.tldw with Bearer token_secret_123"
+      )
+    )
+
+    renderManager()
+    await screen.findByText("skill-1")
+    fireEvent.click(screen.getByRole("button", { name: "Export skill-1" }))
+
+    await waitFor(() => {
+      expect(notificationMock.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Failed to export skill",
+          description: expect.stringContaining("[server-endpoint]")
+        })
+      )
+    })
+
+    const payload = notificationMock.error.mock.calls.at(-1)?.[0] as {
+      description?: string
+    }
+    expect(payload.description).toContain("[redacted-path]")
+    expect(payload.description).toContain("Bearer [redacted-secret]")
+  })
+
   it("bulk deletes selected rows with their current versions", async () => {
     let confirmConfig: { onOk?: () => void | Promise<void> } | undefined
     const confirmSpy = vi.spyOn(Modal, "confirm").mockImplementationOnce(

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -867,6 +867,10 @@ describe("SkillsManager imports", () => {
     }
     expect(payload.description).toContain("[redacted-path]")
     expect(payload.description).toContain("Bearer [redacted-secret]")
+    expect(payload.description).not.toContain("/api/v1/skills/skill-1/export")
+    expect(payload.description).not.toContain("token=sk_live_secret")
+    expect(payload.description).not.toContain("/Users/alice/.tldw")
+    expect(payload.description).not.toContain("token_secret_123")
   })
 
   it("bulk deletes selected rows with their current versions", async () => {

--- a/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
+++ b/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
@@ -526,6 +526,59 @@ describe("background proxy fallback safety", () => {
     expect(mocks.tldwRequest).not.toHaveBeenCalled()
   })
 
+  it("falls back to direct arrayBuffer requests while preserving response metadata", async () => {
+    const buffer = new Uint8Array([7, 8, 9]).buffer
+    mocks.sendMessage.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: {},
+      headers: {
+        "content-disposition": 'attachment; filename="runtime.zip"'
+      }
+    })
+    mocks.tldwRequest.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: buffer,
+      headers: {
+        "content-disposition": 'attachment; filename="direct.zip"'
+      }
+    })
+
+    const { bgRequest } = await importProxy()
+
+    await expect(
+      bgRequest<{
+        ok: boolean
+        status: number
+        data: ArrayBuffer
+        headers: Record<string, string>
+      }>({
+        path: "/api/v1/skills/client-skill/export",
+        method: "GET",
+        responseType: "arrayBuffer",
+        returnResponse: true
+      })
+    ).resolves.toEqual({
+      ok: true,
+      status: 200,
+      data: buffer,
+      headers: {
+        "content-disposition": 'attachment; filename="direct.zip"'
+      }
+    })
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
+    expect(mocks.tldwRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/skills/client-skill/export",
+        method: "GET",
+        responseType: "arrayBuffer"
+      }),
+      expect.any(Object)
+    )
+  })
+
   it("does not fall back to direct request on POST extension timeout", async () => {
     vi.useFakeTimers()
     mocks.sendMessage.mockImplementation(() => new Promise(() => undefined))

--- a/apps/packages/ui/src/services/background-proxy.ts
+++ b/apps/packages/ui/src/services/background-proxy.ts
@@ -570,6 +570,51 @@ async function bgRequestImpl<
     if (typeof Blob !== "undefined" && value instanceof Blob) return true
     return false
   }
+  type RuntimeResponsePayload = {
+    ok: boolean
+    error?: string
+    status?: number
+    data?: unknown
+    headers?: Record<string, string>
+  }
+  const requestDirectArrayBufferFallback = async () => {
+    const storage = createSafeStorage()
+    return await tldwRequest(
+      {
+        path,
+        method,
+        headers: resolvedHeaders,
+        body,
+        noAuth: resolvedNoAuth,
+        timeoutMs,
+        abortSignal,
+        responseType
+      },
+      { getConfig: () => storage.get("tldwConfig").catch(() => null) }
+    )
+  }
+  const resolveArrayBufferResponse = async (
+    resp: RuntimeResponsePayload
+  ): Promise<T> => {
+    if (!resp?.ok || responseType !== "arrayBuffer" || isArrayBufferLike(resp.data)) {
+      return (returnResponse ? resp : resp.data) as T
+    }
+
+    const fallback = await requestDirectArrayBufferFallback()
+    if (!fallback) {
+      const error = buildRequestError("Request failed: missing fallback response")
+      throw error
+    }
+    if (!fallback.ok && !returnResponse) {
+      const msg = formatErrorMessage(
+        fallback.error,
+        `Request failed: ${fallback.status}`
+      )
+      const error = buildRequestError(msg, fallback.status, fallback.data)
+      throw error
+    }
+    return (returnResponse ? fallback : fallback.data) as T
+  }
   const hasRuntimeMessage =
     !preferDirect &&
     Boolean(browser?.runtime?.sendMessage && browser?.runtime?.id)
@@ -693,35 +738,7 @@ async function bgRequestImpl<
             throw markNoFallbackError(error)
           }
         }
-        if (!returnResponse && responseType === "arrayBuffer") {
-          const raw = (resp as any)?.data
-          if (!isArrayBufferLike(raw)) {
-            const storage = createSafeStorage()
-            const fallback = await tldwRequest(
-              {
-                path,
-                method,
-                headers: resolvedHeaders,
-                body,
-                noAuth: resolvedNoAuth,
-                timeoutMs,
-                abortSignal,
-                responseType
-              },
-              { getConfig: () => storage.get("tldwConfig").catch(() => null) }
-            )
-            if (!fallback?.ok) {
-              const msg = formatErrorMessage(
-                fallback?.error,
-                `Request failed: ${fallback?.status}`
-              )
-              const error = buildRequestError(msg, fallback?.status, fallback?.data)
-              throw error
-            }
-            return fallback.data as T
-          }
-        }
-        return (returnResponse ? resp : resp.data) as T
+        return await resolveArrayBufferResponse(resp as RuntimeResponsePayload)
       }
 
       if (abortSignal.aborted) {
@@ -795,35 +812,7 @@ async function bgRequestImpl<
           throw markNoFallbackError(error)
         }
       }
-      if (!returnResponse && responseType === "arrayBuffer") {
-        const raw = (resp as any)?.data
-        if (!isArrayBufferLike(raw)) {
-          const storage = createSafeStorage()
-          const fallback = await tldwRequest(
-            {
-              path,
-              method,
-              headers: resolvedHeaders,
-              body,
-              noAuth: resolvedNoAuth,
-              timeoutMs,
-              abortSignal,
-              responseType
-            },
-            { getConfig: () => storage.get("tldwConfig").catch(() => null) }
-          )
-          if (!fallback?.ok) {
-            const msg = formatErrorMessage(
-              fallback?.error,
-              `Request failed: ${fallback?.status}`
-            )
-            const error = buildRequestError(msg, fallback?.status, fallback?.data)
-            throw error
-          }
-          return fallback.data as T
-        }
-      }
-      return (returnResponse ? resp : resp.data) as T
+      return await resolveArrayBufferResponse(resp as RuntimeResponsePayload)
     }
   } catch (e) {
     if (isNoFallbackError(e)) {

--- a/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
+++ b/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
@@ -144,4 +144,95 @@ describe("workspace API skill methods", () => {
       }
     })
   })
+
+  it("returns exported skill blob with filename metadata from response headers", async () => {
+    const payload = new Uint8Array([1, 2, 3]).buffer
+    vi.mocked(bgRequest).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: payload,
+      headers: {
+        "content-type": "application/zip",
+        "content-disposition": 'attachment; filename="server-skill.zip"'
+      }
+    })
+    const clientCore = {
+      ensureConfigForRequest: vi.fn().mockResolvedValue(undefined)
+    }
+
+    const result = await workspaceApiMethods.exportSkill.call(
+      clientCore as any,
+      "client-skill"
+    )
+
+    expect(result.filename).toBe("server-skill.zip")
+    expect(result.blob).toBeInstanceOf(Blob)
+    expect(result.blob.type).toBe("application/zip")
+    expect(bgRequest).toHaveBeenCalledWith({
+      path: "/api/v1/skills/client-skill/export",
+      method: "GET",
+      responseType: "arrayBuffer",
+      returnResponse: true
+    })
+  })
+
+  it("prefers encoded export filenames from content disposition metadata", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: new Uint8Array([1, 2, 3]).buffer,
+      headers: {
+        "content-disposition": "attachment; filename=\"plain.zip\"; filename*=UTF-8''encoded-skill.zip"
+      }
+    })
+    const clientCore = {
+      ensureConfigForRequest: vi.fn().mockResolvedValue(undefined)
+    }
+
+    const result = await workspaceApiMethods.exportSkill.call(
+      clientCore as any,
+      "client-skill"
+    )
+
+    expect(result.filename).toBe("encoded-skill.zip")
+  })
+
+  it("falls back to a safe export filename when response metadata is unsafe", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: new Uint8Array([4, 5, 6]).buffer,
+      headers: {
+        "content-disposition": 'attachment; filename="../secret.zip"'
+      }
+    })
+    const clientCore = {
+      ensureConfigForRequest: vi.fn().mockResolvedValue(undefined)
+    }
+
+    const result = await workspaceApiMethods.exportSkill.call(
+      clientCore as any,
+      "safe-skill"
+    )
+
+    expect(result.filename).toBe("safe-skill.zip")
+    expect(result.blob).toBeInstanceOf(Blob)
+  })
+
+  it("rejects successful export responses without binary data", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: {
+        "content-disposition": 'attachment; filename="server-skill.zip"'
+      }
+    })
+    const clientCore = {
+      ensureConfigForRequest: vi.fn().mockResolvedValue(undefined)
+    }
+
+    await expect(
+      workspaceApiMethods.exportSkill.call(clientCore as any, "client-skill")
+    ).rejects.toThrow("Export failed: missing export payload")
+  })
 })

--- a/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
+++ b/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
@@ -219,6 +219,35 @@ describe("workspace API skill methods", () => {
     expect(result.blob).toBeInstanceOf(Blob)
   })
 
+  it("preserves safe fallback filename characters from user-provided skill names", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: new Uint8Array([4, 5, 6]).buffer
+    })
+    const clientCore = {
+      ensureConfigForRequest: vi.fn().mockResolvedValue(undefined)
+    }
+
+    const result = await workspaceApiMethods.exportSkill.call(
+      clientCore as any,
+      "  2_Custom Skill!  "
+    )
+
+    expect(result.filename).toBe("2_Custom-Skill.zip")
+  })
+
+  it("rejects export responses without contextual response metadata", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce(undefined)
+    const clientCore = {
+      ensureConfigForRequest: vi.fn().mockResolvedValue(undefined)
+    }
+
+    await expect(
+      workspaceApiMethods.exportSkill.call(clientCore as any, "client-skill")
+    ).rejects.toThrow("Export failed for skill client-skill: missing response")
+  })
+
   it("rejects successful export responses without binary data", async () => {
     vi.mocked(bgRequest).mockResolvedValueOnce({
       ok: true,
@@ -233,6 +262,21 @@ describe("workspace API skill methods", () => {
 
     await expect(
       workspaceApiMethods.exportSkill.call(clientCore as any, "client-skill")
-    ).rejects.toThrow("Export failed: missing export payload")
+    ).rejects.toThrow("Export failed for skill client-skill: missing export payload")
+  })
+
+  it("rejects serialized export responses with invalid binary payloads", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: { lost: "array-buffer" }
+    })
+    const clientCore = {
+      ensureConfigForRequest: vi.fn().mockResolvedValue(undefined)
+    }
+
+    await expect(
+      workspaceApiMethods.exportSkill.call(clientCore as any, "client-skill")
+    ).rejects.toThrow("Export failed for skill client-skill: invalid export payload")
   })
 })

--- a/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
+++ b/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
@@ -197,6 +197,27 @@ describe("workspace API skill methods", () => {
     expect(result.filename).toBe("encoded-skill.zip")
   })
 
+  it("accepts encoded export filenames with RFC 5987 language tags", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: new Uint8Array([1, 2, 3]).buffer,
+      headers: {
+        "content-disposition": "attachment; filename*=UTF-8'en'encoded-lang-skill.zip"
+      }
+    })
+    const clientCore = {
+      ensureConfigForRequest: vi.fn().mockResolvedValue(undefined)
+    }
+
+    const result = await workspaceApiMethods.exportSkill.call(
+      clientCore as any,
+      "client-skill"
+    )
+
+    expect(result.filename).toBe("encoded-lang-skill.zip")
+  })
+
   it("falls back to a safe export filename when response metadata is unsafe", async () => {
     vi.mocked(bgRequest).mockResolvedValueOnce({
       ok: true,

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -772,7 +772,7 @@ const isSafeDownloadFilename = (filename: string | undefined): filename is strin
 const getContentDispositionFilename = (disposition: string | null): string | undefined => {
   if (!disposition) return undefined
 
-  const encodedMatch = disposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i)
+  const encodedMatch = disposition.match(/filename\*\s*=\s*UTF-8'[^']*'([^;]+)/i)
   const plainMatch = disposition.match(/filename\s*=\s*"?([^\";]+)"?/i)
   const rawFilename = encodedMatch?.[1] || plainMatch?.[1]
   if (!rawFilename) return undefined

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -730,20 +730,34 @@ export interface SkillExportDownload {
   filename: string
 }
 
+type SkillExportPayload = ArrayBuffer | ArrayBufferView<ArrayBuffer> | Blob
+
 type BinaryResponsePayload = {
   ok: boolean
   status: number
-  data?: ArrayBuffer
+  data?: SkillExportPayload
   error?: string
   headers?: Record<string, string>
 }
 
 const getSkillExportFallbackFilename = (skillName: string): string => {
   const trimmedName = skillName.trim()
-  const safeName = /^[a-z][a-z0-9-]{0,63}$/.test(trimmedName)
-    ? trimmedName
-    : "skill"
-  return `${safeName}.zip`
+  const safeName = trimmedName
+    .replace(/[^a-zA-Z0-9_-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64)
+  return `${safeName || "skill"}.zip`
+}
+
+const isSkillExportPayload = (value: unknown): value is SkillExportPayload => {
+  if (!value) return false
+  if (value instanceof ArrayBuffer) return true
+  if (ArrayBuffer.isView?.(value)) {
+    return value.buffer instanceof ArrayBuffer
+  }
+  if (typeof Blob !== "undefined" && value instanceof Blob) return true
+  return false
 }
 
 const isSafeDownloadFilename = (filename: string | undefined): filename is string => {
@@ -766,6 +780,8 @@ const getContentDispositionFilename = (disposition: string | null): string | und
   try {
     return decodeURIComponent(rawFilename.trim())
   } catch {
+    // Export filenames are optional, untrusted metadata; keep the raw token so
+    // safety validation can either accept it or fall back to the skill name.
     return rawFilename.trim()
   }
 }
@@ -1018,14 +1034,20 @@ export const workspaceApiMethods = {
       responseType: "arrayBuffer",
       returnResponse: true
     })
+    const exportErrorContext = `Export failed for skill ${name}`
     if (!response) {
-      throw new Error("Export failed")
+      throw new Error(`${exportErrorContext}: missing response`)
     }
     if (!response.ok) {
-      throw new Error(response.error || `Export failed: ${response.status}`)
+      throw new Error(
+        response.error || `${exportErrorContext}: request failed with status ${response.status}`
+      )
     }
     if (!response.data) {
-      throw new Error("Export failed: missing export payload")
+      throw new Error(`${exportErrorContext}: missing export payload`)
+    }
+    if (!isSkillExportPayload(response.data)) {
+      throw new Error(`${exportErrorContext}: invalid export payload`)
     }
 
     const headers = new Headers(response.headers || {})

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -725,6 +725,62 @@ const trimmedOptionalString = (value: string | undefined): string | undefined =>
 const isValidSkillVersion = (version: number | undefined): version is number =>
   Number.isSafeInteger(version) && Number(version) > 0
 
+export interface SkillExportDownload {
+  blob: Blob
+  filename: string
+}
+
+type BinaryResponsePayload = {
+  ok: boolean
+  status: number
+  data?: ArrayBuffer
+  error?: string
+  headers?: Record<string, string>
+}
+
+const getSkillExportFallbackFilename = (skillName: string): string => {
+  const trimmedName = skillName.trim()
+  const safeName = /^[a-z][a-z0-9-]{0,63}$/.test(trimmedName)
+    ? trimmedName
+    : "skill"
+  return `${safeName}.zip`
+}
+
+const isSafeDownloadFilename = (filename: string | undefined): filename is string => {
+  if (!filename) return false
+  const trimmedFilename = filename.trim()
+  if (!trimmedFilename || trimmedFilename === "." || trimmedFilename === "..") {
+    return false
+  }
+  return !/[\/\\\0-\x1f\x7f]/.test(trimmedFilename)
+}
+
+const getContentDispositionFilename = (disposition: string | null): string | undefined => {
+  if (!disposition) return undefined
+
+  const encodedMatch = disposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i)
+  const plainMatch = disposition.match(/filename\s*=\s*"?([^\";]+)"?/i)
+  const rawFilename = encodedMatch?.[1] || plainMatch?.[1]
+  if (!rawFilename) return undefined
+
+  try {
+    return decodeURIComponent(rawFilename.trim())
+  } catch {
+    return rawFilename.trim()
+  }
+}
+
+const resolveSkillExportFilename = (
+  skillName: string,
+  headers: Headers
+): string => {
+  const fallbackFilename = getSkillExportFallbackFilename(skillName)
+  const headerFilename = getContentDispositionFilename(headers.get("content-disposition"))
+  return isSafeDownloadFilename(headerFilename)
+    ? headerFilename.trim()
+    : fallbackFilename
+}
+
 export const workspaceApiMethods = {
   // ── Skills API ──
 
@@ -954,14 +1010,32 @@ export const workspaceApiMethods = {
   async exportSkill(
     this: TldwApiClientCore,
     name: string
-  ): Promise<Blob> {
+  ): Promise<SkillExportDownload> {
     await this.ensureConfigForRequest(true)
-    const res = await bgRequest<ArrayBuffer, AllowedPath>({
+    const response = await bgRequest<BinaryResponsePayload, AllowedPath>({
       path: `/api/v1/skills/${encodeURIComponent(name)}/export` as AllowedPath,
       method: "GET",
-      responseType: "arrayBuffer"
+      responseType: "arrayBuffer",
+      returnResponse: true
     })
-    return new Blob([res], { type: "application/zip" })
+    if (!response) {
+      throw new Error("Export failed")
+    }
+    if (!response.ok) {
+      throw new Error(response.error || `Export failed: ${response.status}`)
+    }
+    if (!response.data) {
+      throw new Error("Export failed: missing export payload")
+    }
+
+    const headers = new Headers(response.headers || {})
+    const blob = new Blob([response.data], {
+      type: headers.get("content-type") || "application/zip"
+    })
+    return {
+      blob,
+      filename: resolveSkillExportFilename(name, headers)
+    }
   },
 
   async executeSkill(

--- a/backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md
+++ b/backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-530.12
 title: Implement Skills export metadata feedback
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-29 01:15'
+updated_date: '2026-06-29 01:32'
 labels:
   - skills
   - webui
@@ -64,6 +64,8 @@ Continue TASK-530 Safe Operations after TASK-530.11 by preserving Skills export 
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented Skills export metadata feedback. The frontend API now preserves server filename metadata for export downloads, safely falls back when metadata is absent or unsafe, rejects missing binary payloads, and the Skills manager now reports successful export starts with the actual download filename while keeping sanitized error feedback intact.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2546
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md
+++ b/backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md
@@ -2,16 +2,20 @@
 id: TASK-530.12
 title: Implement Skills export metadata feedback
 status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-06-29 01:15'
 labels:
-- skills
-- webui
-- safe-operations
-- frontend
-priority: high
-parent_task_id: TASK-530
+  - skills
+  - webui
+  - safe-operations
+  - frontend
+dependencies: []
 documentation:
-- Docs/superpowers/specs/2026-06-29-skills-export-metadata-feedback-design.md
-- Docs/superpowers/plans/2026-06-29-skills-export-metadata-feedback.md
+  - Docs/superpowers/specs/2026-06-29-skills-export-metadata-feedback-design.md
+  - Docs/superpowers/plans/2026-06-29-skills-export-metadata-feedback.md
+parent_task_id: TASK-530
+priority: high
 ---
 
 ## Description
@@ -22,31 +26,54 @@ Continue TASK-530 Safe Operations after TASK-530.11 by preserving Skills export 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Skills export API client returns both Blob and filename metadata parsed from Content-Disposition when available.
-- [ ] #2 Skills export API client falls back to a safe `<skill>.zip` filename when the header is missing, malformed, or unsafe.
-- [ ] #3 Skills manager uses the returned filename for the browser download and shows success feedback naming the actual file.
-- [ ] #4 Existing sanitized export failure feedback remains unchanged.
-- [ ] #5 Focused frontend tests cover metadata filename, fallback filename, success feedback, and error feedback.
+- [x] #1 Skills export API client returns both Blob and filename metadata parsed from Content-Disposition when available.
+- [x] #2 Skills export API client falls back to a safe `<skill>.zip` filename when the header is missing, malformed, or unsafe.
+- [x] #3 Skills manager uses the returned filename for the browser download and shows success feedback naming the actual file.
+- [x] #4 Existing sanitized export failure feedback remains unchanged.
+- [x] #5 Focused frontend tests cover metadata filename, fallback filename, success feedback, and error feedback.
 <!-- AC:END -->
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+<!-- SECTION:NOTES:BEGIN -->
+- Updated `workspaceApiMethods.exportSkill()` to preserve binary response metadata by requesting the full response wrapper and returning `{ blob, filename }`.
+- Added safe filename resolution from `Content-Disposition`, preferring RFC 5987 `filename*` over plain `filename`, with fallback to a safe `<skill>.zip` name.
+- Added a missing-payload guard so an otherwise successful export response without binary data reports an error instead of starting an empty download.
+- Updated the Skills manager export flow to use the returned filename for the browser download and to show success feedback naming the actual file.
+- Preserved sanitized export failure feedback and added regression coverage for the sanitized failure path.
 
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+## Modified Files
+- `apps/packages/ui/src/services/tldw/domains/workspace-api.ts`
+- `apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts`
+- `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+- `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+- `Docs/superpowers/plans/2026-06-29-skills-export-metadata-feedback.md`
+
+## Verification
+- `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot` - RED for missing-payload regression before guard: 1 failed, 13 passed.
+- `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot` - GREEN after guard: 1 file passed, 14 tests passed.
+- `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot` - 2 files passed, 50 tests passed.
+- `git diff --check` - passed.
+
+## Known Skips Or Blockers
+- Bandit skipped: touched code is frontend TypeScript/TSX and Markdown only.
+- Full package typecheck/build skipped: focused Vitest coverage targets the changed Skills export contract and manager workflow.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Skills export metadata feedback. The frontend API now preserves server filename metadata for export downloads, safely falls back when metadata is absent or unsafe, rejects missing binary payloads, and the Skills manager now reports successful export starts with the actual download filename while keeping sanitized error feedback intact.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md
+++ b/backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md
@@ -4,7 +4,7 @@ title: Implement Skills export metadata feedback
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-29 01:32'
+updated_date: '2026-06-29 04:13'
 labels:
   - skills
   - webui
@@ -58,6 +58,19 @@ Continue TASK-530 Safe Operations after TASK-530.11 by preserving Skills export 
 ## Known Skips Or Blockers
 - Bandit skipped: touched code is frontend TypeScript/TSX and Markdown only.
 - Full package typecheck/build skipped: focused Vitest coverage targets the changed Skills export contract and manager workflow.
+
+PR #2546 review follow-up:
+- Addressed Gemini fallback filename feedback by preserving safe uppercase, numeric, underscore, and hyphen characters while replacing unsafe characters with hyphens.
+- Addressed Gemini i18n feedback by changing export success copy to static `{{filename}}` interpolation syntax and updating the test translation stub.
+- Addressed Qodo decode handling feedback with an explicit comment documenting the malformed-header fallback path.
+- Addressed Qodo contextual error feedback by adding skill-specific missing-response, missing-payload, and invalid-payload errors.
+- Addressed Qodo binary fallback feedback by moving arrayBuffer serialization recovery into a shared `bgRequestImpl` helper that also preserves full response metadata when `returnResponse` is true.
+- Added regression coverage for the response-wrapper binary fallback and defensive export payload validation.
+
+Review follow-up verification:
+- `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx src/services/__tests__/background-proxy.test.ts --reporter=dot` - 3 files passed, 98 tests passed.
+- `git diff --check` - passed.
+- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json --pretty false` - still fails on existing baseline diagnostics outside the review fixes; the changed-code `workspace-api.ts` BlobPart diagnostic was fixed and did not recur.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -66,8 +79,6 @@ Continue TASK-530 Safe Operations after TASK-530.11 by preserving Skills export 
 Implemented Skills export metadata feedback. The frontend API now preserves server filename metadata for export downloads, safely falls back when metadata is absent or unsafe, rejects missing binary payloads, and the Skills manager now reports successful export starts with the actual download filename while keeping sanitized error feedback intact.
 
 PR: https://github.com/rmusser01/tldw_server/pull/2546
-<!-- SECTION:FINAL_SUMMARY:END -->
-
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md
+++ b/backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md
@@ -1,0 +1,52 @@
+---
+id: TASK-530.12
+title: Implement Skills export metadata feedback
+status: In Progress
+labels:
+- skills
+- webui
+- safe-operations
+- frontend
+priority: high
+parent_task_id: TASK-530
+documentation:
+- Docs/superpowers/specs/2026-06-29-skills-export-metadata-feedback-design.md
+- Docs/superpowers/plans/2026-06-29-skills-export-metadata-feedback.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-530 Safe Operations after TASK-530.11 by preserving Skills export response metadata through the frontend client and using the server-provided filename for downloads and success feedback. Keep scope limited to export metadata, filename fallback/safety, and user feedback; do not add bulk export or permission/model metadata panels.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Skills export API client returns both Blob and filename metadata parsed from Content-Disposition when available.
+- [ ] #2 Skills export API client falls back to a safe `<skill>.zip` filename when the header is missing, malformed, or unsafe.
+- [ ] #3 Skills manager uses the returned filename for the browser download and shows success feedback naming the actual file.
+- [ ] #4 Existing sanitized export failure feedback remains unchanged.
+- [ ] #5 Focused frontend tests cover metadata filename, fallback filename, success feedback, and error feedback.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md
+++ b/backlog/tasks/task-530.12 - Implement-Skills-export-metadata-feedback.md
@@ -43,6 +43,7 @@ Continue TASK-530 Safe Operations after TASK-530.11 by preserving Skills export 
 - Preserved sanitized export failure feedback and added regression coverage for the sanitized failure path.
 
 ## Modified Files
+
 - `apps/packages/ui/src/services/tldw/domains/workspace-api.ts`
 - `apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts`
 - `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
@@ -50,12 +51,14 @@ Continue TASK-530 Safe Operations after TASK-530.11 by preserving Skills export 
 - `Docs/superpowers/plans/2026-06-29-skills-export-metadata-feedback.md`
 
 ## Verification
+
 - `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot` - RED for missing-payload regression before guard: 1 failed, 13 passed.
 - `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot` - GREEN after guard: 1 file passed, 14 tests passed.
 - `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot` - 2 files passed, 50 tests passed.
 - `git diff --check` - passed.
 
 ## Known Skips Or Blockers
+
 - Bandit skipped: touched code is frontend TypeScript/TSX and Markdown only.
 - Full package typecheck/build skipped: focused Vitest coverage targets the changed Skills export contract and manager workflow.
 
@@ -71,6 +74,15 @@ Review follow-up verification:
 - `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx src/services/__tests__/background-proxy.test.ts --reporter=dot` - 3 files passed, 98 tests passed.
 - `git diff --check` - passed.
 - `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --project tsconfig.json --pretty false` - still fails on existing baseline diagnostics outside the review fixes; the changed-code `workspace-api.ts` BlobPart diagnostic was fixed and did not recur.
+
+Additional PR #2546 CodeRabbit follow-up:
+- Hardened export failure sanitizer coverage with negative assertions for the raw API path, query token, local path, and bearer token value.
+- Extended RFC 5987 parsing to accept non-empty language tags in `filename*` values and added coverage for language-tagged encoded filenames.
+- Fixed Backlog task Markdown heading spacing flagged by markdownlint.
+
+Additional review verification:
+- `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx src/services/__tests__/background-proxy.test.ts --reporter=dot` - 3 files passed, 99 tests passed.
+- `git diff --check` - passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Change summary

Human-authored summary required before merge per the AI-generated PR policy.

## What changed

- Preserve Skills export response metadata through the frontend API client and return `{ blob, filename }`.
- Parse `Content-Disposition` filenames, prefer `filename*`, and fall back to a safe `<skill>.zip` filename when metadata is absent or unsafe.
- Reject missing binary export payloads instead of starting an empty download.
- Use the resolved filename for `/skills` downloads and show success feedback naming the actual file.
- Add focused service and manager regression coverage, including sanitized export failure feedback.

## Verification

- `bunx vitest run src/services/tldw/domains/__tests__/workspace-api.skills.test.ts src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot` - 2 files passed, 50 tests passed.
- `git diff --check origin/dev...HEAD` - passed.

## Notes

- Bandit skipped because touched code is frontend TypeScript/TSX and Markdown only.
- Full package typecheck/build skipped; focused Vitest coverage targets the changed Skills export contract and manager workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves server-provided filenames and content type for Skills export downloads, and shows success feedback with the actual file name. Completes TASK-530.12 by returning `{ blob, filename }` from the client, validating binary payloads, and using safe fallbacks.

- **New Features**
  - `workspaceApiMethods.exportSkill()` returns `{ blob, filename }`; parses `Content-Disposition` (supports `filename*` with RFC 5987 language tags), validates safe names, and uses header `content-type`.
  - Falls back to a sanitized `<skill>.zip`; throws clear errors for missing responses or invalid/missing binary payloads; decoding never accepts path-like names.
  - Skills Manager uses the resolved filename and shows a success notice; background arrayBuffer fallback preserves headers with `returnResponse: true`; tests cover parsing, fallback, success, and sanitized errors.

<sup>Written for commit 429f019f82562437f9c8da55b986cd4b711db85a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

