### PR TITLE
Fix workspace source ingest failure codes

### DIFF
--- a/Docs/superpowers/plans/2026-07-03-research-workspace-source-failure-codes.md
+++ b/Docs/superpowers/plans/2026-07-03-research-workspace-source-failure-codes.md
@@ -1,0 +1,19 @@
+# Research Workspace Source Failure Codes Plan
+
+## Stage 1: Regression Tests
+**Goal**: Capture the missing durable reason-code behavior for failed `workspace_source_ingest` jobs.
+**Success Criteria**: Tests fail because the worker exception lacks a stable `failure_code` and status projection hides job `error_code`.
+**Tests**: Add focused worker and source-status API regression tests.
+**Status**: Complete
+
+## Stage 2: Worker And Projection Fix
+**Goal**: Preserve existing source readiness behavior while exposing actionable failure codes for workspace-source jobs.
+**Success Criteria**: Workspace-source missing-media failures carry `workspace_source_media_not_found`, and source status returns that as `status_reason` plus `job.error_code`.
+**Tests**: Focused pytest tests pass.
+**Status**: Complete
+
+## Stage 3: Verification And Closeout
+**Goal**: Verify touched scope, run security scan, and update the Backlog task with the final result.
+**Success Criteria**: Focused tests, `git diff --check`, and Bandit complete without new findings.
+**Tests**: Focused pytest suite and Bandit on touched production files.
+**Status**: Complete

--- a/backlog/tasks/task-12120 - Implement-Research-Workspace-source-ingestion-and-indexing-worker.md
+++ b/backlog/tasks/task-12120 - Implement-Research-Workspace-source-ingestion-and-indexing-worker.md
@@ -1,0 +1,67 @@
+---
+id: TASK-12120
+title: Implement Research Workspace source ingestion and indexing worker
+status: Done
+labels:
+- research-workspace
+- jobs
+- backend
+- ingestion
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/issues/2056
+- https://github.com/rmusser01/tldw_server/pull/2593
+modified_files:
+- tldw_Server_API/app/services/media_ingest_jobs_worker.py
+- tldw_Server_API/app/core/Workspaces/status_projection.py
+- tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+- tldw_Server_API/app/api/v1/endpoints/workspaces.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+- tldw_Server_API/tests/Workspaces/test_workspace_source_status_api.py
+- tldw_Server_API/tests/Workspaces/test_workspace_source_preview_context_api.py
+- Docs/superpowers/plans/2026-07-03-research-workspace-source-failure-codes.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #2056: add a first-class Jobs worker/path for Research Workspace source ingestion and indexing so workspace source lifecycle progress is owned by a supported worker contract instead of ad hoc or unsupported job behavior. Scope includes job type/payload/idempotency, existing-media no-op behavior, status projection, failed-job reason codes, focused backend tests, and documentation/verification evidence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Adding an existing media source to a workspace never creates an unsupported job failure.
+- [x] #2 New source ingestion from WebUI and extension can be tracked through Jobs without hidden failure states.
+- [x] #3 /api/v1/workspaces/{workspace_id}/sources/status reports progress from the first-class worker when active.
+- [x] #4 Failed jobs expose actionable reason_code/message values instead of raw worker implementation errors.
+- [x] #5 Tests cover worker dispatch, idempotent enqueue/retry, existing-media no-op behavior, API status projection, and extension/WebUI handoff.
+- [x] #6 Live validation matrix or task notes include a passing row/evidence for workspace ingestion/indexing worker ownership.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-07-03-research-workspace-source-failure-codes.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2593 on latest origin/dev and addressed all open review feedback. Follow-up fixes: removed the extra asyncio marker from the new unit test, added explicit type annotations to new test helpers/functions, documented new status projection helpers, made MediaIngestJobError.failure_code always present, and sanitized WorkspaceContextResponse.active_jobs error_code values with the same identifier-only/128-character policy. Verification: focused review-fix tests passed (5 tests); nearby worker/status/preview suite passed (40 tests); git diff --check clean; Bandit on touched production files reported zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed or explicitly split/deferred with rationale.
+- [x] #2 Tests or verification recorded.
+- [x] #3 Documentation updated when relevant.
+- [x] #4 Bandit run for touched backend paths or documented skip.
+- [x] #5 Final summary added.
+- [x] #6 Known skips or blockers documented.
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -135,6 +135,9 @@ from tldw_Server_API.app.core.exceptions import WorkspaceArtifactExportStateErro
 router = APIRouter()
 
 WORKSPACE_ACTIVE_JOB_STATUSES = {"queued", "processing", "running", "retrying"}
+JOB_ERROR_CODE_ALLOWED_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
+)
 
 
 def get_workspace_sandbox_volume_service() -> SandboxWorkspaceVolumeService:
@@ -524,8 +527,23 @@ def _job_status_payload(job: dict[str, Any]) -> dict[str, Any]:
         "job_type": job.get("job_type"),
         "progress_percent": job.get("progress_percent"),
         "progress_message": job.get("progress_message"),
+        "error_code": _safe_job_error_code(job.get("error_code")),
         "error_message": job.get("error_message"),
     }
+
+
+def _safe_job_error_code(value: Any) -> str | None:
+    """Return an API-safe Jobs error code for workspace job summaries.
+
+    Error codes are public identifiers, not free-form error text. Only
+    non-empty `[A-Za-z0-9_.-]` values are exposed, capped to 128 characters.
+    """
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    if any(char not in JOB_ERROR_CODE_ALLOWED_CHARS for char in raw):
+        return None
+    return raw[:128]
 
 
 def _workspace_file_inventory_job_status(job: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -516,6 +516,7 @@ class WorkspaceSourceJobStatus(BaseModel):
     job_type: str | None = None
     progress_percent: float | None = None
     progress_message: str | None = None
+    error_code: str | None = None
     error_message: str | None = None
 
 

--- a/tldw_Server_API/app/core/Workspaces/status_projection.py
+++ b/tldw_Server_API/app/core/Workspaces/status_projection.py
@@ -15,6 +15,9 @@ _FAILED_JOB_STATUSES = frozenset({"failed", "cancelled", "quarantined"})
 _PROCESSING_STATES = frozenset({"queued", "ingesting", "extracting", "chunking", "indexing", "retrying"})
 _PENDING_REASONS = frozenset({"vector_index_pending", "chunking_pending", "extraction_pending"})
 _WORKSPACE_SOURCE_JOB_TYPE = "workspace_source_ingest"
+_ERROR_CODE_ALLOWED_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
+)
 
 
 def build_source_status_projection(
@@ -335,7 +338,7 @@ def _status_from_failed_job(source: dict[str, Any], job: dict[str, Any]) -> dict
     return _base_status(
         source,
         state="failed",
-        reason="job_failed",
+        reason=_failed_job_reason(job),
         progress_percent=_coerce_float(job.get("progress_percent")),
         progress_message=job.get("error_message") or _job_result_error(job) or "Ingestion job failed.",
         job=_job_payload(job),
@@ -649,7 +652,7 @@ def _state_from_job(job: dict[str, Any]) -> str:
 
 
 def _job_payload(job: dict[str, Any]) -> dict[str, Any]:
-    return {
+    payload = {
         "id": job.get("id"),
         "uuid": job.get("uuid"),
         "status": job.get("status"),
@@ -658,6 +661,10 @@ def _job_payload(job: dict[str, Any]) -> dict[str, Any]:
         "progress_message": job.get("progress_message"),
         "error_message": job.get("error_message") or _job_result_error(job),
     }
+    error_code = _job_error_code(job)
+    if error_code is not None:
+        payload["error_code"] = error_code
+    return payload
 
 
 def _attach_stale_job(
@@ -675,6 +682,31 @@ def _job_result_error(job: dict[str, Any]) -> str | None:
     result = _normalize_mapping(job.get("result"))
     raw = result.get("error") or result.get("message")
     return str(raw) if raw else None
+
+
+def _failed_job_reason(job: dict[str, Any]) -> str:
+    """Return the public source-status reason for a failed Jobs row.
+
+    Workspace-source jobs can expose their sanitized persisted error code.
+    Other job types stay collapsed to the generic `job_failed` reason.
+    """
+    if _is_workspace_source_job(job):
+        return _job_error_code(job) or "job_failed"
+    return "job_failed"
+
+
+def _job_error_code(job: dict[str, Any]) -> str | None:
+    """Return a safe, identifier-like Jobs error code for API projection.
+
+    Only non-empty `[A-Za-z0-9_.-]` values are exposed, capped to 128
+    characters, so free-form worker errors cannot become public reason codes.
+    """
+    raw = str(job.get("error_code") or "").strip()
+    if not raw:
+        return None
+    if any(char not in _ERROR_CODE_ALLOWED_CHARS for char in raw):
+        return None
+    return raw[:128]
 
 
 def _job_sort_value(job: dict[str, Any]) -> tuple[str, int]:

--- a/tldw_Server_API/app/services/media_ingest_jobs_worker.py
+++ b/tldw_Server_API/app/services/media_ingest_jobs_worker.py
@@ -54,9 +54,19 @@ class _ProgressState:
 
 
 class MediaIngestJobError(RuntimeError):
-    def __init__(self, message: str, *, retryable: bool = False, backoff_seconds: int | None = None) -> None:
+    """Domain error that lets WorkerSDK persist structured media-ingest failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retryable: bool = False,
+        backoff_seconds: int | None = None,
+        failure_code: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.retryable = retryable
+        self.failure_code = str(failure_code or "").strip() or None
         if backoff_seconds is not None:
             self.backoff_seconds = backoff_seconds
 
@@ -153,7 +163,11 @@ def _workspace_source_job_fields(payload: dict[str, Any]) -> tuple[str, str, int
     source_id = str(payload.get("workspace_source_id") or payload.get("source_id") or "").strip()
     media_id = _coerce_positive_int(payload.get("media_id"))
     if not workspace_id or not source_id or media_id is None:
-        raise MediaIngestJobError("workspace source job missing required identifiers", retryable=False)
+        raise MediaIngestJobError(
+            "workspace source job missing required identifiers",
+            retryable=False,
+            failure_code="workspace_source_invalid_payload",
+        )
     return workspace_id, source_id, media_id
 
 
@@ -282,7 +296,11 @@ def _sync_collection_item_terminal_result(
 def _resolve_user_id(job: dict[str, Any], payload: dict[str, Any]) -> str:
     owner = job.get("owner_user_id") or payload.get("user_id")
     if owner is None or str(owner).strip() == "":
-        raise MediaIngestJobError("missing owner_user_id", retryable=False)
+        raise MediaIngestJobError(
+            "missing owner_user_id",
+            retryable=False,
+            failure_code="media_ingest_missing_owner",
+        )
     return str(owner)
 
 
@@ -392,7 +410,11 @@ async def _handle_workspace_source_job(job: dict[str, Any], jm: JobManager, prog
 
         media = get_media_by_id(db, media_id)
         if media is None:
-            raise MediaIngestJobError("workspace source media item not found", retryable=False)
+            raise MediaIngestJobError(
+                "workspace source media item not found",
+                retryable=False,
+                failure_code="workspace_source_media_not_found",
+            )
 
         progress.percent = 55.0
         progress.message = "check extraction"
@@ -436,13 +458,21 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
     if job_type == _WORKSPACE_SOURCE_JOB_TYPE:
         return await _handle_workspace_source_job(job, jm, progress)
     if job_type != _MEDIA_JOB_TYPE:
-        raise MediaIngestJobError("unsupported job_type", retryable=False)
+        raise MediaIngestJobError(
+            "unsupported job_type",
+            retryable=False,
+            failure_code="media_ingest_unsupported_job_type",
+        )
 
     user_id = _resolve_user_id(job, payload)
     planned_item_id = _planned_collection_item_id(payload)
     source = payload.get("source")
     if not source:
-        raise MediaIngestJobError("missing source", retryable=False)
+        raise MediaIngestJobError(
+            "missing source",
+            retryable=False,
+            failure_code="media_ingest_missing_source",
+        )
 
     source_kind = str(payload.get("source_kind") or "").lower() or "url"
     input_ref = payload.get("input_ref") or payload.get("original_filename") or source

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 
@@ -404,6 +406,72 @@ async def test_workspace_source_ingest_job_reports_existing_media_readiness(monk
     assert updated.get("progress_message") == "completed"
     assert float(updated.get("progress_percent") or 0.0) == 100.0
     assert media_db.closed is True
+
+
+@pytest.mark.unit
+async def test_workspace_source_ingest_job_missing_media_sets_stable_failure_code(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "jobs.db"))
+    monkeypatch.delenv("JOBS_DB_URL", raising=False)
+
+    from tldw_Server_API.app.core.Jobs.manager import JobManager
+    import tldw_Server_API.app.services.media_ingest_jobs_worker as worker
+
+    class _MissingWorkspaceMediaDB:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def get_media_by_id(
+            self,
+            media_id: int,
+            *,
+            include_deleted: bool = False,
+            include_trash: bool = False,
+        ) -> dict[str, object] | None:
+            _ = (include_deleted, include_trash)
+            assert media_id == 404
+            return None
+
+        def close_connection(self) -> None:
+            self.closed = True
+
+    media_db = _MissingWorkspaceMediaDB()
+    monkeypatch.setattr(worker, "_create_db", lambda _user_id: media_db, raising=True)
+
+    jm = JobManager()
+    row = jm.create_job(
+        domain="media_ingest",
+        queue="default",
+        job_type="workspace_source_ingest",
+        payload={
+            "workspace_id": "ws-missing",
+            "workspace_source_id": "src-missing",
+            "media_id": 404,
+            "source_type": "pdf",
+            "title": "Missing workspace source",
+        },
+        owner_user_id="1",
+    )
+
+    job = jm.get_job(int(row.get("id")))
+    with pytest.raises(worker.MediaIngestJobError) as exc_info:
+        await worker._handle_job(job, jm, worker._ProgressState())
+
+    assert str(exc_info.value) == "workspace source media item not found"
+    assert exc_info.value.retryable is False
+    assert exc_info.value.failure_code == "workspace_source_media_not_found"
+    assert media_db.closed is True
+
+
+@pytest.mark.unit
+def test_media_ingest_job_error_exposes_optional_failure_code() -> None:
+    import tldw_Server_API.app.services.media_ingest_jobs_worker as worker
+
+    exc = worker.MediaIngestJobError("fallback failure")
+
+    assert exc.failure_code is None
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Workspaces/test_workspace_source_preview_context_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_source_preview_context_api.py
@@ -359,6 +359,7 @@ def test_workspace_context_filters_active_jobs_to_workspace_sources(
             "job_type": "workspace_source_ingest",
             "progress_percent": 55,
             "progress_message": "Chunking ready source",
+            "error_code": "unsafe/error code with spaces",
             "payload": {"workspace_id": "ws-preview", "media_id": 1},
         },
         {
@@ -407,6 +408,16 @@ def test_workspace_context_filters_active_jobs_to_workspace_sources(
     assert response.status_code == 200, response.text
     payload = response.json()
     assert [job["uuid"] for job in payload["active_jobs"]] == ["uuid-matched"]
+    assert payload["active_jobs"][0]["error_code"] is None
+
+
+@pytest.mark.unit
+def test_workspace_job_status_payload_truncates_safe_error_code() -> None:
+    safe_code = "a" * 200
+
+    payload = workspaces_endpoint._job_status_payload({"error_code": safe_code})
+
+    assert payload["error_code"] == "a" * 128
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/Workspaces/test_workspace_source_status_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_source_status_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -624,6 +625,64 @@ def test_workspace_sources_status_uses_active_media_ingest_job_progress(
     assert source["progress_percent"] == 82.5
     assert source["job"]["id"] == 42
     assert source["job"]["progress_message"] == "vector indexing"
+
+
+@pytest.mark.integration
+def test_workspace_sources_status_exposes_workspace_job_failure_reason_code(
+    workspace_status_app: FastAPI,
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(db_path=str(tmp_path / "failed-workspace-job.db"), client_id="user-1")
+    db.upsert_workspace("ws-failed-job", "Failed Workspace Job")
+    db.add_workspace_source(
+        "ws-failed-job",
+        {
+            "id": "src-missing-media",
+            "media_id": 404,
+            "title": "Missing source media",
+            "source_type": "document",
+            "position": 0,
+            "selected": True,
+        },
+    )
+    jobs = [
+        {
+            "id": 4040,
+            "uuid": "job-4040",
+            "domain": "media_ingest",
+            "job_type": "workspace_source_ingest",
+            "status": "failed",
+            "payload": {
+                "workspace_id": "ws-failed-job",
+                "workspace_source_id": "src-missing-media",
+                "media_id": 404,
+            },
+            "result": None,
+            "progress_percent": 35,
+            "progress_message": "inspect media",
+            "error_code": "workspace_source_media_not_found",
+            "error_message": "Workspace source media item is missing.",
+            "created_at": "2026-05-23T12:00:00Z",
+        },
+    ]
+    _install_overrides(workspace_status_app, db, _MediaStatusDB({}), jobs=jobs)
+    try:
+        with TestClient(workspace_status_app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/workspaces/ws-failed-job/sources/status")
+    finally:
+        _clear_overrides(workspace_status_app)
+
+    assert response.status_code == 200, response.text
+    source = response.json()["sources"][0]
+    assert source["state"] == "failed"
+    assert source["status_reason"] == "workspace_source_media_not_found"
+    assert source["progress_percent"] == 35
+    assert source["progress_message"] == "Workspace source media item is missing."
+    assert source["next_action"] == "retry_ingestion_or_readd_source"
+    assert source["retry_eligible"] is True
+    assert source["job"]["id"] == 4040
+    assert source["job"]["error_code"] == "workspace_source_media_not_found"
+    assert source["job"]["error_message"] == "Workspace source media item is missing."
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- Add stable failure codes to non-retryable media ingest worker validation errors, including workspace source missing-media failures.
- Project safe workspace-source job error codes through source status as status_reason and job.error_code.
- Add regression coverage for worker failure-code behavior and status API exposure.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py tldw_Server_API/tests/Workspaces/test_workspace_source_status_api.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspaces_api.py::test_add_workspace_source_enqueues_workspace_ingest_job tldw_Server_API/tests/Workspaces/test_workspaces_api.py::test_add_workspace_source_ignores_unused_job_manager_override tldw_Server_API/tests/Workspaces/test_workspaces_api.py::test_add_workspace_source_does_not_construct_job_manager tldw_Server_API/tests/Notes_NEW/integration/test_web_clipper_api.py::test_web_clipper_workspace_save_enqueues_workspace_source_ingest_job -q
- git diff --check
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/media_ingest_jobs_worker.py tldw_Server_API/app/core/Workspaces/status_projection.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py -f json -o /tmp/bandit_task_12120.json

## Change summary
This PR was agent-authored. Per repo policy, the human requester must add or confirm a human-owned change summary before merge that explains what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose stable failure codes for workspace-source ingest failures and surface them in source status and workspace context job summaries. Failed jobs now set a clear status_reason and include a sanitized job.error_code.

- **Bug Fixes**
  - Worker raises non-retryable MediaIngestJobError with failure_code for: invalid payload (`workspace_source_invalid_payload`), missing owner (`media_ingest_missing_owner`), unsupported job type (`media_ingest_unsupported_job_type`), missing media (`workspace_source_media_not_found`), and missing source (`media_ingest_missing_source`).
  - Status projection and APIs: for failed workspace-source jobs, map error_code to status_reason; include sanitized job.error_code in source status and workspace context active_jobs (allowed chars [A–Z, a–z, 0–9, `_.-`]; max 128); progress_message prefers error_message.
  - Added tests for missing-media failure code, status reason mapping and job.error_code exposure, and preview-context error_code sanitization/truncation.

<sup>Written for commit c725caad5aa4b23fd87c1b7c26afacf8f77d9485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

