### PR TITLE
Migrate AudioStudio migration alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/src/components/Option/AudioStudio/CompatibilityRedirect.tsx
+++ b/apps/packages/ui/src/components/Option/AudioStudio/CompatibilityRedirect.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { Alert, Spin } from "antd"
+import { Spin } from "antd"
 import { useNavigate } from "react-router-dom"
+import { Alert } from "@/components/ui/primitives/Alert"
 import {
   listLegacyAudiobookProjectsForMigration,
   markLegacyAudiobookProjectMigrated,
@@ -227,7 +228,7 @@ export const CompatibilityRedirect: React.FC = () => {
   if (errorMessage && projects.length === 0) {
     return (
       <div className="mx-auto max-w-3xl p-4">
-        <Alert type="error" showIcon title={errorMessage} />
+        <Alert variant="error" title={errorMessage} />
       </div>
     )
   }

--- a/apps/packages/ui/src/components/Option/AudioStudio/MigrationBanner.tsx
+++ b/apps/packages/ui/src/components/Option/AudioStudio/MigrationBanner.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { Alert, Button, Checkbox, List, Space, Tag, Typography } from "antd"
+import { Button, Checkbox, List, Space, Tag, Typography } from "antd"
+import { Alert } from "@/components/ui/primitives/Alert"
 import type { AudiobookProject } from "@/db/dexie/types"
 import type { AudiobookMigrationCounts } from "@/services/audio-studio"
 
@@ -57,12 +58,12 @@ export const MigrationBanner: React.FC<MigrationBannerProps> = ({
   if (!projects || !selectedProjectIds || !onSelectionChange || !onPreview || !onCommit) {
     return (
       <Alert
-        type="info"
-        showIcon
-        className="rounded-md"
+        variant="info"
         title="Audiobook projects can move into Audio Studio Narration"
-        description="Open the legacy Audiobook Studio route to check local projects and migrate them without deleting Dexie data."
-      />
+      >
+        Open the legacy Audiobook Studio route to check local projects and
+        migrate them without deleting Dexie data.
+      </Alert>
     )
   }
 
@@ -108,17 +109,12 @@ export const MigrationBanner: React.FC<MigrationBannerProps> = ({
           </Typography.Paragraph>
         </div>
 
-        {errorMessage ? (
-          <Alert type="error" showIcon title={errorMessage} />
-        ) : null}
+        {errorMessage ? <Alert variant="error" title={errorMessage} /> : null}
 
         {previewSummary ? (
-          <Alert
-            type="success"
-            showIcon
-            title="Migration preview"
-            description={previewSummary}
-          />
+          <Alert variant="success" title="Migration preview">
+            {previewSummary}
+          </Alert>
         ) : null}
 
         <div className="flex items-center justify-between gap-3">

--- a/apps/packages/ui/src/components/Option/AudioStudio/__tests__/CompatibilityRedirect.test.tsx
+++ b/apps/packages/ui/src/components/Option/AudioStudio/__tests__/CompatibilityRedirect.test.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  expectInsideDesignSystemAlert,
+  expectInsideDesignSystemAlertAsync
+} from "@/test-utils/designSystemAlert"
 
 const dexieMocks = vi.hoisted(() => ({
   listProjects: vi.fn(),
@@ -47,6 +51,7 @@ import {
   AUDIOBOOK_COMPATIBILITY_TARGET,
   CompatibilityRedirect
 } from "../CompatibilityRedirect"
+import { MigrationBanner } from "../MigrationBanner"
 
 const legacyProject = {
   id: "legacy-1",
@@ -108,6 +113,22 @@ describe("CompatibilityRedirect", () => {
     )
   })
 
+  it("renders static migration guidance through the design-system Alert primitive", () => {
+    render(<MigrationBanner />)
+
+    expectInsideDesignSystemAlert(
+      "Audiobook projects can move into Audio Studio Narration"
+    )
+  })
+
+  it("renders legacy project load errors through the design-system Alert primitive", async () => {
+    dexieMocks.listProjects.mockRejectedValueOnce(new Error("Dexie unavailable"))
+
+    render(<CompatibilityRedirect />)
+
+    await expectInsideDesignSystemAlertAsync("Dexie unavailable")
+  })
+
   it("shows a migration banner with local project preview when Dexie projects exist", async () => {
     render(<CompatibilityRedirect />)
 
@@ -136,6 +157,7 @@ describe("CompatibilityRedirect", () => {
     expect(
       await screen.findByText("1 project, 2 chapters, 0 audio assets")
     ).toBeInTheDocument()
+    expectInsideDesignSystemAlert("Migration preview")
   })
 
   it("marks local projects only after commit succeeds and redirects to the migrated project", async () => {
@@ -174,6 +196,7 @@ describe("CompatibilityRedirect", () => {
     expect(
       await screen.findByText("commit failed")
     ).toBeInTheDocument()
+    expectInsideDesignSystemAlert("commit failed")
     expect(dexieMocks.markMigrated).not.toHaveBeenCalled()
     expect(routerMocks.navigate).not.toHaveBeenCalled()
   })

--- a/backlog/tasks/task-45.44.13.5 - Migrate-AudioStudio-migration-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.13.5 - Migrate-AudioStudio-migration-alerts-to-design-system-Alert.md
@@ -1,0 +1,68 @@
+---
+id: TASK-45.44.13.5
+title: Migrate AudioStudio migration alerts to design-system Alert
+status: Done
+labels:
+- design-system
+- webui
+- product-state
+- audio-studio
+parent_task_id: TASK-45.44.13
+references:
+- apps/packages/ui/src/components/Option/AudioStudio/MigrationBanner.tsx
+- apps/packages/ui/src/components/Option/AudioStudio/CompatibilityRedirect.tsx
+- apps/packages/ui/scripts/verify-design-system-product-state.mjs
+documentation:
+- Docs/Design/tldw_web_design_system_contract.md
+- Docs/Design/tldw_web_design_system_inventory.md
+modified_files:
+- apps/packages/ui/src/components/Option/AudioStudio/MigrationBanner.tsx
+- apps/packages/ui/src/components/Option/AudioStudio/CompatibilityRedirect.tsx
+- apps/packages/ui/src/components/Option/AudioStudio/__tests__/CompatibilityRedirect.test.tsx
+- backlog/tasks/task-45.44.13.5 - Migrate-AudioStudio-migration-alerts-to-design-system-Alert.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system migration by resolving current AudioStudio product-state guard drift in MigrationBanner and CompatibilityRedirect. Replace product-state AntD Alert usage with the shared design-system Alert primitive while preserving existing AudioStudio migration/compatibility copy, actions, and tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 AudioStudio migration/compatibility product-state alerts render through the shared design-system Alert primitive while preserving copy and actions.
+- [x] #2 Focused AudioStudio coverage asserts migrated alerts are inside the design-system Alert marker.
+- [x] #3 Direct product-state guard scan over the touched AudioStudio files reports zero findings.
+- [x] #4 Full product-state verifier progress is recorded with unrelated current-dev drift noted if any.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added focused AudioStudio DS Alert marker coverage for static migration guidance, legacy-project load errors, migration preview success, and commit error states.
+- RED: `bunx vitest run src/components/Option/AudioStudio/__tests__/CompatibilityRedirect.test.tsx` failed on missing `data-ds-component="Alert"` ancestors for those four states while the components still rendered AntD Alert.
+- Migrated `MigrationBanner` info/error/success product-state alerts and `CompatibilityRedirect` load-error alert to `@/components/ui/primitives/Alert`, preserving visible copy and actions.
+- GREEN: `bunx vitest run src/components/Option/AudioStudio/__tests__/CompatibilityRedirect.test.tsx` passed with 7 tests.
+- Broader AudioStudio page suite: `bunx vitest run src/components/Option/AudioStudio/__tests__/AudioStudioPage.test.tsx` passed with 36 tests.
+- Direct product-state analyzer over `MigrationBanner.tsx` and `CompatibilityRedirect.tsx` returned `[]` for both files.
+- `git diff --check` passed.
+- Full product-state guard still exits 1 on unrelated current-dev ScheduledTasks/Skills/TTS blockers and 6 stale baseline entries, with `touchedFindingCount: 0` for AudioStudio.
+- Bandit is not applicable because this slice only touches frontend TypeScript/TSX and Backlog markdown.
+- Review cycle: rebased on latest origin/dev and removed the local `rounded-md` override from the AudioStudio guidance Alert so the design-system Alert default radius remains authoritative.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated AudioStudio migration/compatibility product-state alerts from AntD Alert to the shared design-system Alert primitive. Focused tests now assert DS Alert ownership for the static migration guidance, legacy-project load errors, preview success, and commit error states, and direct guard scans report no AudioStudio findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Migrate AudioStudio migration/compatibility product-state alerts from AntD Alert to the shared design-system Alert primitive.
- Add focused DS Alert marker coverage for static guidance, Dexie load errors, migration preview success, and commit errors.
- Add and close `TASK-45.44.13.5` under the design-system long-tail tracker.

## Verification
- RED: `bunx vitest run src/components/Option/AudioStudio/__tests__/CompatibilityRedirect.test.tsx` failed on missing `data-ds-component="Alert"` ancestors before implementation.
- GREEN: `bunx vitest run src/components/Option/AudioStudio/__tests__/CompatibilityRedirect.test.tsx` passed with 7 tests.
- `bunx vitest run src/components/Option/AudioStudio/__tests__/AudioStudioPage.test.tsx` passed with 36 tests.
- `git diff --check origin/dev...HEAD` passed.
- Direct product-state analyzer over `MigrationBanner.tsx` and `CompatibilityRedirect.tsx` returned `[]`.
- Compact full product-state guard still exits 1 on unrelated ScheduledTasks/Skills/TTS findings plus 6 stale baseline entries, with `touchedFindingCount: 0` for AudioStudio.

## Merge gate
Human-authored Change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced AudioStudio migration and compatibility alerts with the design-system `Alert` to standardize UI and enable product-state checks. Added focused tests for static guidance, Dexie load errors, preview success, and commit errors.

- **Refactors**
  - Swapped `antd` `Alert` for `@/components/ui/primitives/Alert` in `MigrationBanner` and `CompatibilityRedirect`.
  - Mapped `type` to `variant`, moved `description` into children, removed `showIcon`, and dropped the local radius override.
  - Added DS-alert test helpers and assertions in `CompatibilityRedirect.test.tsx`.
  - Satisfies Linear `TASK-45.44.13.5`; direct product-state scan reports no findings; existing tests remain green.

<sup>Written for commit 043ac5fcb77e42afc4e82678b3fb53398db8b734. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

