### PR TITLE
Add WebUI AUTH_MODE to local env example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1240,6 +1240,7 @@ jobs:
           - name: chatbooks-streaming
             paths: >-
               tldw_Server_API/tests/Chatbooks
+              tldw_Server_API/tests/Explainer
               tldw_Server_API/tests/Streaming
           - name: llm-adapters-unit
             paths: >-
@@ -2627,6 +2628,7 @@ jobs:
           - name: chatbooks-streaming
             paths: >-
               tldw_Server_API/tests/Chatbooks
+              tldw_Server_API/tests/Explainer
               tldw_Server_API/tests/Streaming
           - name: llm-adapters-unit
             paths: >-
@@ -3887,6 +3889,7 @@ jobs:
           - name: chatbooks-streaming
             paths: >-
               tldw_Server_API/tests/Chatbooks
+              tldw_Server_API/tests/Explainer
               tldw_Server_API/tests/Streaming
           - name: llm-adapters-unit
             paths: >-
@@ -5071,6 +5074,7 @@ jobs:
           - name: chatbooks-streaming
             paths: >-
               tldw_Server_API/tests/Chatbooks
+              tldw_Server_API/tests/Explainer
               tldw_Server_API/tests/Streaming
           - name: llm-adapters-unit
             paths: >-
@@ -6256,6 +6260,7 @@ jobs:
           - name: chatbooks-streaming
             paths: >-
               tldw_Server_API/tests/Chatbooks
+              tldw_Server_API/tests/Explainer
               tldw_Server_API/tests/Streaming
           - name: llm-adapters-unit
             paths: >-

--- a/apps/tldw-frontend/.env.local.example
+++ b/apps/tldw-frontend/.env.local.example
@@ -12,6 +12,10 @@ NEXT_PUBLIC_API_VERSION=v1
 
 # Authentication options (choose one of the below for local/dev):
 
+# Runtime auth mode used by /api/_tldw-webui/runtime-config.
+# Keep this aligned with the backend AUTH_MODE for local single-user setups.
+AUTH_MODE=single_user
+
 # 1) Optional local single-user bootstrap API key (sent in X-API-KEY header)
 # For local single-user setups, this can match the backend SINGLE_USER_API_KEY
 # when you want the browser dev server to authenticate automatically.

--- a/apps/tldw-frontend/README.md
+++ b/apps/tldw-frontend/README.md
@@ -42,6 +42,7 @@ Key variables:
 - `NEXT_PUBLIC_API_URL`: Backend URL (default: `http://127.0.0.1:8000`)
 - `NEXT_PUBLIC_API_BASE_URL`: Optional. Absolute base URL for static assets and WebUI links. If set, this takes precedence over deriving the base from `NEXT_PUBLIC_API_URL`. Useful when the API is mounted under `/api/vN` behind a reverse proxy.
 - `NEXT_PUBLIC_API_VERSION`: API version (default: `v1`)
+- `AUTH_MODE`: Server-side runtime auth mode used by `/api/_tldw-webui/runtime-config`; set to `single_user` for local single-user setups to match the backend.
 - `NEXT_PUBLIC_X_API_KEY`: Optional. Single-user mode API key (sent as `X-API-KEY`).
 - `NEXT_PUBLIC_API_BEARER`: Optional. Bearer token for chat module when server sets `API_BEARER`.
 - `NEXT_PUBLIC_RUNS_CSV_SERVER_THRESHOLD`: Optional. Runs row-count threshold for preferring server-side CSV export (default: `2000`).

--- a/apps/tldw-frontend/README.md
+++ b/apps/tldw-frontend/README.md
@@ -42,7 +42,7 @@ Key variables:
 - `NEXT_PUBLIC_API_URL`: Backend URL (default: `http://127.0.0.1:8000`)
 - `NEXT_PUBLIC_API_BASE_URL`: Optional. Absolute base URL for static assets and WebUI links. If set, this takes precedence over deriving the base from `NEXT_PUBLIC_API_URL`. Useful when the API is mounted under `/api/vN` behind a reverse proxy.
 - `NEXT_PUBLIC_API_VERSION`: API version (default: `v1`)
-- `AUTH_MODE`: Server-side runtime auth mode used by `/api/_tldw-webui/runtime-config`; set to `single_user` for local single-user setups to match the backend.
+- `AUTH_MODE`: Server-side runtime auth mode used by `/api/_tldw-webui/runtime-config` (no `NEXT_PUBLIC_` prefix); set to `single_user` for local single-user setups to match the backend.
 - `NEXT_PUBLIC_X_API_KEY`: Optional. Single-user mode API key (sent as `X-API-KEY`).
 - `NEXT_PUBLIC_API_BEARER`: Optional. Bearer token for chat module when server sets `API_BEARER`.
 - `NEXT_PUBLIC_RUNS_CSV_SERVER_THRESHOLD`: Optional. Runs row-count threshold for preferring server-side CSV export (default: `2000`).

--- a/backlog/tasks/task-12076 - Add-WebUI-AUTH-MODE-to-local-env-example.md
+++ b/backlog/tasks/task-12076 - Add-WebUI-AUTH-MODE-to-local-env-example.md
@@ -1,0 +1,46 @@
+---
+id: TASK-12076
+title: Add WebUI AUTH_MODE to local env example
+status: Done
+labels:
+- webui
+- auth
+- config
+priority: High
+modified_files:
+- apps/tldw-frontend/.env.local.example
+- apps/tldw-frontend/README.md
+- backlog/tasks/task-12076 - Add-WebUI-AUTH-MODE-to-local-env-example.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Persist the local WebUI single-user runtime auth setting in the checked-in .env.local.example so new local dev users do not hit runtime-config auth-mode failures when connecting to a single-user backend.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added AUTH_MODE=single_user to apps/tldw-frontend/.env.local.example with comments tying it to /api/_tldw-webui/runtime-config, and added AUTH_MODE to the WebUI README key variables list so local single-user WebUI dev setup docs match the template. Verification: git diff --check passed; rg confirmed AUTH_MODE=single_user in the template and AUTH_MODE in the README. Bandit skipped for the env template and README because they are non-code documentation/config changes. PR: https://github.com/rmusser01/tldw_server/pull/2561.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12077 - Add-Explainer-tests-to-CI-shard-coverage.md
+++ b/backlog/tasks/task-12077 - Add-Explainer-tests-to-CI-shard-coverage.md
@@ -1,0 +1,45 @@
+---
+id: TASK-12077
+title: Add Explainer tests to CI shard coverage
+status: Done
+labels:
+- ci
+- tests
+priority: High
+modified_files:
+- .github/workflows/ci.yml
+- tldw_Server_API/tests/CI/test_required_workflow_contracts.py
+- backlog/tasks/task-12077 - Add-Explainer-tests-to-CI-shard-coverage.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Assign the existing tldw_Server_API/tests/Explainer test files to full-suite CI shard coverage so the PR shard coverage guard stops failing on newly unsharded tests already present on dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added tldw_Server_API/tests/Explainer to each full-suite chatbooks-streaming shard matrix and updated the CI workflow-contract test so the existing Explainer tests are included in shard coverage. Verification: local shard guard first reproduced the CI failure with four unsharded Explainer files; after the change, Helper_Scripts/ci/check_shard_coverage.py reported new_uncovered=0. The workflow-contract pytest file passed 38/38. Bandit on the touched pytest contract file reported only existing low-severity B101 assert_used findings; rerunning Bandit with B101 excluded passed with no other findings. PR: https://github.com/rmusser01/tldw_server/pull/2561.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12078 - Document-frontend-AUTH-MODE-runtime-config-variable.md
+++ b/backlog/tasks/task-12078 - Document-frontend-AUTH-MODE-runtime-config-variable.md
@@ -1,0 +1,52 @@
+---
+id: TASK-12078
+title: Document frontend AUTH_MODE runtime config variable
+status: Done
+labels:
+- documentation
+- frontend
+modified_files:
+- apps/tldw-frontend/README.md
+- apps/tldw-frontend/.env.local.example
+- backlog/tasks/task-12078 - Document-frontend-AUTH-MODE-runtime-config-variable.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update the frontend README so local setup key variables explicitly mention the server-side AUTH_MODE setting used by /api/_tldw-webui/runtime-config, including that it does not use a NEXT_PUBLIC_ prefix. This addresses PR review feedback for rmusser01/tldw_server#2561.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify PR branch context and existing env template coverage.
+2. Update the README key variables list to explicitly document AUTH_MODE as a server-side runtime-config variable without a NEXT_PUBLIC_ prefix.
+3. Verify the docs diff and whitespace.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated apps/tldw-frontend/README.md so the Key variables list explicitly documents AUTH_MODE as the server-side runtime auth mode used by /api/_tldw-webui/runtime-config, including that it has no NEXT_PUBLIC_ prefix. The .env.local.example already documents AUTH_MODE=single_user on this PR branch, so no env-template change was needed. Verification: git diff --check passed for the touched README and Backlog task. Bandit skipped because the change is documentation-only and does not touch Python code.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
@@ -994,11 +994,12 @@ def test_full_suite_splits_slow_chat_and_retrieval_shards() -> None:
         }
         assert shard_path_sets["chatbooks-streaming"] == {
             "tldw_Server_API/tests/Chatbooks",
+            "tldw_Server_API/tests/Explainer",
             "tldw_Server_API/tests/Streaming",
         }
         chat_core_files = {
             str(path)
-            for dirname in ("Chat", "Chat_NEW", "Chatbooks", "Streaming")
+            for dirname in ("Chat", "Chat_NEW", "Chatbooks", "Explainer", "Streaming")
             for path in Path("tldw_Server_API/tests", dirname).glob("**/test*.py")
         }
         covered_chat_core_files: dict[str, str] = {}


### PR DESCRIPTION
Change summary:
- Added AUTH_MODE=single_user to apps/tldw-frontend/.env.local.example so local WebUI dev copies include the runtime auth mode used by /api/_tldw-webui/runtime-config.
- Added a Backlog.md task recording the config-only verification and Bandit skip.

Verification:
- git diff --cached --check
- rg -n "AUTH_MODE=single_user|runtime-config" apps/tldw-frontend/.env.local.example

Bandit: skipped because the change only touches an env example and Backlog task metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `AUTH_MODE=single_user` to the WebUI `.env.local.example` and updated the README to clarify that `AUTH_MODE` controls `/api/_tldw-webui/runtime-config` (no `NEXT_PUBLIC_` prefix) so local WebUI matches backend single-user mode. Updated CI to include `tldw_Server_API/tests/Explainer` in the `chatbooks-streaming` shard and adjusted the workflow-contract test to keep shard coverage passing.

<sup>Written for commit 2436af405476079fdd6e16c0fa5ba0f527e6a584. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

