### PR TITLE
Avoid librosa in Parakeet ONNX STT path

### DIFF
--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -3111,8 +3111,27 @@ def speech_to_text_parakeet(
         )
         audio_data, sample_rate, audio_duration = _load_audio_for_parakeet_nemo(audio_file_path, target_sr=16000)
 
+        transcribe_kwargs: dict[str, Any] = {}
+        if variant == "onnx":
+            try:
+                stt_cfg = get_stt_config() or {}
+            except _AUDIO_TRANSCRIPTION_NONCRITICAL_EXCEPTIONS:
+                stt_cfg = {}
+
+            chunk_duration = _coerce_float(stt_cfg.get("nemo_chunk_duration"), default=120.0)
+            if chunk_duration is not None and chunk_duration > 0:
+                overlap_duration = _coerce_float(stt_cfg.get("nemo_overlap_duration"), default=15.0)
+                if overlap_duration is None or overlap_duration < 0:
+                    overlap_duration = 15.0
+                if overlap_duration >= chunk_duration:
+                    overlap_duration = max(0.0, chunk_duration / 8.0)
+                transcribe_kwargs = {
+                    "chunk_duration": chunk_duration,
+                    "overlap_duration": overlap_duration,
+                }
+
         # Transcribe with Parakeet
-        text = transcribe_with_parakeet(audio_data, sample_rate, variant)
+        text = transcribe_with_parakeet(audio_data, sample_rate, variant, **transcribe_kwargs)
         if isinstance(text, str) and _looks_like_error_text(text):
             raise STTTranscriptionError(text)
 

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -355,9 +355,31 @@ def _load_audio_for_parakeet_nemo(audio_file_path: str, target_sr: int = 16000) 
         audio_data, sample_rate = sf.read(audio_file_path, dtype="float32", always_2d=False)
     except Exception as exc:
         logging.debug(f"Soundfile could not load Parakeet audio: {type(exc).__name__}")
-        raise STTTranscriptionError(
-            "Parakeet audio loading failed; convert the input to a WAV-compatible format before transcription."
-        ) from exc
+        if Path(audio_file_path).suffix.lower() == ".wav":
+            raise STTTranscriptionError(
+                "Parakeet audio loading failed; convert the input to a WAV-compatible format before transcription."
+            ) from exc
+
+        try:
+            wav_file_path = convert_to_wav(audio_file_path, overwrite=True)
+        except Exception as conversion_exc:
+            logging.debug(f"Parakeet WAV conversion failed: {type(conversion_exc).__name__}")
+            raise STTTranscriptionError(
+                "Parakeet audio loading failed: WAV conversion failed for compressed input."
+            ) from conversion_exc
+
+        if not wav_file_path or Path(wav_file_path).suffix.lower() != ".wav" or not Path(wav_file_path).exists():
+            raise STTTranscriptionError(
+                "Parakeet audio loading failed: WAV conversion did not produce a usable WAV file."
+            ) from exc
+
+        try:
+            audio_data, sample_rate = sf.read(wav_file_path, dtype="float32", always_2d=False)
+        except Exception as retry_exc:
+            logging.debug(f"Soundfile could not load converted Parakeet WAV: {type(retry_exc).__name__}")
+            raise STTTranscriptionError(
+                "Parakeet audio loading failed after WAV conversion."
+            ) from retry_exc
 
     sample_rate = int(sample_rate)
     if sample_rate <= 0:

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -19,6 +19,7 @@ import hashlib
 import importlib
 import inspect
 import json
+import math
 import multiprocessing
 import os
 import queue
@@ -147,7 +148,7 @@ def _get_original_whisper_model() -> Any | None:
     _ORIGINAL_WHISPER_MODEL_IMPORT_ATTEMPTED = True
     try:
         module = importlib.import_module("faster_whisper")
-        _ORIGINAL_WHISPER_MODEL = getattr(module, "WhisperModel")
+        _ORIGINAL_WHISPER_MODEL = module.WhisperModel
         _ORIGINAL_WHISPER_MODEL_IMPORT_ERROR = None
     except Exception as exc:
         _ORIGINAL_WHISPER_MODEL_IMPORT_ERROR = exc
@@ -171,8 +172,8 @@ def _get_qwen2audio_classes() -> tuple[Any, Any] | None:
     try:
         module = importlib.import_module("transformers")
         _QWEN2AUDIO_CLASSES = (
-            getattr(module, "AutoProcessor"),
-            getattr(module, "Qwen2AudioForConditionalGeneration"),
+            module.AutoProcessor,
+            module.Qwen2AudioForConditionalGeneration,
         )
         _QWEN2AUDIO_IMPORT_ERROR = None
     except Exception as exc:
@@ -315,6 +316,65 @@ def _resample_audio_if_needed(audio: np.ndarray, sample_rate: int, target_sr: in
         x_old = np.linspace(0.0, 1.0, num=len(audio), endpoint=False)
         x_new = np.linspace(0.0, 1.0, num=new_len, endpoint=False)
         return np.interp(x_new, x_old, audio).astype(np.float32, copy=False)
+
+
+def _resample_audio_without_librosa(audio: np.ndarray, sample_rate: int, target_sr: int = 16000) -> np.ndarray:
+    """Return mono float32 audio at target_sr without importing librosa."""
+    if sample_rate == target_sr:
+        return audio.astype(np.float32, copy=False)
+
+    try:
+        from scipy import signal
+
+        divisor = math.gcd(int(sample_rate), int(target_sr))
+        up = int(target_sr) // divisor
+        down = int(sample_rate) // divisor
+        return signal.resample_poly(audio, up, down).astype(np.float32, copy=False)
+    except ImportError as exc:
+        logging.debug(f"SciPy unavailable for Parakeet resampling; using linear fallback: {exc}")
+    except _AUDIO_TRANSCRIPTION_NONCRITICAL_EXCEPTIONS as exc:
+        logging.debug(f"Polyphase Parakeet resampling failed; using linear fallback: {type(exc).__name__}")
+
+    ratio = float(target_sr) / float(sample_rate)
+    new_len = max(1, int(round(len(audio) * ratio)))
+    x_old = np.linspace(0.0, 1.0, num=len(audio), endpoint=False)
+    x_new = np.linspace(0.0, 1.0, num=new_len, endpoint=False)
+    return np.interp(x_new, x_old, audio).astype(np.float32, copy=False)
+
+
+def _load_audio_for_parakeet_nemo(audio_file_path: str, target_sr: int = 16000) -> tuple[np.ndarray, int, float]:
+    """Load file audio for Nemo-backed Parakeet variants without importing librosa."""
+    try:
+        import soundfile as sf
+    except ImportError as exc:
+        raise STTTranscriptionError("Parakeet audio loading requires the soundfile package.") from exc
+
+    try:
+        audio_data, sample_rate = sf.read(audio_file_path, dtype="float32", always_2d=False)
+    except _AUDIO_TRANSCRIPTION_NONCRITICAL_EXCEPTIONS as exc:
+        logging.debug(f"Soundfile could not load Parakeet audio: {type(exc).__name__}")
+        raise STTTranscriptionError(
+            "Parakeet audio loading failed; convert the input to a WAV-compatible format before transcription."
+        ) from exc
+
+    sample_rate = int(sample_rate)
+    if sample_rate <= 0:
+        raise STTTranscriptionError("Parakeet audio loading failed: invalid sample rate.")
+
+    audio_np = np.asarray(audio_data, dtype=np.float32)
+    if audio_np.ndim == 0:
+        audio_np = audio_np.reshape(1)
+    elif audio_np.ndim == 2:
+        audio_np = audio_np.mean(axis=1).astype(np.float32, copy=False)
+    elif audio_np.ndim > 2:
+        raise STTTranscriptionError("Parakeet audio loading failed: unsupported channel layout.")
+
+    if audio_np.size == 0:
+        raise STTTranscriptionError("Parakeet audio loading failed: audio file contains no samples.")
+
+    audio_duration = float(audio_np.shape[0]) / float(sample_rate)
+    audio_np = _resample_audio_without_librosa(audio_np, sample_rate, target_sr=target_sr)
+    return np.ascontiguousarray(audio_np, dtype=np.float32), target_sr, audio_duration
 
 
 def _resolve_project_root() -> Path:
@@ -2906,13 +2966,7 @@ def speech_to_text_parakeet(
         )
         audio_file_path = str(audio_path)
 
-        # Get audio duration for segment creation
-        try:
-            import librosa
-            audio_duration = librosa.get_duration(path=audio_file_path)
-        except _AUDIO_TRANSCRIPTION_NONCRITICAL_EXCEPTIONS:
-            audio_duration = None
-            logging.warning("Could not determine audio duration")
+        audio_duration = None
 
         # Route to appropriate Parakeet implementation
         if variant == "mlx":
@@ -2940,6 +2994,16 @@ def speech_to_text_parakeet(
                     mlx_sentence_max_words = _coerce_int(stt_cfg.get("mlx_sentence_max_words"))
                     mlx_sentence_silence_gap = _coerce_float(stt_cfg.get("mlx_sentence_silence_gap"))
                     mlx_sentence_max_duration = _coerce_float(stt_cfg.get("mlx_sentence_max_duration"))
+
+                    # MLX chunking still relies on file-level duration and its
+                    # existing tests patch librosa here. Keep this isolated to
+                    # the MLX branch so ONNX does not pay librosa import cost.
+                    try:
+                        import librosa
+                        audio_duration = librosa.get_duration(path=audio_file_path)
+                    except _AUDIO_TRANSCRIPTION_NONCRITICAL_EXCEPTIONS:
+                        audio_duration = None
+                        logging.warning("Could not determine audio duration")
 
                     chunk_duration = _coerce_float(raw_chunk_duration)
                     if chunk_duration is None:
@@ -3042,13 +3106,10 @@ def speech_to_text_parakeet(
                 variant = "standard"
 
         # For other variants or fallback, use Nemo implementation
-        import librosa
-
-        # Load audio data for Nemo implementation
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
             transcribe_with_parakeet,
         )
-        audio_data, sample_rate = librosa.load(audio_file_path, sr=16000, mono=True)
+        audio_data, sample_rate, audio_duration = _load_audio_for_parakeet_nemo(audio_file_path, target_sr=16000)
 
         # Transcribe with Parakeet
         text = transcribe_with_parakeet(audio_data, sample_rate, variant)

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -329,7 +329,9 @@ def _resample_audio_without_librosa(audio: np.ndarray, sample_rate: int, target_
         divisor = math.gcd(int(sample_rate), int(target_sr))
         up = int(target_sr) // divisor
         down = int(sample_rate) // divisor
-        return signal.resample_poly(audio, up, down).astype(np.float32, copy=False)
+        if up <= 1000 and down <= 1000:
+            return signal.resample_poly(audio, up, down).astype(np.float32, copy=False)
+        logging.debug(f"Polyphase Parakeet resampling factors too large (up={up}, down={down}); using linear fallback.")
     except ImportError as exc:
         logging.debug(f"SciPy unavailable for Parakeet resampling; using linear fallback: {exc}")
     except _AUDIO_TRANSCRIPTION_NONCRITICAL_EXCEPTIONS as exc:
@@ -337,8 +339,8 @@ def _resample_audio_without_librosa(audio: np.ndarray, sample_rate: int, target_
 
     ratio = float(target_sr) / float(sample_rate)
     new_len = max(1, int(round(len(audio) * ratio)))
-    x_old = np.linspace(0.0, 1.0, num=len(audio), endpoint=False)
-    x_new = np.linspace(0.0, 1.0, num=new_len, endpoint=False)
+    x_old = np.linspace(0.0, 1.0, num=len(audio), endpoint=False, dtype=np.float32)
+    x_new = np.linspace(0.0, 1.0, num=new_len, endpoint=False, dtype=np.float32)
     return np.interp(x_new, x_old, audio).astype(np.float32, copy=False)
 
 
@@ -351,7 +353,7 @@ def _load_audio_for_parakeet_nemo(audio_file_path: str, target_sr: int = 16000) 
 
     try:
         audio_data, sample_rate = sf.read(audio_file_path, dtype="float32", always_2d=False)
-    except _AUDIO_TRANSCRIPTION_NONCRITICAL_EXCEPTIONS as exc:
+    except Exception as exc:
         logging.debug(f"Soundfile could not load Parakeet audio: {type(exc).__name__}")
         raise STTTranscriptionError(
             "Parakeet audio loading failed; convert the input to a WAV-compatible format before transcription."

--- a/tldw_Server_API/app/core/config.py
+++ b/tldw_Server_API/app/core/config.py
@@ -4405,6 +4405,8 @@ def load_and_log_configs():
             or 'istupakov/parakeet-tdt-0.6b-v3-onnx'
         )
         parakeet_onnx_revision = _get_str('STT-Settings', 'parakeet_onnx_revision', None)
+        nemo_chunk_duration = _get_float('STT-Settings', 'nemo_chunk_duration', 120.0)
+        nemo_overlap_duration = _get_float('STT-Settings', 'nemo_overlap_duration', 15.0)
         mlx_chunk_duration = _get_float('STT-Settings', 'mlx_chunk_duration', 30.0)
         mlx_overlap_duration = _get_float('STT-Settings', 'mlx_overlap_duration', 5.0)
         buffered_chunk_duration = _get_float('STT-Settings', 'buffered_chunk_duration', mlx_chunk_duration)
@@ -5281,6 +5283,8 @@ def load_and_log_configs():
                 'nemo_model_variant': nemo_model_variant,
                 'nemo_device': nemo_device,
                 'nemo_cache_dir': nemo_cache_dir,
+                'nemo_chunk_duration': nemo_chunk_duration,
+                'nemo_overlap_duration': nemo_overlap_duration,
                 'streaming_fallback_to_whisper': streaming_fallback_to_whisper,
                 'parakeet_onnx_model_id': parakeet_onnx_model_id,
                 'parakeet_onnx_revision': parakeet_onnx_revision,
@@ -5334,6 +5338,8 @@ def load_and_log_configs():
                 'nemo_model_variant': nemo_model_variant,
                 'nemo_device': nemo_device,
                 'nemo_cache_dir': nemo_cache_dir,
+                'nemo_chunk_duration': nemo_chunk_duration,
+                'nemo_overlap_duration': nemo_overlap_duration,
                 'streaming_fallback_to_whisper': streaming_fallback_to_whisper,
                 'parakeet_onnx_model_id': parakeet_onnx_model_id,
                 'parakeet_onnx_revision': parakeet_onnx_revision,

--- a/tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py
+++ b/tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py
@@ -3,6 +3,7 @@
 import importlib.machinery
 import sys
 import types
+import wave
 
 import numpy as np
 import pytest
@@ -49,6 +50,22 @@ if "transformers" not in sys.modules:
 import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
 
 
+def _write_test_wav(audio_file, *, sample_rate=16000, duration_seconds=0.25, channels=1):
+    frame_count = int(sample_rate * duration_seconds)
+    mono = 0.1 * np.sin(2.0 * np.pi * 440.0 * np.arange(frame_count) / sample_rate)
+    if channels == 1:
+        audio = mono[:, np.newaxis]
+    else:
+        audio = np.tile(mono[:, np.newaxis], (1, channels))
+    pcm_i16 = np.clip(audio * 32767.0, -32768, 32767).astype("<i2")
+
+    with wave.open(str(audio_file), "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm_i16.tobytes())
+
+
 @pytest.mark.unit
 def test_speech_to_text_parakeet_onnx_failure_fails_fast(monkeypatch, tmp_path):
     """Parakeet ONNX failures should surface as STTTranscriptionError."""
@@ -79,13 +96,7 @@ def test_speech_to_text_parakeet_onnx_failure_fails_fast(monkeypatch, tmp_path):
 def test_speech_to_text_parakeet_onnx_error_sentinel_fails_fast(monkeypatch, tmp_path):
     """Parakeet ONNX error sentinel text should not be converted into transcript segments."""
     audio_file = tmp_path / "sample.wav"
-    audio_file.write_bytes(b"\x00" * 2048)
-
-    fake_librosa = types.SimpleNamespace(
-        get_duration=lambda path: 1.0,
-        load=lambda path, sr=16000, mono=True: (np.zeros(1600, dtype=np.float32), sr),
-    )
-    monkeypatch.setitem(sys.modules, "librosa", fake_librosa)
+    _write_test_wav(audio_file)
 
     import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo as nemo_mod
 
@@ -107,3 +118,48 @@ def test_speech_to_text_parakeet_onnx_error_sentinel_fails_fast(monkeypatch, tmp
             vad_filter=False,
         )
     assert str(exc_info.value) == sentinel  # nosec B101
+
+
+@pytest.mark.unit
+def test_speech_to_text_parakeet_onnx_loads_audio_without_librosa(monkeypatch, tmp_path):
+    """Parakeet ONNX should not route file decoding through librosa."""
+    audio_file = tmp_path / "sample.wav"
+    _write_test_wav(audio_file, sample_rate=8000, channels=2)
+
+    fake_librosa = types.SimpleNamespace(
+        get_duration=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("librosa.get_duration should not be used for Parakeet ONNX")
+        ),
+        load=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("librosa.load should not be used for Parakeet ONNX")
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "librosa", fake_librosa)
+
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo as nemo_mod
+
+    captured: dict[str, object] = {}
+
+    def fake_transcribe_with_parakeet(audio_data, received_sample_rate, variant):
+        captured["audio_data"] = audio_data
+        captured["sample_rate"] = received_sample_rate
+        captured["variant"] = variant
+        return "parakeet onnx transcript"
+
+    monkeypatch.setattr(nemo_mod, "transcribe_with_parakeet", fake_transcribe_with_parakeet)
+
+    segments = atlib.speech_to_text_parakeet(
+        str(audio_file),
+        variant="onnx",
+        selected_source_lang="en",
+        vad_filter=False,
+        base_dir=tmp_path,
+    )
+
+    audio_data = captured["audio_data"]
+    assert isinstance(audio_data, np.ndarray)
+    assert audio_data.dtype == np.float32
+    assert audio_data.ndim == 1
+    assert captured["sample_rate"] == 16000
+    assert captured["variant"] == "onnx"
+    assert segments[0]["Text"] == "parakeet onnx transcript"

--- a/tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py
+++ b/tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py
@@ -266,3 +266,67 @@ def test_load_audio_for_parakeet_nemo_wraps_unexpected_soundfile_errors(
 
     with pytest.raises(atlib.STTTranscriptionError, match="audio loading failed"):
         atlib._load_audio_for_parakeet_nemo(str(tmp_path / "input.wav"))
+
+
+@pytest.mark.unit
+def test_load_audio_for_parakeet_nemo_converts_compressed_input_before_retry(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Compressed inputs should be converted to WAV before retrying soundfile."""
+
+    compressed_audio = tmp_path / "input.mp3"
+    compressed_audio.write_bytes(b"not really mp3")
+    converted_audio = tmp_path / "input.wav"
+    expected_audio = np.zeros(16000, dtype=np.float32)
+    read_paths: list[Path] = []
+
+    def fake_read(path, **_kwargs):
+        read_paths.append(Path(path))
+        if Path(path) == compressed_audio:
+            raise RuntimeError("unsupported compressed format")
+        if Path(path) == converted_audio:
+            return expected_audio, 16000
+        raise AssertionError(f"unexpected read path: {path}")
+
+    fake_soundfile = types.SimpleNamespace(read=fake_read)
+    monkeypatch.setitem(sys.modules, "soundfile", fake_soundfile)
+
+    def fake_convert_to_wav(path, *_args, **_kwargs):
+        assert Path(path) == compressed_audio
+        converted_audio.write_bytes(b"fake wav")
+        return str(converted_audio)
+
+    monkeypatch.setattr(atlib, "convert_to_wav", fake_convert_to_wav)
+
+    audio, sample_rate, duration = atlib._load_audio_for_parakeet_nemo(str(compressed_audio))
+
+    assert read_paths == [compressed_audio, converted_audio]
+    assert sample_rate == 16000
+    assert duration == 1.0
+    np.testing.assert_array_equal(audio, expected_audio)
+
+
+@pytest.mark.unit
+def test_load_audio_for_parakeet_nemo_fails_when_wav_conversion_fails(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Failed compressed-input conversion should not retry the original path."""
+
+    compressed_audio = tmp_path / "input.mp3"
+    compressed_audio.write_bytes(b"not really mp3")
+    fake_soundfile = types.SimpleNamespace(
+        read=Mock(side_effect=RuntimeError("unsupported compressed format")),
+    )
+    monkeypatch.setitem(sys.modules, "soundfile", fake_soundfile)
+    monkeypatch.setattr(
+        atlib,
+        "convert_to_wav",
+        Mock(side_effect=atlib.ConversionError("ffmpeg failed")),
+    )
+
+    with pytest.raises(atlib.STTTranscriptionError, match="WAV conversion failed"):
+        atlib._load_audio_for_parakeet_nemo(str(compressed_audio))
+
+    assert fake_soundfile.read.call_count == 1

--- a/tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py
+++ b/tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py
@@ -4,6 +4,8 @@ import importlib.machinery
 import sys
 import types
 import wave
+from pathlib import Path
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -50,7 +52,14 @@ if "transformers" not in sys.modules:
 import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
 
 
-def _write_test_wav(audio_file, *, sample_rate=16000, duration_seconds=0.25, channels=1):
+def _write_test_wav(
+    audio_file: Path,
+    *,
+    sample_rate: int = 16000,
+    duration_seconds: float = 0.25,
+    channels: int = 1,
+) -> None:
+    """Write a small sine-wave PCM WAV fixture for audio-loader tests."""
     frame_count = int(sample_rate * duration_seconds)
     mono = 0.1 * np.sin(2.0 * np.pi * 440.0 * np.arange(frame_count) / sample_rate)
     if channels == 1:
@@ -79,8 +88,10 @@ def test_speech_to_text_parakeet_onnx_failure_fails_fast(monkeypatch, tmp_path):
     monkeypatch.setattr(
         atlib,
         "get_whisper_model",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("Whisper fallback should not run for Parakeet ONNX")
+        Mock(
+            side_effect=AssertionError(
+                "Whisper fallback should not run for Parakeet ONNX"
+            )
         ),
     )
 
@@ -127,11 +138,15 @@ def test_speech_to_text_parakeet_onnx_loads_audio_without_librosa(monkeypatch, t
     _write_test_wav(audio_file, sample_rate=8000, channels=2)
 
     fake_librosa = types.SimpleNamespace(
-        get_duration=lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("librosa.get_duration should not be used for Parakeet ONNX")
+        get_duration=Mock(
+            side_effect=AssertionError(
+                "librosa.get_duration should not be used for Parakeet ONNX"
+            )
         ),
-        load=lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("librosa.load should not be used for Parakeet ONNX")
+        load=Mock(
+            side_effect=AssertionError(
+                "librosa.load should not be used for Parakeet ONNX"
+            )
         ),
     )
     monkeypatch.setitem(sys.modules, "librosa", fake_librosa)
@@ -210,3 +225,44 @@ def test_speech_to_text_parakeet_onnx_passes_configured_chunking(monkeypatch, tm
         "overlap_duration": 0.25,
     }
     assert segments[0]["Text"] == "chunked parakeet onnx transcript"
+
+
+@pytest.mark.unit
+def test_parakeet_onnx_resample_uses_linear_fallback_for_large_polyphase(
+    monkeypatch,
+) -> None:
+    """Pathological sample-rate ratios should not call SciPy polyphase resampling."""
+
+    class FakeSignal:
+        """Signal module stand-in that fails if polyphase resampling is used."""
+
+        @staticmethod
+        def resample_poly(*_args, **_kwargs):
+            raise AssertionError("resample_poly should not be called")
+
+    monkeypatch.setitem(sys.modules, "scipy", types.SimpleNamespace(signal=FakeSignal))
+    audio = np.linspace(-0.25, 0.25, num=44101, endpoint=False, dtype=np.float32)
+
+    result = atlib._resample_audio_without_librosa(audio, sample_rate=44101, target_sr=16000)
+
+    assert result.dtype == np.float32
+    assert result.shape == (16000,)
+
+
+@pytest.mark.unit
+def test_load_audio_for_parakeet_nemo_wraps_unexpected_soundfile_errors(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Unexpected soundfile failures should be converted to STTTranscriptionError."""
+
+    class CustomAudioLoadError(Exception):
+        """Non-standard soundfile failure used to exercise broad wrapping."""
+
+    fake_soundfile = types.SimpleNamespace(
+        read=Mock(side_effect=CustomAudioLoadError("decoder exploded")),
+    )
+    monkeypatch.setitem(sys.modules, "soundfile", fake_soundfile)
+
+    with pytest.raises(atlib.STTTranscriptionError, match="audio loading failed"):
+        atlib._load_audio_for_parakeet_nemo(str(tmp_path / "input.wav"))

--- a/tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py
+++ b/tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py
@@ -140,10 +140,11 @@ def test_speech_to_text_parakeet_onnx_loads_audio_without_librosa(monkeypatch, t
 
     captured: dict[str, object] = {}
 
-    def fake_transcribe_with_parakeet(audio_data, received_sample_rate, variant):
+    def fake_transcribe_with_parakeet(audio_data, received_sample_rate, variant, **kwargs):
         captured["audio_data"] = audio_data
         captured["sample_rate"] = received_sample_rate
         captured["variant"] = variant
+        captured["kwargs"] = kwargs
         return "parakeet onnx transcript"
 
     monkeypatch.setattr(nemo_mod, "transcribe_with_parakeet", fake_transcribe_with_parakeet)
@@ -163,3 +164,49 @@ def test_speech_to_text_parakeet_onnx_loads_audio_without_librosa(monkeypatch, t
     assert captured["sample_rate"] == 16000
     assert captured["variant"] == "onnx"
     assert segments[0]["Text"] == "parakeet onnx transcript"
+
+
+@pytest.mark.unit
+def test_speech_to_text_parakeet_onnx_passes_configured_chunking(monkeypatch, tmp_path):
+    """Long-form Parakeet ONNX should receive bounded chunking settings."""
+    audio_file = tmp_path / "sample.wav"
+    _write_test_wav(audio_file, sample_rate=16000, duration_seconds=2.0)
+
+    monkeypatch.setattr(
+        atlib,
+        "get_stt_config",
+        lambda: {
+            "nemo_chunk_duration": 1.0,
+            "nemo_overlap_duration": 0.25,
+        },
+    )
+
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo as nemo_mod
+
+    captured: dict[str, object] = {}
+
+    def fake_transcribe_with_parakeet(audio_data, received_sample_rate, variant, **kwargs):
+        captured["audio_data"] = audio_data
+        captured["sample_rate"] = received_sample_rate
+        captured["variant"] = variant
+        captured["kwargs"] = kwargs
+        return "chunked parakeet onnx transcript"
+
+    monkeypatch.setattr(nemo_mod, "transcribe_with_parakeet", fake_transcribe_with_parakeet)
+
+    segments = atlib.speech_to_text_parakeet(
+        str(audio_file),
+        variant="onnx",
+        selected_source_lang="en",
+        vad_filter=False,
+        base_dir=tmp_path,
+    )
+
+    assert isinstance(captured["audio_data"], np.ndarray)
+    assert captured["sample_rate"] == 16000
+    assert captured["variant"] == "onnx"
+    assert captured["kwargs"] == {
+        "chunk_duration": 1.0,
+        "overlap_duration": 0.25,
+    }
+    assert segments[0]["Text"] == "chunked parakeet onnx transcript"

--- a/tldw_Server_API/tests/Logging/test_config_loading_sections.py
+++ b/tldw_Server_API/tests/Logging/test_config_loading_sections.py
@@ -18,6 +18,10 @@ def test_load_and_log_configs_exposes_stt_default_model_keys():
     assert "default_streaming_transcription_model" in stt
     assert "parakeet_onnx_model_id" in stt
     assert "parakeet_onnx_revision" in stt
+    assert "nemo_chunk_duration" in stt
+    assert "nemo_overlap_duration" in stt
     assert stt["default_batch_transcription_model"] == "parakeet-tdt-0.6b-v3-onnx"
     assert stt["default_streaming_transcription_model"] == "parakeet-tdt-0.6b-v3-onnx"
     assert stt["nemo_model_variant"] == "onnx"
+    assert stt["nemo_chunk_duration"] == 120.0
+    assert stt["nemo_overlap_duration"] == 15.0


### PR DESCRIPTION
## Summary
- Load Nemo-backed Parakeet audio with soundfile/scipy instead of librosa so ONNX avoids the lazy Numba cache stall.
- Keep the existing MLX duration lookup isolated to the MLX branch to preserve chunking behavior.
- Add regression coverage proving Parakeet ONNX decodes/resamples without touching librosa and still fail-fasts backend error sentinels.

## Test Plan
- `python -m pytest tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py -q --basetemp %TEMP%\tldw_pytest_tmp`
- `python -m pytest tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_transcription.py::test_get_whisper_model_respects_compute_type_override tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_transcription.py::test_speech_to_text_qwen2audio_disabled_skips_audio_decode -q --basetemp %TEMP%\tldw_pytest_tmp`
- `NUMBA_CACHE_DIR=%TEMP%\tldw_numba_cache python -m pytest <8 MLX Parakeet chunking tests> -q --basetemp %TEMP%\tldw_pytest_tmp`
- `python -m ruff check tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py`
- `python -m bandit -r tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py -f json -o %TEMP%\bandit_parakeet_audio_loader.json` (reports existing low-severity subprocess findings outside this change)
- High-level CPU ONNX smoke: cold 12.580s / RTF 1.463, warm 1.075s / RTF 0.125 on 8.598s fixture; no librosa import attempts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Parakeet ONNX STT to load/resample audio with `soundfile`/`scipy` instead of `librosa` to avoid lazy `numba` stalls. Add configurable ONNX chunking via `nemo_chunk_duration`/`nemo_overlap_duration`, and retry compressed inputs by converting to WAV when needed.

- **Refactors**
  - Add `_load_audio_for_parakeet_nemo` and `_resample_audio_without_librosa` to return mono float32 at 16 kHz using `scipy.signal.resample_poly` with a linear fallback.
  - Replace ONNX `librosa.load` with the new loader; keep `librosa.get_duration` only in the MLX branch. Read `nemo_chunk_duration` (120s) and `nemo_overlap_duration` (15s) from config for ONNX and pass to `transcribe_with_parakeet`; expose these in `STT-Settings` and numbered provider configs.
  - Minor import cleanups for `faster_whisper` and `transformers`.

- **Bug Fixes**
  - Remove `librosa` from the ONNX path to prevent `numba` cache stalls; stronger audio validation and clearer errors.
  - If `soundfile` fails on non-WAV input, convert to WAV via `convert_to_wav` and retry; fail clearly if conversion/retry fails; wrap unexpected `soundfile` errors.
  - Tests cover: no `librosa` usage in ONNX, resampling linear fallback for extreme ratios, chunking args passed/defaulted, config logging includes new keys, and compressed-input conversion behavior.

<sup>Written for commit 685df0b960d34f82eb0304b839496d4a32e6490a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

