### PR TITLE
fix(frontend): keep chat context rail clear of app nav

### DIFF
--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx
@@ -61,8 +61,6 @@ describe("Playground cockpit rail restore tabs", () => {
     expect(contextRestore.parentElement).toHaveClass(
       ...COCKPIT_LEFT_RESTORE_WRAPPER_CLASS.split(" "),
     );
-    expect(contextRestore.parentElement).toHaveClass("absolute", "left-0");
-    expect(contextRestore.parentElement).toHaveClass("left-0");
     expect(contextRestore.parentElement).not.toHaveClass("fixed");
     expect(contextRestore.parentElement).not.toHaveClass("left-12");
     expect(contextRestore.parentElement).not.toHaveClass("top-1/2");


### PR DESCRIPTION
## Change summary
Human-authored change summary required before merge: please replace this line with the requester-owned explanation of what changed and why.

## Summary
- Reposition the collapsed chat cockpit context restore tab so it anchors inside the chat cockpit shell instead of the viewport left edge.
- Update the rail positioning contract and cockpit restore tests to prevent regressions over the app-wide navigation sidebar.
- Track the fix in Backlog task TASK-12114.

## Test plan
- [x] `cd apps/packages/ui && bunx vitest run src/components/Layouts/__tests__/chat-rail-positioning-contract.guard.test.ts src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx`

Bandit skipped: TypeScript UI/test-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the collapsed chat context restore tab from viewport-fixed to cockpit-scoped positioning so it stays on the chat content edge and doesn’t overlap the app navigation rail. Update the positioning contract and relax Playground tests to assert cockpit scoping and not-fixed behavior; satisfies TASK-12114.

<sup>Written for commit 79ea6a057f271b452f00c782329d9bc1c1c3c814. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

