### PR TITLE
fix(test): repair bit-rotted authnz multiuser load tests (fixes #2580)

### DIFF
--- a/tldw_Server_API/tests/performance/test_authnz_multiuser_sqlite_load.py
+++ b/tldw_Server_API/tests/performance/test_authnz_multiuser_sqlite_load.py
@@ -58,11 +58,17 @@ async def _build_app(tmp_path, monkeypatch):
     # media/audit rows) through the previous app's pool into the previous
     # tmp database — logins then 401 and FK constraints fail (issue #2580).
     # Mirrors the canonical reset set in tests/AuthNZ/conftest.py.
+    from tldw_Server_API.app.core.Audit.unified_audit_service import shutdown_audit_service
+    from tldw_Server_API.app.core.AuthNZ.alerting import reset_security_alert_dispatcher
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import reset_api_key_manager
     from tldw_Server_API.app.core.AuthNZ.lockout_tracker import reset_lockout_tracker
     from tldw_Server_API.app.core.AuthNZ.rate_limiter import reset_rate_limiter
+    from tldw_Server_API.app.core.AuthNZ.scheduler import reset_authnz_scheduler
     from tldw_Server_API.app.core.AuthNZ.token_blacklist import reset_token_blacklist
+    from tldw_Server_API.app.core.Billing.enforcement import reset_billing_enforcer
+    from tldw_Server_API.app.core.Billing.subscription_service import reset_subscription_service
     from tldw_Server_API.app.core.DB_Management.Users_DB import reset_users_db
+    from tldw_Server_API.app.services.org_invite_service import reset_invite_service
     from tldw_Server_API.app.services.registration_service import reset_registration_service
     from tldw_Server_API.app.services.storage_cleanup_service import reset_cleanup_service
     from tldw_Server_API.app.services.storage_quota_service import reset_storage_service
@@ -72,15 +78,21 @@ async def _build_app(tmp_path, monkeypatch):
     await reset_db_pool()
     await reset_session_manager()
     await reset_token_blacklist()
+    await reset_security_alert_dispatcher()
+    await reset_authnz_scheduler()
     await reset_rate_limiter()
     await reset_lockout_tracker()
     reset_settings()
     reset_jwt_service()
     await reset_registration_service()
+    await reset_invite_service()
+    await reset_subscription_service()
+    reset_billing_enforcer()
     await reset_api_key_manager()
     await reset_storage_service()
     await reset_cleanup_service()
     await reset_users_db()
+    await shutdown_audit_service()
 
     await ensure_authnz_schema_ready_once()
 

--- a/tldw_Server_API/tests/performance/test_authnz_multiuser_sqlite_load.py
+++ b/tldw_Server_API/tests/performance/test_authnz_multiuser_sqlite_load.py
@@ -3,6 +3,7 @@ import importlib
 import json
 import os
 import time
+from typing import Any, Awaitable, Callable
 from unittest.mock import patch
 
 import pytest
@@ -45,6 +46,11 @@ async def _build_app(tmp_path, monkeypatch):
     try:
         from tldw_Server_API.app.core.config import settings as core_settings
         core_settings["CSRF_ENABLED"] = False
+        # The lazy core-settings mapping materializes USER_DB_BASE_DIR from env
+        # once; DatabasePaths prefers the settings value over env when it is
+        # non-default, so without this sync the SECOND _build_app in a session
+        # would keep routing per-user DBs into the FIRST test's tmp dir.
+        core_settings["USER_DB_BASE_DIR"] = user_db_base
     except Exception:
         _ = None
 
@@ -165,7 +171,7 @@ async def test_multi_user_sqlite_register_login_load(tmp_path, monkeypatch):
             return i, j, resp.status_code, resp.text
         return None
 
-    async def _run_with_sem(func, *args):
+    async def _run_with_sem(func: Callable[..., Awaitable[Any]], *args: Any) -> Any:
         async with sem:
             return await func(*args)
 

--- a/tldw_Server_API/tests/performance/test_authnz_multiuser_sqlite_load.py
+++ b/tldw_Server_API/tests/performance/test_authnz_multiuser_sqlite_load.py
@@ -53,11 +53,34 @@ async def _build_app(tmp_path, monkeypatch):
     from tldw_Server_API.app.core.AuthNZ.jwt_service import reset_jwt_service
     from tldw_Server_API.app.core.AuthNZ.session_manager import reset_session_manager
     from tldw_Server_API.app.core.AuthNZ.initialize import ensure_authnz_schema_ready_once
+    # Service-layer singletons cache the db pool at first use; without these
+    # resets the SECOND _build_app in a session registers users (and writes
+    # media/audit rows) through the previous app's pool into the previous
+    # tmp database — logins then 401 and FK constraints fail (issue #2580).
+    # Mirrors the canonical reset set in tests/AuthNZ/conftest.py.
+    from tldw_Server_API.app.core.AuthNZ.api_key_manager import reset_api_key_manager
+    from tldw_Server_API.app.core.AuthNZ.lockout_tracker import reset_lockout_tracker
+    from tldw_Server_API.app.core.AuthNZ.rate_limiter import reset_rate_limiter
+    from tldw_Server_API.app.core.AuthNZ.token_blacklist import reset_token_blacklist
+    from tldw_Server_API.app.core.DB_Management.Users_DB import reset_users_db
+    from tldw_Server_API.app.services.registration_service import reset_registration_service
+    from tldw_Server_API.app.services.storage_cleanup_service import reset_cleanup_service
+    from tldw_Server_API.app.services.storage_quota_service import reset_storage_service
+    from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import close_all_chacha_db_instances
 
+    close_all_chacha_db_instances()
     await reset_db_pool()
+    await reset_session_manager()
+    await reset_token_blacklist()
+    await reset_rate_limiter()
+    await reset_lockout_tracker()
     reset_settings()
     reset_jwt_service()
-    await reset_session_manager()
+    await reset_registration_service()
+    await reset_api_key_manager()
+    await reset_storage_service()
+    await reset_cleanup_service()
+    await reset_users_db()
 
     await ensure_authnz_schema_ready_once()
 
@@ -130,9 +153,9 @@ async def test_multi_user_sqlite_register_login_load(tmp_path, monkeypatch):
             return i, j, resp.status_code, resp.text
         return None
 
-    async def _run_with_sem(func, idx, client):
+    async def _run_with_sem(func, *args):
         async with sem:
-            return await func(idx, client)
+            return await func(*args)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:


### PR DESCRIPTION
Fixes #2580 — the two perf tests that ran red in `perf-nightly` since their first-ever execution.

## Root causes (found via instrumented repro, not guesswork)

**1. Arity bit-rot.** `_run_with_sem(func, idx, client)` supported only 2-arg callables; the chat/media stages added later call it with `(func, i, j, token, client)` → `TypeError` before those stages ever ran. Now forwards `*args`.

**2. Cross-app singleton leakage** (the actual source of the reported `FOREIGN KEY constraint failed`). `_build_app` reset only 4 AuthNZ singletons (pool/settings/jwt/session), but service-layer singletons — `registration_service`, `storage_quota_service`, `api_key_manager`, `Users_DB`, etc. — cache the db pool at first use. The **second** app built in one pytest session therefore registered users through the **first** app's pool into the first app's tmp database: `users.db` B stayed empty, all logins 401'd, and media/audit writes referenced user ids that didn't exist in the DB they landed in → FK IntegrityError. Evidence from the repro script: `B: register/login: (200, 401)`, `B: users in B-db: []`, `B: users in A-db: ['alpha', 'bravo']`.

`_build_app` now mirrors the canonical reset set from `tests/AuthNZ/conftest.py` (with an explanatory comment pointing back to this issue).

## Verification

- `test_authnz_multiuser_sqlite_load.py` (both tests, one session): **2 passed** (2m44s)
- Whole perf suite as `perf-nightly` runs it (`PERF=1`): **6 passed** (3m49s)

After merge, `perf-nightly` should go green on its next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs the two AuthNZ multiuser SQLite load tests by forwarding semaphore args, syncing per-user DB paths, and fully resetting app singletons between builds. Resolves the FK failures in #2580 and should restore a green `perf-nightly`.

- **Bug Fixes**
  - `_run_with_sem` now forwards `*args` and accepts any callable, so chat/media stages can pass `(i, j, token, client)` without `TypeError`.
  - `_build_app` mirrors the canonical reset set (scheduler, alerts, invite/subscription/billing, rate limiter/lockouts, audit, etc.), closes ChaCha Notes DBs, and syncs `USER_DB_BASE_DIR` into core settings to prevent cross-app DB pool leakage that led to 401s and FK errors.

<sup>Written for commit 1d7c61a2ecda822601403c1e821f602560b0edda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

