### PR TITLE
feat(skills): expose runtime metadata

### DIFF
--- a/Docs/superpowers/plans/2026-06-29-skills-runtime-metadata-visibility.md
+++ b/Docs/superpowers/plans/2026-06-29-skills-runtime-metadata-visibility.md
@@ -1,0 +1,284 @@
+# Skills Runtime Metadata Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose read-only Skills runtime declaration metadata in API responses and show it in the Skills manager before users run skills.
+
+**Architecture:** Add one backend derivation helper that turns existing skill metadata into a structured runtime dictionary, then surface that through existing Pydantic response models. On the frontend, add optional types plus fallback derivation so the Skills table and test-run modal work with both new and legacy responses.
+
+**Tech Stack:** FastAPI, Pydantic, existing SkillsService registry data, React, TypeScript, Ant Design, Vitest, pytest.
+
+---
+
+## File Structure
+
+- Create `tldw_Server_API/app/core/Skills/runtime_metadata.py`
+  - Pure helper for deriving runtime declaration metadata from `context`, `allowed_tools`, `model`, and `disable_model_invocation`.
+- Modify `tldw_Server_API/app/api/v1/schemas/skills_schemas.py`
+  - Add `SkillRuntimeMetadata`.
+  - Add runtime fields to `SkillSummary` and `SkillResponse` through `SkillBase`.
+- Modify `tldw_Server_API/app/api/v1/endpoints/skills.py`
+  - Use the helper when building list and detail responses.
+- Modify `tldw_Server_API/app/core/Skills/skills_service.py`
+  - Include accurate runtime metadata in `available_skills` dictionaries used by `/skills/context`.
+- Modify `tldw_Server_API/tests/Skills/integration/test_skills_api.py`
+  - Add focused assertions for runtime metadata on list/detail/context payloads.
+- Modify `apps/packages/ui/src/types/skill.ts`
+  - Add optional runtime metadata and optional list-level raw declaration fields.
+- Modify `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+  - Add optional Runtime column and pass selected skill runtime to `SkillPreview`.
+- Modify `apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx`
+  - Show selected-skill runtime impact before actions.
+- Modify `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+  - Cover optional Runtime column and legacy fallback.
+- Modify `apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx`
+  - Cover runtime disclosure text/tags.
+- Update `backlog/tasks/task-530.13 - Implement-Skills-runtime-metadata-visibility.md`
+  - Record touched files, verification, and final summary.
+
+### Task 1: Backend Runtime Metadata Contract
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Skills/runtime_metadata.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/skills_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/skills.py`
+- Modify: `tldw_Server_API/app/core/Skills/skills_service.py`
+- Test: `tldw_Server_API/tests/Skills/integration/test_skills_api.py`
+
+- [ ] **Step 1: Write failing list/detail/context tests**
+
+Add list/detail tests that create a fork skill with declared tools, model override, and `disable-model-invocation: true`, then assert:
+
+```python
+assert body["runtime"] == {
+    "execution_mode": "fork",
+    "test_run_may_call_model": True,
+    "declares_tools": True,
+    "declared_tool_count": 2,
+    "model_override": "gpt-4o",
+    "auto_invocation_enabled": False,
+}
+```
+
+Also assert list summaries include `allowed_tools` and `model`.
+
+Add a separate `/skills/context` assertion using a context-eligible skill where `disable-model-invocation` is false, because the context payload intentionally excludes skills disabled for model auto-invocation. Assert `available_skills` includes runtime metadata without changing `context_text` format.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "runtime_metadata" -q
+```
+
+Expected: FAIL because runtime fields are missing.
+
+- [ ] **Step 3: Add pure runtime metadata helper**
+
+Implement:
+
+```python
+def build_skill_runtime_metadata(
+    *,
+    context: str | None,
+    allowed_tools: list[str] | None,
+    model: str | None,
+    disable_model_invocation: bool | None,
+) -> dict[str, object]:
+    execution_mode = "fork" if context == "fork" else "inline"
+    declared_tool_count = len(allowed_tools or [])
+    return {
+        "execution_mode": execution_mode,
+        "test_run_may_call_model": execution_mode == "fork",
+        "declares_tools": declared_tool_count > 0,
+        "declared_tool_count": declared_tool_count,
+        "model_override": model,
+        "auto_invocation_enabled": not bool(disable_model_invocation),
+    }
+```
+
+- [ ] **Step 4: Add schema and endpoint wiring**
+
+Add `SkillRuntimeMetadata` to schemas, attach it to `SkillBase` and `SkillSummary`, and populate it from `_skill_data_to_response` and `_metadata_to_summary`.
+
+- [ ] **Step 5: Add context payload wiring**
+
+Add `allowed_tools`, `model`, and `runtime` to `SkillsService._build_context_payload()` available skill dictionaries, without changing `context_text`.
+
+- [ ] **Step 6: Run backend tests to verify GREEN**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "runtime_metadata or list_skills_filters_and_sorts_before_pagination or get_context_payload" -q
+```
+
+Expected: PASS.
+
+### Task 2: Frontend Types and Manager Runtime Column
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/skill.ts`
+- Modify: `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+- Test: `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+
+- [ ] **Step 1: Write failing Manager tests**
+
+Add a test that:
+
+- Loads one fork skill with runtime metadata.
+- Opens column visibility.
+- Enables `Runtime`.
+- Asserts `Fork`, `Test may call model`, `2 tools declared`, and `Model override` are visible.
+
+Add a legacy compatibility assertion that a row without `runtime`, `allowed_tools`, or `model` still renders when the Runtime column is enabled.
+
+- [ ] **Step 2: Run Manager tests to verify RED**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot
+```
+
+Expected: FAIL because the Runtime column does not exist.
+
+- [ ] **Step 3: Add frontend runtime types**
+
+Add:
+
+```ts
+export interface SkillRuntimeMetadata {
+  execution_mode: SkillContext
+  test_run_may_call_model: boolean
+  declares_tools: boolean
+  declared_tool_count: number
+  model_override: string | null
+  auto_invocation_enabled: boolean
+}
+```
+
+Make `SkillSummary.allowed_tools`, `SkillSummary.model`, and `SkillSummary.runtime` optional so older responses and existing mocks remain valid.
+
+- [ ] **Step 4: Add Manager fallback helper and Runtime column**
+
+Implement a helper that returns backend `runtime` when present and otherwise derives from `context`, `allowed_tools`, `model`, and `disable_model_invocation`.
+
+Add `runtime` to optional column keys and render text-bearing tags for mode, model-call possibility, declared tool count, model override, and auto-invocation off state.
+
+- [ ] **Step 5: Run Manager tests to verify GREEN**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=dot
+```
+
+Expected: PASS.
+
+### Task 3: SkillPreview Runtime Disclosure
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Skills/Manager.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx`
+- Test: `apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx`
+- Test: `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+
+- [ ] **Step 1: Write failing SkillPreview test**
+
+Add a test that renders `SkillPreview` with fork runtime metadata and asserts the modal shows:
+
+- `Fork`
+- `Test may call model`
+- `2 tools declared`
+- `Auto invocation off`
+- Copy explaining that `Render prompt only` does not invoke fork/model/tool execution.
+
+- [ ] **Step 2: Run SkillPreview tests to verify RED**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Option/Skills/__tests__/SkillPreview.test.tsx --reporter=dot
+```
+
+Expected: FAIL because `SkillPreview` does not accept or render runtime metadata.
+
+- [ ] **Step 3: Pass runtime from Manager to SkillPreview**
+
+Find the selected row by `previewSkill` name and pass derived runtime metadata to `SkillPreview` when available.
+
+- [ ] **Step 4: Render runtime impact in SkillPreview**
+
+Add a compact disclosure block before action buttons. Keep copy behavior-specific:
+
+- Dry render does not invoke fork/model/tool execution.
+- A fork test run may call the configured model.
+- Declared tools are declarations, not availability guarantees.
+
+- [ ] **Step 5: Run frontend focused tests to verify GREEN**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillPreview.test.tsx --reporter=dot
+```
+
+Expected: PASS.
+
+### Task 4: Verification, Security, and Tracking
+
+**Files:**
+- Modify: `backlog/tasks/task-530.13 - Implement-Skills-runtime-metadata-visibility.md`
+
+- [ ] **Step 1: Run backend focused verification**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "runtime_metadata or list_skills_filters_and_sorts_before_pagination or get_context_payload" -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend focused verification**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillPreview.test.tsx --reporter=dot
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run diff and security checks**
+
+Run:
+
+```bash
+git diff --check
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Skills/runtime_metadata.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_skills_runtime_metadata_TASK_530_13.json
+```
+
+Expected: no whitespace errors and no new Bandit findings in touched backend code.
+
+- [ ] **Step 4: Update Backlog task**
+
+Record:
+
+- Spec path.
+- Plan path.
+- Touched files.
+- Verification commands and results.
+- Known skips or baseline failures, if any.
+
+- [ ] **Step 5: Final self-review**
+
+Review the diff for:
+
+- No policy/enforcement changes.
+- No persisted schema changes.
+- No misleading permission language.
+- No UI dependency on `runtime` being present.
+- No changed `context_text` semantics.

--- a/Docs/superpowers/specs/2026-06-29-skills-runtime-metadata-visibility-design.md
+++ b/Docs/superpowers/specs/2026-06-29-skills-runtime-metadata-visibility-design.md
@@ -1,0 +1,125 @@
+# Skills Runtime Metadata Visibility Design
+
+## Status
+
+Approved for TASK-530.13 implementation.
+
+## Problem
+
+The Skills page currently exposes execution details in scattered ways. Detail responses include `allowed_tools`, `model`, `context`, and `disable_model_invocation`, but list summaries do not include enough information for users to scan runtime impact before opening or running a skill. The Skills table reduces runtime behavior to a "Model use" column that can be misread as an execution permission, and the test-run modal uses generic copy that does not reflect the selected skill.
+
+This creates two user problems:
+
+- Beginner users cannot confidently tell whether a test run may call a model or depend on declared tools.
+- Power users cannot scan or verify fork mode, tool declarations, model overrides, and auto-invocation state from the list workflow.
+
+## Goals
+
+- Add structured, read-only runtime declaration metadata to Skills list and detail responses.
+- Show a compact runtime summary in the Skills manager without breaking older responses that lack the new field.
+- Show selected-skill runtime impact before `Render prompt only` and `Run test`.
+- Use honest labels: declarations and possible model calls, not permission guarantees.
+- Keep behavior unchanged. This work only exposes metadata that already exists in skill frontmatter/registry rows.
+
+## Non-Goals
+
+- No policy editor.
+- No RBAC or authorization changes.
+- No mutation of `allowed_tools`, model overrides, or skill execution settings.
+- No enforcement changes in `SkillExecutor`.
+- No database schema migration or persisted runtime column.
+- No redesign of the Skills page layout.
+
+## Runtime Metadata Contract
+
+Add a `SkillRuntimeMetadata` response object:
+
+```json
+{
+  "execution_mode": "inline",
+  "test_run_may_call_model": false,
+  "declares_tools": false,
+  "declared_tool_count": 0,
+  "model_override": null,
+  "auto_invocation_enabled": true
+}
+```
+
+Field meanings:
+
+- `execution_mode`: Existing `context` value, normalized to `inline` or `fork`.
+- `test_run_may_call_model`: `true` when `execution_mode` is `fork`. A non-dry test run may call the configured model in fork mode.
+- `declares_tools`: `true` when the skill declares one or more `allowed_tools`.
+- `declared_tool_count`: Count of declared tool strings.
+- `model_override`: Existing skill model override, if set.
+- `auto_invocation_enabled`: `true` when `disable_model_invocation` is false. This describes whether the skill can be advertised for model auto-invocation context, not whether a user-triggered test run can call a model.
+
+## API Shape
+
+`SkillSummary` should include:
+
+- Existing fields.
+- `allowed_tools: list[str] | None`, optional for list consumers.
+- `model: str | None`, optional for list consumers.
+- `runtime: SkillRuntimeMetadata`.
+
+`SkillResponse` should include:
+
+- Existing detail fields.
+- `runtime: SkillRuntimeMetadata`.
+
+`SkillContextPayload.available_skills` should remain compatible with `SkillSummary`. Runtime metadata in this endpoint is response metadata only; it must not add tool/model text into the LLM-facing `context_text`.
+
+## UI Behavior
+
+Skills manager:
+
+- Add optional table column `Runtime`.
+- Column content should compactly summarize:
+  - `Fork` or `Inline`
+  - `Test may call model` for fork, or `Prompt only by default` for inline
+  - `N tools declared` when `declares_tools` is true
+  - `Model override` when `model_override` is set
+  - `Auto off` when `auto_invocation_enabled` is false
+- The column must tolerate legacy responses without `runtime`, `allowed_tools`, or `model` by deriving a conservative fallback from existing fields.
+
+Skill test-run modal:
+
+- Accept selected-skill runtime metadata when available.
+- Show runtime impact before action buttons.
+- Keep `Render prompt only` copy clearly separate from `Run test`.
+- Do not imply that declared tools are actually available, approved, or executable.
+
+Import review:
+
+- Existing import review can continue to show parsed model/tools. Labels should be interpreted as runtime declarations.
+- No new import mutation behavior is required for this task.
+
+## Accessibility and Copy
+
+- Table column labels and button labels remain text-based and screen-reader visible.
+- Runtime tags must not rely on color alone. The tag text carries the meaning.
+- Modal copy should be concise and state actual behavior:
+  - Dry render does not invoke fork/model/tool execution.
+  - Fork test runs may call the configured model.
+  - Declared tools are declarations, not availability guarantees.
+
+## Risks and Mitigations
+
+- Risk: Users interpret `allowed_tools` as permission guarantees.
+  - Mitigation: Use `declared tools` in UI labels and schema descriptions.
+- Risk: `disable_model_invocation` is misunderstood as "no model call ever."
+  - Mitigation: Expose `auto_invocation_enabled` and keep `test_run_may_call_model` tied to fork mode.
+- Risk: Frontend tests and older mocks break because summaries gain fields.
+  - Mitigation: Make frontend fields optional and add fallback derivation.
+- Risk: Runtime metadata drifts between list/detail/context endpoints.
+  - Mitigation: Use one backend helper to derive the metadata dictionary from existing values.
+
+## Acceptance Criteria
+
+- Skills list responses include accurate `runtime`, `allowed_tools`, and `model` values.
+- Skill detail responses include accurate `runtime`.
+- `/skills/context` remains valid and does not change `context_text` semantics.
+- Skills manager can show a runtime summary column and remains compatible with missing runtime data.
+- SkillPreview displays selected runtime impact before either test action.
+- Backend and frontend focused tests cover the new response shape and UI disclosure.

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -42,6 +42,7 @@ import type {
   SkillImportPreviewResponse,
   SkillListOrder,
   SkillListSort,
+  SkillRuntimeMetadata,
   SkillSummary,
   SkillResponse,
   SkillsListResponse
@@ -94,6 +95,7 @@ type SkillOptionalColumnKey =
   | "argument_hint"
   | "user_invocable"
   | "model_invocation"
+  | "runtime"
 
 interface SkillSortState {
   field?: SkillListSort
@@ -115,7 +117,8 @@ const SKILL_OPTIONAL_COLUMN_KEYS: SkillOptionalColumnKey[] = [
   "context",
   "argument_hint",
   "user_invocable",
-  "model_invocation"
+  "model_invocation",
+  "runtime"
 ]
 
 const getResponseSkillName = (result: unknown): string | undefined => {
@@ -224,6 +227,27 @@ const saveSkillsTablePreferences = (preferences: SkillsTablePreferences) => {
     )
   } catch {
     // Preference persistence is best-effort; rendering must not depend on storage.
+  }
+}
+
+const getSkillRuntimeMetadata = (skill: SkillSummary | null | undefined): SkillRuntimeMetadata | null => {
+  if (!skill) return null
+
+  const declaredToolCount = Array.isArray(skill.allowed_tools) ? skill.allowed_tools.length : 0
+  const runtime = skill.runtime
+  const fallbackContext = skill.context === "fork" ? "fork" : "inline"
+  const runtimeExecutionMode = runtime?.execution_mode
+  const executionMode = runtimeExecutionMode === "fork" || runtimeExecutionMode === "inline"
+    ? runtimeExecutionMode
+    : fallbackContext
+
+  return {
+    execution_mode: executionMode,
+    test_run_may_call_model: runtime?.test_run_may_call_model ?? executionMode === "fork",
+    declares_tools: runtime?.declares_tools ?? declaredToolCount > 0,
+    declared_tool_count: runtime?.declared_tool_count ?? declaredToolCount,
+    model_override: runtime?.model_override ?? skill.model ?? null,
+    auto_invocation_enabled: runtime?.auto_invocation_enabled ?? !skill.disable_model_invocation
   }
 }
 
@@ -352,6 +376,14 @@ export const SkillsManager: React.FC = () => {
     const selectedNames = new Set(selectedSkillNames)
     return currentSkills.filter((skill) => selectedNames.has(skill.name))
   }, [currentSkills, selectedSkillNames])
+  const previewSkillSummary = React.useMemo(
+    () => currentSkills.find((skill) => skill.name === previewSkill) ?? null,
+    [currentSkills, previewSkill]
+  )
+  const previewRuntime = React.useMemo(
+    () => getSkillRuntimeMetadata(previewSkillSummary),
+    [previewSkillSummary]
+  )
   const selectedSkillCount = selectedSkillNames.length
   const totalSkills = data?.total ?? 0
   const hasSearch = searchQuery.length > 0
@@ -887,7 +919,8 @@ export const SkillsManager: React.FC = () => {
     context: t("option:skills.colContext", { defaultValue: "Mode" }),
     argument_hint: t("option:skills.colArgumentHint", { defaultValue: "Argument hint" }),
     user_invocable: t("option:skills.colVisibility", { defaultValue: "Visibility" }),
-    model_invocation: t("option:skills.colModelUse", { defaultValue: "Model use" })
+    model_invocation: t("option:skills.colModelUse", { defaultValue: "Model use" }),
+    runtime: t("option:skills.colRuntime", { defaultValue: "Runtime" })
   }
 
   const columnVisibilityMenuItems: MenuProps["items"] = SKILL_OPTIONAL_COLUMN_KEYS.map(
@@ -974,6 +1007,54 @@ export const SkillsManager: React.FC = () => {
                 : t("option:skills.modelAllowed", { defaultValue: "Model allowed" })}
             </Tag>
           )
+        }]
+      : []),
+    ...(isOptionalColumnVisible("runtime")
+      ? [{
+          title: optionalColumnLabels.runtime,
+          key: "runtime",
+          width: 260,
+          render: (_: unknown, record: SkillSummary) => {
+            const runtime = getSkillRuntimeMetadata(record)
+            if (!runtime) return "-"
+
+            const toolLabel = t("option:skills.runtimeDeclaredTools", {
+              defaultValue: `${runtime.declared_tool_count} tools declared`,
+              count: runtime.declared_tool_count
+            })
+
+            return (
+              <div className="flex flex-wrap gap-1">
+                <Tag color={runtime.execution_mode === "fork" ? "blue" : "green"}>
+                  {runtime.execution_mode === "fork"
+                    ? t("option:skills.runtimeFork", { defaultValue: "Fork" })
+                    : t("option:skills.runtimeInline", { defaultValue: "Inline" })}
+                </Tag>
+                <Tag color={runtime.test_run_may_call_model ? "orange" : "default"}>
+                  {runtime.test_run_may_call_model
+                    ? t("option:skills.runtimeMayCallModel", { defaultValue: "Test may call model" })
+                    : t("option:skills.runtimePromptOnly", { defaultValue: "Prompt only by default" })}
+                </Tag>
+                {runtime.declares_tools && (
+                  <Tag color="geekblue">{toolLabel}</Tag>
+                )}
+                {runtime.model_override && (
+                  <Tag>
+                    {t("option:skills.runtimeModelOverride", {
+                      defaultValue: "Model override"
+                    })}
+                  </Tag>
+                )}
+                {!runtime.auto_invocation_enabled && (
+                  <Tag color="warning">
+                    {t("option:skills.runtimeAutoOff", {
+                      defaultValue: "Auto invocation off"
+                    })}
+                  </Tag>
+                )}
+              </div>
+            )
+          }
         }]
       : []),
     {
@@ -1248,7 +1329,7 @@ export const SkillsManager: React.FC = () => {
               {preview.allowed_tools?.length ? (
                 <div className="sm:col-span-2">
                   <dt className="text-xs font-semibold uppercase text-text-muted">
-                    {t("option:skills.allowedTools", { defaultValue: "Allowed tools" })}
+                    {t("option:skills.declaredTools", { defaultValue: "Declared tools" })}
                   </dt>
                   <dd className="m-0 text-text">{preview.allowed_tools.join(", ")}</dd>
                 </div>
@@ -1813,6 +1894,7 @@ export const SkillsManager: React.FC = () => {
 
       <SkillPreview
         skillName={previewSkill}
+        runtime={previewRuntime}
         onClose={() => setPreviewSkill(null)}
       />
     </div>

--- a/apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx
@@ -3,10 +3,11 @@ import { useMutation } from "@tanstack/react-query"
 import { Alert, Button, Input, Modal, Tag } from "antd"
 import { useTranslation } from "react-i18next"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
-import type { SkillExecutionResult } from "@/types/skill"
+import type { SkillExecutionResult, SkillRuntimeMetadata } from "@/types/skill"
 
 interface SkillPreviewProps {
   skillName: string | null
+  runtime?: SkillRuntimeMetadata | null
   onClose: () => void
 }
 
@@ -14,6 +15,7 @@ type SkillRunMode = "dry-run" | "test-run"
 
 export const SkillPreview: React.FC<SkillPreviewProps> = ({
   skillName,
+  runtime,
   onClose
 }) => {
   const { t } = useTranslation(["option", "common"])
@@ -58,6 +60,32 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
     executeMutation.error instanceof Error
       ? executeMutation.error.message
       : t("option:skills.testRunError", { defaultValue: "Execution failed" })
+  const runtimeToolLabel = runtime
+    ? t("option:skills.runtimeDeclaredTools", {
+        defaultValue: `${runtime.declared_tool_count} tools declared`,
+        count: runtime.declared_tool_count
+      })
+    : ""
+  const testRunDisclosure = runtime
+    ? runtime.execution_mode === "fork"
+      ? runtime.test_run_may_call_model
+        ? t("option:skills.testRunForkMayCallModelDisclosure", {
+            defaultValue:
+              "Run test uses fork execution and may call the configured model for this skill."
+          })
+        : t("option:skills.testRunForkPromptOnlyDisclosure", {
+            defaultValue:
+              "Run test uses fork execution for this skill; model calls are disabled."
+          })
+      : runtime.test_run_may_call_model
+        ? t("option:skills.testRunInlineMayCallModelDisclosure", {
+            defaultValue:
+              "Run test uses inline prompt execution and may call the configured model for this skill."
+          })
+        : t("option:skills.testRunInlineDisclosure", {
+            defaultValue: "Run test uses inline prompt execution for this skill."
+          })
+    : ""
 
   return (
     <Modal
@@ -89,12 +117,68 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
           />
         </div>
 
-        <p className="m-0 text-sm text-text-muted">
-          {t("option:skills.testRunDisclosure", {
-            defaultValue:
-              "This renders the skill with your arguments. Fork-mode skills may call the configured model and allowed tools."
-          })}
-        </p>
+        {runtime ? (
+          <div className="rounded-md border border-border bg-surface p-3">
+            <h3 className="m-0 text-sm font-semibold text-text">
+              {t("option:skills.runtimeImpactTitle", { defaultValue: "Runtime impact" })}
+            </h3>
+            <div className="mt-2 flex flex-wrap gap-1">
+              <Tag color={runtime.execution_mode === "fork" ? "blue" : "green"}>
+                {runtime.execution_mode === "fork"
+                  ? t("option:skills.runtimeFork", { defaultValue: "Fork" })
+                  : t("option:skills.runtimeInline", { defaultValue: "Inline" })}
+              </Tag>
+              <Tag color={runtime.test_run_may_call_model ? "orange" : "default"}>
+                {runtime.test_run_may_call_model
+                  ? t("option:skills.runtimeMayCallModel", { defaultValue: "Test may call model" })
+                  : t("option:skills.runtimePromptOnly", { defaultValue: "Prompt only by default" })}
+              </Tag>
+              {runtime.declares_tools && (
+                <Tag color="geekblue">{runtimeToolLabel}</Tag>
+              )}
+              {runtime.model_override && (
+                <Tag>
+                  {t("option:skills.runtimeModelOverride", {
+                    defaultValue: "Model override"
+                  })}
+                </Tag>
+              )}
+              {!runtime.auto_invocation_enabled && (
+                <Tag color="warning">
+                  {t("option:skills.runtimeAutoOff", {
+                    defaultValue: "Auto invocation off"
+                  })}
+                </Tag>
+              )}
+            </div>
+            <div className="mt-2 space-y-1 text-sm text-text-muted">
+              <p className="m-0">
+                {t("option:skills.renderOnlyDisclosure", {
+                  defaultValue:
+                    "Render prompt only does not invoke fork, model, or tool execution."
+                })}
+              </p>
+              <p className="m-0">
+                {testRunDisclosure}
+              </p>
+              {runtime.declares_tools && (
+                <p className="m-0">
+                  {t("option:skills.declaredToolsDisclosure", {
+                    defaultValue:
+                      "Declared tools are declarations, not availability guarantees."
+                  })}
+                </p>
+              )}
+            </div>
+          </div>
+        ) : (
+          <p className="m-0 text-sm text-text-muted">
+            {t("option:skills.testRunDisclosure", {
+              defaultValue:
+                "This renders the skill with your arguments. Fork-mode skills may call the configured model and allowed tools."
+            })}
+          </p>
+        )}
 
         <div className="flex flex-col gap-2 sm:flex-row">
           <Button

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -66,7 +66,7 @@ vi.mock("../SkillDrawer", () => ({
 }))
 
 vi.mock("../SkillPreview", () => ({
-  SkillPreview: (props: { skillName: string | null }) => {
+  SkillPreview: (props: { skillName: string | null; runtime?: unknown }) => {
     skillPreviewMock(props)
     return props.skillName ? (
       <div data-testid="skill-preview-open">Test run: {props.skillName}</div>
@@ -1295,6 +1295,163 @@ describe("SkillsManager imports", () => {
       "argument_hint"
     )
   }, 10000)
+
+  it("lets power users show runtime declarations in the table", async () => {
+    const runtime = {
+      execution_mode: "fork" as const,
+      test_run_may_call_model: true,
+      declares_tools: true,
+      declared_tool_count: 2,
+      model_override: "gpt-4o",
+      auto_invocation_enabled: false
+    }
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [
+        {
+          ...makeSkill(5),
+          name: "runtime-skill",
+          context: "fork" as const,
+          allowed_tools: ["Read", "Bash(git *)"],
+          model: "gpt-4o",
+          runtime
+        }
+      ],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("runtime-skill")).toBeInTheDocument()
+    expect(screen.queryByRole("columnheader", { name: "Runtime" })).not.toBeInTheDocument()
+
+    fireEvent.click(await getColumnVisibilityOption("Runtime"))
+
+    expect(await screen.findByRole("columnheader", { name: "Runtime" })).toBeInTheDocument()
+    const row = screen.getByText("runtime-skill").closest("tr")
+    expect(row).not.toBeNull()
+    expect(within(row as HTMLTableRowElement).getByText("Fork")).toBeInTheDocument()
+    expect(within(row as HTMLTableRowElement).getByText("Test may call model")).toBeInTheDocument()
+    expect(within(row as HTMLTableRowElement).getByText("2 tools declared")).toBeInTheDocument()
+    expect(within(row as HTMLTableRowElement).getByText("Model override")).toBeInTheDocument()
+    expect(within(row as HTMLTableRowElement).getByText("Auto invocation off")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Test run runtime-skill" }))
+    expect(skillPreviewMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        skillName: "runtime-skill",
+        runtime
+      })
+    )
+  }, 10000)
+
+  it("falls back when runtime declarations are missing from legacy list responses", async () => {
+    window.localStorage.setItem(
+      "tldw:skills-manager:table-preferences:v1",
+      JSON.stringify({
+        density: "comfortable",
+        visibleColumns: ["description", "context", "runtime"]
+      })
+    )
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [
+        {
+          name: "legacy-runtime",
+          description: "Legacy response",
+          argument_hint: null,
+          user_invocable: true,
+          disable_model_invocation: false,
+          version: 1
+        } as any
+      ],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("legacy-runtime")).toBeInTheDocument()
+    expect(screen.getByRole("columnheader", { name: "Runtime" })).toBeInTheDocument()
+    const row = screen.getByText("legacy-runtime").closest("tr")
+    expect(row).not.toBeNull()
+    expect(within(row as HTMLTableRowElement).getByText("Inline")).toBeInTheDocument()
+    expect(
+      within(row as HTMLTableRowElement).getByText("Prompt only by default")
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Test run legacy-runtime" }))
+    expect(skillPreviewMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        skillName: "legacy-runtime",
+        runtime: {
+          execution_mode: "inline",
+          test_run_may_call_model: false,
+          declares_tools: false,
+          declared_tool_count: 0,
+          model_override: null,
+          auto_invocation_enabled: true
+        }
+      })
+    )
+  })
+
+  it("preserves an explicit runtime execution mode before falling back to skill context", async () => {
+    window.localStorage.setItem(
+      "tldw:skills-manager:table-preferences:v1",
+      JSON.stringify({
+        density: "comfortable",
+        visibleColumns: ["description", "context", "runtime"]
+      })
+    )
+    const runtime = {
+      execution_mode: "inline" as const,
+      test_run_may_call_model: false,
+      declares_tools: false,
+      declared_tool_count: 0,
+      model_override: null,
+      auto_invocation_enabled: true
+    }
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [
+        {
+          name: "explicit-inline-runtime",
+          description: "Runtime contract wins",
+          argument_hint: null,
+          user_invocable: true,
+          disable_model_invocation: false,
+          allowed_tools: null,
+          model: null,
+          context: "fork" as const,
+          runtime,
+          version: 1
+        }
+      ],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("explicit-inline-runtime")).toBeInTheDocument()
+    const row = screen.getByText("explicit-inline-runtime").closest("tr")
+    expect(row).not.toBeNull()
+    expect(within(row as HTMLTableRowElement).getByText("Inline")).toBeInTheDocument()
+    expect(within(row as HTMLTableRowElement).queryByText("Fork")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Test run explicit-inline-runtime" }))
+    expect(skillPreviewMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        skillName: "explicit-inline-runtime",
+        runtime
+      })
+    )
+  })
 
   it("restores persisted density and column visibility preferences", async () => {
     window.localStorage.setItem(

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx
@@ -40,6 +40,7 @@ const renderPreview = (props: Partial<React.ComponentProps<typeof SkillPreview>>
     <QueryClientProvider client={queryClient}>
       <SkillPreview
         skillName={props.skillName ?? "summarize"}
+        runtime={props.runtime}
         onClose={props.onClose ?? vi.fn()}
       />
     </QueryClientProvider>
@@ -103,6 +104,57 @@ describe("SkillPreview test-run semantics", () => {
     expect(within(dialog).getByRole("button", { name: "Render prompt only" })).toBeInTheDocument()
     expect(within(dialog).getByRole("button", { name: "Run test" })).toBeInTheDocument()
     expect(within(dialog).queryByRole("button", { name: "Preview" })).not.toBeInTheDocument()
+  })
+
+  it("shows selected runtime impact before running a skill", () => {
+    renderPreview({
+      runtime: {
+        execution_mode: "fork",
+        test_run_may_call_model: true,
+        declares_tools: true,
+        declared_tool_count: 2,
+        model_override: "gpt-4o",
+        auto_invocation_enabled: false
+      }
+    })
+
+    const dialog = screen.getByRole("dialog", { name: "Test run" })
+    expect(within(dialog).getByText("Runtime impact")).toBeInTheDocument()
+    expect(within(dialog).getByText("Fork")).toBeInTheDocument()
+    expect(within(dialog).getByText("Test may call model")).toBeInTheDocument()
+    expect(within(dialog).getByText("2 tools declared")).toBeInTheDocument()
+    expect(within(dialog).getByText("Model override")).toBeInTheDocument()
+    expect(within(dialog).getByText("Auto invocation off")).toBeInTheDocument()
+    expect(
+      within(dialog).getByText(
+        "Render prompt only does not invoke fork, model, or tool execution."
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("keeps fork execution disclosure separate from model-call allowance", () => {
+    renderPreview({
+      runtime: {
+        execution_mode: "fork",
+        test_run_may_call_model: false,
+        declares_tools: false,
+        declared_tool_count: 0,
+        model_override: null,
+        auto_invocation_enabled: true
+      }
+    })
+
+    const dialog = screen.getByRole("dialog", { name: "Test run" })
+    expect(within(dialog).getByText("Fork")).toBeInTheDocument()
+    expect(within(dialog).getByText("Prompt only by default")).toBeInTheDocument()
+    expect(
+      within(dialog).getByText(
+        "Run test uses fork execution for this skill; model calls are disabled."
+      )
+    ).toBeInTheDocument()
+    expect(
+      within(dialog).queryByText("Run test uses inline prompt execution for this skill.")
+    ).not.toBeInTheDocument()
   })
 
   it("runs the skill with supplied arguments from the explicit test action", async () => {

--- a/apps/packages/ui/src/types/skill.ts
+++ b/apps/packages/ui/src/types/skill.ts
@@ -7,6 +7,15 @@ export type SkillContext = "inline" | "fork"
 export type SkillListSort = "name" | "context" | "created_at" | "last_modified"
 export type SkillListOrder = "asc" | "desc"
 
+export interface SkillRuntimeMetadata {
+  execution_mode: SkillContext
+  test_run_may_call_model: boolean
+  declares_tools: boolean
+  declared_tool_count: number
+  model_override: string | null
+  auto_invocation_enabled: boolean
+}
+
 export interface SkillsListParams {
   q?: string
   includeHidden?: boolean
@@ -27,7 +36,10 @@ export interface SkillSummary {
   argument_hint: string | null
   user_invocable: boolean
   disable_model_invocation: boolean
+  allowed_tools?: string[] | null
+  model?: string | null
   context: SkillContext
+  runtime?: SkillRuntimeMetadata | null
   version: number
 }
 
@@ -41,6 +53,7 @@ export interface SkillResponse {
   allowed_tools: string[] | null
   model: string | null
   context: SkillContext
+  runtime?: SkillRuntimeMetadata | null
   content: string
   raw_content?: string | null
   supporting_files: Record<string, string> | null

--- a/backlog/tasks/task-530.13 - Implement-Skills-runtime-metadata-visibility.md
+++ b/backlog/tasks/task-530.13 - Implement-Skills-runtime-metadata-visibility.md
@@ -1,0 +1,90 @@
+---
+id: TASK-530.13
+title: Implement Skills runtime metadata visibility
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-06-30 02:13'
+labels:
+  - skills
+  - webui
+  - safe-operations
+  - backend
+  - frontend
+dependencies: []
+parent_task_id: TASK-530
+priority: high
+ordinal: 530.13
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-530 Safe Operations after TASK-530.12 by exposing read-only Skills runtime declaration metadata so users can understand whether a skill may use fork execution, model calls, model overrides, or declared tools before running it. Keep scope limited to structured metadata and UI visibility; do not add a policy editor, RBAC enforcement changes, tool permission mutation, or execution behavior changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Skills list and detail responses expose structured runtime declaration metadata derived from existing frontmatter/registry fields without adding persisted columns.
+- [x] #2 Runtime metadata names avoid permission guarantees and distinguish declared tools from actually available executable tools.
+- [x] #3 The Skills manager can show a compact runtime summary in the table without breaking older responses that lack the new metadata.
+- [x] #4 The Skill test-run modal shows runtime impact before Render prompt only or Run test actions.
+- [x] #5 Focused backend and frontend tests cover runtime metadata derivation, list response shape, table visibility, and test-run disclosure.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Spec: Docs/superpowers/specs/2026-06-29-skills-runtime-metadata-visibility-design.md
+Plan: Docs/superpowers/plans/2026-06-29-skills-runtime-metadata-visibility.md
+
+Touched implementation files:
+- tldw_Server_API/app/core/Skills/runtime_metadata.py
+- tldw_Server_API/app/api/v1/schemas/skills_schemas.py
+- tldw_Server_API/app/api/v1/endpoints/skills.py
+- tldw_Server_API/app/core/Skills/skills_service.py
+- tldw_Server_API/tests/Skills/integration/test_skills_api.py
+- apps/packages/ui/src/types/skill.ts
+- apps/packages/ui/src/components/Option/Skills/Manager.tsx
+- apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx
+- apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+- apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx
+
+Verification:
+- source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -q: PASS, 74 passed.
+- bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillPreview.test.tsx --reporter=dot: PASS, 46 passed. Local worktree needed the tracked antd symlink temporarily pointed at the installed Bun cache, then restored.
+- git diff --check: PASS.
+- source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Skills/runtime_metadata.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_skills_runtime_metadata_TASK_530_13.json: PASS, zero findings.
+- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc -p tsconfig.json --noEmit --pretty false: FAIL on existing baseline errors outside this task and one pre-existing row-selection prop typing issue in Skills Manager; no runtime metadata type errors observed before the baseline failure list.
+
+Scope notes:
+- No policy editor, RBAC change, database migration, or skill execution behavior change.
+- Runtime metadata is derived from existing frontmatter/registry fields.
+- Test-generated untracked watchlist template artifacts were removed from the worktree.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2549
+
+Review follow-up after PR #2549 rebase:
+- Rebased codex/skills-runtime-metadata onto latest origin/dev.
+- Addressed Qodo wording feedback by aligning allowed_tools schema descriptions around declared tool strings.
+- Addressed Gemini inline comments by defaulting explicit null runtime fields to inline/false, normalizing single-string allowed_tools before counting declarations, and defaulting legacy frontend context to inline.
+- Added regression coverage for legacy null API fields, single-string tool declarations, context payload null context, and legacy UI list responses opening the test-run preview.
+- Addressed CodeRabbit follow-up by preserving explicit runtime.execution_mode values, separating fork/inline disclosure from model-call allowance in SkillPreview, using repo-relative verification commands, and removing a duplicate final-summary marker.
+- Verification: pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -q passed (74 tests); Vitest Manager/SkillPreview passed (46 tests); git diff --check passed; Bandit touched backend scope passed with zero findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented read-only Skills runtime metadata visibility for TASK-530.13. Backend list/detail/context responses now expose structured runtime declarations plus raw declared tools/model values. The Skills manager has an optional Runtime column with legacy-response fallback, and the test-run modal shows selected-skill runtime impact before dry render or test execution. Import review copy now says Declared tools. Focused frontend tests, full Skills API integration tests, diff check, and Bandit pass; full UI typecheck remains blocked by existing baseline errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -61,6 +61,7 @@ from tldw_Server_API.app.core.Skills.exceptions import (
     SkillValidationError,
 )
 from tldw_Server_API.app.core.Skills.skill_executor import RequestContext, SkillExecutor
+from tldw_Server_API.app.core.Skills.runtime_metadata import build_skill_runtime_metadata
 from tldw_Server_API.app.core.Skills.skills_service import SkillsService
 
 router = APIRouter()
@@ -116,16 +117,26 @@ async def get_skills_service(
 
 def _skill_data_to_response(skill_data: dict) -> SkillResponse:
     """Convert skill data dict to SkillResponse."""
+    allowed_tools = skill_data.get("allowed_tools")
+    model = skill_data.get("model")
+    context = skill_data.get("context") or "inline"
+    disable_model_invocation = bool(skill_data.get("disable_model_invocation"))
     return SkillResponse(
         id=skill_data["id"],
         name=skill_data["name"],
         description=skill_data.get("description"),
         argument_hint=skill_data.get("argument_hint"),
-        disable_model_invocation=skill_data.get("disable_model_invocation", False),
+        disable_model_invocation=disable_model_invocation,
         user_invocable=skill_data.get("user_invocable", True),
-        allowed_tools=skill_data.get("allowed_tools"),
-        model=skill_data.get("model"),
-        context=skill_data.get("context", "inline"),
+        allowed_tools=allowed_tools,
+        model=model,
+        context=context,
+        runtime=build_skill_runtime_metadata(
+            context=context,
+            allowed_tools=allowed_tools,
+            model=model,
+            disable_model_invocation=disable_model_invocation,
+        ),
         content=skill_data["content"],
         supporting_files=skill_data.get("supporting_files"),
         directory_path=skill_data["directory_path"],
@@ -137,13 +148,25 @@ def _skill_data_to_response(skill_data: dict) -> SkillResponse:
 
 def _metadata_to_summary(metadata) -> SkillSummary:
     """Convert SkillMetadata to SkillSummary."""
+    allowed_tools = getattr(metadata, "allowed_tools", None)
+    model = getattr(metadata, "model", None)
+    context = getattr(metadata, "context", None) or "inline"
+    disable_model_invocation = bool(getattr(metadata, "disable_model_invocation", False))
     return SkillSummary(
         name=metadata.name,
         description=metadata.description,
         argument_hint=metadata.argument_hint,
         user_invocable=metadata.user_invocable,
-        disable_model_invocation=metadata.disable_model_invocation,
-        context=metadata.context,
+        disable_model_invocation=disable_model_invocation,
+        allowed_tools=allowed_tools,
+        model=model,
+        context=context,
+        runtime=build_skill_runtime_metadata(
+            context=context,
+            allowed_tools=allowed_tools,
+            model=model,
+            disable_model_invocation=disable_model_invocation,
+        ),
         version=metadata.version or 1,
     )
 

--- a/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
@@ -105,11 +105,27 @@ class SkillFrontmatter(BaseModel):
     argument_hint: str | None = Field(None, max_length=100, description="Hint shown in UI (e.g., '[issue-number]')")
     disable_model_invocation: bool = Field(False, description="If true, only user can invoke (not auto-invoked by LLM)")
     user_invocable: bool = Field(True, description="If false, hidden from user UI (background knowledge only)")
-    allowed_tools: list[str] | None = Field(None, description="Tools allowed without permission when skill is active")
+    allowed_tools: list[str] | None = Field(None, description="Declared tool strings")
     model: str | None = Field(None, description="Override model for this skill")
     context: SkillContext = Field("inline", description="'inline' or 'fork' (fork runs in isolated subagent)")
 
     model_config = ConfigDict(extra='ignore')
+
+
+class SkillRuntimeMetadata(BaseModel):
+    """Read-only runtime declarations derived from skill metadata."""
+    execution_mode: SkillContext = Field("inline", description="Declared execution context mode")
+    test_run_may_call_model: bool = Field(
+        False,
+        description="Whether a non-dry user-triggered test run may call the configured model",
+    )
+    declares_tools: bool = Field(False, description="Whether the skill declares tool strings")
+    declared_tool_count: int = Field(0, ge=0, description="Count of declared tool strings")
+    model_override: str | None = Field(None, description="Declared model override")
+    auto_invocation_enabled: bool = Field(
+        True,
+        description="Whether the skill can be advertised for model auto-invocation context",
+    )
 
 
 class SkillBase(BaseModel):
@@ -119,9 +135,13 @@ class SkillBase(BaseModel):
     argument_hint: str | None = Field(None, max_length=100, description="Hint shown in UI")
     disable_model_invocation: bool = Field(False, description="If true, only user can invoke")
     user_invocable: bool = Field(True, description="If false, hidden from user UI")
-    allowed_tools: list[str] | None = Field(None, description="Tools allowed during skill execution")
+    allowed_tools: list[str] | None = Field(None, description="Declared tool strings")
     model: str | None = Field(None, description="Override model for this skill")
     context: SkillContext = Field("inline", description="Execution context mode")
+    runtime: SkillRuntimeMetadata = Field(
+        default_factory=SkillRuntimeMetadata,
+        description="Read-only runtime declarations derived from skill metadata",
+    )
 
     @field_validator("name")
     @classmethod
@@ -193,7 +213,13 @@ class SkillSummary(BaseModel):
     argument_hint: str | None = Field(None, description="Hint shown in UI")
     user_invocable: bool = Field(..., description="If false, hidden from user UI")
     disable_model_invocation: bool = Field(..., description="If true, only user can invoke")
+    allowed_tools: list[str] | None = Field(None, description="Declared tool strings")
+    model: str | None = Field(None, description="Declared model override")
     context: SkillContext = Field(..., description="Execution context mode")
+    runtime: SkillRuntimeMetadata = Field(
+        default_factory=SkillRuntimeMetadata,
+        description="Read-only runtime declarations derived from skill metadata",
+    )
     version: int = Field(..., description="Version for optimistic locking")
 
     model_config = ConfigDict(from_attributes=True)
@@ -261,7 +287,7 @@ class SkillExecutionResult(BaseModel):
     """Result of skill execution."""
     skill_name: str = Field(..., description="Name of the executed skill")
     rendered_prompt: str = Field(..., description="Prompt with arguments substituted")
-    allowed_tools: list[str] | None = Field(None, description="Tools allowed for this skill")
+    allowed_tools: list[str] | None = Field(None, description="Declared tool strings")
     model_override: str | None = Field(None, description="Model override if specified")
     execution_mode: SkillContext = Field(..., description="How the skill was executed")
     fork_output: str | None = Field(None, description="Output from fork execution (if applicable)")
@@ -320,7 +346,7 @@ class SkillImportPreviewResponse(BaseModel):
     argument_hint: str | None = Field(None, description="Parsed argument hint")
     disable_model_invocation: bool | None = Field(None, description="Whether model invocation is disabled")
     user_invocable: bool | None = Field(None, description="Whether users can invoke the skill directly")
-    allowed_tools: list[str] | None = Field(None, description="Parsed allowed tools")
+    allowed_tools: list[str] | None = Field(None, description="Parsed declared tool strings")
     model: str | None = Field(None, description="Parsed model override")
     context: SkillContext | None = Field(None, description="Parsed execution context")
     supporting_file_count: int = Field(0, description="Number of supporting files included in the import")

--- a/tldw_Server_API/app/core/Skills/runtime_metadata.py
+++ b/tldw_Server_API/app/core/Skills/runtime_metadata.py
@@ -1,0 +1,37 @@
+"""Helpers for exposing read-only skill runtime declaration metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+SkillRuntimeMetadataDict = dict[str, str | bool | int | None]
+
+
+def _normalize_allowed_tool_declarations(allowed_tools: Sequence[str] | str | None) -> list[str]:
+    """Return declared tool strings without treating a single string as a sequence."""
+    if allowed_tools is None:
+        return []
+    if isinstance(allowed_tools, str):
+        return [allowed_tools] if allowed_tools else []
+    return [tool for tool in allowed_tools if isinstance(tool, str)]
+
+
+def build_skill_runtime_metadata(
+    *,
+    context: str | None,
+    allowed_tools: Sequence[str] | str | None,
+    model: str | None,
+    disable_model_invocation: bool | None,
+) -> SkillRuntimeMetadataDict:
+    """Derive structured runtime declarations from existing skill metadata."""
+    execution_mode = "fork" if context == "fork" else "inline"
+    declared_tool_count = len(_normalize_allowed_tool_declarations(allowed_tools))
+
+    return {
+        "execution_mode": execution_mode,
+        "test_run_may_call_model": execution_mode == "fork",
+        "declares_tools": declared_tool_count > 0,
+        "declared_tool_count": declared_tool_count,
+        "model_override": model,
+        "auto_invocation_enabled": not bool(disable_model_invocation),
+    }

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -52,6 +52,7 @@ from tldw_Server_API.app.core.Skills.exceptions import (
     SkillStorageError,
     SkillValidationError,
 )
+from tldw_Server_API.app.core.Skills.runtime_metadata import build_skill_runtime_metadata
 from tldw_Server_API.app.core.Skills.skill_parser import SkillFrontmatter, SkillParser
 
 # Skill name validation pattern (same as in schemas)
@@ -1671,7 +1672,15 @@ class SkillsService:
                     "argument_hint": s.get("argument_hint"),
                     "user_invocable": bool(s.get("user_invocable")),
                     "disable_model_invocation": bool(s.get("disable_model_invocation")),
-                    "context": s.get("context", "inline"),
+                    "allowed_tools": s.get("allowed_tools"),
+                    "model": s.get("model"),
+                    "context": s.get("context") or "inline",
+                    "runtime": build_skill_runtime_metadata(
+                        context=s.get("context") or "inline",
+                        allowed_tools=s.get("allowed_tools"),
+                        model=s.get("model"),
+                        disable_model_invocation=bool(s.get("disable_model_invocation")),
+                    ),
                     "version": int(s.get("version") or 1),
                 }
                 for s in skills

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -7,6 +7,7 @@ import os
 import zipfile
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -29,6 +30,7 @@ from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_
 from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.endpoints.skills import (
     MAX_SKILL_IMPORT_PREVIEW_UPLOAD_BYTES,
+    _skill_data_to_response,
     _metadata_to_summary,
 )
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
@@ -37,6 +39,7 @@ from tldw_Server_API.app.core.Context_Integrity.resolver import clear_global_con
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Skills.exceptions import SkillsError
+from tldw_Server_API.app.core.Skills.runtime_metadata import build_skill_runtime_metadata
 from tldw_Server_API.app.core.Skills.skills_service import SkillsService
 
 pytestmark = pytest.mark.integration
@@ -374,6 +377,67 @@ class TestListSkills:
 
         assert summary.version == 1
 
+    def test_metadata_summary_defaults_explicit_none_runtime_fields(self) -> None:
+        """Legacy metadata with explicit null runtime fields still produces a valid summary."""
+        metadata = SimpleNamespace(
+            name="legacy-runtime",
+            description=None,
+            argument_hint=None,
+            user_invocable=True,
+            disable_model_invocation=None,
+            allowed_tools=["Read"],
+            model=None,
+            context=None,
+            version=1,
+        )
+
+        summary = _metadata_to_summary(metadata)
+
+        assert summary.context == "inline"
+        assert summary.disable_model_invocation is False
+        assert summary.runtime.execution_mode == "inline"
+        assert summary.runtime.declared_tool_count == 1
+
+    def test_skill_response_defaults_explicit_none_runtime_fields(self) -> None:
+        """Detail responses preserve schema defaults when legacy rows contain nulls."""
+        now = datetime.now(timezone.utc)
+        response = _skill_data_to_response(
+            {
+                "id": "legacy-runtime-id",
+                "name": "legacy-runtime",
+                "description": None,
+                "argument_hint": None,
+                "disable_model_invocation": None,
+                "user_invocable": True,
+                "allowed_tools": ["Read"],
+                "model": None,
+                "context": None,
+                "content": "Body",
+                "supporting_files": None,
+                "directory_path": "/tmp/legacy-runtime",
+                "created_at": now,
+                "last_modified": now,
+                "version": 1,
+            }
+        )
+
+        assert response.context == "inline"
+        assert response.disable_model_invocation is False
+        assert response.runtime.execution_mode == "inline"
+        assert response.runtime.declared_tool_count == 1
+
+    def test_runtime_metadata_counts_single_tool_string_as_one(self) -> None:
+        """Defensive runtime metadata treats one tool string as one declaration."""
+        metadata = build_skill_runtime_metadata(
+            context="fork",
+            allowed_tools="Read",
+            model=None,
+            disable_model_invocation=False,
+        )
+
+        assert metadata["declares_tools"] is True
+        assert metadata["declared_tool_count"] == 1
+
     def test_list_skills_search_filters_before_pagination(self, client):
         for i in range(12):
             r = client.post(
@@ -463,6 +527,50 @@ class TestListSkills:
             "has_more": True,
             "next_offset": 1,
         }
+
+    def test_list_and_detail_responses_include_runtime_metadata(self, client):
+        r = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={
+                "name": "runtime-review",
+                "content": (
+                    "---\n"
+                    "description: Runtime metadata review\n"
+                    "context: fork\n"
+                    "allowed-tools:\n"
+                    "  - Read\n"
+                    "  - \"Bash(git *)\"\n"
+                    "model: gpt-4o\n"
+                    "disable-model-invocation: true\n"
+                    "---\n\n"
+                    "Use this with runtime metadata."
+                ),
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        r = client.get(f"{SKILLS_PREFIX}/?q=runtime-review")
+        assert r.status_code == 200, r.text
+        list_body = r.json()
+        assert list_body["count"] == 1
+        summary = list_body["skills"][0]
+        assert summary["allowed_tools"] == ["Read", "Bash(git *)"]
+        assert summary["model"] == "gpt-4o"
+        assert summary["runtime"] == {
+            "execution_mode": "fork",
+            "test_run_may_call_model": True,
+            "declares_tools": True,
+            "declared_tool_count": 2,
+            "model_override": "gpt-4o",
+            "auto_invocation_enabled": False,
+        }
+
+        r = client.get(f"{SKILLS_PREFIX}/runtime-review")
+        assert r.status_code == 200, r.text
+        detail = r.json()
+        assert detail["allowed_tools"] == ["Read", "Bash(git *)"]
+        assert detail["model"] == "gpt-4o"
+        assert detail["runtime"] == summary["runtime"]
 
     def test_list_skills_explicit_hidden_filter(self, client):
         for name, user_invocable in (("visible", "true"), ("hidden", "false")):
@@ -1415,6 +1523,69 @@ class TestContextPayload:
         assert listed["ctx-skill"]["version"] == 1
         ctx_line = next(line for line in data["context_text"].splitlines() if "ctx-skill" in line)
         assert "version" not in ctx_line.lower()
+
+    def test_get_context_payload_includes_runtime_metadata(self, client):
+        r = client.post(
+            f"{SKILLS_PREFIX}/",
+            json={
+                "name": "ctx-runtime",
+                "content": (
+                    "---\n"
+                    "description: Context runtime test\n"
+                    "argument-hint: \"[topic]\"\n"
+                    "context: fork\n"
+                    "allowed-tools:\n"
+                    "  - Read\n"
+                    "model: gpt-4o-mini\n"
+                    "---\n\n"
+                    "Context runtime body"
+                ),
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        r = client.get(f"{SKILLS_PREFIX}/context")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        listed = {skill["name"]: skill for skill in data["available_skills"]}
+        assert listed["ctx-runtime"]["allowed_tools"] == ["Read"]
+        assert listed["ctx-runtime"]["model"] == "gpt-4o-mini"
+        assert listed["ctx-runtime"]["runtime"] == {
+            "execution_mode": "fork",
+            "test_run_may_call_model": True,
+            "declares_tools": True,
+            "declared_tool_count": 1,
+            "model_override": "gpt-4o-mini",
+            "auto_invocation_enabled": True,
+        }
+        ctx_line = next(line for line in data["context_text"].splitlines() if "ctx-runtime" in line)
+        assert "gpt-4o-mini" not in ctx_line
+        assert "Read" not in ctx_line
+
+    def test_context_payload_defaults_explicit_none_context(self):
+        service = SkillsService.__new__(SkillsService)
+        service._is_skill_allowed = lambda _name, purpose: True
+
+        payload = service._build_context_payload(
+            [
+                {
+                    "name": "legacy-context",
+                    "description": "Legacy context row",
+                    "argument_hint": None,
+                    "user_invocable": True,
+                    "disable_model_invocation": False,
+                    "allowed_tools": ["Read"],
+                    "model": None,
+                    "context": None,
+                    "version": 1,
+                }
+            ]
+        )
+
+        skill = payload["available_skills"][0]
+        assert skill["context"] == "inline"
+        assert skill["runtime"]["execution_mode"] == "inline"
+        assert skill["runtime"]["declared_tool_count"] == 1
 
     def test_get_context_payload_uses_async_service_method(self, client, monkeypatch):
         calls = {"async": 0}


### PR DESCRIPTION
## Summary
- Exposes structured read-only Skills runtime declarations on list/detail/context responses.
- Adds an optional Runtime column and selected-skill test-run disclosure in the Skills manager.
- Renames import review tool wording to Declared tools to avoid permission-language ambiguity.

## Verification
- `python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -q` (70 passed)
- `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillPreview.test.tsx --reporter=dot` (44 passed)
- `git diff --check`
- `python -m bandit -r tldw_Server_API/app/core/Skills/runtime_metadata.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Skills/skills_service.py -f json -o /tmp/bandit_skills_runtime_metadata_TASK_530_13.json` (zero findings)

## Notes
- Full UI typecheck remains blocked by existing baseline errors unrelated to this task.
- Repo merge policy still requires a human-authored Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes read-only Skills runtime metadata in API list/detail/context responses and surfaces it in the Skills manager and test-run modal. Users can see fork mode, whether a test may call a model, declared tools, model overrides, and auto-invocation state before running a skill (addresses TASK-530.13).

- **New Features**
  - Backend: Adds a derivation helper and `SkillRuntimeMetadata` schema; includes `runtime`, `allowed_tools`, and `model` in list/detail and `/skills/context` `available_skills`; normalizes single-string `allowed_tools`; safely defaults legacy nulls (`inline`, false); execution behavior and `context_text` unchanged.
  - Frontend: Adds an optional Runtime column with fallback derivation when `runtime` is missing and preserves explicit `runtime.execution_mode`; passes derived runtime to `SkillPreview` and shows compact “Runtime impact” tags; renames “Allowed tools” to “Declared tools” to avoid permission ambiguity.

<sup>Written for commit 042ea216da941ab13d8c3ba6eb204a46758089e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

