### PR TITLE
MCP Unified residual UX hardening

### DIFF
--- a/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
@@ -1808,11 +1808,15 @@ async def _gateway_readiness_status(
     profile_manager: GatewayProfileManager | None,
     external_registry_manager: GatewayExternalRegistryManager | None,
     admin_auth: GatewayAdminAuthConfig | None,
+    status_path: str,
 ) -> dict[str, Any]:
     """Return best-effort package-local gateway readiness metadata."""
 
     warnings: list[dict[str, str]] = []
     next_actions: list[str] = []
+    mount_path = status_path.rsplit("/status", 1)[0] if status_path.endswith("/status") else status_path
+    if not mount_path:
+        mount_path = "/"
     package_summary = package_metadata_summary()
     package_payload = {
         key: package_summary.get(key)
@@ -1866,7 +1870,9 @@ async def _gateway_readiness_status(
             )
             next_actions.append("Configure a default profile before relying on profile-scoped gateway calls.")
         except Exception:  # noqa: BLE001 - status must remain best-effort.
-            logger.exception("Default profile readiness check failed during gateway status.")
+            logger.opt(exception=True).warning(
+                "Gateway default profile readiness check failed"
+            )
             warnings.append(
                 _status_warning(
                     "default_profile_status_unavailable",
@@ -1918,7 +1924,9 @@ async def _gateway_readiness_status(
             )
             external_servers["unavailable"] = external_servers["total"]
         except Exception:  # noqa: BLE001 - status must remain best-effort.
-            logger.exception("External registry readiness check failed during gateway status.")
+            logger.opt(exception=True).warning(
+                "Gateway external registry readiness check failed"
+            )
             warnings.append(
                 _status_warning(
                     "external_registry_status_unavailable",
@@ -1958,7 +1966,7 @@ async def _gateway_readiness_status(
         "status": "ok",
         "name": _runtime_name(runtime),
         "version": _runtime_version(runtime),
-        "transport": {"base_path": "package-local-mounted", "mount_path": "unknown"},
+        "transport": {"base_path": "package-local-mounted", "mount_path": mount_path},
         "package": package_payload,
         "profile_store": profile_store,
         "default_profile": default_profile,
@@ -2055,7 +2063,7 @@ def create_gateway_router(
         )
 
     @router.get("/status", response_model=GatewayReadinessStatusResponse)
-    async def gateway_status() -> dict[str, Any]:
+    async def gateway_status(request: Request) -> dict[str, Any]:
         """Return best-effort package-local gateway readiness metadata."""
 
         return await _gateway_readiness_status(
@@ -2063,6 +2071,7 @@ def create_gateway_router(
             profile_manager=resolved_profile_manager,
             external_registry_manager=resolved_external_registry_manager,
             admin_auth=resolved_admin_auth,
+            status_path=str(request.url.path),
         )
 
     @router.post(

--- a/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
@@ -485,6 +485,81 @@ class ExternalRuntimeOperationResponse(BaseModel):
     errors: dict[str, Any] | None = None
 
 
+class GatewayStatusWarning(BaseModel):
+    """Non-secret readiness warning for the package-local gateway status."""
+
+    reason_code: str
+    message: str
+
+
+class GatewayPackageStatus(BaseModel):
+    """Package-boundary metadata for the package-local gateway status."""
+
+    package_name: str | None = None
+    package_import_name: str | None = None
+    package_status: str | None = None
+    publishing_status: str | None = None
+    source_distribution: str | None = None
+    dependency_version_policy: str | None = None
+
+
+class GatewayTransportStatus(BaseModel):
+    """Transport metadata for the package-local gateway status."""
+
+    base_path: str
+    mount_path: str
+
+
+class GatewayStoreReadinessStatus(BaseModel):
+    """Non-secret store readiness metadata for the package-local gateway status."""
+
+    model_config = ConfigDict(extra="allow")
+
+    kind: str
+    persistent: bool | None = None
+
+
+class GatewayDefaultProfileStatus(BaseModel):
+    """Default profile readiness metadata for the package-local gateway status."""
+
+    configured: bool
+    profile_id: str | None = None
+    source: str
+
+
+class GatewayAdminAuthStatus(BaseModel):
+    """Admin authentication readiness metadata without secret values."""
+
+    enabled: bool
+    configured: bool
+    header_name: str | None = None
+
+
+class GatewayExternalServersStatus(BaseModel):
+    """External MCP server count summary for the package-local gateway status."""
+
+    total: int
+    enabled: int
+    unavailable: int
+
+
+class GatewayReadinessStatusResponse(BaseModel):
+    """Response body for package-local gateway readiness status."""
+
+    status: str
+    name: str
+    version: str
+    transport: GatewayTransportStatus
+    package: GatewayPackageStatus
+    profile_store: GatewayStoreReadinessStatus
+    default_profile: GatewayDefaultProfileStatus
+    admin_auth: GatewayAdminAuthStatus
+    external_registry_store: GatewayStoreReadinessStatus
+    external_servers: GatewayExternalServersStatus
+    warnings: list[GatewayStatusWarning]
+    next_actions: list[str]
+
+
 class _GatewayAdminAuthHandlingRoute(APIRoute):
     """Route wrapper that keeps router-only admin auth failures JSON-stable."""
 
@@ -1732,7 +1807,7 @@ async def _gateway_readiness_status(
     *,
     profile_manager: GatewayProfileManager | None,
     external_registry_manager: GatewayExternalRegistryManager | None,
-    admin_auth: GatewayAdminAuthConfig,
+    admin_auth: GatewayAdminAuthConfig | None,
 ) -> dict[str, Any]:
     """Return best-effort package-local gateway readiness metadata."""
 
@@ -1860,12 +1935,18 @@ async def _gateway_readiness_status(
             )
         )
 
+    admin_auth_enabled = bool(admin_auth.enabled) if admin_auth is not None else False
+    admin_auth_configured = (
+        bool(admin_auth.api_key is not None or admin_auth.verifier is not None)
+        if admin_auth is not None
+        else False
+    )
     admin_auth_payload = {
-        "enabled": bool(admin_auth.enabled),
-        "configured": bool(admin_auth.api_key is not None or admin_auth.verifier is not None),
-        "header_name": admin_auth.header_name if admin_auth.enabled else None,
+        "enabled": admin_auth_enabled,
+        "configured": admin_auth_configured,
+        "header_name": admin_auth.header_name if admin_auth_enabled and admin_auth is not None else None,
     }
-    if admin_auth.enabled and not admin_auth_payload["configured"]:
+    if admin_auth_enabled and not admin_auth_payload["configured"]:
         warnings.append(
             _status_warning(
                 "admin_auth_not_configured",
@@ -1973,7 +2054,7 @@ def create_gateway_router(
             policy_explain_permission_checker=policy_explain_permission_checker,
         )
 
-    @router.get("/status", response_model=GatewayStatusResponse)
+    @router.get("/status", response_model=GatewayReadinessStatusResponse)
     async def gateway_status() -> dict[str, Any]:
         """Return best-effort package-local gateway readiness metadata."""
 

--- a/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
+++ b/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
@@ -4,25 +4,46 @@ title: Implement MCP Unified residual UX hardening
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-29 04:56'
+updated_date: 2026-06-29 04:56
 labels:
-  - mcp
-  - ux
-  - security
-  - docs
+- mcp
+- ux
+- security
+- docs
 dependencies: []
 references:
-  - TASK-12054
-  - TASK-2372
-  - >-
-    Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
-  - >-
-    Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
+- TASK-12054
+- TASK-2372
+- Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+- Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
 documentation:
-  - >-
-    Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
-  - >-
-    Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+- Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
+- Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+modified_files:
+- Docs/MCP/Unified/Client_Snippets.md
+- Docs/MCP/Unified/Developer_Guide.md
+- Docs/MCP/Unified/Modules.md
+- Docs/MCP/Unified/README.md
+- Docs/MCP/Unified/Smoke_Client.md
+- Docs/MCP/Unified/System_Admin_Guide.md
+- Docs/MCP/Unified/User_Guide.md
+- Docs/MCP/Unified/Using_Modules_YAML.md
+- apps/mcp-unified/README.md
+- apps/mcp-unified/USER_GUIDE.md
+- apps/mcp-unified/src/mcp_unified/README.md
+- apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
+- tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml
+- tldw_Server_API/Config_Files/mcp_modules.yaml
+- tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+- tldw_Server_API/app/core/MCP_unified/docker/Dockerfile
+- tldw_Server_API/app/core/MCP_unified/module_surface.py
+- tldw_Server_API/app/core/MCP_unified/protocol.py
+- tldw_Server_API/app/core/MCP_unified/server.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
+- tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
 ---
 
 ## Description
@@ -60,32 +81,6 @@ Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementati
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented the approved residual MCP Unified UX hardening work and addressed PR review feedback after rebasing onto latest dev.
 
-Changed files:
-- Docs/MCP/Unified/Client_Snippets.md
-- Docs/MCP/Unified/Developer_Guide.md
-- Docs/MCP/Unified/Modules.md
-- Docs/MCP/Unified/README.md
-- Docs/MCP/Unified/Smoke_Client.md
-- Docs/MCP/Unified/System_Admin_Guide.md
-- Docs/MCP/Unified/User_Guide.md
-- Docs/MCP/Unified/Using_Modules_YAML.md
-- apps/mcp-unified/README.md
-- apps/mcp-unified/USER_GUIDE.md
-- apps/mcp-unified/src/mcp_unified/README.md
-- apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
-- tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml
-- tldw_Server_API/Config_Files/mcp_modules.yaml
-- tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
-- tldw_Server_API/app/core/MCP_unified/docker/Dockerfile
-- tldw_Server_API/app/core/MCP_unified/module_surface.py
-- tldw_Server_API/app/core/MCP_unified/protocol.py
-- tldw_Server_API/app/core/MCP_unified/server.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
-- tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
-
 Summary:
 - Made high-risk MCP modules fail closed by default: filesystem, run_command, and codegraph remain available only through explicit opt-in configuration; status reports disabled-but-available high-risk modules with next actions.
 - Expanded package-local /mcp/status to include non-secret readiness metadata for package publication status, profile store/default profile, admin auth configuration, external registry store, and external server counts.
@@ -105,10 +100,22 @@ Verification:
 
 Clean PR branch follow-up:
 - Moved the MCP residual UX work to clean branch codex/mcp-residual-ux-clean based on latest origin/dev.
-- Final diff review found and removed unrelated README/TASK-12061 drift from the cherry-pick; remaining diff is scoped to MCP docs, package-local gateway status, MCP server/protocol/endpoint behavior, focused tests, and Backlog/spec records.
-- Re-ran clean-branch verification after rebasing on origin/dev: 63 passed for docs/basic/http tests, 5 passed for gateway status/basic JSON-RPC subset, 4 passed for Docker packaging contract, Bandit 0 findings.
+- Final diff review removed unrelated README/TASK-12061 drift from the cherry-pick; remaining diff is scoped to MCP docs, package-local gateway status, MCP server/protocol/endpoint behavior, focused tests, and Backlog/spec records.
+- PR: https://github.com/rmusser01/tldw_server/pull/2548
 
-PR: https://github.com/rmusser01/tldw_server/pull/2548
+PR review follow-up after rebasing on latest origin/dev:
+- Defended package-local /mcp/status against missing package metadata keys and missing admin auth configuration.
+- Added an explicit GatewayReadinessStatusResponse response_model and nested Pydantic response models for /mcp/status OpenAPI truthfulness.
+- Changed configured enabled MCP modules that did not register/load to report status=not_loaded and reason=module_not_loaded instead of appearing enabled or as normal disabled opt-ins.
+- Made gateway import-boundary tests use the real apps/mcp-unified/src package path so clean worktrees without editable package installs can run the full suite.
+
+Verification:
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q --tb=short tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py -> 32 passed, 6 warnings
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q --tb=short tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -> 205 passed, 5 warnings
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q --tb=short tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -> 33 passed, 4 warnings
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q --tb=short tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py -> 4 passed, 4 warnings
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/core/MCP_unified/module_surface.py tldw_Server_API/app/core/MCP_unified/server.py apps/mcp-unified/src/mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_pr2548_review_fixes.json -> 0 findings
+- git diff --check -> clean
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
+++ b/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
@@ -4,7 +4,7 @@ title: Implement MCP Unified residual UX hardening
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-29 04:51'
+updated_date: '2026-06-29 04:56'
 labels:
   - mcp
   - ux
@@ -107,6 +107,8 @@ Clean PR branch follow-up:
 - Moved the MCP residual UX work to clean branch codex/mcp-residual-ux-clean based on latest origin/dev.
 - Final diff review found and removed unrelated README/TASK-12061 drift from the cherry-pick; remaining diff is scoped to MCP docs, package-local gateway status, MCP server/protocol/endpoint behavior, focused tests, and Backlog/spec records.
 - Re-ran clean-branch verification after rebasing on origin/dev: 63 passed for docs/basic/http tests, 5 passed for gateway status/basic JSON-RPC subset, 4 passed for Docker packaging contract, Bandit 0 findings.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2548
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
+++ b/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
@@ -4,46 +4,25 @@ title: Implement MCP Unified residual UX hardening
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-06-29 04:38
+updated_date: '2026-06-29 04:51'
 labels:
-- mcp
-- ux
-- security
-- docs
+  - mcp
+  - ux
+  - security
+  - docs
 dependencies: []
 references:
-- TASK-12054
-- TASK-2372
-- Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
-- Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
+  - TASK-12054
+  - TASK-2372
+  - >-
+    Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+  - >-
+    Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
 documentation:
-- Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
-- Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
-modified_files:
-- Docs/MCP/Unified/Client_Snippets.md
-- Docs/MCP/Unified/Developer_Guide.md
-- Docs/MCP/Unified/Modules.md
-- Docs/MCP/Unified/README.md
-- Docs/MCP/Unified/Smoke_Client.md
-- Docs/MCP/Unified/System_Admin_Guide.md
-- Docs/MCP/Unified/User_Guide.md
-- Docs/MCP/Unified/Using_Modules_YAML.md
-- apps/mcp-unified/README.md
-- apps/mcp-unified/USER_GUIDE.md
-- apps/mcp-unified/src/mcp_unified/README.md
-- apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
-- tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml
-- tldw_Server_API/Config_Files/mcp_modules.yaml
-- tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
-- tldw_Server_API/app/core/MCP_unified/docker/Dockerfile
-- tldw_Server_API/app/core/MCP_unified/module_surface.py
-- tldw_Server_API/app/core/MCP_unified/protocol.py
-- tldw_Server_API/app/core/MCP_unified/server.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
-- tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
+  - >-
+    Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
+  - >-
+    Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
 ---
 
 ## Description
@@ -122,6 +101,12 @@ Verification:
 - source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py -> 4 passed, 4 warnings
 - source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit apps/mcp-unified/src/mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py -f json -o /tmp/bandit_mcp_review_fixes.json -> 0 findings
 - git diff --check -> clean
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/core/MCP_unified/module_surface.py tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py apps/mcp-unified/src/mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_residual_ux.json -> 0 findings
+
+Clean PR branch follow-up:
+- Moved the MCP residual UX work to clean branch codex/mcp-residual-ux-clean based on latest origin/dev.
+- Final diff review found and removed unrelated README/TASK-12061 drift from the cherry-pick; remaining diff is scoped to MCP docs, package-local gateway status, MCP server/protocol/endpoint behavior, focused tests, and Backlog/spec records.
+- Re-ran clean-branch verification after rebasing on origin/dev: 63 passed for docs/basic/http tests, 5 passed for gateway status/basic JSON-RPC subset, 4 passed for Docker packaging contract, Bandit 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12064 - Rebase-PR-2548-and-verify-MCP-residual-UX-review-follow-ups.md
+++ b/backlog/tasks/task-12064 - Rebase-PR-2548-and-verify-MCP-residual-UX-review-follow-ups.md
@@ -1,0 +1,66 @@
+---
+id: TASK-12064
+title: Rebase PR 2548 and verify MCP residual UX review follow-ups
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-29 20:17'
+labels:
+  - pr-2548
+  - mcp
+  - ci
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track rebasing PR #2548 onto latest dev, verifying all PR review comments/issues are addressed, investigating failing PR checks, and recording final verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR branch is rebased onto latest origin/dev
+- [x] #2 All GitHub review threads and top-level comments have been checked and actionable issues addressed or documented
+- [x] #3 Relevant local tests and Bandit on touched scope have been run
+- [x] #4 PR branch is pushed and PR status is reported
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Fetched latest `origin/dev` and PR head, then rebased `codex/mcp-residual-ux-clean` onto `origin/dev`.
+- Verified the existing PR review fixes after rebase: package gateway readiness uses `package_summary.get(...)`, admin-auth `None` is handled, `/mcp/status` has `GatewayReadinessStatusResponse`, and MCP status distinguishes configured-but-not-loaded modules.
+- Queried review threads and top-level comments; no unresolved review threads remained at the time of inspection.
+- Investigated old PR check failures. The README release metadata failure is already fixed on rebased `dev`; local contract test passes.
+- Root-caused the MCP authz CI failures to tests assuming the high-risk `run_command` module is loaded by default after this PR intentionally made it explicit opt-in.
+- Updated `tldw_Server_API/tests/MCP/test_mcp_tools_execute_authz.py` so run-command authz tests write a temporary explicit MCP modules YAML and set `MCP_MODULES_CONFIG` via `monkeypatch` before resetting the MCP server.
+
+Verification:
+- Targeted red check before the fix reproduced the two `Tool not found: run` failures.
+- Targeted rerun after the fix: `2 passed, 3 warnings`.
+- Full authz file: `4 passed, 3 warnings`.
+- MCP focused suite: `270 passed, 7 warnings`.
+- Release docs metadata contract: `1 passed, 3 warnings`.
+- CI-style MCP shard: `577 passed, 4 skipped, 975 warnings`.
+- `git diff --check`: passed.
+- Bandit on touched MCP/app/test scope wrote `/tmp/bandit_pr2548_mcp_scope.json`; only LOW-severity B101 assert findings in the touched pytest file, no production-code findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2548's `codex/mcp-residual-ux-clean` branch onto latest `origin/dev`, verified the GitHub review feedback remains addressed, and fixed the PR-specific MCP authz CI failure by making the run-command tests explicitly opt into the high-risk `run_command` module. Local verification passed for the focused authz tests, MCP focused suite, release docs contract, CI-style MCP shard, whitespace check, and Bandit touched-scope scan with only test assert warnings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12065 - Address-PR-2548-post-push-CodeRabbit-and-CI-follow-up.md
+++ b/backlog/tasks/task-12065 - Address-PR-2548-post-push-CodeRabbit-and-CI-follow-up.md
@@ -1,0 +1,88 @@
+---
+id: TASK-12065
+title: Address PR 2548 post-push CodeRabbit and CI follow-up
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-30 02:31'
+labels:
+  - pr-2548
+  - mcp
+  - review
+  - ci
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2548'
+  - >-
+    Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track the second PR #2548 rebase pass: handle new CodeRabbit review threads, inspect post-push CI failures, update tests, verify, and push the branch on latest dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Branch is rebased onto the latest fetched origin/dev
+- [x] #2 New unresolved PR review comments are verified and addressed or documented
+- [x] #3 Fresh failing GitHub Actions checks are inspected and actionable failures are fixed or documented
+- [x] #4 Relevant local tests, diff check, and Bandit are run
+- [x] #5 Branch is pushed and final PR status is reported
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Used a temporary four-stage implementation plan for refresh, review fixes, CI follow-up, and verification; removed the temporary plan file before commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Fetched latest `origin/dev` and rebased `codex/mcp-residual-ux-clean`; after `origin/dev` advanced during the first rebase, rebased again onto `5b61874981` and the local branch is `0 5` relative to `origin/dev`.
+- Verified new CodeRabbit comments against current code and reproduced each behavior with RED tests:
+  - package-local `/mcp/status` hard-coded `transport.mount_path` to `unknown`.
+  - package-local readiness warnings exposed generic exception class names for profile/registry status failures.
+  - HTTP permission details overwrote protocol-provided recovery metadata.
+  - disabled high-risk module guidance hard-coded `Config_Files/mcp_modules.yaml`.
+  - docs local-link validation treated root-relative API/site links as filesystem paths.
+- Implemented minimal fixes:
+  - Pass `Request` into the package-local status route and derive `transport.mount_path` from `request.url.path`.
+  - Log generic profile/registry readiness exceptions server-side with `logger.opt(exception=True).warning(...)` and return fixed warning bodies.
+  - Preserve protocol-supplied `hint`, `reason_code`, and `next_action` in `_mcp_permission_detail` before falling back to endpoint defaults.
+  - Keep `write_tools_disabled` recovery metadata specific in `MCPProtocol._error_recovery_metadata` so the HTTP boundary can preserve the correct next action.
+  - Use config-path-neutral disabled-module guidance (`your MCP modules config`).
+  - Skip root-relative Markdown targets in the MCP docs local-link contract test.
+- Inspected the four failed GitHub Actions aggregate checks. Their logs only report shard group result `cancelled`; the run conclusion is `cancelled`, so no actionable pytest/build failure was available from those aggregate logs. A new push should trigger a fresh check set.
+
+Verification:
+- RED run before implementation: 4 focused tests failed for expected reasons.
+- GREEN focused rerun: 4 passed, 4 warnings.
+- Affected MCP/docs/basic/http suite: 67 passed, 5 warnings.
+- Full package gateway suite: 206 passed, 5 warnings.
+- Docker packaging contract: 4 passed, 4 warnings.
+- Docs contract rerun after root-relative link filter: 13 passed, 3 warnings.
+- `git diff --check`: passed.
+- Bandit touched production scope wrote `/tmp/bandit_pr2548_followup.json`: exit 0, no findings.
+- Final post-rebase verification on `9cbb86936e`: docs/basic/http suite 67 passed, full package gateway suite 208 passed, Docker packaging contract 4 passed, `git diff --check` passed, and Bandit touched production scope wrote `/tmp/bandit_pr2548_rebase.json` with exit 0.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2548's branch onto latest `origin/dev` (`5b61874981`), addressed the new CodeRabbit review threads with tested fixes for package-local status warning redaction, request-derived mount path metadata, recovery metadata preservation, write-tools-disabled next-action specificity, config-neutral disabled-module guidance, and root-relative docs-link handling. Inspected the failed aggregate CI checks and found the run was cancelled with shard groups reporting `cancelled`, not an actionable pytest/build failure. Local verification passed for the focused RED/GREEN tests, docs/basic/http suite, full package-gateway suite, Docker contract, diff check, and Bandit touched production scope.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
@@ -808,11 +808,12 @@ def _mcp_permission_detail(
     """Return an HTTP-friendly permission detail for MCP authorization errors."""
     if response.error is None or response.error.code != -32001:
         return None
+    error_data = response.error.data if isinstance(response.error.data, dict) else {}
     return {
         "message": response.error.message or "Insufficient permissions",
-        "hint": hint,
-        "reason_code": reason_code,
-        "next_action": next_action,
+        "hint": str(error_data.get("hint") or hint),
+        "reason_code": str(error_data.get("reason_code") or reason_code),
+        "next_action": str(error_data.get("next_action") or next_action),
     }
 
 

--- a/tldw_Server_API/app/core/MCP_unified/module_surface.py
+++ b/tldw_Server_API/app/core/MCP_unified/module_surface.py
@@ -68,7 +68,7 @@ def _disabled_next_action(module_name: str, tier: str) -> str:
     else:
         risk = "this capability"
     return (
-        f"Enable `{module_name}` in Config_Files/mcp_modules.yaml only if this "
+        f"Enable `{module_name}` in your MCP modules config only if this "
         f"deployment should expose {risk}; restart TLDW Server and recheck /api/v1/mcp/status."
     )
 

--- a/tldw_Server_API/app/core/MCP_unified/module_surface.py
+++ b/tldw_Server_API/app/core/MCP_unified/module_surface.py
@@ -88,7 +88,8 @@ def describe_module_surface(modules: dict[str, Any]) -> dict[str, Any]:
             ("unknown", "No risk tier is registered yet."),
         )
         if not _is_enabled(payload):
-            if tier in EXPLICIT_OPT_IN_TIERS:
+            explicitly_disabled = isinstance(payload, dict) and payload.get("enabled") is False
+            if explicitly_disabled and tier in EXPLICIT_OPT_IN_TIERS:
                 disabled_available.append(
                     {
                         "id": module_name,

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -1958,9 +1958,16 @@ class MCPProtocol:
                 "next_action": "Send Authorization: Bearer <token> or X-API-KEY with the request.",
             }
         if code == ErrorCode.AUTHORIZATION_ERROR:
-            reason_code = "write_tools_disabled" if "write tools are disabled" in lowered else "permission_denied"
+            if "write tools are disabled" in lowered:
+                return {
+                    "reason_code": "write_tools_disabled",
+                    "next_action": (
+                        "Enable write tools (set MCP_DISABLE_WRITE_TOOLS=0) "
+                        "or switch to a read-only operation."
+                    ),
+                }
             return {
-                "reason_code": reason_code,
+                "reason_code": "permission_denied",
                 "next_action": "Use a token or API key with the required MCP permission.",
             }
         if code == ErrorCode.MODULE_ERROR:

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -475,7 +475,7 @@ class MCPServer:
         enabled = bool(module_config.get("enabled", True))
         return module_id, {
             "enabled": enabled,
-            "status": "configured" if enabled else "disabled",
+            "status": "not_loaded" if enabled else "disabled",
             "name": str(module_config.get("name") or module_id),
             "department": str(module_config.get("department") or "general"),
         }
@@ -568,6 +568,7 @@ class MCPServer:
         return {
             "degraded": "module_degraded",
             "inactive": "module_inactive",
+            "not_loaded": "module_not_loaded",
             "unhealthy": "module_unhealthy",
             "error": "module_error",
         }.get(normalized, "module_problem")
@@ -592,6 +593,7 @@ class MCPServer:
         for module_id, health in health_results.items():
             status_value = getattr(getattr(health, "status", ""), "value", getattr(health, "status", ""))
             status = str(status_value or "unknown")
+            seen.add(module_id)
             if status == "healthy":
                 continue
             raw_reason = str(getattr(health, "message", "") or "").strip()
@@ -627,6 +629,18 @@ class MCPServer:
                     self._mask_secrets(raw_reason),
                 )
             problems.append(self._problem_module_entry(module_id, status, source="registration"))
+            seen.add(module_id)
+
+        for module_id, payload in sorted(self._configured_modules_for_status.items()):
+            if module_id in seen or not isinstance(payload, dict):
+                continue
+            if payload.get("enabled") is not True:
+                continue
+            status = str(payload.get("status") or "not_loaded")
+            if status not in {"not_loaded", "inactive"}:
+                continue
+            problems.append(self._problem_module_entry(module_id, status, source="configuration"))
+            seen.add(module_id)
 
         return problems
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
@@ -172,6 +172,19 @@ def test_describe_module_surface_reports_disabled_available_high_risk_modules():
     assert all(m["next_action"] for m in surface["disabled_available"])
 
 
+def test_describe_module_surface_does_not_advertise_not_loaded_modules_as_opt_ins():
+    """Configured-but-not-loaded modules should not look enabled or operator-disabled."""
+    from tldw_Server_API.app.core.MCP_unified.module_surface import describe_module_surface
+
+    surface = describe_module_surface({
+        "filesystem": {"enabled": True, "status": "not_loaded"},
+    })
+
+    assert surface["enabled_count"] == 0
+    assert surface["disabled_available_count"] == 0
+    assert "local_files" not in surface["tiers"]
+
+
 def test_default_mcp_modules_yaml_disables_local_file_and_process_modules():
     """Checked-in defaults should not expose local files or host commands."""
     import yaml
@@ -595,27 +608,36 @@ class TestMCPServer:
         assert [m["id"] for m in status["surface"]["disabled_available"]] == ["filesystem", "run_command"]
         assert all(m["requires_explicit_opt_in"] for m in status["surface"]["disabled_available"])
 
-    async def test_server_status_does_not_enable_configured_but_unloaded_modules(self, monkeypatch):
-        """Configured modules should not appear enabled until their health is registered."""
+    async def test_server_status_reports_enabled_config_missing_from_health_as_not_loaded(self, monkeypatch):
+        """Configured enabled modules missing health should not appear as enabled surface modules."""
         server = MCPServer()
         server.initialized = True
         server._configured_modules_for_status = {
-            "media": {"enabled": True, "status": "configured"},
-            "filesystem": {"enabled": True, "status": "configured"},
-            "run_command": {"enabled": False, "status": "disabled"},
+            "media": {"enabled": True, "status": "not_loaded"},
+            "filesystem": {"enabled": True, "status": "not_loaded"},
         }
 
         async def _check_all_health():
             return {"media": ModuleHealth(status=HealthStatus.HEALTHY)}
 
+        async def _list_registrations():
+            return []
+
         monkeypatch.setattr(server.module_registry, "check_all_health", _check_all_health)
+        monkeypatch.setattr(server.module_registry, "list_registrations", _list_registrations)
 
         status = await server.get_status()
 
         assert status["surface"]["enabled_count"] == 1
         assert [m["id"] for m in status["surface"]["tiers"]["read_only"]["modules"]] == ["media"]
         assert "local_files" not in status["surface"]["tiers"]
-        assert [m["id"] for m in status["surface"]["disabled_available"]] == ["run_command"]
+        assert status["surface"]["disabled_available_count"] == 0
+        assert {
+            "id": "filesystem",
+            "status": "not_loaded",
+            "reason": "module_not_loaded",
+            "next_action": "Check module configuration and dependencies, then restart or disable the module.",
+        } in status["problem_modules"]
 
     async def test_server_status_includes_sanitized_problem_modules(self, monkeypatch):
         """Server status should expose actionable, canned module problem reasons."""

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
@@ -170,6 +170,8 @@ def test_describe_module_surface_reports_disabled_available_high_risk_modules():
     assert surface["disabled_available_count"] == 3
     assert all(m["requires_explicit_opt_in"] is True for m in surface["disabled_available"])
     assert all(m["next_action"] for m in surface["disabled_available"])
+    assert all("your MCP modules config" in m["next_action"] for m in surface["disabled_available"])
+    assert all("Config_Files/mcp_modules.yaml" not in m["next_action"] for m in surface["disabled_available"])
 
 
 def test_describe_module_surface_does_not_advertise_not_loaded_modules_as_opt_ins():

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -211,6 +211,7 @@ class _FakeLogger:
     def __init__(self) -> None:
         self.opt_calls: list[dict[str, Any]] = []
         self.error_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.warning_calls: list[tuple[str, tuple[Any, ...]]] = []
 
     def opt(self, **kwargs: Any) -> _FakeLogger:
         self.opt_calls.append(kwargs)
@@ -218,6 +219,9 @@ class _FakeLogger:
 
     def error(self, message: str, *args: Any) -> None:
         self.error_calls.append((message, args))
+
+    def warning(self, message: str, *args: Any) -> None:
+        self.warning_calls.append((message, args))
 
 
 def _assert_jsonrpc_error(
@@ -517,6 +521,11 @@ class _ProfileManagementErrorManagerDouble(_ProfileManagementManagerDouble):
         return await super().delete_profile(profile_id)
 
 
+class _ProfileManagementRuntimeErrorManagerDouble(_ProfileManagementManagerDouble):
+    async def get_default_profile(self) -> dict[str, Any]:
+        raise RuntimeError("profile backend leaked detail")
+
+
 def _external_server_response_payload(
     server_id: str,
     server_name: str,
@@ -612,6 +621,11 @@ class _ExternalRegistryManagerDouble:
 class _ExternalRegistryBootstrapDouble:
     def __init__(self, manager: _ExternalRegistryManagerDouble) -> None:
         self.external_registry_manager = manager
+
+
+class _ExternalRegistryRuntimeErrorManagerDouble(_ExternalRegistryManagerDouble):
+    async def list_servers(self, enabled: bool | None = None) -> dict[str, Any]:
+        raise RuntimeError("external registry leaked detail")
 
 
 class _ExternalRegistryErrorManagerDouble(_ExternalRegistryManagerDouble):
@@ -2416,7 +2430,47 @@ def test_gateway_status_includes_package_boundary_metadata() -> None:
     assert payload["package"]["package_status"] == "internal-experimental"
     assert payload["package"]["publishing_status"] == "not-published"
     assert payload["package"]["source_distribution"] == "tldw-server"
+    assert payload["transport"]["mount_path"] == "/mcp"
     assert "next_actions" in payload
+
+
+def test_gateway_status_generic_readiness_warnings_do_not_leak_exception_types(
+    monkeypatch,
+) -> None:
+    fake_logger = _FakeLogger()
+    monkeypatch.setattr(gateway_fastapi, "logger", fake_logger)
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        profile_manager=_ProfileManagementRuntimeErrorManagerDouble("runtime-error"),
+        enable_profile_management=True,
+        external_registry_manager=_ExternalRegistryRuntimeErrorManagerDouble("runtime-error"),
+        enable_external_registry_management=True,
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    warning_messages = {
+        warning["reason_code"]: warning["message"]
+        for warning in payload["warnings"]
+    }
+    assert warning_messages["default_profile_status_unavailable"] == (
+        "Default profile readiness check failed."
+    )
+    assert warning_messages["external_registry_status_unavailable"] == (
+        "External registry readiness check failed."
+    )
+    serialized_payload = json.dumps(payload)
+    assert "RuntimeError" not in serialized_payload
+    assert "profile backend leaked detail" not in serialized_payload
+    assert "external registry leaked detail" not in serialized_payload
+    assert fake_logger.opt_calls == [{"exception": True}, {"exception": True}]
+    assert fake_logger.warning_calls == [
+        ("Gateway default profile readiness check failed", ()),
+        ("Gateway external registry readiness check failed", ()),
+    ]
 
 
 def test_gateway_status_route_has_pydantic_response_model() -> None:
@@ -2452,6 +2506,7 @@ async def test_gateway_readiness_status_handles_missing_admin_auth() -> None:
         profile_manager=None,
         external_registry_manager=None,
         admin_auth=None,
+        status_path="/mcp/status",
     )
 
     assert payload["admin_auth"] == {

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -22,7 +23,8 @@ from mcp_unified.gateway.external_runtime import GatewayExternalRuntimeError
 from mcp_unified.storage.models import ExternalServerDefinition
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
-GATEWAY_ROOT = REPO_ROOT / "mcp_unified" / "gateway"
+GATEWAY_PACKAGE_ROOT = REPO_ROOT / "apps" / "mcp-unified" / "src"
+GATEWAY_ROOT = GATEWAY_PACKAGE_ROOT / "mcp_unified" / "gateway"
 PROFILE_DISCOVERY_READ_TOOL_NAMES = {
     "tool_categories.list",
     "profile.tools.list",
@@ -956,6 +958,14 @@ def test_gateway_package_does_not_import_tldw_server_api() -> None:
 
 
 def test_gateway_stdio_submodule_import_does_not_eagerly_import_fastapi_transport() -> None:
+    env = {
+        **os.environ,
+        "PYTHONPATH": (
+            f"{GATEWAY_PACKAGE_ROOT}{os.pathsep}{os.environ['PYTHONPATH']}"
+            if os.environ.get("PYTHONPATH")
+            else str(GATEWAY_PACKAGE_ROOT)
+        ),
+    }
     result = subprocess.run(
         [
             sys.executable,
@@ -965,6 +975,7 @@ def test_gateway_stdio_submodule_import_does_not_eagerly_import_fastapi_transpor
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,
+        env=env,
         text=True,
     )
 
@@ -2392,7 +2403,7 @@ def test_gateway_status_includes_package_boundary_metadata() -> None:
         for route in app.routes
         if getattr(route, "path", None) == "/mcp/status"
     )
-    assert getattr(status_route, "response_model", None) is gateway_fastapi.GatewayStatusResponse
+    assert getattr(status_route, "response_model", None) is gateway_fastapi.GatewayReadinessStatusResponse
 
     with TestClient(app) as client:
         response = client.get("/mcp/status")
@@ -2408,20 +2419,46 @@ def test_gateway_status_includes_package_boundary_metadata() -> None:
     assert "next_actions" in payload
 
 
-def test_gateway_status_tolerates_partial_package_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_gateway_status_route_has_pydantic_response_model() -> None:
+    app = create_gateway_app(_FakeGatewayRuntime())
+
+    schema = app.openapi()["paths"]["/mcp/status"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+
+    assert schema == {"$ref": "#/components/schemas/GatewayReadinessStatusResponse"}
+
+
+def test_gateway_status_tolerates_missing_package_metadata(monkeypatch) -> None:
     monkeypatch.setattr(
         gateway_fastapi,
         "package_metadata_summary",
-        lambda: {"publishing_status": "not-published"},
+        lambda: {"package_name": "mcp-unified"},
     )
     app = create_gateway_app(_FakeGatewayRuntime())
+
     with TestClient(app) as client:
         response = client.get("/mcp/status")
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["package"]["package_name"] is None
-    assert payload["package"]["publishing_status"] == "not-published"
+    assert payload["package"]["package_name"] == "mcp-unified"
+    assert payload["package"]["publishing_status"] is None
+    assert not any(warning["reason_code"] == "package_not_published" for warning in payload["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_gateway_readiness_status_handles_missing_admin_auth() -> None:
+    payload = await gateway_fastapi._gateway_readiness_status(
+        _FakeGatewayRuntime(),
+        profile_manager=None,
+        external_registry_manager=None,
+        admin_auth=None,
+    )
+
+    assert payload["admin_auth"] == {
+        "enabled": False,
+        "configured": False,
+        "header_name": None,
+    }
 
 
 def test_gateway_status_reports_profile_store_admin_auth_and_default_profile() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
@@ -421,6 +421,37 @@ def test_modules_permission_detail_mentions_modules_and_recovery(client: TestCli
     assert "tools" not in detail["hint"].lower()
 
 
+def test_permission_detail_preserves_protocol_recovery_metadata():
+    from tldw_Server_API.app.api.v1.endpoints import mcp_unified_endpoint as endpoint
+    from tldw_Server_API.app.core.MCP_unified.protocol import MCPError, MCPResponse
+
+    response = MCPResponse(
+        error=MCPError(
+            code=-32001,
+            message="Write tools are disabled for this profile",
+            data={
+                "hint": "Enable write tools on the selected MCP profile.",
+                "reason_code": "write_tools_disabled",
+                "next_action": "Switch to a profile that permits write tools before retrying.",
+            },
+        ),
+        id=1,
+    )
+
+    detail = endpoint._mcp_permission_detail(
+        response,
+        hint="Use a token or API key with tools execution permission.",
+        next_action="Use a token or API key with the required MCP permission.",
+    )
+
+    assert detail == {
+        "message": "Write tools are disabled for this profile",
+        "hint": "Enable write tools on the selected MCP profile.",
+        "reason_code": "write_tools_disabled",
+        "next_action": "Switch to a profile that permits write tools before retrying.",
+    }
+
+
 def test_invalid_safe_config_keeps_structured_recovery_detail(client: TestClient):
     response = client.post(
         "/api/v1/mcp/request",
@@ -450,6 +481,23 @@ async def test_jsonrpc_invalid_params_error_data_includes_recovery_metadata():
     assert response.error.code == -32602
     assert response.error.data["reason_code"] == "invalid_params"
     assert response.error.data["next_action"]
+
+
+def test_jsonrpc_write_tools_disabled_recovery_metadata_has_specific_next_action():
+    from tldw_Server_API.app.core.MCP_unified.protocol import ErrorCode, MCPProtocol
+
+    metadata = MCPProtocol._error_recovery_metadata(
+        ErrorCode.AUTHORIZATION_ERROR,
+        "Write tools are disabled for this profile",
+    )
+
+    assert metadata == {
+        "reason_code": "write_tools_disabled",
+        "next_action": (
+            "Enable write tools (set MCP_DISABLE_WRITE_TOOLS=0) "
+            "or switch to a read-only operation."
+        ),
+    }
 
 
 def test_websocket_query_auth_is_marked_legacy_in_endpoint_copy():

--- a/tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
@@ -241,7 +241,12 @@ def test_unified_mcp_docs_reference_existing_local_targets() -> None:
     for doc_path in docs_to_check:
         text = _read(doc_path)
         for target in re.findall(r"\]\(([^)#][^)]+)\)", text):
-            if "://" in target or target.startswith("#") or target.startswith("mailto:"):
+            if (
+                "://" in target
+                or target.startswith("#")
+                or target.startswith("mailto:")
+                or target.startswith("/")
+            ):
                 continue
             normalized = target.split("#", 1)[0]
             if not normalized:

--- a/tldw_Server_API/tests/MCP/test_mcp_tools_execute_authz.py
+++ b/tldw_Server_API/tests/MCP/test_mcp_tools_execute_authz.py
@@ -16,6 +16,50 @@ from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
 client = TestClient(app)
 
 
+def _write_run_command_test_config(tmp_path: Path) -> Path:
+    """Write an explicit opt-in MCP module config for tests that execute `run`."""
+    config_path = tmp_path / "mcp_modules_with_run.yaml"
+    config_path.write_text(
+        """
+modules:
+  - id: template
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.template_module:TemplateModule
+    enabled: true
+    name: Template
+    version: "1.0.0"
+    department: demo
+    settings: {}
+  - id: filesystem
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module:FilesystemModule
+    enabled: true
+    name: Filesystem
+    version: "1.0.0"
+    department: system
+    settings: {}
+  - id: knowledge
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.knowledge_module:KnowledgeModule
+    enabled: true
+    name: Knowledge
+    version: "1.0.0"
+    department: knowledge
+    settings: {}
+  - id: run_command
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.run_command_module:RunCommandModule
+    enabled: true
+    name: Run Command
+    version: "0.1.0"
+    department: system
+    settings:
+      spill_dir: .mcp-test-spills
+      spill_threshold_bytes: 65536
+      preview_line_limit: 200
+      preview_byte_limit: 51200
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return config_path
+
+
 def _run(coro):
 
 
@@ -54,13 +98,18 @@ def test_tools_execute_with_bearer_token_no_permission_403():
 def test_tools_execute_with_api_key_and_role_permission_allows_200(tmp_path, monkeypatch):
 
 
+    from tldw_Server_API.app.core.MCP_unified.server import reset_mcp_server
+
     # Point AuthNZ DB to a fresh SQLite file
     db_file = tmp_path / "mcp_allow.sqlite"
-    os.environ["DATABASE_URL"] = f"sqlite:///{db_file}"
-    os.environ["AUTH_MODE"] = "single_user"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_file}")
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(_write_run_command_test_config(tmp_path)))
+    monkeypatch.setenv("MCP_MODULES", "")
     # Reset settings and DB pool to pick up new config
     _run(reset_db_pool())
     reset_settings()
+    _run(reset_mcp_server())
 
     # Run AuthNZ migrations (creates RBAC tables and expands api_keys schema)
     ensure_authnz_tables(Path(db_file))
@@ -200,15 +249,15 @@ def test_tools_execute_with_api_key_and_role_permission_allows_200(tmp_path, mon
     assert "[exit:0 |" in run_body["result"]
 
 
-def test_tools_execute_with_api_key_can_run_virtual_cli_help(tmp_path):
+def test_tools_execute_with_api_key_can_run_virtual_cli_help(tmp_path, monkeypatch):
     from tldw_Server_API.app.core.MCP_unified.config import get_config
     from tldw_Server_API.app.core.MCP_unified.server import get_mcp_server, reset_mcp_server
 
     db_file = tmp_path / "mcp_run_help.sqlite"
-    os.environ["DATABASE_URL"] = f"sqlite:///{db_file}"
-    os.environ["AUTH_MODE"] = "single_user"
-    os.environ.pop("MCP_MODULES", None)
-    os.environ.pop("MCP_MODULES_CONFIG", None)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_file}")
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(_write_run_command_test_config(tmp_path)))
+    monkeypatch.setenv("MCP_MODULES", "")
 
     _run(reset_db_pool())
     reset_settings()


### PR DESCRIPTION
## Summary
- Makes high-risk MCP modules explicit opt-in by default and exposes disabled-but-available module guidance in `/api/v1/mcp/status`.
- Expands package-local `/mcp/status` readiness metadata for package state, profile/default profile, admin auth, external registry, and external server counts.
- Adds recoverability metadata for HTTP/JSON-RPC errors and corrects MCP docs/quickstarts/package Docker wording so they do not imply a shipped standalone gateway.

## Final review
- Moved the MCP work onto clean branch `codex/mcp-residual-ux-clean` based on latest `origin/dev`.
- Reviewed `origin/dev..HEAD` scope and removed unrelated README/TASK-12061 drift from the cherry-pick before pushing.
- Remaining diff is scoped to MCP docs, package-local gateway status, MCP server/protocol/endpoint behavior, focused tests, and Backlog/spec records.

## Verification
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py` -> 63 passed, 5 warnings
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -k "gateway_status or basic_jsonrpc_flow"` -> 5 passed, 197 deselected, 4 warnings
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py` -> 4 passed, 4 warnings
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/core/MCP_unified/module_surface.py tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py apps/mcp-unified/src/mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_residual_ux_clean_rebased.json` -> 0 findings

## Merge note
This PR is AI-authored. Per repo policy, a human-written Change summary is still required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens MCP Unified UX with safer defaults, typed readiness, and clearer recovery. High‑risk modules remain opt‑in, package‑local `/mcp/status` is richer and typed, and HTTP/JSON‑RPC errors preserve recovery hints.

- **New Features**
  - Package-local `/mcp/status`: returns `GatewayReadinessStatusResponse` with nested models, adds `transport.mount_path`, tolerates missing package keys, handles missing admin auth, and redacts readiness warning details while logging server-side.
  - Module status: enabled-but-unregistered modules report under `problem_modules` with `status: not_loaded` and `reason: module_not_loaded`; they are not counted as enabled or shown as disabled opt-ins; disabled guidance now says “your MCP modules config”.
  - Error recovery: HTTP permission details keep protocol `hint`, `reason_code`, and `next_action`; “write tools disabled” maps to `write_tools_disabled` with a concrete next action.
  - Tests/docs: authz tests explicitly opt into `run_command`; docs link check skips root‑relative links; OpenAPI shows the typed `/mcp/status` schema.

- **Migration**
  - If you rely on local filesystem, command execution, or external federation, explicitly enable those modules in your MCP modules config, restart, then verify via `/api/v1/mcp/status`.
  - Clients should read recovery hints from JSON‑RPC `error.data` or HTTP headers (`X-MCP-Reason-Code`, `X-MCP-Next-Action`) to guide retries or fixes.

<sup>Written for commit e11e4af29c058d8021041ee742a0820b376a5323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

