### PR TITLE
Auto-publish backend PyPI versions from main

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,13 +11,119 @@ on:
           - testpypi
           - pypi
         default: testpypi
+  push:
+    branches:
+      - main
+    paths:
+      - pyproject.toml
 
 permissions:
   contents: read
 
+concurrency:
+  group: publish-pypi-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  detect-version:
+    name: Detect PyPI Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.detect.outputs.version }}
+      published: ${{ steps.detect.outputs.published }}
+      should_publish: ${{ steps.detect.outputs.should_publish }}
+      reason: ${{ steps.detect.outputs.reason }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Detect package version on PyPI
+        id: detect
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          import tomllib
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+          from pathlib import Path
+
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
+          name = project["name"]
+          version = project["version"]
+          event_name = os.environ["GITHUB_EVENT_NAME"]
+          url = f"https://pypi.org/pypi/{urllib.parse.quote(name)}/json"
+
+          published = False
+          reason = "manual_dispatch"
+
+          if event_name == "push":
+              request = urllib.request.Request(
+                  url,
+                  headers={
+                      "Accept": "application/json",
+                      "User-Agent": "tldw-server-publish-workflow",
+                  },
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=15) as response:
+                      payload = json.load(response)
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 404:
+                      payload = {"releases": {}}
+                  else:
+                      print(f"PyPI lookup failed for {name} {version}: HTTP {exc.code}", file=sys.stderr)
+                      raise
+              except urllib.error.URLError as exc:
+                  print(f"PyPI lookup failed for {name} {version}: {exc}", file=sys.stderr)
+                  raise
+
+              published = version in payload.get("releases", {})
+              reason = "already_published" if published else "missing_from_pypi"
+
+          should_publish = event_name == "push" and not published
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              print(f"version={version}", file=output)
+              print(f"published={str(published).lower()}", file=output)
+              print(f"should_publish={str(should_publish).lower()}", file=output)
+              print(f"reason={reason}", file=output)
+
+          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          summary.write_text(
+              "\n".join(
+                  [
+                      "## PyPI publish decision",
+                      "",
+                      f"- Package: `{name}`",
+                      f"- Version: `{version}`",
+                      f"- Event: `{event_name}`",
+                      f"- Already on PyPI: `{str(published).lower()}`",
+                      f"- Auto publish: `{str(should_publish).lower()}`",
+                      f"- Reason: `{reason}`",
+                  ]
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+
   build:
     name: Build Distributions
+    needs: detect-version
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-version.outputs.should_publish == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -48,7 +154,9 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    needs: build
+    needs:
+      - detect-version
+      - build
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi' }}
     runs-on: ubuntu-latest
     permissions:
@@ -70,8 +178,10 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: build
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' }}
+    needs:
+      - detect-version
+      - build
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi') || (github.event_name == 'push' && needs.detect-version.outputs.should_publish == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/backlog/tasks/task-12123 - Auto-publish-backend-PyPI-releases-from-main-version-bumps.md
+++ b/backlog/tasks/task-12123 - Auto-publish-backend-PyPI-releases-from-main-version-bumps.md
@@ -1,0 +1,58 @@
+---
+id: TASK-12123
+title: Auto-publish backend PyPI releases from main version bumps
+status: Done
+labels:
+- packaging
+- pypi
+- ci
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update the backend/API PyPI publish workflow so pushes to main publish tldw-server only when pyproject.toml contains a version that is not already present on PyPI. Keep manual workflow_dispatch publishing available.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Pushes to main can trigger backend PyPI publishing without manual dispatch.
+- [x] #2 Workflow detects the pyproject.toml project.version and skips publishing when that version already exists on PyPI.
+- [x] #3 Workflow fails closed on PyPI lookup errors instead of publishing blindly.
+- [x] #4 Manual workflow_dispatch target=testpypi and target=pypi behavior remains available.
+- [x] #5 Validation and final summary are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- 2026-07-03: Design review adjustments before implementation:
+  - Keep manual TestPyPI/PyPI workflow_dispatch behavior.
+  - Add push-to-main publishing only for versions missing from PyPI.
+  - Fail closed when the PyPI version lookup errors instead of assuming publish is safe.
+  - Serialize publish workflow runs per ref to avoid duplicate publish races.
+- 2026-07-03: Updated `.github/workflows/publish-pypi.yml` to add a `push` trigger on `main` scoped to `pyproject.toml`, a `detect-version` job that reads `pyproject.toml` and queries the PyPI JSON API, and publish gating so automatic production publishing only runs when the pushed version is absent from PyPI. Manual TestPyPI/PyPI dispatch paths still build and publish via the existing inputs.
+- 2026-07-03: Verification:
+  - `python -c 'import yaml; yaml.safe_load(open(".github/workflows/publish-pypi.yml")); print("yaml ok")'` passed.
+  - Manual-dispatch local detect script simulation produced `version=0.1.34`, `published=false`, `should_publish=false`, `reason=manual_dispatch`.
+  - Push-event local detect script simulation against PyPI produced `version=0.1.34`, `published=false`, `should_publish=true`, `reason=missing_from_pypi`.
+  - `git diff --check` passed.
+  - Bandit skipped because only GitHub Actions YAML and Backlog markdown changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added automatic backend/API PyPI publishing for new versions pushed to `main`. The workflow now detects the current `pyproject.toml` package version, queries PyPI, skips already-published versions, fails closed on lookup errors, and preserves manual `workflow_dispatch` publishing to TestPyPI and PyPI. Validation covered YAML parsing, local manual/push detection simulations, and whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Add a push-to-main publish path for tldw-server when pyproject.toml contains a version missing from PyPI.
- Add a detect-version gate that reads project.version, queries PyPI, skips already-published versions, and fails closed on lookup errors.
- Keep manual workflow_dispatch publishing to TestPyPI and PyPI unchanged.

## Validation
- YAML parse/structure check passed for .github/workflows/publish-pypi.yml.
- Manual dispatch detect simulation: version=0.1.34, should_publish=false, reason=manual_dispatch.
- Push detect simulation against PyPI: version=0.1.34, should_publish=true, reason=missing_from_pypi.
- git diff --check passed.
- Bandit skipped: workflow YAML and Backlog markdown only.

## Notes
- Push trigger is scoped to pyproject.toml so code-only pushes do not unexpectedly publish an unpublished version.
- Manual TestPyPI run 28677038736 was still queued when this PR was opened.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-publish new `tldw-server` versions to PyPI when a version bump is pushed to `main` and that version isn’t on PyPI. Manual `workflow_dispatch` to `TestPyPI` and `PyPI` is unchanged.

- **New Features**
  - Adds a push-to-`main` trigger scoped to `pyproject.toml`.
  - Adds `detect-version` job that reads `project.version`, queries PyPI, and gates publish; exposes `version`, `published`, `should_publish`, and `reason`; fails closed on lookup errors.
  - Serializes runs per ref to prevent duplicate publishes.
  - Satisfies TASK-12123 acceptance criteria.

<sup>Written for commit a1749caa7c8293e1be2772936e048b70d01f9097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

