### PR TITLE
feat: complete Chat Workspace live flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1169,6 +1169,10 @@ jobs:
           - name: chat-character-db-api
             paths: >-
               tldw_Server_API/tests/Characters/test_characters_endpoint.py
+          - name: visual-identities
+            paths: >-
+              tldw_Server_API/tests/Character_Chat/test_visual_identity_expression_metadata.py
+              tldw_Server_API/tests/Visual_Identities
           - name: chat-character-unit-core
             paths: >-
               tldw_Server_API/tests/Character_Chat_NEW/test_utils.py
@@ -2565,6 +2569,10 @@ jobs:
           - name: chat-character-db-api
             paths: >-
               tldw_Server_API/tests/Characters/test_characters_endpoint.py
+          - name: visual-identities
+            paths: >-
+              tldw_Server_API/tests/Character_Chat/test_visual_identity_expression_metadata.py
+              tldw_Server_API/tests/Visual_Identities
           - name: chat-character-unit-core
             paths: >-
               tldw_Server_API/tests/Character_Chat_NEW/test_utils.py
@@ -3834,6 +3842,10 @@ jobs:
           - name: chat-character-db-api
             paths: >-
               tldw_Server_API/tests/Characters/test_characters_endpoint.py
+          - name: visual-identities
+            paths: >-
+              tldw_Server_API/tests/Character_Chat/test_visual_identity_expression_metadata.py
+              tldw_Server_API/tests/Visual_Identities
           - name: chat-character-unit-core
             paths: >-
               tldw_Server_API/tests/Character_Chat_NEW/test_utils.py
@@ -5027,6 +5039,10 @@ jobs:
           - name: chat-character-db-api
             paths: >-
               tldw_Server_API/tests/Characters/test_characters_endpoint.py
+          - name: visual-identities
+            paths: >-
+              tldw_Server_API/tests/Character_Chat/test_visual_identity_expression_metadata.py
+              tldw_Server_API/tests/Visual_Identities
           - name: chat-character-unit-core
             paths: >-
               tldw_Server_API/tests/Character_Chat_NEW/test_utils.py
@@ -6221,6 +6237,10 @@ jobs:
           - name: chat-character-db-api
             paths: >-
               tldw_Server_API/tests/Characters/test_characters_endpoint.py
+          - name: visual-identities
+            paths: >-
+              tldw_Server_API/tests/Character_Chat/test_visual_identity_expression_metadata.py
+              tldw_Server_API/tests/Visual_Identities
           - name: chat-character-unit-core
             paths: >-
               tldw_Server_API/tests/Character_Chat_NEW/test_utils.py

--- a/Docs/superpowers/plans/2026-06-26-chat-workspace-live-flow-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-26-chat-workspace-live-flow-implementation-plan.md
@@ -1,0 +1,40 @@
+# Chat Workspace Live Flow Implementation Plan
+
+Backlog: TASK-12130
+GitHub: #2031, parent #1239
+
+## Stage 1: Scoped Chat Flow Audit
+**Goal**: Identify every `/chat-workspace` send, create, load, and resume path that can touch server chat state.
+**Success Criteria**: The implementation targets are narrowed to concrete call sites and tests, with no speculative UI rewrites.
+**Tests**: Read existing Chat Workspace, `useMessageOption`, `useChatActions`, server loader, API client, and scoped-history tests.
+**Status**: Complete
+
+## Stage 2: Baseline Focused Coverage
+**Goal**: Establish the current behavior of the existing focused frontend tests before changing implementation code.
+**Success Criteria**: Relevant tests either pass at baseline or any pre-existing failures are documented before edits.
+**Tests**: Focused Vitest runs for Chat Workspace panel/page, server chat loading, persona chat creation, and chat action integrations.
+**Status**: Complete
+
+## Stage 3: Failing Scoped Persistence Regression Tests
+**Goal**: Add tests proving workspace-scoped sends cannot create or resume global chats when a workspace scope is available.
+**Success Criteria**: At least one focused test fails before the production fix because the hook drops workspace scope on chat creation.
+**Tests**: Extended `useChatActions` persona and character integration coverage to assert scoped `createChat`, scoped character persistence/stream calls, scoped settings sync, workspace normal/RAG server-chat bootstrap, and a global-chat compatibility regression.
+**Status**: Complete
+
+## Stage 4: Minimal Scoped Chat Fix
+**Goal**: Thread `scope` through the missing `useChatActions` create paths while preserving existing global chat behavior.
+**Success Criteria**: Workspace sends create/resume workspace-scoped server chats; global sends keep current API payloads; stale assistant metadata reset behavior remains unchanged.
+**Tests**: The new regression tests and existing focused hook tests pass.
+**Status**: Complete
+
+## Stage 5: Chat Workspace Acceptance Surface
+**Goal**: Confirm model/persona state, streaming stop, error recovery, draft/staged context preservation, and hydration guards meet #2031 acceptance.
+**Success Criteria**: Existing or new focused tests cover the acceptance criteria that are feasible without the live-backend fixture from #2035.
+**Tests**: Chat Workspace panel/page tests plus any small additions for missing state labels or disabled send behavior.
+**Status**: Complete
+
+## Stage 6: Verification and Tracker Update
+**Goal**: Run targeted verification, update Backlog, and report the precise state of #2031.
+**Success Criteria**: Focused tests pass or failures are documented with concrete blockers; TASK-12130 records touched files and verification.
+**Tests**: Focused Vitest suite from Stage 2, plus Bandit only if Python files are touched.
+**Status**: Complete

--- a/Docs/superpowers/plans/2026-06-30-chat-workspace-live-backend-smoke-plan.md
+++ b/Docs/superpowers/plans/2026-06-30-chat-workspace-live-backend-smoke-plan.md
@@ -1,0 +1,46 @@
+# Chat Workspace Live-Backend Smoke Implementation Plan
+
+Backlog: TASK-12131
+GitHub: #2035, parent #1239
+
+## Stage 1: Harness Audit
+**Goal**: Identify existing WebUI Playwright auth, workspace seeding, backend interception, and release-gate patterns.
+**Success Criteria**: The new spec follows existing `apps/tldw-frontend/e2e` helper conventions and does not require a developer-local LLM provider.
+**Tests**: Read `playwright.config.ts`, `e2e/utils/helpers.ts`, real-backend workflow specs, Chat Workspace components, and Stage 5 release gate.
+**Status**: Complete
+
+## Stage 2: Red Browser Coverage
+**Goal**: Add focused `/chat-workspace` Playwright coverage that initially fails because no focused spec or release-gate reference exists.
+**Success Criteria**: The spec opens `/chat-workspace`, seeds workspace/model/assistant state, stages a source, sends a message, captures workspace scope in backend requests, observes streaming/stop, and verifies error recovery preserves draft/staged context.
+**Tests**: Run the new spec directly and confirm the first red failure is missing/unimplemented coverage rather than a harness syntax error.
+**Status**: Complete
+
+Red evidence: the first focused Stage 5 guard run failed because `/chat-workspace` did not reference `e2e/smoke/chat-workspace-live-backend.spec.ts`.
+
+## Stage 3: Realistic Backend Fixture
+**Goal**: Implement deterministic route handlers that simulate the live backend enough for route-specific browser proof.
+**Success Criteria**: Handlers expose health/config/model/persona/chat/RAG endpoints, stream deterministic chunks, delay streaming long enough for Stop generation, and record request bodies/query params for assertions.
+**Tests**: Run the new spec and assert request captures include `scope_type=workspace`, `workspace_id`, selected model/persona state, and staged `ragMediaIds`.
+**Status**: Complete
+
+Implemented in `apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts`.
+
+## Stage 4: Release Gate Reference
+**Goal**: Make Stage 5 release-gate coverage explicitly reference the focused `/chat-workspace` proof instead of relying only on route-load checks.
+**Success Criteria**: The release gate contains an auditable pointer to the focused spec for Chat Workspace route proof.
+**Tests**: Add/update a small guard or inline constant assertion if the existing release-gate tests can cover the reference without adding brittle text checks.
+**Status**: Complete
+
+Stage 5 now requires `/chat-workspace` to reference `e2e/smoke/chat-workspace-live-backend.spec.ts`; route-only no-backend startup probes are narrowly allowlisted for that route.
+
+## Stage 5: Verification and Task Update
+**Goal**: Run targeted Playwright/Vitest verification, update Backlog, and report the precise #2035 state.
+**Success Criteria**: New focused spec passes; release-gate reference check passes; TASK-12131 records touched files, verification, Bandit applicability, and remaining risk.
+**Tests**: Targeted Playwright spec, any guard/unit test changed for the release-gate reference, `git diff --check`, and Bandit only if Python files are touched.
+**Status**: Complete
+
+Verification:
+- `npx playwright test e2e/smoke/chat-workspace-live-backend.spec.ts --project=chromium` passed.
+- `npx playwright test e2e/smoke/stage5-release-gate.spec.ts --project=chromium --grep "Chat Workspace"` passed.
+- `git diff --check` passed.
+- Bandit not applicable; no Python files touched.

--- a/Docs/superpowers/plans/2026-07-02-chat-workspace-source-rail-lifecycle-plan.md
+++ b/Docs/superpowers/plans/2026-07-02-chat-workspace-source-rail-lifecycle-plan.md
@@ -1,0 +1,75 @@
+# Chat Workspace Source Rail Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete GitHub issue #2032 by making `/chat-workspace` source browsing, staging, unstaging, state rendering, and staged send behavior work against real workspace sources.
+
+**Architecture:** Keep Chat Workspace as the active chat surface and route source-management actions to canonical Research Workspace/Media routes. The page owns browsed/staged source state, the rail exposes per-source lifecycle actions, and the chat panel continues to translate staged context into structured media ids plus fallback summary text.
+
+**Tech Stack:** React, Zustand workspace store, React Testing Library/Vitest, Playwright smoke tests.
+
+---
+
+## Design Review Adjustments
+
+- A source with `status: "ready"` but an invalid or missing `mediaId` remains stageable. It cannot be carried structurally, so existing fallback-summary behavior must cover it.
+- Staging is disabled for processing, error, and unknown/unavailable source states, but unstaging remains enabled for any already-staged source.
+- Browse should not surprise users by navigating away from Chat Workspace. It should mark the source as browsed and prime the workspace store focus target; explicit Add/Open links handle route changes.
+- Source loading/error state should come from `useWorkspaceStore` (`sourcesLoading`, `sourcesError`) instead of invented local state.
+- Workspace-switch guards must also protect any new individual unstage callback, matching the existing stale-clear protection.
+- Duplicate source titles need disambiguated accessible action names for new buttons, matching the current browse/stage suffix behavior.
+
+## Stage 1: Lifecycle Unit And Component Tests
+
+**Goal:** Add failing coverage for source unstage, lifecycle states, empty states, and route actions.
+**Success Criteria:** Focused Vitest tests fail for missing unstage/loading/error/link behavior before implementation.
+**Tests:** `WorkspaceRail.test.tsx`, `ContextStagingCard.test.tsx`, `ChatWorkspacePage.test.tsx`, `staging.test.ts`.
+**Status:** Complete
+
+- [x] Add a failing `staging.test.ts` case for removing one staged source while preserving others.
+- [x] Add failing `WorkspaceRail.test.tsx` cases for Add/Open route links, unstage action, ready-with-invalid-media stageability, processing/error disabled staging, loading state, source error state, no-source empty state, and filtered-empty state.
+- [x] Add a failing `ContextStagingCard.test.tsx` case for removing one staged source by source id.
+- [x] Add a failing `ChatWorkspacePage.test.tsx` case showing individual unstage is ignored for stale previous-workspace callbacks.
+- [x] Run focused Vitest and confirm the new tests fail for the expected missing behavior.
+
+## Stage 2: Source Rail And Staging Lifecycle Implementation
+
+**Goal:** Implement the minimal UI and state plumbing needed to satisfy the failing component tests.
+**Success Criteria:** Stage 1 tests pass without changing the existing successful send contracts.
+**Tests:** Same focused Vitest files as Stage 1.
+**Status:** Complete
+
+- [x] Add `unstageWorkspaceSource` to `staging.ts`.
+- [x] Extend `ContextStagingCard` with an optional `onRemoveSource` callback and per-source Remove buttons.
+- [x] Extend `WorkspaceRail` props for `sourcesLoading`, `sourcesError`, `onUnstageSource`, and canonical source-management route URLs.
+- [x] Render Add source and Open library as route links to `/research-workspace?tab=sources` and `/media`.
+- [x] Render clear source lifecycle states and disable only non-actionable stage buttons.
+- [x] Pass source loading/error state and unstage handlers from `ChatWorkspacePage` through `ChatWorkspaceConsole`.
+- [x] Guard individual unstage against stale workspace state.
+- [x] Run focused Vitest and confirm the Stage 1 tests pass.
+
+## Stage 3: Browser Workflow Proof
+
+**Goal:** Add browser coverage for stage, unstage, re-stage, and send with staged context.
+**Success Criteria:** A deterministic Playwright smoke test proves unstage removes the source before send and re-stage sends ready media ids structurally.
+**Tests:** `apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts`.
+**Status:** Complete
+
+- [x] Extend the existing Chat Workspace live-backend fixture with a stage/unstage/re-stage workflow.
+- [x] Assert unstage removes the source from the staged context and prevents accidental send with stale context.
+- [x] Re-stage the ready source, send, and assert the RAG request includes the expected `include_media_ids`.
+- [x] Keep the route-link proof local to Chat Workspace; do not depend on full Research Workspace source UI in this smoke test.
+- [x] Run the focused Playwright spec.
+
+## Stage 4: Verification And Backlog Finalization
+
+**Goal:** Record verification evidence and complete the Backlog task once tests pass.
+**Success Criteria:** Focused Vitest, focused Playwright, and whitespace checks pass; Bandit is documented as not applicable because no Python changed.
+**Tests:** Focused Vitest, focused Playwright, `git diff --check`.
+**Status:** Complete
+
+- [x] Run focused Vitest for Chat Workspace component and staging tests.
+- [x] Run focused Playwright Chat Workspace smoke spec.
+- [x] Run `git diff --check`.
+- [x] Mark Bandit not applicable for this TypeScript-only scope.
+- [x] Update `TASK-12132` with touched files, verification results, completed acceptance criteria, and final summary.

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspaceConsole.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspaceConsole.tsx
@@ -18,6 +18,8 @@ export type ChatWorkspaceConsoleProps = {
   workspaceId?: string | null
   workspaceName: string
   sources: WorkspaceSource[]
+  sourcesLoading?: boolean
+  sourcesError?: string | null
   browsedSourceId: string | null
   stagedSources: StagedWorkspaceSource[]
   selectedModelLabel: string
@@ -32,6 +34,7 @@ export type ChatWorkspaceConsoleProps = {
   streaming: boolean
   onBrowseSource: (sourceId: string) => void
   onStageSources: (sourceIds: string[]) => void
+  onUnstageSource: (sourceId: string) => void
   onClearStagedSources: () => void
   onRuntimeStateChange: (state: ChatWorkspaceRuntimeState) => void
 }
@@ -40,6 +43,8 @@ export const ChatWorkspaceConsole = ({
   workspaceId,
   workspaceName,
   sources,
+  sourcesLoading,
+  sourcesError,
   browsedSourceId,
   stagedSources,
   selectedModelLabel,
@@ -52,6 +57,7 @@ export const ChatWorkspaceConsole = ({
   streaming,
   onBrowseSource,
   onStageSources,
+  onUnstageSource,
   onClearStagedSources,
   onRuntimeStateChange
 }: ChatWorkspaceConsoleProps) => {
@@ -72,10 +78,13 @@ export const ChatWorkspaceConsole = ({
           <WorkspaceRail
             workspaceName={workspaceName}
             sources={sources}
+            sourcesLoading={sourcesLoading}
+            sourcesError={sourcesError}
             browsedSourceId={browsedSourceId}
             stagedSourceIds={stagedSourceIds}
             onBrowseSource={onBrowseSource}
             onStageSources={onStageSources}
+            onUnstageSource={onUnstageSource}
           />
         </div>
 
@@ -87,6 +96,7 @@ export const ChatWorkspaceConsole = ({
               workspaceName={workspaceName}
               stagedSources={stagedSources}
               onClearStagedSources={onClearStagedSources}
+              onRemoveStagedSource={onUnstageSource}
               backendAvailable={chatBackendAvailable}
               effectiveAssistantDefault={effectiveAssistantDefault}
               onRuntimeStateChange={onRuntimeStateChange}

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx
@@ -6,7 +6,7 @@ import { useWorkspaceStore } from "@/store/workspace"
 import { ConnectionPhase } from "@/types/connection"
 
 import { ChatWorkspaceConsole } from "./ChatWorkspaceConsole"
-import { stageWorkspaceSources } from "./staging"
+import { stageWorkspaceSources, unstageWorkspaceSource } from "./staging"
 import type {
   ChatWorkspaceRuntimeState,
   StagedWorkspaceSource
@@ -43,6 +43,9 @@ export const ChatWorkspacePage = () => {
   const effectiveAssistantDefault = useWorkspaceStore(
     (state) => state.effectiveAssistantDefault
   )
+  const sourcesLoading = useWorkspaceStore((state) => state.sourcesLoading)
+  const sourcesError = useWorkspaceStore((state) => state.sourcesError)
+  const focusSourceById = useWorkspaceStore((state) => state.focusSourceById)
   const setRouteContext = useChatSurfaceCoordinatorStore(
     (state) => state.setRouteContext
   )
@@ -94,6 +97,7 @@ export const ChatWorkspacePage = () => {
 
   const handleBrowseSource = React.useCallback(
     (sourceId: string) => {
+      focusSourceById(sourceId)
       setWorkspaceContext((current) => ({
         workspaceId,
         browsedSourceId: sourceId,
@@ -101,7 +105,7 @@ export const ChatWorkspacePage = () => {
           current.workspaceId === workspaceId ? current.stagedSources : []
       }))
     },
-    [workspaceId]
+    [focusSourceById, workspaceId]
   )
 
   const handleStageSources = React.useCallback(
@@ -133,6 +137,24 @@ export const ChatWorkspacePage = () => {
     )
   }, [workspaceId])
 
+  const handleUnstageSource = React.useCallback(
+    (sourceId: string) => {
+      setWorkspaceContext((current) =>
+        current.workspaceId === workspaceId
+          ? {
+              workspaceId,
+              browsedSourceId: current.browsedSourceId,
+              stagedSources: unstageWorkspaceSource(
+                current.stagedSources,
+                sourceId
+              )
+            }
+          : current
+      )
+    },
+    [workspaceId]
+  )
+
   const handleRuntimeStateChange = React.useCallback(
     (state: ChatWorkspaceRuntimeState) => {
       setRuntimeState((current) => ({ ...current, ...state }))
@@ -147,6 +169,8 @@ export const ChatWorkspacePage = () => {
         workspaceId={workspaceId}
         workspaceName={scopeLabel}
         sources={sources}
+        sourcesLoading={sourcesLoading}
+        sourcesError={sourcesError}
         browsedSourceId={browsedSourceId}
         stagedSources={stagedSources}
         selectedModelLabel={runtimeState.selectedModelLabel}
@@ -161,6 +185,7 @@ export const ChatWorkspacePage = () => {
         streaming={runtimeState.streaming}
         onBrowseSource={handleBrowseSource}
         onStageSources={handleStageSources}
+        onUnstageSource={handleUnstageSource}
         onClearStagedSources={handleClearStagedSources}
         onRuntimeStateChange={handleRuntimeStateChange}
       />

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/ContextStagingCard.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/ContextStagingCard.tsx
@@ -7,6 +7,7 @@ export type ContextStagingCardProps = {
   onClear: () => void
   onInsert: () => void
   onSend: () => void
+  onRemoveSource?: (sourceId: string) => void
 }
 
 const actionButtonClass =
@@ -21,7 +22,8 @@ export const ContextStagingCard = ({
   canSend = true,
   onClear,
   onInsert,
-  onSend
+  onSend,
+  onRemoveSource
 }: ContextStagingCardProps) => {
   const hasSources = sources.length > 0
   const sendDisabled = isSending || !canSend || !hasSources
@@ -56,9 +58,21 @@ export const ContextStagingCard = ({
                   <span className="min-w-0 break-words font-medium text-text">
                     {source.title}
                   </span>
-                  <span className="rounded-full border border-border bg-surface px-2 py-0.5 text-[11px] font-medium text-text-muted">
-                    {source.availability}
-                  </span>
+                  <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <span className="rounded-full border border-border bg-surface px-2 py-0.5 text-[11px] font-medium text-text-muted">
+                      {source.availability}
+                    </span>
+                    {onRemoveSource ? (
+                      <button
+                        type="button"
+                        className={actionButtonClass}
+                        onClick={() => onRemoveSource(source.sourceId)}
+                        aria-label={`Remove ${source.title} from staged context`}
+                      >
+                        Remove
+                      </button>
+                    ) : null}
+                  </div>
                 </div>
                 <div className="flex min-w-0 flex-wrap gap-x-2 gap-y-1 text-xs text-text-muted">
                   <span className="min-w-0 break-words">{source.scopeLabel}</span>

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
@@ -32,6 +32,7 @@ export type WorkspaceChatPanelProps = {
   workspaceName?: string | null
   stagedSources: StagedWorkspaceSource[]
   onClearStagedSources: () => void
+  onRemoveStagedSource?: (sourceId: string) => void
   backendAvailable: boolean
   effectiveAssistantDefault?: EffectiveWorkspaceAssistantDefault | null
   onRuntimeStateChange?: (state: ChatWorkspaceRuntimeState) => void
@@ -101,6 +102,7 @@ export const WorkspaceChatPanel = ({
   workspaceName,
   stagedSources,
   onClearStagedSources,
+  onRemoveStagedSource,
   backendAvailable,
   effectiveAssistantDefault,
   onRuntimeStateChange
@@ -390,6 +392,7 @@ export const WorkspaceChatPanel = ({
             onClear={onClearStagedSources}
             onInsert={insertStagedSummary}
             onSend={submitMessage}
+            onRemoveSource={onRemoveStagedSource}
           />
         ) : null}
 

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceRail.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceRail.tsx
@@ -1,13 +1,19 @@
 import { useMemo, useState } from "react"
+import { Link, useInRouterContext } from "react-router-dom"
 import type { WorkspaceSource } from "@/types/workspace"
 
 export type WorkspaceRailProps = {
   workspaceName: string
   sources: WorkspaceSource[]
+  sourcesLoading?: boolean
+  sourcesError?: string | null
   browsedSourceId: string | null
   stagedSourceIds: string[]
   onBrowseSource: (sourceId: string) => void
   onStageSources: (sourceIds: string[]) => void
+  onUnstageSource?: (sourceId: string) => void
+  addSourceHref?: string
+  openLibraryHref?: string
 }
 
 const panelClass = "rounded-md border border-border bg-surface px-3 py-2"
@@ -15,17 +21,36 @@ const headingClass = "text-[11px] font-semibold text-text-muted"
 const buttonClass =
   "inline-flex min-h-[28px] min-w-0 items-center justify-center break-words rounded-md border border-border px-2.5 py-1 text-xs font-medium text-text transition-colors hover:bg-surface2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus disabled:cursor-not-allowed disabled:opacity-50"
 
-const getSourceStatus = (source: WorkspaceSource) => source.status || "ready"
+const DEFAULT_ADD_SOURCE_HREF = "/research-workspace?tab=sources"
+const DEFAULT_OPEN_LIBRARY_HREF = "/media"
+
+type SourceRailStatus = "ready" | "processing" | "error" | "unavailable"
+
+const getSourceStatus = (source: WorkspaceSource): SourceRailStatus => {
+  if (source.status === "processing" || source.status === "error") {
+    return source.status
+  }
+  if (source.status === "ready" || !source.status) {
+    return "ready"
+  }
+  return "unavailable"
+}
 
 export const WorkspaceRail = ({
   workspaceName,
   sources,
+  sourcesLoading = false,
+  sourcesError = null,
   browsedSourceId,
   stagedSourceIds,
   onBrowseSource,
-  onStageSources
+  onStageSources,
+  onUnstageSource,
+  addSourceHref = DEFAULT_ADD_SOURCE_HREF,
+  openLibraryHref = DEFAULT_OPEN_LIBRARY_HREF
 }: WorkspaceRailProps) => {
   const [filter, setFilter] = useState("")
+  const inRouterContext = useInRouterContext()
   const stagedSourceIdSet = useMemo(
     () => new Set(stagedSourceIds),
     [stagedSourceIds]
@@ -79,17 +104,35 @@ export const WorkspaceRail = ({
       <section className={panelClass}>
         <h3 className={headingClass}>Library</h3>
         <div className="mt-2 flex flex-wrap gap-2">
-          <button type="button" className={buttonClass} disabled>
-            Add source unavailable
-          </button>
-          <button type="button" className={buttonClass} disabled>
-            Open library unavailable
-          </button>
+          {inRouterContext ? (
+            <>
+              <Link to={addSourceHref} className={buttonClass}>
+                Add source
+              </Link>
+              <Link to={openLibraryHref} className={buttonClass}>
+                Open library
+              </Link>
+            </>
+          ) : (
+            <>
+              <a href={addSourceHref} className={buttonClass}>
+                Add source
+              </a>
+              <a href={openLibraryHref} className={buttonClass}>
+                Open library
+              </a>
+            </>
+          )}
         </div>
       </section>
 
       <section className={panelClass}>
         <h3 className={headingClass}>Sources</h3>
+        {sourcesLoading && sources.length > 0 ? (
+          <p className="mt-2 text-xs text-text-muted" role="status">
+            Refreshing workspace sources
+          </p>
+        ) : null}
         {visibleSources.length > 0 ? (
           <ul className="mt-2 space-y-2">
             {visibleSources.map((source) => {
@@ -137,19 +180,30 @@ export const WorkspaceRail = ({
                       >
                         Browse {source.title}
                       </button>
-                      <button
-                        type="button"
-                        className={buttonClass}
-                        aria-label={`Stage ${source.title}${actionNameSuffix} for chat`}
-                        disabled={!isReady}
-                        onClick={() => {
-                          if (isReady) {
-                            onStageSources([source.id])
-                          }
-                        }}
-                      >
-                        Stage {source.title} for chat
-                      </button>
+                      {isStaged ? (
+                        <button
+                          type="button"
+                          className={buttonClass}
+                          aria-label={`Unstage ${source.title}${actionNameSuffix} from chat`}
+                          onClick={() => onUnstageSource?.(source.id)}
+                        >
+                          Unstage {source.title} from chat
+                        </button>
+                      ) : (
+                        <button
+                          type="button"
+                          className={buttonClass}
+                          aria-label={`Stage ${source.title}${actionNameSuffix} for chat`}
+                          disabled={!isReady}
+                          onClick={() => {
+                            if (isReady) {
+                              onStageSources([source.id])
+                            }
+                          }}
+                        >
+                          Stage {source.title} for chat
+                        </button>
+                      )}
                     </div>
                   </div>
                 </li>
@@ -158,7 +212,13 @@ export const WorkspaceRail = ({
           </ul>
         ) : (
           <p className="mt-2 rounded-md border border-dashed border-border bg-surface2/40 px-2 py-1.5 text-xs text-text-muted">
-            No sources match the filter
+            {sourcesError
+              ? sourcesError
+              : sourcesLoading
+                ? "Loading workspace sources"
+                : sources.length === 0
+                  ? "No workspace sources yet"
+                  : "No sources match the filter"}
           </p>
         )}
       </section>

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx
@@ -33,6 +33,9 @@ const workspaceState = vi.hoisted((): { value: any } => ({
     }
   }
 }))
+const workspaceActions = vi.hoisted(() => ({
+  focusSourceById: vi.fn(() => true)
+}))
 const connectionState = vi.hoisted(() => ({
   value: {
     phase: "connected",
@@ -43,6 +46,9 @@ const connectionState = vi.hoisted(() => ({
 const chatPanelClearHandlers = vi.hoisted(
   () => new Map<string, () => void>()
 )
+const chatPanelRemoveHandlers = vi.hoisted(
+  () => new Map<string, (sourceId: string) => void>()
+)
 
 vi.mock("@/store/chat-surface-coordinator", () => ({
   useChatSurfaceCoordinatorStore: (selector: any) =>
@@ -51,7 +57,12 @@ vi.mock("@/store/chat-surface-coordinator", () => ({
 
 vi.mock("@/store/workspace", () => ({
   useWorkspaceStore: (selector: any) =>
-    selector(workspaceState.value)
+    selector({
+      sourcesLoading: false,
+      sourcesError: null,
+      ...workspaceActions,
+      ...workspaceState.value
+    })
 }))
 
 vi.mock("@/hooks/useConnectionState", () => ({
@@ -63,6 +74,7 @@ vi.mock("../WorkspaceChatPanel", () => ({
     stagedSources,
     workspaceId,
     onClearStagedSources,
+    onRemoveStagedSource,
     backendAvailable,
     effectiveAssistantDefault,
     onRuntimeStateChange
@@ -70,6 +82,7 @@ vi.mock("../WorkspaceChatPanel", () => ({
     stagedSources: unknown[]
     workspaceId?: string | null
     onClearStagedSources: () => void
+    onRemoveStagedSource?: (sourceId: string) => void
     backendAvailable: boolean
     effectiveAssistantDefault?: { assistantId?: string | null } | null
     onRuntimeStateChange?: (state: unknown) => void
@@ -78,6 +91,9 @@ vi.mock("../WorkspaceChatPanel", () => ({
 
     if (workspaceId) {
       chatPanelClearHandlers.set(workspaceId, onClearStagedSources)
+      if (onRemoveStagedSource) {
+        chatPanelRemoveHandlers.set(workspaceId, onRemoveStagedSource)
+      }
     }
 
     React.useEffect(() => {
@@ -108,6 +124,7 @@ describe("ChatWorkspacePage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     chatPanelRuntimeState.backendAvailable = true
+    workspaceActions.focusSourceById.mockReturnValue(true)
     workspaceState.value = {
       workspaceId: "workspace-1",
       workspaceName: "Default workspace",
@@ -137,6 +154,7 @@ describe("ChatWorkspacePage", () => {
       serverUrl: "http://127.0.0.1:8000"
     }
     chatPanelClearHandlers.clear()
+    chatPanelRemoveHandlers.clear()
   })
 
   it("sets chat surface route context and renders the console regions", () => {
@@ -159,6 +177,7 @@ describe("ChatWorkspacePage", () => {
     render(<ChatWorkspacePage />)
 
     fireEvent.click(screen.getByRole("button", { name: "Browse Operator Notes" }))
+    expect(workspaceActions.focusSourceById).toHaveBeenCalledWith("source-1")
     expect(screen.getByTestId("workspace-chat-panel")).toHaveTextContent("staged:0")
 
     fireEvent.click(
@@ -336,6 +355,46 @@ describe("ChatWorkspacePage", () => {
 
     act(() => {
       clearWorkspaceOne?.()
+    })
+
+    expect(screen.getByTestId("workspace-chat-panel")).toHaveTextContent("staged:1")
+    expect(screen.getByTestId("workspace-chat-panel")).toHaveTextContent(
+      "workspace:workspace-2"
+    )
+  })
+
+  it("ignores stale individual unstage callbacks from a previous workspace", () => {
+    const { rerender } = render(<ChatWorkspacePage />)
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Stage Operator Notes for chat" })
+    )
+    expect(screen.getByTestId("workspace-chat-panel")).toHaveTextContent("staged:1")
+    const removeWorkspaceOne = chatPanelRemoveHandlers.get("workspace-1")
+    expect(removeWorkspaceOne).toBeDefined()
+
+    workspaceState.value = {
+      workspaceId: "workspace-2",
+      workspaceName: "Second workspace",
+      sources: [
+        {
+          id: "source-2",
+          mediaId: 202,
+          title: "Second Notes",
+          type: "document",
+          status: "ready",
+          addedAt: new Date("2026-05-03T00:00:00Z")
+        }
+      ]
+    }
+    rerender(<ChatWorkspacePage />)
+    fireEvent.click(
+      screen.getByRole("button", { name: "Stage Second Notes for chat" })
+    )
+    expect(screen.getByTestId("workspace-chat-panel")).toHaveTextContent("staged:1")
+
+    act(() => {
+      removeWorkspaceOne?.("source-1")
     })
 
     expect(screen.getByTestId("workspace-chat-panel")).toHaveTextContent("staged:1")

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ContextStagingCard.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ContextStagingCard.test.tsx
@@ -85,6 +85,40 @@ describe("ContextStagingCard", () => {
     expect(onSend).toHaveBeenCalledTimes(1)
   })
 
+  it("removes one staged source without clearing all staged context", () => {
+    const onRemoveSource = vi.fn()
+    const onClear = vi.fn()
+
+    render(
+      <ContextStagingCard
+        sources={[
+          staged[0],
+          {
+            sourceId: "s2",
+            mediaId: 2,
+            title: "Research Clip",
+            type: "video",
+            scopeLabel: "Default workspace",
+            availability: "ready"
+          }
+        ]}
+        onClear={onClear}
+        onInsert={vi.fn()}
+        onSend={vi.fn()}
+        onRemoveSource={onRemoveSource}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove Operator Notes from staged context"
+      })
+    )
+
+    expect(onRemoveSource).toHaveBeenCalledWith("s1")
+    expect(onClear).not.toHaveBeenCalled()
+  })
+
   it("disables send and labels the sending state without relying on color", () => {
     const onSend = vi.fn()
 

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceRail.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceRail.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
+import { MemoryRouter } from "react-router-dom"
 import { WorkspaceRail } from "../WorkspaceRail"
 import type { WorkspaceSource } from "@/types/workspace"
 
@@ -66,6 +67,78 @@ describe("WorkspaceRail", () => {
     )
 
     expect(onStageSources).toHaveBeenCalledWith(["source-1"])
+  })
+
+  it("routes source-management actions to canonical surfaces", () => {
+    render(
+      <WorkspaceRail
+        workspaceName="Default workspace"
+        sources={sources}
+        browsedSourceId={null}
+        stagedSourceIds={[]}
+        onBrowseSource={vi.fn()}
+        onStageSources={vi.fn()}
+        onUnstageSource={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("link", { name: "Add source" })).toHaveAttribute(
+      "href",
+      "/research-workspace?tab=sources"
+    )
+    expect(screen.getByRole("link", { name: "Open library" })).toHaveAttribute(
+      "href",
+      "/media"
+    )
+  })
+
+  it("uses SPA links for source-management actions inside a router", () => {
+    render(
+      <MemoryRouter>
+        <WorkspaceRail
+          workspaceName="Default workspace"
+          sources={sources}
+          browsedSourceId={null}
+          stagedSourceIds={[]}
+          onBrowseSource={vi.fn()}
+          onStageSources={vi.fn()}
+          onUnstageSource={vi.fn()}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole("link", { name: "Add source" })).toHaveAttribute(
+      "href",
+      "/research-workspace?tab=sources"
+    )
+    expect(screen.getByRole("link", { name: "Open library" })).toHaveAttribute(
+      "href",
+      "/media"
+    )
+  })
+
+  it("unstages one source without staging another", () => {
+    const onStageSources = vi.fn()
+    const onUnstageSource = vi.fn()
+
+    render(
+      <WorkspaceRail
+        workspaceName="Default workspace"
+        sources={sources}
+        browsedSourceId={null}
+        stagedSourceIds={["source-1"]}
+        onBrowseSource={vi.fn()}
+        onStageSources={onStageSources}
+        onUnstageSource={onUnstageSource}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Unstage Operator Notes from chat" })
+    )
+
+    expect(onUnstageSource).toHaveBeenCalledWith("source-1")
+    expect(onStageSources).not.toHaveBeenCalled()
   })
 
   it("filters sources without changing browse or staged state", () => {
@@ -146,6 +219,150 @@ describe("WorkspaceRail", () => {
     fireEvent.click(stageButton)
 
     expect(onStageSources).not.toHaveBeenCalled()
+  })
+
+  it("keeps ready sources without structured media ids stageable for fallback context", () => {
+    const onStageSources = vi.fn()
+
+    render(
+      <WorkspaceRail
+        workspaceName="Default workspace"
+        sources={[
+          {
+            ...sources[0],
+            mediaId: 0,
+            title: "Fallback Brief",
+            statusMessage: "No structured media id available."
+          }
+        ]}
+        browsedSourceId={null}
+        stagedSourceIds={[]}
+        onBrowseSource={vi.fn()}
+        onStageSources={onStageSources}
+        onUnstageSource={vi.fn()}
+      />
+    )
+
+    const stageButton = screen.getByRole("button", {
+      name: "Stage Fallback Brief for chat"
+    })
+
+    expect(stageButton).toBeEnabled()
+
+    fireEvent.click(stageButton)
+
+    expect(onStageSources).toHaveBeenCalledWith(["source-1"])
+  })
+
+  it("renders processing, error, and unavailable states with disabled stage actions", () => {
+    render(
+      <WorkspaceRail
+        workspaceName="Default workspace"
+        sources={[
+          {
+            ...sources[0],
+            id: "processing-source",
+            title: "Processing Brief",
+            status: "processing",
+            statusMessage: "Still indexing."
+          },
+          {
+            ...sources[0],
+            id: "error-source",
+            title: "Failed Brief",
+            status: "error",
+            statusMessage: "Indexing failed."
+          },
+          {
+            ...sources[0],
+            id: "unavailable-source",
+            title: "Unavailable Brief",
+            status: "blocked" as WorkspaceSource["status"]
+          }
+        ]}
+        browsedSourceId={null}
+        stagedSourceIds={[]}
+        onBrowseSource={vi.fn()}
+        onStageSources={vi.fn()}
+        onUnstageSource={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("processing")).toBeInTheDocument()
+    expect(screen.getByText("error")).toBeInTheDocument()
+    expect(screen.getByText("unavailable")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Stage Processing Brief for chat" })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole("button", { name: "Stage Failed Brief for chat" })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole("button", { name: "Stage Unavailable Brief for chat" })
+    ).toBeDisabled()
+  })
+
+  it("distinguishes loading, source error, no-source, and filtered-empty states", () => {
+    const { rerender } = render(
+      <WorkspaceRail
+        workspaceName="Default workspace"
+        sources={[]}
+        sourcesLoading
+        browsedSourceId={null}
+        stagedSourceIds={[]}
+        onBrowseSource={vi.fn()}
+        onStageSources={vi.fn()}
+        onUnstageSource={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Loading workspace sources")).toBeInTheDocument()
+
+    rerender(
+      <WorkspaceRail
+        workspaceName="Default workspace"
+        sources={[]}
+        sourcesError="Could not load workspace sources."
+        browsedSourceId={null}
+        stagedSourceIds={[]}
+        onBrowseSource={vi.fn()}
+        onStageSources={vi.fn()}
+        onUnstageSource={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Could not load workspace sources.")).toBeInTheDocument()
+
+    rerender(
+      <WorkspaceRail
+        workspaceName="Default workspace"
+        sources={[]}
+        browsedSourceId={null}
+        stagedSourceIds={[]}
+        onBrowseSource={vi.fn()}
+        onStageSources={vi.fn()}
+        onUnstageSource={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("No workspace sources yet")).toBeInTheDocument()
+
+    rerender(
+      <WorkspaceRail
+        workspaceName="Default workspace"
+        sources={sources}
+        browsedSourceId={null}
+        stagedSourceIds={[]}
+        onBrowseSource={vi.fn()}
+        onStageSources={vi.fn()}
+        onUnstageSource={vi.fn()}
+      />
+    )
+    fireEvent.change(screen.getByRole("searchbox", { name: "Filter sources" }), {
+      target: { value: "missing" }
+    })
+
+    expect(screen.getByText("No sources match the filter")).toBeInTheDocument()
   })
 
   it("disambiguates duplicate source title action names", () => {

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/staging.test.ts
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/staging.test.ts
@@ -4,7 +4,8 @@ import {
   buildStagedSourceFromWorkspaceSource,
   formatStagedSourceInsertText,
   getReadyStagedMediaIds,
-  stageWorkspaceSources
+  stageWorkspaceSources,
+  unstageWorkspaceSource
 } from "../staging"
 
 const source = (overrides: Partial<WorkspaceSource> = {}): WorkspaceSource => ({
@@ -55,6 +56,16 @@ describe("chat workspace staging", () => {
 
     expect(staged).toHaveLength(1)
     expect(staged[0].title).toBe("Renamed")
+  })
+
+  it("removes one staged source without clearing the rest", () => {
+    const first = buildStagedSourceFromWorkspaceSource(source(), "A")
+    const second = buildStagedSourceFromWorkspaceSource(
+      source({ id: "source-2", mediaId: 202, title: "Research Clip" }),
+      "A"
+    )
+
+    expect(unstageWorkspaceSource([first, second], "source-1")).toEqual([second])
   })
 
   it("formats insert text and leaves sending to the user", () => {

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/staging.ts
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/staging.ts
@@ -33,6 +33,12 @@ export const stageWorkspaceSources = (
   return Array.from(byId.values())
 }
 
+export const unstageWorkspaceSource = (
+  existing: StagedWorkspaceSource[],
+  sourceId: string
+): StagedWorkspaceSource[] =>
+  existing.filter((source) => source.sourceId !== sourceId)
+
 const formatRowValueForInsert = (
   value: string,
   fallback: string,

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -68,8 +68,10 @@ import {
   Keyboard,
   Maximize2,
   Minimize2,
+  Moon,
   PanelRightOpen,
   Search,
+  Sun,
   X,
 } from "lucide-react";
 import { CHAT_BACKGROUND_IMAGE_SETTING } from "@/services/settings/ui-settings";
@@ -83,6 +85,7 @@ import { useStorage } from "@plasmohq/storage/hook";
 import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings";
 import { useMcpToolsStore } from "@/store/mcp-tools";
 import { useDesktop, useMobile } from "@/hooks/useMediaQuery";
+import { useDarkMode } from "@/hooks/useDarkmode";
 import { useLoadLocalConversation } from "@/hooks/useLoadLocalConversation";
 import { tldwClient } from "@/services/tldw/TldwApiClient";
 import { resolvePlaygroundShortcutAction } from "./playground-shortcuts";
@@ -368,6 +371,7 @@ export const Playground = () => {
     React.useState<ComposerDockLayoutMetrics | null>(null);
   const [composerHasDraft, setComposerHasDraft] = React.useState(false);
   const { t } = useTranslation(["playground", "common"]);
+  const { mode: themeMode, toggleDarkMode } = useDarkMode();
   const navigate = useNavigate();
   const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING);
   const [stickyChatInput] = useStorage(
@@ -796,6 +800,10 @@ export const Playground = () => {
     focusModeActive
       ? toText(t("playground:cockpit.cockpit", "Cockpit"))
       : toText(t("playground:cockpit.focus", "Focus"));
+  const isDarkTheme = themeMode !== "light";
+  const themeToggleLabel = isDarkTheme
+    ? toText(t("common:theme.switchToLight", "Switch to light theme"))
+    : toText(t("common:theme.switchToDark", "Switch to dark theme"));
   const exitFocusLabel = toText(
     t("playground:cockpit.exitFocus", "Exit focus"),
   );
@@ -3633,6 +3641,20 @@ export const Playground = () => {
                   </span>
                 </div>
                 <div className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    data-testid="chat-header-theme-toggle"
+                    aria-label={themeToggleLabel}
+                    onClick={toggleDarkMode}
+                    title={themeToggleLabel}
+                    className="inline-flex min-h-[26px] min-w-[26px] items-center justify-center rounded-full border border-border bg-surface2 px-1.5 py-0.5 text-text hover:bg-surface sm:px-2"
+                  >
+                    {isDarkTheme ? (
+                      <Sun className="h-3 w-3" aria-hidden="true" />
+                    ) : (
+                      <Moon className="h-3 w-3" aria-hidden="true" />
+                    )}
+                  </button>
                   <button
                     type="button"
                     data-testid="playground-chat-layout-mode-trigger"

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -77,6 +77,11 @@ const storageState = vi.hoisted(() => ({
   values: new Map<string, unknown>(),
 }));
 
+const darkModeState = vi.hoisted(() => ({
+  mode: "dark" as "system" | "dark" | "light",
+  toggleDarkMode: vi.fn(),
+}));
+
 const chatSettingsState = vi.hoisted(() => ({
   syncChatSettingsForServerChat: vi.fn(async (_params: unknown) => null),
 }));
@@ -288,6 +293,13 @@ vi.mock("@/hooks/useSetting", () => ({
   useSetting: () => [""],
 }));
 
+vi.mock("@/hooks/useDarkmode", () => ({
+  useDarkMode: () => ({
+    mode: darkModeState.mode,
+    toggleDarkMode: darkModeState.toggleDarkMode,
+  }),
+}));
+
 vi.mock("@plasmohq/storage/hook", () => ({
   useStorage: (key: string, defaultValue: unknown) => {
     const [value, setValue] = React.useState(
@@ -378,6 +390,8 @@ describe("Playground cockpit shell", () => {
     sessionPersistenceState.value.sessionScopeReady = true;
     sessionPersistenceState.value.clearPersistedSession.mockClear();
     chatSettingsState.syncChatSettingsForServerChat.mockClear();
+    darkModeState.mode = "dark";
+    darkModeState.toggleDarkMode.mockClear();
 	    cockpitChatRenderState.starterDeckSignals = [];
 	    routerLocationState.value = null;
     routerNavigateState.navigate.mockClear();
@@ -427,6 +441,17 @@ describe("Playground cockpit shell", () => {
         forceRefresh: true,
       });
     });
+  });
+
+  it("exposes the shared theme toggle contract in the cockpit header", async () => {
+    render(<Playground />);
+
+    const themeToggle = await screen.findByTestId("chat-header-theme-toggle");
+    expect(themeToggle).toHaveAccessibleName("Switch to light theme");
+
+    fireEvent.click(themeToggle);
+
+    expect(darkModeState.toggleDarkMode).toHaveBeenCalledTimes(1);
   });
 
   it("renders Character Chat recent sessions only for the active character workflow", async () => {

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
@@ -9,6 +9,7 @@ const {
   createChatMock,
   streamCharacterChatCompletionMock,
   persistCharacterCompletionMock,
+  addChatMessageMock,
   normalChatModeMock,
   resolveVisualIdentityBindingMock
 } = vi.hoisted(() => ({
@@ -18,6 +19,7 @@ const {
     assistant_message_id: "assistant-server-1",
     version: 1
   })),
+  addChatMessageMock: vi.fn(async () => ({ id: "user-server-1", version: 1 })),
   normalChatModeMock: vi.fn(),
   resolveVisualIdentityBindingMock: vi.fn(async () => ({
     actor_kind: "character",
@@ -153,7 +155,7 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
     createChat: createChatMock,
     streamCharacterChatCompletion: streamCharacterChatCompletionMock,
     persistCharacterCompletion: persistCharacterCompletionMock,
-    addChatMessage: vi.fn(async () => ({ id: "user-server-1", version: 1 })),
+    addChatMessage: addChatMessageMock,
     getChatSettings: vi.fn(async () => ({ settings: null })),
     initialize: vi.fn(async () => null),
     resolveVisualIdentityBinding: resolveVisualIdentityBindingMock
@@ -408,7 +410,8 @@ describe("useChatActions character integration", () => {
       expect.objectContaining({
         assistant_content: "Tracked reply",
         speaker_character_id: 42
-      })
+      }),
+      undefined
     )
     const lastPersistCall = persistCharacterCompletionMock.mock.calls.at(-1) as
       | unknown[]
@@ -476,7 +479,8 @@ describe("useChatActions character integration", () => {
         assistant_content: "Tracked reply",
         speaker_character_id: 99,
         speaker_character_name: "Miku"
-      })
+      }),
+      undefined
     )
   })
 
@@ -533,7 +537,8 @@ describe("useChatActions character integration", () => {
         assistant_content: "Tracked reply",
         speaker_character_id: 4,
         speaker_character_name: "Ashley"
-      })
+      }),
+      undefined
     )
   })
 
@@ -590,7 +595,71 @@ describe("useChatActions character integration", () => {
         assistant_content: "Tracked reply",
         speaker_character_id: 99,
         speaker_character_name: "Miku"
-      })
+      }),
+      undefined
     )
+  })
+
+  it("passes workspace scope through when creating a character-backed chat", async () => {
+    const scope = { type: "workspace", workspaceId: "workspace-1" } as const
+    const options = {
+      ...createHookOptions(),
+      scope,
+      serverChatId: null,
+      serverChatTitle: null,
+      serverChatCharacterId: null,
+      serverChatAssistantKind: null,
+      serverChatAssistantId: null,
+      selectedCharacter: null,
+      selectedAssistant: {
+        kind: "character" as const,
+        id: "char-scoped",
+        name: "Scoped Character",
+        system_prompt: "Scoped prompt",
+        metadata: {
+          selectionMode: "tracked" as const
+        }
+      }
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Hello workspace character",
+        image: ""
+      })
+    })
+
+    expect(createChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        character_id: "char-scoped",
+        state: "in-progress"
+      }),
+      { scope }
+    )
+    expect(addChatMessageMock).toHaveBeenCalledWith(
+      "unexpected-new-chat",
+      expect.objectContaining({
+        role: "user",
+        content: "Hello workspace character"
+      }),
+      { scope }
+    )
+    expect(streamCharacterChatCompletionMock).toHaveBeenCalledWith(
+      "unexpected-new-chat",
+      expect.objectContaining({
+        include_character_context: true,
+        model: "deepseek-chat"
+      }),
+      expect.objectContaining({ scope })
+    )
+    expect(persistCharacterCompletionMock).toHaveBeenCalledWith(
+      "unexpected-new-chat",
+      expect.objectContaining({
+        assistant_content: "Tracked reply"
+      }),
+      { scope }
+    )
+    expect(normalChatModeMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
@@ -7,7 +7,10 @@ import { useChatActions } from "../useChatActions"
 
 const {
   createChatMock,
+  getChatMock,
+  addChatMessageMock,
   normalChatModeMock,
+  ragModeMock,
   streamCharacterChatCompletionMock,
   baseSaveMessageOnSuccessMock,
   syncChatSettingsForServerChatMock,
@@ -16,7 +19,10 @@ const {
   buildChatSurfaceScopeKeyFromConfigMock
 } = vi.hoisted(() => ({
   createChatMock: vi.fn(),
+  getChatMock: vi.fn(),
+  addChatMessageMock: vi.fn(),
   normalChatModeMock: vi.fn(),
+  ragModeMock: vi.fn(),
   streamCharacterChatCompletionMock: vi.fn(),
   baseSaveMessageOnSuccessMock: vi.fn(
     async (_payload?: unknown): Promise<string | null> => "history-persona"
@@ -36,7 +42,7 @@ vi.mock("@/hooks/chat-modes/continueChatMode", () => ({
 }))
 
 vi.mock("@/hooks/chat-modes/ragMode", () => ({
-  ragMode: vi.fn()
+  ragMode: ragModeMock
 }))
 
 vi.mock("@/hooks/chat-modes/tabChatMode", () => ({
@@ -145,6 +151,8 @@ vi.mock("@/store/playground-session", () => ({
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: {
     createChat: createChatMock,
+    getChat: getChatMock,
+    addChatMessage: addChatMessageMock,
     streamCharacterChatCompletion: streamCharacterChatCompletionMock,
     initialize: vi.fn(async () => null),
     getConfig: getConfigMock
@@ -263,6 +271,15 @@ describe("useChatActions persona integration", () => {
       assistant_id: "garden-helper",
       persona_memory_mode: "read_only"
     })
+    getChatMock.mockResolvedValue({
+      id: "workspace-existing-chat",
+      scope_type: "workspace",
+      workspace_id: "workspace-plain"
+    })
+    addChatMessageMock.mockImplementation(async (_chatId, payload) => ({
+      id: `server-message-${payload?.role ?? "message"}`,
+      version: 1
+    }))
     normalChatModeMock.mockResolvedValue(undefined)
   })
 
@@ -342,6 +359,48 @@ describe("useChatActions persona integration", () => {
     )
   })
 
+  it("passes workspace scope through when creating a persona-backed chat", async () => {
+    const scope = { type: "workspace", workspaceId: "workspace-1" } as const
+    const options = {
+      ...createHookOptions(),
+      scope
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Hello scoped persona",
+        image: ""
+      })
+    })
+
+    expect(createChatMock).toHaveBeenCalledWith(
+      {
+        assistant_kind: "persona",
+        assistant_id: "garden-helper",
+        persona_memory_mode: "read_only",
+        state: "in-progress",
+        topic_label: undefined,
+        cluster_id: undefined,
+        source: undefined,
+        external_ref: undefined
+      },
+      { scope }
+    )
+    expect(normalChatModeMock).toHaveBeenCalledWith(
+      "Hello scoped persona",
+      "",
+      false,
+      [],
+      [],
+      expect.any(AbortSignal),
+      expect.objectContaining({
+        historyId: "history-persona",
+        serverChatId: "persona-chat-1"
+      })
+    )
+  })
+
   it("routes an inherited workspace persona default when no explicit assistant is selected", async () => {
     const inheritedWorkspaceAssistant = {
       kind: "persona" as const,
@@ -411,6 +470,266 @@ describe("useChatActions persona integration", () => {
           avatarUrl: undefined
         },
         serverChatId: "workspace-persona-chat"
+      })
+    )
+  })
+
+  it("creates a workspace-scoped server chat for plain normal sends", async () => {
+    const scope = { type: "workspace", workspaceId: "workspace-plain" } as const
+    createChatMock.mockResolvedValueOnce({
+      id: "workspace-plain-chat",
+      title: "Workspace plain chat",
+      state: "in-progress",
+      version: 3
+    })
+    normalChatModeMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const params = args[6] as {
+        historyId: string | null
+        saveMessageOnSuccess: (payload: Record<string, unknown>) => Promise<string | null>
+        serverChatId?: string | null
+      }
+      expect(params.historyId).toBe("history-persona")
+      expect(params.serverChatId).toBe("workspace-plain-chat")
+      await params.saveMessageOnSuccess({
+        historyId: "history-persona",
+        isRegenerate: false,
+        selectedModel: "deepseek-chat",
+        message: "Plain workspace hello",
+        image: "",
+        fullText: "Plain workspace reply",
+        source: []
+      })
+    })
+    const options = {
+      ...createHookOptions(),
+      scope,
+      serverChatId: null,
+      serverChatTitle: null,
+      selectedAssistant: null
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Plain workspace hello",
+        image: ""
+      })
+    })
+
+    expect(createChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: "in-progress"
+      }),
+      { scope }
+    )
+    expect(options.setServerChatId).toHaveBeenCalledWith("workspace-plain-chat")
+    expect(options.setServerChatAssistantKind).toHaveBeenCalledWith(null)
+    expect(options.setServerChatAssistantId).toHaveBeenCalledWith(null)
+    expect(normalChatModeMock).toHaveBeenCalledWith(
+      "Plain workspace hello",
+      "",
+      false,
+      [],
+      [],
+      expect.any(AbortSignal),
+      expect.objectContaining({
+        historyId: "history-persona",
+        serverChatId: "workspace-plain-chat"
+      })
+    )
+    expect(baseSaveMessageOnSuccessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: "workspace-plain-chat"
+      })
+    )
+    expect(addChatMessageMock).toHaveBeenCalledWith(
+      "workspace-plain-chat",
+      expect.objectContaining({
+        role: "user",
+        content: "Plain workspace hello"
+      }),
+      { scope }
+    )
+    expect(addChatMessageMock).toHaveBeenCalledWith(
+      "workspace-plain-chat",
+      expect.objectContaining({
+        role: "assistant",
+        content: "Plain workspace reply"
+      }),
+      { scope }
+    )
+  })
+
+  it("rejects a stale server chat id from another scope before workspace sends", async () => {
+    const scope = { type: "workspace", workspaceId: "workspace-fresh" } as const
+    getChatMock.mockResolvedValueOnce({
+      id: "stale-global-chat",
+      scope_type: "global",
+      workspace_id: null
+    })
+    createChatMock.mockResolvedValueOnce({
+      id: "workspace-fresh-chat",
+      title: "Workspace fresh chat",
+      state: "in-progress"
+    })
+    normalChatModeMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const params = args[6] as {
+        serverChatId?: string | null
+        conversationId?: string | null
+      }
+      expect(params.serverChatId).toBe("workspace-fresh-chat")
+      expect(params.conversationId).toBe("workspace-fresh-chat")
+    })
+    const options = {
+      ...createHookOptions(),
+      scope,
+      serverChatId: "stale-global-chat",
+      serverChatTitle: "Stale global chat",
+      serverChatMetaLoaded: true,
+      selectedAssistant: null
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Use the active workspace",
+        image: ""
+      })
+    })
+
+    expect(getChatMock).toHaveBeenCalledWith("stale-global-chat", { scope })
+    expect(options.setServerChatId).toHaveBeenCalledWith(null)
+    expect(options.setServerChatMetaLoaded).toHaveBeenCalledWith(false)
+    expect(createChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: "in-progress"
+      }),
+      { scope }
+    )
+    expect(options.setServerChatId).toHaveBeenLastCalledWith(
+      "workspace-fresh-chat"
+    )
+  })
+
+  it("creates a workspace-scoped server chat for staged RAG sends", async () => {
+    const scope = { type: "workspace", workspaceId: "workspace-rag" } as const
+    createChatMock.mockResolvedValueOnce({
+      id: "workspace-rag-chat",
+      title: "Workspace RAG chat",
+      state: "in-progress"
+    })
+    ragModeMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const params = args[6] as {
+        historyId: string | null
+        saveMessageOnSuccess: (payload: Record<string, unknown>) => Promise<string | null>
+        serverChatId?: string | null
+      }
+      expect(params.historyId).toBe("history-persona")
+      expect(params.serverChatId).toBe("workspace-rag-chat")
+      await params.saveMessageOnSuccess({
+        historyId: "history-persona",
+        isRegenerate: false,
+        selectedModel: "deepseek-chat",
+        message: "Use staged source",
+        image: "",
+        fullText: "RAG reply",
+        source: [],
+        saveToDb: false
+      })
+    })
+    const options = {
+      ...createHookOptions(),
+      scope,
+      serverChatId: null,
+      serverChatTitle: null,
+      selectedAssistant: null
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Use staged source",
+        image: "",
+        requestOverrides: {
+          fileRetrievalEnabled: true,
+          ragMediaIds: [101]
+        }
+      })
+    })
+
+    expect(createChatMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: "in-progress"
+      }),
+      { scope }
+    )
+    expect(ragModeMock).toHaveBeenCalledWith(
+      "Use staged source",
+      "",
+      false,
+      [],
+      [],
+      expect.any(AbortSignal),
+      expect.objectContaining({
+        historyId: "history-persona",
+        serverChatId: "workspace-rag-chat",
+        ragMediaIds: [101]
+      })
+    )
+    expect(baseSaveMessageOnSuccessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: "workspace-rag-chat"
+      })
+    )
+  })
+
+  it("keeps plain global sends out of the workspace server-chat bootstrap path", async () => {
+    let capturedParams:
+      | {
+          conversationId?: string | null
+          serverChatId?: string | null
+        }
+      | null = null
+    normalChatModeMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const params = args[6] as {
+        conversationId?: string | null
+        saveMessageOnSuccess: (
+          payload: Record<string, unknown>
+        ) => Promise<string | null>
+        serverChatId?: string | null
+      }
+      capturedParams = params
+      await params.saveMessageOnSuccess({
+        historyId: "history-persona",
+        isRegenerate: false,
+        selectedModel: "deepseek-chat",
+        message: "Plain global hello",
+        image: "",
+        fullText: "Plain global reply",
+        source: []
+      })
+    })
+    const options = {
+      ...createHookOptions(),
+      selectedAssistant: null,
+      serverChatId: "existing-global-chat",
+      serverChatTitle: "Existing global chat"
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Plain global hello",
+        image: ""
+      })
+    })
+
+    expect(createChatMock).not.toHaveBeenCalled()
+    expect(capturedParams?.serverChatId).toBeUndefined()
+    expect(capturedParams?.conversationId).toBeUndefined()
+    expect(baseSaveMessageOnSuccessMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        conversationId: "existing-global-chat"
       })
     )
   })

--- a/apps/packages/ui/src/hooks/chat/useChatActions.ts
+++ b/apps/packages/ui/src/hooks/chat/useChatActions.ts
@@ -81,7 +81,8 @@ import {
 import {
   tldwClient,
   type ChatResearchContext,
-  type ConversationState
+  type ConversationState,
+  type ServerChatSummary
 } from "@/services/tldw/TldwApiClient"
 import type { ChatScope } from "@/types/chat-scope"
 import { getServerCapabilities } from "@/services/tldw/server-capabilities"
@@ -89,6 +90,7 @@ import { generateTitle } from "@/services/title"
 import { syncChatSettingsForServerChat } from "@/services/chat-settings"
 import { buildChatSurfaceScopeKeyFromConfig } from "@/services/chat-surface-scope"
 import { usePlaygroundSessionStore } from "@/store/playground-session"
+import { validateCachedServerChatId } from "@/store/workspace-sync-contract"
 import { trackCompareMetric } from "@/utils/compare-metrics"
 import { MAX_COMPARE_MODELS } from "@/hooks/chat/compare-constants"
 import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord"
@@ -980,7 +982,8 @@ export const useChatActions = ({
         await syncChatSettingsForServerChat({
           historyId: historyKey,
           serverChatId: payloadConversationId,
-          allowScratchFallback: true
+          allowScratchFallback: true,
+          ...(scope ? { scope } : {})
         })
       } catch {
         // Best-effort scratch-to-server settings reconciliation.
@@ -1125,9 +1128,10 @@ export const useChatActions = ({
           const mirroredMessage = await tldwClient.addChatMessage(
             resolvedServerConversationId,
             {
-            role: "assistant",
-            content: mirroredContent
-            }
+              role: "assistant",
+              content: mirroredContent
+            },
+            scope ? { scope } : undefined
           )
 
           await updateImageEventSyncMetadata(payload, {
@@ -1162,21 +1166,29 @@ export const useChatActions = ({
           const assistantContent = payload.fullText.trim()
 
           if (userContent.length > 0) {
-            await tldwClient.addChatMessage(cid, {
-              role: "user",
-              content: userContent,
-              ...(payload.userMetadataExtra
-                ? { metadata_extra: payload.userMetadataExtra }
-                : {})
-            })
+            await tldwClient.addChatMessage(
+              cid,
+              {
+                role: "user",
+                content: userContent,
+                ...(payload.userMetadataExtra
+                  ? { metadata_extra: payload.userMetadataExtra }
+                  : {})
+              },
+              scope ? { scope } : undefined
+            )
           }
 
           if (assistantContent.length > 0) {
-            await tldwClient.addChatMessage(cid, {
-              role: "assistant",
-              content: assistantContent,
-              metadata_extra: payload.assistantMetadataExtra
-            })
+            await tldwClient.addChatMessage(
+              cid,
+              {
+                role: "assistant",
+                content: assistantContent,
+                metadata_extra: payload.assistantMetadataExtra
+              },
+              scope ? { scope } : undefined
+            )
           }
         } catch {
           // Ignore sync errors; local history is still saved.
@@ -1347,7 +1359,162 @@ export const useChatActions = ({
       setServerChatTitle,
       setServerChatTopic,
       setServerChatVersion,
+      scope,
       temporaryChat
+    ]
+  )
+
+  const ensureWorkspaceServerChatForTurn = React.useCallback(
+    async ({
+      message,
+      serverChatIdOverride
+    }: {
+      message: string
+      serverChatIdOverride?: string | null
+    }): Promise<{ chatId: string | null; historyId: string | null }> => {
+      const overrideChatId =
+        typeof serverChatIdOverride === "string" &&
+        serverChatIdOverride.trim().length > 0
+          ? serverChatIdOverride.trim()
+          : null
+      const resolvedServerChatId = overrideChatId || serverChatId
+
+      if (scope?.type !== "workspace" || temporaryChat) {
+        return { chatId: null, historyId: null }
+      }
+
+      if (resolvedServerChatId) {
+        let validatedServerChatId: string | null = null
+        try {
+          const chat: ServerChatSummary = await tldwClient.getChat(
+            resolvedServerChatId,
+            { scope }
+          )
+          validatedServerChatId = validateCachedServerChatId({
+            cachedId: resolvedServerChatId,
+            serverScope: {
+              scope_type: chat.scope_type || "",
+              workspace_id: chat.workspace_id || null
+            },
+            expectedScope: scope
+          })
+        } catch {
+          validatedServerChatId = null
+        }
+
+        if (!validatedServerChatId) {
+          setServerChatId(null)
+          setServerChatTitle(null)
+          setServerChatCharacterId(null)
+          setServerChatAssistantKind(null)
+          setServerChatAssistantId(null)
+          setServerChatPersonaMemoryMode(null)
+          setServerChatMetaLoaded(false)
+          setServerChatState("in-progress")
+          setServerChatVersion(null)
+          setServerChatTopic(null)
+          setServerChatClusterId(null)
+          setServerChatSource(null)
+          setServerChatExternalRef(null)
+          invalidateServerChatHistory()
+        } else {
+          const ensuredHistoryId = await ensureServerChatHistoryId(
+            validatedServerChatId,
+            serverChatTitle || undefined
+          )
+          return { chatId: validatedServerChatId, historyId: ensuredHistoryId }
+        }
+      }
+
+      const titleSeed = message.trim().slice(0, 80)
+      const createPayload = {
+        title: titleSeed.length > 0 ? titleSeed : undefined,
+        state: serverChatState || "in-progress",
+        topic_label: serverChatTopic || undefined,
+        cluster_id: serverChatClusterId || undefined,
+        source: serverChatSource || undefined,
+        external_ref: serverChatExternalRef || undefined
+      }
+      const created = (await tldwClient.createChat(createPayload, {
+        scope
+      })) as TldwChatMeta
+
+      let rawId: string | number | undefined
+      if (created && typeof created === "object") {
+        const {
+          id,
+          chat_id,
+          version,
+          state,
+          conversation_state,
+          topic_label,
+          cluster_id,
+          source,
+          external_ref
+        } = created
+        rawId = id ?? chat_id
+        setServerChatState(
+          normalizeConversationState(state ?? conversation_state ?? null)
+        )
+        setServerChatVersion(typeof version === "number" ? version : null)
+        setServerChatTopic(topic_label ?? null)
+        setServerChatClusterId(cluster_id ?? null)
+        setServerChatSource(source ?? null)
+        setServerChatExternalRef(external_ref ?? null)
+      } else if (typeof created === "string" || typeof created === "number") {
+        rawId = created
+      }
+
+      const normalizedId = rawId != null ? String(rawId) : ""
+      if (!normalizedId) {
+        throw new Error("Failed to create workspace chat session")
+      }
+
+      const createdTitle =
+        created && typeof created === "object"
+          ? String(created.title ?? "")
+          : titleSeed
+      setServerChatId(normalizedId)
+      setServerChatTitle(createdTitle)
+      setServerChatCharacterId(null)
+      setServerChatAssistantKind(null)
+      setServerChatAssistantId(null)
+      setServerChatPersonaMemoryMode(null)
+      setServerChatMetaLoaded(true)
+      invalidateServerChatHistory()
+
+      const ensuredHistoryId = await ensureServerChatHistoryId(
+        normalizedId,
+        createdTitle || titleSeed || undefined
+      )
+      return { chatId: normalizedId, historyId: ensuredHistoryId }
+    },
+    [
+      ensureServerChatHistoryId,
+      invalidateServerChatHistory,
+      scope,
+      serverChatClusterId,
+      serverChatExternalRef,
+      serverChatId,
+      serverChatSource,
+      serverChatState,
+      serverChatTitle,
+      serverChatTopic,
+      setServerChatAssistantId,
+      setServerChatAssistantKind,
+      setServerChatCharacterId,
+      setServerChatClusterId,
+      setServerChatExternalRef,
+      setServerChatId,
+      setServerChatMetaLoaded,
+      setServerChatPersonaMemoryMode,
+      setServerChatSource,
+      setServerChatState,
+      setServerChatTitle,
+      setServerChatTopic,
+      setServerChatVersion,
+      temporaryChat,
+      tldwClient
     ]
   )
 
@@ -1688,14 +1855,17 @@ export const useChatActions = ({
         : effectiveServerChatCharacterId
       let createdNewChat = false
       if (!chatId) {
-        const created = await tldwClient.createChat({
+        const createPayload = {
           character_id: activeCharacter.id,
           state: serverChatState || "in-progress",
           topic_label: serverChatTopic || undefined,
           cluster_id: serverChatClusterId || undefined,
           source: effectiveServerChatSource || WEBUI_CHARACTER_CHAT_SOURCE,
           external_ref: serverChatExternalRef || undefined
-        }) as TldwChatMeta
+        }
+        const created = (scope
+          ? await tldwClient.createChat(createPayload, { scope })
+          : await tldwClient.createChat(createPayload)) as TldwChatMeta
 
         let rawId: string | number | undefined
         if (created && typeof created === "object") {
@@ -1762,7 +1932,10 @@ export const useChatActions = ({
           const createdGreeting = (await tldwClient.addChatMessage(chatId, {
             role: "assistant",
             content: greetingText
-          })) as { id?: string | number; version?: number } | null
+          }, scope ? { scope } : undefined)) as {
+            id?: string | number
+            version?: number
+          } | null
           if (createdGreeting?.id != null) {
             setMessages((prev) => {
               const updated = [...prev] as (Message & {
@@ -1830,7 +2003,8 @@ export const useChatActions = ({
         if (payload.content || payload.image_base64) {
           const createdUser = (await tldwClient.addChatMessage(
             chatId,
-            payload
+            payload,
+            scope ? { scope } : undefined
           )) as TldwChatMessage | null
           persistedUserServerMessageId =
             createdUser?.id != null ? String(createdUser.id) : undefined
@@ -1911,7 +2085,7 @@ export const useChatActions = ({
             resolvedMessageSteeringPrompts
           )
         },
-        { signal }
+        { signal, ...(scope ? { scope } : {}) }
       )) {
         resetInactivityTimer()
         const interruptionEvent =
@@ -2136,7 +2310,8 @@ export const useChatActions = ({
 
           const persisted = (await tldwClient.persistCharacterCompletion(
             chatId,
-            persistPayload
+            persistPayload,
+            scope ? { scope } : undefined
           )) as
             | {
                 assistant_message_id?: string | number
@@ -2204,7 +2379,10 @@ export const useChatActions = ({
               const createdAsst = (await tldwClient.addChatMessage(chatId, {
                 role: "assistant",
                 content: finalPersistedContent
-              })) as { id?: string | number; version?: number } | null
+              }, scope ? { scope } : undefined)) as {
+                id?: string | number
+                version?: number
+              } | null
               assistantPersistedToServer = createdAsst?.id != null
               setMessages((prev) =>
                 ((prev as any[]).map((m) => {
@@ -2327,7 +2505,10 @@ export const useChatActions = ({
           const createdAsst = (await tldwClient.addChatMessage(activeChatId, {
             role: "assistant",
             content: assistantContent
-          })) as { id?: string | number; version?: number } | null
+          }, scope ? { scope } : undefined)) as {
+            id?: string | number
+            version?: number
+          } | null
           if (createdAsst?.id == null) return false
           assistantPersistedToServer = true
           setMessages((prev) =>
@@ -2935,6 +3116,24 @@ export const useChatActions = ({
       })
       if (shouldUseRag) {
         markSteeringApplied()
+        const workspaceServerChat = await ensureWorkspaceServerChatForTurn({
+          message,
+          serverChatIdOverride
+        })
+        const scopedRagModeParams = workspaceServerChat.chatId
+          ? {
+              ...chatModeParamsWithRegen,
+              historyId:
+                workspaceServerChat.historyId ?? chatModeParamsWithRegen.historyId,
+              serverChatId: workspaceServerChat.chatId,
+              conversationId: workspaceServerChat.chatId,
+              saveMessageOnSuccess: (data: SaveMessageData) =>
+                saveMessageOnSuccess({
+                  ...data,
+                  conversationId: workspaceServerChat.chatId
+                })
+            }
+          : chatModeParamsWithRegen
         const ragResult = await ragMode(
           message,
           image,
@@ -2942,7 +3141,7 @@ export const useChatActions = ({
           chatHistory || messages,
           memory || history,
           signal,
-          chatModeParamsWithRegen
+          scopedRagModeParams
         )
         return toChatSubmitResult(ragResult)
       } else {
@@ -3103,6 +3302,24 @@ export const useChatActions = ({
                     effectiveAssistantState.systemPromptSnapshot ?? undefined
                 }
               : enhancedChatModeParams
+          const workspaceServerChat = await ensureWorkspaceServerChatForTurn({
+            message,
+            serverChatIdOverride
+          })
+          const scopedNormalModeParams = workspaceServerChat.chatId
+            ? {
+                ...normalModeParams,
+                historyId:
+                  workspaceServerChat.historyId ?? normalModeParams.historyId,
+                serverChatId: workspaceServerChat.chatId,
+                conversationId: workspaceServerChat.chatId,
+                saveMessageOnSuccess: (data: SaveMessageData) =>
+                  saveMessageOnSuccess({
+                    ...data,
+                    conversationId: workspaceServerChat.chatId
+                  })
+              }
+            : normalModeParams
           const normalResult = await normalChatMode(
             message,
             image,
@@ -3110,7 +3327,7 @@ export const useChatActions = ({
             baseMessages,
             baseHistory,
             signal,
-            normalModeParams
+            scopedNormalModeParams
           )
           return toChatSubmitResult(normalResult)
         } else {

--- a/apps/packages/ui/src/services/__tests__/chat-settings.sync.test.ts
+++ b/apps/packages/ui/src/services/__tests__/chat-settings.sync.test.ts
@@ -141,7 +141,8 @@ describe("syncChatSettingsForServerChat", () => {
     expect(mocks.updateChatSettings).toHaveBeenCalledTimes(1)
     expect(mocks.updateChatSettings).toHaveBeenCalledWith(
       serverChatId,
-      localSettings
+      localSettings,
+      undefined
     )
     expect(result).toEqual(localSettings)
   })
@@ -181,7 +182,8 @@ describe("syncChatSettingsForServerChat", () => {
           id: "persona-11",
           system_prompt_snapshot: "Keep answers structured and calm."
         })
-      })
+      }),
+      undefined
     )
     expect(
       state.storage.get(
@@ -235,6 +237,36 @@ describe("syncChatSettingsForServerChat", () => {
     } finally {
       warnSpy.mockRestore()
     }
+  })
+
+  it("passes workspace scope through server settings sync", async () => {
+    const historyId = "history-workspace-sync"
+    const serverChatId = "chat-workspace-sync"
+    const scope = { type: "workspace", workspaceId: "workspace-1" } as const
+    const localSettings = createSettings({
+      authorNote: "Workspace-scoped note."
+    })
+    state.storage.set(
+      getChatSettingsStorageKey(
+        resolveChatSettingsKey({ historyId, serverChatId: null })
+      ),
+      localSettings
+    )
+    state.remoteSettings = null
+
+    const result = await syncChatSettingsForServerChat({
+      historyId,
+      serverChatId,
+      scope
+    })
+
+    expect(mocks.getChatSettings).toHaveBeenCalledWith(serverChatId, { scope })
+    expect(mocks.updateChatSettings).toHaveBeenCalledWith(
+      serverChatId,
+      localSettings,
+      { scope }
+    )
+    expect(result).toEqual(localSettings)
   })
 })
 

--- a/apps/packages/ui/src/services/chat-settings.ts
+++ b/apps/packages/ui/src/services/chat-settings.ts
@@ -10,6 +10,7 @@ import {
   ConversationContextSettings,
   DeepResearchAttachment
 } from "@/types/chat-session-settings"
+import type { ChatScope } from "@/types/chat-scope"
 
 const storage = createSafeStorage()
 const MAX_CHAT_SETTINGS_BYTES = 200_000
@@ -665,9 +666,11 @@ export const syncChatSettingsForServerChat = async (params: {
   historyId: string | null
   serverChatId: string | null
   allowScratchFallback?: boolean
+  scope?: ChatScope
 }): Promise<ChatSettingsRecord | null> => {
-  const { historyId, serverChatId, allowScratchFallback = false } = params
+  const { historyId, serverChatId, allowScratchFallback = false, scope } = params
   if (!serverChatId) return null
+  const scopeOptions = scope ? { scope } : undefined
 
   const serverKey = resolveChatSettingsKey({ historyId: null, serverChatId })
   const localKey = resolveChatSettingsKey({ historyId, serverChatId: null })
@@ -686,7 +689,7 @@ export const syncChatSettingsForServerChat = async (params: {
 
   let remoteSettings: ChatSettingsRecord | null = null
   try {
-    const res = await tldwClient.getChatSettings(serverChatId)
+    const res = await tldwClient.getChatSettings(serverChatId, scopeOptions)
     remoteSettings = coerceSettings(res.settings)
   } catch (error) {
     if (!isMissingRemoteChatSettingsError(error)) {
@@ -696,7 +699,11 @@ export const syncChatSettingsForServerChat = async (params: {
 
   if (!remoteSettings && localSettings) {
     try {
-      const res = await tldwClient.updateChatSettings(serverChatId, localSettings)
+      const res = await tldwClient.updateChatSettings(
+        serverChatId,
+        localSettings,
+        scopeOptions
+      )
       const synced = coerceSettings(res.settings) || localSettings
       await saveChatSettingsForKey(serverKey, synced)
       if (usedScratchFallback) {
@@ -727,7 +734,7 @@ export const syncChatSettingsForServerChat = async (params: {
 
   if (mergedTime >= remoteTime) {
     try {
-      await tldwClient.updateChatSettings(serverChatId, merged)
+      await tldwClient.updateChatSettings(serverChatId, merged, scopeOptions)
     } catch (error) {
       console.warn("Failed to reconcile chat settings to server", error)
     }

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -4973,10 +4973,14 @@ export class TldwApiClientBase {
     })
   }
 
-  async getChatSettings(chat_id: string | number): Promise<ChatSettingsResponse> {
+  async getChatSettings(
+    chat_id: string | number,
+    options?: { scope?: ChatScope }
+  ): Promise<ChatSettingsResponse> {
     const cid = String(chat_id)
+    const query = this.buildQuery(toChatScopeParams(options?.scope))
     return await bgRequest<ChatSettingsResponse>({
-      path: `/api/v1/chats/${cid}/settings`,
+      path: appendPathQuery(`/api/v1/chats/${cid}/settings`, query),
       method: "GET",
       expectedStatuses: [404]
     })
@@ -4984,11 +4988,13 @@ export class TldwApiClientBase {
 
   async updateChatSettings(
     chat_id: string | number,
-    settings: Record<string, unknown>
+    settings: Record<string, unknown>,
+    options?: { scope?: ChatScope }
   ): Promise<ChatSettingsResponse> {
     const cid = String(chat_id)
+    const query = this.buildQuery(toChatScopeParams(options?.scope))
     return await bgRequest<ChatSettingsResponse>({
-      path: `/api/v1/chats/${cid}/settings`,
+      path: appendPathQuery(`/api/v1/chats/${cid}/settings`, query),
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: { settings }

--- a/apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts
@@ -1,0 +1,727 @@
+import { type Page, type Route } from "@playwright/test"
+
+import { expect, test } from "./smoke.setup"
+import { seedAuth, waitForAppShell } from "../utils/helpers"
+
+const API_SERVER_URL = "http://127.0.0.1:8000"
+const API_KEY = "THIS-IS-A-SECURE-KEY-123-FAKE-KEY"
+const WORKSPACE_ID = "workspace-chat-live-smoke"
+const WORKSPACE_NAME = "Chat Live Smoke Workspace"
+const MODEL_ID = "e2e-chat-model"
+const SELECTED_MODEL = `tldw:${MODEL_ID}`
+const PERSONA_ID = "workspace_smoke_persona"
+const PERSONA_NAME = "Workspace Smoke Persona"
+const READY_SOURCE_ID = "workspace-smoke-ready-source"
+const READY_SOURCE_TITLE = "Workspace Smoke Source"
+const READY_SOURCE_MEDIA_ID = 24601
+const FALLBACK_SOURCE_ID = "workspace-smoke-fallback-source"
+const FALLBACK_SOURCE_TITLE = "Workspace Smoke Fallback Source"
+
+type CapturedRequest = {
+  method: string
+  path: string
+  query: Record<string, string>
+  body: unknown
+}
+
+type BackendFixtureMode = "success" | "streaming" | "failure"
+
+type BackendFixture = {
+  chatCreates: CapturedRequest[]
+  chatMessages: CapturedRequest[]
+  chatCompletions: CapturedRequest[]
+  ragSearches: CapturedRequest[]
+}
+
+const CORS_HEADERS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-headers": "*",
+  "access-control-allow-methods": "GET,POST,PUT,DELETE,OPTIONS",
+  "access-control-expose-headers": "*"
+}
+
+const nowIso = () => "2026-06-30T12:00:00.000Z"
+
+const parseRequestJson = async (route: Route): Promise<unknown> => {
+  const raw = route.request().postData()
+  if (!raw) return null
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return raw
+  }
+}
+
+const captureRequest = async (route: Route): Promise<CapturedRequest> => {
+  const request = route.request()
+  const url = new URL(request.url())
+  return {
+    method: request.method().toUpperCase(),
+    path: url.pathname,
+    query: Object.fromEntries(url.searchParams.entries()),
+    body: await parseRequestJson(route)
+  }
+}
+
+const fulfillJson = async (
+  route: Route,
+  status: number,
+  body: unknown
+): Promise<void> => {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    headers: CORS_HEADERS,
+    body: JSON.stringify(body)
+  })
+}
+
+const fulfillOptions = async (route: Route): Promise<void> => {
+  await route.fulfill({
+    status: 204,
+    headers: CORS_HEADERS
+  })
+}
+
+const makeChatSummary = (id: string, title = "Workspace smoke chat") => ({
+  id,
+  chat_id: id,
+  title,
+  state: "in-progress",
+  version: 1,
+  created_at: nowIso(),
+  updated_at: nowIso(),
+  assistant_kind: null,
+  assistant_id: null,
+  character_id: null,
+  persona_memory_mode: null,
+  scope_type: "workspace",
+  workspace_id: WORKSPACE_ID
+})
+
+const installBackendFixture = async (
+  page: Page,
+  options: { mode?: BackendFixtureMode; streamDelayMs?: number } = {}
+): Promise<BackendFixture> => {
+  const mode = options.mode ?? "success"
+  const streamDelayMs = options.streamDelayMs ?? 4_000
+  const fixture: BackendFixture = {
+    chatCreates: [],
+    chatMessages: [],
+    chatCompletions: [],
+    ragSearches: []
+  }
+
+  await page.route("**/openapi.json", async (route) => {
+    await fulfillJson(route, 200, {
+      openapi: "3.1.0",
+      info: { title: "tldw e2e fixture", version: "0.0.0" },
+      paths: {
+        "/api/v1/chats/": {},
+        "/api/v1/chat/completions": {},
+        "/api/v1/rag/search": {}
+      }
+    })
+  })
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request()
+    const method = request.method().toUpperCase()
+    const url = new URL(request.url())
+    const path = url.pathname
+
+    if (method === "OPTIONS") {
+      await fulfillOptions(route)
+      return
+    }
+
+    if (path === "/api/v1/health" || path === "/api/v1/health/live") {
+      await fulfillJson(route, 200, {
+        status: "healthy",
+        ok: true,
+        version: "e2e-chat-workspace"
+      })
+      return
+    }
+
+    if (
+      path === "/api/v1/setup/first-run/state" ||
+      path === "/api/v1/setup/first-run/metadata"
+    ) {
+      await fulfillJson(route, 200, {
+        status: "completed",
+        setup_required: false,
+        setup_completed: true,
+        current_step: null,
+        completed_steps: ["first_chat"],
+        acknowledged_steps: ["first_chat"],
+        connection: {
+          frontend_origin: "http://localhost:8080",
+          api_origin: API_SERVER_URL,
+          browser_access: "local"
+        }
+      })
+      return
+    }
+
+    if (path === "/api/v1/config/docs-info") {
+      await fulfillJson(route, 200, {
+        server_version: "e2e-chat-workspace",
+        openapi_url: "/openapi.json",
+        features: {
+          rag: true,
+          persona_live_control: true,
+          chat_workspace: true
+        }
+      })
+      return
+    }
+
+    if (path === "/api/v1/config/providers") {
+      await fulfillJson(route, 200, {
+        any_configured: true,
+        providers: [
+          {
+            name: "openai",
+            configured: true,
+            requires_api_key: true,
+            key_source: "e2e"
+          }
+        ]
+      })
+      return
+    }
+
+    if (path === "/api/v1/llm/providers") {
+      await fulfillJson(route, 200, {
+        providers: [
+          {
+            name: "openai",
+            is_configured: true,
+            configured: true,
+            default_model: MODEL_ID,
+            models: [MODEL_ID]
+          }
+        ],
+        any_configured: true
+      })
+      return
+    }
+
+    if (path === "/api/v1/llm/models/metadata") {
+      await fulfillJson(route, 200, {
+        models: [
+          {
+            id: MODEL_ID,
+            name: MODEL_ID,
+            model: MODEL_ID,
+            provider: "openai",
+            type: "chat",
+            capabilities: ["chat"],
+            modalities: ["text"],
+            is_configured: true,
+            provider_is_configured: true,
+            catalog_only: false
+          }
+        ],
+        total: 1
+      })
+      return
+    }
+
+    if (path === "/api/v1/rag/health") {
+      await fulfillJson(route, 200, { status: "healthy", ok: true })
+      return
+    }
+
+    if (path === "/api/v1/rag/search" && method === "POST") {
+      const captured = await captureRequest(route)
+      fixture.ragSearches.push(captured)
+      await fulfillJson(route, 200, {
+        generated_answer: `Grounded answer for ${READY_SOURCE_TITLE}`,
+        results: [
+          {
+            content: "The workspace smoke source contains a deterministic proof point.",
+            metadata: {
+              title: READY_SOURCE_TITLE,
+              source: READY_SOURCE_TITLE,
+              type: "pdf",
+              url: "workspace://smoke-source",
+              media_id: READY_SOURCE_MEDIA_ID
+            }
+          }
+        ],
+        citations: [],
+        metadata: { fixture: "chat-workspace-live-backend" }
+      })
+      return
+    }
+
+    if ((path === "/api/v1/chats" || path === "/api/v1/chats/") && method === "GET") {
+      await fulfillJson(route, 200, { items: [], chats: [], total: 0 })
+      return
+    }
+
+    if ((path === "/api/v1/chats" || path === "/api/v1/chats/") && method === "POST") {
+      const captured = await captureRequest(route)
+      fixture.chatCreates.push(captured)
+      const body = captured.body as Record<string, unknown> | null
+      const id = `workspace-chat-smoke-server-${fixture.chatCreates.length}`
+      await fulfillJson(
+        route,
+        200,
+        makeChatSummary(
+          id,
+          typeof body?.title === "string" ? body.title : "Workspace smoke chat"
+        )
+      )
+      return
+    }
+
+    const chatSettingsMatch = path.match(/^\/api\/v1\/chats\/([^/]+)\/settings\/?$/)
+    if (chatSettingsMatch) {
+      await fulfillJson(route, 200, {
+        chat_id: chatSettingsMatch[1],
+        settings: {},
+        version: 1
+      })
+      return
+    }
+
+    const chatMessagesMatch = path.match(/^\/api\/v1\/chats\/([^/]+)\/messages\/?$/)
+    if (chatMessagesMatch && method === "GET") {
+      await fulfillJson(route, 200, { items: [], messages: [], total: 0 })
+      return
+    }
+    if (chatMessagesMatch && method === "POST") {
+      const captured = await captureRequest(route)
+      fixture.chatMessages.push(captured)
+      await fulfillJson(route, 200, {
+        id: `workspace-message-${fixture.chatMessages.length}`,
+        chat_id: chatMessagesMatch[1],
+        role: (captured.body as Record<string, unknown> | null)?.role ?? "assistant",
+        content: (captured.body as Record<string, unknown> | null)?.content ?? "",
+        version: fixture.chatMessages.length,
+        created_at: nowIso()
+      })
+      return
+    }
+
+    const chatMatch = path.match(/^\/api\/v1\/chats\/([^/]+)\/?$/)
+    if (chatMatch && method === "GET") {
+      await fulfillJson(route, 200, makeChatSummary(chatMatch[1]))
+      return
+    }
+
+    if (path === "/api/v1/chat/completions" && method === "POST") {
+      const captured = await captureRequest(route)
+      fixture.chatCompletions.push(captured)
+
+      if (mode === "failure") {
+        await fulfillJson(route, 503, {
+          detail: "Deterministic workspace failure"
+        })
+        return
+      }
+
+      if (mode === "streaming") {
+        await new Promise((resolve) => setTimeout(resolve, streamDelayMs))
+        try {
+          await route.fulfill({
+            status: 200,
+            contentType: "text/event-stream",
+            headers: {
+              ...CORS_HEADERS,
+              "cache-control": "no-cache",
+              connection: "keep-alive"
+            },
+            body: [
+              `data: ${JSON.stringify({
+                id: "chatcmpl-workspace-smoke",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { content: "streamed workspace reply" } }]
+              })}`,
+              "",
+              "data: [DONE]",
+              ""
+            ].join("\n")
+          })
+        } catch {
+          // The user-facing stop flow aborts the fetch before this delayed
+          // fixture responds. The aborted request has already exercised the UI.
+        }
+        return
+      }
+
+      await fulfillJson(route, 200, {
+        id: "chatcmpl-workspace-smoke",
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: "deterministic workspace response"
+            }
+          }
+        ]
+      })
+      return
+    }
+
+    await fulfillJson(route, 200, { status: "ok", fixture: "chat-workspace-live-backend" })
+  })
+
+  return fixture
+}
+
+const seedChatWorkspaceState = async (
+  page: Page,
+  options: {
+    sourceId?: string
+    sourceTitle?: string
+    mediaId?: number
+  } = {}
+): Promise<void> => {
+  const sourceId = options.sourceId ?? READY_SOURCE_ID
+  const sourceTitle = options.sourceTitle ?? READY_SOURCE_TITLE
+  const mediaId = options.mediaId ?? READY_SOURCE_MEDIA_ID
+
+  await seedAuth(page, {
+    serverUrl: API_SERVER_URL,
+    apiKey: API_KEY,
+    allowOffline: false
+  })
+
+  await page.addInitScript(
+    ({ mediaId, sourceId, sourceTitle }) => {
+      const seedValue = (key: string, value: unknown) => {
+        localStorage.setItem(key, JSON.stringify(value))
+        localStorage.setItem(`plasmo-storage-${key}`, JSON.stringify(value))
+      }
+      const now = "2026-06-30T12:00:00.000Z"
+      const source = {
+        id: sourceId,
+        mediaId,
+        title: sourceTitle,
+        type: "pdf",
+        status: "ready",
+        statusMessage: "Indexed for workspace smoke coverage.",
+        addedAt: now
+      }
+      const snapshot = {
+        workspaceId: "workspace-chat-live-smoke",
+        workspaceName: "Chat Live Smoke Workspace",
+        workspaceTag: "workspace:chat-live-smoke",
+        workspaceCreatedAt: now,
+        workspaceChatReferenceId: "workspace-chat-live-smoke",
+        sources: [source],
+        selectedSourceIds: [],
+        sourceFolders: [],
+        sourceFolderMemberships: [],
+        selectedSourceFolderIds: [],
+        activeFolderId: null,
+        generatedArtifacts: [],
+        notes: "",
+        currentNote: {
+          id: 1,
+          title: "Chat smoke note",
+          content: "",
+          keywords: [],
+          version: 1,
+          isDirty: false
+        },
+        workspaceBanner: {
+          title: "",
+          subtitle: "",
+          image: null
+        },
+        leftPaneCollapsed: false,
+        rightPaneCollapsed: false,
+        audioSettings: {
+          provider: "openai",
+          model: "gpt-4o-mini-tts",
+          voice: "alloy",
+          speed: 1,
+          format: "mp3"
+        }
+      }
+
+      seedValue("selectedModel", "tldw:e2e-chat-model")
+      seedValue("defaultApiProvider", "openai")
+      seedValue("selectedAssistant", {
+        kind: "persona",
+        id: "workspace_smoke_persona",
+        name: "Workspace Smoke Persona",
+        system_prompt: "Answer as the workspace smoke persona.",
+        metadata: { selectionMode: "overlay" }
+      })
+      seedValue("tldwModelsCache", {
+        version: 3,
+        timestamp: Date.parse(now),
+        scope: "http://127.0.0.1:8000|single-user|key|none",
+        models: [
+          {
+            id: "e2e-chat-model",
+            name: "e2e-chat-model",
+            provider: "openai",
+            type: "chat",
+            capabilities: ["chat"],
+            modalities: ["text"],
+            isConfigured: true,
+            providerIsConfigured: true,
+            catalogOnly: false
+          }
+        ]
+      })
+      localStorage.setItem(
+        "tldw-workspace",
+        JSON.stringify({
+          state: {
+            workspaceId: "workspace-chat-live-smoke",
+            workspaceName: "Chat Live Smoke Workspace",
+            workspaceTag: "workspace:chat-live-smoke",
+            workspaceCreatedAt: now,
+            workspaceChatReferenceId: "workspace-chat-live-smoke",
+            sources: [source],
+            selectedSourceIds: [],
+            sourceFolders: [],
+            sourceFolderMemberships: [],
+            selectedSourceFolderIds: [],
+            activeFolderId: null,
+            generatedArtifacts: [],
+            notes: "",
+            currentNote: snapshot.currentNote,
+            workspaceBanner: snapshot.workspaceBanner,
+            leftPaneCollapsed: false,
+            rightPaneCollapsed: false,
+            audioSettings: snapshot.audioSettings,
+            savedWorkspaces: [
+              {
+                id: "workspace-chat-live-smoke",
+                name: "Chat Live Smoke Workspace",
+                tag: "workspace:chat-live-smoke",
+                createdAt: now,
+                lastAccessedAt: now,
+                collectionId: null
+              }
+            ],
+            archivedWorkspaces: [],
+            workspaceCollections: [],
+            workspaceSnapshots: {
+              "workspace-chat-live-smoke": snapshot
+            },
+            workspaceChatSessions: {}
+          },
+          version: 1
+        })
+      )
+      localStorage.setItem(
+        "tldw-workspace:workspace:workspace-chat-live-smoke:snapshot",
+        JSON.stringify(snapshot)
+      )
+      localStorage.setItem(
+        "tldw-workspace",
+        JSON.stringify({
+          schema: "workspace_split_v1",
+          splitVersion: 1,
+          state: {
+            workspaceId: "workspace-chat-live-smoke",
+            savedWorkspaces: [
+              {
+                id: "workspace-chat-live-smoke",
+                name: "Chat Live Smoke Workspace",
+                tag: "workspace:chat-live-smoke",
+                createdAt: now,
+                lastAccessedAt: now,
+                collectionId: null
+              }
+            ],
+            archivedWorkspaces: [],
+            workspaceCollections: [],
+            workspaceIds: ["workspace-chat-live-smoke"],
+            workspaceSnapshots: {
+              "workspace-chat-live-smoke": snapshot
+            },
+            workspaceChatSessions: {}
+          },
+          version: 1
+        })
+      )
+    },
+    { mediaId, sourceId, sourceTitle }
+  )
+}
+
+const openSeededChatWorkspace = async (page: Page): Promise<void> => {
+  await page.goto("/chat-workspace", { waitUntil: "domcontentloaded" })
+  await waitForAppShell(page)
+  await expect(page.getByTestId("chat-workspace-page")).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: WORKSPACE_NAME, exact: true })
+  ).toBeVisible()
+  await expect(page.getByText(SELECTED_MODEL)).toBeVisible()
+  await expect(page.getByText(PERSONA_NAME)).toBeVisible()
+}
+
+test.describe("Chat Workspace live-backend smoke coverage", () => {
+  test("sends staged workspace media through scoped backend requests", async ({ page }) => {
+    const fixture = await installBackendFixture(page)
+    await seedChatWorkspaceState(page)
+    await openSeededChatWorkspace(page)
+
+    await page
+      .getByRole("button", { name: `Stage ${READY_SOURCE_TITLE} for chat` })
+      .click()
+    await expect(
+      page.getByRole("region", { name: "Staged context" })
+    ).toContainText(READY_SOURCE_TITLE)
+
+    const message = "Summarize the staged source for the release gate"
+    await page.getByLabel("Chat workspace message").fill(message)
+    await expect(page.getByRole("button", { name: "Send message" })).toBeEnabled()
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    await expect(page.getByText("deterministic workspace response")).toBeVisible()
+    await expect(page.getByRole("region", { name: "Staged context" })).toHaveCount(0)
+    await expect(page.getByLabel("Chat workspace message")).toHaveValue("")
+
+    expect(fixture.chatCreates).toHaveLength(1)
+    expect(fixture.chatCreates[0]?.body).toMatchObject({
+      scope_type: "workspace",
+      workspace_id: WORKSPACE_ID
+    })
+    expect(fixture.ragSearches).toHaveLength(1)
+    expect(fixture.ragSearches[0]?.body).toMatchObject({
+      include_media_ids: [READY_SOURCE_MEDIA_ID],
+      sources: ["media_db"]
+    })
+    const completionBody = fixture.chatCompletions[0]?.body as {
+      messages?: Array<{ content?: unknown }>
+    }
+    expect(JSON.stringify(completionBody.messages)).toContain(
+      "The workspace smoke source contains a deterministic proof point."
+    )
+    expect(fixture.chatMessages.map((entry) => entry.path)).toContain(
+      "/api/v1/chats/workspace-chat-smoke-server-1/messages"
+    )
+  })
+
+  test("browses, unstages, re-stages, and sends the selected workspace source", async ({ page }) => {
+    const fixture = await installBackendFixture(page)
+    await seedChatWorkspaceState(page)
+    await openSeededChatWorkspace(page)
+
+    await expect(page.getByRole("link", { name: "Add source" })).toHaveAttribute(
+      "href",
+      "/research-workspace?tab=sources"
+    )
+    await expect(page.getByRole("link", { name: "Open library" })).toHaveAttribute(
+      "href",
+      "/media"
+    )
+
+    await page.getByRole("button", { name: `Browse ${READY_SOURCE_TITLE}` }).click()
+    await expect(page.getByText("Browsing")).toBeVisible()
+
+    await page
+      .getByRole("button", { name: `Stage ${READY_SOURCE_TITLE} for chat` })
+      .click()
+    await expect(
+      page.getByRole("region", { name: "Staged context" })
+    ).toContainText(READY_SOURCE_TITLE)
+
+    await page
+      .getByRole("button", { name: `Unstage ${READY_SOURCE_TITLE} from chat` })
+      .click()
+    await expect(page.getByRole("region", { name: "Staged context" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Send message" })).toBeDisabled()
+
+    await page
+      .getByRole("button", { name: `Stage ${READY_SOURCE_TITLE} for chat` })
+      .click()
+    await page
+      .getByLabel("Chat workspace message")
+      .fill("Use the re-staged source after unstage")
+    await page.getByRole("button", { name: "Send with staged context" }).click()
+
+    await expect(page.getByText("deterministic workspace response")).toBeVisible()
+    expect(fixture.ragSearches).toHaveLength(1)
+    expect(fixture.ragSearches[0]?.body).toMatchObject({
+      include_media_ids: [READY_SOURCE_MEDIA_ID],
+      sources: ["media_db"]
+    })
+    const completionBody = fixture.chatCompletions[0]?.body as {
+      messages?: Array<{ content?: unknown }>
+    }
+    expect(JSON.stringify(completionBody.messages)).toContain(
+      "The workspace smoke source contains a deterministic proof point."
+    )
+  })
+
+  test("shows stop generation while the workspace stream is active", async ({ page }) => {
+    const fixture = await installBackendFixture(page, {
+      mode: "streaming",
+      streamDelayMs: 4_000
+    })
+    await seedChatWorkspaceState(page)
+    await openSeededChatWorkspace(page)
+
+    await page.getByLabel("Chat workspace message").fill("Stream long enough to stop")
+    await expect(page.getByRole("button", { name: "Send message" })).toBeEnabled()
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const stopButton = page.getByRole("button", { name: "Stop generating" })
+    await expect(stopButton).toBeVisible()
+    await expect.poll(() => fixture.chatCreates.length).toBeGreaterThan(0)
+    expect(fixture.chatCreates[0]?.body).toMatchObject({
+      scope_type: "workspace",
+      workspace_id: WORKSPACE_ID
+    })
+    await expect.poll(() => fixture.chatCompletions.length).toBeGreaterThan(0)
+    expect(fixture.chatCompletions[0]?.body).toMatchObject({
+      stream: true,
+      conversation_id: "workspace-chat-smoke-server-1"
+    })
+
+    await stopButton.click()
+    await expect(stopButton).toBeHidden()
+  })
+
+  test("preserves draft and staged fallback context after send failure", async ({ page }) => {
+    const fixture = await installBackendFixture(page, { mode: "failure" })
+    await seedChatWorkspaceState(page, {
+      sourceId: FALLBACK_SOURCE_ID,
+      sourceTitle: FALLBACK_SOURCE_TITLE,
+      mediaId: 0
+    })
+    await openSeededChatWorkspace(page)
+
+    await page
+      .getByRole("button", { name: `Stage ${FALLBACK_SOURCE_TITLE} for chat` })
+      .click()
+    await expect(
+      page.getByRole("region", { name: "Staged context" })
+    ).toContainText(FALLBACK_SOURCE_TITLE)
+
+    const draft = "Keep this draft when the backend fails"
+    await page.getByLabel("Chat workspace message").fill(draft)
+    await expect(page.getByRole("button", { name: "Send message" })).toBeEnabled()
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    await expect(
+      page.getByRole("alert").filter({ hasText: "Stream completion failed" })
+    ).toBeVisible()
+    await expect(page.getByLabel("Chat workspace message")).toHaveValue(draft)
+    await expect(
+      page.getByRole("region", { name: "Staged context" })
+    ).toContainText(FALLBACK_SOURCE_TITLE)
+
+    expect(fixture.ragSearches).toHaveLength(0)
+    expect(fixture.chatCompletions).toHaveLength(1)
+    const completionBody = fixture.chatCompletions[0]?.body as {
+      messages?: Array<{ content?: unknown }>
+    }
+    expect(JSON.stringify(completionBody.messages)).toContain("Context sources:")
+    expect(JSON.stringify(completionBody.messages)).toContain(FALLBACK_SOURCE_TITLE)
+  })
+
+})

--- a/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
+++ b/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
@@ -716,6 +716,27 @@ export const SMOKE_HARD_GATE_ALLOWLIST: SmokeHardGateAllowlistRule[] = [
     routes: ["/characters"]
   },
   {
+    id: "m5-chat-workspace-startup-backend-refused-console",
+    scope: "console",
+    pattern: /Failed to load resource: net::ERR_CONNECTION_REFUSED/i,
+    rationale:
+      "Chat Workspace route smoke may run without a local API server; focused smoke proof covers the scoped backend chat flow.",
+    owner: "WebUI",
+    expiresOn: "2026-09-30",
+    routes: ["/chat-workspace"]
+  },
+  {
+    id: "m5-chat-workspace-startup-backend-refused-request",
+    scope: "request",
+    pattern:
+      /\/api\/v1\/(?:notifications(?:\/stream)?|persona\/profiles)(?:[/?][^)]*)?\s+\(net::ERR_CONNECTION_REFUSED\)/i,
+    rationale:
+      "Chat Workspace startup probes for notifications/persona data can be unavailable in route-only smoke; scoped backend chat is covered by the focused proof.",
+    owner: "WebUI",
+    expiresOn: "2026-09-30",
+    routes: ["/chat-workspace"]
+  },
+  {
     id: "m5-model-metadata-rate-limit-log-noise",
     scope: "console",
     pattern:

--- a/apps/tldw-frontend/e2e/smoke/stage5-release-gate.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/stage5-release-gate.spec.ts
@@ -81,11 +81,20 @@ type CriticalRoute = {
   expectedPath?: string
   allowRedirectPanel?: boolean
   loadTimeoutMs?: number
+  focusedProof?: string
 }
+
+const FOCUSED_PROOF_ROUTES = new Map<string, string>([
+  ["/chat-workspace", "e2e/smoke/chat-workspace-live-backend.spec.ts"]
+])
 
 const CRITICAL_ROUTES: CriticalRoute[] = [
   { path: "/chat", name: "Chat" },
-  { path: "/chat-workspace", name: "Chat Workspace" },
+  {
+    path: "/chat-workspace",
+    name: "Chat Workspace",
+    focusedProof: "e2e/smoke/chat-workspace-live-backend.spec.ts"
+  },
   { path: "/settings", name: "Settings" },
   { path: "/chat/settings", name: "Chat Settings", expectedPath: "/settings/chat" },
   { path: "/settings/chatbooks", name: "Chatbooks Settings" },
@@ -117,6 +126,14 @@ test.describe("Stage 5 release gate", () => {
       test.setTimeout(
         Math.max(180_000, routeLoadTimeout * NAVIGATION_MAX_ATTEMPTS + 45_000)
       )
+      const expectedFocusedProof = FOCUSED_PROOF_ROUTES.get(route.path)
+      if (expectedFocusedProof) {
+        expect(
+          route.focusedProof,
+          `${route.name} (${route.path}) must reference its focused smoke proof`
+        ).toBe(expectedFocusedProof)
+      }
+
       await seedAuth(page)
 
       const response = await gotoCriticalRoute(

--- a/apps/tldw-frontend/e2e/smoke/stage6-interaction-stage1.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/stage6-interaction-stage1.spec.ts
@@ -1,14 +1,33 @@
+import type { Page } from "@playwright/test"
 import { test, expect, seedAuth, SMOKE_LOAD_TIMEOUT } from "./smoke.setup"
 import { waitForAppShell } from "../utils/helpers"
 
 const LOAD_TIMEOUT = SMOKE_LOAD_TIMEOUT
 const UNRESOLVED_TEMPLATE_PATTERN = /\{\{[^{}\n]{1,120}\}\}/g
 
+const prepareChatRoute = async (page: Page) => {
+  await page.route("**/api/v1/llm/providers**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ providers: [], any_configured: false })
+    })
+  })
+  await page.route("**/api/v1/llm/models/metadata**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ models: [], total: 0 })
+    })
+  })
+  await seedAuth(page)
+}
+
 test.describe("Stage 6 interaction stage 1 defect closures", () => {
   test("chat route does not expose unresolved template placeholders", async ({
     page
   }) => {
-    await seedAuth(page)
+    await prepareChatRoute(page)
 
     await page.goto("/chat", {
       waitUntil: "domcontentloaded",
@@ -35,7 +54,7 @@ test.describe("Stage 6 interaction stage 1 defect closures", () => {
   test("chat route exposes an explicit theme toggle control", async ({
     page
   }) => {
-    await seedAuth(page)
+    await prepareChatRoute(page)
 
     await page.goto("/chat", {
       waitUntil: "domcontentloaded",

--- a/backlog/tasks/task-12130 - Implement-Chat-Workspace-live-backend-flow-and-scoped-persistence.md
+++ b/backlog/tasks/task-12130 - Implement-Chat-Workspace-live-backend-flow-and-scoped-persistence.md
@@ -1,0 +1,76 @@
+---
+id: TASK-12130
+title: Implement Chat Workspace live backend flow and scoped persistence
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-07-03 19:52
+labels:
+- WebUI
+- Front-End
+- ChatWorkspace
+dependencies: []
+references:
+- https://github.com/rmusser01/tldw_server/issues/2031
+- https://github.com/rmusser01/tldw_server/issues/1239
+- https://github.com/rmusser01/tldw_server/pull/2595
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #2031 for the Chat Workspace epic #1239: make /chat-workspace operate as a live backend chat surface with workspace-scoped chat creation/resume, streaming/stop support, draft and staged-context preservation on errors, and clear model/persona readiness state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Model selection is usable or clearly inherited in Chat Workspace runtime state.
+- [x] #2 Persona/assistant selection is usable or clearly inherited in Chat Workspace runtime state.
+- [x] #3 Hydrated Workspace sends create or resume workspace-scoped server chats.
+- [x] #4 Streaming renders incrementally and Stop generation aborts the request.
+- [x] #5 Send errors preserve draft text and staged context.
+- [x] #6 Workspace-scoped history persists, reloads, and switches without leaking global chats.
+- [x] #7 No send path can create a global or empty-workspace chat while Workspace identity is hydrating.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-26-chat-workspace-live-flow-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Wired Chat Workspace scope through persona-backed chat creation so `createChat` receives `{ scope }` when invoked from a workspace.
+- Wired workspace scope through character-backed chat creation, greeting/user/assistant persistence, streaming, and completion persistence.
+- Added workspace-only server chat bootstrap for plain normal sends and staged RAG sends so hydrated workspace turns create/resume workspace-scoped server chats and pass the server chat id as `conversationId` for persistence.
+- Kept global/plain non-workspace sends out of the workspace bootstrap path with a red/green regression test.
+- Threaded scope through chat settings sync and the monolithic `TldwApiClient` settings helpers.
+- Updated focused tests for persona, character, settings sync, normal workspace sends, staged RAG sends, and global compatibility.
+- Verification: `./node_modules/.bin/vitest run src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.dynamic-ui-fallback.test.tsx src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx src/hooks/chat/__tests__/personaServerChat.test.ts src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx src/hooks/__tests__/useServerChatLoader.test.ts src/services/__tests__/chat-settings.sync.test.ts` passed 8 files / 75 tests.
+- Verification: `git diff --check` passed.
+- Verification: `NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit --project tsconfig.json` failed on existing unrelated repo-wide TypeScript errors outside the changed files.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed #2031 Chat Workspace live backend flow. Workspace sends create/resume scoped server chats, persona and character paths preserve workspace scope through chat creation and completion persistence, hydrated sends avoid global-chat leakage, streaming stop remains available, and failures preserve draft plus staged context.
+
+Post-review update: validated cached workspace server chat ids with `getChat(..., { scope })` before reuse, cleared stale server chat state before creating a fresh workspace chat, threaded workspace scope through all server-message mirroring calls, and kept `tldwClient` in the callback dependency list.
+
+Verification: focused Chat Workspace/Playground/hooks/settings Vitest passed 11 files / 127 tests; targeted hook Vitest passed 10 tests after type cleanup; Playwright chat-workspace live-backend smoke passed 4 tests; Stage 5 Chat Workspace release gate passed 1 test; Stage 6 interaction smoke passed 2 tests; shard coverage guard passed; git diff --check passed. Bandit is not applicable because no Python files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Tests or verification recorded.
+- [x] #2 Documentation updated when relevant: implementation plan updated.
+- [x] #3 Bandit skipped: no Python files touched.
+- [x] #4 Final summary added.
+- [x] #5 Acceptance criteria completed, including the live-backend smoke proof tracked by #2035.
+- [x] #6 Known skips/blockers documented: Bandit not applicable because no Python files were touched; repo-wide TypeScript baseline was not used as the final gate for this frontend branch.
+<!-- DOD:END -->

--- a/backlog/tasks/task-12131 - Add-Chat-Workspace-live-backend-browser-smoke-coverage.md
+++ b/backlog/tasks/task-12131 - Add-Chat-Workspace-live-backend-browser-smoke-coverage.md
@@ -1,0 +1,80 @@
+---
+id: TASK-12131
+title: Add Chat Workspace live-backend browser smoke coverage
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-07-03 19:52
+labels:
+- WebUI
+- Front-End
+- ChatWorkspace
+- E2E
+dependencies: []
+references:
+- https://github.com/rmusser01/tldw_server/issues/2035
+- https://github.com/rmusser01/tldw_server/issues/1239
+- https://github.com/rmusser01/tldw_server/pull/2595
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #2035 for the Chat Workspace epic #1239: add focused Playwright coverage that opens /chat-workspace in an authenticated shell, exercises workspace-scoped send behavior against a live or realistic backend, verifies streaming/stop, error recovery, staged context, and links the release gate to this focused proof.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WebUI Playwright coverage opens /chat-workspace in an authenticated shell against a live or realistic test backend.
+- [x] #2 Coverage selects or seeds a usable model and persona/assistant state where applicable.
+- [x] #3 Coverage sends a workspace-scoped message and verifies the request carries workspace scope.
+- [x] #4 Coverage observes streaming or a deterministic mocked streaming state.
+- [x] #5 Coverage verifies stop generation when streaming is active.
+- [x] #6 Coverage exercises send failure/error recovery without clearing draft or staged context.
+- [x] #7 Coverage stages at least one workspace source and verifies structured media ids or fallback summary behavior.
+- [x] #8 The release gate references this focused proof rather than relying only on backend-unavailable route smoke.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-30-chat-workspace-live-backend-smoke-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented #2035 focused Chat Workspace browser smoke coverage.
+
+Touched files:
+- apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts
+- apps/tldw-frontend/e2e/smoke/stage5-release-gate.spec.ts
+- apps/tldw-frontend/e2e/smoke/smoke.setup.ts
+- Docs/superpowers/plans/2026-06-30-chat-workspace-live-backend-smoke-plan.md
+
+Implementation notes:
+- Added deterministic authenticated /chat-workspace Playwright coverage with seeded workspace, selected model, overlay persona, and staged sources.
+- Backend fixture covers health/config/model/chat/RAG endpoints, captures request bodies, returns selected-source generated RAG answer, delays streaming so Stop generation is visible, and returns deterministic streaming failure for recovery assertions.
+- Assertions verify workspace scope in chat creation, structured include_media_ids for ready staged media, fallback context injection for staged source without valid media id, stop button during active streaming, and draft/staged context preservation after failure.
+- Stage 5 release gate now requires /chat-workspace to reference the focused proof spec and narrowly allowlists no-backend startup probes for notifications/persona on route-only smoke.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed focused #2035 Chat Workspace live-backend browser smoke coverage and release-gate reference.
+
+Post-review update: made the smoke fixture deterministic by replacing `Date.now()` with the fixed seeded timestamp, seeded the current split workspace persistence keys for reliable workspace hydration, and made the streaming assertion wait for the captured chat-create request before checking scope. Stage 6 chat route smoke now stubs model/provider metadata so it tests the theme-toggle interaction without unrelated offline backend overlays.
+
+Verification: npx playwright test e2e/smoke/chat-workspace-live-backend.spec.ts --project=chromium passed 4 tests; npx playwright test e2e/smoke/stage5-release-gate.spec.ts --project=chromium --grep "Chat Workspace" passed 1 test; npx playwright test e2e/smoke/stage6-interaction-stage1.spec.ts --project=chromium passed 2 tests; git diff --check passed. Bandit is not applicable because no Python files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12132 - Complete-Chat-Workspace-source-rail-and-staged-context-lifecycle.md
+++ b/backlog/tasks/task-12132 - Complete-Chat-Workspace-source-rail-and-staged-context-lifecycle.md
@@ -1,0 +1,103 @@
+---
+id: TASK-12132
+title: Complete Chat Workspace source rail and staged-context lifecycle
+status: Done
+assignee: []
+created_date: 2026-07-02 03:33
+updated_date: 2026-07-03 19:52
+labels:
+- WebUI
+- Front-End
+- ChatWorkspace
+dependencies: []
+references:
+- https://github.com/rmusser01/tldw_server/issues/2032
+- https://github.com/rmusser01/tldw_server/issues/1239
+- https://github.com/rmusser01/tldw_server/pull/2595
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #2032. Finish the /chat-workspace source rail and staged-context lifecycle so real workspace sources can be browsed, staged, unstaged, and sent without leaking state across workspace switches.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Source rail is wired to real workspace sources for browse/open workflows.
+- [x] #2 Add source and open library actions either work or route to the canonical source-management flow.
+- [x] #3 Users can stage and unstage individual sources without clearing all context.
+- [x] #4 Ready, processing, error, and unavailable states are rendered with clear actions and non-actionable states disabled.
+- [x] #5 Empty states distinguish no workspace sources, filtered-out sources, and source loading/error states.
+- [x] #6 Staged context sends ready media through structured media ids when possible.
+- [x] #7 Staged context inserts a readable fallback summary when sources cannot be carried structurally.
+- [x] #8 Switching workspace clears stale browsed/staged source state and cannot leak prior workspace context.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan file: Docs/superpowers/plans/2026-07-02-chat-workspace-source-rail-lifecycle-plan.md
+
+Design review adjustments before implementation:
+- Ready sources with invalid/missing mediaId remain stageable and use fallback summary text.
+- Processing/error/unavailable sources cannot be staged, but already-staged sources can always be unstaged.
+- Browse primes workspace source focus without implicit navigation; Add/Open actions route explicitly.
+- Source loading/error states come from the workspace store.
+- Individual unstage guards against stale prior-workspace callbacks.
+- Duplicate source titles keep disambiguated accessible action names.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan after design review. Worktree-local tracker supersedes an accidentally-created base-checkout duplicate that was removed before behavior edits.
+
+Implementation completed in the chat-workspace-live-flow worktree.
+
+Touched #2032 files:
+- apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceRail.tsx
+- apps/packages/ui/src/components/Option/ChatWorkspace/ContextStagingCard.tsx
+- apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx
+- apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspaceConsole.tsx
+- apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
+- apps/packages/ui/src/components/Option/ChatWorkspace/staging.ts
+- apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceRail.test.tsx
+- apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ContextStagingCard.test.tsx
+- apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx
+- apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/staging.test.ts
+- apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts
+- Docs/superpowers/plans/2026-07-02-chat-workspace-source-rail-lifecycle-plan.md
+
+Verification:
+- RED: bunx vitest run src/components/Option/ChatWorkspace/__tests__/staging.test.ts src/components/Option/ChatWorkspace/__tests__/WorkspaceRail.test.tsx src/components/Option/ChatWorkspace/__tests__/ContextStagingCard.test.tsx src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx failed for expected missing unstage/link/state behavior under apps/packages/ui.
+- GREEN: same focused Vitest command passed: 4 files, 36 tests.
+- Browser: TLDW_WEB_URL=http://localhost:18080 TLDW_WEB_CMD="bun run dev -- -p 18080" npx playwright test e2e/smoke/chat-workspace-live-backend.spec.ts --project=chromium passed: 4 tests. Escalation was required because sandbox blocked binding the fresh local dev server; fresh port was needed because 8080 had a stale reused server.
+- Whitespace: git diff --check passed.
+- Bandit: not applicable; #2032 touched TypeScript/TSX/docs/test files only, no Python.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed #2032 locally. Chat Workspace source rail uses real workspace source loading/error state, routes Add source/Open library to canonical source-management surfaces, primes workspace source focus on browse, supports individual unstage from both rail and staged context, renders ready/processing/error/unavailable source states, distinguishes loading/error/no-source/filter-empty states, preserves workspace-switch stale-callback guards, and keeps ready sources with invalid media ids stageable for fallback-summary sends.
+
+Post-review update: internal source-management links now use React Router `Link` when a router context is present, with the existing anchor fallback preserved for isolated renders/tests.
+
+Verification: focused Chat Workspace/Playground/hooks/settings Vitest passed 11 files / 127 tests; Playwright chat-workspace live-backend smoke passed 4 tests; Stage 5 Chat Workspace release gate passed 1 test; git diff --check passed. Bandit remains not applicable because no Python files were touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused component tests cover unstage and source state variants.
+- [x] #8 At least one browser workflow covers stage, unstage, and send with staged context.
+- [x] #9 git diff --check passes.
+- [x] #10 Bandit is run on touched Python scope or explicitly marked not applicable.
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Makes Chat Workspace create and resume workspace-scoped server chats across normal, persona, character, and staged-RAG send paths.
- Completes the source rail and staged-context lifecycle for real workspace sources, including browse, stage, unstage, source states, fallback summaries, and workspace-switch clearing.
- Adds deterministic Chat Workspace live-backend Playwright smoke coverage and wires the Stage 5 release gate to that focused proof.

## Change summary
AI-generated PR. Before merge, a maintainer must add a human-written Change summary explaining what changed and why these implementation choices were made, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Test Plan
- [x] `bunx vitest run src/components/Option/ChatWorkspace/__tests__ src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx src/services/__tests__/chat-settings.sync.test.ts --maxWorkers=1`
- [x] `npx playwright test e2e/smoke/chat-workspace-live-backend.spec.ts --project=chromium`
- [x] `npx playwright test e2e/smoke/stage5-release-gate.spec.ts --project=chromium --grep "Chat Workspace"`
- [x] `git diff --check origin/dev...HEAD`
- [x] Bandit not applicable: no Python files touched.

Closes #2031
Closes #2032
Closes #2035
Refs #1239

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Chat Workspace now runs as a live, workspace-scoped chat surface. It completes the source rail lifecycle and adds a focused Playwright proof wired into the Stage 5 release gate.

- New Features
  - Create/resume workspace-scoped server chats across normal, persona, character, and staged‑RAG sends; preserves drafts, supports streaming/stop, and clears state on workspace switch.
  - Source rail: browse, stage, unstage, per‑source status, staged summary insert/send, remove a single staged source; routes Add source/Open library to canonical surfaces; shows loading/error states.
  - Server chat settings sync honors workspace scope and passes scope through API calls for chat settings.
  - Focused Playwright smoke for /chat-workspace against a live backend; Stage 5 release gate links to this proof and allowlists route‑only startup probes.

<sup>Written for commit f580e393b9e52c4982f5c2154e328d8a7d33f395. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

