### PR TITLE
Add standalone MCP docs source sync

### DIFF
--- a/Docs/superpowers/plans/2026-07-02-standalone-mcp-docs-stage4a-source-sync-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-02-standalone-mcp-docs-stage4a-source-sync-implementation-plan.md
@@ -1,0 +1,1348 @@
+# Standalone MCP Docs Stage 4A Source Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bounded `docs.sync_source` support for already-known local and URL docs sources in the standalone MCP docs corpus.
+
+**Architecture:** Extend the runtime-neutral `mcp_unified.docs` package with explicit source registry tables, source-population hooks in import/URL ingest paths, and a deterministic `DocsSourceSyncService`. Keep sync execution synchronous, SQLite + FTS5 only, and isolated from `tldw_Server_API`; the built-in `tldw_server` MCP module remains a thin host adapter.
+
+**Tech Stack:** Python 3.10+, dataclasses, stdlib `sqlite3`, `pathlib`, existing Stage 1 local importers, existing Stage 2 URL policy/fetch/extraction seams, pytest with fake resolver/transport objects, Bandit for touched Python paths.
+
+---
+
+## Source References
+
+- Design spec: `Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md`
+- Stage 1 plan: `Docs/superpowers/plans/2026-06-30-standalone-mcp-docs-corpus-stage1-plan.md`
+- Stage 2 plan: `Docs/superpowers/plans/2026-06-30-standalone-mcp-docs-url-acquisition-implementation-plan.md`
+- Stage 3 plan: `Docs/superpowers/plans/2026-07-01-standalone-mcp-docs-stage3-server-mounting-plan.md`
+- Backlog design task: `TASK-12091`
+- Backlog planning task: `TASK-12092`
+
+## Scope
+
+Included in Stage 4A.1:
+
+- `DocsSettings` source-sync limits and query-persistence policy.
+- `docs_sources`, `docs_source_documents`, and `docs_sync_runs`.
+- `docs_documents.lifecycle_status` and `docs_documents.preserve_on_source_tombstone`.
+- Source population from `docs.import_path` and `docs.ingest_url`.
+- Query-bearing URL source creation only when `persist_url_query_strings=true`.
+- `docs.list(kind="sources")`.
+- `docs.sync_source` for `local_file`, `local_directory`, and `url_page` sources.
+- Strict dry-run with no corpus DB mutation.
+- Sync-aware document/chunk replacement that merges existing user collections/keywords with source defaults.
+- Thin host exposure through `DocsModule`.
+
+Excluded from Stage 4A.1:
+
+- `url_sitemap` registration and sync. The first implementation PR should keep sitemap disabled and unreachable.
+- Recursive crawling, broad link discovery, browser automation, cookies, Playwright, embeddings, rerankers, Jobs/Scheduler wrappers, Media DB, ChromaDB, and host RAG bridges.
+
+## File Structure
+
+Create:
+
+- `apps/mcp-unified/src/mcp_unified/docs/source_utils.py` - pure helpers for file URI canonicalization, URL redaction/query detection, source default metadata, and source item URIs.
+- `apps/mcp-unified/src/mcp_unified/docs/sync.py` - `DocsSourceSyncService`, sync request/result dataclasses, local and URL sync orchestration.
+- `tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py` - source schema, store helper, source list, sync run, and metadata-preservation tests.
+- `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py` - import and URL ingest source creation/linking tests.
+- `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py` - local and URL `docs.sync_source` service/tool tests.
+
+Modify:
+
+- `apps/mcp-unified/src/mcp_unified/docs/models.py` - add source/sync literals and dataclasses.
+- `apps/mcp-unified/src/mcp_unified/docs/settings.py` - add source-sync and query-persistence settings.
+- `apps/mcp-unified/src/mcp_unified/docs/store/schema.sql` - add Stage 4A tables and columns for fresh databases.
+- `apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py` - add migration guards, source helpers, source-aware document upsert, source list, run records, and lifecycle-aware search/list filtering.
+- `apps/mcp-unified/src/mcp_unified/docs/importers/local.py` - create/link local file or directory sources while preserving current import behavior.
+- `apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py` - create/link URL page sources after successful ingest, enforce query persistence policy for refreshable sources.
+- `apps/mcp-unified/src/mcp_unified/docs/mcp_module.py` - advertise/execute `docs.sync_source`, return real sources, and report source-sync capability in `docs.status`.
+- `apps/mcp-unified/src/mcp_unified/docs/__init__.py` - export new source/sync dataclasses if tests need public imports.
+- `tldw_Server_API/app/core/MCP_unified/modules/implementations/docs_module.py` - no new business logic; host validation may need `docs.sync_source` argument checks.
+- Existing docs tests under `tldw_Server_API/tests/MCP_unified/docs/` - extend settings, provider, acquisition, importer, host adapter, and boundary tests.
+
+Do not modify:
+
+- `pyproject.toml` for new required dependencies.
+- `tldw_Server_API` scraping services.
+- Media DB/RAG/ChromaDB services.
+- Jobs/Scheduler code.
+
+## Shared Contracts
+
+Use these names consistently across implementation tasks.
+
+```python
+SourceType = Literal["local_file", "local_directory", "url_page", "url_sitemap"]
+SourceLinkStatus = Literal["active", "tombstoned", "failed"]
+SyncMode = Literal["dry_run", "apply"]
+StalePolicy = Literal["report", "tombstone"]
+SyncItemStatus = Literal["created", "updated", "unchanged", "missing", "tombstoned", "failed", "skipped"]
+SyncRunStatus = Literal["completed", "partial", "skipped", "denied", "failed"]
+
+
+@dataclass(frozen=True)
+class SourceRecord:
+    id: int
+    source_type: SourceType
+    canonical_uri: str
+    display_name: str
+    source_path: str | None
+    source_url: str | None
+    redacted_source_url: str | None
+    sync_enabled: bool
+    last_sync_status: str | None
+    last_sync_started_at: str | None
+    last_sync_completed_at: str | None
+    last_error_code: str | None
+    document_count: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SyncSourceRequest:
+    source_id: int | None = None
+    source_uri: str | None = None
+    mode: SyncMode = "dry_run"
+    max_documents: int | None = None
+    max_pages: int | None = None
+    stale_policy: StalePolicy = "report"
+    force: bool = False
+```
+
+Stable reason codes to add where missing:
+
+```python
+SOURCE_NOT_FOUND = "source_not_found"
+SOURCE_SELECTOR_INVALID = "source_selector_invalid"
+SOURCE_SCOPE_DENIED = "source_scope_denied"
+SOURCE_SYNC_DISABLED = "source_sync_disabled"
+SOURCE_SYNC_UNSUPPORTED_TYPE = "source_sync_unsupported_type"
+SOURCE_SYNC_LIMIT_EXCEEDED = "source_sync_limit_exceeded"
+URL_QUERY_NOT_PERSISTED = "url_query_not_persisted"
+STALE_REPORTED = "stale_reported"
+TOMBSTONED = "tombstoned"
+```
+
+## Test Command Conventions
+
+Use the worktree virtual environment:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs -q
+```
+
+If `.venv` is absent or cannot import project dependencies, stop and report that environment problem. Do not switch to global Python.
+
+---
+
+### Task 1: Settings, Models, And Source-Sync Status
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/settings.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/models.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/mcp_module.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py`
+
+- [ ] **Step 1: Write failing settings and status tests**
+
+Add to `tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py`:
+
+```python
+def test_from_mapping_uses_safe_source_sync_defaults() -> None:
+    settings = DocsSettings.from_mapping({})
+
+    assert settings.enable_source_sync is True  # nosec B101
+    assert settings.max_sync_documents == 500  # nosec B101
+    assert settings.max_sync_pages == 25  # nosec B101
+    assert settings.max_sync_run_items == 500  # nosec B101
+    assert settings.default_stale_policy == "report"  # nosec B101
+    assert settings.sitemap_sync_enabled is False  # nosec B101
+    assert settings.persist_url_query_strings is False  # nosec B101
+
+
+def test_from_mapping_parses_source_sync_values() -> None:
+    settings = DocsSettings.from_mapping(
+        {
+            "enable_source_sync": "false",
+            "max_sync_documents": "9",
+            "max_sync_pages": "7",
+            "max_sync_run_items": "5",
+            "default_stale_policy": "tombstone",
+            "sitemap_sync_enabled": "true",
+            "persist_url_query_strings": "true",
+        }
+    )
+
+    assert settings.enable_source_sync is False  # nosec B101
+    assert settings.max_sync_documents == 9  # nosec B101
+    assert settings.max_sync_pages == 7  # nosec B101
+    assert settings.max_sync_run_items == 5  # nosec B101
+    assert settings.default_stale_policy == "tombstone"  # nosec B101
+    assert settings.sitemap_sync_enabled is True  # nosec B101
+    assert settings.persist_url_query_strings is True  # nosec B101
+
+
+@pytest.mark.parametrize("value", ["", "delete", "hide"])
+def test_from_mapping_rejects_unknown_default_stale_policy(value: str) -> None:
+    with pytest.raises(ValueError, match="default_stale_policy"):
+        DocsSettings.from_mapping({"default_stale_policy": value})
+```
+
+Add to `test_provider_status_reports_web_acquisition_disabled` in `test_docs_mcp_provider.py`:
+
+```python
+assert status["source_sync"]["enabled"] is True  # nosec B101
+assert status["source_sync"]["default_stale_policy"] == "report"  # nosec B101
+assert status["source_sync"]["max_sync_documents"] == 500  # nosec B101
+assert status["source_sync"]["sitemap_sync_enabled"] is False  # nosec B101
+```
+
+- [ ] **Step 2: Run tests to verify red state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py::test_provider_status_reports_web_acquisition_disabled \
+  -q
+```
+
+Expected: FAIL with missing `DocsSettings` attributes or missing `source_sync` status.
+
+- [ ] **Step 3: Implement settings and status**
+
+In `settings.py`, add:
+
+```python
+StalePolicy = Literal["report", "tombstone"]
+
+
+def _coerce_stale_policy(value: object, field_name: str) -> StalePolicy:
+    text = str(value or "report").strip().lower()
+    if text not in {"report", "tombstone"}:
+        raise ValueError(f"{field_name} must be report or tombstone")
+    return cast(StalePolicy, text)
+```
+
+Extend `DocsSettings` and `from_mapping()`:
+
+```python
+enable_source_sync: bool = True
+max_sync_documents: int = 500
+max_sync_pages: int = 25
+max_sync_run_items: int = 500
+default_stale_policy: StalePolicy = "report"
+sitemap_sync_enabled: bool = False
+persist_url_query_strings: bool = False
+```
+
+In `mcp_module.py`, add:
+
+```python
+def _source_sync_status(settings: DocsSettings) -> dict[str, Any]:
+    return {
+        "enabled": settings.enable_source_sync,
+        "max_sync_documents": settings.max_sync_documents,
+        "max_sync_pages": settings.max_sync_pages,
+        "max_sync_run_items": settings.max_sync_run_items,
+        "default_stale_policy": settings.default_stale_policy,
+        "sitemap_sync_enabled": settings.sitemap_sync_enabled,
+        "persist_url_query_strings": settings.persist_url_query_strings,
+    }
+```
+
+Then set `status["source_sync"] = _source_sync_status(self.settings)` in `docs.status`.
+
+- [ ] **Step 4: Run tests to verify green state**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/settings.py apps/mcp-unified/src/mcp_unified/docs/models.py apps/mcp-unified/src/mcp_unified/docs/mcp_module.py tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
+git commit -m "feat: add docs source sync settings"
+```
+
+### Task 2: Source Registry Schema And Store Helpers
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/store/schema.sql`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/models.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_schema_store.py`
+
+- [ ] **Step 1: Write failing store tests**
+
+Create `tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py`:
+
+```python
+from __future__ import annotations
+
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from mcp_unified.docs.models import AccessScope
+from mcp_unified.docs.store.sqlite import DocsCatalogStore
+
+pytestmark = pytest.mark.unit
+
+
+def test_migrate_adds_source_tables_and_document_lifecycle_columns(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+
+    with closing(store.connect()) as conn:
+        tables = {
+            row["name"]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual')")
+        }
+        document_columns = {row["name"] for row in conn.execute("PRAGMA table_info(docs_documents)")}
+
+    assert {"docs_sources", "docs_source_documents", "docs_sync_runs"}.issubset(tables)  # nosec B101
+    assert "lifecycle_status" in document_columns  # nosec B101
+    assert "preserve_on_source_tombstone" in document_columns  # nosec B101
+
+
+def test_store_upserts_and_lists_sources_by_scope(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope_a = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    scope_b = AccessScope(owner_scope="owner-b", profile_scope="profile-a")
+
+    source_id = store.upsert_source(
+        scope=scope_a,
+        source_type="local_file",
+        canonical_uri="file:///docs/a.md",
+        display_name="a.md",
+        source_path="/docs/a.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={"default_keywords": ["local"]},
+    )
+    second_id = store.upsert_source(
+        scope=scope_a,
+        source_type="local_file",
+        canonical_uri="file:///docs/a.md",
+        display_name="a.md updated",
+        source_path="/docs/a.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={"default_keywords": ["local"]},
+    )
+
+    assert second_id == source_id  # nosec B101
+    assert [source["canonical_uri"] for source in store.list_sources(scope=scope_a)] == ["file:///docs/a.md"]  # nosec B101
+    assert store.list_sources(scope=scope_b) == []  # nosec B101
+
+
+def test_upsert_document_for_sync_merges_existing_organization(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    document_id = store.upsert_document(
+        scope=scope,
+        title="Guide",
+        document_type="text",
+        canonical_uri="file:///guide.txt",
+        source_path="/guide.txt",
+        source_url=None,
+        text="old sqlite body",
+        sections=[],
+        chunks=[{"text": "old sqlite body", "citation": "guide.txt"}],
+        keywords=("manual",),
+        collection_names=("Manual",),
+        metadata={"importer": "local"},
+    )
+
+    updated_id = store.upsert_document_for_sync(
+        scope=scope,
+        title="Guide",
+        document_type="text",
+        canonical_uri="file:///guide.txt",
+        source_path="/guide.txt",
+        source_url=None,
+        text="new sqlite body",
+        sections=[],
+        chunks=[{"text": "new sqlite body", "citation": "guide.txt"}],
+        source_default_keywords=("source-default",),
+        source_default_collections=("Source Defaults",),
+        metadata={"importer": "local", "sync": True},
+    )
+
+    assert updated_id == document_id  # nosec B101
+    assert store.search_chunks(scope, "new", limit=10)[0]["title"] == "Guide"  # nosec B101
+    assert {item["keyword"] for item in store.list_keywords(scope)} == {"manual", "source-default"}  # nosec B101
+    assert {item["name"] for item in store.list_collections(scope)} == {"Manual", "Source Defaults"}  # nosec B101
+```
+
+- [ ] **Step 2: Run tests to verify red state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py -q
+```
+
+Expected: FAIL with missing `upsert_source`, `list_sources`, or `upsert_document_for_sync`.
+
+- [ ] **Step 3: Implement schema additions**
+
+In `schema.sql`, add `lifecycle_status` and `preserve_on_source_tombstone` to fresh `docs_documents`, plus:
+
+```sql
+CREATE TABLE IF NOT EXISTS docs_sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_scope TEXT NOT NULL DEFAULT '',
+    profile_scope TEXT NOT NULL DEFAULT '',
+    source_type TEXT NOT NULL,
+    canonical_uri TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    source_path TEXT,
+    source_url TEXT,
+    redacted_source_url TEXT,
+    policy_profile TEXT,
+    sync_enabled INTEGER NOT NULL DEFAULT 1,
+    last_sync_status TEXT,
+    last_sync_started_at TEXT,
+    last_sync_completed_at TEXT,
+    last_error_code TEXT,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (owner_scope, profile_scope, canonical_uri)
+);
+
+CREATE TABLE IF NOT EXISTS docs_source_documents (
+    source_id INTEGER NOT NULL REFERENCES docs_sources(id) ON DELETE CASCADE,
+    document_id INTEGER NOT NULL REFERENCES docs_documents(id) ON DELETE CASCADE,
+    source_item_uri TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    last_seen_at TEXT,
+    last_hash TEXT,
+    last_error_code TEXT,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (source_id, source_item_uri)
+);
+
+CREATE TABLE IF NOT EXISTS docs_sync_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_scope TEXT NOT NULL DEFAULT '',
+    profile_scope TEXT NOT NULL DEFAULT '',
+    source_id INTEGER NOT NULL REFERENCES docs_sources(id) ON DELETE CASCADE,
+    mode TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at TEXT,
+    requested_limits_json TEXT NOT NULL DEFAULT '{}',
+    counts_json TEXT NOT NULL DEFAULT '{}',
+    warnings_json TEXT NOT NULL DEFAULT '[]',
+    error_code TEXT,
+    metadata_json TEXT NOT NULL DEFAULT '{}'
+);
+```
+
+- [ ] **Step 4: Implement store helpers**
+
+Add these public methods to `DocsCatalogStore` with the listed signatures:
+
+- `upsert_source(self, *, scope: AccessScope, source_type: str, canonical_uri: str, display_name: str, source_path: str | None, source_url: str | None, redacted_source_url: str | None, policy_profile: str | None, sync_enabled: bool, metadata: Mapping[str, Any]) -> int`
+- `get_source(self, *, scope: AccessScope, source_id: int | None = None, canonical_uri: str | None = None) -> dict[str, Any] | None`
+- `list_sources(self, *, scope: AccessScope, limit: int = 50, offset: int = 0) -> list[dict[str, Any]]`
+- `link_source_document(self, *, scope: AccessScope, source_id: int, document_id: int, source_item_uri: str, status: str, last_hash: str | None, metadata: Mapping[str, Any]) -> None`
+- `source_document_links(self, *, scope: AccessScope, source_id: int) -> list[dict[str, Any]]`
+- `record_sync_run(self, *, scope: AccessScope, source_id: int, mode: str, status: str, requested_limits: Mapping[str, Any], counts: Mapping[str, int], warnings: list[str], error_code: str | None, metadata: Mapping[str, Any]) -> int`
+- `upsert_document_for_sync(self, *, scope: AccessScope, title: str, document_type: str, canonical_uri: str, source_path: str | None, source_url: str | None, text: str, sections: Sequence[Mapping[str, Any]], chunks: Sequence[Mapping[str, Any]], source_default_keywords: Iterable[str], source_default_collections: Iterable[str], metadata: Mapping[str, Any]) -> int`
+
+Add migration guards in `migrate()`:
+
+```python
+self._ensure_document_lifecycle_columns(conn)
+self._ensure_source_tables(conn)
+```
+
+Keep `upsert_document()` replacement-oriented; `upsert_document_for_sync()` must read existing collection/keyword membership in the same transaction, union it with source defaults, then call the existing row/chunk replacement helpers.
+
+- [ ] **Step 5: Run tests to verify green state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_schema_store.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/store/schema.sql apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py apps/mcp-unified/src/mcp_unified/docs/models.py tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py tldw_Server_API/tests/MCP_unified/docs/test_docs_schema_store.py
+git commit -m "feat: add docs source registry store"
+```
+
+### Task 3: Populate Sources From Local Imports
+
+**Files:**
+
+- Create: `apps/mcp-unified/src/mcp_unified/docs/source_utils.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/importers/local.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_importers.py`
+
+- [ ] **Step 1: Write failing local source population tests**
+
+Create `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py` with:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcp_unified.docs.importers.local import DocsImportService
+from mcp_unified.docs.models import AccessScope
+from mcp_unified.docs.settings import DocsSettings
+from mcp_unified.docs.store.sqlite import DocsCatalogStore
+
+pytestmark = pytest.mark.unit
+
+
+def _service(tmp_path: Path, root: Path) -> tuple[DocsImportService, DocsCatalogStore]:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root.resolve(),))
+    return DocsImportService(settings=settings, store=store), store
+
+
+def test_import_file_creates_local_file_source_and_link(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite sync source.\n", encoding="utf-8")
+    service, store = _service(tmp_path, root)
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+
+    result = service.import_path(scope=scope, path=guide, keywords=("setup",), collection_names=("Docs",))
+
+    sources = store.list_sources(scope=scope)
+    links = store.source_document_links(scope=scope, source_id=sources[0]["id"])
+    assert result["source"]["source_type"] == "local_file"  # nosec B101
+    assert sources[0]["source_type"] == "local_file"  # nosec B101
+    assert sources[0]["metadata"]["default_keywords"] == ["setup"]  # nosec B101
+    assert links[0]["document_id"] == result["documents"][0]["id"]  # nosec B101
+    assert links[0]["status"] == "active"  # nosec B101
+
+
+def test_import_directory_creates_one_directory_source_with_file_items(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "a.md").write_text("# A\n\nSQLite A.\n", encoding="utf-8")
+    (root / "b.md").write_text("# B\n\nSQLite B.\n", encoding="utf-8")
+    service, store = _service(tmp_path, root)
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+
+    service.import_path(scope=scope, path=root, keywords=("shared",), collection_names=("Docs",))
+
+    sources = store.list_sources(scope=scope)
+    links = store.source_document_links(scope=scope, source_id=sources[0]["id"])
+    assert len(sources) == 1  # nosec B101
+    assert sources[0]["source_type"] == "local_directory"  # nosec B101
+    assert sorted(link["source_item_uri"].rsplit("/", 1)[-1] for link in links) == ["a.md", "b.md"]  # nosec B101
+```
+
+- [ ] **Step 2: Run tests to verify red state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py -q
+```
+
+Expected: FAIL because imports do not create sources or source links.
+
+- [ ] **Step 3: Implement local source helpers**
+
+Create `source_utils.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+def file_uri_for_path(path: Path, *, directory: bool = False) -> str:
+    uri = path.expanduser().resolve().as_uri()
+    return f"{uri}/" if directory and not uri.endswith("/") else uri
+
+
+def source_defaults_metadata(*, keywords: tuple[str, ...], collection_names: tuple[str, ...]) -> dict[str, list[str]]:
+    return {
+        "default_keywords": list(keywords),
+        "default_collections": list(collection_names),
+    }
+
+
+def redacted_url_for_display(url: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path or "/", "", ""))
+
+
+def url_has_query(url: str) -> bool:
+    return bool(urlsplit(url).query)
+```
+
+- [ ] **Step 4: Link imports to sources**
+
+In `DocsImportService.import_path()`:
+
+```python
+source_type = "local_file" if target.is_file() else "local_directory"
+source_id = self.store.upsert_source(
+    scope=scope,
+    source_type=source_type,
+    canonical_uri=file_uri_for_path(target, directory=target.is_dir()),
+    display_name=target.name or str(target),
+    source_path=str(target),
+    source_url=None,
+    redacted_source_url=None,
+    policy_profile=self.settings.web_source_profile,
+    sync_enabled=True,
+    metadata=source_defaults_metadata(keywords=keyword_tuple, collection_names=collection_tuple),
+)
+```
+
+After each document upsert:
+
+```python
+self.store.link_source_document(
+    scope=scope,
+    source_id=source_id,
+    document_id=document_id,
+    source_item_uri=file_uri_for_path(file_path),
+    status="active",
+    last_hash=None,
+    metadata={"importer": "local"},
+)
+```
+
+Return `"source": self.store.get_source(scope=scope, source_id=source_id)` in the import result.
+
+- [ ] **Step 5: Run tests to verify green state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_importers.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/source_utils.py apps/mcp-unified/src/mcp_unified/docs/importers/local.py tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py tldw_Server_API/tests/MCP_unified/docs/test_docs_importers.py
+git commit -m "feat: track local docs import sources"
+```
+
+### Task 4: Populate URL Sources With Query Safeguards
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/source_utils.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_service.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py`
+
+- [ ] **Step 1: Write failing URL source tests**
+
+Add to `test_docs_source_population.py`:
+
+```python
+from mcp_unified.docs.acquisition.models import FetchResponse
+from mcp_unified.docs.acquisition.service import DocsAcquisitionService
+from tldw_Server_API.tests.MCP_unified.docs.helpers import FakeResolver, FakeTransport
+
+
+def test_ingest_url_creates_url_page_source_for_queryless_url(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    service = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport([FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"sync body"])]),
+    )
+
+    result = service.ingest_url(scope=AccessScope(), url="https://example.com/page")
+
+    sources = store.list_sources(scope=AccessScope())
+    assert result["source"]["source_type"] == "url_page"  # nosec B101
+    assert sources[0]["source_url"] == "https://example.com/page"  # nosec B101
+    assert sources[0]["redacted_source_url"] == "https://example.com/page"  # nosec B101
+
+
+def test_ingest_query_url_does_not_create_refreshable_source_by_default(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    service = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport([FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"query body"])]),
+    )
+
+    result = service.ingest_url(scope=AccessScope(), url="https://example.com/page?token=secret")
+
+    assert result["status"] == "created"  # nosec B101
+    assert result["reason_code"] == "ok"  # nosec B101
+    assert result["source"] is None  # nosec B101
+    assert "url_query_not_persisted" in result["warnings"]  # nosec B101
+    assert store.list_sources(scope=AccessScope()) == []  # nosec B101
+```
+
+Add a companion opt-in test:
+
+```python
+def test_ingest_query_url_creates_source_when_query_persistence_enabled(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+            "persist_url_query_strings": True,
+        }
+    )
+    service = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport([FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"query body"])]),
+    )
+
+    result = service.ingest_url(scope=AccessScope(), url="https://example.com/page?token=secret")
+
+    sources = store.list_sources(scope=AccessScope())
+    assert result["source"]["source_url"] == "https://example.com/page?token=secret"  # nosec B101
+    assert sources[0]["redacted_source_url"] == "https://example.com/page"  # nosec B101
+```
+
+- [ ] **Step 2: Run tests to verify red state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_service.py \
+  -q
+```
+
+Expected: FAIL because successful URL ingest does not create a source or warnings.
+
+- [ ] **Step 3: Implement URL source creation**
+
+In `DocsAcquisitionService.ingest_url()`, after `document_id` is known:
+
+```python
+warnings = list(parsed.warnings)
+source: dict[str, Any] | None = None
+can_persist_query_source = self.settings.persist_url_query_strings or not url_has_query(parsed.canonical_uri)
+if can_persist_query_source:
+    redacted_source_url = redacted_url_for_display(parsed.canonical_uri)
+    source_id = self.store.upsert_source(
+        scope=scope,
+        source_type="url_page",
+        canonical_uri=parsed.canonical_uri,
+        display_name=parsed.title,
+        source_path=None,
+        source_url=parsed.canonical_uri,
+        redacted_source_url=redacted_source_url,
+        policy_profile=self.settings.web_source_profile,
+        sync_enabled=True,
+        metadata=source_defaults_metadata(
+            keywords=tuple(keywords),
+            collection_names=tuple(collection_names),
+        ),
+    )
+    self.store.link_source_document(
+        scope=scope,
+        source_id=source_id,
+        document_id=document_id,
+        source_item_uri=parsed.canonical_uri,
+        status="active",
+        last_hash=new_hash,
+        metadata={"importer": "url"},
+    )
+    source = self.store.get_source(scope=scope, source_id=source_id)
+else:
+    warnings.append("url_query_not_persisted")
+```
+
+Return `"source": source` and `"warnings": warnings`.
+
+- [ ] **Step 4: Run tests to verify green state**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py apps/mcp-unified/src/mcp_unified/docs/source_utils.py tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_service.py tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
+git commit -m "feat: track approved url docs sources"
+```
+
+### Task 5: Source Listing And `docs.sync_source` Tool Contract
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/mcp_module.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/sync.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py`
+
+- [ ] **Step 1: Write failing provider contract tests**
+
+Create the first tests in `test_docs_source_sync.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcp_unified.docs.mcp_module import DocsMCPToolProvider
+from mcp_unified.docs.models import AccessScope
+from mcp_unified.docs.settings import DocsSettings
+from mcp_unified.docs.store.sqlite import DocsCatalogStore
+
+pytestmark = pytest.mark.unit
+
+
+def test_provider_advertises_sync_source_when_enabled(tmp_path: Path) -> None:
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(tmp_path,)))
+
+    tools = {tool["name"]: tool for tool in provider.tool_definitions()}
+
+    assert "docs.sync_source" in tools  # nosec B101
+    assert tools["docs.sync_source"]["metadata"]["category"] == "ingestion"  # nosec B101
+    assert tools["docs.sync_source"]["metadata"]["readOnlyHint"] is False  # nosec B101
+
+
+def test_provider_list_sources_returns_real_sources(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    store.upsert_source(
+        scope=scope,
+        source_type="local_file",
+        canonical_uri="file:///docs/guide.md",
+        display_name="guide.md",
+        source_path="/docs/guide.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"), store=store)
+
+    result = provider.execute("docs.list", {"kind": "sources"}, scope=scope)
+
+    assert result["sources"][0]["canonical_uri"] == "file:///docs/guide.md"  # nosec B101
+    assert result["warnings"] == []  # nosec B101
+```
+
+- [ ] **Step 2: Run tests to verify red state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py::test_provider_advertises_sync_source_when_enabled \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py::test_provider_list_sources_returns_real_sources \
+  -q
+```
+
+Expected: FAIL because the tool is absent and source listing returns the Stage 1 warning.
+
+- [ ] **Step 3: Add provider wiring**
+
+In `mcp_module.py`, instantiate:
+
+```python
+self.source_sync = DocsSourceSyncService(settings=settings, store=self.store)
+```
+
+Add a `docs.sync_source` tool when `settings.enable_source_sync` is true:
+
+```python
+_tool(
+    "docs.sync_source",
+    "Refresh one existing docs source with bounded dry-run or apply semantics.",
+    {
+        "source_id": {"type": "integer"},
+        "source_uri": {"type": "string"},
+        "mode": {"type": "string"},
+        "max_documents": {"type": "integer"},
+        "max_pages": {"type": "integer"},
+        "stale_policy": {"type": "string"},
+        "force": {"type": "boolean"},
+    },
+    [],
+    "ingestion",
+)
+```
+
+Change `docs.list(kind="sources")` to:
+
+```python
+return {"sources": self.store.list_sources(scope=scope, limit=limit, offset=offset), "warnings": []}
+```
+
+For `docs.sync_source`, call `self.source_sync.sync_source(scope=scope, request=request)`. If sync is disabled, return `{"status": "denied", "reason_code": "source_sync_disabled"}` for stale direct calls.
+
+- [ ] **Step 4: Run tests to verify green state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py \
+  -q
+```
+
+Expected: PASS for existing provider tests plus the new contract tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/mcp_module.py apps/mcp-unified/src/mcp_unified/docs/sync.py tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py
+git commit -m "feat: expose docs source sync tool"
+```
+
+### Task 6: Local File And Directory Source Sync
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/sync.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/importers/local.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py`
+
+- [ ] **Step 1: Add failing local sync tests**
+
+Add to `test_docs_source_sync.py`:
+
+```python
+def test_local_file_sync_dry_run_does_not_mutate_document_or_run_rows(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nOld sqlite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    imported = provider.execute("docs.import_path", {"path": str(guide)}, scope=scope)
+    source_id = imported["source"]["id"]
+    guide.write_text("# Guide\n\nNew sqlite content.\n", encoding="utf-8")
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id, "mode": "dry_run"}, scope=scope)
+    search = provider.execute("docs.search", {"query": "New"}, scope=scope)
+    status = provider.store.status()
+
+    assert result["mode"] == "dry_run"  # nosec B101
+    assert result["counts"]["updated"] == 1  # nosec B101
+    assert search["results"] == []  # nosec B101
+    assert status["counts"]["sync_runs"] == 0  # nosec B101
+
+
+def test_local_file_sync_apply_updates_content_and_preserves_user_metadata(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nOld sqlite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    imported = provider.execute("docs.import_path", {"path": str(guide), "keywords": ["source"], "collections": ["Source"]}, scope=scope)
+    document_id = imported["documents"][0]["id"]
+    source_id = imported["source"]["id"]
+    provider.execute("docs.keywords.apply", {"document_id": document_id, "keywords": ["manual"]}, scope=scope)
+    provider.execute("docs.collections.set_membership", {"collection": "Manual", "document_id": document_id, "action": "add"}, scope=scope)
+    guide.write_text("# Guide\n\nNew sqlite content.\n", encoding="utf-8")
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id, "mode": "apply"}, scope=scope)
+    search = provider.execute("docs.search", {"query": "New", "filters": {"keywords": ["manual"], "collection": "Manual"}}, scope=scope)
+
+    assert result["counts"]["updated"] == 1  # nosec B101
+    assert search["results"][0]["document_id"] == document_id  # nosec B101
+```
+
+Add directory missing/report/tombstone tests:
+
+```python
+def test_local_directory_sync_report_missing_does_not_hide_document(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(root)}, scope=scope)
+    source_id = imported["source"]["id"]
+    guide.unlink()
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id, "mode": "apply", "stale_policy": "report"}, scope=scope)
+    search = provider.execute("docs.search", {"query": "SQLite"}, scope=scope)
+
+    assert result["counts"]["missing"] == 1  # nosec B101
+    assert result["counts"]["tombstoned"] == 0  # nosec B101
+    assert search["results"]  # nosec B101
+
+
+def test_local_directory_sync_tombstone_hides_document_from_default_search(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(root)}, scope=scope)
+    source_id = imported["source"]["id"]
+    guide.unlink()
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id, "mode": "apply", "stale_policy": "tombstone"}, scope=scope)
+    search = provider.execute("docs.search", {"query": "SQLite"}, scope=scope)
+
+    assert result["counts"]["tombstoned"] == 1  # nosec B101
+    assert search["results"] == []  # nosec B101
+```
+
+- [ ] **Step 2: Run tests to verify red state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py -q
+```
+
+Expected: FAIL because local sync logic is not implemented.
+
+- [ ] **Step 3: Implement local sync service**
+
+In `sync.py`, implement:
+
+```python
+class DocsSourceSyncService:
+    def __init__(self, *, settings: DocsSettings, store: DocsCatalogStore, resolver: object | None = None, transport: object | None = None) -> None:
+        self.settings = settings
+        self.store = store
+        self.importer = DocsImportService(settings=settings, store=store)
+        self.acquisition = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    def sync_source(self, *, scope: AccessScope, request: SyncSourceRequest) -> dict[str, Any]:
+        source = self._select_source(scope=scope, request=request)
+        if source["source_type"] == "local_file":
+            return self._sync_local_file(scope=scope, source=source, request=request)
+        if source["source_type"] == "local_directory":
+            return self._sync_local_directory(scope=scope, source=source, request=request)
+        if source["source_type"] == "url_page":
+            return self._sync_url_page(scope=scope, source=source, request=request)
+        return self._denied(source=source, request=request, reason_code="source_sync_unsupported_type")
+```
+
+Rules to enforce in local methods:
+
+- `dry_run` parses and hashes files but does not call any store mutation method.
+- `apply` calls `upsert_document_for_sync()` only for changed or forced content.
+- `stale_policy="report"` returns missing items without updating link status.
+- `stale_policy="tombstone"` in apply mode calls `store.tombstone_source_item(scope=scope, source_id=source_id, source_item_uri=item_uri)`.
+- `max_documents` is enforced before parsing all directory candidates.
+- Every path goes through the existing trusted-root and symlink checks.
+
+- [ ] **Step 4: Make default search lifecycle-aware**
+
+In `search_chunks()`, `count_search_chunks()`, and `list_documents()`, add:
+
+```sql
+AND d.lifecycle_status = 'active'
+```
+
+Tombstoning should set `docs_documents.lifecycle_status='tombstoned'` only when all source links for the document are tombstoned and `preserve_on_source_tombstone=0`.
+
+- [ ] **Step 5: Run tests to verify green state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_retrieval_context.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/sync.py apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py apps/mcp-unified/src/mcp_unified/docs/importers/local.py tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py tldw_Server_API/tests/MCP_unified/docs/test_docs_retrieval_context.py
+git commit -m "feat: sync local docs sources"
+```
+
+### Task 7: URL Page Source Sync
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/sync.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_fetcher.py`
+
+- [ ] **Step 1: Add failing URL sync tests**
+
+Add to `test_docs_source_sync.py`:
+
+```python
+def test_url_page_sync_apply_refreshes_existing_source_with_fake_transport(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"old sqlite body"]),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"new sqlite body"]),
+        ]
+    )
+    acquisition = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
+    scope = AccessScope()
+    ingested = acquisition.ingest_url(scope=scope, url="https://example.com/page")
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=ingested["source"]["id"], mode="apply"))
+    search = store.search_chunks(scope=scope, query="new", limit=10)
+
+    assert result["counts"]["updated"] == 1  # nosec B101
+    assert search[0]["title"]  # nosec B101
+```
+
+Add no-fetch-before-approval:
+
+```python
+def test_url_page_sync_does_not_fetch_when_policy_requires_approval(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_page",
+        canonical_uri="https://example.com/page",
+        display_name="page",
+        source_path=None,
+        source_url="https://example.com/page",
+        redacted_source_url="https://example.com/page",
+        policy_profile="local_first",
+        sync_enabled=True,
+        metadata={},
+    )
+    settings = DocsSettings.from_mapping({"db_path": str(tmp_path / "docs.db"), "enable_web_acquisition": True, "web_source_profile": "local_first"})
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport([FetchResponse(status_code=200, body_chunks=[b"never"])])
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="apply"))
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "approval_required"  # nosec B101
+    assert resolver.calls == []  # nosec B101
+    assert transport.calls == []  # nosec B101
+```
+
+- [ ] **Step 2: Run tests to verify red state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py -q
+```
+
+Expected: FAIL because URL sync is not implemented.
+
+- [ ] **Step 3: Implement URL page sync**
+
+In `_sync_url_page()`:
+
+- Require `settings.enable_web_acquisition=true`.
+- Fetch exactly `source["source_url"]`.
+- Reuse `DocsAcquisitionService` with the same resolver/transport seams.
+- Return `approval_required` or `source_policy_denied` without fetch when policy blocks.
+- In dry-run, compute item status from old vs new hash and return without store mutation.
+- In apply, call `upsert_document_for_sync()` and `link_source_document()`.
+- Record a sync run only in apply mode.
+- Use `redacted_source_url` in response/source metadata.
+
+- [ ] **Step 4: Run tests to verify green state**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_fetcher.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/sync.py apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_fetcher.py
+git commit -m "feat: sync url page docs sources"
+```
+
+### Task 8: Host Exposure, Boundary Tests, And Verification
+
+**Files:**
+
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/docs_module.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/docs/test_docs_package_metadata.py`
+
+- [ ] **Step 1: Add host and boundary tests**
+
+Add to `test_docs_module_shim.py`:
+
+```python
+async def test_docs_module_exposes_sync_source_without_media_or_rag(tmp_path: Path) -> None:
+    module = DocsModule(ModuleConfig(name="docs", settings={"db_path": str(tmp_path / "docs.db"), "trusted_roots": [str(tmp_path)]}))
+    await module.on_initialize()
+
+    tools = {tool["name"]: tool for tool in await module.get_tools()}
+
+    assert "docs.sync_source" in tools  # nosec B101
+    assert tools["docs.sync_source"]["metadata"]["category"] == "ingestion"  # nosec B101
+```
+
+Extend `test_docs_package_does_not_import_optional_web_acquisition_dependencies()` with no new exceptions. Keep `trafilatura` and `bs4` out of import-time dependencies.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_package_metadata.py \
+  -q
+```
+
+Expected: PASS after the host shim recognizes `docs.sync_source` arguments.
+
+- [ ] **Step 3: Run full docs test slice**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run import-boundary and Bandit security checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py -q
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit \
+  -r apps/mcp-unified/src/mcp_unified/docs tldw_Server_API/app/core/MCP_unified/modules/implementations/docs_module.py \
+  -f json -o /tmp/bandit_mcp_docs_stage4a.json
+```
+
+Expected: pytest PASS. Bandit exits 0 or reports only accepted existing findings outside changed code; fix new findings in touched code before continuing.
+
+- [ ] **Step 5: Commit final verification adjustments**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/docs_module.py tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py tldw_Server_API/tests/MCP_unified/docs/test_docs_package_metadata.py
+git commit -m "test: verify docs source sync host boundary"
+```
+
+## Self-Review Checklist
+
+- [ ] Spec coverage: tasks cover source registry, source population, source listing, local sync, URL page sync, dry-run no mutation, metadata merge, query-persistence safeguards, host exposure, no Media/RAG bridge, and boundary tests.
+- [ ] Optional sitemap isolation: no Stage 4A.1 task creates `docs.sources.register` or `url_sitemap` sync.
+- [ ] Placeholder scan: run `rg -n "T[B]D|TO[D]O|fill[ ]in|appropria[t]e|implement[ ]later|similar[ ]to" Docs/superpowers/plans/2026-07-02-standalone-mcp-docs-stage4a-source-sync-implementation-plan.md` and fix any match.
+- [ ] Type/signature consistency: `SyncSourceRequest`, `DocsSourceSyncService.sync_source`, `upsert_document_for_sync`, and source store helper names match across tasks.
+- [ ] Verification commands: focused pytest, docs pytest slice, import-boundary pytest, and Bandit command are included.
+
+## Execution Handoff
+
+Plan complete when this file passes the self-review checklist and `git diff --check`.
+
+Two execution options:
+
+1. **Subagent-Driven (recommended)** - dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** - execute tasks in this session using executing-plans, with checkpoints after each task.

--- a/Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
+++ b/Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
@@ -1,0 +1,485 @@
+# Standalone MCP Docs Stage 4A Bounded Source Sync Design
+
+Date: 2026-07-01
+Status: Draft for user review
+Backlog: TASK-12091
+Related:
+- Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-catalog-design.md
+- Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-url-acquisition-design.md
+- Docs/superpowers/plans/2026-07-01-standalone-mcp-docs-stage3-server-mounting-plan.md
+
+## Summary
+
+Stage 4A adds bounded source refresh to the standalone MCP docs corpus. The
+new `docs.sync_source` tool refreshes sources that the corpus already knows
+about, such as a trusted local file, trusted local directory, approved URL
+page, or explicitly configured sitemap source. It is not a crawler, browser
+automation layer, embedding pipeline, reranker, job worker, or
+`tldw_server` Media/RAG bridge.
+
+The main architectural change is to make source identity explicit. Stage 1 and
+Stage 2 store provenance on each document, but `docs.list(kind="sources")`
+still returns only a Stage 1 warning. Stage 4A introduces scoped source records
+and sync run records so agents can see what can be refreshed, run a dry-run,
+apply a bounded refresh, and receive stable item-level results.
+
+## Goals
+
+- Add a `docs_sources` registry for local and URL-backed sources.
+- Populate source records from `docs.import_path` and `docs.ingest_url`.
+- Expose `docs.list(kind="sources")` with real source records.
+- Add `docs.sync_source` for scoped, bounded refresh of existing sources.
+- Support dry-run and apply modes with deterministic item-level results.
+- Reuse Stage 1 local path scope checks for local sync.
+- Reuse Stage 2 source policy, DNS/IP guards, redirect handling, extraction,
+  and content limits for URL sync.
+- Keep stale/missing handling conservative by default: report first, tombstone
+  only when explicitly requested.
+- Keep baseline standalone installs dependency-light and FTS5-only.
+- Preserve the `mcp_unified.docs` import boundary: no `tldw_Server_API`
+  imports, no eager optional web/browser imports.
+
+## Non-Goals
+
+- No arbitrary URL or path crawling from `docs.sync_source`.
+- No broad recursive link discovery.
+- No Playwright, browser profile, cookies, session cloning, or authenticated
+  web capture in this slice.
+- No embeddings, vector indexes, reranking, or answer generation.
+- No Jobs or Scheduler implementation. A host can wrap sync later.
+- No Media DB, ChromaDB, RAG service, AuthNZ, or full `tldw_server` runtime
+  dependency in `mcp_unified.docs`.
+- No hard delete of missing documents by default.
+- No background daemon or automatic recurring sync.
+
+## Current Baseline
+
+The merged Stage 1-3 docs package already has:
+
+- `DocsSettings` with trusted roots and web acquisition policy settings.
+- `DocsImportService.import_path()` for trusted local file/tree import.
+- `DocsAcquisitionService.ingest_url()` for one approved URL.
+- `DocsCatalogStore.upsert_document()` with scoped documents, FTS5 chunks,
+  collections, and keywords.
+- `DocsMCPToolProvider` with `docs.search`, `docs.get`, `docs.context`,
+  `docs.list`, `docs.import_path`, `docs.ingest_url`, and management tools.
+
+The gap is source lifecycle. `docs_documents` stores `source_path`,
+`source_url`, and `metadata_json`, but there is no first-class source table,
+no sync run table, and `docs.list(kind="sources")` returns a
+`sources_not_populated_in_stage1` warning.
+
+## Source Model
+
+Stage 4A should add explicit, scoped source records.
+
+### `docs_sources`
+
+Each source belongs to an owner/profile scope and has one stable identity.
+
+Recommended fields:
+
+- `id`
+- `owner_scope`
+- `profile_scope`
+- `source_type`: `local_file`, `local_directory`, `url_page`, or
+  `url_sitemap`
+- `canonical_uri`: unique source identifier within the scope
+- `display_name`
+- `source_path`
+- `source_url`
+- `policy_profile`
+- `sync_enabled`
+- `last_sync_status`
+- `last_sync_started_at`
+- `last_sync_completed_at`
+- `last_error_code`
+- `metadata_json`
+- `created_at`
+- `updated_at`
+
+The unique key should be `(owner_scope, profile_scope, canonical_uri)`.
+
+Canonical URI rules:
+
+- Local files and directories use normalized `file://` URIs derived from the
+  resolved trusted-root path.
+- URL pages use the Stage 2 normalized canonical URL after redirects when a
+  fetch succeeds, otherwise the normalized redacted requested URL.
+- Sitemaps use the normalized sitemap URL.
+- Query strings may be part of the canonical URL for fetch identity, but logs,
+  errors, audit summaries, and source list display must use redacted forms.
+
+### `docs_source_documents`
+
+A source can map to many documents, and a document can be reachable from more
+than one source.
+
+Recommended fields:
+
+- `source_id`
+- `document_id`
+- `source_item_uri`
+- `status`: `active`, `missing`, `tombstoned`, or `failed`
+- `last_seen_at`
+- `last_hash`
+- `last_error_code`
+- `metadata_json`
+
+The unique key should be `(source_id, source_item_uri)`.
+
+### `docs_sync_runs`
+
+Sync runs record tool-level outcomes without requiring a background job system.
+
+Recommended fields:
+
+- `id`
+- `owner_scope`
+- `profile_scope`
+- `source_id`
+- `mode`: `dry_run` or `apply`
+- `status`: `completed`, `partial`, `skipped`, `denied`, or `failed`
+- `started_at`
+- `completed_at`
+- `requested_limits_json`
+- `counts_json`
+- `warnings_json`
+- `error_code`
+- `metadata_json`
+
+Item-level results can live in `metadata_json` initially. If implementation
+proves that large run histories need separate rows, a later slice can split
+them into `docs_sync_run_items`.
+
+## Tool Contract
+
+### `docs.list(kind="sources")`
+
+Returns scoped source records:
+
+```json
+{
+  "sources": [
+    {
+      "id": 1,
+      "source_type": "local_directory",
+      "canonical_uri": "file:///repo/docs/",
+      "display_name": "Project docs",
+      "sync_enabled": true,
+      "last_sync_status": "completed",
+      "last_sync_completed_at": "2026-07-01T12:00:00Z",
+      "document_count": 12,
+      "metadata": {}
+    }
+  ]
+}
+```
+
+The list must apply store-level owner/profile scope filters before returning
+records.
+
+### `docs.sync_source`
+
+`docs.sync_source` is a write-capable ingestion tool.
+
+Input schema:
+
+- `source_id`: integer, preferred source selector.
+- `source_uri`: string, alternative selector for `canonical_uri`.
+- `mode`: `dry_run` or `apply`; default `dry_run`.
+- `max_documents`: positive integer; default from settings.
+- `max_pages`: positive integer for URL/sitemap sources; default from settings.
+- `stale_policy`: `report` or `tombstone`; default `report`.
+- `force`: boolean; default false. When false, unchanged content is counted
+  without rewriting chunks.
+
+Selector rules:
+
+- Exactly one of `source_id` or `source_uri` must be supplied.
+- The source must exist in the active access scope.
+- The source must have `sync_enabled=true`.
+- `docs.sync_source` must not create a new arbitrary source from an untracked
+  path or URL. New sources are created by `docs.import_path` or
+  `docs.ingest_url`.
+
+Response shape:
+
+```json
+{
+  "status": "completed",
+  "reason_code": "ok",
+  "mode": "apply",
+  "source": {
+    "id": 1,
+    "source_type": "local_directory",
+    "canonical_uri": "file:///repo/docs/"
+  },
+  "counts": {
+    "created": 1,
+    "updated": 2,
+    "unchanged": 8,
+    "missing": 1,
+    "tombstoned": 0,
+    "failed": 0,
+    "skipped": 0
+  },
+  "items": [
+    {
+      "source_item_uri": "file:///repo/docs/index.md",
+      "status": "updated",
+      "document_id": 42,
+      "reason_code": "ok"
+    }
+  ],
+  "warnings": []
+}
+```
+
+For `dry_run`, no documents, chunks, collection memberships, keywords, source
+links, or source status fields are mutated. A sync run record may be stored for
+auditability if the implementation marks it clearly as dry-run.
+
+## Local Source Sync
+
+Local file and directory sync use Stage 1 import rules.
+
+Local file sync:
+
+1. Resolve the source path.
+2. Enforce trusted-root path scope and symlink escape checks.
+3. If the file is missing, return `missing`.
+4. If the suffix is unsupported, return `failed` with
+   `unsupported_import_format`.
+5. Parse, chunk, hash, and compare with the linked document.
+6. In apply mode, upsert the document only when content or metadata changed,
+   unless `force=true`.
+
+Local directory sync:
+
+1. Resolve the directory source path.
+2. Enforce trusted-root path scope.
+3. Enumerate supported files deterministically.
+4. Enforce `max_documents` before parsing all candidates.
+5. Upsert active files through the same parser/chunker path as import.
+6. Compare enumerated item URIs with previously linked source items.
+7. Report previously linked items that are no longer present as `missing`.
+8. Only set source-item status to `tombstoned` when
+   `stale_policy="tombstone"` and `mode="apply"`.
+
+Directory sync should not recurse outside the source root even if symlinks
+point elsewhere. Existing Stage 1 path checks remain the authority.
+
+## URL Page Sync
+
+URL page sync refreshes exactly one existing `url_page` source.
+
+Rules:
+
+- Requires `settings.enable_web_acquisition=true`.
+- Reuses Stage 2 `SourcePolicy`, `URLFetcher`, and extraction service.
+- Re-evaluates policy before every fetch.
+- Does not fetch when policy returns `approval_required` or `denied`.
+- Re-runs DNS/IP and redirect checks.
+- Reuses content-type and body-size limits.
+- Uses the final canonical URL as the source item URI.
+- Does not follow page links.
+
+If the refreshed final URL differs from the stored source canonical URI because
+of redirects, the implementation should update source metadata with the final
+URL in apply mode, but it must not silently widen policy. The redirected target
+must still pass policy.
+
+## Sitemap Source Sync
+
+Sitemap support is allowed in Stage 4A only for explicit `url_sitemap` sources.
+It is still not a crawler.
+
+Rules:
+
+- A sitemap source must already exist and must have a canonical sitemap URL.
+- Fetch the sitemap URL through the same Stage 2 URL fetcher and policy checks.
+- Parse XML with stdlib XML tooling configured to avoid external entity
+  expansion.
+- Accept only `<url><loc>...</loc></url>` entries in Stage 4A.
+- Ignore sitemap index recursion unless a later task explicitly adds it.
+- Every discovered URL must pass the source policy and must be same-origin or
+  under an explicitly allowed URL prefix for the source.
+- Enforce `max_pages` before page fetches.
+- Fetch each accepted page with Stage 2 guards.
+- No JavaScript rendering, no cookies, no browser extraction.
+
+If `respect_robots=true` and no standalone robots checker is available, sitemap
+sync must fail closed with `robots_unavailable` before fetching page content.
+
+## Stale And Tombstone Semantics
+
+Default stale behavior is report-only.
+
+- `stale_policy="report"`: missing items are returned in the response and run
+  record, but existing documents remain searchable.
+- `stale_policy="tombstone"`: apply mode marks the source item as
+  `tombstoned`.
+- Add `lifecycle_status` to `docs_documents` with default `active`.
+- A document is hidden from default search only when all source links for that
+  document are tombstoned or missing and the document is not manually
+  preserved.
+- Legacy rows without source links remain `active` after migration.
+- Hard delete is out of scope.
+
+## Settings
+
+Extend `DocsSettings` with source-sync limits:
+
+- `enable_source_sync`: default true.
+- `max_sync_documents`: default 500.
+- `max_sync_pages`: default 25.
+- `max_sync_run_items`: default 500.
+- `default_stale_policy`: `report`.
+- `sitemap_sync_enabled`: default false unless explicitly enabled.
+
+Profile behavior:
+
+- `locked_down`: local source sync can run for trusted roots; URL and sitemap
+  sync return `capability_disabled` unless web acquisition is explicitly
+  enabled with narrow URL prefixes.
+- `local_first`: local sync is enabled; URL page sync is allowed only for
+  preapproved domains or allowed URL prefixes; sitemap sync requires explicit
+  `sitemap_sync_enabled=true`.
+- `online_capable`: same as `local_first`, with unknown public domains allowed
+  only when `allow_arbitrary_public_domains=true`; sitemap still requires
+  `sitemap_sync_enabled=true`.
+
+## Reason Codes
+
+Stable reason codes should include:
+
+- `ok`
+- `source_not_found`
+- `source_selector_invalid`
+- `source_scope_denied`
+- `source_sync_disabled`
+- `source_sync_unsupported_type`
+- `source_sync_limit_exceeded`
+- `path_scope_denied`
+- `import_path_not_found`
+- `unsupported_import_format`
+- `web_acquisition_disabled`
+- `approval_required`
+- `source_policy_denied`
+- `fetch_failed`
+- `extract_empty`
+- `sitemap_sync_disabled`
+- `sitemap_fetch_failed`
+- `sitemap_parse_failed`
+- `sitemap_url_out_of_scope`
+- `robots_unavailable`
+- `stale_reported`
+- `tombstoned`
+
+Tool responses should expose reason codes at both run and item levels.
+
+## MCP And Permission Behavior
+
+- `docs.sync_source` is category `ingestion` and `readOnlyHint=false`.
+- Listing sources is read-only.
+- Sync must use the same access scope object as other docs tools.
+- Store methods must enforce scope internally; callers cannot bypass scope by
+  omitting filters.
+- If a host later wraps sync in Jobs or Scheduler, the host must pass the same
+  scope into the standalone service.
+
+## Host Integration
+
+The built-in `tldw_server` MCP server should expose the same tool through the
+existing `DocsModule` shim and docs host adapter.
+
+Stage 4A host integration remains thin:
+
+- translate module config into `DocsSettings`;
+- translate request context metadata into `AccessScope`;
+- do not bridge Media DB or RAG stores;
+- do not import host services from `mcp_unified.docs`;
+- do not start background workers.
+
+Jobs/Scheduler integration is a later host-specific wrapper. The standalone
+service should be synchronous and deterministic in Stage 4A.
+
+## Testing Strategy
+
+Unit tests:
+
+- source schema migration and legacy row compatibility;
+- source creation from local import;
+- source creation from URL ingest;
+- source listing with owner/profile scope enforcement;
+- sync selector validation;
+- dry-run does not mutate documents, source links, or statuses;
+- local file sync created/updated/unchanged behavior;
+- local directory sync deterministic enumeration and max-document limit;
+- missing local file report mode;
+- tombstone mode marks source item only in apply mode;
+- URL sync no-fetch-before-approval;
+- URL sync denial for source policy and private redirect cases;
+- sitemap disabled failure;
+- sitemap parsing with safe XML settings;
+- sitemap out-of-scope URL rejection;
+- source sync status reporting in `docs.status`.
+
+Integration tests:
+
+- import local directory, list source, dry-run sync, apply sync, search updated
+  content;
+- ingest approved URL, list source, sync source with fake transport;
+- sitemap source sync with fake sitemap and fake page transport;
+- `DocsModule` exposes `docs.sync_source` through the host shim without Media
+  DB/RAG imports.
+
+Boundary tests:
+
+- `mcp_unified.docs` imports no `tldw_Server_API` modules;
+- baseline docs package imports without Playwright, trafilatura,
+  BeautifulSoup4, requests, httpx, aiohttp, ChromaDB, or RAG services;
+- URL/sitemap sync tests use fake resolver/transport and never require live
+  internet.
+
+Security tests:
+
+- local symlink escape denial;
+- unsupported local suffix failure;
+- URL scheme denial;
+- localhost/private/link-local DNS denial;
+- redirect-to-private denial;
+- oversized response denial;
+- unsupported content type denial;
+- sitemap XML external entity is not resolved;
+- no fetch before approval-required result.
+
+## Implementation Slices
+
+Recommended Stage 4A implementation sequence:
+
+1. Source registry schema and store helpers.
+2. Populate sources from `docs.import_path` and `docs.ingest_url`.
+3. `docs.list(kind="sources")` and `docs.status` source-sync capability.
+4. Local file/directory `docs.sync_source`.
+5. URL page `docs.sync_source`.
+6. Optional explicit sitemap source sync.
+7. Host shim registration and boundary tests.
+
+If the work needs to be split into multiple PRs, stop after slice 4. Local
+source sync is independently useful and proves the source model before adding
+more URL risk.
+
+## Implementation Planning Defaults
+
+- The first Stage 4A implementation plan should include slices 1 through 5:
+  source registry, source population, source list/status, local sync, and URL
+  page sync.
+- Explicit sitemap source sync should be planned as the final task in the same
+  plan and can be deferred to Stage 4A.2 if the first PR needs to stay smaller.
+- Store run item details in `docs_sync_runs.metadata_json` in Stage 4A, bounded
+  by `max_sync_run_items`; do not add `docs_sync_run_items` until result sizes
+  justify another table.
+- Add `docs_documents.lifecycle_status` in Stage 4A so tombstone behavior has
+  clear search semantics while preserving legacy active rows.

--- a/Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
+++ b/Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
@@ -109,15 +109,23 @@ Canonical URI rules:
   source is not created until policy allows a fetch and the fetch produces a
   canonical, fetch-capable URL.
 - Sitemaps use the normalized sitemap URL.
-- `source_url` stores the fetch target for URL-backed sources and may include
-  query parameters needed to refresh the source.
+- `source_url` stores the fetch target for URL-backed sources.
 - `redacted_source_url` stores the display/logging form. Tool results, source
   lists, errors, warnings, and sync-run metadata must use redacted URL forms
   unless the caller explicitly requests full source metadata through a future
   privileged diagnostic path. Stage 4A does not add that diagnostic path.
-- Query strings may be part of `canonical_uri` and `source_url` for fetch
-  identity, but logs, errors, audit summaries, and source list display must use
-  redacted forms.
+- Query strings are sensitive persistence. By default, a URL with a query string
+  may be ingested as a document, but Stage 4A must not create a refreshable
+  `url_page` source or persist a fetch-capable query-bearing `source_url` unless
+  `settings.persist_url_query_strings=true`.
+- When query persistence is disabled and an otherwise allowed URL contains a
+  query string, the response should include `url_query_not_persisted` and source
+  listing/sync should not expose a refreshable URL source for that document.
+- When query persistence is enabled, query strings may be part of
+  `canonical_uri` and `source_url` for fetch identity, but logs, errors, audit
+  summaries, source list display, and sync-run metadata must use redacted forms.
+- URL credentials in userinfo remain denied by Stage 2 policy and must never be
+  persisted.
 
 ### `docs_source_documents`
 
@@ -129,7 +137,8 @@ Recommended fields:
 - `source_id`
 - `document_id`
 - `source_item_uri`
-- `status`: `active`, `missing`, `tombstoned`, or `failed`
+- `status`: `active`, `tombstoned`, or `failed`. Missing source items are run
+  results, not a persisted source-link status in Stage 4A report mode.
 - `last_seen_at`
 - `last_hash`
 - `last_error_code`
@@ -263,6 +272,10 @@ Sync must not erase user organization.
 - Sync must not call `DocsCatalogStore.upsert_document()` with empty keyword or
   collection arguments for an existing document unless the source explicitly has
   an empty replacement policy. Stage 4A does not add replacement policy.
+- The implementation should add a sync-aware store helper, such as
+  `upsert_document_for_sync()`, that performs document/chunk replacement and
+  collection/keyword merging inside one write transaction. The existing
+  `upsert_document()` can remain replacement-oriented for direct imports.
 - User-applied keywords and collection memberships survive unchanged content,
   updated content, missing-source report mode, and tombstone mode.
 - If a future source wants authoritative replacement semantics, it needs a new
@@ -327,6 +340,13 @@ must still pass policy.
 Sitemap support is allowed in Stage 4A only for explicit `url_sitemap` sources.
 It is still not a crawler.
 
+Stage 4A.1 may defer sitemap source creation and sitemap sync entirely. If the
+optional sitemap slice is implemented, it must first add a narrow source
+registration path, such as `docs.sources.register`, limited to `url_sitemap`
+sources and protected by the same URL policy checks. Until that registration
+path exists, sitemap sync must remain disabled or unreachable because no user can
+create a valid sitemap source.
+
 Rules:
 
 - A sitemap source must already exist and must have a canonical sitemap URL.
@@ -354,7 +374,8 @@ sync must fail closed with `robots_unavailable` before fetching page content.
 Default stale behavior is report-only.
 
 - `stale_policy="report"`: missing items are returned in the response and run
-  record, but existing documents remain searchable.
+  record, source-link status is not changed, and existing documents remain
+  searchable.
 - `stale_policy="tombstone"`: apply mode marks the source item as
   `tombstoned`.
 - Add `lifecycle_status` to `docs_documents` with default `active`.
@@ -362,7 +383,7 @@ Default stale behavior is report-only.
   Stage 4A does not expose a public tool to set it; the field exists so future
   manual-preservation flows have a defined search rule.
 - A document is hidden from default search only when all source links for that
-  document are tombstoned or missing and `preserve_on_source_tombstone=false`.
+  document are tombstoned and `preserve_on_source_tombstone=false`.
 - Legacy rows without source links remain `active` after migration.
 - Hard delete is out of scope.
 
@@ -376,6 +397,9 @@ Extend `DocsSettings` with source-sync limits:
 - `max_sync_run_items`: default 500.
 - `default_stale_policy`: `report`.
 - `sitemap_sync_enabled`: default false unless explicitly enabled.
+- `persist_url_query_strings`: default false. Enables storing fetch-capable URL
+  sources whose canonical URL contains query parameters. Redacted display forms
+  are still mandatory.
 
 Profile behavior:
 
@@ -403,6 +427,7 @@ Stable reason codes should include:
 - `path_scope_denied`
 - `import_path_not_found`
 - `unsupported_import_format`
+- `url_query_not_persisted`
 - `web_acquisition_disabled`
 - `approval_required`
 - `source_policy_denied`
@@ -455,6 +480,8 @@ Unit tests:
 - source creation from URL ingest;
 - URL source identity stores a fetch-capable `source_url` while source lists
   and run metadata expose only redacted URL forms;
+- query-bearing URL ingest does not create a refreshable source unless
+  `persist_url_query_strings=true`;
 - source listing with owner/profile scope enforcement;
 - sync selector validation;
 - dry-run does not mutate documents, source links, source timestamps,
@@ -463,11 +490,12 @@ Unit tests:
   source defaults;
 - local file sync created/updated/unchanged behavior;
 - local directory sync deterministic enumeration and max-document limit;
-- missing local file report mode;
+- missing local file report mode does not persist a missing source-link status;
 - tombstone mode marks source item only in apply mode;
 - URL sync no-fetch-before-approval;
 - URL sync denial for source policy and private redirect cases;
 - sitemap disabled failure;
+- sitemap source registration, if the optional sitemap slice is implemented;
 - sitemap parsing with safe XML settings;
 - sitemap `DOCTYPE` and `ENTITY` declaration rejection;
 - sitemap `max_pages` enforcement before page fetches;
@@ -479,7 +507,8 @@ Integration tests:
 - import local directory, list source, dry-run sync, apply sync, search updated
   content;
 - ingest approved URL, list source, sync source with fake transport;
-- sitemap source sync with fake sitemap and fake page transport;
+- optional sitemap source registration and sync with fake sitemap and fake page
+  transport;
 - `DocsModule` exposes `docs.sync_source` through the host shim without Media
   DB/RAG imports.
 
@@ -514,7 +543,7 @@ Recommended Stage 4A implementation sequence:
 3. `docs.list(kind="sources")` and `docs.status` source-sync capability.
 4. Local file/directory `docs.sync_source`.
 5. URL page `docs.sync_source`.
-6. Optional explicit sitemap source sync.
+6. Optional explicit sitemap source registration and sync.
 7. Host shim registration and boundary tests.
 
 If the work needs to be split into multiple PRs, stop after slice 4. Local
@@ -526,8 +555,9 @@ more URL risk.
 - The first Stage 4A implementation plan should include slices 1 through 5:
   source registry, source population, source list/status, local sync, and URL
   page sync.
-- Explicit sitemap source sync should be planned as the final task in the same
-  plan and can be deferred to Stage 4A.2 if the first PR needs to stay smaller.
+- Explicit sitemap source registration and sync should be planned as the final
+  task in the same plan and can be deferred to Stage 4A.2 if the first PR needs
+  to stay smaller.
 - Store run item details in `docs_sync_runs.metadata_json` in Stage 4A, bounded
   by `max_sync_run_items`; do not add `docs_sync_run_items` until result sizes
   justify another table.

--- a/Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
+++ b/Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
@@ -54,7 +54,7 @@ apply a bounded refresh, and receive stable item-level results.
 
 ## Current Baseline
 
-The merged Stage 1-3 docs package already has:
+The current Stage 1-3 stacked branch already has:
 
 - `DocsSettings` with trusted roots and web acquisition policy settings.
 - `DocsImportService.import_path()` for trusted local file/tree import.
@@ -88,6 +88,7 @@ Recommended fields:
 - `display_name`
 - `source_path`
 - `source_url`
+- `redacted_source_url`
 - `policy_profile`
 - `sync_enabled`
 - `last_sync_status`
@@ -104,11 +105,19 @@ Canonical URI rules:
 
 - Local files and directories use normalized `file://` URIs derived from the
   resolved trusted-root path.
-- URL pages use the Stage 2 normalized canonical URL after redirects when a
-  fetch succeeds, otherwise the normalized redacted requested URL.
+- URL pages use the Stage 2 normalized canonical URL after redirects. A URL
+  source is not created until policy allows a fetch and the fetch produces a
+  canonical, fetch-capable URL.
 - Sitemaps use the normalized sitemap URL.
-- Query strings may be part of the canonical URL for fetch identity, but logs,
-  errors, audit summaries, and source list display must use redacted forms.
+- `source_url` stores the fetch target for URL-backed sources and may include
+  query parameters needed to refresh the source.
+- `redacted_source_url` stores the display/logging form. Tool results, source
+  lists, errors, warnings, and sync-run metadata must use redacted URL forms
+  unless the caller explicitly requests full source metadata through a future
+  privileged diagnostic path. Stage 4A does not add that diagnostic path.
+- Query strings may be part of `canonical_uri` and `source_url` for fetch
+  identity, but logs, errors, audit summaries, and source list display must use
+  redacted forms.
 
 ### `docs_source_documents`
 
@@ -237,8 +246,27 @@ Response shape:
 ```
 
 For `dry_run`, no documents, chunks, collection memberships, keywords, source
-links, or source status fields are mutated. A sync run record may be stored for
-auditability if the implementation marks it clearly as dry-run.
+links, source status fields, source timestamps, or sync run records are
+mutated. Dry-run audit persistence is deferred to a host wrapper or later
+diagnostic feature so the Stage 4A standalone dry-run path is strictly
+read-only.
+
+## Metadata Preservation
+
+Sync must not erase user organization.
+
+- `docs.import_path` and `docs.ingest_url` should record their initial
+  collection and keyword arguments as source defaults in `docs_sources`
+  metadata.
+- In apply mode, sync merges source-default collections and keywords with the
+  document's existing collections and keywords.
+- Sync must not call `DocsCatalogStore.upsert_document()` with empty keyword or
+  collection arguments for an existing document unless the source explicitly has
+  an empty replacement policy. Stage 4A does not add replacement policy.
+- User-applied keywords and collection memberships survive unchanged content,
+  updated content, missing-source report mode, and tombstone mode.
+- If a future source wants authoritative replacement semantics, it needs a new
+  explicit source metadata policy and separate tests.
 
 ## Local Source Sync
 
@@ -252,7 +280,9 @@ Local file sync:
 4. If the suffix is unsupported, return `failed` with
    `unsupported_import_format`.
 5. Parse, chunk, hash, and compare with the linked document.
-6. In apply mode, upsert the document only when content or metadata changed,
+6. In apply mode, merge existing user collections/keywords with source-default
+   collections/keywords.
+7. In apply mode, upsert the document only when content or metadata changed,
    unless `force=true`.
 
 Local directory sync:
@@ -261,10 +291,12 @@ Local directory sync:
 2. Enforce trusted-root path scope.
 3. Enumerate supported files deterministically.
 4. Enforce `max_documents` before parsing all candidates.
-5. Upsert active files through the same parser/chunker path as import.
-6. Compare enumerated item URIs with previously linked source items.
-7. Report previously linked items that are no longer present as `missing`.
-8. Only set source-item status to `tombstoned` when
+5. Merge existing user collections/keywords with source-default
+   collections/keywords for each active document.
+6. Upsert active files through the same parser/chunker path as import.
+7. Compare enumerated item URIs with previously linked source items.
+8. Report previously linked items that are no longer present as `missing`.
+9. Only set source-item status to `tombstoned` when
    `stale_policy="tombstone"` and `mode="apply"`.
 
 Directory sync should not recurse outside the source root even if symlinks
@@ -301,11 +333,16 @@ Rules:
 - Fetch the sitemap URL through the same Stage 2 URL fetcher and policy checks.
 - Parse XML with stdlib XML tooling configured to avoid external entity
   expansion.
+- Reject sitemap bodies containing `DOCTYPE` or `ENTITY` declarations before
+  XML parsing.
 - Accept only `<url><loc>...</loc></url>` entries in Stage 4A.
 - Ignore sitemap index recursion unless a later task explicitly adds it.
 - Every discovered URL must pass the source policy and must be same-origin or
   under an explicitly allowed URL prefix for the source.
-- Enforce `max_pages` before page fetches.
+- Enforce `max_pages` while collecting `<loc>` entries and before page fetches;
+  entries beyond the limit are counted as skipped without being fetched.
+- Cap stored run item details at `max_sync_run_items`; additional item summaries
+  are counted but not persisted into run metadata.
 - Fetch each accepted page with Stage 2 guards.
 - No JavaScript rendering, no cookies, no browser extraction.
 
@@ -321,9 +358,11 @@ Default stale behavior is report-only.
 - `stale_policy="tombstone"`: apply mode marks the source item as
   `tombstoned`.
 - Add `lifecycle_status` to `docs_documents` with default `active`.
+- Add `preserve_on_source_tombstone` to `docs_documents` with default false.
+  Stage 4A does not expose a public tool to set it; the field exists so future
+  manual-preservation flows have a defined search rule.
 - A document is hidden from default search only when all source links for that
-  document are tombstoned or missing and the document is not manually
-  preserved.
+  document are tombstoned or missing and `preserve_on_source_tombstone=false`.
 - Legacy rows without source links remain `active` after migration.
 - Hard delete is out of scope.
 
@@ -373,6 +412,8 @@ Stable reason codes should include:
 - `sitemap_fetch_failed`
 - `sitemap_parse_failed`
 - `sitemap_url_out_of_scope`
+- `sitemap_xml_forbidden_doctype`
+- `sitemap_xml_forbidden_entity`
 - `robots_unavailable`
 - `stale_reported`
 - `tombstoned`
@@ -412,9 +453,14 @@ Unit tests:
 - source schema migration and legacy row compatibility;
 - source creation from local import;
 - source creation from URL ingest;
+- URL source identity stores a fetch-capable `source_url` while source lists
+  and run metadata expose only redacted URL forms;
 - source listing with owner/profile scope enforcement;
 - sync selector validation;
-- dry-run does not mutate documents, source links, or statuses;
+- dry-run does not mutate documents, source links, source timestamps,
+  statuses, or sync-run rows;
+- sync preserves existing user-applied collections and keywords while merging
+  source defaults;
 - local file sync created/updated/unchanged behavior;
 - local directory sync deterministic enumeration and max-document limit;
 - missing local file report mode;
@@ -423,6 +469,8 @@ Unit tests:
 - URL sync denial for source policy and private redirect cases;
 - sitemap disabled failure;
 - sitemap parsing with safe XML settings;
+- sitemap `DOCTYPE` and `ENTITY` declaration rejection;
+- sitemap `max_pages` enforcement before page fetches;
 - sitemap out-of-scope URL rejection;
 - source sync status reporting in `docs.status`.
 
@@ -453,6 +501,8 @@ Security tests:
 - oversized response denial;
 - unsupported content type denial;
 - sitemap XML external entity is not resolved;
+- sitemap XML `DOCTYPE` or `ENTITY` declarations are rejected before parser
+  construction;
 - no fetch before approval-required result.
 
 ## Implementation Slices

--- a/apps/mcp-unified/src/mcp_unified/docs/acquisition/fetcher.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/acquisition/fetcher.py
@@ -50,6 +50,14 @@ class URLFetcher:
                 normalized = normalize_url(current_url)
             except URLPolicyError:
                 return FetchResult(status="denied", reason="malformed_url", redirects=tuple(redirects))
+            if self.settings.respect_robots:
+                return FetchResult(
+                    status="denied",
+                    reason="robots_unavailable",
+                    final_url=normalized.redacted_url,
+                    redirects=tuple(redirects),
+                    safe_argument_hash=decision.safe_argument_hash,
+                )
             if not bool(getattr(self.transport, "dials_validated_address", False)):
                 return FetchResult(
                     status="denied",

--- a/apps/mcp-unified/src/mcp_unified/docs/acquisition/fetcher.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/acquisition/fetcher.py
@@ -1,3 +1,5 @@
+"""HTTP URL fetching with MCP docs egress policy enforcement."""
+
 from __future__ import annotations
 
 import socket
@@ -18,6 +20,8 @@ _MAX_HEADER_BYTES = 65536
 
 
 class URLFetcher:
+    """Fetch allowed HTTP(S) URLs through validated DNS resolution and transport."""
+
     def __init__(
         self,
         *,
@@ -32,6 +36,7 @@ class URLFetcher:
         self.transport = transport or ValidatedAddressHTTPTransport()
 
     def fetch(self, raw_url: str) -> FetchResult:
+        """Fetch a URL after policy checks, redirect validation, and size limits."""
         current_url = raw_url
         redirects: list[RedirectHop] = []
         while True:

--- a/apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py
@@ -50,36 +50,20 @@ class DocsAcquisitionService:
                 "redirects": [],
             }
 
-        fetched = self.fetcher.fetch(url)
-        if fetched.status != "fetched":
+        fetched_document = self._fetch_parsed_url(url=url, title_override=title_override)
+        if fetched_document["status"] != "fetched":
             logger.info(
                 "Docs URL fetch did not produce ingestable content: status={} reason={} final_url={} redirects={}",
-                fetched.status,
-                fetched.reason,
-                fetched.final_url,
-                len(fetched.redirects),
+                fetched_document["status"],
+                fetched_document["reason_code"],
+                fetched_document.get("final_url"),
+                len(fetched_document.get("redirects", [])),
             )
-            return {
-                "status": fetched.status,
-                "reason_code": fetched.reason,
-                "final_url": fetched.final_url,
-                "redirects": [asdict(item) for item in fetched.redirects],
-                "safe_argument_hash": fetched.safe_argument_hash,
-            }
+            return fetched_document
 
-        content_type = fetched.headers.get("content-type", "text/html")
-        document_url = fetched.canonical_url or fetched.final_url or url
-        parsed = extract_fetched_document(url=document_url, content_type=content_type, body=fetched.body)
-        if title_override:
-            parsed = replace(parsed, title=title_override)
-        if not parsed.text.strip():
-            return {
-                "status": "failed",
-                "reason_code": "extract_empty",
-                "final_url": fetched.final_url,
-                "redirects": [asdict(item) for item in fetched.redirects],
-            }
-
+        fetched = fetched_document["fetch"]
+        parsed = fetched_document["parsed"]
+        content_type = fetched_document["content_type"]
         previous_hash = _existing_content_hash(self.store, scope, parsed.canonical_uri)
         new_hash = sha256(parsed.text.encode("utf-8")).hexdigest()
         keyword_tuple = tuple(keywords)
@@ -161,6 +145,42 @@ class DocsAcquisitionService:
             },
             "source": source,
             "warnings": warnings,
+        }
+
+    def _fetch_parsed_url(
+        self,
+        *,
+        url: str,
+        title_override: str | None = None,
+    ) -> dict[str, Any]:
+        fetched = self.fetcher.fetch(url)
+        if fetched.status != "fetched":
+            return {
+                "status": fetched.status,
+                "reason_code": fetched.reason,
+                "final_url": fetched.final_url,
+                "redirects": [asdict(item) for item in fetched.redirects],
+                "safe_argument_hash": fetched.safe_argument_hash,
+            }
+
+        content_type = fetched.headers.get("content-type", "text/html")
+        document_url = fetched.canonical_url or fetched.final_url or url
+        parsed = extract_fetched_document(url=document_url, content_type=content_type, body=fetched.body)
+        if title_override:
+            parsed = replace(parsed, title=title_override)
+        if not parsed.text.strip():
+            return {
+                "status": "failed",
+                "reason_code": "extract_empty",
+                "final_url": fetched.final_url,
+                "redirects": [asdict(item) for item in fetched.redirects],
+            }
+        return {
+            "status": "fetched",
+            "reason_code": "ok",
+            "fetch": fetched,
+            "parsed": parsed,
+            "content_type": content_type,
         }
 
 

--- a/apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py
@@ -11,6 +11,7 @@ from ..errors import DocsError
 from ..importers.base import chunks_from_text
 from ..models import AccessScope
 from ..settings import DocsSettings
+from ..source_utils import redacted_url_for_display, source_defaults_metadata, url_has_query
 from ..store.sqlite import DocsCatalogStore
 from .extract import extract_fetched_document
 from .fetcher import URLFetcher
@@ -81,6 +82,8 @@ class DocsAcquisitionService:
 
         previous_hash = _existing_content_hash(self.store, scope, parsed.canonical_uri)
         new_hash = sha256(parsed.text.encode("utf-8")).hexdigest()
+        keyword_tuple = tuple(keywords)
+        collection_tuple = tuple(collection_names)
         chunks = [
             {"text": chunk, "citation": f"{parsed.source_url or parsed.canonical_uri}#{index + 1}"}
             for index, chunk in enumerate(chunks_from_text(parsed.text))
@@ -95,8 +98,8 @@ class DocsAcquisitionService:
             text=parsed.text,
             sections=[asdict(section) for section in parsed.sections],
             chunks=chunks,
-            keywords=keywords,
-            collection_names=collection_names,
+            keywords=keyword_tuple,
+            collection_names=collection_tuple,
             metadata={
                 "importer": "url",
                 "extraction_method": parsed.extraction_method,
@@ -105,6 +108,38 @@ class DocsAcquisitionService:
                 "warnings": list(parsed.warnings),
             },
         )
+        warnings = list(parsed.warnings)
+        source: dict[str, Any] | None = None
+        can_persist_query_source = self.settings.persist_url_query_strings or not url_has_query(parsed.canonical_uri)
+        if can_persist_query_source:
+            redacted_source_url = redacted_url_for_display(parsed.canonical_uri)
+            source_id = self.store.upsert_source(
+                scope=scope,
+                source_type="url_page",
+                canonical_uri=parsed.canonical_uri,
+                display_name=parsed.title,
+                source_path=None,
+                source_url=parsed.canonical_uri,
+                redacted_source_url=redacted_source_url,
+                policy_profile=self.settings.web_source_profile,
+                sync_enabled=True,
+                metadata=source_defaults_metadata(
+                    keywords=keyword_tuple,
+                    collection_names=collection_tuple,
+                ),
+            )
+            self.store.link_source_document(
+                scope=scope,
+                source_id=source_id,
+                document_id=document_id,
+                source_item_uri=parsed.canonical_uri,
+                status="active",
+                last_hash=new_hash,
+                metadata={"importer": "url"},
+            )
+            source = self.store.get_source(scope=scope, source_id=source_id)
+        else:
+            warnings.append("url_query_not_persisted")
         status = "created" if previous_hash is None else "unchanged" if previous_hash == new_hash else "updated"
         return {
             "status": status,
@@ -124,6 +159,8 @@ class DocsAcquisitionService:
                 "content_type": content_type,
                 "bytes": len(fetched.body),
             },
+            "source": source,
+            "warnings": warnings,
         }
 
 

--- a/apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py
@@ -64,21 +64,29 @@ class DocsAcquisitionService:
         fetched = fetched_document["fetch"]
         parsed = fetched_document["parsed"]
         content_type = fetched_document["content_type"]
-        previous_hash = _existing_content_hash(self.store, scope, parsed.canonical_uri)
+        can_persist_query_uri = self.settings.persist_url_query_strings or not url_has_query(parsed.canonical_uri)
+        document_canonical_uri = (
+            parsed.canonical_uri if can_persist_query_uri else redacted_url_for_display(parsed.canonical_uri)
+        )
+        document_source_url = parsed.source_url if can_persist_query_uri else None
+        citation_base = parsed.source_url or parsed.canonical_uri
+        if not can_persist_query_uri:
+            citation_base = document_canonical_uri
+        previous_hash = _existing_content_hash(self.store, scope, document_canonical_uri)
         new_hash = sha256(parsed.text.encode("utf-8")).hexdigest()
         keyword_tuple = tuple(keywords)
         collection_tuple = tuple(collection_names)
         chunks = [
-            {"text": chunk, "citation": f"{parsed.source_url or parsed.canonical_uri}#{index + 1}"}
+            {"text": chunk, "citation": f"{citation_base}#{index + 1}"}
             for index, chunk in enumerate(chunks_from_text(parsed.text))
         ]
         document_id = self.store.upsert_document(
             scope=scope,
             title=parsed.title,
             document_type=parsed.document_type,
-            canonical_uri=parsed.canonical_uri,
+            canonical_uri=document_canonical_uri,
             source_path=parsed.source_path,
-            source_url=parsed.source_url,
+            source_url=document_source_url,
             text=parsed.text,
             sections=[asdict(section) for section in parsed.sections],
             chunks=chunks,
@@ -94,8 +102,7 @@ class DocsAcquisitionService:
         )
         warnings = list(parsed.warnings)
         source: dict[str, Any] | None = None
-        can_persist_query_source = self.settings.persist_url_query_strings or not url_has_query(parsed.canonical_uri)
-        if can_persist_query_source:
+        if can_persist_query_uri:
             redacted_source_url = redacted_url_for_display(parsed.canonical_uri)
             source_id = self.store.upsert_source(
                 scope=scope,
@@ -131,8 +138,8 @@ class DocsAcquisitionService:
             "document": {
                 "id": document_id,
                 "title": parsed.title,
-                "canonical_uri": parsed.canonical_uri,
-                "source_url": parsed.source_url,
+                "canonical_uri": document_canonical_uri,
+                "source_url": document_source_url,
                 "chunks": len(chunks),
                 "extraction_method": parsed.extraction_method,
             },

--- a/apps/mcp-unified/src/mcp_unified/docs/importers/local.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/importers/local.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from ..errors import DocsError
 from ..models import AccessScope
 from ..settings import DocsSettings
+from ..source_utils import file_uri_for_path, source_defaults_metadata
 from ..store.sqlite import DocsCatalogStore
 from .base import ParsedDocument, chunks_from_text
 from .html import parse_html
@@ -32,6 +33,19 @@ class DocsImportService:
         files = self._iter_import_files(target)
         keyword_tuple = tuple(keywords)
         collection_tuple = tuple(collection_names)
+        source_type = "local_file" if target.is_file() else "local_directory"
+        source_id = self.store.upsert_source(
+            scope=scope,
+            source_type=source_type,
+            canonical_uri=file_uri_for_path(target, directory=target.is_dir()),
+            display_name=target.name or str(target),
+            source_path=str(target),
+            source_url=None,
+            redacted_source_url=None,
+            policy_profile=self.settings.web_source_profile,
+            sync_enabled=True,
+            metadata=source_defaults_metadata(keywords=keyword_tuple, collection_names=collection_tuple),
+        )
         imported: list[dict] = []
 
         for file_path in files:
@@ -59,12 +73,25 @@ class DocsImportService:
                 metadata={"importer": "local"},
                 prune_orphan_keywords=False,
             )
+            self.store.link_source_document(
+                scope=scope,
+                source_id=source_id,
+                document_id=document_id,
+                source_item_uri=file_uri_for_path(file_path),
+                status="active",
+                last_hash=None,
+                metadata={"importer": "local"},
+            )
             imported.append({"id": document_id, "title": parsed.title, "chunks": len(chunks)})
 
         if imported:
             self.store.prune_orphan_keywords(scope=scope)
 
-        return {"status": "created" if imported else "unchanged", "documents": imported}
+        return {
+            "status": "created" if imported else "unchanged",
+            "documents": imported,
+            "source": self.store.get_source(scope=scope, source_id=source_id),
+        }
 
     def _assert_allowed_path(self, path: Path) -> Path:
         resolved = path.expanduser().resolve()

--- a/apps/mcp-unified/src/mcp_unified/docs/importers/local.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/importers/local.py
@@ -33,6 +33,23 @@ class DocsImportService:
         files = self._iter_import_files(target)
         keyword_tuple = tuple(keywords)
         collection_tuple = tuple(collection_names)
+        parsed_imports: list[tuple[Path, ParsedDocument, list[dict[str, str]]]] = []
+
+        for file_path in files:
+            parsed = self._parse_file(file_path)
+            chunk_texts = chunks_from_text(parsed.text)
+            chunks = [
+                {
+                    "text": chunk,
+                    "citation": f"{file_path.name}:{idx + 1}",
+                }
+                for idx, chunk in enumerate(chunk_texts)
+            ]
+            parsed_imports.append((file_path, parsed, chunks))
+
+        if not parsed_imports:
+            return {"status": "unchanged", "documents": [], "source": None}
+
         source_type = "local_file" if target.is_file() else "local_directory"
         source_id = self.store.upsert_source(
             scope=scope,
@@ -48,16 +65,7 @@ class DocsImportService:
         )
         imported: list[dict] = []
 
-        for file_path in files:
-            parsed = self._parse_file(file_path)
-            chunk_texts = chunks_from_text(parsed.text)
-            chunks = [
-                {
-                    "text": chunk,
-                    "citation": f"{file_path.name}:{idx + 1}",
-                }
-                for idx, chunk in enumerate(chunk_texts)
-            ]
+        for file_path, parsed, chunks in parsed_imports:
             document_id = self.store.upsert_document(
                 scope=scope,
                 title=parsed.title,

--- a/apps/mcp-unified/src/mcp_unified/docs/importers/local.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/importers/local.py
@@ -126,13 +126,17 @@ class DocsImportService:
                 details={"path": str(target)},
             )
 
+        source_root = target.expanduser().resolve()
         files: list[Path] = []
         for candidate in sorted(target.rglob("*")):
             if not candidate.is_file():
                 continue
             if candidate.suffix.lower() not in SUPPORTED_SUFFIXES:
                 continue
-            files.append(self._assert_allowed_path(candidate))
+            resolved_candidate = self._assert_allowed_path(candidate)
+            if not _path_is_relative_to(resolved_candidate, source_root):
+                continue
+            files.append(resolved_candidate)
         return files
 
     def _parse_file(self, path: Path) -> ParsedDocument:
@@ -180,3 +184,11 @@ class DocsImportService:
                     "max_import_file_bytes": self.settings.max_import_file_bytes,
                 },
             )
+
+
+def _path_is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True

--- a/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
@@ -7,12 +7,13 @@ from typing import Any
 from .acquisition.extract import available_extractors
 from .acquisition.service import DocsAcquisitionService
 from .importers.local import DocsImportService
-from .models import AccessScope, ContextRequest, SearchFilters, SearchRequest
+from .models import AccessScope, ContextRequest, SearchFilters, SearchRequest, SyncSourceRequest
 from .retrieval.aliases import DocsAliasResolver
 from .retrieval.context import DocsContextBuilder
 from .retrieval.search import DocsRetrievalService
 from .settings import DocsSettings
 from .store.sqlite import DocsCatalogStore
+from .sync import DocsSourceSyncService
 
 WRITE_CATEGORIES = {"ingestion", "management"}
 
@@ -68,6 +69,7 @@ class DocsMCPToolProvider:
         self.context = DocsContextBuilder(self.retrieval)
         self.aliases = DocsAliasResolver(self.store)
         self.importer = DocsImportService(settings=settings, store=self.store)
+        self.source_sync = DocsSourceSyncService(settings=settings, store=self.store)
         self.acquisition = (
             DocsAcquisitionService(settings=settings, store=self.store) if settings.enable_web_acquisition else None
         )
@@ -178,6 +180,24 @@ class DocsMCPToolProvider:
                 "retrieval",
             ),
         ]
+        if self.settings.enable_source_sync:
+            tools.append(
+                _tool(
+                    "docs.sync_source",
+                    "Refresh one existing docs source with bounded dry-run or apply semantics.",
+                    {
+                        "source_id": {"type": "integer"},
+                        "source_uri": {"type": "string"},
+                        "mode": {"type": "string"},
+                        "max_documents": {"type": "integer"},
+                        "max_pages": {"type": "integer"},
+                        "stale_policy": {"type": "string"},
+                        "force": {"type": "boolean"},
+                    },
+                    [],
+                    "ingestion",
+                )
+            )
         if self.acquisition is not None:
             tools.append(
                 _tool(
@@ -272,6 +292,10 @@ class DocsMCPToolProvider:
                 collection_names=tuple(str(item) for item in args.get("collections") or ()),
                 title_override=_optional_str(args.get("title")),
             )
+        if tool_name == "docs.sync_source":
+            if not self.settings.enable_source_sync:
+                return {"status": "denied", "reason_code": "source_sync_disabled"}
+            return self.source_sync.sync_source(scope=scope, request=_sync_source_request_from_args(args))
         return self._execute_management_or_list(tool_name=tool_name, args=args, scope=scope)
 
     def _execute_management_or_list(self, *, tool_name: str, args: dict[str, Any], scope: AccessScope) -> Any:
@@ -290,7 +314,7 @@ class DocsMCPToolProvider:
             if kind == "keywords":
                 return self.retrieval.list_keywords(scope=scope)
             if kind == "sources":
-                return {"sources": [], "warnings": [{"code": "sources_not_populated_in_stage1"}]}
+                return {"sources": self.store.list_sources(scope=scope, limit=limit, offset=offset), "warnings": []}
             raise ValueError(f"Unsupported docs.list kind: {kind}")
         if tool_name == "docs.collections.list":
             return self.retrieval.list_collections(scope=scope)
@@ -353,6 +377,18 @@ def _filters_from_args(args: dict[str, Any]) -> SearchFilters:
     )
 
 
+def _sync_source_request_from_args(args: dict[str, Any]) -> SyncSourceRequest:
+    return SyncSourceRequest(
+        source_id=_optional_int(args.get("source_id")),
+        source_uri=_optional_str(args.get("source_uri")),
+        mode=str(args.get("mode") or "dry_run"),
+        max_documents=_optional_int(args.get("max_documents")),
+        max_pages=_optional_int(args.get("max_pages")),
+        stale_policy=str(args.get("stale_policy") or "report"),
+        force=bool(args.get("force", False)),
+    )
+
+
 def _optional_str(value: Any) -> str | None:
     if value is None:
         return None
@@ -371,3 +407,11 @@ def _required_int(args: dict[str, Any], name: str) -> int:
     if name not in args:
         raise ValueError(f"{name} is required")
     return int(args[name])
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    return int(value)

--- a/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
@@ -13,7 +13,7 @@ from .retrieval.context import DocsContextBuilder
 from .retrieval.search import DocsRetrievalService
 from .settings import DocsSettings
 from .store.sqlite import DocsCatalogStore
-from .sync import DocsSourceSyncService
+from .sync import DocsSourceSyncService, source_summary_for_tool_response
 
 WRITE_CATEGORIES = {"ingestion", "management"}
 
@@ -295,7 +295,10 @@ class DocsMCPToolProvider:
         if tool_name == "docs.sync_source":
             if not self.settings.enable_source_sync:
                 return {"status": "denied", "reason_code": "source_sync_disabled"}
-            return self.source_sync.sync_source(scope=scope, request=_sync_source_request_from_args(args))
+            request, error = _sync_source_request_from_args(args, self.settings)
+            if error is not None:
+                return error
+            return self.source_sync.sync_source(scope=scope, request=request)
         return self._execute_management_or_list(tool_name=tool_name, args=args, scope=scope)
 
     def _execute_management_or_list(self, *, tool_name: str, args: dict[str, Any], scope: AccessScope) -> Any:
@@ -314,7 +317,11 @@ class DocsMCPToolProvider:
             if kind == "keywords":
                 return self.retrieval.list_keywords(scope=scope)
             if kind == "sources":
-                return {"sources": self.store.list_sources(scope=scope, limit=limit, offset=offset), "warnings": []}
+                sources = [
+                    source_summary_for_tool_response(source)
+                    for source in self.store.list_sources(scope=scope, limit=limit, offset=offset)
+                ]
+                return {"sources": sources, "warnings": []}
             raise ValueError(f"Unsupported docs.list kind: {kind}")
         if tool_name == "docs.collections.list":
             return self.retrieval.list_collections(scope=scope)
@@ -377,16 +384,106 @@ def _filters_from_args(args: dict[str, Any]) -> SearchFilters:
     )
 
 
-def _sync_source_request_from_args(args: dict[str, Any]) -> SyncSourceRequest:
-    return SyncSourceRequest(
-        source_id=_optional_int(args.get("source_id")),
-        source_uri=_optional_str(args.get("source_uri")),
-        mode=str(args.get("mode") or "dry_run"),
-        max_documents=_optional_int(args.get("max_documents")),
-        max_pages=_optional_int(args.get("max_pages")),
-        stale_policy=str(args.get("stale_policy") or "report"),
-        force=bool(args.get("force", False)),
+def _sync_source_request_from_args(
+    args: dict[str, Any],
+    settings: DocsSettings,
+) -> tuple[SyncSourceRequest, dict[str, str] | None]:
+    source_id, error = _optional_positive_int(args.get("source_id"), "source_id")
+    if error is not None:
+        return SyncSourceRequest(), error
+    max_documents, error = _optional_positive_int(args.get("max_documents"), "max_documents")
+    if error is not None:
+        return SyncSourceRequest(), error
+    max_pages, error = _optional_positive_int(args.get("max_pages"), "max_pages")
+    if error is not None:
+        return SyncSourceRequest(), error
+    mode, error = _optional_choice(args.get("mode"), "mode", default="dry_run", allowed={"dry_run", "apply"})
+    if error is not None:
+        return SyncSourceRequest(), error
+    stale_policy, error = _optional_choice(
+        args.get("stale_policy"),
+        "stale_policy",
+        default=settings.default_stale_policy,
+        allowed={"report", "tombstone"},
     )
+    if error is not None:
+        return SyncSourceRequest(), error
+    force, error = _optional_bool(args.get("force"), "force", default=False)
+    if error is not None:
+        return SyncSourceRequest(), error
+
+    return SyncSourceRequest(
+        source_id=source_id,
+        source_uri=_optional_str(args.get("source_uri")),
+        mode=mode,
+        max_documents=max_documents,
+        max_pages=max_pages,
+        stale_policy=stale_policy,
+        force=force,
+    ), None
+
+
+def _invalid_sync_request(field: str) -> dict[str, str]:
+    return {
+        "status": "denied",
+        "reason_code": "source_sync_request_invalid",
+        "field": field,
+    }
+
+
+def _optional_choice(
+    value: Any,
+    field: str,
+    *,
+    default: str,
+    allowed: set[str],
+) -> tuple[str, dict[str, str] | None]:
+    text = _optional_str(value)
+    if text is None:
+        return default, None
+    normalized = text.lower()
+    if normalized not in allowed:
+        return default, _invalid_sync_request(field)
+    return normalized, None
+
+
+def _optional_bool(value: Any, field: str, *, default: bool) -> tuple[bool, dict[str, str] | None]:
+    if value is None:
+        return default, None
+    if isinstance(value, bool):
+        return value, None
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if not normalized:
+            return default, None
+        if normalized in {"1", "true", "t", "yes", "y", "on"}:
+            return True, None
+        if normalized in {"0", "false", "f", "no", "n", "off"}:
+            return False, None
+    return default, _invalid_sync_request(field)
+
+
+def _optional_positive_int(value: Any, field: str) -> tuple[int | None, dict[str, str] | None]:
+    if value is None:
+        return None, None
+    if isinstance(value, bool):
+        return None, _invalid_sync_request(field)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None, None
+        try:
+            parsed = int(text, 10)
+        except ValueError:
+            return None, _invalid_sync_request(field)
+    elif isinstance(value, int):
+        parsed = value
+    else:
+        return None, _invalid_sync_request(field)
+
+    if parsed <= 0:
+        return None, _invalid_sync_request(field)
+    return parsed, None
 
 
 def _optional_str(value: Any) -> str | None:
@@ -407,11 +504,3 @@ def _required_int(args: dict[str, Any], name: str) -> int:
     if name not in args:
         raise ValueError(f"{name} is required")
     return int(args[name])
-
-
-def _optional_int(value: Any) -> int | None:
-    if value is None:
-        return None
-    if isinstance(value, str) and not value.strip():
-        return None
-    return int(value)

--- a/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
@@ -47,6 +47,18 @@ def _web_policy_status(settings: DocsSettings) -> dict[str, Any]:
     }
 
 
+def _source_sync_status(settings: DocsSettings) -> dict[str, Any]:
+    return {
+        "enabled": settings.enable_source_sync,
+        "max_sync_documents": settings.max_sync_documents,
+        "max_sync_pages": settings.max_sync_pages,
+        "max_sync_run_items": settings.max_sync_run_items,
+        "default_stale_policy": settings.default_stale_policy,
+        "sitemap_sync_enabled": settings.sitemap_sync_enabled,
+        "persist_url_query_strings": settings.persist_url_query_strings,
+    }
+
+
 class DocsMCPToolProvider:
     def __init__(self, *, settings: DocsSettings, store: DocsCatalogStore | None = None) -> None:
         self.settings = settings
@@ -192,6 +204,7 @@ class DocsMCPToolProvider:
             status["web_extractors"] = available_extractors() if self.acquisition is not None else []
             status["web_source_profile"] = self.settings.web_source_profile
             status["web_policy"] = _web_policy_status(self.settings)
+            status["source_sync"] = _source_sync_status(self.settings)
             status["web_acquisition_unavailable_reason"] = (
                 None if self.acquisition is not None else "web_acquisition_disabled"
             )

--- a/apps/mcp-unified/src/mcp_unified/docs/models.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/models.py
@@ -6,6 +6,12 @@ from typing import Any, Literal
 ScopeValue = str | None
 DocumentType = Literal["markdown", "mdx", "text", "html", "other"]
 RetrievalMode = Literal["metadata", "snippet", "section", "full", "chunk", "chunk_with_neighbors"]
+SourceType = Literal["local_file", "local_directory", "url_page", "url_sitemap"]
+SourceLinkStatus = Literal["active", "tombstoned", "failed"]
+SyncMode = Literal["dry_run", "apply"]
+StalePolicy = Literal["report", "tombstone"]
+SyncItemStatus = Literal["created", "updated", "unchanged", "missing", "tombstoned", "failed", "skipped"]
+SyncRunStatus = Literal["completed", "partial", "skipped", "denied", "failed"]
 
 
 @dataclass(frozen=True)
@@ -54,6 +60,35 @@ class DocumentRecord:
     source_url: str | None
     content_hash: str
     metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SourceRecord:
+    id: int
+    source_type: SourceType
+    canonical_uri: str
+    display_name: str
+    source_path: str | None
+    source_url: str | None
+    redacted_source_url: str | None
+    sync_enabled: bool
+    last_sync_status: str | None
+    last_sync_started_at: str | None
+    last_sync_completed_at: str | None
+    last_error_code: str | None
+    document_count: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SyncSourceRequest:
+    source_id: int | None = None
+    source_uri: str | None = None
+    mode: SyncMode = "dry_run"
+    max_documents: int | None = None
+    max_pages: int | None = None
+    stale_policy: StalePolicy = "report"
+    force: bool = False
 
 
 @dataclass(frozen=True)

--- a/apps/mcp-unified/src/mcp_unified/docs/settings.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/settings.py
@@ -10,6 +10,7 @@ from typing import Literal, cast
 from .models import AccessScope
 
 SourceProfile = Literal["locked_down", "local_first", "online_capable"]
+StalePolicy = Literal["report", "tombstone"]
 
 _TRUE_VALUES = {"true", "1", "yes", "on"}
 _FALSE_VALUES = {"false", "0", "no", "off"}
@@ -114,6 +115,13 @@ def _coerce_source_profile(value: object, field_name: str) -> SourceProfile:
     return cast(SourceProfile, value)
 
 
+def _coerce_stale_policy(value: object, field_name: str) -> StalePolicy:
+    text = "report" if value is None else str(value).strip().lower()
+    if text not in {"report", "tombstone"}:
+        raise ValueError(f"{field_name} must be report or tombstone")
+    return cast(StalePolicy, text)
+
+
 @dataclass(frozen=True)
 class DocsSettings:
     db_path: Path
@@ -132,6 +140,13 @@ class DocsSettings:
     url_user_agent: str = _DEFAULT_URL_USER_AGENT
     respect_robots: bool = False
     allow_arbitrary_public_domains: bool = False
+    enable_source_sync: bool = True
+    max_sync_documents: int = 500
+    max_sync_pages: int = 25
+    max_sync_run_items: int = 500
+    default_stale_policy: StalePolicy = "report"
+    sitemap_sync_enabled: bool = False
+    persist_url_query_strings: bool = False
 
     @classmethod
     def from_mapping(cls, values: dict) -> "DocsSettings":
@@ -181,5 +196,30 @@ class DocsSettings:
             allow_arbitrary_public_domains=_coerce_bool(
                 values.get("allow_arbitrary_public_domains", False),
                 "allow_arbitrary_public_domains",
+            ),
+            enable_source_sync=_coerce_bool(values.get("enable_source_sync", True), "enable_source_sync"),
+            max_sync_documents=_coerce_positive_int(
+                values.get("max_sync_documents", 500),
+                "max_sync_documents",
+            ),
+            max_sync_pages=_coerce_positive_int(
+                values.get("max_sync_pages", 25),
+                "max_sync_pages",
+            ),
+            max_sync_run_items=_coerce_positive_int(
+                values.get("max_sync_run_items", 500),
+                "max_sync_run_items",
+            ),
+            default_stale_policy=_coerce_stale_policy(
+                values.get("default_stale_policy", "report"),
+                "default_stale_policy",
+            ),
+            sitemap_sync_enabled=_coerce_bool(
+                values.get("sitemap_sync_enabled", False),
+                "sitemap_sync_enabled",
+            ),
+            persist_url_query_strings=_coerce_bool(
+                values.get("persist_url_query_strings", False),
+                "persist_url_query_strings",
             ),
         )

--- a/apps/mcp-unified/src/mcp_unified/docs/settings.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/settings.py
@@ -34,7 +34,7 @@ def _coerce_bool(value: object, field_name: str) -> bool:
 def _coerce_trusted_roots(value: object) -> tuple[Path, ...]:
     if value is None or value == "":
         return ()
-    if isinstance(value, str | PathLike):
+    if isinstance(value, (str, PathLike)):
         items = (value,)
     else:
         items = tuple(value) if isinstance(value, Iterable) else (value,)

--- a/apps/mcp-unified/src/mcp_unified/docs/source_utils.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/source_utils.py
@@ -1,12 +1,23 @@
+"""Shared source URI helpers for MCP docs ingestion and sync."""
+
 from __future__ import annotations
 
 from pathlib import Path
 from urllib.parse import SplitResult, urlsplit, urlunsplit
+from urllib.request import url2pathname
 
 
 def file_uri_for_path(path: Path, *, directory: bool = False) -> str:
     uri = path.expanduser().resolve().as_uri()
     return f"{uri}/" if directory and not uri.endswith("/") else uri
+
+
+def path_from_file_uri(uri: str) -> Path:
+    """Decode a local file URI into a filesystem path."""
+    parts = urlsplit(uri)
+    if parts.scheme != "file" or parts.netloc not in {"", "localhost"}:
+        raise ValueError("Only local file URIs are supported")
+    return Path(url2pathname(parts.path))
 
 
 def source_defaults_metadata(*, keywords: tuple[str, ...], collection_names: tuple[str, ...]) -> dict[str, list[str]]:

--- a/apps/mcp-unified/src/mcp_unified/docs/source_utils.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/source_utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+def file_uri_for_path(path: Path, *, directory: bool = False) -> str:
+    uri = path.expanduser().resolve().as_uri()
+    return f"{uri}/" if directory and not uri.endswith("/") else uri
+
+
+def source_defaults_metadata(*, keywords: tuple[str, ...], collection_names: tuple[str, ...]) -> dict[str, list[str]]:
+    return {
+        "default_keywords": list(keywords),
+        "default_collections": list(collection_names),
+    }
+
+
+def redacted_url_for_display(url: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path or "/", "", ""))
+
+
+def url_has_query(url: str) -> bool:
+    return bool(urlsplit(url).query)

--- a/apps/mcp-unified/src/mcp_unified/docs/source_utils.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/source_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 
 def file_uri_for_path(path: Path, *, directory: bool = False) -> str:
@@ -18,8 +18,17 @@ def source_defaults_metadata(*, keywords: tuple[str, ...], collection_names: tup
 
 def redacted_url_for_display(url: str) -> str:
     parts = urlsplit(url)
-    return urlunsplit((parts.scheme, parts.netloc, parts.path or "/", "", ""))
+    return urlunsplit((parts.scheme, _redacted_netloc(parts), parts.path or "/", "", ""))
 
 
 def url_has_query(url: str) -> bool:
     return bool(urlsplit(url).query)
+
+
+def _redacted_netloc(parts: SplitResult) -> str:
+    hostname = parts.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    if parts.port is not None:
+        return f"{hostname}:{parts.port}"
+    return hostname

--- a/apps/mcp-unified/src/mcp_unified/docs/store/schema.sql
+++ b/apps/mcp-unified/src/mcp_unified/docs/store/schema.sql
@@ -59,6 +59,9 @@ CREATE TABLE IF NOT EXISTS docs_sources (
     UNIQUE (owner_scope, profile_scope, canonical_uri)
 );
 
+CREATE INDEX IF NOT EXISTS docs_sources_scope_display_idx
+    ON docs_sources (owner_scope, profile_scope, display_name);
+
 CREATE TABLE IF NOT EXISTS docs_source_documents (
     source_id INTEGER NOT NULL REFERENCES docs_sources(id) ON DELETE CASCADE,
     document_id INTEGER NOT NULL REFERENCES docs_documents(id) ON DELETE CASCADE,
@@ -70,6 +73,9 @@ CREATE TABLE IF NOT EXISTS docs_source_documents (
     metadata_json TEXT NOT NULL DEFAULT '{}',
     PRIMARY KEY (source_id, source_item_uri)
 );
+
+CREATE INDEX IF NOT EXISTS docs_source_documents_document_idx
+    ON docs_source_documents (document_id);
 
 CREATE TABLE IF NOT EXISTS docs_sync_runs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -86,6 +92,9 @@ CREATE TABLE IF NOT EXISTS docs_sync_runs (
     error_code TEXT,
     metadata_json TEXT NOT NULL DEFAULT '{}'
 );
+
+CREATE INDEX IF NOT EXISTS docs_sync_runs_source_started_idx
+    ON docs_sync_runs (source_id, started_at DESC);
 
 CREATE TABLE IF NOT EXISTS docs_collections (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/apps/mcp-unified/src/mcp_unified/docs/store/schema.sql
+++ b/apps/mcp-unified/src/mcp_unified/docs/store/schema.sql
@@ -18,6 +18,8 @@ CREATE TABLE IF NOT EXISTS docs_documents (
     source_url TEXT,
     content_hash TEXT NOT NULL,
     text TEXT NOT NULL,
+    lifecycle_status TEXT NOT NULL DEFAULT 'active',
+    preserve_on_source_tombstone INTEGER NOT NULL DEFAULT 0,
     metadata_json TEXT NOT NULL DEFAULT '{}',
     package_name TEXT,
     package_version TEXT,
@@ -34,6 +36,56 @@ CREATE INDEX IF NOT EXISTS docs_documents_scope_type_idx
 
 CREATE INDEX IF NOT EXISTS docs_documents_scope_package_idx
     ON docs_documents (owner_scope, profile_scope, package_name, package_version);
+
+CREATE TABLE IF NOT EXISTS docs_sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_scope TEXT NOT NULL DEFAULT '',
+    profile_scope TEXT NOT NULL DEFAULT '',
+    source_type TEXT NOT NULL,
+    canonical_uri TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    source_path TEXT,
+    source_url TEXT,
+    redacted_source_url TEXT,
+    policy_profile TEXT,
+    sync_enabled INTEGER NOT NULL DEFAULT 1,
+    last_sync_status TEXT,
+    last_sync_started_at TEXT,
+    last_sync_completed_at TEXT,
+    last_error_code TEXT,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (owner_scope, profile_scope, canonical_uri)
+);
+
+CREATE TABLE IF NOT EXISTS docs_source_documents (
+    source_id INTEGER NOT NULL REFERENCES docs_sources(id) ON DELETE CASCADE,
+    document_id INTEGER NOT NULL REFERENCES docs_documents(id) ON DELETE CASCADE,
+    source_item_uri TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    last_seen_at TEXT,
+    last_hash TEXT,
+    last_error_code TEXT,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (source_id, source_item_uri)
+);
+
+CREATE TABLE IF NOT EXISTS docs_sync_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_scope TEXT NOT NULL DEFAULT '',
+    profile_scope TEXT NOT NULL DEFAULT '',
+    source_id INTEGER NOT NULL REFERENCES docs_sources(id) ON DELETE CASCADE,
+    mode TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at TEXT,
+    requested_limits_json TEXT NOT NULL DEFAULT '{}',
+    counts_json TEXT NOT NULL DEFAULT '{}',
+    warnings_json TEXT NOT NULL DEFAULT '[]',
+    error_code TEXT,
+    metadata_json TEXT NOT NULL DEFAULT '{}'
+);
 
 CREATE TABLE IF NOT EXISTS docs_collections (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
@@ -29,6 +29,8 @@ _COUNT_SQL = {
 }
 _SCOPE_TABLE_INFO_SQL = {
     "docs_documents": "PRAGMA table_info(docs_documents)",
+    "docs_sources": "PRAGMA table_info(docs_sources)",
+    "docs_sync_runs": "PRAGMA table_info(docs_sync_runs)",
     "docs_collections": "PRAGMA table_info(docs_collections)",
     "docs_keywords": "PRAGMA table_info(docs_keywords)",
     "docs_aliases": "PRAGMA table_info(docs_aliases)",
@@ -41,6 +43,14 @@ _SCOPE_BACKFILL_SQL = {
     "docs_documents": (
         "UPDATE docs_documents SET owner_scope = ? WHERE owner_scope IS NULL",
         "UPDATE docs_documents SET profile_scope = ? WHERE profile_scope IS NULL",
+    ),
+    "docs_sources": (
+        "UPDATE docs_sources SET owner_scope = ? WHERE owner_scope IS NULL",
+        "UPDATE docs_sources SET profile_scope = ? WHERE profile_scope IS NULL",
+    ),
+    "docs_sync_runs": (
+        "UPDATE docs_sync_runs SET owner_scope = ? WHERE owner_scope IS NULL",
+        "UPDATE docs_sync_runs SET profile_scope = ? WHERE profile_scope IS NULL",
     ),
     "docs_collections": (
         "UPDATE docs_collections SET owner_scope = ? WHERE owner_scope IS NULL",
@@ -79,6 +89,8 @@ class DocsCatalogStore:
         schema = resources.files(_STORE_PACKAGE).joinpath(_SCHEMA_RESOURCE).read_text(encoding="utf-8")
         with closing(self.connect()) as conn:
             conn.executescript(schema)
+            self._ensure_document_lifecycle_columns(conn)
+            self._ensure_source_tables(conn)
             self._backfill_scope_sentinels(conn)
             self._ensure_documents_scope_uri_unique_index(conn)
             self._ensure_collection_description_column(conn)
@@ -123,52 +135,21 @@ class DocsCatalogStore:
 
         with closing(self.connect()) as conn:
             with conn:
-                cursor = conn.execute(
-                    """
-                    INSERT INTO docs_documents (
-                        owner_scope,
-                        profile_scope,
-                        title,
-                        document_type,
-                        canonical_uri,
-                        source_path,
-                        source_url,
-                        content_hash,
-                        text,
-                        metadata_json,
-                        package_name,
-                        package_version
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(owner_scope, profile_scope, canonical_uri)
-                    DO UPDATE SET title = excluded.title,
-                        document_type = excluded.document_type,
-                        source_path = excluded.source_path,
-                        source_url = excluded.source_url,
-                        content_hash = excluded.content_hash,
-                        text = excluded.text,
-                        metadata_json = excluded.metadata_json,
-                        package_name = excluded.package_name,
-                        package_version = excluded.package_version,
-                        updated_at = CURRENT_TIMESTAMP
-                    RETURNING id
-                    """,
-                    (
-                        owner_scope,
-                        profile_scope,
-                        title,
-                        document_type,
-                        canonical_uri,
-                        source_path,
-                        source_url,
-                        content_hash,
-                        text,
-                        metadata_json,
-                        package_name,
-                        package_version,
-                    ),
+                document_id = self._upsert_document_record(
+                    conn,
+                    owner_scope,
+                    profile_scope,
+                    title,
+                    document_type,
+                    canonical_uri,
+                    source_path,
+                    source_url,
+                    content_hash,
+                    text,
+                    metadata_json,
+                    package_name,
+                    package_version,
                 )
-                document_id = int(cursor.fetchone()["id"])
 
                 self._replace_document_rows(conn, document_id, title, sections, chunks)
                 self._replace_document_keywords(conn, owner_scope, profile_scope, document_id, keywords)
@@ -180,6 +161,353 @@ class DocsCatalogStore:
                     profile_scope,
                     document_id,
                     collection_names,
+                )
+                return document_id
+
+    def upsert_source(
+        self,
+        *,
+        scope: AccessScope,
+        source_type: str,
+        canonical_uri: str,
+        display_name: str,
+        source_path: str | None,
+        source_url: str | None,
+        redacted_source_url: str | None,
+        policy_profile: str | None,
+        sync_enabled: bool,
+        metadata: Mapping[str, Any],
+    ) -> int:
+        owner_scope, profile_scope = _scope_values(scope)
+        metadata_json = _json_dump(dict(metadata or {}))
+        with closing(self.connect()) as conn:
+            with conn:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO docs_sources (
+                        owner_scope,
+                        profile_scope,
+                        source_type,
+                        canonical_uri,
+                        display_name,
+                        source_path,
+                        source_url,
+                        redacted_source_url,
+                        policy_profile,
+                        sync_enabled,
+                        metadata_json
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(owner_scope, profile_scope, canonical_uri)
+                    DO UPDATE SET source_type = excluded.source_type,
+                        display_name = excluded.display_name,
+                        source_path = excluded.source_path,
+                        source_url = excluded.source_url,
+                        redacted_source_url = excluded.redacted_source_url,
+                        policy_profile = excluded.policy_profile,
+                        sync_enabled = excluded.sync_enabled,
+                        metadata_json = excluded.metadata_json,
+                        updated_at = CURRENT_TIMESTAMP
+                    RETURNING id
+                    """,
+                    (
+                        owner_scope,
+                        profile_scope,
+                        source_type,
+                        canonical_uri,
+                        display_name,
+                        source_path,
+                        source_url,
+                        redacted_source_url,
+                        policy_profile,
+                        1 if sync_enabled else 0,
+                        metadata_json,
+                    ),
+                )
+                return int(cursor.fetchone()["id"])
+
+    def get_source(
+        self,
+        *,
+        scope: AccessScope,
+        source_id: int | None = None,
+        canonical_uri: str | None = None,
+    ) -> dict[str, Any] | None:
+        if (source_id is None) == (canonical_uri is None):
+            raise ValueError("Pass exactly one source selector.")
+
+        owner_scope, profile_scope = _scope_values(scope)
+        if source_id is not None:
+            sql = """
+                SELECT s.*, COUNT(DISTINCT sd.document_id) AS document_count
+                FROM docs_sources s
+                LEFT JOIN docs_source_documents sd ON sd.source_id = s.id
+                WHERE s.owner_scope = ?
+                  AND s.profile_scope = ?
+                  AND s.id = ?
+                GROUP BY s.id
+                """
+            selector_param: object = source_id
+        else:
+            sql = """
+                SELECT s.*, COUNT(DISTINCT sd.document_id) AS document_count
+                FROM docs_sources s
+                LEFT JOIN docs_source_documents sd ON sd.source_id = s.id
+                WHERE s.owner_scope = ?
+                  AND s.profile_scope = ?
+                  AND s.canonical_uri = ?
+                GROUP BY s.id
+                """
+            selector_param = canonical_uri
+
+        with closing(self.connect()) as conn:
+            row = conn.execute(sql, (owner_scope, profile_scope, selector_param)).fetchone()
+        return _source_from_row(row) if row is not None else None
+
+    def list_sources(self, *, scope: AccessScope, limit: int = 50, offset: int = 0) -> list[dict[str, Any]]:
+        owner_scope, profile_scope = _scope_values(scope)
+        with closing(self.connect()) as conn:
+            rows = conn.execute(
+                """
+                SELECT s.*, COUNT(DISTINCT sd.document_id) AS document_count
+                FROM docs_sources s
+                LEFT JOIN docs_source_documents sd ON sd.source_id = s.id
+                WHERE s.owner_scope = ? AND s.profile_scope = ?
+                GROUP BY s.id
+                ORDER BY s.display_name COLLATE NOCASE ASC, s.id ASC
+                LIMIT ? OFFSET ?
+                """,
+                (
+                    owner_scope,
+                    profile_scope,
+                    _bounded_non_negative(limit, default=50),
+                    _bounded_non_negative(offset, default=0),
+                ),
+            ).fetchall()
+        return [_source_from_row(row) for row in rows]
+
+    def link_source_document(
+        self,
+        *,
+        scope: AccessScope,
+        source_id: int,
+        document_id: int,
+        source_item_uri: str,
+        status: str,
+        last_hash: str | None,
+        metadata: Mapping[str, Any],
+    ) -> None:
+        owner_scope, profile_scope = _scope_values(scope)
+        normalized_item_uri = _required_name(source_item_uri, "source item URI")
+        normalized_status = _required_name(status, "source link status")
+        metadata_json = _json_dump(dict(metadata or {}))
+        with closing(self.connect()) as conn:
+            with conn:
+                self._assert_source_in_scope(conn, owner_scope, profile_scope, source_id)
+                self._assert_document_in_scope(conn, owner_scope, profile_scope, document_id)
+                conn.execute(
+                    """
+                    INSERT INTO docs_source_documents (
+                        source_id,
+                        document_id,
+                        source_item_uri,
+                        status,
+                        last_seen_at,
+                        last_hash,
+                        last_error_code,
+                        metadata_json
+                    )
+                    VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, ?, NULL, ?)
+                    ON CONFLICT(source_id, source_item_uri)
+                    DO UPDATE SET document_id = excluded.document_id,
+                        status = excluded.status,
+                        last_seen_at = CURRENT_TIMESTAMP,
+                        last_hash = excluded.last_hash,
+                        last_error_code = NULL,
+                        metadata_json = excluded.metadata_json
+                    """,
+                    (
+                        source_id,
+                        document_id,
+                        normalized_item_uri,
+                        normalized_status,
+                        _optional_text(last_hash),
+                        metadata_json,
+                    ),
+                )
+
+    def source_document_links(self, *, scope: AccessScope, source_id: int) -> list[dict[str, Any]]:
+        owner_scope, profile_scope = _scope_values(scope)
+        with closing(self.connect()) as conn:
+            self._assert_source_in_scope(conn, owner_scope, profile_scope, source_id)
+            rows = conn.execute(
+                """
+                SELECT sd.*, d.title, d.canonical_uri
+                FROM docs_source_documents sd
+                JOIN docs_documents d ON d.id = sd.document_id
+                WHERE sd.source_id = ?
+                  AND d.owner_scope = ?
+                  AND d.profile_scope = ?
+                ORDER BY sd.source_item_uri COLLATE NOCASE ASC
+                """,
+                (source_id, owner_scope, profile_scope),
+            ).fetchall()
+        return [_source_document_link_from_row(row) for row in rows]
+
+    def record_sync_run(
+        self,
+        *,
+        scope: AccessScope,
+        source_id: int,
+        mode: str,
+        status: str,
+        requested_limits: Mapping[str, Any],
+        counts: Mapping[str, int],
+        warnings: list[str],
+        error_code: str | None,
+        metadata: Mapping[str, Any],
+    ) -> int:
+        owner_scope, profile_scope = _scope_values(scope)
+        requested_limits_json = _json_dump(dict(requested_limits or {}))
+        counts_json = _json_dump(dict(counts or {}))
+        warnings_json = json.dumps(warnings or [], sort_keys=True, separators=(",", ":"), default=str)
+        metadata_json = _json_dump(dict(metadata or {}))
+        with closing(self.connect()) as conn:
+            with conn:
+                self._assert_source_in_scope(conn, owner_scope, profile_scope, source_id)
+                cursor = conn.execute(
+                    """
+                    INSERT INTO docs_sync_runs (
+                        owner_scope,
+                        profile_scope,
+                        source_id,
+                        mode,
+                        status,
+                        completed_at,
+                        requested_limits_json,
+                        counts_json,
+                        warnings_json,
+                        error_code,
+                        metadata_json
+                    )
+                    VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        owner_scope,
+                        profile_scope,
+                        source_id,
+                        mode,
+                        status,
+                        requested_limits_json,
+                        counts_json,
+                        warnings_json,
+                        error_code,
+                        metadata_json,
+                    ),
+                )
+                sync_run_id = int(cursor.lastrowid)
+                run_row = conn.execute(
+                    """
+                    SELECT started_at, completed_at
+                    FROM docs_sync_runs
+                    WHERE id = ?
+                    """,
+                    (sync_run_id,),
+                ).fetchone()
+                conn.execute(
+                    """
+                    UPDATE docs_sources
+                    SET last_sync_status = ?,
+                        last_sync_started_at = ?,
+                        last_sync_completed_at = ?,
+                        last_error_code = ?,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = ?
+                      AND owner_scope = ?
+                      AND profile_scope = ?
+                    """,
+                    (
+                        status,
+                        run_row["started_at"],
+                        run_row["completed_at"],
+                        error_code,
+                        source_id,
+                        owner_scope,
+                        profile_scope,
+                    ),
+                )
+                return sync_run_id
+
+    def upsert_document_for_sync(
+        self,
+        *,
+        scope: AccessScope,
+        title: str,
+        document_type: str,
+        canonical_uri: str,
+        source_path: str | None,
+        source_url: str | None,
+        text: str,
+        sections: Sequence[Mapping[str, Any]],
+        chunks: Sequence[Mapping[str, Any]],
+        source_default_keywords: Iterable[str],
+        source_default_collections: Iterable[str],
+        metadata: Mapping[str, Any],
+    ) -> int:
+        owner_scope, profile_scope = _scope_values(scope)
+        metadata_map = dict(metadata or {})
+        metadata_json = _json_dump(metadata_map)
+        content_hash = sha256(text.encode("utf-8")).hexdigest()
+        package_name = _optional_text(metadata_map.get("package_name") or metadata_map.get("package"))
+        package_version = _optional_text(metadata_map.get("version") or metadata_map.get("package_version"))
+
+        with closing(self.connect()) as conn:
+            with conn:
+                existing_row = conn.execute(
+                    """
+                    SELECT id
+                    FROM docs_documents
+                    WHERE owner_scope = ? AND profile_scope = ? AND canonical_uri = ?
+                    """,
+                    (owner_scope, profile_scope, canonical_uri),
+                ).fetchone()
+                existing_document_id = int(existing_row["id"]) if existing_row is not None else None
+                existing_keywords = (
+                    self._keywords_for_document(conn, owner_scope, profile_scope, existing_document_id)
+                    if existing_document_id is not None
+                    else ()
+                )
+                existing_collections = (
+                    self._collections_for_document(conn, owner_scope, profile_scope, existing_document_id)
+                    if existing_document_id is not None
+                    else ()
+                )
+                merged_keywords = _normalized_names((*existing_keywords, *source_default_keywords))
+                merged_collections = _normalized_names((*existing_collections, *source_default_collections))
+
+                document_id = self._upsert_document_record(
+                    conn,
+                    owner_scope,
+                    profile_scope,
+                    title,
+                    document_type,
+                    canonical_uri,
+                    source_path,
+                    source_url,
+                    content_hash,
+                    text,
+                    metadata_json,
+                    package_name,
+                    package_version,
+                )
+                self._replace_document_rows(conn, document_id, title, sections, chunks)
+                self._replace_document_keywords(conn, owner_scope, profile_scope, document_id, merged_keywords)
+                self._replace_collection_memberships(
+                    conn,
+                    owner_scope,
+                    profile_scope,
+                    document_id,
+                    merged_collections,
                 )
                 return document_id
 
@@ -625,6 +953,71 @@ class DocsCatalogStore:
             return int(row["id"]) if row is not None else None
 
     @staticmethod
+    def _upsert_document_record(
+        conn: sqlite3.Connection,
+        owner_scope: str,
+        profile_scope: str,
+        title: str,
+        document_type: str,
+        canonical_uri: str,
+        source_path: str | None,
+        source_url: str | None,
+        content_hash: str,
+        text: str,
+        metadata_json: str,
+        package_name: str | None,
+        package_version: str | None,
+    ) -> int:
+        cursor = conn.execute(
+            """
+            INSERT INTO docs_documents (
+                owner_scope,
+                profile_scope,
+                title,
+                document_type,
+                canonical_uri,
+                source_path,
+                source_url,
+                content_hash,
+                text,
+                lifecycle_status,
+                metadata_json,
+                package_name,
+                package_version
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?)
+            ON CONFLICT(owner_scope, profile_scope, canonical_uri)
+            DO UPDATE SET title = excluded.title,
+                document_type = excluded.document_type,
+                source_path = excluded.source_path,
+                source_url = excluded.source_url,
+                content_hash = excluded.content_hash,
+                text = excluded.text,
+                lifecycle_status = 'active',
+                metadata_json = excluded.metadata_json,
+                package_name = excluded.package_name,
+                package_version = excluded.package_version,
+                updated_at = CURRENT_TIMESTAMP
+            RETURNING id
+            """,
+            (
+                owner_scope,
+                profile_scope,
+                title,
+                document_type,
+                canonical_uri,
+                source_path,
+                source_url,
+                content_hash,
+                text,
+                metadata_json,
+                package_name,
+                package_version,
+            ),
+        )
+        return int(cursor.fetchone()["id"])
+
+    @staticmethod
     def _ensure_collection(
         conn: sqlite3.Connection,
         owner_scope: str,
@@ -669,6 +1062,95 @@ class DocsCatalogStore:
                 message="Document not found in active scope.",
                 details={"document_id": document_id},
             )
+
+    @staticmethod
+    def _assert_source_in_scope(
+        conn: sqlite3.Connection,
+        owner_scope: str,
+        profile_scope: str,
+        source_id: int,
+    ) -> None:
+        row = conn.execute(
+            """
+            SELECT id
+            FROM docs_sources
+            WHERE owner_scope = ? AND profile_scope = ? AND id = ?
+            """,
+            (owner_scope, profile_scope, source_id),
+        ).fetchone()
+        if row is None:
+            raise DocsError(
+                code="source_not_found",
+                message="Source not found in active scope.",
+                details={"source_id": source_id},
+            )
+
+    @staticmethod
+    def _ensure_document_lifecycle_columns(conn: sqlite3.Connection) -> None:
+        rows = conn.execute("PRAGMA table_info(docs_documents)").fetchall()
+        columns = {row["name"] for row in rows}
+        if "lifecycle_status" not in columns:
+            conn.execute("ALTER TABLE docs_documents ADD COLUMN lifecycle_status TEXT NOT NULL DEFAULT 'active'")
+        if "preserve_on_source_tombstone" not in columns:
+            conn.execute(
+                "ALTER TABLE docs_documents ADD COLUMN preserve_on_source_tombstone INTEGER NOT NULL DEFAULT 0"
+            )
+
+    @staticmethod
+    def _ensure_source_tables(conn: sqlite3.Connection) -> None:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS docs_sources (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                owner_scope TEXT NOT NULL DEFAULT '',
+                profile_scope TEXT NOT NULL DEFAULT '',
+                source_type TEXT NOT NULL,
+                canonical_uri TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                source_path TEXT,
+                source_url TEXT,
+                redacted_source_url TEXT,
+                policy_profile TEXT,
+                sync_enabled INTEGER NOT NULL DEFAULT 1,
+                last_sync_status TEXT,
+                last_sync_started_at TEXT,
+                last_sync_completed_at TEXT,
+                last_error_code TEXT,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (owner_scope, profile_scope, canonical_uri)
+            );
+
+            CREATE TABLE IF NOT EXISTS docs_source_documents (
+                source_id INTEGER NOT NULL REFERENCES docs_sources(id) ON DELETE CASCADE,
+                document_id INTEGER NOT NULL REFERENCES docs_documents(id) ON DELETE CASCADE,
+                source_item_uri TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                last_seen_at TEXT,
+                last_hash TEXT,
+                last_error_code TEXT,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                PRIMARY KEY (source_id, source_item_uri)
+            );
+
+            CREATE TABLE IF NOT EXISTS docs_sync_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                owner_scope TEXT NOT NULL DEFAULT '',
+                profile_scope TEXT NOT NULL DEFAULT '',
+                source_id INTEGER NOT NULL REFERENCES docs_sources(id) ON DELETE CASCADE,
+                mode TEXT NOT NULL,
+                status TEXT NOT NULL,
+                started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                completed_at TEXT,
+                requested_limits_json TEXT NOT NULL DEFAULT '{}',
+                counts_json TEXT NOT NULL DEFAULT '{}',
+                warnings_json TEXT NOT NULL DEFAULT '[]',
+                error_code TEXT,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+            """
+        )
 
     @staticmethod
     def _backfill_scope_sentinels(conn: sqlite3.Connection) -> None:
@@ -977,6 +1459,48 @@ class DocsCatalogStore:
         ]
 
     @staticmethod
+    def _keywords_for_document(
+        conn: sqlite3.Connection,
+        owner_scope: str,
+        profile_scope: str,
+        document_id: int,
+    ) -> tuple[str, ...]:
+        rows = conn.execute(
+            """
+            SELECT kw.name
+            FROM docs_document_keywords dk
+            JOIN docs_keywords kw ON kw.id = dk.keyword_id
+            WHERE dk.document_id = ?
+              AND kw.owner_scope = ?
+              AND kw.profile_scope = ?
+            ORDER BY kw.name COLLATE NOCASE ASC
+            """,
+            (document_id, owner_scope, profile_scope),
+        ).fetchall()
+        return tuple(row["name"] for row in rows)
+
+    @staticmethod
+    def _collections_for_document(
+        conn: sqlite3.Connection,
+        owner_scope: str,
+        profile_scope: str,
+        document_id: int,
+    ) -> tuple[str, ...]:
+        rows = conn.execute(
+            """
+            SELECT col.name
+            FROM docs_collection_members cm
+            JOIN docs_collections col ON col.id = cm.collection_id
+            WHERE cm.document_id = ?
+              AND col.owner_scope = ?
+              AND col.profile_scope = ?
+            ORDER BY col.name COLLATE NOCASE ASC
+            """,
+            (document_id, owner_scope, profile_scope),
+        ).fetchall()
+        return tuple(row["name"] for row in rows)
+
+    @staticmethod
     def _chunks_for_document(conn: sqlite3.Connection, document_id: int) -> list[dict[str, Any]]:
         rows = conn.execute(
             """
@@ -1155,4 +1679,43 @@ def _document_from_row(row: sqlite3.Row) -> dict[str, Any]:
         "version": row["package_version"],
         "created_at": row["created_at"],
         "updated_at": row["updated_at"],
+    }
+
+
+def _source_from_row(row: sqlite3.Row) -> dict[str, Any]:
+    keys = set(row.keys())
+    return {
+        "id": int(row["id"]),
+        "source_type": row["source_type"],
+        "canonical_uri": row["canonical_uri"],
+        "display_name": row["display_name"],
+        "source_path": row["source_path"],
+        "source_url": row["source_url"],
+        "redacted_source_url": row["redacted_source_url"],
+        "policy_profile": row["policy_profile"],
+        "sync_enabled": bool(row["sync_enabled"]),
+        "last_sync_status": row["last_sync_status"],
+        "last_sync_started_at": row["last_sync_started_at"],
+        "last_sync_completed_at": row["last_sync_completed_at"],
+        "last_error_code": row["last_error_code"],
+        "document_count": int(row["document_count"] or 0) if "document_count" in keys else 0,
+        "metadata": _json_load(row["metadata_json"]),
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _source_document_link_from_row(row: sqlite3.Row) -> dict[str, Any]:
+    keys = set(row.keys())
+    return {
+        "source_id": int(row["source_id"]),
+        "document_id": int(row["document_id"]),
+        "source_item_uri": row["source_item_uri"],
+        "status": row["status"],
+        "last_seen_at": row["last_seen_at"],
+        "last_hash": row["last_hash"],
+        "last_error_code": row["last_error_code"],
+        "metadata": _json_load(row["metadata_json"]),
+        "title": row["title"] if "title" in keys else None,
+        "canonical_uri": row["canonical_uri"] if "canonical_uri" in keys else None,
     }

--- a/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
@@ -239,9 +239,12 @@ class DocsCatalogStore:
         owner_scope, profile_scope = _scope_values(scope)
         if source_id is not None:
             sql = """
-                SELECT s.*, COUNT(DISTINCT sd.document_id) AS document_count
+                SELECT s.*, COUNT(DISTINCT d.id) AS document_count
                 FROM docs_sources s
                 LEFT JOIN docs_source_documents sd ON sd.source_id = s.id
+                LEFT JOIN docs_documents d ON d.id = sd.document_id
+                    AND d.owner_scope = ?
+                    AND d.profile_scope = ?
                 WHERE s.owner_scope = ?
                   AND s.profile_scope = ?
                   AND s.id = ?
@@ -250,9 +253,12 @@ class DocsCatalogStore:
             selector_param: object = source_id
         else:
             sql = """
-                SELECT s.*, COUNT(DISTINCT sd.document_id) AS document_count
+                SELECT s.*, COUNT(DISTINCT d.id) AS document_count
                 FROM docs_sources s
                 LEFT JOIN docs_source_documents sd ON sd.source_id = s.id
+                LEFT JOIN docs_documents d ON d.id = sd.document_id
+                    AND d.owner_scope = ?
+                    AND d.profile_scope = ?
                 WHERE s.owner_scope = ?
                   AND s.profile_scope = ?
                   AND s.canonical_uri = ?
@@ -261,7 +267,10 @@ class DocsCatalogStore:
             selector_param = canonical_uri
 
         with closing(self.connect()) as conn:
-            row = conn.execute(sql, (owner_scope, profile_scope, selector_param)).fetchone()
+            row = conn.execute(
+                sql,
+                (owner_scope, profile_scope, owner_scope, profile_scope, selector_param),
+            ).fetchone()
         return _source_from_row(row) if row is not None else None
 
     def list_sources(self, *, scope: AccessScope, limit: int = 50, offset: int = 0) -> list[dict[str, Any]]:
@@ -269,15 +278,20 @@ class DocsCatalogStore:
         with closing(self.connect()) as conn:
             rows = conn.execute(
                 """
-                SELECT s.*, COUNT(DISTINCT sd.document_id) AS document_count
+                SELECT s.*, COUNT(DISTINCT d.id) AS document_count
                 FROM docs_sources s
                 LEFT JOIN docs_source_documents sd ON sd.source_id = s.id
+                LEFT JOIN docs_documents d ON d.id = sd.document_id
+                    AND d.owner_scope = ?
+                    AND d.profile_scope = ?
                 WHERE s.owner_scope = ? AND s.profile_scope = ?
                 GROUP BY s.id
                 ORDER BY s.display_name COLLATE NOCASE ASC, s.id ASC
                 LIMIT ? OFFSET ?
                 """,
                 (
+                    owner_scope,
+                    profile_scope,
                     owner_scope,
                     profile_scope,
                     _bounded_non_negative(limit, default=50),
@@ -1122,6 +1136,9 @@ class DocsCatalogStore:
                 UNIQUE (owner_scope, profile_scope, canonical_uri)
             );
 
+            CREATE INDEX IF NOT EXISTS docs_sources_scope_display_idx
+                ON docs_sources (owner_scope, profile_scope, display_name);
+
             CREATE TABLE IF NOT EXISTS docs_source_documents (
                 source_id INTEGER NOT NULL REFERENCES docs_sources(id) ON DELETE CASCADE,
                 document_id INTEGER NOT NULL REFERENCES docs_documents(id) ON DELETE CASCADE,
@@ -1133,6 +1150,9 @@ class DocsCatalogStore:
                 metadata_json TEXT NOT NULL DEFAULT '{}',
                 PRIMARY KEY (source_id, source_item_uri)
             );
+
+            CREATE INDEX IF NOT EXISTS docs_source_documents_document_idx
+                ON docs_source_documents (document_id);
 
             CREATE TABLE IF NOT EXISTS docs_sync_runs (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1149,6 +1169,9 @@ class DocsCatalogStore:
                 error_code TEXT,
                 metadata_json TEXT NOT NULL DEFAULT '{}'
             );
+
+            CREATE INDEX IF NOT EXISTS docs_sync_runs_source_started_idx
+                ON docs_sync_runs (source_id, started_at DESC);
             """
         )
 

--- a/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
@@ -228,6 +228,52 @@ class DocsCatalogStore:
                 )
                 return int(cursor.fetchone()["id"])
 
+    def retarget_source(
+        self,
+        *,
+        scope: AccessScope,
+        source_id: int,
+        canonical_uri: str,
+        display_name: str,
+        source_url: str | None,
+        redacted_source_url: str | None,
+    ) -> bool:
+        owner_scope, profile_scope = _scope_values(scope)
+        normalized_canonical_uri = _required_name(canonical_uri, "canonical URI")
+        normalized_display_name = _required_name(display_name, "display name")
+        with closing(self.connect()) as conn:
+            with conn:
+                try:
+                    cursor = conn.execute(
+                        """
+                        UPDATE docs_sources
+                        SET canonical_uri = ?,
+                            display_name = ?,
+                            source_url = ?,
+                            redacted_source_url = ?,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = ?
+                          AND owner_scope = ?
+                          AND profile_scope = ?
+                        """,
+                        (
+                            normalized_canonical_uri,
+                            normalized_display_name,
+                            source_url,
+                            redacted_source_url,
+                            source_id,
+                            owner_scope,
+                            profile_scope,
+                        ),
+                    )
+                except sqlite3.IntegrityError as exc:
+                    raise DocsError(
+                        code="source_canonical_uri_conflict",
+                        message="Source canonical URI conflicts with an existing source.",
+                        details={"source_id": source_id, "canonical_uri": normalized_canonical_uri},
+                    ) from exc
+                return cursor.rowcount > 0
+
     def get_source(
         self,
         *,
@@ -244,9 +290,11 @@ class DocsCatalogStore:
                 SELECT s.*, COUNT(DISTINCT d.id) AS document_count
                 FROM docs_sources s
                 LEFT JOIN docs_source_documents sd ON sd.source_id = s.id
+                    AND sd.status = 'active'
                 LEFT JOIN docs_documents d ON d.id = sd.document_id
                     AND d.owner_scope = ?
                     AND d.profile_scope = ?
+                    AND d.lifecycle_status = 'active'
                 WHERE s.owner_scope = ?
                   AND s.profile_scope = ?
                   AND s.id = ?
@@ -258,9 +306,11 @@ class DocsCatalogStore:
                 SELECT s.*, COUNT(DISTINCT d.id) AS document_count
                 FROM docs_sources s
                 LEFT JOIN docs_source_documents sd ON sd.source_id = s.id
+                    AND sd.status = 'active'
                 LEFT JOIN docs_documents d ON d.id = sd.document_id
                     AND d.owner_scope = ?
                     AND d.profile_scope = ?
+                    AND d.lifecycle_status = 'active'
                 WHERE s.owner_scope = ?
                   AND s.profile_scope = ?
                   AND s.canonical_uri = ?
@@ -283,9 +333,11 @@ class DocsCatalogStore:
                 SELECT s.*, COUNT(DISTINCT d.id) AS document_count
                 FROM docs_sources s
                 LEFT JOIN docs_source_documents sd ON sd.source_id = s.id
+                    AND sd.status = 'active'
                 LEFT JOIN docs_documents d ON d.id = sd.document_id
                     AND d.owner_scope = ?
                     AND d.profile_scope = ?
+                    AND d.lifecycle_status = 'active'
                 WHERE s.owner_scope = ? AND s.profile_scope = ?
                 GROUP BY s.id
                 ORDER BY s.display_name COLLATE NOCASE ASC, s.id ASC

--- a/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
@@ -779,6 +779,7 @@ class DocsCatalogStore:
                 SELECT *
                 FROM docs_documents
                 WHERE id = ? AND owner_scope = ? AND profile_scope = ?
+                  AND lifecycle_status = 'active'
                 """,
                 (document_id, owner_scope, profile_scope),
             ).fetchone()
@@ -835,9 +836,13 @@ class DocsCatalogStore:
         with closing(self.connect()) as conn:
             rows = conn.execute(
                 """
-                SELECT col.id, col.name, col.description, COUNT(cm.document_id) AS document_count
+                SELECT col.id, col.name, col.description, COUNT(d.id) AS document_count
                 FROM docs_collections col
                 LEFT JOIN docs_collection_members cm ON cm.collection_id = col.id
+                LEFT JOIN docs_documents d ON d.id = cm.document_id
+                    AND d.owner_scope = col.owner_scope
+                    AND d.profile_scope = col.profile_scope
+                    AND d.lifecycle_status = 'active'
                 WHERE col.owner_scope = ? AND col.profile_scope = ?
                 GROUP BY col.id, col.name, col.description
                 ORDER BY col.name COLLATE NOCASE ASC
@@ -859,9 +864,13 @@ class DocsCatalogStore:
         with closing(self.connect()) as conn:
             rows = conn.execute(
                 """
-                SELECT kw.id, kw.name, COUNT(dk.document_id) AS document_count
+                SELECT kw.id, kw.name, COUNT(d.id) AS document_count
                 FROM docs_keywords kw
                 LEFT JOIN docs_document_keywords dk ON dk.keyword_id = kw.id
+                LEFT JOIN docs_documents d ON d.id = dk.document_id
+                    AND d.owner_scope = kw.owner_scope
+                    AND d.profile_scope = kw.profile_scope
+                    AND d.lifecycle_status = 'active'
                 WHERE kw.owner_scope = ? AND kw.profile_scope = ?
                 GROUP BY kw.id, kw.name
                 ORDER BY kw.name COLLATE NOCASE ASC
@@ -892,6 +901,7 @@ class DocsCatalogStore:
                 FROM docs_documents
                 WHERE owner_scope = ?
                   AND profile_scope = ?
+                  AND lifecycle_status = 'active'
                   AND (title = ? OR title LIKE ? ESCAPE '\\')
                 ORDER BY
                     CASE WHEN title = ? THEN 0 ELSE 1 END,
@@ -902,9 +912,13 @@ class DocsCatalogStore:
             ).fetchall()
             collection_rows = conn.execute(
                 """
-                SELECT col.name, col.description, COUNT(cm.document_id) AS document_count
+                SELECT col.name, col.description, COUNT(d.id) AS document_count
                 FROM docs_collections col
                 LEFT JOIN docs_collection_members cm ON cm.collection_id = col.id
+                LEFT JOIN docs_documents d ON d.id = cm.document_id
+                    AND d.owner_scope = col.owner_scope
+                    AND d.profile_scope = col.profile_scope
+                    AND d.lifecycle_status = 'active'
                 WHERE col.owner_scope = ?
                   AND col.profile_scope = ?
                   AND (col.name = ? OR col.name LIKE ? ESCAPE '\\')
@@ -1067,6 +1081,7 @@ class DocsCatalogStore:
                     SELECT id
                     FROM docs_documents
                     WHERE id = ? AND owner_scope = ? AND profile_scope = ?
+                      AND lifecycle_status = 'active'
                     """,
                     (int(normalized), owner_scope, profile_scope),
                 ).fetchone()
@@ -1075,9 +1090,13 @@ class DocsCatalogStore:
 
             row = conn.execute(
                 """
-                SELECT document_id
-                FROM docs_aliases
-                WHERE owner_scope = ? AND profile_scope = ? AND name = ?
+                SELECT a.document_id
+                FROM docs_aliases a
+                JOIN docs_documents d ON d.id = a.document_id
+                    AND d.owner_scope = a.owner_scope
+                    AND d.profile_scope = a.profile_scope
+                    AND d.lifecycle_status = 'active'
+                WHERE a.owner_scope = ? AND a.profile_scope = ? AND a.name = ?
                 """,
                 (owner_scope, profile_scope, normalized),
             ).fetchone()
@@ -1090,6 +1109,7 @@ class DocsCatalogStore:
                 FROM docs_documents
                 WHERE owner_scope = ?
                   AND profile_scope = ?
+                  AND lifecycle_status = 'active'
                   AND (
                       canonical_uri = ?
                       OR source_path = ?

--- a/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
@@ -26,6 +26,7 @@ _COUNT_SQL = {
     "docs_chunks": "SELECT COUNT(*) AS count FROM docs_chunks",
     "docs_collections": "SELECT COUNT(*) AS count FROM docs_collections",
     "docs_keywords": "SELECT COUNT(*) AS count FROM docs_keywords",
+    "docs_sync_runs": "SELECT COUNT(*) AS count FROM docs_sync_runs",
 }
 _SCOPE_TABLE_INFO_SQL = {
     "docs_documents": "PRAGMA table_info(docs_documents)",
@@ -106,6 +107,7 @@ class DocsCatalogStore:
                     "chunks": self._count(conn, "docs_chunks"),
                     "collections": self._count(conn, "docs_collections"),
                     "keywords": self._count(conn, "docs_keywords"),
+                    "sync_runs": self._count(conn, "docs_sync_runs"),
                 },
             }
 
@@ -349,6 +351,19 @@ class DocsCatalogStore:
                         metadata_json,
                     ),
                 )
+                if normalized_status == "active":
+                    conn.execute(
+                        """
+                        UPDATE docs_documents
+                        SET lifecycle_status = 'active',
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = ?
+                          AND owner_scope = ?
+                          AND profile_scope = ?
+                          AND lifecycle_status != 'active'
+                        """,
+                        (document_id, owner_scope, profile_scope),
+                    )
 
     def source_document_links(self, *, scope: AccessScope, source_id: int) -> list[dict[str, Any]]:
         owner_scope, profile_scope = _scope_values(scope)
@@ -367,6 +382,73 @@ class DocsCatalogStore:
                 (source_id, owner_scope, profile_scope),
             ).fetchall()
         return [_source_document_link_from_row(row) for row in rows]
+
+    def tombstone_source_item(
+        self,
+        *,
+        scope: AccessScope,
+        source_id: int,
+        source_item_uri: str,
+    ) -> bool:
+        owner_scope, profile_scope = _scope_values(scope)
+        normalized_item_uri = _required_name(source_item_uri, "source item URI")
+        with closing(self.connect()) as conn:
+            with conn:
+                self._assert_source_in_scope(conn, owner_scope, profile_scope, source_id)
+                row = conn.execute(
+                    """
+                    SELECT sd.document_id, d.preserve_on_source_tombstone
+                    FROM docs_source_documents sd
+                    JOIN docs_documents d ON d.id = sd.document_id
+                    WHERE sd.source_id = ?
+                      AND sd.source_item_uri = ?
+                      AND d.owner_scope = ?
+                      AND d.profile_scope = ?
+                    """,
+                    (source_id, normalized_item_uri, owner_scope, profile_scope),
+                ).fetchone()
+                if row is None:
+                    return False
+
+                document_id = int(row["document_id"])
+                conn.execute(
+                    """
+                    UPDATE docs_source_documents
+                    SET status = 'tombstoned',
+                        last_seen_at = CURRENT_TIMESTAMP,
+                        last_error_code = NULL
+                    WHERE source_id = ?
+                      AND source_item_uri = ?
+                    """,
+                    (source_id, normalized_item_uri),
+                )
+                active_link_row = conn.execute(
+                    """
+                    SELECT COUNT(*) AS count
+                    FROM docs_source_documents sd
+                    JOIN docs_sources s ON s.id = sd.source_id
+                    WHERE sd.document_id = ?
+                      AND s.owner_scope = ?
+                      AND s.profile_scope = ?
+                      AND sd.status != 'tombstoned'
+                    """,
+                    (document_id, owner_scope, profile_scope),
+                ).fetchone()
+                has_non_tombstoned_links = int(active_link_row["count"] or 0) > 0
+                should_preserve = bool(row["preserve_on_source_tombstone"])
+                if not has_non_tombstoned_links and not should_preserve:
+                    conn.execute(
+                        """
+                        UPDATE docs_documents
+                        SET lifecycle_status = 'tombstoned',
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = ?
+                          AND owner_scope = ?
+                          AND profile_scope = ?
+                        """,
+                        (document_id, owner_scope, profile_scope),
+                    )
+                return True
 
     def record_sync_run(
         self,
@@ -567,6 +649,7 @@ class DocsCatalogStore:
             WHERE docs_chunks_fts MATCH ?
               AND d.owner_scope = ?
               AND d.profile_scope = ?
+              AND d.lifecycle_status = 'active'
                 """,
                 where_sql,
                 """
@@ -619,6 +702,7 @@ class DocsCatalogStore:
             WHERE docs_chunks_fts MATCH ?
               AND d.owner_scope = ?
               AND d.profile_scope = ?
+              AND d.lifecycle_status = 'active'
                 """,
                 where_sql,
             )
@@ -681,6 +765,7 @@ class DocsCatalogStore:
                 SELECT *
                 FROM docs_documents
                 WHERE owner_scope = ? AND profile_scope = ?
+                  AND lifecycle_status = 'active'
                 ORDER BY title COLLATE NOCASE ASC, id ASC
                 LIMIT ? OFFSET ?
                 """,

--- a/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/store/sqlite.py
@@ -1,3 +1,5 @@
+"""SQLite storage for the standalone MCP documentation catalog."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
@@ -6,7 +8,6 @@ from hashlib import sha256
 from importlib import resources
 import json
 from pathlib import Path
-import re
 import sqlite3
 from typing import Any
 
@@ -39,7 +40,6 @@ _SCOPE_TABLE_INFO_SQL = {
 _INDEX_LIST_SQL = {
     "docs_documents": "PRAGMA index_list(docs_documents)",
 }
-_SAFE_SQLITE_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 _SCOPE_BACKFILL_SQL = {
     "docs_documents": (
         "UPDATE docs_documents SET owner_scope = ? WHERE owner_scope IS NULL",
@@ -75,6 +75,7 @@ class DocsCatalogStore:
         self.db_path = Path(db_path)
 
     def connect(self) -> sqlite3.Connection:
+        """Open a configured SQLite connection for catalog operations."""
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(self.db_path, timeout=_SQLITE_BUSY_TIMEOUT_SECONDS)
         conn.row_factory = sqlite3.Row
@@ -1797,12 +1798,8 @@ def _table_has_unique_index(conn: sqlite3.Connection, table_name: str, columns: 
         if not bool(index["unique"]):
             continue
         index_name = str(index["name"])
-        if not _SAFE_SQLITE_IDENTIFIER_RE.fullmatch(index_name):
-            continue
         try:
-            # lgtm[py/sql-injection]: index_name comes from SQLite metadata and is
-            # validated against a simple identifier allowlist before interpolation.
-            indexed_columns = conn.execute(f'PRAGMA index_info("{index_name}")').fetchall()
+            indexed_columns = conn.execute("SELECT name FROM pragma_index_info(?)", (index_name,)).fetchall()
         except sqlite3.Error:
             continue
         if tuple(row["name"] for row in indexed_columns) == columns:

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .models import AccessScope, SyncSourceRequest
+from .settings import DocsSettings
+from .store.sqlite import DocsCatalogStore
+
+_SYNC_MODES = {"dry_run", "apply"}
+_STALE_POLICIES = {"report", "tombstone"}
+_ZERO_COUNTS = {"created": 0, "updated": 0, "unchanged": 0, "failed": 0, "skipped": 0}
+
+
+class DocsSourceSyncService:
+    def __init__(
+        self,
+        *,
+        settings: DocsSettings,
+        store: DocsCatalogStore,
+        resolver: object | None = None,
+        transport: object | None = None,
+    ) -> None:
+        self.settings = settings
+        self.store = store
+        self.resolver = resolver
+        self.transport = transport
+
+    def sync_source(self, *, scope: AccessScope, request: SyncSourceRequest) -> dict[str, Any]:
+        if not self.settings.enable_source_sync:
+            return {"status": "denied", "reason_code": "source_sync_disabled"}
+
+        validation = _validate_request(request)
+        if validation is not None:
+            return validation
+
+        source = self._get_source(scope=scope, request=request)
+        if source is None:
+            return {"status": "denied", "reason_code": "source_not_found"}
+        if not source["sync_enabled"]:
+            return _response(
+                status="denied",
+                reason_code="source_sync_disabled",
+                source=source,
+                request=request,
+            )
+        if source["source_type"] == "url_sitemap" and not self.settings.sitemap_sync_enabled:
+            return _response(
+                status="denied",
+                reason_code="sitemap_sync_disabled",
+                source=source,
+                request=request,
+            )
+
+        return _response(
+            status="skipped",
+            reason_code="source_sync_unsupported_type",
+            source=source,
+            request=request,
+        )
+
+    def _get_source(self, *, scope: AccessScope, request: SyncSourceRequest) -> dict[str, Any] | None:
+        if request.source_id is not None:
+            return self.store.get_source(scope=scope, source_id=int(request.source_id))
+        return self.store.get_source(scope=scope, canonical_uri=str(request.source_uri or "").strip())
+
+
+def _validate_request(request: SyncSourceRequest) -> dict[str, Any] | None:
+    has_id = request.source_id is not None
+    has_uri = bool(str(request.source_uri or "").strip())
+    if has_id == has_uri:
+        return {"status": "denied", "reason_code": "source_selector_invalid"}
+
+    if str(request.mode) not in _SYNC_MODES:
+        return {"status": "denied", "reason_code": "source_sync_request_invalid", "field": "mode"}
+    if str(request.stale_policy) not in _STALE_POLICIES:
+        return {"status": "denied", "reason_code": "source_sync_request_invalid", "field": "stale_policy"}
+
+    return None
+
+
+def _response(
+    *,
+    status: str,
+    reason_code: str,
+    source: dict[str, Any],
+    request: SyncSourceRequest,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "reason_code": reason_code,
+        "source": _source_summary(source),
+        "mode": str(request.mode),
+        "stale_policy": str(request.stale_policy),
+        "counts": dict(_ZERO_COUNTS),
+        "warnings": [],
+    }
+
+
+def _source_summary(source: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": source["id"],
+        "source_type": source["source_type"],
+        "canonical_uri": source["canonical_uri"],
+        "display_name": source["display_name"],
+        "sync_enabled": source["sync_enabled"],
+        "document_count": source["document_count"],
+    }

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -290,11 +290,153 @@ class DocsSourceSyncService:
         source: dict[str, Any],
         request: SyncSourceRequest,
     ) -> dict[str, Any]:
-        return _response(
-            status="skipped",
-            reason_code="source_sync_unsupported_type",
+        if not self.settings.enable_web_acquisition:
+            return _response(
+                status="denied",
+                reason_code="web_acquisition_disabled",
+                source=source,
+                request=request,
+            )
+
+        source_url = str(source.get("source_url") or "").strip()
+        if not source_url:
+            return self._failed(
+                source=source,
+                request=request,
+                reason_code="source_url_missing",
+                warning="URL source does not include a source URL.",
+            )
+
+        decision = self.acquisition.policy.evaluate(source_url)
+        if decision.status != "allowed":
+            reason_code = "approval_required" if decision.status == "approval_required" else "source_policy_denied"
+            return _response(
+                status="denied",
+                reason_code=reason_code,
+                source=source,
+                request=request,
+            )
+
+        limit = self._document_limit(request)
+        if limit < 1:
+            return _sync_response(
+                status="denied",
+                reason_code="source_sync_limit_exceeded",
+                source=source,
+                request=request,
+                counts=dict(_ZERO_COUNTS),
+                items=[],
+                warnings=[f"sync_item_count=1 exceeds max_documents={limit}"],
+            )
+
+        fetched_document = self.acquisition._fetch_parsed_url(url=source_url)
+        if fetched_document["status"] != "fetched":
+            reason_code = str(fetched_document.get("reason_code") or "fetch_failed")
+            if fetched_document["status"] == "approval_required":
+                return _response(
+                    status="denied",
+                    reason_code="approval_required",
+                    source=source,
+                    request=request,
+                )
+            if fetched_document["status"] == "denied":
+                return _response(
+                    status="denied",
+                    reason_code=reason_code,
+                    source=source,
+                    request=request,
+                )
+            return self._failed(source=source, request=request, reason_code=reason_code, warning=reason_code)
+
+        mode = str(request.mode).strip().lower()
+        source_id = int(source["id"])
+        parsed = fetched_document["parsed"]
+        fetched = fetched_document["fetch"]
+        chunks, content_hash = self._parsed_url_sync_item(parsed)
+        links = self.store.source_document_links(scope=scope, source_id=source_id)
+        link = _url_page_link(links=links, source_url=source_url, parsed_uri=parsed.canonical_uri)
+        item_status = self._local_item_status(
+            scope=scope,
+            parsed=parsed,
+            link=link,
+            content_hash=content_hash,
+            force=request.force,
+        )
+        counts = dict(_ZERO_COUNTS)
+        counts[item_status] = 1
+        default_keywords = _metadata_string_tuple(source.get("metadata"), "default_keywords")
+        default_collections = _metadata_string_tuple(source.get("metadata"), "default_collections")
+        document_id = int(link["document_id"]) if link is not None else None
+
+        if mode == "apply":
+            if item_status in {"created", "updated"}:
+                document_id = self.store.upsert_document_for_sync(
+                    scope=scope,
+                    title=parsed.title,
+                    document_type=parsed.document_type,
+                    canonical_uri=parsed.canonical_uri,
+                    source_path=parsed.source_path,
+                    source_url=parsed.source_url,
+                    text=parsed.text,
+                    sections=[asdict(section) for section in parsed.sections],
+                    chunks=chunks,
+                    source_default_keywords=default_keywords,
+                    source_default_collections=default_collections,
+                    metadata=_url_sync_metadata(parsed=parsed, fetched=fetched),
+                )
+                self.store.link_source_document(
+                    scope=scope,
+                    source_id=source_id,
+                    document_id=document_id,
+                    source_item_uri=parsed.canonical_uri,
+                    status="active",
+                    last_hash=content_hash,
+                    metadata={"importer": "url"},
+                )
+            elif link is not None and link.get("last_hash") != content_hash:
+                self.store.link_source_document(
+                    scope=scope,
+                    source_id=source_id,
+                    document_id=int(link["document_id"]),
+                    source_item_uri=str(link["source_item_uri"]),
+                    status="active",
+                    last_hash=content_hash,
+                    metadata=link.get("metadata") or {"importer": "url"},
+                )
+
+            self.store.record_sync_run(
+                scope=scope,
+                source_id=source_id,
+                mode=mode,
+                status="completed",
+                requested_limits={
+                    "max_documents": request.max_documents,
+                    "max_pages": request.max_pages,
+                    "effective_max_documents": self._document_limit(request),
+                },
+                counts=counts,
+                warnings=list(parsed.warnings),
+                error_code=None,
+                metadata={"source_type": source["source_type"]},
+            )
+            source = self.store.get_source(scope=scope, source_id=source_id) or source
+
+        return _sync_response(
+            status="completed",
+            reason_code="ok",
             source=source,
             request=request,
+            counts=counts,
+            items=[
+                {
+                    "source_item_uri": redacted_url_for_display(parsed.canonical_uri),
+                    "status": item_status,
+                    "document_id": document_id,
+                    "canonical_uri": redacted_url_for_display(parsed.canonical_uri),
+                    "title": parsed.title,
+                }
+            ],
+            warnings=list(parsed.warnings),
         )
 
     def _denied(self, *, source: dict[str, Any], request: SyncSourceRequest, reason_code: str) -> dict[str, Any]:
@@ -350,6 +492,17 @@ class DocsSourceSyncService:
         ]
         content_hash = sha256(parsed.text.encode("utf-8")).hexdigest()
         return parsed, chunks, content_hash
+
+    def _parsed_url_sync_item(self, parsed: ParsedDocument) -> tuple[list[dict[str, str]], str]:
+        chunks = [
+            {
+                "text": chunk,
+                "citation": f"{parsed.source_url or parsed.canonical_uri}#{idx + 1}",
+            }
+            for idx, chunk in enumerate(chunks_from_text(parsed.text))
+        ]
+        content_hash = sha256(parsed.text.encode("utf-8")).hexdigest()
+        return chunks, content_hash
 
     def _local_item_status(
         self,
@@ -503,9 +656,37 @@ def _existing_content_hash(store: DocsCatalogStore, scope: AccessScope, canonica
     return str(value) if value else None
 
 
+def _url_page_link(
+    *,
+    links: list[dict[str, Any]],
+    source_url: str,
+    parsed_uri: str,
+) -> dict[str, Any] | None:
+    for link in links:
+        if str(link.get("source_item_uri") or "") == parsed_uri:
+            return link
+    for link in links:
+        if str(link.get("source_item_uri") or "") == source_url:
+            return link
+    active_links = [link for link in links if link.get("status") == "active"]
+    if len(active_links) == 1:
+        return active_links[0]
+    return None
+
+
 def _local_sync_metadata(parsed: ParsedDocument) -> dict[str, Any]:
     return {
         "importer": "local",
         "extraction_method": parsed.extraction_method,
+        "warnings": list(parsed.warnings),
+    }
+
+
+def _url_sync_metadata(*, parsed: ParsedDocument, fetched: Any) -> dict[str, Any]:
+    return {
+        "importer": "url",
+        "extraction_method": parsed.extraction_method,
+        "fetch_status_code": fetched.status_code,
+        "redirect_count": len(fetched.redirects),
         "warnings": list(parsed.warnings),
     }

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -355,12 +355,17 @@ class DocsSourceSyncService:
         chunks, content_hash = self._parsed_url_sync_item(parsed)
         links = self.store.source_document_links(scope=scope, source_id=source_id)
         link = _url_page_link(links=links, source_url=source_url, parsed_uri=parsed.canonical_uri)
-        item_status = self._local_item_status(
-            scope=scope,
-            parsed=parsed,
-            link=link,
-            content_hash=content_hash,
-            force=request.force,
+        stale_active_links = _stale_url_page_links(links=links, parsed_uri=parsed.canonical_uri)
+        item_status = (
+            "updated"
+            if stale_active_links
+            else self._local_item_status(
+                scope=scope,
+                parsed=parsed,
+                link=link,
+                content_hash=content_hash,
+                force=request.force,
+            )
         )
         counts = dict(_ZERO_COUNTS)
         counts[item_status] = 1
@@ -393,6 +398,12 @@ class DocsSourceSyncService:
                     last_hash=content_hash,
                     metadata={"importer": "url"},
                 )
+                for stale_link in stale_active_links:
+                    self.store.tombstone_source_item(
+                        scope=scope,
+                        source_id=source_id,
+                        source_item_uri=str(stale_link["source_item_uri"]),
+                    )
             elif link is not None and link.get("last_hash") != content_hash:
                 self.store.link_source_document(
                     scope=scope,
@@ -672,6 +683,14 @@ def _url_page_link(
     if len(active_links) == 1:
         return active_links[0]
     return None
+
+
+def _stale_url_page_links(*, links: list[dict[str, Any]], parsed_uri: str) -> list[dict[str, Any]]:
+    return [
+        link
+        for link in links
+        if link.get("status") == "active" and str(link.get("source_item_uri") or "") != parsed_uri
+    ]
 
 
 def _local_sync_metadata(parsed: ParsedDocument) -> dict[str, Any]:

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -12,7 +12,7 @@ from .importers.base import ParsedDocument, chunks_from_text
 from .importers.local import DocsImportService
 from .models import AccessScope, SyncSourceRequest
 from .settings import DocsSettings
-from .source_utils import file_uri_for_path, redacted_url_for_display
+from .source_utils import file_uri_for_path, redacted_url_for_display, url_has_query
 from .store.sqlite import DocsCatalogStore
 
 _SYNC_MODES = {"dry_run", "apply"}
@@ -352,10 +352,13 @@ class DocsSourceSyncService:
         source_id = int(source["id"])
         parsed = fetched_document["parsed"]
         fetched = fetched_document["fetch"]
-        chunks, content_hash = self._parsed_url_sync_item(parsed)
+        can_persist_query_uri = self.settings.persist_url_query_strings or not url_has_query(parsed.canonical_uri)
+        sync_uri = parsed.canonical_uri if can_persist_query_uri else redacted_url_for_display(parsed.canonical_uri)
+        document_source_url = parsed.source_url if can_persist_query_uri else None
+        chunks, content_hash = self._parsed_url_sync_item(parsed, citation_base=sync_uri)
         links = self.store.source_document_links(scope=scope, source_id=source_id)
-        link = _url_page_link(links=links, source_url=source_url, parsed_uri=parsed.canonical_uri)
-        stale_active_links = _stale_url_page_links(links=links, parsed_uri=parsed.canonical_uri)
+        link = _url_page_link(links=links, source_url=source_url, parsed_uri=sync_uri)
+        stale_active_links = _stale_url_page_links(links=links, parsed_uri=sync_uri)
         item_status = (
             "updated"
             if stale_active_links
@@ -374,15 +377,15 @@ class DocsSourceSyncService:
         document_id = int(link["document_id"]) if link is not None else None
 
         if mode == "apply":
-            if _url_source_needs_retarget(source=source, parsed_uri=parsed.canonical_uri):
+            if _url_source_needs_retarget(source=source, parsed_uri=sync_uri):
                 try:
                     retargeted = self.store.retarget_source(
                         scope=scope,
                         source_id=source_id,
-                        canonical_uri=parsed.canonical_uri,
+                        canonical_uri=sync_uri,
                         display_name=parsed.title,
-                        source_url=parsed.canonical_uri,
-                        redacted_source_url=redacted_url_for_display(parsed.canonical_uri),
+                        source_url=sync_uri,
+                        redacted_source_url=redacted_url_for_display(sync_uri),
                     )
                 except DocsError as exc:
                     return self._failed(
@@ -405,9 +408,9 @@ class DocsSourceSyncService:
                     scope=scope,
                     title=parsed.title,
                     document_type=parsed.document_type,
-                    canonical_uri=parsed.canonical_uri,
+                    canonical_uri=sync_uri,
                     source_path=parsed.source_path,
-                    source_url=parsed.source_url,
+                    source_url=document_source_url,
                     text=parsed.text,
                     sections=[asdict(section) for section in parsed.sections],
                     chunks=chunks,
@@ -419,7 +422,7 @@ class DocsSourceSyncService:
                     scope=scope,
                     source_id=source_id,
                     document_id=document_id,
-                    source_item_uri=parsed.canonical_uri,
+                    source_item_uri=sync_uri,
                     status="active",
                     last_hash=content_hash,
                     metadata={"importer": "url"},
@@ -530,11 +533,17 @@ class DocsSourceSyncService:
         content_hash = sha256(parsed.text.encode("utf-8")).hexdigest()
         return parsed, chunks, content_hash
 
-    def _parsed_url_sync_item(self, parsed: ParsedDocument) -> tuple[list[dict[str, str]], str]:
+    def _parsed_url_sync_item(
+        self,
+        parsed: ParsedDocument,
+        *,
+        citation_base: str | None = None,
+    ) -> tuple[list[dict[str, str]], str]:
+        base = citation_base or parsed.source_url or parsed.canonical_uri
         chunks = [
             {
                 "text": chunk,
-                "citation": f"{parsed.source_url or parsed.canonical_uri}#{idx + 1}",
+                "citation": f"{base}#{idx + 1}",
             }
             for idx, chunk in enumerate(chunks_from_text(parsed.text))
         ]

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -4,11 +4,21 @@ from typing import Any
 
 from .models import AccessScope, SyncSourceRequest
 from .settings import DocsSettings
+from .source_utils import redacted_url_for_display
 from .store.sqlite import DocsCatalogStore
 
 _SYNC_MODES = {"dry_run", "apply"}
 _STALE_POLICIES = {"report", "tombstone"}
-_ZERO_COUNTS = {"created": 0, "updated": 0, "unchanged": 0, "failed": 0, "skipped": 0}
+_URL_SOURCE_TYPES = {"url_page", "url_sitemap"}
+_ZERO_COUNTS = {
+    "created": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "missing": 0,
+    "tombstoned": 0,
+    "failed": 0,
+    "skipped": 0,
+}
 
 
 class DocsSourceSyncService:
@@ -70,10 +80,27 @@ def _validate_request(request: SyncSourceRequest) -> dict[str, Any] | None:
     if has_id == has_uri:
         return {"status": "denied", "reason_code": "source_selector_invalid"}
 
-    if str(request.mode) not in _SYNC_MODES:
+    if request.source_id is not None and (
+        isinstance(request.source_id, bool) or not isinstance(request.source_id, int) or request.source_id <= 0
+    ):
+        return {"status": "denied", "reason_code": "source_sync_request_invalid", "field": "source_id"}
+    if request.max_documents is not None and (
+        isinstance(request.max_documents, bool)
+        or not isinstance(request.max_documents, int)
+        or request.max_documents <= 0
+    ):
+        return {"status": "denied", "reason_code": "source_sync_request_invalid", "field": "max_documents"}
+    if request.max_pages is not None and (
+        isinstance(request.max_pages, bool) or not isinstance(request.max_pages, int) or request.max_pages <= 0
+    ):
+        return {"status": "denied", "reason_code": "source_sync_request_invalid", "field": "max_pages"}
+
+    if str(request.mode).strip().lower() not in _SYNC_MODES:
         return {"status": "denied", "reason_code": "source_sync_request_invalid", "field": "mode"}
-    if str(request.stale_policy) not in _STALE_POLICIES:
+    if str(request.stale_policy).strip().lower() not in _STALE_POLICIES:
         return {"status": "denied", "reason_code": "source_sync_request_invalid", "field": "stale_policy"}
+    if not isinstance(request.force, bool):
+        return {"status": "denied", "reason_code": "source_sync_request_invalid", "field": "force"}
 
     return None
 
@@ -89,19 +116,44 @@ def _response(
         "status": status,
         "reason_code": reason_code,
         "source": _source_summary(source),
-        "mode": str(request.mode),
-        "stale_policy": str(request.stale_policy),
+        "mode": str(request.mode).strip().lower(),
+        "stale_policy": str(request.stale_policy).strip().lower(),
+        "force": request.force,
         "counts": dict(_ZERO_COUNTS),
         "warnings": [],
     }
 
 
 def _source_summary(source: dict[str, Any]) -> dict[str, Any]:
+    public_source = source_summary_for_tool_response(source)
     return {
-        "id": source["id"],
-        "source_type": source["source_type"],
-        "canonical_uri": source["canonical_uri"],
-        "display_name": source["display_name"],
-        "sync_enabled": source["sync_enabled"],
-        "document_count": source["document_count"],
+        "id": public_source["id"],
+        "source_type": public_source["source_type"],
+        "canonical_uri": public_source["canonical_uri"],
+        "display_name": public_source["display_name"],
+        "display_uri": public_source.get("display_uri", public_source["canonical_uri"]),
+        "redacted_source_url": public_source.get("redacted_source_url"),
+        "sync_enabled": public_source["sync_enabled"],
+        "document_count": public_source["document_count"],
     }
+
+
+def source_summary_for_tool_response(source: dict[str, Any]) -> dict[str, Any]:
+    if source["source_type"] not in _URL_SOURCE_TYPES:
+        return dict(source)
+
+    redacted_uri = _redacted_source_uri(source)
+    public_source = dict(source)
+    public_source.pop("source_url", None)
+    public_source["canonical_uri"] = redacted_uri
+    public_source["display_uri"] = redacted_uri
+    public_source["redacted_source_url"] = redacted_uri
+    return public_source
+
+
+def _redacted_source_uri(source: dict[str, Any]) -> str:
+    redacted_uri = source.get("redacted_source_url")
+    if isinstance(redacted_uri, str) and redacted_uri.strip():
+        return redacted_uri.strip()
+    raw_uri = source.get("canonical_uri") or source.get("source_url") or ""
+    return redacted_url_for_display(str(raw_uri))

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -374,6 +374,32 @@ class DocsSourceSyncService:
         document_id = int(link["document_id"]) if link is not None else None
 
         if mode == "apply":
+            if _url_source_needs_retarget(source=source, parsed_uri=parsed.canonical_uri):
+                try:
+                    retargeted = self.store.retarget_source(
+                        scope=scope,
+                        source_id=source_id,
+                        canonical_uri=parsed.canonical_uri,
+                        display_name=parsed.title,
+                        source_url=parsed.canonical_uri,
+                        redacted_source_url=redacted_url_for_display(parsed.canonical_uri),
+                    )
+                except DocsError as exc:
+                    return self._failed(
+                        source=source,
+                        request=request,
+                        reason_code=exc.code,
+                        warning=exc.message,
+                    )
+                if not retargeted:
+                    return self._failed(
+                        source=source,
+                        request=request,
+                        reason_code="source_not_found",
+                        warning="Source not found while retargeting URL source.",
+                    )
+                source = self.store.get_source(scope=scope, source_id=source_id) or source
+
             if item_status in {"created", "updated"}:
                 document_id = self.store.upsert_document_for_sync(
                     scope=scope,
@@ -691,6 +717,10 @@ def _stale_url_page_links(*, links: list[dict[str, Any]], parsed_uri: str) -> li
         for link in links
         if link.get("status") == "active" and str(link.get("source_item_uri") or "") != parsed_uri
     ]
+
+
+def _url_source_needs_retarget(*, source: dict[str, Any], parsed_uri: str) -> bool:
+    return str(source.get("canonical_uri") or "") != parsed_uri or str(source.get("source_url") or "") != parsed_uri
 
 
 def _local_sync_metadata(parsed: ParsedDocument) -> dict[str, Any]:

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -12,7 +12,7 @@ from .importers.base import ParsedDocument, chunks_from_text
 from .importers.local import DocsImportService
 from .models import AccessScope, SyncSourceRequest
 from .settings import DocsSettings
-from .source_utils import file_uri_for_path, redacted_url_for_display, url_has_query
+from .source_utils import file_uri_for_path, path_from_file_uri, redacted_url_for_display, url_has_query
 from .store.sqlite import DocsCatalogStore
 
 _SYNC_MODES = {"dry_run", "apply"}
@@ -97,10 +97,19 @@ class DocsSourceSyncService:
         try:
             target = self._source_path(source)
             resolved = self.importer._assert_allowed_path(target)
+            if not resolved.is_file():
+                if _is_tombstone_stale_policy(request):
+                    return self._failed(
+                        source=source,
+                        request=request,
+                        reason_code="import_path_not_found",
+                        warning="Import path does not exist.",
+                    )
+                return self._sync_local_paths(scope=scope, source=source, request=request, files=[])
         except DocsError as exc:
             return self._failed(source=source, request=request, reason_code=exc.code, warning=exc.message)
 
-        files = [resolved] if resolved.is_file() else []
+        files = [resolved]
         return self._sync_local_paths(scope=scope, source=source, request=request, files=files)
 
     def _sync_local_directory(
@@ -113,7 +122,16 @@ class DocsSourceSyncService:
         try:
             target = self._source_path(source)
             resolved = self.importer._assert_allowed_path(target)
-            files = self.importer._iter_import_files(resolved) if resolved.is_dir() else []
+            if not resolved.is_dir():
+                if _is_tombstone_stale_policy(request):
+                    return self._failed(
+                        source=source,
+                        request=request,
+                        reason_code="import_path_not_found",
+                        warning="Import path does not exist.",
+                    )
+                return self._sync_local_paths(scope=scope, source=source, request=request, files=[])
+            files = self.importer._iter_import_files(resolved)
         except DocsError as exc:
             return self._failed(source=source, request=request, reason_code=exc.code, warning=exc.message)
 
@@ -168,6 +186,19 @@ class DocsSourceSyncService:
                         "source_item_uri": item_uri,
                         "status": "failed",
                         "reason_code": exc.code,
+                    }
+                )
+                continue
+            except (OSError, UnicodeDecodeError) as exc:
+                reason = "read_failed" if isinstance(exc, OSError) else "decode_failed"
+                counts["failed"] += 1
+                warnings.append(reason)
+                items.append(
+                    {
+                        "source_item_uri": item_uri,
+                        "status": "failed",
+                        "reason_code": reason,
+                        "message": str(exc),
                     }
                 )
                 continue
@@ -508,7 +539,14 @@ class DocsSourceSyncService:
             return Path(str(source_path))
         canonical_uri = str(source.get("canonical_uri") or "")
         if canonical_uri.startswith("file://"):
-            return Path(canonical_uri.removeprefix("file://"))
+            try:
+                return path_from_file_uri(canonical_uri)
+            except ValueError as exc:
+                raise DocsError(
+                    code="source_path_invalid",
+                    message="Local source canonical URI is not a local file URI.",
+                    details={"source_id": source.get("id"), "canonical_uri": canonical_uri},
+                ) from exc
         raise DocsError(
             code="source_path_missing",
             message="Local source does not include a source path.",
@@ -598,6 +636,10 @@ def _validate_request(request: SyncSourceRequest) -> dict[str, Any] | None:
         return {"status": "denied", "reason_code": "source_sync_request_invalid", "field": "force"}
 
     return None
+
+
+def _is_tombstone_stale_policy(request: SyncSourceRequest) -> bool:
+    return str(request.stale_policy).strip().lower() == "tombstone"
 
 
 def _response(

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -117,17 +117,6 @@ class DocsSourceSyncService:
         except DocsError as exc:
             return self._failed(source=source, request=request, reason_code=exc.code, warning=exc.message)
 
-        limit = self._document_limit(request)
-        if len(files) > limit:
-            return _sync_response(
-                status="denied",
-                reason_code="source_sync_limit_exceeded",
-                source=source,
-                request=request,
-                counts=dict(_ZERO_COUNTS),
-                items=[],
-                warnings=[f"candidate_count={len(files)} exceeds max_documents={limit}"],
-            )
         return self._sync_local_paths(scope=scope, source=source, request=request, files=files)
 
     def _sync_local_paths(
@@ -146,13 +135,29 @@ class DocsSourceSyncService:
         source_id = int(source["id"])
         links = self.store.source_document_links(scope=scope, source_id=source_id)
         links_by_uri = {str(link["source_item_uri"]): link for link in links}
-        current_uris: set[str] = set()
+        current_uris = {file_uri_for_path(file_path) for file_path in files}
+        stale_links = [
+            link
+            for link in links
+            if str(link["source_item_uri"]) not in current_uris and link.get("status") != "tombstoned"
+        ]
+        limit = self._document_limit(request)
+        sync_item_count = len(files) + len(stale_links)
+        if sync_item_count > limit:
+            return _sync_response(
+                status="denied",
+                reason_code="source_sync_limit_exceeded",
+                source=source,
+                request=request,
+                counts=dict(_ZERO_COUNTS),
+                items=[],
+                warnings=[f"sync_item_count={sync_item_count} exceeds max_documents={limit}"],
+            )
         default_keywords = _metadata_string_tuple(source.get("metadata"), "default_keywords")
         default_collections = _metadata_string_tuple(source.get("metadata"), "default_collections")
 
         for file_path in files:
             item_uri = file_uri_for_path(file_path)
-            current_uris.add(item_uri)
             try:
                 parsed, chunks, content_hash = self._parsed_local_sync_item(file_path)
             except DocsError as exc:
@@ -224,10 +229,8 @@ class DocsSourceSyncService:
                 }
             )
 
-        for link in links:
+        for link in stale_links:
             item_uri = str(link["source_item_uri"])
-            if item_uri in current_uris or link.get("status") == "tombstoned":
-                continue
             if stale_policy == "tombstone":
                 counts["tombstoned"] += 1
                 item_status = "tombstoned"

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+from dataclasses import asdict
+from hashlib import sha256
+from pathlib import Path
 from typing import Any
 
+from .acquisition.service import DocsAcquisitionService
+from .errors import DocsError
+from .importers.base import ParsedDocument, chunks_from_text
+from .importers.local import DocsImportService
 from .models import AccessScope, SyncSourceRequest
 from .settings import DocsSettings
-from .source_utils import redacted_url_for_display
+from .source_utils import file_uri_for_path, redacted_url_for_display
 from .store.sqlite import DocsCatalogStore
 
 _SYNC_MODES = {"dry_run", "apply"}
@@ -32,8 +40,13 @@ class DocsSourceSyncService:
     ) -> None:
         self.settings = settings
         self.store = store
-        self.resolver = resolver
-        self.transport = transport
+        self.importer = DocsImportService(settings=settings, store=store)
+        self.acquisition = DocsAcquisitionService(
+            settings=settings,
+            store=store,
+            resolver=resolver,
+            transport=transport,
+        )
 
     def sync_source(self, *, scope: AccessScope, request: SyncSourceRequest) -> dict[str, Any]:
         if not self.settings.enable_source_sync:
@@ -61,6 +74,219 @@ class DocsSourceSyncService:
                 request=request,
             )
 
+        if source["source_type"] == "local_file":
+            return self._sync_local_file(scope=scope, source=source, request=request)
+        if source["source_type"] == "local_directory":
+            return self._sync_local_directory(scope=scope, source=source, request=request)
+        if source["source_type"] == "url_page":
+            return self._sync_url_page(scope=scope, source=source, request=request)
+        return self._denied(source=source, request=request, reason_code="source_sync_unsupported_type")
+
+    def _get_source(self, *, scope: AccessScope, request: SyncSourceRequest) -> dict[str, Any] | None:
+        if request.source_id is not None:
+            return self.store.get_source(scope=scope, source_id=int(request.source_id))
+        return self.store.get_source(scope=scope, canonical_uri=str(request.source_uri or "").strip())
+
+    def _sync_local_file(
+        self,
+        *,
+        scope: AccessScope,
+        source: dict[str, Any],
+        request: SyncSourceRequest,
+    ) -> dict[str, Any]:
+        try:
+            target = self._source_path(source)
+            resolved = self.importer._assert_allowed_path(target)
+        except DocsError as exc:
+            return self._failed(source=source, request=request, reason_code=exc.code, warning=exc.message)
+
+        files = [resolved] if resolved.is_file() else []
+        return self._sync_local_paths(scope=scope, source=source, request=request, files=files)
+
+    def _sync_local_directory(
+        self,
+        *,
+        scope: AccessScope,
+        source: dict[str, Any],
+        request: SyncSourceRequest,
+    ) -> dict[str, Any]:
+        try:
+            target = self._source_path(source)
+            resolved = self.importer._assert_allowed_path(target)
+            files = self.importer._iter_import_files(resolved) if resolved.is_dir() else []
+        except DocsError as exc:
+            return self._failed(source=source, request=request, reason_code=exc.code, warning=exc.message)
+
+        limit = self._document_limit(request)
+        if len(files) > limit:
+            return _sync_response(
+                status="denied",
+                reason_code="source_sync_limit_exceeded",
+                source=source,
+                request=request,
+                counts=dict(_ZERO_COUNTS),
+                items=[],
+                warnings=[f"candidate_count={len(files)} exceeds max_documents={limit}"],
+            )
+        return self._sync_local_paths(scope=scope, source=source, request=request, files=files)
+
+    def _sync_local_paths(
+        self,
+        *,
+        scope: AccessScope,
+        source: dict[str, Any],
+        request: SyncSourceRequest,
+        files: list[Path],
+    ) -> dict[str, Any]:
+        mode = str(request.mode).strip().lower()
+        stale_policy = str(request.stale_policy).strip().lower()
+        counts = dict(_ZERO_COUNTS)
+        items: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        source_id = int(source["id"])
+        links = self.store.source_document_links(scope=scope, source_id=source_id)
+        links_by_uri = {str(link["source_item_uri"]): link for link in links}
+        current_uris: set[str] = set()
+        default_keywords = _metadata_string_tuple(source.get("metadata"), "default_keywords")
+        default_collections = _metadata_string_tuple(source.get("metadata"), "default_collections")
+
+        for file_path in files:
+            item_uri = file_uri_for_path(file_path)
+            current_uris.add(item_uri)
+            try:
+                parsed, chunks, content_hash = self._parsed_local_sync_item(file_path)
+            except DocsError as exc:
+                counts["failed"] += 1
+                warnings.append(exc.code)
+                items.append(
+                    {
+                        "source_item_uri": item_uri,
+                        "status": "failed",
+                        "reason_code": exc.code,
+                    }
+                )
+                continue
+
+            link = links_by_uri.get(item_uri)
+            item_status = self._local_item_status(
+                scope=scope,
+                parsed=parsed,
+                link=link,
+                content_hash=content_hash,
+                force=request.force,
+            )
+            counts[item_status] += 1
+            document_id = int(link["document_id"]) if link is not None else None
+
+            if mode == "apply":
+                if item_status in {"created", "updated"}:
+                    document_id = self.store.upsert_document_for_sync(
+                        scope=scope,
+                        title=parsed.title,
+                        document_type=parsed.document_type,
+                        canonical_uri=parsed.canonical_uri,
+                        source_path=parsed.source_path,
+                        source_url=parsed.source_url,
+                        text=parsed.text,
+                        sections=[asdict(section) for section in parsed.sections],
+                        chunks=chunks,
+                        source_default_keywords=default_keywords,
+                        source_default_collections=default_collections,
+                        metadata=_local_sync_metadata(parsed),
+                    )
+                    self.store.link_source_document(
+                        scope=scope,
+                        source_id=source_id,
+                        document_id=document_id,
+                        source_item_uri=item_uri,
+                        status="active",
+                        last_hash=content_hash,
+                        metadata={"importer": "local"},
+                    )
+                elif link is not None and link.get("last_hash") != content_hash:
+                    self.store.link_source_document(
+                        scope=scope,
+                        source_id=source_id,
+                        document_id=int(link["document_id"]),
+                        source_item_uri=item_uri,
+                        status="active",
+                        last_hash=content_hash,
+                        metadata=link.get("metadata") or {"importer": "local"},
+                    )
+
+            items.append(
+                {
+                    "source_item_uri": item_uri,
+                    "status": item_status,
+                    "document_id": document_id,
+                    "canonical_uri": parsed.canonical_uri,
+                    "title": parsed.title,
+                }
+            )
+
+        for link in links:
+            item_uri = str(link["source_item_uri"])
+            if item_uri in current_uris or link.get("status") == "tombstoned":
+                continue
+            if stale_policy == "tombstone":
+                counts["tombstoned"] += 1
+                item_status = "tombstoned"
+                if mode == "apply":
+                    self.store.tombstone_source_item(
+                        scope=scope,
+                        source_id=source_id,
+                        source_item_uri=item_uri,
+                    )
+            else:
+                counts["missing"] += 1
+                item_status = "missing"
+            items.append(
+                {
+                    "source_item_uri": item_uri,
+                    "status": item_status,
+                    "document_id": int(link["document_id"]),
+                    "canonical_uri": link.get("canonical_uri"),
+                    "title": link.get("title"),
+                }
+            )
+
+        run_status = "partial" if counts["failed"] else "completed"
+        reason_code = "partial_failure" if counts["failed"] else "ok"
+        if mode == "apply":
+            self.store.record_sync_run(
+                scope=scope,
+                source_id=source_id,
+                mode=mode,
+                status=run_status,
+                requested_limits={
+                    "max_documents": request.max_documents,
+                    "max_pages": request.max_pages,
+                    "effective_max_documents": self._document_limit(request),
+                },
+                counts=counts,
+                warnings=warnings,
+                error_code=None if reason_code == "ok" else reason_code,
+                metadata={"source_type": source["source_type"]},
+            )
+            source = self.store.get_source(scope=scope, source_id=source_id) or source
+
+        return _sync_response(
+            status=run_status,
+            reason_code=reason_code,
+            source=source,
+            request=request,
+            counts=counts,
+            items=items,
+            warnings=warnings,
+        )
+
+    def _sync_url_page(
+        self,
+        *,
+        scope: AccessScope,
+        source: dict[str, Any],
+        request: SyncSourceRequest,
+    ) -> dict[str, Any]:
         return _response(
             status="skipped",
             reason_code="source_sync_unsupported_type",
@@ -68,10 +294,77 @@ class DocsSourceSyncService:
             request=request,
         )
 
-    def _get_source(self, *, scope: AccessScope, request: SyncSourceRequest) -> dict[str, Any] | None:
-        if request.source_id is not None:
-            return self.store.get_source(scope=scope, source_id=int(request.source_id))
-        return self.store.get_source(scope=scope, canonical_uri=str(request.source_uri or "").strip())
+    def _denied(self, *, source: dict[str, Any], request: SyncSourceRequest, reason_code: str) -> dict[str, Any]:
+        return _response(status="skipped", reason_code=reason_code, source=source, request=request)
+
+    def _failed(
+        self,
+        *,
+        source: dict[str, Any],
+        request: SyncSourceRequest,
+        reason_code: str,
+        warning: str,
+    ) -> dict[str, Any]:
+        counts = dict(_ZERO_COUNTS)
+        counts["failed"] = 1
+        return _sync_response(
+            status="failed",
+            reason_code=reason_code,
+            source=source,
+            request=request,
+            counts=counts,
+            items=[],
+            warnings=[warning],
+        )
+
+    def _source_path(self, source: dict[str, Any]) -> Path:
+        source_path = source.get("source_path")
+        if source_path:
+            return Path(str(source_path))
+        canonical_uri = str(source.get("canonical_uri") or "")
+        if canonical_uri.startswith("file://"):
+            return Path(canonical_uri.removeprefix("file://"))
+        raise DocsError(
+            code="source_path_missing",
+            message="Local source does not include a source path.",
+            details={"source_id": source.get("id")},
+        )
+
+    def _document_limit(self, request: SyncSourceRequest) -> int:
+        limits = [self.settings.max_sync_documents, self.settings.max_sync_run_items]
+        if request.max_documents is not None:
+            limits.append(int(request.max_documents))
+        return min(limits)
+
+    def _parsed_local_sync_item(self, file_path: Path) -> tuple[ParsedDocument, list[dict[str, str]], str]:
+        parsed = self.importer._parse_file(file_path)
+        chunks = [
+            {
+                "text": chunk,
+                "citation": f"{file_path.name}:{idx + 1}",
+            }
+            for idx, chunk in enumerate(chunks_from_text(parsed.text))
+        ]
+        content_hash = sha256(parsed.text.encode("utf-8")).hexdigest()
+        return parsed, chunks, content_hash
+
+    def _local_item_status(
+        self,
+        *,
+        scope: AccessScope,
+        parsed: ParsedDocument,
+        link: dict[str, Any] | None,
+        content_hash: str,
+        force: bool,
+    ) -> str:
+        if link is None:
+            return "created"
+        if force:
+            return "updated"
+        previous_hash = link.get("last_hash") or _existing_content_hash(self.store, scope, parsed.canonical_uri)
+        if previous_hash == content_hash and link.get("status") == "active":
+            return "unchanged"
+        return "updated"
 
 
 def _validate_request(request: SyncSourceRequest) -> dict[str, Any] | None:
@@ -120,7 +413,31 @@ def _response(
         "stale_policy": str(request.stale_policy).strip().lower(),
         "force": request.force,
         "counts": dict(_ZERO_COUNTS),
+        "items": [],
         "warnings": [],
+    }
+
+
+def _sync_response(
+    *,
+    status: str,
+    reason_code: str,
+    source: dict[str, Any],
+    request: SyncSourceRequest,
+    counts: dict[str, int],
+    items: list[dict[str, Any]],
+    warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "reason_code": reason_code,
+        "source": _source_summary(source),
+        "mode": str(request.mode).strip().lower(),
+        "stale_policy": str(request.stale_policy).strip().lower(),
+        "force": request.force,
+        "counts": {key: int(counts.get(key, 0)) for key in _ZERO_COUNTS},
+        "items": items,
+        "warnings": warnings,
     }
 
 
@@ -157,3 +474,35 @@ def _redacted_source_uri(source: dict[str, Any]) -> str:
         return redacted_uri.strip()
     raw_uri = source.get("canonical_uri") or source.get("source_url") or ""
     return redacted_url_for_display(str(raw_uri))
+
+
+def _metadata_string_tuple(metadata: object, key: str) -> tuple[str, ...]:
+    if not isinstance(metadata, dict):
+        return ()
+    value = metadata.get(key) or ()
+    if isinstance(value, str):
+        values: Iterable[object] = (value,)
+    elif isinstance(value, Iterable):
+        values = value
+    else:
+        values = (value,)
+    return tuple(str(item).strip() for item in values if str(item).strip())
+
+
+def _existing_content_hash(store: DocsCatalogStore, scope: AccessScope, canonical_uri: str) -> str | None:
+    try:
+        document = store.get_document(scope, canonical_uri, mode="snippet")
+    except DocsError as exc:
+        if exc.code == "document_not_found":
+            return None
+        raise
+    value = document.get("content_hash")
+    return str(value) if value else None
+
+
+def _local_sync_metadata(parsed: ParsedDocument) -> dict[str, Any]:
+    return {
+        "importer": "local",
+        "extraction_method": parsed.extraction_method,
+        "warnings": list(parsed.warnings),
+    }

--- a/backlog/tasks/task-12091 - Design-standalone-MCP-docs-Stage-4A-bounded-source-sync.md
+++ b/backlog/tasks/task-12091 - Design-standalone-MCP-docs-Stage-4A-bounded-source-sync.md
@@ -2,14 +2,19 @@
 id: TASK-12091
 title: Design standalone MCP docs Stage 4A bounded source sync
 status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-07-02 03:44'
 labels:
-- mcp
-- docs
-- design
-priority: high
+  - mcp
+  - docs
+  - design
+dependencies: []
 documentation:
-- Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-catalog-design.md
-- Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
+  - Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-catalog-design.md
+  - >-
+    Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
+priority: high
 ---
 
 ## Description
@@ -30,18 +35,19 @@ Write the Stage 4A design/spec for bounded source refresh in the standalone MCP 
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+<!-- SECTION:NOTES:BEGIN -->
 - Created `Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md` as the Stage 4A bounded `docs.sync_source` design spec.
 - Grounded the design in the current Stage 1-3 stacked branch seams: `DocsSettings`, `DocsImportService.import_path`, `DocsAcquisitionService.ingest_url`, `DocsCatalogStore.upsert_document`, and `DocsMCPToolProvider`.
 - Self-review pass removed ambiguity around tombstone/search behavior and replaced open decisions with explicit implementation planning defaults.
 - Review follow-up addressed the identified spec risks: sync now preserves existing collections/keywords while merging source defaults; dry-run is strictly read-only and writes no sync-run rows; URL sources separate fetch-capable `source_url` from redacted display/logging; tombstone preservation uses a concrete `preserve_on_source_tombstone` column; sitemap sync rejects `DOCTYPE`/`ENTITY`, enforces `max_pages` before page fetches, and caps stored run item details.
-- Verification: review follow-up `rg` scan for stale ambiguity markers returned no matches; `git diff --check` passed.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+- Second review follow-up tightened Stage 4A around four implementation risks: query-bearing URL refresh sources now require explicit `persist_url_query_strings` opt-in; metadata preservation now requires a sync-aware transactional upsert/merge helper instead of relying on replacement-oriented `upsert_document()`; report-mode missing items no longer persist missing source-link status or hide documents; optional sitemap sync now requires a narrow sitemap source registration path or remains deferred/disabled.
+- Verification after second review follow-up: `git diff --check` passed; stale wording scan for persisted missing-source hiding and old sitemap assumptions returned no matches; positive scan confirmed `persist_url_query_strings`, `upsert_document_for_sync()`, missing-status, and sitemap-registration wording; `backlog task view TASK-12091 --plain` renders cleanly.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Pending user approval before finalizing this design task.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12091 - Design-standalone-MCP-docs-Stage-4A-bounded-source-sync.md
+++ b/backlog/tasks/task-12091 - Design-standalone-MCP-docs-Stage-4A-bounded-source-sync.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-12091
 title: Design standalone MCP docs Stage 4A bounded source sync
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-02 03:44'
+updated_date: '2026-07-02 03:47'
 labels:
   - mcp
   - docs
@@ -25,12 +25,12 @@ Write the Stage 4A design/spec for bounded source refresh in the standalone MCP 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Stage 4A design spec defines docs.sync_source semantics, inputs, outputs, status values, and reason codes.
-- [ ] #2 Spec keeps baseline standalone installs dependency-light and preserves the no tldw_Server_API import boundary for mcp_unified.docs.
-- [ ] #3 Spec defines bounded local trusted-root refresh and URL/source refresh behavior using existing Stage 1/2 services.
-- [ ] #4 Spec explicitly excludes broad crawling, Playwright/browser extraction, embeddings/reranking, Jobs/Scheduler implementation, and Media/RAG host bridges from Stage 4A.
-- [ ] #5 Spec covers stale/missing document handling, idempotency/dedupe, audit/provenance updates, and security tests.
-- [ ] #6 Spec self-review and whitespace verification are recorded before final summary.
+- [x] #1 Stage 4A design spec defines docs.sync_source semantics, inputs, outputs, status values, and reason codes.
+- [x] #2 Spec keeps baseline standalone installs dependency-light and preserves the no tldw_Server_API import boundary for mcp_unified.docs.
+- [x] #3 Spec defines bounded local trusted-root refresh and URL/source refresh behavior using existing Stage 1/2 services.
+- [x] #4 Spec explicitly excludes broad crawling, Playwright/browser extraction, embeddings/reranking, Jobs/Scheduler implementation, and Media/RAG host bridges from Stage 4A.
+- [x] #5 Spec covers stale/missing document handling, idempotency/dedupe, audit/provenance updates, and security tests.
+- [x] #6 Spec self-review and whitespace verification are recorded before final summary.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -47,15 +47,15 @@ Write the Stage 4A design/spec for bounded source refresh in the standalone MCP 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Pending user approval before finalizing this design task.
+Stage 4A bounded source sync design is complete and approved to move into implementation planning. The spec defines docs.sync_source semantics, source registry/run records, local and URL source refresh behavior, redaction and query persistence rules, metadata preservation via sync-aware merge, conservative stale/tombstone semantics, optional sitemap registration/sync boundaries, host integration constraints, and test strategy. Verification was docs-focused: git diff --check passed, targeted stale-wording scans passed, positive contract-term scans passed, and backlog task rendering passed. Bandit was skipped because this task changed only documentation and Backlog metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12091 - Design-standalone-MCP-docs-Stage-4A-bounded-source-sync.md
+++ b/backlog/tasks/task-12091 - Design-standalone-MCP-docs-Stage-4A-bounded-source-sync.md
@@ -32,9 +32,10 @@ Write the Stage 4A design/spec for bounded source refresh in the standalone MCP 
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Created `Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md` as the Stage 4A bounded `docs.sync_source` design spec.
-- Grounded the design in the merged Stage 1-3 docs package seams: `DocsSettings`, `DocsImportService.import_path`, `DocsAcquisitionService.ingest_url`, `DocsCatalogStore.upsert_document`, and `DocsMCPToolProvider`.
+- Grounded the design in the current Stage 1-3 stacked branch seams: `DocsSettings`, `DocsImportService.import_path`, `DocsAcquisitionService.ingest_url`, `DocsCatalogStore.upsert_document`, and `DocsMCPToolProvider`.
 - Self-review pass removed ambiguity around tombstone/search behavior and replaced open decisions with explicit implementation planning defaults.
-- Verification: placeholder/ambiguity `rg` scan returned no matches; `git diff --check` passed.
+- Review follow-up addressed the identified spec risks: sync now preserves existing collections/keywords while merging source defaults; dry-run is strictly read-only and writes no sync-run rows; URL sources separate fetch-capable `source_url` from redacted display/logging; tombstone preservation uses a concrete `preserve_on_source_tombstone` column; sitemap sync rejects `DOCTYPE`/`ENTITY`, enforces `max_pages` before page fetches, and caps stored run item details.
+- Verification: review follow-up `rg` scan for stale ambiguity markers returned no matches; `git diff --check` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12091 - Design-standalone-MCP-docs-Stage-4A-bounded-source-sync.md
+++ b/backlog/tasks/task-12091 - Design-standalone-MCP-docs-Stage-4A-bounded-source-sync.md
@@ -1,0 +1,54 @@
+---
+id: TASK-12091
+title: Design standalone MCP docs Stage 4A bounded source sync
+status: In Progress
+labels:
+- mcp
+- docs
+- design
+priority: high
+documentation:
+- Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-catalog-design.md
+- Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write the Stage 4A design/spec for bounded source refresh in the standalone MCP docs corpus. Scope: docs.sync_source for already-known local and URL sources, conservative stale handling, source-policy reuse, optional sitemap refresh under strict same-origin limits, no arbitrary crawler/browser/embeddings/reranking/Media-RAG bridge, and no tldw_server imports in mcp_unified.docs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Stage 4A design spec defines docs.sync_source semantics, inputs, outputs, status values, and reason codes.
+- [ ] #2 Spec keeps baseline standalone installs dependency-light and preserves the no tldw_Server_API import boundary for mcp_unified.docs.
+- [ ] #3 Spec defines bounded local trusted-root refresh and URL/source refresh behavior using existing Stage 1/2 services.
+- [ ] #4 Spec explicitly excludes broad crawling, Playwright/browser extraction, embeddings/reranking, Jobs/Scheduler implementation, and Media/RAG host bridges from Stage 4A.
+- [ ] #5 Spec covers stale/missing document handling, idempotency/dedupe, audit/provenance updates, and security tests.
+- [ ] #6 Spec self-review and whitespace verification are recorded before final summary.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Created `Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md` as the Stage 4A bounded `docs.sync_source` design spec.
+- Grounded the design in the merged Stage 1-3 docs package seams: `DocsSettings`, `DocsImportService.import_path`, `DocsAcquisitionService.ingest_url`, `DocsCatalogStore.upsert_document`, and `DocsMCPToolProvider`.
+- Self-review pass removed ambiguity around tombstone/search behavior and replaced open decisions with explicit implementation planning defaults.
+- Verification: placeholder/ambiguity `rg` scan returned no matches; `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12092 - Plan-standalone-MCP-docs-Stage-4A-source-sync-implementation.md
+++ b/backlog/tasks/task-12092 - Plan-standalone-MCP-docs-Stage-4A-source-sync-implementation.md
@@ -1,0 +1,56 @@
+---
+id: TASK-12092
+title: Plan standalone MCP docs Stage 4A source sync implementation
+status: Done
+assignee: []
+created_date: '2026-07-02 03:48'
+updated_date: '2026-07-02 03:57'
+labels:
+  - mcp
+  - docs
+  - planning
+dependencies:
+  - TASK-12091
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a detailed implementation plan for the approved standalone MCP docs Stage 4A bounded source sync design. The plan should cover source registry schema/store helpers, source population from import/URL ingest, source listing/status, local file/directory sync, URL page sync, host shim registration, tests, verification, and defer/optional handling for sitemap registration/sync.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan is saved under Docs/superpowers/plans with a dated Stage 4A source sync filename.
+- [x] #2 Plan maps the concrete files/modules to create or modify and explains each file responsibility.
+- [x] #3 Plan decomposes slices 1-5 into TDD-oriented tasks with exact commands, expected outcomes, and commit points.
+- [x] #4 Plan explicitly defers or isolates optional sitemap source registration/sync from the first implementation PR.
+- [x] #5 Plan self-review covers spec coverage, placeholder scan, type/signature consistency, and verification commands.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Planning completed for approved Stage 4A source sync design. Plan path: Docs/superpowers/plans/2026-07-02-standalone-mcp-docs-stage4a-source-sync-implementation-plan.md. Scope is Stage 4A.1 slices 1-5 plus host exposure; optional sitemap registration/sync remains isolated from the first implementation PR. Self-review verification: git diff --check passed; placeholder scan with word-boundary patterns returned no matches; positive coverage scan confirmed source registry, source population, docs.sync_source, query persistence, metadata merge, dry-run, sitemap isolation, host boundary, and Bandit command coverage. Bandit was skipped for this planning task because only documentation and Backlog metadata changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the Stage 4A source sync implementation plan at Docs/superpowers/plans/2026-07-02-standalone-mcp-docs-stage4a-source-sync-implementation-plan.md. The plan maps concrete files, source registry helpers, import/URL source population, source listing/status, local and URL sync services, host exposure, tests, verification commands, and keeps sitemap registration/sync out of the first implementation PR. Verification was docs-focused: git diff --check passed, placeholder scan passed, coverage scan passed, and Bandit was skipped because this task changed only planning and Backlog metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Backlog task records plan path, review notes, verification, and any known skips.
+<!-- DOD:END -->

--- a/backlog/tasks/task-12093 - Implement-standalone-MCP-docs-Stage-4A-source-sync.md
+++ b/backlog/tasks/task-12093 - Implement-standalone-MCP-docs-Stage-4A-source-sync.md
@@ -1,0 +1,83 @@
+---
+id: TASK-12093
+title: Implement standalone MCP docs Stage 4A source sync
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-02 07:53'
+labels:
+  - mcp
+  - docs
+  - source-sync
+dependencies: []
+references:
+  - TASK-12091
+  - TASK-12092
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
+  - >-
+    Docs/superpowers/plans/2026-07-02-standalone-mcp-docs-stage4a-source-sync-implementation-plan.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved Stage 4A.1 standalone MCP docs source-sync plan: source-sync settings/status, source registry schema/store helpers, local and URL source population, docs.list(kind="sources"), docs.sync_source for local files/directories and URL pages, host exposure, focused tests, docs test slice verification, and Bandit on touched Python paths. Sitemap registration/sync remains deferred.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-07-02-standalone-mcp-docs-stage4a-source-sync-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Stage 4A.1 bounded source sync for the standalone MCP docs corpus.
+
+What changed:
+- Added source-sync settings/status and public source/sync model contracts.
+- Added SQLite source registry tables, source-document links, sync runs, lifecycle columns, migration guards, scoped source helpers, active-only document counts, and sync-aware document upserts that preserve user keywords/collections while merging source defaults.
+- Populated refreshable sources from local imports and approved URL ingests, with query-bearing URL sources disabled by default unless `persist_url_query_strings=true`.
+- Added query/credential-safe source utilities and public response redaction so query-bearing URL tokens are not exposed in docs.list or docs.sync_source responses.
+- Exposed `docs.list(kind="sources")` and `docs.sync_source` through the standalone provider and host DocsModule shim.
+- Implemented local_file/local_directory sync with strict dry-run immutability, apply mode, source-link hashing, metadata preservation, max-document/stale-link limits before mutation, report/tombstone stale policy, symlink escape prevention, and lifecycle-aware search/get/resolve/facet filtering.
+- Implemented url_page sync for existing sources only, using the Stage 2 policy/resolver/transport/extraction seams, preflight policy denial before fetch, dry-run/apply behavior, sync-run recording only for apply, redirect/canonical retarget reconciliation, active-only source document counts, and redacted public summaries.
+- Kept sitemap registration/sync disabled/unsupported and did not add crawling, browser automation, jobs/scheduler, Media DB, ChromaDB, RAG, or host service bridges.
+
+Verification:
+- Focused host/boundary tests: `16 passed, 4 warnings`.
+- Full docs test slice: `253 passed, 4 warnings`.
+- Final lifecycle focused review tests: `57 passed, 3 warnings`.
+- Bandit: exit 0, no findings; report written to `/tmp/bandit_mcp_docs_stage4a.json`.
+- `git diff --check`: clean.
+
+Known deferrals:
+- Sitemap source registration/sync remains deferred to Stage 4A.2 or later.
+- Optional scraping pipeline dependencies remain out of the baseline standalone install.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12094 - Address-PR-2574-docs-review-findings.md
+++ b/backlog/tasks/task-12094 - Address-PR-2574-docs-review-findings.md
@@ -1,0 +1,58 @@
+---
+id: TASK-12094
+title: Address PR 2574 docs review findings
+status: Done
+labels:
+- mcp
+- docs
+- review-fix
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/pull/2574
+modified_files:
+- apps/mcp-unified/src/mcp_unified/docs/acquisition/fetcher.py
+- apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py
+- apps/mcp-unified/src/mcp_unified/docs/sync.py
+- tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_fetcher.py
+- tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_service.py
+- tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
+- tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix review findings from the MCP docs source sync PR: prevent query-bearing URL secrets from leaking through ingested document metadata/MCP outputs when query persistence is disabled, and make respect_robots fail closed until a robots checker exists.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for query-bearing URL redaction across ingest/search/get/context outputs. 2. Add/fix failing regression for respect_robots fail-closed behavior without resolving or fetching. 3. Patch acquisition/fetcher behavior minimally. 4. Run focused docs tests, Bandit on touched source, and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR 2574 review findings. URL fetching now fails closed with robots_unavailable before DNS/transport when respect_robots=True and no robots checker is available. URL ingestion now sanitizes query-bearing document canonical_uri/citations and clears document source_url when persist_url_query_strings=False. Source sync now applies the same default sanitization when redirects land on query-bearing URLs, while preserving raw query URLs only for opt-in persist_url_query_strings=True paths. Added regressions for docs.ingest_url, docs.search, docs.get, docs.context, docs.list documents, and URL source sync outputs with ?token=secret. Verification: focused red/green regressions passed after the fix; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs -q -> 254 passed, 4 warnings; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r apps/mcp-unified/src/mcp_unified/docs/acquisition/fetcher.py apps/mcp-unified/src/mcp_unified/docs/acquisition/service.py apps/mcp-unified/src/mcp_unified/docs/sync.py -f json -o /tmp/bandit_mcp_docs_review_fix.json -> no findings; git diff --check -> clean. Follow-up review found a source-sync redirect leak; fixed and covered in test_docs_source_sync.py.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12120 - Rebase-PR-2574-and-address-review-comments.md
+++ b/backlog/tasks/task-12120 - Rebase-PR-2574-and-address-review-comments.md
@@ -1,0 +1,63 @@
+---
+id: TASK-12120
+title: Rebase PR 2574 and address review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-03 18:34'
+labels:
+  - mcp
+  - docs
+  - review-fix
+  - rebase
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2574'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR 2574 onto the latest dev branch, resolve conflicts, inspect open PR review threads/comments, and address remaining actionable issues before pushing the PR branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Fetch latest dev and rebase the PR branch. 2. Resolve rebase conflicts conservatively. 3. Inspect unresolved PR review threads and comments. 4. Add focused tests and fixes for actionable comments. 5. Run relevant docs tests, Bandit on touched source, diff checks, commit, and push.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Rebased branch onto origin/dev and resolved conflicts in notification_service.py and MCP local importer sync behavior. Added review-fix tests for local sync item failures, missing local source paths, decoded file URIs, and SQLite migration unique index detection. Verification so far: focused regression tests passed; full MCP docs suite passed with 267 passed/4 warnings; Bandit touched-scope report had zero findings; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR 2574 onto origin/dev, resolved rebase conflicts, addressed actionable review threads, and added regression coverage for local sync read/decode failures, missing/non-scannable local source tombstone safety, file URI decoding, and SQLite index introspection. Verification: focused regressions passed, full MCP docs suite passed with 268 passed/4 warnings, touched-scope Bandit reported zero findings, and git diff --check passed. The DocsError/DB_Management comments were handled with standalone MCP package boundary rationale rather than code relocation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_fetcher.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_fetcher.py
@@ -260,7 +260,7 @@ def test_fetcher_returns_approval_required_without_resolver_or_transport() -> No
     assert transport.calls == []  # nosec B101
 
 
-def test_fetcher_respect_robots_does_not_fail_closed_without_robots_client() -> None:
+def test_fetcher_respect_robots_fails_closed_without_robots_client() -> None:
     settings = _settings(respect_robots=True)
     resolver = FakeResolver({"example.com": ["93.184.216.34"]})
     transport = FakeTransport(
@@ -269,10 +269,10 @@ def test_fetcher_respect_robots_does_not_fail_closed_without_robots_client() -> 
 
     result = _fetcher(resolver=resolver, transport=transport, settings=settings).fetch("https://example.com/docs")
 
-    assert result.status == "fetched"  # nosec B101
-    assert result.body == b"<h1>Ok</h1>"  # nosec B101
-    assert resolver.calls == [("example.com", 443)]  # nosec B101
-    assert len(transport.calls) == 1  # nosec B101
+    assert result.status == "denied"  # nosec B101
+    assert result.reason == "robots_unavailable"  # nosec B101
+    assert resolver.calls == []  # nosec B101
+    assert transport.calls == []  # nosec B101
 
 
 def test_fetcher_revalidates_redirect_target_and_denies_private_redirect() -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_service.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_acquisition_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -60,7 +61,7 @@ def test_service_returns_approval_required_without_fetch(tmp_path: Path) -> None
     assert transport.calls == []  # nosec B101
 
 
-def test_service_robots_flag_does_not_disable_fetch_without_robots_client(tmp_path: Path) -> None:
+def test_service_respect_robots_fails_closed_without_robots_client(tmp_path: Path) -> None:
     settings = DocsSettings.from_mapping(
         {
             "enable_web_acquisition": True,
@@ -77,10 +78,10 @@ def test_service_robots_flag_does_not_disable_fetch_without_robots_client(tmp_pa
 
     result = service.ingest_url(scope=AccessScope(), url="https://example.com/docs")
 
-    assert result["status"] == "created"  # nosec B101
-    assert result["reason_code"] == "ok"  # nosec B101
-    assert resolver.calls == [("example.com", 443)]  # nosec B101
-    assert len(transport.calls) == 1  # nosec B101
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "robots_unavailable"  # nosec B101
+    assert resolver.calls == []  # nosec B101
+    assert transport.calls == []  # nosec B101
 
 
 def test_service_ingests_approved_page_into_search_and_context(tmp_path: Path) -> None:
@@ -149,7 +150,9 @@ def test_service_reports_unchanged_for_same_content(tmp_path: Path) -> None:
     assert second["status"] == "unchanged"  # nosec B101
 
 
-def test_service_preserves_query_in_stored_canonical_uri_without_redacted_final_url_leakage(tmp_path: Path) -> None:
+def test_service_does_not_store_or_return_query_bearing_url_when_query_persistence_disabled(
+    tmp_path: Path,
+) -> None:
     settings = DocsSettings.from_mapping(
         {
             "enable_web_acquisition": True,
@@ -166,15 +169,23 @@ def test_service_preserves_query_in_stored_canonical_uri_without_redacted_final_
         ]
     )
     service = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
+    scope = AccessScope()
 
-    first = service.ingest_url(scope=AccessScope(), url="https://example.com/page?version=alpha")
-    second = service.ingest_url(scope=AccessScope(), url="https://example.com/page?version=beta")
-    documents = store.list_documents(scope=AccessScope(), limit=10, offset=0)
+    result = service.ingest_url(scope=scope, url="https://example.com/page?token=secret")
+    documents = store.list_documents(scope=scope, limit=10, offset=0)
+    stored = store.get_document(scope, result["document"]["id"], mode="full")
+    search = DocsRetrievalService(store).search(scope=scope, request=SearchRequest(query="alpha"))
+    context = DocsContextBuilder(DocsRetrievalService(store)).build(scope=scope, request=ContextRequest(query="alpha"))
 
-    assert first["status"] == "created"  # nosec B101
-    assert second["status"] == "created"  # nosec B101
-    assert first["fetch"]["final_url"] == "https://example.com/page"  # nosec B101
-    assert sorted(document["canonical_uri"] for document in documents) == [  # nosec B101
-        "https://example.com/page?version=alpha",
-        "https://example.com/page?version=beta",
-    ]
+    serialized = json.dumps([result, documents, stored, search, context], sort_keys=True)
+
+    assert result["status"] == "created"  # nosec B101
+    assert result["document"]["canonical_uri"] == "https://example.com/page"  # nosec B101
+    assert result["document"]["source_url"] is None  # nosec B101
+    assert result["source"] is None  # nosec B101
+    assert result["fetch"]["final_url"] == "https://example.com/page"  # nosec B101
+    assert "url_query_not_persisted" in result["warnings"]  # nosec B101
+    assert documents[0]["canonical_uri"] == "https://example.com/page"  # nosec B101
+    assert documents[0]["source_url"] is None  # nosec B101
+    assert "token=secret" not in serialized  # nosec B101
+    assert "?token" not in serialized  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_importers.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_importers.py
@@ -109,6 +109,34 @@ def test_import_directory_skips_unsupported_files(tmp_path: Path) -> None:
     assert [document["title"] for document in result["documents"]] == ["Guide"]  # nosec B101
 
 
+def test_import_directory_skips_symlink_escaping_source_directory(tmp_path: Path) -> None:
+    trusted_root = tmp_path
+    root = trusted_root / "workspace"
+    root.mkdir()
+    (root / "public.md").write_text("# Public\n\nSQLite public.\n", encoding="utf-8")
+    secret = trusted_root / "secret.md"
+    secret.write_text("# Secret\n\nClassified sibling content.\n", encoding="utf-8")
+    link = root / "secret.md"
+    try:
+        link.symlink_to(secret)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable in this environment: {exc}")
+    service, store = _service(tmp_path, trusted_root)
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+
+    result = service.import_path(
+        scope=scope,
+        path=root,
+        keywords=(),
+        collection_names=(),
+    )
+    search_results = store.search_chunks(scope=scope, query="Classified", limit=10)
+
+    assert result["status"] == "created"  # nosec B101
+    assert [document["title"] for document in result["documents"]] == ["Public"]  # nosec B101
+    assert search_results == []  # nosec B101
+
+
 def test_import_directory_materializes_metadata_iterables_for_each_file(tmp_path: Path) -> None:
     root = tmp_path / "workspace"
     root.mkdir()

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
@@ -247,6 +247,10 @@ def test_provider_status_reports_web_acquisition_disabled(tmp_path: Path) -> Non
     assert status["web_policy"]["allow_arbitrary_public_domains"] is False  # nosec B101
     assert status["web_policy"]["preapproved_domains"] == []  # nosec B101
     assert status["web_policy"]["allowed_url_prefixes"] == []  # nosec B101
+    assert status["source_sync"]["enabled"] is True  # nosec B101
+    assert status["source_sync"]["default_stale_policy"] == "report"  # nosec B101
+    assert status["source_sync"]["max_sync_documents"] == 500  # nosec B101
+    assert status["source_sync"]["sitemap_sync_enabled"] is False  # nosec B101
 
 
 def test_provider_status_reports_custom_web_policy(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
+from mcp_unified.docs.acquisition.models import FetchResponse
+from mcp_unified.docs.acquisition.service import DocsAcquisitionService
 from mcp_unified.docs.mcp_module import DocsMCPToolProvider
 from mcp_unified.docs.models import AccessScope
 from mcp_unified.docs.settings import DocsSettings
 from mcp_unified.docs.store.sqlite import DocsCatalogStore
+from tldw_Server_API.tests.MCP_unified.docs.helpers import FakeResolver, FakeTransport
 
 pytestmark = pytest.mark.unit
 
@@ -144,6 +148,45 @@ def test_provider_ingest_url_delegates_to_acquisition_service(tmp_path: Path) ->
             "title_override": "Guide",
         }
     ]
+
+
+def test_provider_retrieval_outputs_do_not_leak_query_bearing_ingest_url(tmp_path: Path) -> None:
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    acquisition = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"alpha docs"])]
+        ),
+    )
+    provider = DocsMCPToolProvider(settings=settings, store=store)
+    provider.acquisition = acquisition
+
+    ingest = provider.execute("docs.ingest_url", {"url": "https://example.com/page?token=secret"}, scope=scope)
+
+    search = provider.execute("docs.search", {"query": "alpha"}, scope=scope)
+    document = provider.execute("docs.get", {"id": str(ingest["document"]["id"]), "mode": "full"}, scope=scope)
+    context = provider.execute("docs.context", {"query": "alpha"}, scope=scope)
+    listing = provider.execute("docs.list", {"kind": "documents"}, scope=scope)
+    serialized = json.dumps([ingest, search, document, context, listing], sort_keys=True)
+
+    assert ingest["document"]["canonical_uri"] == "https://example.com/page"  # nosec B101
+    assert ingest["document"]["source_url"] is None  # nosec B101
+    assert search["results"][0]["uri"] == "https://example.com/page"  # nosec B101
+    assert document["source_url"] is None  # nosec B101
+    assert "token=secret" not in serialized  # nosec B101
+    assert "?token" not in serialized  # nosec B101
 
 
 def test_provider_rejects_empty_ingest_url_when_enabled(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py
@@ -36,6 +36,22 @@ async def test_docs_module_advertises_provider_tools(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_docs_module_exposes_sync_source_without_media_or_rag(tmp_path: Path) -> None:
+    module = DocsModule(
+        ModuleConfig(
+            name="docs",
+            settings={"db_path": str(tmp_path / "docs.db"), "trusted_roots": [str(tmp_path)]},
+        )
+    )
+    await module.on_initialize()
+
+    tools = {tool["name"]: tool for tool in await module.get_tools()}
+
+    assert "docs.sync_source" in tools  # nosec B101
+    assert tools["docs.sync_source"]["metadata"]["category"] == "ingestion"  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_docs_module_executes_with_context_scope(tmp_path: Path) -> None:
     doc_path = tmp_path / "guide.md"
     doc_path.write_text("# Guide\n\nSQLite local docs.\n", encoding="utf-8")

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_schema_store.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_schema_store.py
@@ -337,6 +337,55 @@ def test_migrate_backfills_legacy_null_default_scope_rows(tmp_path: Path) -> Non
     assert [document["title"] for document in documents] == ["Updated Legacy Doc"]  # nosec B101
 
 
+def test_migrate_recognizes_existing_scope_unique_index_with_quoted_name(tmp_path: Path) -> None:
+    db_path = tmp_path / "docs.db"
+    with closing(DocsCatalogStore(db_path).connect()) as conn:
+        conn.execute(
+            """
+            CREATE TABLE docs_documents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                owner_scope TEXT NOT NULL DEFAULT '',
+                profile_scope TEXT NOT NULL DEFAULT '',
+                title TEXT NOT NULL,
+                document_type TEXT NOT NULL,
+                canonical_uri TEXT NOT NULL,
+                source_path TEXT,
+                source_url TEXT,
+                content_hash TEXT NOT NULL,
+                text TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                package_name TEXT,
+                package_version TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE UNIQUE INDEX "legacy scope uri unique idx"
+            ON docs_documents (owner_scope, profile_scope, canonical_uri)
+            """
+        )
+        conn.commit()
+
+    DocsCatalogStore(db_path).migrate()
+
+    with closing(DocsCatalogStore(db_path).connect()) as conn:
+        unique_scope_indexes = [
+            row["name"]
+            for row in conn.execute("PRAGMA index_list(docs_documents)").fetchall()
+            if bool(row["unique"])
+            and tuple(
+                column["name"]
+                for column in conn.execute("SELECT name FROM pragma_index_info(?)", (row["name"],)).fetchall()
+            )
+            == ("owner_scope", "profile_scope", "canonical_uri")
+        ]
+
+    assert unique_scope_indexes == ["legacy scope uri unique idx"]  # nosec B101
+
+
 def test_list_keywords_includes_keyword_field(tmp_path: Path) -> None:
     store = DocsCatalogStore(tmp_path / "docs.db")
     store.migrate()

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py
@@ -51,6 +51,18 @@ def test_from_mapping_uses_safe_url_acquisition_defaults() -> None:
     assert settings.allow_arbitrary_public_domains is False  # nosec B101
 
 
+def test_from_mapping_uses_safe_source_sync_defaults() -> None:
+    settings = DocsSettings.from_mapping({})
+
+    assert settings.enable_source_sync is True  # nosec B101
+    assert settings.max_sync_documents == 500  # nosec B101
+    assert settings.max_sync_pages == 25  # nosec B101
+    assert settings.max_sync_run_items == 500  # nosec B101
+    assert settings.default_stale_policy == "report"  # nosec B101
+    assert settings.sitemap_sync_enabled is False  # nosec B101
+    assert settings.persist_url_query_strings is False  # nosec B101
+
+
 def test_from_mapping_parses_url_acquisition_values() -> None:
     settings = DocsSettings.from_mapping(
         {
@@ -82,6 +94,28 @@ def test_from_mapping_parses_url_acquisition_values() -> None:
     assert settings.allow_arbitrary_public_domains is False  # nosec B101
 
 
+def test_from_mapping_parses_source_sync_values() -> None:
+    settings = DocsSettings.from_mapping(
+        {
+            "enable_source_sync": "false",
+            "max_sync_documents": "9",
+            "max_sync_pages": "7",
+            "max_sync_run_items": "5",
+            "default_stale_policy": "tombstone",
+            "sitemap_sync_enabled": "true",
+            "persist_url_query_strings": "true",
+        }
+    )
+
+    assert settings.enable_source_sync is False  # nosec B101
+    assert settings.max_sync_documents == 9  # nosec B101
+    assert settings.max_sync_pages == 7  # nosec B101
+    assert settings.max_sync_run_items == 5  # nosec B101
+    assert settings.default_stale_policy == "tombstone"  # nosec B101
+    assert settings.sitemap_sync_enabled is True  # nosec B101
+    assert settings.persist_url_query_strings is True  # nosec B101
+
+
 def test_from_mapping_parses_default_scope() -> None:
     settings = DocsSettings.from_mapping({"default_scope": {"owner_scope": "owner-a", "profile_scope": "profile-a"}})
 
@@ -92,6 +126,12 @@ def test_from_mapping_parses_default_scope() -> None:
 def test_from_mapping_rejects_unknown_web_source_profile(profile: str) -> None:
     with pytest.raises(ValueError, match="web_source_profile"):
         DocsSettings.from_mapping({"web_source_profile": profile})
+
+
+@pytest.mark.parametrize("value", ["", "delete", "hide"])
+def test_from_mapping_rejects_unknown_default_stale_policy(value: str) -> None:
+    with pytest.raises(ValueError, match="default_stale_policy"):
+        DocsSettings.from_mapping({"default_stale_policy": value})
 
 
 @pytest.mark.parametrize("field", ["max_url_redirects", "max_url_body_bytes"])

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
@@ -164,8 +164,14 @@ def test_ingest_query_url_creates_source_when_query_persistence_enabled(tmp_path
     result = service.ingest_url(scope=AccessScope(), url="https://example.com/page?token=secret")
 
     sources = store.list_sources(scope=AccessScope())
+    links = store.source_document_links(scope=AccessScope(), source_id=sources[0]["id"])
     assert result["source"]["source_url"] == "https://example.com/page?token=secret"  # nosec B101
+    assert result["source"]["document_count"] == 1  # nosec B101
     assert sources[0]["redacted_source_url"] == "https://example.com/page"  # nosec B101
+    assert len(links) == 1  # nosec B101
+    assert links[0]["document_id"] == result["document"]["id"]  # nosec B101
+    assert links[0]["source_item_uri"] == "https://example.com/page?token=secret"  # nosec B101
+    assert links[0]["status"] == "active"  # nosec B101
 
 
 def test_ingest_query_url_preserves_extraction_and_query_warnings(
@@ -174,10 +180,10 @@ def test_ingest_query_url_preserves_extraction_and_query_warnings(
 ) -> None:
     real_import_module = importlib.import_module
 
-    def fake_import(name: str) -> object:
+    def fake_import(name: str, package: str | None = None) -> object:
         if name in {"trafilatura", "bs4"}:
             raise ImportError(name)
-        return real_import_module(name)
+        return real_import_module(name, package)
 
     store = DocsCatalogStore(tmp_path / "docs.db")
     store.migrate()

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcp_unified.docs.importers.local import DocsImportService
+from mcp_unified.docs.models import AccessScope
+from mcp_unified.docs.settings import DocsSettings
+from mcp_unified.docs.store.sqlite import DocsCatalogStore
+
+pytestmark = pytest.mark.unit
+
+
+def _service(tmp_path: Path, root: Path) -> tuple[DocsImportService, DocsCatalogStore]:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root.resolve(),))
+    return DocsImportService(settings=settings, store=store), store
+
+
+def test_import_file_creates_local_file_source_and_link(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite sync source.\n", encoding="utf-8")
+    service, store = _service(tmp_path, root)
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+
+    result = service.import_path(scope=scope, path=guide, keywords=("setup",), collection_names=("Docs",))
+
+    sources = store.list_sources(scope=scope)
+    links = store.source_document_links(scope=scope, source_id=sources[0]["id"])
+    assert result["source"]["source_type"] == "local_file"  # nosec B101
+    assert sources[0]["source_type"] == "local_file"  # nosec B101
+    assert sources[0]["metadata"]["default_keywords"] == ["setup"]  # nosec B101
+    assert links[0]["document_id"] == result["documents"][0]["id"]  # nosec B101
+    assert links[0]["status"] == "active"  # nosec B101
+
+
+def test_import_directory_creates_one_directory_source_with_file_items(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "a.md").write_text("# A\n\nSQLite A.\n", encoding="utf-8")
+    (root / "b.md").write_text("# B\n\nSQLite B.\n", encoding="utf-8")
+    service, store = _service(tmp_path, root)
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+
+    service.import_path(scope=scope, path=root, keywords=("shared",), collection_names=("Docs",))
+
+    sources = store.list_sources(scope=scope)
+    links = store.source_document_links(scope=scope, source_id=sources[0]["id"])
+    assert len(sources) == 1  # nosec B101
+    assert sources[0]["source_type"] == "local_directory"  # nosec B101
+    assert sorted(link["source_item_uri"].rsplit("/", 1)[-1] for link in links) == ["a.md", "b.md"]  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 import pytest
 
+from mcp_unified.docs.errors import DocsError
 from mcp_unified.docs.importers.local import DocsImportService
 from mcp_unified.docs.models import AccessScope
 from mcp_unified.docs.settings import DocsSettings
+from mcp_unified.docs.source_utils import redacted_url_for_display, url_has_query
 from mcp_unified.docs.store.sqlite import DocsCatalogStore
 
 pytestmark = pytest.mark.unit
@@ -38,6 +40,21 @@ def test_import_file_creates_local_file_source_and_link(tmp_path: Path) -> None:
     assert links[0]["status"] == "active"  # nosec B101
 
 
+def test_failed_single_file_import_does_not_create_source(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    unsupported = root / "data.bin"
+    unsupported.write_bytes(b"binary")
+    service, store = _service(tmp_path, root)
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+
+    with pytest.raises(DocsError) as excinfo:
+        service.import_path(scope=scope, path=unsupported, keywords=("setup",), collection_names=("Docs",))
+
+    assert excinfo.value.code == "unsupported_import_format"  # nosec B101
+    assert store.list_sources(scope=scope) == []  # nosec B101
+
+
 def test_import_directory_creates_one_directory_source_with_file_items(tmp_path: Path) -> None:
     root = tmp_path / "workspace"
     root.mkdir()
@@ -52,4 +69,18 @@ def test_import_directory_creates_one_directory_source_with_file_items(tmp_path:
     links = store.source_document_links(scope=scope, source_id=sources[0]["id"])
     assert len(sources) == 1  # nosec B101
     assert sources[0]["source_type"] == "local_directory"  # nosec B101
+    assert sources[0]["canonical_uri"].endswith("/")  # nosec B101
     assert sorted(link["source_item_uri"].rsplit("/", 1)[-1] for link in links) == ["a.md", "b.md"]  # nosec B101
+
+
+def test_redacted_url_for_display_removes_credentials_query_and_fragment() -> None:
+    assert redacted_url_for_display("https://user:token@example.com/docs?x=1#frag") == "https://example.com/docs"  # nosec B101
+    assert (  # nosec B101
+        redacted_url_for_display("https://user:token@[2001:db8::1]:8443/docs?x=1#frag")
+        == "https://[2001:db8::1]:8443/docs"
+    )
+
+
+def test_url_has_query_detects_query_strings() -> None:
+    assert url_has_query("https://example.com/docs?x=1") is True  # nosec B101
+    assert url_has_query("https://example.com/docs#frag") is False  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
@@ -4,12 +4,15 @@ from pathlib import Path
 
 import pytest
 
+from mcp_unified.docs.acquisition.models import FetchResponse
+from mcp_unified.docs.acquisition.service import DocsAcquisitionService
 from mcp_unified.docs.errors import DocsError
 from mcp_unified.docs.importers.local import DocsImportService
 from mcp_unified.docs.models import AccessScope
 from mcp_unified.docs.settings import DocsSettings
 from mcp_unified.docs.source_utils import redacted_url_for_display, url_has_query
 from mcp_unified.docs.store.sqlite import DocsCatalogStore
+from tldw_Server_API.tests.MCP_unified.docs.helpers import FakeResolver, FakeTransport
 
 pytestmark = pytest.mark.unit
 
@@ -71,6 +74,91 @@ def test_import_directory_creates_one_directory_source_with_file_items(tmp_path:
     assert sources[0]["source_type"] == "local_directory"  # nosec B101
     assert sources[0]["canonical_uri"].endswith("/")  # nosec B101
     assert sorted(link["source_item_uri"].rsplit("/", 1)[-1] for link in links) == ["a.md", "b.md"]  # nosec B101
+
+
+def test_ingest_url_creates_url_page_source_for_queryless_url(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    service = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"sync body"])]
+        ),
+    )
+
+    result = service.ingest_url(scope=AccessScope(), url="https://example.com/page")
+
+    sources = store.list_sources(scope=AccessScope())
+    assert result["source"]["source_type"] == "url_page"  # nosec B101
+    assert sources[0]["source_url"] == "https://example.com/page"  # nosec B101
+    assert sources[0]["redacted_source_url"] == "https://example.com/page"  # nosec B101
+
+
+def test_ingest_query_url_does_not_create_refreshable_source_by_default(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    service = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"query body"])]
+        ),
+    )
+
+    result = service.ingest_url(scope=AccessScope(), url="https://example.com/page?token=secret")
+
+    assert result["status"] == "created"  # nosec B101
+    assert result["reason_code"] == "ok"  # nosec B101
+    assert result["source"] is None  # nosec B101
+    assert "url_query_not_persisted" in result["warnings"]  # nosec B101
+    assert store.list_sources(scope=AccessScope()) == []  # nosec B101
+
+
+def test_ingest_query_url_creates_source_when_query_persistence_enabled(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+            "persist_url_query_strings": True,
+        }
+    )
+    service = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"query body"])]
+        ),
+    )
+
+    result = service.ingest_url(scope=AccessScope(), url="https://example.com/page?token=secret")
+
+    sources = store.list_sources(scope=AccessScope())
+    assert result["source"]["source_url"] == "https://example.com/page?token=secret"  # nosec B101
+    assert sources[0]["redacted_source_url"] == "https://example.com/page"  # nosec B101
 
 
 def test_redacted_url_for_display_removes_credentials_query_and_fragment() -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_population.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
 import pytest
@@ -99,9 +100,15 @@ def test_ingest_url_creates_url_page_source_for_queryless_url(tmp_path: Path) ->
     result = service.ingest_url(scope=AccessScope(), url="https://example.com/page")
 
     sources = store.list_sources(scope=AccessScope())
+    links = store.source_document_links(scope=AccessScope(), source_id=sources[0]["id"])
     assert result["source"]["source_type"] == "url_page"  # nosec B101
+    assert result["source"]["document_count"] == 1  # nosec B101
     assert sources[0]["source_url"] == "https://example.com/page"  # nosec B101
     assert sources[0]["redacted_source_url"] == "https://example.com/page"  # nosec B101
+    assert len(links) == 1  # nosec B101
+    assert links[0]["document_id"] == result["document"]["id"]  # nosec B101
+    assert links[0]["source_item_uri"] == "https://example.com/page"  # nosec B101
+    assert links[0]["status"] == "active"  # nosec B101
 
 
 def test_ingest_query_url_does_not_create_refreshable_source_by_default(tmp_path: Path) -> None:
@@ -159,6 +166,104 @@ def test_ingest_query_url_creates_source_when_query_persistence_enabled(tmp_path
     sources = store.list_sources(scope=AccessScope())
     assert result["source"]["source_url"] == "https://example.com/page?token=secret"  # nosec B101
     assert sources[0]["redacted_source_url"] == "https://example.com/page"  # nosec B101
+
+
+def test_ingest_query_url_preserves_extraction_and_query_warnings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import_module = importlib.import_module
+
+    def fake_import(name: str) -> object:
+        if name in {"trafilatura", "bs4"}:
+            raise ImportError(name)
+        return real_import_module(name)
+
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    service = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [
+                FetchResponse(
+                    status_code=200,
+                    headers={"content-type": "text/html"},
+                    body_chunks=[b"<html><body><h1>Guide</h1><p>Static fallback body.</p></body></html>"],
+                )
+            ]
+        ),
+    )
+
+    result = service.ingest_url(scope=AccessScope(), url="https://example.com/page?token=secret")
+
+    assert result["status"] == "created"  # nosec B101
+    assert result["source"] is None  # nosec B101
+    assert "rich_extractors_unavailable" in result["warnings"]  # nosec B101
+    assert "url_query_not_persisted" in result["warnings"]  # nosec B101
+    assert store.list_sources(scope=AccessScope()) == []  # nosec B101
+
+
+def test_ingest_url_fetch_failure_does_not_create_source(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    service = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": []}),
+        transport=FakeTransport([]),
+    )
+
+    result = service.ingest_url(scope=AccessScope(), url="https://example.com/page")
+
+    assert result["status"] == "failed"  # nosec B101
+    assert result["reason_code"] == "dns_resolution_failed"  # nosec B101
+    assert store.list_sources(scope=AccessScope()) == []  # nosec B101
+
+
+def test_ingest_url_extract_empty_does_not_create_source(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    service = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"  \n\t"])]
+        ),
+    )
+
+    result = service.ingest_url(scope=AccessScope(), url="https://example.com/page")
+
+    assert result["status"] == "failed"  # nosec B101
+    assert result["reason_code"] == "extract_empty"  # nosec B101
+    assert store.list_sources(scope=AccessScope()) == []  # nosec B101
 
 
 def test_redacted_url_for_display_removes_credentials_query_and_fragment() -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -226,7 +226,7 @@ def test_url_page_sync_retires_previous_redirect_target_when_canonical_changes_w
         [
             FetchResponse(status_code=302, headers={"location": "https://example.com/b"}),
             FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"oldbmarker body"]),
-            FetchResponse(status_code=302, headers={"location": "https://example.com/c"}),
+            FetchResponse(status_code=302, headers={"location": "https://example.com/c?token=secret"}),
             FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"newcmarker body"]),
         ]
     )
@@ -237,13 +237,28 @@ def test_url_page_sync_retires_previous_redirect_target_when_canonical_changes_w
     service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
 
     result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="apply"))
+    listed = DocsMCPToolProvider(settings=settings, store=store).execute("docs.list", {"kind": "sources"}, scope=scope)
+    stored_source = store.get_source(scope=scope, source_id=source_id)
     links = store.source_document_links(scope=scope, source_id=source_id)
     active_links = [link for link in links if link["status"] == "active"]
     old_search = store.search_chunks(scope=scope, query="oldbmarker", limit=10)
     new_search = store.search_chunks(scope=scope, query="newcmarker", limit=10)
+    future_transport = FakeTransport(
+        [FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"newcmarker body"])]
+    )
+    future_service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=future_transport)
+    future_service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="dry_run"))
 
     assert result["counts"]["updated"] == 1  # nosec B101
-    assert [link["source_item_uri"] for link in active_links] == ["https://example.com/c"]  # nosec B101
+    assert "token=secret" not in repr(result["source"])  # nosec B101
+    assert result["source"]["canonical_uri"] == "https://example.com/c"  # nosec B101
+    assert result["source"]["document_count"] == 1  # nosec B101
+    assert listed["sources"][0]["canonical_uri"] == "https://example.com/c"  # nosec B101
+    assert listed["sources"][0]["document_count"] == 1  # nosec B101
+    assert stored_source["id"] == source_id  # nosec B101
+    assert stored_source["source_url"] == "https://example.com/c?token=secret"  # nosec B101
+    assert [link["source_item_uri"] for link in active_links] == ["https://example.com/c?token=secret"]  # nosec B101
+    assert future_transport.calls[0][1].target == "/c?token=secret"  # nosec B101
     assert old_search == []  # nosec B101
     assert new_search  # nosec B101
 
@@ -277,11 +292,16 @@ def test_url_page_sync_relinks_same_body_when_canonical_changes(
     service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
 
     result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="apply"))
+    listed = DocsMCPToolProvider(settings=settings, store=store).execute("docs.list", {"kind": "sources"}, scope=scope)
     links = store.source_document_links(scope=scope, source_id=source_id)
     active_links = [link for link in links if link["status"] == "active"]
 
     assert result["counts"]["updated"] == 1  # nosec B101
     assert result["counts"]["unchanged"] == 0  # nosec B101
+    assert result["source"]["canonical_uri"] == "https://example.com/c"  # nosec B101
+    assert result["source"]["document_count"] == 1  # nosec B101
+    assert listed["sources"][0]["canonical_uri"] == "https://example.com/c"  # nosec B101
+    assert listed["sources"][0]["document_count"] == 1  # nosec B101
     assert [link["source_item_uri"] for link in active_links] == ["https://example.com/c"]  # nosec B101
 
 

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import closing
+import json
 from pathlib import Path
 
 import pytest
@@ -246,7 +247,11 @@ def test_url_page_sync_retires_previous_redirect_target_when_canonical_changes_w
     service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
 
     result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="apply"))
-    listed = DocsMCPToolProvider(settings=settings, store=store).execute("docs.list", {"kind": "sources"}, scope=scope)
+    provider = DocsMCPToolProvider(settings=settings, store=store)
+    listed = provider.execute("docs.list", {"kind": "sources"}, scope=scope)
+    listed_documents = provider.execute("docs.list", {"kind": "documents"}, scope=scope)
+    provider_search = provider.execute("docs.search", {"query": "newcmarker"}, scope=scope)
+    provider_context = provider.execute("docs.context", {"query": "newcmarker"}, scope=scope)
     stored_source = store.get_source(scope=scope, source_id=source_id)
     links = store.source_document_links(scope=scope, source_id=source_id)
     active_links = [link for link in links if link["status"] == "active"]
@@ -257,6 +262,7 @@ def test_url_page_sync_retires_previous_redirect_target_when_canonical_changes_w
     )
     future_service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=future_transport)
     future_service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="dry_run"))
+    serialized = json.dumps([result, listed, listed_documents, provider_search, provider_context], sort_keys=True)
 
     assert result["counts"]["updated"] == 1  # nosec B101
     assert "token=secret" not in repr(result["source"])  # nosec B101
@@ -265,9 +271,12 @@ def test_url_page_sync_retires_previous_redirect_target_when_canonical_changes_w
     assert listed["sources"][0]["canonical_uri"] == "https://example.com/c"  # nosec B101
     assert listed["sources"][0]["document_count"] == 1  # nosec B101
     assert stored_source["id"] == source_id  # nosec B101
-    assert stored_source["source_url"] == "https://example.com/c?token=secret"  # nosec B101
-    assert [link["source_item_uri"] for link in active_links] == ["https://example.com/c?token=secret"]  # nosec B101
-    assert future_transport.calls[0][1].target == "/c?token=secret"  # nosec B101
+    assert stored_source["canonical_uri"] == "https://example.com/c"  # nosec B101
+    assert stored_source["source_url"] == "https://example.com/c"  # nosec B101
+    assert [link["source_item_uri"] for link in active_links] == ["https://example.com/c"]  # nosec B101
+    assert future_transport.calls[0][1].target == "/c"  # nosec B101
+    assert "token=secret" not in serialized  # nosec B101
+    assert "?token" not in serialized  # nosec B101
     assert old_search == []  # nosec B101
     assert new_search  # nosec B101
 

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -401,6 +401,31 @@ def test_local_directory_sync_tombstone_hides_document_from_default_search(tmp_p
     assert search["results"] == []  # nosec B101
 
 
+def test_local_directory_sync_counts_stale_items_toward_limit_before_tombstoning(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "a.md").write_text("# A\n\nSQLite A.\n", encoding="utf-8")
+    (root / "b.md").write_text("# B\n\nSQLite B.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(root)}, scope=scope)
+    source_id = imported["source"]["id"]
+    for file_path in root.iterdir():
+        file_path.unlink()
+
+    result = provider.execute(
+        "docs.sync_source",
+        {"source_id": source_id, "mode": "apply", "stale_policy": "tombstone", "max_documents": 1},
+        scope=scope,
+    )
+    search = provider.execute("docs.search", {"query": "SQLite"}, scope=scope)
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "source_sync_limit_exceeded"  # nosec B101
+    assert result["counts"]["tombstoned"] == 0  # nosec B101
+    assert sorted(match["title"] for match in search["results"]) == ["A", "B"]  # nosec B101
+
+
 def test_local_directory_sync_limit_exceeded_before_parsing_candidates(tmp_path: Path) -> None:
     root = tmp_path / "workspace"
     root.mkdir()
@@ -427,6 +452,32 @@ def test_local_directory_sync_limit_exceeded_before_parsing_candidates(tmp_path:
     assert result["reason_code"] == "source_sync_limit_exceeded"  # nosec B101
     assert search["results"] == []  # nosec B101
     assert status["counts"]["sync_runs"] == 0  # nosec B101
+
+
+def test_local_directory_sync_skips_symlink_escaping_source_directory(tmp_path: Path) -> None:
+    trusted_root = tmp_path
+    root = trusted_root / "workspace"
+    root.mkdir()
+    (root / "public.md").write_text("# Public\n\nSQLite public.\n", encoding="utf-8")
+    secret = trusted_root / "secret.md"
+    secret.write_text("# Secret\n\nClassified sibling content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(
+        settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(trusted_root,))
+    )
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(root)}, scope=scope)
+    source_id = imported["source"]["id"]
+    link = root / "secret.md"
+    try:
+        link.symlink_to(secret)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable in this environment: {exc}")
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id, "mode": "apply"}, scope=scope)
+    search = provider.execute("docs.search", {"query": "Classified"}, scope=scope)
+
+    assert result["counts"]["created"] == 0  # nosec B101
+    assert search["results"] == []  # nosec B101
 
 
 def test_local_file_sync_apply_unchanged_does_not_rewrite_without_force(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -208,6 +208,83 @@ def test_url_page_sync_private_address_denial_preserves_old_content_without_run(
     assert status["counts"]["sync_runs"] == 0  # nosec B101
 
 
+def test_url_page_sync_retires_previous_redirect_target_when_canonical_changes_with_new_body(
+    tmp_path: Path,
+) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(status_code=302, headers={"location": "https://example.com/b"}),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"oldbmarker body"]),
+            FetchResponse(status_code=302, headers={"location": "https://example.com/c"}),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"newcmarker body"]),
+        ]
+    )
+    acquisition = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
+    scope = AccessScope()
+    ingested = acquisition.ingest_url(scope=scope, url="https://example.com/a")
+    source_id = ingested["source"]["id"]
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="apply"))
+    links = store.source_document_links(scope=scope, source_id=source_id)
+    active_links = [link for link in links if link["status"] == "active"]
+    old_search = store.search_chunks(scope=scope, query="oldbmarker", limit=10)
+    new_search = store.search_chunks(scope=scope, query="newcmarker", limit=10)
+
+    assert result["counts"]["updated"] == 1  # nosec B101
+    assert [link["source_item_uri"] for link in active_links] == ["https://example.com/c"]  # nosec B101
+    assert old_search == []  # nosec B101
+    assert new_search  # nosec B101
+
+
+def test_url_page_sync_relinks_same_body_when_canonical_changes(
+    tmp_path: Path,
+) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(status_code=302, headers={"location": "https://example.com/b"}),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"samebodymarker"]),
+            FetchResponse(status_code=302, headers={"location": "https://example.com/c"}),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"samebodymarker"]),
+        ]
+    )
+    acquisition = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
+    scope = AccessScope()
+    ingested = acquisition.ingest_url(scope=scope, url="https://example.com/a")
+    source_id = ingested["source"]["id"]
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="apply"))
+    links = store.source_document_links(scope=scope, source_id=source_id)
+    active_links = [link for link in links if link["status"] == "active"]
+
+    assert result["counts"]["updated"] == 1  # nosec B101
+    assert result["counts"]["unchanged"] == 0  # nosec B101
+    assert [link["source_item_uri"] for link in active_links] == ["https://example.com/c"]  # nosec B101
+
+
 def test_provider_advertises_sync_source_when_enabled(tmp_path: Path) -> None:
     provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(tmp_path,)))
 

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -12,6 +12,7 @@ from mcp_unified.docs.errors import DocsError
 from mcp_unified.docs.mcp_module import DocsMCPToolProvider
 from mcp_unified.docs.models import AccessScope, SyncSourceRequest
 from mcp_unified.docs.settings import DocsSettings
+from mcp_unified.docs.source_utils import file_uri_for_path
 from mcp_unified.docs.sync import DocsSourceSyncService
 from mcp_unified.docs.store.sqlite import DocsCatalogStore
 from tldw_Server_API.tests.MCP_unified.docs.helpers import FakeResolver, FakeTransport
@@ -700,6 +701,137 @@ def test_local_directory_sync_tombstone_hides_document_from_default_search(tmp_p
 
     assert result["counts"]["tombstoned"] == 1  # nosec B101
     assert search["results"] == []  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("exception", "reason_code"),
+    [
+        (OSError("permission denied"), "read_failed"),
+        (UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"), "decode_failed"),
+    ],
+)
+def test_local_directory_sync_records_file_parse_failures_and_continues(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception: Exception,
+    reason_code: str,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    good = root / "good.md"
+    bad = root / "bad.md"
+    good.write_text("# Good\n\nOld good content.\n", encoding="utf-8")
+    bad.write_text("# Bad\n\nBad content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(root)}, scope=scope)
+    source_id = imported["source"]["id"]
+    good.write_text("# Good\n\nNew good content.\n", encoding="utf-8")
+    original_parse = provider.source_sync._parsed_local_sync_item
+
+    def flaky_parse(file_path: Path):
+        if file_path.name == "bad.md":
+            raise exception
+        return original_parse(file_path)
+
+    monkeypatch.setattr(provider.source_sync, "_parsed_local_sync_item", flaky_parse)
+
+    try:
+        result = provider.execute("docs.sync_source", {"source_id": source_id, "mode": "apply"}, scope=scope)
+    except (OSError, UnicodeDecodeError) as exc:
+        pytest.fail(f"sync should record {type(exc).__name__} as an item failure")
+    search = provider.execute("docs.search", {"query": "New"}, scope=scope)
+
+    assert result["status"] == "partial"  # nosec B101
+    assert result["reason_code"] == "partial_failure"  # nosec B101
+    assert result["counts"]["failed"] == 1  # nosec B101
+    assert result["counts"]["updated"] == 1  # nosec B101
+    assert reason_code in result["warnings"]  # nosec B101
+    assert any(item["reason_code"] == reason_code for item in result["items"])  # nosec B101
+    assert search["results"][0]["title"] == "Good"  # nosec B101
+
+
+def test_local_directory_sync_missing_source_root_does_not_tombstone_existing_links(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(tmp_path,)))
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(root)}, scope=scope)
+    source_id = imported["source"]["id"]
+    guide.unlink()
+    root.rmdir()
+
+    result = provider.execute(
+        "docs.sync_source",
+        {"source_id": source_id, "mode": "apply", "stale_policy": "tombstone"},
+        scope=scope,
+    )
+    search = provider.execute("docs.search", {"query": "SQLite"}, scope=scope)
+    links = provider.store.source_document_links(scope=scope, source_id=source_id)
+
+    assert result["status"] == "failed"  # nosec B101
+    assert result["reason_code"] == "import_path_not_found"  # nosec B101
+    assert result["counts"]["tombstoned"] == 0  # nosec B101
+    assert search["results"]  # nosec B101
+    assert links[0]["status"] == "active"  # nosec B101
+
+
+def test_local_file_sync_missing_source_file_does_not_tombstone_existing_link(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(guide)}, scope=scope)
+    source_id = imported["source"]["id"]
+    guide.unlink()
+
+    result = provider.execute(
+        "docs.sync_source",
+        {"source_id": source_id, "mode": "apply", "stale_policy": "tombstone"},
+        scope=scope,
+    )
+    search = provider.execute("docs.search", {"query": "SQLite"}, scope=scope)
+    links = provider.store.source_document_links(scope=scope, source_id=source_id)
+
+    assert result["status"] == "failed"  # nosec B101
+    assert result["reason_code"] == "import_path_not_found"  # nosec B101
+    assert result["counts"]["tombstoned"] == 0  # nosec B101
+    assert search["results"]  # nosec B101
+    assert links[0]["status"] == "active"  # nosec B101
+
+
+def test_local_file_sync_decodes_file_uri_source_path(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide with spaces.md"
+    guide.write_text("# Guide\n\nSQLite content.\n", encoding="utf-8")
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="local_file",
+        canonical_uri=file_uri_for_path(guide),
+        display_name=guide.name,
+        source_path=None,
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)), store=store)
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id, "mode": "apply"}, scope=scope)
+    search = provider.execute("docs.search", {"query": "SQLite"}, scope=scope)
+
+    assert result["counts"]["created"] == 1  # nosec B101
+    assert result["items"][0]["canonical_uri"] == file_uri_for_path(guide)  # nosec B101
+    assert search["results"][0]["title"] == "Guide"  # nosec B101
 
 
 def test_local_directory_sync_tombstone_hides_document_from_lookup_and_facets(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -4,10 +4,14 @@ from pathlib import Path
 
 import pytest
 
+from mcp_unified.docs.acquisition.models import FetchResponse
+from mcp_unified.docs.acquisition.service import DocsAcquisitionService
 from mcp_unified.docs.mcp_module import DocsMCPToolProvider
-from mcp_unified.docs.models import AccessScope
+from mcp_unified.docs.models import AccessScope, SyncSourceRequest
 from mcp_unified.docs.settings import DocsSettings
+from mcp_unified.docs.sync import DocsSourceSyncService
 from mcp_unified.docs.store.sqlite import DocsCatalogStore
+from tldw_Server_API.tests.MCP_unified.docs.helpers import FakeResolver, FakeTransport
 
 pytestmark = pytest.mark.unit
 
@@ -20,6 +24,188 @@ ZERO_SYNC_COUNTS = {
     "failed": 0,
     "skipped": 0,
 }
+
+
+def test_url_page_sync_apply_refreshes_existing_source_with_fake_transport(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"old sqlite body"]),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"new sqlite body"]),
+        ]
+    )
+    acquisition = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
+    scope = AccessScope()
+    ingested = acquisition.ingest_url(scope=scope, url="https://example.com/page")
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=ingested["source"]["id"], mode="apply"))
+    search = store.search_chunks(scope=scope, query="new", limit=10)
+
+    assert result["counts"]["updated"] == 1  # nosec B101
+    assert search[0]["title"]  # nosec B101
+
+
+def test_url_page_sync_does_not_fetch_when_policy_requires_approval(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_page",
+        canonical_uri="https://example.com/page",
+        display_name="page",
+        source_path=None,
+        source_url="https://example.com/page",
+        redacted_source_url="https://example.com/page",
+        policy_profile="local_first",
+        sync_enabled=True,
+        metadata={},
+    )
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "local_first",
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport([FetchResponse(status_code=200, body_chunks=[b"never"])])
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="apply"))
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "approval_required"  # nosec B101
+    assert resolver.calls == []  # nosec B101
+    assert transport.calls == []  # nosec B101
+
+
+def test_url_page_sync_dry_run_does_not_mutate_content_links_or_runs(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"old sqlite body"]),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"new sqlite body"]),
+        ]
+    )
+    acquisition = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
+    scope = AccessScope()
+    ingested = acquisition.ingest_url(scope=scope, url="https://example.com/page")
+    source_id = ingested["source"]["id"]
+    source_before = store.get_source(scope=scope, source_id=source_id)
+    links_before = store.source_document_links(scope=scope, source_id=source_id)
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(
+        scope=scope,
+        request=SyncSourceRequest(source_id=source_id, mode="dry_run"),
+    )
+    search_new = store.search_chunks(scope=scope, query="new", limit=10)
+    search_old = store.search_chunks(scope=scope, query="old", limit=10)
+    status = store.status()
+
+    assert result["counts"]["updated"] == 1  # nosec B101
+    assert search_new == []  # nosec B101
+    assert search_old  # nosec B101
+    assert store.get_source(scope=scope, source_id=source_id) == source_before  # nosec B101
+    assert store.source_document_links(scope=scope, source_id=source_id) == links_before  # nosec B101
+    assert status["counts"]["sync_runs"] == 0  # nosec B101
+
+
+def test_url_page_sync_redacts_query_bearing_source_summary(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+            "persist_url_query_strings": True,
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"old sqlite body"]),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"new sqlite body"]),
+        ]
+    )
+    acquisition = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
+    scope = AccessScope()
+    ingested = acquisition.ingest_url(scope=scope, url="https://example.com/page?token=secret")
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(
+        scope=scope,
+        request=SyncSourceRequest(source_id=ingested["source"]["id"], mode="apply"),
+    )
+
+    assert "token=secret" not in repr(result["source"])  # nosec B101
+    assert result["source"]["canonical_uri"] == "https://example.com/page"  # nosec B101
+    assert result["source"]["display_uri"] == "https://example.com/page"  # nosec B101
+    assert result["source"]["redacted_source_url"] == "https://example.com/page"  # nosec B101
+
+
+def test_url_page_sync_private_address_denial_preserves_old_content_without_run(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "web_source_profile": "online_capable",
+            "allow_arbitrary_public_domains": True,
+        }
+    )
+    scope = AccessScope()
+    ingest_transport = FakeTransport(
+        [FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"old sqlite body"])]
+    )
+    acquisition = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=ingest_transport,
+    )
+    ingested = acquisition.ingest_url(scope=scope, url="https://example.com/page")
+    source_id = ingested["source"]["id"]
+    sync_resolver = FakeResolver({"example.com": ["127.0.0.1"]})
+    sync_transport = FakeTransport([FetchResponse(status_code=200, body_chunks=[b"new sqlite body"])])
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=sync_resolver, transport=sync_transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="apply"))
+    search_old = store.search_chunks(scope=scope, query="old", limit=10)
+    search_new = store.search_chunks(scope=scope, query="new", limit=10)
+    status = store.status()
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "egress_private_address_denied"  # nosec B101
+    assert search_old  # nosec B101
+    assert search_new == []  # nosec B101
+    assert sync_transport.calls == []  # nosec B101
+    assert status["counts"]["sync_runs"] == 0  # nosec B101
 
 
 def test_provider_advertises_sync_source_when_enabled(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcp_unified.docs.mcp_module import DocsMCPToolProvider
+from mcp_unified.docs.models import AccessScope
+from mcp_unified.docs.settings import DocsSettings
+from mcp_unified.docs.store.sqlite import DocsCatalogStore
+
+pytestmark = pytest.mark.unit
+
+
+def test_provider_advertises_sync_source_when_enabled(tmp_path: Path) -> None:
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(tmp_path,)))
+
+    tools = {tool["name"]: tool for tool in provider.tool_definitions()}
+
+    assert "docs.sync_source" in tools  # nosec B101
+    assert tools["docs.sync_source"]["metadata"]["category"] == "ingestion"  # nosec B101
+    assert tools["docs.sync_source"]["metadata"]["readOnlyHint"] is False  # nosec B101
+
+
+def test_provider_omits_sync_source_when_disabled(tmp_path: Path) -> None:
+    provider = DocsMCPToolProvider(
+        settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(tmp_path,), enable_source_sync=False)
+    )
+
+    tools = {tool["name"]: tool for tool in provider.tool_definitions()}
+
+    assert "docs.sync_source" not in tools  # nosec B101
+
+
+def test_provider_list_sources_returns_real_sources(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    store.upsert_source(
+        scope=scope,
+        source_type="local_file",
+        canonical_uri="file:///docs/guide.md",
+        display_name="guide.md",
+        source_path="/docs/guide.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"), store=store)
+
+    result = provider.execute("docs.list", {"kind": "sources"}, scope=scope)
+
+    assert result["sources"][0]["canonical_uri"] == "file:///docs/guide.md"  # nosec B101
+    assert result["warnings"] == []  # nosec B101
+
+
+def test_provider_sync_source_denies_stale_call_when_disabled(tmp_path: Path) -> None:
+    provider = DocsMCPToolProvider(
+        settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(tmp_path,), enable_source_sync=False)
+    )
+
+    result = provider.execute("docs.sync_source", {"source_uri": "file:///docs/guide.md"}, scope=AccessScope())
+
+    assert result == {"status": "denied", "reason_code": "source_sync_disabled"}  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {},
+        {"source_id": 1, "source_uri": "file:///docs/guide.md"},
+    ],
+)
+def test_provider_sync_source_validates_exactly_one_selector_without_mutation(
+    tmp_path: Path,
+    arguments: dict[str, object],
+) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="local_file",
+        canonical_uri="file:///docs/guide.md",
+        display_name="guide.md",
+        source_path="/docs/guide.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    before = store.get_source(scope=scope, source_id=source_id)
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"), store=store)
+
+    result = provider.execute("docs.sync_source", arguments, scope=scope)
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "source_selector_invalid"  # nosec B101
+    assert store.get_source(scope=scope, source_id=source_id) == before  # nosec B101
+
+
+def test_provider_sync_source_denies_missing_source(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"), store=store)
+
+    result = provider.execute("docs.sync_source", {"source_id": 404}, scope=AccessScope())
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "source_not_found"  # nosec B101
+
+
+def test_provider_sync_source_returns_stable_unsupported_response_for_sitemap(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_sitemap",
+        canonical_uri="https://example.com/sitemap.xml",
+        display_name="Example sitemap",
+        source_path=None,
+        source_url="https://example.com/sitemap.xml",
+        redacted_source_url="https://example.com/sitemap.xml",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"), store=store)
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id}, scope=scope)
+
+    assert result["status"] in {"denied", "skipped"}  # nosec B101
+    assert result["reason_code"] in {"source_sync_unsupported_type", "sitemap_sync_disabled"}  # nosec B101
+    assert result["source"]["id"] == source_id  # nosec B101
+    assert result["source"]["canonical_uri"] == "https://example.com/sitemap.xml"  # nosec B101
+    assert result["counts"] == {"created": 0, "updated": 0, "unchanged": 0, "failed": 0, "skipped": 0}  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from contextlib import closing
 from pathlib import Path
 
 import pytest
 
 from mcp_unified.docs.acquisition.models import FetchResponse
 from mcp_unified.docs.acquisition.service import DocsAcquisitionService
+from mcp_unified.docs.errors import DocsError
 from mcp_unified.docs.mcp_module import DocsMCPToolProvider
 from mcp_unified.docs.models import AccessScope, SyncSourceRequest
 from mcp_unified.docs.settings import DocsSettings
@@ -24,6 +26,13 @@ ZERO_SYNC_COUNTS = {
     "failed": 0,
     "skipped": 0,
 }
+
+
+def _document_count(items: list[dict], name: str) -> int:
+    for item in items:
+        if item.get("name") == name or item.get("keyword") == name:
+            return int(item["document_count"])
+    raise AssertionError(f"{name!r} not found")
 
 
 def test_url_page_sync_apply_refreshes_existing_source_with_fake_transport(tmp_path: Path) -> None:
@@ -682,6 +691,54 @@ def test_local_directory_sync_tombstone_hides_document_from_default_search(tmp_p
 
     assert result["counts"]["tombstoned"] == 1  # nosec B101
     assert search["results"] == []  # nosec B101
+
+
+def test_local_directory_sync_tombstone_hides_document_from_lookup_and_facets(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Tombstone Guide\n\nTombstone visibility content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    imported = provider.execute(
+        "docs.import_path",
+        {"path": str(root), "keywords": ["obsolete"], "collections": ["Archive"]},
+        scope=scope,
+    )
+    document_id = imported["documents"][0]["id"]
+    source_id = imported["source"]["id"]
+    with closing(provider.store.connect()) as conn:
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO docs_aliases (owner_scope, profile_scope, name, document_id)
+                VALUES (?, ?, ?, ?)
+                """,
+                (scope.owner_scope, scope.profile_scope, "old-guide", document_id),
+            )
+    guide.unlink()
+
+    result = provider.execute(
+        "docs.sync_source",
+        {"source_id": source_id, "mode": "apply", "stale_policy": "tombstone"},
+        scope=scope,
+    )
+    search = provider.execute("docs.search", {"query": "visibility"}, scope=scope)
+    resolved = provider.execute("docs.resolve", {"name": "Tombstone Guide"}, scope=scope)
+    collections = provider.execute("docs.list", {"kind": "collections"}, scope=scope)
+    keywords = provider.execute("docs.list", {"kind": "keywords"}, scope=scope)
+
+    assert result["counts"]["tombstoned"] == 1  # nosec B101
+    assert search["results"] == []  # nosec B101
+    with pytest.raises(DocsError) as direct_get:
+        provider.execute("docs.get", {"id": str(document_id)}, scope=scope)
+    with pytest.raises(DocsError) as alias_get:
+        provider.execute("docs.get", {"id": "old-guide"}, scope=scope)
+    assert direct_get.value.code == "document_not_found"  # nosec B101
+    assert alias_get.value.code == "document_not_found"  # nosec B101
+    assert resolved["matches"] == []  # nosec B101
+    assert _document_count(collections["collections"], "Archive") == 0  # nosec B101
+    assert _document_count(keywords["keywords"], "obsolete") == 0  # nosec B101
 
 
 def test_local_directory_sync_counts_stale_items_toward_limit_before_tombstoning(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -300,3 +300,181 @@ def test_provider_sync_source_returns_stable_unsupported_response_for_sitemap(tm
     assert result["source"]["id"] == source_id  # nosec B101
     assert result["source"]["canonical_uri"] == "https://example.com/sitemap.xml"  # nosec B101
     assert result["counts"] == ZERO_SYNC_COUNTS  # nosec B101
+
+
+def test_local_file_sync_dry_run_does_not_mutate_document_or_run_rows(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nOld sqlite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    imported = provider.execute("docs.import_path", {"path": str(guide)}, scope=scope)
+    source_id = imported["source"]["id"]
+    guide.write_text("# Guide\n\nNew sqlite content.\n", encoding="utf-8")
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id, "mode": "dry_run"}, scope=scope)
+    search = provider.execute("docs.search", {"query": "New"}, scope=scope)
+    status = provider.store.status()
+
+    assert result["mode"] == "dry_run"  # nosec B101
+    assert result["counts"]["updated"] == 1  # nosec B101
+    assert search["results"] == []  # nosec B101
+    assert status["counts"]["sync_runs"] == 0  # nosec B101
+
+
+def test_local_file_sync_apply_updates_content_and_preserves_user_metadata(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nOld sqlite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    imported = provider.execute(
+        "docs.import_path",
+        {"path": str(guide), "keywords": ["source"], "collections": ["Source"]},
+        scope=scope,
+    )
+    document_id = imported["documents"][0]["id"]
+    source_id = imported["source"]["id"]
+    provider.execute("docs.keywords.apply", {"document_id": document_id, "keywords": ["manual"]}, scope=scope)
+    provider.execute(
+        "docs.collections.set_membership",
+        {"collection": "Manual", "document_id": document_id, "action": "add"},
+        scope=scope,
+    )
+    guide.write_text("# Guide\n\nNew sqlite content.\n", encoding="utf-8")
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id, "mode": "apply"}, scope=scope)
+    search = provider.execute(
+        "docs.search",
+        {"query": "New", "filters": {"keywords": ["manual"], "collection": "Manual"}},
+        scope=scope,
+    )
+
+    assert result["counts"]["updated"] == 1  # nosec B101
+    assert search["results"][0]["document_id"] == document_id  # nosec B101
+
+
+def test_local_directory_sync_report_missing_does_not_hide_document(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(root)}, scope=scope)
+    source_id = imported["source"]["id"]
+    guide.unlink()
+
+    result = provider.execute(
+        "docs.sync_source",
+        {"source_id": source_id, "mode": "apply", "stale_policy": "report"},
+        scope=scope,
+    )
+    search = provider.execute("docs.search", {"query": "SQLite"}, scope=scope)
+
+    assert result["counts"]["missing"] == 1  # nosec B101
+    assert result["counts"]["tombstoned"] == 0  # nosec B101
+    assert search["results"]  # nosec B101
+
+
+def test_local_directory_sync_tombstone_hides_document_from_default_search(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(root)}, scope=scope)
+    source_id = imported["source"]["id"]
+    guide.unlink()
+
+    result = provider.execute(
+        "docs.sync_source",
+        {"source_id": source_id, "mode": "apply", "stale_policy": "tombstone"},
+        scope=scope,
+    )
+    search = provider.execute("docs.search", {"query": "SQLite"}, scope=scope)
+
+    assert result["counts"]["tombstoned"] == 1  # nosec B101
+    assert search["results"] == []  # nosec B101
+
+
+def test_local_directory_sync_limit_exceeded_before_parsing_candidates(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(
+        settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,), max_import_file_bytes=64)
+    )
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(root)}, scope=scope)
+    source_id = imported["source"]["id"]
+    large = root / "large.md"
+    large.write_text("# Large\n\n" + ("too large " * 20), encoding="utf-8")
+
+    result = provider.execute(
+        "docs.sync_source",
+        {"source_id": source_id, "mode": "apply", "max_documents": 1},
+        scope=scope,
+    )
+    search = provider.execute("docs.search", {"query": "large"}, scope=scope)
+    status = provider.store.status()
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "source_sync_limit_exceeded"  # nosec B101
+    assert search["results"] == []  # nosec B101
+    assert status["counts"]["sync_runs"] == 0  # nosec B101
+
+
+def test_local_file_sync_apply_unchanged_does_not_rewrite_without_force(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(guide)}, scope=scope)
+    document_id = imported["documents"][0]["id"]
+    source_id = imported["source"]["id"]
+    before = provider.execute("docs.get", {"id": str(document_id), "mode": "chunk"}, scope=scope)
+    before_chunk_ids = [chunk["id"] for chunk in before["chunks"]]
+
+    unchanged = provider.execute("docs.sync_source", {"source_id": source_id, "mode": "apply"}, scope=scope)
+    after_unchanged = provider.execute("docs.get", {"id": str(document_id), "mode": "chunk"}, scope=scope)
+    forced = provider.execute(
+        "docs.sync_source",
+        {"source_id": source_id, "mode": "apply", "force": True},
+        scope=scope,
+    )
+    after_forced = provider.execute("docs.get", {"id": str(document_id), "mode": "chunk"}, scope=scope)
+
+    assert unchanged["counts"]["unchanged"] == 1  # nosec B101
+    assert after_unchanged["chunks"] and [chunk["id"] for chunk in after_unchanged["chunks"]] == before_chunk_ids  # nosec B101
+    assert forced["counts"]["updated"] == 1  # nosec B101
+    assert [chunk["id"] for chunk in after_forced["chunks"]] != before_chunk_ids  # nosec B101
+
+
+def test_local_file_sync_report_missing_deleted_source_file_keeps_document_visible(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    guide = root / "guide.md"
+    guide.write_text("# Guide\n\nSQLite content.\n", encoding="utf-8")
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(root,)))
+    scope = AccessScope()
+    imported = provider.execute("docs.import_path", {"path": str(guide)}, scope=scope)
+    source_id = imported["source"]["id"]
+    guide.unlink()
+
+    result = provider.execute(
+        "docs.sync_source",
+        {"source_id": source_id, "mode": "apply", "stale_policy": "report"},
+        scope=scope,
+    )
+    search = provider.execute("docs.search", {"query": "SQLite"}, scope=scope)
+
+    assert result["counts"]["missing"] == 1  # nosec B101
+    assert result["counts"]["tombstoned"] == 0  # nosec B101
+    assert search["results"]  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -11,6 +11,16 @@ from mcp_unified.docs.store.sqlite import DocsCatalogStore
 
 pytestmark = pytest.mark.unit
 
+ZERO_SYNC_COUNTS = {
+    "created": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "missing": 0,
+    "tombstoned": 0,
+    "failed": 0,
+    "skipped": 0,
+}
+
 
 def test_provider_advertises_sync_source_when_enabled(tmp_path: Path) -> None:
     provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db", trusted_roots=(tmp_path,)))
@@ -54,6 +64,37 @@ def test_provider_list_sources_returns_real_sources(tmp_path: Path) -> None:
 
     assert result["sources"][0]["canonical_uri"] == "file:///docs/guide.md"  # nosec B101
     assert result["warnings"] == []  # nosec B101
+
+
+def test_provider_list_sources_redacts_query_bearing_url_sources(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    store.upsert_source(
+        scope=scope,
+        source_type="url_page",
+        canonical_uri="https://example.com/page?token=secret",
+        display_name="Example page",
+        source_path=None,
+        source_url="https://example.com/page?token=secret",
+        redacted_source_url="https://example.com/page",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    provider = DocsMCPToolProvider(
+        settings=DocsSettings(db_path=tmp_path / "docs.db", persist_url_query_strings=True),
+        store=store,
+    )
+
+    result = provider.execute("docs.list", {"kind": "sources"}, scope=scope)
+
+    source = result["sources"][0]
+    assert "token=secret" not in repr(source)  # nosec B101
+    assert "source_url" not in source  # nosec B101
+    assert source["canonical_uri"] == "https://example.com/page"  # nosec B101
+    assert source["display_uri"] == "https://example.com/page"  # nosec B101
+    assert source["redacted_source_url"] == "https://example.com/page"  # nosec B101
 
 
 def test_provider_sync_source_denies_stale_call_when_disabled(tmp_path: Path) -> None:
@@ -113,6 +154,127 @@ def test_provider_sync_source_denies_missing_source(tmp_path: Path) -> None:
     assert result["reason_code"] == "source_not_found"  # nosec B101
 
 
+def test_provider_sync_source_redacts_query_bearing_url_summary(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_page",
+        canonical_uri="https://example.com/page?token=secret",
+        display_name="Example page",
+        source_path=None,
+        source_url="https://example.com/page?token=secret",
+        redacted_source_url="https://example.com/page",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    provider = DocsMCPToolProvider(
+        settings=DocsSettings(db_path=tmp_path / "docs.db", persist_url_query_strings=True),
+        store=store,
+    )
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id}, scope=scope)
+
+    source = result["source"]
+    assert "token=secret" not in repr(source)  # nosec B101
+    assert "source_url" not in source  # nosec B101
+    assert source["canonical_uri"] == "https://example.com/page"  # nosec B101
+    assert source["display_uri"] == "https://example.com/page"  # nosec B101
+    assert source["redacted_source_url"] == "https://example.com/page"  # nosec B101
+    assert result["counts"] == ZERO_SYNC_COUNTS  # nosec B101
+
+
+def test_provider_sync_source_parses_force_false_string(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="local_file",
+        canonical_uri="file:///docs/guide.md",
+        display_name="guide.md",
+        source_path="/docs/guide.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"), store=store)
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id, "force": "false"}, scope=scope)
+
+    assert result["force"] is False  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("arguments", "field"),
+    [
+        ({"source_id": True}, "source_id"),
+        ({"source_id": 1, "max_documents": True}, "max_documents"),
+        ({"source_id": 1, "max_pages": "not-an-int"}, "max_pages"),
+        ({"source_id": 1, "max_documents": 0}, "max_documents"),
+    ],
+)
+def test_provider_sync_source_returns_stable_invalid_response_for_malformed_args(
+    tmp_path: Path,
+    arguments: dict[str, object],
+    field: str,
+) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    store.upsert_source(
+        scope=scope,
+        source_type="local_file",
+        canonical_uri="file:///docs/guide.md",
+        display_name="guide.md",
+        source_path="/docs/guide.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"), store=store)
+
+    result = provider.execute("docs.sync_source", arguments, scope=scope)
+
+    assert result == {  # nosec B101
+        "status": "denied",
+        "reason_code": "source_sync_request_invalid",
+        "field": field,
+    }
+
+
+def test_provider_sync_source_uses_custom_default_stale_policy(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="local_file",
+        canonical_uri="file:///docs/guide.md",
+        display_name="guide.md",
+        source_path="/docs/guide.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    provider = DocsMCPToolProvider(
+        settings=DocsSettings(db_path=tmp_path / "docs.db", default_stale_policy="tombstone"),
+        store=store,
+    )
+
+    result = provider.execute("docs.sync_source", {"source_id": source_id}, scope=scope)
+
+    assert result["stale_policy"] == "tombstone"  # nosec B101
+
+
 def test_provider_sync_source_returns_stable_unsupported_response_for_sitemap(tmp_path: Path) -> None:
     store = DocsCatalogStore(tmp_path / "docs.db")
     store.migrate()
@@ -133,8 +295,8 @@ def test_provider_sync_source_returns_stable_unsupported_response_for_sitemap(tm
 
     result = provider.execute("docs.sync_source", {"source_id": source_id}, scope=scope)
 
-    assert result["status"] in {"denied", "skipped"}  # nosec B101
-    assert result["reason_code"] in {"source_sync_unsupported_type", "sitemap_sync_disabled"}  # nosec B101
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "sitemap_sync_disabled"  # nosec B101
     assert result["source"]["id"] == source_id  # nosec B101
     assert result["source"]["canonical_uri"] == "https://example.com/sitemap.xml"  # nosec B101
-    assert result["counts"] == {"created": 0, "updated": 0, "unchanged": 0, "failed": 0, "skipped": 0}  # nosec B101
+    assert result["counts"] == ZERO_SYNC_COUNTS  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_utils.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcp_unified.docs import source_utils
+
+pytestmark = pytest.mark.unit
+
+
+def test_path_from_file_uri_uses_os_specific_path_decoding(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_url2pathname(path: str) -> str:
+        calls.append(path)
+        return r"C:\Users\Alice\My Docs\guide.md"
+
+    monkeypatch.setattr(source_utils, "url2pathname", fake_url2pathname)
+
+    path = source_utils.path_from_file_uri("file:///C:/Users/Alice/My%20Docs/guide.md")
+
+    assert path == Path(r"C:\Users\Alice\My Docs\guide.md")  # nosec B101
+    assert calls == ["/C:/Users/Alice/My%20Docs/guide.md"]  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py
@@ -111,6 +111,75 @@ def test_source_document_count_ignores_out_of_scope_links(tmp_path: Path) -> Non
     assert store.list_sources(scope=scope_a)[0]["document_count"] == 0  # nosec B101
 
 
+def test_source_document_count_ignores_tombstoned_source_links(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_page",
+        canonical_uri="https://example.com/b",
+        display_name="b",
+        source_path=None,
+        source_url="https://example.com/b",
+        redacted_source_url="https://example.com/b",
+        policy_profile="online_capable",
+        sync_enabled=True,
+        metadata={},
+    )
+    old_document_id = store.upsert_document(
+        scope=scope,
+        title="Old",
+        document_type="text",
+        canonical_uri="https://example.com/b",
+        source_path=None,
+        source_url="https://example.com/b",
+        text="old sqlite body",
+        sections=[],
+        chunks=[{"text": "old sqlite body", "citation": "b"}],
+        keywords=(),
+        collection_names=(),
+        metadata={},
+    )
+    new_document_id = store.upsert_document(
+        scope=scope,
+        title="New",
+        document_type="text",
+        canonical_uri="https://example.com/c",
+        source_path=None,
+        source_url="https://example.com/c",
+        text="new sqlite body",
+        sections=[],
+        chunks=[{"text": "new sqlite body", "citation": "c"}],
+        keywords=(),
+        collection_names=(),
+        metadata={},
+    )
+    store.link_source_document(
+        scope=scope,
+        source_id=source_id,
+        document_id=old_document_id,
+        source_item_uri="https://example.com/b",
+        status="active",
+        last_hash="old",
+        metadata={},
+    )
+    store.link_source_document(
+        scope=scope,
+        source_id=source_id,
+        document_id=new_document_id,
+        source_item_uri="https://example.com/c",
+        status="active",
+        last_hash="new",
+        metadata={},
+    )
+    store.tombstone_source_item(scope=scope, source_id=source_id, source_item_uri="https://example.com/b")
+
+    assert store.get_source(scope=scope, source_id=source_id)["document_count"] == 1  # nosec B101
+    assert store.get_source(scope=scope, canonical_uri="https://example.com/b")["document_count"] == 1  # nosec B101
+    assert store.list_sources(scope=scope)[0]["document_count"] == 1  # nosec B101
+
+
 def test_upsert_document_for_sync_merges_existing_organization(tmp_path: Path) -> None:
     store = DocsCatalogStore(tmp_path / "docs.db")
     store.migrate()

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py
@@ -63,6 +63,54 @@ def test_store_upserts_and_lists_sources_by_scope(tmp_path: Path) -> None:
     assert store.list_sources(scope=scope_b) == []  # nosec B101
 
 
+def test_source_document_count_ignores_out_of_scope_links(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope_a = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    scope_b = AccessScope(owner_scope="owner-b", profile_scope="profile-a")
+
+    source_id = store.upsert_source(
+        scope=scope_a,
+        source_type="local_file",
+        canonical_uri="file:///docs/a.md",
+        display_name="a.md",
+        source_path="/docs/a.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    out_of_scope_document_id = store.upsert_document(
+        scope=scope_b,
+        title="Other Owner",
+        document_type="text",
+        canonical_uri="file:///other-owner.txt",
+        source_path="/other-owner.txt",
+        source_url=None,
+        text="other owner sqlite body",
+        sections=[],
+        chunks=[{"text": "other owner sqlite body", "citation": "other-owner.txt"}],
+        keywords=(),
+        collection_names=(),
+        metadata={},
+    )
+
+    with closing(store.connect()) as conn:
+        conn.execute(
+            """
+            INSERT INTO docs_source_documents (source_id, document_id, source_item_uri)
+            VALUES (?, ?, ?)
+            """,
+            (source_id, out_of_scope_document_id, "file:///other-owner.txt"),
+        )
+        conn.commit()
+
+    assert store.get_source(scope=scope_a, source_id=source_id)["document_count"] == 0  # nosec B101
+    assert store.get_source(scope=scope_a, canonical_uri="file:///docs/a.md")["document_count"] == 0  # nosec B101
+    assert store.list_sources(scope=scope_a)[0]["document_count"] == 0  # nosec B101
+
+
 def test_upsert_document_for_sync_merges_existing_organization(tmp_path: Path) -> None:
     store = DocsCatalogStore(tmp_path / "docs.db")
     store.migrate()

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_sources_store.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from mcp_unified.docs.models import AccessScope
+from mcp_unified.docs.store.sqlite import DocsCatalogStore
+
+pytestmark = pytest.mark.unit
+
+
+def test_migrate_adds_source_tables_and_document_lifecycle_columns(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+
+    with closing(store.connect()) as conn:
+        tables = {
+            row["name"]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual')")
+        }
+        document_columns = {row["name"] for row in conn.execute("PRAGMA table_info(docs_documents)")}
+
+    assert {"docs_sources", "docs_source_documents", "docs_sync_runs"}.issubset(tables)  # nosec B101
+    assert "lifecycle_status" in document_columns  # nosec B101
+    assert "preserve_on_source_tombstone" in document_columns  # nosec B101
+
+
+def test_store_upserts_and_lists_sources_by_scope(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope_a = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    scope_b = AccessScope(owner_scope="owner-b", profile_scope="profile-a")
+
+    source_id = store.upsert_source(
+        scope=scope_a,
+        source_type="local_file",
+        canonical_uri="file:///docs/a.md",
+        display_name="a.md",
+        source_path="/docs/a.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={"default_keywords": ["local"]},
+    )
+    second_id = store.upsert_source(
+        scope=scope_a,
+        source_type="local_file",
+        canonical_uri="file:///docs/a.md",
+        display_name="a.md updated",
+        source_path="/docs/a.md",
+        source_url=None,
+        redacted_source_url=None,
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={"default_keywords": ["local"]},
+    )
+
+    assert second_id == source_id  # nosec B101
+    assert [source["canonical_uri"] for source in store.list_sources(scope=scope_a)] == ["file:///docs/a.md"]  # nosec B101
+    assert store.list_sources(scope=scope_b) == []  # nosec B101
+
+
+def test_upsert_document_for_sync_merges_existing_organization(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+    document_id = store.upsert_document(
+        scope=scope,
+        title="Guide",
+        document_type="text",
+        canonical_uri="file:///guide.txt",
+        source_path="/guide.txt",
+        source_url=None,
+        text="old sqlite body",
+        sections=[],
+        chunks=[{"text": "old sqlite body", "citation": "guide.txt"}],
+        keywords=("manual",),
+        collection_names=("Manual",),
+        metadata={"importer": "local"},
+    )
+
+    updated_id = store.upsert_document_for_sync(
+        scope=scope,
+        title="Guide",
+        document_type="text",
+        canonical_uri="file:///guide.txt",
+        source_path="/guide.txt",
+        source_url=None,
+        text="new sqlite body",
+        sections=[],
+        chunks=[{"text": "new sqlite body", "citation": "guide.txt"}],
+        source_default_keywords=("source-default",),
+        source_default_collections=("Source Defaults",),
+        metadata={"importer": "local", "sync": True},
+    )
+
+    assert updated_id == document_id  # nosec B101
+    assert store.search_chunks(scope, "new", limit=10)[0]["title"] == "Guide"  # nosec B101
+    assert {item["keyword"] for item in store.list_keywords(scope)} == {"manual", "source-default"}  # nosec B101
+    assert {item["name"] for item in store.list_collections(scope)} == {"Manual", "Source Defaults"}  # nosec B101


### PR DESCRIPTION
## Summary
- Adds bounded source registry and source-sync support for standalone MCP docs, covering local file/directory and approved URL page sources.
- Wires source population, source listing, docs.sync_source, host DocsModule exposure, lifecycle/tombstone filtering, and query-safe URL redaction.
- Keeps sitemap sync, broad crawling, browser automation, Jobs/Scheduler, Media DB, ChromaDB, and host RAG bridges out of this slice.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs -q` (`253 passed, 4 warnings`)
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r apps/mcp-unified/src/mcp_unified/docs tldw_Server_API/app/core/MCP_unified/modules/implementations/docs_module.py -f json -o /tmp/bandit_mcp_docs_stage4a.json` (exit 0)
- [x] `git diff --check`

## Change summary
AI-authored PR. Per project policy, a human requester must add the merge-gate Change summary in their own words before this is merge-ready.

## Backlog
- TASK-12093

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded source registry and `docs.sync_source` to the standalone `mcp_unified.docs` corpus to refresh known local files/dirs and approved URL pages. Hardens URL privacy, reconciles redirects, hides tombstoned docs, and exposes the tool via the host module with web off by default. Satisfies TASK-12093 (Stage 4A).

- **New Features**
  - Source registry and `docs.sync_source` (dry-run/apply) for local files/dirs and approved URL pages; reconciles redirects and retargets sources; bounded tombstoning with redacted URLs.
  - Source-sync settings (enable/limits, stale policy); extended SQLite schema/store for sources, sync runs, and document lifecycle; retrieval hides tombstoned docs; `docs.list(kind="sources")`; exposed via host `DocsModule` with default `docs` config.
  - Introduced `docs-web` extra for `beautifulsoup4` and `trafilatura`.

- **Bug Fixes**
  - URL acquisition privacy: no query-bearing URL data in ingested metadata, MCP outputs, or retrieval outputs when query persistence is disabled.
  - Robots policy now fails closed when `respect_robots` is enabled without a checker; fetcher/service updated.
  - Avoids stale source rows on import failure, scopes source document counts correctly, and skips symlinks that escape trusted roots during directory import.

<sup>Written for commit 1c350e1b2e232cb720b1ce1d82cbf5026062d2af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

