### PR TITLE
Update local single-user WebUI setup guide

### DIFF
--- a/Docs/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Getting_Started/Profile_Local_Single_User.md
@@ -90,7 +90,7 @@ bun run dev -- -p 8080
 # npm run dev -- -p 8080
 ```
 
-Open http://localhost:8080.
+Open http://127.0.0.1:8080.
 
 ## Verify
 

--- a/Docs/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Getting_Started/Profile_Local_Single_User.md
@@ -66,53 +66,6 @@ Start the WebUI in a second terminal when you are ready for the cohesive first-t
 ```bash
 cd apps/tldw-frontend
 cp .env.local.example .env.local
-bun install
-bun run dev -- -p 8080
-```
-
-Confirm `.env.local` contains:
-
-```bash
-NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
-NEXT_PUBLIC_API_VERSION=v1
-# Optional local single-user bootstrap auth:
-# NEXT_PUBLIC_X_API_KEY=your_single_user_api_key
-```
-
-If Bun is not installed, use the Bun install steps or npm fallback in [Local Profile: Add the WebUI](../../README.md#local-profile-add-the-webui).
-
-Then open http://127.0.0.1:8080 to open the WebUI.
-
-## Verify
-
-In another terminal:
-
-```bash
-make verify-local-single
-```
-
-PowerShell / no-`make` equivalent:
-
-```powershell
-.\.venv\Scripts\python -m tldw_Server_API.cli.wizard.cli verify --profile local-single --env-file tldw_Server_API/Config_Files/.env --base-url http://127.0.0.1:8000 --first-value
-```
-
-Manual spot checks:
-
-```bash
-curl -sS http://127.0.0.1:8000/health
-curl -sS http://127.0.0.1:8000/docs > /dev/null && echo "docs-ok"
-curl -sS http://127.0.0.1:8000/api/v1/config/quickstart
-curl -sS http://127.0.0.1:8080 > /dev/null && echo "webui-ok"
-```
-
-## Start the WebUI
-
-Keep the API server running at `http://127.0.0.1:8000`. In another terminal:
-
-```bash
-cd apps/tldw-frontend
-cp .env.local.example .env.local
 ```
 
 Edit `.env.local` so it points the WebUI at the local API:
@@ -139,9 +92,26 @@ bun run dev -- -p 8080
 
 Open http://localhost:8080.
 
-After starting the WebUI, verify it responds:
+## Verify
+
+In another terminal:
 
 ```bash
+make verify-local-single
+```
+
+PowerShell / no-`make` equivalent:
+
+```powershell
+.\.venv\Scripts\python -m tldw_Server_API.cli.wizard.cli verify --profile local-single --env-file tldw_Server_API/Config_Files/.env --base-url http://127.0.0.1:8000 --first-value
+```
+
+Manual spot checks:
+
+```bash
+curl -sS http://127.0.0.1:8000/health
+curl -sS http://127.0.0.1:8000/docs > /dev/null && echo "docs-ok"
+curl -sS http://127.0.0.1:8000/api/v1/config/quickstart
 curl -sS http://127.0.0.1:8080 > /dev/null && echo "webui-ok"
 ```
 

--- a/Docs/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Getting_Started/Profile_Local_Single_User.md
@@ -11,6 +11,7 @@ Prerequisites:
 - Python 3.10+
 - `ffmpeg`
 - Git
+- Bun for the WebUI (`npm` also works as a fallback)
 
 ```bash
 git clone https://github.com/rmusser01/tldw_server.git
@@ -105,11 +106,50 @@ curl -sS http://127.0.0.1:8000/api/v1/config/quickstart
 curl -sS http://127.0.0.1:8080 > /dev/null && echo "webui-ok"
 ```
 
+## Start the WebUI
+
+Keep the API server running at `http://127.0.0.1:8000`. In another terminal:
+
+```bash
+cd apps/tldw-frontend
+cp .env.local.example .env.local
+```
+
+Confirm `.env.local` points the WebUI at the local API:
+
+```bash
+NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
+NEXT_PUBLIC_API_VERSION=v1
+# Optional in single-user mode:
+# NEXT_PUBLIC_X_API_KEY=your_single_user_api_key
+```
+
+`NEXT_PUBLIC_X_API_KEY` is browser-visible. Use it only for local single-user convenience, and avoid exposing this setup directly to the public internet.
+
+Install and start the WebUI:
+
+```bash
+bun install
+bun run dev -- -p 8080
+
+# npm fallback:
+# npm install
+# npm run dev -- -p 8080
+```
+
+Open http://localhost:8080.
+
+After starting the WebUI, verify it responds:
+
+```bash
+curl -sS http://127.0.0.1:8080 > /dev/null && echo "webui-ok"
+```
+
 ## First Value
 
 Open http://127.0.0.1:8080 to open the WebUI and complete first-time setup there. The setup completion gate is the first successful chat response from your selected hosted API key or local OpenAI-compatible provider. Immediately after that, add your first source so chat can use your own material.
 
-The CLI verify command still runs a provider-independent first-value ingest/search verification. It posts a small Markdown document to `/api/v1/media/add`, then searches for `tldw-onboarding-verification-unique` through `/api/v1/media/search`.
+If you prefer terminal verification, the CLI verify command still runs a provider-independent first-value ingest/search check. It posts a small Markdown document to `/api/v1/media/add`, then searches for `tldw-onboarding-verification-unique` through `/api/v1/media/search`.
 
 ```bash
 make verify-local-single

--- a/Docs/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Getting_Started/Profile_Local_Single_User.md
@@ -169,12 +169,16 @@ Local audio setup can use host-side config and model files directly. After this 
 - If install fails due to Python version, rerun with `PYTHON=python3.12 make install-local` or another supported interpreter.
 - If startup fails on audio/video dependencies, verify `ffmpeg -version`.
 - If port `8000` is in use, stop the conflicting process or run `uvicorn` on another port.
+- If the WebUI port `8080` is in use, stop the conflicting process or start Next.js on another port with `bun run dev -- -p 8081`.
+- If `bun install` fails, verify Bun with `bun --version`, or use the npm fallback commands from the WebUI section.
+- If the WebUI loads but cannot reach the API, confirm `.env.local` uses the same host and port as the running API, usually `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000`.
 - If direct API calls return `401`, confirm `SINGLE_USER_API_KEY` in `tldw_Server_API/Config_Files/.env` and use it as `X-API-KEY`.
 - If WebUI setup cannot save provider settings, use `/setup` as the backend/operator recovery surface and inspect `tldw_Server_API/Config_Files/.env` only as a troubleshooting step.
 - On Windows, use WSL2 for the Makefile path or run the PowerShell equivalents.
 
 ## Optional Add-ons
 
-- Add the WebUI after the API is healthy: see [Local Profile: Add the WebUI](../../README.md#local-profile-add-the-webui).
-- Keep provider setup in the WebUI first-run wizard for the normal path; use file-based configuration only for recovery, automation, or advanced deployments.
+- Keep provider setup in the WebUI first-run wizard for the normal path; add provider API keys to `tldw_Server_API/Config_Files/.env` only for recovery, automation, or advanced deployments, then restart the server.
+- For deeper WebUI development details, see [Extension & Web UI Development Guide](../../apps/DEVELOPMENT.md) and [tldw-frontend README](../../apps/tldw-frontend/README.md).
+- For LAN, mobile, reverse-proxy, or custom-host browser access, see [Run the Web UI (WIP)](../../README.md#run-the-web-ui-wip).
 - Install development extras with `source .venv/bin/activate && pip install -e ".[dev]"`.

--- a/Docs/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Getting_Started/Profile_Local_Single_User.md
@@ -115,9 +115,9 @@ cd apps/tldw-frontend
 cp .env.local.example .env.local
 ```
 
-Confirm `.env.local` points the WebUI at the local API:
+Edit `.env.local` so it points the WebUI at the local API:
 
-```bash
+```dotenv
 NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
 NEXT_PUBLIC_API_VERSION=v1
 # Optional in single-user mode:

--- a/Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
@@ -70,9 +70,9 @@ cd apps/tldw-frontend
 cp .env.local.example .env.local
 ```
 
-Confirm `.env.local` points the WebUI at the local API:
+Edit `.env.local` so it points the WebUI at the local API:
 
-```bash
+```dotenv
 NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
 NEXT_PUBLIC_API_VERSION=v1
 # Optional in single-user mode:

--- a/Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the local single-user setup guide self-contained for running the local FastAPI server and the Next.js WebUI.
 
-**Architecture:** This is a documentation-only change. Keep the existing local API flow intact, insert the WebUI flow after API verification, and finish by updating troubleshooting, optional add-ons, and Backlog task state. No server, frontend, Makefile, Docker, or environment-template behavior changes are part of this plan.
+**Architecture:** This is a documentation-only change. Keep the existing local API flow intact, extend the current WebUI startup flow in the `## Start` section, and finish by updating verification, troubleshooting, optional add-ons, and Backlog task state. No server, frontend, Makefile, Docker, or environment-template behavior changes are part of this plan.
 
 **Tech Stack:** Markdown documentation, Backlog.md MCP task tracking, shell-based docs hygiene checks.
 
@@ -14,7 +14,7 @@
 
 - Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
   - Responsibility: canonical local single-user guide for API and WebUI setup.
-- Modify: `backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md`
+- Modify: `backlog/tasks/task-12075 - Update-Local-Single-User-Setup-guide-with-WebUI.md`
   - Responsibility: task status, implementation notes, verification, and final summary.
 - Existing reference: `Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md`
   - Responsibility: approved design constraints.
@@ -39,7 +39,7 @@ sed -n '1,180p' Docs/Getting_Started/Profile_Local_Single_User.md
 sed -n '1,220p' Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
 ```
 
-Expected: the guide still has API-only setup and an optional WebUI link, and the spec says the guide should become self-contained.
+Expected: the guide still has the local API setup, and the spec says the guide should become self-contained for the WebUI happy path.
 
 - [x] **Step 2: Add WebUI prerequisites to `Prepare`**
 
@@ -56,15 +56,11 @@ Prerequisites:
 
 Expected: the guide still lists the original API prerequisites and now names Bun for the WebUI.
 
-- [x] **Step 3: Insert `Start the WebUI` after API verification**
+- [x] **Step 3: Extend the WebUI startup path in `Start`**
 
-After the existing API manual spot checks block in `Docs/Getting_Started/Profile_Local_Single_User.md`, add:
+In `Docs/Getting_Started/Profile_Local_Single_User.md`, extend the existing WebUI startup block under `## Start` so it contains:
 
 ````markdown
-## Start the WebUI
-
-Keep the API server running at `http://127.0.0.1:8000`. In another terminal:
-
 ```bash
 cd apps/tldw-frontend
 cp .env.local.example .env.local
@@ -95,15 +91,13 @@ bun run dev -- -p 8080
 Open http://localhost:8080.
 ````
 
-Expected: the local guide contains the complete WebUI setup path and no longer requires the README add-on section for the happy path.
+Expected: the local guide contains one complete WebUI setup path and no longer requires the README add-on section for the happy path.
 
 - [x] **Step 4: Add WebUI verification**
 
-In the `Verify` section after the API manual spot checks, add a short WebUI spot check:
+In the `Verify` manual spot checks, include a WebUI spot check:
 
 ````markdown
-After starting the WebUI, verify it responds:
-
 ```bash
 curl -sS http://127.0.0.1:8080 > /dev/null && echo "webui-ok"
 ```
@@ -113,10 +107,12 @@ Expected: the guide verifies both services: API at `8000`, WebUI at `8080`.
 
 - [x] **Step 5: Update `First Value` for API or WebUI entry**
 
-Replace the first paragraph under `## First Value` with:
+Update the first-value copy so it recognizes the WebUI setup flow and preserves the provider-independent terminal check:
 
 ```markdown
-Use the WebUI at http://localhost:8080 for the first browser workflow, or run the provider-independent first-value ingest/search verification from the terminal. The verify command posts a small Markdown document to `/api/v1/media/add`, then searches for `tldw-onboarding-verification-unique` through `/api/v1/media/search`.
+Open http://127.0.0.1:8080 to open the WebUI and complete first-time setup there. The setup completion gate is the first successful chat response from your selected hosted API key or local OpenAI-compatible provider. Immediately after that, add your first source so chat can use your own material.
+
+If you prefer terminal verification, the CLI verify command still runs a provider-independent first-value ingest/search check. It posts a small Markdown document to `/api/v1/media/add`, then searches for `tldw-onboarding-verification-unique` through `/api/v1/media/search`.
 ```
 
 Expected: first-value guidance recognizes the WebUI as a valid local starting point while preserving the existing provider-independent verification command.
@@ -143,7 +139,7 @@ Expected: common WebUI local failures have direct fixes.
 Replace the current optional add-ons list with:
 
 ```markdown
-- Add provider API keys to `tldw_Server_API/Config_Files/.env`, then restart the server.
+- Keep provider setup in the WebUI first-run wizard for the normal path; add provider API keys to `tldw_Server_API/Config_Files/.env` only for recovery, automation, or advanced deployments, then restart the server.
 - For deeper WebUI development details, see [Extension & Web UI Development Guide](../../apps/DEVELOPMENT.md) and [tldw-frontend README](../../apps/tldw-frontend/README.md).
 - For LAN, mobile, reverse-proxy, or custom-host browser access, see [Run the Web UI (WIP)](../../README.md#run-the-web-ui-wip).
 - Install development extras with `source .venv/bin/activate && pip install -e ".[dev]"`.
@@ -153,7 +149,7 @@ Expected: the old "Add the WebUI" link is gone because the guide now contains th
 
 - [x] **Step 3: Check for stale README-only wording**
 
-Run:
+Run this against the guide:
 
 ```bash
 rg -n "Add the WebUI|Local Profile: Add the WebUI|does not include the WebUI by default" Docs/Getting_Started/Profile_Local_Single_User.md
@@ -165,7 +161,7 @@ Expected: no matches.
 
 **Files:**
 - Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
-- Modify: `backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md`
+- Modify: `backlog/tasks/task-12075 - Update-Local-Single-User-Setup-guide-with-WebUI.md`
 
 - [x] **Step 1: Review the rendered command order in plain text**
 
@@ -175,7 +171,7 @@ Run:
 sed -n '1,220p' Docs/Getting_Started/Profile_Local_Single_User.md
 ```
 
-Expected: the order is Prepare, Start API, Verify API, Start WebUI, First Value, Audio Path, Troubleshoot, Optional Add-ons.
+Expected: the order is Prepare, Start, Verify, First Value, Audio Path, Troubleshoot, Optional Add-ons.
 
 - [x] **Step 2: Check Markdown whitespace**
 
@@ -221,11 +217,11 @@ else
 fi
 ```
 
-Expected: either the checker passes, or the skip message prints because the checker is absent. If the virtual environment is unavailable, record that verification blocker in `TASK-12072` and continue with the static checks above.
+Expected: either the checker passes, or the skip message prints because the checker is absent. If the virtual environment is unavailable, record that verification blocker in `TASK-12075` and continue with the static checks above.
 
 - [x] **Step 6: Record Bandit skip**
 
-Use Backlog MCP `task_edit` on `TASK-12072` and add implementation notes:
+Use Backlog MCP `task_edit` on `TASK-12075` and add implementation notes:
 
 ```text
 Bandit skipped: documentation-only Markdown changes; no Python code touched.
@@ -235,21 +231,21 @@ Expected: Backlog task notes explain why Bandit does not apply.
 
 - [x] **Step 7: Update Backlog final summary and acceptance criteria**
 
-Use Backlog MCP `task_edit` on `TASK-12072` to record:
+Use Backlog MCP `task_edit` on `TASK-12075` to record:
 
 ```text
 Final summary: Updated the local single-user guide to include self-contained WebUI prerequisites, env setup, start commands, verification, troubleshooting, and deeper-reference links.
 Verification: Markdown whitespace check passed; referenced docs exist; README WebUI anchor checked; onboarding docs checker result recorded.
 ```
 
-Expected: `TASK-12072` contains verification and final summary notes. Mark acceptance criteria and Definition of Done complete only after the guide edit and checks have actually passed.
+Expected: `TASK-12075` contains verification and final summary notes. Mark acceptance criteria and Definition of Done complete only after the guide edit and checks have actually passed.
 
 - [x] **Step 8: Commit the documentation update**
 
 Run:
 
 ```bash
-git add Docs/Getting_Started/Profile_Local_Single_User.md "backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md"
+git add Docs/Getting_Started/Profile_Local_Single_User.md "backlog/tasks/task-12075 - Update-Local-Single-User-Setup-guide-with-WebUI.md"
 git commit -m "docs: add local webui setup guide"
 ```
 

--- a/Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
@@ -1,0 +1,256 @@
+# Local Single-User WebUI Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the local single-user setup guide self-contained for running the local FastAPI server and the Next.js WebUI.
+
+**Architecture:** This is a documentation-only change. Keep the existing local API flow intact, insert the WebUI flow after API verification, and finish by updating troubleshooting, optional add-ons, and Backlog task state. No server, frontend, Makefile, Docker, or environment-template behavior changes are part of this plan.
+
+**Tech Stack:** Markdown documentation, Backlog.md MCP task tracking, shell-based docs hygiene checks.
+
+---
+
+## File Structure
+
+- Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
+  - Responsibility: canonical local single-user guide for API and WebUI setup.
+- Modify: `backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md`
+  - Responsibility: task status, implementation notes, verification, and final summary.
+- Existing reference: `Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md`
+  - Responsibility: approved design constraints.
+- Existing reference: `README.md`
+  - Responsibility: existing WebUI add-on and advanced networking wording.
+- Existing reference: `apps/tldw-frontend/README.md`
+  - Responsibility: deeper WebUI development and auth-mode details.
+- Existing reference: `apps/DEVELOPMENT.md`
+  - Responsibility: extension/WebUI development workflow.
+
+## Task 1: Update Local Guide Happy Path
+
+**Files:**
+- Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
+
+- [ ] **Step 1: Read the current local guide and approved design**
+
+Run:
+
+```bash
+sed -n '1,180p' Docs/Getting_Started/Profile_Local_Single_User.md
+sed -n '1,220p' Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
+```
+
+Expected: the guide still has API-only setup and an optional WebUI link, and the spec says the guide should become self-contained.
+
+- [ ] **Step 2: Add WebUI prerequisites to `Prepare`**
+
+In `Docs/Getting_Started/Profile_Local_Single_User.md`, update the prerequisites list to:
+
+```markdown
+Prerequisites:
+
+- Python 3.10+
+- `ffmpeg`
+- Git
+- Bun for the WebUI (`npm` also works as a fallback)
+```
+
+Expected: the guide still lists the original API prerequisites and now names Bun for the WebUI.
+
+- [ ] **Step 3: Insert `Start the WebUI` after API verification**
+
+After the existing API manual spot checks block in `Docs/Getting_Started/Profile_Local_Single_User.md`, add:
+
+````markdown
+## Start the WebUI
+
+Keep the API server running at `http://127.0.0.1:8000`. In another terminal:
+
+```bash
+cd apps/tldw-frontend
+cp .env.local.example .env.local
+```
+
+Confirm `.env.local` points the WebUI at the local API:
+
+```bash
+NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
+NEXT_PUBLIC_API_VERSION=v1
+# Optional in single-user mode:
+# NEXT_PUBLIC_X_API_KEY=your_single_user_api_key
+```
+
+`NEXT_PUBLIC_X_API_KEY` is browser-visible. Use it only for local single-user convenience, and avoid exposing this setup directly to the public internet.
+
+Install and start the WebUI:
+
+```bash
+bun install
+bun run dev -- -p 8080
+
+# npm fallback:
+# npm install
+# npm run dev -- -p 8080
+```
+
+Open http://localhost:8080.
+````
+
+Expected: the local guide contains the complete WebUI setup path and no longer requires the README add-on section for the happy path.
+
+- [ ] **Step 4: Add WebUI verification**
+
+In the `Verify` section after the API manual spot checks, add a short WebUI spot check:
+
+````markdown
+After starting the WebUI, verify it responds:
+
+```bash
+curl -sS http://127.0.0.1:8080 > /dev/null && echo "webui-ok"
+```
+````
+
+Expected: the guide verifies both services: API at `8000`, WebUI at `8080`.
+
+- [ ] **Step 5: Update `First Value` for API or WebUI entry**
+
+Replace the first paragraph under `## First Value` with:
+
+```markdown
+Use the WebUI at http://localhost:8080 for the first browser workflow, or run the provider-independent first-value ingest/search verification from the terminal. The verify command posts a small Markdown document to `/api/v1/media/add`, then searches for `tldw-onboarding-verification-unique` through `/api/v1/media/search`.
+```
+
+Expected: first-value guidance recognizes the WebUI as a valid local starting point while preserving the existing provider-independent verification command.
+
+## Task 2: Update Troubleshooting and References
+
+**Files:**
+- Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
+
+- [ ] **Step 1: Add WebUI troubleshooting bullets**
+
+In the `Troubleshoot` section, add these bullets after the existing port `8000` bullet:
+
+```markdown
+- If the WebUI port `8080` is in use, stop the conflicting process or start Next.js on another port with `bun run dev -- -p 8081`.
+- If `bun install` fails, verify Bun with `bun --version`, or use the npm fallback commands from the WebUI section.
+- If the WebUI loads but cannot reach the API, confirm `.env.local` uses the same host and port as the running API, usually `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000`.
+```
+
+Expected: common WebUI local failures have direct fixes.
+
+- [ ] **Step 2: Replace optional add-on WebUI link**
+
+Replace the current optional add-ons list with:
+
+```markdown
+- Add provider API keys to `tldw_Server_API/Config_Files/.env`, then restart the server.
+- For deeper WebUI development details, see [Extension & Web UI Development Guide](../../apps/DEVELOPMENT.md) and [tldw-frontend README](../../apps/tldw-frontend/README.md).
+- For LAN, mobile, reverse-proxy, or custom-host browser access, see [Run the Web UI (WIP)](../../README.md#run-the-web-ui-wip).
+- Install development extras with `source .venv/bin/activate && pip install -e ".[dev]"`.
+```
+
+Expected: the old "Add the WebUI" link is gone because the guide now contains that path.
+
+- [ ] **Step 3: Check for stale README-only wording**
+
+Run:
+
+```bash
+rg -n "Add the WebUI|Local Profile: Add the WebUI|does not include the WebUI by default" Docs/Getting_Started/Profile_Local_Single_User.md
+```
+
+Expected: no matches.
+
+## Task 3: Verify Documentation and Finalize Task
+
+**Files:**
+- Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
+- Modify: `backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md`
+
+- [ ] **Step 1: Review the rendered command order in plain text**
+
+Run:
+
+```bash
+sed -n '1,220p' Docs/Getting_Started/Profile_Local_Single_User.md
+```
+
+Expected: the order is Prepare, Start API, Verify API, Start WebUI, First Value, Audio Path, Troubleshoot, Optional Add-ons.
+
+- [ ] **Step 2: Check Markdown whitespace**
+
+Run:
+
+```bash
+git diff --check -- Docs/Getting_Started/Profile_Local_Single_User.md
+```
+
+Expected: no output and exit code `0`.
+
+- [ ] **Step 3: Check referenced files exist**
+
+Run:
+
+```bash
+test -f apps/DEVELOPMENT.md
+test -f apps/tldw-frontend/README.md
+test -f README.md
+```
+
+Expected: each command exits `0`.
+
+- [ ] **Step 4: Check README anchor exists**
+
+Run:
+
+```bash
+rg -n "^### Run the Web UI \\(WIP\\)" README.md
+```
+
+Expected: one match for the README section linked from Optional Add-ons.
+
+- [ ] **Step 5: Run targeted onboarding docs hygiene if available**
+
+Run:
+
+```bash
+if test -f Helper_Scripts/docs/check_onboarding_command_boundaries.py; then
+  source .venv/bin/activate && python Helper_Scripts/docs/check_onboarding_command_boundaries.py
+else
+  echo "check_onboarding_command_boundaries.py not present; skipped"
+fi
+```
+
+Expected: either the checker passes, or the skip message prints because the checker is absent. If the virtual environment is unavailable, record that verification blocker in `TASK-12072` and continue with the static checks above.
+
+- [ ] **Step 6: Record Bandit skip**
+
+Use Backlog MCP `task_edit` on `TASK-12072` and add implementation notes:
+
+```text
+Bandit skipped: documentation-only Markdown changes; no Python code touched.
+```
+
+Expected: Backlog task notes explain why Bandit does not apply.
+
+- [ ] **Step 7: Update Backlog final summary and acceptance criteria**
+
+Use Backlog MCP `task_edit` on `TASK-12072` to record:
+
+```text
+Final summary: Updated the local single-user guide to include self-contained WebUI prerequisites, env setup, start commands, verification, troubleshooting, and deeper-reference links.
+Verification: Markdown whitespace check passed; referenced docs exist; README WebUI anchor checked; onboarding docs checker result recorded.
+```
+
+Expected: `TASK-12072` contains verification and final summary notes. Mark acceptance criteria and Definition of Done complete only after the guide edit and checks have actually passed.
+
+- [ ] **Step 8: Commit the documentation update**
+
+Run:
+
+```bash
+git add Docs/Getting_Started/Profile_Local_Single_User.md "backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md"
+git commit -m "docs: add local webui setup guide"
+```
+
+Expected: commit succeeds and includes only the guide and Backlog task update.

--- a/Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
@@ -30,7 +30,7 @@
 **Files:**
 - Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
 
-- [ ] **Step 1: Read the current local guide and approved design**
+- [x] **Step 1: Read the current local guide and approved design**
 
 Run:
 
@@ -41,7 +41,7 @@ sed -n '1,220p' Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-
 
 Expected: the guide still has API-only setup and an optional WebUI link, and the spec says the guide should become self-contained.
 
-- [ ] **Step 2: Add WebUI prerequisites to `Prepare`**
+- [x] **Step 2: Add WebUI prerequisites to `Prepare`**
 
 In `Docs/Getting_Started/Profile_Local_Single_User.md`, update the prerequisites list to:
 
@@ -56,7 +56,7 @@ Prerequisites:
 
 Expected: the guide still lists the original API prerequisites and now names Bun for the WebUI.
 
-- [ ] **Step 3: Insert `Start the WebUI` after API verification**
+- [x] **Step 3: Insert `Start the WebUI` after API verification**
 
 After the existing API manual spot checks block in `Docs/Getting_Started/Profile_Local_Single_User.md`, add:
 
@@ -97,7 +97,7 @@ Open http://localhost:8080.
 
 Expected: the local guide contains the complete WebUI setup path and no longer requires the README add-on section for the happy path.
 
-- [ ] **Step 4: Add WebUI verification**
+- [x] **Step 4: Add WebUI verification**
 
 In the `Verify` section after the API manual spot checks, add a short WebUI spot check:
 
@@ -111,7 +111,7 @@ curl -sS http://127.0.0.1:8080 > /dev/null && echo "webui-ok"
 
 Expected: the guide verifies both services: API at `8000`, WebUI at `8080`.
 
-- [ ] **Step 5: Update `First Value` for API or WebUI entry**
+- [x] **Step 5: Update `First Value` for API or WebUI entry**
 
 Replace the first paragraph under `## First Value` with:
 
@@ -126,7 +126,7 @@ Expected: first-value guidance recognizes the WebUI as a valid local starting po
 **Files:**
 - Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
 
-- [ ] **Step 1: Add WebUI troubleshooting bullets**
+- [x] **Step 1: Add WebUI troubleshooting bullets**
 
 In the `Troubleshoot` section, add these bullets after the existing port `8000` bullet:
 
@@ -138,7 +138,7 @@ In the `Troubleshoot` section, add these bullets after the existing port `8000` 
 
 Expected: common WebUI local failures have direct fixes.
 
-- [ ] **Step 2: Replace optional add-on WebUI link**
+- [x] **Step 2: Replace optional add-on WebUI link**
 
 Replace the current optional add-ons list with:
 
@@ -151,7 +151,7 @@ Replace the current optional add-ons list with:
 
 Expected: the old "Add the WebUI" link is gone because the guide now contains that path.
 
-- [ ] **Step 3: Check for stale README-only wording**
+- [x] **Step 3: Check for stale README-only wording**
 
 Run:
 
@@ -167,7 +167,7 @@ Expected: no matches.
 - Modify: `Docs/Getting_Started/Profile_Local_Single_User.md`
 - Modify: `backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md`
 
-- [ ] **Step 1: Review the rendered command order in plain text**
+- [x] **Step 1: Review the rendered command order in plain text**
 
 Run:
 
@@ -177,7 +177,7 @@ sed -n '1,220p' Docs/Getting_Started/Profile_Local_Single_User.md
 
 Expected: the order is Prepare, Start API, Verify API, Start WebUI, First Value, Audio Path, Troubleshoot, Optional Add-ons.
 
-- [ ] **Step 2: Check Markdown whitespace**
+- [x] **Step 2: Check Markdown whitespace**
 
 Run:
 
@@ -187,7 +187,7 @@ git diff --check -- Docs/Getting_Started/Profile_Local_Single_User.md
 
 Expected: no output and exit code `0`.
 
-- [ ] **Step 3: Check referenced files exist**
+- [x] **Step 3: Check referenced files exist**
 
 Run:
 
@@ -199,7 +199,7 @@ test -f README.md
 
 Expected: each command exits `0`.
 
-- [ ] **Step 4: Check README anchor exists**
+- [x] **Step 4: Check README anchor exists**
 
 Run:
 
@@ -209,7 +209,7 @@ rg -n "^### Run the Web UI \\(WIP\\)" README.md
 
 Expected: one match for the README section linked from Optional Add-ons.
 
-- [ ] **Step 5: Run targeted onboarding docs hygiene if available**
+- [x] **Step 5: Run targeted onboarding docs hygiene if available**
 
 Run:
 
@@ -223,7 +223,7 @@ fi
 
 Expected: either the checker passes, or the skip message prints because the checker is absent. If the virtual environment is unavailable, record that verification blocker in `TASK-12072` and continue with the static checks above.
 
-- [ ] **Step 6: Record Bandit skip**
+- [x] **Step 6: Record Bandit skip**
 
 Use Backlog MCP `task_edit` on `TASK-12072` and add implementation notes:
 
@@ -233,7 +233,7 @@ Bandit skipped: documentation-only Markdown changes; no Python code touched.
 
 Expected: Backlog task notes explain why Bandit does not apply.
 
-- [ ] **Step 7: Update Backlog final summary and acceptance criteria**
+- [x] **Step 7: Update Backlog final summary and acceptance criteria**
 
 Use Backlog MCP `task_edit` on `TASK-12072` to record:
 
@@ -244,7 +244,7 @@ Verification: Markdown whitespace check passed; referenced docs exist; README We
 
 Expected: `TASK-12072` contains verification and final summary notes. Mark acceptance criteria and Definition of Done complete only after the guide edit and checks have actually passed.
 
-- [ ] **Step 8: Commit the documentation update**
+- [x] **Step 8: Commit the documentation update**
 
 Run:
 

--- a/Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
+++ b/Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
@@ -1,7 +1,7 @@
 # Local Single-User WebUI Guide Design
 
 Date: 2026-06-30
-Status: Draft for spec review
+Status: Implemented
 Backlog: TASK-12072
 
 ## Summary

--- a/Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
+++ b/Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-30
 Status: Implemented
-Backlog: TASK-12072
+Backlog: TASK-12075
 
 ## Summary
 
@@ -40,9 +40,11 @@ profile should carry the complete happy path.
 
 ## Current Repo Fit
 
-`Docs/Getting_Started/Profile_Local_Single_User.md` currently covers the local
-API profile and links to the README for WebUI setup. The README already contains
-the core local WebUI commands:
+`Docs/Getting_Started/Profile_Local_Single_User.md` covers the local API
+profile and, on the current base branch, already includes a concise WebUI start
+block. The guide still needs the complete local WebUI environment, auth warning,
+npm fallback, verification, troubleshooting, and deeper-reference cleanup. The
+README already contains the core local WebUI commands:
 
 - copy `apps/tldw-frontend/.env.local.example` to `.env.local`;
 - configure `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_API_VERSION`;
@@ -58,19 +60,18 @@ inline the essential commands and point to those files for deeper details.
 
 Use a fully self-contained local full-stack guide.
 
-The page keeps the existing API-first shape, then adds a WebUI path once the API
-has been verified. This ordering keeps failure modes simple: users first prove
-the backend is healthy, then connect the browser UI to that known-good backend.
+The page keeps the existing API-first shape and extends the WebUI path in the
+existing `## Start` section. Verification then checks both services. This keeps
+the final document aligned with the current base branch and avoids two separate
+WebUI startup sections.
 
 ## Document Structure
 
 Update `Profile_Local_Single_User.md` as follows:
 
 - **Prepare**: add Bun to prerequisites with Node/npm as an optional fallback.
-- **Start**: keep API startup unchanged and state that the API runs at
-  `http://127.0.0.1:8000`.
-- **Verify**: keep API verification unchanged.
-- **Start the WebUI**: add a new section after API verification with:
+- **Start**: keep API startup unchanged, state that the API runs at
+  `http://127.0.0.1:8000`, and extend the existing WebUI startup block with:
   - `cd apps/tldw-frontend`;
   - `cp .env.local.example .env.local`;
   - required `.env.local` values for the local API:
@@ -81,7 +82,7 @@ Update `Profile_Local_Single_User.md` as follows:
   - `bun run dev -- -p 8080`;
   - npm fallback commands;
   - browser URL `http://localhost:8080`.
-- **Verify**: add a WebUI spot check:
+- **Verify**: keep API verification unchanged and add a WebUI spot check:
   `curl -sS http://127.0.0.1:8080 > /dev/null && echo "webui-ok"`.
 - **First Value**: explain that users can start from the WebUI or rerun
   `make verify-local-single` for provider-independent ingest/search

--- a/Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
+++ b/Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
@@ -109,10 +109,10 @@ This is a documentation-only change. Verification should include:
 
 ## Risks
 
-- The frontend example `.env.local.example` currently uses `localhost` while the
-  local API guide uses `127.0.0.1`. The guide should explicitly say the value
-  must match the running API host and use `127.0.0.1` for consistency with
-  `make start-local-single`.
+- The frontend example `.env.local.example` already uses `127.0.0.1`, matching
+  the local API guide. The remaining risk is that users may mix `localhost` and
+  `127.0.0.1` across API and WebUI URLs, so the guide should keep host guidance
+  consistent with `make start-local-single`.
 - `NEXT_PUBLIC_X_API_KEY` is browser-visible by design. The guide should keep
   it framed as local single-user convenience and avoid suggesting this setup for
   public internet exposure.

--- a/Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
+++ b/Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
@@ -1,0 +1,132 @@
+# Local Single-User WebUI Guide Design
+
+Date: 2026-06-30
+Status: Draft for spec review
+Backlog: TASK-12072
+
+## Summary
+
+Make `Docs/Getting_Started/Profile_Local_Single_User.md` a self-contained
+local full-stack setup guide. A reader should be able to install dependencies,
+configure single-user auth, start the FastAPI server, start the Next.js WebUI,
+verify both services, and understand common local troubleshooting without
+needing to jump to the README add-on section.
+
+The README and frontend README remain useful deeper references, but the local
+profile should carry the complete happy path.
+
+## Goals
+
+- Document the local API and WebUI setup in one canonical guide.
+- Keep the current API install, start, verify, and first-value flow intact.
+- Add WebUI prerequisites, environment configuration, install/start commands,
+  URLs, verification checks, and troubleshooting.
+- Use `http://127.0.0.1:8000` as the API URL in this guide because the local
+  profile starts Uvicorn on `127.0.0.1`.
+- Use WebUI port `8080` to match existing quickstart and local browser defaults.
+- Include Bun as the recommended frontend package manager and npm as a fallback.
+- Keep advanced LAN, custom-host, reverse-proxy, and deeper frontend development
+  details as links rather than expanding the local profile into a deployment
+  guide.
+
+## Non-Goals
+
+- No changes to server behavior, frontend behavior, Makefile targets, Docker
+  compose files, or environment templates.
+- No attempt to redesign the whole getting-started index.
+- No dedicated local WebUI Makefile target in this slice.
+- No live dependency installation or local service startup as part of the docs
+  update.
+
+## Current Repo Fit
+
+`Docs/Getting_Started/Profile_Local_Single_User.md` currently covers the local
+API profile and links to the README for WebUI setup. The README already contains
+the core local WebUI commands:
+
+- copy `apps/tldw-frontend/.env.local.example` to `.env.local`;
+- configure `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_API_VERSION`;
+- optionally configure `NEXT_PUBLIC_X_API_KEY`;
+- run `bun install`;
+- run `bun run dev -- -p 8080`.
+
+`apps/tldw-frontend/README.md` also documents Bun installation, npm fallback,
+advanced deployment mode, and auth-mode behavior. The local profile should
+inline the essential commands and point to those files for deeper details.
+
+## Approved Approach
+
+Use a fully self-contained local full-stack guide.
+
+The page keeps the existing API-first shape, then adds a WebUI path once the API
+has been verified. This ordering keeps failure modes simple: users first prove
+the backend is healthy, then connect the browser UI to that known-good backend.
+
+## Document Structure
+
+Update `Profile_Local_Single_User.md` as follows:
+
+- **Prepare**: add Bun to prerequisites with Node/npm as an optional fallback.
+- **Start**: keep API startup unchanged and state that the API runs at
+  `http://127.0.0.1:8000`.
+- **Verify**: keep API verification unchanged.
+- **Start the WebUI**: add a new section after API verification with:
+  - `cd apps/tldw-frontend`;
+  - `cp .env.local.example .env.local`;
+  - required `.env.local` values for the local API:
+    `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000` and
+    `NEXT_PUBLIC_API_VERSION=v1`;
+  - optional `NEXT_PUBLIC_X_API_KEY` guidance for single-user mode;
+  - `bun install`;
+  - `bun run dev -- -p 8080`;
+  - npm fallback commands;
+  - browser URL `http://localhost:8080`.
+- **Verify**: add a WebUI spot check:
+  `curl -sS http://127.0.0.1:8080 > /dev/null && echo "webui-ok"`.
+- **First Value**: explain that users can start from the WebUI or rerun
+  `make verify-local-single` for provider-independent ingest/search
+  verification.
+- **Troubleshoot**: add local WebUI issues for port `8080`, dependency install
+  failures, API URL mismatch, and single-user auth failures.
+- **Optional Add-ons**: remove the old "Add the WebUI" link as the primary path
+  and replace it with links to deeper WebUI development and advanced networking
+  docs.
+
+## Verification
+
+This is a documentation-only change. Verification should include:
+
+- Markdown review of the edited local profile for clear command order and no
+  broken internal references.
+- Link/reference spot checks for:
+  - `apps/tldw-frontend/README.md`;
+  - `apps/DEVELOPMENT.md`;
+  - README WebUI advanced networking section if referenced.
+- Targeted docs hygiene command if an existing onboarding docs checker applies.
+- Bandit is not applicable because no Python code changes are planned; record
+  that skip in the Backlog task during finalization.
+
+## Risks
+
+- The frontend example `.env.local.example` currently uses `localhost` while the
+  local API guide uses `127.0.0.1`. The guide should explicitly say the value
+  must match the running API host and use `127.0.0.1` for consistency with
+  `make start-local-single`.
+- `NEXT_PUBLIC_X_API_KEY` is browser-visible by design. The guide should keep
+  it framed as local single-user convenience and avoid suggesting this setup for
+  public internet exposure.
+- Duplicating core WebUI commands creates a maintenance surface. Keep the
+  self-contained path concise and link to the frontend README for details that
+  are likely to change independently.
+
+## Success Criteria
+
+- A new local user can follow only `Profile_Local_Single_User.md` to run both
+  the API and WebUI locally.
+- The guide names both local service URLs:
+  - API: `http://127.0.0.1:8000`;
+  - WebUI: `http://localhost:8080`.
+- The guide contains enough WebUI troubleshooting to diagnose the common local
+  setup failures without searching the README.
+- The README remains a reference, not a required continuation step for the
+  local WebUI happy path.

--- a/backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md
+++ b/backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md
@@ -1,11 +1,15 @@
 ---
 id: TASK-12072
 title: Update Local Single-User Setup guide with WebUI
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-06-30 06:14
 labels:
 - docs
 - getting-started
 - webui
+dependencies: []
 modified_files:
 - Docs/Getting_Started/Profile_Local_Single_User.md
 - Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
@@ -20,9 +24,9 @@ Make Docs/Getting_Started/Profile_Local_Single_User.md self-contained for runnin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Local single-user guide documents WebUI setup without requiring the README add-on section.
-- [ ] #2 Guide covers API/WebUI URLs, .env.local values, Bun/npm start path, verification, and common troubleshooting.
-- [ ] #3 Related docs links remain accurate and avoid conflicting localhost/127.0.0.1 guidance.
+- [x] #1 Local single-user guide documents WebUI setup without requiring the README add-on section.
+- [x] #2 Guide covers API/WebUI URLs, .env.local values, Bun/npm start path, verification, and common troubleshooting.
+- [x] #3 Related docs links remain accurate and avoid conflicting localhost/127.0.0.1 guidance.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -33,22 +37,35 @@ Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-p
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in commits 435f9eb9543ed3a9488da242c743ae951b9eb47f and ea1fc7fef9cbb3475ccc29c98229c4015bbeb5dd.
 
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Verification:
+- Reviewed Docs/Getting_Started/Profile_Local_Single_User.md command order with sed -n 1,230p.
+- git diff --check -- Docs/Getting_Started/Profile_Local_Single_User.md passed.
+- Referenced files exist: apps/DEVELOPMENT.md, apps/tldw-frontend/README.md, and README.md.
+- README anchor exists: ### Run the Web UI (WIP).
+- Stale README-only wording check found no matches.
+- source .venv/bin/activate and python Helper_Scripts/docs/check_onboarding_command_boundaries.py passed.
+- Bandit skipped: documentation-only Markdown changes; no Python code touched.
+
+Subagent reviews:
+- Task 1 spec review passed; Task 1 quality review passed.
+- Task 2 spec review passed; Task 2 quality review passed.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Updated the local single-user setup guide so it is self-contained for API plus WebUI setup. The guide now includes WebUI prerequisites, `.env.local` values, Bun and npm start paths, WebUI verification, first-value guidance, troubleshooting for common local WebUI issues, and links to deeper WebUI and advanced networking docs.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md
+++ b/backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md
@@ -52,6 +52,8 @@ Verification:
 Subagent reviews:
 - Task 1 spec review passed; Task 1 quality review passed.
 - Task 2 spec review passed; Task 2 quality review passed.
+
+Final review fixes applied: clarified that `.env.local` must be edited to use the shown local API values, marked execution plan checklist items complete, and updated the design spec status to Implemented.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md
+++ b/backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md
@@ -1,0 +1,47 @@
+---
+id: TASK-12072
+title: Update Local Single-User Setup guide with WebUI
+status: In Progress
+labels:
+- docs
+- getting-started
+- webui
+modified_files:
+- Docs/Getting_Started/Profile_Local_Single_User.md
+- Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make Docs/Getting_Started/Profile_Local_Single_User.md self-contained for running the local API plus the Next.js WebUI, including prerequisites, start steps, verification, and troubleshooting.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Local single-user guide documents WebUI setup without requiring the README add-on section.
+- [ ] #2 Guide covers API/WebUI URLs, .env.local values, Bun/npm start path, verification, and common troubleshooting.
+- [ ] #3 Related docs links remain accurate and avoid conflicting localhost/127.0.0.1 guidance.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md
+++ b/backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md
@@ -9,6 +9,7 @@ labels:
 modified_files:
 - Docs/Getting_Started/Profile_Local_Single_User.md
 - Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
+- Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
 ---
 
 ## Description
@@ -23,6 +24,12 @@ Make Docs/Getting_Started/Profile_Local_Single_User.md self-contained for runnin
 - [ ] #2 Guide covers API/WebUI URLs, .env.local values, Bun/npm start path, verification, and common troubleshooting.
 - [ ] #3 Related docs links remain accurate and avoid conflicting localhost/127.0.0.1 guidance.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 

--- a/backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md
+++ b/backlog/tasks/task-12072 - Update-Local-Single-User-Setup-guide-with-WebUI.md
@@ -4,7 +4,7 @@ title: Update Local Single-User Setup guide with WebUI
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-06-30 06:14
+updated_date: 2026-06-30 06:24
 labels:
 - docs
 - getting-started
@@ -54,6 +54,8 @@ Subagent reviews:
 - Task 2 spec review passed; Task 2 quality review passed.
 
 Final review fixes applied: clarified that `.env.local` must be edited to use the shown local API values, marked execution plan checklist items complete, and updated the design spec status to Implemented.
+
+Final review minor cleanup: aligned the implementation plan WebUI `.env.local` wording and env fence with the final guide.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12075 - Update-Local-Single-User-Setup-guide-with-WebUI.md
+++ b/backlog/tasks/task-12075 - Update-Local-Single-User-Setup-guide-with-WebUI.md
@@ -4,17 +4,12 @@ title: Update Local Single-User Setup guide with WebUI
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-06-30 07:17
+updated_date: '2026-06-30 15:12'
 labels:
-- docs
-- getting-started
-- webui
+  - docs
+  - getting-started
+  - webui
 dependencies: []
-modified_files:
-- Docs/Getting_Started/Profile_Local_Single_User.md
-- Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
-- Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
-- backlog/tasks/task-12075 - Update-Local-Single-User-Setup-guide-with-WebUI.md
 ---
 
 ## Description
@@ -55,6 +50,8 @@ Subagent reviews:
 - Task 2 spec review passed; Task 2 quality review passed.
 
 Final review fixes applied: clarified that .env.local must be edited to use the shown local API values, marked execution plan checklist items complete, updated the design spec status to Implemented, aligned plan wording with the final guide, and rebased the task record to TASK-12075 to avoid the existing TASK-12072 on origin/dev.
+
+Review follow-up: corrected the design-spec risk note so it reflects that apps/tldw-frontend/.env.local.example already uses 127.0.0.1; the documented risk is now users mixing localhost and 127.0.0.1 across API/WebUI URLs.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12075 - Update-Local-Single-User-Setup-guide-with-WebUI.md
+++ b/backlog/tasks/task-12075 - Update-Local-Single-User-Setup-guide-with-WebUI.md
@@ -1,10 +1,10 @@
 ---
-id: TASK-12072
+id: TASK-12075
 title: Update Local Single-User Setup guide with WebUI
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-06-30 06:24
+updated_date: 2026-06-30 07:17
 labels:
 - docs
 - getting-started
@@ -14,6 +14,7 @@ modified_files:
 - Docs/Getting_Started/Profile_Local_Single_User.md
 - Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md
 - Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md
+- backlog/tasks/task-12075 - Update-Local-Single-User-Setup-guide-with-WebUI.md
 ---
 
 ## Description
@@ -38,30 +39,28 @@ Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-p
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented in commits 435f9eb9543ed3a9488da242c743ae951b9eb47f and ea1fc7fef9cbb3475ccc29c98229c4015bbeb5dd.
+Implemented on a clean PR branch based on origin/dev. The current base already included a compact WebUI block under ## Start, so the final guide extends that block with explicit .env.local values, browser-visible API-key guidance, Bun/npm commands, and a WebUI response check instead of adding a duplicate startup section.
 
 Verification:
-- Reviewed Docs/Getting_Started/Profile_Local_Single_User.md command order with sed -n 1,230p.
-- git diff --check -- Docs/Getting_Started/Profile_Local_Single_User.md passed.
+- Reviewed Docs/Getting_Started/Profile_Local_Single_User.md command order with sed.
+- git diff --check -- Docs/Getting_Started/Profile_Local_Single_User.md Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md passed.
 - Referenced files exist: apps/DEVELOPMENT.md, apps/tldw-frontend/README.md, and README.md.
 - README anchor exists: ### Run the Web UI (WIP).
-- Stale README-only wording check found no matches.
-- source .venv/bin/activate and python Helper_Scripts/docs/check_onboarding_command_boundaries.py passed.
+- Stale README-only wording check against the guide found no matches.
+- Helper_Scripts/docs/check_onboarding_command_boundaries.py passed.
 - Bandit skipped: documentation-only Markdown changes; no Python code touched.
 
 Subagent reviews:
 - Task 1 spec review passed; Task 1 quality review passed.
 - Task 2 spec review passed; Task 2 quality review passed.
 
-Final review fixes applied: clarified that `.env.local` must be edited to use the shown local API values, marked execution plan checklist items complete, and updated the design spec status to Implemented.
-
-Final review minor cleanup: aligned the implementation plan WebUI `.env.local` wording and env fence with the final guide.
+Final review fixes applied: clarified that .env.local must be edited to use the shown local API values, marked execution plan checklist items complete, updated the design spec status to Implemented, aligned plan wording with the final guide, and rebased the task record to TASK-12075 to avoid the existing TASK-12072 on origin/dev.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Updated the local single-user setup guide so it is self-contained for API plus WebUI setup. The guide now includes WebUI prerequisites, `.env.local` values, Bun and npm start paths, WebUI verification, first-value guidance, troubleshooting for common local WebUI issues, and links to deeper WebUI and advanced networking docs.
+Updated the local single-user setup guide so it is self-contained for API plus WebUI setup. The guide now includes WebUI prerequisites, .env.local values, Bun and npm start paths, WebUI verification, first-value guidance, troubleshooting for common local WebUI issues, and links to deeper WebUI and advanced networking docs.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Make the local single-user guide self-contained for starting the API and Next.js WebUI.
- Add explicit WebUI `.env.local` values, browser-visible API-key guidance, Bun/npm commands, and WebUI verification.
- Update troubleshooting, deeper-reference links, design/plan artifacts, and Backlog task tracking as `TASK-12075`.

## Test Plan
- `git diff --check origin/dev...HEAD -- Docs/Getting_Started/Profile_Local_Single_User.md Docs/superpowers/specs/2026-06-30-local-single-user-webui-guide-design.md Docs/superpowers/plans/2026-06-30-local-single-user-webui-guide-implementation-plan.md "backlog/tasks/task-12075 - Update-Local-Single-User-Setup-guide-with-WebUI.md"`
- `rg -n "Add the WebUI|Local Profile: Add the WebUI|does not include the WebUI by default" Docs/Getting_Started/Profile_Local_Single_User.md` (expected no matches)
- `rg -n "^### Run the Web UI \(WIP\)" README.md`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python Helper_Scripts/docs/check_onboarding_command_boundaries.py`
- Bandit skipped: Markdown-only documentation changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the local single-user guide self-contained for running the API and Next.js WebUI. Removes the README dependency and aligns with TASK-12075.

It now includes explicit `.env.local` values (`NEXT_PUBLIC_API_URL=http://127.0.0.1:8000`, `NEXT_PUBLIC_API_VERSION=v1`, optional `NEXT_PUBLIC_X_API_KEY` with a browser-visible warning), `bun`/`npm` start commands, a WebUI curl check, targeted troubleshooting (port 8080 conflicts, Bun install, API reachability), links to `apps/DEVELOPMENT.md`, `apps/tldw-frontend/README.md`, advanced networking, and adds design/spec and implementation plan docs.

<sup>Written for commit 0f6ad72ccc49e4245aa20890eab422b27db22da9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

