### PR TITLE
Harden audio transcription input handling

### DIFF
--- a/Docs/superpowers/plans/2026-07-03-audio-transcription-pipeline-hardening-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-audio-transcription-pipeline-hardening-plan.md
@@ -1,0 +1,25 @@
+# Audio Transcription Pipeline Hardening Plan
+
+## Stage 1: Endpoint Canonicalization
+**Goal**: Ensure `/audio/transcriptions` either passes a usable canonical WAV path to adapters or returns a clear client error.
+**Success Criteria**: Conversion import/conversion failures and unusable conversion outputs do not fall back to the original compressed upload; existing WAV no-op conversion remains valid.
+**Tests**: Added endpoint regression coverage for conversion failure, empty conversion output, and non-WAV conversion output.
+**Status**: Complete
+
+## Stage 2: Provider Boundary Guards
+**Goal**: Keep direct soundfile-backed provider paths from silently accepting compressed inputs that the loader cannot decode.
+**Success Criteria**: Canary, Qwen3 ASR, VibeVoice, and Parakeet MLX buffered direct-call paths either canonicalize to WAV or raise clear provider errors without deleting caller-owned files.
+**Tests**: Added focused unit tests for Canary, Qwen3 ASR, VibeVoice, Parakeet MLX buffered path conversion behavior, and MLX converted-path base_dir safety.
+**Status**: Complete
+
+## Stage 3: In-Memory Sample Rate Normalization
+**Goal**: Make NeMo Parakeet and Canary direct NumPy transcription honor non-16 kHz sample rates.
+**Success Criteria**: Non-16 kHz NumPy inputs are resampled to 16 kHz before direct model transcription; ONNX/MLX behavior remains unchanged.
+**Tests**: Added unit tests that patch model transcribe calls and verify array length normalization for Parakeet and Canary, plus empty-array no-crash coverage.
+**Status**: Complete
+
+## Stage 4: Verification and Closeout
+**Goal**: Validate the focused bugfix without widening the branch scope.
+**Success Criteria**: Focused pytest targets pass, Ruff passes on touched Python files, Bandit runs on touched Python paths, and task notes capture any known skips.
+**Tests**: Focused pytest suite passed (`79 passed, 2 skipped`); high-signal Ruff rules passed; `compileall` passed; `git diff --check` passed; Bandit ran and reported only existing low-severity subprocess findings outside this diff.
+**Status**: Complete

--- a/Docs/superpowers/plans/2026-07-03-audio-transcription-pipeline-hardening-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-audio-transcription-pipeline-hardening-plan.md
@@ -21,5 +21,5 @@
 ## Stage 4: Verification and Closeout
 **Goal**: Validate the focused bugfix without widening the branch scope.
 **Success Criteria**: Focused pytest targets pass, Ruff passes on touched Python files, Bandit runs on touched Python paths, and task notes capture any known skips.
-**Tests**: Focused pytest suite passed (`79 passed, 2 skipped`); high-signal Ruff rules passed; `compileall` passed; `git diff --check` passed; Bandit ran and reported only existing low-severity subprocess findings outside this diff.
+**Tests**: After PR review fixes, focused pytest suite passed (`85 passed, 2 skipped`); high-signal Ruff rules passed; `compileall` passed; `git diff --check` passed; Bandit ran and reported only existing low-severity subprocess findings outside this diff.
 **Status**: Complete

--- a/backlog/tasks/task-12126 - Harden-audio-transcription-pipeline-input-handling.md
+++ b/backlog/tasks/task-12126 - Harden-audio-transcription-pipeline-input-handling.md
@@ -43,6 +43,21 @@ Verification:
 - `python -m bandit -r ... -f json -o C:\Users\GDesktop-1\AppData\Local\Temp\bandit_audio_transcription_pipeline.json` -> ran; nonzero due existing low-severity subprocess findings in `Audio_Transcription_Lib.py` outside this diff.
 
 PR: https://github.com/rmusser01/tldw_server/pull/2597
+
+PR review follow-up:
+- Rebased on latest `origin/dev` (`48f66ad281`) and dropped unrelated carried-over `audio.cpp` planning commits from the PR branch.
+- Verified and fixed existing-WAV `base_dir` validation for the Parakeet MLX helper.
+- Forced endpoint and direct-provider conversion calls to use fresh canonical WAV outputs (`overwrite=True`) to avoid spoofed `.wav` bypasses and stale sibling WAV reuse.
+- Added docstrings/type hints requested for new helpers/tests without broad style churn.
+- Hardened `_prepare_numpy_audio_for_nemo` for invalid sample rates and oversized fallback interpolation.
+- Added direct helper regression tests for stereo downmix, polyphase guard fallback, SciPy import fallback, invalid sample rates, and oversized resample ratios.
+
+PR review verification:
+- `python -m pytest tldw_Server_API/tests/Audio/test_audio_transcriptions_adapter_path.py tldw_Server_API/tests/Audio/test_stt_provider_adapter.py tldw_Server_API/tests/Media_Ingestion_Modification/test_nemo_transcription.py tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_mlx.py -q --basetemp C:\Users\GDesktop-1\AppData\Local\Temp\tldw_pytest_tmp_pr_rebase_final` -> `85 passed, 2 skipped`.
+- `python -m ruff check ... --select E9,F821,F822,F823,B904,BLE001` -> passed.
+- `python -m compileall -q` on touched production files -> passed.
+- `git diff --check` -> passed; Git reported expected Windows LF-to-CRLF warnings only.
+- `python -m bandit -r ... -f json -o C:\Users\GDesktop-1\AppData\Local\Temp\bandit_audio_transcription_pipeline_pr_rebase_final.json` -> ran; nonzero due existing low-severity subprocess findings in `Audio_Transcription_Lib.py` outside this diff.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12126 - Harden-audio-transcription-pipeline-input-handling.md
+++ b/backlog/tasks/task-12126 - Harden-audio-transcription-pipeline-input-handling.md
@@ -41,6 +41,8 @@ Verification:
 - `python -m compileall -q` on touched production files -> passed.
 - `git diff --check` -> passed; Git reported expected Windows LF-to-CRLF warnings only.
 - `python -m bandit -r ... -f json -o C:\Users\GDesktop-1\AppData\Local\Temp\bandit_audio_transcription_pipeline.json` -> ran; nonzero due existing low-severity subprocess findings in `Audio_Transcription_Lib.py` outside this diff.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2597
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12126 - Harden-audio-transcription-pipeline-input-handling.md
+++ b/backlog/tasks/task-12126 - Harden-audio-transcription-pipeline-input-handling.md
@@ -1,0 +1,54 @@
+---
+id: TASK-12126
+title: Harden audio transcription pipeline input handling
+status: Done
+labels:
+- audio
+- transcription
+- stt
+- bugfix
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address follow-up bugs in the audio transcription pipeline where compressed or non-canonical audio can reach WAV-only loaders after conversion failure, and where in-memory NeMo Parakeet/Canary paths can ignore the caller-provided sample rate.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] `/audio/transcriptions` no longer falls back to the original upload when canonical WAV conversion fails.
+- [x] Soundfile-backed local providers do not receive compressed originals through the endpoint conversion fallback.
+- [x] Direct Canary and Parakeet MLX buffered paths either receive canonical WAV input or fail with a clear provider error.
+- [x] In-memory Parakeet and Canary transcription normalizes non-16 kHz NumPy audio before direct model calls.
+- [x] Focused regression tests, Ruff, and Bandit are run for the touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Using a scoped worktree on `codex/audio-transcription-pipeline-hardening`. Backlog CLI/MCP is unavailable in this environment, so this task was created as a manual repository-policy exception approved in-thread.
+
+Implemented minimal hardening for the five verified issues:
+- `/audio/transcriptions` rejects conversion import failures, conversion errors, empty conversion results, non-WAV conversion results, and missing conversion outputs with `invalid_audio`.
+- Canary, Qwen3 ASR, and VibeVoice adapter paths canonicalize compressed direct-call inputs to WAV before soundfile/provider loading.
+- Parakeet MLX buffered path canonicalizes compressed direct-call inputs to WAV before duration/buffered loading and rejects converted paths outside `base_dir`.
+- NeMo Parakeet and Canary direct NumPy paths fold channels, handle scalar/empty arrays, resample non-16 kHz input to 16 kHz, and fall back without SciPy.
+
+Verification:
+- `python -m pytest tldw_Server_API/tests/Audio/test_audio_transcriptions_adapter_path.py tldw_Server_API/tests/Audio/test_stt_provider_adapter.py tldw_Server_API/tests/Media_Ingestion_Modification/test_nemo_transcription.py tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_mlx.py -q --basetemp C:\Users\GDesktop-1\AppData\Local\Temp\tldw_pytest_tmp` -> `79 passed, 2 skipped`.
+- `python -m ruff check ... --select E9,F821,F822,F823,B904,BLE001` -> passed.
+- `python -m compileall -q` on touched production files -> passed.
+- `git diff --check` -> passed; Git reported expected Windows LF-to-CRLF warnings only.
+- `python -m bandit -r ... -f json -o C:\Users\GDesktop-1\AppData\Local\Temp\bandit_audio_transcription_pipeline.json` -> ran; nonzero due existing low-severity subprocess findings in `Audio_Transcription_Lib.py` outside this diff.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -713,11 +713,18 @@ async def create_transcription(
             )
         except ImportError as e:
             logger.debug(
-                'convert_to_wav import failed; using original temp file: path={}, error={}',
+                'convert_to_wav import failed; rejecting audio upload: path={}, error={}',
                 temp_audio_path,
                 e,
             )
-            canonical_path = temp_audio_path
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_dictation_error_detail(
+                    http_status=status.HTTP_400_BAD_REQUEST,
+                    detail_status="invalid_audio",
+                    message="Audio file could not be converted to canonical WAV.",
+                ),
+            ) from e
         else:
             try:
                 canonical_path = _convert_to_wav(
@@ -728,16 +735,56 @@ async def create_transcription(
                 )
             except (ConversionError, OSError, RuntimeError, ValueError) as e:
                 logger.debug(
-                    'convert_to_wav failed; using original temp file: path={}, error={}',
+                    'convert_to_wav failed; rejecting audio upload: path={}, error={}',
                     temp_audio_path,
                     e,
                 )
-                canonical_path = temp_audio_path
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=_dictation_error_detail(
+                        http_status=status.HTTP_400_BAD_REQUEST,
+                        detail_status="invalid_audio",
+                        message="Audio file could not be converted to canonical WAV.",
+                    ),
+                ) from e
+
+        if not canonical_path:
+            logger.debug(
+                'convert_to_wav returned empty output; rejecting audio upload: input_path={}',
+                temp_audio_path,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_dictation_error_detail(
+                    http_status=status.HTTP_400_BAD_REQUEST,
+                    detail_status="invalid_audio",
+                    message="Audio file could not be converted to canonical WAV.",
+                ),
+            )
+
+        canonical_path_obj = PathLib(canonical_path)
+        if (
+            canonical_path_obj.suffix.lower() != ".wav"
+            or not canonical_path_obj.exists()
+        ):
+            logger.debug(
+                'convert_to_wav returned unusable output; rejecting audio upload: input_path={}, output_path={}',
+                temp_audio_path,
+                canonical_path,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_dictation_error_detail(
+                    http_status=status.HTTP_400_BAD_REQUEST,
+                    detail_status="invalid_audio",
+                    message="Audio file could not be converted to canonical WAV.",
+                ),
+            )
 
         if is_test_mode():
             logger.debug("TEST_MODE: canonical audio path resolved")
 
-        base_dir = PathLib(canonical_path).parent
+        base_dir = canonical_path_obj.parent
 
         sf_mod = _audio_shim_attr("sf")
         duration_seconds = 0.0

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -159,6 +159,16 @@ def _sniff_audio_upload_suffix(sample: bytes) -> str:
     return ""
 
 
+def _has_wav_container_header(path: PathLib) -> bool:
+    """Return True when a file starts with a RIFF/WAVE container header."""
+    try:
+        with path.open("rb") as handle:
+            header = handle.read(12)
+    except _AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS:
+        return False
+    return len(header) >= 12 and header.startswith(b"RIFF") and header[8:12] == b"WAVE"
+
+
 def _resolve_audio_upload_suffix(
     filename: str | None,
     content_type: str | None,
@@ -759,6 +769,7 @@ async def create_transcription(
         if (
             canonical_path_obj.suffix.lower() != ".wav"
             or not canonical_path_obj.exists()
+            or not _has_wav_container_header(canonical_path_obj)
         ):
             logger.debug(
                 'convert_to_wav returned unusable output; rejecting audio upload: input_path={}, output_path={}',

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -704,6 +704,20 @@ async def create_transcription(
             temp_audio_path = tmp_file.name
 
         # Convert to canonical 16k mono WAV for consistent processing; base_dir constrains output location.
+        def _raise_invalid_audio(cause: Exception | None = None) -> None:
+            """Raise the canonical invalid_audio response for failed WAV preparation."""
+            exc = HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_dictation_error_detail(
+                    http_status=status.HTTP_400_BAD_REQUEST,
+                    detail_status="invalid_audio",
+                    message="Audio file could not be converted to canonical WAV.",
+                ),
+            )
+            if cause is not None:
+                raise exc from cause
+            raise exc
+
         try:
             from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib import (
                 ConversionError,
@@ -717,20 +731,13 @@ async def create_transcription(
                 temp_audio_path,
                 e,
             )
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=_dictation_error_detail(
-                    http_status=status.HTTP_400_BAD_REQUEST,
-                    detail_status="invalid_audio",
-                    message="Audio file could not be converted to canonical WAV.",
-                ),
-            ) from e
+            _raise_invalid_audio(cause=e)
         else:
             try:
                 canonical_path = _convert_to_wav(
                     temp_audio_path,
                     offset=0,
-                    overwrite=False,
+                    overwrite=True,
                     base_dir=PathLib(temp_audio_path).parent,
                 )
             except (ConversionError, OSError, RuntimeError, ValueError) as e:
@@ -739,28 +746,14 @@ async def create_transcription(
                     temp_audio_path,
                     e,
                 )
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=_dictation_error_detail(
-                        http_status=status.HTTP_400_BAD_REQUEST,
-                        detail_status="invalid_audio",
-                        message="Audio file could not be converted to canonical WAV.",
-                    ),
-                ) from e
+                _raise_invalid_audio(cause=e)
 
         if not canonical_path:
             logger.debug(
                 'convert_to_wav returned empty output; rejecting audio upload: input_path={}',
                 temp_audio_path,
             )
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=_dictation_error_detail(
-                    http_status=status.HTTP_400_BAD_REQUEST,
-                    detail_status="invalid_audio",
-                    message="Audio file could not be converted to canonical WAV.",
-                ),
-            )
+            _raise_invalid_audio()
 
         canonical_path_obj = PathLib(canonical_path)
         if (
@@ -772,14 +765,7 @@ async def create_transcription(
                 temp_audio_path,
                 canonical_path,
             )
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=_dictation_error_detail(
-                    http_status=status.HTTP_400_BAD_REQUEST,
-                    detail_status="invalid_audio",
-                    message="Audio file could not be converted to canonical WAV.",
-                ),
-            )
+            _raise_invalid_audio()
 
         if is_test_mode():
             logger.debug("TEST_MODE: canonical audio path resolved")

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -401,6 +401,45 @@ def _load_audio_for_parakeet_nemo(audio_file_path: str, target_sr: int = 16000) 
     return np.ascontiguousarray(audio_np, dtype=np.float32), target_sr, audio_duration
 
 
+def _ensure_wav_path_for_parakeet_mlx(audio_file_path: str, base_dir: Optional[Path] = None) -> str:
+    path_obj = Path(audio_file_path)
+    if path_obj.suffix.lower() == ".wav":
+        return str(path_obj)
+
+    try:
+        wav_file_path = convert_to_wav(
+            str(path_obj),
+            offset=0,
+            overwrite=False,
+            base_dir=base_dir,
+        )
+    except (ConversionError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        logging.debug(f"Parakeet MLX WAV conversion failed: {type(exc).__name__}")
+        raise STTTranscriptionError(
+            "Parakeet MLX audio loading failed: WAV conversion failed for compressed input."
+        ) from exc
+
+    if not wav_file_path:
+        raise STTTranscriptionError(
+            "Parakeet MLX audio loading failed: WAV conversion did not produce a usable WAV file."
+        )
+
+    wav_path = Path(wav_file_path)
+    if base_dir is not None:
+        safe_wav_path = resolve_safe_local_path(wav_path, base_dir)
+        if safe_wav_path is None:
+            raise STTTranscriptionError(
+                "Parakeet MLX audio loading failed: converted WAV path is outside the allowed directory."
+            )
+        wav_path = safe_wav_path
+
+    if wav_path.suffix.lower() != ".wav" or not wav_path.exists():
+        raise STTTranscriptionError(
+            "Parakeet MLX audio loading failed: WAV conversion did not produce a usable WAV file."
+        )
+    return str(wav_path)
+
+
 def _resolve_project_root() -> Path:
     """
     Return the repository root used to anchor shared model directories.
@@ -3005,6 +3044,7 @@ def speech_to_text_parakeet(
                     logging.warning("MLX not available on this platform, falling back to standard Parakeet")
                     variant = "standard"
                 else:
+                    audio_file_path = _ensure_wav_path_for_parakeet_mlx(audio_file_path, base_dir=base_dir)
                     stt_cfg = get_stt_config() or {}
                     raw_chunk_duration = stt_cfg.get("mlx_chunk_duration")
                     raw_overlap_duration = stt_cfg.get("mlx_overlap_duration")

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -402,15 +402,23 @@ def _load_audio_for_parakeet_nemo(audio_file_path: str, target_sr: int = 16000) 
 
 
 def _ensure_wav_path_for_parakeet_mlx(audio_file_path: str, base_dir: Optional[Path] = None) -> str:
+    """Return a WAV path for Parakeet MLX while enforcing optional base_dir containment."""
     path_obj = Path(audio_file_path)
     if path_obj.suffix.lower() == ".wav":
+        if base_dir is not None:
+            safe_path = resolve_safe_local_path(path_obj, base_dir)
+            if safe_path is None:
+                raise STTTranscriptionError(
+                    "Parakeet MLX audio loading failed: WAV path is outside the allowed directory."
+                )
+            return str(safe_path)
         return str(path_obj)
 
     try:
         wav_file_path = convert_to_wav(
             str(path_obj),
             offset=0,
-            overwrite=False,
+            overwrite=True,
             base_dir=base_dir,
         )
     except (ConversionError, OSError, RuntimeError, TypeError, ValueError) as exc:

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Nemo.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Nemo.py
@@ -90,6 +90,9 @@ _NEMO_RESAMPLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     ImportError,
     *_NEMO_NONCRITICAL_EXCEPTIONS,
 )
+_NEMO_MIN_SAMPLE_RATE = 8000
+_NEMO_MAX_SAMPLE_RATE = 192000
+_NEMO_MAX_RESAMPLE_RATIO = 8.0
 
 torch: Any | None = None
 _TORCH_IMPORT_ERROR: Exception | None = None
@@ -146,14 +149,23 @@ def _prepare_numpy_audio_for_nemo(
     *,
     target_sample_rate: int = 16000,
 ) -> tuple[np.ndarray, int]:
+    """Normalize NumPy audio to mono float32 and resample it for NeMo models."""
     audio_np = np.asarray(audio_data, dtype=np.float32)
     if audio_np.ndim == 0:
         audio_np = audio_np.reshape(1)
     elif audio_np.ndim > 1:
         audio_np = np.mean(audio_np, axis=1).astype(np.float32, copy=False)
+    if sample_rate <= 0:
+        raise ValueError("NeMo numpy audio preparation failed: sample_rate must be positive.")
+    if target_sample_rate <= 0:
+        raise ValueError("NeMo numpy audio preparation failed: target_sample_rate must be positive.")
+    if sample_rate < _NEMO_MIN_SAMPLE_RATE or sample_rate > _NEMO_MAX_SAMPLE_RATE:
+        raise ValueError(
+            "NeMo numpy audio preparation failed: sample_rate is outside the supported range."
+        )
     if audio_np.size == 0:
         return np.ascontiguousarray(audio_np, dtype=np.float32), target_sample_rate
-    if sample_rate == target_sample_rate or sample_rate <= 0:
+    if sample_rate == target_sample_rate:
         return np.ascontiguousarray(audio_np, dtype=np.float32), target_sample_rate
 
     try:
@@ -169,7 +181,11 @@ def _prepare_numpy_audio_for_nemo(
         logging.debug(f"NeMo numpy audio polyphase resample failed; using linear fallback: {type(exc).__name__}")
 
     ratio = float(target_sample_rate) / float(sample_rate)
+    if ratio > _NEMO_MAX_RESAMPLE_RATIO:
+        raise ValueError("NeMo numpy audio preparation failed: resample ratio is too large.")
     new_len = max(1, int(round(len(audio_np) * ratio)))
+    if new_len > int(len(audio_np) * _NEMO_MAX_RESAMPLE_RATIO):
+        raise ValueError("NeMo numpy audio preparation failed: resampled audio would be too large.")
     x_old = np.linspace(0.0, 1.0, num=len(audio_np), endpoint=False, dtype=np.float32)
     x_new = np.linspace(0.0, 1.0, num=new_len, endpoint=False, dtype=np.float32)
     resampled = np.interp(x_new, x_old, audio_np)

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Nemo.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Nemo.py
@@ -19,6 +19,7 @@
 
 import logging
 import importlib
+import math
 import os
 import sys
 import tempfile
@@ -85,6 +86,10 @@ _NEMO_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     TypeError,
     ValueError,
 )
+_NEMO_RESAMPLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    ImportError,
+    *_NEMO_NONCRITICAL_EXCEPTIONS,
+)
 
 torch: Any | None = None
 _TORCH_IMPORT_ERROR: Exception | None = None
@@ -133,6 +138,42 @@ def _temp_wav_from_numpy(audio_np: np.ndarray, sample_rate: int) -> str:
         import soundfile as sf
         sf.write(tmp_file.name, audio_np, sample_rate)
         return tmp_file.name
+
+
+def _prepare_numpy_audio_for_nemo(
+    audio_data: np.ndarray,
+    sample_rate: int,
+    *,
+    target_sample_rate: int = 16000,
+) -> tuple[np.ndarray, int]:
+    audio_np = np.asarray(audio_data, dtype=np.float32)
+    if audio_np.ndim == 0:
+        audio_np = audio_np.reshape(1)
+    elif audio_np.ndim > 1:
+        audio_np = np.mean(audio_np, axis=1).astype(np.float32, copy=False)
+    if audio_np.size == 0:
+        return np.ascontiguousarray(audio_np, dtype=np.float32), target_sample_rate
+    if sample_rate == target_sample_rate or sample_rate <= 0:
+        return np.ascontiguousarray(audio_np, dtype=np.float32), target_sample_rate
+
+    try:
+        from scipy import signal
+
+        divisor = math.gcd(int(sample_rate), int(target_sample_rate))
+        up = int(target_sample_rate) // divisor
+        down = int(sample_rate) // divisor
+        if up <= 1000 and down <= 1000:
+            resampled = signal.resample_poly(audio_np, up, down)
+            return np.ascontiguousarray(resampled, dtype=np.float32), target_sample_rate
+    except _NEMO_RESAMPLE_EXCEPTIONS as exc:
+        logging.debug(f"NeMo numpy audio polyphase resample failed; using linear fallback: {type(exc).__name__}")
+
+    ratio = float(target_sample_rate) / float(sample_rate)
+    new_len = max(1, int(round(len(audio_np) * ratio)))
+    x_old = np.linspace(0.0, 1.0, num=len(audio_np), endpoint=False, dtype=np.float32)
+    x_new = np.linspace(0.0, 1.0, num=new_len, endpoint=False, dtype=np.float32)
+    resampled = np.interp(x_new, x_old, audio_np)
+    return np.ascontiguousarray(resampled, dtype=np.float32), target_sample_rate
 
 
 def is_nemo_available() -> bool:
@@ -503,13 +544,13 @@ def transcribe_with_canary(
         return result
 
     if isinstance(audio_data, np.ndarray):
-        audio_np = np.asarray(audio_data, dtype=np.float32)
+        audio_np, model_sample_rate = _prepare_numpy_audio_for_nemo(audio_data, sample_rate)
         try:
             transcriptions = model.transcribe([audio_np], batch_size=1, **lang_kwargs)
             return _extract_result(transcriptions)
         except _NEMO_NONCRITICAL_EXCEPTIONS as direct_err:
             logging.debug(f"Canary direct numpy transcription failed, falling back to temp file: {direct_err}")
-            audio_path = _temp_wav_from_numpy(audio_np, sample_rate)
+            audio_path = _temp_wav_from_numpy(audio_np, model_sample_rate)
             audio_source = audio_path
             cleanup_temp = True
 
@@ -588,7 +629,7 @@ def transcribe_with_parakeet(
             )
             transcriptions = [result] if result else ["[No transcription produced]"]
         elif isinstance(audio_source, np.ndarray):
-            audio_np = np.asarray(audio_source, dtype=np.float32)
+            audio_np, model_sample_rate = _prepare_numpy_audio_for_nemo(audio_source, sample_rate)
             try:
                 transcriptions = model.transcribe(
                     audio_np,
@@ -598,7 +639,7 @@ def transcribe_with_parakeet(
                 )
             except _NEMO_NONCRITICAL_EXCEPTIONS as direct_err:
                 logging.debug(f"Parakeet direct numpy transcription failed, falling back to temp file: {direct_err}")
-                audio_path = _temp_wav_from_numpy(audio_np, sample_rate)
+                audio_path = _temp_wav_from_numpy(audio_np, model_sample_rate)
                 audio_source = audio_path
                 cleanup_temp = True
                 transcriptions = model.transcribe(

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
@@ -152,6 +152,56 @@ def _raise_if_cancelled(cancel_check: Callable[[], bool] | None) -> None:
         raise TranscriptionCancelled("Cancelled by user")
 
 
+def _resolve_adapter_audio_path(audio_path: str, base_dir: Path | None) -> Path:
+    path_obj = Path(audio_path)
+    if base_dir is None:
+        return path_obj
+
+    safe_path = resolve_safe_local_path(path_obj, base_dir)
+    if safe_path is None:
+        raise BadRequestError(f"Audio path rejected outside base_dir: {audio_path}")
+    return safe_path
+
+
+def _canonicalize_wav_for_soundfile_adapter(audio_path: str, base_dir: Path | None) -> Path:
+    path_obj = _resolve_adapter_audio_path(audio_path, base_dir)
+    if path_obj.suffix.lower() == ".wav":
+        return path_obj
+
+    try:
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib import (  # type: ignore
+            ConversionError,
+            convert_to_wav,
+        )
+    except ImportError as exc:
+        raise BadRequestError("Audio WAV conversion is not available for this STT provider") from exc
+
+    try:
+        converted_path = convert_to_wav(
+            str(path_obj),
+            offset=0,
+            overwrite=False,
+            base_dir=base_dir,
+        )
+    except (ConversionError, OSError, RuntimeError, ValueError) as exc:
+        raise BadRequestError(f"Failed to convert audio file to WAV: {exc}") from exc
+
+    if not converted_path:
+        raise BadRequestError("Audio conversion did not produce a usable WAV file")
+
+    converted_obj = Path(converted_path)
+    if base_dir is not None:
+        safe_converted = resolve_safe_local_path(converted_obj, base_dir)
+        if safe_converted is None:
+            raise BadRequestError(f"Converted audio path rejected outside base_dir: {converted_path}")
+        converted_obj = safe_converted
+
+    if converted_obj.suffix.lower() != ".wav" or not converted_obj.exists():
+        raise BadRequestError("Audio conversion did not produce a usable WAV file")
+
+    return converted_obj
+
+
 def _normalize_parakeet_variant(raw: str | None) -> str:
     variant = (raw or "").strip().lower()
     if not variant or variant not in _SUPPORTED_PARAKEET_VARIANTS:
@@ -460,13 +510,7 @@ class CanaryAdapter(SttProviderAdapter):
             transcribe_with_canary,
         )
 
-        path_obj = Path(audio_path)
-        if base_dir is not None:
-            # Enforce that local audio paths stay within base_dir for path safety.
-            safe_path = resolve_safe_local_path(path_obj, base_dir)
-            if safe_path is None:
-                raise BadRequestError(f"Audio path rejected outside base_dir: {audio_path}")
-            path_obj = safe_path
+        path_obj = _canonicalize_wav_for_soundfile_adapter(audio_path, base_dir)
 
         _raise_if_cancelled(cancel_check)
         try:
@@ -636,8 +680,9 @@ class Qwen3ASRAdapter(SttProviderAdapter):
                 model_path = "./models/qwen3_asr/1.7B"
 
         _raise_if_cancelled(cancel_check)
+        audio_path_for_provider = str(_canonicalize_wav_for_soundfile_adapter(audio_path, base_dir))
         artifact = transcribe_with_qwen3_asr(
-            audio_path,
+            audio_path_for_provider,
             model_path=model_path,
             language=language,
             word_timestamps=word_timestamps,
@@ -694,8 +739,9 @@ class VibeVoiceAdapter(SttProviderAdapter):
                 model_name = "microsoft/VibeVoice-ASR"
 
         _raise_if_cancelled(cancel_check)
+        audio_path_for_provider = str(_canonicalize_wav_for_soundfile_adapter(audio_path, base_dir))
         artifact = transcribe_with_vibevoice(
-            audio_path,
+            audio_path_for_provider,
             model_id=model_name,
             language=language,
             hotwords=list(hotwords) if hotwords else None,

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
@@ -153,6 +153,7 @@ def _raise_if_cancelled(cancel_check: Callable[[], bool] | None) -> None:
 
 
 def _resolve_adapter_audio_path(audio_path: str, base_dir: Path | None) -> Path:
+    """Resolve an adapter input path and enforce base_dir containment when provided."""
     path_obj = Path(audio_path)
     if base_dir is None:
         return path_obj
@@ -164,6 +165,7 @@ def _resolve_adapter_audio_path(audio_path: str, base_dir: Path | None) -> Path:
 
 
 def _canonicalize_wav_for_soundfile_adapter(audio_path: str, base_dir: Path | None) -> Path:
+    """Convert compressed adapter input to a fresh WAV path accepted by soundfile loaders."""
     path_obj = _resolve_adapter_audio_path(audio_path, base_dir)
     if path_obj.suffix.lower() == ".wav":
         return path_obj
@@ -180,7 +182,7 @@ def _canonicalize_wav_for_soundfile_adapter(audio_path: str, base_dir: Path | No
         converted_path = convert_to_wav(
             str(path_obj),
             offset=0,
-            overwrite=False,
+            overwrite=True,
             base_dir=base_dir,
         )
     except (ConversionError, OSError, RuntimeError, ValueError) as exc:

--- a/tldw_Server_API/tests/Audio/test_audio_transcriptions_adapter_path.py
+++ b/tldw_Server_API/tests/Audio/test_audio_transcriptions_adapter_path.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 import soundfile as sf
+from fastapi import status
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -353,3 +354,144 @@ def test_audio_transcriptions_prevents_cross_provider_fallback(
         assert detail.get("status") == "provider_unavailable"
         assert detail.get("provider") == "external"
         assert detail.get("resolved_provider") == "faster-whisper"
+
+
+def test_audio_transcriptions_rejects_upload_when_wav_conversion_fails(
+    monkeypatch,
+    bypass_api_limits,
+):
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", TEST_API_KEY)
+    monkeypatch.setenv("SINGLE_USER_TEST_API_KEY", TEST_API_KEY)
+    monkeypatch.setenv("SINGLE_USER_FIXED_ID", "1")
+
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+    import tldw_Server_API.app.api.v1.endpoints.audio.audio as audio_ep
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.stt_provider_adapter as stt_adapter
+
+    async def _fake_get_request_user() -> User:
+        return User(id=1, username="single_user")
+
+    async def _allow_job(*_args, **_kwargs):
+        return True, None
+
+    async def _noop_async(*_args, **_kwargs):
+        return None
+
+    class _StubAdapter:
+        def transcribe_batch(self, *args, **kwargs):
+            pytest.fail("adapter should not receive original upload after conversion failure")
+
+    class _StubRegistry:
+        def resolve_provider_for_model(self, _model):
+            return "external", "external:stub", None
+
+        def get_adapter(self, _provider):
+            return _StubAdapter()
+
+    def _fail_convert(*_args, **_kwargs):
+        raise atlib.ConversionError("ffmpeg failed")
+
+    monkeypatch.setattr(audio_ep, "can_start_job", _allow_job)
+    monkeypatch.setattr(audio_ep, "increment_jobs_started", _noop_async)
+    monkeypatch.setattr(audio_ep, "finish_job", _noop_async)
+    monkeypatch.setattr(audio_ep, "check_daily_minutes_allow", _allow_job)
+    monkeypatch.setattr(audio_ep, "add_daily_minutes", _noop_async)
+    monkeypatch.setattr(stt_adapter, "get_stt_provider_registry", lambda: _StubRegistry())
+    monkeypatch.setattr(atlib, "convert_to_wav", _fail_convert)
+
+    app = FastAPI()
+    app.dependency_overrides[get_request_user] = _fake_get_request_user
+    app.include_router(audio_router, prefix="/api/v1/audio")
+
+    with bypass_api_limits(app), TestClient(app) as client:
+        headers = {"X-API-KEY": TEST_API_KEY}
+        files = {"file": ("sample.mp3", io.BytesIO(b"not a decodable mp3"), "audio/mpeg")}
+        data = {"model": "external:stub", "response_format": "json"}
+        resp = client.post(
+            "/api/v1/audio/transcriptions",
+            headers=headers,
+            files=files,
+            data=data,
+        )
+        if resp.status_code == 404:
+            pytest.skip("audio/transcriptions endpoint not mounted in this build")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.text
+        detail = resp.json().get("detail") or {}
+        assert detail.get("status") == "invalid_audio"
+
+
+@pytest.mark.parametrize("conversion_output_kind", ["empty", "non_wav"])
+def test_audio_transcriptions_rejects_unusable_conversion_output(
+    monkeypatch,
+    bypass_api_limits,
+    tmp_path,
+    conversion_output_kind,
+):
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", TEST_API_KEY)
+    monkeypatch.setenv("SINGLE_USER_TEST_API_KEY", TEST_API_KEY)
+    monkeypatch.setenv("SINGLE_USER_FIXED_ID", "1")
+
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+    import tldw_Server_API.app.api.v1.endpoints.audio.audio as audio_ep
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.stt_provider_adapter as stt_adapter
+
+    async def _fake_get_request_user() -> User:
+        return User(id=1, username="single_user")
+
+    async def _allow_job(*_args, **_kwargs):
+        return True, None
+
+    async def _noop_async(*_args, **_kwargs):
+        return None
+
+    class _StubAdapter:
+        def transcribe_batch(self, *args, **kwargs):
+            pytest.fail("adapter should not receive a non-WAV conversion output")
+
+    class _StubRegistry:
+        def resolve_provider_for_model(self, _model):
+            return "external", "external:stub", None
+
+        def get_adapter(self, _provider):
+            return _StubAdapter()
+
+    if conversion_output_kind == "empty":
+        conversion_output = None
+    else:
+        bad_output = tmp_path / "converted.mp3"
+        bad_output.write_bytes(b"still compressed")
+        conversion_output = str(bad_output)
+
+    monkeypatch.setattr(audio_ep, "can_start_job", _allow_job)
+    monkeypatch.setattr(audio_ep, "increment_jobs_started", _noop_async)
+    monkeypatch.setattr(audio_ep, "finish_job", _noop_async)
+    monkeypatch.setattr(audio_ep, "check_daily_minutes_allow", _allow_job)
+    monkeypatch.setattr(audio_ep, "add_daily_minutes", _noop_async)
+    monkeypatch.setattr(stt_adapter, "get_stt_provider_registry", lambda: _StubRegistry())
+    monkeypatch.setattr(atlib, "convert_to_wav", lambda *args, **kwargs: conversion_output)
+
+    app = FastAPI()
+    app.dependency_overrides[get_request_user] = _fake_get_request_user
+    app.include_router(audio_router, prefix="/api/v1/audio")
+
+    with bypass_api_limits(app), TestClient(app) as client:
+        headers = {"X-API-KEY": TEST_API_KEY}
+        files = {"file": ("sample.webm", io.BytesIO(b"not webm"), "audio/webm")}
+        data = {"model": "external:stub", "response_format": "json"}
+        resp = client.post(
+            "/api/v1/audio/transcriptions",
+            headers=headers,
+            files=files,
+            data=data,
+        )
+        if resp.status_code == 404:
+            pytest.skip("audio/transcriptions endpoint not mounted in this build")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.text
+        detail = resp.json().get("detail") or {}
+        assert detail.get("status") == "invalid_audio"

--- a/tldw_Server_API/tests/Audio/test_audio_transcriptions_adapter_path.py
+++ b/tldw_Server_API/tests/Audio/test_audio_transcriptions_adapter_path.py
@@ -434,6 +434,75 @@ def test_audio_transcriptions_rejects_upload_when_wav_conversion_fails(
         assert detail.get("status") == "invalid_audio"
 
 
+def test_audio_transcriptions_rejects_spoofed_wav_output(
+    monkeypatch: pytest.MonkeyPatch,
+    bypass_api_limits: Any,
+) -> None:
+    """Reject a .wav conversion output when its bytes are not a WAV container."""
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", TEST_API_KEY)
+    monkeypatch.setenv("SINGLE_USER_TEST_API_KEY", TEST_API_KEY)
+    monkeypatch.setenv("SINGLE_USER_FIXED_ID", "1")
+
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+    import tldw_Server_API.app.api.v1.endpoints.audio.audio as audio_ep
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.stt_provider_adapter as stt_adapter
+
+    async def _fake_get_request_user() -> User:
+        return User(id=1, username="single_user")
+
+    async def _allow_job(*_args: object, **_kwargs: object) -> tuple[bool, None]:
+        return True, None
+
+    async def _noop_async(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    class _StubAdapter:
+        def transcribe_batch(self, *args: object, **kwargs: object) -> dict[str, Any]:
+            return {"text": "should not transcribe"}
+
+    class _StubRegistry:
+        def resolve_provider_for_model(self, _model: object) -> tuple[str, str, None]:
+            return "external", "external:stub", None
+
+        def get_adapter(self, _provider: object) -> _StubAdapter:
+            return _StubAdapter()
+
+    monkeypatch.setattr(audio_ep, "can_start_job", _allow_job)
+    monkeypatch.setattr(audio_ep, "increment_jobs_started", _noop_async)
+    monkeypatch.setattr(audio_ep, "finish_job", _noop_async)
+    monkeypatch.setattr(audio_ep, "check_daily_minutes_allow", _allow_job)
+    monkeypatch.setattr(audio_ep, "add_daily_minutes", _noop_async)
+    monkeypatch.setattr(stt_adapter, "get_stt_provider_registry", lambda: _StubRegistry())
+    monkeypatch.setattr(atlib, "convert_to_wav", lambda path, *args, **kwargs: path)
+
+    app = FastAPI()
+    app.dependency_overrides[get_request_user] = _fake_get_request_user
+    app.include_router(audio_router, prefix="/api/v1/audio")
+
+    with bypass_api_limits(app), TestClient(app) as client:
+        headers = {"X-API-KEY": TEST_API_KEY}
+        files = {"file": ("sample.wav", io.BytesIO(b"not a wav"), "audio/wav")}
+        data = {"model": "external:stub", "response_format": "json"}
+        resp = client.post(
+            "/api/v1/audio/transcriptions",
+            headers=headers,
+            files=files,
+            data=data,
+        )
+        if resp.status_code == 404:
+            pytest.skip("audio/transcriptions endpoint not mounted in this build")
+        np.testing.assert_equal(
+            resp.status_code,
+            status.HTTP_400_BAD_REQUEST,
+            err_msg=resp.text,
+        )
+        detail = resp.json().get("detail") or {}
+        np.testing.assert_equal(detail.get("status"), "invalid_audio")
+
+
 @pytest.mark.parametrize("conversion_output_kind", ["empty", "non_wav"])
 def test_audio_transcriptions_rejects_unusable_conversion_output(
     monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/tests/Audio/test_audio_transcriptions_adapter_path.py
+++ b/tldw_Server_API/tests/Audio/test_audio_transcriptions_adapter_path.py
@@ -1,5 +1,6 @@
 import io
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -21,10 +22,10 @@ def _make_wav_bytes(duration_sec: float = 0.1, sr: int = 16000) -> bytes:
 
 
 def test_audio_transcriptions_uses_adapter_base_dir(
-    monkeypatch,
-    bypass_api_limits,
-):
-
+    monkeypatch: pytest.MonkeyPatch,
+    bypass_api_limits: Any,
+) -> None:
+    """Successful uploads pass adapter base_dir and force canonical WAV conversion."""
 
     monkeypatch.setenv("TEST_MODE", "true")
     monkeypatch.setenv("AUTH_MODE", "single_user")
@@ -39,25 +40,25 @@ def test_audio_transcriptions_uses_adapter_base_dir(
     async def _fake_get_request_user() -> User:
         return User(id=1, username="single_user")
 
-    async def _allow_job(*_args, **_kwargs):
+    async def _allow_job(*_args: object, **_kwargs: object) -> tuple[bool, None]:
         return True, None
 
-    async def _noop_async(*_args, **_kwargs):
+    async def _noop_async(*_args: object, **_kwargs: object) -> None:
         return None
 
     class _StubAdapter:
         def transcribe_batch(
             self,
-            audio_path,
+            audio_path: str,
             *,
-            model=None,
-            language=None,
-            task="transcribe",
-            word_timestamps=False,
-            prompt=None,
-            hotwords=None,
-            base_dir=None,
-        ):
+            model: str | None = None,
+            language: str | None = None,
+            task: str = "transcribe",
+            word_timestamps: bool = False,
+            prompt: str | None = None,
+            hotwords: list[str] | None = None,
+            base_dir: Path | None = None,
+        ) -> dict[str, Any]:
             assert hotwords is None
             assert base_dir is not None
             assert base_dir == Path(audio_path).parent
@@ -77,10 +78,10 @@ def test_audio_transcriptions_uses_adapter_base_dir(
             }
 
     class _StubRegistry:
-        def resolve_provider_for_model(self, _model):
+        def resolve_provider_for_model(self, _model: object) -> tuple[str, str, None]:
             return "external", "external:stub", None
 
-        def get_adapter(self, _provider):
+        def get_adapter(self, _provider: object) -> _StubAdapter:
             return _StubAdapter()
 
     monkeypatch.setattr(audio_ep, "can_start_job", _allow_job)
@@ -90,8 +91,15 @@ def test_audio_transcriptions_uses_adapter_base_dir(
     monkeypatch.setattr(audio_ep, "add_daily_minutes", _noop_async)
     import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.stt_provider_adapter as stt_adapter
 
+    captured_conversion: dict[str, Any] = {}
+
+    def _capture_convert_to_wav(path: str, *args: object, **kwargs: object) -> str:
+        captured_conversion["path"] = path
+        captured_conversion["overwrite"] = kwargs.get("overwrite")
+        return path
+
     monkeypatch.setattr(stt_adapter, "get_stt_provider_registry", lambda: _StubRegistry())
-    monkeypatch.setattr(atlib, "convert_to_wav", lambda path, *args, **kwargs: path)
+    monkeypatch.setattr(atlib, "convert_to_wav", _capture_convert_to_wav)
 
     app = FastAPI()
     app.dependency_overrides[get_request_user] = _fake_get_request_user
@@ -113,6 +121,8 @@ def test_audio_transcriptions_uses_adapter_base_dir(
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["text"] == "stub transcript"
+        assert Path(captured_conversion["path"]).suffix == ".wav"
+        assert captured_conversion["overwrite"] is True
 
 
 def test_audio_transcriptions_derives_suffix_for_extensionless_upload(
@@ -357,9 +367,10 @@ def test_audio_transcriptions_prevents_cross_provider_fallback(
 
 
 def test_audio_transcriptions_rejects_upload_when_wav_conversion_fails(
-    monkeypatch,
-    bypass_api_limits,
-):
+    monkeypatch: pytest.MonkeyPatch,
+    bypass_api_limits: Any,
+) -> None:
+    """Reject compressed uploads instead of falling back when WAV conversion fails."""
     monkeypatch.setenv("TEST_MODE", "true")
     monkeypatch.setenv("AUTH_MODE", "single_user")
     monkeypatch.setenv("SINGLE_USER_API_KEY", TEST_API_KEY)
@@ -374,24 +385,24 @@ def test_audio_transcriptions_rejects_upload_when_wav_conversion_fails(
     async def _fake_get_request_user() -> User:
         return User(id=1, username="single_user")
 
-    async def _allow_job(*_args, **_kwargs):
+    async def _allow_job(*_args: object, **_kwargs: object) -> tuple[bool, None]:
         return True, None
 
-    async def _noop_async(*_args, **_kwargs):
+    async def _noop_async(*_args: object, **_kwargs: object) -> None:
         return None
 
     class _StubAdapter:
-        def transcribe_batch(self, *args, **kwargs):
+        def transcribe_batch(self, *args: object, **kwargs: object) -> None:
             pytest.fail("adapter should not receive original upload after conversion failure")
 
     class _StubRegistry:
-        def resolve_provider_for_model(self, _model):
+        def resolve_provider_for_model(self, _model: object) -> tuple[str, str, None]:
             return "external", "external:stub", None
 
-        def get_adapter(self, _provider):
+        def get_adapter(self, _provider: object) -> _StubAdapter:
             return _StubAdapter()
 
-    def _fail_convert(*_args, **_kwargs):
+    def _fail_convert(*_args: object, **_kwargs: object) -> None:
         raise atlib.ConversionError("ffmpeg failed")
 
     monkeypatch.setattr(audio_ep, "can_start_job", _allow_job)
@@ -425,11 +436,12 @@ def test_audio_transcriptions_rejects_upload_when_wav_conversion_fails(
 
 @pytest.mark.parametrize("conversion_output_kind", ["empty", "non_wav"])
 def test_audio_transcriptions_rejects_unusable_conversion_output(
-    monkeypatch,
-    bypass_api_limits,
-    tmp_path,
-    conversion_output_kind,
-):
+    monkeypatch: pytest.MonkeyPatch,
+    bypass_api_limits: Any,
+    tmp_path: Path,
+    conversion_output_kind: str,
+) -> None:
+    """Reject conversion outputs that are empty, missing, or not canonical WAV files."""
     monkeypatch.setenv("TEST_MODE", "true")
     monkeypatch.setenv("AUTH_MODE", "single_user")
     monkeypatch.setenv("SINGLE_USER_API_KEY", TEST_API_KEY)
@@ -444,21 +456,21 @@ def test_audio_transcriptions_rejects_unusable_conversion_output(
     async def _fake_get_request_user() -> User:
         return User(id=1, username="single_user")
 
-    async def _allow_job(*_args, **_kwargs):
+    async def _allow_job(*_args: object, **_kwargs: object) -> tuple[bool, None]:
         return True, None
 
-    async def _noop_async(*_args, **_kwargs):
+    async def _noop_async(*_args: object, **_kwargs: object) -> None:
         return None
 
     class _StubAdapter:
-        def transcribe_batch(self, *args, **kwargs):
+        def transcribe_batch(self, *args: object, **kwargs: object) -> None:
             pytest.fail("adapter should not receive a non-WAV conversion output")
 
     class _StubRegistry:
-        def resolve_provider_for_model(self, _model):
+        def resolve_provider_for_model(self, _model: object) -> tuple[str, str, None]:
             return "external", "external:stub", None
 
-        def get_adapter(self, _provider):
+        def get_adapter(self, _provider: object) -> _StubAdapter:
             return _StubAdapter()
 
     if conversion_output_kind == "empty":

--- a/tldw_Server_API/tests/Audio/test_stt_provider_adapter.py
+++ b/tldw_Server_API/tests/Audio/test_stt_provider_adapter.py
@@ -3,6 +3,8 @@ import importlib
 import importlib.machinery
 import sys
 import builtins
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -577,7 +579,11 @@ def test_transcribe_batch_canary_normalizes_artifact(monkeypatch, tmp_path):
 
 
 @pytest.mark.unit
-def test_transcribe_batch_canary_converts_compressed_input_before_soundfile(monkeypatch, tmp_path):
+def test_transcribe_batch_canary_converts_compressed_input_before_soundfile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Canary adapter converts compressed input before soundfile reads it."""
     spa = _import_module()
 
     import numpy as np
@@ -593,8 +599,9 @@ def test_transcribe_batch_canary_converts_compressed_input_before_soundfile(monk
 
     captured = {}
 
-    def fake_convert_to_wav(path, *args, **kwargs):
+    def fake_convert_to_wav(path: str, *args: object, **kwargs: object) -> str:
         captured["input_path"] = str(path)
+        captured["overwrite"] = kwargs.get("overwrite")
         return str(converted_wav)
 
     monkeypatch.setattr(atlib, "convert_to_wav", fake_convert_to_wav)
@@ -603,7 +610,13 @@ def test_transcribe_batch_canary_converts_compressed_input_before_soundfile(monk
         "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo"
     )
 
-    def fake_transcribe_with_canary(audio_np, sample_rate, language, task="transcribe", target_language=None):
+    def fake_transcribe_with_canary(
+        audio_np: Any,
+        sample_rate: int,
+        language: str,
+        task: str = "transcribe",
+        target_language: str | None = None,
+    ) -> str:
         assert sample_rate == 16000
         assert len(audio_np) == 1600
         return "canary transcript"
@@ -625,10 +638,15 @@ def test_transcribe_batch_canary_converts_compressed_input_before_soundfile(monk
 
     assert artifact["text"] == "canary transcript"
     assert captured["input_path"] == str(compressed_file)
+    assert captured["overwrite"] is True
 
 
 @pytest.mark.unit
-def test_transcribe_batch_qwen3_asr_converts_compressed_input(monkeypatch, tmp_path):
+def test_transcribe_batch_qwen3_asr_converts_compressed_input(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Qwen3-ASR adapter passes a freshly converted WAV path to the provider."""
     spa = _import_module()
 
     import sys
@@ -640,21 +658,26 @@ def test_transcribe_batch_qwen3_asr_converts_compressed_input(monkeypatch, tmp_p
     converted_wav.write_bytes(b"RIFFfakeWAVE")
     captured = {}
 
-    monkeypatch.setattr(atlib, "convert_to_wav", lambda path, *args, **kwargs: str(converted_wav))
+    def fake_convert_to_wav(path: str, *args: object, **kwargs: object) -> str:
+        captured["convert_input"] = str(path)
+        captured["overwrite"] = kwargs.get("overwrite")
+        return str(converted_wav)
+
+    monkeypatch.setattr(atlib, "convert_to_wav", fake_convert_to_wav)
 
     fake_qwen3_mod = types.ModuleType(
         "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Qwen3ASR"
     )
 
     def fake_transcribe_with_qwen3_asr(
-        audio_path,
+        audio_path: str,
         *,
-        model_path=None,
-        language=None,
-        word_timestamps=False,
-        base_dir=None,
-        cancel_check=None,
-    ):
+        model_path: str | None = None,
+        language: str | None = None,
+        word_timestamps: bool = False,
+        base_dir: Path | None = None,
+        cancel_check: object = None,
+    ) -> dict[str, Any]:
         captured["audio_path"] = str(audio_path)
         captured["base_dir"] = base_dir
         return {
@@ -684,12 +707,18 @@ def test_transcribe_batch_qwen3_asr_converts_compressed_input(monkeypatch, tmp_p
     )
 
     assert artifact["text"] == "qwen3 transcript"
+    assert captured["convert_input"] == str(compressed_file)
+    assert captured["overwrite"] is True
     assert captured["audio_path"] == str(converted_wav)
     assert captured["base_dir"] == tmp_path
 
 
 @pytest.mark.unit
-def test_transcribe_batch_vibevoice_converts_compressed_input(monkeypatch, tmp_path):
+def test_transcribe_batch_vibevoice_converts_compressed_input(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """VibeVoice adapter passes a freshly converted WAV path to the provider."""
     spa = _import_module()
 
     import sys
@@ -701,21 +730,26 @@ def test_transcribe_batch_vibevoice_converts_compressed_input(monkeypatch, tmp_p
     converted_wav.write_bytes(b"RIFFfakeWAVE")
     captured = {}
 
-    monkeypatch.setattr(atlib, "convert_to_wav", lambda path, *args, **kwargs: str(converted_wav))
+    def fake_convert_to_wav(path: str, *args: object, **kwargs: object) -> str:
+        captured["convert_input"] = str(path)
+        captured["overwrite"] = kwargs.get("overwrite")
+        return str(converted_wav)
+
+    monkeypatch.setattr(atlib, "convert_to_wav", fake_convert_to_wav)
 
     fake_vibe_mod = types.ModuleType(
         "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_VibeVoice"
     )
 
     def fake_transcribe_with_vibevoice(
-        audio_path,
+        audio_path: str,
         *,
-        model_id=None,
-        language=None,
-        hotwords=None,
-        base_dir=None,
-        cancel_check=None,
-    ):
+        model_id: str | None = None,
+        language: str | None = None,
+        hotwords: list[str] | None = None,
+        base_dir: Path | None = None,
+        cancel_check: object = None,
+    ) -> dict[str, Any]:
         captured["audio_path"] = str(audio_path)
         captured["base_dir"] = base_dir
         return {
@@ -745,6 +779,8 @@ def test_transcribe_batch_vibevoice_converts_compressed_input(monkeypatch, tmp_p
     )
 
     assert artifact["text"] == "vibe transcript"
+    assert captured["convert_input"] == str(compressed_file)
+    assert captured["overwrite"] is True
     assert captured["audio_path"] == str(converted_wav)
     assert captured["base_dir"] == tmp_path
 

--- a/tldw_Server_API/tests/Audio/test_stt_provider_adapter.py
+++ b/tldw_Server_API/tests/Audio/test_stt_provider_adapter.py
@@ -577,6 +577,179 @@ def test_transcribe_batch_canary_normalizes_artifact(monkeypatch, tmp_path):
 
 
 @pytest.mark.unit
+def test_transcribe_batch_canary_converts_compressed_input_before_soundfile(monkeypatch, tmp_path):
+    spa = _import_module()
+
+    import numpy as np
+    import soundfile as sf
+    import sys
+
+    compressed_file = tmp_path / "sample_canary.mp3"
+    compressed_file.write_bytes(b"not really mp3")
+    converted_wav = tmp_path / "sample_canary.wav"
+    sf.write(str(converted_wav), np.zeros(1600, dtype="float32"), 16000)
+
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+
+    captured = {}
+
+    def fake_convert_to_wav(path, *args, **kwargs):
+        captured["input_path"] = str(path)
+        return str(converted_wav)
+
+    monkeypatch.setattr(atlib, "convert_to_wav", fake_convert_to_wav)
+
+    fake_nemo_mod = types.ModuleType(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo"
+    )
+
+    def fake_transcribe_with_canary(audio_np, sample_rate, language, task="transcribe", target_language=None):
+        assert sample_rate == 16000
+        assert len(audio_np) == 1600
+        return "canary transcript"
+
+    fake_nemo_mod.transcribe_with_canary = fake_transcribe_with_canary
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo",
+        fake_nemo_mod,
+    )
+
+    adapter = spa.CanaryAdapter()
+    artifact = adapter.transcribe_batch(
+        str(compressed_file),
+        model="nemo-canary-1b",
+        language="en",
+        base_dir=tmp_path,
+    )
+
+    assert artifact["text"] == "canary transcript"
+    assert captured["input_path"] == str(compressed_file)
+
+
+@pytest.mark.unit
+def test_transcribe_batch_qwen3_asr_converts_compressed_input(monkeypatch, tmp_path):
+    spa = _import_module()
+
+    import sys
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+
+    compressed_file = tmp_path / "sample_qwen3.webm"
+    compressed_file.write_bytes(b"not really webm")
+    converted_wav = tmp_path / "sample_qwen3.wav"
+    converted_wav.write_bytes(b"RIFFfakeWAVE")
+    captured = {}
+
+    monkeypatch.setattr(atlib, "convert_to_wav", lambda path, *args, **kwargs: str(converted_wav))
+
+    fake_qwen3_mod = types.ModuleType(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Qwen3ASR"
+    )
+
+    def fake_transcribe_with_qwen3_asr(
+        audio_path,
+        *,
+        model_path=None,
+        language=None,
+        word_timestamps=False,
+        base_dir=None,
+        cancel_check=None,
+    ):
+        captured["audio_path"] = str(audio_path)
+        captured["base_dir"] = base_dir
+        return {
+            "text": "qwen3 transcript",
+            "language": language or "en",
+            "segments": [
+                {"start_seconds": 0.0, "end_seconds": 1.0, "Text": "qwen3 transcript"}
+            ],
+            "diarization": {"enabled": False, "speakers": None},
+            "usage": {"duration_ms": 1000, "tokens": None},
+            "metadata": {"provider": "qwen3-asr", "model": model_path or "model"},
+        }
+
+    fake_qwen3_mod.transcribe_with_qwen3_asr = fake_transcribe_with_qwen3_asr
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Qwen3ASR",
+        fake_qwen3_mod,
+    )
+
+    adapter = spa.Qwen3ASRAdapter()
+    artifact = adapter.transcribe_batch(
+        str(compressed_file),
+        model="./models/qwen3_asr/1.7B",
+        language="en",
+        base_dir=tmp_path,
+    )
+
+    assert artifact["text"] == "qwen3 transcript"
+    assert captured["audio_path"] == str(converted_wav)
+    assert captured["base_dir"] == tmp_path
+
+
+@pytest.mark.unit
+def test_transcribe_batch_vibevoice_converts_compressed_input(monkeypatch, tmp_path):
+    spa = _import_module()
+
+    import sys
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+
+    compressed_file = tmp_path / "sample_vibevoice.m4a"
+    compressed_file.write_bytes(b"not really m4a")
+    converted_wav = tmp_path / "sample_vibevoice.wav"
+    converted_wav.write_bytes(b"RIFFfakeWAVE")
+    captured = {}
+
+    monkeypatch.setattr(atlib, "convert_to_wav", lambda path, *args, **kwargs: str(converted_wav))
+
+    fake_vibe_mod = types.ModuleType(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_VibeVoice"
+    )
+
+    def fake_transcribe_with_vibevoice(
+        audio_path,
+        *,
+        model_id=None,
+        language=None,
+        hotwords=None,
+        base_dir=None,
+        cancel_check=None,
+    ):
+        captured["audio_path"] = str(audio_path)
+        captured["base_dir"] = base_dir
+        return {
+            "text": "vibe transcript",
+            "language": language or "en",
+            "segments": [
+                {"start_seconds": 0.0, "end_seconds": 1.0, "Text": "vibe transcript"}
+            ],
+            "diarization": {"enabled": False, "speakers": None},
+            "usage": {"duration_ms": 1000, "tokens": None},
+            "metadata": {"provider": "vibevoice", "model": model_id or "model"},
+        }
+
+    fake_vibe_mod.transcribe_with_vibevoice = fake_transcribe_with_vibevoice
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_VibeVoice",
+        fake_vibe_mod,
+    )
+
+    adapter = spa.VibeVoiceAdapter()
+    artifact = adapter.transcribe_batch(
+        str(compressed_file),
+        model="microsoft/VibeVoice-ASR",
+        language="en",
+        base_dir=tmp_path,
+    )
+
+    assert artifact["text"] == "vibe transcript"
+    assert captured["audio_path"] == str(converted_wav)
+    assert captured["base_dir"] == tmp_path
+
+
+@pytest.mark.unit
 def test_transcribe_batch_external_normalizes_artifact(monkeypatch, tmp_path):
     spa = _import_module()
 

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_nemo_transcription.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_nemo_transcription.py
@@ -6,6 +6,8 @@ import pytest
 import numpy as np
 import tempfile
 import os
+import sys
+import types
 from unittest.mock import Mock, patch, MagicMock
 from pathlib import Path
 
@@ -190,7 +192,7 @@ class TestNemoTranscription:
         assert kwargs.get("target_lang") == "en"
 
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo.load_canary_model')
-    def test_transcribe_with_canary_resamples_numpy_before_direct_transcribe(self, mock_load_model):
+    def test_transcribe_with_canary_resamples_numpy_before_direct_transcribe(self, mock_load_model: MagicMock) -> None:
         """Canary direct NumPy path should honor non-16kHz caller sample rates."""
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
             transcribe_with_canary,
@@ -209,7 +211,7 @@ class TestNemoTranscription:
         assert len(args[0][0]) == 16000
 
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo.load_parakeet_model')
-    def test_transcribe_with_parakeet_resamples_numpy_before_direct_transcribe(self, mock_load_model):
+    def test_transcribe_with_parakeet_resamples_numpy_before_direct_transcribe(self, mock_load_model: MagicMock) -> None:
         """Parakeet direct NumPy path should honor non-16kHz caller sample rates."""
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
             transcribe_with_parakeet,
@@ -227,7 +229,7 @@ class TestNemoTranscription:
         assert len(args[0]) == 16000
 
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo.load_parakeet_model')
-    def test_transcribe_with_parakeet_empty_numpy_does_not_resample_crash(self, mock_load_model):
+    def test_transcribe_with_parakeet_empty_numpy_does_not_resample_crash(self, mock_load_model: MagicMock) -> None:
         """Parakeet direct NumPy path should not crash before provider validation on empty audio."""
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
             transcribe_with_parakeet,
@@ -243,6 +245,105 @@ class TestNemoTranscription:
         assert result == "empty parakeet"
         args, _kwargs = mock_model.transcribe.call_args
         assert args[0].size == 0
+
+    def test_prepare_numpy_audio_for_nemo_downmixes_stereo(self) -> None:
+        """Direct helper should downmix multi-channel arrays to mono."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
+            _prepare_numpy_audio_for_nemo,
+        )
+
+        audio_data = np.column_stack(
+            (
+                np.ones(8, dtype=np.float32),
+                np.zeros(8, dtype=np.float32),
+            )
+        )
+
+        audio_np, sample_rate = _prepare_numpy_audio_for_nemo(audio_data, 16000)
+
+        assert sample_rate == 16000
+        assert audio_np.shape == (8,)
+        assert np.allclose(audio_np, 0.5)
+
+    def test_prepare_numpy_audio_for_nemo_skips_polyphase_when_terms_are_large(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Large up/down terms should use the linear fallback instead of resample_poly."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
+            _prepare_numpy_audio_for_nemo,
+        )
+
+        fake_scipy = types.ModuleType("scipy")
+        fake_signal = types.SimpleNamespace(
+            resample_poly=lambda *_args, **_kwargs: pytest.fail("resample_poly should not be used")
+        )
+        fake_scipy.signal = fake_signal
+        monkeypatch.setitem(sys.modules, "scipy", fake_scipy)
+
+        audio_np, sample_rate = _prepare_numpy_audio_for_nemo(
+            np.ones(16001, dtype=np.float32),
+            16001,
+        )
+
+        assert sample_rate == 16000
+        assert len(audio_np) == 16000
+
+    def test_prepare_numpy_audio_for_nemo_uses_linear_fallback_without_scipy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SciPy import failure should fall back to bounded linear interpolation."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
+            _prepare_numpy_audio_for_nemo,
+        )
+
+        real_import = __import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "scipy":
+                raise ImportError("scipy unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+
+        audio_np, sample_rate = _prepare_numpy_audio_for_nemo(
+            np.ones(8000, dtype=np.float32),
+            8000,
+        )
+
+        assert sample_rate == 16000
+        assert len(audio_np) == 16000
+
+    def test_prepare_numpy_audio_for_nemo_rejects_invalid_sample_rates(self) -> None:
+        """Invalid or implausible sample rates should fail before resampling."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
+            _prepare_numpy_audio_for_nemo,
+        )
+
+        with pytest.raises(ValueError, match="sample_rate must be positive"):
+            _prepare_numpy_audio_for_nemo(np.ones(8, dtype=np.float32), 0)
+
+        with pytest.raises(ValueError, match="supported range"):
+            _prepare_numpy_audio_for_nemo(np.ones(8, dtype=np.float32), 1)
+
+    def test_prepare_numpy_audio_for_nemo_rejects_large_resample_ratio(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Fallback interpolation should fail fast when the requested ratio is too large."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
+            _prepare_numpy_audio_for_nemo,
+        )
+
+        monkeypatch.setitem(sys.modules, "scipy", None)
+
+        with pytest.raises(ValueError, match="resample ratio is too large"):
+            _prepare_numpy_audio_for_nemo(
+                np.ones(8000, dtype=np.float32),
+                8000,
+                target_sample_rate=128000,
+            )
 
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo.load_canary_model')
     def test_transcribe_with_canary_sanitizes_runtime_errors(self, mock_load_model):

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_nemo_transcription.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_nemo_transcription.py
@@ -315,6 +315,32 @@ class TestNemoTranscription:
         assert sample_rate == 16000
         assert len(audio_np) == 16000
 
+    def test_prepare_numpy_audio_for_nemo_uses_linear_fallback_when_scipy_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SciPy resampling failure should fall back to bounded linear interpolation."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
+            _prepare_numpy_audio_for_nemo,
+        )
+
+        fake_scipy = types.ModuleType("scipy")
+
+        def fail_resample_poly(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("polyphase resampling failed")
+
+        fake_signal = types.SimpleNamespace(resample_poly=fail_resample_poly)
+        fake_scipy.signal = fake_signal
+        monkeypatch.setitem(sys.modules, "scipy", fake_scipy)
+
+        audio_np, sample_rate = _prepare_numpy_audio_for_nemo(
+            np.ones(8000, dtype=np.float32),
+            8000,
+        )
+
+        np.testing.assert_equal(sample_rate, 16000)
+        np.testing.assert_equal(len(audio_np), 16000)
+
     def test_prepare_numpy_audio_for_nemo_rejects_invalid_sample_rates(self) -> None:
         """Invalid or implausible sample rates should fail before resampling."""
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_nemo_transcription.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_nemo_transcription.py
@@ -190,6 +190,61 @@ class TestNemoTranscription:
         assert kwargs.get("target_lang") == "en"
 
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo.load_canary_model')
+    def test_transcribe_with_canary_resamples_numpy_before_direct_transcribe(self, mock_load_model):
+        """Canary direct NumPy path should honor non-16kHz caller sample rates."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
+            transcribe_with_canary,
+        )
+
+        audio_data = np.ones(8000, dtype=np.float32)
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ["resampled canary"]
+        mock_load_model.return_value = mock_model
+
+        result = transcribe_with_canary(audio_data, 8000, "en")
+
+        assert result == "resampled canary"
+        args, _kwargs = mock_model.transcribe.call_args
+        assert isinstance(args[0], list)
+        assert len(args[0][0]) == 16000
+
+    @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo.load_parakeet_model')
+    def test_transcribe_with_parakeet_resamples_numpy_before_direct_transcribe(self, mock_load_model):
+        """Parakeet direct NumPy path should honor non-16kHz caller sample rates."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
+            transcribe_with_parakeet,
+        )
+
+        audio_data = np.ones(8000, dtype=np.float32)
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ["resampled parakeet"]
+        mock_load_model.return_value = mock_model
+
+        result = transcribe_with_parakeet(audio_data, 8000, "standard")
+
+        assert result == "resampled parakeet"
+        args, _kwargs = mock_model.transcribe.call_args
+        assert len(args[0]) == 16000
+
+    @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo.load_parakeet_model')
+    def test_transcribe_with_parakeet_empty_numpy_does_not_resample_crash(self, mock_load_model):
+        """Parakeet direct NumPy path should not crash before provider validation on empty audio."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
+            transcribe_with_parakeet,
+        )
+
+        audio_data = np.array([], dtype=np.float32)
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ["empty parakeet"]
+        mock_load_model.return_value = mock_model
+
+        result = transcribe_with_parakeet(audio_data, 8000, "standard")
+
+        assert result == "empty parakeet"
+        args, _kwargs = mock_model.transcribe.call_args
+        assert args[0].size == 0
+
+    @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo.load_canary_model')
     def test_transcribe_with_canary_sanitizes_runtime_errors(self, mock_load_model):
         """Canary runtime failures should not leak backend exception text."""
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_mlx.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_mlx.py
@@ -7,6 +7,8 @@ import numpy as np
 import tempfile
 import os
 import builtins
+import sys
+import types
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock, call
 import soundfile as sf
@@ -201,6 +203,71 @@ class TestParakeetMLX:
 
         model = mlx_mod.load_parakeet_mlx_model(force_reload=True)
         assert model is None
+
+    def test_speech_to_text_parakeet_mlx_buffered_converts_compressed_path(self, monkeypatch, tmp_path):
+        """MLX buffered path should not pass compressed source files to soundfile loaders."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Buffered_Transcription as buffered_mod
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Lib as atlib
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Parakeet_MLX as mlx_mod
+
+        compressed_file = tmp_path / "sample.m4a"
+        compressed_file.write_bytes(b"not really m4a")
+        converted_wav = tmp_path / "sample.wav"
+        converted_wav.write_bytes(b"RIFFfakeWAVE")
+        captured = {}
+
+        monkeypatch.setattr(mlx_mod, "check_mlx_available", lambda: True)
+        monkeypatch.setattr(atlib, "get_stt_config", lambda: {"mlx_chunk_duration": 30.0})
+        monkeypatch.setitem(
+            sys.modules,
+            "librosa",
+            types.SimpleNamespace(get_duration=lambda path: 120.0),
+        )
+
+        def fake_convert_to_wav(path, *args, **kwargs):
+            captured["convert_input"] = str(path)
+            return str(converted_wav)
+
+        def fake_transcribe_long_audio(audio_path, *args, **kwargs):
+            captured["audio_path"] = str(audio_path)
+            return "mlx transcript"
+
+        monkeypatch.setattr(atlib, "convert_to_wav", fake_convert_to_wav)
+        monkeypatch.setattr(buffered_mod, "transcribe_long_audio", fake_transcribe_long_audio)
+
+        segments = atlib.speech_to_text_parakeet(
+            str(compressed_file),
+            variant="mlx",
+            base_dir=tmp_path,
+        )
+
+        assert captured["convert_input"] == str(compressed_file)
+        assert captured["audio_path"] == str(converted_wav)
+        assert segments[0]["Text"] == "mlx transcript"
+
+    def test_speech_to_text_parakeet_mlx_rejects_converted_path_outside_base_dir(self, monkeypatch, tmp_path):
+        """MLX conversion output should remain inside base_dir when one is provided."""
+        from tldw_Server_API.app.core.exceptions import STTTranscriptionError
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Lib as atlib
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Parakeet_MLX as mlx_mod
+
+        compressed_file = tmp_path / "sample.m4a"
+        compressed_file.write_bytes(b"not really m4a")
+        outside_dir = tmp_path.parent / f"{tmp_path.name}_outside"
+        outside_dir.mkdir(exist_ok=True)
+        converted_wav = outside_dir / "sample.wav"
+        converted_wav.write_bytes(b"RIFFfakeWAVE")
+
+        monkeypatch.setattr(mlx_mod, "check_mlx_available", lambda: True)
+        monkeypatch.setattr(atlib, "get_stt_config", lambda: {"mlx_chunk_duration": 30.0})
+        monkeypatch.setattr(atlib, "convert_to_wav", lambda *args, **kwargs: str(converted_wav))
+
+        with pytest.raises(STTTranscriptionError, match="outside the allowed directory"):
+            atlib.speech_to_text_parakeet(
+                str(compressed_file),
+                variant="mlx",
+                base_dir=tmp_path,
+            )
 
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX.load_parakeet_mlx_model')
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX.check_mlx_available')

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_mlx.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_mlx.py
@@ -204,7 +204,11 @@ class TestParakeetMLX:
         model = mlx_mod.load_parakeet_mlx_model(force_reload=True)
         assert model is None
 
-    def test_speech_to_text_parakeet_mlx_buffered_converts_compressed_path(self, monkeypatch, tmp_path):
+    def test_speech_to_text_parakeet_mlx_buffered_converts_compressed_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
         """MLX buffered path should not pass compressed source files to soundfile loaders."""
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Buffered_Transcription as buffered_mod
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Lib as atlib
@@ -224,11 +228,12 @@ class TestParakeetMLX:
             types.SimpleNamespace(get_duration=lambda path: 120.0),
         )
 
-        def fake_convert_to_wav(path, *args, **kwargs):
+        def fake_convert_to_wav(path: str, *args: object, **kwargs: object) -> str:
             captured["convert_input"] = str(path)
+            captured["overwrite"] = kwargs.get("overwrite")
             return str(converted_wav)
 
-        def fake_transcribe_long_audio(audio_path, *args, **kwargs):
+        def fake_transcribe_long_audio(audio_path: str, *args: object, **kwargs: object) -> str:
             captured["audio_path"] = str(audio_path)
             return "mlx transcript"
 
@@ -242,10 +247,34 @@ class TestParakeetMLX:
         )
 
         assert captured["convert_input"] == str(compressed_file)
+        assert captured["overwrite"] is True
         assert captured["audio_path"] == str(converted_wav)
         assert segments[0]["Text"] == "mlx transcript"
 
-    def test_speech_to_text_parakeet_mlx_rejects_converted_path_outside_base_dir(self, monkeypatch, tmp_path):
+    def test_speech_to_text_parakeet_mlx_rejects_existing_wav_outside_base_dir(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Existing WAV inputs should still be checked by the MLX helper."""
+        from tldw_Server_API.app.core.exceptions import STTTranscriptionError
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Lib as atlib
+
+        outside_dir = tmp_path.parent / f"{tmp_path.name}_existing_wav_outside"
+        outside_dir.mkdir(exist_ok=True)
+        outside_wav = outside_dir / "sample.wav"
+        outside_wav.write_bytes(b"RIFFfakeWAVE")
+
+        with pytest.raises(STTTranscriptionError, match="WAV path is outside the allowed directory"):
+            atlib._ensure_wav_path_for_parakeet_mlx(
+                str(outside_wav),
+                base_dir=tmp_path,
+            )
+
+    def test_speech_to_text_parakeet_mlx_rejects_converted_path_outside_base_dir(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
         """MLX conversion output should remain inside base_dir when one is provided."""
         from tldw_Server_API.app.core.exceptions import STTTranscriptionError
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Lib as atlib


### PR DESCRIPTION
## Summary
- Reject audio uploads when canonical WAV conversion fails or returns empty, missing, or non-WAV output instead of falling back to compressed originals.
- Canonicalize compressed direct-call inputs for Canary, Qwen3 ASR, VibeVoice, and Parakeet MLX, including base_dir checks for converted paths.
- Normalize NeMo Parakeet and Canary ndarray input to mono 16 kHz, with fallback resampling and edge-case coverage.

## Change summary
TODO: Human requester must replace this with the human-written change summary required by Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md before merge.

## Test Plan
- [x] Focused pytest suite: 79 passed, 2 skipped
- [x] Ruff high-signal rules: passed
- [x] compileall on touched production files: passed
- [x] git diff --check: passed
- [x] Bandit on touched production files: ran; existing low-severity subprocess findings remain in Audio_Transcription_Lib.py outside this diff

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the audio transcription pipeline by enforcing canonical 16 kHz mono WAV at the endpoint and adapters, validating RIFF/WAVE headers, and normalizing NumPy inputs for NeMo. Removes fallbacks to compressed inputs and forces fresh conversions (`overwrite=True`) to prevent spoofed or stale WAV reuse. Addresses TASK-12126.

- **Bug Fixes**
  - Endpoint: rejects when WAV conversion import fails or conversion yields empty/missing/non-WAV output; validates `.wav`, existence, and RIFF/WAVE header; uses `overwrite=True`; returns 400 `invalid_audio` with no fallback.
  - Adapters: Canary, Qwen3 ASR, and VibeVoice convert compressed inputs to WAV with `overwrite=True` and enforce adapter `base_dir`; Parakeet MLX uses `_ensure_wav_path_for_parakeet_mlx` to validate existing/converted paths stay inside `base_dir` before buffered loading.
  - NeMo NumPy: `_prepare_numpy_audio_for_nemo` downmixes to mono float32 and resamples to 16 kHz; validates sample rate range; guards large ratios; uses polyphase when available and bounded linear fallback otherwise; handles empty/scalar arrays.
  - Tests: coverage for endpoint rejection (including header spoofing), adapter conversions (including `overwrite=True`), MLX `base_dir`, and NeMo resampling with SciPy/polyphase failure fallbacks; focused suite: 85 passed, 2 skipped.

- **Migration**
  - Clients may now receive 400 `invalid_audio` when uploads cannot be converted to WAV. Upload canonical WAV or a decodable format.

<sup>Written for commit 8f5ecc600f59a1415c9ad28824a480cee734a814. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

