### PR TITLE
Migrate TTS product-state alerts to design-system Alert

### DIFF
--- a/apps/packages/ui/scripts/design-system-product-state-baseline.json
+++ b/apps/packages/ui/scripts/design-system-product-state-baseline.json
@@ -561,61 +561,6 @@
     "migrationQueue": "shared-product-state"
   },
   {
-    "id": "antd-product-state-import:src/components/Option/TTS/TtsPlaygroundPage.tsx:Alert#antd-alert-ttsplaygroundpage-type-info-line-548-1132c3s",
-    "path": "src/components/Option/TTS/TtsPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/TTS/TtsPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/TTS/TtsPlaygroundPage.tsx:Alert#antd-alert-ttsplaygroundpage-type-info-line-567-1aq483",
-    "path": "src/components/Option/TTS/TtsPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/TTS/TtsPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/TTS/TtsPlaygroundPage.tsx:Alert#antd-alert-ttsplaygroundpage-type-warning-line-524-d703fg",
-    "path": "src/components/Option/TTS/TtsPlaygroundPage.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/TTS/TtsPlaygroundPage.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/TTS/VoiceCloningManager.tsx:Alert#antd-alert-voicecloningmanager-type-warning-provider-dis-zpbhde",
-    "path": "src/components/Option/TTS/VoiceCloningManager.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/TTS/VoiceCloningManager.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
-    "id": "antd-product-state-import:src/components/Option/TTS/VoiceCloningManager.tsx:Alert#antd-alert-voicecloningmanager-type-warning-voice-roles-dyycgq",
-    "path": "src/components/Option/TTS/VoiceCloningManager.tsx",
-    "rule": "antd-product-state-import",
-    "subject": "Alert",
-    "state": "allowed_legacy_exception",
-    "owner": "design-system",
-    "reason": "Existing AntD Alert product-state UI in src/components/Option/TTS/VoiceCloningManager.tsx before the stable duplicate-id guard.",
-    "replacement": "tldw design-system state primitive",
-    "migrationQueue": "shared-product-state"
-  },
-  {
     "id": "antd-product-state-import:src/components/Quiz/tabs/CreateTab.tsx:Alert#antd-alert-createtab-type-info-line-1003-u954tt",
     "path": "src/components/Quiz/tabs/CreateTab.tsx",
     "rule": "antd-product-state-import",

--- a/apps/packages/ui/src/components/Option/TTS/TtsPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/TTS/TtsPlaygroundPage.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import {
   Button,
   Input,
-  Alert,
   Progress,
   Typography,
   Space,
@@ -36,6 +35,7 @@ import {
   OPENAI_TTS_VOICES,
   useTtsProviderData
 } from "@/hooks/useTtsProviderData"
+import { Alert } from "@/components/ui/primitives/Alert"
 import type {
   Model as ElevenLabsModel,
   Voice as ElevenLabsVoice
@@ -533,12 +533,15 @@ const TtsPlaygroundPage: React.FC = () => {
 
       {capabilities?.ffmpegAvailable === false && (
         <Alert
-          type="warning"
-          showIcon
+          variant="warning"
           className="mt-3 mb-0"
-          message={t("playground:tts.ffmpegWarningTitle", "ffmpeg not detected")}
-          description={t("playground:tts.ffmpegWarningBody", "Some audio processing features require ffmpeg. Install it for full functionality.")}
-        />
+          title={t("playground:tts.ffmpegWarningTitle", "ffmpeg not detected")}
+        >
+          {t(
+            "playground:tts.ffmpegWarningBody",
+            "Some audio processing features require ffmpeg. Install it for full functionality."
+          )}
+        </Alert>
       )}
 
       <div className="mt-4 space-y-4">
@@ -617,40 +620,38 @@ const TtsPlaygroundPage: React.FC = () => {
 
             {showElevenLabsHint && (
               <Alert
-                type={hasElevenLabsKey ? "warning" : "info"}
-                showIcon
+                variant={hasElevenLabsKey ? "warning" : "info"}
                 title={elevenLabsHintTitle}
-                description={
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span>
-                      {hasElevenLabsLoadError && isTimeoutLikeError(elevenLabsError)
-                        ? elevenLabsTimeoutBody
-                        : elevenLabsHintBody}
-                    </span>
-                    {hasElevenLabsKey && (
-                      <Button
-                        size="small"
-                        type="link"
-                        onClick={() => {
-                          void refetchElevenLabs()
-                        }}
-                      >
-                        {t("common:retry", "Retry")}
-                      </Button>
-                    )}
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span>
+                    {hasElevenLabsLoadError && isTimeoutLikeError(elevenLabsError)
+                      ? elevenLabsTimeoutBody
+                      : elevenLabsHintBody}
+                  </span>
+                  {hasElevenLabsKey && (
                     <Button
                       size="small"
                       type="link"
-                      onClick={handleElevenLabsApiKeyFocus}
+                      onClick={() => {
+                        void refetchElevenLabs()
+                      }}
                     >
-                      {t(
-                        "playground:tts.elevenLabsMissingCta",
-                        "Set API key in Settings"
-                      )}
+                      {t("common:retry", "Retry")}
                     </Button>
-                  </div>
-                }
-              />
+                  )}
+                  <Button
+                    size="small"
+                    type="link"
+                    onClick={handleElevenLabsApiKeyFocus}
+                  >
+                    {t(
+                      "playground:tts.elevenLabsMissingCta",
+                      "Set API key in Settings"
+                    )}
+                  </Button>
+                </div>
+              </Alert>
             )}
 
             {ttsSettings?.ttsProvider === "elevenlabs" && elevenLabsData && (

--- a/apps/packages/ui/src/components/Option/TTS/VoiceCloningManager.tsx
+++ b/apps/packages/ui/src/components/Option/TTS/VoiceCloningManager.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useTranslation } from "react-i18next"
 import {
-  Alert,
   Button,
   Input,
   List,
@@ -14,6 +14,7 @@ import {
   notification
 } from "antd"
 import { Trash2, Play, UploadCloud, Wand2 } from "lucide-react"
+import { Alert } from "@/components/ui/primitives/Alert"
 import type { TldwTtsProvidersInfo } from "@/services/tldw/audio-providers"
 import { getProviderLabel } from "@/utils/provider-registry"
 import {
@@ -85,6 +86,7 @@ export const VoiceCloningManager: React.FC<VoiceCloningManagerProps> = ({
   onSelectVoice,
   onSelectVoices
 }) => {
+  const { t } = useTranslation(["playground"])
   const queryClient = useQueryClient()
   const { data: customVoices = [], isLoading: voicesLoading } = useQuery<TldwCustomVoice[]>(
     {
@@ -306,19 +308,44 @@ export const VoiceCloningManager: React.FC<VoiceCloningManagerProps> = ({
 
   const voiceRoleError = React.useMemo(() => {
     if (!useVoiceRoles) return null
-    if (voiceCards.length < 1) return "Select at least one voice."
-    if (voiceCards.length > 4) return "Select up to four voices."
+    if (voiceCards.length < 1) {
+      return t(
+        "playground:tts.cloning.voiceRoleSelectAtLeastOne",
+        "Select at least one voice."
+      )
+    }
+    if (voiceCards.length > 4) {
+      return t(
+        "playground:tts.cloning.voiceRoleSelectUpToFour",
+        "Select up to four voices."
+      )
+    }
     const roles = new Set<string>()
     const voices = new Set<string>()
     for (const card of voiceCards) {
-      if (!card.voiceId) return "Each role needs a voice."
-      if (roles.has(card.role)) return "Roles must be unique."
-      if (voices.has(card.voiceId)) return "Voices must be unique."
+      if (!card.voiceId) {
+        return t(
+          "playground:tts.cloning.voiceRoleNeedsVoice",
+          "Each role needs a voice."
+        )
+      }
+      if (roles.has(card.role)) {
+        return t(
+          "playground:tts.cloning.voiceRoleUniqueRoles",
+          "Roles must be unique."
+        )
+      }
+      if (voices.has(card.voiceId)) {
+        return t(
+          "playground:tts.cloning.voiceRoleUniqueVoices",
+          "Voices must be unique."
+        )
+      }
       roles.add(card.role)
       voices.add(card.voiceId)
     }
     return null
-  }, [useVoiceRoles, voiceCards])
+  }, [t, useVoiceRoles, voiceCards])
 
   const roleVoiceOptions = React.useMemo(() => {
     return customVoices.map((voice) => ({
@@ -422,11 +449,17 @@ export const VoiceCloningManager: React.FC<VoiceCloningManagerProps> = ({
 
       {providerUnavailable && (
         <Alert
-          type="warning"
-          showIcon
-          title="Provider disabled on server"
-          description="Enable this provider in Config_Files/tts_providers_config.yaml to upload voices."
-        />
+          title={t(
+            "playground:tts.cloning.providerDisabledTitle",
+            "Provider disabled on server"
+          )}
+          variant="warning"
+        >
+          {t(
+            "playground:tts.cloning.providerDisabledBody",
+            "Enable this provider in Config_Files/tts_providers_config.yaml to upload voices."
+          )}
+        </Alert>
       )}
 
       <div className="flex flex-wrap items-center gap-2">
@@ -555,11 +588,14 @@ export const VoiceCloningManager: React.FC<VoiceCloningManagerProps> = ({
               </div>
               {voiceRoleError && (
                 <Alert
-                  type="warning"
-                  showIcon
-                  title="Voice roles need attention"
-                  description={voiceRoleError}
-                />
+                  title={t(
+                    "playground:tts.cloning.voiceRolesAttentionTitle",
+                    "Voice roles need attention"
+                  )}
+                  variant="warning"
+                >
+                  {voiceRoleError}
+                </Alert>
               )}
             </>
           )}

--- a/apps/packages/ui/src/components/Option/TTS/__tests__/TtsPlaygroundPage.defaults.test.tsx
+++ b/apps/packages/ui/src/components/Option/TTS/__tests__/TtsPlaygroundPage.defaults.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import TtsPlaygroundPage from "@/components/Option/TTS/TtsPlaygroundPage"
+import { expectInsideDesignSystemAlert } from "@/test-utils/designSystemAlert"
 
 const DEFAULT_KITTEN_MODEL = "KittenML/kitten-tts-nano-0.8"
 
@@ -29,6 +30,12 @@ const providerDataState = vi.hoisted(() => ({
   tldwVoiceCatalog: [
     { id: "Bella", name: "Bella", language: "en" }
   ]
+}))
+
+const capabilitiesState = vi.hoisted(() => ({
+  data: {
+    ffmpegAvailable: true
+  }
 }))
 
 vi.mock("@/services/tts", () => ({
@@ -79,9 +86,7 @@ vi.mock("@/hooks/useTtsPlayground", () => ({
 
 vi.mock("@/hooks/useServerCapabilities", () => ({
   useServerCapabilities: () => ({
-    capabilities: {
-      ffmpegAvailable: true
-    }
+    capabilities: capabilitiesState.data
   })
 }))
 
@@ -99,6 +104,9 @@ vi.mock("@/components/Common/PageShell", () => ({
 
 describe("TtsPlaygroundPage defaults", () => {
   beforeEach(() => {
+    capabilitiesState.data = {
+      ffmpegAvailable: true
+    }
     providerDataState.hasAudio = true
     providerDataState.tldwVoiceCatalog = [
       { id: "Bella", name: "Bella", language: "en" }
@@ -191,6 +199,58 @@ describe("TtsPlaygroundPage defaults", () => {
     expect(screen.getByText(/Open Speech Settings/)).toBeInTheDocument()
     expect(screen.getByText(/Browser/)).toBeInTheDocument()
     expect(container.querySelectorAll(".ant-alert")).toHaveLength(0)
+  })
+
+  it("renders the ffmpeg warning with the design-system Alert primitive", async () => {
+    capabilitiesState.data = {
+      ffmpegAvailable: false
+    }
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false
+        }
+      }
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TtsPlaygroundPage />
+      </QueryClientProvider>
+    )
+
+    await screen.findByText("ffmpeg not detected")
+    expectInsideDesignSystemAlert("ffmpeg not detected")
+    expectInsideDesignSystemAlert(
+      "Some audio processing features require ffmpeg. Install it for full functionality."
+    )
+  })
+
+  it("renders ElevenLabs setup guidance with the design-system Alert primitive", async () => {
+    ttsSettingsState.data = {
+      ...ttsSettingsState.data,
+      ttsProvider: "elevenlabs",
+      elevenLabsApiKey: ""
+    }
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false
+        }
+      }
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TtsPlaygroundPage />
+      </QueryClientProvider>
+    )
+
+    await screen.findByText("ElevenLabs needs an API key")
+    expectInsideDesignSystemAlert("ElevenLabs needs an API key")
+    expectInsideDesignSystemAlert(
+      "Add your ElevenLabs API key in Settings to load voices and models."
+    )
   })
 
   it("keeps Play disabled when tldw server TTS setup is required", async () => {

--- a/apps/packages/ui/src/components/Option/TTS/__tests__/VoiceCloningManager.test.tsx
+++ b/apps/packages/ui/src/components/Option/TTS/__tests__/VoiceCloningManager.test.tsx
@@ -7,6 +7,7 @@ import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { TldwTtsProvidersInfo } from "@/services/tldw/audio-providers"
+import { expectInsideDesignSystemAlert } from "@/test-utils/designSystemAlert"
 import { VoiceCloningManager } from "../VoiceCloningManager"
 
 const mocks = vi.hoisted(() => ({
@@ -17,6 +18,17 @@ const mocks = vi.hoisted(() => ({
   synthesizeSpeech: vi.fn(),
   notificationError: vi.fn(),
   notificationSuccess: vi.fn()
+}))
+
+const translationState = vi.hoisted(() => ({
+  overrides: {} as Record<string, string>
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) =>
+      translationState.overrides[key] ?? fallback ?? key
+  })
 }))
 
 vi.mock("antd", async () => {
@@ -74,7 +86,9 @@ const rawServerError = (method: string, path: string, action: string) =>
     `Request failed: 500 (${method} ${path}) token=sk_secret_${action} /Users/alice/private/${action}.json`
   )
 
-const renderVoiceCloningManager = () => {
+const renderVoiceCloningManager = (
+  nextProvidersInfo: TldwTtsProvidersInfo | null = providersInfo
+) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -88,7 +102,7 @@ const renderVoiceCloningManager = () => {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <VoiceCloningManager providersInfo={providersInfo} />
+      <VoiceCloningManager providersInfo={nextProvidersInfo} />
     </QueryClientProvider>
   )
 }
@@ -108,6 +122,7 @@ const expectSanitizedDescription = () => {
 describe("VoiceCloningManager", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    translationState.overrides = {}
     mocks.listCustomVoices.mockResolvedValue([customVoice])
     mocks.uploadCustomVoice.mockResolvedValue({
       voice_id: "new-voice",
@@ -198,5 +213,34 @@ describe("VoiceCloningManager", () => {
       )
     })
     expectSanitizedDescription()
+  })
+
+  it("renders disabled provider guidance with the design-system Alert primitive", async () => {
+    translationState.overrides = {
+      "playground:tts.cloning.providerDisabledTitle": "Translated provider disabled",
+      "playground:tts.cloning.providerDisabledBody": "Translated provider body"
+    }
+    renderVoiceCloningManager({ providers: {}, voices: {} })
+
+    await screen.findByText("Translated provider disabled")
+
+    expectInsideDesignSystemAlert("Translated provider disabled")
+    expectInsideDesignSystemAlert("Translated provider body")
+  })
+
+  it("renders voice role validation with the design-system Alert primitive", async () => {
+    const user = userEvent.setup()
+    translationState.overrides = {
+      "playground:tts.cloning.voiceRolesAttentionTitle": "Translated role warning",
+      "playground:tts.cloning.voiceRoleNeedsVoice": "Translated missing voice"
+    }
+    mocks.listCustomVoices.mockResolvedValueOnce([])
+    renderVoiceCloningManager()
+
+    await user.click(screen.getByRole("switch"))
+
+    await screen.findByText("Translated role warning")
+    expectInsideDesignSystemAlert("Translated role warning")
+    expectInsideDesignSystemAlert("Translated missing voice")
   })
 })

--- a/backlog/tasks/task-45.44.13 - Migrate-design-system-product-state-Other-shared-surfaces-and-long-tail-triage.md
+++ b/backlog/tasks/task-45.44.13 - Migrate-design-system-product-state-Other-shared-surfaces-and-long-tail-triage.md
@@ -43,3 +43,9 @@ Mirror the linked GitHub product-area migration issue. Closure requires zero cur
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- TASK-45.44.13.6 migrates TTS playground and voice-cloning Alert product states to the design-system Alert primitive, removes five TTS baseline exceptions, and is tracked in PR https://github.com/rmusser01/tldw_server/pull/2552.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-45.44.13.6 - Migrate-TTS-product-state-alerts-to-design-system-Alert.md
+++ b/backlog/tasks/task-45.44.13.6 - Migrate-TTS-product-state-alerts-to-design-system-Alert.md
@@ -1,0 +1,78 @@
+---
+id: TASK-45.44.13.6
+title: Migrate TTS product-state alerts to design-system Alert
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-30 04:53'
+labels:
+  - design-system
+  - webui
+  - product-state
+  - tts
+dependencies: []
+references:
+  - apps/packages/ui/src/components/Option/TTS/TtsPlaygroundPage.tsx
+  - apps/packages/ui/src/components/Option/TTS/VoiceCloningManager.tsx
+  - apps/packages/ui/scripts/verify-design-system-product-state.mjs
+documentation:
+  - Docs/Design/tldw_web_design_system_contract.md
+  - Docs/Design/tldw_web_design_system_inventory.md
+parent_task_id: TASK-45.44.13
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue the tldw_server WebUI design-system product-state migration by replacing remaining TTS AntD Alert product-state surfaces in TtsPlaygroundPage and VoiceCloningManager with the shared design-system Alert primitive while preserving copy, actions, and layout behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 TTS product-state Alert surfaces in TtsPlaygroundPage and VoiceCloningManager render through the shared design-system Alert primitive while preserving existing user-facing copy and actions.
+- [x] #2 Focused TTS coverage asserts migrated alerts are inside the design-system Alert marker.
+- [x] #3 Direct product-state guard scan over the touched TTS files reports zero findings for the migrated Alert surfaces.
+- [x] #4 Verification records focused Vitest coverage, product-state guard status, diff whitespace, TypeScript touched-file status where practical, and Bandit applicability.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- RED: `bunx vitest run src/components/Option/TTS/__tests__/TtsPlaygroundPage.defaults.test.tsx` failed on the new ffmpeg and ElevenLabs assertions because the visible text had no `data-ds-component="Alert"` ancestor while the component still used AntD Alert.
+- RED: `bunx vitest run src/components/Option/TTS/__tests__/VoiceCloningManager.test.tsx` failed on the new disabled-provider and voice-role validation assertions for the same missing design-system Alert marker.
+- Migrated TtsPlaygroundPage ffmpeg warning and ElevenLabs setup/load guidance to `@/components/ui/primitives/Alert`, preserving titles, body copy, retry/settings actions, and layout classes.
+- Migrated VoiceCloningManager disabled-provider and voice-role validation alerts to the shared design-system Alert primitive while preserving copy and surrounding upload/role flows.
+- Removed the five matching TTS Alert baseline exceptions from `design-system-product-state-baseline.json`.
+- GREEN: `bunx vitest run src/components/Option/TTS/__tests__/TtsPlaygroundPage.defaults.test.tsx` passed 6 tests.
+- GREEN: `bunx vitest run src/components/Option/TTS/__tests__/VoiceCloningManager.test.tsx` passed 4 tests.
+- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 54 tests.
+- Direct product-state analyzer over `TtsPlaygroundPage.tsx` and `VoiceCloningManager.tsx` returned `[]` for both files.
+- `bun run verify:design-system-state` still exits 1 on unrelated current-dev Skills/ScheduledTasks blockers plus one unrelated stale Models baseline row; no TTS blocked or stale findings remain.
+- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide TypeScript debt; no diagnostics reference the touched TTS component/test files.
+- `git diff --check` passed.
+- Bandit is not applicable because this slice only touches frontend TypeScript/TSX, JSON baseline data, and Backlog markdown.
+- PR: https://github.com/rmusser01/tldw_server/pull/2552
+- Review follow-up: Gemini flagged the newly migrated VoiceCloningManager alert title/body strings as hardcoded. Added `useTranslation(["playground"])` and `playground:tts.cloning.*` fallback keys for disabled-provider guidance and voice-role alert titles.
+- RED review test: `bunx vitest run src/components/Option/TTS/__tests__/VoiceCloningManager.test.tsx` failed 2/4 assertions because translated provider and voice-role alert strings were not rendered.
+- GREEN review verification: `bunx vitest run src/components/Option/TTS/__tests__/VoiceCloningManager.test.tsx` passed 4 tests; the combined TTS regression command passed 10 tests; `product-state-guard.test.ts` passed 54 tests; direct analyzer over the touched TTS files exited 0; `git diff --check` passed.
+- Review verifier status: `bun run verify:design-system-state` still exits 1 only on unrelated Skills/ScheduledTasks blocked findings plus the unrelated stale Models baseline row; `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide TypeScript debt with no diagnostics in touched VoiceCloningManager files.
+- Review follow-up: verified the voice-role Alert body still used hardcoded `voiceRoleError` strings. Localized all five voice-role validation branches with `playground:tts.cloning.voiceRole*` fallback keys before rendering the existing localized warning title.
+- RED body-localization test: `bunx vitest run src/components/Option/TTS/__tests__/VoiceCloningManager.test.tsx` failed 1/4 because `Translated missing voice` was not rendered.
+- GREEN body-localization test: `bunx vitest run src/components/Option/TTS/__tests__/VoiceCloningManager.test.tsx` passed 4 tests.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Migrated the remaining TTS playground and voice-cloning product-state Alert callouts from AntD Alert to the shared design-system Alert primitive. Focused tests now assert DS Alert ownership for ffmpeg warning, ElevenLabs setup guidance, disabled provider guidance, and voice-role validation; the five obsolete TTS baseline exceptions were removed. PR review follow-up made the newly migrated VoiceCloningManager alert labels and voice-role validation body strings translation-backed with `playground:tts.cloning.*` fallback keys.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary
- Migrates TtsPlaygroundPage ffmpeg and ElevenLabs guidance from AntD Alert to the shared design-system Alert primitive.
- Migrates VoiceCloningManager disabled-provider and voice-role validation alerts to the design-system Alert primitive.
- Adds focused DS Alert marker coverage for those four TTS states and removes the five obsolete TTS Alert baseline exceptions.

## Verification
- RED: `bunx vitest run src/components/Option/TTS/__tests__/TtsPlaygroundPage.defaults.test.tsx` failed on missing DS Alert ancestors before implementation.
- RED: `bunx vitest run src/components/Option/TTS/__tests__/VoiceCloningManager.test.tsx` failed on missing DS Alert ancestors before implementation.
- GREEN: `bunx vitest run src/components/Option/TTS/__tests__/TtsPlaygroundPage.defaults.test.tsx src/components/Option/TTS/__tests__/VoiceCloningManager.test.tsx --reporter=dot` passed 10 tests.
- `bunx vitest run src/design-system/__tests__/product-state-guard.test.ts --reporter=dot` passed 54 tests.
- Direct analyzer over `TtsPlaygroundPage.tsx` and `VoiceCloningManager.tsx` returned `[]`.
- `git diff --check` passed.

## Known unrelated blockers
- `bun run verify:design-system-state` still exits 1 on current-dev Skills/ScheduledTasks blockers plus one unrelated stale Models baseline row; no TTS blocked or stale findings remain.
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false` still exits 2 on existing repo-wide TypeScript debt; no diagnostics reference the touched TTS component/test files.
- Bandit not run: this slice touches only frontend TypeScript/TSX, JSON baseline data, and Backlog markdown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated all TTS product-state alerts to the design-system `Alert` to standardize UI and pass product-state guards. Also localized VoiceCloningManager alert text and voice-role validation messages.

- **Refactors**
  - Replaced `antd` Alert with design-system `Alert` (`@/components/ui/primitives/Alert`) for: ffmpeg warning, ElevenLabs setup/load guidance (kept Retry/Settings actions), disabled provider, and voice-role validation.
  - Localized VoiceCloningManager alert titles and all voice-role validation bodies using `useTranslation` with `playground:tts.cloning.*` keys.
  - Added focused tests with `expectInsideDesignSystemAlert` covering ffmpeg warning, ElevenLabs guidance, disabled provider, and voice-role validation.
  - Removed five TTS baseline exceptions from `apps/packages/ui/scripts/design-system-product-state-baseline.json`.

<sup>Written for commit c8d2c9626949fd5c6a10240db22d75905abc29fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

