### PR TITLE
docs(mcp): explain standalone profile discovery

### DIFF
--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -112,6 +112,30 @@ List bundled profile presets:
 mcp-unified-gateway list-presets
 ```
 
+Option A: duplicate a preset, then preview the new stored profile:
+
+```bash
+mcp-unified-gateway duplicate-preset project-researcher \
+  --profile-id <new-profile-id> --config ./gateway.json
+
+mcp-unified-gateway preview-profile-tools --profile <new-profile-id> \
+  --config ./gateway.json
+```
+
+Option B: create a profile from JSON, then preview the ID declared inside that
+file:
+
+```bash
+mcp-unified-gateway create-profile --profile-file ./profile.json \
+  --config ./gateway.json
+
+mcp-unified-gateway preview-profile-tools --profile <profile-id-from-json> \
+  --config ./gateway.json
+```
+
+For a minimal custom profile JSON template and the recommended discovery flow,
+see [USER_GUIDE.md](USER_GUIDE.md#3-work-with-profiles).
+
 Run the deterministic in-process smoke scenario:
 
 ```bash
@@ -144,6 +168,9 @@ mcp-unified-gateway tool-events report --group-by profile --config ./gateway.jso
 `explain-policy` explains one profile/tool decision before execution. It reports
 the effective `allow`, `ask`, or `deny` outcome, reason code, contributing
 policy state, and redacted subjects for a hypothetical tool call.
+It does not execute filesystem tools or fully validate authored
+`policy_document.path_grants`; verify those with safe runtime tool calls against
+representative allowed and denied paths.
 
 `preview-profile-tools` previews a profile's effective tool surface across
 installed tools and profile recommendations so operators can see which tools are
@@ -154,10 +181,10 @@ approval grants.
 Local CLI examples:
 
 ```bash
-mcp-unified-gateway explain-policy --profile researcher --tool fs.patch \
+mcp-unified-gateway explain-policy --profile <profile-id> --tool fs.patch \
   --args-json-file ./patch-args.json --config ./gateway.json
 
-mcp-unified-gateway preview-profile-tools --profile researcher \
+mcp-unified-gateway preview-profile-tools --profile <profile-id> \
   --category filesystem --config ./gateway.json
 ```
 
@@ -167,10 +194,10 @@ Remote CLI example:
 export MCP_UNIFIED_GATEWAY_URL=http://127.0.0.1:8000/mcp
 export MCP_UNIFIED_GATEWAY_ADMIN_KEY=replace-with-admin-key
 
-printf '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
-  --remote --profile researcher --tool fs.read --args-stdin
+echo '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
+  --remote --profile <profile-id> --tool fs.read --args-stdin
 
-mcp-unified-gateway preview-profile-tools --remote --profile researcher \
+mcp-unified-gateway preview-profile-tools --remote --profile <profile-id> \
   --category filesystem --session-id "$MCP_SESSION_ID" --exclude-denied
 ```
 
@@ -180,9 +207,9 @@ Admin API examples:
 curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/policy/explain" \
   -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"profile_id":"researcher","tool_name":"fs.read","arguments":{"path":"src/app.py"}}'
+  -d '{"profile_id":"<profile-id>","tool_name":"fs.read","arguments":{"path":"src/app.py"}}'
 
-curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/researcher/tool-preview" \
+curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/<profile-id>/tool-preview" \
   -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"category":"filesystem","include_denied":true,"session_id":"session-1"}'

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -138,6 +138,120 @@ mcp-unified-gateway get-default-profile \
   --config ./gateway.json
 ```
 
+### Know Which Tools Are Available
+
+The standalone gateway does not have one static global tool list. The effective
+tool surface depends on the installed backend tools, registered external MCP
+servers, profile policy, credentials, workspace/path grants, approvals, and any
+session-scoped grants. Use discovery in this order:
+
+1. Start with presets to understand the intended role shape:
+
+   ```bash
+   mcp-unified-gateway list-presets
+   mcp-unified-gateway show-preset project-researcher
+   ```
+
+2. Create or duplicate a profile into the configured store.
+
+3. Preview that stored profile's effective tool surface:
+
+   ```bash
+   mcp-unified-gateway preview-profile-tools --profile <profile-id> \
+     --config ./gateway.json
+
+   mcp-unified-gateway preview-profile-tools --profile <profile-id> \
+     --category filesystem --exclude-denied --config ./gateway.json
+   ```
+
+4. For a running gateway, the final model-facing discovery surface is still the
+   MCP `tools/list` response for that authenticated session/profile. Profiles
+   can also expose bridge tools such as `tool_categories.list`, `tool_search`,
+   `tool_describe`, and `profile.tools.list` so clients can discover deferred
+   or recommended tools without expanding the direct executable surface.
+
+### Create A Custom Profile
+
+For most operators, duplicating a bundled preset is the safest starting point.
+When a preset is not close enough, create a profile JSON document and store it
+with `create-profile`.
+
+Minimal read-oriented profile:
+
+```json
+{
+  "id": "docs-researcher",
+  "name": "Docs Researcher",
+  "description": "Read-only documentation and workspace research profile.",
+  "policy_document": {
+    "allowed_tools": [
+      "tool_categories.list",
+      "tool_search",
+      "tool_describe",
+      "profile.tools.list",
+      "fs.list",
+      "fs.read",
+      "fs.stat",
+      "fs.glob",
+      "fs.grep"
+    ],
+    "capabilities": [
+      "filesystem.read"
+    ],
+    "path_scope_mode": "workspace_root",
+    "path_grants": [
+      {
+        "path": "docs",
+        "actions": ["read"]
+      },
+      {
+        "path": "src",
+        "actions": ["read"]
+      }
+    ]
+  },
+  "metadata": {
+    "agent_metadata": {
+      "ui_label": "Docs Researcher"
+    }
+  }
+}
+```
+
+Save the document as `docs-researcher.json`, then create and inspect it:
+
+```bash
+mcp-unified-gateway create-profile --profile-file ./docs-researcher.json \
+  --config ./gateway.json
+
+mcp-unified-gateway show-profile docs-researcher --config ./gateway.json
+```
+
+Validate the profile's tool surface before assigning it:
+
+```bash
+mcp-unified-gateway preview-profile-tools --profile docs-researcher \
+  --config ./gateway.json
+```
+
+Use `explain-policy` to inspect tool-level allow/ask/deny decisions,
+`permission_rules`, and runtime TTL grants for a hypothetical call:
+
+```bash
+echo '{"path":"docs/README.md"}' | mcp-unified-gateway explain-policy \
+  --profile docs-researcher --tool fs.read --args-stdin --config ./gateway.json
+```
+
+`explain-policy` does not execute filesystem tools and should not be treated as
+a full validation of authored `policy_document.path_grants`. Validate path
+grants with safe runtime tool calls against representative allowed and denied
+paths in the intended workspace/session before assigning the profile.
+
+If a tool is missing, first check whether the backend tool is installed or only
+recommended, then check `policy_document.allowed_tools`, path grants, external
+server registration, credential grants, and approval/session state. Use
+`patch-profile` for small policy updates after creation.
+
 ### Profile Tooling Discovery
 
 `list-presets` includes compact tooling discovery metadata for role presets.
@@ -185,6 +299,14 @@ content plus file size, newline style, SHA-256 when available, truncation state,
 and a short-lived read receipt for complete hashed reads when the filesystem
 module has a stable `read_receipt_secret` configured.
 
+For Jupyter notebooks, use `notebook.read` instead of `fs.read` when the caller
+needs notebook structure rather than raw JSON. It returns notebook metadata,
+cell ids, cell types, execution counts, output counts, byte size, SHA-256, and
+an optional read receipt. Source is omitted by default. Callers can pass
+`include_source=true` for bounded source previews, narrow the response with
+`cell_ids`, and tune `max_source_chars` or `max_total_source_chars` within the
+module limits.
+
 For existing-file edits, prefer `fs.patch` over whole-file replacement. It
 accepts unified diff text, derives affected paths before execution for path
 policy checks, validates context in memory, and only writes after preimage
@@ -196,6 +318,15 @@ and it also requires either `expected_sha256` or a valid `read_receipt` from
 `fs.write` `mode="create"` fails if the file already exists. `mode="replace"`
 requires either `expected_sha256` or a valid `read_receipt` from `fs.read`.
 
+For notebook edits, use `notebook.edit_cell` instead of `fs.write`. It performs
+one cell-scoped operation by stable cell id: `mode="replace"` updates the target
+cell source, `mode="insert"` adds a `code`, `markdown`, or `raw` cell before or
+after the target, and `mode="delete"` removes the target cell. Replacing a code
+cell clears stored outputs and execution count so stale execution artifacts are
+not preserved. Like file edits, notebook edits require either
+`expected_sha256` or a valid read receipt from `notebook.read`, and they can use
+`dry_run=true` before writing.
+
 This read-before-mutate flow protects against stale edits: if a file changes
 after the model read it, the expected hash or receipt no longer matches and the
 write is rejected instead of silently overwriting newer content.
@@ -203,11 +334,12 @@ write is rejected instead of silently overwriting newer content.
 For concurrent editing workflows, `fs.lock_acquire` and `fs.lock_release`
 provide advisory leases for workspace-relative file paths. A successful acquire
 returns a `lease_id` that callers can pass to `fs.edit` and `fs.write` as
-`lock_lease_id`, or to `fs.patch` as `lock_lease_id_by_path`. Leases do not
-replace hashes or read receipts; mutation tools still run their normal preimage
-checks. Operators can set `require_lock_for_mutation=true` on the filesystem
-module when they want mutations to fail with `lock_required` unless the caller
-supplies a matching active lease.
+`lock_lease_id`, to `notebook.edit_cell` as `lock_lease_id`, or to `fs.patch` as
+`lock_lease_id_by_path`. Leases do not replace hashes or read receipts;
+mutation tools still run their normal preimage checks. Operators can set
+`require_lock_for_mutation=true` on the filesystem module when they want
+mutations to fail with `lock_required` unless the caller supplies a matching
+active lease.
 
 The packaged lock manager supports `lock_manager_backend` values of `memory`,
 `in_memory`, or `sqlite`. The memory and in-memory backends are process-local
@@ -241,12 +373,19 @@ profile with `write` can use `fs.write` and patch-created files when policy also
 allows creation. Deny grants take precedence over broader allow grants, so a
 private subtree can remain read-only or blocked under a writable parent.
 
+Tool allow lists and path grants are separate checks. A profile must allow
+`notebook.read` or `notebook.edit_cell` as tools, and the target path must also
+have the matching `read` or `edit` path action. The shorthand mental model is
+`NotebookRead(path)` for a read action and `NotebookEdit(path)` for an edit
+action; these are policy concepts, not extra executable tool names.
+
 The file-policy action vocabulary is broader than the tools currently shipped.
 The executable filesystem actions today are:
 
 - `read`: inspect file content, directory listings, search results, and path
-  metadata.
-- `edit`: bounded existing-file edits through `fs.patch` or `fs.edit`.
+  metadata, including notebook structure through `notebook.read`.
+- `edit`: bounded existing-file edits through `fs.patch`, `fs.edit`, or
+  `notebook.edit_cell`.
 - `write`: deliberate whole-file create or replace through `fs.write`.
 - `lock`: acquire or release advisory path locks through `fs.lock_acquire` and
   `fs.lock_release`.
@@ -380,10 +519,10 @@ approval grants.
 Local CLI examples:
 
 ```bash
-mcp-unified-gateway explain-policy --profile researcher --tool fs.patch \
+mcp-unified-gateway explain-policy --profile <profile-id> --tool fs.patch \
   --args-json-file ./patch-args.json --config ./gateway.json
 
-mcp-unified-gateway preview-profile-tools --profile researcher \
+mcp-unified-gateway preview-profile-tools --profile <profile-id> \
   --category filesystem --config ./gateway.json
 ```
 
@@ -393,10 +532,10 @@ Remote CLI example:
 export MCP_UNIFIED_GATEWAY_URL=http://127.0.0.1:8000/mcp
 export MCP_UNIFIED_GATEWAY_ADMIN_KEY=replace-with-admin-key
 
-printf '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
-  --remote --profile researcher --tool fs.read --args-stdin
+echo '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
+  --remote --profile <profile-id> --tool fs.read --args-stdin
 
-mcp-unified-gateway preview-profile-tools --remote --profile researcher \
+mcp-unified-gateway preview-profile-tools --remote --profile <profile-id> \
   --category filesystem --session-id "$MCP_SESSION_ID" --exclude-denied
 ```
 
@@ -406,9 +545,9 @@ Direct admin API examples:
 curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/policy/explain" \
   -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"profile_id":"researcher","tool_name":"fs.read","arguments":{"path":"src/app.py"}}'
+  -d '{"profile_id":"<profile-id>","tool_name":"fs.read","arguments":{"path":"src/app.py"}}'
 
-curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/researcher/tool-preview" \
+curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/<profile-id>/tool-preview" \
   -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"category":"filesystem","include_denied":true,"session_id":"session-1"}'

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -112,6 +112,30 @@ List bundled profile presets:
 mcp-unified-gateway list-presets
 ```
 
+Option A: duplicate a preset, then preview the new stored profile:
+
+```bash
+mcp-unified-gateway duplicate-preset project-researcher \
+  --profile-id <new-profile-id> --config ./gateway.json
+
+mcp-unified-gateway preview-profile-tools --profile <new-profile-id> \
+  --config ./gateway.json
+```
+
+Option B: create a profile from JSON, then preview the ID declared inside that
+file:
+
+```bash
+mcp-unified-gateway create-profile --profile-file ./profile.json \
+  --config ./gateway.json
+
+mcp-unified-gateway preview-profile-tools --profile <profile-id-from-json> \
+  --config ./gateway.json
+```
+
+For a minimal custom profile JSON template and the recommended discovery flow,
+see [USER_GUIDE.md](USER_GUIDE.md#3-work-with-profiles).
+
 Run the deterministic in-process smoke scenario:
 
 ```bash
@@ -144,6 +168,9 @@ mcp-unified-gateway tool-events report --group-by profile --config ./gateway.jso
 `explain-policy` explains one profile/tool decision before execution. It reports
 the effective `allow`, `ask`, or `deny` outcome, reason code, contributing
 policy state, and redacted subjects for a hypothetical tool call.
+It does not execute filesystem tools or fully validate authored
+`policy_document.path_grants`; verify those with safe runtime tool calls against
+representative allowed and denied paths.
 
 `preview-profile-tools` previews a profile's effective tool surface across
 installed tools and profile recommendations so operators can see which tools are
@@ -154,10 +181,10 @@ approval grants.
 Local CLI examples:
 
 ```bash
-mcp-unified-gateway explain-policy --profile researcher --tool fs.patch \
+mcp-unified-gateway explain-policy --profile <profile-id> --tool fs.patch \
   --args-json-file ./patch-args.json --config ./gateway.json
 
-mcp-unified-gateway preview-profile-tools --profile researcher \
+mcp-unified-gateway preview-profile-tools --profile <profile-id> \
   --category filesystem --config ./gateway.json
 ```
 
@@ -167,10 +194,10 @@ Remote CLI example:
 export MCP_UNIFIED_GATEWAY_URL=http://127.0.0.1:8000/mcp
 export MCP_UNIFIED_GATEWAY_ADMIN_KEY=replace-with-admin-key
 
-printf '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
-  --remote --profile researcher --tool fs.read --args-stdin
+echo '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
+  --remote --profile <profile-id> --tool fs.read --args-stdin
 
-mcp-unified-gateway preview-profile-tools --remote --profile researcher \
+mcp-unified-gateway preview-profile-tools --remote --profile <profile-id> \
   --category filesystem --session-id "$MCP_SESSION_ID" --exclude-denied
 ```
 
@@ -180,9 +207,9 @@ Admin API examples:
 curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/policy/explain" \
   -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"profile_id":"researcher","tool_name":"fs.read","arguments":{"path":"src/app.py"}}'
+  -d '{"profile_id":"<profile-id>","tool_name":"fs.read","arguments":{"path":"src/app.py"}}'
 
-curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/researcher/tool-preview" \
+curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/<profile-id>/tool-preview" \
   -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"category":"filesystem","include_denied":true,"session_id":"session-1"}'

--- a/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+++ b/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
@@ -6,6 +6,9 @@ credential grants, configuration snapshots, and remote runtime commands.
 
 The package is currently internal/experimental and distributed with the
 `tldw-server` source tree. It is not a separately published standalone package.
+The package CLI does not launch a supported end-user gateway server; remote
+runtime commands require an already running package-local gateway mounted by a
+host application.
 
 ## Publishing Readiness
 
@@ -51,6 +54,12 @@ Confirm the CLI is available:
 ```bash
 mcp-unified-gateway package-info
 ```
+
+When a host application mounts the package gateway, use `GET /mcp/status` for
+package-local readiness. The response reports static package boundary metadata,
+profile/external registry store persistence, default profile state, admin-auth
+configured state, external server counts, warnings, and next actions. For the
+embedded TLDW Server product, use `/api/v1/mcp/status` instead.
 
 For a quick standalone JSON-RPC smoke check, confirm the smoke client is also
 available and run the deterministic in-process fixture:
@@ -128,6 +137,120 @@ Show the current default:
 mcp-unified-gateway get-default-profile \
   --config ./gateway.json
 ```
+
+### Know Which Tools Are Available
+
+The standalone gateway does not have one static global tool list. The effective
+tool surface depends on the installed backend tools, registered external MCP
+servers, profile policy, credentials, workspace/path grants, approvals, and any
+session-scoped grants. Use discovery in this order:
+
+1. Start with presets to understand the intended role shape:
+
+   ```bash
+   mcp-unified-gateway list-presets
+   mcp-unified-gateway show-preset project-researcher
+   ```
+
+2. Create or duplicate a profile into the configured store.
+
+3. Preview that stored profile's effective tool surface:
+
+   ```bash
+   mcp-unified-gateway preview-profile-tools --profile <profile-id> \
+     --config ./gateway.json
+
+   mcp-unified-gateway preview-profile-tools --profile <profile-id> \
+     --category filesystem --exclude-denied --config ./gateway.json
+   ```
+
+4. For a running gateway, the final model-facing discovery surface is still the
+   MCP `tools/list` response for that authenticated session/profile. Profiles
+   can also expose bridge tools such as `tool_categories.list`, `tool_search`,
+   `tool_describe`, and `profile.tools.list` so clients can discover deferred
+   or recommended tools without expanding the direct executable surface.
+
+### Create A Custom Profile
+
+For most operators, duplicating a bundled preset is the safest starting point.
+When a preset is not close enough, create a profile JSON document and store it
+with `create-profile`.
+
+Minimal read-oriented profile:
+
+```json
+{
+  "id": "docs-researcher",
+  "name": "Docs Researcher",
+  "description": "Read-only documentation and workspace research profile.",
+  "policy_document": {
+    "allowed_tools": [
+      "tool_categories.list",
+      "tool_search",
+      "tool_describe",
+      "profile.tools.list",
+      "fs.list",
+      "fs.read",
+      "fs.stat",
+      "fs.glob",
+      "fs.grep"
+    ],
+    "capabilities": [
+      "filesystem.read"
+    ],
+    "path_scope_mode": "workspace_root",
+    "path_grants": [
+      {
+        "path": "docs",
+        "actions": ["read"]
+      },
+      {
+        "path": "src",
+        "actions": ["read"]
+      }
+    ]
+  },
+  "metadata": {
+    "agent_metadata": {
+      "ui_label": "Docs Researcher"
+    }
+  }
+}
+```
+
+Save the document as `docs-researcher.json`, then create and inspect it:
+
+```bash
+mcp-unified-gateway create-profile --profile-file ./docs-researcher.json \
+  --config ./gateway.json
+
+mcp-unified-gateway show-profile docs-researcher --config ./gateway.json
+```
+
+Validate the profile's tool surface before assigning it:
+
+```bash
+mcp-unified-gateway preview-profile-tools --profile docs-researcher \
+  --config ./gateway.json
+```
+
+Use `explain-policy` to inspect tool-level allow/ask/deny decisions,
+`permission_rules`, and runtime TTL grants for a hypothetical call:
+
+```bash
+echo '{"path":"docs/README.md"}' | mcp-unified-gateway explain-policy \
+  --profile docs-researcher --tool fs.read --args-stdin --config ./gateway.json
+```
+
+`explain-policy` does not execute filesystem tools and should not be treated as
+a full validation of authored `policy_document.path_grants`. Validate path
+grants with safe runtime tool calls against representative allowed and denied
+paths in the intended workspace/session before assigning the profile.
+
+If a tool is missing, first check whether the backend tool is installed or only
+recommended, then check `policy_document.allowed_tools`, path grants, external
+server registration, credential grants, and approval/session state. Use
+`patch-profile` for small policy updates after creation.
 
 ### Profile Tooling Discovery
 
@@ -396,10 +519,10 @@ approval grants.
 Local CLI examples:
 
 ```bash
-mcp-unified-gateway explain-policy --profile researcher --tool fs.patch \
+mcp-unified-gateway explain-policy --profile <profile-id> --tool fs.patch \
   --args-json-file ./patch-args.json --config ./gateway.json
 
-mcp-unified-gateway preview-profile-tools --profile researcher \
+mcp-unified-gateway preview-profile-tools --profile <profile-id> \
   --category filesystem --config ./gateway.json
 ```
 
@@ -409,10 +532,10 @@ Remote CLI example:
 export MCP_UNIFIED_GATEWAY_URL=http://127.0.0.1:8000/mcp
 export MCP_UNIFIED_GATEWAY_ADMIN_KEY=replace-with-admin-key
 
-printf '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
-  --remote --profile researcher --tool fs.read --args-stdin
+echo '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
+  --remote --profile <profile-id> --tool fs.read --args-stdin
 
-mcp-unified-gateway preview-profile-tools --remote --profile researcher \
+mcp-unified-gateway preview-profile-tools --remote --profile <profile-id> \
   --category filesystem --session-id "$MCP_SESSION_ID" --exclude-denied
 ```
 
@@ -422,9 +545,9 @@ Direct admin API examples:
 curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/policy/explain" \
   -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"profile_id":"researcher","tool_name":"fs.read","arguments":{"path":"src/app.py"}}'
+  -d '{"profile_id":"<profile-id>","tool_name":"fs.read","arguments":{"path":"src/app.py"}}'
 
-curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/researcher/tool-preview" \
+curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/<profile-id>/tool-preview" \
   -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"category":"filesystem","include_denied":true,"session_id":"session-1"}'

--- a/backlog/tasks/task-12014 - Document-MCP-Unified-standalone-custom-profile-setup.md
+++ b/backlog/tasks/task-12014 - Document-MCP-Unified-standalone-custom-profile-setup.md
@@ -1,0 +1,50 @@
+---
+id: TASK-12014
+title: Document MCP Unified standalone custom profile setup
+status: Done
+labels:
+- docs
+- mcp-unified
+modified_files:
+- apps/mcp-unified/USER_GUIDE.md
+- apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+- apps/mcp-unified/README.md
+- apps/mcp-unified/src/mcp_unified/README.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a clear user-facing path for discovering available tools and creating or configuring a custom standalone MCP Unified profile.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Standalone MCP Unified docs explain how to discover tools and presets before profile authoring.
+- [x] #2 Docs include a minimal custom profile JSON example for create-profile.
+- [x] #3 Docs explain preview-profile-tools and explain-policy as validation steps after profile creation.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- PR #2555 review follow-up: changed unscoped profile examples to use a generic `<profile-id>` placeholder and switched simple JSON stdin examples from `printf` to `echo` in both USER_GUIDE copies.
+- PR #2555 Qodo follow-up: clarified that `explain-policy` explains tool/permission/TTL decisions but does not fully validate authored `policy_document.path_grants`, and split the README quick profile workflow into duplicate-preset and create-from-JSON options.
+- Rebase follow-up: synced pre-existing USER_GUIDE drift between the root and packaged documentation copies so package-boundary notes and notebook file-tool guidance are present in both places.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated standalone MCP Unified docs to add a clear custom profile workflow: tool/preset discovery, stored profile preview, minimal create-profile JSON, explain-policy guidance, and troubleshooting guidance for missing tools. Mirrored changes into the packaged src/mcp_unified README and USER_GUIDE copies. Rebased PR #2555 on latest dev, addressed review comments by using generic `<profile-id>` placeholders for unscoped profile examples, `echo` for simple JSON stdin examples, clearer README duplicate/create alternatives, and explicit `explain-policy` path-grant limitations. Also resynced pre-existing USER_GUIDE drift exposed by the rebase. Verification: cmp confirmed README and USER_GUIDE root/src copies match; MCPProfile.model_validate accepted the documented JSON example; git diff --check passed for touched docs and backlog task. Bandit skipped because only Markdown/backlog documentation changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary

- Clarifies that standalone MCP Unified tool availability is dynamic and should be discovered through presets, stored profile preview, and runtime `tools/list`.
- Adds a minimal custom profile JSON example for `create-profile`, including discovery tools, read-only filesystem tools, capabilities, and path grants.
- Mirrors README and USER_GUIDE updates into the packaged `src/mcp_unified` docs and records Backlog task `TASK-12014`.

## Change summary

Pending human-written summary before merge, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Verification

- `cmp -s apps/mcp-unified/README.md apps/mcp-unified/src/mcp_unified/README.md`
- `cmp -s apps/mcp-unified/USER_GUIDE.md apps/mcp-unified/src/mcp_unified/USER_GUIDE.md`
- `PYTHONPATH=apps/mcp-unified/src python -c 'from mcp_unified.profiles.models import MCPProfile; ...'` -> `docs-researcher 9`
- `git diff --check -- apps/mcp-unified/README.md apps/mcp-unified/USER_GUIDE.md apps/mcp-unified/src/mcp_unified/README.md apps/mcp-unified/src/mcp_unified/USER_GUIDE.md backlog/tasks`

Bandit skipped because this PR only changes Markdown and Backlog task documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands and clarifies standalone profile discovery in `mcp-unified-gateway`, so operators can preview and validate tool availability before assigning a profile. Mirrors updates in both root docs and packaged `src/mcp_unified` copies.

- **Docs**
  - Details discovery order: presets → stored profile preview → runtime `tools/list` (plus bridge tools `tool_categories.list`, `tool_search`, `tool_describe`, `profile.tools.list`).
  - Adds minimal read-only `docs-researcher` profile JSON and CLI for `duplicate-preset`, `create-profile`, `preview-profile-tools`, and `explain-policy` (Option A/B workflow).
  - Clarifies `explain-policy` limits: does not execute filesystem tools or fully validate `policy_document.path_grants`; validate with safe runtime tool calls.
  - Documents notebook tools (`notebook.read`, `notebook.edit_cell`), path-policy mapping (read/edit), and lock usage with notebook edits.
  - Notes package-local readiness via `GET /mcp/status` when the gateway is host-mounted; clarifies package scope vs. host server for remote commands.
  - Updates CLI and admin examples to use `<profile-id>` placeholders and `echo` for JSON stdin.
  - Satisfies TASK-12014: discovery before authoring, minimal JSON example, and post-creation validation steps.

<sup>Written for commit 7badd7428d7c33532c9644875717baadbf4f502a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

