### PR TITLE
Add rag MCP module

### DIFF
--- a/Docs/MCP/Unified/Client_Snippets.md
+++ b/Docs/MCP/Unified/Client_Snippets.md
@@ -94,6 +94,16 @@ exec_resp = requests.post(
 print(exec_resp.json())
 ```
 
+## RAG JSON-RPC Examples
+
+```json
+{"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.search","arguments":{"query":"What did I save about retrieval?","sources":["media","notes"],"top_k":5}},"id":"rag-search-1"}
+```
+
+```json
+{"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.answer","arguments":{"query":"Summarize the evidence on contextual retrieval.","sources":["media_db"],"include_documents":true}},"id":"rag-answer-1"}
+```
+
 ## Notes
 - Tool discovery can be narrowed with catalogs: `GET /api/v1/mcp/tools?catalog=<name>` or `?catalog_id=<id>`.
 - Unresolved catalogs return an empty result with `_meta.catalog.status=unresolved`; use `/api/v1/mcp/tool_catalogs` to list visible catalog names.

--- a/Docs/MCP/Unified/User_Guide.md
+++ b/Docs/MCP/Unified/User_Guide.md
@@ -206,6 +206,15 @@ curl -X POST http://127.0.0.1:8000/api/v1/mcp/request \
   }'
 ```
 
+### RAG tools
+
+- `rag.capabilities` lists MCP-safe RAG capabilities and limits.
+- `rag.source_health` reports safe, canonical source readiness.
+- `rag.search` retrieves bounded, citation-aware evidence without answer generation.
+- `rag.answer` generates a grounded answer over retrieved evidence and reports `answered`, `partial`, or `abstained`.
+
+Accepted source aliases are normalized through the existing RAG source registry. Responses use canonical source ids such as `media_db` and `notes`. Catalogs can group `rag.*`, `knowledge.*`, `media.*`, and `notes.*` for retrieval workflows, but catalog membership does not grant execution rights.
+
 ### Convenience HTTP endpoints
 
 - `GET /api/v1/mcp/tools`

--- a/Docs/MCP/mcp_tool_catalogs.md
+++ b/Docs/MCP/mcp_tool_catalogs.md
@@ -97,6 +97,19 @@ When `catalog_strict` is omitted or false, unresolved catalogs use the default
 fail-open behavior. When `catalog_strict: true`, unresolved catalogs return an
 empty tool list.
 
+Recommended Catalog: `library-rag`
+- Use this catalog to keep existing-library retrieval workflows compact for autonomous clients.
+- Catalogs shape discovery only; they do not create a `research.*` MCP layer and do not grant execution rights.
+- Suggested entries:
+  - `rag.capabilities`
+  - `rag.source_health`
+  - `rag.search`
+  - `rag.answer`
+  - `knowledge.search`
+  - `knowledge.get`
+  - `media.search`
+  - `notes.search`
+
 Recommended Catalog: `kanban-safe-orchestrator`
 - Use this catalog to expose only workflow-control primitives to autonomous agents.
 - Suggested entries:

--- a/Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
@@ -459,7 +459,7 @@ git commit -m "feat: add rag mcp module"
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py`
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_config_safe_defaults.py` if category-map coverage needs extension.
 
-- [ ] **Step 1: Write failing registration/config tests**
+- [x] **Step 1: Write failing registration/config tests**
 
 Add tests:
 
@@ -531,7 +531,7 @@ async def test_catalog_membership_does_not_grant_rag_execute_permission():
 
 This test must prove catalogs reduce discovery noise only. They must not bypass `tools.execute:rag.*`, API-key scopes, MCP scopes, governance category checks, or module/source authorization.
 
-- [ ] **Step 2: Run registration/config tests to verify failures**
+- [x] **Step 2: Run registration/config tests to verify failures**
 
 Run:
 
@@ -545,7 +545,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: FAIL because `rag` is not configured yet.
 
-- [ ] **Step 3: Update config**
+- [x] **Step 3: Update config**
 
 Add to `mcp_modules.yaml` after `knowledge`:
 
@@ -585,13 +585,15 @@ If the policy file has an MCP category map, map `mcp.search` and `mcp.rag_genera
 
 Do not rely on tool metadata alone for MCP rate limiting. Keep metadata for governance/observability, but make runtime categories deterministic through `mcp_tool_categories.yaml`. `rag.answer` must require the configured `rag_generation` category; if that mapping or matching policy is missing, return a guarded configuration error and do not execute the tool under the runtime fallback category.
 
+Implementation note: the runtime category allowlist now recognizes `rag_generation`, so `rag.answer` cannot silently fall back to `read` when using the default module metadata. The YAML category map and `mcp.rag_generation` policy are still installed as the operator-visible configuration path.
+
 Add to `module_surface.py`:
 
 ```python
 "rag": ("read_only", "Run grounded retrieval and answer generation over configured knowledge sources."),
 ```
 
-- [ ] **Step 4: Run registration/config tests to verify pass**
+- [x] **Step 4: Run registration/config tests to verify pass**
 
 Run the pytest command from Step 2.
 

--- a/Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
@@ -136,7 +136,7 @@ Run the same pytest command from Step 2.
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add \
@@ -156,7 +156,7 @@ git commit -m "refactor: share rag transport helpers"
 - Create: `tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py`
 - Create/Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py`
 
-- [ ] **Step 1: Write failing contract tests**
+- [x] **Step 1: Write failing contract tests**
 
 Add tests that import private helpers from `rag_module.py` until the module API stabilizes:
 
@@ -219,7 +219,7 @@ def test_compact_response_truncates_documents_and_preserves_citations():
     assert payload["metadata"]["max_content_chars"] == 3
 ```
 
-- [ ] **Step 2: Run tests to verify failures**
+- [x] **Step 2: Run tests to verify failures**
 
 Run:
 
@@ -231,7 +231,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: FAIL because `rag_module.py` and helpers do not exist.
 
-- [ ] **Step 3: Add contract helpers in `rag_module.py`**
+- [x] **Step 3: Add contract helpers in `rag_module.py`**
 
 Implement only pure helpers first:
 
@@ -283,7 +283,7 @@ def _build_mcp_rag_request(tool_name: str, arguments: dict[str, Any]) -> tuple[U
 
 Add `_compact_rag_response()`, `_answer_status()`, `_domain_error_payload()`, `_mcp_safe_search_agent_overrides()`, and `_unsupported_scope_warnings_or_error()` as pure functions. Keep all payloads JSON-serializable and avoid provider secrets, paths, and prompts.
 
-- [ ] **Step 4: Run contract tests to verify pass**
+- [x] **Step 4: Run contract tests to verify pass**
 
 Run the pytest command from Step 2.
 

--- a/Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
@@ -627,7 +627,7 @@ git commit -m "config: register rag mcp module"
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py` only if adding `rag.*` to built-in profile metadata exposes a missing-prefix test.
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py` only if discovery/canExecute fixtures need `rag.*` coverage.
 
-- [ ] **Step 1: Write failing docs/discovery tests where applicable**
+- [x] **Step 1: Write failing docs/discovery tests where applicable**
 
 If built-in profile metadata is updated to include `rag.search` or `rag.answer`, add/update tests so `rag` is categorized and progressive disclosure limits still pass.
 
@@ -652,7 +652,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: PASS if no profile metadata changes are needed; otherwise FAIL until category fixtures are updated.
 
-- [ ] **Step 2: Update docs**
+- [x] **Step 2: Update docs**
 
 Add a concise `rag.*` section:
 
@@ -693,7 +693,7 @@ Add JSON-RPC snippets for:
 {"jsonrpc":"2.0","method":"tools/call","params":{"name":"rag.answer","arguments":{"query":"Summarize the evidence on contextual retrieval.", "sources":["media_db"], "include_documents":true}},"id":"rag-answer-1"}
 ```
 
-- [ ] **Step 3: Run targeted test suite**
+- [x] **Step 3: Run targeted test suite**
 
 Run:
 
@@ -713,7 +713,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 4: Run smoke through MCP protocol**
+- [x] **Step 4: Run smoke through MCP protocol**
 
 Add or run an automated smoke test that registers `RagModule` with a stub pipeline and calls:
 
@@ -731,7 +731,7 @@ Expected:
 
 Also add or run an automated HTTP facade smoke through `POST /api/v1/mcp/tools/execute` for `rag.search` with a stub server, asserting the existing wrapper contract remains intact.
 
-- [ ] **Step 5: Run Bandit on touched code scopes**
+- [x] **Step 5: Run Bandit on touched code scopes**
 
 Run:
 
@@ -745,7 +745,7 @@ source .venv/bin/activate && python -m bandit -r \
 
 Expected: exit 0 or no new findings in touched code. Fix new findings before continuing.
 
-- [ ] **Step 6: Commit final docs and hardening**
+- [x] **Step 6: Commit final docs and hardening**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
@@ -306,7 +306,7 @@ git commit -m "feat: add rag mcp contract helpers"
 - Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py`
 - Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py`
 
-- [ ] **Step 1: Write failing module tests**
+- [x] **Step 1: Write failing module tests**
 
 Add async tests for:
 
@@ -371,7 +371,7 @@ Also add tests for:
 - MCP execution forces out-of-scope Search-Agent and research defaults off even when config/profile defaults enable `enable_research_loop`, `search_url_scraping`, `enable_image_search`, `enable_video_search`, web fallback, or similar external provider behavior.
 - RAG-domain pipeline exceptions become structured `ok:false` payloads.
 
-- [ ] **Step 2: Run module tests to verify failures**
+- [x] **Step 2: Run module tests to verify failures**
 
 Run:
 
@@ -383,7 +383,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: FAIL because `RagModule.get_tools()` and `execute_tool()` are not implemented.
 
-- [ ] **Step 3: Implement `RagModule`**
+- [x] **Step 3: Implement `RagModule`**
 
 Implement:
 
@@ -431,13 +431,13 @@ Execution rules:
 - `context.db_paths` keys should accept existing MCP conventions (`media`, `chacha`, `prompts`, `kanban`) and map to RAG pipeline keys (`media_db_path`, `notes_db_path`, `character_db_path`, `prompts_db_path`, `kanban_db_path`).
 - Do not enable Search-Agent web/research loop flags, URL scraping, image search, or video search through MCP first-slice arguments.
 
-- [ ] **Step 4: Run module tests to verify pass**
+- [x] **Step 4: Run module tests to verify pass**
 
 Run the pytest command from Step 2.
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
@@ -60,7 +60,7 @@ Do not modify in the first slice:
 - Modify: `tldw_Server_API/tests/RAG_NEW/unit/test_rag_unified_search_agent_defaults.py`
 - Modify: `tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py`
 
-- [ ] **Step 1: Write failing helper extraction tests**
+- [x] **Step 1: Write failing helper extraction tests**
 
 Create `tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py` with tests for:
 
@@ -91,7 +91,7 @@ def test_build_source_health_payload_uses_existing_paths_without_leaking_paths(m
 
 Also update existing tests to import `build_unified_pipeline_kwargs`, `resolve_existing_source_db_paths`, and source-health helpers from `tldw_Server_API.app.core.RAG.rag_service.transport` instead of monkeypatching `rag_unified`.
 
-- [ ] **Step 2: Run tests to verify failures**
+- [x] **Step 2: Run tests to verify failures**
 
 Run:
 
@@ -105,7 +105,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: FAIL because `rag_service.transport` does not exist and existing tests still target endpoint-local helpers.
 
-- [ ] **Step 3: Add `rag_service.transport`**
+- [x] **Step 3: Add `rag_service.transport`**
 
 Move or wrap these route-local helpers from `rag_unified.py` into `transport.py`:
 
@@ -130,7 +130,7 @@ Implementation notes:
 - `log_rag_queries_for_org_context()` should preserve best-effort behavior and never raise.
 - `rag_unified.py` should import these helpers and expose thin route wrappers only.
 
-- [ ] **Step 4: Run extraction tests to verify pass**
+- [x] **Step 4: Run extraction tests to verify pass**
 
 Run the same pytest command from Step 2.
 
@@ -289,7 +289,7 @@ Run the pytest command from Step 2.
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add \

--- a/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
+++ b/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
@@ -4,7 +4,7 @@ title: Implement rag.* MCP module
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-03 17:33'
+updated_date: '2026-07-04 23:21'
 labels:
   - mcp
   - rag
@@ -43,6 +43,10 @@ Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 2026-07-03 review follow-up: addressed code-review findings for source-module registration checks, all-sources-filtered allow_partial behavior, MCP-to-billing RAG daily quota enforcement, PermissionError propagation for MCP auth/quota failures, bounded/redacted citation payloads, source_health context db_paths, empty sources_used semantics, and MCP top_k capability alignment. Added regression coverage in MCP RAG module tests and RAG transport helper tests. Verification: 67-test MCP/RAG helper/source-health suite passed; focused RAG module + transport helper suite passed; Bandit on touched Python scope completed with zero findings after test fixture cleanup.
+
+2026-07-04 PR follow-up: rebase codex/rag-mcp-module onto latest origin/dev and address fresh PR review comments from CodeRabbit/Qodo/Gemini. Scope: keep PR on rag.* MCP only, fix still-valid comments with minimal changes, validate, then force-push rebased branch and retarget PR to dev.
+
+2026-07-04 PR follow-up completed: rebased codex/rag-mcp-module onto latest origin/dev, tightened rag.* MCP review fixes for explicit-null defaults, strict booleans, include_documents pipeline handling, client-safe RAG error summaries, pipeline exception logging, test marker classification, and verified org metadata hints for RAG billing. Verification: focused RAG/MCP suite passed (73 tests); git diff --check passed; Bandit on touched Python scope completed with zero findings (/tmp/bandit_rag_mcp_pr2587_followup.json).
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
+++ b/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12120
 title: Implement rag.* MCP module
-status: In Progress
+status: Done
 labels:
 - mcp
 - rag
@@ -11,6 +11,9 @@ references:
 modified_files:
 - backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
 - Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
+- Docs/MCP/mcp_tool_catalogs.md
+- Docs/MCP/Unified/User_Guide.md
+- Docs/MCP/Unified/Client_Snippets.md
 - tldw_Server_API/app/api/v1/endpoints/rag_unified.py
 - tldw_Server_API/app/core/RAG/rag_service/transport.py
 - tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py
@@ -24,6 +27,8 @@ modified_files:
 - tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_rag_module_registration.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_knowledge_search_defaults.py
+- tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py
 ---
 
 ## Description
@@ -56,7 +61,7 @@ Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added a proper rag.* MCP module without a research.* layer. Verification: targeted MCP/RAG suite passed (80 tests), and Bandit completed with zero findings for rag_module.py, rag_service/transport.py, and rag_unified.py.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
+++ b/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
@@ -2,9 +2,13 @@
 id: TASK-12120
 title: Implement rag.* MCP module
 status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-07-03 16:59
 labels:
 - mcp
 - rag
+dependencies: []
 references:
 - Docs/superpowers/specs/2026-07-03-rag-mcp-module-design.md
 - Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
@@ -39,11 +43,11 @@ Implement the approved first-slice rag.* MCP module with capabilities, source_he
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Expose rag.capabilities, rag.source_health, rag.search, and rag.answer through MCP with strict schemas and no research.* layer.
-- [ ] #2 Preserve existing RAG behavior through shared transport helpers while adding MCP-specific normalization, metadata, truncation, and citation coverage.
-- [ ] #3 Enforce MCP module/tool/category/security/quota controls and per-source authorization posture described in the approved plan.
-- [ ] #4 Register rag module, mcp.search, and rag_generation governance configuration with fail-closed behavior for missing generation policy.
-- [ ] #5 Cover behavior with targeted unit/integration tests, HTTP tools/execute compatibility, JSON-RPC wrapper compatibility, knowledge.search regression, and Bandit on touched scope.
+- [x] #1 Expose rag.capabilities, rag.source_health, rag.search, and rag.answer through MCP with strict schemas and no research.* layer.
+- [x] #2 Preserve existing RAG behavior through shared transport helpers while adding MCP-specific normalization, metadata, truncation, and citation coverage.
+- [x] #3 Enforce MCP module/tool/category/security/quota controls and per-source authorization posture described in the approved plan.
+- [x] #4 Register rag module, mcp.search, and rag_generation governance configuration with fail-closed behavior for missing generation policy.
+- [x] #5 Cover behavior with targeted unit/integration tests, HTTP tools/execute compatibility, JSON-RPC wrapper compatibility, knowledge.search regression, and Bandit on touched scope.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -54,22 +58,26 @@ Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added a proper rag.* MCP module without a research.* layer. Verification: targeted MCP/RAG suite passed (80 tests), and Bandit completed with zero findings for rag_module.py, rag_service/transport.py, and rag_unified.py.
+
+Review follow-up: integrated code-review findings by making default rag.* MCP controls enforce protocol/RBAC/source authorization, forcing MCP-safe RAG pipeline overrides, redacting raw document/response metadata, returning source_health as an ok/warnings contract, and adding regression coverage. Verification: targeted MCP/RAG suite passed (85 tests), and Bandit completed with zero findings for rag_module.py.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
+++ b/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
@@ -16,6 +16,14 @@ modified_files:
 - tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py
 - tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
+- tldw_Server_API/Config_Files/mcp_modules.yaml
+- tldw_Server_API/Config_Files/mcp_tool_categories.yaml
+- tldw_Server_API/Config_Files/resource_governor_policies.yaml
+- tldw_Server_API/app/core/MCP_unified/module_surface.py
+- tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_rag_module_registration.py
 ---
 
 ## Description

--- a/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
+++ b/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
@@ -11,6 +11,9 @@ references:
 modified_files:
 - backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
 - Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
+- tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+- tldw_Server_API/app/core/RAG/rag_service/transport.py
+- tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py
 - tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
 - tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
 ---

--- a/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
+++ b/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
@@ -4,35 +4,14 @@ title: Implement rag.* MCP module
 status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-07-03 16:59
+updated_date: '2026-07-03 17:33'
 labels:
-- mcp
-- rag
+  - mcp
+  - rag
 dependencies: []
 references:
-- Docs/superpowers/specs/2026-07-03-rag-mcp-module-design.md
-- Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
-modified_files:
-- backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
-- Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
-- Docs/MCP/mcp_tool_catalogs.md
-- Docs/MCP/Unified/User_Guide.md
-- Docs/MCP/Unified/Client_Snippets.md
-- tldw_Server_API/app/api/v1/endpoints/rag_unified.py
-- tldw_Server_API/app/core/RAG/rag_service/transport.py
-- tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py
-- tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
-- tldw_Server_API/Config_Files/mcp_modules.yaml
-- tldw_Server_API/Config_Files/mcp_tool_categories.yaml
-- tldw_Server_API/Config_Files/resource_governor_policies.yaml
-- tldw_Server_API/app/core/MCP_unified/module_surface.py
-- tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_rag_module_registration.py
-- tldw_Server_API/app/core/MCP_unified/tests/test_knowledge_search_defaults.py
-- tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py
+  - Docs/superpowers/specs/2026-07-03-rag-mcp-module-design.md
+  - Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
 ---
 
 ## Description
@@ -62,6 +41,8 @@ Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+2026-07-03 review follow-up: addressed code-review findings for source-module registration checks, all-sources-filtered allow_partial behavior, MCP-to-billing RAG daily quota enforcement, PermissionError propagation for MCP auth/quota failures, bounded/redacted citation payloads, source_health context db_paths, empty sources_used semantics, and MCP top_k capability alignment. Added regression coverage in MCP RAG module tests and RAG transport helper tests. Verification: 67-test MCP/RAG helper/source-health suite passed; focused RAG module + transport helper suite passed; Bandit on touched Python scope completed with zero findings after test fixture cleanup.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -70,6 +51,8 @@ Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
 Added a proper rag.* MCP module without a research.* layer. Verification: targeted MCP/RAG suite passed (80 tests), and Bandit completed with zero findings for rag_module.py, rag_service/transport.py, and rag_unified.py.
 
 Review follow-up: integrated code-review findings by making default rag.* MCP controls enforce protocol/RBAC/source authorization, forcing MCP-safe RAG pipeline overrides, redacting raw document/response metadata, returning source_health as an ok/warnings contract, and adding regression coverage. Verification: targeted MCP/RAG suite passed (85 tests), and Bandit completed with zero findings for rag_module.py.
+
+Second review follow-up: integrated remaining findings around source module availability, empty authorized source sets, shared RAG daily billing limit enforcement for MCP, auth/quota error propagation, citation bounds/redaction, source_health context db_paths, and MCP top_k limit alignment. Verification: 67-test MCP/RAG helper/source-health suite passed; Bandit on touched Python scope completed with zero findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
+++ b/backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
@@ -1,0 +1,59 @@
+---
+id: TASK-12120
+title: Implement rag.* MCP module
+status: In Progress
+labels:
+- mcp
+- rag
+references:
+- Docs/superpowers/specs/2026-07-03-rag-mcp-module-design.md
+- Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
+modified_files:
+- backlog/tasks/task-12120 - Implement-rag.-MCP-module.md
+- Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved first-slice rag.* MCP module with capabilities, source_health, search, and answer tools. Keep the implementation aligned to the existing RAG pipeline and MCP security/governance controls; do not add a research.* facade or external-provider research loop.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Expose rag.capabilities, rag.source_health, rag.search, and rag.answer through MCP with strict schemas and no research.* layer.
+- [ ] #2 Preserve existing RAG behavior through shared transport helpers while adding MCP-specific normalization, metadata, truncation, and citation coverage.
+- [ ] #3 Enforce MCP module/tool/category/security/quota controls and per-source authorization posture described in the approved plan.
+- [ ] #4 Register rag module, mcp.search, and rag_generation governance configuration with fail-closed behavior for missing generation policy.
+- [ ] #5 Cover behavior with targeted unit/integration tests, HTTP tools/execute compatibility, JSON-RPC wrapper compatibility, knowledge.search regression, and Bandit on touched scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-07-03-rag-mcp-module-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/mcp_modules.yaml
+++ b/tldw_Server_API/Config_Files/mcp_modules.yaml
@@ -172,6 +172,17 @@ modules:
       respect_robots: false
       max_import_file_bytes: 2000000
 
+  - id: rag
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.rag_module:RagModule
+    enabled: true
+    name: RAG
+    version: "1.0.0"
+    department: knowledge
+    max_concurrent: 6
+    settings:
+      max_documents: 6
+      max_content_chars: 2000
+
   - id: run_command
     class: tldw_Server_API.app.core.MCP_unified.modules.implementations.run_command_module:RunCommandModule
     # Disabled by default because it can run configured local command families.

--- a/tldw_Server_API/Config_Files/mcp_tool_categories.yaml
+++ b/tldw_Server_API/Config_Files/mcp_tool_categories.yaml
@@ -12,6 +12,8 @@ delete_media: ingestion
 
 media.search: read
 knowledge.search: read
+rag.search: search
+rag.answer: rag_generation
 notes.search: read
 chats.search: read
 prompts.search: read

--- a/tldw_Server_API/Config_Files/resource_governor_policies.yaml
+++ b/tldw_Server_API/Config_Files/resource_governor_policies.yaml
@@ -56,6 +56,15 @@ policies:
     <<: *mcp_base
     requests: { rpm: 120, burst: 1.0 }  # Higher limit for read ops
 
+  mcp.search:
+    <<: *mcp_base
+    requests: { rpm: 60, burst: 1.0 }
+
+  mcp.rag_generation:
+    requests: { rpm: 30, burst: 1.0 }
+    scopes: [user, api_key]
+    fail_mode: fallback_memory
+
   # AuthNZ guardrails (login, reset-password, etc.)
   # Applied by RG ingress via /api/v1/auth* route_map entries.
   authnz.default:

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -7,7 +7,6 @@ All features are accessible through explicit parameters.
 
 import asyncio
 import hashlib
-import inspect
 import json
 import os
 import time
@@ -63,6 +62,7 @@ from tldw_Server_API.app.core.RAG.rag_service.request_resolution import (
     ResolvedRAGRequest,
     resolve_rag_request,
 )
+from tldw_Server_API.app.core.RAG.rag_service import transport as rag_transport
 from tldw_Server_API.app.core.RAG.rag_service.retrieval_plan import (
     RetrievalPlan,
     build_retrieval_plan,
@@ -73,7 +73,7 @@ from tldw_Server_API.app.core.RAG.rag_service.response_mapping import (
 )
 from tldw_Server_API.app.core.RAG.rag_service.source_health import build_source_health_entries
 from tldw_Server_API.app.core.RAG.rag_service.streaming_executor import stream_rag_events
-from tldw_Server_API.app.core.config import get_config_value, settings
+from tldw_Server_API.app.core.config import get_config_value
 
 # Unified Pipeline
 from tldw_Server_API.app.core.RAG.rag_service.unified_pipeline import (
@@ -211,36 +211,18 @@ def _build_unified_pipeline_kwargs(
     retrieval_plan: Optional[RetrievalPlan] = None,
 ) -> dict[str, Any]:
     """Translate a resolved standard request into core pipeline keyword arguments."""
-    if resolved_request is None:
-        resolved_request = resolve_rag_request(
-            request,
-            current_user=current_user,
-            single_user_id_resolver=DatabasePaths.get_single_user_id,
-            search_agent_setting_fn=_search_agent_setting,
-        )
-    if retrieval_plan is None:
-        retrieval_plan = build_retrieval_plan(resolved_request)
-    payload = dict(resolved_request.payload)
-    payload["sources"] = list(retrieval_plan.sources)
-    payload["media_db_path"] = db_paths.get("media_db_path")
-    payload["notes_db_path"] = db_paths.get("notes_db_path")
-    payload["character_db_path"] = db_paths.get("character_db_path")
-    payload["kanban_db_path"] = db_paths.get("kanban_db_path")
-    payload["prompts_db_path"] = db_paths.get("prompts_db_path")
-    payload["media_db"] = media_db
-    payload["chacha_db"] = chacha_db
-    if prompts_db is not None:
-        payload["prompts_db"] = prompts_db
-    payload["index_namespace"] = retrieval_plan.index_namespace
-    payload["retrieval_plan"] = retrieval_plan
-    payload["user_id"] = resolved_request.user_id
-    payload["feedback_user_id"] = resolved_request.feedback_user_id
-    signature = inspect.signature(unified_rag_pipeline)
-    params = list(signature.parameters.values())
-    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
-        return payload
-    allowed = set(signature.parameters.keys())
-    return {k: v for k, v in payload.items() if k in allowed}
+    return rag_transport.build_unified_pipeline_kwargs(
+        request=request,
+        db_paths=db_paths,
+        media_db=media_db,
+        chacha_db=chacha_db,
+        current_user=current_user,
+        prompts_db=prompts_db,
+        resolved_request=resolved_request,
+        retrieval_plan=retrieval_plan,
+        search_agent_setting_fn=_search_agent_setting,
+        single_user_id_resolver=DatabasePaths.get_single_user_id,
+    )
 
 
 def _build_batch_pipeline_kwargs(
@@ -285,23 +267,15 @@ def _build_standard_request_bundle(
     prompts_db: Optional[PromptsDatabase] = None,
 ) -> ResolvedRequestBundle:
     """Resolve a standard request once and attach endpoint-owned pipeline resources."""
-    return build_request_bundle(
+    return rag_transport.build_standard_request_bundle(
         request=request,
         current_user=current_user,
-        resolve_request_kwargs={
-            "single_user_id_resolver": DatabasePaths.get_single_user_id,
-            "search_agent_setting_fn": _search_agent_setting,
-        },
-        pipeline_kwargs_builder=lambda *, resolved_request, retrieval_plan: _build_unified_pipeline_kwargs(
-            request=request,
-            db_paths=db_paths,
-            media_db=media_db,
-            chacha_db=chacha_db,
-            prompts_db=prompts_db,
-            current_user=current_user,
-            resolved_request=resolved_request,
-            retrieval_plan=retrieval_plan,
-        ),
+        db_paths=db_paths,
+        media_db=media_db,
+        chacha_db=chacha_db,
+        prompts_db=prompts_db,
+        search_agent_setting_fn=_search_agent_setting,
+        single_user_id_resolver=DatabasePaths.get_single_user_id,
     )
 
 
@@ -476,26 +450,7 @@ def _resolve_kanban_db_path(current_user: Optional[User], request_user_id: Optio
 
 def _resolve_source_health_user_id(current_user: Optional[User], request_user_id: Optional[str] = None) -> Optional[str]:
     """Resolve a filesystem-safe user directory component without creating storage."""
-    candidates: list[Any] = []
-    if current_user is not None:
-        for attr in ("id", "id_int"):
-            candidates.append(getattr(current_user, attr, None))
-    candidates.append(request_user_id)
-
-    for candidate in candidates:
-        if candidate is None:
-            continue
-        raw = str(candidate).strip()
-        if raw.isdigit() and int(raw) > 0:
-            return raw
-    try:
-        fallback = DatabasePaths.get_single_user_id()
-        fallback_raw = str(fallback).strip()
-        if fallback_raw.isdigit() and int(fallback_raw) > 0:
-            return fallback_raw
-    except (RuntimeError, ValueError, OSError, TypeError):
-        logger.debug("Failed to resolve single-user ID for source health path", exc_info=True)
-    return None
+    return rag_transport.resolve_source_health_user_id(current_user, request_user_id)
 
 
 def _resolve_existing_source_db_paths(
@@ -503,32 +458,12 @@ def _resolve_existing_source_db_paths(
     request_user_id: Optional[str] = None,
 ) -> dict[str, str]:
     """Return existing source database paths without creating source storage."""
-    user_id = _resolve_source_health_user_id(current_user, request_user_id)
-    if user_id is None:
-        return {}
-
-    user_dir = DatabasePaths.resolve_user_db_base_dir() / user_id
-    candidates = {
-        "media_db": user_dir / DatabasePaths.MEDIA_DB_NAME,
-        "chacha_db": user_dir / DatabasePaths.CHACHA_DB_NAME,
-        "prompts_db": user_dir / DatabasePaths.PROMPTS_SUBDIR / DatabasePaths.PROMPTS_DB_NAME,
-        "kanban_db": user_dir / DatabasePaths.KANBAN_DB_NAME,
-    }
-    return {
-        source_key: str(path)
-        for source_key, path in candidates.items()
-        if path.is_file()
-    }
+    return rag_transport.resolve_existing_source_db_paths(current_user, request_user_id)
 
 
 def _media_db_uses_non_file_storage() -> bool:
     """Return whether Media DB search is configured for non-file content storage."""
-    backend_mode_hint = (
-        os.getenv("CONTENT_DB_MODE")
-        or os.getenv("TLDW_CONTENT_DB_BACKEND")
-        or str(settings.get("CONTENT_DB_BACKEND", "sqlite"))
-    )
-    return backend_mode_hint.strip().lower() in {"postgres", "postgresql"}
+    return rag_transport.media_db_uses_non_file_storage()
 
 
 def _build_source_health_source_sets(
@@ -537,41 +472,10 @@ def _build_source_health_source_sets(
     media_backend_uses_non_file_storage: bool = False,
 ) -> tuple[set[Any], set[Any]]:
     """Derive ready and empty source sets without creating source storage."""
-    configured: set[Any] = set()
-    empty: set[Any] = set()
-    if "media_db" in existing_paths or media_backend_uses_non_file_storage:
-        configured.add("media_db")
-    else:
-        empty.add("media_db")
-    if "chacha_db" in existing_paths:
-        configured.update(
-            {
-                "notes",
-                "chats",
-                "characters",
-                "world_books",
-                "dictionaries",
-            }
-        )
-    else:
-        empty.update(
-            {
-                "notes",
-                "chats",
-                "characters",
-                "world_books",
-                "dictionaries",
-            }
-        )
-    if "prompts_db" in existing_paths:
-        configured.add("prompts")
-    else:
-        empty.add("prompts")
-    if "kanban_db" in existing_paths:
-        configured.add("kanban")
-    else:
-        empty.add("kanban")
-    return configured, empty
+    return rag_transport.build_source_health_source_sets(
+        existing_paths=existing_paths,
+        media_backend_uses_non_file_storage=media_backend_uses_non_file_storage,
+    )
 
 
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
@@ -592,71 +496,11 @@ async def _log_rag_queries_for_org(
 
     This function never raises; failures are logged at debug level only.
     """
-    if units <= 0:
-        return
-
-    try:
-        # Resolve org_id from request state if available.
-        org_id: Optional[int] = None
-        try:
-            state = getattr(request_raw, "state", None)
-            if state is not None:
-                org_ids = getattr(state, "org_ids", None)
-                if isinstance(org_ids, (list, tuple)) and org_ids:
-                    org_id_candidate = org_ids[0]
-                    try:
-                        org_id = int(org_id_candidate)
-                    except (TypeError, ValueError):
-                        org_id = None
-        except (AttributeError, TypeError):
-            org_id = None
-
-        # Fallback: derive org_id from AuthNZ org memberships.
-        if org_id is None and current_user and current_user.id_int is not None:
-            try:
-                from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
-                from tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo import AuthnzOrgsTeamsRepo
-
-                pool = await get_db_pool()
-                repo = AuthnzOrgsTeamsRepo(db_pool=pool)
-                memberships = await repo.list_org_memberships_for_user(current_user.id_int)
-                if memberships:
-                    candidate = memberships[0].get("org_id")
-                    if candidate is not None:
-                        org_id = int(candidate)
-            except Exception:  # noqa: BLE001 - best-effort fallback for org lookup
-                org_id = None
-
-        if org_id is None:
-            return
-
-        try:
-            from datetime import datetime, timezone
-
-            from tldw_Server_API.app.core.DB_Management.Resource_Daily_Ledger import (
-                LedgerEntry,
-                ResourceDailyLedger,
-            )
-
-            ledger = ResourceDailyLedger()
-            await ledger.initialize()
-
-            now = datetime.now(timezone.utc)
-            entry = LedgerEntry(  # type: ignore[call-arg]
-                entity_scope="org",
-                entity_value=str(org_id),
-                category="rag_queries",
-                units=int(units),
-                op_id=f"rag:{org_id}:{uuid4()}",
-                occurred_at=now,
-            )
-            await ledger.add(entry)
-        except Exception:  # noqa: BLE001 - ledger failures must not impact requests
-            # Ledger write failures must never impact request flow.
-            logger.debug("RAG query ledger write failed; continuing without usage record", exc_info=True)
-    except Exception:  # noqa: BLE001 - guard against unexpected failures in logging helper
-        # Guard against any unexpected failure paths.
-        logger.debug("RAG query logging failed; continuing without usage record", exc_info=True)
+    await rag_transport.log_rag_queries_for_org_context(
+        request_like=request_raw,
+        current_user=current_user,
+        units=units,
+    )
 
 
 # =============== Ablation helper ===============

--- a/tldw_Server_API/app/core/MCP_unified/module_surface.py
+++ b/tldw_Server_API/app/core/MCP_unified/module_surface.py
@@ -8,6 +8,7 @@ from typing import Any
 MODULE_RISK_TIERS: dict[str, tuple[str, str]] = {
     "media": ("read_only", "Search and retrieve existing media records."),
     "knowledge": ("read_only", "Search and retrieve knowledge records."),
+    "rag": ("read_only", "Run grounded retrieval and answer generation over configured knowledge sources."),
     "chats": ("read_only", "Read chat/session context."),
     "prompts": ("read_only", "Read prompt library entries."),
     "prompts_catalog": ("read_only", "Expose configured prompt catalogs."),

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
@@ -40,6 +40,8 @@ _SEARCH_MODES = ("hybrid", "vector", "fts")
 _PROFILES = ("fast", "balanced", "accuracy")
 
 _EXTERNAL_RESEARCH_DISABLED_OVERRIDES: dict[str, Any] = {
+    "search_depth_mode": None,
+    "enable_query_classification": False,
     "enable_research_loop": False,
     "search_url_scraping": False,
     "enable_image_search": False,
@@ -57,6 +59,58 @@ _UNSUPPORTED_SOURCE_SCOPES: dict[str, tuple[str, ...]] = {
     "prompt_id": ("prompts",),
     "prompt_ids": ("prompts",),
 }
+_SOURCE_PERMISSION_TOOLS: dict[str, str] = {
+    "media_db": "media.search",
+    "notes": "notes.search",
+    "chats": "chats.search",
+    "characters": "characters.search",
+    "kanban": "kanban.cards.search",
+    "prompts": "prompts.search",
+    "world_books": "characters.search",
+    "dictionaries": "characters.search",
+}
+_SAFE_DOCUMENT_KEYS = frozenset(
+    {
+        "id",
+        "source",
+        "source_type",
+        "source_id",
+        "title",
+        "uri",
+        "url",
+        "score",
+        "score_type",
+        "rank",
+        "chunk_id",
+        "document_id",
+        "media_id",
+        "note_id",
+        "created_at",
+        "updated_at",
+    }
+)
+_SAFE_DOCUMENT_METADATA_KEYS = frozenset(
+    {
+        "source",
+        "source_type",
+        "source_id",
+        "title",
+        "uri",
+        "url",
+        "score_type",
+        "chunk_id",
+        "document_id",
+        "media_id",
+        "note_id",
+        "page",
+        "page_number",
+        "start_time",
+        "end_time",
+        "timestamp",
+        "created_at",
+        "updated_at",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,18 +126,36 @@ class _McpRagControls:
     """Injectable MCP control hooks used by the RAG module.
 
     The protocol layer performs the primary module/tool execution checks before
-    calling modules. These hooks keep RAG-specific tests and host integrations
-    explicit without importing FastAPI dependencies into the module.
+    calling modules. These hooks reuse that server-owned protocol state for
+    direct module invocation and per-source RAG authorization.
     """
 
     async def enforce_protocol_rate(self, context: Any | None, tool_name: str, category: str) -> None:
-        del context, tool_name, category
+        metadata = getattr(context, "metadata", None)
+        if isinstance(metadata, dict) and metadata.get("rg_ingress_enforced"):
+            return
+        limiter = getattr(self._protocol(), "rate_limiter", None)
+        if limiter is None:
+            from ...auth.rate_limiter import get_rate_limiter
+
+            limiter = get_rate_limiter()
+        key = self._rate_limit_key(context, tool_name)
+        if key is None:
+            return
+        try:
+            await limiter.check_rate_limit(key, category=category)
+        except Exception as exc:  # noqa: BLE001 - normalizes host limiter exceptions for MCP payloads.
+            from ...auth.rate_limiter import RateLimitExceeded
+
+            if isinstance(exc, RateLimitExceeded):
+                raise PermissionError(f"MCP rate limit exceeded; retry after {exc.retry_after}s") from exc
+            raise
 
     async def enforce_rag_rbac_rate_limit(self, context: Any | None, resource: str) -> None:
-        del context, resource
+        await self._ensure_tool_allowed(context, resource)
 
     async def require_mcp_rag_read_scope(self, context: Any | None, tool_name: str) -> None:
-        del context, tool_name
+        await self._ensure_tool_allowed(context, tool_name)
 
     async def authorize_sources(
         self,
@@ -93,14 +165,61 @@ class _McpRagControls:
         sources_explicit: bool,
         allow_partial: bool,
     ) -> _SourceAuthorization:
-        del context, sources_explicit, allow_partial
-        return _SourceAuthorization(sources=list(sources), sources_unavailable=[], warnings=[])
+        del sources_explicit, allow_partial
+        allowed_sources: list[str] = []
+        unavailable_sources: list[str] = []
+        warnings: list[str] = []
+        for source in sources:
+            permission_tool = _SOURCE_PERMISSION_TOOLS.get(source)
+            if permission_tool is None:
+                unavailable_sources.append(source)
+                warnings.append(f"{source} unavailable: no MCP source permission tool is registered")
+                continue
+            if await self._tool_allowed(context, permission_tool):
+                allowed_sources.append(source)
+                continue
+            unavailable_sources.append(source)
+            warnings.append(f"{source} unavailable: MCP tool permission denied for {permission_tool}")
+        return _SourceAuthorization(
+            sources=allowed_sources,
+            sources_unavailable=unavailable_sources,
+            warnings=warnings,
+        )
 
     async def check_rag_query_quota(self, context: Any | None, units: int = 1) -> None:
-        del context, units
+        if units <= 0:
+            return
+        await self.enforce_protocol_rate(context, "rag.query", "rag_generation")
 
     async def log_rag_query_usage(self, context: Any | None, units: int = 1) -> None:
         await rag_transport.log_rag_queries_for_org_context(request_like=context, current_user=None, units=units)
+
+    def _protocol(self) -> Any:
+        from ...server import get_mcp_server
+
+        return get_mcp_server().protocol
+
+    @staticmethod
+    def _rate_limit_key(context: Any | None, tool_name: str) -> str | None:
+        user_id = getattr(context, "user_id", None)
+        if user_id:
+            return f"user:{user_id}:tool:{tool_name}"
+        client_id = getattr(context, "client_id", None)
+        if client_id:
+            return f"client:{client_id}:tool:{tool_name}"
+        return None
+
+    async def _tool_allowed(self, context: Any | None, tool_name: str) -> bool:
+        if context is None or not getattr(context, "user_id", None):
+            return False
+        has_tool_permission = getattr(self._protocol(), "_has_tool_permission", None)
+        if not callable(has_tool_permission):
+            return False
+        return bool(await has_tool_permission(context, tool_name, is_write=False))
+
+    async def _ensure_tool_allowed(self, context: Any | None, tool_name: str) -> None:
+        if not await self._tool_allowed(context, tool_name):
+            raise PermissionError(f"MCP tool permission denied: {tool_name}")
 
 _SEARCH_PROPERTIES: dict[str, Any] = {
     "query": {"type": "string", "minLength": 1, "maxLength": 20000},
@@ -249,9 +368,55 @@ def _source_from_document(document: dict[str, Any]) -> str | None:
     return None
 
 
+def _safe_json_value(value: Any) -> Any | None:
+    """Return bounded scalar/list metadata values suitable for MCP responses."""
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return value[:1000]
+    if isinstance(value, (list, tuple)):
+        safe_items = [_safe_json_value(item) for item in value[:20]]
+        return [item for item in safe_items if item is not None]
+    return None
+
+
+def _safe_metadata(metadata: Any, allowed_keys: frozenset[str]) -> dict[str, Any]:
+    """Allowlist metadata keys and scalar values before returning to MCP clients."""
+    if not isinstance(metadata, dict):
+        return {}
+    safe: dict[str, Any] = {}
+    for key in sorted(allowed_keys):
+        if key not in metadata:
+            continue
+        value = _safe_json_value(metadata.get(key))
+        if value is not None:
+            safe[key] = value
+    return safe
+
+
+def _model_to_plain_dict(value: Any) -> dict[str, Any]:
+    """Convert Pydantic v1/v2 models to plain JSON-safe dictionaries."""
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json", exclude_none=True)
+    dict_method = getattr(value, "dict", None)
+    if callable(dict_method):
+        return dict_method(exclude_none=True)
+    return dict(value) if isinstance(value, dict) else {}
+
+
 def _compact_document(document: dict[str, Any], *, max_content_chars: int) -> dict[str, Any]:
-    compacted = dict(document)
-    content = compacted.get("content")
+    compacted: dict[str, Any] = {}
+    for key in sorted(_SAFE_DOCUMENT_KEYS):
+        if key not in document:
+            continue
+        value = _safe_json_value(document.get(key))
+        if value is not None:
+            compacted[key] = value
+    safe_metadata = _safe_metadata(document.get("metadata"), _SAFE_DOCUMENT_METADATA_KEYS)
+    if safe_metadata:
+        compacted["metadata"] = safe_metadata
+    content = document.get("content")
     if not isinstance(content, str):
         content = "" if content is None else str(content)
     truncated = max_content_chars >= 0 and len(content) > max_content_chars
@@ -294,18 +459,21 @@ def _compact_rag_response(
     if not sources_used:
         sources_used = list(request_metadata.get("sources_requested") or [])
 
-    metadata = dict(response.metadata or {})
-    metadata.update(
-        {
-            "sources_requested": list(request_metadata.get("sources_requested") or []),
-            "sources_used": sources_used,
-            "sources_unavailable": list(request_metadata.get("sources_unavailable") or []),
-            "documents_truncated": len(documents) > len(selected_documents),
-            "max_documents": max_documents,
-            "max_content_chars": max_content_chars,
-            "hard_citation_coverage": _hard_citation_coverage(response.metadata or {}),
-        }
-    )
+    response_metadata = response.metadata or {}
+    trust = response_metadata.get("knowledge_trust")
+    trust_state = str(trust.get("state", "")).strip().lower() if isinstance(trust, dict) else None
+    metadata = {
+        "sources_requested": list(request_metadata.get("sources_requested") or []),
+        "sources_used": sources_used,
+        "sources_unavailable": list(request_metadata.get("sources_unavailable") or []),
+        "warnings": list(request_metadata.get("warnings") or []),
+        "documents_truncated": len(documents) > len(selected_documents),
+        "max_documents": max_documents,
+        "max_content_chars": max_content_chars,
+        "hard_citation_coverage": _hard_citation_coverage(response_metadata),
+    }
+    if trust_state:
+        metadata["knowledge_trust_state"] = trust_state
 
     payload: dict[str, Any] = {
         "ok": not bool(response.errors),
@@ -579,6 +747,8 @@ class RagModule(BaseModule):
             await self._controls.enforce_protocol_rate(context, tool_name, "search")
             await self._controls.enforce_rag_rbac_rate_limit(context, "rag.search")
             await self._controls.require_mcp_rag_read_scope(context, tool_name)
+            sources_explicit = _sources_were_explicit(args)
+            allow_partial = bool(args.get("allow_partial", False))
             requested_sources = (
                 _normalize_mcp_sources(args.get("sources"))
                 if args.get("sources") is not None
@@ -587,17 +757,35 @@ class RagModule(BaseModule):
             authorization = await self._controls.authorize_sources(
                 context,
                 requested_sources,
-                sources_explicit=_sources_were_explicit(args),
-                allow_partial=bool(args.get("allow_partial", False)),
+                sources_explicit=sources_explicit,
+                allow_partial=allow_partial,
             )
+            if authorization.sources_unavailable and sources_explicit and not allow_partial:
+                return {
+                    "ok": False,
+                    "reason_code": "source_unavailable",
+                    "sources_requested": requested_sources,
+                    "sources_unavailable": authorization.sources_unavailable,
+                    "warnings": authorization.warnings,
+                }
             current_user = _current_user_from_context(context)
             payload = rag_transport.build_source_health_payload(current_user=current_user)
-            payload.sources = [
+            visible_sources = [
                 entry
                 for entry in payload.sources
                 if entry.source_id in set(authorization.sources)
             ]
-            return payload
+            return {
+                "ok": True,
+                "sources": [_model_to_plain_dict(entry) for entry in visible_sources],
+                "sources_requested": requested_sources,
+                "sources_unavailable": list(authorization.sources_unavailable),
+                "warnings": list(authorization.warnings),
+                "metadata": {
+                    "sources_explicit": sources_explicit,
+                    "allow_partial": allow_partial,
+                },
+            }
         if tool_name in {_TOOL_SEARCH, _TOOL_ANSWER}:
             return await self._execute_rag_query(tool_name, args, context)
         return {"ok": False, "reason_code": "unknown_tool", "message": f"Unknown tool: {tool_name}"}

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
@@ -1,0 +1,323 @@
+"""MCP ``rag.*`` module backed by the unified RAG pipeline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import (
+    UnifiedRAGRequest,
+    UnifiedRAGResponse,
+)
+from tldw_Server_API.app.core.Text2SQL.source_registry import normalize_sources_public
+
+from ..base import BaseModule, create_tool_definition
+
+_TOOL_CAPABILITIES = "rag.capabilities"
+_TOOL_SOURCE_HEALTH = "rag.source_health"
+_TOOL_SEARCH = "rag.search"
+_TOOL_ANSWER = "rag.answer"
+
+_CANONICAL_PUBLIC_SOURCES = (
+    "media_db",
+    "notes",
+    "chats",
+    "characters",
+    "kanban",
+    "prompts",
+    "world_books",
+    "dictionaries",
+)
+_DEFERRED_STAGE_ONE_SOURCES = frozenset({"sql"})
+_SEARCH_MODES = ("hybrid", "vector", "fts")
+_PROFILES = ("fast", "balanced", "accuracy")
+
+_SEARCH_PROPERTIES: dict[str, Any] = {
+    "query": {"type": "string", "minLength": 1, "maxLength": 20000},
+    "sources": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Canonical or accepted alias source ids.",
+    },
+    "search_mode": {"type": "string", "enum": list(_SEARCH_MODES), "default": "hybrid"},
+    "top_k": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+    "min_score": {"type": "number", "minimum": 0.0, "maximum": 1.0, "default": 0.0},
+    "rag_profile": {"type": "string", "enum": list(_PROFILES)},
+    "include_documents": {"type": "boolean", "default": True},
+    "include_chunk_citations": {"type": "boolean", "default": True},
+    "allow_partial": {"type": "boolean", "default": False},
+    "max_documents": {"type": "integer", "minimum": 0, "maximum": 20, "default": 6},
+    "max_content_chars": {"type": "integer", "minimum": 0, "maximum": 8000, "default": 2000},
+}
+
+
+def _sources_were_explicit(arguments: dict[str, Any]) -> bool:
+    """Return whether the caller supplied the sources key before model defaults."""
+    return "sources" in arguments and arguments.get("sources") is not None
+
+
+def _required_string(arguments: dict[str, Any], key: str, *, max_length: int) -> str:
+    value = arguments.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} is required")
+    value = value.strip()
+    if len(value) > max_length:
+        raise ValueError(f"{key} exceeds maximum length")
+    return value
+
+
+def _bounded_int(value: Any, *, minimum: int, maximum: int) -> int:
+    if value is None:
+        return minimum
+    if isinstance(value, bool):
+        raise ValueError("integer value must not be boolean")
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("integer value required") from exc
+    if result < minimum or result > maximum:
+        raise ValueError(f"integer value must be between {minimum} and {maximum}")
+    return result
+
+
+def _bounded_float(value: Any, *, minimum: float, maximum: float) -> float:
+    if value is None:
+        return minimum
+    if isinstance(value, bool):
+        raise ValueError("float value must not be boolean")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("float value required") from exc
+    if result < minimum or result > maximum:
+        raise ValueError(f"float value must be between {minimum} and {maximum}")
+    return result
+
+
+def _enum(value: Any, allowed: tuple[str, ...]) -> str:
+    if not isinstance(value, str):
+        raise ValueError("enum value must be a string")
+    normalized = value.strip().lower()
+    if normalized not in allowed:
+        raise ValueError(f"unsupported value: {value}")
+    return normalized
+
+
+def _optional_enum(value: Any, allowed: tuple[str, ...]) -> str | None:
+    if value is None:
+        return None
+    return _enum(value, allowed)
+
+
+def _normalize_mcp_sources(value: Any) -> list[str]:
+    if value is None:
+        return normalize_sources_public(None)
+    if not isinstance(value, list):
+        raise ValueError("sources must be a list of strings")
+    if any(not isinstance(source, str) for source in value):
+        raise ValueError("sources entries must be strings")
+    sources = normalize_sources_public(value)
+    deferred = sorted(set(sources) & _DEFERRED_STAGE_ONE_SOURCES)
+    if deferred:
+        raise ValueError(f"unsupported Stage 1 source: {deferred[0]}")
+    disallowed = sorted(set(sources) - set(_CANONICAL_PUBLIC_SOURCES))
+    if disallowed:
+        raise ValueError(f"unsupported Stage 1 source: {disallowed[0]}")
+    return sources
+
+
+def _build_mcp_rag_request(
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> tuple[UnifiedRAGRequest, dict[str, Any]]:
+    """Map strict MCP arguments into a unified RAG request plus MCP metadata."""
+    if tool_name not in {_TOOL_SEARCH, _TOOL_ANSWER}:
+        raise ValueError(f"unsupported rag request tool: {tool_name}")
+    if "advanced" in arguments:
+        raise ValueError("advanced is not supported by rag.* first slice")
+
+    sources_explicit = _sources_were_explicit(arguments)
+    sources = _normalize_mcp_sources(arguments.get("sources"))
+    max_documents = _bounded_int(arguments.get("max_documents", 6), minimum=0, maximum=20)
+    max_content_chars = _bounded_int(arguments.get("max_content_chars", 2000), minimum=0, maximum=8000)
+
+    payload: dict[str, Any] = {
+        "query": _required_string(arguments, "query", max_length=20000),
+        "sources": sources,
+        "search_mode": _enum(arguments.get("search_mode", "hybrid"), _SEARCH_MODES),
+        "top_k": _bounded_int(arguments.get("top_k", 10), minimum=1, maximum=50),
+        "min_score": _bounded_float(arguments.get("min_score", 0.0), minimum=0.0, maximum=1.0),
+        "rag_profile": _optional_enum(arguments.get("rag_profile"), _PROFILES),
+        "enable_generation": tool_name == _TOOL_ANSWER,
+        "enable_citations": True,
+        "enable_chunk_citations": bool(arguments.get("include_chunk_citations", True)),
+        "include_metadata": True,
+        "include_sources": bool(arguments.get("include_documents", True)),
+    }
+    if tool_name == _TOOL_SEARCH:
+        payload["enable_generation"] = False
+
+    request = UnifiedRAGRequest(**payload)
+    return request, {
+        "sources_explicit": sources_explicit,
+        "sources_requested": list(sources),
+        "allow_partial": bool(arguments.get("allow_partial", False)),
+        "max_documents": max_documents,
+        "max_content_chars": max_content_chars,
+    }
+
+
+def _source_from_document(document: dict[str, Any]) -> str | None:
+    metadata = document.get("metadata")
+    if isinstance(metadata, dict):
+        raw_source = metadata.get("source") or metadata.get("source_type")
+        if isinstance(raw_source, str) and raw_source.strip():
+            return raw_source.strip()
+    raw_source = document.get("source") or document.get("source_type")
+    if isinstance(raw_source, str) and raw_source.strip():
+        return raw_source.strip()
+    return None
+
+
+def _compact_document(document: dict[str, Any], *, max_content_chars: int) -> dict[str, Any]:
+    compacted = dict(document)
+    content = compacted.get("content")
+    if not isinstance(content, str):
+        content = "" if content is None else str(content)
+    truncated = max_content_chars >= 0 and len(content) > max_content_chars
+    compacted["content"] = content[:max_content_chars] if truncated else content
+    compacted["content_truncated"] = truncated
+    return compacted
+
+
+def _hard_citation_coverage(metadata: dict[str, Any]) -> float | None:
+    hard_citations = metadata.get("hard_citations")
+    if not isinstance(hard_citations, dict):
+        return None
+    coverage = hard_citations.get("coverage")
+    if isinstance(coverage, (int, float)):
+        return float(coverage)
+    return None
+
+
+def _compact_rag_response(
+    response: UnifiedRAGResponse,
+    *,
+    mode: str,
+    request_metadata: dict[str, Any],
+    max_documents: int,
+    max_content_chars: int,
+) -> dict[str, Any]:
+    """Return a bounded JSON-serializable MCP payload from a RAG response."""
+    documents = list(response.documents or [])
+    selected_documents = documents[:max_documents]
+    compacted_documents = [
+        _compact_document(document, max_content_chars=max_content_chars)
+        for document in selected_documents
+        if isinstance(document, dict)
+    ]
+    sources_used = []
+    for document in compacted_documents:
+        source = _source_from_document(document)
+        if source and source not in sources_used:
+            sources_used.append(source)
+    if not sources_used:
+        sources_used = list(request_metadata.get("sources_requested") or [])
+
+    metadata = dict(response.metadata or {})
+    metadata.update(
+        {
+            "sources_requested": list(request_metadata.get("sources_requested") or []),
+            "sources_used": sources_used,
+            "sources_unavailable": list(request_metadata.get("sources_unavailable") or []),
+            "documents_truncated": len(documents) > len(selected_documents),
+            "max_documents": max_documents,
+            "max_content_chars": max_content_chars,
+            "hard_citation_coverage": _hard_citation_coverage(response.metadata or {}),
+        }
+    )
+
+    payload: dict[str, Any] = {
+        "ok": not bool(response.errors),
+        "mode": mode,
+        "query": response.query,
+        "documents": compacted_documents,
+        "citations": list(response.citations or []),
+        "chunk_citations": list(response.chunk_citations or []),
+        "metadata": metadata,
+        "timings": dict(response.timings or {}),
+        "errors": list(response.errors or []),
+    }
+    return payload
+
+
+class RagModule(BaseModule):
+    """Read-only MCP tools for curated RAG search and grounded answers."""
+
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"initialized": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        tools = [
+            create_tool_definition(
+                name=_TOOL_CAPABILITIES,
+                description="Describe the curated rag.* MCP tool surface and supported sources.",
+                parameters={"properties": {}, "required": []},
+                metadata={"category": "utility", "readOnlyHint": True},
+            ),
+            create_tool_definition(
+                name=_TOOL_SOURCE_HEALTH,
+                description="Report safe readiness details for RAG sources available to this context.",
+                parameters={
+                    "properties": {
+                        "sources": {"type": "array", "items": {"type": "string"}},
+                        "allow_partial": {"type": "boolean", "default": False},
+                    },
+                    "required": [],
+                },
+                metadata={"category": "search", "readOnlyHint": True},
+            ),
+            create_tool_definition(
+                name=_TOOL_SEARCH,
+                description="Run retrieval over configured local knowledge sources without answer generation.",
+                parameters={"properties": dict(_SEARCH_PROPERTIES), "required": ["query"]},
+                metadata={"category": "search", "readOnlyHint": True},
+            ),
+            create_tool_definition(
+                name=_TOOL_ANSWER,
+                description="Run retrieval and return a grounded answer with citation-aware status metadata.",
+                parameters={"properties": dict(_SEARCH_PROPERTIES), "required": ["query"]},
+                metadata={"category": "rag_generation", "readOnlyHint": True},
+            ),
+        ]
+        for tool in tools:
+            tool["inputSchema"]["additionalProperties"] = False
+        return tools
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> Any:
+        del context
+        args = arguments or {}
+        if tool_name == _TOOL_CAPABILITIES:
+            return {"ok": True, "tools": [_TOOL_CAPABILITIES, _TOOL_SOURCE_HEALTH, _TOOL_SEARCH, _TOOL_ANSWER]}
+        if tool_name == _TOOL_SOURCE_HEALTH:
+            sources = _normalize_mcp_sources(args.get("sources"))
+            return {"ok": True, "sources": [{"source_id": source, "status": "unknown"} for source in sources]}
+        if tool_name in {_TOOL_SEARCH, _TOOL_ANSWER}:
+            request, metadata = _build_mcp_rag_request(tool_name, args)
+            return {
+                "ok": False,
+                "reason_code": "not_implemented",
+                "query": request.query,
+                "metadata": metadata,
+            }
+        return {"ok": False, "reason_code": "unknown_tool", "message": f"Unknown tool: {tool_name}"}

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -38,6 +39,8 @@ _CANONICAL_PUBLIC_SOURCES = (
 _DEFERRED_STAGE_ONE_SOURCES = frozenset({"sql"})
 _SEARCH_MODES = ("hybrid", "vector", "fts")
 _PROFILES = ("fast", "balanced", "accuracy")
+_MCP_TOP_K_MAX = 50
+_MAX_CITATIONS = 20
 
 _EXTERNAL_RESEARCH_DISABLED_OVERRIDES: dict[str, Any] = {
     "search_depth_mode": None,
@@ -111,6 +114,30 @@ _SAFE_DOCUMENT_METADATA_KEYS = frozenset(
         "updated_at",
     }
 )
+_SAFE_CITATION_KEYS = frozenset(
+    {
+        "id",
+        "source",
+        "source_type",
+        "source_id",
+        "document_id",
+        "chunk_id",
+        "media_id",
+        "note_id",
+        "title",
+        "uri",
+        "url",
+        "text",
+        "quote",
+        "snippet",
+        "page",
+        "page_number",
+        "start_time",
+        "end_time",
+        "timestamp",
+        "score",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -175,6 +202,10 @@ class _McpRagControls:
                 unavailable_sources.append(source)
                 warnings.append(f"{source} unavailable: no MCP source permission tool is registered")
                 continue
+            if not await self._source_tool_registered(permission_tool):
+                unavailable_sources.append(source)
+                warnings.append(f"{source} unavailable: MCP source module for {permission_tool} is not active")
+                continue
             if await self._tool_allowed(context, permission_tool):
                 allowed_sources.append(source)
                 continue
@@ -190,9 +221,18 @@ class _McpRagControls:
         if units <= 0:
             return
         await self.enforce_protocol_rate(context, "rag.query", "rag_generation")
+        await rag_transport.enforce_rag_query_limit_for_org_context(
+            request_like=context,
+            current_user=_current_user_from_context(context),
+            units=units,
+        )
 
     async def log_rag_query_usage(self, context: Any | None, units: int = 1) -> None:
-        await rag_transport.log_rag_queries_for_org_context(request_like=context, current_user=None, units=units)
+        await rag_transport.log_rag_queries_for_org_context(
+            request_like=context,
+            current_user=_current_user_from_context(context),
+            units=units,
+        )
 
     def _protocol(self) -> Any:
         from ...server import get_mcp_server
@@ -217,6 +257,16 @@ class _McpRagControls:
             return False
         return bool(await has_tool_permission(context, tool_name, is_write=False))
 
+    async def _source_tool_registered(self, tool_name: str) -> bool:
+        module_registry = getattr(self._protocol(), "module_registry", None)
+        find_module_for_tool = getattr(module_registry, "find_module_for_tool", None)
+        if not callable(find_module_for_tool):
+            return False
+        result = find_module_for_tool(tool_name)
+        if inspect.isawaitable(result):
+            result = await result
+        return result is not None
+
     async def _ensure_tool_allowed(self, context: Any | None, tool_name: str) -> None:
         if not await self._tool_allowed(context, tool_name):
             raise PermissionError(f"MCP tool permission denied: {tool_name}")
@@ -229,7 +279,7 @@ _SEARCH_PROPERTIES: dict[str, Any] = {
         "description": "Canonical or accepted alias source ids.",
     },
     "search_mode": {"type": "string", "enum": list(_SEARCH_MODES), "default": "hybrid"},
-    "top_k": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+    "top_k": {"type": "integer", "minimum": 1, "maximum": _MCP_TOP_K_MAX, "default": 10},
     "min_score": {"type": "number", "minimum": 0.0, "maximum": 1.0, "default": 0.0},
     "rag_profile": {"type": "string", "enum": list(_PROFILES)},
     "include_documents": {"type": "boolean", "default": True},
@@ -334,7 +384,7 @@ def _build_mcp_rag_request(
         "query": _required_string(arguments, "query", max_length=20000),
         "sources": sources,
         "search_mode": _enum(arguments.get("search_mode", "hybrid"), _SEARCH_MODES),
-        "top_k": _bounded_int(arguments.get("top_k", 10), minimum=1, maximum=50),
+        "top_k": _bounded_int(arguments.get("top_k", 10), minimum=1, maximum=_MCP_TOP_K_MAX),
         "min_score": _bounded_float(arguments.get("min_score", 0.0), minimum=0.0, maximum=1.0),
         "rag_profile": _optional_enum(arguments.get("rag_profile"), _PROFILES),
         "enable_generation": tool_name == _TOOL_ANSWER,
@@ -392,6 +442,19 @@ def _safe_metadata(metadata: Any, allowed_keys: frozenset[str]) -> dict[str, Any
         if value is not None:
             safe[key] = value
     return safe
+
+
+def _compact_citations(citations: Any) -> tuple[list[dict[str, Any]], bool]:
+    """Return bounded citation dictionaries without backend/debug payloads."""
+    if not isinstance(citations, list):
+        return [], False
+    selected = citations[:_MAX_CITATIONS]
+    compacted = [
+        _safe_metadata(citation, _SAFE_CITATION_KEYS)
+        for citation in selected
+        if isinstance(citation, dict)
+    ]
+    return compacted, len(citations) > len(selected)
 
 
 def _model_to_plain_dict(value: Any) -> dict[str, Any]:
@@ -456,10 +519,10 @@ def _compact_rag_response(
         source = _source_from_document(document)
         if source and source not in sources_used:
             sources_used.append(source)
-    if not sources_used:
-        sources_used = list(request_metadata.get("sources_requested") or [])
 
     response_metadata = response.metadata or {}
+    citations, citations_truncated = _compact_citations(response.citations or [])
+    chunk_citations, chunk_citations_truncated = _compact_citations(response.chunk_citations or [])
     trust = response_metadata.get("knowledge_trust")
     trust_state = str(trust.get("state", "")).strip().lower() if isinstance(trust, dict) else None
     metadata = {
@@ -468,6 +531,8 @@ def _compact_rag_response(
         "sources_unavailable": list(request_metadata.get("sources_unavailable") or []),
         "warnings": list(request_metadata.get("warnings") or []),
         "documents_truncated": len(documents) > len(selected_documents),
+        "citations_truncated": citations_truncated,
+        "chunk_citations_truncated": chunk_citations_truncated,
         "max_documents": max_documents,
         "max_content_chars": max_content_chars,
         "hard_citation_coverage": _hard_citation_coverage(response_metadata),
@@ -480,8 +545,8 @@ def _compact_rag_response(
         "mode": mode,
         "query": response.query,
         "documents": compacted_documents,
-        "citations": list(response.citations or []),
-        "chunk_citations": list(response.chunk_citations or []),
+        "citations": citations,
+        "chunk_citations": chunk_citations,
         "metadata": metadata,
         "timings": dict(response.timings or {}),
         "errors": list(response.errors or []),
@@ -663,6 +728,22 @@ def _db_paths_from_context(context: Any | None) -> dict[str, str | None]:
     }
 
 
+def _source_health_existing_paths_from_context(context: Any | None) -> dict[str, str]:
+    """Map MCP context DB paths to source-health storage keys."""
+    db_paths = _db_paths_from_context(context)
+    source_paths = {
+        "media_db": db_paths.get("media_db_path"),
+        "chacha_db": db_paths.get("notes_db_path"),
+        "prompts_db": db_paths.get("prompts_db_path"),
+        "kanban_db": db_paths.get("kanban_db_path"),
+    }
+    return {
+        source_key: str(path)
+        for source_key, path in source_paths.items()
+        if path
+    }
+
+
 def _current_user_from_context(context: Any | None) -> Any | None:
     user_id = getattr(context, "user_id", None)
     if user_id is None:
@@ -742,7 +823,9 @@ class RagModule(BaseModule):
         args = arguments or {}
         if tool_name == _TOOL_CAPABILITIES:
             await self._controls.enforce_protocol_rate(context, tool_name, "utility")
-            return {"ok": True, **rag_transport.build_rag_capabilities_payload()}
+            payload = rag_transport.build_rag_capabilities_payload()
+            payload["limits"] = {**payload.get("limits", {}), "top_k_max": _MCP_TOP_K_MAX}
+            return {"ok": True, **payload}
         if tool_name == _TOOL_SOURCE_HEALTH:
             await self._controls.enforce_protocol_rate(context, tool_name, "search")
             await self._controls.enforce_rag_rbac_rate_limit(context, "rag.search")
@@ -769,7 +852,20 @@ class RagModule(BaseModule):
                     "warnings": authorization.warnings,
                 }
             current_user = _current_user_from_context(context)
-            payload = rag_transport.build_source_health_payload(current_user=current_user)
+            existing_source_paths = _source_health_existing_paths_from_context(context)
+            if existing_source_paths:
+                def _context_existing_paths(
+                    _current_user: Any | None = None,
+                    _request_user_id: str | None = None,
+                ) -> dict[str, str]:
+                    return dict(existing_source_paths)
+
+                payload = rag_transport.build_source_health_payload(
+                    current_user=current_user,
+                    existing_source_db_paths_fn=_context_existing_paths,
+                )
+            else:
+                payload = rag_transport.build_source_health_payload(current_user=current_user)
             visible_sources = [
                 entry
                 for entry in payload.sources
@@ -834,6 +930,16 @@ class RagModule(BaseModule):
                 }
             request_metadata["sources_unavailable"] = list(authorization.sources_unavailable)
             request_metadata["warnings"] = list(request_metadata.get("warnings") or []) + list(authorization.warnings)
+            if not authorization.sources:
+                return {
+                    "ok": False,
+                    "mode": mode,
+                    "reason_code": "source_unavailable",
+                    "message": "No authorized RAG sources are available for this request.",
+                    "sources_requested": list(request_metadata.get("sources_requested") or []),
+                    "sources_unavailable": list(authorization.sources_unavailable),
+                    "warnings": list(request_metadata.get("warnings") or []),
+                }
             request = _copy_rag_request_with_updates(request, {"sources": list(authorization.sources)})
             await self._controls.check_rag_query_quota(context, units=1)
             bundle = rag_transport.build_standard_request_bundle(
@@ -859,13 +965,8 @@ class RagModule(BaseModule):
             if payload.get("ok") is True:
                 await self._controls.log_rag_query_usage(context, units=1)
             return payload
-        except PermissionError as exc:
-            return {
-                "ok": False,
-                "mode": mode,
-                "reason_code": "authorization_denied",
-                "message": str(exc) or "RAG MCP authorization denied.",
-            }
+        except PermissionError:
+            raise
         except Exception as exc:  # noqa: BLE001 - RAG domain errors become structured MCP payloads.
             return {
                 "ok": False,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 
+from loguru import logger
+
 from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import (
     UnifiedRAGRequest,
     UnifiedRAGResponse,
@@ -158,6 +160,7 @@ class _McpRagControls:
     """
 
     async def enforce_protocol_rate(self, context: Any | None, tool_name: str, category: str) -> None:
+        """Apply MCP protocol rate limits for a RAG tool call."""
         metadata = getattr(context, "metadata", None)
         if isinstance(metadata, dict) and metadata.get("rg_ingress_enforced"):
             return
@@ -179,9 +182,11 @@ class _McpRagControls:
             raise
 
     async def enforce_rag_rbac_rate_limit(self, context: Any | None, resource: str) -> None:
+        """Require read access to the RAG protocol resource."""
         await self._ensure_tool_allowed(context, resource)
 
     async def require_mcp_rag_read_scope(self, context: Any | None, tool_name: str) -> None:
+        """Require the caller's MCP scopes to allow the requested RAG tool."""
         await self._ensure_tool_allowed(context, tool_name)
 
     async def authorize_sources(
@@ -192,6 +197,7 @@ class _McpRagControls:
         sources_explicit: bool,
         allow_partial: bool,
     ) -> _SourceAuthorization:
+        """Filter requested RAG sources by installed source modules and permissions."""
         del sources_explicit, allow_partial
         allowed_sources: list[str] = []
         unavailable_sources: list[str] = []
@@ -218,6 +224,7 @@ class _McpRagControls:
         )
 
     async def check_rag_query_quota(self, context: Any | None, units: int = 1) -> None:
+        """Enforce MCP and billing quotas before running a RAG query."""
         if units <= 0:
             return
         await self.enforce_protocol_rate(context, "rag.query", "rag_generation")
@@ -228,6 +235,7 @@ class _McpRagControls:
         )
 
     async def log_rag_query_usage(self, context: Any | None, units: int = 1) -> None:
+        """Record successful RAG query usage for the caller's billing context."""
         await rag_transport.log_rag_queries_for_org_context(
             request_like=context,
             current_user=_current_user_from_context(context),
@@ -250,6 +258,7 @@ class _McpRagControls:
         return None
 
     async def _tool_allowed(self, context: Any | None, tool_name: str) -> bool:
+        """Return whether protocol RBAC grants the given read-only tool."""
         if context is None or not getattr(context, "user_id", None):
             return False
         has_tool_permission = getattr(self._protocol(), "_has_tool_permission", None)
@@ -258,6 +267,7 @@ class _McpRagControls:
         return bool(await has_tool_permission(context, tool_name, is_write=False))
 
     async def _source_tool_registered(self, tool_name: str) -> bool:
+        """Return whether the source-owning MCP module exposes a backing tool."""
         module_registry = getattr(self._protocol(), "module_registry", None)
         find_module_for_tool = getattr(module_registry, "find_module_for_tool", None)
         if not callable(find_module_for_tool):
@@ -268,6 +278,7 @@ class _McpRagControls:
         return result is not None
 
     async def _ensure_tool_allowed(self, context: Any | None, tool_name: str) -> None:
+        """Raise when the caller lacks permission for a read-only MCP tool."""
         if not await self._tool_allowed(context, tool_name):
             raise PermissionError(f"MCP tool permission denied: {tool_name}")
 
@@ -305,9 +316,10 @@ def _required_string(arguments: dict[str, Any], key: str, *, max_length: int) ->
     return value
 
 
-def _bounded_int(value: Any, *, minimum: int, maximum: int) -> int:
+def _bounded_int(value: Any, *, minimum: int, maximum: int, default: int | None = None) -> int:
+    """Parse an integer argument using the schema default for explicit null."""
     if value is None:
-        return minimum
+        return minimum if default is None else default
     if isinstance(value, bool):
         raise ValueError("integer value must not be boolean")
     try:
@@ -319,9 +331,10 @@ def _bounded_int(value: Any, *, minimum: int, maximum: int) -> int:
     return result
 
 
-def _bounded_float(value: Any, *, minimum: float, maximum: float) -> float:
+def _bounded_float(value: Any, *, minimum: float, maximum: float, default: float | None = None) -> float:
+    """Parse a float argument using the schema default for explicit null."""
     if value is None:
-        return minimum
+        return minimum if default is None else default
     if isinstance(value, bool):
         raise ValueError("float value must not be boolean")
     try:
@@ -331,6 +344,15 @@ def _bounded_float(value: Any, *, minimum: float, maximum: float) -> float:
     if result < minimum or result > maximum:
         raise ValueError(f"float value must be between {minimum} and {maximum}")
     return result
+
+
+def _bounded_bool(value: Any, *, default: bool) -> bool:
+    """Parse a boolean argument using the schema default for explicit null."""
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise ValueError("boolean value required")
+    return value
 
 
 def _enum(value: Any, allowed: tuple[str, ...]) -> str:
@@ -377,21 +399,26 @@ def _build_mcp_rag_request(
 
     sources_explicit = _sources_were_explicit(arguments)
     sources = _normalize_mcp_sources(arguments.get("sources"))
-    max_documents = _bounded_int(arguments.get("max_documents", 6), minimum=0, maximum=20)
-    max_content_chars = _bounded_int(arguments.get("max_content_chars", 2000), minimum=0, maximum=8000)
+    max_documents = _bounded_int(arguments.get("max_documents", 6), minimum=0, maximum=20, default=6)
+    max_content_chars = _bounded_int(
+        arguments.get("max_content_chars", 2000),
+        minimum=0,
+        maximum=8000,
+        default=2000,
+    )
+    include_documents = _bounded_bool(arguments.get("include_documents", True), default=True)
 
     payload: dict[str, Any] = {
         "query": _required_string(arguments, "query", max_length=20000),
         "sources": sources,
         "search_mode": _enum(arguments.get("search_mode", "hybrid"), _SEARCH_MODES),
-        "top_k": _bounded_int(arguments.get("top_k", 10), minimum=1, maximum=_MCP_TOP_K_MAX),
-        "min_score": _bounded_float(arguments.get("min_score", 0.0), minimum=0.0, maximum=1.0),
+        "top_k": _bounded_int(arguments.get("top_k", 10), minimum=1, maximum=_MCP_TOP_K_MAX, default=10),
+        "min_score": _bounded_float(arguments.get("min_score", 0.0), minimum=0.0, maximum=1.0, default=0.0),
         "rag_profile": _optional_enum(arguments.get("rag_profile"), _PROFILES),
         "enable_generation": tool_name == _TOOL_ANSWER,
         "enable_citations": True,
-        "enable_chunk_citations": bool(arguments.get("include_chunk_citations", True)),
+        "enable_chunk_citations": _bounded_bool(arguments.get("include_chunk_citations", True), default=True),
         "include_metadata": True,
-        "include_sources": bool(arguments.get("include_documents", True)),
     }
     if tool_name == _TOOL_SEARCH:
         payload["enable_generation"] = False
@@ -400,7 +427,8 @@ def _build_mcp_rag_request(
     return request, {
         "sources_explicit": sources_explicit,
         "sources_requested": list(sources),
-        "allow_partial": bool(arguments.get("allow_partial", False)),
+        "allow_partial": _bounded_bool(arguments.get("allow_partial", False), default=False),
+        "include_documents": include_documents,
         "max_documents": max_documents,
         "max_content_chars": max_content_chars,
     }
@@ -457,6 +485,19 @@ def _compact_citations(citations: Any) -> tuple[list[dict[str, Any]], bool]:
     return compacted, len(citations) > len(selected)
 
 
+def _compact_errors(errors: Any) -> tuple[list[dict[str, Any]], int]:
+    """Return a stable client-safe error summary without backend exception text."""
+    if not isinstance(errors, list) or not errors:
+        return [], 0
+    return [
+        {
+            "reason_code": "rag_pipeline_error",
+            "message": "RAG pipeline returned one or more errors.",
+            "count": len(errors),
+        }
+    ], len(errors)
+
+
 def _model_to_plain_dict(value: Any) -> dict[str, Any]:
     """Convert Pydantic v1/v2 models to plain JSON-safe dictionaries."""
     model_dump = getattr(value, "model_dump", None)
@@ -507,7 +548,9 @@ def _compact_rag_response(
     max_content_chars: int,
 ) -> dict[str, Any]:
     """Return a bounded JSON-serializable MCP payload from a RAG response."""
-    documents = list(response.documents or [])
+    include_documents = bool(request_metadata.get("include_documents", True))
+    raw_documents = list(response.documents or [])
+    documents = raw_documents if include_documents else []
     selected_documents = documents[:max_documents]
     compacted_documents = [
         _compact_document(document, max_content_chars=max_content_chars)
@@ -523,6 +566,7 @@ def _compact_rag_response(
     response_metadata = response.metadata or {}
     citations, citations_truncated = _compact_citations(response.citations or [])
     chunk_citations, chunk_citations_truncated = _compact_citations(response.chunk_citations or [])
+    errors, error_count = _compact_errors(response.errors or [])
     trust = response_metadata.get("knowledge_trust")
     trust_state = str(trust.get("state", "")).strip().lower() if isinstance(trust, dict) else None
     metadata = {
@@ -530,9 +574,10 @@ def _compact_rag_response(
         "sources_used": sources_used,
         "sources_unavailable": list(request_metadata.get("sources_unavailable") or []),
         "warnings": list(request_metadata.get("warnings") or []),
-        "documents_truncated": len(documents) > len(selected_documents),
+        "documents_truncated": include_documents and len(raw_documents) > len(selected_documents),
         "citations_truncated": citations_truncated,
         "chunk_citations_truncated": chunk_citations_truncated,
+        "error_count": error_count,
         "max_documents": max_documents,
         "max_content_chars": max_content_chars,
         "hard_citation_coverage": _hard_citation_coverage(response_metadata),
@@ -541,7 +586,7 @@ def _compact_rag_response(
         metadata["knowledge_trust_state"] = trust_state
 
     payload: dict[str, Any] = {
-        "ok": not bool(response.errors),
+        "ok": error_count == 0,
         "mode": mode,
         "query": response.query,
         "documents": compacted_documents,
@@ -549,7 +594,7 @@ def _compact_rag_response(
         "chunk_citations": chunk_citations,
         "metadata": metadata,
         "timings": dict(response.timings or {}),
-        "errors": list(response.errors or []),
+        "errors": errors,
     }
     if mode == "answer":
         payload["answer"] = {
@@ -831,7 +876,7 @@ class RagModule(BaseModule):
             await self._controls.enforce_rag_rbac_rate_limit(context, "rag.search")
             await self._controls.require_mcp_rag_read_scope(context, tool_name)
             sources_explicit = _sources_were_explicit(args)
-            allow_partial = bool(args.get("allow_partial", False))
+            allow_partial = _bounded_bool(args.get("allow_partial", False), default=False)
             requested_sources = (
                 _normalize_mcp_sources(args.get("sources"))
                 if args.get("sources") is not None
@@ -953,6 +998,7 @@ class RagModule(BaseModule):
             pipeline_kwargs = dict(bundle.pipeline_kwargs)
             pipeline_kwargs.update(_mcp_safe_search_agent_overrides())
             pipeline_kwargs["enable_generation"] = tool_name == _TOOL_ANSWER
+            pipeline_kwargs["include_sources"] = bool(request_metadata.get("include_documents", True))
             result = await unified_rag_pipeline(**pipeline_kwargs)
             response = rag_result_to_response(rag_result_from_unified_search_result(result))
             payload = _compact_rag_response(
@@ -968,6 +1014,12 @@ class RagModule(BaseModule):
         except PermissionError:
             raise
         except Exception as exc:  # noqa: BLE001 - RAG domain errors become structured MCP payloads.
+            logger.exception(
+                "RAG MCP pipeline failed for tool={tool_name} mode={mode}: {error_type}",
+                tool_name=tool_name,
+                mode=mode,
+                error_type=exc.__class__.__name__,
+            )
             return {
                 "ok": False,
                 "mode": mode,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 
 from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import (
     UnifiedRAGRequest,
     UnifiedRAGResponse,
 )
+from tldw_Server_API.app.core.RAG.rag_service import transport as rag_transport
+from tldw_Server_API.app.core.RAG.rag_service.response_mapping import (
+    rag_result_from_unified_search_result,
+    rag_result_to_response,
+)
+from tldw_Server_API.app.core.RAG.rag_service.unified_pipeline import unified_rag_pipeline
 from tldw_Server_API.app.core.Text2SQL.source_registry import normalize_sources_public
 
 from ..base import BaseModule, create_tool_definition
@@ -30,6 +38,69 @@ _CANONICAL_PUBLIC_SOURCES = (
 _DEFERRED_STAGE_ONE_SOURCES = frozenset({"sql"})
 _SEARCH_MODES = ("hybrid", "vector", "fts")
 _PROFILES = ("fast", "balanced", "accuracy")
+
+_EXTERNAL_RESEARCH_DISABLED_OVERRIDES: dict[str, Any] = {
+    "enable_research_loop": False,
+    "search_url_scraping": False,
+    "enable_image_search": False,
+    "enable_video_search": False,
+    "enable_discussion_search": False,
+    "enable_web_fallback": False,
+    "web_fallback_enabled": False,
+}
+
+_UNSUPPORTED_SOURCE_SCOPES: dict[str, tuple[str, ...]] = {
+    "conversation_id": ("chats",),
+    "conversation_ids": ("chats",),
+    "character_id": ("characters", "chats"),
+    "character_ids": ("characters", "chats"),
+    "prompt_id": ("prompts",),
+    "prompt_ids": ("prompts",),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceAuthorization:
+    """Result of per-source MCP authorization for a RAG request."""
+
+    sources: list[str]
+    sources_unavailable: list[str]
+    warnings: list[str]
+
+
+class _McpRagControls:
+    """Injectable MCP control hooks used by the RAG module.
+
+    The protocol layer performs the primary module/tool execution checks before
+    calling modules. These hooks keep RAG-specific tests and host integrations
+    explicit without importing FastAPI dependencies into the module.
+    """
+
+    async def enforce_protocol_rate(self, context: Any | None, tool_name: str, category: str) -> None:
+        del context, tool_name, category
+
+    async def enforce_rag_rbac_rate_limit(self, context: Any | None, resource: str) -> None:
+        del context, resource
+
+    async def require_mcp_rag_read_scope(self, context: Any | None, tool_name: str) -> None:
+        del context, tool_name
+
+    async def authorize_sources(
+        self,
+        context: Any | None,
+        sources: list[str],
+        *,
+        sources_explicit: bool,
+        allow_partial: bool,
+    ) -> _SourceAuthorization:
+        del context, sources_explicit, allow_partial
+        return _SourceAuthorization(sources=list(sources), sources_unavailable=[], warnings=[])
+
+    async def check_rag_query_quota(self, context: Any | None, units: int = 1) -> None:
+        del context, units
+
+    async def log_rag_query_usage(self, context: Any | None, units: int = 1) -> None:
+        await rag_transport.log_rag_queries_for_org_context(request_like=context, current_user=None, units=units)
 
 _SEARCH_PROPERTIES: dict[str, Any] = {
     "query": {"type": "string", "minLength": 1, "maxLength": 20000},
@@ -247,11 +318,206 @@ def _compact_rag_response(
         "timings": dict(response.timings or {}),
         "errors": list(response.errors or []),
     }
+    if mode == "answer":
+        payload["answer"] = {
+            "text": _answer_text(response.generated_answer),
+            "status": _answer_status(response),
+        }
     return payload
+
+
+def _answer_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        text = value.get("text") or value.get("answer") or value.get("content")
+        if text is not None:
+            return str(text)
+    return "" if value is None else str(value)
+
+
+def _answer_status(response: UnifiedRAGResponse) -> str:
+    """Classify generated answer grounding for MCP clients."""
+    answer = _answer_text(response.generated_answer).strip()
+    if not answer:
+        return "abstained"
+    citations = list(response.citations or []) + list(response.chunk_citations or [])
+    coverage = _hard_citation_coverage(response.metadata or {})
+    trust = (response.metadata or {}).get("knowledge_trust")
+    trust_state = str(trust.get("state", "")).strip().lower() if isinstance(trust, dict) else ""
+    if citations and (coverage is None or coverage >= 0.99) and trust_state not in {"weak", "uncited", "unsupported"}:
+        return "answered"
+    return "partial"
+
+
+def _mcp_safe_search_agent_overrides() -> dict[str, Any]:
+    """Force Stage 1 MCP RAG away from external research/web provider paths."""
+    return dict(_EXTERNAL_RESEARCH_DISABLED_OVERRIDES)
+
+
+def _copy_rag_request_with_updates(request: UnifiedRAGRequest, updates: dict[str, Any]) -> UnifiedRAGRequest:
+    model_copy = getattr(request, "model_copy", None)
+    if callable(model_copy):
+        return model_copy(update=updates)
+    return request.copy(update=updates)
+
+
+def _list_from_scalar_or_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return list(value)
+    return [value]
+
+
+def _metadata_values(metadata: dict[str, Any], *keys: str) -> list[Any]:
+    values: list[Any] = []
+    for key in keys:
+        values.extend(_list_from_scalar_or_list(metadata.get(key)))
+    return values
+
+
+def _normalize_media_ids(values: list[Any]) -> list[int]:
+    normalized: list[int] = []
+    for value in values:
+        if isinstance(value, bool):
+            raise ValueError("media_id scope must be an integer")
+        try:
+            media_id = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("media_id scope must be an integer") from exc
+        if media_id <= 0:
+            raise ValueError("media_id scope must be positive")
+        if media_id not in normalized:
+            normalized.append(media_id)
+    return normalized
+
+
+def _normalize_note_ids(values: list[Any]) -> list[str]:
+    normalized: list[str] = []
+    for value in values:
+        raw = str(value).strip()
+        if not raw:
+            raise ValueError("note_id scope must not be empty")
+        if raw not in normalized:
+            normalized.append(raw)
+    return normalized
+
+
+def _intersect_or_apply(existing: list[Any] | None, scoped: list[Any]) -> list[Any]:
+    if existing is None:
+        return list(scoped)
+    scoped_set = {str(item) for item in scoped}
+    return [item for item in existing if str(item) in scoped_set]
+
+
+def _apply_supported_source_scopes(
+    request: UnifiedRAGRequest,
+    context: Any | None,
+) -> UnifiedRAGRequest:
+    """Apply enforceable item/workspace scopes before retrieval."""
+    metadata = getattr(context, "metadata", None)
+    if not isinstance(metadata, dict):
+        metadata = {}
+    updates: dict[str, Any] = {}
+
+    media_values = _metadata_values(metadata, "media_id", "media_ids")
+    if media_values:
+        scoped_media_ids = _normalize_media_ids(media_values)
+        updates["include_media_ids"] = _intersect_or_apply(request.include_media_ids, scoped_media_ids)
+
+    note_values = _metadata_values(metadata, "note_id", "note_ids")
+    if note_values:
+        scoped_note_ids = _normalize_note_ids(note_values)
+        updates["include_note_ids"] = _intersect_or_apply(request.include_note_ids, scoped_note_ids)
+
+    workspace_id = metadata.get("workspace_id")
+    if isinstance(workspace_id, str) and workspace_id.strip():
+        updates["workspace_id"] = workspace_id.strip()
+
+    if not updates:
+        return request
+    return _copy_rag_request_with_updates(request, updates)
+
+
+def _unsupported_scope_warnings_or_error(
+    request: UnifiedRAGRequest,
+    request_metadata: dict[str, Any],
+    context: Any | None,
+) -> tuple[UnifiedRAGRequest | None, dict[str, Any] | None, list[str]]:
+    """Fail or filter sources whose scoped retrieval is not enforceable in Stage 1."""
+    metadata = getattr(context, "metadata", None)
+    if not isinstance(metadata, dict):
+        return request, None, []
+    active_scopes = [
+        key
+        for key in _UNSUPPORTED_SOURCE_SCOPES
+        if _list_from_scalar_or_list(metadata.get(key))
+    ]
+    if not active_scopes:
+        return request, None, []
+
+    requested_sources = set(request.sources or [])
+    affected_sources: set[str] = set()
+    for key in active_scopes:
+        affected_sources.update(_UNSUPPORTED_SOURCE_SCOPES[key])
+    affected_requested = sorted(requested_sources & affected_sources)
+    if not affected_requested:
+        return request, None, []
+
+    if request_metadata.get("sources_explicit", False):
+        return None, {
+            "ok": False,
+            "reason_code": "unsupported_scope",
+            "message": "Requested scope cannot be enforced for one or more Stage 1 RAG sources.",
+            "scopes": active_scopes,
+            "sources": affected_requested,
+        }, []
+
+    filtered_sources = [source for source in (request.sources or []) if source not in affected_sources]
+    warnings = [
+        f"filtered unsupported scoped source {source}"
+        for source in affected_requested
+    ]
+    return _copy_rag_request_with_updates(request, {"sources": filtered_sources}), None, warnings
+
+
+def _db_paths_from_context(context: Any | None) -> dict[str, str | None]:
+    raw_paths = getattr(context, "db_paths", None)
+    paths = raw_paths if isinstance(raw_paths, dict) else {}
+    chacha_path = paths.get("chacha") or paths.get("chacha_db") or paths.get("notes") or paths.get("notes_db_path")
+    return {
+        "media_db_path": paths.get("media_db_path") or paths.get("media") or paths.get("media_db"),
+        "notes_db_path": chacha_path,
+        "character_db_path": paths.get("character_db_path") or paths.get("characters") or chacha_path,
+        "kanban_db_path": paths.get("kanban_db_path") or paths.get("kanban"),
+        "prompts_db_path": paths.get("prompts_db_path") or paths.get("prompts"),
+    }
+
+
+def _current_user_from_context(context: Any | None) -> Any | None:
+    user_id = getattr(context, "user_id", None)
+    if user_id is None:
+        return None
+    id_int = None
+    try:
+        id_int = int(user_id)
+    except (TypeError, ValueError):
+        id_int = None
+    return SimpleNamespace(id=user_id, id_int=id_int, username=str(user_id))
 
 
 class RagModule(BaseModule):
     """Read-only MCP tools for curated RAG search and grounded answers."""
+
+    def __init__(
+        self,
+        config: Any,
+        *,
+        controls: _McpRagControls | None = None,
+    ) -> None:
+        super().__init__(config)
+        self._controls = controls or _McpRagControls()
 
     async def on_initialize(self) -> None:
         return None
@@ -305,19 +571,118 @@ class RagModule(BaseModule):
         arguments: dict[str, Any],
         context: Any | None = None,
     ) -> Any:
-        del context
         args = arguments or {}
         if tool_name == _TOOL_CAPABILITIES:
-            return {"ok": True, "tools": [_TOOL_CAPABILITIES, _TOOL_SOURCE_HEALTH, _TOOL_SEARCH, _TOOL_ANSWER]}
+            await self._controls.enforce_protocol_rate(context, tool_name, "utility")
+            return {"ok": True, **rag_transport.build_rag_capabilities_payload()}
         if tool_name == _TOOL_SOURCE_HEALTH:
-            sources = _normalize_mcp_sources(args.get("sources"))
-            return {"ok": True, "sources": [{"source_id": source, "status": "unknown"} for source in sources]}
+            await self._controls.enforce_protocol_rate(context, tool_name, "search")
+            await self._controls.enforce_rag_rbac_rate_limit(context, "rag.search")
+            await self._controls.require_mcp_rag_read_scope(context, tool_name)
+            requested_sources = (
+                _normalize_mcp_sources(args.get("sources"))
+                if args.get("sources") is not None
+                else list(_CANONICAL_PUBLIC_SOURCES)
+            )
+            authorization = await self._controls.authorize_sources(
+                context,
+                requested_sources,
+                sources_explicit=_sources_were_explicit(args),
+                allow_partial=bool(args.get("allow_partial", False)),
+            )
+            current_user = _current_user_from_context(context)
+            payload = rag_transport.build_source_health_payload(current_user=current_user)
+            payload.sources = [
+                entry
+                for entry in payload.sources
+                if entry.source_id in set(authorization.sources)
+            ]
+            return payload
         if tool_name in {_TOOL_SEARCH, _TOOL_ANSWER}:
-            request, metadata = _build_mcp_rag_request(tool_name, args)
+            return await self._execute_rag_query(tool_name, args, context)
+        return {"ok": False, "reason_code": "unknown_tool", "message": f"Unknown tool: {tool_name}"}
+
+    async def _execute_rag_query(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None,
+    ) -> dict[str, Any]:
+        category = "rag_generation" if tool_name == _TOOL_ANSWER else "search"
+        await self._controls.enforce_protocol_rate(context, tool_name, category)
+        try:
+            request, request_metadata = _build_mcp_rag_request(tool_name, arguments)
+            request = _apply_supported_source_scopes(request, context)
+            request, scope_error, scope_warnings = _unsupported_scope_warnings_or_error(
+                request,
+                request_metadata,
+                context,
+            )
+            if scope_error is not None:
+                scope_error["mode"] = "answer" if tool_name == _TOOL_ANSWER else "search"
+                return scope_error
+            if scope_warnings:
+                request_metadata["warnings"] = list(scope_warnings)
+        except ValueError as exc:
+            return {"ok": False, "reason_code": "invalid_arguments", "message": str(exc)}
+
+        mode = "answer" if tool_name == _TOOL_ANSWER else "search"
+        try:
+            await self._controls.enforce_rag_rbac_rate_limit(context, "rag.search")
+            await self._controls.require_mcp_rag_read_scope(context, tool_name)
+            authorization = await self._controls.authorize_sources(
+                context,
+                list(request.sources or []),
+                sources_explicit=bool(request_metadata.get("sources_explicit", False)),
+                allow_partial=bool(request_metadata.get("allow_partial", False)),
+            )
+            if authorization.sources_unavailable and not request_metadata.get("allow_partial", False):
+                return {
+                    "ok": False,
+                    "mode": mode,
+                    "reason_code": "source_unavailable",
+                    "sources_unavailable": authorization.sources_unavailable,
+                    "warnings": authorization.warnings,
+                }
+            request_metadata["sources_unavailable"] = list(authorization.sources_unavailable)
+            request_metadata["warnings"] = list(request_metadata.get("warnings") or []) + list(authorization.warnings)
+            request = _copy_rag_request_with_updates(request, {"sources": list(authorization.sources)})
+            await self._controls.check_rag_query_quota(context, units=1)
+            bundle = rag_transport.build_standard_request_bundle(
+                request=request,
+                current_user=_current_user_from_context(context),
+                db_paths=_db_paths_from_context(context),
+                media_db=None,
+                chacha_db=None,
+                prompts_db=None,
+            )
+            pipeline_kwargs = dict(bundle.pipeline_kwargs)
+            pipeline_kwargs.update(_mcp_safe_search_agent_overrides())
+            pipeline_kwargs["enable_generation"] = tool_name == _TOOL_ANSWER
+            result = await unified_rag_pipeline(**pipeline_kwargs)
+            response = rag_result_to_response(rag_result_from_unified_search_result(result))
+            payload = _compact_rag_response(
+                response,
+                mode=mode,
+                request_metadata=request_metadata,
+                max_documents=int(request_metadata["max_documents"]),
+                max_content_chars=int(request_metadata["max_content_chars"]),
+            )
+            if payload.get("ok") is True:
+                await self._controls.log_rag_query_usage(context, units=1)
+            return payload
+        except PermissionError as exc:
             return {
                 "ok": False,
-                "reason_code": "not_implemented",
-                "query": request.query,
-                "metadata": metadata,
+                "mode": mode,
+                "reason_code": "authorization_denied",
+                "message": str(exc) or "RAG MCP authorization denied.",
             }
-        return {"ok": False, "reason_code": "unknown_tool", "message": f"Unknown tool: {tool_name}"}
+        except Exception as exc:  # noqa: BLE001 - RAG domain errors become structured MCP payloads.
+            return {
+                "ok": False,
+                "mode": mode,
+                "reason_code": "rag_pipeline_error",
+                "message": "RAG pipeline failed.",
+                "error_type": exc.__class__.__name__,
+            }

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
@@ -404,6 +404,7 @@ async def test_runtime_config_provider_observes_post_construction_get_config_pat
     [
         ("web", True, "network"),
         ("utility", False, "utility"),
+        ("rag_generation", False, "rag_generation"),
     ],
 )
 async def test_category_preserves_non_legacy_metadata_categories(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_knowledge_search_defaults.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_knowledge_search_defaults.py
@@ -3,7 +3,7 @@ import pytest
 from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.knowledge_module import KnowledgeModule
 from tldw_Server_API.app.core.MCP_unified.modules.registry import get_module_registry, reset_module_registry
-from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext, _trusted_compat_claims_metadata
 
 
 class _NotesSearchModule(BaseModule):
@@ -23,7 +23,21 @@ class _NotesSearchModule(BaseModule):
 
     async def execute_tool(self, tool_name, arguments, context=None):
         self.__class__.calls.append(tool_name)
-        return {"results": [], "has_more": False, "next_offset": None, "total_estimated": 0}
+        source = tool_name.split(".", 1)[0]
+        return {
+            "results": [
+                {
+                    "id": f"{source}-1",
+                    "uri": f"{source}://1",
+                    "source": source,
+                    "score": 1.0,
+                    "score_type": "fts",
+                }
+            ],
+            "has_more": False,
+            "next_offset": None,
+            "total_estimated": 1,
+        }
 
 
 class _MediaSearchModule(_NotesSearchModule):
@@ -54,6 +68,17 @@ class _PromptsSearchModule(_NotesSearchModule):
         return [{"name": "prompts.search", "description": "", "inputSchema": {"type": "object"}}]
 
 
+class _RagSearchSentinelModule(_NotesSearchModule):
+    calls = []
+
+    async def get_tools(self) -> list[dict]:
+        return [{"name": "rag.search", "description": "", "inputSchema": {"type": "object"}}]
+
+    async def execute_tool(self, tool_name, arguments, context=None):
+        self.__class__.calls.append(tool_name)
+        raise AssertionError("knowledge.search must not invoke rag.search")
+
+
 @pytest.mark.asyncio
 async def test_knowledge_search_defaults_to_all_advertised_sources():
     await reset_module_registry()
@@ -63,23 +88,34 @@ async def test_knowledge_search_defaults_to_all_advertised_sources():
         _ChatsSearchModule.calls = []
         _CharactersSearchModule.calls = []
         _PromptsSearchModule.calls = []
+        _RagSearchSentinelModule.calls = []
         registry = get_module_registry()
         await registry.register_module("notes", _NotesSearchModule, ModuleConfig(name="notes"))
         await registry.register_module("media", _MediaSearchModule, ModuleConfig(name="media"))
         await registry.register_module("chats", _ChatsSearchModule, ModuleConfig(name="chats"))
         await registry.register_module("characters", _CharactersSearchModule, ModuleConfig(name="characters"))
         await registry.register_module("prompts", _PromptsSearchModule, ModuleConfig(name="prompts"))
+        await registry.register_module("rag", _RagSearchSentinelModule, ModuleConfig(name="rag"))
 
         km = KnowledgeModule(ModuleConfig(name="knowledge"))
         await km.on_initialize()
-        ctx = RequestContext(request_id="knowledge-defaults", user_id="1", client_id="cli")
+        metadata = _trusted_compat_claims_metadata(
+            auth_via="single_user_test_api_key",
+            compat_claims_source="mounted_http",
+        )
+        metadata["roles"] = ["admin"]
+        metadata["permissions"] = ["*"]
+        ctx = RequestContext(request_id="knowledge-defaults", user_id="1", client_id="cli", metadata=metadata)
 
-        await km.execute_tool("knowledge.search", {"query": "hello"}, context=ctx)
+        result = await km.execute_tool("knowledge.search", {"query": "hello"}, context=ctx)
 
         assert _NotesSearchModule.calls == ["notes.search"]  # nosec B101
         assert _MediaSearchModule.calls == ["media.search"]  # nosec B101
         assert _ChatsSearchModule.calls == ["chats.search"]  # nosec B101
         assert _CharactersSearchModule.calls == ["characters.search"]  # nosec B101
         assert _PromptsSearchModule.calls == ["prompts.search"]  # nosec B101
+        assert _RagSearchSentinelModule.calls == []  # nosec B101
+        assert result["total_estimated"] == 5  # nosec B101
+        assert {item["score_type"] for item in result["results"]} == {"fts"}  # nosec B101
     finally:
         await reset_module_registry()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py
@@ -23,9 +23,13 @@ class _NoopTelemetry:
         _operation_name: str,
         _attributes: dict[str, Any] | None = None,
     ) -> Any:
-        class _Context:
-            def __enter__(self) -> None:
+        class _Span:
+            def set_attribute(self, _key: str, _value: Any) -> None:
                 return None
+
+        class _Context:
+            def __enter__(self) -> _Span:
+                return _Span()
 
             def __exit__(self, *_exc_info: Any) -> None:
                 return None
@@ -679,3 +683,92 @@ async def test_protocol_resources_list_uses_catalog_filter(monkeypatch):
     uris = {res.get("uri") for res in result.get("resources", [])}
     assert "allowed://one" in uris
     assert "blocked://one" not in uris
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_catalog_membership_does_not_grant_rag_execute_permission() -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, ModuleConfig, create_tool_definition
+    from tldw_Server_API.app.core.MCP_unified.modules.registry import ModuleRegistry
+    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, MCPRequest, RequestContext
+
+    class _ToolCatalogProvider:
+        async def resolve_tool_names(
+            self,
+            *,
+            catalog_name: str | None,
+            catalog_id: Any,
+            metadata: dict[str, Any],
+            strict: bool,
+        ) -> set[str]:
+            del catalog_name, catalog_id, metadata, strict
+            return {"rag.search", "rag.answer", "knowledge.search"}
+
+    class _RagModuleStub(BaseModule):
+        async def on_initialize(self) -> None:
+            return None
+
+        async def on_shutdown(self) -> None:
+            return None
+
+        async def check_health(self) -> dict[str, bool]:
+            return {"ok": True}
+
+        async def get_tools(self) -> list[dict[str, Any]]:
+            return [
+                create_tool_definition(
+                    name="rag.search",
+                    description="RAG search",
+                    parameters={"properties": {"query": {"type": "string"}}, "required": ["query"]},
+                    metadata={"category": "search", "readOnlyHint": True},
+                ),
+                create_tool_definition(
+                    name="rag.answer",
+                    description="RAG answer",
+                    parameters={"properties": {"query": {"type": "string"}}, "required": ["query"]},
+                    metadata={"category": "rag_generation", "readOnlyHint": True},
+                ),
+            ]
+
+        def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
+            del tool_name
+            if "query" not in arguments:
+                raise ValueError("query required")
+
+        async def execute_tool(
+            self,
+            tool_name: str,
+            arguments: dict[str, Any],
+            context: RequestContext | None = None,
+        ) -> dict[str, str]:
+            del arguments, context
+            return {"tool": tool_name}
+
+    registry = ModuleRegistry()
+    await registry.register_module("rag", _RagModuleStub, ModuleConfig(name="rag"))
+    proto = MCPProtocol(dependencies=_protocol_dependencies(tool_catalog_provider=_ToolCatalogProvider()))
+    proto.module_registry = registry
+
+    async def _allow_module(_context: RequestContext, _module_id: str) -> bool:
+        return True
+
+    async def _deny_answer(_context: RequestContext, tool_name: str, **_kwargs: Any) -> bool:
+        return tool_name != "rag.answer"
+
+    proto._has_module_permission = _allow_module  # type: ignore[method-assign]
+    proto._has_tool_permission = _deny_answer  # type: ignore[method-assign]
+
+    ctx = RequestContext(request_id="rag-catalog", user_id="1", client_id="unit")
+    listed = await proto._handle_tools_list({"catalog": "library-rag", "catalog_strict": True}, ctx)
+    by_name = {tool["name"]: tool for tool in listed["tools"]}
+
+    assert set(by_name) == {"rag.search", "rag.answer"}  # nosec B101
+    assert by_name["rag.search"]["canExecute"] is True  # nosec B101
+    assert by_name["rag.answer"]["canExecute"] is False  # nosec B101
+
+    denied = await proto.process_request(
+        MCPRequest(method="tools/call", params={"name": "rag.answer", "arguments": {"query": "q"}}, id=1),
+        ctx,
+    )
+
+    assert denied.error is not None  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import UnifiedRAGResponse
+from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import (
+    KnowledgeSourceHealthResponse,
+    UnifiedRAGResponse,
+)
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations import rag_module as rag_module_impl
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.rag_module import (
@@ -83,6 +86,18 @@ class _DenyNotesSearchRBAC:
 class _NoopRateLimiter:
     async def check_rate_limit(self, *args, **kwargs):  # noqa: ANN001
         del args, kwargs
+
+
+def _install_source_tool_registry(protocol: MCPProtocol, *tool_names: str) -> None:
+    available = set(tool_names)
+    original_find_module_for_tool = protocol.module_registry.find_module_for_tool
+
+    async def find_module_for_tool(tool_name: str):  # noqa: ANN001
+        if tool_name in available:
+            return SimpleNamespace(name="source-module")
+        return await original_find_module_for_tool(tool_name)
+
+    protocol.module_registry.find_module_for_tool = find_module_for_tool  # type: ignore[method-assign]
 
 
 def test_mcp_sources_accept_aliases_but_return_canonical_ids() -> None:
@@ -169,7 +184,7 @@ def test_compact_response_redacts_raw_document_and_response_metadata() -> None:
                     "prompt": "SECRET_PROMPT",
                     "debug": {"raw": "SECRET_DEBUG"},
                 },
-                "provider_payload": {"token": "SECRET_TOKEN"},
+                "provider_payload": {"raw_value": "SECRET_VALUE"},
             }
         ],
         citations=[],
@@ -204,6 +219,69 @@ def test_compact_response_redacts_raw_document_and_response_metadata() -> None:
     assert payload["metadata"]["knowledge_trust_state"] == "grounded"  # nosec B101
 
 
+def test_compact_response_bounds_and_redacts_citations() -> None:
+    response = UnifiedRAGResponse(
+        query="q",
+        documents=[],
+        citations=[
+            {
+                "id": f"c-{index}",
+                "text": "x" * 1200,
+                "title": "Allowed",
+                "metadata": {"path": "SECRET_PATH"},
+                "provider_payload": "SECRET_PROVIDER",
+            }
+            for index in range(25)
+        ],
+        chunk_citations=[
+            {
+                "id": f"chunk-{index}",
+                "snippet": "y" * 1200,
+                "debug": "SECRET_DEBUG",
+            }
+            for index in range(25)
+        ],
+        metadata={},
+    )
+
+    payload = _compact_rag_response(
+        response,
+        mode="search",
+        request_metadata={"sources_requested": ["media_db"], "sources_explicit": True},
+        max_documents=1,
+        max_content_chars=2000,
+    )
+
+    assert len(payload["citations"]) == 20  # nosec B101
+    assert len(payload["chunk_citations"]) == 20  # nosec B101
+    assert len(payload["citations"][0]["text"]) == 1000  # nosec B101
+    assert len(payload["chunk_citations"][0]["snippet"]) == 1000  # nosec B101
+    assert "SECRET_" not in repr(payload["citations"])  # nosec B101
+    assert "SECRET_" not in repr(payload["chunk_citations"])  # nosec B101
+    assert payload["metadata"]["citations_truncated"] is True  # nosec B101
+    assert payload["metadata"]["chunk_citations_truncated"] is True  # nosec B101
+
+
+def test_compact_response_does_not_report_requested_sources_as_used_when_empty() -> None:
+    response = UnifiedRAGResponse(
+        query="q",
+        documents=[],
+        citations=[],
+        chunk_citations=[],
+        metadata={},
+    )
+
+    payload = _compact_rag_response(
+        response,
+        mode="search",
+        request_metadata={"sources_requested": ["media_db"], "sources_explicit": True},
+        max_documents=1,
+        max_content_chars=2000,
+    )
+
+    assert payload["metadata"]["sources_used"] == []  # nosec B101
+
+
 @pytest.mark.asyncio
 async def test_rag_module_exposes_four_strict_tools() -> None:
     module = RagModule(ModuleConfig(name="rag"))
@@ -217,8 +295,18 @@ async def test_rag_module_exposes_four_strict_tools() -> None:
 
 
 @pytest.mark.asyncio
+async def test_rag_capabilities_reports_mcp_top_k_limit() -> None:
+    controls = _RecordingControls()
+    module = RagModule(ModuleConfig(name="rag"), controls=controls)
+
+    out = await module.execute_tool("rag.capabilities", {}, context=RequestContext(request_id="limits", user_id="1"))
+
+    assert out["limits"]["top_k_max"] == 50  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_rag_search_executes_shared_pipeline_without_generation(monkeypatch: pytest.MonkeyPatch) -> None:
-    module = RagModule(ModuleConfig(name="rag"))
+    module = RagModule(ModuleConfig(name="rag"), controls=_RecordingControls())
     calls: dict[str, object] = {}
 
     async def fake_pipeline(**kwargs):
@@ -257,7 +345,7 @@ async def test_rag_search_executes_shared_pipeline_without_generation(monkeypatc
 
 @pytest.mark.asyncio
 async def test_rag_answer_marks_grounded_cited_output_answered(monkeypatch: pytest.MonkeyPatch) -> None:
-    module = RagModule(ModuleConfig(name="rag"))
+    module = RagModule(ModuleConfig(name="rag"), controls=_RecordingControls())
 
     async def fake_pipeline(**kwargs):  # noqa: ARG001
         return SimpleNamespace(
@@ -285,7 +373,7 @@ async def test_rag_answer_marks_grounded_cited_output_answered(monkeypatch: pyte
 
 @pytest.mark.asyncio
 async def test_rag_answer_never_marks_uncited_output_answered(monkeypatch: pytest.MonkeyPatch) -> None:
-    module = RagModule(ModuleConfig(name="rag"))
+    module = RagModule(ModuleConfig(name="rag"), controls=_RecordingControls())
 
     async def fake_pipeline(**kwargs):  # noqa: ARG001
         return SimpleNamespace(
@@ -315,7 +403,7 @@ async def test_rag_answer_never_marks_uncited_output_answered(monkeypatch: pytes
 async def test_rag_search_applies_supported_scopes_and_disables_external_research(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = RagModule(ModuleConfig(name="rag"))
+    module = RagModule(ModuleConfig(name="rag"), controls=_RecordingControls())
     calls: dict[str, object] = {}
 
     async def fake_pipeline(**kwargs):
@@ -413,6 +501,43 @@ async def test_rag_source_health_fails_closed_when_explicit_source_is_unavailabl
     assert out["reason_code"] == "source_unavailable"  # nosec B101
     assert out["sources_unavailable"] == ["notes"]  # nosec B101
     assert out["warnings"] == ["notes unavailable"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_source_health_uses_context_db_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    controls = _RecordingControls()
+    module = RagModule(ModuleConfig(name="rag"), controls=controls)
+    captured_paths: dict[str, str] = {}
+
+    def fake_health_payload(**kwargs):  # noqa: ANN003
+        resolver = kwargs["existing_source_db_paths_fn"]
+        captured_paths.update(resolver(None, None))
+        return KnowledgeSourceHealthResponse(sources=[])
+
+    monkeypatch.setattr(rag_module_impl.rag_transport, "build_source_health_payload", fake_health_payload)
+
+    out = await module.execute_tool(
+        "rag.source_health",
+        {},
+        context=RequestContext(
+            request_id="source-health-db-paths",
+            user_id="1",
+            db_paths={
+                "media": "media.db",
+                "chacha": "notes.db",
+                "prompts": "prompts.db",
+                "kanban": "kanban.db",
+            },
+        ),
+    )
+
+    assert out["ok"] is True  # nosec B101
+    assert captured_paths == {  # nosec B101
+        "media_db": "media.db",
+        "chacha_db": "notes.db",
+        "prompts_db": "prompts.db",
+        "kanban_db": "kanban.db",
+    }
 
 
 @pytest.mark.asyncio
@@ -517,11 +642,37 @@ async def test_default_controls_enforce_source_tool_permission(monkeypatch: pyte
 
 
 @pytest.mark.asyncio
+async def test_default_controls_require_source_tool_module_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"))
+    protocol = MCPProtocol()
+    protocol.rbac_policy = _AllowAllRBAC()
+    protocol.rate_limiter = _NoopRateLimiter()
+    monkeypatch.setattr(mcp_server_module, "_server", SimpleNamespace(protocol=protocol))
+
+    async def fail_if_pipeline_runs(**kwargs):  # noqa: ANN001
+        del kwargs
+        raise AssertionError("pipeline must not run when source module is unavailable")
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fail_if_pipeline_runs)
+
+    out = await module.execute_tool(
+        "rag.search",
+        {"query": "q", "sources": ["media"]},
+        context=RequestContext(request_id="source-module-required", user_id="1", client_id="unit"),
+    )
+
+    assert out["ok"] is False  # nosec B101
+    assert out["reason_code"] == "source_unavailable"  # nosec B101
+    assert out["sources_unavailable"] == ["media_db"]  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_default_controls_authorize_character_backed_rag_sources(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"))
     protocol = MCPProtocol()
     protocol.rbac_policy = _AllowAllRBAC()
     protocol.rate_limiter = _NoopRateLimiter()
+    _install_source_tool_registry(protocol, "characters.search")
     monkeypatch.setattr(mcp_server_module, "_server", SimpleNamespace(protocol=protocol))
     calls: dict[str, object] = {}
 
@@ -551,6 +702,60 @@ async def test_default_controls_authorize_character_backed_rag_sources(monkeypat
 
     assert out["ok"] is True  # nosec B101
     assert calls["sources"] == ["world_books", "dictionaries"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_allow_partial_does_not_run_pipeline_when_all_sources_filtered(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"), controls=_UnavailableNotesControls())
+
+    async def fail_if_pipeline_runs(**kwargs):  # noqa: ANN001
+        del kwargs
+        raise AssertionError("pipeline must not run with no authorized sources")
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fail_if_pipeline_runs)
+
+    out = await module.execute_tool(
+        "rag.search",
+        {"query": "q", "sources": ["notes"], "allow_partial": True},
+        context=RequestContext(request_id="all-filtered", user_id="1"),
+    )
+
+    assert out["ok"] is False  # nosec B101
+    assert out["reason_code"] == "source_unavailable"  # nosec B101
+    assert out["sources_unavailable"] == ["notes"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_default_controls_enforce_rag_query_billing_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"))
+    protocol = MCPProtocol()
+    protocol.rbac_policy = _AllowAllRBAC()
+    protocol.rate_limiter = _NoopRateLimiter()
+    _install_source_tool_registry(protocol, "media.search")
+    monkeypatch.setattr(mcp_server_module, "_server", SimpleNamespace(protocol=protocol))
+
+    async def deny_limit(*, request_like, current_user=None, units: int = 1):  # noqa: ANN001
+        del request_like, current_user, units
+        raise PermissionError("RAG query daily limit exceeded")
+
+    async def fail_if_pipeline_runs(**kwargs):  # noqa: ANN001
+        del kwargs
+        raise AssertionError("pipeline must not run when RAG query billing limit is exceeded")
+
+    monkeypatch.setattr(
+        rag_module_impl.rag_transport,
+        "enforce_rag_query_limit_for_org_context",
+        deny_limit,
+        raising=False,
+    )
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fail_if_pipeline_runs)
+
+    with pytest.raises(PermissionError, match="daily limit"):
+        await module.execute_tool(
+            "rag.search",
+            {"query": "q", "sources": ["media"]},
+            context=RequestContext(request_id="rag-quota", user_id="1", client_id="unit"),
+        )
 
 
 @pytest.mark.asyncio
@@ -635,6 +840,8 @@ async def test_rag_module_jsonrpc_tools_call_smoke(monkeypatch: pytest.MonkeyPat
     protocol = MCPProtocol()
     protocol.module_registry = registry
     protocol.rbac_policy = _AllowAllRBAC()
+    protocol.rate_limiter = _NoopRateLimiter()
+    _install_source_tool_registry(protocol, "media.search")
     context = RequestContext(request_id="rag-jsonrpc-smoke", user_id="1", client_id="unit")
 
     search = await protocol.process_request(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import UnifiedRAGResponse
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.rag_module import (
+    RagModule,
+    _build_mcp_rag_request,
+    _compact_rag_response,
+)
+
+
+def test_mcp_sources_accept_aliases_but_return_canonical_ids() -> None:
+    request, metadata = _build_mcp_rag_request(
+        "rag.search",
+        {"query": "q", "sources": ["media", "notes"]},
+    )
+
+    assert request.sources == ["media_db", "notes"]  # nosec B101
+    assert metadata["sources_explicit"] is True  # nosec B101
+    assert metadata["sources_requested"] == ["media_db", "notes"]  # nosec B101
+
+
+def test_mcp_sources_omitted_tracks_implicit_default() -> None:
+    request, metadata = _build_mcp_rag_request("rag.search", {"query": "q"})
+
+    assert request.sources == ["media_db"]  # nosec B101
+    assert metadata["sources_explicit"] is False  # nosec B101
+
+
+def test_advanced_is_rejected() -> None:
+    with pytest.raises(ValueError, match="advanced"):
+        _build_mcp_rag_request("rag.search", {"query": "q", "advanced": {"debug_mode": True}})
+
+
+def test_sql_source_is_rejected_in_stage_one() -> None:
+    with pytest.raises(ValueError, match="sql"):
+        _build_mcp_rag_request("rag.search", {"query": "q", "sources": ["sql"]})
+
+
+def test_unknown_and_internal_sources_are_rejected() -> None:
+    for source in ("unknown", "claims"):
+        with pytest.raises(ValueError, match=source):
+            _build_mcp_rag_request("rag.search", {"query": "q", "sources": [source]})
+
+
+def test_compact_response_truncates_documents_and_preserves_citations() -> None:
+    response = UnifiedRAGResponse(
+        query="q",
+        documents=[{"id": "d1", "content": "abcdef", "metadata": {"source": "media_db"}, "score": 0.9}],
+        citations=[{"id": "c1"}],
+        chunk_citations=[{"id": "chunk-1"}],
+        metadata={
+            "hard_citations": {"coverage": 0.5},
+            "knowledge_trust": {"state": "grounded"},
+        },
+    )
+
+    payload = _compact_rag_response(
+        response,
+        mode="search",
+        request_metadata={"sources_requested": ["media_db"], "sources_explicit": True},
+        max_documents=1,
+        max_content_chars=3,
+    )
+
+    assert payload["documents"][0]["content"] == "abc"  # nosec B101
+    assert payload["documents"][0]["content_truncated"] is True  # nosec B101
+    assert payload["chunk_citations"] == [{"id": "chunk-1"}]  # nosec B101
+    assert payload["metadata"]["hard_citation_coverage"] == 0.5  # nosec B101
+    assert payload["metadata"]["sources_used"] == ["media_db"]  # nosec B101
+    assert payload["metadata"]["sources_unavailable"] == []  # nosec B101
+    assert payload["metadata"]["documents_truncated"] is False  # nosec B101
+    assert payload["metadata"]["max_documents"] == 1  # nosec B101
+    assert payload["metadata"]["max_content_chars"] == 3  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_module_exposes_four_strict_tools() -> None:
+    module = RagModule(ModuleConfig(name="rag"))
+
+    tools = {tool["name"]: tool for tool in await module.get_tools()}
+
+    assert set(tools) == {"rag.capabilities", "rag.source_health", "rag.search", "rag.answer"}  # nosec B101
+    for tool_name in ("rag.capabilities", "rag.source_health", "rag.search", "rag.answer"):
+        assert tools[tool_name]["inputSchema"]["additionalProperties"] is False  # nosec B101
+    assert tools["rag.answer"]["metadata"]["category"] == "rag_generation"  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
@@ -19,6 +19,8 @@ from tldw_Server_API.app.core.MCP_unified.modules.registry import ModuleRegistry
 from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, MCPRequest, RequestContext
 from tldw_Server_API.app.core.MCP_unified import server as mcp_server_module
 
+pytestmark = pytest.mark.unit
+
 
 class _RecordingControls:
     def __init__(self) -> None:
@@ -118,6 +120,36 @@ def test_mcp_sources_omitted_tracks_implicit_default() -> None:
     assert metadata["sources_explicit"] is False  # nosec B101
 
 
+def test_mcp_explicit_nulls_use_schema_defaults() -> None:
+    request, metadata = _build_mcp_rag_request(
+        "rag.search",
+        {
+            "query": "q",
+            "top_k": None,
+            "min_score": None,
+            "include_documents": None,
+            "include_chunk_citations": None,
+            "allow_partial": None,
+            "max_documents": None,
+            "max_content_chars": None,
+        },
+    )
+
+    assert request.top_k == 10  # nosec B101
+    assert request.min_score == 0.0  # nosec B101
+    assert request.enable_chunk_citations is True  # nosec B101
+    assert metadata["include_documents"] is True  # nosec B101
+    assert metadata["allow_partial"] is False  # nosec B101
+    assert metadata["max_documents"] == 6  # nosec B101
+    assert metadata["max_content_chars"] == 2000  # nosec B101
+
+
+def test_mcp_boolean_arguments_are_strict() -> None:
+    for key in ("include_documents", "include_chunk_citations", "allow_partial"):
+        with pytest.raises(ValueError, match="boolean"):
+            _build_mcp_rag_request("rag.search", {"query": "q", key: "false"})
+
+
 def test_advanced_is_rejected() -> None:
     with pytest.raises(ValueError, match="advanced"):
         _build_mcp_rag_request("rag.search", {"query": "q", "advanced": {"debug_mode": True}})
@@ -163,6 +195,58 @@ def test_compact_response_truncates_documents_and_preserves_citations() -> None:
     assert payload["metadata"]["documents_truncated"] is False  # nosec B101
     assert payload["metadata"]["max_documents"] == 1  # nosec B101
     assert payload["metadata"]["max_content_chars"] == 3  # nosec B101
+
+
+def test_compact_response_omits_documents_when_requested() -> None:
+    response = UnifiedRAGResponse(
+        query="q",
+        documents=[{"id": "d1", "content": "Evidence", "metadata": {"source": "media_db"}, "score": 0.9}],
+        citations=[],
+        chunk_citations=[],
+        metadata={},
+    )
+
+    payload = _compact_rag_response(
+        response,
+        mode="search",
+        request_metadata={"sources_requested": ["media_db"], "sources_explicit": True, "include_documents": False},
+        max_documents=1,
+        max_content_chars=2000,
+    )
+
+    assert payload["documents"] == []  # nosec B101
+    assert payload["metadata"]["sources_used"] == []  # nosec B101
+    assert payload["metadata"]["documents_truncated"] is False  # nosec B101
+
+
+def test_compact_response_redacts_raw_pipeline_errors() -> None:
+    response = UnifiedRAGResponse(
+        query="q",
+        documents=[],
+        citations=[],
+        chunk_citations=[],
+        metadata={},
+        errors=["Traceback SECRET_PATH provider payload"],
+    )
+
+    payload = _compact_rag_response(
+        response,
+        mode="search",
+        request_metadata={"sources_requested": ["media_db"], "sources_explicit": True},
+        max_documents=1,
+        max_content_chars=2000,
+    )
+
+    assert payload["ok"] is False  # nosec B101
+    assert payload["errors"] == [  # nosec B101
+        {
+            "reason_code": "rag_pipeline_error",
+            "message": "RAG pipeline returned one or more errors.",
+            "count": 1,
+        }
+    ]
+    assert payload["metadata"]["error_count"] == 1  # nosec B101
+    assert "SECRET_PATH" not in repr(payload)  # nosec B101
 
 
 def test_compact_response_redacts_raw_document_and_response_metadata() -> None:
@@ -282,7 +366,6 @@ def test_compact_response_does_not_report_requested_sources_as_used_when_empty()
     assert payload["metadata"]["sources_used"] == []  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_module_exposes_four_strict_tools() -> None:
     module = RagModule(ModuleConfig(name="rag"))
 
@@ -294,7 +377,6 @@ async def test_rag_module_exposes_four_strict_tools() -> None:
     assert tools["rag.answer"]["metadata"]["category"] == "rag_generation"  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_capabilities_reports_mcp_top_k_limit() -> None:
     controls = _RecordingControls()
     module = RagModule(ModuleConfig(name="rag"), controls=controls)
@@ -304,7 +386,6 @@ async def test_rag_capabilities_reports_mcp_top_k_limit() -> None:
     assert out["limits"]["top_k_max"] == 50  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_search_executes_shared_pipeline_without_generation(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"), controls=_RecordingControls())
     calls: dict[str, object] = {}
@@ -339,11 +420,45 @@ async def test_rag_search_executes_shared_pipeline_without_generation(monkeypatc
     assert "answer" not in out  # nosec B101
     assert calls["enable_generation"] is False  # nosec B101
     assert calls["sources"] == ["media_db"]  # nosec B101
+    assert calls["include_sources"] is True  # nosec B101
     assert calls["media_db_path"] == "media.db"  # nosec B101
     assert calls["notes_db_path"] == "notes.db"  # nosec B101
 
 
-@pytest.mark.asyncio
+async def test_rag_search_can_suppress_returned_documents(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"), controls=_RecordingControls())
+    calls: dict[str, object] = {}
+
+    async def fake_pipeline(**kwargs):
+        calls.update(kwargs)
+        return SimpleNamespace(
+            documents=[{"id": "d1", "content": "Evidence", "metadata": {"source": "media_db"}, "score": 0.9}],
+            query="q",
+            metadata={},
+            timings={},
+            citations=[],
+            chunk_citations=[],
+            generated_answer=None,
+            errors=[],
+            total_time=0.1,
+            cache_hit=False,
+            expanded_queries=[],
+        )
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+
+    out = await module.execute_tool(
+        "rag.search",
+        {"query": "q", "include_documents": False},
+        context=RequestContext(request_id="include-documents-false", user_id="1"),
+    )
+
+    assert out["ok"] is True  # nosec B101
+    assert calls["include_sources"] is False  # nosec B101
+    assert out["documents"] == []  # nosec B101
+    assert out["metadata"]["documents_truncated"] is False  # nosec B101
+
+
 async def test_rag_answer_marks_grounded_cited_output_answered(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"), controls=_RecordingControls())
 
@@ -371,7 +486,6 @@ async def test_rag_answer_marks_grounded_cited_output_answered(monkeypatch: pyte
     assert out["answer"]["status"] == "answered"  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_answer_never_marks_uncited_output_answered(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"), controls=_RecordingControls())
 
@@ -399,7 +513,6 @@ async def test_rag_answer_never_marks_uncited_output_answered(monkeypatch: pytes
     assert out["answer"]["status"] != "answered"  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_search_applies_supported_scopes_and_disables_external_research(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -444,7 +557,6 @@ async def test_rag_search_applies_supported_scopes_and_disables_external_researc
     assert calls["search_depth_mode"] is None  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_capabilities_uses_only_protocol_rate_control() -> None:
     controls = _RecordingControls()
     module = RagModule(ModuleConfig(name="rag"), controls=controls)
@@ -455,7 +567,6 @@ async def test_rag_capabilities_uses_only_protocol_rate_control() -> None:
     assert controls.calls == [("protocol_rate", "rag.capabilities", "utility")]  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_source_health_uses_read_controls_without_query_quota() -> None:
     controls = _RecordingControls()
     module = RagModule(ModuleConfig(name="rag"), controls=controls)
@@ -471,7 +582,6 @@ async def test_rag_source_health_uses_read_controls_without_query_quota() -> Non
     assert not any(call[0] == "usage" for call in controls.calls)  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_source_health_reports_unavailable_sources_with_ok_contract() -> None:
     module = RagModule(ModuleConfig(name="rag"), controls=_UnavailableNotesControls())
 
@@ -487,7 +597,6 @@ async def test_rag_source_health_reports_unavailable_sources_with_ok_contract() 
     assert all(source["source_id"] != "notes" for source in out["sources"])  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_source_health_fails_closed_when_explicit_source_is_unavailable() -> None:
     module = RagModule(ModuleConfig(name="rag"), controls=_UnavailableNotesControls())
 
@@ -503,7 +612,6 @@ async def test_rag_source_health_fails_closed_when_explicit_source_is_unavailabl
     assert out["warnings"] == ["notes unavailable"]  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_source_health_uses_context_db_paths(monkeypatch: pytest.MonkeyPatch) -> None:
     controls = _RecordingControls()
     module = RagModule(ModuleConfig(name="rag"), controls=controls)
@@ -540,7 +648,6 @@ async def test_rag_source_health_uses_context_db_paths(monkeypatch: pytest.Monke
     }
 
 
-@pytest.mark.asyncio
 async def test_rag_search_uses_quota_and_usage_controls(monkeypatch: pytest.MonkeyPatch) -> None:
     controls = _RecordingControls()
     module = RagModule(ModuleConfig(name="rag"), controls=controls)
@@ -572,7 +679,6 @@ async def test_rag_search_uses_quota_and_usage_controls(monkeypatch: pytest.Monk
     assert ("usage", 1) in controls.calls  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_answer_uses_generation_category_controls(monkeypatch: pytest.MonkeyPatch) -> None:
     controls = _RecordingControls()
     module = RagModule(ModuleConfig(name="rag"), controls=controls)
@@ -601,7 +707,6 @@ async def test_rag_answer_uses_generation_category_controls(monkeypatch: pytest.
     assert ("usage", 1) in controls.calls  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_explicit_unavailable_source_fails_closed() -> None:
     module = RagModule(ModuleConfig(name="rag"), controls=_UnavailableNotesControls())
 
@@ -616,7 +721,6 @@ async def test_explicit_unavailable_source_fails_closed() -> None:
     assert out["sources_unavailable"] == ["notes"]  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_default_controls_enforce_source_tool_permission(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"))
     protocol = MCPProtocol()
@@ -641,7 +745,6 @@ async def test_default_controls_enforce_source_tool_permission(monkeypatch: pyte
     assert out["sources_unavailable"] == ["notes"]  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_default_controls_require_source_tool_module_registered(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"))
     protocol = MCPProtocol()
@@ -666,7 +769,6 @@ async def test_default_controls_require_source_tool_module_registered(monkeypatc
     assert out["sources_unavailable"] == ["media_db"]  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_default_controls_authorize_character_backed_rag_sources(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"))
     protocol = MCPProtocol()
@@ -704,7 +806,6 @@ async def test_default_controls_authorize_character_backed_rag_sources(monkeypat
     assert calls["sources"] == ["world_books", "dictionaries"]  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_allow_partial_does_not_run_pipeline_when_all_sources_filtered(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"), controls=_UnavailableNotesControls())
 
@@ -725,7 +826,6 @@ async def test_allow_partial_does_not_run_pipeline_when_all_sources_filtered(mon
     assert out["sources_unavailable"] == ["notes"]  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_default_controls_enforce_rag_query_billing_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"))
     protocol = MCPProtocol()
@@ -758,7 +858,6 @@ async def test_default_controls_enforce_rag_query_billing_limit(monkeypatch: pyt
         )
 
 
-@pytest.mark.asyncio
 async def test_allow_partial_filters_unavailable_sources(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"), controls=_UnavailableNotesControls())
     calls: dict[str, object] = {}
@@ -792,7 +891,6 @@ async def test_allow_partial_filters_unavailable_sources(monkeypatch: pytest.Mon
     assert out["metadata"]["sources_unavailable"] == ["notes"]  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_explicit_unsupported_conversation_scope_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
     module = RagModule(ModuleConfig(name="rag"))
     called = False
@@ -815,7 +913,6 @@ async def test_explicit_unsupported_conversation_scope_fails_closed(monkeypatch:
     assert called is False  # nosec B101
 
 
-@pytest.mark.asyncio
 async def test_rag_module_jsonrpc_tools_call_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_pipeline(**kwargs):  # noqa: ANN001
         generated_answer = "Grounded answer." if kwargs.get("enable_generation") else None

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
@@ -14,6 +14,7 @@ from tldw_Server_API.app.core.MCP_unified.modules.implementations.rag_module imp
 )
 from tldw_Server_API.app.core.MCP_unified.modules.registry import ModuleRegistry
 from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, MCPRequest, RequestContext
+from tldw_Server_API.app.core.MCP_unified import server as mcp_server_module
 
 
 class _RecordingControls:
@@ -70,6 +71,18 @@ class _AllowAllRBAC:
     async def check_permission(self, *args, **kwargs):  # noqa: ANN001
         del args, kwargs
         return True
+
+
+class _DenyNotesSearchRBAC:
+    async def check_permission(self, _user_id, resource, _action, resource_id=None):  # noqa: ANN001
+        if getattr(resource, "value", resource) == "tool" and resource_id == "notes.search":
+            return False
+        return True
+
+
+class _NoopRateLimiter:
+    async def check_rate_limit(self, *args, **kwargs):  # noqa: ANN001
+        del args, kwargs
 
 
 def test_mcp_sources_accept_aliases_but_return_canonical_ids() -> None:
@@ -135,6 +148,60 @@ def test_compact_response_truncates_documents_and_preserves_citations() -> None:
     assert payload["metadata"]["documents_truncated"] is False  # nosec B101
     assert payload["metadata"]["max_documents"] == 1  # nosec B101
     assert payload["metadata"]["max_content_chars"] == 3  # nosec B101
+
+
+def test_compact_response_redacts_raw_document_and_response_metadata() -> None:
+    response = UnifiedRAGResponse(
+        query="q",
+        documents=[
+            {
+                "id": "d1",
+                "content": "Evidence",
+                "score": 0.9,
+                "source": "media_db",
+                "metadata": {
+                    "source": "media_db",
+                    "source_id": "42",
+                    "title": "Allowed title",
+                    "path": "SECRET_PATH",
+                    "db_path": "SECRET_DB",
+                    "provider": "SECRET_PROVIDER",
+                    "prompt": "SECRET_PROMPT",
+                    "debug": {"raw": "SECRET_DEBUG"},
+                },
+                "provider_payload": {"token": "SECRET_TOKEN"},
+            }
+        ],
+        citations=[],
+        chunk_citations=[],
+        metadata={
+            "hard_citations": {"coverage": 0.5},
+            "knowledge_trust": {"state": "grounded"},
+            "provider_debug": "SECRET_PROVIDER",
+            "prompt": "SECRET_PROMPT",
+            "db_path": "SECRET_DB",
+        },
+    )
+
+    payload = _compact_rag_response(
+        response,
+        mode="search",
+        request_metadata={"sources_requested": ["media_db"], "sources_explicit": True},
+        max_documents=1,
+        max_content_chars=2000,
+    )
+
+    document = payload["documents"][0]
+    assert document["metadata"] == {  # nosec B101
+        "source": "media_db",
+        "source_id": "42",
+        "title": "Allowed title",
+    }
+    assert "provider_payload" not in document  # nosec B101
+    rendered_payload = repr(payload)
+    assert "SECRET_" not in rendered_payload  # nosec B101
+    assert "knowledge_trust" not in payload["metadata"]  # nosec B101
+    assert payload["metadata"]["knowledge_trust_state"] == "grounded"  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -284,6 +351,9 @@ async def test_rag_search_applies_supported_scopes_and_disables_external_researc
     assert calls["search_url_scraping"] is False  # nosec B101
     assert calls["enable_image_search"] is False  # nosec B101
     assert calls["enable_video_search"] is False  # nosec B101
+    assert calls["enable_web_fallback"] is False  # nosec B101
+    assert calls["enable_query_classification"] is False  # nosec B101
+    assert calls["search_depth_mode"] is None  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -304,12 +374,45 @@ async def test_rag_source_health_uses_read_controls_without_query_quota() -> Non
 
     out = await module.execute_tool("rag.source_health", {}, context=RequestContext(request_id="r6", user_id="1"))
 
-    assert hasattr(out, "sources")  # nosec B101
+    assert out["ok"] is True  # nosec B101
+    assert isinstance(out["sources"], list)  # nosec B101
     assert ("protocol_rate", "rag.source_health", "search") in controls.calls  # nosec B101
     assert ("rbac_rate", "rag.search") in controls.calls  # nosec B101
     assert ("read_scope", "rag.source_health") in controls.calls  # nosec B101
     assert not any(call[0] == "quota" for call in controls.calls)  # nosec B101
     assert not any(call[0] == "usage" for call in controls.calls)  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_source_health_reports_unavailable_sources_with_ok_contract() -> None:
+    module = RagModule(ModuleConfig(name="rag"), controls=_UnavailableNotesControls())
+
+    out = await module.execute_tool(
+        "rag.source_health",
+        {"sources": ["media", "notes"], "allow_partial": True},
+        context=RequestContext(request_id="source-health-partial", user_id="1"),
+    )
+
+    assert out["ok"] is True  # nosec B101
+    assert out["sources_unavailable"] == ["notes"]  # nosec B101
+    assert out["warnings"] == ["notes unavailable"]  # nosec B101
+    assert all(source["source_id"] != "notes" for source in out["sources"])  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_source_health_fails_closed_when_explicit_source_is_unavailable() -> None:
+    module = RagModule(ModuleConfig(name="rag"), controls=_UnavailableNotesControls())
+
+    out = await module.execute_tool(
+        "rag.source_health",
+        {"sources": ["notes"]},
+        context=RequestContext(request_id="source-health-denied", user_id="1"),
+    )
+
+    assert out["ok"] is False  # nosec B101
+    assert out["reason_code"] == "source_unavailable"  # nosec B101
+    assert out["sources_unavailable"] == ["notes"]  # nosec B101
+    assert out["warnings"] == ["notes unavailable"]  # nosec B101
 
 
 @pytest.mark.asyncio
@@ -386,6 +489,68 @@ async def test_explicit_unavailable_source_fails_closed() -> None:
     assert out["ok"] is False  # nosec B101
     assert out["reason_code"] == "source_unavailable"  # nosec B101
     assert out["sources_unavailable"] == ["notes"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_default_controls_enforce_source_tool_permission(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"))
+    protocol = MCPProtocol()
+    protocol.rbac_policy = _DenyNotesSearchRBAC()
+    protocol.rate_limiter = _NoopRateLimiter()
+    monkeypatch.setattr(mcp_server_module, "_server", SimpleNamespace(protocol=protocol))
+
+    async def fail_if_pipeline_runs(**kwargs):  # noqa: ANN001
+        del kwargs
+        raise AssertionError("pipeline must not run when source authorization fails")
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fail_if_pipeline_runs)
+
+    out = await module.execute_tool(
+        "rag.search",
+        {"query": "q", "sources": ["notes"]},
+        context=RequestContext(request_id="source-auth", user_id="1", client_id="unit"),
+    )
+
+    assert out["ok"] is False  # nosec B101
+    assert out["reason_code"] == "source_unavailable"  # nosec B101
+    assert out["sources_unavailable"] == ["notes"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_default_controls_authorize_character_backed_rag_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"))
+    protocol = MCPProtocol()
+    protocol.rbac_policy = _AllowAllRBAC()
+    protocol.rate_limiter = _NoopRateLimiter()
+    monkeypatch.setattr(mcp_server_module, "_server", SimpleNamespace(protocol=protocol))
+    calls: dict[str, object] = {}
+
+    async def fake_pipeline(**kwargs):
+        calls.update(kwargs)
+        return SimpleNamespace(
+            documents=[],
+            query="q",
+            metadata={},
+            timings={},
+            citations=[],
+            chunk_citations=[],
+            generated_answer=None,
+            errors=[],
+            total_time=0.1,
+            cache_hit=False,
+            expanded_queries=[],
+        )
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+
+    out = await module.execute_tool(
+        "rag.search",
+        {"query": "q", "sources": ["world_books", "dictionaries"]},
+        context=RequestContext(request_id="character-backed-sources", user_id="1", client_id="unit"),
+    )
+
+    assert out["ok"] is True  # nosec B101
+    assert calls["sources"] == ["world_books", "dictionaries"]  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
@@ -12,7 +12,8 @@ from tldw_Server_API.app.core.MCP_unified.modules.implementations.rag_module imp
     _build_mcp_rag_request,
     _compact_rag_response,
 )
-from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+from tldw_Server_API.app.core.MCP_unified.modules.registry import ModuleRegistry
+from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, MCPRequest, RequestContext
 
 
 class _RecordingControls:
@@ -63,6 +64,12 @@ class _UnavailableNotesControls(_RecordingControls):
             sources_unavailable=unavailable,
             warnings=["notes unavailable"] if unavailable else [],
         )
+
+
+class _AllowAllRBAC:
+    async def check_permission(self, *args, **kwargs):  # noqa: ANN001
+        del args, kwargs
+        return True
 
 
 def test_mcp_sources_accept_aliases_but_return_canonical_ids() -> None:
@@ -436,3 +443,58 @@ async def test_explicit_unsupported_conversation_scope_fails_closed(monkeypatch:
     assert out["ok"] is False  # nosec B101
     assert out["reason_code"] == "unsupported_scope"  # nosec B101
     assert called is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_module_jsonrpc_tools_call_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_pipeline(**kwargs):  # noqa: ANN001
+        generated_answer = "Grounded answer." if kwargs.get("enable_generation") else None
+        return SimpleNamespace(
+            documents=[{"id": "d1", "content": "Evidence", "metadata": {"source": "media_db"}, "score": 0.9}],
+            query=kwargs["query"],
+            metadata={"hard_citations": {"coverage": 1.0}, "knowledge_trust": {"state": "grounded"}},
+            timings={},
+            citations=[{"id": "c1"}] if generated_answer else [],
+            chunk_citations=[],
+            generated_answer=generated_answer,
+            errors=[],
+            total_time=0.1,
+            cache_hit=False,
+            expanded_queries=[],
+        )
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+
+    registry = ModuleRegistry()
+    await registry.register_module("rag", RagModule, ModuleConfig(name="rag"))
+    protocol = MCPProtocol()
+    protocol.module_registry = registry
+    protocol.rbac_policy = _AllowAllRBAC()
+    context = RequestContext(request_id="rag-jsonrpc-smoke", user_id="1", client_id="unit")
+
+    search = await protocol.process_request(
+        MCPRequest(
+            method="tools/call",
+            params={"name": "rag.search", "arguments": {"query": "q"}},
+            id="smoke-rag-search",
+        ),
+        context,
+    )
+    answer = await protocol.process_request(
+        MCPRequest(
+            method="tools/call",
+            params={"name": "rag.answer", "arguments": {"query": "q"}},
+            id="smoke-rag-answer",
+        ),
+        context,
+    )
+
+    assert search.error is None  # nosec B101
+    assert answer.error is None  # nosec B101
+    search_payload = search.result["content"][0]["json"]
+    answer_payload = answer.result["content"][0]["json"]
+    assert search.result["content"][0]["type"] == "json"  # nosec B101
+    assert answer.result["content"][0]["type"] == "json"  # nosec B101
+    assert search_payload["ok"] is True  # nosec B101
+    assert "answer" not in search_payload  # nosec B101
+    assert answer_payload["answer"]["status"] in {"answered", "partial", "abstained"}  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py
@@ -1,14 +1,68 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import UnifiedRAGResponse
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations import rag_module as rag_module_impl
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.rag_module import (
     RagModule,
     _build_mcp_rag_request,
     _compact_rag_response,
 )
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+
+
+class _RecordingControls:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    async def enforce_protocol_rate(self, context, tool_name: str, category: str):  # noqa: ANN001
+        self.calls.append(("protocol_rate", tool_name, category))
+
+    async def enforce_rag_rbac_rate_limit(self, context, resource: str):  # noqa: ANN001
+        self.calls.append(("rbac_rate", resource))
+
+    async def require_mcp_rag_read_scope(self, context, tool_name: str):  # noqa: ANN001
+        self.calls.append(("read_scope", tool_name))
+
+    async def authorize_sources(
+        self,
+        context,  # noqa: ANN001
+        sources: list[str],
+        *,
+        sources_explicit: bool,
+        allow_partial: bool,
+    ):
+        self.calls.append(("authorize_sources", tuple(sources), sources_explicit, allow_partial))
+        return rag_module_impl._SourceAuthorization(sources=sources, sources_unavailable=[], warnings=[])
+
+    async def check_rag_query_quota(self, context, units: int = 1):  # noqa: ANN001
+        self.calls.append(("quota", units))
+
+    async def log_rag_query_usage(self, context, units: int = 1):  # noqa: ANN001
+        self.calls.append(("usage", units))
+
+
+class _UnavailableNotesControls(_RecordingControls):
+    async def authorize_sources(
+        self,
+        context,  # noqa: ANN001
+        sources: list[str],
+        *,
+        sources_explicit: bool,
+        allow_partial: bool,
+    ):
+        self.calls.append(("authorize_sources", tuple(sources), sources_explicit, allow_partial))
+        allowed = [source for source in sources if source != "notes"]
+        unavailable = ["notes"] if "notes" in sources else []
+        return rag_module_impl._SourceAuthorization(
+            sources=allowed,
+            sources_unavailable=unavailable,
+            warnings=["notes unavailable"] if unavailable else [],
+        )
 
 
 def test_mcp_sources_accept_aliases_but_return_canonical_ids() -> None:
@@ -86,3 +140,299 @@ async def test_rag_module_exposes_four_strict_tools() -> None:
     for tool_name in ("rag.capabilities", "rag.source_health", "rag.search", "rag.answer"):
         assert tools[tool_name]["inputSchema"]["additionalProperties"] is False  # nosec B101
     assert tools["rag.answer"]["metadata"]["category"] == "rag_generation"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_search_executes_shared_pipeline_without_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"))
+    calls: dict[str, object] = {}
+
+    async def fake_pipeline(**kwargs):
+        calls.update(kwargs)
+        return SimpleNamespace(
+            documents=[{"id": "d1", "content": "Evidence", "metadata": {"source": "media_db"}, "score": 0.9}],
+            query="q",
+            metadata={"hard_citations": {"coverage": 1.0}},
+            timings={"retrieval": 1.2},
+            citations=[],
+            chunk_citations=[],
+            generated_answer=None,
+            errors=[],
+            total_time=1.2,
+            cache_hit=False,
+            expanded_queries=[],
+        )
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+    ctx = RequestContext(
+        request_id="r1",
+        user_id="1",
+        db_paths={"media": "media.db", "chacha": "notes.db"},
+    )
+
+    out = await module.execute_tool("rag.search", {"query": "q", "sources": ["media"]}, context=ctx)
+
+    assert out["ok"] is True  # nosec B101
+    assert out["mode"] == "search"  # nosec B101
+    assert "answer" not in out  # nosec B101
+    assert calls["enable_generation"] is False  # nosec B101
+    assert calls["sources"] == ["media_db"]  # nosec B101
+    assert calls["media_db_path"] == "media.db"  # nosec B101
+    assert calls["notes_db_path"] == "notes.db"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_answer_marks_grounded_cited_output_answered(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"))
+
+    async def fake_pipeline(**kwargs):  # noqa: ARG001
+        return SimpleNamespace(
+            documents=[{"id": "d1", "content": "Evidence", "metadata": {"source": "media_db"}, "score": 0.9}],
+            query="q",
+            metadata={"hard_citations": {"coverage": 1.0}, "knowledge_trust": {"state": "grounded"}},
+            timings={},
+            citations=[{"id": "c1"}],
+            chunk_citations=[],
+            generated_answer="Grounded answer.",
+            errors=[],
+            total_time=0.1,
+            cache_hit=False,
+            expanded_queries=[],
+        )
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+
+    out = await module.execute_tool("rag.answer", {"query": "q"}, context=RequestContext(request_id="r2", user_id="1"))
+
+    assert out["ok"] is True  # nosec B101
+    assert out["answer"]["text"] == "Grounded answer."  # nosec B101
+    assert out["answer"]["status"] == "answered"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_answer_never_marks_uncited_output_answered(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"))
+
+    async def fake_pipeline(**kwargs):  # noqa: ARG001
+        return SimpleNamespace(
+            documents=[{"id": "d1", "content": "Weak evidence", "metadata": {"source": "media_db"}, "score": 0.4}],
+            query="q",
+            metadata={"hard_citations": {"coverage": 0.0}, "knowledge_trust": {"state": "weak"}},
+            timings={},
+            citations=[],
+            chunk_citations=[],
+            generated_answer="Unsupported answer.",
+            errors=[],
+            total_time=0.1,
+            cache_hit=False,
+            expanded_queries=[],
+        )
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+
+    out = await module.execute_tool("rag.answer", {"query": "q"}, context=RequestContext(request_id="r3", user_id="1"))
+
+    assert out["ok"] is True  # nosec B101
+    assert out["answer"]["status"] in {"partial", "abstained"}  # nosec B101
+    assert out["answer"]["status"] != "answered"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_search_applies_supported_scopes_and_disables_external_research(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = RagModule(ModuleConfig(name="rag"))
+    calls: dict[str, object] = {}
+
+    async def fake_pipeline(**kwargs):
+        calls.update(kwargs)
+        return SimpleNamespace(
+            documents=[],
+            query="q",
+            metadata={},
+            timings={},
+            citations=[],
+            chunk_citations=[],
+            generated_answer=None,
+            errors=[],
+            total_time=0.1,
+            cache_hit=False,
+            expanded_queries=[],
+        )
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+    ctx = RequestContext(
+        request_id="r4",
+        user_id="1",
+        session_id="session-1",
+        metadata={"media_ids": [1, "2"], "note_id": "note-7", "workspace_id": "ws-1"},
+    )
+
+    await module.execute_tool("rag.search", {"query": "q", "sources": ["media", "notes"]}, context=ctx)
+
+    assert calls["include_media_ids"] == [1, 2]  # nosec B101
+    assert calls["include_note_ids"] == ["note-7"]  # nosec B101
+    assert calls["workspace_id"] == "ws-1"  # nosec B101
+    assert calls["enable_research_loop"] is False  # nosec B101
+    assert calls["search_url_scraping"] is False  # nosec B101
+    assert calls["enable_image_search"] is False  # nosec B101
+    assert calls["enable_video_search"] is False  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_capabilities_uses_only_protocol_rate_control() -> None:
+    controls = _RecordingControls()
+    module = RagModule(ModuleConfig(name="rag"), controls=controls)
+
+    out = await module.execute_tool("rag.capabilities", {}, context=RequestContext(request_id="r5", user_id="1"))
+
+    assert out["ok"] is True  # nosec B101
+    assert controls.calls == [("protocol_rate", "rag.capabilities", "utility")]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_source_health_uses_read_controls_without_query_quota() -> None:
+    controls = _RecordingControls()
+    module = RagModule(ModuleConfig(name="rag"), controls=controls)
+
+    out = await module.execute_tool("rag.source_health", {}, context=RequestContext(request_id="r6", user_id="1"))
+
+    assert hasattr(out, "sources")  # nosec B101
+    assert ("protocol_rate", "rag.source_health", "search") in controls.calls  # nosec B101
+    assert ("rbac_rate", "rag.search") in controls.calls  # nosec B101
+    assert ("read_scope", "rag.source_health") in controls.calls  # nosec B101
+    assert not any(call[0] == "quota" for call in controls.calls)  # nosec B101
+    assert not any(call[0] == "usage" for call in controls.calls)  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_search_uses_quota_and_usage_controls(monkeypatch: pytest.MonkeyPatch) -> None:
+    controls = _RecordingControls()
+    module = RagModule(ModuleConfig(name="rag"), controls=controls)
+
+    async def fake_pipeline(**kwargs):  # noqa: ARG001
+        return SimpleNamespace(
+            documents=[],
+            query="q",
+            metadata={},
+            timings={},
+            citations=[],
+            chunk_citations=[],
+            generated_answer=None,
+            errors=[],
+            total_time=0.1,
+            cache_hit=False,
+            expanded_queries=[],
+        )
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+
+    out = await module.execute_tool("rag.search", {"query": "q"}, context=RequestContext(request_id="r7", user_id="1"))
+
+    assert out["ok"] is True  # nosec B101
+    assert ("protocol_rate", "rag.search", "search") in controls.calls  # nosec B101
+    assert ("rbac_rate", "rag.search") in controls.calls  # nosec B101
+    assert ("read_scope", "rag.search") in controls.calls  # nosec B101
+    assert ("quota", 1) in controls.calls  # nosec B101
+    assert ("usage", 1) in controls.calls  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_rag_answer_uses_generation_category_controls(monkeypatch: pytest.MonkeyPatch) -> None:
+    controls = _RecordingControls()
+    module = RagModule(ModuleConfig(name="rag"), controls=controls)
+
+    async def fake_pipeline(**kwargs):  # noqa: ARG001
+        return SimpleNamespace(
+            documents=[],
+            query="q",
+            metadata={},
+            timings={},
+            citations=[],
+            chunk_citations=[],
+            generated_answer=None,
+            errors=[],
+            total_time=0.1,
+            cache_hit=False,
+            expanded_queries=[],
+        )
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+
+    await module.execute_tool("rag.answer", {"query": "q"}, context=RequestContext(request_id="r8", user_id="1"))
+
+    assert ("protocol_rate", "rag.answer", "rag_generation") in controls.calls  # nosec B101
+    assert ("quota", 1) in controls.calls  # nosec B101
+    assert ("usage", 1) in controls.calls  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_explicit_unavailable_source_fails_closed() -> None:
+    module = RagModule(ModuleConfig(name="rag"), controls=_UnavailableNotesControls())
+
+    out = await module.execute_tool(
+        "rag.search",
+        {"query": "q", "sources": ["notes"]},
+        context=RequestContext(request_id="r9", user_id="1"),
+    )
+
+    assert out["ok"] is False  # nosec B101
+    assert out["reason_code"] == "source_unavailable"  # nosec B101
+    assert out["sources_unavailable"] == ["notes"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_allow_partial_filters_unavailable_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"), controls=_UnavailableNotesControls())
+    calls: dict[str, object] = {}
+
+    async def fake_pipeline(**kwargs):
+        calls.update(kwargs)
+        return SimpleNamespace(
+            documents=[],
+            query="q",
+            metadata={},
+            timings={},
+            citations=[],
+            chunk_citations=[],
+            generated_answer=None,
+            errors=[],
+            total_time=0.1,
+            cache_hit=False,
+            expanded_queries=[],
+        )
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+
+    out = await module.execute_tool(
+        "rag.search",
+        {"query": "q", "sources": ["media", "notes"], "allow_partial": True},
+        context=RequestContext(request_id="r10", user_id="1"),
+    )
+
+    assert out["ok"] is True  # nosec B101
+    assert calls["sources"] == ["media_db"]  # nosec B101
+    assert out["metadata"]["sources_unavailable"] == ["notes"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_explicit_unsupported_conversation_scope_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = RagModule(ModuleConfig(name="rag"))
+    called = False
+
+    async def fake_pipeline(**kwargs):  # noqa: ARG001
+        nonlocal called
+        called = True
+        return SimpleNamespace(documents=[], query="q", metadata={}, timings={}, citations=[], chunk_citations=[])
+
+    monkeypatch.setattr(rag_module_impl, "unified_rag_pipeline", fake_pipeline)
+
+    out = await module.execute_tool(
+        "rag.search",
+        {"query": "q", "sources": ["chats"]},
+        context=RequestContext(request_id="r11", user_id="1", metadata={"conversation_id": "c1"}),
+    )
+
+    assert out["ok"] is False  # nosec B101
+    assert out["reason_code"] == "unsupported_scope"  # nosec B101
+    assert called is False  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module_registration.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module_registration.py
@@ -42,6 +42,17 @@ def test_module_surface_classifies_rag_as_read_only() -> None:
     assert MODULE_RISK_TIERS["rag"][0] == "read_only"  # nosec B101
 
 
+def test_rag_docs_include_curated_catalog_and_jsonrpc_examples() -> None:
+    catalog_docs = Path("Docs/MCP/mcp_tool_catalogs.md").read_text()
+    snippets_docs = Path("Docs/MCP/Unified/Client_Snippets.md").read_text()
+
+    assert "Recommended Catalog: `library-rag`" in catalog_docs  # nosec B101
+    for tool_name in ("rag.capabilities", "rag.source_health", "rag.search", "rag.answer"):
+        assert tool_name in catalog_docs  # nosec B101
+    assert '"name":"rag.search"' in snippets_docs  # nosec B101
+    assert '"name":"rag.answer"' in snippets_docs  # nosec B101
+
+
 class _CategoryProbeRateLimiter:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module_registration.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module_registration.py
@@ -12,6 +12,8 @@ from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, Module
 from tldw_Server_API.app.core.MCP_unified.modules.registry import ModuleRegistry
 from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, MCPRequest, RequestContext
 
+pytestmark = pytest.mark.unit
+
 
 def test_rag_module_is_in_default_module_config() -> None:
     config = yaml.safe_load(Path("tldw_Server_API/Config_Files/mcp_modules.yaml").read_text())
@@ -147,8 +149,6 @@ def _protocol_with_probe_limiter(registry: ModuleRegistry, limiter: _CategoryPro
     )
 
 
-@pytest.mark.unit
-@pytest.mark.asyncio
 async def test_rag_tool_categories_reach_tools_call_rate_limiter() -> None:
     registry = ModuleRegistry()
     await registry.register_module(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module_registration.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_rag_module_registration.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import yaml
+
+from tldw_Server_API.app.core.MCP_unified.module_surface import MODULE_RISK_TIERS
+from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, ModuleConfig, create_tool_definition
+from tldw_Server_API.app.core.MCP_unified.modules.registry import ModuleRegistry
+from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, MCPRequest, RequestContext
+
+
+def test_rag_module_is_in_default_module_config() -> None:
+    config = yaml.safe_load(Path("tldw_Server_API/Config_Files/mcp_modules.yaml").read_text())
+
+    rag = next(module for module in config["modules"] if module["id"] == "rag")
+
+    assert rag["enabled"] is True  # nosec B101
+    assert rag["class"].endswith("rag_module:RagModule")  # nosec B101
+    assert rag["department"] == "knowledge"  # nosec B101
+
+
+def test_rag_tool_category_config_separates_generation() -> None:
+    mapping = yaml.safe_load(Path("tldw_Server_API/Config_Files/mcp_tool_categories.yaml").read_text())
+
+    assert mapping["rag.search"] == "search"  # nosec B101
+    assert mapping["rag.answer"] == "rag_generation"  # nosec B101
+
+
+def test_rag_search_and_answer_have_concrete_mcp_policies() -> None:
+    policies = yaml.safe_load(Path("tldw_Server_API/Config_Files/resource_governor_policies.yaml").read_text())
+
+    assert "mcp.search" in policies["policies"]  # nosec B101
+    assert "mcp.rag_generation" in policies["policies"]  # nosec B101
+    assert policies["policies"]["mcp.rag_generation"]["scopes"] == ["user", "api_key"]  # nosec B101
+
+
+def test_module_surface_classifies_rag_as_read_only() -> None:
+    assert MODULE_RISK_TIERS["rag"][0] == "read_only"  # nosec B101
+
+
+class _CategoryProbeRateLimiter:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def check_rate_limit(self, key: str, *, category: str = "default") -> None:
+        self.calls.append((key, category))
+
+
+class _AllowAllRBAC:
+    async def check_permission(self, *args: Any, **kwargs: Any) -> bool:
+        del args, kwargs
+        return True
+
+
+class _NoopMetrics:
+    def __getattr__(self, _name: str):
+        return lambda *args, **kwargs: None
+
+
+class _NoopTelemetry:
+    def trace_context(self, _operation_name: str, _attributes: dict[str, Any] | None = None) -> Any:
+        class _Span:
+            def set_attribute(self, _key: str, _value: Any) -> None:
+                return None
+
+        class _Context:
+            def __enter__(self) -> _Span:
+                return _Span()
+
+            def __exit__(self, *_exc_info: Any) -> None:
+                return None
+
+        return _Context()
+
+
+class _RagCategoryProbeModule(BaseModule):
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"ok": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return [
+            create_tool_definition(
+                name="rag.search",
+                description="probe search",
+                parameters={"properties": {"query": {"type": "string"}}, "required": ["query"]},
+                metadata={"category": "search", "readOnlyHint": True},
+            ),
+            create_tool_definition(
+                name="rag.answer",
+                description="probe answer",
+                parameters={"properties": {"query": {"type": "string"}}, "required": ["query"]},
+                metadata={"category": "rag_generation", "readOnlyHint": True},
+            ),
+        ]
+
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
+        del tool_name
+        if "query" not in arguments:
+            raise ValueError("query required")
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: RequestContext | None = None,
+    ) -> dict[str, str]:
+        del arguments, context
+        return {"tool": tool_name}
+
+
+def _protocol_with_probe_limiter(registry: ModuleRegistry, limiter: _CategoryProbeRateLimiter) -> MCPProtocol:
+    return MCPProtocol(
+        dependencies=SimpleNamespace(
+            module_registry=registry,
+            rbac_policy=_AllowAllRBAC(),
+            rate_limiter=limiter,
+            metrics_collector=_NoopMetrics(),
+            telemetry_provider=_NoopTelemetry(),
+            redis_client_factory=lambda **_kwargs: None,
+            tool_catalog_provider=object(),
+            effective_policy_resolver=object(),
+            approval_evaluator=object(),
+            path_scope_enforcer=object(),
+            external_access_evaluator=object(),
+        )
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rag_tool_categories_reach_tools_call_rate_limiter() -> None:
+    registry = ModuleRegistry()
+    await registry.register_module(
+        "rag_category_probe",
+        _RagCategoryProbeModule,
+        ModuleConfig(name="rag_category_probe"),
+    )
+    limiter = _CategoryProbeRateLimiter()
+    proto = _protocol_with_probe_limiter(registry, limiter)
+    ctx = RequestContext(request_id="rag-categories", user_id="1", client_id="unit")
+
+    search = await proto.process_request(
+        MCPRequest(method="tools/call", params={"name": "rag.search", "arguments": {"query": "q"}}, id=1),
+        ctx,
+    )
+    answer = await proto.process_request(
+        MCPRequest(method="tools/call", params={"name": "rag.answer", "arguments": {"query": "q"}}, id=2),
+        ctx,
+    )
+
+    assert search.error is None  # nosec B101
+    assert answer.error is None  # nosec B101
+    tool_categories = [category for key, category in limiter.calls if ":tool:" in key]
+    assert tool_categories == ["search", "rag_generation"]  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py
@@ -179,6 +179,7 @@ class ToolExecutionRuntime:
                         "browser",
                         "code",
                         "filesystem",
+                        "rag_generation",
                         "shell",
                         "search",
                         "tool_discovery",

--- a/tldw_Server_API/app/core/RAG/rag_service/transport.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/transport.py
@@ -316,12 +316,41 @@ def _allow_orgless_rag_billing_access() -> bool:
         return False
 
 
+def _membership_is_active(membership: dict[str, Any]) -> bool:
+    """Return whether an org membership row grants active access."""
+    return str(membership.get("status") or "").strip().lower() == "active"
+
+
+async def _verified_org_ids_for_user(current_user: Optional[Any]) -> list[int]:
+    """Return active organization ids for a user, or an empty list if unavailable."""
+    if not current_user or getattr(current_user, "id_int", None) is None:
+        return []
+    try:
+        from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+        from tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo import AuthnzOrgsTeamsRepo
+
+        pool = await get_db_pool()
+        repo = AuthnzOrgsTeamsRepo(db_pool=pool)
+        memberships = await repo.list_org_memberships_for_user(current_user.id_int)
+    except Exception:  # noqa: BLE001 - callers decide whether missing org context is fatal.
+        return []
+
+    org_ids: list[int] = []
+    for membership in memberships:
+        if not _membership_is_active(membership):
+            continue
+        org_id = _first_positive_int(membership.get("org_id"))
+        if org_id is not None and org_id not in org_ids:
+            org_ids.append(org_id)
+    return org_ids
+
+
 async def resolve_org_id_for_rag_context(
     *,
     request_like: Any = None,
     current_user: Optional[Any] = None,
 ) -> int | None:
-    """Resolve a billing organization from HTTP request state or MCP context metadata."""
+    """Resolve a billing organization from trusted state or verified user memberships."""
     state = getattr(request_like, "state", None)
     if state is not None:
         org_id = _first_positive_int(
@@ -332,31 +361,19 @@ async def resolve_org_id_for_rag_context(
             return org_id
 
     metadata = getattr(request_like, "metadata", None)
+    hinted_org_id = None
     if isinstance(metadata, dict):
-        org_id = _first_positive_int(metadata.get("org_id"), metadata.get("org_ids"))
-        if org_id is not None:
-            return org_id
+        hinted_org_id = _first_positive_int(metadata.get("org_id"), metadata.get("org_ids"))
 
-    direct_org_id = _first_positive_int(getattr(request_like, "org_id", None))
-    if direct_org_id is not None:
-        return direct_org_id
+    hinted_org_id = hinted_org_id or _first_positive_int(getattr(request_like, "org_id", None))
+    verified_org_ids = await _verified_org_ids_for_user(current_user)
+    if not verified_org_ids:
+        return None
 
-    if current_user and getattr(current_user, "id_int", None) is not None:
-        try:
-            from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
-            from tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo import AuthnzOrgsTeamsRepo
+    if hinted_org_id in verified_org_ids:
+        return hinted_org_id
 
-            pool = await get_db_pool()
-            repo = AuthnzOrgsTeamsRepo(db_pool=pool)
-            memberships = await repo.list_org_memberships_for_user(current_user.id_int)
-            for membership in memberships:
-                org_id = _first_positive_int(membership.get("org_id"))
-                if org_id is not None:
-                    return org_id
-        except Exception:  # noqa: BLE001 - callers decide whether missing org context is fatal.
-            return None
-
-    return None
+    return verified_org_ids[0]
 
 
 async def enforce_rag_query_limit_for_org_context(

--- a/tldw_Server_API/app/core/RAG/rag_service/transport.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/transport.py
@@ -1,0 +1,389 @@
+"""Transport-neutral RAG helper seams shared by HTTP and MCP callers."""
+
+from __future__ import annotations
+
+import inspect
+import os
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+from uuid import uuid4
+
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import (
+    KnowledgeSourceHealthResponse,
+    UnifiedBatchRequest,
+    UnifiedRAGRequest,
+)
+from tldw_Server_API.app.core.config import RAG_SERVICE_CONFIG, get_config_value, settings
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.RAG.rag_service.request_bundle import (
+    ResolvedRequestBundle,
+    build_request_bundle,
+)
+from tldw_Server_API.app.core.RAG.rag_service.request_resolution import (
+    ResolvedRAGRequest,
+    resolve_rag_request,
+)
+from tldw_Server_API.app.core.RAG.rag_service.retrieval_plan import (
+    RetrievalPlan,
+    build_retrieval_plan,
+)
+from tldw_Server_API.app.core.RAG.rag_service.source_health import build_source_health_entries
+from tldw_Server_API.app.core.RAG.rag_service.unified_pipeline import (
+    unified_batch_pipeline,
+    unified_rag_pipeline,
+)
+
+SearchAgentSettingFn = Callable[[str, str], Optional[str]]
+ExistingSourceDbPathsFn = Callable[..., dict[str, str]]
+MediaBackendStorageFn = Callable[[], bool]
+
+_BATCH_ROUND2_DEFAULT_FIELDS = {
+    "enable_suggestions",
+    "enable_structured_response",
+    "enable_image_search",
+    "enable_video_search",
+}
+
+
+def search_agent_setting(env_key: str, config_key: str) -> Optional[str]:
+    """Read Search-Agent setting with env-over-config precedence."""
+    env_value = os.getenv(env_key)
+    if env_value is not None:
+        return env_value
+    try:
+        return get_config_value("Search-Agent", config_key, default=None)
+    except (TypeError, ValueError):
+        return None
+
+
+def build_unified_pipeline_kwargs(
+    request: UnifiedRAGRequest,
+    db_paths: dict[str, Optional[str]],
+    media_db: Any,
+    chacha_db: Any,
+    current_user: Optional[Any],
+    prompts_db: Optional[Any] = None,
+    resolved_request: Optional[ResolvedRAGRequest] = None,
+    retrieval_plan: Optional[RetrievalPlan] = None,
+    *,
+    search_agent_setting_fn: SearchAgentSettingFn = search_agent_setting,
+    single_user_id_resolver: Callable[[], Any] = DatabasePaths.get_single_user_id,
+) -> dict[str, Any]:
+    """Translate a resolved standard request into core pipeline keyword arguments."""
+    if resolved_request is None:
+        resolved_request = resolve_rag_request(
+            request,
+            current_user=current_user,
+            single_user_id_resolver=single_user_id_resolver,
+            search_agent_setting_fn=search_agent_setting_fn,
+        )
+    if retrieval_plan is None:
+        retrieval_plan = build_retrieval_plan(resolved_request)
+    payload = dict(resolved_request.payload)
+    payload["sources"] = list(retrieval_plan.sources)
+    payload["media_db_path"] = db_paths.get("media_db_path")
+    payload["notes_db_path"] = db_paths.get("notes_db_path")
+    payload["character_db_path"] = db_paths.get("character_db_path")
+    payload["kanban_db_path"] = db_paths.get("kanban_db_path")
+    payload["prompts_db_path"] = db_paths.get("prompts_db_path")
+    payload["media_db"] = media_db
+    payload["chacha_db"] = chacha_db
+    if prompts_db is not None:
+        payload["prompts_db"] = prompts_db
+    payload["index_namespace"] = retrieval_plan.index_namespace
+    payload["retrieval_plan"] = retrieval_plan
+    payload["user_id"] = resolved_request.user_id
+    payload["feedback_user_id"] = resolved_request.feedback_user_id
+    signature = inspect.signature(unified_rag_pipeline)
+    params = list(signature.parameters.values())
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
+        return payload
+    allowed = set(signature.parameters.keys())
+    return {key: value for key, value in payload.items() if key in allowed}
+
+
+def build_batch_pipeline_kwargs(
+    request: UnifiedBatchRequest,
+    db_paths: dict[str, Optional[str]],
+    current_user: Optional[Any],
+    resolved_request: Optional[ResolvedRAGRequest] = None,
+    retrieval_plan: Optional[RetrievalPlan] = None,
+    *,
+    search_agent_setting_fn: SearchAgentSettingFn = search_agent_setting,
+    single_user_id_resolver: Callable[[], Any] = DatabasePaths.get_single_user_id,
+) -> dict[str, Any]:
+    """Translate a resolved batch request into shared batch pipeline options."""
+    if resolved_request is None:
+        resolved_request = resolve_rag_request(
+            request,
+            current_user=current_user,
+            single_user_id_resolver=single_user_id_resolver,
+            search_agent_setting_fn=search_agent_setting_fn,
+            search_agent_allowed_fields=_BATCH_ROUND2_DEFAULT_FIELDS,
+        )
+    if retrieval_plan is None:
+        retrieval_plan = build_retrieval_plan(resolved_request)
+    payload = dict(resolved_request.payload)
+    payload.pop("queries", None)
+    payload.pop("query", None)
+    payload.pop("max_concurrent", None)
+    payload.pop("enable_checkpoint", None)
+    payload["sources"] = list(retrieval_plan.sources)
+    payload.update(db_paths)
+    payload["index_namespace"] = retrieval_plan.index_namespace
+    payload["retrieval_plan"] = retrieval_plan
+    payload["user_id"] = resolved_request.user_id
+    payload["feedback_user_id"] = resolved_request.feedback_user_id
+    signature = inspect.signature(unified_batch_pipeline)
+    params = list(signature.parameters.values())
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
+        return payload
+    allowed = set(signature.parameters.keys())
+    return {key: value for key, value in payload.items() if key in allowed}
+
+
+def build_standard_request_bundle(
+    request: UnifiedRAGRequest,
+    *,
+    current_user: Optional[Any],
+    db_paths: dict[str, Optional[str]],
+    media_db: Any,
+    chacha_db: Any,
+    prompts_db: Optional[Any] = None,
+    search_agent_setting_fn: SearchAgentSettingFn = search_agent_setting,
+    single_user_id_resolver: Callable[[], Any] = DatabasePaths.get_single_user_id,
+) -> ResolvedRequestBundle:
+    """Resolve a standard request once and attach transport-owned pipeline resources."""
+    return build_request_bundle(
+        request=request,
+        current_user=current_user,
+        resolve_request_kwargs={
+            "single_user_id_resolver": single_user_id_resolver,
+            "search_agent_setting_fn": search_agent_setting_fn,
+        },
+        pipeline_kwargs_builder=lambda *, resolved_request, retrieval_plan: build_unified_pipeline_kwargs(
+            request=request,
+            db_paths=db_paths,
+            media_db=media_db,
+            chacha_db=chacha_db,
+            prompts_db=prompts_db,
+            current_user=current_user,
+            resolved_request=resolved_request,
+            retrieval_plan=retrieval_plan,
+            search_agent_setting_fn=search_agent_setting_fn,
+            single_user_id_resolver=single_user_id_resolver,
+        ),
+    )
+
+
+def resolve_source_health_user_id(current_user: Optional[Any], request_user_id: Optional[str] = None) -> Optional[str]:
+    """Resolve a filesystem-safe user directory component without creating storage."""
+    candidates: list[Any] = []
+    if current_user is not None:
+        for attr in ("id", "id_int"):
+            candidates.append(getattr(current_user, attr, None))
+    candidates.append(request_user_id)
+
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        raw = str(candidate).strip()
+        if raw.isdigit() and int(raw) > 0:
+            return raw
+    try:
+        fallback = DatabasePaths.get_single_user_id()
+        fallback_raw = str(fallback).strip()
+        if fallback_raw.isdigit() and int(fallback_raw) > 0:
+            return fallback_raw
+    except (RuntimeError, ValueError, OSError, TypeError):
+        logger.debug("Failed to resolve single-user ID for source health path", exc_info=True)
+    return None
+
+
+def resolve_existing_source_db_paths(
+    current_user: Optional[Any],
+    request_user_id: Optional[str] = None,
+) -> dict[str, str]:
+    """Return existing source database paths without creating source storage."""
+    user_id = resolve_source_health_user_id(current_user, request_user_id)
+    if user_id is None:
+        return {}
+
+    user_dir = DatabasePaths.resolve_user_db_base_dir() / user_id
+    candidates = {
+        "media_db": user_dir / DatabasePaths.MEDIA_DB_NAME,
+        "chacha_db": user_dir / DatabasePaths.CHACHA_DB_NAME,
+        "prompts_db": user_dir / DatabasePaths.PROMPTS_SUBDIR / DatabasePaths.PROMPTS_DB_NAME,
+        "kanban_db": user_dir / DatabasePaths.KANBAN_DB_NAME,
+    }
+    return {
+        source_key: str(path)
+        for source_key, path in candidates.items()
+        if path.is_file()
+    }
+
+
+def media_db_uses_non_file_storage() -> bool:
+    """Return whether Media DB search is configured for non-file content storage."""
+    backend_mode_hint = (
+        os.getenv("CONTENT_DB_MODE")
+        or os.getenv("TLDW_CONTENT_DB_BACKEND")
+        or str(settings.get("CONTENT_DB_BACKEND", "sqlite"))
+    )
+    return backend_mode_hint.strip().lower() in {"postgres", "postgresql"}
+
+
+def build_source_health_source_sets(
+    *,
+    existing_paths: dict[str, str],
+    media_backend_uses_non_file_storage: bool = False,
+) -> tuple[set[Any], set[Any]]:
+    """Derive ready and empty source sets without creating source storage."""
+    configured: set[Any] = set()
+    empty: set[Any] = set()
+    if "media_db" in existing_paths or media_backend_uses_non_file_storage:
+        configured.add("media_db")
+    else:
+        empty.add("media_db")
+    if "chacha_db" in existing_paths:
+        configured.update({"notes", "chats", "characters", "world_books", "dictionaries"})
+    else:
+        empty.update({"notes", "chats", "characters", "world_books", "dictionaries"})
+    if "prompts_db" in existing_paths:
+        configured.add("prompts")
+    else:
+        empty.add("prompts")
+    if "kanban_db" in existing_paths:
+        configured.add("kanban")
+    else:
+        empty.add("kanban")
+    return configured, empty
+
+
+def build_source_health_payload(
+    *,
+    current_user: Optional[Any],
+    request_user_id: Optional[str] = None,
+    existing_source_db_paths_fn: ExistingSourceDbPathsFn = resolve_existing_source_db_paths,
+    media_db_uses_non_file_storage_fn: MediaBackendStorageFn = media_db_uses_non_file_storage,
+) -> KnowledgeSourceHealthResponse:
+    """Build a safe source-health response without opening retrievers or source databases."""
+    existing_paths = existing_source_db_paths_fn(current_user, request_user_id)
+    configured_sources, empty_sources = build_source_health_source_sets(
+        existing_paths=existing_paths,
+        media_backend_uses_non_file_storage=media_db_uses_non_file_storage_fn(),
+    )
+    return KnowledgeSourceHealthResponse(
+        sources=build_source_health_entries(
+            configured_sources=configured_sources,
+            empty_sources=empty_sources,
+        )
+    )
+
+
+async def log_rag_queries_for_org_context(
+    *,
+    request_like: Any = None,
+    current_user: Optional[Any] = None,
+    units: int = 1,
+) -> None:
+    """Best-effort RAG query usage logger for an HTTP/MCP request context."""
+    if units <= 0:
+        return
+    try:
+        org_id: Optional[int] = None
+        try:
+            state = getattr(request_like, "state", None)
+            if state is not None:
+                org_ids = getattr(state, "org_ids", None)
+                if isinstance(org_ids, (list, tuple)) and org_ids:
+                    org_id = int(org_ids[0])
+        except (AttributeError, TypeError, ValueError):
+            org_id = None
+
+        if org_id is None and current_user and getattr(current_user, "id_int", None) is not None:
+            try:
+                from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+                from tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo import AuthnzOrgsTeamsRepo
+
+                pool = await get_db_pool()
+                repo = AuthnzOrgsTeamsRepo(db_pool=pool)
+                memberships = await repo.list_org_memberships_for_user(current_user.id_int)
+                if memberships:
+                    candidate = memberships[0].get("org_id")
+                    if candidate is not None:
+                        org_id = int(candidate)
+            except Exception:  # noqa: BLE001 - usage logging is best-effort.
+                org_id = None
+
+        if org_id is None:
+            return
+
+        from tldw_Server_API.app.core.DB_Management.Resource_Daily_Ledger import (
+            LedgerEntry,
+            ResourceDailyLedger,
+        )
+
+        ledger = ResourceDailyLedger()
+        await ledger.initialize()
+        await ledger.add(
+            LedgerEntry(  # type: ignore[call-arg]
+                entity_scope="org",
+                entity_value=str(org_id),
+                category="rag_queries",
+                units=int(units),
+                op_id=f"rag:{org_id}:{uuid4()}",
+                occurred_at=datetime.now(timezone.utc),
+            )
+        )
+    except Exception:  # noqa: BLE001 - ledger failures must not impact callers.
+        logger.debug("RAG query logging failed; continuing without usage record", exc_info=True)
+
+
+def build_rag_capabilities_payload() -> dict[str, Any]:
+    """Return the curated RAG capabilities summary shared by HTTP and MCP."""
+    return {
+        "features": {
+            "agentic_chunking": {
+                "supported": True,
+                "strategies": ["standard", "agentic"],
+            },
+            "sources": {
+                "supported": True,
+                "datastores": [
+                    "media_db",
+                    "notes",
+                    "chats",
+                    "characters",
+                    "kanban",
+                    "prompts",
+                    "world_books",
+                    "dictionaries",
+                ],
+            },
+            "citation_generation": {
+                "supported": True,
+                "styles": ["apa", "mla", "chicago", "harvard", "ieee"],
+            },
+            "answer_generation": {
+                "supported": True,
+                "configurable_model": True,
+            },
+            "reranking": {
+                "supported": True,
+                "strategies": ["flashrank", "cross_encoder", "hybrid", "llama_cpp"],
+            },
+        },
+        "defaults": {
+            "sources": ["media_db"],
+            "search_mode": "hybrid",
+            "top_k": 10,
+            "rag_service": RAG_SERVICE_CONFIG,
+        },
+        "limits": {
+            "query_max_length": 20000,
+            "top_k_max": 100,
+        },
+    }

--- a/tldw_Server_API/app/core/RAG/rag_service/transport.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/transport.py
@@ -283,6 +283,116 @@ def build_source_health_payload(
     )
 
 
+def _first_positive_int(*values: Any) -> int | None:
+    """Return the first positive integer value from a sequence of loose inputs."""
+    for value in values:
+        if value is None or isinstance(value, bool):
+            continue
+        if isinstance(value, (list, tuple)) and value:
+            nested = _first_positive_int(*value)
+            if nested is not None:
+                return nested
+            continue
+        try:
+            candidate = int(value)
+        except (TypeError, ValueError):
+            continue
+        if candidate > 0:
+            return candidate
+    return None
+
+
+def _allow_orgless_rag_billing_access() -> bool:
+    """Return whether RAG billing checks may pass without org context."""
+    try:
+        from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+        from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime, is_test_mode
+
+        auth_mode = str(getattr(get_settings(), "AUTH_MODE", "") or "").strip().lower()
+        if auth_mode == "single_user":
+            return True
+        return bool(is_test_mode() or is_explicit_pytest_runtime())
+    except Exception:  # noqa: BLE001 - fail closed if the auth mode cannot be resolved.
+        return False
+
+
+async def resolve_org_id_for_rag_context(
+    *,
+    request_like: Any = None,
+    current_user: Optional[Any] = None,
+) -> int | None:
+    """Resolve a billing organization from HTTP request state or MCP context metadata."""
+    state = getattr(request_like, "state", None)
+    if state is not None:
+        org_id = _first_positive_int(
+            getattr(state, "org_id", None),
+            getattr(state, "org_ids", None),
+        )
+        if org_id is not None:
+            return org_id
+
+    metadata = getattr(request_like, "metadata", None)
+    if isinstance(metadata, dict):
+        org_id = _first_positive_int(metadata.get("org_id"), metadata.get("org_ids"))
+        if org_id is not None:
+            return org_id
+
+    direct_org_id = _first_positive_int(getattr(request_like, "org_id", None))
+    if direct_org_id is not None:
+        return direct_org_id
+
+    if current_user and getattr(current_user, "id_int", None) is not None:
+        try:
+            from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+            from tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo import AuthnzOrgsTeamsRepo
+
+            pool = await get_db_pool()
+            repo = AuthnzOrgsTeamsRepo(db_pool=pool)
+            memberships = await repo.list_org_memberships_for_user(current_user.id_int)
+            for membership in memberships:
+                org_id = _first_positive_int(membership.get("org_id"))
+                if org_id is not None:
+                    return org_id
+        except Exception:  # noqa: BLE001 - callers decide whether missing org context is fatal.
+            return None
+
+    return None
+
+
+async def enforce_rag_query_limit_for_org_context(
+    *,
+    request_like: Any = None,
+    current_user: Optional[Any] = None,
+    units: int = 1,
+) -> None:
+    """Enforce the shared RAG daily-query billing limit outside FastAPI DI."""
+    if units <= 0:
+        return
+
+    from tldw_Server_API.app.core.Billing.enforcement import (
+        LimitCategory,
+        enforcement_enabled,
+        get_billing_enforcer,
+    )
+
+    if not enforcement_enabled():
+        return
+
+    org_id = await resolve_org_id_for_rag_context(request_like=request_like, current_user=current_user)
+    if org_id is None:
+        if _allow_orgless_rag_billing_access():
+            return
+        raise PermissionError("An active organization context is required for billing enforcement")
+
+    result = await get_billing_enforcer().check_limit(
+        org_id,
+        LimitCategory.RAG_QUERIES_DAY,
+        requested_units=units,
+    )
+    if result.should_block:
+        raise PermissionError(result.message or f"Limit exceeded for {LimitCategory.RAG_QUERIES_DAY.value}")
+
+
 async def log_rag_queries_for_org_context(
     *,
     request_like: Any = None,
@@ -293,31 +403,7 @@ async def log_rag_queries_for_org_context(
     if units <= 0:
         return
     try:
-        org_id: Optional[int] = None
-        try:
-            state = getattr(request_like, "state", None)
-            if state is not None:
-                org_ids = getattr(state, "org_ids", None)
-                if isinstance(org_ids, (list, tuple)) and org_ids:
-                    org_id = int(org_ids[0])
-        except (AttributeError, TypeError, ValueError):
-            org_id = None
-
-        if org_id is None and current_user and getattr(current_user, "id_int", None) is not None:
-            try:
-                from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
-                from tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo import AuthnzOrgsTeamsRepo
-
-                pool = await get_db_pool()
-                repo = AuthnzOrgsTeamsRepo(db_pool=pool)
-                memberships = await repo.list_org_memberships_for_user(current_user.id_int)
-                if memberships:
-                    candidate = memberships[0].get("org_id")
-                    if candidate is not None:
-                        org_id = int(candidate)
-            except Exception:  # noqa: BLE001 - usage logging is best-effort.
-                org_id = None
-
+        org_id = await resolve_org_id_for_rag_context(request_like=request_like, current_user=current_user)
         if org_id is None:
             return
 

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py
@@ -389,6 +389,58 @@ def test_tools_execute_attaches_workspace_headers_to_metadata(monkeypatch):
     assert server.last_metadata.get("cwd") == "src/app"
 
 
+def test_tools_execute_preserves_rag_json_content_wrapper(monkeypatch):
+    monkeypatch.setattr(mcp_ep, "is_single_user_profile_mode", lambda: True)
+
+    class _RagJsonServer(_DummyServer):
+        async def handle_http_request(
+            self,
+            request,
+            client_id: Optional[str] = None,
+            user_id: Optional[str] = None,
+            metadata: Optional[Dict[str, Any]] = None,
+        ):
+            from tldw_Server_API.app.core.MCP_unified.protocol import MCPResponse
+
+            self.last_metadata = metadata or {}
+            arguments = getattr(request, "params", {}).get("arguments", {})
+            return MCPResponse(
+                result={
+                    "content": [
+                        {
+                            "type": "json",
+                            "json": {
+                                "ok": True,
+                                "tool": getattr(request, "params", {}).get("name"),
+                                "query": arguments.get("query"),
+                            },
+                        }
+                    ],
+                    "module": "rag",
+                },
+                id=getattr(request, "id", None),
+            )
+
+    server = _RagJsonServer()
+    monkeypatch.setattr(mcp_ep, "get_mcp_server", lambda: server)
+
+    headers = {"X-API-KEY": os.getenv("SINGLE_USER_API_KEY", "THIS-IS-A-SECURE-KEY-123-FAKE-KEY")}
+    payload = {"tool_name": "rag.search", "arguments": {"query": "hello"}}
+
+    response = client.post("/api/v1/mcp/tools/execute", headers=headers, json=payload)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["module"] == "rag"
+    assert body["result"]["content"][0]["type"] == "json"
+    assert body["result"]["content"][0]["json"] == {
+        "ok": True,
+        "tool": "rag.search",
+        "query": "hello",
+    }
+    assert "query" not in body["result"]
+
+
 def test_tools_execute_api_key_scopes_enforced(monkeypatch):
     """
     Ensure /mcp/tools/execute respects API key scopes.

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import UnifiedRAGRequest
+from tldw_Server_API.app.core.RAG.rag_service.transport import (
+    build_source_health_payload,
+    build_unified_pipeline_kwargs,
+)
+
+
+def test_build_unified_pipeline_kwargs_preserves_search_agent_defaults() -> None:
+    request = UnifiedRAGRequest(query="default behavior check")
+
+    kwargs = build_unified_pipeline_kwargs(
+        request=request,
+        db_paths={
+            "media_db_path": None,
+            "notes_db_path": None,
+            "character_db_path": None,
+            "kanban_db_path": None,
+        },
+        media_db=None,
+        chacha_db=None,
+        current_user=None,
+        search_agent_setting_fn=lambda env_key, config_key: {  # noqa: ARG005
+            "SEARCH_QUERY_CLASSIFICATION": "true",
+        }.get(env_key),
+    )
+
+    assert kwargs["enable_query_classification"] is True  # nosec B101
+    assert kwargs["sources"] == ["media_db"]  # nosec B101
+
+
+def test_build_source_health_payload_uses_existing_paths_without_leaking_paths() -> None:
+    payload = build_source_health_payload(
+        current_user=SimpleNamespace(id=1, id_int=1),
+        existing_source_db_paths_fn=lambda *_args, **_kwargs: {"media_db": "/secret/media.db"},
+        media_db_uses_non_file_storage_fn=lambda: False,
+    )
+
+    assert [entry.source_id for entry in payload.sources][:2] == ["media_db", "notes"]  # nosec B101
+    assert "/secret" not in str(payload)  # nosec B101

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import UnifiedRAGRequest
+from tldw_Server_API.app.core.Billing import enforcement as billing_enforcement
 from tldw_Server_API.app.core.RAG.rag_service.transport import (
     build_source_health_payload,
     build_unified_pipeline_kwargs,
+    enforce_rag_query_limit_for_org_context,
+    resolve_org_id_for_rag_context,
 )
 
 
@@ -41,3 +46,61 @@ def test_build_source_health_payload_uses_existing_paths_without_leaking_paths()
 
     assert [entry.source_id for entry in payload.sources][:2] == ["media_db", "notes"]  # nosec B101
     assert "/secret" not in str(payload)  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_resolve_org_id_for_rag_context_uses_request_metadata_and_state() -> None:
+    metadata_context = SimpleNamespace(metadata={"org_id": "42"})
+    state_context = SimpleNamespace(state=SimpleNamespace(org_ids=[7]))
+
+    assert await resolve_org_id_for_rag_context(request_like=metadata_context) == 42  # nosec B101
+    assert await resolve_org_id_for_rag_context(request_like=state_context) == 7  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_enforce_rag_query_limit_for_org_context_uses_rag_daily_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeEnforcer:
+        async def check_limit(self, org_id, category, *, requested_units):  # noqa: ANN001
+            captured.update(
+                {
+                    "org_id": org_id,
+                    "category": category,
+                    "requested_units": requested_units,
+                }
+            )
+            return SimpleNamespace(should_block=False, message=None)
+
+    monkeypatch.setattr(billing_enforcement, "enforcement_enabled", lambda: True)
+    monkeypatch.setattr(billing_enforcement, "get_billing_enforcer", lambda: FakeEnforcer())
+
+    await enforce_rag_query_limit_for_org_context(
+        request_like=SimpleNamespace(metadata={"org_id": 55}),
+        units=3,
+    )
+
+    assert captured == {  # nosec B101
+        "org_id": 55,
+        "category": billing_enforcement.LimitCategory.RAG_QUERIES_DAY,
+        "requested_units": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_enforce_rag_query_limit_for_org_context_raises_when_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class BlockingEnforcer:
+        async def check_limit(self, org_id, category, *, requested_units):  # noqa: ANN001
+            del org_id, category, requested_units
+            return SimpleNamespace(should_block=True, message="RAG query daily limit exceeded")
+
+    monkeypatch.setattr(billing_enforcement, "enforcement_enabled", lambda: True)
+    monkeypatch.setattr(billing_enforcement, "get_billing_enforcer", lambda: BlockingEnforcer())
+
+    with pytest.raises(PermissionError, match="daily limit"):
+        await enforce_rag_query_limit_for_org_context(
+            request_like=SimpleNamespace(metadata={"org_id": 55}),
+            units=1,
+        )

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py
@@ -13,6 +13,8 @@ from tldw_Server_API.app.core.RAG.rag_service.transport import (
     resolve_org_id_for_rag_context,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def test_build_unified_pipeline_kwargs_preserves_search_agent_defaults() -> None:
     request = UnifiedRAGRequest(query="default behavior check")
@@ -48,16 +50,52 @@ def test_build_source_health_payload_uses_existing_paths_without_leaking_paths()
     assert "/secret" not in str(payload)  # nosec B101
 
 
-@pytest.mark.asyncio
-async def test_resolve_org_id_for_rag_context_uses_request_metadata_and_state() -> None:
-    metadata_context = SimpleNamespace(metadata={"org_id": "42"})
+async def test_resolve_org_id_for_rag_context_uses_request_state_without_membership() -> None:
     state_context = SimpleNamespace(state=SimpleNamespace(org_ids=[7]))
 
-    assert await resolve_org_id_for_rag_context(request_like=metadata_context) == 42  # nosec B101
     assert await resolve_org_id_for_rag_context(request_like=state_context) == 7  # nosec B101
 
 
-@pytest.mark.asyncio
+async def test_resolve_org_id_for_rag_context_verifies_metadata_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeRepo:
+        def __init__(self, db_pool):  # noqa: ANN001
+            del db_pool
+
+        async def list_org_memberships_for_user(self, user_id):  # noqa: ANN001
+            assert user_id == 1  # nosec B101
+            return [
+                {"org_id": 42, "status": "active"},
+                {"org_id": 99, "status": "inactive"},
+            ]
+
+    async def fake_pool():
+        return object()
+
+    monkeypatch.setattr("tldw_Server_API.app.core.AuthNZ.database.get_db_pool", fake_pool)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo.AuthnzOrgsTeamsRepo",
+        FakeRepo,
+    )
+
+    current_user = SimpleNamespace(id_int=1)
+
+    assert await resolve_org_id_for_rag_context(  # nosec B101
+        request_like=SimpleNamespace(metadata={"org_id": "42"}),
+        current_user=current_user,
+    ) == 42
+    assert await resolve_org_id_for_rag_context(  # nosec B101
+        request_like=SimpleNamespace(metadata={"org_id": "99"}),
+        current_user=current_user,
+    ) == 42
+    assert await resolve_org_id_for_rag_context(  # nosec B101
+        request_like=SimpleNamespace(org_id=42),
+        current_user=current_user,
+    ) == 42
+    assert await resolve_org_id_for_rag_context(  # nosec B101
+        request_like=SimpleNamespace(metadata={"org_id": "42"}),
+    ) is None
+
+
 async def test_enforce_rag_query_limit_for_org_context_uses_rag_daily_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
@@ -76,7 +114,7 @@ async def test_enforce_rag_query_limit_for_org_context_uses_rag_daily_limit(monk
     monkeypatch.setattr(billing_enforcement, "get_billing_enforcer", lambda: FakeEnforcer())
 
     await enforce_rag_query_limit_for_org_context(
-        request_like=SimpleNamespace(metadata={"org_id": 55}),
+        request_like=SimpleNamespace(state=SimpleNamespace(org_id=55)),
         units=3,
     )
 
@@ -87,7 +125,6 @@ async def test_enforce_rag_query_limit_for_org_context_uses_rag_daily_limit(monk
     }
 
 
-@pytest.mark.asyncio
 async def test_enforce_rag_query_limit_for_org_context_raises_when_blocked(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -101,6 +138,6 @@ async def test_enforce_rag_query_limit_for_org_context_raises_when_blocked(
 
     with pytest.raises(PermissionError, match="daily limit"):
         await enforce_rag_query_limit_for_org_context(
-            request_like=SimpleNamespace(metadata={"org_id": 55}),
+            request_like=SimpleNamespace(state=SimpleNamespace(org_id=55)),
             units=1,
         )


### PR DESCRIPTION
## Summary
- Adds the first-slice `rag.*` MCP module: `rag.capabilities`, `rag.source_health`, `rag.search`, and `rag.answer`.
- Reuses the unified RAG transport/pipeline while adding MCP normalization, strict schemas, source authorization, quota/rate controls, and safe response compaction.
- Registers MCP module/tool/governance config and documents usage without adding a `research.*` layer.

## Review Follow-Up
- Hardened default RAG MCP controls so direct module use enforces protocol RBAC/read-scope/source permission checks.
- Forced MCP-safe RAG overrides to disable search-agent quality mode, query classification, research loops, and web fallback paths.
- Redacted raw document/response metadata and changed `rag.source_health` to an `ok`/warnings contract.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_rag_module.py tldw_Server_API/app/core/MCP_unified/tests/test_rag_module_registration.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py tldw_Server_API/tests/MCP_unified/test_mcp_knowledge_rbac.py tldw_Server_API/app/core/MCP_unified/tests/test_knowledge_search_defaults.py tldw_Server_API/tests/RAG_NEW/unit/test_rag_transport_helpers.py tldw_Server_API/tests/RAG_NEW/unit/test_rag_unified_search_agent_defaults.py tldw_Server_API/tests/RAG_NEW/integration/test_rag_source_health_endpoint.py`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/rag_module.py -f json -o /tmp/bandit_rag_mcp_review_fixes_continue.json`

## Change Summary Merge Gate
This PR is materially AI-authored. A human requester must add a human-written Change summary explaining what changed and why before this PR is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new MCP `rag.*` module for safe retrieval and grounded answers on the existing RAG pipeline, with tighter auth, org-scoped quotas, and shared transport helpers. Updates configs, docs, and tests; preserves MCP JSON content wrapping.

- **New Features**
  - Added `rag.capabilities`, `rag.source_health`, `rag.search`, and `rag.answer`.
  - Normalizes sources via the existing registry; strict schemas.
  - Enforces protocol RBAC/read scopes and source permission checks; catalog membership does not grant execution.
  - Org-scoped quotas and categories: `rag.search` → `search`, `rag.answer` → `rag_generation`; policies `mcp.search` (60 rpm) and `mcp.rag_generation` (30 rpm, `fail_mode: fallback_memory`); defaults `max_documents=6`, `max_content_chars=2000`.
  - Compacts responses and redacts raw metadata; `source_health` returns `ok` plus warnings.
  - Hardened MCP defaults: disabled search-agent quality mode, query classification, research loops, and web fallbacks.
  - Docs add JSON-RPC examples and a `library-rag` catalog recommendation.

- **Refactors**
  - Extracted transport-neutral helpers in `tldw_Server_API.app.core.RAG.rag_service.transport`; reused by HTTP and MCP for request resolution, quotas, and source-health payloads.
  - Simplified `rag_unified.py`; added `rag` risk tier and updated runtime allowlist for `rag_generation`.
  - Expanded tests for module registration/execution, catalog filtering and non-privilege, transport helpers, quotas/defaults, and preserving MCP JSON content wrappers.

<sup>Written for commit 92367194b736e3e3e43e6898af5f92d9b80e6fbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

