### PR TITLE
Prepare 0.1.34 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,43 @@ and this project adheres to Some kind of Versioning
 ### Removed
 
 
+## [0.1.34] - 2026-07-02
+
+> Rollup coverage: this entry covers current `dev` work that landed after the
+> `0.1.33` release-prep metadata through PR #2568, including the post-PR #2567
+> review follow-ups and current-main CodeQL alert cleanup.
+
+### Added
+
+- **PR 2568 Follow-Up Coverage** — Added Backlog records and focused
+  regression coverage for Jobs event-filter SQL helpers, public metrics-label
+  hashing, frontend auth persistence, and the `mcp-unified` PEP 561
+  `py.typed` marker/package-data contract.
+
+### Changed
+
+- **Jobs, WebSearch, And Auth Persistence Cleanup** — Moved Jobs event-filter
+  SQL construction behind DB management helpers, replaced WebSearch diagnostic
+  `print()` calls with structured Loguru logging, clarified Google parser debug
+  formatting, and restored browser persistence for manually entered API keys
+  and bearer tokens while preserving environment-provided auth precedence.
+- **CodeQL Suppression Hygiene** — Updated validated path/auth/download/sync
+  suppressions from legacy LGTM comments to scoped CodeQL annotations with
+  local rationale on the reviewed paths.
+
+### Fixed
+
+- **PR 2567/2568 Review Follow-Ups** — Addressed review findings for DB-layer
+  ownership, missing helper/class docstrings, pytest unit markers, metrics tests
+  using public label normalization, WebSearch logging ambiguity, frontend auth
+  reload behavior, and the `mcp-unified` typed-marker package-data mismatch.
+
+### Removed
+
+- Removed stray WebSearch parser diagnostic `print()` calls from the current
+  release line.
+
+
 ## [0.1.33] - 2026-07-01
 
 > Rollup coverage: this entry covers work that landed after the `0.1.32`

--- a/Docs/mkdocs.yml
+++ b/Docs/mkdocs.yml
@@ -59,13 +59,13 @@ markdown_extensions:
 
 extra:
   generator: false
-  version: v0.1.33
+  version: v0.1.34
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/rmusser01/tldw_server
       name: GitHub
 copyright: |
-  © 2024-2025 tldw_Server - v0.1.33 - <a href="https://github.com/rmusser01/tldw_server">GitHub</a>
+  © 2024-2025 tldw_Server - v0.1.34 - <a href="https://github.com/rmusser01/tldw_server">GitHub</a>
 
 nav:
   - Home: User_Guides/index.md

--- a/Helper_Scripts/release.py
+++ b/Helper_Scripts/release.py
@@ -290,16 +290,6 @@ def update_readme_release_references(readme_text: str, version: str) -> str:
             rf"\g<1>{version}\g<2>",
             "current release line",
         ),
-        (
-            rf"(?m)^(- The `dev` branch currently contains additional unreleased work beyond `){_SEMVER_PATTERN}(`; see \[CHANGELOG\.md\]\(CHANGELOG\.md\) for branch-level detail and \[Docs/Published/RELEASE_NOTES\.md\]\(Docs/Published/RELEASE_NOTES\.md\) for the published release entry point\.)$",
-            rf"\g<1>{version}\g<2>",
-            "beyond-release reference",
-        ),
-        (
-            rf"(?m)^(Currently landing on `dev` \(post-`){_SEMVER_PATTERN}(` branch work\):)$",
-            rf"\g<1>{version}\g<2>",
-            "post-release reference",
-        ),
     ]
 
     updated_text = readme_text
@@ -307,6 +297,28 @@ def update_readme_release_references(readme_text: str, version: str) -> str:
         updated_text, count = re.subn(pattern, replacement, updated_text)
         if count == 0:
             raise ValueError(f"Missing README anchor for {anchor_name}")
+
+    branch_line_pattern = rf"(?m)^- The `dev` branch .*beyond `{_SEMVER_PATTERN}`.*$"
+
+    def _replace_branch_line(match: re.Match[str]) -> str:
+        return re.sub(_SEMVER_PATTERN, version, match.group(0))
+
+    updated_text, count = re.subn(
+        branch_line_pattern,
+        _replace_branch_line,
+        updated_text,
+        count=1,
+    )
+    if count == 0:
+        raise ValueError("Missing README anchor for beyond-release reference")
+
+    updated_text, post_count = re.subn(
+        rf"(?m)^(Currently landing on `dev` \(post-`){_SEMVER_PATTERN}(` branch work\):)$",
+        rf"\g<1>{version}\g<2>",
+        updated_text,
+    )
+    if post_count == 0 and f"post-`{version}` branch work" not in updated_text:
+        raise ValueError("Missing README anchor for post-release reference")
 
     return updated_text
 

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Optional add-ons (apply AFTER your base profile is healthy):
 ## Current Status
 
 Current release line:
-- `0.1.33` Beta status. Expect rough edges and please report issues.
+- `0.1.34` Beta status. Expect rough edges and please report issues.
 - Primary client surfaces are the Next.js WebUI, Admin UI, and browser extension.
 - Package metadata is prepared under the canonical PyPI name `tldw-server`; use a repository checkout until publishing is complete.
-- The `dev` branch carries work beyond `0.1.33`, including post-`0.1.33` branch work, and is prepared for the `0.1.33` release merge to `main`; see [CHANGELOG.md](CHANGELOG.md) for the PR rollup and [Docs/Published/RELEASE_NOTES.md](Docs/Published/RELEASE_NOTES.md) for the published release entry point.
+- The `dev` branch carries work beyond `0.1.34`, including post-`0.1.34` branch work, and is prepared for the `0.1.34` release merge to `main`; see [CHANGELOG.md](CHANGELOG.md) for the PR rollup and [Docs/Published/RELEASE_NOTES.md](Docs/Published/RELEASE_NOTES.md) for the published release entry point.
 
 <details>
 <summary>Current focus and migration notes from the old Gradio version</summary>
@@ -146,18 +146,17 @@ Current release line:
 ## What's New (in the last few releases)
 
 <details>
-<summary>0.1.33 release-prep rollup</summary>
+<summary>0.1.34 release-prep rollup</summary>
 
-Included in the `0.1.33` release-prep rollup:
-- Post-`0.1.32` dev/main stabilization for PR #1982 and PR #2557, including full-suite shard coverage mapping, MkDocs deploy verification, grouped CI fixes, and circuit-breaker flake cleanup.
-- Fish Audio S2 TTS support, including provider registration, native backend/adapter wiring, voice metadata resolution, managed reference imports, contract fixes, and setup documentation.
-- Explainer Workspace persistence, expansion jobs, grounding snapshots, chatbook export/import, UI surfaces, verification coverage, and follow-up hardening.
-- MCP, Skills, and package-gateway readiness work covering runtime metadata, recovery/readiness fields, risky-module opt-in handling, standalone profile discovery, and residual UX review fixes.
-- Chunking and moderation internals refactored around shared helpers and compiler abstractions while preserving existing parsing, dispatch, metrics, and service behavior.
-- Release documentation and packaging cleanup for README skimming, root implementation-plan cleanup, MCP package-path clarity, VCS/manual backend extras, and stale release-branch artifacts.
+Included in the `0.1.34` release-prep rollup:
+- Post-`0.1.33` dev follow-ups for PR #2568, covering review feedback from the dev-to-main PR #2567 path and current-main CodeQL alert cleanup.
+- Jobs event-filter SQL construction moved behind DB management helpers, with focused regression coverage for backend/column validation.
+- WebSearch diagnostic logging cleaned up by replacing `print()` calls with structured Loguru logging and clearer Google raw-result debug formatting.
+- Frontend auth persistence restored for manually entered API keys and bearer tokens while preserving environment-provided auth precedence.
+- `mcp-unified` typed-marker/package-data coverage restored, and related package-boundary tests kept aligned with release metadata.
 
 Still active on `dev`:
-- Final CI for PR #2557 must clear before the prepared `0.1.33` release metadata is merged.
+- Final CI for the prepared `0.1.34` release metadata must clear before this release is merged toward `main`.
 - Treat [CHANGELOG.md](CHANGELOG.md) as the authoritative branch-level history for what has entered the release train.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full running history and [Docs/Published/RELEASE_NOTES.md](Docs/Published/RELEASE_NOTES.md) for published release notes.

--- a/backlog/tasks/task-12091 - Prep-0.1.34-release-from-current-dev.md
+++ b/backlog/tasks/task-12091 - Prep-0.1.34-release-from-current-dev.md
@@ -1,0 +1,53 @@
+---
+id: TASK-12091
+title: Prep 0.1.34 release from current dev
+status: Done
+assignee: []
+created_date: '2026-07-02 02:52'
+updated_date: '2026-07-02 02:58'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2557'
+  - 'https://github.com/rmusser01/tldw_server/pull/2568'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prepare release metadata, changelog, README, and documentation version references for a new release based on the current origin/dev tip after PR #2557 and PR #2568 merged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Package and docs version metadata are advanced from 0.1.33 to the new release version
+- [x] #2 CHANGELOG has a new release entry covering work since 0.1.33
+- [x] #3 README release line and rollup notes describe the new release state
+- [x] #4 Relevant release/docs contract and packaging checks pass locally
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Prepared 0.1.34 from current origin/dev tip 30495536d3 after PR #2557 and PR #2568 merged.
+- Updated pyproject package version, Docs/mkdocs version metadata, README current release line/rollup, and CHANGELOG 0.1.34 entry.
+- Added release-helper regression coverage so the helper updates the repository README wording now used by the docs contract. Red/green: the new test first failed with Missing README anchor for beyond-release reference, then passed after Helper_Scripts/release.py was patched.
+- Verification passed: release/docs/helper test slice (54 passed), git diff --check, Bandit on Helper_Scripts/release.py and the release docs contract test with B101 skipped for pytest asserts, pre-commit on touched files, package build, twine check, and wheel metadata check showing tldw-server 0.1.34.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Prepared the current dev tip for release 0.1.34. Updated root package metadata, MkDocs version metadata, README release status/rollup copy, and CHANGELOG with a 0.1.34 entry covering PR #2568 follow-ups after 0.1.33. Hardened the release helper so it can update the repository README wording used by the docs contract, with a red/green regression test. Validation passed for release/docs helper tests, package build, twine artifact checks, Bandit, pre-commit, and wheel metadata. Known skip/blocker note: formal make release was not run because the release helper is intentionally main-only; this branch prepares dev metadata for the release path.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 ###########################
 [project]
 name = "tldw-server"
-version = "0.1.33"
+version = "0.1.34"
 description = "A comprehensive research assistant and media analysis platform - Too Long; Didn't Watch Server"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/tldw_Server_API/tests/Docs/test_release_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_release_docs_contract.py
@@ -112,6 +112,17 @@ def test_repository_release_metadata_matches_pyproject() -> None:
     assert f"v{current_version}" in mkdocs_text
 
 
+def test_release_helper_updates_repository_readme_release_references() -> None:
+    readme_text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    target_version = "9.9.9"
+
+    updated_text = update_readme_release_references(readme_text, target_version)
+
+    assert f"`{target_version}` Beta status. Expect rough edges and please report issues." in updated_text
+    assert f"beyond `{target_version}`" in updated_text
+    assert f"post-`{target_version}` branch work" in updated_text
+
+
 def test_mkdocs_version_metadata_raises_for_missing_anchor() -> None:
     with pytest.raises(ValueError, match="(?i)mkdocs|anchor|version"):
         update_mkdocs_version_metadata("extra:\n  generator: false\n", "0.1.30")


### PR DESCRIPTION
## Change summary

Pending human-authored change summary before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Technical summary

- Bump root package and docs metadata from `0.1.33` to `0.1.34`.
- Add a `0.1.34` CHANGELOG entry covering current-dev work after `0.1.33`, especially PR #2568 review/CodeQL follow-ups.
- Update README current release and rollup copy for the `0.1.34` release-prep branch.
- Harden `Helper_Scripts/release.py` so the release helper can update the repository README wording currently accepted by the docs contract.
- Add Backlog task `TASK-12091`.

## Verification

- `python -m pytest tldw_Server_API/tests/Docs/test_release_docs_contract.py::test_release_helper_updates_repository_readme_release_references -q` red/green: failed before helper fix, passed after.
- `python -m pytest tldw_Server_API/tests/Docs/test_release_docs_contract.py tldw_Server_API/tests/Utils/test_release_helper.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_standalone_pyproject_matches_release_metadata -q` — 54 passed.
- `git diff --check` on touched files — passed.
- `python -m bandit -q -r Helper_Scripts/release.py tldw_Server_API/tests/Docs/test_release_docs_contract.py -s B101` — passed.
- `pre-commit run --files ...` on touched files — passed.
- `python -m build --no-isolation --sdist --wheel --outdir /private/tmp/tldw_release_0_1_34_dist` — built `tldw_server-0.1.34` artifacts.
- `python -m twine check /private/tmp/tldw_release_0_1_34_dist/tldw_server-0.1.34.tar.gz /private/tmp/tldw_release_0_1_34_dist/tldw_server-0.1.34-py3-none-any.whl` — passed.
- Wheel metadata check reported `tldw-server` / `0.1.34`.

## Release boundary

`make release` was not run here because the release helper intentionally only cuts formal releases from `main`; this PR prepares release metadata on `dev` for the dev-to-main release path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the 0.1.34 release by bumping version metadata, updating README references, and adding a rollup CHANGELOG entry for post-0.1.33 work. Hardened the release helper to handle current README wording; added coverage and validated packaging/docs checks. No runtime changes.

- **Refactors**
  - Advanced version metadata to 0.1.34 across `pyproject.toml` and docs; updated `README.md` release references and rollup.
  - Added a 0.1.34 CHANGELOG entry capturing PR #2568 follow-ups and CodeQL suppression hygiene.
  - Hardened `Helper_Scripts/release.py` to update current README anchors; added a regression test in the release docs contract.
  - Added backlog task TASK-12091; no migration required.

<sup>Written for commit edc89a2e0960984bc534e69293de84b3d1e3bf21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

