### PR TITLE
Fix Ant Design dark mode contrast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1372,6 +1372,7 @@ jobs:
           - name: product-flashcards
             paths: >-
               tldw_Server_API/tests/Flashcards/test*.py
+              tldw_Server_API/tests/Explainer
           - name: product-notes-persona
             paths: >-
               tldw_Server_API/tests/Notes
@@ -2759,6 +2760,7 @@ jobs:
           - name: product-flashcards
             paths: >-
               tldw_Server_API/tests/Flashcards/test*.py
+              tldw_Server_API/tests/Explainer
           - name: product-notes-persona
             paths: >-
               tldw_Server_API/tests/Notes
@@ -4019,6 +4021,7 @@ jobs:
           - name: product-flashcards
             paths: >-
               tldw_Server_API/tests/Flashcards/test*.py
+              tldw_Server_API/tests/Explainer
           - name: product-notes-persona
             paths: >-
               tldw_Server_API/tests/Notes
@@ -5203,6 +5206,7 @@ jobs:
           - name: product-flashcards
             paths: >-
               tldw_Server_API/tests/Flashcards/test*.py
+              tldw_Server_API/tests/Explainer
           - name: product-notes-persona
             paths: >-
               tldw_Server_API/tests/Notes
@@ -6388,6 +6392,7 @@ jobs:
           - name: product-flashcards
             paths: >-
               tldw_Server_API/tests/Flashcards/test*.py
+              tldw_Server_API/tests/Explainer
           - name: product-notes-persona
             paths: >-
               tldw_Server_API/tests/Notes

--- a/apps/packages/ui/src/assets/tailwind-shared.css
+++ b/apps/packages/ui/src/assets/tailwind-shared.css
@@ -366,12 +366,19 @@ body {
 }
 
 /* Ant Design bridge: keep generated component CSS aligned with app theme tokens. */
-.ant-card,
+.ant-card {
+  background-color: rgb(var(--color-surface)) !important;
+  color: rgb(var(--color-text)) !important;
+  border-color: rgb(var(--color-border)) !important;
+}
+
 .ant-popover-inner,
 .ant-dropdown-menu,
 .ant-modal-content,
-.ant-modal-header {
-  background-color: rgb(var(--color-surface)) !important;
+.ant-modal-header,
+.ant-drawer-content,
+.ant-drawer-header {
+  background-color: rgb(var(--color-elevated)) !important;
   color: rgb(var(--color-text)) !important;
   border-color: rgb(var(--color-border)) !important;
 }
@@ -379,7 +386,7 @@ body {
 .ant-card-head,
 .ant-modal-title,
 .ant-drawer-title,
-.ant-typography,
+.ant-typography:not(.ant-typography-danger):not(.ant-typography-success):not(.ant-typography-warning),
 .ant-form-item-label > label,
 .ant-checkbox-wrapper,
 .ant-radio-wrapper,
@@ -389,8 +396,7 @@ body {
   color: rgb(var(--color-text)) !important;
 }
 
-.ant-card-head,
-.ant-modal-header {
+.ant-card-head {
   border-color: rgb(var(--color-border)) !important;
 }
 
@@ -405,6 +411,18 @@ body {
 .ant-tabs .ant-tabs-tab:hover .ant-tabs-tab-btn,
 .ant-tabs .ant-tabs-tab-active .ant-tabs-tab-btn {
   color: rgb(var(--color-primary)) !important;
+}
+
+.ant-typography.ant-typography-danger {
+  color: rgb(var(--color-danger)) !important;
+}
+
+.ant-typography.ant-typography-success {
+  color: rgb(var(--color-success)) !important;
+}
+
+.ant-typography.ant-typography-warning {
+  color: rgb(var(--color-warn)) !important;
 }
 
 .ant-input,
@@ -448,6 +466,118 @@ body {
   box-shadow: 0 0 0 2px rgb(var(--color-focus) / 0.4) !important;
 }
 
+.ant-form-item-has-error .ant-form-item-explain,
+.ant-form-item-has-error .ant-form-item-explain-error {
+  color: rgb(var(--color-danger)) !important;
+}
+
+.ant-form-item-has-warning .ant-form-item-explain,
+.ant-form-item-has-warning .ant-form-item-explain-warning {
+  color: rgb(var(--color-warn)) !important;
+}
+
+.ant-form-item-has-success .ant-form-item-explain,
+.ant-form-item-has-success .ant-form-item-explain-success {
+  color: rgb(var(--color-success)) !important;
+}
+
+.ant-input-status-error,
+.ant-input-status-error:hover,
+.ant-input-affix-wrapper-status-error,
+.ant-input-affix-wrapper-status-error:hover,
+.ant-input-number-status-error,
+.ant-input-number-status-error:hover,
+.ant-picker-status-error,
+.ant-picker-status-error:hover,
+.ant-select-status-error .ant-select-selector,
+.ant-select-status-error .ant-select-selector:hover,
+.ant-form-item-has-error .ant-input,
+.ant-form-item-has-error .ant-input:hover,
+.ant-form-item-has-error .ant-input-affix-wrapper,
+.ant-form-item-has-error .ant-input-affix-wrapper:hover,
+.ant-form-item-has-error .ant-input-number,
+.ant-form-item-has-error .ant-input-number:hover,
+.ant-form-item-has-error .ant-select-selector,
+.ant-form-item-has-error .ant-select-selector:hover,
+.ant-form-item-has-error .ant-picker,
+.ant-form-item-has-error .ant-picker:hover {
+  border-color: rgb(var(--color-danger)) !important;
+}
+
+.ant-input-status-error:focus,
+.ant-input-affix-wrapper-status-error.ant-input-affix-wrapper-focused,
+.ant-input-number-status-error.ant-input-number-focused,
+.ant-picker-status-error.ant-picker-focused,
+.ant-select-status-error.ant-select-focused .ant-select-selector,
+.ant-form-item-has-error .ant-input:focus,
+.ant-form-item-has-error .ant-input-affix-wrapper-focused,
+.ant-form-item-has-error .ant-input-number-focused,
+.ant-form-item-has-error .ant-select-focused .ant-select-selector,
+.ant-form-item-has-error .ant-picker-focused {
+  border-color: rgb(var(--color-danger)) !important;
+  box-shadow: 0 0 0 2px rgb(var(--color-danger) / 0.24) !important;
+}
+
+.ant-input-status-warning,
+.ant-input-status-warning:hover,
+.ant-input-affix-wrapper-status-warning,
+.ant-input-affix-wrapper-status-warning:hover,
+.ant-input-number-status-warning,
+.ant-input-number-status-warning:hover,
+.ant-picker-status-warning,
+.ant-picker-status-warning:hover,
+.ant-select-status-warning .ant-select-selector,
+.ant-select-status-warning .ant-select-selector:hover,
+.ant-form-item-has-warning .ant-input,
+.ant-form-item-has-warning .ant-input:hover,
+.ant-form-item-has-warning .ant-input-affix-wrapper,
+.ant-form-item-has-warning .ant-input-affix-wrapper:hover,
+.ant-form-item-has-warning .ant-input-number,
+.ant-form-item-has-warning .ant-input-number:hover,
+.ant-form-item-has-warning .ant-select-selector,
+.ant-form-item-has-warning .ant-select-selector:hover,
+.ant-form-item-has-warning .ant-picker,
+.ant-form-item-has-warning .ant-picker:hover {
+  border-color: rgb(var(--color-warn)) !important;
+}
+
+.ant-input-status-warning:focus,
+.ant-input-affix-wrapper-status-warning.ant-input-affix-wrapper-focused,
+.ant-input-number-status-warning.ant-input-number-focused,
+.ant-picker-status-warning.ant-picker-focused,
+.ant-select-status-warning.ant-select-focused .ant-select-selector,
+.ant-form-item-has-warning .ant-input:focus,
+.ant-form-item-has-warning .ant-input-affix-wrapper-focused,
+.ant-form-item-has-warning .ant-input-number-focused,
+.ant-form-item-has-warning .ant-select-focused .ant-select-selector,
+.ant-form-item-has-warning .ant-picker-focused {
+  border-color: rgb(var(--color-warn)) !important;
+  box-shadow: 0 0 0 2px rgb(var(--color-warn) / 0.24) !important;
+}
+
+.ant-input-status-success,
+.ant-input-status-success:hover,
+.ant-input-affix-wrapper-status-success,
+.ant-input-affix-wrapper-status-success:hover,
+.ant-input-number-status-success,
+.ant-input-number-status-success:hover,
+.ant-picker-status-success,
+.ant-picker-status-success:hover,
+.ant-select-status-success .ant-select-selector,
+.ant-select-status-success .ant-select-selector:hover,
+.ant-form-item-has-success .ant-input,
+.ant-form-item-has-success .ant-input:hover,
+.ant-form-item-has-success .ant-input-affix-wrapper,
+.ant-form-item-has-success .ant-input-affix-wrapper:hover,
+.ant-form-item-has-success .ant-input-number,
+.ant-form-item-has-success .ant-input-number:hover,
+.ant-form-item-has-success .ant-select-selector,
+.ant-form-item-has-success .ant-select-selector:hover,
+.ant-form-item-has-success .ant-picker,
+.ant-form-item-has-success .ant-picker:hover {
+  border-color: rgb(var(--color-success)) !important;
+}
+
 .ant-input::placeholder,
 .ant-input-textarea::placeholder,
 .ant-input-textarea textarea::placeholder,
@@ -477,17 +607,51 @@ body {
   background-color: rgb(var(--color-elevated)) !important;
 }
 
-.ant-btn-default {
+.ant-btn-default:not(.ant-btn-dangerous) {
   background-color: rgb(var(--color-surface)) !important;
   border-color: rgb(var(--color-border)) !important;
   color: rgb(var(--color-text)) !important;
 }
 
-.ant-btn-default:hover,
-.ant-btn-default:focus {
+.ant-btn-default:not(.ant-btn-dangerous):hover,
+.ant-btn-default:not(.ant-btn-dangerous):focus {
   background-color: rgb(var(--color-surface-2)) !important;
   border-color: rgb(var(--color-primary)) !important;
   color: rgb(var(--color-text)) !important;
+}
+
+.ant-btn-default.ant-btn-dangerous {
+  background-color: rgb(var(--color-danger) / 0.12) !important;
+  border-color: rgb(var(--color-danger)) !important;
+  color: rgb(var(--color-danger)) !important;
+}
+
+.ant-btn-default.ant-btn-dangerous:hover,
+.ant-btn-default.ant-btn-dangerous:focus {
+  background-color: rgb(var(--color-danger) / 0.18) !important;
+  border-color: rgb(var(--color-danger)) !important;
+  color: rgb(var(--color-danger)) !important;
+}
+
+.ant-input-disabled,
+.ant-input[disabled],
+.ant-input-affix-wrapper-disabled,
+.ant-input-affix-wrapper-disabled input,
+.ant-input-number-disabled,
+.ant-input-number-disabled input,
+.ant-picker-disabled,
+.ant-picker-disabled input,
+.ant-select-disabled .ant-select-selector,
+.ant-select-disabled .ant-select-selection-item,
+.ant-select-disabled .ant-select-arrow,
+.ant-checkbox-wrapper-disabled,
+.ant-radio-wrapper-disabled,
+.ant-btn-default:disabled,
+.ant-btn-default.ant-btn-disabled {
+  background-color: rgb(var(--color-surface-2) / 0.5) !important;
+  border-color: rgb(var(--color-border) / 0.5) !important;
+  color: rgb(var(--color-text-muted) / 0.72) !important;
+  cursor: not-allowed !important;
 }
 
 .focus-ring:focus-visible {

--- a/apps/packages/ui/src/assets/tailwind-shared.css
+++ b/apps/packages/ui/src/assets/tailwind-shared.css
@@ -365,7 +365,48 @@ body {
   box-shadow: none !important;
 }
 
-/* Inputs/selects background + focus states for light/dark themes */
+/* Ant Design bridge: keep generated component CSS aligned with app theme tokens. */
+.ant-card,
+.ant-popover-inner,
+.ant-dropdown-menu,
+.ant-modal-content,
+.ant-modal-header {
+  background-color: rgb(var(--color-surface)) !important;
+  color: rgb(var(--color-text)) !important;
+  border-color: rgb(var(--color-border)) !important;
+}
+
+.ant-card-head,
+.ant-modal-title,
+.ant-drawer-title,
+.ant-typography,
+.ant-form-item-label > label,
+.ant-checkbox-wrapper,
+.ant-radio-wrapper,
+.ant-tabs .ant-tabs-tab-btn,
+.ant-segmented,
+.ant-segmented-item-label {
+  color: rgb(var(--color-text)) !important;
+}
+
+.ant-card-head,
+.ant-modal-header {
+  border-color: rgb(var(--color-border)) !important;
+}
+
+.ant-form-item-extra,
+.ant-form-item-explain,
+.ant-typography-secondary,
+.ant-typography .ant-typography-secondary,
+.ant-tabs .ant-tabs-tab:not(.ant-tabs-tab-active) .ant-tabs-tab-btn {
+  color: rgb(var(--color-text-muted)) !important;
+}
+
+.ant-tabs .ant-tabs-tab:hover .ant-tabs-tab-btn,
+.ant-tabs .ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: rgb(var(--color-primary)) !important;
+}
+
 .ant-input,
 .ant-input-affix-wrapper,
 .ant-input-number,
@@ -374,10 +415,19 @@ body {
 .ant-input-textarea textarea,
 .ant-select-selector,
 .ant-picker {
-  background-color: rgb(var(--color-surface-2));
-  border-color: rgb(var(--color-border));
-  color: rgb(var(--color-text));
+  background-color: rgb(var(--color-surface-2)) !important;
+  border-color: rgb(var(--color-border)) !important;
+  color: rgb(var(--color-text)) !important;
   transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.ant-input input,
+.ant-input-affix-wrapper input,
+.ant-input-number-input,
+.ant-picker-input > input,
+.ant-select-selection-item,
+.ant-select-selection-search-input {
+  color: rgb(var(--color-text)) !important;
 }
 
 .ant-input:hover,
@@ -385,7 +435,7 @@ body {
 .ant-input-number:hover,
 .ant-select-selector:hover,
 .ant-picker:hover {
-  border-color: rgb(var(--color-primary));
+  border-color: rgb(var(--color-primary)) !important;
 }
 
 .ant-input:focus,
@@ -394,15 +444,50 @@ body {
 .ant-input-number-focused,
 .ant-select-focused .ant-select-selector,
 .ant-picker-focused {
-  border-color: rgb(var(--color-primary));
-  box-shadow: 0 0 0 2px rgb(var(--color-focus) / 0.4);
+  border-color: rgb(var(--color-primary)) !important;
+  box-shadow: 0 0 0 2px rgb(var(--color-focus) / 0.4) !important;
 }
 
 .ant-input::placeholder,
 .ant-input-textarea::placeholder,
 .ant-input-textarea textarea::placeholder,
+.ant-input-affix-wrapper input::placeholder,
+.ant-picker-input > input::placeholder,
 .ant-select-selection-placeholder {
-  color: rgb(var(--color-text-muted));
+  color: rgb(var(--color-text-muted)) !important;
+}
+
+.ant-input-password-icon,
+.ant-select-arrow,
+.ant-picker-suffix,
+.ant-picker-clear {
+  color: rgb(var(--color-text-muted)) !important;
+}
+
+.ant-segmented {
+  background-color: rgb(var(--color-surface-2)) !important;
+}
+
+.ant-segmented .ant-segmented-item-selected {
+  background-color: rgb(var(--color-surface)) !important;
+  color: rgb(var(--color-text)) !important;
+}
+
+.ant-segmented .ant-segmented-item:not(.ant-segmented-item-selected):hover {
+  background-color: rgb(var(--color-elevated)) !important;
+}
+
+.ant-btn-default {
+  background-color: rgb(var(--color-surface)) !important;
+  border-color: rgb(var(--color-border)) !important;
+  color: rgb(var(--color-text)) !important;
+}
+
+.ant-btn-default:hover,
+.ant-btn-default:focus {
+  background-color: rgb(var(--color-surface-2)) !important;
+  border-color: rgb(var(--color-primary)) !important;
+  color: rgb(var(--color-text)) !important;
 }
 
 .focus-ring:focus-visible {

--- a/backlog/tasks/task-12078 - Fix-Settings-dark-mode-Ant-Design-contrast.md
+++ b/backlog/tasks/task-12078 - Fix-Settings-dark-mode-Ant-Design-contrast.md
@@ -4,12 +4,14 @@ title: Fix Settings dark mode Ant Design contrast
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-30 19:52'
+updated_date: 2026-06-30 19:52
 labels:
-  - webui
-  - accessibility
-  - dark-mode
+- webui
+- accessibility
+- dark-mode
 dependencies: []
+modified_files:
+- apps/packages/ui/src/assets/tailwind-shared.css
 ---
 
 ## Description
@@ -27,20 +29,18 @@ Settings pages render several Ant Design components with light-theme text and su
 
 ## Implementation Notes
 
-<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Root cause: Ant Design generated component styles were still winning for Settings labels, tabs, helper text, inputs, segmented controls, and default buttons, so those controls kept light-theme black text/surfaces inside the app dark shell.
 
 Implementation: extended the shared AntD bridge in apps/packages/ui/src/assets/tailwind-shared.css to map common AntD text, surface, border, input, tab, segmented, and default-button selectors to semantic app tokens with enough specificity to beat generated component CSS.
 
 Verification: browser checked http://127.0.0.1:3000/settings/tldw in dark mode. Computed contrast after fix: heading 15.58, inactive tab 8.93, active tab 5.57, form label 15.58, helper text 9.69, input 13.29, password wrapper 13.29, segmented 13.29, selected segmented label 14.36, default button 14.36. Timeouts tab interaction selected successfully and browser console had no warnings/errors. Ran git diff --check and bun run test:run ../packages/ui/src/components/Option/Settings/__tests__/tldw-settings-tabs.test.tsx from apps/tldw-frontend: 4 tests passed. Earlier bunx vitest from repo root failed before test execution because temporary latest Vitest could not resolve jsdom and globbed nested worktrees; reran through package-local script successfully. Bandit skipped because only CSS changed.
-<!-- SECTION:NOTES:END -->
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed Settings dark-mode readability by extending the shared Ant Design CSS bridge so Settings tabs, labels, helper text, inputs, segmented controls, cards/modals, and default buttons use the app semantic theme tokens. Verified the live Settings route in dark mode with computed contrast checks and a tab interaction; package-local Settings tab tests passed. Bandit not applicable for CSS-only change.
-<!-- SECTION:FINAL_SUMMARY:END -->
-
+Fixed Settings dark-mode readability by extending the shared Ant Design CSS bridge so Settings tabs, labels, helper text, inputs, segmented controls, cards/modals, and default buttons use the app semantic theme tokens. Follow-up PR review fixes preserve AntD danger/success/warning/disabled states, keep card surfaces distinct from elevated overlays, and preserve dangerous default-button styling while retaining dark-mode readability. Verified the live Settings route in dark mode with computed contrast checks and a tab interaction before review follow-up; package-local Settings tab tests passed. Bandit not applicable for CSS-only change.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12078 - Fix-Settings-dark-mode-Ant-Design-contrast.md
+++ b/backlog/tasks/task-12078 - Fix-Settings-dark-mode-Ant-Design-contrast.md
@@ -1,0 +1,54 @@
+---
+id: TASK-12078
+title: Fix Settings dark mode Ant Design contrast
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-30 19:52'
+labels:
+  - webui
+  - accessibility
+  - dark-mode
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Settings pages render several Ant Design components with light-theme text and surfaces in dark mode, causing dark text on dark app backgrounds. Fix the shared AntD theme/override layer and validate the Settings page in the browser.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Settings form labels, tab labels, helper text, inputs, segmented controls, and default buttons are readable in dark mode.
+- [x] #2 The fix uses shared theme/override infrastructure rather than one-off copy changes.
+- [x] #3 Browser validation confirms key Settings controls meet readable contrast in dark mode.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: Ant Design generated component styles were still winning for Settings labels, tabs, helper text, inputs, segmented controls, and default buttons, so those controls kept light-theme black text/surfaces inside the app dark shell.
+
+Implementation: extended the shared AntD bridge in apps/packages/ui/src/assets/tailwind-shared.css to map common AntD text, surface, border, input, tab, segmented, and default-button selectors to semantic app tokens with enough specificity to beat generated component CSS.
+
+Verification: browser checked http://127.0.0.1:3000/settings/tldw in dark mode. Computed contrast after fix: heading 15.58, inactive tab 8.93, active tab 5.57, form label 15.58, helper text 9.69, input 13.29, password wrapper 13.29, segmented 13.29, selected segmented label 14.36, default button 14.36. Timeouts tab interaction selected successfully and browser console had no warnings/errors. Ran git diff --check and bun run test:run ../packages/ui/src/components/Option/Settings/__tests__/tldw-settings-tabs.test.tsx from apps/tldw-frontend: 4 tests passed. Earlier bunx vitest from repo root failed before test execution because temporary latest Vitest could not resolve jsdom and globbed nested worktrees; reran through package-local script successfully. Bandit skipped because only CSS changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed Settings dark-mode readability by extending the shared Ant Design CSS bridge so Settings tabs, labels, helper text, inputs, segmented controls, cards/modals, and default buttons use the app semantic theme tokens. Verified the live Settings route in dark mode with computed contrast checks and a tab interaction; package-local Settings tab tests passed. Bandit not applicable for CSS-only change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12079 - Add-Explainer-tests-to-CI-shard-coverage.md
+++ b/backlog/tasks/task-12079 - Add-Explainer-tests-to-CI-shard-coverage.md
@@ -1,0 +1,56 @@
+---
+id: TASK-12079
+title: Add Explainer tests to CI shard coverage
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-30 20:11'
+labels:
+  - ci
+  - tests
+  - explainer
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Assign the existing Explainer pytest files reported by the shard coverage guard to a CI shard so the pull request can pass coverage validation after rebasing on dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Explainer pytest files reported by the guard are covered by the CI shard map.
+- [x] #2 The local shard coverage guard passes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect the CI shard matrix and choose the nearest backend shard for Explainer tests. - Complete
+2. Add the missing Explainer test paths to the shard map. - Complete
+3. Run the shard coverage guard locally and record the result. - Complete
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Assigned tldw_Server_API/tests/Explainer to the existing product-flashcards shard block in each repeated full-suite matrix block. The local shard coverage guard now reports new_uncovered=0. Bandit is not applicable because this task only changes CI YAML and task metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added `tldw_Server_API/tests/Explainer` to the repeated `product-flashcards` shard blocks in `.github/workflows/ci.yml`, keeping the shard count stable while assigning the existing Explainer tests to the full-suite matrices. Verified with `python Helper_Scripts/ci/check_shard_coverage.py --ci-file .github/workflows/ci.yml`, which now reports `new_uncovered=0`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12080 - Fix-Explainer-endpoint-auth-dependency-boundary.md
+++ b/backlog/tasks/task-12080 - Fix-Explainer-endpoint-auth-dependency-boundary.md
@@ -1,0 +1,55 @@
+---
+id: TASK-12080
+title: Fix Explainer endpoint auth dependency boundary
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-01 00:08'
+labels:
+  - ci
+  - auth
+  - explainer
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The full-suite core-utils-tooling CI shard fails because the Explainer endpoint imports common auth dependency symbols directly from core.AuthNZ instead of the API dependency boundary module. Route the endpoint through the approved auth_deps exports so the lint boundary guard passes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Explainer endpoint imports common auth dependency symbols from tldw_Server_API.app.api.v1.API_Deps.auth_deps instead of core.AuthNZ.User_DB_Handling.
+- [x] #2 The endpoint auth dependency boundary lint test passes locally.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect the Explainer endpoint and API auth dependency exports. - Complete
+2. Replace direct core AuthNZ imports with the approved auth_deps import path. - Complete
+3. Run the focused lint test and relevant sanity checks. - Complete
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated the Explainer endpoint to import `User` and `get_request_user` from `tldw_Server_API.app.api.v1.API_Deps.auth_deps` instead of directly from `core.AuthNZ.User_DB_Handling`, matching the endpoint auth dependency boundary used elsewhere. Verified with the focused lint test, Explainer endpoint tests, and Bandit on the touched endpoint.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/explainer.py
+++ b/tldw_Server_API/app/api/v1/endpoints/explainer.py
@@ -32,7 +32,7 @@ from tldw_Server_API.app.api.v1.schemas.explainer import (
     ExplainerSessionResponse,
     ExplainerSessionSummaryResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.core.Chatbooks.chatbook_models import ContentType
 from tldw_Server_API.app.core.Chatbooks.chatbook_service import ChatbookService
 from tldw_Server_API.app.core.DB_Management.Explainer_DB import ExplainerDatabase


### PR DESCRIPTION
## Summary

- What changed:
  - Expanded the shared Ant Design CSS bridge so AntD-generated components use the app semantic text, surface, border, input, tab, segmented, validation, disabled, and default/danger button tokens in dark mode.
  - Fixed unreadable dark-mode controls on Settings and Companion Home without page-level styling.
  - Added Backlog records for the contrast fix, CI shard coverage fix, and Explainer auth-boundary fix.
  - Added `tldw_Server_API/tests/Explainer` to the existing `product-flashcards` full-suite shard blocks so the Explainer tests are covered by CI.
  - Updated the Explainer endpoint to import common auth dependency symbols through `API_Deps.auth_deps`, satisfying the endpoint auth-boundary lint guard.
- Why:
  - AntD generated styles were overriding the app dark theme tokens, producing unreadable dark-on-dark and light-on-light surfaces.
  - The review feedback correctly identified that broad `!important` rules needed explicit validation, disabled, elevated overlay, and danger-button exceptions.
  - Shard coverage exposed that existing Explainer tests were unassigned, and once assigned, the endpoint auth-boundary lint test surfaced an existing import boundary violation.

## Change summary

Human requester note required before merge: per the repo AI-generated PR policy, a human maintainer/requester must replace or confirm this section in their own words before merging.

AI-drafted context: This PR centralizes AntD dark-mode fixes in `tailwind-shared.css`, preserves AntD semantic states, keeps overlays visually elevated, assigns Explainer tests to CI shard coverage, and routes the Explainer endpoint auth imports through the approved API dependency boundary.

## Validation

- [x] Tests added/updated for behavior changes
  - Existing targeted Settings and Companion Home tests cover the affected UI behavior; CI shard map updated so existing Explainer tests now run.
- [x] Relevant unit/integration tests pass locally
  - `git diff --check`
  - `python Helper_Scripts/ci/check_shard_coverage.py --ci-file .github/workflows/ci.yml` -> `new_uncovered=0`
  - `bun run test:run ../packages/ui/src/components/Option/Settings/__tests__/tldw-settings-tabs.test.tsx` -> 4 passed
  - `bun run test:run ../packages/ui/src/components/Option/CompanionHome/__tests__/GettingStartedSection.test.tsx ../packages/ui/src/components/Option/CompanionHome/__tests__/CompanionHomePage.test.tsx` -> 15 passed
  - `python -m pytest tldw_Server_API/tests/lint/test_endpoint_auth_deps_import_boundary.py -q` -> 3 passed
  - `python -m pytest tldw_Server_API/tests/Explainer/test_explainer_endpoints.py -q` -> 14 passed
  - `python -m bandit -q -r tldw_Server_API/app/api/v1/endpoints/explainer.py` -> no findings
- [x] Docs updated (if behavior, routes, or config changed)
  - Backlog tasks TASK-12078, TASK-12079, and TASK-12080 document scope and verification; no user-facing docs required.

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
  - Not run locally; targeted browser validation and focused Vitest coverage were used for this scoped UI fix.
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
  - Not run locally; broader GitHub checks are running on the PR.
- [x] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List`
  - Targeted Settings and Companion browser validation had no console warnings/errors.
- [x] No `Maximum update depth exceeded` warnings on audited routes
  - Targeted Settings and Companion browser validation had no console warnings/errors.
- [x] No unresolved `{{...}}` placeholders on audited routes
  - Checked during targeted route validation.
- [ ] WebUI/extension parity validated for shared UI fixes
  - WebUI routes were validated; extension parity was not separately run.
- [x] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path
  - Not applicable; no Flashcards UI behavior changed.
- [x] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary`
  - Not applicable; no Flashcards drawer behavior changed.
- [x] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors
  - Not applicable; no Flashcards help/copy/import behavior changed.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally
  - Not applicable; Watchlists UI behavior did not change.
- [x] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports
  - Not applicable; Watchlists UI behavior did not change.
- [x] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text)
  - Not applicable; Watchlists UI behavior did not change.
- [x] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present)
  - Not applicable; Watchlists UI behavior did not change.
- [x] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md`
  - Not applicable; Watchlists UI behavior did not change.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally
  - Not applicable; Watchlists UI behavior did not change.
- [x] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap
  - Not applicable; Watchlists polling/notifications did not change.
- [x] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn)
  - Not applicable; Watchlists Activity polling did not change.
- [x] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs
  - Not applicable; Watchlists batch triage behavior did not change.
- [x] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md`
  - Not applicable; Watchlists scale behavior did not change.

## Risk & Rollback

- Risk level: Low
- Rollback plan:
  - Revert the PR branch commits that touch `apps/packages/ui/src/assets/tailwind-shared.css`, `.github/workflows/ci.yml`, `tldw_Server_API/app/api/v1/endpoints/explainer.py`, and the associated Backlog task files.
  - If a specific AntD state regresses, revert only the relevant selector block in `tailwind-shared.css` and keep the CI shard/auth-boundary fixes.
