### PR TITLE
fix(e2e): repair UX Smoke Gate theme-toggle test (red since Jul 1)

### DIFF
--- a/apps/tldw-frontend/e2e/smoke/stage6-interaction-stage1.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/stage6-interaction-stage1.spec.ts
@@ -51,12 +51,12 @@ test.describe("Stage 6 interaction stage 1 defect closures", () => {
     expect(bodyText).not.toContain("{{percentage}}")
   })
 
-  test("chat route exposes an explicit theme toggle control", async ({
+  test("home route exposes an explicit theme toggle control", async ({
     page
   }) => {
     await prepareChatRoute(page)
 
-    await page.goto("/chat", {
+    await page.goto("/", {
       waitUntil: "domcontentloaded",
       timeout: LOAD_TIMEOUT
     })

--- a/backlog/tasks/task-12117 - Fix-PR-2571-release-CI-failures.md
+++ b/backlog/tasks/task-12117 - Fix-PR-2571-release-CI-failures.md
@@ -42,6 +42,8 @@ Addressed the current 96 CodeQL annotations from check-run 84944194830. Existing
 
 After push, the GitHub code scanning alert gate still surfaced 95 open CodeQL alerts that were not cleared by inline comments. Reviewed and dismissed the PR-associated false-positive/test-only CodeQL alerts in GitHub code scanning; zero open PR CodeQL alerts remain. Also fixed the stale UX smoke assertion that expected the chat header theme toggle on the new Companion Home route by moving that check to `/chat`, where the shared chat header is actually rendered.
 
+Follow-up resolution (fix/ux-smoke-theme-toggle-route): the `/chat` retarget could never pass (the cockpit layout suppresses the classic header entirely); the real regression was `_app.tsx` treating sessions as unauthenticated after the runtime bootstrap moved the stored API key into the in-memory runtime override, which hid the header shell on every route. Fixed `_app.tsx` to count runtime auth material as authenticated and moved the theme-toggle smoke check back to `/` (verified green locally with the full stage6 pair).
+
 Updated CHANGELOG.md release entry for 0.1.34 to cover work that landed after the release metadata push: PRs #2570, #2573, #2575, #2576, #2565, #2578, #2316, #2579, and PR #2571 release-stabilization/CodeQL follow-ups. No version bump was made because pyproject.toml is already prepped as 0.1.34 for this release.
 <!-- SECTION:NOTES:END -->
 

--- a/backlog/tasks/task-12119 - Rebase-PR-2589-onto-latest-dev.md
+++ b/backlog/tasks/task-12119 - Rebase-PR-2589-onto-latest-dev.md
@@ -1,0 +1,45 @@
+---
+id: TASK-12119
+title: Rebase PR 2589 onto latest dev
+status: Done
+labels:
+- pr-rebase
+references:
+- https://github.com/rmusser01/tldw_server/pull/2589
+modified_files:
+- apps/tldw-frontend/e2e/smoke/stage6-interaction-stage1.spec.ts
+- backlog/tasks/task-12117 - Fix-PR-2571-release-CI-failures.md
+- backlog/tasks/task-12119 - Rebase-PR-2589-onto-latest-dev.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve merge conflicts on PR #2589 (`fix/ux-smoke-theme-toggle-route`) and rebase it onto the latest `dev` branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR #2589 is rebased onto latest `dev`. Conflict resolution kept `dev`'s existing runtime-auth shell fix/unit coverage and preserved the smoke test change that checks the theme toggle on `/` instead of `/chat`. Verification: `bunx vitest run __tests__/app/app-layout.test.tsx` passed 17/17, and `npx playwright test e2e/smoke/stage6-interaction-stage1.spec.ts --reporter=line --grep "home route exposes"` passed 1/1. Bandit skipped: touched code is frontend TypeScript/test markdown only, no Python scope.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Root-cause chain (three acts)

1. **Jul 1 — credential hardening (still live).** The web runtime bootstrap (`apps/tldw-frontend/extension/shims/runtime-bootstrap.ts`, `seedTldwConfigFromEnv`) captures a stored single-user API key into an in-memory runtime override (`setRuntimeApiKey` / `setRuntimeSingleUserApiKeyOverride`) and then strips `apiKey`/`accessToken` from the persisted `tldwConfig`. (The `useConfig.tsx` wiper deleted on Jul 2 was only part of this hardening; the bootstrap half remained.)
2. **The shell auth gate never learned about the override.** `pages/_app.tsx` hides the entire header/sidebar shell when `!isAuthenticated`, but `getConfiguredAuthState()` only inspects `config.apiKey` (now stripped) and `hasEnvApiAuth()` only inspects build-time `NEXT_PUBLIC_X_API_KEY`/`NEXT_PUBLIC_API_BEARER` (unset in the smoke bundle). Result: under the smoke suite's seeded auth, **every route rendered header-less**, so `chat-header-theme-toggle` could not appear anywhere — verified locally on `/`, `/chat`, and `/media` (API requests all succeed via the override; only the shell gating was wrong).
3. **Jul 3 — the home→`/chat` retarget could never pass** regardless: the `/chat` cockpit layout suppresses the classic `Layouts/Header` entirely.

## Fix

- `pages/_app.tsx`: count runtime auth material (`getRuntimeApiKey()` / `getRuntimeApiBearer()`) as environment-provided auth — the missing half of the Jul-1 hardening.
- `e2e/smoke/stage6-interaction-stage1.spec.ts`: revert the Jul-3 retarget; the test is again "home route exposes an explicit theme toggle control" on `goto("/")` with the same unweakened assertion.
- `backlog/tasks/task-12117`: noted the final resolution.

## Verified locally (CI-mirrored stack)

Backend via `server_lifecycle.py start` with the smoke-gate job env (fresh single-user DB, `SINGLE_USER_API_KEY=smoke-ci-key-12345`), mock OpenAI on :18080, `bun run build:prod` + staged standalone assets, web served by the workflow's `TLDW_WEB_CMD` standalone server on :8080.

Full gate-mirroring run of the stage6 pair:

```
bunx playwright test e2e/smoke/stage6-interaction-stage1.spec.ts e2e/smoke/stage6-interaction-stage2.spec.ts --reporter=line
  6 passed (4.8s)
```

Also green with the app change: stage4 axe (31 passed, 1 skipped), stage5 release gate (14 passed), and the related unit suites (`app-layout`, `app-networking-guard`, `runtime-bootstrap`, `api.credentials` — 56 passed).

The UX Smoke Gate should go green on the next dev run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red UX Smoke Gate theme-toggle test by treating runtime API credentials as authenticated so the shell renders, and by checking the toggle on the home route. Restores the expected UI and unblocks CI.

- **Bug Fixes**
  - `pages/_app.tsx`: count `getRuntimeApiKey()` and `getRuntimeApiBearer()` as environment auth so single-user sessions render the header/sidebar.
  - `e2e/smoke/stage6-interaction-stage1.spec.ts`: assert the theme toggle on `/` instead of `/chat` (cockpit hides the classic header).
  - `__tests__/app/app-layout.test.tsx`: add regression test to ensure runtime-override credentials are treated as authenticated for shell chrome.

<sup>Written for commit c0a5ba438c2d2f0f2926358ee6a3fe9fb9a7ec93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

