### PR TITLE
Harden MCP Unified residual UX and defaults

### DIFF
--- a/Docs/MCP/Unified/Client_Snippets.md
+++ b/Docs/MCP/Unified/Client_Snippets.md
@@ -13,6 +13,10 @@ Primary examples use header or WebSocket subprotocol auth. Query-string tokens a
 ## JSON-RPC over HTTP (Initialize → Tools List → Tools Call)
 
 ```bash
+# Status preflight - confirms the embedded TLDW MCP surface is mounted
+curl -s -H "Authorization: Bearer <token>" \
+  http://127.0.0.1:8000/api/v1/mcp/status
+
 # Initialize (optional) - negotiates an mcp-session-id and can carry a base64 safe config
 cfg=$(printf '{"snippet_length": 200}' | base64)
 curl -i -H "Authorization: Bearer <token>" \

--- a/Docs/MCP/Unified/Developer_Guide.md
+++ b/Docs/MCP/Unified/Developer_Guide.md
@@ -1452,6 +1452,12 @@ Complete API documentation is available at:
 | -32001 | Permission denied | Insufficient permissions |
 | -32002 | Rate limit exceeded | Too many requests |
 
+Known JSON-RPC failures may add recovery metadata under `error.data`, for
+example `reason_code` and `next_action`. HTTP convenience endpoints keep their
+existing public body shape: object `detail` payloads may include those fields,
+while string `detail` payloads expose equivalent `X-MCP-Reason-Code` and
+`X-MCP-Next-Action` headers.
+
 ## Resources
 
 - [JSON-RPC 2.0 Specification](https://www.jsonrpc.org/specification)

--- a/Docs/MCP/Unified/Modules.md
+++ b/Docs/MCP/Unified/Modules.md
@@ -6,7 +6,7 @@
 
 - Unified MCP exposes tools, resources, and prompts through pluggable modules.
 - Each module subclasses `BaseModule` and is registered through YAML configuration or environment variables.
-- `GET /api/v1/mcp/status` includes a `surface` summary that groups enabled modules by user-facing risk tier.
+- `GET /api/v1/mcp/status` includes a `surface` summary that groups enabled modules by user-facing risk tier and lists high-risk modules available but disabled.
 
 ## Capability Risk Tiers
 
@@ -23,12 +23,19 @@ Use these tiers to explain what an enabled module can do before connecting an MC
 
 The tier is explanatory, not a permission grant. Execution still depends on RBAC, module settings, tool schemas, and runtime policy.
 
+High-risk modules in `local_files`, `local_process`, and `external_network`
+are explicit opt-ins. The default config keeps local filesystem and command
+execution modules disabled; `/api/v1/mcp/status` reports them under
+`surface.disabled_available` with `requires_explicit_opt_in: true` and a
+`next_action`. After changing `mcp_modules.yaml`, restart TLDW Server and
+recheck `/api/v1/mcp/status`.
+
 ## Quick Start
 
 1. Implement the module under `tldw_Server_API/app/core/MCP_unified/modules/implementations/`.
 2. Add a module entry to `tldw_Server_API/Config_Files/mcp_modules.yaml` (or define `MCP_MODULES`).
 3. Restart the server and verify availability with `GET /api/v1/mcp/modules` and `/api/v1/mcp/tools`.
-4. Check `GET /api/v1/mcp/status` and review `surface.tiers` to confirm the effective capability surface before connecting an agent.
+4. Check `GET /api/v1/mcp/status` and review `surface.tiers` plus `surface.disabled_available` to confirm the effective capability surface before connecting an agent.
 
 ## Module Interface
 
@@ -79,7 +86,18 @@ modules:
 - `MCP_MODULES_CONFIG` - override path to the YAML configuration (defaults to `tldw_Server_API/Config_Files/mcp_modules.yaml`).
 - `MCP_MODULES` - comma-separated definitions (`id=module.path:Class`), e.g. `MCP_MODULES="example=tldw_Server_API.app.core.MCP_unified.modules.implementations.template_module:TemplateModule"`.
 - Optional accelerator: `MCP_ENABLE_MEDIA_MODULE=true` registers `MediaModule` when no YAML or explicit environment configuration is provided.
+- Optional explicit opt-ins: `MCP_ENABLE_FILESYSTEM_MODULE=true`, `MCP_ENABLE_GIT_MODULE=true`, `MCP_ENABLE_SANDBOX_MODULE=true`, and `MCP_ENABLE_BROWSER_CDP_MODULE=true` register local high-risk modules only when no YAML entry already declares the module.
 - `MCP_EXTERNAL_SERVERS_CONFIG` - optional override path for external federation server registry (used by `external_federation` module).
+
+## Migration Note: Local File And Process Modules
+
+Default installs no longer expose local filesystem or local command execution
+tools. If an existing deployment intentionally used those defaults, copy the
+relevant entries from
+`tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml` into your
+selected `mcp_modules.yaml`, review the risk comments, set `enabled: true`,
+restart TLDW Server, then verify the module moved from
+`surface.disabled_available` to `surface.tiers`.
 
 ## External Federation Module
 

--- a/Docs/MCP/Unified/README.md
+++ b/Docs/MCP/Unified/README.md
@@ -4,6 +4,14 @@
 
 The MCP Unified stack is the production Model Context Protocol surface that ships with TLDW. Use this directory as the starting point for all current development, deployment, and client-integration work.
 
+## Which Path Should I Use?
+
+| Use case | Current path | Status |
+| --- | --- | --- |
+| Connect MCP clients to TLDW Server | `/api/v1/mcp/status`, `/api/v1/mcp/request`, `/api/v1/mcp/ws` | Supported embedded TLDW surface. |
+| Test a package-local mounted gateway | `/mcp/status`, `/mcp/request`, `/mcp/ws` | Package-local or host-mounted examples only; the embedding app supplies the server process. |
+| Run a separate standalone gateway process | None | Standalone gateway is planned but not shipped; there is no supported `serve` command today. |
+
 ## Available Guides
 
 - `Developer_Guide.md` - System architecture, extension patterns, testing strategy

--- a/Docs/MCP/Unified/Smoke_Client.md
+++ b/Docs/MCP/Unified/Smoke_Client.md
@@ -1,9 +1,9 @@
 # MCP Unified Smoke Client
 
 The MCP Unified smoke client runs a small JSON-RPC scenario against the
-standalone MCP gateway or a compatible MCP server. It is meant for PR checks,
-operator validation, and quick manual testing before adding more specialized
-tool scenarios.
+embedded TLDW MCP endpoint, a package-local host-mounted gateway, or another
+compatible MCP server. It is meant for PR checks, operator validation, and
+quick manual testing before adding more specialized tool scenarios.
 
 ## Scope
 
@@ -27,10 +27,10 @@ absolute paths, bearer tokens, API keys, or long payloads.
 
 ## Commands
 
-Install the package-local gateway extra first:
+Install the package-local gateway extra first from the repository root:
 
 ```bash
-python -m pip install -e "mcp_unified[gateway]"
+python -m pip install -e "apps/mcp-unified[gateway]"
 ```
 
 Run the deterministic in-process fixture:
@@ -39,24 +39,35 @@ Run the deterministic in-process fixture:
 mcp-unified-smoke inprocess --json-report -
 ```
 
-Run a live HTTP endpoint:
+Run a live embedded TLDW HTTP endpoint:
 
 ```bash
 mcp-unified-smoke http \
-  --url http://127.0.0.1:8000/mcp/request \
+  --url http://127.0.0.1:8000/api/v1/mcp/request \
   --profile-id backend-engineer \
   --api-key-env TLDW_API_KEY \
   --json-report /tmp/mcp-smoke-http.json
 ```
 
-Run a live WebSocket endpoint:
+Run a live embedded TLDW WebSocket endpoint:
 
 ```bash
 mcp-unified-smoke websocket \
-  --url ws://127.0.0.1:8000/mcp/ws \
+  --url ws://127.0.0.1:8000/api/v1/mcp/ws \
   --profile-id backend-engineer \
   --bearer-token-env TLDW_JWT \
   --json-report /tmp/mcp-smoke-ws.json
+```
+
+Run a package-local host-mounted HTTP endpoint only when another application
+has mounted the package gateway at `/mcp`:
+
+```bash
+mcp-unified-smoke http \
+  --url http://127.0.0.1:8000/mcp/request \
+  --profile-id backend-engineer \
+  --api-key-env MCP_GATEWAY_ADMIN_KEY \
+  --json-report /tmp/mcp-smoke-package-local-http.json
 ```
 
 Run a stdio subprocess:
@@ -105,7 +116,7 @@ Use safe target overrides when the server does not expose the fixture defaults:
 
 ```bash
 mcp-unified-smoke http \
-  --url http://127.0.0.1:8000/mcp/request \
+  --url http://127.0.0.1:8000/api/v1/mcp/request \
   --safe-tool-name search.docs \
   --safe-tool-arguments-json '{"query":"smoke"}' \
   --safe-resource-uri resource://docs/index \
@@ -149,7 +160,7 @@ Recommended CI pattern:
 
 ```bash
 mcp-unified-smoke http \
-  --url "$MCP_SMOKE_URL" \
+  --url "${MCP_SMOKE_URL:-http://127.0.0.1:8000/api/v1/mcp/request}" \
   --profile-id "$MCP_SMOKE_PROFILE" \
   --api-key-env MCP_SMOKE_API_KEY \
   --mode strict \

--- a/Docs/MCP/Unified/System_Admin_Guide.md
+++ b/Docs/MCP/Unified/System_Admin_Guide.md
@@ -16,6 +16,10 @@
 
 ## Deployment Overview
 
+> **Current state:** MCP Unified is operated as part of TLDW Server at
+> `/api/v1/mcp`. The package-local gateway boundary is internal/experimental;
+> this guide does not describe a separately shipped standalone gateway process.
+
 The MCP Unified module is a critical component of the TLDW server that provides:
 - Secure API access to media processing capabilities
 - WebSocket and HTTP endpoints for client connections
@@ -94,20 +98,19 @@ WantedBy=multi-user.target
 Create `/etc/tldw/config/mcp.env`:
 ```bash
 # CRITICAL SECURITY SETTINGS - MUST CHANGE IN PRODUCTION
+AUTH_MODE=multi_user
+SINGLE_USER_API_KEY=""  # single_user only; leave unset for multi_user
 MCP_JWT_SECRET="$(openssl rand -base64 32)"
 MCP_API_KEY_SALT="$(openssl rand -base64 32)"
 
-# Server Configuration
-MCP_HOST=0.0.0.0
-MCP_PORT=8000
-MCP_WORKERS=4
+# TLDW Server process binding is controlled by gunicorn/uvicorn and systemd.
 MCP_LOG_LEVEL=INFO
 MCP_LOG_FILE=/var/log/tldw/mcp/mcp.log
 
 # Database
 MCP_DATABASE_URL=postgresql+asyncpg://tldw:password@localhost/tldw_mcp
 MCP_DATABASE_POOL_SIZE=20
-MCP_DATABASE_MAX_OVERFLOW=40
+MCP_DATABASE_POOL_TIMEOUT=30
 
 # Redis (for distributed deployments)
 MCP_REDIS_URL=redis://localhost:6379/0
@@ -122,28 +125,28 @@ REDIS_URL=redis://localhost:6379/0
 
 # Security
 MCP_CORS_ORIGINS=["https://app.example.com"]
-MCP_TRUSTED_PROXIES=["127.0.0.1", "10.0.0.0/8"]
-MCP_MAX_REQUEST_SIZE=10485760  # 10MB
-MCP_REQUEST_TIMEOUT=30
+MCP_TRUST_X_FORWARDED=true
+MCP_TRUSTED_PROXY_IPS=["127.0.0.1", "10.0.0.0/8"]
+MCP_TRUSTED_PROXY_DEPTH=1
+MCP_HTTP_MAX_BODY_BYTES=10485760  # 10MB
 
 # Authentication
-MCP_AUTH_MODE=jwt  # jwt, api_key, or both
 MCP_JWT_ALGORITHM=HS256
-MCP_JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
-MCP_JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
-MCP_PASSWORD_MIN_LENGTH=12
-MCP_PASSWORD_REQUIRE_SPECIAL=true
+MCP_JWT_ACCESS_EXPIRE=30
+MCP_JWT_REFRESH_EXPIRE=7
+MCP_WS_AUTH_REQUIRED=true
+MCP_WS_ALLOW_QUERY_AUTH=false
 
 # Monitoring
 MCP_METRICS_ENABLED=true
 MCP_METRICS_PORT=9090
-MCP_HEALTH_CHECK_INTERVAL=30
-MCP_HEALTH_CHECK_TIMEOUT=5
+MCP_HEALTH_PATH=/api/v1/mcp/health
 
 # Module Configuration
-MCP_MODULES_ENABLED=["media", "rag", "chat", "admin"]
+MCP_MODULES_CONFIG=/etc/tldw/config/mcp_modules.yaml
 MCP_MODULE_TIMEOUT=60
 MCP_MODULE_MAX_RETRIES=3
+MCP_ENABLE_MEDIA_MODULE=true
 ```
 
 ### Nginx Configuration
@@ -382,7 +385,8 @@ sysctl -p /etc/sysctl.d/99-tldw.conf
 ```python
 # Configure in environment
 MCP_DATABASE_POOL_SIZE=20
-MCP_DATABASE_MAX_OVERFLOW=40
+MCP_DATABASE_POOL_TIMEOUT=30
+MCP_DATABASE_POOL_RECYCLE=1800
 MCP_REDIS_POOL_SIZE=10
 ```
 
@@ -529,7 +533,7 @@ curl http://localhost:8000/api/v1/mcp/metrics | grep database_pool
 
 # Increase pool size
 MCP_DATABASE_POOL_SIZE=50
-MCP_DATABASE_MAX_OVERFLOW=100
+MCP_DATABASE_POOL_TIMEOUT=45
 
 # Check PostgreSQL connections
 psql -U postgres -c "SELECT count(*) FROM pg_stat_activity WHERE datname='tldw_mcp';"

--- a/Docs/MCP/Unified/User_Guide.md
+++ b/Docs/MCP/Unified/User_Guide.md
@@ -19,6 +19,14 @@ MCP Unified is the TLDW server's production Model Context Protocol surface. It s
 
 Main base path: `http://127.0.0.1:8000/api/v1/mcp`
 
+## Which Path Should I Use?
+
+| Use case | Current path | Status |
+| --- | --- | --- |
+| Connect MCP clients to TLDW Server | `/api/v1/mcp/status`, `/api/v1/mcp/request`, `/api/v1/mcp/ws` | Supported embedded TLDW surface. Start TLDW Server with `uvicorn` and use these paths. |
+| Test a package-local mounted gateway | `/mcp/status`, `/mcp/request`, `/mcp/ws` | Package-local or host-mounted examples only. Another app must mount `apps/mcp-unified`; the package CLI does not launch a server. |
+| Run a separate standalone gateway process | None | Standalone gateway is planned but not shipped. Do not look for a `serve` command in this release. |
+
 ## 2. Golden Path Quickstart
 
 ### Prerequisites

--- a/Docs/MCP/Unified/User_Guide.md
+++ b/Docs/MCP/Unified/User_Guide.md
@@ -322,6 +322,20 @@ modules:
 
 Replace `<content-db>.db` with your configured per-user content DB filename.
 
+### Safer local module defaults
+
+Default installs no longer expose local filesystem or local command execution
+tools. They appear in `/api/v1/mcp/status` under
+`surface.disabled_available` with `requires_explicit_opt_in: true` until an
+operator enables them.
+
+To restore a previous local workflow intentionally:
+
+1. Copy the relevant entries from `tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml`.
+2. Set only the needed modules to `enabled: true` in the selected `mcp_modules.yaml`.
+3. Restart TLDW Server.
+4. Recheck `/api/v1/mcp/status`; the module should move from `surface.disabled_available` to `surface.tiers`.
+
 ### Environment variable registration (quick dev path)
 
 ```bash
@@ -533,6 +547,7 @@ There is no built-in autonomous multi-stage agent loop. The safe pattern is expl
 | Module degraded or unhealthy | `/api/v1/mcp/status` `problem_modules` | Follow `next_action`, check module config/dependencies, then restart or disable the module. |
 | Invalid safe config | HTTP 400 with `detail.code=invalid_safe_config` | Remove `config` or send base64url-encoded JSON object data only. |
 | Empty tool list | `/status` `modules`, `problem_modules`, `config_warnings`, and `/tool_catalogs` | Confirm modules are enabled, the catalog filter resolves, and the caller has discovery/execute permissions. |
+| Local file or command tool missing | `/api/v1/mcp/status` `surface.disabled_available` | Enable the module explicitly in YAML only if this deployment should expose local file/process access, then restart. |
 
 ### `503 Server not initialized` on `/health`
 

--- a/Docs/MCP/Unified/User_Guide.md
+++ b/Docs/MCP/Unified/User_Guide.md
@@ -215,6 +215,12 @@ curl -X POST http://127.0.0.1:8000/api/v1/mcp/request \
 - `GET /api/v1/mcp/prompts`
 
 The convenience endpoints map to MCP operations and keep the same RBAC behavior.
+When a failure has a known recovery path, JSON-RPC responses include
+`error.data.reason_code` and `error.data.next_action`. Convenience HTTP
+endpoints preserve their existing response body shape: object-shaped `detail`
+may include `reason_code` and `next_action`, while string-shaped `detail`
+exposes the same metadata in `X-MCP-Reason-Code` and `X-MCP-Next-Action`
+headers.
 
 ### Sessions and safe config
 

--- a/Docs/MCP/Unified/Using_Modules_YAML.md
+++ b/Docs/MCP/Unified/Using_Modules_YAML.md
@@ -34,6 +34,7 @@ Rules
   - The server logs and ignores entries outside this namespace.
 - If `modules:` is empty and `MCP_ENABLE_MEDIA_MODULE=1`, MediaModule is auto-enabled with defaults.
 - Enabled modules appear in the `/api/v1/mcp/status` `surface` summary, grouped by risk tier.
+- Disabled high-risk modules appear in `surface.disabled_available` with `requires_explicit_opt_in: true` and a `next_action`.
 
 Capability Risk Tiers
 - `read_only`: Reads/searches existing TLDW data, such as `media`, `knowledge`, `chats`, `prompts`, and `mcp_discovery`.
@@ -44,6 +45,34 @@ Capability Risk Tiers
 - `unknown`: Custom modules that have not been classified yet.
 
 Before enabling a high-risk tier, verify the relevant module settings, RBAC permissions, and runtime policy. The tier explains capability shape; it does not grant execution permission.
+
+Safer Default Migration
+- Local filesystem and local command execution modules are disabled by default.
+- Existing explicit YAML entries with `enabled: true` still opt in and continue to load.
+- Missing-YAML fallback only registers `filesystem` when `MCP_ENABLE_FILESYSTEM_MODULE=true`.
+- To restore previous local behavior, copy the relevant entries from `tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml`, set only the modules this deployment needs to `enabled: true`, restart TLDW Server, and recheck `/api/v1/mcp/status`.
+
+Opt-in example:
+
+```yaml
+modules:
+  - id: filesystem
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module:FilesystemModule
+    enabled: true
+    name: Filesystem
+    version: "1.0.0"
+    department: system
+    settings: {}
+
+  - id: run_command
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.run_command_module:RunCommandModule
+    enabled: true
+    name: Run Command
+    version: "0.1.0"
+    department: system
+    settings:
+      spill_dir: ${MCP_RUN_COMMAND_SPILL_DIR:-.mcp/spills}
+```
 
 Runtime Controls
 - `max_concurrent`: Limits concurrent calls per module (0 disables guard).

--- a/Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
@@ -1,0 +1,1080 @@
+# MCP Unified Residual UX Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the residual Unified MCP UX, trust, defaults, and recovery gaps identified after TASK-2393 without expanding the standalone gateway scope.
+**Architecture:** Apply contract-backed changes across documentation, module defaults, status metadata, HTTP/JSON-RPC recovery metadata, WebSocket auth copy, and package-gateway readiness status. The supported product remains embedded TLDW MCP at `/api/v1/mcp`; `apps/mcp-unified` remains an internal/experimental package boundary.
+**Tech Stack:** Python 3.10+, FastAPI, Pydantic, pytest, PyYAML, Backlog.md, Bandit.
+
+---
+
+## Context
+
+Design spec:
+`Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md`
+
+Tracking task:
+`TASK-12054`
+
+Related completed remediation:
+`TASK-2393`
+
+This plan intentionally does not add `mcp-unified-gateway serve`, package publishing, or a supported standalone gateway promise. The work is residual hardening around the already-supported embedded MCP surface and the internal package gateway boundary.
+
+## File Map
+
+Runtime and API files:
+
+- `tldw_Server_API/app/core/MCP_unified/server.py`
+  - Loads configured modules from `MCP_MODULES_CONFIG`, `MCP_MODULES`, and optional env flags.
+  - Currently auto-enables `filesystem` by default when absent from YAML.
+  - Builds `/api/v1/mcp/status` using module health only.
+- `tldw_Server_API/app/core/MCP_unified/module_surface.py`
+  - Groups enabled modules by user-facing risk tier.
+  - Does not yet expose disabled-but-available high-risk modules.
+- `tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py`
+  - HTTP helper endpoints, WebSocket endpoint docs, and HTTP error mapping.
+  - Currently mixes string `detail` bodies and object `detail` bodies.
+- `tldw_Server_API/app/core/MCP_unified/protocol.py`
+  - JSON-RPC error shape and `error.data` hint enrichment.
+- `apps/mcp-unified/src/mcp_unified/gateway/fastapi.py`
+  - Package-local FastAPI gateway router and `/status`.
+- `apps/mcp-unified/src/mcp_unified/package_metadata.py`
+  - Static package status and publishing metadata.
+
+Configuration and docs:
+
+- `tldw_Server_API/Config_Files/mcp_modules.yaml`
+  - Default module config. `filesystem` and `run_command` are currently enabled.
+- `Docs/MCP/Unified/README.md`
+- `Docs/MCP/Unified/User_Guide.md`
+- `Docs/MCP/Unified/System_Admin_Guide.md`
+- `Docs/MCP/Unified/Client_Snippets.md`
+- `Docs/MCP/Unified/Smoke_Client.md`
+- `Docs/MCP/Unified/Modules.md`
+- `Docs/MCP/Unified/Using_Modules_YAML.md`
+- `tldw_Server_API/app/core/MCP_unified/docker/Dockerfile`
+- `tldw_Server_API/app/core/MCP_unified/docker/README.md`
+- `apps/mcp-unified/README.md`
+- `apps/mcp-unified/USER_GUIDE.md`
+- `apps/mcp-unified/src/mcp_unified/README.md`
+
+Tests to extend:
+
+- `tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+- `tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py`
+
+## Guardrails
+
+- Before making implementation edits, confirm there is an implementation Backlog task distinct from this planning task. This planning task is `TASK-12054`; execution should create or reuse a separate implementation task unless the user explicitly scopes the next step to planning only.
+- Preserve JSON-RPC outer error shape: `{"jsonrpc":"2.0","error":{...},"id":...}`.
+- Add JSON-RPC recovery fields only under `error.data`; do not rename `message`, `code`, or `id`.
+- Preserve HTTP helper endpoint body compatibility:
+  - If an endpoint currently returns string `detail`, keep string `detail` and add additive recovery headers.
+  - If an endpoint already returns object `detail`, extend that object with `reason_code` and `next_action`.
+- Keep query-string WebSocket auth documented as legacy and disabled by default. Do not present `?token=` or `?api_key=` as the normal path.
+- Disable high-risk local file/process defaults, but keep explicit operator opt-ins honored:
+  - `enabled: true` in the selected modules YAML still loads that module.
+  - Explicit env flags such as `MCP_ENABLE_FILESYSTEM_MODULE=true` still load fallback modules when no YAML entry is present.
+- Do not introduce new dependencies.
+- Use `source .venv/bin/activate` before Python, pytest, or Bandit commands.
+- Commit after each coherent working stage. Do not commit unrelated dirty worktree files.
+
+---
+
+## Stage 0: Backlog Execution Setup
+
+**Goal:** Satisfy repository task-tracking requirements before any implementation file edits.
+
+**Success Criteria:**
+
+- The implementation worker has read the Backlog workflow instructions through MCP or CLI fallback.
+- A Backlog task exists for implementation work, separate from planning task `TASK-12054`.
+- The implementation task links this plan and the design spec.
+- The task is marked `In Progress` before code/docs/config edits begin.
+
+**Steps:**
+
+- [ ] Read the Backlog workflow overview using the installed MCP server, for example:
+
+```text
+backlog://workflow/overview
+```
+
+If MCP resources are unavailable, use the official fallback:
+
+```bash
+backlog task list --plain
+```
+
+- [ ] Search for an existing implementation task to avoid duplicates:
+
+```bash
+backlog search "MCP Unified residual UX hardening" --plain
+```
+
+- [ ] If no implementation task exists, create one with labels `mcp`, `ux`, `security`, `docs`, and references to:
+  - `TASK-12054`
+  - `TASK-2372`
+  - `Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md`
+  - `Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md`
+- [ ] Mark the implementation task `In Progress`.
+- [ ] Add an implementation note that Stage 0 is complete and record the task id in the first implementation commit message.
+
+**Verification:**
+
+```bash
+backlog task <IMPLEMENTATION_TASK_ID> --plain
+```
+
+**Commit:**
+
+Do not commit Stage 0 alone unless it creates/edits a Backlog task file. If it does, include that task file in the first implementation commit.
+
+---
+
+## Stage 1: Documentation Contract Tests And Copy Cleanup
+
+**Goal:** Make the docs consistently explain the supported embedded surface, internal package boundary, legacy query auth, and exact first-run paths.
+
+**Success Criteria:**
+
+- Docs consistently direct users to `/api/v1/mcp/status` and `/api/v1/mcp/request` for TLDW Server.
+- Package-local `/mcp/status` and `/mcp/request` are labeled as package/host-mounted examples only.
+- Primary docs include a "Which path should I use?" table that separates embedded TLDW paths, package-local mounted paths, and future standalone gateway status.
+- No quickstart instructs `python -m pip install -e "mcp_unified[gateway]"`.
+- No normal WebSocket example uses `?token=jwt-token`.
+- Package README/User Guide do not promise `serve`, publishing, or supported standalone operation.
+- Admin guide no longer documents stale `MCP_*` variables as active config.
+
+**Tests First:**
+
+- [ ] Extend `tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py`.
+
+Add tests equivalent to:
+
+```python
+def test_unified_mcp_docs_use_supported_embedded_paths_for_smoke_and_snippets() -> None:
+    docs = "\n\n".join([
+        _read("Docs/MCP/Unified/Client_Snippets.md"),
+        _read("Docs/MCP/Unified/Smoke_Client.md"),
+        _read("Docs/MCP/Unified/User_Guide.md"),
+    ])
+    _require("/api/v1/mcp/status" in docs, "Docs should show embedded status path.")
+    _require("/api/v1/mcp/request" in docs, "Docs should show embedded request path.")
+    _require('mcp_unified[gateway]' not in docs, "Docs should not install a non-root package path.")
+```
+
+```python
+def test_unified_mcp_docs_label_every_package_local_request_example() -> None:
+    smoke = _read("Docs/MCP/Unified/Smoke_Client.md")
+    for line_no, line in enumerate(smoke.splitlines(), start=1):
+        if "http://127.0.0.1:8000/mcp/request" not in line:
+            continue
+        window = "\n".join(smoke.splitlines()[max(0, line_no - 5): line_no + 4]).lower()
+        _require(
+            "package-local" in window or "host-mounted" in window,
+            f"Unlabeled package-local /mcp/request example near Smoke_Client.md:{line_no}",
+        )
+```
+
+```python
+def test_unified_mcp_docs_have_path_decision_table() -> None:
+    docs = "\n\n".join([
+        _read("Docs/MCP/Unified/README.md"),
+        _read("Docs/MCP/Unified/User_Guide.md"),
+    ]).lower()
+    for snippet in (
+        "which path should i use",
+        "/api/v1/mcp/status",
+        "/api/v1/mcp/request",
+        "/mcp/status",
+        "package-local",
+        "standalone gateway",
+        "planned but not shipped",
+    ):
+        _require(snippet in docs, f"Path decision docs should mention {snippet}.")
+```
+
+```python
+def test_unified_mcp_docs_do_not_normalize_query_token_auth() -> None:
+    docs = "\n\n".join([
+        _read("Docs/MCP/Unified/User_Guide.md"),
+        _read("Docs/MCP/Unified/Client_Snippets.md"),
+        _read("Docs/MCP/Unified/Smoke_Client.md"),
+    ]).lower()
+    _require("?token=jwt-token" not in docs, "Docs should not show query token auth as a normal example.")
+    _require("disabled by default" in docs and "query auth" in docs, "Docs should frame query auth as legacy/disabled.")
+```
+
+```python
+def test_unified_mcp_package_docs_do_not_promise_serve_or_publishing() -> None:
+    docs = "\n\n".join([
+        _read("apps/mcp-unified/README.md"),
+        _read("apps/mcp-unified/USER_GUIDE.md"),
+        _read("apps/mcp-unified/src/mcp_unified/README.md"),
+    ]).lower()
+    forbidden = [
+        "mcp-unified-gateway serve",
+        "pip install mcp-unified",
+        "published to pypi",
+        "production standalone gateway",
+    ]
+    found = [phrase for phrase in forbidden if phrase in docs]
+    _require(not found, f"Package docs imply unsupported standalone/published flows: {found}")
+    _require("not published" in docs, "Package docs should state the package is not published.")
+    _require("internal" in docs and "experimental" in docs, "Package docs should state internal/experimental status.")
+```
+
+```python
+def test_unified_mcp_docs_reference_existing_local_targets() -> None:
+    import re
+
+    docs_to_check = [
+        "Docs/MCP/Unified/README.md",
+        "Docs/MCP/Unified/User_Guide.md",
+        "Docs/MCP/Unified/Smoke_Client.md",
+        "Docs/MCP/Unified/Client_Snippets.md",
+        "apps/mcp-unified/README.md",
+        "apps/mcp-unified/USER_GUIDE.md",
+    ]
+    missing: list[str] = []
+    for doc_path in docs_to_check:
+        text = _read(doc_path)
+        for target in re.findall(r"\]\(([^)#][^)]+)\)", text):
+            if "://" in target or target.startswith("#") or target.startswith("mailto:"):
+                continue
+            normalized = target.split("#", 1)[0]
+            if not normalized:
+                continue
+            candidate = Path(doc_path).parent / normalized
+            if not candidate.exists():
+                missing.append(f"{doc_path} -> {target}")
+    _require(not missing, "Docs reference missing local targets: " + ", ".join(missing))
+```
+
+```python
+def test_unified_mcp_admin_env_docs_do_not_include_known_stale_mcp_vars() -> None:
+    guide = _read("Docs/MCP/Unified/System_Admin_Guide.md")
+    stale = {
+        "MCP_HOST",
+        "MCP_PORT",
+        "MCP_AUTH_MODE",
+        "MCP_MODULES_ENABLED",
+        "MCP_DATABASE_MAX_OVERFLOW",
+        "MCP_TRUSTED_PROXIES",
+        "MCP_MAX_REQUEST_SIZE",
+        "MCP_REQUEST_TIMEOUT",
+    }
+    found = {name for name in stale if name in guide}
+    _require(not found, f"System admin guide documents stale MCP env vars: {sorted(found)}")
+```
+
+Optional stronger contract after the known stale vars are removed:
+
+```python
+def test_unified_mcp_admin_env_docs_match_config_aliases_for_core_mcp_vars() -> None:
+    import re
+    from tldw_Server_API.app.core.MCP_unified.config import MCPConfig
+
+    aliases = {
+        str(field.validation_alias)
+        for field in MCPConfig.model_fields.values()
+        if str(field.validation_alias).startswith("MCP_")
+    }
+    documented = set(re.findall(r"\bMCP_[A-Z0-9_]+\b", _read("Docs/MCP/Unified/System_Admin_Guide.md")))
+    allowed_module_or_runtime_vars = {
+        "MCP_MODULES",
+        "MCP_MODULES_CONFIG",
+        "MCP_EXTERNAL_SERVERS_CONFIG",
+        "MCP_ENABLE_FILESYSTEM_MODULE",
+        "MCP_ENABLE_GIT_MODULE",
+        "MCP_ENABLE_SANDBOX_MODULE",
+        "MCP_ENABLE_BROWSER_CDP_MODULE",
+        "MCP_BROWSER_CDP_URL",
+        "MCP_ENABLE_WEB_FETCH_MODULE",
+        "MCP_ENABLE_WEB_SEARCH_MODULE",
+        "MCP_ENABLE_WEB_RESEARCH_MODULE",
+        "MCP_RUN_COMMAND_SPILL_DIR",
+    }
+    stale = documented - aliases - allowed_module_or_runtime_vars
+    _require(not stale, f"Unexpected documented MCP vars: {sorted(stale)}")
+```
+
+Run red:
+
+```bash
+source .venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
+```
+
+Expected initial failures:
+
+- `Smoke_Client.md` still references `mcp_unified[gateway]`.
+- `Smoke_Client.md` still uses `/mcp/request` without sufficient package-local framing.
+- `System_Admin_Guide.md` still lists stale `MCP_*` variables.
+
+**Implementation:**
+
+- [ ] Update `Docs/MCP/Unified/Smoke_Client.md`.
+  - Use `python -m pip install -e "apps/mcp-unified[gateway]"` only if referring to editable package tests.
+  - Prefer embedded TLDW examples:
+    - `GET http://127.0.0.1:8000/api/v1/mcp/status`
+    - `POST http://127.0.0.1:8000/api/v1/mcp/request`
+  - Label `/mcp/request` as package-local/host-mounted only.
+- [ ] Update `Docs/MCP/Unified/Client_Snippets.md`.
+  - Add a status preflight against `/api/v1/mcp/status`.
+  - Keep auth examples header-based.
+- [ ] Update `Docs/MCP/Unified/User_Guide.md`.
+  - Ensure query auth is explicitly "legacy, disabled by default".
+  - Ensure the golden path shows status, initialize, tools/list, and tools/call with expected response markers.
+- [ ] Add or tighten a "Which path should I use?" section in `Docs/MCP/Unified/README.md` or `Docs/MCP/Unified/User_Guide.md`.
+  - Embedded TLDW Server: `/api/v1/mcp/status`, `/api/v1/mcp/request`, `/api/v1/mcp/ws`.
+  - Package-local mounted gateway: `/mcp/status`, `/mcp/request`, only when an embedding app mounts `apps/mcp-unified`.
+  - Standalone gateway process: planned but not shipped; no `serve` command.
+- [ ] Update `Docs/MCP/Unified/System_Admin_Guide.md`.
+  - Remove stale config block entries that are not `MCPConfig` aliases or explicitly supported module/runtime vars.
+  - Replace with current AuthNZ plus MCP env examples: `AUTH_MODE`, `SINGLE_USER_API_KEY`, `MCP_JWT_SECRET`, `MCP_API_KEY_SALT`, `MCP_DATABASE_URL`, `MCP_RATE_LIMIT_*`, `MCP_WS_*`, `MCP_HTTP_MAX_BODY_BYTES`, CORS/security-header vars, and module opt-in vars.
+- [ ] Update package docs if needed:
+  - `apps/mcp-unified/README.md`
+  - `apps/mcp-unified/USER_GUIDE.md`
+  - `apps/mcp-unified/src/mcp_unified/README.md`
+  - Keep package docs clear that CLI commands are management utilities, not a server launcher.
+
+**Verification:**
+
+```bash
+source .venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
+```
+
+**Commit:**
+
+```bash
+git add Docs/MCP/Unified apps/mcp-unified tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
+git commit -m "docs: clarify mcp embedded and package paths"
+```
+
+---
+
+## Stage 2: Safer Module Defaults And Status Disclosure
+
+**Goal:** Disable high-risk local file/process modules by default and make `/api/v1/mcp/status` explain which high-risk modules are available but require explicit opt-in.
+
+**Success Criteria:**
+
+- `filesystem` and `run_command` are disabled in the default `mcp_modules.yaml`.
+- Missing-YAML fallback no longer auto-enables `filesystem` by default.
+- Explicit YAML `enabled: true` and explicit `MCP_ENABLE_FILESYSTEM_MODULE=true` still opt in.
+- `/api/v1/mcp/status` includes enabled risk tiers and a disabled-available list for high-risk modules.
+- Users see a next action for enabling disabled high-risk modules.
+- A migration note and explicit opt-in YAML example explain how existing operators can restore previous local file/process module behavior.
+
+**Tests First:**
+
+- [ ] Extend `tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py`.
+
+Add or adapt:
+
+```python
+def test_describe_module_surface_reports_disabled_available_high_risk_modules():
+    from tldw_Server_API.app.core.MCP_unified.module_surface import describe_module_surface
+
+    surface = describe_module_surface({
+        "media": {"enabled": True, "status": "healthy"},
+        "filesystem": {"enabled": False, "status": "disabled"},
+        "run_command": {"enabled": False, "status": "disabled"},
+        "external_federation": {"enabled": False, "status": "disabled"},
+    })
+
+    assert surface["enabled_count"] == 1
+    assert [m["id"] for m in surface["tiers"]["read_only"]["modules"]] == ["media"]
+    disabled_ids = [m["id"] for m in surface["disabled_available"]]
+    assert disabled_ids == ["external_federation", "filesystem", "run_command"]
+    assert all(m["requires_explicit_opt_in"] is True for m in surface["disabled_available"])
+```
+
+```python
+def test_default_mcp_modules_yaml_disables_local_file_and_process_modules():
+    import yaml
+    from pathlib import Path
+
+    data = yaml.safe_load(Path("tldw_Server_API/Config_Files/mcp_modules.yaml").read_text())
+    modules = {entry["id"]: entry for entry in data["modules"]}
+
+    assert modules["filesystem"]["enabled"] is False
+    assert modules["run_command"]["enabled"] is False
+    assert modules["codegraph"]["enabled"] is False
+```
+
+```python
+async def test_filesystem_fallback_requires_explicit_opt_in(monkeypatch, tmp_path):
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    missing_config = tmp_path / "missing-mcp-modules.yaml"
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(missing_config))
+    monkeypatch.setenv("MCP_MODULES", "")
+    monkeypatch.delenv("MCP_ENABLE_FILESYSTEM_MODULE", raising=False)
+
+    registered = []
+    server = MCPServer()
+
+    async def _register_module(module_id, cls, config):
+        registered.append(module_id)
+
+    monkeypatch.setattr(server.module_registry, "register_module", _register_module)
+
+    await server._register_default_modules()
+
+    assert "filesystem" not in registered
+```
+
+```python
+async def test_filesystem_fallback_registers_with_explicit_env_opt_in(monkeypatch, tmp_path):
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    missing_config = tmp_path / "missing-mcp-modules.yaml"
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(missing_config))
+    monkeypatch.setenv("MCP_MODULES", "")
+    monkeypatch.setenv("MCP_ENABLE_FILESYSTEM_MODULE", "true")
+
+    registered = []
+    server = MCPServer()
+
+    async def _register_module(module_id, cls, config):
+        registered.append(module_id)
+
+    monkeypatch.setattr(server.module_registry, "register_module", _register_module)
+
+    await server._register_default_modules()
+
+    assert "filesystem" in registered
+```
+
+```python
+async def test_explicit_yaml_enabled_high_risk_modules_still_register(monkeypatch, tmp_path):
+    import textwrap
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    config_path = tmp_path / "mcp_modules.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            modules:
+              - id: filesystem
+                class: tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module:FilesystemModule
+                enabled: true
+                name: Filesystem
+                version: "1.0.0"
+                department: system
+                settings: {}
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(config_path))
+    monkeypatch.setenv("MCP_MODULES", "")
+    monkeypatch.delenv("MCP_ENABLE_FILESYSTEM_MODULE", raising=False)
+
+    registered = []
+    server = MCPServer()
+
+    async def _register_module(module_id, cls, config):
+        registered.append(module_id)
+
+    monkeypatch.setattr(server.module_registry, "register_module", _register_module)
+
+    await server._register_default_modules()
+
+    assert "filesystem" in registered
+```
+
+```python
+async def test_server_status_includes_disabled_available_from_config(monkeypatch):
+    from tldw_Server_API.app.core.MCP_unified.modules.base import HealthStatus, ModuleHealth
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    server = MCPServer()
+    server.initialized = True
+    server._configured_modules_for_status = {
+        "media": {"enabled": True},
+        "filesystem": {"enabled": False},
+        "run_command": {"enabled": False},
+    }
+
+    async def _check_all_health():
+        return {"media": ModuleHealth(status=HealthStatus.HEALTHY)}
+
+    monkeypatch.setattr(server.module_registry, "check_all_health", _check_all_health)
+
+    status = await server.get_status()
+
+    assert status["surface"]["enabled_count"] == 1
+    assert [m["id"] for m in status["surface"]["disabled_available"]] == ["filesystem", "run_command"]
+```
+
+Run red:
+
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  -k "module_surface or default_mcp_modules_yaml or filesystem_fallback or explicit_yaml_enabled_high_risk or server_status_includes"
+```
+
+Expected initial failures:
+
+- `filesystem` and `run_command` are enabled in YAML.
+- `server.py` auto-enables `filesystem` when absent from YAML.
+- `describe_module_surface()` omits disabled modules.
+- `server.get_status()` has no configured disabled module memory.
+
+**Implementation:**
+
+- [ ] Update `tldw_Server_API/app/core/MCP_unified/module_surface.py`.
+  - Add a constant such as:
+    - `EXPLICIT_OPT_IN_TIERS = {"local_files", "local_process", "external_network"}`
+  - Keep existing `enabled_count` and `tiers` behavior for compatibility.
+  - Add:
+    - `disabled_available_count`
+    - `disabled_available`
+  - Each disabled entry should include:
+    - `id`
+    - `tier`
+    - `label`
+    - `description`
+    - `requires_explicit_opt_in: True`
+    - `next_action`
+  - Keep deterministic sorted ordering by module id.
+- [ ] Update `tldw_Server_API/app/core/MCP_unified/server.py`.
+  - Add an instance field, for example `self._configured_modules_for_status: dict[str, dict[str, Any]] = {}`.
+  - Populate it during `_register_default_modules()` from all YAML/env/fallback candidates before skipping disabled modules.
+  - Store only sanitized status fields: `enabled`, `status`, `name`, `department`.
+  - Change filesystem fallback from default-on to explicit opt-in:
+    - Use `self._env_flag_enabled("MCP_ENABLE_FILESYSTEM_MODULE")` instead of `os.getenv(..., "true")`.
+  - In `get_status()`, merge health results into the configured module map before calling `describe_module_surface()`.
+- [ ] Update `tldw_Server_API/Config_Files/mcp_modules.yaml`.
+  - Set `filesystem.enabled: false`.
+  - Set `run_command.enabled: false`.
+  - Add short comments explaining explicit opt-in and status verification.
+- [ ] Add an operator opt-in example for previous local module behavior.
+  - Prefer `tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml` or a clearly titled section in `Docs/MCP/Unified/Using_Modules_YAML.md`.
+  - Include `filesystem.enabled: true` and `run_command.enabled: true` examples with risk notes.
+- [ ] Update module docs:
+  - `Docs/MCP/Unified/Modules.md`
+  - `Docs/MCP/Unified/Using_Modules_YAML.md`
+  - `Docs/MCP/Unified/User_Guide.md`
+  - Mention `surface.disabled_available`, `requires_explicit_opt_in`, and the restart requirement.
+  - Add a migration note: after this change, default installs no longer expose local file/process modules unless explicitly enabled.
+
+**Verification:**
+
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  -k "module_surface or default_mcp_modules_yaml or filesystem_fallback or explicit_yaml_enabled_high_risk or server_status_includes"
+```
+
+**Commit:**
+
+```bash
+git add \
+  tldw_Server_API/app/core/MCP_unified/module_surface.py \
+  tldw_Server_API/app/core/MCP_unified/server.py \
+  tldw_Server_API/Config_Files/mcp_modules.yaml \
+  tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  Docs/MCP/Unified/Modules.md \
+  Docs/MCP/Unified/Using_Modules_YAML.md \
+  Docs/MCP/Unified/User_Guide.md
+git commit -m "feat: make risky mcp modules explicit opt in"
+```
+
+---
+
+## Stage 3: HTTP And JSON-RPC Recovery Metadata
+
+**Goal:** Make common failures actionable without breaking existing HTTP helper or JSON-RPC clients.
+
+**Success Criteria:**
+
+- HTTP string `detail` responses remain strings.
+- HTTP string-detail recovery metadata is exposed via additive headers.
+- HTTP object `detail` responses include `reason_code` and `next_action`.
+- JSON-RPC known invalid-params and authorization failures include recovery metadata under `error.data`.
+- `/api/v1/mcp/modules` permission copy mentions modules, not tools.
+- WebSocket endpoint copy does not normalize query auth.
+
+**Tests First:**
+
+- [ ] Extend `tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py`.
+
+Add tests equivalent to:
+
+```python
+def test_tools_execute_unauth_preserves_string_detail_and_adds_recovery_headers(client: TestClient):
+    response = client.post(
+        "/api/v1/mcp/tools/execute",
+        json={"tool_name": "media.search", "arguments": {}},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authentication required"
+    assert response.headers["x-mcp-reason-code"] == "authentication_required"
+    assert response.headers["x-mcp-next-action"]
+```
+
+```python
+def test_modules_permission_detail_mentions_modules_and_recovery(client: TestClient):
+    response = client.get("/api/v1/mcp/modules")
+
+    assert response.status_code == 403
+    detail = response.json()["detail"]
+    assert detail["reason_code"] == "permission_denied"
+    assert detail["next_action"]
+    assert "modules" in detail["hint"].lower()
+    assert "tools" not in detail["hint"].lower()
+```
+
+```python
+def test_invalid_safe_config_keeps_structured_recovery_detail(client: TestClient):
+    response = client.post(
+        "/api/v1/mcp/request",
+        json={"jsonrpc": "2.0", "method": "initialize", "params": {}, "id": 1},
+        params={"config": "not-base64-json"},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "invalid_safe_config"
+    assert detail["next_action"]
+```
+
+Add a focused JSON-RPC test in the same file or in a protocol test file:
+
+```python
+async def test_jsonrpc_invalid_params_error_data_includes_recovery_metadata():
+    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, MCPRequest
+    from tldw_Server_API.app.core.MCP_unified.protocol_types import RequestContext
+
+    protocol = MCPProtocol()
+    response = await protocol.process_request(
+        MCPRequest(method="tools/call", params={}, id=1),
+        RequestContext(request_id="invalid-params-test", client_id="pytest", user_id="1"),
+    )
+
+    assert response.error is not None
+    assert response.error.code == -32602
+    assert response.error.data["reason_code"] == "invalid_params"
+    assert response.error.data["next_action"]
+```
+
+Add a WebSocket copy/signature test. Do not assert on OpenAPI for this route; FastAPI WebSocket routes are not reliably emitted as HTTP OpenAPI paths.
+
+```python
+def test_websocket_query_auth_is_marked_legacy_in_endpoint_copy():
+    import inspect
+    from tldw_Server_API.app.api.v1.endpoints import mcp_unified_endpoint as endpoint
+
+    signature = inspect.signature(endpoint.websocket_endpoint)
+    token_description = signature.parameters["token"].default.description.lower()
+    api_key_description = signature.parameters["api_key"].default.description.lower()
+    docstring = inspect.getdoc(endpoint.websocket_endpoint).lower()
+
+    assert "legacy" in token_description
+    assert "disabled by default" in token_description
+    assert "legacy" in api_key_description
+    assert "disabled by default" in api_key_description
+    assert "?token=jwt-token" not in docstring
+```
+
+Run red:
+
+```bash
+source .venv/bin/activate
+python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
+```
+
+Expected initial failures:
+
+- String-detail HTTP errors have no recovery headers.
+- `/modules` permission hint says "listing tools".
+- JSON-RPC invalid params only adds a hint, not `reason_code` and `next_action`.
+- WebSocket token query parameter is described as normal auth.
+
+**Implementation:**
+
+- [ ] Update `tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py`.
+  - Add helpers:
+    - `_mcp_recovery_headers(reason_code: str, next_action: str) -> dict[str, str]`
+    - `_mcp_permission_detail(response: MCPResponse, *, hint: str, reason_code: str = "permission_denied", next_action: str) -> dict[str, str] | None`
+    - Optional `_raise_string_detail_error(...)` wrapper to avoid repeated header boilerplate.
+  - For existing string-body errors, keep the same string `detail` and add headers:
+    - `401 Authentication required` -> `x-mcp-reason-code: authentication_required`
+    - `400 invalid params` -> `x-mcp-reason-code: invalid_params`
+    - `502 no response` -> `x-mcp-reason-code: upstream_no_response`
+    - `500 generic MCP tool execution failed` -> `x-mcp-reason-code: mcp_tool_execution_failed`
+  - For existing object-body permission errors, add `reason_code` and `next_action`.
+  - Fix `/modules` hint from "listing tools" to "listing modules".
+  - Update WebSocket `token` and `api_key` `Query(...)` descriptions to say legacy query auth is disabled by default and headers/subprotocol auth is preferred.
+  - Update the WebSocket docstring example to omit `?token=jwt-token`.
+- [ ] Update `tldw_Server_API/app/core/MCP_unified/protocol.py`.
+  - Preserve existing `_attach_error_hint()` behavior.
+  - When `data is None` and the code/message match a known recoverable case, return:
+    - `reason_code`
+    - `next_action`
+    - existing `hint`, when applicable
+  - Do not overwrite existing governance or approval `error.data`.
+- [ ] Update troubleshooting docs if needed:
+  - `Docs/MCP/Unified/User_Guide.md`
+  - `Docs/MCP/Unified/Developer_Guide.md`
+  - Document that HTTP helper endpoints may expose recovery metadata in `detail` or `x-mcp-*` headers depending on backward-compatible body shape.
+
+**Verification:**
+
+```bash
+source .venv/bin/activate
+python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
+```
+
+**Commit:**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py \
+  tldw_Server_API/app/core/MCP_unified/protocol.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py \
+  Docs/MCP/Unified/User_Guide.md \
+  Docs/MCP/Unified/Developer_Guide.md
+git commit -m "feat: add mcp recovery metadata without breaking responses"
+```
+
+---
+
+## Stage 4: Package Gateway Readiness Status
+
+**Goal:** Make package-local `/status` useful for power users and embedders without implying the package is published or a supported standalone server.
+
+**Success Criteria:**
+
+- `GET /mcp/status` still returns `status`, `name`, and `version`.
+- Response adds static package boundary metadata:
+  - `package_status: internal-experimental`
+  - `publishing_status: not-published`
+  - `source_distribution: tldw-server`
+- Response exposes best-effort readiness:
+  - profile store kind/persistence
+  - external registry store kind/persistence when mounted
+  - default profile status when available
+  - admin auth enabled/configured state
+  - external server counts when a registry manager is mounted
+  - warning/next action list
+- No secrets, env var values, API keys, commands, or credential material are returned.
+
+**Tests First:**
+
+- [ ] Extend `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`.
+
+Add tests near existing gateway route/status tests:
+
+```python
+def test_gateway_status_includes_package_boundary_metadata() -> None:
+    app = create_gateway_app(_FakeGatewayRuntime())
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["name"] == "unit-gateway"
+    assert payload["version"] == "0.0-test"
+    assert payload["package"]["package_status"] == "internal-experimental"
+    assert payload["package"]["publishing_status"] == "not-published"
+    assert payload["package"]["source_distribution"] == "tldw-server"
+    assert "next_actions" in payload
+```
+
+```python
+def test_gateway_status_reports_profile_store_admin_auth_and_default_profile() -> None:
+    manager = _ProfileManagementManagerDouble("default")
+    # If the status implementation reads manager.store_metadata directly, add the same
+    # lightweight shape used by the real manager instead of changing unrelated doubles.
+    manager.store_metadata = type(
+        "_StoreMetadata",
+        (),
+        {"to_payload": lambda self: {"kind": "memory", "persistent": False}},
+    )()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        profile_manager=manager,
+        enable_profile_management=True,
+        admin_auth=GatewayAdminAuthConfig(enabled=True, api_key="unit-test-key"),
+    )
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    payload = response.json()
+    assert payload["profile_store"]["kind"] in {"memory", "sqlite"}
+    assert payload["default_profile"]["configured"] is True
+    assert payload["admin_auth"]["enabled"] is True
+    assert payload["admin_auth"]["configured"] is True
+    assert "unit-test-key" not in json.dumps(payload)
+```
+
+```python
+def test_gateway_status_counts_external_servers_best_effort() -> None:
+    manager = _ExternalRegistryManagerDouble("enabled")
+    manager.store_metadata = type(
+        "_StoreMetadata",
+        (),
+        {"to_payload": lambda self: {"kind": "memory", "persistent": False}},
+    )()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        external_registry_manager=manager,
+        enable_external_registry_management=True,
+    )
+    with TestClient(app) as client:
+        payload = client.get("/mcp/status").json()
+
+    assert payload["external_servers"]["total"] >= 1
+    assert payload["external_servers"]["enabled"] >= 1
+    assert payload["external_registry_store"]["kind"] in {"memory", "sqlite"}
+```
+
+Run red:
+
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  -k "gateway_status"
+```
+
+Expected initial failures:
+
+- `/mcp/status` only returns `status`, `name`, and `version`.
+
+**Implementation:**
+
+- [ ] Update `apps/mcp-unified/src/mcp_unified/gateway/fastapi.py`.
+  - Import `package_metadata_summary`.
+  - Add an async helper such as `_gateway_readiness_status(...)`.
+  - Keep existing `status`, `name`, and `version` keys.
+  - Include a compact `package` object with only non-sensitive fields:
+    - `package_name`
+    - `package_import_name`
+    - `package_status`
+    - `publishing_status`
+    - `source_distribution`
+    - `dependency_version_policy`
+  - Use `profile_manager.store_metadata.to_payload()` when available.
+  - Use `profile_manager.get_default_profile()` best-effort, catching known management errors and generic exceptions into non-secret warning objects.
+  - Use `external_registry_manager.store_metadata.to_payload()` and `list_servers(enabled=None)`/`list_servers(enabled=True)` best-effort for counts.
+  - Use `admin_auth.enabled` and non-secret configured state; do not return the API key.
+  - Add warnings and next actions for:
+    - package not published
+    - memory/non-persistent store
+    - default profile missing
+    - admin auth enabled but key missing
+    - external registry unavailable
+- [ ] Update package docs:
+  - `apps/mcp-unified/README.md`
+  - `apps/mcp-unified/USER_GUIDE.md`
+  - Mention `/status` as package-local readiness/status, not TLDW Server embedded status.
+
+**Verification:**
+
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  -k "gateway_status"
+```
+
+**Commit:**
+
+```bash
+git add \
+  apps/mcp-unified/src/mcp_unified/gateway/fastapi.py \
+  apps/mcp-unified/README.md \
+  apps/mcp-unified/USER_GUIDE.md \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+git commit -m "feat: expand package gateway readiness status"
+```
+
+---
+
+## Stage 5: Docker Production-Signal Cleanup
+
+**Goal:** Remove misleading production-readiness language from the MCP-specific Docker path while preserving the current experimental contract.
+
+**Success Criteria:**
+
+- MCP-specific Dockerfile and docs no longer describe the image as production-optimized or production-ready.
+- Docker docs continue to say this path is experimental and not the supported standalone gateway.
+- Existing entrypoint contract remains unchanged.
+
+**Tests First:**
+
+- [ ] Extend `tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py`.
+
+Add:
+
+```python
+DOCKERFILE = Path("tldw_Server_API/app/core/MCP_unified/docker/Dockerfile")
+
+
+def test_mcp_specific_dockerfile_does_not_claim_production_readiness() -> None:
+    _ensure(DOCKERFILE.exists(), "MCP-specific Dockerfile is missing")
+    text = DOCKERFILE.read_text(encoding="utf-8").lower()
+    forbidden = [
+        "optimized for production deployment",
+        "production-ready",
+        "production grade",
+    ]
+    found = [phrase for phrase in forbidden if phrase in text]
+    _ensure(not found, f"MCP-specific Dockerfile has misleading production language: {found}")
+    _ensure("experimental" in text, "MCP-specific Dockerfile should label this path experimental")
+```
+
+Run red:
+
+```bash
+source .venv/bin/activate
+python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
+```
+
+Expected initial failure:
+
+- Dockerfile contains "Optimized for production deployment with security best practices".
+
+**Implementation:**
+
+- [ ] Update `tldw_Server_API/app/core/MCP_unified/docker/Dockerfile`.
+  - Replace production-optimized comments with experimental/package-specific comments.
+  - Keep security hygiene comments if they are factual, but avoid production-readiness claims.
+- [ ] Update `tldw_Server_API/app/core/MCP_unified/docker/README.md` only if needed to keep language aligned.
+- [ ] Update `tldw_Server_API/app/core/MCP_unified/README.md` only if needed to keep Docker section aligned.
+
+**Verification:**
+
+```bash
+source .venv/bin/activate
+python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
+```
+
+**Commit:**
+
+```bash
+git add \
+  tldw_Server_API/app/core/MCP_unified/docker/Dockerfile \
+  tldw_Server_API/app/core/MCP_unified/docker/README.md \
+  tldw_Server_API/app/core/MCP_unified/README.md \
+  tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
+git commit -m "docs: mark mcp docker path experimental"
+```
+
+---
+
+## Stage 6: Final Verification And Backlog Finalization
+
+**Goal:** Prove the residual hardening work is coherent, then update Backlog with results.
+
+**Success Criteria:**
+
+- All targeted tests pass.
+- Bandit is run on the touched code scope.
+- Backlog task has final summary, verification notes, and completed DoD.
+- Git history contains small coherent commits.
+
+**Verification Commands:**
+
+Run targeted tests:
+
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
+```
+
+Run package gateway status tests:
+
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  -k "gateway_status"
+```
+
+Run Docker contract:
+
+```bash
+source .venv/bin/activate
+python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
+```
+
+Run Bandit on touched code paths:
+
+```bash
+source .venv/bin/activate
+python -m bandit \
+  tldw_Server_API/app/core/MCP_unified/module_surface.py \
+  tldw_Server_API/app/core/MCP_unified/server.py \
+  tldw_Server_API/app/core/MCP_unified/protocol.py \
+  tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py \
+  apps/mcp-unified/src/mcp_unified/gateway/fastapi.py \
+  -f json \
+  -o /tmp/bandit_mcp_residual_ux.json
+```
+
+If Bandit reports existing baseline findings outside changed lines, record them in Backlog and do not silently ignore new findings in touched code.
+
+**Backlog Finalization:**
+
+- [ ] Update `TASK-12054` while planning work is complete.
+- [ ] If executing this implementation in the same branch, create or update a separate implementation task before code edits beyond this plan.
+- [ ] Record:
+  - Test commands and pass/fail result.
+  - Bandit output path.
+  - Known skips or blockers.
+  - Final summary.
+
+**Final Implementation Commit:**
+
+Only after all stages pass:
+
+```bash
+git status --short
+git log --oneline --decorate -5
+```
+
+Confirm only intended files are changed, then commit any final Backlog/doc-status update:
+
+```bash
+git add backlog/tasks/task-12054\ -\ Plan-MCP-Unified-residual-UX-hardening-implementation.md
+git commit -m "chore: finalize mcp residual ux plan tracking"
+```
+
+---
+
+## Acceptance Checklist
+
+- [ ] Supported product mental model is clear: embedded TLDW MCP at `/api/v1/mcp`.
+- [ ] Internal package boundary is clear: `apps/mcp-unified` is experimental and not published.
+- [ ] High-risk local file/process modules are disabled by default.
+- [ ] Explicit operator opt-ins still work.
+- [ ] `/api/v1/mcp/status` shows enabled tiers plus disabled-available high-risk modules.
+- [ ] `/mcp/status` package-local response is useful but does not imply publishing/support status.
+- [ ] HTTP helper errors are more actionable without body-shape breakage.
+- [ ] JSON-RPC recovery metadata is additive under `error.data`.
+- [ ] Query auth is framed as legacy/disabled by default.
+- [ ] Docker path no longer sends production-readiness signals.
+- [ ] Docs contract tests prevent regression on the above.
+- [ ] Targeted tests and Bandit verification are recorded.

--- a/Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
+++ b/Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
@@ -1,0 +1,411 @@
+# MCP Unified Residual UX Hardening Design
+
+Date: 2026-06-28
+Status: Draft for spec review
+Backlog: TASK-2372
+Builds on: TASK-2393
+
+## Summary
+
+This design closes the remaining Unified MCP UX and trust gaps found after the
+completed TASK-2393 remediation. It does not reopen the completed remediation
+slice. Instead, it adds a narrower residual hardening pass focused on product
+truth, safer first-run defaults, error recovery, status/readiness clarity, and
+documentation contracts.
+
+The supported user-facing product remains embedded TLDW MCP at
+`/api/v1/mcp`. The `apps/mcp-unified` package is an internal and experimental
+package boundary for future standalone gateway work. A runnable standalone
+gateway server command remains out of scope for this pass and belongs to the
+future Phase B standalone gateway work.
+
+## Goals
+
+- Make the current embedded vs package-local vs future-standalone model
+  impossible to misunderstand in docs, client examples, smoke guides, admin
+  guides, and package metadata.
+- Require explicit opt-in before enabling local filesystem or local process
+  MCP capabilities by default.
+- Preserve compatibility except for that intentional safer-default change.
+- Improve diagnostics for known failure modes without redesigning the MCP
+  protocol.
+- Make status/readiness useful for both first-time users and returning power
+  users.
+- Add contract tests so the same UX regressions do not recur.
+
+## Non-Goals
+
+- No `mcp-unified-gateway serve` command.
+- No standalone gateway product completion.
+- No PyPI/TestPyPI publishing changes.
+- No package marketplace, server installer, or third-party registry work.
+- No broad MCP Hub UI redesign.
+- No broad JSON-RPC protocol redesign.
+- No removal of legacy query-auth support in this pass.
+
+## Product Positioning
+
+The documentation and package status should use one consistent model:
+
+- Embedded TLDW MCP is supported today and uses the TLDW Server launch path.
+- `apps/mcp-unified` is an internal, experimental package boundary with CLI
+  utilities, package-local smoke tests, profile/policy primitives, and gateway
+  building blocks.
+- The package-local FastAPI gateway app is an embeddable factory, not a
+  supported end-user standalone server unless a later Phase B adds and verifies
+  a serve command.
+- MCP-specific Docker assets are experimental unless a tested supported image
+  is explicitly added later.
+
+This wording should appear in the primary hosted docs, client snippets,
+package docs, smoke client docs, and admin docs. Docs should not use
+"standalone gateway" as a promise unless the same page also states the current
+unsupported/experimental state.
+
+## Findings Addressed
+
+This residual pass addresses these latest-review findings:
+
+- Package-local docs still read like a runnable standalone gateway product.
+- The gateway CLI can validate/configure/administer, but not launch an
+  end-user gateway server.
+- Admin configuration docs are not tightly checked against actual `MCPConfig`
+  names and host-level AuthNZ boundaries.
+- MCP-specific Docker still contains production-sounding language.
+- Default module configuration exposes high-risk local file/process capability
+  too early.
+- WebSocket docs and generated OpenAPI copy still present query-token auth as
+  a normal path.
+- Known errors still collapse to generic messages in important user flows.
+- Package gateway `/status` is too thin for readiness and troubleshooting.
+- Smoke/client docs mix package-local and embedded base paths.
+
+## Compatibility Guardrails
+
+Runtime and API changes must be additive except for the deliberate safer-default
+change to high-risk modules.
+
+The safer-default behavior change must include:
+
+- a migration note for users who depended on default filesystem or command
+  tools
+- an opt-in YAML example
+- a guarantee that existing explicit operator configuration enabling these
+  modules remains honored; only implicit defaults and generated default configs
+  change
+- tests that explicitly enable those modules when they need them
+- status output that explains "available but disabled by default" instead of
+  making tools look missing
+
+Error handling must preserve JSON-RPC compatibility:
+
+- JSON-RPC errors keep the current error shape.
+- Known structured details may be added under `error.data`.
+- HTTP helper endpoints must preserve existing status codes and public error
+  body shape where clients may already depend on it. Endpoints that already
+  return object-shaped `detail` may add `reason_code` and `next_action` keys.
+  Endpoints that currently return string-shaped `detail` should keep that
+  string stable and expose recovery metadata through additive response headers
+  or another explicitly documented additive channel.
+- Initial structured errors should cover only known classes: auth required,
+  permission denied, invalid params, unresolved catalog, module unavailable,
+  external/upstream unavailable, and unsupported/experimental launch path.
+
+WebSocket query-auth behavior should not be removed in this pass. Docs and
+OpenAPI text should mark query-token and query-api-key auth as legacy,
+disabled by default, and not recommended. Normal examples should use headers
+or subprotocol-based auth.
+
+Env-var docs checks must allow explicitly documented host/AuthNZ-level
+exceptions. The test should fail unknown variables only when they are neither
+real `MCPConfig` aliases nor listed in a documented exception map.
+
+## Design Areas
+
+### 1. Product Truth And Docs Contracts
+
+Add docs contract tests that scan the hosted MCP docs, client snippets,
+package-local docs, smoke docs, admin docs, and package README for consistent
+status language. The tests should assert that:
+
+- hosted MCP docs identify `/api/v1/mcp` as the supported path
+- package docs identify `apps/mcp-unified` as internal/experimental
+- package docs do not claim an end-user serve path exists
+- smoke and client-facing examples clearly label embedded vs package-local
+  examples
+- client-facing examples use embedded `/api/v1/mcp` unless they are explicitly
+  labeled package-local, in-process, or host-mounted gateway examples
+- docs use the correct package install path: `apps/mcp-unified[...]`
+- docs link targets exist
+
+The docs should include a short "Which path should I use?" table:
+
+- "I want to connect MCP clients to TLDW": start TLDW Server and use
+  `/api/v1/mcp`.
+- "I am testing the future package boundary": install `apps/mcp-unified`.
+- "I want a separate standalone gateway process": not supported yet; see the
+  Phase B standalone gateway design.
+
+### 2. Safer Default Capability Surface
+
+Disable local filesystem and local process modules in the default module config
+unless the operator explicitly opts in. The initial target modules are the
+high-risk tiers already described in `module_surface.py`:
+
+- `filesystem`
+- `run_command`
+- `sandbox`
+- `browser_cdp`
+- `git`
+- other modules classified as `local_files` or `local_process`
+
+The design should prefer configuration-level opt-in over hiding tools at a
+later layer. That keeps the mental model simple: high-risk modules are not
+enabled until an operator enables them.
+
+Existing explicit operator configuration remains authoritative. If a local
+deployment already has `enabled: true` for one of these modules in its module
+YAML, that explicit opt-in should continue to enable the module. The behavior
+change applies to implicit defaults, checked-in default configs, and generated
+starter configs.
+
+Status output should be extended beyond enabled modules. The surface summary
+should include:
+
+- `enabled_count`
+- `tiers`
+- `disabled_available`
+- `requires_explicit_opt_in`
+
+Each disabled high-risk module should show an id, risk tier, short
+description, and next action such as "enable this module in
+Config_Files/mcp_modules.yaml only if this deployment should expose local file
+access."
+
+### 3. Runtime And API Trust Improvements
+
+Add small diagnostic improvements where users currently hit generic failures.
+
+HTTP helper endpoints should expose structured recovery metadata for known
+failures without breaking existing public error shapes.
+
+Endpoints that already return object-shaped `detail` may extend that object:
+
+```json
+{
+  "reason_code": "permission_denied",
+  "message": "Permission denied for listing MCP modules.",
+  "next_action": "Use a token or API key with the required MCP permission."
+}
+```
+
+Endpoints that currently return string-shaped `detail` should preserve the
+string and add equivalent metadata through an additive channel, for example:
+
+```http
+HTTP/1.1 500 Internal Server Error
+X-MCP-Reason-Code: module_unavailable
+X-MCP-Next-Action: Check /api/v1/mcp/status for problem_modules.
+
+{"detail":"Failed to list MCP modules"}
+```
+
+JSON-RPC should keep its current error code/message behavior, but known errors
+may add structured data:
+
+```json
+{
+  "code": -32602,
+  "message": "Invalid params",
+  "data": {
+    "reason_code": "invalid_params",
+    "next_action": "Check the tool input schema from tools/list."
+  }
+}
+```
+
+Generated endpoint docs should be corrected so WebSocket query auth is not the
+normal-path example. Query auth parameters can remain visible, but their
+description should say they are legacy and disabled by default unless
+`MCP_WS_ALLOW_QUERY_AUTH=true`.
+
+Route-specific copy should be corrected where it references the wrong action,
+such as saying "listing tools" while the user is listing modules.
+
+### 4. Package Gateway Readiness Status
+
+The package-local gateway `/status` response should become a best-effort
+readiness report. It must not require a fully configured external runtime to
+respond.
+
+The response should include redacted fields when available:
+
+- package status and publishing status
+- version
+- transport base path or mount context if known
+- store kind and whether persistence is configured
+- default profile id or "none"
+- admin auth enabled/disabled
+- external server count and unavailable count
+- warnings
+- next actions
+
+If a field is unavailable because the app is embedded by another host, the
+response should say `unknown` or omit the field rather than failing.
+
+Publishing status here is a static support/readiness label from package
+metadata, such as `not-published`. It must not imply PyPI integration,
+release automation, marketplace readiness, or any publishing workflow change.
+
+### 5. Admin, Docker, And Smoke Cleanup
+
+Admin docs should be checked against actual `MCPConfig` aliases plus an
+explicit allowlist for host/AuthNZ variables. Unsupported MCP-like variables
+should be removed or marked as host-level examples.
+
+Docker cleanup should quarantine rather than repair:
+
+- remove production-ready language from the MCP-specific Dockerfile comments
+  and docs
+- label the directory experimental
+- ensure primary docs do not present that Dockerfile as a supported launch path
+- defer a tested standalone Docker image to Phase B
+
+Smoke and client docs should separate:
+
+- embedded TLDW HTTP/WebSocket examples at `/api/v1/mcp`
+- package-local smoke/in-process examples
+- remote gateway examples that require an already-running host-mounted gateway
+
+Embedded status examples must use the exact hosted status path, such as
+`/api/v1/mcp/status`. Package-local gateway examples may use `/status` only
+when the example is explicitly labeled as package-local or host-mounted gateway
+behavior. The smoke and client docs should not imply the package CLI starts a
+server.
+
+## Data Flow And Mental Model
+
+First-time embedded user:
+
+1. Reads "Which path should I use?"
+2. Starts TLDW Server.
+3. Uses one documented auth path.
+4. Calls status and sees enabled modules plus high-risk modules disabled by
+   default.
+5. Lists tools and runs a safe read-only diagnostic call.
+6. If they need files or commands, follows explicit opt-in docs.
+
+Experienced operator:
+
+1. Uses the operator cheatsheet.
+2. Checks `/api/v1/mcp/status` and reads `surface` plus
+   `problem_modules`.
+3. Enables high-risk modules deliberately through YAML.
+4. Uses structured errors and reason codes to diagnose auth, permission,
+   catalog, module, or upstream failures.
+5. Uses package-local docs only when working on the future standalone package
+   boundary.
+
+Package-boundary developer:
+
+1. Installs `apps/mcp-unified[gateway,dev]`.
+2. Runs package-info, preset listing, validate-config, and in-process smoke.
+3. Understands that remote runtime commands require an already-running mounted
+   gateway supplied by a host.
+4. Uses package `/status` readiness fields to diagnose store/admin/profile
+   configuration.
+
+## Testing Strategy
+
+Add focused tests before implementation where practical:
+
+- docs contract tests for product status language, install paths, base paths,
+  status paths, missing links, client snippet path consistency, and absence of
+  normal-path query-token examples
+- config/module tests proving high-risk modules are disabled by default and
+  existing explicit `enabled: true` operator config remains honored
+- status tests proving disabled high-risk modules are shown as available and
+  requiring opt-in
+- HTTP endpoint tests for known recovery metadata that preserves existing
+  error body shape
+- JSON-RPC protocol tests for structured `error.data` on known failures without
+  changing the outer error shape
+- package gateway status tests for best-effort readiness fields
+- admin env-var docs tests using a real-alias set plus explicit exception map
+- Docker/docs contract tests ensuring the MCP-specific Docker path is
+  experimental only
+- smoke docs tests for correct package path and embedded/package base paths
+
+Verification should include:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py -v
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_config_safe_defaults.py -v
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -v
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -v
+python -m bandit -r tldw_Server_API/app/core/MCP_unified tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py -f json -o /tmp/bandit_mcp_residual_ux.json
+```
+
+The exact test set may be refined during implementation, but the plan should
+cover docs contracts, safer defaults, status, known errors, and package status.
+
+## Sequencing
+
+1. Product truth and docs contract tests.
+2. Safer high-risk defaults and migration docs.
+3. Status/module-surface visibility for disabled available capabilities.
+4. Known-error details and WebSocket auth docs cleanup.
+5. Package gateway readiness status.
+6. Admin env-var, Docker, and smoke docs cleanup.
+7. Focused verification, Bandit touched-scope scan, and Backlog closeout.
+
+## Risks And Mitigations
+
+- Risk: safer defaults break local workflows.
+  Mitigation: migration note, opt-in example, explicit test fixtures, and clear
+  status next actions.
+
+- Risk: structured errors accidentally change client contracts.
+  Mitigation: keep JSON-RPC outer shape stable and add details only under
+  `error.data`.
+
+- Risk: docs contracts become brittle.
+  Mitigation: assert stable promises and required phrases, not exact prose.
+
+- Risk: env-var docs tests reject legitimate host-level configuration.
+  Mitigation: maintain an explicit exception map with comments.
+
+- Risk: package gateway readiness implies product readiness.
+  Mitigation: include package status and publishing status in the response and
+  keep docs explicit that the gateway is experimental.
+
+## Acceptance Criteria
+
+- Primary docs, client snippets, package docs, smoke docs, and admin docs use
+  one consistent embedded/package/future-standalone model.
+- No docs imply `mcp-unified-gateway` launches an end-user standalone server.
+- High-risk local file/process modules are disabled by default and have an
+  explicit opt-in path.
+- Existing explicit operator config that enables high-risk modules remains
+  honored.
+- Status shows disabled high-risk capabilities as available but requiring
+  explicit opt-in.
+- WebSocket query auth is documented as legacy, disabled by default, and not
+  the normal path.
+- Known HTTP helper failures expose reason code and next action without
+  breaking existing status codes or string/object error body shape.
+- JSON-RPC compatibility is preserved while known errors may include
+  structured `error.data`.
+- Package gateway `/status` returns best-effort readiness without requiring a
+  fully initialized runtime.
+- Embedded client and smoke examples use `/api/v1/mcp/status`; package-local
+  `/status` examples are explicitly labeled package-local or host-mounted.
+- Package gateway `/status` treats publishing status as static readiness
+  metadata, not as publishing workflow scope.
+- Admin/env-var docs are mechanically checked against `MCPConfig` plus an
+  explicit host/AuthNZ allowlist.
+- MCP-specific Docker assets are clearly experimental and not a supported
+  launch path.
+- Focused tests and Bandit touched-scope scan pass or document only existing
+  unrelated baseline findings.

--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -124,6 +124,15 @@ Validate a gateway config file:
 mcp-unified-gateway validate-config ./gateway.json
 ```
 
+## Package-Local Status
+
+When a host application mounts the package gateway, `GET /mcp/status` returns
+best-effort readiness metadata for that package-local mount. It includes package
+status (`internal-experimental`, `not-published`), runtime name/version,
+profile store persistence, default profile state, admin-auth configured state,
+external server counts, warnings, and next actions. It is not the embedded TLDW
+Server status endpoint; embedded users should call `/api/v1/mcp/status`.
+
 Build an aggregate tool-use report when reporting is enabled:
 
 ```bash

--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -8,6 +8,10 @@ the `tldw-server` repository, but it is not published as an independent PyPI
 package yet. Treat this directory as the supported package-local integration
 surface for early standalone gateway work.
 
+This package does not currently ship an end-user standalone gateway server
+launcher. `mcp-unified-gateway` commands manage local configuration or talk to
+an already mounted remote gateway supplied by a host application.
+
 ## What Is Included
 
 - JSON-RPC gateway runtime primitives for HTTP, WebSocket, and stdio entrypoints.

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -6,6 +6,9 @@ credential grants, configuration snapshots, and remote runtime commands.
 
 The package is currently internal/experimental and distributed with the
 `tldw-server` source tree. It is not a separately published standalone package.
+The package CLI does not launch a supported end-user gateway server; remote
+runtime commands require an already running package-local gateway mounted by a
+host application.
 
 ## Publishing Readiness
 

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -55,6 +55,12 @@ Confirm the CLI is available:
 mcp-unified-gateway package-info
 ```
 
+When a host application mounts the package gateway, use `GET /mcp/status` for
+package-local readiness. The response reports static package boundary metadata,
+profile/external registry store persistence, default profile state, admin-auth
+configured state, external server counts, warnings, and next actions. For the
+embedded TLDW Server product, use `/api/v1/mcp/status` instead.
+
 For a quick standalone JSON-RPC smoke check, confirm the smoke client is also
 available and run the deterministic in-process fixture:
 

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -124,6 +124,15 @@ Validate a gateway config file:
 mcp-unified-gateway validate-config ./gateway.json
 ```
 
+## Package-Local Status
+
+When a host application mounts the package gateway, `GET /mcp/status` returns
+best-effort readiness metadata for that package-local mount. It includes package
+status (`internal-experimental`, `not-published`), runtime name/version,
+profile store persistence, default profile state, admin-auth configured state,
+external server counts, warnings, and next actions. It is not the embedded TLDW
+Server status endpoint; embedded users should call `/api/v1/mcp/status`.
+
 Build an aggregate tool-use report when reporting is enabled:
 
 ```bash

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -8,6 +8,10 @@ the `tldw-server` repository, but it is not published as an independent PyPI
 package yet. Treat this directory as the supported package-local integration
 surface for early standalone gateway work.
 
+This package does not currently ship an end-user standalone gateway server
+launcher. `mcp-unified-gateway` commands manage local configuration or talk to
+an already mounted remote gateway supplied by a host application.
+
 ## What Is Included
 
 - JSON-RPC gateway runtime primitives for HTTP, WebSocket, and stdio entrypoints.

--- a/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
@@ -1653,7 +1653,7 @@ async def _gateway_readiness_status(
     next_actions: list[str] = []
     package_summary = package_metadata_summary()
     package_payload = {
-        key: package_summary[key]
+        key: package_summary.get(key)
         for key in (
             "package_name",
             "package_import_name",
@@ -1663,7 +1663,7 @@ async def _gateway_readiness_status(
             "dependency_version_policy",
         )
     }
-    if package_payload["publishing_status"] == "not-published":
+    if package_payload.get("publishing_status") == "not-published":
         warnings.append(
             _status_warning(
                 "package_not_published",
@@ -1703,11 +1703,12 @@ async def _gateway_readiness_status(
                 )
             )
             next_actions.append("Configure a default profile before relying on profile-scoped gateway calls.")
-        except Exception as exc:  # noqa: BLE001 - status must remain best-effort.
+        except Exception:  # noqa: BLE001 - status must remain best-effort.
+            logger.exception("Default profile readiness check failed during gateway status.")
             warnings.append(
                 _status_warning(
                     "default_profile_status_unavailable",
-                    f"Default profile readiness check failed: {exc.__class__.__name__}.",
+                    "Default profile readiness check failed.",
                 )
             )
     else:
@@ -1727,12 +1728,20 @@ async def _gateway_readiness_status(
         external_registry_store = _read_store_metadata(external_registry_manager)
         try:
             all_result = await external_registry_manager.list_servers(enabled=None)
-            enabled_result = await external_registry_manager.list_servers(enabled=True)
             external_registry_store = _store_payload_from_result(all_result, external_registry_store)
             all_servers = all_result.get("servers", []) if isinstance(all_result, dict) else []
-            enabled_servers = enabled_result.get("servers", []) if isinstance(enabled_result, dict) else []
             total = len(all_servers) if isinstance(all_servers, list) else 0
-            enabled = len(enabled_servers) if isinstance(enabled_servers, list) else 0
+            enabled = 0
+            if isinstance(all_servers, list):
+                enabled = sum(
+                    1
+                    for server in all_servers
+                    if (
+                        server.get("enabled", True)
+                        if isinstance(server, dict)
+                        else getattr(server, "enabled", True)
+                    )
+                )
             external_servers = {
                 "total": total,
                 "enabled": enabled,
@@ -1746,11 +1755,12 @@ async def _gateway_readiness_status(
                 )
             )
             external_servers["unavailable"] = external_servers["total"]
-        except Exception as exc:  # noqa: BLE001 - status must remain best-effort.
+        except Exception:  # noqa: BLE001 - status must remain best-effort.
+            logger.exception("External registry readiness check failed during gateway status.")
             warnings.append(
                 _status_warning(
                     "external_registry_status_unavailable",
-                    f"External registry readiness check failed: {exc.__class__.__name__}.",
+                    "External registry readiness check failed.",
                 )
             )
             next_actions.append("Check external registry store configuration before using remote MCP servers.")

--- a/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ConfigDict
 
 from mcp_unified.storage.models import CredentialGrant, ExternalServerDefinition
 from mcp_unified.interfaces.storage import AuditStore
+from mcp_unified.package_metadata import package_metadata_summary
 from mcp_unified.profiles import MCPProfile
 
 from .admin_auth import (
@@ -1609,6 +1610,188 @@ def _mount_policy_explain_routes(
             return _policy_explain_error_response(exc)
 
 
+def _read_store_metadata(manager: Any) -> dict[str, Any]:
+    """Return non-secret store metadata from a gateway manager."""
+
+    store_metadata = getattr(manager, "store_metadata", None)
+    to_payload = getattr(store_metadata, "to_payload", None)
+    if callable(to_payload):
+        try:
+            payload = to_payload()
+            if isinstance(payload, dict):
+                return dict(payload)
+        except Exception:  # noqa: BLE001 - status must remain best-effort.
+            logger.debug("Gateway status store metadata lookup failed", exc_info=True)
+    return {"kind": "unknown", "persistent": None}
+
+
+def _store_payload_from_result(result: dict[str, Any], fallback: dict[str, Any]) -> dict[str, Any]:
+    """Return a store payload from a manager result when present."""
+
+    store = result.get("store") if isinstance(result, dict) else None
+    if isinstance(store, dict):
+        return dict(store)
+    return fallback
+
+
+def _status_warning(reason_code: str, message: str) -> dict[str, str]:
+    """Return a small non-secret readiness warning object."""
+
+    return {"reason_code": reason_code, "message": message}
+
+
+async def _gateway_readiness_status(
+    runtime: GatewayRuntime,
+    *,
+    profile_manager: GatewayProfileManager | None,
+    external_registry_manager: GatewayExternalRegistryManager | None,
+    admin_auth: GatewayAdminAuthConfig,
+) -> dict[str, Any]:
+    """Return best-effort package-local gateway readiness metadata."""
+
+    warnings: list[dict[str, str]] = []
+    next_actions: list[str] = []
+    package_summary = package_metadata_summary()
+    package_payload = {
+        key: package_summary[key]
+        for key in (
+            "package_name",
+            "package_import_name",
+            "package_status",
+            "publishing_status",
+            "source_distribution",
+            "dependency_version_policy",
+        )
+    }
+    if package_payload["publishing_status"] == "not-published":
+        warnings.append(
+            _status_warning(
+                "package_not_published",
+                "Package metadata is internal/experimental and not published.",
+            )
+        )
+        next_actions.append(
+            "Install from apps/mcp-unified in this repository; do not use public PyPI install guidance."
+        )
+
+    profile_store = {"kind": "unknown", "persistent": None}
+    default_profile: dict[str, Any] = {"configured": False, "profile_id": None, "source": "none"}
+    if profile_manager is not None:
+        profile_store = _read_store_metadata(profile_manager)
+        try:
+            default_result = await profile_manager.get_default_profile()
+            profile_store = _store_payload_from_result(default_result, profile_store)
+            default = default_result.get("default") if isinstance(default_result, dict) else None
+            profile = default_result.get("profile") if isinstance(default_result, dict) else None
+            profile_id = None
+            source = "unknown"
+            if isinstance(default, dict):
+                profile_id = default.get("profile_id")
+                source = str(default.get("source") or "unknown")
+            if profile_id is None and isinstance(profile, dict):
+                profile_id = profile.get("id")
+            default_profile = {
+                "configured": bool(profile_id),
+                "profile_id": profile_id,
+                "source": source,
+            }
+        except GatewayProfileManagementError as exc:
+            warnings.append(
+                _status_warning(
+                    exc.reason_code,
+                    "Default profile readiness check failed.",
+                )
+            )
+            next_actions.append("Configure a default profile before relying on profile-scoped gateway calls.")
+        except Exception as exc:  # noqa: BLE001 - status must remain best-effort.
+            warnings.append(
+                _status_warning(
+                    "default_profile_status_unavailable",
+                    f"Default profile readiness check failed: {exc.__class__.__name__}.",
+                )
+            )
+    else:
+        next_actions.append("Mount profile management if this host should expose package-local profile readiness.")
+
+    if profile_store.get("persistent") is False:
+        warnings.append(
+            _status_warning(
+                "profile_store_not_persistent",
+                "Profile management is using a non-persistent store.",
+            )
+        )
+
+    external_registry_store = {"kind": "unknown", "persistent": None}
+    external_servers = {"total": 0, "enabled": 0, "unavailable": 0}
+    if external_registry_manager is not None:
+        external_registry_store = _read_store_metadata(external_registry_manager)
+        try:
+            all_result = await external_registry_manager.list_servers(enabled=None)
+            enabled_result = await external_registry_manager.list_servers(enabled=True)
+            external_registry_store = _store_payload_from_result(all_result, external_registry_store)
+            all_servers = all_result.get("servers", []) if isinstance(all_result, dict) else []
+            enabled_servers = enabled_result.get("servers", []) if isinstance(enabled_result, dict) else []
+            total = len(all_servers) if isinstance(all_servers, list) else 0
+            enabled = len(enabled_servers) if isinstance(enabled_servers, list) else 0
+            external_servers = {
+                "total": total,
+                "enabled": enabled,
+                "unavailable": 0,
+            }
+        except GatewayExternalRegistryManagementError as exc:
+            warnings.append(
+                _status_warning(
+                    exc.reason_code,
+                    "External server registry readiness check failed.",
+                )
+            )
+            external_servers["unavailable"] = external_servers["total"]
+        except Exception as exc:  # noqa: BLE001 - status must remain best-effort.
+            warnings.append(
+                _status_warning(
+                    "external_registry_status_unavailable",
+                    f"External registry readiness check failed: {exc.__class__.__name__}.",
+                )
+            )
+            next_actions.append("Check external registry store configuration before using remote MCP servers.")
+
+    if external_registry_store.get("persistent") is False:
+        warnings.append(
+            _status_warning(
+                "external_registry_store_not_persistent",
+                "External server registry is using a non-persistent store.",
+            )
+        )
+
+    admin_auth_payload = {
+        "enabled": bool(admin_auth.enabled),
+        "configured": bool(admin_auth.api_key is not None or admin_auth.verifier is not None),
+        "header_name": admin_auth.header_name if admin_auth.enabled else None,
+    }
+    if admin_auth.enabled and not admin_auth_payload["configured"]:
+        warnings.append(
+            _status_warning(
+                "admin_auth_not_configured",
+                "Admin auth is enabled but no verifier is configured.",
+            )
+        )
+
+    return {
+        "status": "ok",
+        "name": _runtime_name(runtime),
+        "version": _runtime_version(runtime),
+        "transport": {"base_path": "package-local-mounted", "mount_path": "unknown"},
+        "package": package_payload,
+        "profile_store": profile_store,
+        "default_profile": default_profile,
+        "admin_auth": admin_auth_payload,
+        "external_registry_store": external_registry_store,
+        "external_servers": external_servers,
+        "warnings": warnings,
+        "next_actions": next_actions,
+    }
+
+
 def create_gateway_router(
     runtime: GatewayRuntime,
     *,
@@ -1694,14 +1877,15 @@ def create_gateway_router(
         )
 
     @router.get("/status")
-    async def gateway_status() -> dict[str, str]:
-        """Return lightweight gateway health and runtime identity metadata."""
+    async def gateway_status() -> dict[str, Any]:
+        """Return best-effort package-local gateway readiness metadata."""
 
-        return {
-            "status": "ok",
-            "name": _runtime_name(runtime),
-            "version": _runtime_version(runtime),
-        }
+        return await _gateway_readiness_status(
+            runtime,
+            profile_manager=resolved_profile_manager,
+            external_registry_manager=resolved_external_registry_manager,
+            admin_auth=resolved_admin_auth,
+        )
 
     @router.post(
         "/request",

--- a/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
@@ -351,6 +351,93 @@ class DeleteCredentialGrantResponse(BaseModel):
     store: StoreMetadataResponse
 
 
+class GatewayStatusStoreResponse(BaseModel):
+    """Best-effort readiness metadata for a gateway backing store."""
+
+    model_config = ConfigDict(extra="allow")
+
+    kind: str
+    persistent: bool | None = None
+
+
+class GatewayStatusPackageResponse(BaseModel):
+    """Package boundary metadata exposed by the gateway status endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    package_name: str | None = None
+    package_import_name: str | None = None
+    package_status: str | None = None
+    publishing_status: str | None = None
+    source_distribution: str | None = None
+    dependency_version_policy: str | None = None
+
+
+class GatewayStatusTransportResponse(BaseModel):
+    """Transport metadata exposed by the gateway status endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    base_path: str
+    mount_path: str
+
+
+class GatewayStatusDefaultProfileResponse(BaseModel):
+    """Default profile readiness metadata."""
+
+    model_config = ConfigDict(extra="allow")
+
+    configured: bool
+    profile_id: str | None = None
+    source: str
+
+
+class GatewayStatusAdminAuthResponse(BaseModel):
+    """Admin-auth readiness metadata without secret values."""
+
+    model_config = ConfigDict(extra="allow")
+
+    enabled: bool
+    configured: bool
+    header_name: str | None = None
+
+
+class GatewayStatusExternalServersResponse(BaseModel):
+    """External server readiness counts."""
+
+    model_config = ConfigDict(extra="allow")
+
+    total: int
+    enabled: int
+    unavailable: int
+
+
+class GatewayStatusWarningResponse(BaseModel):
+    """Non-secret readiness warning returned by gateway status."""
+
+    reason_code: str
+    message: str
+
+
+class GatewayStatusResponse(BaseModel):
+    """Response body for package-local gateway readiness status."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    name: str
+    version: str
+    transport: GatewayStatusTransportResponse
+    package: GatewayStatusPackageResponse
+    profile_store: GatewayStatusStoreResponse
+    default_profile: GatewayStatusDefaultProfileResponse
+    admin_auth: GatewayStatusAdminAuthResponse
+    external_registry_store: GatewayStatusStoreResponse
+    external_servers: GatewayStatusExternalServersResponse
+    warnings: list[GatewayStatusWarningResponse]
+    next_actions: list[str]
+
+
 class ExternalRuntimeServerStatusResponse(BaseModel):
     """Response row for one external MCP server runtime."""
 
@@ -1886,7 +1973,7 @@ def create_gateway_router(
             policy_explain_permission_checker=policy_explain_permission_checker,
         )
 
-    @router.get("/status")
+    @router.get("/status", response_model=GatewayStatusResponse)
     async def gateway_status() -> dict[str, Any]:
         """Return best-effort package-local gateway readiness metadata."""
 

--- a/backlog/tasks/task-12054 - Plan-MCP-Unified-residual-UX-hardening-implementation.md
+++ b/backlog/tasks/task-12054 - Plan-MCP-Unified-residual-UX-hardening-implementation.md
@@ -1,0 +1,62 @@
+---
+id: TASK-12054
+title: Plan MCP Unified residual UX hardening implementation
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-28 04:03'
+labels:
+  - mcp
+  - ux
+  - docs
+  - security
+  - planning
+dependencies: []
+references:
+  - TASK-2372
+  - >-
+    Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the implementation plan for the approved MCP Unified residual UX hardening design. The plan should translate TASK-2372's reviewed spec into bite-sized TDD implementation tasks with exact files, commands, verification, migration handling, and guardrails.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan exists at Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md.
+- [x] #2 Plan maps latest-dev files, current behavior, test targets, verification commands, and incremental commit boundaries.
+- [x] #3 Plan includes Stage 0 Backlog setup before implementation edits.
+- [x] #4 Plan preserves approved scope: no serve command, no package publishing, no Docker productionization.
+- [x] #5 Plan review subagent approved the plan.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan-review pass approved after fixes for Backlog setup, pytest filtering, explicit opt-in tests, docs contract coverage, and Stage 2 selectors.
+
+Mechanical check passed: git diff --check against plan/task files produced no output.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implementation plan created and approved. Plan reviewer approved after fixes for Backlog setup, pytest filtering, explicit opt-in tests, docs contract coverage, and Stage 2 selectors. Verification for planning: git diff --check on plan/task files passed; no runtime tests or Bandit were run because this task only creates the implementation plan.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
+++ b/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
@@ -54,6 +54,11 @@ Implement the approved residual MCP Unified UX hardening work from TASK-2372 and
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] High-risk MCP modules default to disabled unless explicitly opted in, and status surfaces disabled opt-in guidance.
+- [x] `/mcp/status` exposes package, profile, and external-registry readiness without leaking secrets or crashing on partial metadata.
+- [x] HTTP and JSON-RPC MCP error responses include recovery metadata without breaking legacy detail strings.
+- [x] Standalone package, Docker, and embedded MCP docs distinguish shipped embedded endpoints from package-local host-mounted `/mcp` examples.
+- [x] Focused tests and Bandit verification are recorded for the touched MCP code paths.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -73,7 +78,7 @@ Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementati
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the approved residual MCP Unified UX hardening work.
+Implemented the approved residual MCP Unified UX hardening work and addressed PR review feedback after rebasing onto latest dev.
 
 Changed files:
 - Docs/MCP/Unified/Client_Snippets.md
@@ -102,16 +107,19 @@ Changed files:
 - tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
 
 Summary:
-- Made high-risk MCP modules fail closed by default: filesystem, run_command, and codegraph remain available only through explicit opt-in configuration; status now reports disabled-but-available high-risk modules with next actions.
+- Made high-risk MCP modules fail closed by default: filesystem, run_command, and codegraph remain available only through explicit opt-in configuration; status reports disabled-but-available high-risk modules with next actions.
 - Expanded package-local /mcp/status to include non-secret readiness metadata for package publication status, profile store/default profile, admin auth configuration, external registry store, and external server counts.
+- Addressed review feedback so /mcp/status tolerates partial package metadata, logs unexpected profile/registry readiness exceptions server-side while returning generic warnings, and counts external registry enabled servers from a single store scan.
+- Prevented configured-but-unloaded MCP modules from appearing in the enabled module surface until health registration confirms they loaded.
 - Added recovery metadata for HTTP and JSON-RPC errors without changing legacy string details where clients may depend on them.
 - Corrected MCP docs, smoke-client examples, package docs, and Docker wording so they distinguish embedded /api/v1/mcp from host-mounted /mcp and do not imply a shipped standalone gateway process.
 
 Verification:
-- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -> 63 passed, 5 warnings
-- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -k "gateway_status or basic_jsonrpc_flow" -> 5 passed, 197 deselected, 4 warnings
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -> 64 passed, 5 warnings
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -k "gateway_status or basic_jsonrpc_flow" -> 8 passed, 197 deselected, 4 warnings
 - source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py -> 4 passed, 4 warnings
-- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/core/MCP_unified/module_surface.py tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py apps/mcp-unified/src/mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_residual_ux.json -> 0 findings
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit apps/mcp-unified/src/mcp_unified/gateway/fastapi.py tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py -f json -o /tmp/bandit_mcp_review_fixes.json -> 0 findings
+- git diff --check -> clean
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
+++ b/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
@@ -1,0 +1,56 @@
+---
+id: TASK-12055
+title: Implement MCP Unified residual UX hardening
+status: In Progress
+labels:
+- mcp
+- ux
+- security
+- docs
+references:
+- TASK-12054
+- TASK-2372
+- Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+- Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
+documentation:
+- Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
+- Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved residual MCP Unified UX hardening work from TASK-2372 and TASK-12054. Scope covers safer high-risk module defaults, richer embedded and package-local status readiness, HTTP/JSON-RPC recovery metadata, docs/quickstart truthfulness, and Docker/package wording without pretending the standalone gateway is shipped.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
+++ b/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
@@ -1,12 +1,16 @@
 ---
 id: TASK-12055
 title: Implement MCP Unified residual UX hardening
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-06-29 04:38
 labels:
 - mcp
 - ux
 - security
 - docs
+dependencies: []
 references:
 - TASK-12054
 - TASK-2372
@@ -15,6 +19,31 @@ references:
 documentation:
 - Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
 - Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementation-plan.md
+modified_files:
+- Docs/MCP/Unified/Client_Snippets.md
+- Docs/MCP/Unified/Developer_Guide.md
+- Docs/MCP/Unified/Modules.md
+- Docs/MCP/Unified/README.md
+- Docs/MCP/Unified/Smoke_Client.md
+- Docs/MCP/Unified/System_Admin_Guide.md
+- Docs/MCP/Unified/User_Guide.md
+- Docs/MCP/Unified/Using_Modules_YAML.md
+- apps/mcp-unified/README.md
+- apps/mcp-unified/USER_GUIDE.md
+- apps/mcp-unified/src/mcp_unified/README.md
+- apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
+- tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml
+- tldw_Server_API/Config_Files/mcp_modules.yaml
+- tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+- tldw_Server_API/app/core/MCP_unified/docker/Dockerfile
+- tldw_Server_API/app/core/MCP_unified/module_surface.py
+- tldw_Server_API/app/core/MCP_unified/protocol.py
+- tldw_Server_API/app/core/MCP_unified/server.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
+- tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
 ---
 
 ## Description
@@ -35,22 +64,62 @@ Docs/superpowers/plans/2026-06-28-mcp-unified-residual-ux-hardening-implementati
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the approved residual MCP Unified UX hardening work.
 
+Changed files:
+- Docs/MCP/Unified/Client_Snippets.md
+- Docs/MCP/Unified/Developer_Guide.md
+- Docs/MCP/Unified/Modules.md
+- Docs/MCP/Unified/README.md
+- Docs/MCP/Unified/Smoke_Client.md
+- Docs/MCP/Unified/System_Admin_Guide.md
+- Docs/MCP/Unified/User_Guide.md
+- Docs/MCP/Unified/Using_Modules_YAML.md
+- apps/mcp-unified/README.md
+- apps/mcp-unified/USER_GUIDE.md
+- apps/mcp-unified/src/mcp_unified/README.md
+- apps/mcp-unified/src/mcp_unified/gateway/fastapi.py
+- tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml
+- tldw_Server_API/Config_Files/mcp_modules.yaml
+- tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+- tldw_Server_API/app/core/MCP_unified/docker/Dockerfile
+- tldw_Server_API/app/core/MCP_unified/module_surface.py
+- tldw_Server_API/app/core/MCP_unified/protocol.py
+- tldw_Server_API/app/core/MCP_unified/server.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
+- tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
+
+Summary:
+- Made high-risk MCP modules fail closed by default: filesystem, run_command, and codegraph remain available only through explicit opt-in configuration; status now reports disabled-but-available high-risk modules with next actions.
+- Expanded package-local /mcp/status to include non-secret readiness metadata for package publication status, profile store/default profile, admin auth configuration, external registry store, and external server counts.
+- Added recovery metadata for HTTP and JSON-RPC errors without changing legacy string details where clients may depend on them.
+- Corrected MCP docs, smoke-client examples, package docs, and Docker wording so they distinguish embedded /api/v1/mcp from host-mounted /mcp and do not imply a shipped standalone gateway process.
+
+Verification:
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py -> 63 passed, 5 warnings
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -k "gateway_status or basic_jsonrpc_flow" -> 5 passed, 197 deselected, 4 warnings
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py -> 4 passed, 4 warnings
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/core/MCP_unified/module_surface.py tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py apps/mcp-unified/src/mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_residual_ux.json -> 0 findings
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
+++ b/backlog/tasks/task-12055 - Implement-MCP-Unified-residual-UX-hardening.md
@@ -56,6 +56,7 @@ Implement the approved residual MCP Unified UX hardening work from TASK-2372 and
 <!-- AC:BEGIN -->
 - [x] High-risk MCP modules default to disabled unless explicitly opted in, and status surfaces disabled opt-in guidance.
 - [x] `/mcp/status` exposes package, profile, and external-registry readiness without leaking secrets or crashing on partial metadata.
+- [x] `/mcp/status` has a Pydantic response model for the expanded readiness contract.
 - [x] HTTP and JSON-RPC MCP error responses include recovery metadata without breaking legacy detail strings.
 - [x] Standalone package, Docker, and embedded MCP docs distinguish shipped embedded endpoints from package-local host-mounted `/mcp` examples.
 - [x] Focused tests and Bandit verification are recorded for the touched MCP code paths.
@@ -109,6 +110,7 @@ Changed files:
 Summary:
 - Made high-risk MCP modules fail closed by default: filesystem, run_command, and codegraph remain available only through explicit opt-in configuration; status reports disabled-but-available high-risk modules with next actions.
 - Expanded package-local /mcp/status to include non-secret readiness metadata for package publication status, profile store/default profile, admin auth configuration, external registry store, and external server counts.
+- Added a Pydantic response model for the expanded package-local /mcp/status readiness contract.
 - Addressed review feedback so /mcp/status tolerates partial package metadata, logs unexpected profile/registry readiness exceptions server-side while returning generic warnings, and counts external registry enabled servers from a single store scan.
 - Prevented configured-but-unloaded MCP modules from appearing in the enabled module surface until health registration confirms they loaded.
 - Added recovery metadata for HTTP and JSON-RPC errors without changing legacy string details where clients may depend on them.

--- a/backlog/tasks/task-2372 - Design-MCP-Unified-residual-UX-hardening-after-TASK-2393.md
+++ b/backlog/tasks/task-2372 - Design-MCP-Unified-residual-UX-hardening-after-TASK-2393.md
@@ -1,0 +1,68 @@
+---
+id: TASK-2372
+title: Design MCP Unified residual UX hardening after TASK-2393
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-06-28 03:22'
+labels:
+  - mcp
+  - ux
+  - docs
+  - security
+  - standalone
+dependencies: []
+references:
+  - Docs/superpowers/plans/2026-06-26-mcp-unified-standalone-ux-remediation.md
+  - >-
+    backlog/tasks/task-2393 -
+    Plan-and-implement-MCP-Unified-standalone-UX-remediation.md
+  - >-
+    Docs/superpowers/specs/2026-05-26-mcp-unified-standalone-library-gateway-design.md
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a residual hardening design for the remaining Unified MCP standalone/embedded UX findings after completed TASK-2393. Scope includes package-local gateway truthfulness, safer default high-risk capability opt-in, docs/admin/Docker contracts, WebSocket auth copy, known-error recovery, package gateway readiness status, and smoke/docs consistency. Full standalone gateway serving remains out of scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Residual design references completed TASK-2393 and does not reopen its completed scope.
+- [ ] #2 Design covers remaining latest-review findings with explicit in-scope and out-of-scope boundaries.
+- [ ] #3 Design includes safer high-risk defaults with migration and explicit opt-in guidance.
+- [ ] #4 Design includes compatibility guardrails for additive API/runtime changes and JSON-RPC compatibility.
+- [ ] #5 Design is reviewed and approved before implementation planning starts.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- 2026-06-28: Drafted residual hardening design in Docs/superpowers/specs/2026-06-28-mcp-unified-residual-ux-hardening-design.md.
+- 2026-06-28: Spec review iteration 1 found missing client-doc coverage, explicit-config migration semantics, and publishing-status ambiguity. Patched all three.
+- 2026-06-28: Spec review iteration 2 found HTTP error-shape compatibility risk and status-path ambiguity. Patched additive HTTP metadata language and explicit /api/v1/mcp/status vs package /status requirements.
+- 2026-06-28: Spec review iteration 3 approved the design with no blocking contradictions or unsafe ambiguity.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Design spec written and approved by spec review loop; awaiting user review before implementation planning.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml
+++ b/tldw_Server_API/Config_Files/mcp_modules.local_opt_in.example.yaml
@@ -1,0 +1,26 @@
+modules:
+  # Local file/workspace access. Enable only for deployments where MCP clients
+  # should inspect or mutate configured local filesystem scopes.
+  - id: filesystem
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module:FilesystemModule
+    enabled: true
+    name: Filesystem
+    version: "1.0.0"
+    department: system
+    max_concurrent: 16
+    settings: {}
+
+  # Local command execution. Enable only after reviewing allowed command
+  # families, RBAC, logging, and host sandboxing posture.
+  - id: run_command
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.run_command_module:RunCommandModule
+    enabled: true
+    name: Run Command
+    version: "0.1.0"
+    department: system
+    max_concurrent: 16
+    settings:
+      spill_dir: ${MCP_RUN_COMMAND_SPILL_DIR:-.mcp/spills}
+      spill_threshold_bytes: 65536
+      preview_line_limit: 200
+      preview_byte_limit: 51200

--- a/tldw_Server_API/Config_Files/mcp_modules.yaml
+++ b/tldw_Server_API/Config_Files/mcp_modules.yaml
@@ -110,7 +110,9 @@ modules:
 
   - id: filesystem
     class: tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module:FilesystemModule
-    enabled: true
+    # Disabled by default because it exposes local file/workspace access.
+    # Set enabled: true only for deployments that intentionally grant this capability.
+    enabled: false
     name: Filesystem
     version: "1.0.0"
     department: system
@@ -144,7 +146,9 @@ modules:
 
   - id: run_command
     class: tldw_Server_API.app.core.MCP_unified.modules.implementations.run_command_module:RunCommandModule
-    enabled: true
+    # Disabled by default because it can run configured local command families.
+    # Set enabled: true only for deployments that intentionally grant this capability.
+    enabled: false
     name: Run Command
     version: "0.1.0"
     department: system

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
@@ -117,6 +117,7 @@ def _parse_safe_config_query(config: str | None) -> dict[str, Any]:
             status_code=400,
             detail={
                 "code": "invalid_safe_config",
+                "reason_code": "invalid_params",
                 "message": "The config query parameter must be base64url-encoded JSON.",
                 "next_action": "Remove the config parameter or send a valid encoded JSON object.",
             },
@@ -789,13 +790,29 @@ def _jsonrpc_error_response(response: MCPResponse) -> JSONResponse:
     return JSONResponse(mcp_response_to_json(response))
 
 
-def _mcp_permission_detail(response: MCPResponse, *, hint: str) -> dict[str, str] | None:
+def _mcp_recovery_headers(reason_code: str, next_action: str) -> dict[str, str]:
+    """Return additive recovery headers for string-body HTTP errors."""
+    return {
+        "X-MCP-Reason-Code": reason_code,
+        "X-MCP-Next-Action": next_action,
+    }
+
+
+def _mcp_permission_detail(
+    response: MCPResponse,
+    *,
+    hint: str,
+    reason_code: str = "permission_denied",
+    next_action: str = "Use a token or API key with the required MCP permission.",
+) -> dict[str, str] | None:
     """Return an HTTP-friendly permission detail for MCP authorization errors."""
     if response.error is None or response.error.code != -32001:
         return None
     return {
         "message": response.error.message or "Insufficient permissions",
         "hint": hint,
+        "reason_code": reason_code,
+        "next_action": next_action,
     }
 
 
@@ -817,8 +834,8 @@ def _is_anonymous_mcp_request(http_request: Request, auth: McpAuthContext) -> bo
 async def websocket_endpoint(
     websocket: WebSocket,
     client_id: Optional[str] = Query(None, description="Client identifier"),
-    token: Optional[str] = Query(None, description="Authentication token"),
-    api_key: Optional[str] = Query(None, description="API key for authentication"),
+    token: Optional[str] = Query(None, description="Legacy query authentication token; disabled by default unless MCP_WS_ALLOW_QUERY_AUTH=true. Prefer headers or WebSocket subprotocol auth."),
+    api_key: Optional[str] = Query(None, description="Legacy query API key; disabled by default unless MCP_WS_ALLOW_QUERY_AUTH=true. Prefer headers or WebSocket subprotocol auth."),
     mcp_session_id: Optional[str] = Query(None, description="Stable MCP session identifier"),
     workspace_id: Optional[str] = Query(None, description="Trusted workspace identifier"),
     cwd: Optional[str] = Query(None, description="Current working directory within the workspace"),
@@ -828,13 +845,17 @@ async def websocket_endpoint(
 
     Supports:
     - Full MCP protocol over WebSocket
-    - Optional authentication via token parameter
+    - Header or WebSocket subprotocol authentication
+    - Legacy query auth only when explicitly enabled
     - Real-time bidirectional communication
     - Automatic reconnection support
 
     Example:
     ```javascript
-    const ws = new WebSocket('ws://localhost:8000/api/v1/mcp/ws?client_id=my-client&token=jwt-token');
+    const ws = new WebSocket(
+        'ws://localhost:8000/api/v1/mcp/ws?client_id=my-client',
+        ['bearer', jwtToken]
+    );
 
     ws.onopen = () => {
         ws.send(JSON.stringify({
@@ -962,6 +983,7 @@ async def mcp_request(
         permission_detail = _mcp_permission_detail(
             resp_obj,
             hint="Permission denied for listing tools. Contact an admin.",
+            next_action="Use a token or API key with tools discovery permission.",
         )
         if permission_detail is not None:
             raise HTTPException(status_code=403, detail=permission_detail)
@@ -1232,12 +1254,20 @@ async def list_tools(
         if response.error.code == -32001:
             raise HTTPException(
                 status_code=403,
-                detail={
-                    "message": response.error.message or "Insufficient permissions",
-                    "hint": "Permission denied for listing tools. Contact an admin.",
-                },
+                detail=_mcp_permission_detail(
+                    response,
+                    hint="Permission denied for listing tools. Contact an admin.",
+                    next_action="Use a token or API key with tools discovery permission.",
+                ),
             )
-        raise HTTPException(status_code=500, detail="Failed to list MCP tools")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to list MCP tools",
+            headers=_mcp_recovery_headers(
+                "mcp_tool_list_failed",
+                "Check /api/v1/mcp/status for problem_modules and config_warnings.",
+            ),
+        )
 
     return response.result
 
@@ -1369,7 +1399,13 @@ async def execute_tool(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authentication required",
-            headers={"WWW-Authenticate": "Bearer"},
+            headers={
+                "WWW-Authenticate": "Bearer",
+                **_mcp_recovery_headers(
+                    "authentication_required",
+                    "Send Authorization: Bearer <token> or X-API-KEY with the request.",
+                ),
+            },
         )
 
     user = auth.user
@@ -1385,24 +1421,46 @@ async def execute_tool(
 
     if response is None:
         logger.error("MCP server returned no response for tools/call", tool=request.tool_name)
-        raise HTTPException(status_code=502, detail="MCP tool execution returned no response")
+        raise HTTPException(
+            status_code=502,
+            detail="MCP tool execution returned no response",
+            headers=_mcp_recovery_headers(
+                "upstream_no_response",
+                "Check /api/v1/mcp/status for problem_modules, then retry the tool call.",
+            ),
+        )
 
     if response.error:
         # Map authorization failures to 403 with a helpful hint
         if response.error.code == -32001:  # AUTHORIZATION_ERROR
-            hint = {
-                "message": response.error.message or "Insufficient permissions",
-                "hint": (
+            detail = _mcp_permission_detail(
+                response,
+                hint=(
                     f"Permission denied. Ask an admin to grant tools.execute:{request.tool_name} "
                     f"or tools.execute:* to your role (Admin → Access Control)."
                 ),
-            }
-            raise HTTPException(status_code=403, detail=hint)
+                next_action=f"Ask an admin to grant tools.execute:{request.tool_name} or tools.execute:*.",
+            )
+            raise HTTPException(status_code=403, detail=detail)
         # Invalid params
         if response.error.code == -32602:
-            raise HTTPException(status_code=400, detail=response.error.message)
+            raise HTTPException(
+                status_code=400,
+                detail=response.error.message,
+                headers=_mcp_recovery_headers(
+                    "invalid_params",
+                    "Check the tool input schema from /api/v1/mcp/tools and retry.",
+                ),
+            )
         # Other errors
-        raise HTTPException(status_code=500, detail="MCP tool execution failed")
+        raise HTTPException(
+            status_code=500,
+            detail="MCP tool execution failed",
+            headers=_mcp_recovery_headers(
+                "mcp_tool_execution_failed",
+                "Check /api/v1/mcp/status for problem_modules and retry with valid tool arguments.",
+            ),
+        )
 
     execution_time = (time.time() - start_time) * 1000
 
@@ -1463,12 +1521,20 @@ async def list_modules(
         if response.error.code == -32001:
             raise HTTPException(
                 status_code=403,
-                detail={
-                    "message": response.error.message or "Insufficient permissions",
-                    "hint": "Permission denied for listing tools. Contact an admin.",
-                },
+                detail=_mcp_permission_detail(
+                    response,
+                    hint="Permission denied for listing modules. Contact an admin.",
+                    next_action="Use a token or API key with permission to list MCP modules.",
+                ),
             )
-        raise HTTPException(status_code=500, detail="Failed to list MCP modules")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to list MCP modules",
+            headers=_mcp_recovery_headers(
+                "module_unavailable",
+                "Check /api/v1/mcp/status for problem_modules.",
+            ),
+        )
 
     return response.result
 
@@ -1503,12 +1569,20 @@ async def get_modules_health(
         if response.error.code == -32001:
             raise HTTPException(
                 status_code=403,
-                detail={
-                    "message": response.error.message or "Insufficient permissions",
-                    "hint": "Permission denied for listing modules. Contact an admin.",
-                },
+                detail=_mcp_permission_detail(
+                    response,
+                    hint="Permission denied for listing modules. Contact an admin.",
+                    next_action="Use an admin token or a principal with system.logs permission.",
+                ),
             )
-        raise HTTPException(status_code=500, detail="Failed to get MCP module health")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to get MCP module health",
+            headers=_mcp_recovery_headers(
+                "module_unavailable",
+                "Check /api/v1/mcp/status for problem_modules.",
+            ),
+        )
 
     return response.result
 

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
@@ -834,8 +834,20 @@ def _is_anonymous_mcp_request(http_request: Request, auth: McpAuthContext) -> bo
 async def websocket_endpoint(
     websocket: WebSocket,
     client_id: Optional[str] = Query(None, description="Client identifier"),
-    token: Optional[str] = Query(None, description="Legacy query authentication token; disabled by default unless MCP_WS_ALLOW_QUERY_AUTH=true. Prefer headers or WebSocket subprotocol auth."),
-    api_key: Optional[str] = Query(None, description="Legacy query API key; disabled by default unless MCP_WS_ALLOW_QUERY_AUTH=true. Prefer headers or WebSocket subprotocol auth."),
+    token: Optional[str] = Query(
+        None,
+        description=(
+            "Legacy query authentication token; disabled by default unless "
+            "MCP_WS_ALLOW_QUERY_AUTH=true. Prefer headers or WebSocket subprotocol auth."
+        ),
+    ),
+    api_key: Optional[str] = Query(
+        None,
+        description=(
+            "Legacy query API key; disabled by default unless MCP_WS_ALLOW_QUERY_AUTH=true. "
+            "Prefer headers or WebSocket subprotocol auth."
+        ),
+    ),
     mcp_session_id: Optional[str] = Query(None, description="Stable MCP session identifier"),
     workspace_id: Optional[str] = Query(None, description="Trusted workspace identifier"),
     cwd: Optional[str] = Query(None, description="Current working directory within the workspace"),

--- a/tldw_Server_API/app/core/MCP_unified/docker/Dockerfile
+++ b/tldw_Server_API/app/core/MCP_unified/docker/Dockerfile
@@ -1,5 +1,5 @@
-# Multi-stage Dockerfile for MCP Unified Module
-# Optimized for production deployment with security best practices
+# Experimental multi-stage Dockerfile for MCP Unified package-boundary smoke tests.
+# Unified MCP is embedded in TLDW Server today; this is not a supported standalone gateway image.
 
 # Stage 1: Builder
 FROM python:3.11-slim as builder

--- a/tldw_Server_API/app/core/MCP_unified/module_surface.py
+++ b/tldw_Server_API/app/core/MCP_unified/module_surface.py
@@ -42,6 +42,8 @@ TIER_LABELS: dict[str, str] = {
     "unknown": "Unclassified module",
 }
 
+EXPLICIT_OPT_IN_TIERS = {"local_files", "local_process", "external_network"}
+
 _DISABLED_STATUSES = {"disabled", "not_loaded", "inactive"}
 
 
@@ -55,6 +57,22 @@ def _is_enabled(payload: Any) -> bool:
     return True
 
 
+def _disabled_next_action(module_name: str, tier: str) -> str:
+    """Return user-facing guidance for enabling a disabled high-risk module."""
+    if tier == "local_files":
+        risk = "local file or workspace access"
+    elif tier == "local_process":
+        risk = "local process or sandbox execution"
+    elif tier == "external_network":
+        risk = "external network or federated MCP access"
+    else:
+        risk = "this capability"
+    return (
+        f"Enable `{module_name}` in Config_Files/mcp_modules.yaml only if this "
+        f"deployment should expose {risk}; restart TLDW Server and recheck /api/v1/mcp/status."
+    )
+
+
 def describe_module_surface(modules: dict[str, Any]) -> dict[str, Any]:
     """Group enabled MCP modules into user-facing capability risk tiers."""
     tiers: dict[str, dict[str, Any]] = {
@@ -62,20 +80,34 @@ def describe_module_surface(modules: dict[str, Any]) -> dict[str, Any]:
         for key, label in TIER_LABELS.items()
     }
     enabled_count = 0
+    disabled_available: list[dict[str, Any]] = []
 
     for module_name, payload in sorted(modules.items()):
-        if not _is_enabled(payload):
-            continue
-
-        enabled_count += 1
         tier, description = MODULE_RISK_TIERS.get(
             module_name,
             ("unknown", "No risk tier is registered yet."),
         )
+        if not _is_enabled(payload):
+            if tier in EXPLICIT_OPT_IN_TIERS:
+                disabled_available.append(
+                    {
+                        "id": module_name,
+                        "tier": tier,
+                        "label": TIER_LABELS.get(tier, TIER_LABELS["unknown"]),
+                        "description": description,
+                        "requires_explicit_opt_in": True,
+                        "next_action": _disabled_next_action(module_name, tier),
+                    }
+                )
+            continue
+
+        enabled_count += 1
         tiers[tier]["modules"].append({"id": module_name, "description": description})
 
     return {
         "enabled_count": enabled_count,
+        "disabled_available_count": len(disabled_available),
+        "disabled_available": disabled_available,
         "tiers": {
             key: value
             for key, value in tiers.items()

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -1911,7 +1911,13 @@ class MCPProtocol:
         data: Optional[Any]
     ) -> Optional[Any]:
         """Attach a structured hint for common error scenarios."""
+        metadata = self._error_recovery_metadata(code, message)
         if data is not None:
+            if isinstance(data, dict) and metadata and not any(key in data for key in ("governance", "approval")):
+                merged = dict(data)
+                for key, value in metadata.items():
+                    merged.setdefault(key, value)
+                return merged
             return data
 
         hint: Optional[str] = None
@@ -1932,8 +1938,41 @@ class MCPProtocol:
         elif code == ErrorCode.AUTHORIZATION_ERROR and "write tools are disabled" in lowered:
             hint = "Enable write tools (set MCP_DISABLE_WRITE_TOOLS=0) or switch to a read-only operation."
 
+        recovery: dict[str, Any] = dict(metadata or {})
         if hint:
-            return {"hint": hint}
+            recovery["hint"] = hint
+        return recovery or None
+
+    @staticmethod
+    def _error_recovery_metadata(code: ErrorCode, message: str) -> dict[str, str] | None:
+        """Return additive recovery metadata for known JSON-RPC errors."""
+        lowered = message.lower()
+        if code == ErrorCode.INVALID_PARAMS:
+            return {
+                "reason_code": "invalid_params",
+                "next_action": "Check the method parameters or tool input schema from tools/list before retrying.",
+            }
+        if code == ErrorCode.AUTHENTICATION_ERROR:
+            return {
+                "reason_code": "authentication_required",
+                "next_action": "Send Authorization: Bearer <token> or X-API-KEY with the request.",
+            }
+        if code == ErrorCode.AUTHORIZATION_ERROR:
+            reason_code = "write_tools_disabled" if "write tools are disabled" in lowered else "permission_denied"
+            return {
+                "reason_code": reason_code,
+                "next_action": "Use a token or API key with the required MCP permission.",
+            }
+        if code == ErrorCode.MODULE_ERROR:
+            return {
+                "reason_code": "module_unavailable",
+                "next_action": "Check /api/v1/mcp/status for problem_modules.",
+            }
+        if code == ErrorCode.TIMEOUT_ERROR:
+            return {
+                "reason_code": "upstream_unavailable",
+                "next_action": "Retry after checking the upstream module or external service.",
+            }
         return None
 
     async def _check_authorization(

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -306,6 +306,7 @@ class MCPServer:
         self._initialize_lock = asyncio.Lock()
         self.startup_time = datetime.now(timezone.utc)
         self.shutdown_event = asyncio.Event()
+        self._configured_modules_for_status: dict[str, dict[str, Any]] = {}
 
         # Background tasks
         self.background_tasks: set[asyncio.Task] = set()
@@ -464,6 +465,33 @@ class MCPServer:
     def _env_flag_explicitly_disabled(name: str) -> bool:
         """Return True when an env flag is set to a common disabled value."""
         return os.getenv(name, "").strip().lower() in {"0", "false", "off", "no", "n"}
+
+    @staticmethod
+    def _module_status_entry(module_config: dict[str, Any]) -> tuple[str, dict[str, Any]] | None:
+        """Return a sanitized status entry for a configured module."""
+        module_id = str(module_config.get("id") or "").strip()
+        if not module_id:
+            return None
+        enabled = bool(module_config.get("enabled", True))
+        return module_id, {
+            "enabled": enabled,
+            "status": "configured" if enabled else "disabled",
+            "name": str(module_config.get("name") or module_id),
+            "department": str(module_config.get("department") or "general"),
+        }
+
+    def _remember_configured_modules_for_status(self, modules: list[Any]) -> None:
+        """Store sanitized configured-module metadata for status reporting."""
+        remembered: dict[str, dict[str, Any]] = {}
+        for module_config in modules:
+            if not isinstance(module_config, dict):
+                continue
+            entry = self._module_status_entry(module_config)
+            if entry is None:
+                continue
+            module_id, payload = entry
+            remembered[module_id] = payload
+        self._configured_modules_for_status = remembered
 
     def _default_media_db_path(self) -> str:
         """Return the host-provided default media DB path for module config."""
@@ -768,9 +796,9 @@ class MCPServer:
                     })
                     logger.info("TEST_MODE auto-enabled MediaModule for deterministic tool catalogs")
 
-            # 5) Filesystem module is enabled by default for workspace-bounded fs primitives.
-            if os.getenv("MCP_ENABLE_FILESYSTEM_MODULE", "true").strip().lower() not in {"0", "false", "off", "no", "n"}:
-                if not any(m.get("id") == "filesystem" for m in modules_to_load if isinstance(m, dict)):
+            # 5) Filesystem module requires explicit opt-in for workspace-bounded fs primitives.
+            if not any(m.get("id") == "filesystem" for m in modules_to_load if isinstance(m, dict)):
+                if self._env_flag_enabled("MCP_ENABLE_FILESYSTEM_MODULE"):
                     modules_to_load.append({
                         "id": "filesystem",
                         "class": "tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module:FilesystemModule",
@@ -780,7 +808,18 @@ class MCPServer:
                         "department": "management",
                         "settings": {},
                     })
-                    logger.info("MCP filesystem module enabled by default; queuing FilesystemModule for registration")
+                    logger.info("MCP_ENABLE_FILESYSTEM_MODULE=true; queuing FilesystemModule for registration")
+                else:
+                    modules_to_load.append({
+                        "id": "filesystem",
+                        "class": "tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module:FilesystemModule",
+                        "enabled": False,
+                        "name": "Filesystem",
+                        "version": "1.0.0",
+                        "department": "management",
+                        "settings": {},
+                    })
+                    logger.info("MCP filesystem module available but disabled; set MCP_ENABLE_FILESYSTEM_MODULE=true or enable it in YAML to opt in")
 
             # 6) Optional: Git module - disabled by default
             if self._env_flag_enabled("MCP_ENABLE_GIT_MODULE"):
@@ -876,6 +915,8 @@ class MCPServer:
                         },
                     })
                     logger.info("MCP browser CDP module enabled/configured; queuing BrowserCDPModule for registration")
+
+            self._remember_configured_modules_for_status(modules_to_load)
 
             # Register all specified modules
             from .modules.base import ModuleConfig  # Local import to avoid cycles
@@ -1867,12 +1908,16 @@ class MCPServer:
 
         # Get module health
         health_results = await self.module_registry.check_all_health()
-        module_surface = describe_module_surface(
-            {
-                module_id: {"status": health.status.value}
-                for module_id, health in health_results.items()
-            }
-        )
+        surface_modules = {
+            module_id: dict(payload)
+            for module_id, payload in self._configured_modules_for_status.items()
+        }
+        for module_id, health in health_results.items():
+            entry = dict(surface_modules.get(module_id, {}))
+            entry["enabled"] = True
+            entry["status"] = health.status.value
+            surface_modules[module_id] = entry
+        module_surface = describe_module_surface(surface_modules)
         problem_modules = await self._problem_modules_from_health(health_results)
         config_warnings = get_config_warnings()
 

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -1911,6 +1911,7 @@ class MCPServer:
         surface_modules = {
             module_id: dict(payload)
             for module_id, payload in self._configured_modules_for_status.items()
+            if payload.get("enabled") is False
         }
         for module_id, health in health_results.items():
             entry = dict(surface_modules.get(module_id, {}))

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
@@ -152,6 +152,119 @@ def test_describe_module_surface_groups_enabled_modules_by_risk():
     assert surface["enabled_count"] == 8
 
 
+def test_describe_module_surface_reports_disabled_available_high_risk_modules():
+    """Disabled high-risk modules should remain visible as explicit opt-ins."""
+    from tldw_Server_API.app.core.MCP_unified.module_surface import describe_module_surface
+
+    surface = describe_module_surface({
+        "media": {"enabled": True, "status": "healthy"},
+        "filesystem": {"enabled": False, "status": "disabled"},
+        "run_command": {"enabled": False, "status": "disabled"},
+        "external_federation": {"enabled": False, "status": "disabled"},
+    })
+
+    assert surface["enabled_count"] == 1
+    assert [m["id"] for m in surface["tiers"]["read_only"]["modules"]] == ["media"]
+    disabled_ids = [m["id"] for m in surface["disabled_available"]]
+    assert disabled_ids == ["external_federation", "filesystem", "run_command"]
+    assert surface["disabled_available_count"] == 3
+    assert all(m["requires_explicit_opt_in"] is True for m in surface["disabled_available"])
+    assert all(m["next_action"] for m in surface["disabled_available"])
+
+
+def test_default_mcp_modules_yaml_disables_local_file_and_process_modules():
+    """Checked-in defaults should not expose local files or host commands."""
+    import yaml
+    from pathlib import Path
+
+    data = yaml.safe_load(Path("tldw_Server_API/Config_Files/mcp_modules.yaml").read_text(encoding="utf-8"))
+    modules = {entry["id"]: entry for entry in data["modules"]}
+
+    assert modules["filesystem"]["enabled"] is False
+    assert modules["run_command"]["enabled"] is False
+    assert modules["codegraph"]["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_filesystem_fallback_requires_explicit_opt_in(monkeypatch, tmp_path):
+    """Missing YAML fallback must not auto-enable filesystem access."""
+    missing_config = tmp_path / "missing-mcp-modules.yaml"
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(missing_config))
+    monkeypatch.setenv("MCP_MODULES", "")
+    monkeypatch.delenv("MCP_ENABLE_FILESYSTEM_MODULE", raising=False)
+
+    registered = []
+    server = MCPServer()
+
+    async def _register_module(module_id, cls, config):
+        registered.append(module_id)
+
+    monkeypatch.setattr(server.module_registry, "register_module", _register_module)
+
+    await server._register_default_modules()
+
+    assert "filesystem" not in registered
+
+
+@pytest.mark.asyncio
+async def test_filesystem_fallback_registers_with_explicit_env_opt_in(monkeypatch, tmp_path):
+    """The legacy fallback path should remain available with explicit env opt-in."""
+    missing_config = tmp_path / "missing-mcp-modules.yaml"
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(missing_config))
+    monkeypatch.setenv("MCP_MODULES", "")
+    monkeypatch.setenv("MCP_ENABLE_FILESYSTEM_MODULE", "true")
+
+    registered = []
+    server = MCPServer()
+
+    async def _register_module(module_id, cls, config):
+        registered.append(module_id)
+
+    monkeypatch.setattr(server.module_registry, "register_module", _register_module)
+
+    await server._register_default_modules()
+
+    assert "filesystem" in registered
+
+
+@pytest.mark.asyncio
+async def test_explicit_yaml_enabled_high_risk_modules_still_register(monkeypatch, tmp_path):
+    """Safer defaults must not override an operator's explicit YAML opt-in."""
+    import textwrap
+
+    config_path = tmp_path / "mcp_modules.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            modules:
+              - id: filesystem
+                class: tldw_Server_API.app.core.MCP_unified.modules.implementations.filesystem_module:FilesystemModule
+                enabled: true
+                name: Filesystem
+                version: "1.0.0"
+                department: system
+                settings: {}
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(config_path))
+    monkeypatch.setenv("MCP_MODULES", "")
+    monkeypatch.delenv("MCP_ENABLE_FILESYSTEM_MODULE", raising=False)
+
+    registered = []
+    server = MCPServer()
+
+    async def _register_module(module_id, cls, config):
+        registered.append(module_id)
+
+    monkeypatch.setattr(server.module_registry, "register_module", _register_module)
+
+    await server._register_default_modules()
+
+    assert "filesystem" in registered
+
+
 class TestJWTManager:
     """Test JWT authentication manager"""
 
@@ -460,6 +573,27 @@ class TestMCPServer:
         assert [m["id"] for m in status["surface"]["tiers"]["read_only"]["modules"]] == ["media"]
         assert [m["id"] for m in status["surface"]["tiers"]["local_files"]["modules"]] == ["filesystem"]
         assert [m["id"] for m in status["surface"]["tiers"]["local_process"]["modules"]] == ["run_command"]
+
+    async def test_server_status_includes_disabled_available_from_config(self, monkeypatch):
+        """Server status should include configured high-risk modules skipped as disabled."""
+        server = MCPServer()
+        server.initialized = True
+        server._configured_modules_for_status = {
+            "media": {"enabled": True},
+            "filesystem": {"enabled": False},
+            "run_command": {"enabled": False},
+        }
+
+        async def _check_all_health():
+            return {"media": ModuleHealth(status=HealthStatus.HEALTHY)}
+
+        monkeypatch.setattr(server.module_registry, "check_all_health", _check_all_health)
+
+        status = await server.get_status()
+
+        assert status["surface"]["enabled_count"] == 1
+        assert [m["id"] for m in status["surface"]["disabled_available"]] == ["filesystem", "run_command"]
+        assert all(m["requires_explicit_opt_in"] for m in status["surface"]["disabled_available"])
 
     async def test_server_status_includes_sanitized_problem_modules(self, monkeypatch):
         """Server status should expose actionable, canned module problem reasons."""

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
@@ -595,6 +595,28 @@ class TestMCPServer:
         assert [m["id"] for m in status["surface"]["disabled_available"]] == ["filesystem", "run_command"]
         assert all(m["requires_explicit_opt_in"] for m in status["surface"]["disabled_available"])
 
+    async def test_server_status_does_not_enable_configured_but_unloaded_modules(self, monkeypatch):
+        """Configured modules should not appear enabled until their health is registered."""
+        server = MCPServer()
+        server.initialized = True
+        server._configured_modules_for_status = {
+            "media": {"enabled": True, "status": "configured"},
+            "filesystem": {"enabled": True, "status": "configured"},
+            "run_command": {"enabled": False, "status": "disabled"},
+        }
+
+        async def _check_all_health():
+            return {"media": ModuleHealth(status=HealthStatus.HEALTHY)}
+
+        monkeypatch.setattr(server.module_registry, "check_all_health", _check_all_health)
+
+        status = await server.get_status()
+
+        assert status["surface"]["enabled_count"] == 1
+        assert [m["id"] for m in status["surface"]["tiers"]["read_only"]["modules"]] == ["media"]
+        assert "local_files" not in status["surface"]["tiers"]
+        assert [m["id"] for m in status["surface"]["disabled_available"]] == ["run_command"]
+
     async def test_server_status_includes_sanitized_problem_modules(self, monkeypatch):
         """Server status should expose actionable, canned module problem reasons."""
         server = MCPServer()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 
 DOCKER_README = Path("tldw_Server_API/app/core/MCP_unified/docker/README.md")
+DOCKERFILE = Path("tldw_Server_API/app/core/MCP_unified/docker/Dockerfile")
 ENTRYPOINT = Path("tldw_Server_API/app/core/MCP_unified/docker/entrypoint.sh")
 CORE_README = Path("tldw_Server_API/app/core/MCP_unified/README.md")
 
@@ -27,6 +28,25 @@ def test_mcp_specific_docker_path_is_marked_experimental() -> None:
         "embedded in tldw server today" in text,
         "MCP-specific Docker README should point users back to the embedded TLDW Server path",
     )
+
+
+def test_mcp_specific_dockerfile_does_not_claim_production_readiness() -> None:
+    _ensure(DOCKERFILE.exists(), "MCP-specific Dockerfile is missing")
+    text = DOCKERFILE.read_text(encoding="utf-8").lower()
+
+    _ensure(
+        "experimental" in text,
+        "MCP-specific Dockerfile should mark this path experimental",
+    )
+    for stale_phrase in (
+        "optimized for production deployment",
+        "production-ready",
+        "production grade",
+    ):
+        _ensure(
+            stale_phrase not in text,
+            f"MCP-specific Dockerfile should not claim {stale_phrase!r}",
+        )
 
 
 def test_primary_mcp_readme_flags_docker_deployment_as_experimental() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -2387,6 +2387,13 @@ def test_gateway_external_runtime_lifecycle_logs_unexpected_startup_exception(
 
 def test_gateway_status_includes_package_boundary_metadata() -> None:
     app = create_gateway_app(_FakeGatewayRuntime())
+    status_route = next(
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == "/mcp/status"
+    )
+    assert getattr(status_route, "response_model", None) is gateway_fastapi.GatewayStatusResponse
+
     with TestClient(app) as client:
         response = client.get("/mcp/status")
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -2401,6 +2401,22 @@ def test_gateway_status_includes_package_boundary_metadata() -> None:
     assert "next_actions" in payload
 
 
+def test_gateway_status_tolerates_partial_package_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        gateway_fastapi,
+        "package_metadata_summary",
+        lambda: {"publishing_status": "not-published"},
+    )
+    app = create_gateway_app(_FakeGatewayRuntime())
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["package"]["package_name"] is None
+    assert payload["package"]["publishing_status"] == "not-published"
+
+
 def test_gateway_status_reports_profile_store_admin_auth_and_default_profile() -> None:
     manager = _ProfileManagementManagerDouble("default")
     manager.store_metadata = type(
@@ -2425,6 +2441,28 @@ def test_gateway_status_reports_profile_store_admin_auth_and_default_profile() -
     assert "unit-test-key" not in json.dumps(payload)
 
 
+def test_gateway_status_uses_generic_profile_warning_for_unexpected_failures() -> None:
+    class _UnexpectedProfileFailureManager(_ProfileManagementManagerDouble):
+        async def get_default_profile(self) -> dict[str, Any]:
+            raise RuntimeError("profile store exploded")
+
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        profile_manager=_UnexpectedProfileFailureManager("default"),
+        enable_profile_management=True,
+    )
+    with TestClient(app) as client:
+        payload = client.get("/mcp/status").json()
+
+    warning = next(
+        item
+        for item in payload["warnings"]
+        if item["reason_code"] == "default_profile_status_unavailable"
+    )
+    assert warning["message"] == "Default profile readiness check failed."
+    assert "RuntimeError" not in json.dumps(payload)
+
+
 def test_gateway_status_counts_external_servers_best_effort() -> None:
     manager = _ExternalRegistryManagerDouble("enabled")
     manager.store_metadata = type(
@@ -2443,6 +2481,29 @@ def test_gateway_status_counts_external_servers_best_effort() -> None:
     assert payload["external_servers"]["total"] >= 1
     assert payload["external_servers"]["enabled"] >= 1
     assert payload["external_registry_store"]["kind"] in {"memory", "sqlite"}
+    assert manager.calls == [("list_servers", (), {"enabled": None})]
+
+
+def test_gateway_status_uses_generic_external_registry_warning_for_unexpected_failures() -> None:
+    class _UnexpectedExternalRegistryFailureManager(_ExternalRegistryManagerDouble):
+        async def list_servers(self, enabled: bool | None = None) -> dict[str, Any]:
+            raise RuntimeError("external registry exploded")
+
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        external_registry_manager=_UnexpectedExternalRegistryFailureManager("enabled"),
+        enable_external_registry_management=True,
+    )
+    with TestClient(app) as client:
+        payload = client.get("/mcp/status").json()
+
+    warning = next(
+        item
+        for item in payload["warnings"]
+        if item["reason_code"] == "external_registry_status_unavailable"
+    )
+    assert warning["message"] == "External registry readiness check failed."
+    assert "RuntimeError" not in json.dumps(payload)
 
 
 def test_gateway_external_runtime_lifecycle_stops_on_shutdown() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -2385,6 +2385,66 @@ def test_gateway_external_runtime_lifecycle_logs_unexpected_startup_exception(
     ]
 
 
+def test_gateway_status_includes_package_boundary_metadata() -> None:
+    app = create_gateway_app(_FakeGatewayRuntime())
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["name"] == "unit-gateway"
+    assert payload["version"] == "0.0-test"
+    assert payload["package"]["package_status"] == "internal-experimental"
+    assert payload["package"]["publishing_status"] == "not-published"
+    assert payload["package"]["source_distribution"] == "tldw-server"
+    assert "next_actions" in payload
+
+
+def test_gateway_status_reports_profile_store_admin_auth_and_default_profile() -> None:
+    manager = _ProfileManagementManagerDouble("default")
+    manager.store_metadata = type(
+        "_StoreMetadata",
+        (),
+        {"to_payload": lambda self: {"kind": "memory", "persistent": False}},
+    )()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        profile_manager=manager,
+        enable_profile_management=True,
+        admin_auth=GatewayAdminAuthConfig(enabled=True, api_key="unit-test-key"),
+    )
+    with TestClient(app) as client:
+        response = client.get("/mcp/status")
+
+    payload = response.json()
+    assert payload["profile_store"]["kind"] in {"memory", "sqlite"}
+    assert payload["default_profile"]["configured"] is True
+    assert payload["admin_auth"]["enabled"] is True
+    assert payload["admin_auth"]["configured"] is True
+    assert "unit-test-key" not in json.dumps(payload)
+
+
+def test_gateway_status_counts_external_servers_best_effort() -> None:
+    manager = _ExternalRegistryManagerDouble("enabled")
+    manager.store_metadata = type(
+        "_StoreMetadata",
+        (),
+        {"to_payload": lambda self: {"kind": "memory", "persistent": False}},
+    )()
+    app = create_gateway_app(
+        _FakeGatewayRuntime(),
+        external_registry_manager=manager,
+        enable_external_registry_management=True,
+    )
+    with TestClient(app) as client:
+        payload = client.get("/mcp/status").json()
+
+    assert payload["external_servers"]["total"] >= 1
+    assert payload["external_servers"]["enabled"] >= 1
+    assert payload["external_registry_store"]["kind"] in {"memory", "sqlite"}
+
+
 def test_gateway_external_runtime_lifecycle_stops_on_shutdown() -> None:
     from mcp_unified.gateway.lifecycle import GatewayExternalRuntimeLifecycleConfig
 
@@ -5249,11 +5309,11 @@ def test_gateway_fastapi_app_handles_basic_jsonrpc_flow() -> None:
     with TestClient(app) as client:
         status = client.get("/mcp/status")
         assert status.status_code == 200
-        assert status.json() == {
-            "status": "ok",
-            "name": "unit-gateway",
-            "version": "0.0-test",
-        }
+        status_payload = status.json()
+        assert status_payload["status"] == "ok"
+        assert status_payload["name"] == "unit-gateway"
+        assert status_payload["version"] == "0.0-test"
+        assert status_payload["package"]["package_status"] == "internal-experimental"
 
         initialized = client.post(
             "/mcp/request",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
@@ -396,3 +396,73 @@ def test_request_guard_requires_client_certificate(monkeypatch):
             headers={"x-ssl-client-verify": "SUCCESS"},
         )
         assert r_valid.status_code == 200
+
+
+def test_tools_execute_unauth_preserves_string_detail_and_adds_recovery_headers(client: TestClient):
+    response = client.post(
+        "/api/v1/mcp/tools/execute",
+        json={"tool_name": "media.search", "arguments": {}},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authentication required"
+    assert response.headers["x-mcp-reason-code"] == "authentication_required"
+    assert response.headers["x-mcp-next-action"]
+
+
+def test_modules_permission_detail_mentions_modules_and_recovery(client: TestClient):
+    response = client.get("/api/v1/mcp/modules")
+
+    assert response.status_code == 403
+    detail = response.json()["detail"]
+    assert detail["reason_code"] == "permission_denied"
+    assert detail["next_action"]
+    assert "modules" in detail["hint"].lower()
+    assert "tools" not in detail["hint"].lower()
+
+
+def test_invalid_safe_config_keeps_structured_recovery_detail(client: TestClient):
+    response = client.post(
+        "/api/v1/mcp/request",
+        json={"jsonrpc": "2.0", "method": "initialize", "params": {}, "id": 1},
+        params={"config": "not-base64-json"},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "invalid_safe_config"
+    assert detail["reason_code"] == "invalid_params"
+    assert detail["next_action"]
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_invalid_params_error_data_includes_recovery_metadata():
+    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, MCPRequest
+    from tldw_Server_API.app.core.MCP_unified.protocol_types import RequestContext
+
+    protocol = MCPProtocol()
+    response = await protocol.process_request(
+        MCPRequest(method="tools/call", params={}, id=1),
+        RequestContext(request_id="invalid-params-test", client_id="pytest", user_id="1"),
+    )
+
+    assert response.error is not None
+    assert response.error.code == -32602
+    assert response.error.data["reason_code"] == "invalid_params"
+    assert response.error.data["next_action"]
+
+
+def test_websocket_query_auth_is_marked_legacy_in_endpoint_copy():
+    import inspect
+    from tldw_Server_API.app.api.v1.endpoints import mcp_unified_endpoint as endpoint
+
+    signature = inspect.signature(endpoint.websocket_endpoint)
+    token_description = signature.parameters["token"].default.description.lower()
+    api_key_description = signature.parameters["api_key"].default.description.lower()
+    docstring = inspect.getdoc(endpoint.websocket_endpoint).lower()
+
+    assert "legacy" in token_description
+    assert "disabled by default" in token_description
+    assert "legacy" in api_key_description
+    assert "disabled by default" in api_key_description
+    assert "?token=jwt-token" not in docstring

--- a/tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py
@@ -1,6 +1,7 @@
 """Documentation contracts for the Unified MCP user journey."""
 
 from pathlib import Path
+import re
 
 import pytest
 
@@ -125,3 +126,146 @@ def test_unified_mcp_operator_cheatsheet_covers_power_user_workflows() -> None:
         "websocket",
     ):
         _require(phrase in text, f"Operator cheatsheet should mention {phrase}.")
+
+
+def test_unified_mcp_docs_use_supported_embedded_paths_for_smoke_and_snippets() -> None:
+    """Client-facing quickstarts should default to the embedded TLDW MCP path."""
+    docs = "\n\n".join(
+        [
+            _read("Docs/MCP/Unified/Client_Snippets.md"),
+            _read("Docs/MCP/Unified/Smoke_Client.md"),
+            _read("Docs/MCP/Unified/User_Guide.md"),
+        ]
+    )
+
+    _require("/api/v1/mcp/status" in docs, "Docs should show embedded status path.")
+    _require("/api/v1/mcp/request" in docs, "Docs should show embedded request path.")
+    _require(
+        "mcp_unified[gateway]" not in docs,
+        "Docs should not install a non-root package path.",
+    )
+
+
+def test_unified_mcp_docs_label_every_package_local_request_example() -> None:
+    """Package-local request examples must be framed as host-mounted/package-local."""
+    smoke = _read("Docs/MCP/Unified/Smoke_Client.md")
+
+    for line_no, line in enumerate(smoke.splitlines(), start=1):
+        if "http://127.0.0.1:8000/mcp/request" not in line:
+            continue
+        window = "\n".join(smoke.splitlines()[max(0, line_no - 5) : line_no + 4]).lower()
+        _require(
+            "package-local" in window or "host-mounted" in window,
+            f"Unlabeled package-local /mcp/request example near Smoke_Client.md:{line_no}",
+        )
+
+
+def test_unified_mcp_docs_have_path_decision_table() -> None:
+    """Primary docs should distinguish embedded, package-local, and future paths."""
+    docs = "\n\n".join(
+        [
+            _read("Docs/MCP/Unified/README.md"),
+            _read("Docs/MCP/Unified/User_Guide.md"),
+        ]
+    ).lower()
+
+    for snippet in (
+        "which path should i use",
+        "/api/v1/mcp/status",
+        "/api/v1/mcp/request",
+        "/mcp/status",
+        "package-local",
+        "standalone gateway",
+        "planned but not shipped",
+    ):
+        _require(snippet in docs, f"Path decision docs should mention {snippet}.")
+
+
+def test_unified_mcp_docs_do_not_normalize_query_token_auth() -> None:
+    """Normal examples should keep query-string auth framed as legacy only."""
+    docs = "\n\n".join(
+        [
+            _read("Docs/MCP/Unified/User_Guide.md"),
+            _read("Docs/MCP/Unified/Client_Snippets.md"),
+            _read("Docs/MCP/Unified/Smoke_Client.md"),
+        ]
+    ).lower()
+
+    _require(
+        "?token=jwt-token" not in docs,
+        "Docs should not show query token auth as a normal example.",
+    )
+    _require(
+        "disabled by default" in docs and "query auth" in docs,
+        "Docs should frame query auth as legacy/disabled.",
+    )
+
+
+def test_unified_mcp_package_docs_do_not_promise_serve_or_publishing() -> None:
+    """Package docs should not promise an unsupported standalone server product."""
+    docs = "\n\n".join(
+        [
+            _read("apps/mcp-unified/README.md"),
+            _read("apps/mcp-unified/USER_GUIDE.md"),
+            _read("apps/mcp-unified/src/mcp_unified/README.md"),
+        ]
+    ).lower()
+
+    forbidden = [
+        "mcp-unified-gateway serve",
+        "pip install mcp-unified",
+        "published to pypi",
+        "production standalone gateway",
+    ]
+    found = [phrase for phrase in forbidden if phrase in docs]
+    _require(not found, f"Package docs imply unsupported standalone/published flows: {found}")
+    _require("not published" in docs, "Package docs should state the package is not published.")
+    _require(
+        "internal" in docs and "experimental" in docs,
+        "Package docs should state internal/experimental status.",
+    )
+
+
+def test_unified_mcp_docs_reference_existing_local_targets() -> None:
+    """Relative markdown links in the high-traffic MCP docs should stay valid."""
+    docs_to_check = [
+        "Docs/MCP/Unified/README.md",
+        "Docs/MCP/Unified/User_Guide.md",
+        "Docs/MCP/Unified/Smoke_Client.md",
+        "Docs/MCP/Unified/Client_Snippets.md",
+        "apps/mcp-unified/README.md",
+        "apps/mcp-unified/USER_GUIDE.md",
+    ]
+    missing: list[str] = []
+
+    for doc_path in docs_to_check:
+        text = _read(doc_path)
+        for target in re.findall(r"\]\(([^)#][^)]+)\)", text):
+            if "://" in target or target.startswith("#") or target.startswith("mailto:"):
+                continue
+            normalized = target.split("#", 1)[0]
+            if not normalized:
+                continue
+            candidate = Path(doc_path).parent / normalized
+            if not candidate.exists():
+                missing.append(f"{doc_path} -> {target}")
+
+    _require(not missing, "Docs reference missing local targets: " + ", ".join(missing))
+
+
+def test_unified_mcp_admin_env_docs_do_not_include_known_stale_mcp_vars() -> None:
+    """Admin docs should not list stale MCP-only env vars as live config."""
+    guide = _read("Docs/MCP/Unified/System_Admin_Guide.md")
+    stale = {
+        "MCP_HOST",
+        "MCP_PORT",
+        "MCP_AUTH_MODE",
+        "MCP_MODULES_ENABLED",
+        "MCP_DATABASE_MAX_OVERFLOW",
+        "MCP_TRUSTED_PROXIES",
+        "MCP_MAX_REQUEST_SIZE",
+        "MCP_REQUEST_TIMEOUT",
+    }
+    found = {name for name in stale if name in guide}
+
+    _require(not found, f"System admin guide documents stale MCP env vars: {sorted(found)}")


### PR DESCRIPTION
## Summary
- Clarifies MCP docs around supported embedded `/api/v1/mcp` paths, package-local `/mcp` examples, legacy query auth, and the non-shipped standalone gateway boundary.
- Makes high-risk local MCP modules explicit opt-in while preserving YAML/env opt-in paths and surfacing disabled-available modules in status.
- Adds actionable recovery metadata for HTTP/JSON-RPC errors, expands package-local gateway readiness status, and marks the MCP Docker path experimental.

## Change summary
AI-drafted PR. Per project policy, a human-authored Change summary explaining what changed and why these implementation choices were made is required before merge.

## Test Plan
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Docs/test_mcp_unified_docs_contract.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py` -> 63 passed
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -k "gateway_status or basic_jsonrpc_flow"` -> 5 passed
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py` -> 4 passed
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/core/MCP_unified/module_surface.py tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py apps/mcp-unified/src/mcp_unified/gateway/fastapi.py -f json -o /tmp/bandit_mcp_residual_ux_pr.json` -> 0 findings
- `git diff --check` -> clean

## Notes
- Branch was rebased onto latest `origin/dev` before PR creation.
- Backlog implementation task: `TASK-12055`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens MCP Unified UX and defaults: clarifies supported embedded endpoints, makes high‑risk modules explicit opt‑in, adds recovery metadata, improves status/readiness, and types the package‑local gateway status response. Expands the package‑local `/mcp/status` with package boundary metadata; marks the MCP Docker path experimental; and updates docs and the smoke client to the embedded `/api/v1/mcp` surface. Addresses TASK-12055.

- New Features
  - Safer defaults: high‑risk modules (`filesystem`, `run_command`, external federation) are disabled; `/api/v1/mcp/status` lists them under `surface.disabled_available` with `requires_explicit_opt_in` and a `next_action`.
  - Better recovery: JSON‑RPC errors add `error.data.reason_code` and `error.data.next_action`; HTTP string‑body errors add `X-MCP-Reason-Code` and `X-MCP-Next-Action`; permission errors include concise hints.
  - Clearer status/docs: expanded `/api/v1/mcp/status`; package‑local `/mcp/status` reports package boundary readiness (name/version, publishing status, profile store, default profile, admin‑auth, warnings, next actions) and now uses a typed response model; docs/snippets and smoke client default to embedded paths; standalone gateway not shipped; MCP Dockerfile labeled experimental.

- Migration
  - If you use local filesystem or command execution, opt in via `tldw_Server_API/Config_Files/mcp_modules.yaml` (`enabled: true`); see `mcp_modules.local_opt_in.example.yaml`.
  - Default client integrations should use `/api/v1/mcp/*`; only use `/mcp/*` when a host app mounts the package‑local gateway.

<sup>Written for commit b074de216c1dbd682cc893c891fcbdfb5f7fd10a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

