### PR TITLE
fix(frontend): make chat focus mode fullscreen

### DIFF
--- a/Docs/superpowers/plans/2026-07-03-chat-focus-fullscreen.md
+++ b/Docs/superpowers/plans/2026-07-03-chat-focus-fullscreen.md
@@ -1,0 +1,27 @@
+## Stage 1: Regression Coverage
+
+**Goal**: Capture the expected fullscreen focus-mode behavior before implementation.
+**Success Criteria**: Tests fail because focus mode does not request shell chrome hiding and still renders the top cockpit controls instead of a dedicated exit control.
+**Tests**: Targeted Vitest coverage for shared layout shell overrides and Playground focus mode.
+**Status**: Complete
+
+## Stage 2: Shared Shell Override Hook
+
+**Goal**: Reuse the existing OptionLayout shell override channel from route content without rendering a nested layout shell.
+**Success Criteria**: Focus-mode content can request `hideHeader` and `hideSidebar` across WebUI and extension shells.
+**Tests**: Shared layout shell override tests pass.
+**Status**: Complete
+
+## Stage 3: Focus Mode UX
+
+**Goal**: Make focus mode hide non-chat chrome and provide a single clear escape hatch.
+**Success Criteria**: Focus mode shows chat transcript, composer, and an `Exit focus` control only; clicking the control returns to cockpit mode.
+**Tests**: Playground cockpit-control tests pass.
+**Status**: Complete
+
+## Stage 4: Verification And PR Prep
+
+**Goal**: Validate the focused UI in tests and browser, then prepare the PR update.
+**Success Criteria**: Targeted tests pass, browser screenshot shows fullscreen focus mode, task notes are updated, and changes are committed/pushed.
+**Tests**: Targeted Vitest command plus visual browser check.
+**Status**: Complete

--- a/apps/packages/ui/src/components/Layouts/Layout.tsx
+++ b/apps/packages/ui/src/components/Layouts/Layout.tsx
@@ -680,28 +680,29 @@ export function useOptionLayoutShellOverrides(
   const shell = useContext(LayoutShellContext)
   const globalShell = getGlobalShell()
   const location = useLocation()
+  const { hideHeader, hideSidebar } = request ?? {}
   const requestedOverrides = React.useMemo(() => {
-    if (!request) return null
-
     const overrides: LayoutShellOverrides = {}
-    if (request.hideHeader) overrides.hideHeader = true
-    if (request.hideSidebar) overrides.hideSidebar = true
+    if (hideHeader) overrides.hideHeader = true
+    if (hideSidebar) overrides.hideSidebar = true
     if (Object.keys(overrides).length === 0) return null
 
     overrides.sourcePath = location.pathname
     return overrides
-  }, [location.pathname, request?.hideHeader, request?.hideSidebar])
+  }, [hideHeader, hideSidebar, location.pathname])
 
   React.useEffect(() => {
     if (!requestedOverrides) return
 
     let timeoutId: ReturnType<typeof setTimeout> | null = null
-    let appliedOverrides = false
+    let appliedSetOverrides:
+      | ((overrides: LayoutShellOverrides | null) => void)
+      | null = null
     const applyOverrides = () => {
       const setOverrides = shell.setOverrides || globalShell?.setOverrides
       if (!setOverrides) return false
       setOverrides(requestedOverrides)
-      appliedOverrides = true
+      appliedSetOverrides = setOverrides
       return true
     }
 
@@ -713,9 +714,7 @@ export function useOptionLayoutShellOverrides(
 
     return () => {
       if (timeoutId) clearTimeout(timeoutId)
-      if (!appliedOverrides) return
-      const setOverrides = shell.setOverrides || globalShell?.setOverrides
-      setOverrides?.(null)
+      appliedSetOverrides?.(null)
     }
   }, [globalShell?.setOverrides, requestedOverrides, shell.setOverrides])
 }

--- a/apps/packages/ui/src/components/Layouts/Layout.tsx
+++ b/apps/packages/ui/src/components/Layouts/Layout.tsx
@@ -654,6 +654,11 @@ type LayoutShellGlobal = {
   setOverrides?: (overrides: LayoutShellOverrides | null) => void
 }
 
+export type OptionLayoutShellOverrideRequest = Pick<
+  LayoutShellOverrides,
+  "hideHeader" | "hideSidebar"
+>
+
 const LayoutShellContext = React.createContext<LayoutShellContextValue>({
   inShell: false
 })
@@ -669,24 +674,23 @@ const getGlobalShell = (): LayoutShellGlobal | null => {
   return scope.__tldwOptionShell
 }
 
-function NestedLayoutContent({
-  props,
-  shell,
-  globalShell
-}: {
-  props: OptionLayoutProps
-  shell: LayoutShellContextValue
-  globalShell: LayoutShellGlobal | null
-}) {
+export function useOptionLayoutShellOverrides(
+  request: OptionLayoutShellOverrideRequest | null
+) {
+  const shell = useContext(LayoutShellContext)
+  const globalShell = getGlobalShell()
   const location = useLocation()
   const requestedOverrides = React.useMemo(() => {
+    if (!request) return null
+
     const overrides: LayoutShellOverrides = {}
-    if (props.hideHeader) overrides.hideHeader = true
-    if (props.hideSidebar) overrides.hideSidebar = true
+    if (request.hideHeader) overrides.hideHeader = true
+    if (request.hideSidebar) overrides.hideSidebar = true
     if (Object.keys(overrides).length === 0) return null
+
     overrides.sourcePath = location.pathname
     return overrides
-  }, [location.pathname, props.hideHeader, props.hideSidebar])
+  }, [location.pathname, request?.hideHeader, request?.hideSidebar])
 
   React.useEffect(() => {
     if (!requestedOverrides) return
@@ -714,6 +718,18 @@ function NestedLayoutContent({
       setOverrides?.(null)
     }
   }, [globalShell?.setOverrides, requestedOverrides, shell.setOverrides])
+}
+
+function NestedLayoutContent({ props }: { props: OptionLayoutProps }) {
+  const requestedOverrides = React.useMemo(() => {
+    const overrides: OptionLayoutShellOverrideRequest = {}
+    if (props.hideHeader) overrides.hideHeader = true
+    if (props.hideSidebar) overrides.hideSidebar = true
+    if (Object.keys(overrides).length === 0) return null
+    return overrides
+  }, [props.hideHeader, props.hideSidebar])
+
+  useOptionLayoutShellOverrides(requestedOverrides)
 
   return (
     <DemoModeProvider>
@@ -790,13 +806,7 @@ export default function OptionLayout(props: OptionLayoutProps) {
     (globalShell?.ownerId == null || globalShell.ownerId !== ownerId)
 
   if (shell.inShell || externalShell || isNextApp) {
-    return (
-      <NestedLayoutContent
-        props={props}
-        shell={shell}
-        globalShell={globalShell}
-      />
-    )
+    return <NestedLayoutContent props={props} />
   }
 
   return (

--- a/apps/packages/ui/src/components/Layouts/__tests__/Layout.shell-overrides.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/Layout.shell-overrides.test.tsx
@@ -2,10 +2,10 @@
 
 import React from "react"
 import { MemoryRouter } from "react-router-dom"
-import { render } from "@testing-library/react"
+import { render, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import OptionLayout from "../Layout"
+import OptionLayout, { useOptionLayoutShellOverrides } from "../Layout"
 
 const storeMessageOptionMock = vi.hoisted(() =>
   vi.fn(() => ({ historyId: null, serverChatId: null }))
@@ -93,5 +93,50 @@ describe("OptionLayout shell overrides", () => {
 
     expect(otherOwnerSetOverrides).not.toHaveBeenCalled()
     vi.useRealTimers()
+  })
+
+  it("lets route content request header and sidebar shell hiding", async () => {
+    const setOverrides = vi.fn()
+    const externalShell: {
+      mounted: boolean
+      ownerId: string
+      setOverrides?: (overrides: unknown) => void
+    } = {
+      mounted: true,
+      ownerId: "root-shell",
+      setOverrides
+    }
+    ;(
+      globalThis as typeof globalThis & {
+        __tldwOptionShell?: typeof externalShell
+      }
+    ).__tldwOptionShell = externalShell
+
+    function FocusRouteContent() {
+      useOptionLayoutShellOverrides({
+        hideHeader: true,
+        hideSidebar: true
+      })
+
+      return <div>Focus route</div>
+    }
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <FocusRouteContent />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(setOverrides).toHaveBeenCalledWith({
+        hideHeader: true,
+        hideSidebar: true,
+        sourcePath: "/chat"
+      })
+    })
+
+    unmount()
+
+    expect(setOverrides).toHaveBeenLastCalledWith(null)
   })
 })

--- a/apps/packages/ui/src/components/Layouts/__tests__/Layout.shell-overrides.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/Layout.shell-overrides.test.tsx
@@ -139,4 +139,53 @@ describe("OptionLayout shell overrides", () => {
 
     expect(setOverrides).toHaveBeenLastCalledWith(null)
   })
+
+  it("clears the same shell setter that accepted route content overrides", async () => {
+    const originalSetOverrides = vi.fn()
+    const replacementSetOverrides = vi.fn()
+    const externalShell: {
+      mounted: boolean
+      ownerId: string
+      setOverrides?: (overrides: unknown) => void
+    } = {
+      mounted: true,
+      ownerId: "root-shell",
+      setOverrides: originalSetOverrides
+    }
+    ;(
+      globalThis as typeof globalThis & {
+        __tldwOptionShell?: typeof externalShell
+      }
+    ).__tldwOptionShell = externalShell
+
+    function FocusRouteContent() {
+      useOptionLayoutShellOverrides({
+        hideHeader: true,
+        hideSidebar: true
+      })
+
+      return <div>Focus route</div>
+    }
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <FocusRouteContent />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(originalSetOverrides).toHaveBeenCalledWith({
+        hideHeader: true,
+        hideSidebar: true,
+        sourcePath: "/chat"
+      })
+    })
+
+    externalShell.setOverrides = replacementSetOverrides
+
+    unmount()
+
+    expect(originalSetOverrides).toHaveBeenLastCalledWith(null)
+    expect(replacementSetOverrides).not.toHaveBeenCalled()
+  })
 })

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -3642,7 +3642,7 @@ export const Playground = () => {
                     type="button"
                     data-testid="playground-chat-layout-mode-trigger"
                     aria-label={chatLayoutToggleLabel}
-                    aria-pressed={false}
+                    aria-pressed={focusModeActive}
                     onClick={() => handleChatLayoutModeChange(nextChatLayoutMode)}
                     title={chatLayoutToggleLabel}
                     className="inline-flex min-h-[26px] min-w-[26px] items-center justify-center gap-1 rounded-full border border-border bg-surface2 px-1.5 py-0.5 text-text hover:bg-surface sm:px-2"

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -45,6 +45,7 @@ import {
 import { buildPlaygroundCompositionPreviewSummary } from "./playground-composition-preview";
 import { ChatErrorBoundary } from "@/components/Common/Playground/ChatErrorBoundary";
 import { hasVisibleAssistantResponse } from "@/components/Common/Playground/message-visibility";
+import { useOptionLayoutShellOverrides } from "@/components/Layouts/Layout";
 import { useMessageOption } from "@/hooks/useMessageOption";
 import { usePlaygroundSessionPersistence } from "@/hooks/usePlaygroundSessionPersistence";
 import { shouldRestorePersistedPlaygroundSession } from "@/hooks/playground-session-restore";
@@ -66,6 +67,7 @@ import {
   ChevronDown,
   Keyboard,
   Maximize2,
+  Minimize2,
   PanelRightOpen,
   Search,
   X,
@@ -761,14 +763,23 @@ export const Playground = () => {
     chatLayoutMode === "focus" || chatLayoutMode === "cockpit"
       ? chatLayoutMode
       : defaultChatLayoutMode;
+  const focusModeActive = normalizedChatLayoutMode === "focus";
+  useOptionLayoutShellOverrides(
+    focusModeActive
+      ? {
+          hideHeader: true,
+          hideSidebar: true,
+        }
+      : null,
+  );
   const normalizedCockpitContextRailVisible =
     cockpitContextRailVisible !== false;
   const normalizedCockpitRuntimeRailVisible =
     cockpitRuntimeRailVisible !== false;
   const mobileCockpitComposerConstrained =
-    isMobileViewport && normalizedChatLayoutMode === "cockpit";
+    isMobileViewport && !focusModeActive;
   const cockpitRailCollapsedWideContent =
-    normalizedChatLayoutMode === "cockpit" &&
+    !focusModeActive &&
     (!normalizedCockpitContextRailVisible ||
       !normalizedCockpitRuntimeRailVisible);
   const chatContentWidthClassName = cockpitRailCollapsedWideContent
@@ -781,15 +792,18 @@ export const Playground = () => {
     [setChatLayoutMode],
   );
   const nextChatLayoutMode: PlaygroundCockpitMode =
-    normalizedChatLayoutMode === "focus" ? "cockpit" : "focus";
+    focusModeActive ? "cockpit" : "focus";
   const chatLayoutToggleLabel =
-    normalizedChatLayoutMode === "focus"
+    focusModeActive
       ? toText(t("playground:cockpit.showPanels", "Show cockpit panels"))
       : toText(t("playground:cockpit.enterFocus", "Enter focus chat"));
   const chatLayoutToggleText =
-    normalizedChatLayoutMode === "focus"
+    focusModeActive
       ? toText(t("playground:cockpit.cockpit", "Cockpit"))
       : toText(t("playground:cockpit.focus", "Focus"));
+  const exitFocusLabel = toText(
+    t("playground:cockpit.exitFocus", "Exit focus"),
+  );
 
   React.useEffect(() => {
     setRouteContext({ routeId: "chat", surface: "webui" });
@@ -3514,6 +3528,20 @@ export const Playground = () => {
         </div>
       )}
 
+      {focusModeActive && (
+        <button
+          type="button"
+          data-testid="playground-focus-exit"
+          aria-label={exitFocusLabel}
+          title={exitFocusLabel}
+          onClick={() => handleChatLayoutModeChange("cockpit")}
+          className="fixed right-3 top-3 z-50 inline-flex min-h-[34px] items-center gap-2 rounded-full border border-border bg-surface/95 px-3 py-1.5 text-xs font-semibold text-text shadow-lg backdrop-blur transition hover:bg-surface2 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus sm:right-4 sm:top-4"
+        >
+          <Minimize2 className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{exitFocusLabel}</span>
+        </button>
+      )}
+
       <div className="relative z-10 flex h-full min-h-0 w-full">
         <PlaygroundCockpitShell
           mode={normalizedChatLayoutMode}
@@ -3530,7 +3558,7 @@ export const Playground = () => {
             data-testid="playground-chat-shell"
             className="flex h-full min-h-0 min-w-0 flex-1 flex-col"
           >
-            {parentMeta?.parentHistoryId && (
+            {!focusModeActive && parentMeta?.parentHistoryId && (
               <div className="flex w-full justify-center px-5 pt-2">
                 <div className="inline-flex flex-wrap items-center justify-center gap-2">
                   <button
@@ -3575,7 +3603,8 @@ export const Playground = () => {
                 </div>
               </div>
             )}
-            <div className="px-2 pt-1 sm:px-4 sm:pt-2">
+            {!focusModeActive && (
+              <div className="px-2 pt-1 sm:px-4 sm:pt-2">
               <div
                 className={`mx-auto flex w-full ${chatContentWidthClassName} items-center justify-between gap-2 text-[10px] text-text-muted sm:text-[11px]`}
               >
@@ -3613,7 +3642,7 @@ export const Playground = () => {
                     type="button"
                     data-testid="playground-chat-layout-mode-trigger"
                     aria-label={chatLayoutToggleLabel}
-                    aria-pressed={normalizedChatLayoutMode === "focus"}
+                    aria-pressed={false}
                     onClick={() => handleChatLayoutModeChange(nextChatLayoutMode)}
                     title={chatLayoutToggleLabel}
                     className="inline-flex min-h-[26px] min-w-[26px] items-center justify-center gap-1 rounded-full border border-border bg-surface2 px-1.5 py-0.5 text-text hover:bg-surface sm:px-2"
@@ -3919,6 +3948,7 @@ export const Playground = () => {
                 />
               ) : null}
             </div>
+            )}
             <div
               ref={containerRef}
               data-testid={
@@ -3970,7 +4000,7 @@ export const Playground = () => {
                   : ""
               }`}
             >
-              {!isMobileViewport ? (
+              {!isMobileViewport && !focusModeActive ? (
                 <div
                   className={`mx-auto w-full ${chatContentWidthClassName} px-4 pt-2 text-[11px] text-text-muted`}
                 >
@@ -4055,7 +4085,7 @@ export const Playground = () => {
             </div>
           </div>
         </PlaygroundCockpitShell>
-        {shouldShowArtifactsEdgeExpand && (
+        {!focusModeActive && shouldShowArtifactsEdgeExpand && (
           <button
             ref={artifactsEdgeExpandRef}
             type="button"
@@ -4084,7 +4114,7 @@ export const Playground = () => {
             </span>
           </button>
         )}
-        {artifactsOpen && (
+        {!focusModeActive && artifactsOpen && (
           <>
             <div className="hidden h-full w-[36%] min-w-[280px] max-w-[520px] shrink-0 lg:flex">
               {renderArtifactsPanel()}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
@@ -99,6 +99,10 @@ const storageState = vi.hoisted(() => ({
   values: new Map<string, unknown>(),
 }));
 
+const layoutShellOverrideState = vi.hoisted(() => ({
+  overrides: [] as unknown[],
+}));
+
 const modelSettingsState = vi.hoisted(() => ({
   value: {
     systemPrompt: "",
@@ -198,6 +202,13 @@ vi.mock("@/components/Option/Playground/PlaygroundForm", () => ({
 
 vi.mock("@/components/Option/Playground/PlaygroundChat", () => ({
   PlaygroundChat: () => <div data-testid="playground-chat" />,
+}));
+
+vi.mock("@/components/Layouts/Layout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+  useOptionLayoutShellOverrides: (overrides: unknown) => {
+    layoutShellOverrideState.overrides.push(overrides);
+  },
 }));
 
 vi.mock("@/components/Sidepanel/Chat/ArtifactsPanel", () => ({
@@ -373,6 +384,7 @@ describe("Playground cockpit controls", () => {
     storageState.values.clear();
     storageState.values.set("playgroundChatContextRailVisible", true);
     storageState.values.set("playgroundChatRuntimeRailVisible", true);
+    layoutShellOverrideState.overrides = [];
     modelSettingsState.value.systemPrompt = "";
     modelSettingsState.value.setSystemPrompt = vi.fn();
     modelSettingsState.value.temperature = 0.7;
@@ -1202,8 +1214,30 @@ describe("Playground cockpit controls", () => {
     expect(
       screen.queryByRole("region", { name: "Next message composition" }),
     ).toBeNull();
+    await waitFor(() => {
+      expect(layoutShellOverrideState.overrides).toContainEqual({
+        hideHeader: true,
+        hideSidebar: true,
+      });
+    });
+    expect(
+      screen.queryByTestId("playground-chat-layout-mode-trigger"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("playground-shortcuts-help-trigger"),
+    ).toBeNull();
+    const exitFocus = screen.getByTestId("playground-focus-exit");
+    expect(exitFocus).toHaveTextContent("Exit focus");
     expect(screen.getByTestId("playground-chat")).toBeInTheDocument();
     expect(screen.getByTestId("playground-form")).toBeInTheDocument();
+
+    fireEvent.click(exitFocus);
+
+    await waitFor(() => {
+      expect(storageState.values.get("playgroundChatLayoutMode")).toBe(
+        "cockpit",
+      );
+    });
   });
 
   it("wires ready-state runtime regenerate to the shared chat handler", async () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
@@ -1237,6 +1237,11 @@ describe("Playground cockpit controls", () => {
       expect(storageState.values.get("playgroundChatLayoutMode")).toBe(
         "cockpit",
       );
+      expect(
+        layoutShellOverrideState.overrides[
+          layoutShellOverrideState.overrides.length - 1
+        ],
+      ).toBeNull();
     });
   });
 

--- a/backlog/tasks/task-12115 - Make-chat-focus-mode-truly-fullscreen.md
+++ b/backlog/tasks/task-12115 - Make-chat-focus-mode-truly-fullscreen.md
@@ -4,7 +4,7 @@ title: Make chat focus mode truly fullscreen
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-03 01:43'
+updated_date: '2026-07-03 02:07'
 labels:
   - webui
   - chat
@@ -29,33 +29,27 @@ Update chat focus mode so it hides the app shell/header/sidebar and cockpit rail
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 Plan: Docs/superpowers/plans/2026-07-03-chat-focus-fullscreen.md
 
-Verification: targeted Vitest passed: bun run test:run ../packages/ui/src/components/Layouts/__tests__/Layout.shell-overrides.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx (22 tests passed).
+Verification: targeted Vitest passed: bun run test:run ../packages/ui/src/components/Layouts/__tests__/Layout.shell-overrides.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx (23 tests passed after adding the shell cleanup regression).
 
 Verification: browser check on http://127.0.0.1:18001/chat confirmed focus mode hides header/sidebar, chat sidebar, context/runtime rails, and top focus/shortcut controls while preserving transcript, composer, and Exit focus. Desktop screenshot: /tmp/tldw-chat-focus-fullscreen.png. Mobile screenshot: /tmp/tldw-chat-focus-fullscreen-mobile.png.
 
-Known skip/failure: bun run typecheck still fails on existing unrelated files (AudioStudio TimelineEditor referrerPolicy, ScheduledTasks response typing, Skills Checkbox props, scheduled-tasks service params, mcp-hub path typing, voice-cloning ArrayBuffer, knowledge QA fixture assertions, flashcards E2E never callable). The touched Playground type error found during the first typecheck was fixed and absent in the rerun.
+Verification: git diff --check passed.
+
+Typecheck baseline: bun run typecheck was rerun and remains blocked by existing unrelated latest-dev errors outside this PR scope (AudioStudio TimelineEditor referrerPolicy, ScheduledTasks response typing, Skills Checkbox props, scheduled-tasks service params, mcp-hub path typing, voice-cloning ArrayBuffer, knowledge QA fixture assertions, flashcards E2E never callable). No touched files are present in the current typecheck error output.
 
 Bandit: skipped because this change only touches frontend TypeScript/TSX tests and Markdown; no Python touched.
 
-Branch verification: after switching to codex/chat-focus-fullscreen from origin/dev, targeted Vitest was rerun and passed (22 tests). Broad typecheck still fails only on the same unrelated baseline files listed above.
-
 PR: https://github.com/rmusser01/tldw_server/pull/2578
+
+Review follow-up: rebased on latest dev and addressed PR review comments for shell cleanup, focus accessibility/test coverage, and task marker structure. The Qodo broad-typecheck comment was evaluated against latest dev; the remaining typecheck failures are pre-existing, unrelated baseline errors and are not changed by this PR.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added a shared OptionLayout shell override hook and wired chat focus mode to hide app shell chrome, cockpit rails, top shortcut/status chrome, artifacts rails, and comparison breadcrumbs. Focus mode now leaves the chat transcript/composer plus a fixed Exit focus control, and the control returns the user to cockpit mode. Added regression coverage for the shared shell override hook and focus-mode UX.
-<!-- SECTION:FINAL_SUMMARY:END -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-
+Added a shared OptionLayout shell override hook and wired chat focus mode to hide app shell chrome, cockpit rails, top shortcut/status chrome, artifacts rails, and comparison breadcrumbs. Focus mode now leaves the chat transcript/composer plus a fixed Exit focus control, and the control returns the user to cockpit mode. Added regression coverage for the shared shell override hook and focus-mode UX. Review follow-up captures the exact shell setter used for cleanup, keeps focus accessibility state dynamic, verifies focus exit clears shell overrides, and fixes the Backlog final-summary marker structure.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12115 - Make-chat-focus-mode-truly-fullscreen.md
+++ b/backlog/tasks/task-12115 - Make-chat-focus-mode-truly-fullscreen.md
@@ -1,0 +1,69 @@
+---
+id: TASK-12115
+title: Make chat focus mode truly fullscreen
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-03 01:43'
+labels:
+  - webui
+  - chat
+  - ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update chat focus mode so it hides the app shell/header/sidebar and cockpit rails, leaving only the chat surface plus a clear escape-hatch control to exit focus mode. Add regression coverage before implementation and verify the WebUI rendering.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focus mode hides the app header/sidebar shell chrome in WebUI and shared UI surfaces.
+- [x] #2 Focus mode hides chat cockpit rails and the top shortcut/status strip, leaving chat transcript, composer, and one clear exit control.
+- [x] #3 Exit focus returns the chat to cockpit mode without losing the current chat state.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Plan: Docs/superpowers/plans/2026-07-03-chat-focus-fullscreen.md
+
+Verification: targeted Vitest passed: bun run test:run ../packages/ui/src/components/Layouts/__tests__/Layout.shell-overrides.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx (22 tests passed).
+
+Verification: browser check on http://127.0.0.1:18001/chat confirmed focus mode hides header/sidebar, chat sidebar, context/runtime rails, and top focus/shortcut controls while preserving transcript, composer, and Exit focus. Desktop screenshot: /tmp/tldw-chat-focus-fullscreen.png. Mobile screenshot: /tmp/tldw-chat-focus-fullscreen-mobile.png.
+
+Known skip/failure: bun run typecheck still fails on existing unrelated files (AudioStudio TimelineEditor referrerPolicy, ScheduledTasks response typing, Skills Checkbox props, scheduled-tasks service params, mcp-hub path typing, voice-cloning ArrayBuffer, knowledge QA fixture assertions, flashcards E2E never callable). The touched Playground type error found during the first typecheck was fixed and absent in the rerun.
+
+Bandit: skipped because this change only touches frontend TypeScript/TSX tests and Markdown; no Python touched.
+
+Branch verification: after switching to codex/chat-focus-fullscreen from origin/dev, targeted Vitest was rerun and passed (22 tests). Broad typecheck still fails only on the same unrelated baseline files listed above.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2578
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a shared OptionLayout shell override hook and wired chat focus mode to hide app shell chrome, cockpit rails, top shortcut/status chrome, artifacts rails, and comparison breadcrumbs. Focus mode now leaves the chat transcript/composer plus a fixed Exit focus control, and the control returns the user to cockpit mode. Added regression coverage for the shared shell override hook and focus-mode UX.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

- Added a shared OptionLayout shell override hook so route content can request the app header/sidebar be hidden without rendering a nested layout shell.
- Wired chat focus mode to hide app shell chrome, cockpit rails, the top focus/shortcut/status strip, comparison breadcrumbs, and artifacts rail surfaces.
- Added a fixed `Exit focus` control that returns the chat to cockpit mode.
- Added regression coverage for the shell override hook and focus-mode UX.

## Verification

- `bun run test:run ../packages/ui/src/components/Layouts/__tests__/Layout.shell-overrides.test.tsx ../packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx` - 22 tests passed.
- Browser verification on `http://127.0.0.1:18001/chat`: focus mode hides header/sidebar, chat sidebar, context/runtime rails, and top focus/shortcut controls while keeping transcript, composer, and Exit focus.
- `bun run typecheck` still fails on existing unrelated baseline errors in AudioStudio, ScheduledTasks, Skills, scheduled-tasks services, MCP hub path typing, voice-cloning ArrayBuffer typing, knowledge QA fixtures, and flashcards E2E. No touched file appears in the rerun.

## Notes

Bandit skipped because this touches frontend TypeScript/TSX tests and Markdown only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chat focus mode truly fullscreen by hiding app chrome and cockpit rails, with a clear exit control. Export a shared shell override hook so routes can hide header/sidebar across shells without nesting; meets TASK-12115.

- **New Features**
  - Added `useOptionLayoutShellOverrides` to let route content request `hideHeader`/`hideSidebar` across shells, and to clear the same setter on unmount/navigation; added tests for apply/cleanup and route-driven overrides.
  - Focus mode now shows only the chat transcript and composer; hides header, sidebar, chat sidebar, context/runtime rails, artifacts surfaces, top focus/shortcut strip, and breadcrumbs.
  - Added a fixed “Exit focus” button that returns to cockpit mode and clears shell overrides without losing state.

<sup>Written for commit 763c4e76ce81f533c21ece40e55d4c4778edafda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

