### PR TITLE
Move VCS-only extras to manual install docs

### DIFF
--- a/Docs/OCR/OCR_Providers.md
+++ b/Docs/OCR/OCR_Providers.md
@@ -123,10 +123,11 @@ Quick setup
   - Download model weights: `python3 tools/download_model.py` (use a directory name without periods, e.g., `DotsOCR`).
 - Recommended: serve with vLLM for performance (see upstream docs).
 
-Install via extras (optional)
-- You can install the project with the dots extra:
-  - `pip install .[ocr_dots]`
-  - This pulls the dots.ocr repo via a VCS dependency.
+Manual install
+- `dots.ocr` is not installed by a `tldw-server` package extra because PyPI rejects direct Git dependencies in package metadata.
+- Install it from the upstream repo before using `ocr_backend=dots`:
+  - `git clone https://github.com/rednote-hilab/dots.ocr.git && cd dots.ocr`
+  - `pip install -e .`
 
 Backend specifics
 - CLI mode: shells out to `python -m dots_ocr.parser <image.png>` per page (or use `DOTS_OCR_CMD` to specify an explicit command).
@@ -159,9 +160,10 @@ Environment
 Docs
 - See detailed guide at `Docs/OCR/POINTS-Reader.md`.
 
-Install via extras (optional)
+Install via extras/manual source setup (optional)
 - Local transformers path: `pip install .[ocr_points_transformers]`
-  - Includes `transformers`, `torch`, and the WePOINTS toolkit via VCS.
+  - Includes the PyPI-installable `transformers` and `torch` dependencies.
+  - Install the WePOINTS toolkit manually from `https://github.com/WePOINTS/WePOINTS` before using `POINTS_MODE=transformers`.
 - SGLang client only: `pip install .[ocr_points_sglang]`
 
 ## DeepSeek-OCR (backend: `deepseek`)

--- a/Docs/OCR/OCR_Providers.md
+++ b/Docs/OCR/OCR_Providers.md
@@ -160,9 +160,9 @@ Environment
 Docs
 - See detailed guide at `Docs/OCR/POINTS-Reader.md`.
 
-Install via extras/manual source setup (optional)
-- Local transformers path: `pip install .[ocr_points_transformers]`
-  - Includes the PyPI-installable `transformers` and `torch` dependencies.
+Manual source setup (optional)
+- Local transformers path:
+  - Install `transformers` and a CUDA/CPU-compatible `torch`.
   - Install the WePOINTS toolkit manually from `https://github.com/WePOINTS/WePOINTS` before using `POINTS_MODE=transformers`.
 - SGLang client only: `pip install .[ocr_points_sglang]`
 

--- a/Docs/OCR/POINTS-Reader.md
+++ b/Docs/OCR/POINTS-Reader.md
@@ -62,10 +62,11 @@ pip install -e .
 2) Ensure `transformers` and `torch` match your CUDA setup.
 3) Optional: set `POINTS_MODEL_PATH` to a local cache or custom path.
 
-Extras install (optional):
-- You can install project + deps in one step for the local path:
+Extras/manual source setup (optional):
+- Install the project dependencies for the local path:
   - `pip install .[ocr_points_transformers]`
-  - Brings in `transformers`, `torch`, and WePOINTS via VCS.
+  - This installs the PyPI-publishable `transformers` and `torch` dependencies.
+- Install WePOINTS manually from source with the steps above. It is not bundled in `tldw-server` package metadata because PyPI rejects direct Git dependencies.
 
 ### SGLang Server
 

--- a/Docs/OCR/POINTS-Reader.md
+++ b/Docs/OCR/POINTS-Reader.md
@@ -62,10 +62,10 @@ pip install -e .
 2) Ensure `transformers` and `torch` match your CUDA setup.
 3) Optional: set `POINTS_MODEL_PATH` to a local cache or custom path.
 
-Extras/manual source setup (optional):
-- Install the project dependencies for the local path:
-  - `pip install .[ocr_points_transformers]`
-  - This installs the PyPI-publishable `transformers` and `torch` dependencies.
+Manual source setup (optional):
+- Install the local path dependencies:
+  - `pip install "transformers>=5.5.3"`
+  - Install a CUDA/CPU-compatible PyTorch build for your platform.
 - Install WePOINTS manually from source with the steps above. It is not bundled in `tldw-server` package metadata because PyPI rejects direct Git dependencies.
 
 ### SGLang Server

--- a/Docs/Published/User_Guides/WebUI_Extension/TTS_Getting_Started.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/TTS_Getting_Started.md
@@ -123,7 +123,7 @@ Installer flags:
 | ElevenLabs | Hosted API | `ELEVENLABS_API_KEY` | Yes (via ElevenLabs voices) | [TTS Setup Guide](../../STT-TTS/TTS-SETUP-GUIDE.md#commercial-providers) |
 | Kokoro ONNX | Local ONNX | `pip install -e ".[TTS_kokoro_onnx]"` + `espeak-ng` | No | [Getting Started](./Getting-Started-STT_and_TTS.md#option-b-kokoro-tts-local-onnx) |
 | NeuTTS Air | Local hybrid | `pip install -e ".[TTS_neutts]"` + `espeak-ng` | **Required** (reference audio + text) | [NeuTTS Runbook](../../STT-TTS/NEUTTS_TTS_SETUP.md) |
-| Chatterbox | Local PyTorch | `pip install -e ".[TTS_chatterbox]"` (+ `.[TTS_chatterbox_lang]` for multilingual) | Yes (5–20 s) | [Chatterbox Runbook](../../STT-TTS/CHATTERBOX_SETUP.md) |
+| Chatterbox | Local PyTorch | Manual runtime deps + `pip install chatterbox-tts` (+ `.[TTS_chatterbox_lang]` for multilingual preprocessing) | Yes (5–20 s) | [Chatterbox Runbook](../../STT-TTS/CHATTERBOX_SETUP.md) |
 | VibeVoice | Local PyTorch | `pip install -e ".[TTS_vibevoice]"` + clone [VibeVoice](https://github.com/microsoft/VibeVoice) | Yes (3–30 s) | [VibeVoice Guide](../../STT-TTS/VIBEVOICE_GETTING_STARTED.md) |
 | Higgs Audio V2 | Local PyTorch | `pip install -e ".[TTS_higgs]"` + install `bosonai/higgs-audio` | Yes (3–10 s) | [TTS Setup Guide](../../STT-TTS/TTS-SETUP-GUIDE.md#higgs-audio-v2-setup) |
 | Dia | Local PyTorch | `pip install torch transformers accelerate nltk spacy` | Yes (dialogue prompts) | [TTS Setup Guide](../../STT-TTS/TTS-SETUP-GUIDE.md#dia-setup) |
@@ -289,7 +289,7 @@ Each section highlights installation, configuration, and a smoke test.
 - **Verify**: use the sample curl from [NeuTTS Runbook](../../STT-TTS/NEUTTS_TTS_SETUP.md) and confirm the WAV plays back.
 
 ### Chatterbox
-- **Install**: `pip install -e ".[TTS_chatterbox]"`; add `.[TTS_chatterbox_lang]` if you plan to enable `use_multilingual`. If the runtime still reports missing `chatterbox`, install upstream with `pip install chatterbox-tts` (or from source).
+- **Install**: install the manual runtime dependencies from the Chatterbox runbook, then `pip install chatterbox-tts`; add `.[TTS_chatterbox_lang]` if you plan to enable `use_multilingual`.
 - **Models**: cache `ResembleAI/chatterbox` locally with `huggingface-cli download ...`.
 - **Config**:
   ```yaml

--- a/Docs/STT-TTS/CHATTERBOX_SETUP.md
+++ b/Docs/STT-TTS/CHATTERBOX_SETUP.md
@@ -31,6 +31,13 @@ pip install -e .[TTS_chatterbox_lang]
 pip install chatterbox-tts
 ```
 
+If you need the optional Perth watermark runtime, install it manually from source. It is not bundled in `tldw-server` package metadata because PyPI rejects direct Git dependencies.
+```bash
+git clone https://github.com/resemble-ai/Perth.git
+cd Perth
+pip install -e .
+```
+
 Option B - Install upstream Chatterbox from source:
 ```bash
 git clone https://github.com/resemble-ai/chatterbox
@@ -304,7 +311,7 @@ The WebUI uses the same `/api/v1/audio/speech` endpoint under the hood and will 
 
 ## Troubleshooting
 1) Import error: `chatterbox` not found
-- Install upstream package: `pip install chatterbox-tts`, or use repo’s vendored module with `pip install -e .[TTS_chatterbox]`.
+- Install upstream package: `pip install chatterbox-tts`, or install upstream Chatterbox from source. The `TTS_chatterbox` extra installs repo-side support dependencies only.
 
 2) Model download blocked/offline
 - Pre-download via `hf download ResembleAI/chatterbox --local-dir ./models/chatterbox` and set offline env vars.

--- a/Docs/STT-TTS/CHATTERBOX_SETUP.md
+++ b/Docs/STT-TTS/CHATTERBOX_SETUP.md
@@ -23,18 +23,19 @@ Key files:
 
 ## Install Options
 
-Option A - Install repo extras, then install the upstream Chatterbox package:
+Option A - Install Chatterbox runtime dependencies and the upstream package:
 ```bash
-pip install -e .[TTS_chatterbox]
+pip install torch torchaudio numpy scipy transformers tokenizers huggingface_hub safetensors librosa pyloudnorm diffusers einops conformer s3tokenizer omegaconf
+pip install chatterbox-tts
 # Optional language preprocessing utilities for multilingual
 pip install -e .[TTS_chatterbox_lang]
-pip install chatterbox-tts
 ```
 
 If you need the optional Perth watermark runtime, install it manually from source. It is not bundled in `tldw-server` package metadata because PyPI rejects direct Git dependencies.
 ```bash
 git clone https://github.com/resemble-ai/Perth.git
 cd Perth
+git checkout ce86c49d029f42272c1902eccb675556b9ed2330
 pip install -e .
 ```
 
@@ -311,7 +312,7 @@ The WebUI uses the same `/api/v1/audio/speech` endpoint under the hood and will 
 
 ## Troubleshooting
 1) Import error: `chatterbox` not found
-- Install upstream package: `pip install chatterbox-tts`, or install upstream Chatterbox from source. The `TTS_chatterbox` extra installs repo-side support dependencies only.
+- Install upstream package: `pip install chatterbox-tts`, or install upstream Chatterbox from source.
 
 2) Model download blocked/offline
 - Pre-download via `hf download ResembleAI/chatterbox --local-dir ./models/chatterbox` and set offline env vars.

--- a/Docs/User_Guides/WebUI_Extension/TTS_Getting_Started.md
+++ b/Docs/User_Guides/WebUI_Extension/TTS_Getting_Started.md
@@ -123,7 +123,7 @@ Installer flags:
 | ElevenLabs | Hosted API | `ELEVENLABS_API_KEY` | Yes (via ElevenLabs voices) | [TTS Setup Guide](../../STT-TTS/TTS-SETUP-GUIDE.md#commercial-providers) |
 | Kokoro ONNX | Local ONNX | `pip install -e ".[TTS_kokoro_onnx]"` + `espeak-ng` | No | [Getting Started](./Getting-Started-STT_and_TTS.md#option-b-kokoro-tts-local-onnx) |
 | NeuTTS Air | Local hybrid | `pip install -e ".[TTS_neutts]"` + `espeak-ng` | **Required** (reference audio + text) | [NeuTTS Runbook](../../STT-TTS/NEUTTS_TTS_SETUP.md) |
-| Chatterbox | Local PyTorch | `pip install -e ".[TTS_chatterbox]"` (+ `.[TTS_chatterbox_lang]` for multilingual) | Yes (5–20 s) | [Chatterbox Runbook](../../STT-TTS/CHATTERBOX_SETUP.md) |
+| Chatterbox | Local PyTorch | Manual runtime deps + `pip install chatterbox-tts` (+ `.[TTS_chatterbox_lang]` for multilingual preprocessing) | Yes (5–20 s) | [Chatterbox Runbook](../../STT-TTS/CHATTERBOX_SETUP.md) |
 | VibeVoice | Local PyTorch | `pip install -e ".[TTS_vibevoice]"` + clone [VibeVoice](https://github.com/microsoft/VibeVoice) | Yes (3–30 s) | [VibeVoice Guide](../../STT-TTS/VIBEVOICE_GETTING_STARTED.md) |
 | Higgs Audio V2 | Local PyTorch | `pip install -e ".[TTS_higgs]"` + install `bosonai/higgs-audio` | Yes (3–10 s) | [TTS Setup Guide](../../STT-TTS/TTS-SETUP-GUIDE.md#higgs-audio-v2-setup) |
 | Dia | Local PyTorch | `pip install torch transformers accelerate nltk spacy` | Yes (dialogue prompts) | [TTS Setup Guide](../../STT-TTS/TTS-SETUP-GUIDE.md#dia-setup) |
@@ -289,7 +289,7 @@ Each section highlights installation, configuration, and a smoke test.
 - **Verify**: use the sample curl from [NeuTTS Runbook](../../STT-TTS/NEUTTS_TTS_SETUP.md) and confirm the WAV plays back.
 
 ### Chatterbox
-- **Install**: `pip install -e ".[TTS_chatterbox]"`; add `.[TTS_chatterbox_lang]` if you plan to enable `use_multilingual`. If the runtime still reports missing `chatterbox`, install upstream with `pip install chatterbox-tts` (or from source).
+- **Install**: install the manual runtime dependencies from the Chatterbox runbook, then `pip install chatterbox-tts`; add `.[TTS_chatterbox_lang]` if you plan to enable `use_multilingual`.
 - **Models**: cache `ResembleAI/chatterbox` locally with `hf download ...`.
 - **Config**:
   ```yaml

--- a/backlog/tasks/task-12071 - Move-direct-VCS-extras-to-manual-install-docs.md
+++ b/backlog/tasks/task-12071 - Move-direct-VCS-extras-to-manual-install-docs.md
@@ -4,7 +4,7 @@ title: Move direct VCS extras to manual install docs
 status: Done
 assignee: []
 created_date: '2026-06-29 19:53'
-updated_date: '2026-06-30 01:06'
+updated_date: '2026-06-30 02:08'
 labels:
   - packaging
   - pypi
@@ -40,12 +40,14 @@ Removed direct VCS dependency entries from pyproject optional metadata for ocr_d
 PR review follow-up: PointsReaderBackend.available() now requires the manual WePOINTS module for transformers mode, logs a specific WePOINTS-missing warning, and import errors from optional/manual dependencies are caught as runtime failures instead of escaping OCR flow. Added focused unit coverage for missing WePOINTS availability and ModuleNotFoundError handling. Verification: pytest tldw_Server_API/tests/MediaIngestion_NEW/test_ocr_backend_points.py -q passed (4 passed); optional dependency scan still reports direct-url-deps 0; git diff --check passed.
 
 Final review-fix verification: Bandit on points_reader.py passed with zero findings after the WePOINTS logging refinement.
+
+Additional PR review follow-up: removed the backend-named extras ocr_dots, ocr_points_transformers, and TTS_chatterbox from published package metadata and from the aggregate all extra so manual-only backends no longer look like successful extras installs. Updated OCR/POINTS/Chatterbox docs, including published WebUI docs, to use explicit manual install steps. Pinned the Perth manual install to the previously used commit ce86c49d029f42272c1902eccb675556b9ed2330. Scoped ImportError/ModuleNotFoundError handling to the POINTS transformers path with _POINTS_TRANSFORMERS_EXCEPTIONS and added a regression test ensuring explicit SGLang import errors do not fall through to transformers. Verification: POINTS backend tests passed (5 passed); pyproject parse/direct URL scan passed; package build --no-isolation succeeded; twine check passed; wheel metadata has direct_url_requires=0 and extras_removed_present=[]; Bandit on points_reader.py passed with zero findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Moved source-only direct VCS dependencies out of published package metadata and into manual install documentation. Local package build and twine validation pass, and generated wheel/sdist metadata contains no direct git/URL Requires-Dist entries. Bandit was skipped because the touched files are package metadata and Markdown docs, not Python code.
+Moved source-only direct VCS dependencies out of published package metadata and into manual install documentation. Removed backend-named extras that would otherwise install successfully without the manual backend, kept the SGLang client and Chatterbox language preprocessing extras, and validated generated wheel metadata has no direct URL requirements or removed extras. Runtime handling now requires WePOINTS for POINTS transformers mode and scopes import-error handling to transformers so SGLang errors are not masked. Local package build, twine validation, focused POINTS tests, and Bandit on touched Python passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12071 - Move-direct-VCS-extras-to-manual-install-docs.md
+++ b/backlog/tasks/task-12071 - Move-direct-VCS-extras-to-manual-install-docs.md
@@ -4,7 +4,7 @@ title: Move direct VCS extras to manual install docs
 status: Done
 assignee: []
 created_date: '2026-06-29 19:53'
-updated_date: '2026-06-29 20:00'
+updated_date: '2026-06-30 01:06'
 labels:
   - packaging
   - pypi
@@ -36,6 +36,10 @@ Remove direct VCS dependencies from published package metadata so tldw-server ca
 
 <!-- SECTION:NOTES:BEGIN -->
 Removed direct VCS dependency entries from pyproject optional metadata for ocr_dots, ocr_points_transformers, and TTS_chatterbox while preserving normal PyPI-installable dependencies. Updated OCR and Chatterbox setup docs to direct users to manual source installs for dots.ocr, WePOINTS, and Perth. Verification: pyproject TOML parse passed; optional dependency scan reported zero direct URL deps; python -m build --no-isolation built wheel and sdist to /tmp/tldw_pypi_manual_ocr_dots_dist; twine check passed for both artifacts; wheel and sdist metadata inspection reported direct_url_requires=0. Isolated build without --no-isolation was skipped because sandboxed pip could not reach package indexes to install build-system packages.
+
+PR review follow-up: PointsReaderBackend.available() now requires the manual WePOINTS module for transformers mode, logs a specific WePOINTS-missing warning, and import errors from optional/manual dependencies are caught as runtime failures instead of escaping OCR flow. Added focused unit coverage for missing WePOINTS availability and ModuleNotFoundError handling. Verification: pytest tldw_Server_API/tests/MediaIngestion_NEW/test_ocr_backend_points.py -q passed (4 passed); optional dependency scan still reports direct-url-deps 0; git diff --check passed.
+
+Final review-fix verification: Bandit on points_reader.py passed with zero findings after the WePOINTS logging refinement.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12071 - Move-direct-VCS-extras-to-manual-install-docs.md
+++ b/backlog/tasks/task-12071 - Move-direct-VCS-extras-to-manual-install-docs.md
@@ -1,0 +1,55 @@
+---
+id: TASK-12071
+title: Move direct VCS extras to manual install docs
+status: Done
+assignee: []
+created_date: '2026-06-29 19:53'
+updated_date: '2026-06-29 20:00'
+labels:
+  - packaging
+  - pypi
+  - ocr
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove direct VCS dependencies from published package metadata so tldw-server can be uploaded to PyPI/TestPyPI. Preserve guidance for users who need optional source-only OCR/TTS backends by documenting manual installation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Published package metadata no longer contains direct git/VCS dependencies.
+- [x] #2 Docs explain manual installation for dots-ocr, WePOINTS, and resemble-perth where relevant.
+- [x] #3 Package build/check verification confirms the metadata is acceptable locally.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect package metadata and docs references for direct VCS extras. 2. Remove direct VCS dependency entries from pyproject metadata. 3. Add or update docs with manual installation guidance for affected optional backends. 4. Build/check the package and inspect metadata for direct URL dependency removal.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Removed direct VCS dependency entries from pyproject optional metadata for ocr_dots, ocr_points_transformers, and TTS_chatterbox while preserving normal PyPI-installable dependencies. Updated OCR and Chatterbox setup docs to direct users to manual source installs for dots.ocr, WePOINTS, and Perth. Verification: pyproject TOML parse passed; optional dependency scan reported zero direct URL deps; python -m build --no-isolation built wheel and sdist to /tmp/tldw_pypi_manual_ocr_dots_dist; twine check passed for both artifacts; wheel and sdist metadata inspection reported direct_url_requires=0. Isolated build without --no-isolation was skipped because sandboxed pip could not reach package indexes to install build-system packages.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved source-only direct VCS dependencies out of published package metadata and into manual install documentation. Local package build and twine validation pass, and generated wheel/sdist metadata contains no direct git/URL Requires-Dist entries. Bandit was skipped because the touched files are package metadata and Markdown docs, not Python code.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,16 +266,16 @@ chunking_multilingual = [
 
 # OCR providers (optional)
 ocr_dots = [
-  # Dots OCR from source
-  "dots-ocr @ git+https://github.com/rednote-hilab/dots.ocr.git"
+  # dots.ocr is installed manually from source; direct VCS dependencies are not
+  # accepted in PyPI package metadata.
 ]
 
 ocr_points_transformers = [
   # Local inference requirements for POINTS-Reader via HF Transformers
   "transformers>=5.5.3",
   "torch>=2.11.0",
-  # WePOINTS toolkit (installed from source)
-  "wepoints @ git+https://github.com/WePOINTS/WePOINTS.git"
+  # WePOINTS is installed manually from source; direct VCS dependencies are not
+  # accepted in PyPI package metadata.
 ]
 
 ocr_points_sglang = [
@@ -433,7 +433,8 @@ TTS_chatterbox = [
   # Audio / DSP
   "librosa>=0.10.0",
   "pyloudnorm>=0.1.1",
-  "resemble-perth @ git+https://github.com/resemble-ai/Perth.git@ce86c49d029f42272c1902eccb675556b9ed2330",
+  # resemble-perth is installed manually from source when watermark support is
+  # needed; direct VCS dependencies are not accepted in PyPI package metadata.
   # Diffusion / attention utils used in matcha blocks
   "diffusers>=0.29.0",
   "einops>=0.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,19 +265,8 @@ chunking_multilingual = [
 ]
 
 # OCR providers (optional)
-ocr_dots = [
-  # dots.ocr is installed manually from source; direct VCS dependencies are not
-  # accepted in PyPI package metadata.
-]
-
-ocr_points_transformers = [
-  # Local inference requirements for POINTS-Reader via HF Transformers
-  "transformers>=5.5.3",
-  "torch>=2.11.0",
-  # WePOINTS is installed manually from source; direct VCS dependencies are not
-  # accepted in PyPI package metadata.
-]
-
+# Source-only backends such as dots.ocr and POINTS transformers are installed
+# manually; direct VCS dependencies are not accepted in PyPI package metadata.
 ocr_points_sglang = [
   # Client-side only; server runs separately
   "requests>=2.31.0"
@@ -419,32 +408,6 @@ TTS_echo_tts = [
   "einops>=0.8.0"
 ]
 
-TTS_chatterbox = [
-  # Core compute
-  "torch>=2.11.0",
-  "torchaudio>=2.11.0",
-  "numpy>=1.24.0",
-  "scipy>=1.10.0",
-  # HF stack
-  "transformers>=5.5.3",
-  "tokenizers>=0.13.0",
-  "huggingface_hub>=0.21.0",
-  "safetensors>=0.4.2",
-  # Audio / DSP
-  "librosa>=0.10.0",
-  "pyloudnorm>=0.1.1",
-  # resemble-perth is installed manually from source when watermark support is
-  # needed; direct VCS dependencies are not accepted in PyPI package metadata.
-  # Diffusion / attention utils used in matcha blocks
-  "diffusers>=0.29.0",
-  "einops>=0.7.0",
-  # Conformer block dependency (for matcha decoder)
-  "conformer>=0.3.2",
-  # S3 tokenizer backend
-  "s3tokenizer>=0.1.6",
-  "omegaconf>=2.3.0",
-]
-
 # Optional language preprocessing extras for multilingual text tokenization
 TTS_chatterbox_lang = [
   "pykakasi>=2.2.1",          # Japanese romanization -> hiragana
@@ -502,7 +465,7 @@ gpu_monitoring = [
 
 # All optional dependencies
 all = [
-  "tldw-server[dev,evaluation,data-tools,chunking_multilingual,gradio,ingestion_email,media_wiki,web_research,STT_All,TTS_All,TTS_higgs,TTS_vibevoice,TTS_chatterbox,backend_onnx,db_postgres,ocr_dots,ocr_points_transformers,ocr_points_sglang,gpu_monitoring]"
+  "tldw-server[dev,evaluation,data-tools,chunking_multilingual,gradio,ingestion_email,media_wiki,web_research,STT_All,TTS_All,TTS_higgs,TTS_vibevoice,backend_onnx,db_postgres,ocr_points_sglang,gpu_monitoring]"
 ]
 
 ###########################

--- a/tldw_Server_API/README.md
+++ b/tldw_Server_API/README.md
@@ -133,7 +133,7 @@ Using dots.ocr
   - Create env (Python 3.12), install a compatible PyTorch build (CUDA/CPU), then `pip install -e .` from the dots.ocr repo.
   - Download model weights: `python3 tools/download_model.py` (save directory name should not contain periods; e.g., `DotsOCR`).
   - Recommended: run a vLLM server with the downloaded weights for best performance and consistency.
-- Optional extras: `pip install .[ocr_dots]` to pull dots.ocr automatically.
+- Manual install: `dots.ocr` is not bundled in `tldw-server` package metadata because PyPI rejects direct Git dependencies. Install it from the upstream repo before selecting `ocr_backend=dots`.
 - Backend behavior:
   - The `dots` backend shells out to `python -m dots_ocr.parser` per page image.
   - If dots.ocr is not installed/available, auto-detect falls back to `tesseract` unless `ocr_backend=dots` is explicitly forced.
@@ -150,7 +150,7 @@ Integration tests
 
 Two integration modes
 - Transformers (local model):
-  - Install WePOINTS and use the HF model `tencent/POINTS-Reader` locally.
+  - Install WePOINTS manually from source and use the HF model `tencent/POINTS-Reader` locally.
   - Env (optional): `POINTS_MODEL_PATH` to override model id/path.
   - Requirements: `transformers`, `torch` (CUDA recommended for performance).
 - SGLang server (recommended for production):
@@ -165,8 +165,8 @@ Prompt and generation
 - Set `POINTS_PROMPT` to override the default extraction prompt (tables in HTML, others in Markdown).
 - Optional generation envs: `POINTS_MAX_NEW_TOKENS`, `POINTS_TEMPERATURE`, `POINTS_REPETITION_PENALTY`, `POINTS_TOP_P`, `POINTS_TOP_K`, `POINTS_DO_SAMPLE`.
 
-Install via extras (optional)
-- Local transformers path: `pip install .[ocr_points_transformers]`
+Install via extras/manual source setup (optional)
+- Local transformers path: `pip install .[ocr_points_transformers]`, then install WePOINTS manually from the upstream repo.
 - SGLang client only: `pip install .[ocr_points_sglang]`
 
 Notes

--- a/tldw_Server_API/README.md
+++ b/tldw_Server_API/README.md
@@ -165,8 +165,8 @@ Prompt and generation
 - Set `POINTS_PROMPT` to override the default extraction prompt (tables in HTML, others in Markdown).
 - Optional generation envs: `POINTS_MAX_NEW_TOKENS`, `POINTS_TEMPERATURE`, `POINTS_REPETITION_PENALTY`, `POINTS_TOP_P`, `POINTS_TOP_K`, `POINTS_DO_SAMPLE`.
 
-Install via extras/manual source setup (optional)
-- Local transformers path: `pip install .[ocr_points_transformers]`, then install WePOINTS manually from the upstream repo.
+Manual source setup (optional)
+- Local transformers path: install `transformers` and a CUDA/CPU-compatible `torch`, then install WePOINTS manually from the upstream repo.
 - SGLang client only: `pip install .[ocr_points_sglang]`
 
 Notes

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/points_reader.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/points_reader.py
@@ -15,6 +15,8 @@ _TF_IMAGE_PROCESSOR = None
 _TF_LOCK = threading.Lock()
 _POINTS_RUNTIME_EXCEPTIONS = (
     ConnectionError,
+    ImportError,
+    ModuleNotFoundError,
     OSError,
     RuntimeError,
     TimeoutError,
@@ -22,6 +24,8 @@ _POINTS_RUNTIME_EXCEPTIONS = (
     ValueError,
     json.JSONDecodeError,
 )
+
+_WEPOINTS_MODULE = "wepoints"
 
 
 def _resolve_mode() -> str:
@@ -63,7 +67,10 @@ class PointsReaderBackend(OCRBackend):
             try:
                 has_tf = importlib.util.find_spec("transformers") is not None
                 has_torch = importlib.util.find_spec("torch") is not None
-                return bool(has_tf and has_torch)
+                has_wepoints = importlib.util.find_spec(_WEPOINTS_MODULE) is not None
+                if has_tf and has_torch and not has_wepoints:
+                    logging.warning("PointsReaderBackend transformers mode unavailable: WePOINTS missing")
+                return bool(has_tf and has_torch and has_wepoints)
             except (AttributeError, ImportError, ValueError):
                 return False
         return False
@@ -90,7 +97,10 @@ class PointsReaderBackend(OCRBackend):
 
     def ocr_image(self, image_bytes: bytes, lang: str | None = None) -> str:
         if not self.available():
-            logging.warning("PointsReaderBackend not available: install 'transformers'+'torch' or set up SGLang (requests)")
+            logging.warning(
+                "PointsReaderBackend not available: install 'transformers'+'torch' plus WePOINTS, "
+                "or configure POINTS_SGLANG_URL for SGLang"
+            )
             return ""
 
         prompt = os.getenv("POINTS_PROMPT") or (
@@ -120,7 +130,10 @@ class PointsReaderBackend(OCRBackend):
             try:
                 return _ocr_via_transformers(img_path, prompt)
             except _POINTS_RUNTIME_EXCEPTIONS as e:
-                logging.error(f"POINTS Transformers path failed: {e}", exc_info=True)
+                if isinstance(e, (ImportError, ModuleNotFoundError)) and "wepoints" in str(e).lower():
+                    logging.error(f"POINTS Transformers path failed: WePOINTS missing: {e}", exc_info=True)
+                else:
+                    logging.error(f"POINTS Transformers path failed: {e}", exc_info=True)
                 return ""
 
 

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/points_reader.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/points_reader.py
@@ -15,14 +15,17 @@ _TF_IMAGE_PROCESSOR = None
 _TF_LOCK = threading.Lock()
 _POINTS_RUNTIME_EXCEPTIONS = (
     ConnectionError,
-    ImportError,
-    ModuleNotFoundError,
     OSError,
     RuntimeError,
     TimeoutError,
     TypeError,
     ValueError,
     json.JSONDecodeError,
+)
+
+_POINTS_TRANSFORMERS_EXCEPTIONS = _POINTS_RUNTIME_EXCEPTIONS + (
+    ImportError,
+    ModuleNotFoundError,
 )
 
 _WEPOINTS_MODULE = "wepoints"
@@ -129,7 +132,7 @@ class PointsReaderBackend(OCRBackend):
 
             try:
                 return _ocr_via_transformers(img_path, prompt)
-            except _POINTS_RUNTIME_EXCEPTIONS as e:
+            except _POINTS_TRANSFORMERS_EXCEPTIONS as e:
                 if isinstance(e, (ImportError, ModuleNotFoundError)) and "wepoints" in str(e).lower():
                     logging.error(f"POINTS Transformers path failed: WePOINTS missing: {e}", exc_info=True)
                 else:

--- a/tldw_Server_API/tests/MediaIngestion_NEW/test_ocr_backend_points.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/test_ocr_backend_points.py
@@ -90,3 +90,25 @@ def test_points_transformers_missing_optional_dependency_returns_empty(monkeypat
     out = points_reader.PointsReaderBackend().ocr_image(b"not-a-real-image", lang="eng")
 
     assert out == ""
+
+
+@pytest.mark.unit
+def test_points_sglang_import_error_does_not_fall_through_to_transformers(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends import (
+        points_reader,
+    )
+
+    monkeypatch.setenv("POINTS_MODE", "sglang")
+    monkeypatch.setenv("POINTS_SGLANG_URL", "http://127.0.0.1:9999/v1/chat/completions")
+
+    def fail_sglang(image_path, prompt):
+        raise ModuleNotFoundError("No module named 'requests'")
+
+    def fail_transformers(image_path, prompt):
+        pytest.fail("SGLang import failures must not fall through to transformers")
+
+    monkeypatch.setattr(points_reader, "_ocr_via_sglang", fail_sglang)
+    monkeypatch.setattr(points_reader, "_ocr_via_transformers", fail_transformers)
+
+    with pytest.raises(ModuleNotFoundError):
+        points_reader.PointsReaderBackend().ocr_image(b"not-a-real-image", lang="eng")

--- a/tldw_Server_API/tests/MediaIngestion_NEW/test_ocr_backend_points.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/test_ocr_backend_points.py
@@ -51,3 +51,42 @@ def test_points_backend_sglang_mock(monkeypatch):
     )
     out = backend.ocr_image(png_bytes, lang="eng")
     assert isinstance(out, str) and out == "MOCK_TEXT"
+
+
+@pytest.mark.unit
+def test_points_transformers_requires_wepoints(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader import (
+        PointsReaderBackend,
+    )
+
+    monkeypatch.setenv("POINTS_MODE", "transformers")
+
+    def fake_find_spec(name):
+        if name in {"transformers", "torch"}:
+            return object()
+        if name == "wepoints":
+            return None
+        raise AssertionError(f"unexpected module probe: {name}")
+
+    monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
+
+    assert PointsReaderBackend.available() is False
+
+
+@pytest.mark.unit
+def test_points_transformers_missing_optional_dependency_returns_empty(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends import (
+        points_reader,
+    )
+
+    monkeypatch.setenv("POINTS_MODE", "transformers")
+    monkeypatch.setattr(points_reader.PointsReaderBackend, "available", classmethod(lambda cls: True))
+    monkeypatch.setattr(
+        points_reader,
+        "_ocr_via_transformers",
+        lambda image_path, prompt: (_ for _ in ()).throw(ModuleNotFoundError("No module named 'wepoints'")),
+    )
+
+    out = points_reader.PointsReaderBackend().ocr_image(b"not-a-real-image", lang="eng")
+
+    assert out == ""


### PR DESCRIPTION
## Summary
- Remove source-only direct VCS dependencies from published tldw-server package metadata.
- Document manual source installs for dots.ocr, WePOINTS, and Perth.
- Add Backlog task TASK-12071 with verification notes.

## Why
PyPI/TestPyPI reject package metadata containing direct Git dependencies. TestPyPI initially rejected dots-ocr, and the remaining direct VCS extras would have caused the same class of failure.

## Verification
- python -m build --no-isolation --outdir /tmp/tldw_pypi_manual_ocr_dots_dist
- python -m twine check /tmp/tldw_pypi_manual_ocr_dots_dist/*
- Wheel metadata inspection: direct_url_requires=0
- TestPyPI publish succeeded: https://github.com/rmusser01/tldw_server/actions/runs/28399227750

## Merge note
Per repo policy, this AI-authored PR still needs a human-authored Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed VCS-only OCR/TTS extras and backend-named extras from `pyproject.toml`, updated docs to manual installs for source-only deps, and enforced `WePOINTS` for POINTS transformers to unblock PyPI/TestPyPI (TASK-12071).

- **Dependencies**
  - Removed `ocr_dots`, `ocr_points_transformers`, and `TTS_chatterbox` extras and dropped them from the `all` extra; no direct VCS URLs remain in wheel/sdist (`twine check` OK).
  - POINTS transformers now requires `wepoints`; missing module logs a clear warning and marks the backend unavailable. Import errors are scoped to transformers; added unit tests.

- **Migration**
  - `dots.ocr`: install from source; the `ocr_dots` extra is removed.
  - POINTS (Transformers): install `transformers` and a CUDA/CPU `torch`, then install `WePOINTS` from source; or use SGLang via `.[ocr_points_sglang]`.
  - Chatterbox: install runtime deps + `pip install chatterbox-tts`; optional `Perth` watermark must be installed from source.

<sup>Written for commit 833581cc4f2efba25013bd0ac80a84a5b3008e74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

