### PR TITLE
Prepare MCP Unified 0.2.0 release

### DIFF
--- a/apps/mcp-unified/pyproject.toml
+++ b/apps/mcp-unified/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unified"
-version = "0.1.1"
+version = "0.2.0"
 description = "Standalone MCP Unified runtime and gateway package boundary."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/apps/mcp-unified/src/mcp_unified/__init__.py
+++ b/apps/mcp-unified/src/mcp_unified/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"

--- a/backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md
+++ b/backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md
@@ -1,0 +1,48 @@
+---
+id: TASK-12118
+title: Prepare MCP Unified 0.2.0 package release
+status: In Progress
+labels:
+- mcp
+- packaging
+- pypi
+- release
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prepare the standalone mcp-unified package for the next PyPI release after the docs corpus/server mounting work landed on main. Bump the package version, run release-candidate checks, publish through TestPyPI first, smoke install, then publish to PyPI after explicit release confirmation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 mcp-unified package version is bumped from 0.1.1 to 0.2.0 before any publish attempt
+- [x] #2 local MCP Unified RC and publish dry-run checks pass from a clean release worktree
+- [ ] #3 TestPyPI publish is triggered only with explicit MCP_UNIFIED_PUBLISH confirmation and smoke-installed successfully
+- [ ] #4 PyPI publish is triggered only after TestPyPI smoke succeeds and final confirmation is explicit
+- [ ] #5 post-publish PyPI smoke install verifies CLI entry points
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verified release prep on the 0.2.0 worktree. Version bumped in apps/mcp-unified/pyproject.toml and apps/mcp-unified/src/mcp_unified/__init__.py. Ran package-boundary tests (47 passed), Ruff on touched package init, full make mcp-unified-rc (RC status ok), make mcp-unified-publish-dry-run (RC status ok), and Bandit on touched code (zero findings).
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Bumps the standalone `mcp-unified` package from `0.1.1` to `0.2.0` after the standalone docs corpus/server mounting work landed on `main`. The package remains `internal-experimental` and `published`; this only updates the distributable version for the next TestPyPI/PyPI release.

## Why

PyPI will reject reusing `0.1.1`, and the docs corpus/server mounting work adds a new standalone package surface. A `0.2.0` pre-1.0 minor bump keeps the next publish distinct and signals the new capability without implying production maturity.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 47 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check apps/mcp-unified/src/mcp_unified/__init__.py` -> clean
- `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-rc` -> RC status ok
- `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run` -> RC status ok
- Generated artifacts: `mcp_unified-0.2.0-py3-none-any.whl`, `mcp_unified-0.2.0.tar.gz`
- Bandit touched-code scan -> zero findings

Backlog: TASK-12118


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `mcp-unified` to 0.2.0 to prepare the standalone package release with the new docs corpus/server mounting capability now on main. Keeps the package internal-experimental and sets a fresh distributable for TestPyPI/PyPI; aligns with TASK-12118.

<sup>Written for commit c551a1a1ef802809f6a922db2e38149c18f0a3b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

