### PR TITLE
Add standalone MCP docs source discovery

### DIFF
--- a/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
@@ -1238,7 +1238,7 @@ git commit -m "feat: sync docs sitemap sources"
 - Modify: `tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py`
 - Modify: `tldw_Server_API/Config_Files/mcp_modules.yaml` only if explicit defaults need to be visible.
 
-- [ ] **Step 1: Write host shim tests**
+- [x] **Step 1: Write host shim tests**
 
 Add:
 
@@ -1271,7 +1271,7 @@ Extend `test_repo_docs_mcp_config_keeps_web_acquisition_disabled`:
 assert settings.get("enable_source_discovery", False) is False  # nosec B101
 ```
 
-- [ ] **Step 2: Run red/green**
+- [x] **Step 2: Run red/green**
 
 Run:
 
@@ -1283,7 +1283,7 @@ Run:
 
 Expected first run: FAIL if host/provider wiring is incomplete. After provider wiring, PASS. If config lacks explicit `enable_source_discovery`, either keep the `.get(..., False)` assertion or add the explicit disabled config key with docs-only rationale.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py \

--- a/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
@@ -995,7 +995,7 @@ git commit -m "feat: expose docs source discovery tool"
 - Modify: `apps/mcp-unified/src/mcp_unified/docs/discovery.py`
 - Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py`
 
-- [ ] **Step 1: Write failing sitemap sync tests**
+- [x] **Step 1: Write failing sitemap sync tests**
 
 Add:
 
@@ -1164,7 +1164,7 @@ def test_url_sitemap_sync_tombstones_missing_links_only_in_apply_mode(tmp_path: 
     assert store.search_chunks(scope=scope, query="new", limit=10)  # nosec B101
 ```
 
-- [ ] **Step 2: Run red tests**
+- [x] **Step 2: Run red tests**
 
 Run:
 
@@ -1178,7 +1178,7 @@ Run:
 
 Expected: FAIL because sitemap sync currently returns `sitemap_sync_disabled` or unsupported.
 
-- [ ] **Step 3: Implement shared sitemap sync**
+- [x] **Step 3: Implement shared sitemap sync**
 
 Prefer adding a helper on `DocsSourceDiscoveryService`, for example:
 
@@ -1216,13 +1216,13 @@ Then in `DocsSourceSyncService.sync_source()` replace the disabled-only `url_sit
 - report or tombstone stale links according to `request.stale_policy`;
 - record sync run only in apply mode.
 
-- [ ] **Step 4: Run green tests**
+- [x] **Step 4: Run green tests**
 
 Run the command from Step 2.
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/mcp-unified/src/mcp_unified/docs/sync.py \

--- a/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
@@ -880,7 +880,7 @@ git commit -m "feat: apply docs source discovery"
 - Modify: `apps/mcp-unified/src/mcp_unified/docs/__init__.py`
 - Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py`
 
-- [ ] **Step 1: Write failing provider tests**
+- [x] **Step 1: Write failing provider tests**
 
 Add:
 
@@ -921,7 +921,7 @@ def test_provider_stale_discover_source_call_is_disabled(tmp_path: Path) -> None
     assert result["reason_code"] == "source_discovery_disabled"  # nosec B101
 ```
 
-- [ ] **Step 2: Run red tests**
+- [x] **Step 2: Run red tests**
 
 Run:
 
@@ -935,7 +935,7 @@ Run:
 
 Expected: FAIL with missing provider support.
 
-- [ ] **Step 3: Wire provider**
+- [x] **Step 3: Wire provider**
 
 In `DocsMCPToolProvider.__init__`, instantiate:
 
@@ -972,13 +972,13 @@ _tool(
 
 Add `_discover_source_request_from_args()` mirroring `_sync_source_request_from_args()` with explicit validation.
 
-- [ ] **Step 4: Run green tests**
+- [x] **Step 4: Run green tests**
 
 Run the command from Step 2.
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/mcp-unified/src/mcp_unified/docs/mcp_module.py \

--- a/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
@@ -1,0 +1,1359 @@
+# Standalone MCP Docs Stage 4B Source Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bounded `docs.discover_source` support plus `url_sitemap` refresh for the standalone MCP docs corpus.
+
+**Architecture:** Add a runtime-neutral `DocsSourceDiscoveryService` that reuses Stage 2 URL policy/fetch seams and Stage 4A source registry/sync helpers. Discovery is explicit, synchronous, dry-run first, bounded by config, and independent from `tldw_Server_API`; apply mode either registers sitemap sources or ingests accepted pages through `DocsAcquisitionService.ingest_url()`.
+
+**Tech Stack:** Python 3.10+, dataclasses, stdlib `html.parser`, stdlib XML parsing, optional lazy `beautifulsoup4`/`trafilatura`, stdlib `sqlite3`, pytest fake resolver/transport tests, Bandit on touched Python paths.
+
+---
+
+## Source References
+
+- Design spec: `Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md`
+- Stage 2 URL acquisition spec: `Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-url-acquisition-design.md`
+- Stage 4A source sync spec: `Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md`
+- Stage 4A implementation plan: `Docs/superpowers/plans/2026-07-02-standalone-mcp-docs-stage4a-source-sync-implementation-plan.md`
+- Backlog planning task: `TASK-12122`
+
+## Scope
+
+Included in Stage 4B.1:
+
+- `DocsSettings` discovery flags and caps.
+- `DiscoverSourceRequest` and discovery result shape helpers.
+- `docs.status` source discovery status.
+- `docs.discover_source` advertisement, validation, and execution.
+- Sitemap `urlset` parsing from explicit sitemap URLs.
+- One-hop HTML page-link discovery from explicit seed pages.
+- Optional lazy BeautifulSoup link extraction with stdlib fallback.
+- Dry-run discovery with no docs-store mutation.
+- Apply register mode for `url_sitemap` sources.
+- Apply ingest and register-and-ingest modes through `DocsAcquisitionService.ingest_url()`.
+- `docs.sync_source` support for registered `url_sitemap` sources when `sitemap_sync_enabled=true`.
+- Query redaction, same-origin/prefix policy, fake transport/resolver tests, and import-boundary coverage.
+
+Excluded from Stage 4B.1:
+
+- Broad recursive crawling.
+- Sitemap index support unless implementation stays small after `urlset` support.
+- Browser automation, JavaScript rendering, cookies, login/session scraping, Playwright.
+- New required dependencies.
+- Jobs/Scheduler wrappers, background recurrence, Media DB, ChromaDB, host RAG bridge.
+- New crawler graph tables.
+
+## File Structure
+
+Create:
+
+- `apps/mcp-unified/src/mcp_unified/docs/discovery.py` - candidate dataclasses, sitemap parser, page-link extractor, `DocsSourceDiscoveryService`, public response shaping.
+- `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py` - unit and integration coverage for discovery helpers, service dry-run/apply, redaction, and metadata propagation.
+
+Modify:
+
+- `apps/mcp-unified/src/mcp_unified/docs/settings.py` - discovery settings and coercion.
+- `apps/mcp-unified/src/mcp_unified/docs/models.py` - discovery literals and request dataclass.
+- `apps/mcp-unified/src/mcp_unified/docs/mcp_module.py` - discovery status, tool definition, argument parsing, execution.
+- `apps/mcp-unified/src/mcp_unified/docs/sync.py` - `url_sitemap` sync branch using shared discovery helpers.
+- `apps/mcp-unified/src/mcp_unified/docs/__init__.py` - export `DiscoverSourceRequest` if needed by tests.
+- `tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py` - settings defaults/parsing.
+- `tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py` - provider advertisement/status/argument validation.
+- `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py` - `url_sitemap` sync coverage.
+- `tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py` - host shim advertisement and config default checks.
+- `tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py` - include discovery module in optional dependency/import-boundary assertions.
+- `backlog/tasks/task-12122 - Plan-standalone-MCP-docs-Stage-4B-source-discovery-implementation.md` - task tracking and verification.
+
+Do not modify:
+
+- `pyproject.toml` for new required dependencies.
+- `tldw_Server_API` scraping/media/RAG services.
+- Jobs/Scheduler code.
+- Browser or Playwright tooling.
+
+## Shared Contracts
+
+Use these names consistently.
+
+```python
+DiscoveryKind = Literal["auto", "sitemap", "page_links"]
+DiscoveryMode = Literal["dry_run", "apply"]
+DiscoveryApplyAction = Literal["register", "ingest", "register_and_ingest"]
+DiscoveryCandidateStatus = Literal["accepted", "duplicate", "denied", "skipped", "ingested", "failed"]
+
+
+@dataclass(frozen=True)
+class DiscoverSourceRequest:
+    url: str
+    kind: DiscoveryKind = "auto"
+    mode: DiscoveryMode = "dry_run"
+    apply_action: DiscoveryApplyAction | None = None
+    max_pages: int | None = None
+    max_depth: int | None = None
+    collections: tuple[str, ...] = ()
+    keywords: tuple[str, ...] = ()
+    title: str | None = None
+    include_seed: bool = False
+```
+
+Stable reason codes to add where missing:
+
+```python
+SOURCE_DISCOVERY_DISABLED = "source_discovery_disabled"
+SOURCE_DISCOVERY_REQUEST_INVALID = "source_discovery_request_invalid"
+SOURCE_DISCOVERY_KIND_UNSUPPORTED = "source_discovery_kind_unsupported"
+SOURCE_DISCOVERY_LIMIT_EXCEEDED = "source_discovery_limit_exceeded"
+SOURCE_DISCOVERY_NO_CANDIDATES = "source_discovery_no_candidates"
+SITEMAP_CONTENT_TYPE_DENIED = "sitemap_content_type_denied"
+SITEMAP_FETCH_FAILED = "sitemap_fetch_failed"
+SITEMAP_PARSE_FAILED = "sitemap_parse_failed"
+SITEMAP_INDEX_UNSUPPORTED = "sitemap_index_unsupported"
+SITEMAP_XML_FORBIDDEN_DOCTYPE = "sitemap_xml_forbidden_doctype"
+SITEMAP_XML_FORBIDDEN_ENTITY = "sitemap_xml_forbidden_entity"
+CANDIDATE_OUT_OF_SCOPE = "candidate_out_of_scope"
+CANDIDATE_QUERY_NOT_PERSISTED = "candidate_query_not_persisted"
+CANDIDATE_DUPLICATE = "candidate_duplicate"
+PAGE_LINK_CONTENT_TYPE_DENIED = "page_link_content_type_denied"
+PAGE_LINK_REGISTRATION_UNSUPPORTED = "page_link_registration_unsupported"
+ROBOTS_UNAVAILABLE = "robots_unavailable"
+```
+
+## Test Command Conventions
+
+Run commands from the worktree root:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-docs-source-discovery-design
+```
+
+Use the project virtual environment:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs -q
+```
+
+If the virtual environment cannot import the project, stop and report the environment problem. Do not switch to global Python.
+
+---
+
+### Task 1: Settings, Models, And Status Surface
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/settings.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/models.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/mcp_module.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py`
+
+- [ ] **Step 1: Write failing settings tests**
+
+Add to `test_docs_settings.py`:
+
+```python
+def test_from_mapping_uses_safe_source_discovery_defaults() -> None:
+    settings = DocsSettings.from_mapping({})
+
+    assert settings.enable_source_discovery is False  # nosec B101
+    assert settings.max_discovery_pages == 25  # nosec B101
+    assert settings.max_discovery_depth == 1  # nosec B101
+    assert settings.max_discovery_sitemaps == 3  # nosec B101
+    assert settings.discovery_apply_default == "register"  # nosec B101
+    assert settings.discovery_same_origin_only is True  # nosec B101
+
+
+def test_from_mapping_parses_source_discovery_values() -> None:
+    settings = DocsSettings.from_mapping(
+        {
+            "enable_source_discovery": "true",
+            "max_discovery_pages": "7",
+            "max_discovery_depth": "1",
+            "max_discovery_sitemaps": "2",
+            "discovery_apply_default": "register_and_ingest",
+            "discovery_same_origin_only": "false",
+        }
+    )
+
+    assert settings.enable_source_discovery is True  # nosec B101
+    assert settings.max_discovery_pages == 7  # nosec B101
+    assert settings.max_discovery_depth == 1  # nosec B101
+    assert settings.max_discovery_sitemaps == 2  # nosec B101
+    assert settings.discovery_apply_default == "register_and_ingest"  # nosec B101
+    assert settings.discovery_same_origin_only is False  # nosec B101
+
+
+@pytest.mark.parametrize("value", ["", "crawl", "register+ingest"])
+def test_from_mapping_rejects_unknown_discovery_apply_default(value: str) -> None:
+    with pytest.raises(ValueError, match="discovery_apply_default"):
+        DocsSettings.from_mapping({"discovery_apply_default": value})
+```
+
+- [ ] **Step 2: Write failing status tests**
+
+Add to the existing provider status test in `test_docs_mcp_provider.py`:
+
+```python
+assert status["source_discovery"]["enabled"] is False  # nosec B101
+assert status["source_discovery"]["available"] is False  # nosec B101
+assert status["source_discovery"]["disabled_reason"] == "source_discovery_disabled"  # nosec B101
+assert status["source_discovery"]["supported_kinds"] == ["sitemap", "page_links"]  # nosec B101
+```
+
+Add a new enabled case:
+
+```python
+def test_provider_status_reports_source_discovery_when_enabled(tmp_path: Path) -> None:
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "enable_source_discovery": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": ("https://example.com/docs/",),
+        }
+    )
+    provider = DocsMCPToolProvider(settings=settings)
+
+    status = provider.execute("docs.status", {}, scope=AccessScope())
+
+    assert status["source_discovery"]["enabled"] is True  # nosec B101
+    assert status["source_discovery"]["available"] is True  # nosec B101
+    assert status["source_discovery"]["max_discovery_pages"] == 25  # nosec B101
+```
+
+- [ ] **Step 3: Run red tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py::test_provider_status_reports_web_acquisition_disabled \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py::test_provider_status_reports_source_discovery_when_enabled \
+  -q
+```
+
+Expected: FAIL with missing discovery settings/status fields.
+
+- [ ] **Step 4: Implement settings, models, and status**
+
+In `settings.py`, add:
+
+```python
+DiscoveryApplyDefault = Literal["register", "ingest", "register_and_ingest"]
+
+
+def _coerce_discovery_apply_default(value: object, field_name: str) -> DiscoveryApplyDefault:
+    text = "register" if value is None else str(value).strip().lower()
+    if text not in {"register", "ingest", "register_and_ingest"}:
+        raise ValueError(f"{field_name} must be register, ingest, or register_and_ingest")
+    return cast(DiscoveryApplyDefault, text)
+```
+
+Extend `DocsSettings` and `from_mapping()`:
+
+```python
+enable_source_discovery: bool = False
+max_discovery_pages: int = 25
+max_discovery_depth: int = 1
+max_discovery_sitemaps: int = 3
+discovery_apply_default: DiscoveryApplyDefault = "register"
+discovery_same_origin_only: bool = True
+```
+
+In `models.py`, add the shared `DiscoverSourceRequest` dataclass and literals from the Shared Contracts section.
+
+In `mcp_module.py`, add:
+
+```python
+def _source_discovery_status(settings: DocsSettings) -> dict[str, Any]:
+    enabled = settings.enable_source_discovery
+    available = enabled and settings.enable_web_acquisition
+    disabled_reason = None if available else (
+        "web_acquisition_disabled" if enabled else "source_discovery_disabled"
+    )
+    return {
+        "enabled": enabled,
+        "available": available,
+        "disabled_reason": disabled_reason,
+        "supported_kinds": ["sitemap", "page_links"],
+        "max_discovery_pages": settings.max_discovery_pages,
+        "max_discovery_depth": settings.max_discovery_depth,
+        "max_discovery_sitemaps": settings.max_discovery_sitemaps,
+        "discovery_apply_default": settings.discovery_apply_default,
+        "discovery_same_origin_only": settings.discovery_same_origin_only,
+    }
+```
+
+Set `status["source_discovery"] = _source_discovery_status(self.settings)`.
+
+- [ ] **Step 5: Run green tests**
+
+Run the same command from Step 3.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/settings.py \
+  apps/mcp-unified/src/mcp_unified/docs/models.py \
+  apps/mcp-unified/src/mcp_unified/docs/mcp_module.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
+git commit -m "feat: add docs source discovery settings"
+```
+
+### Task 2: Discovery Parser And Candidate Helpers
+
+**Files:**
+
+- Create: `apps/mcp-unified/src/mcp_unified/docs/discovery.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py`
+
+- [ ] **Step 1: Write failing pure-helper tests**
+
+Create `test_docs_source_discovery.py` with these first tests:
+
+```python
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from mcp_unified.docs.discovery import (
+    DiscoveredURLCandidate,
+    extract_page_links,
+    parse_sitemap_urlset,
+    public_candidate,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_parse_sitemap_urlset_rejects_doctype() -> None:
+    body = b'<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><urlset />'
+
+    result = parse_sitemap_urlset(body, max_pages=10)
+
+    assert result.reason_code == "sitemap_xml_forbidden_doctype"  # nosec B101
+    assert result.candidates == []  # nosec B101
+
+
+def test_parse_sitemap_urlset_enforces_page_limit_before_candidates() -> None:
+    body = b"""
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://example.com/a</loc></url>
+      <url><loc>https://example.com/b</loc></url>
+      <url><loc>https://example.com/c</loc></url>
+    </urlset>
+    """
+
+    result = parse_sitemap_urlset(body, max_pages=2)
+
+    assert result.reason_code == "ok"  # nosec B101
+    assert [item.url for item in result.candidates] == [  # nosec B101
+        "https://example.com/a",
+        "https://example.com/b",
+    ]
+    assert result.skipped == 1  # nosec B101
+
+
+def test_extract_page_links_prefers_beautifulsoup_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+    original_import = importlib.import_module
+
+    def fake_import(name: str):
+        if name == "bs4":
+            seen.append(name)
+        return original_import(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    html = b'<a href="/docs/a">A</a><a rel="nofollow" href="/docs/b">B</a>'
+
+    links = extract_page_links("https://example.com/docs/index.html", html)
+
+    assert "https://example.com/docs/a" in links  # nosec B101
+    assert "https://example.com/docs/b" not in links  # nosec B101
+    assert seen == ["bs4"] or seen == []  # nosec B101
+
+
+def test_public_candidate_redacts_query_bearing_url() -> None:
+    candidate = DiscoveredURLCandidate(
+        url="https://example.com/page?token=secret",
+        display_url="https://example.com/page",
+        status="accepted",
+        reason_code="ok",
+        source_kind="sitemap",
+        parent_url="https://example.com/sitemap.xml?token=secret",
+        parent_display_url="https://example.com/sitemap.xml",
+        safe_argument_hash="hash",
+    )
+
+    serialized = json.dumps(public_candidate(candidate), sort_keys=True)
+
+    assert "token=secret" not in serialized  # nosec B101
+    assert "https://example.com/page" in serialized  # nosec B101
+    assert "hash" in serialized  # nosec B101
+```
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py \
+  -q
+```
+
+Expected: FAIL because `mcp_unified.docs.discovery` does not exist.
+
+- [ ] **Step 3: Implement pure helpers**
+
+Create `discovery.py` with:
+
+```python
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from typing import Literal
+from urllib.parse import urljoin, urlsplit, urlunsplit
+from xml.etree import ElementTree
+
+from .acquisition.policy import safe_argument_hash
+from .source_utils import redacted_url_for_display
+
+
+CandidateStatus = Literal["accepted", "duplicate", "denied", "skipped", "ingested", "failed"]
+
+
+@dataclass(frozen=True)
+class DiscoveredURLCandidate:
+    url: str
+    display_url: str
+    status: CandidateStatus
+    reason_code: str
+    source_kind: str
+    parent_url: str
+    parent_display_url: str
+    safe_argument_hash: str
+
+
+@dataclass(frozen=True)
+class SitemapParseResult:
+    status: str
+    reason_code: str
+    candidates: list[DiscoveredURLCandidate]
+    skipped: int = 0
+
+
+def parse_sitemap_urlset(body: bytes, *, max_pages: int, parent_url: str = "") -> SitemapParseResult:
+    upper = body[:4096].upper()
+    if b"<!DOCTYPE" in upper:
+        return SitemapParseResult(status="denied", reason_code="sitemap_xml_forbidden_doctype", candidates=[])
+    if b"<!ENTITY" in upper:
+        return SitemapParseResult(status="denied", reason_code="sitemap_xml_forbidden_entity", candidates=[])
+    try:
+        root = ElementTree.fromstring(body)
+    except ElementTree.ParseError:
+        return SitemapParseResult(status="failed", reason_code="sitemap_parse_failed", candidates=[])
+    if _local_name(root.tag) == "sitemapindex":
+        return SitemapParseResult(status="denied", reason_code="sitemap_index_unsupported", candidates=[])
+    if _local_name(root.tag) != "urlset":
+        return SitemapParseResult(status="failed", reason_code="sitemap_parse_failed", candidates=[])
+    locs = [
+        (loc.text or "").strip()
+        for url_node in root.iter()
+        if _local_name(url_node.tag) == "url"
+        for loc in list(url_node)
+        if _local_name(loc.tag) == "loc" and (loc.text or "").strip()
+    ]
+    selected = locs[:max_pages]
+    parent_display = redacted_url_for_display(parent_url) if parent_url else ""
+    candidates = [
+        DiscoveredURLCandidate(
+            url=url,
+            display_url=redacted_url_for_display(url),
+            status="accepted",
+            reason_code="ok",
+            source_kind="sitemap",
+            parent_url=parent_url,
+            parent_display_url=parent_display,
+            safe_argument_hash=safe_argument_hash(url),
+        )
+        for url in selected
+    ]
+    return SitemapParseResult(status="completed", reason_code="ok", candidates=candidates, skipped=max(0, len(locs) - len(selected)))
+```
+
+Also add `extract_page_links()` with lazy BeautifulSoup preference and stdlib fallback. Use `_strip_fragment(url)` before dedupe and skip unsupported schemes.
+
+- [ ] **Step 4: Preserve import boundaries**
+
+Do not import `bs4` at module import time. If `test_docs_package_does_not_import_optional_web_acquisition_dependencies` flags `bs4`, move the import behind `importlib.import_module("bs4")` inside the extractor.
+
+- [ ] **Step 5: Run green tests**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/discovery.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py
+git commit -m "feat: add docs source discovery parsers"
+```
+
+### Task 3: Discovery Service Dry-Run
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/discovery.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py`
+
+- [ ] **Step 1: Write failing dry-run tests**
+
+Add:
+
+```python
+from mcp_unified.docs.acquisition.models import FetchResponse
+from mcp_unified.docs.discovery import DocsSourceDiscoveryService
+from mcp_unified.docs.models import AccessScope, DiscoverSourceRequest
+from mcp_unified.docs.settings import DocsSettings
+from mcp_unified.docs.store.sqlite import DocsCatalogStore
+from tldw_Server_API.tests.MCP_unified.docs.helpers import FakeResolver, FakeTransport
+
+
+def _store(tmp_path: Path) -> DocsCatalogStore:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    return store
+
+
+def _settings(tmp_path: Path, **overrides: object) -> DocsSettings:
+    values: dict[str, object] = {
+        "db_path": str(tmp_path / "docs.db"),
+        "enable_web_acquisition": True,
+        "enable_source_discovery": True,
+        "web_source_profile": "locked_down",
+        "allowed_url_prefixes": ("https://example.com/docs/", "https://example.com/sitemap.xml"),
+    }
+    values.update(overrides)
+    return DocsSettings.from_mapping(values)
+
+
+def test_discover_source_disabled_returns_without_fetch(tmp_path: Path) -> None:
+    settings = _settings(tmp_path, enable_source_discovery=False)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport([FetchResponse(status_code=200, headers={"content-type": "text/xml"}, body_chunks=[b"never"])])
+    service = DocsSourceDiscoveryService(settings=settings, store=_store(tmp_path), resolver=resolver, transport=transport)
+
+    result = service.discover_source(scope=AccessScope(), request=DiscoverSourceRequest(url="https://example.com/sitemap.xml"))
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "source_discovery_disabled"  # nosec B101
+    assert resolver.calls == []  # nosec B101
+    assert transport.calls == []  # nosec B101
+
+
+def test_discover_source_requires_web_acquisition_without_fetch(tmp_path: Path) -> None:
+    settings = _settings(tmp_path, enable_web_acquisition=False)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport([FetchResponse(status_code=200, headers={"content-type": "text/xml"}, body_chunks=[b"never"])])
+    service = DocsSourceDiscoveryService(settings=settings, store=_store(tmp_path), resolver=resolver, transport=transport)
+
+    result = service.discover_source(scope=AccessScope(), request=DiscoverSourceRequest(url="https://example.com/sitemap.xml"))
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "web_acquisition_disabled"  # nosec B101
+    assert resolver.calls == []  # nosec B101
+    assert transport.calls == []  # nosec B101
+
+
+def test_discover_sitemap_dry_run_returns_candidates_without_mutation(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "application/xml"},
+                body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"],
+            )
+        ]
+    )
+    service = DocsSourceDiscoveryService(settings=_settings(tmp_path), store=store, resolver=resolver, transport=transport)
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(url="https://example.com/sitemap.xml", kind="sitemap"),
+    )
+
+    assert result["status"] == "completed"  # nosec B101
+    assert result["counts"]["accepted"] == 1  # nosec B101
+    assert result["candidates"][0]["url"] == "https://example.com/docs/a"  # nosec B101
+    assert store.status()["counts"]["documents"] == 0  # nosec B101
+    assert store.list_sources(scope=AccessScope()) == []  # nosec B101
+
+
+def test_discover_source_approval_required_does_not_resolve_or_fetch(tmp_path: Path) -> None:
+    settings = _settings(
+        tmp_path,
+        web_source_profile="local_first",
+        allowed_url_prefixes=(),
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport([FetchResponse(status_code=200, headers={"content-type": "application/xml"}, body_chunks=[b"never"])])
+    service = DocsSourceDiscoveryService(settings=settings, store=_store(tmp_path), resolver=resolver, transport=transport)
+
+    result = service.discover_source(scope=AccessScope(), request=DiscoverSourceRequest(url="https://example.com/sitemap.xml"))
+
+    assert result["status"] == "approval_required"  # nosec B101
+    assert result["reason_code"] == "source_approval_required"  # nosec B101
+    assert resolver.calls == []  # nosec B101
+    assert transport.calls == []  # nosec B101
+
+
+def test_discover_sitemap_filters_scope_duplicates_and_query_leaks(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "application/xml"},
+                body_chunks=[
+                    b"""
+                    <urlset>
+                      <url><loc>https://example.com/docs/a</loc></url>
+                      <url><loc>https://example.com/docs/a#fragment</loc></url>
+                      <url><loc>https://evil.example/docs/a</loc></url>
+                      <url><loc>https://example.com/docs/b?token=secret</loc></url>
+                    </urlset>
+                    """
+                ],
+            )
+        ]
+    )
+    service = DocsSourceDiscoveryService(settings=_settings(tmp_path), store=store, resolver=resolver, transport=transport)
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(url="https://example.com/sitemap.xml", kind="sitemap"),
+    )
+    serialized = json.dumps(result, sort_keys=True)
+
+    assert result["counts"]["accepted"] == 1  # nosec B101
+    assert result["counts"]["duplicates"] == 1  # nosec B101
+    assert result["counts"]["denied"] == 1  # nosec B101
+    assert result["counts"]["skipped"] == 1  # nosec B101
+    assert result["candidates"][0]["url"] == "https://example.com/docs/a"  # nosec B101
+    assert "token=secret" not in serialized  # nosec B101
+    assert "?token" not in serialized  # nosec B101
+```
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py::test_discover_source_disabled_returns_without_fetch \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py::test_discover_source_requires_web_acquisition_without_fetch \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py::test_discover_sitemap_dry_run_returns_candidates_without_mutation \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py::test_discover_source_approval_required_does_not_resolve_or_fetch \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py::test_discover_sitemap_filters_scope_duplicates_and_query_leaks \
+  -q
+```
+
+Expected: FAIL with missing `DocsSourceDiscoveryService`.
+
+- [ ] **Step 3: Implement dry-run service**
+
+In `discovery.py`, add `DocsSourceDiscoveryService`:
+
+```python
+class DocsSourceDiscoveryService:
+    def __init__(self, *, settings: DocsSettings, store: DocsCatalogStore, resolver: object | None = None, transport: object | None = None) -> None:
+        self.settings = settings
+        self.store = store
+        self.policy = SourcePolicy(
+            web_source_profile=settings.web_source_profile,
+            preapproved_domains=settings.preapproved_domains,
+            allowed_url_prefixes=settings.allowed_url_prefixes,
+            denied_domains=settings.denied_domains,
+            allow_arbitrary_public_domains=settings.allow_arbitrary_public_domains,
+        )
+        self.fetcher = URLFetcher(settings=settings, policy=self.policy, resolver=resolver, transport=transport)
+        self.acquisition = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    def discover_source(self, *, scope: AccessScope, request: DiscoverSourceRequest) -> dict[str, Any]:
+        if not self.settings.enable_source_discovery:
+            return {"status": "denied", "reason_code": "source_discovery_disabled", "counts": _zero_discovery_counts(), "candidates": [], "warnings": []}
+        if not self.settings.enable_web_acquisition:
+            return {"status": "denied", "reason_code": "web_acquisition_disabled", "counts": _zero_discovery_counts(), "candidates": [], "warnings": []}
+        validation = _validate_discovery_request(request, self.settings)
+        if validation is not None:
+            return validation
+        fetched = self.fetcher.fetch(request.url)
+        if fetched.status != "fetched":
+            return _fetch_failure_response(fetched)
+        kind = _resolve_kind(request.kind, request.url, fetched.headers)
+        candidates, warnings = self._candidates_for_fetched(kind=kind, request=request, fetched=fetched)
+        candidates, filter_warnings = _filter_candidates(
+            candidates,
+            seed_url=fetched.canonical_url or request.url,
+            policy=self.policy,
+            settings=self.settings,
+            max_pages=_effective_discovery_page_limit(request, self.settings),
+        )
+        warnings.extend(filter_warnings)
+        return _discovery_response(status="completed", reason_code="ok", request=request, source=None, candidates=candidates, warnings=warnings)
+```
+
+Keep `_validate_discovery_request()` small: reject non-positive caps, `max_depth != 1`, unknown kind/mode/action, and `page_links + apply_action=register + include_seed=false`.
+
+Add `_filter_candidates()` with these rules:
+
+- normalize fragments away before dedupe;
+- call `SourcePolicy.evaluate()` for every candidate;
+- deny candidates outside the seed origin unless they match an explicit allowed URL prefix;
+- skip query-bearing candidates unless `settings.persist_url_query_strings` is true;
+- bound accepted candidates before any candidate-page fetches;
+- keep denied/skipped/duplicate candidates in the public response with redacted display URLs and `safe_argument_hash`.
+
+- [ ] **Step 4: Run green tests**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/discovery.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
+git commit -m "feat: add docs source discovery dry run"
+```
+
+### Task 4: Apply Register And Ingest Modes
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/discovery.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py`
+
+- [ ] **Step 1: Write failing apply tests**
+
+Add:
+
+```python
+def test_discover_sitemap_apply_register_creates_source_without_documents(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "application/xml"},
+                body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"],
+            )
+        ]
+    )
+    service = DocsSourceDiscoveryService(settings=_settings(tmp_path), store=store, resolver=resolver, transport=transport)
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(
+            url="https://example.com/sitemap.xml",
+            kind="sitemap",
+            mode="apply",
+            apply_action="register",
+            collections=("Reference",),
+            keywords=("docs",),
+            title="Example docs sitemap",
+        ),
+    )
+
+    assert result["status"] == "completed"  # nosec B101
+    assert result["source"]["source_type"] == "url_sitemap"  # nosec B101
+    assert "sitemap_sync_disabled" in result["warnings"]  # nosec B101
+    assert store.status()["counts"]["documents"] == 0  # nosec B101
+    sources = store.list_sources(scope=AccessScope())
+    assert sources[0]["metadata"]["default_collections"] == ["Reference"]  # nosec B101
+    assert sources[0]["metadata"]["default_keywords"] == ["docs"]  # nosec B101
+
+
+def test_discover_sitemap_apply_ingests_candidates_and_links_sitemap_source(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(status_code=200, headers={"content-type": "application/xml"}, body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"]),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"alpha reference body"]),
+        ]
+    )
+    settings = _settings(tmp_path, sitemap_sync_enabled=True)
+    service = DocsSourceDiscoveryService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(
+            url="https://example.com/sitemap.xml",
+            kind="sitemap",
+            mode="apply",
+            apply_action="register_and_ingest",
+            collections=("Reference",),
+            keywords=("docs",),
+        ),
+    )
+
+    assert result["counts"]["ingested"] == 1  # nosec B101
+    assert result["candidates"][0]["document_id"]  # nosec B101
+    assert store.search_chunks(scope=AccessScope(), query="alpha", limit=10)  # nosec B101
+    links = store.source_document_links(scope=AccessScope(), source_id=result["source"]["id"])
+    assert links[0]["source_item_uri"] == "https://example.com/docs/a"  # nosec B101
+```
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py::test_discover_sitemap_apply_register_creates_source_without_documents \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py::test_discover_sitemap_apply_ingests_candidates_and_links_sitemap_source \
+  -q
+```
+
+Expected: FAIL because apply mode is not implemented.
+
+- [ ] **Step 3: Implement apply mode**
+
+In `DocsSourceDiscoveryService.discover_source()`:
+
+- compute `apply_action = request.apply_action or settings.discovery_apply_default`;
+- for sitemap register/register-and-ingest, call `store.upsert_source()` with `source_type="url_sitemap"`;
+- store metadata:
+
+```python
+metadata = source_defaults_metadata(keywords=request.keywords, collection_names=request.collections)
+metadata.update({"discovery_kind": "sitemap", "same_origin_only": self.settings.discovery_same_origin_only})
+```
+
+- warn with `sitemap_sync_disabled` when `settings.sitemap_sync_enabled is False`;
+- for `ingest` and `register_and_ingest`, call `self.acquisition.ingest_url()` for accepted candidates, passing `keywords=request.keywords` and `collection_names=request.collections`;
+- when a candidate ingests and a sitemap source exists, load the document via `store.get_document(scope, document_id, mode="metadata")` and link it with `store.link_source_document()`;
+- never pass query-bearing raw URLs into public response fields.
+
+- [ ] **Step 4: Run green tests**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/discovery.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
+git commit -m "feat: apply docs source discovery"
+```
+
+### Task 5: MCP Provider Tool Wiring
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/mcp_module.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/__init__.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py`
+
+- [ ] **Step 1: Write failing provider tests**
+
+Add:
+
+```python
+def test_provider_advertises_discover_source_when_enabled(tmp_path: Path) -> None:
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "enable_source_discovery": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": ("https://example.com/docs/",),
+        }
+    )
+    provider = DocsMCPToolProvider(settings=settings)
+
+    tools = {tool["name"]: tool for tool in provider.tool_definitions()}
+
+    assert "docs.discover_source" in tools  # nosec B101
+    assert tools["docs.discover_source"]["metadata"]["category"] == "ingestion"  # nosec B101
+    assert tools["docs.discover_source"]["metadata"]["readOnlyHint"] is False  # nosec B101
+
+
+def test_provider_omits_discover_source_when_disabled(tmp_path: Path) -> None:
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"))
+
+    names = {tool["name"] for tool in provider.tool_definitions()}
+
+    assert "docs.discover_source" not in names  # nosec B101
+
+
+def test_provider_stale_discover_source_call_is_disabled(tmp_path: Path) -> None:
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"))
+
+    result = provider.execute("docs.discover_source", {"url": "https://example.com/sitemap.xml"}, scope=AccessScope())
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "source_discovery_disabled"  # nosec B101
+```
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py::test_provider_advertises_discover_source_when_enabled \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py::test_provider_omits_discover_source_when_disabled \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py::test_provider_stale_discover_source_call_is_disabled \
+  -q
+```
+
+Expected: FAIL with missing provider support.
+
+- [ ] **Step 3: Wire provider**
+
+In `DocsMCPToolProvider.__init__`, instantiate:
+
+```python
+self.discovery = (
+    DocsSourceDiscoveryService(settings=settings, store=self.store)
+    if settings.enable_source_discovery and settings.enable_web_acquisition
+    else None
+)
+```
+
+Add tool definition:
+
+```python
+_tool(
+    "docs.discover_source",
+    "Discover bounded sitemap or page-link URL candidates and optionally register or ingest them.",
+    {
+        "url": {"type": "string"},
+        "kind": {"type": "string"},
+        "mode": {"type": "string"},
+        "apply_action": {"type": "string"},
+        "max_pages": {"type": "integer"},
+        "max_depth": {"type": "integer"},
+        "collections": {"type": "array"},
+        "keywords": {"type": "array"},
+        "title": {"type": "string"},
+        "include_seed": {"type": "boolean"},
+    },
+    ["url"],
+    "ingestion",
+)
+```
+
+Add `_discover_source_request_from_args()` mirroring `_sync_source_request_from_args()` with explicit validation.
+
+- [ ] **Step 4: Run green tests**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/mcp_module.py \
+  apps/mcp-unified/src/mcp_unified/docs/__init__.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
+git commit -m "feat: expose docs source discovery tool"
+```
+
+### Task 6: `url_sitemap` Sync Source Refresh
+
+**Files:**
+
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/sync.py`
+- Modify: `apps/mcp-unified/src/mcp_unified/docs/discovery.py`
+- Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py`
+
+- [ ] **Step 1: Write failing sitemap sync tests**
+
+Add:
+
+```python
+def test_url_sitemap_sync_apply_ingests_current_candidates(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_sitemap",
+        canonical_uri="https://example.com/sitemap.xml",
+        display_name="Example sitemap",
+        source_path=None,
+        source_url="https://example.com/sitemap.xml",
+        redacted_source_url="https://example.com/sitemap.xml",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={"default_keywords": ["docs"], "default_collections": ["Reference"]},
+    )
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "sitemap_sync_enabled": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": ("https://example.com/sitemap.xml", "https://example.com/docs/"),
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(status_code=200, headers={"content-type": "application/xml"}, body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"]),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"alpha sync body"]),
+        ]
+    )
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="apply"))
+
+    assert result["status"] == "completed"  # nosec B101
+    assert result["counts"]["created"] == 1  # nosec B101
+    assert store.search_chunks(scope=scope, query="alpha", limit=10)  # nosec B101
+    assert _document_count(store.list_keywords(scope), "docs") == 1  # nosec B101
+    assert _document_count(store.list_collections(scope), "Reference") == 1  # nosec B101
+
+
+def test_url_sitemap_sync_dry_run_does_not_mutate(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_sitemap",
+        canonical_uri="https://example.com/sitemap.xml",
+        display_name="Example sitemap",
+        source_path=None,
+        source_url="https://example.com/sitemap.xml",
+        redacted_source_url="https://example.com/sitemap.xml",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={"default_keywords": ["docs"], "default_collections": ["Reference"]},
+    )
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "sitemap_sync_enabled": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": ("https://example.com/sitemap.xml", "https://example.com/docs/"),
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(status_code=200, headers={"content-type": "application/xml"}, body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"]),
+            FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"alpha sync body"]),
+        ]
+    )
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="dry_run"))
+
+    assert result["status"] == "completed"  # nosec B101
+    assert result["counts"]["created"] == 1  # nosec B101
+    assert store.status()["counts"]["documents"] == 0  # nosec B101
+    assert store.source_document_links(scope=scope, source_id=source_id) == []  # nosec B101
+    assert store.status()["counts"]["sync_runs"] == 0  # nosec B101
+```
+
+Add a stale test:
+
+```python
+def test_url_sitemap_sync_tombstones_missing_links_only_in_apply_mode(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "sitemap_sync_enabled": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": (
+                "https://example.com/sitemap.xml",
+                "https://example.com/docs/old",
+                "https://example.com/docs/new",
+            ),
+        }
+    )
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_sitemap",
+        canonical_uri="https://example.com/sitemap.xml",
+        display_name="Example sitemap",
+        source_path=None,
+        source_url="https://example.com/sitemap.xml",
+        redacted_source_url="https://example.com/sitemap.xml",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    acquisition = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=resolver,
+        transport=FakeTransport(
+            [FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"old sitemap body"])]
+        ),
+    )
+    old_ingested = acquisition.ingest_url(scope=scope, url="https://example.com/docs/old")
+    old_doc = store.get_document(scope, old_ingested["document"]["id"], mode="metadata")
+    store.link_source_document(
+        scope=scope,
+        source_id=source_id,
+        document_id=old_ingested["document"]["id"],
+        source_item_uri="https://example.com/docs/old",
+        status="active",
+        last_hash=old_doc["content_hash"],
+        metadata={"importer": "url_sitemap"},
+    )
+    service = DocsSourceSyncService(
+        settings=settings,
+        store=store,
+        resolver=resolver,
+        transport=FakeTransport(
+            [
+                FetchResponse(status_code=200, headers={"content-type": "application/xml"}, body_chunks=[b"<urlset><url><loc>https://example.com/docs/new</loc></url></urlset>"]),
+                FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"new sitemap body"]),
+            ]
+        ),
+    )
+
+    result = service.sync_source(
+        scope=scope,
+        request=SyncSourceRequest(source_id=source_id, mode="apply", stale_policy="tombstone"),
+    )
+    links = store.source_document_links(scope=scope, source_id=source_id)
+    old_links = [link for link in links if link["source_item_uri"] == "https://example.com/docs/old"]
+
+    assert result["counts"]["created"] == 1  # nosec B101
+    assert result["counts"]["tombstoned"] == 1  # nosec B101
+    assert old_links[0]["status"] == "tombstoned"  # nosec B101
+    assert store.search_chunks(scope=scope, query="old", limit=10) == []  # nosec B101
+    assert store.search_chunks(scope=scope, query="new", limit=10)  # nosec B101
+```
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py::test_url_sitemap_sync_apply_ingests_current_candidates \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py::test_url_sitemap_sync_dry_run_does_not_mutate \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py::test_url_sitemap_sync_tombstones_missing_links_only_in_apply_mode \
+  -q
+```
+
+Expected: FAIL because sitemap sync currently returns `sitemap_sync_disabled` or unsupported.
+
+- [ ] **Step 3: Implement shared sitemap sync**
+
+Prefer adding a helper on `DocsSourceDiscoveryService`, for example:
+
+```python
+def discover_sitemap_candidates(self, *, url: str, max_pages: int) -> tuple[list[DiscoveredURLCandidate], list[str], dict[str, Any]]:
+    fetched = self.fetcher.fetch(url)
+    if fetched.status != "fetched":
+        return [], [str(fetched.reason or "sitemap_fetch_failed")], {
+            "status": fetched.status,
+            "reason_code": fetched.reason or "sitemap_fetch_failed",
+            "safe_argument_hash": fetched.safe_argument_hash,
+        }
+    parsed = parse_sitemap_urlset(fetched.body, max_pages=max_pages, parent_url=url)
+    if parsed.reason_code != "ok":
+        return [], [parsed.reason_code], {"status": parsed.status, "reason_code": parsed.reason_code}
+    candidates, warnings = _filter_candidates(
+        parsed.candidates,
+        seed_url=fetched.canonical_url or url,
+        policy=self.policy,
+        settings=self.settings,
+        max_pages=max_pages,
+    )
+    return candidates, warnings, {"status": "completed", "reason_code": "ok"}
+```
+
+Then in `DocsSourceSyncService.sync_source()` replace the disabled-only `url_sitemap` path with:
+
+- deny with `sitemap_sync_disabled` when `settings.sitemap_sync_enabled` is false;
+- fetch and parse sitemap candidates;
+- enforce `min(request.max_pages, settings.max_sync_pages, settings.max_sync_run_items)`;
+- compare candidates to `store.source_document_links()`;
+- in dry-run, return counts/items only;
+- in apply, call `DocsAcquisitionService.ingest_url()` for new/updated candidates with source defaults from `source["metadata"]`;
+- link successful documents to the sitemap source;
+- report or tombstone stale links according to `request.stale_policy`;
+- record sync run only in apply mode.
+
+- [ ] **Step 4: Run green tests**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/docs/sync.py \
+  apps/mcp-unified/src/mcp_unified/docs/discovery.py \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+git commit -m "feat: sync docs sitemap sources"
+```
+
+### Task 7: Host Shim And Config Safety
+
+**Files:**
+
+- Modify: `tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py`
+- Modify: `tldw_Server_API/Config_Files/mcp_modules.yaml` only if explicit defaults need to be visible.
+
+- [ ] **Step 1: Write host shim tests**
+
+Add:
+
+```python
+@pytest.mark.asyncio
+async def test_docs_module_exposes_discover_source_when_enabled(tmp_path: Path) -> None:
+    module = DocsModule(
+        ModuleConfig(
+            name="docs",
+            settings={
+                "db_path": str(tmp_path / "docs.db"),
+                "enable_web_acquisition": True,
+                "enable_source_discovery": True,
+                "web_source_profile": "locked_down",
+                "allowed_url_prefixes": ["https://example.com/docs/"],
+            },
+        )
+    )
+    await module.on_initialize()
+
+    tools = {tool["name"]: tool for tool in await module.get_tools()}
+
+    assert "docs.discover_source" in tools  # nosec B101
+    assert tools["docs.discover_source"]["metadata"]["category"] == "ingestion"  # nosec B101
+```
+
+Extend `test_repo_docs_mcp_config_keeps_web_acquisition_disabled`:
+
+```python
+assert settings.get("enable_source_discovery", False) is False  # nosec B101
+```
+
+- [ ] **Step 2: Run red/green**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py \
+  -q
+```
+
+Expected first run: FAIL if host/provider wiring is incomplete. After provider wiring, PASS. If config lacks explicit `enable_source_discovery`, either keep the `.get(..., False)` assertion or add the explicit disabled config key with docs-only rationale.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py \
+  tldw_Server_API/Config_Files/mcp_modules.yaml
+git commit -m "test: cover docs discovery host shim"
+```
+
+Only include `mcp_modules.yaml` if it actually changed.
+
+### Task 8: Full Verification And Plan Closeout
+
+**Files:**
+
+- Modify: `backlog/tasks/task-12122 - Plan-standalone-MCP-docs-Stage-4B-source-discovery-implementation.md`
+
+- [ ] **Step 1: Run focused docs tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Bandit on touched Python paths**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r apps/mcp-unified/src/mcp_unified/docs tldw_Server_API/tests/MCP_unified/docs -f json -o /tmp/bandit_mcp_docs_stage4b_source_discovery.json
+```
+
+Expected: exit 0 or only accepted test-file assert findings already annotated with `# nosec B101`. Fix new findings in touched production code before continuing.
+
+- [ ] **Step 3: Run import-boundary test explicitly**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py -q
+```
+
+Expected: PASS; no top-level optional web dependency imports and no `tldw_Server_API` imports from `mcp_unified.docs`.
+
+- [ ] **Step 4: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Update Backlog task**
+
+Record:
+
+- implementation plan path;
+- touched files;
+- verification results;
+- Bandit result or docs-only skip if this plan task stops before code implementation;
+- final summary.
+
+- [ ] **Step 6: Commit plan closeout**
+
+```bash
+git add backlog/tasks/task-12122\ -\ Plan-standalone-MCP-docs-Stage-4B-source-discovery-implementation.md
+git commit -m "chore: close mcp docs discovery plan task"
+```
+
+For the current planning-only PR, Bandit can be skipped with the rationale "documentation and Backlog metadata only." For the later implementation PR, Bandit is required on touched Python paths.

--- a/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
@@ -755,7 +755,7 @@ git commit -m "feat: add docs source discovery dry run"
 - Modify: `apps/mcp-unified/src/mcp_unified/docs/discovery.py`
 - Test: `tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py`
 
-- [ ] **Step 1: Write failing apply tests**
+- [x] **Step 1: Write failing apply tests**
 
 Add:
 
@@ -827,7 +827,7 @@ def test_discover_sitemap_apply_ingests_candidates_and_links_sitemap_source(tmp_
     assert links[0]["source_item_uri"] == "https://example.com/docs/a"  # nosec B101
 ```
 
-- [ ] **Step 2: Run red tests**
+- [x] **Step 2: Run red tests**
 
 Run:
 
@@ -840,7 +840,7 @@ Run:
 
 Expected: FAIL because apply mode is not implemented.
 
-- [ ] **Step 3: Implement apply mode**
+- [x] **Step 3: Implement apply mode**
 
 In `DocsSourceDiscoveryService.discover_source()`:
 
@@ -858,13 +858,13 @@ metadata.update({"discovery_kind": "sitemap", "same_origin_only": self.settings.
 - when a candidate ingests and a sitemap source exists, load the document via `store.get_document(scope, document_id, mode="metadata")` and link it with `store.link_source_document()`;
 - never pass query-bearing raw URLs into public response fields.
 
-- [ ] **Step 4: Run green tests**
+- [x] **Step 4: Run green tests**
 
 Run the command from Step 2.
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/mcp-unified/src/mcp_unified/docs/discovery.py \

--- a/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
@@ -17,6 +17,7 @@
 - Stage 4A source sync spec: `Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md`
 - Stage 4A implementation plan: `Docs/superpowers/plans/2026-07-02-standalone-mcp-docs-stage4a-source-sync-implementation-plan.md`
 - Backlog planning task: `TASK-12122`
+- Backlog implementation task: `TASK-12124`
 
 ## Scope
 
@@ -1297,9 +1298,9 @@ Only include `mcp_modules.yaml` if it actually changed.
 
 **Files:**
 
-- Modify: `backlog/tasks/task-12122 - Plan-standalone-MCP-docs-Stage-4B-source-discovery-implementation.md`
+- Modify: `backlog/tasks/task-12124 - Implement-standalone-MCP-docs-Stage-4B-source-discovery.md`
 
-- [ ] **Step 1: Run focused docs tests**
+- [x] **Step 1: Run focused docs tests**
 
 Run:
 
@@ -1309,7 +1310,7 @@ Run:
 
 Expected: PASS.
 
-- [ ] **Step 2: Run Bandit on touched Python paths**
+- [x] **Step 2: Run Bandit on touched Python paths**
 
 Run:
 
@@ -1319,7 +1320,7 @@ Run:
 
 Expected: exit 0 or only accepted test-file assert findings already annotated with `# nosec B101`. Fix new findings in touched production code before continuing.
 
-- [ ] **Step 3: Run import-boundary test explicitly**
+- [x] **Step 3: Run import-boundary test explicitly**
 
 Run:
 
@@ -1329,7 +1330,7 @@ Run:
 
 Expected: PASS; no top-level optional web dependency imports and no `tldw_Server_API` imports from `mcp_unified.docs`.
 
-- [ ] **Step 4: Run diff hygiene**
+- [x] **Step 4: Run diff hygiene**
 
 Run:
 
@@ -1339,7 +1340,7 @@ git diff --check
 
 Expected: no output.
 
-- [ ] **Step 5: Update Backlog task**
+- [x] **Step 5: Update Backlog task**
 
 Record:
 
@@ -1349,11 +1350,12 @@ Record:
 - Bandit result or docs-only skip if this plan task stops before code implementation;
 - final summary.
 
-- [ ] **Step 6: Commit plan closeout**
+- [x] **Step 6: Commit plan closeout**
 
 ```bash
-git add backlog/tasks/task-12122\ -\ Plan-standalone-MCP-docs-Stage-4B-source-discovery-implementation.md
-git commit -m "chore: close mcp docs discovery plan task"
+git add Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md \
+  backlog/tasks/task-12124\ -\ Implement-standalone-MCP-docs-Stage-4B-source-discovery.md
+git commit -m "chore: close mcp docs discovery implementation task"
 ```
 
 For the current planning-only PR, Bandit can be skipped with the rationale "documentation and Backlog metadata only." For the later implementation PR, Bandit is required on touched Python paths.

--- a/Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
+++ b/Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
@@ -38,8 +38,10 @@ instance, browser automation, or mandatory scraping dependencies.
 - Reuse Stage 4A source records and source-document links so discovered pages
   are visible through `docs.list(kind="sources")` and refreshable through
   `docs.sync_source`.
-- Keep web scraping optional: `beautifulsoup4` and `trafilatura` remain lazy
-  optional extractors, not baseline imports.
+- Keep web scraping optional: when installed, `beautifulsoup4` is preferred for
+  HTML link extraction and `trafilatura` remains preferred for page body
+  extraction through the Stage 2 ingestion path. Both remain lazy optional
+  imports, not baseline dependencies.
 - Preserve locked-down deployment profiles where URL acquisition and discovery
   are unavailable unless explicitly configured.
 - Keep `mcp_unified.docs` independent from `tldw_Server_API` runtime imports.
@@ -136,9 +138,12 @@ Profile behavior:
 - `online_capable`: same as `local_first`, plus unknown public domains only
   when `allow_arbitrary_public_domains=true`.
 
-`sitemap_sync_enabled` remains default `false`. Stage 4B may enable sitemap
-source registration and initial ingestion while leaving repeated sitemap sync
-behind this explicit flag.
+`sitemap_sync_enabled` remains default `false`. Stage 4B may allow sitemap
+source registration and initial ingestion when source discovery is enabled, but
+repeated refresh through `docs.sync_source` still returns
+`sitemap_sync_disabled` until this flag is true. Registration responses should
+include that warning when they create a sitemap source that is not yet
+syncable.
 
 ## Tool Contract
 
@@ -205,6 +210,7 @@ Response shape:
     {
       "url": "https://example.com/docs/install",
       "display_url": "https://example.com/docs/install",
+      "safe_argument_hash": "ab12...",
       "status": "accepted",
       "reason_code": "ok",
       "source_kind": "sitemap",
@@ -215,11 +221,14 @@ Response shape:
 }
 ```
 
-Apply-mode responses include `source.id`, per-candidate ingest status,
-document IDs when ingestion succeeds, and bounded warnings. URL query strings
-must be redacted in all public fields unless query persistence is explicitly
-enabled and a future privileged diagnostic path is added. Stage 4B does not add
-that diagnostic path.
+Candidate `url`, `display_url`, and `parent_url` fields are public display
+values, not privileged fetch logs. They must use redacted URL forms whenever
+query strings are present. `safe_argument_hash` is the stable correlation value
+for a query-bearing candidate. Apply-mode responses include `source.id`,
+per-candidate ingest status, document IDs when ingestion succeeds, and bounded
+warnings. Raw query-bearing fetch URLs must not appear in public tool responses
+even when `persist_url_query_strings=true`; a future privileged diagnostic path
+would be required for that. Stage 4B does not add that diagnostic path.
 
 ## Discovery Semantics
 
@@ -261,8 +270,9 @@ Rules:
 
 - Fetch the seed URL through `URLFetcher`.
 - Accept only HTML content types for link discovery.
-- Extract links with a stdlib `html.parser` based extractor first. BeautifulSoup
-  may be used if installed, but must remain a lazy optional import.
+- Prefer BeautifulSoup for link extraction when `beautifulsoup4` is installed,
+  imported lazily inside the extractor. Fall back to a stdlib `html.parser`
+  extractor when BeautifulSoup is unavailable.
 - Normalize relative links against the final fetched seed URL.
 - Drop fragments before dedupe.
 - Skip unsupported schemes such as `mailto:`, `tel:`, `data:`, `file:`, and
@@ -329,6 +339,10 @@ Rules:
 - Apply mode ingests accepted current candidates through
   `DocsAcquisitionService.ingest_url()` and links successful documents to the
   sitemap source with the page URL as `source_item_uri`.
+- Sitemap source defaults in `docs_sources.metadata_json`, including
+  `default_keywords` and `default_collections`, are passed into each page
+  ingestion call and merged with any existing user organization using the Stage
+  4A sync-aware merge semantics.
 - Active sitemap links absent from the current sitemap are reported as
   `missing` under `stale_policy=report`.
 - Under `stale_policy=tombstone`, apply mode tombstones sitemap source links
@@ -420,7 +434,11 @@ Unit tests:
 - sitemap parser rejects or skips out-of-scope candidates;
 - page-link extractor normalizes relative links, drops fragments, skips
   unsupported schemes, and dedupes candidates;
+- page-link extractor prefers BeautifulSoup when installed and falls back to
+  stdlib parsing without making `beautifulsoup4` mandatory;
 - query-bearing candidates are skipped unless query persistence is enabled;
+- query-bearing candidates never expose raw query strings in public tool
+  response fields;
 - dry-run does not mutate source, document, chunk, keyword, collection, or run
   tables.
 
@@ -430,6 +448,8 @@ Integration tests:
   candidates and no documents;
 - apply sitemap discovery with fake sitemap and fake page bodies ingests
   bounded pages and creates searchable FTS5 chunks;
+- sitemap discovery and sitemap sync apply registered default collections and
+  keywords to ingested pages without replacing user-added metadata;
 - apply register mode creates a `url_sitemap` source without ingesting pages;
 - `docs.sync_source` refreshes a registered `url_sitemap` source when
   `sitemap_sync_enabled=true`;
@@ -472,12 +492,12 @@ bulk page ingestion and repeated sitemap sync to follow-ups.
   `sitemap_index_unsupported`.
 - Whether apply mode should persist bounded discovery run summaries in
   `docs_sync_runs.metadata_json` or add a small `docs_discovery_runs` table.
-- Whether page-link extraction should use stdlib only in the first PR, leaving
-  BeautifulSoup-assisted anchor metadata to a follow-up.
+- Whether page-link extraction should expose additional BeautifulSoup-derived
+  anchor metadata beyond URL and rel filtering.
 
 Recommended defaults:
 
 - Defer sitemap indexes unless the first implementation remains small.
 - Avoid a new discovery-runs table until there is a concrete audit UI/API need.
-- Use stdlib link extraction first; keep BeautifulSoup optional for rich body
-  extraction already covered by Stage 2.
+- Prefer BeautifulSoup when installed for link extraction, with a stdlib parser
+  fallback so the standalone package still works without optional web extras.

--- a/Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
+++ b/Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
@@ -1,0 +1,483 @@
+# Standalone MCP Docs Stage 4B Bounded Source Discovery Design
+
+Date: 2026-07-03
+Status: Draft for user review
+Backlog: TASK-12121
+Related:
+- Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-catalog-design.md
+- Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-url-acquisition-design.md
+- Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
+- Docs/superpowers/plans/2026-07-02-standalone-mcp-docs-stage4a-source-sync-implementation-plan.md
+
+## Summary
+
+Stage 4B adds explicit, bounded source discovery to the standalone MCP docs
+corpus. The new discovery slice lets an agent inspect a sitemap or one approved
+HTML seed page, see candidate document URLs, and then optionally register or
+ingest a capped set of accepted pages into the existing SQLite + FTS5 corpus.
+
+This is not a broad crawler. Stage 4A already added a source registry and
+`docs.sync_source` for known local and URL page sources. Stage 4B fills the
+deferred gap: how a standalone MCP server safely turns a known website entry
+point into a small document collection without requiring a `tldw_server`
+instance, browser automation, or mandatory scraping dependencies.
+
+## Goals
+
+- Add a bounded discovery service for explicit sitemap URLs and explicit HTML
+  seed pages.
+- Expose a `docs.discover_source` MCP tool with dry-run and apply modes.
+- Let dry-run return normalized, redacted, policy-filtered candidate URLs
+  without mutating the corpus.
+- Let apply register a refreshable `url_sitemap` source, ingest accepted page
+  candidates through `DocsAcquisitionService.ingest_url()`, or both.
+- Extend `docs.sync_source` to refresh registered `url_sitemap` sources when
+  `sitemap_sync_enabled=true`.
+- Reuse Stage 2 source policy, DNS/IP guards, redirect handling, extraction,
+  content limits, query redaction, and fake transport/resolver seams.
+- Reuse Stage 4A source records and source-document links so discovered pages
+  are visible through `docs.list(kind="sources")` and refreshable through
+  `docs.sync_source`.
+- Keep web scraping optional: `beautifulsoup4` and `trafilatura` remain lazy
+  optional extractors, not baseline imports.
+- Preserve locked-down deployment profiles where URL acquisition and discovery
+  are unavailable unless explicitly configured.
+- Keep `mcp_unified.docs` independent from `tldw_Server_API` runtime imports.
+
+## Non-Goals
+
+- No broad recursive crawler.
+- No automatic site-wide crawl from an arbitrary domain.
+- No browser automation, Playwright, browser profile access, cookies,
+  JavaScript rendering, login/session reuse, or stealth scraping behavior.
+- No robots.txt auto-discovery unless a standalone robots checker is added in
+  the same implementation with fail-closed tests. Until then,
+  `respect_robots=true` continues to fail closed.
+- No mandatory `beautifulsoup4`, `trafilatura`, requests, httpx, aiohttp, or
+  Playwright dependency.
+- No embeddings, vector index, reranking, answer generation, Media DB bridge,
+  ChromaDB bridge, Jobs/Scheduler worker, or `tldw_server` RAG service coupling.
+- No persisted query-bearing refreshable source unless
+  `persist_url_query_strings=true`.
+- No background recurring discovery.
+
+## Approaches Considered
+
+### Recommended: Explicit Discovery Tool Plus Existing Ingestion
+
+Add `docs.discover_source` as the only new Stage 4B tool. It fetches an
+explicit sitemap URL or HTML seed page under the existing Stage 2 URL policy,
+returns candidates in dry-run mode, and in apply mode calls existing ingestion
+paths for accepted pages. Registered sitemap sources are then refreshed through
+the existing `docs.sync_source` tool. This keeps arbitrary seed discovery out
+of `docs.sync_source` while still making approved sitemap sources refreshable.
+
+Trade-off: this adds one new tool contract and one new `url_sitemap` branch in
+`docs.sync_source`, but it avoids overloading `docs.sync_source` with arbitrary
+seed URLs.
+
+### Minimal: Only Enable `url_sitemap` In `docs.sync_source`
+
+This would implement Stage 4A's deferred sitemap sync path by adding a narrow
+sitemap registration mechanism and sitemap handling inside `docs.sync_source`.
+It is smaller, but it does not solve HTML page link discovery and gives agents
+less control over candidate review before ingestion.
+
+### Rejected: General Crawler Or Host Scraping Bridge
+
+A general crawler, browser scraper, or direct `tldw_server` scraping bridge
+would ingest more pages with less prompting, but it violates the standalone
+package boundary and creates avoidable security, privacy, and dependency risk.
+
+## Current Baseline
+
+The merged Stage 4A branch includes:
+
+- `DocsSettings` with web acquisition, source sync, sitemap sync, and query
+  persistence settings.
+- `DocsAcquisitionService.ingest_url()` for one approved URL.
+- `URLFetcher` with policy checks, resolver/transport seams, manual redirects,
+  SSRF defenses, content-type checks, and byte limits.
+- Optional lazy extraction through `trafilatura` and BeautifulSoup, with stdlib
+  fallback extraction.
+- `docs_sources`, `docs_source_documents`, and `docs_sync_runs` tables.
+- `docs.list(kind="sources")`.
+- `docs.sync_source` for `local_file`, `local_directory`, and `url_page`.
+- A disabled `url_sitemap` source type that returns `sitemap_sync_disabled`
+  unless explicitly enabled.
+
+Stage 4B should build on those seams. It should not introduce a second HTTP
+stack or an alternate ingestion path.
+
+## Settings
+
+Add discovery-specific settings to `DocsSettings`.
+
+- `enable_source_discovery`: default `false`. Tool is not advertised unless
+  both this and `enable_web_acquisition` are true.
+- `max_discovery_pages`: default `25`. Hard cap for accepted page candidates
+  and ingested pages.
+- `max_discovery_depth`: default `1`. Stage 4B.1 supports only explicit
+  sitemap entries and one-hop HTML links from a seed page; higher values are
+  rejected until a later crawler slice exists.
+- `max_discovery_sitemaps`: default `3`. Only needed if sitemap index support
+  is implemented; otherwise keep sitemap index support deferred.
+- `discovery_apply_default`: default `register`. Allowed values:
+  `register`, `ingest`, or `register_and_ingest`.
+- `discovery_same_origin_only`: default `true`; Stage 4B should treat `false`
+  as unsupported unless the URL is also under an explicit allowed URL prefix.
+
+Profile behavior:
+
+- `locked_down`: discovery is disabled by default. If enabled, it may fetch
+  only explicit `allowed_url_prefixes`; domain-only allow rules are not enough.
+- `local_first`: discovery may use configured `preapproved_domains` and
+  `allowed_url_prefixes`; unknown public domains return `approval_required`.
+- `online_capable`: same as `local_first`, plus unknown public domains only
+  when `allow_arbitrary_public_domains=true`.
+
+`sitemap_sync_enabled` remains default `false`. Stage 4B may enable sitemap
+source registration and initial ingestion while leaving repeated sitemap sync
+behind this explicit flag.
+
+## Tool Contract
+
+### `docs.discover_source`
+
+`docs.discover_source` is an ingestion-category tool because apply mode writes
+sources and documents. It is advertised only when source discovery and web
+acquisition are enabled.
+
+Input schema:
+
+- `url`: required string. Explicit sitemap URL or HTML seed page URL.
+- `kind`: `auto`, `sitemap`, or `page_links`; default `auto`.
+- `mode`: `dry_run` or `apply`; default `dry_run`.
+- `apply_action`: `register`, `ingest`, or `register_and_ingest`; default from
+  settings.
+- `max_pages`: optional positive integer capped by `max_discovery_pages`.
+- `max_depth`: optional positive integer; Stage 4B.1 accepts only `1`.
+- `collections`: optional array of collection names applied to ingested pages.
+- `keywords`: optional array of keywords applied to ingested pages.
+- `title`: optional display title for the registered discovery source.
+- `include_seed`: optional boolean; default `false` for page-link discovery.
+  When true, the seed page can be ingested along with discovered links.
+
+Selector rules:
+
+- `url` must pass the existing Stage 2 source policy before any network I/O.
+- For `kind=auto`, a URL whose path ends in `.xml` or whose fetched content
+  type is XML is treated as `sitemap`; otherwise it is `page_links`.
+- `mode=dry_run` performs network fetches but must not mutate the docs store.
+- `mode=apply` may create or update a `url_sitemap` source and/or ingest
+  accepted candidates through `DocsAcquisitionService.ingest_url()`.
+- `apply_action=ingest` without `register` still creates normal `url_page`
+  sources for each ingested page because `ingest_url()` already owns that path.
+- `apply_action=register` creates a refreshable `url_sitemap` source for
+  sitemap discovery and does not ingest candidate pages.
+- `apply_action=register` is invalid for `page_links` unless `include_seed=true`;
+  in that narrow case it may register the seed as a `url_page` source. It must
+  not persist a discovered-link graph.
+
+Response shape:
+
+```json
+{
+  "status": "completed",
+  "reason_code": "ok",
+  "mode": "dry_run",
+  "kind": "sitemap",
+  "source": {
+    "id": null,
+    "source_type": "url_sitemap",
+    "canonical_uri": "https://example.com/sitemap.xml",
+    "display_uri": "https://example.com/sitemap.xml"
+  },
+  "counts": {
+    "accepted": 12,
+    "duplicates": 1,
+    "denied": 0,
+    "skipped": 4,
+    "ingested": 0,
+    "failed": 0
+  },
+  "candidates": [
+    {
+      "url": "https://example.com/docs/install",
+      "display_url": "https://example.com/docs/install",
+      "status": "accepted",
+      "reason_code": "ok",
+      "source_kind": "sitemap",
+      "parent_url": "https://example.com/sitemap.xml"
+    }
+  ],
+  "warnings": []
+}
+```
+
+Apply-mode responses include `source.id`, per-candidate ingest status,
+document IDs when ingestion succeeds, and bounded warnings. URL query strings
+must be redacted in all public fields unless query persistence is explicitly
+enabled and a future privileged diagnostic path is added. Stage 4B does not add
+that diagnostic path.
+
+## Discovery Semantics
+
+### Sitemap Discovery
+
+Sitemap discovery handles an explicit sitemap URL. Stage 4B.1 should support
+`urlset` sitemaps with `<url><loc>...</loc></url>` entries.
+
+Rules:
+
+- Fetch the sitemap URL through `URLFetcher`.
+- Require an XML-ish content type or a `.xml` path when `kind=sitemap` is
+  explicitly requested; return `sitemap_content_type_denied` otherwise.
+- Reject bodies containing `DOCTYPE` or `ENTITY` before XML parsing.
+- Use stdlib XML parsing configured with no external entity resolution.
+- Ignore `lastmod`, `changefreq`, and `priority` for ingestion decisions in
+  Stage 4B. Store them only as candidate metadata if they are cheap to retain.
+- Enforce `max_pages` while collecting `<loc>` entries and before page fetches.
+- Normalize, dedupe, and policy-check each URL before ingestion.
+- Require same-origin with the sitemap URL, unless the target URL is under an
+  explicit allowed URL prefix.
+- Skip query-bearing candidates unless `persist_url_query_strings=true`.
+- Do not fetch candidate pages in dry-run mode.
+- In apply mode, fetch candidate pages only by calling `ingest_url()` so Stage 2
+  SSRF, redirect, content type, extraction, and source population behavior is
+  reused.
+
+Sitemap index support is optional for Stage 4B.1. If implemented, it must be
+bounded by `max_discovery_sitemaps`, require same-origin or allowed prefixes for
+child sitemap URLs, and apply the same XML `DOCTYPE`/`ENTITY` rejection to every
+child sitemap. Otherwise return `sitemap_index_unsupported`.
+
+### Page-Link Discovery
+
+Page-link discovery handles one explicit HTML seed page and extracts links from
+that page only.
+
+Rules:
+
+- Fetch the seed URL through `URLFetcher`.
+- Accept only HTML content types for link discovery.
+- Extract links with a stdlib `html.parser` based extractor first. BeautifulSoup
+  may be used if installed, but must remain a lazy optional import.
+- Normalize relative links against the final fetched seed URL.
+- Drop fragments before dedupe.
+- Skip unsupported schemes such as `mailto:`, `tel:`, `data:`, `file:`, and
+  JavaScript URLs.
+- Skip links with `rel=nofollow` in Stage 4B.1 if the extractor exposes the
+  attribute cheaply; otherwise do not attempt full robots semantics.
+- Require same-origin with the seed URL unless the target URL is under an
+  explicit allowed URL prefix.
+- Enforce path-prefix boundaries when an allowed URL prefix matched the seed.
+- Enforce `max_pages` before candidate page fetches.
+- Do not recursively fetch discovered pages in Stage 4B.1. `max_depth` exists
+  to make the boundary explicit, not to implement a crawler in this slice.
+
+When `include_seed=true` and `mode=apply`, the seed page is ingested through
+`ingest_url()` before discovered link candidates, and it counts against the
+effective page cap.
+
+## Data Model
+
+Use the Stage 4A tables first.
+
+For sitemap discovery:
+
+- `docs_sources.source_type = "url_sitemap"` stores the sitemap source.
+- `docs_sources.canonical_uri` is the normalized sitemap URL.
+- `docs_sources.source_url` stores the fetch-capable sitemap URL only when
+  query persistence policy allows it.
+- `docs_sources.metadata_json` stores discovery defaults:
+  `default_keywords`, `default_collections`, `discovery_kind`,
+  `same_origin_only`, and bounded path prefixes if provided.
+- Each ingested page remains a normal `url_page` source from `ingest_url()`.
+- The sitemap source may link to ingested page documents through
+  `docs_source_documents` using each page canonical URL as `source_item_uri`.
+
+For page-link discovery:
+
+- A separate `url_sitemap` source should not be created.
+- If apply mode registers without candidate ingestion, it may create or update a
+  `url_page` source for the seed page only when `include_seed=true`.
+- If link candidates are ingested, each candidate becomes a normal `url_page`
+  source through `ingest_url()`.
+- Candidate link sets are not persisted as a crawl graph in Stage 4B. Page-link
+  discovery is a one-shot helper for creating small collections from an
+  explicit seed page.
+
+Stage 4B should not add a broad crawler state table. If audit history is needed
+for apply mode, store bounded discovery summaries in the parent source
+metadata or add a narrowly scoped `docs_discovery_runs` table only after the
+implementation proves `docs_sync_runs` cannot represent the result. Dry-run
+must remain non-mutating.
+
+## Sitemap Source Sync
+
+Stage 4B should make registered `url_sitemap` sources refreshable through
+`docs.sync_source` when `sitemap_sync_enabled=true`.
+
+Rules:
+
+- `docs.sync_source` for `url_sitemap` reuses the same sitemap parser,
+  candidate normalization, source policy, same-origin checks, query redaction,
+  and page caps as `docs.discover_source`.
+- Dry-run re-fetches the sitemap and reports candidate changes without mutating
+  documents, chunks, source links, source rows, or sync-run rows.
+- Apply mode ingests accepted current candidates through
+  `DocsAcquisitionService.ingest_url()` and links successful documents to the
+  sitemap source with the page URL as `source_item_uri`.
+- Active sitemap links absent from the current sitemap are reported as
+  `missing` under `stale_policy=report`.
+- Under `stale_policy=tombstone`, apply mode tombstones sitemap source links
+  using the Stage 4A source-link tombstone path. It must not hard-delete
+  documents.
+- `max_pages`, `max_documents`, and `max_sync_run_items` all cap work before
+  page fetches.
+- Repeated sitemap sync does not recurse into discovered HTML links. Each page
+  is still a single `url_page` source if it was ingested.
+
+This keeps recurring refresh tied to explicit sitemap membership while leaving
+recursive crawl refresh for a later, separately reviewed feature.
+
+## Source Policy And Security
+
+Discovery must inherit Stage 2 URL policy and Stage 4A redaction rules:
+
+- Policy evaluation happens before every network request.
+- Resolver and transport seams must be injectable and tested with fake objects.
+- Private, loopback, link-local, multicast, unspecified, and reserved IP ranges
+  remain denied.
+- Redirects are manual and every redirect target must pass policy, DNS, and IP
+  checks.
+- No fetch happens for `approval_required` results.
+- URL credentials remain denied.
+- Query strings are redacted in display/logging/tool responses and are not
+  persisted in refreshable sources unless `persist_url_query_strings=true`.
+- Candidate pages beyond caps are counted as skipped and never fetched.
+- Candidate result arrays are bounded by `max_discovery_pages` and
+  `max_sync_run_items` style limits.
+- Discovery must never import `tldw_Server_API`, Media DB, ChromaDB, RAG, or
+  host scraping modules from `mcp_unified.docs`.
+
+If `respect_robots=true`, discovery must fail closed with `robots_unavailable`
+before fetching sitemap or page content until a standalone robots checker is
+implemented with deterministic tests.
+
+## Error Handling And Reason Codes
+
+Add stable reason codes where missing:
+
+- `source_discovery_disabled`
+- `source_discovery_request_invalid`
+- `source_discovery_kind_unsupported`
+- `source_discovery_limit_exceeded`
+- `source_discovery_no_candidates`
+- `sitemap_content_type_denied`
+- `sitemap_fetch_failed`
+- `sitemap_parse_failed`
+- `sitemap_index_unsupported`
+- `sitemap_xml_forbidden_doctype`
+- `sitemap_xml_forbidden_entity`
+- `sitemap_sync_disabled`
+- `candidate_out_of_scope`
+- `candidate_query_not_persisted`
+- `candidate_duplicate`
+- `page_link_content_type_denied`
+- `page_link_registration_unsupported`
+- `robots_unavailable`
+
+Apply mode should return `partial` when at least one candidate ingests and at
+least one accepted candidate fails. It should return `failed` only when no
+candidate can be processed after discovery succeeds.
+
+## MCP And Permission Behavior
+
+- `docs.discover_source` is category `ingestion` with `readOnlyHint=false`.
+- `docs.status` reports source discovery availability, effective caps,
+  supported discovery kinds, and disabled reason.
+- Stale clients that call `docs.discover_source` while disabled receive
+  `source_discovery_disabled`.
+- Scope handling uses the existing `AccessScope` object and store-level owner
+  and profile filters.
+- Host `DocsModule` only forwards the tool and settings. It must not add
+  scraping, RAG, Media DB, Jobs, or Scheduler business logic.
+
+## Testing Strategy
+
+Unit tests:
+
+- settings parse source discovery flags and caps;
+- `docs.status` reports discovery disabled by default and enabled when
+  configured;
+- provider advertises `docs.discover_source` only when discovery and web
+  acquisition are enabled;
+- stale disabled tool call returns `source_discovery_disabled`;
+- sitemap XML parser rejects `DOCTYPE` and `ENTITY`;
+- sitemap parser enforces `max_pages` before page fetches;
+- sitemap parser rejects or skips out-of-scope candidates;
+- page-link extractor normalizes relative links, drops fragments, skips
+  unsupported schemes, and dedupes candidates;
+- query-bearing candidates are skipped unless query persistence is enabled;
+- dry-run does not mutate source, document, chunk, keyword, collection, or run
+  tables.
+
+Integration tests:
+
+- dry-run sitemap discovery with fake resolver/transport returns accepted
+  candidates and no documents;
+- apply sitemap discovery with fake sitemap and fake page bodies ingests
+  bounded pages and creates searchable FTS5 chunks;
+- apply register mode creates a `url_sitemap` source without ingesting pages;
+- `docs.sync_source` refreshes a registered `url_sitemap` source when
+  `sitemap_sync_enabled=true`;
+- `docs.sync_source` reports or tombstones stale sitemap source links according
+  to `stale_policy`;
+- page-link discovery ingests one-hop same-origin links and applies requested
+  collections/keywords;
+- `docs.sync_source` can refresh `url_page` sources created by discovery;
+- host `DocsModule` exposes the tool without importing Media/RAG services.
+
+Boundary and security tests:
+
+- no live internet;
+- no top-level imports of BeautifulSoup, trafilatura, requests, httpx, aiohttp,
+  Playwright, ChromaDB, RAG, or `tldw_Server_API` from `mcp_unified.docs`;
+- no network call when source policy returns approval-required;
+- redirect-to-private denial still applies during discovery;
+- respect-robots fail-closed behavior applies before sitemap/page fetch;
+- tool responses never leak query strings by default.
+
+## Implementation Slices
+
+1. Settings, status, and tool advertisement for disabled/enabled discovery.
+2. Candidate models and pure URL normalization/dedupe helpers.
+3. Safe sitemap fetch and parser for explicit `urlset` sitemaps.
+4. Safe one-hop HTML link extraction from explicit seed pages.
+5. `DocsSourceDiscoveryService.discover_source()` dry-run path.
+6. Apply register mode for `url_sitemap` sources.
+7. Apply ingest/register-and-ingest mode using `DocsAcquisitionService`.
+8. `docs.sync_source` support for registered `url_sitemap` sources.
+9. Host `DocsModule` forwarding and import-boundary tests.
+
+If the implementation needs to split into multiple PRs, stop after slice 6.
+That delivers reviewable discovery and source registration while deferring
+bulk page ingestion and repeated sitemap sync to follow-ups.
+
+## Open Decisions For Implementation Planning
+
+- Whether Stage 4B.1 should support sitemap indexes or explicitly return
+  `sitemap_index_unsupported`.
+- Whether apply mode should persist bounded discovery run summaries in
+  `docs_sync_runs.metadata_json` or add a small `docs_discovery_runs` table.
+- Whether page-link extraction should use stdlib only in the first PR, leaving
+  BeautifulSoup-assisted anchor metadata to a follow-up.
+
+Recommended defaults:
+
+- Defer sitemap indexes unless the first implementation remains small.
+- Avoid a new discovery-runs table until there is a concrete audit UI/API need.
+- Use stdlib link extraction first; keep BeautifulSoup optional for rich body
+  extraction already covered by Stage 2.

--- a/apps/mcp-unified/src/mcp_unified/docs/__init__.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/__init__.py
@@ -6,6 +6,7 @@ from .mcp_module import DocsMCPToolProvider
 from .models import (
     AccessScope,
     ContextRequest,
+    DiscoverSourceRequest,
     DocumentRecord,
     DocumentType,
     RetrievalMode,
@@ -26,6 +27,7 @@ from .store import DocsCatalogStore
 __all__ = [
     "AccessScope",
     "ContextRequest",
+    "DiscoverSourceRequest",
     "DocsCatalogStore",
     "DocsError",
     "DocsImportService",

--- a/apps/mcp-unified/src/mcp_unified/docs/discovery.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/discovery.py
@@ -131,6 +131,40 @@ class DocsSourceDiscoveryService:
             source=source,
         )
 
+    def discover_sitemap_candidates(
+        self,
+        *,
+        url: str,
+        max_pages: int,
+    ) -> tuple[list[DiscoveredURLCandidate], list[str], dict[str, Any]]:
+        fetched = self.fetcher.fetch(url)
+        if fetched.status != "fetched":
+            return [], [str(fetched.reason or "sitemap_fetch_failed")], {
+                "status": fetched.status,
+                "reason_code": fetched.reason or "sitemap_fetch_failed",
+                "safe_argument_hash": fetched.safe_argument_hash,
+            }
+
+        parsed = parse_sitemap_urlset(fetched.body, max_pages=max_pages, parent_url=url)
+        if parsed.reason_code != "ok":
+            return [], [parsed.reason_code], {
+                "status": parsed.status,
+                "reason_code": parsed.reason_code,
+            }
+
+        warnings: list[str] = []
+        if parsed.skipped:
+            warnings.append("source_discovery_limit_exceeded")
+        candidates, filter_warnings = _filter_candidates(
+            parsed.candidates,
+            seed_url=fetched.canonical_url or url,
+            policy=self.policy,
+            settings=self.settings,
+            max_pages=max_pages,
+        )
+        warnings.extend(filter_warnings)
+        return candidates, warnings, {"status": "completed", "reason_code": "ok"}
+
     def _candidates_for_fetched(
         self,
         *,

--- a/apps/mcp-unified/src/mcp_unified/docs/discovery.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/discovery.py
@@ -14,7 +14,7 @@ from .acquisition.policy import safe_argument_hash
 from .acquisition.policy import SourcePolicy
 from .models import AccessScope, DiscoverSourceRequest
 from .settings import DocsSettings
-from .source_utils import redacted_url_for_display, url_has_query
+from .source_utils import redacted_url_for_display, source_defaults_metadata, url_has_query
 from .store.sqlite import DocsCatalogStore
 
 CandidateStatus = Literal["accepted", "duplicate", "denied", "skipped", "ingested", "failed"]
@@ -31,6 +31,7 @@ class DiscoveredURLCandidate:
     parent_url: str
     parent_display_url: str
     safe_argument_hash: str
+    document_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -112,12 +113,22 @@ class DocsSourceDiscoveryService:
             max_pages=_effective_discovery_page_limit(request, self.settings),
         )
         warnings.extend(filter_warnings)
+        source: dict[str, Any] | None = None
+        if request.mode == "apply":
+            source, candidates, apply_warnings = self._apply_discovery(
+                scope=scope,
+                kind=kind,
+                request=request,
+                candidates=candidates,
+            )
+            warnings.extend(apply_warnings)
         return _discovery_response(
             status="completed",
             reason_code="ok",
             request=request,
             candidates=candidates,
             warnings=warnings,
+            source=source,
         )
 
     def _candidates_for_fetched(
@@ -154,6 +165,120 @@ class DocsSourceDiscoveryService:
             ]
             return candidates, []
         return [], ["source_discovery_kind_unsupported"]
+
+    def _apply_discovery(
+        self,
+        *,
+        scope: AccessScope,
+        kind: str,
+        request: DiscoverSourceRequest,
+        candidates: list[DiscoveredURLCandidate],
+    ) -> tuple[dict[str, Any] | None, list[DiscoveredURLCandidate], list[str]]:
+        apply_action = request.apply_action or self.settings.discovery_apply_default
+        source: dict[str, Any] | None = None
+        warnings: list[str] = []
+        if kind == "sitemap" and apply_action in {"register", "register_and_ingest"}:
+            source = self._register_sitemap_source(scope=scope, request=request)
+            if not self.settings.sitemap_sync_enabled:
+                warnings.append("sitemap_sync_disabled")
+
+        if apply_action in {"ingest", "register_and_ingest"}:
+            candidates = self._ingest_accepted_candidates(
+                scope=scope,
+                request=request,
+                candidates=candidates,
+                source=source,
+            )
+            if source is not None:
+                source = self.store.get_source(scope=scope, source_id=int(source["id"]))
+
+        return _public_source_for_response(source), candidates, warnings
+
+    def _register_sitemap_source(self, *, scope: AccessScope, request: DiscoverSourceRequest) -> dict[str, Any]:
+        can_persist_query_uri = self.settings.persist_url_query_strings or not url_has_query(request.url)
+        canonical_uri = request.url if can_persist_query_uri else redacted_url_for_display(request.url)
+        redacted_source_url = redacted_url_for_display(request.url)
+        metadata: dict[str, Any] = source_defaults_metadata(
+            keywords=request.keywords,
+            collection_names=request.collections,
+        )
+        metadata.update(
+            {
+                "discovery_kind": "sitemap",
+                "same_origin_only": self.settings.discovery_same_origin_only,
+            }
+        )
+        source_id = self.store.upsert_source(
+            scope=scope,
+            source_type="url_sitemap",
+            canonical_uri=canonical_uri,
+            display_name=request.title or redacted_source_url,
+            source_path=None,
+            source_url=request.url if can_persist_query_uri else None,
+            redacted_source_url=redacted_source_url,
+            policy_profile=self.settings.web_source_profile,
+            sync_enabled=self.settings.sitemap_sync_enabled,
+            metadata=metadata,
+        )
+        source = self.store.get_source(scope=scope, source_id=source_id)
+        if source is None:
+            raise RuntimeError("Registered sitemap source could not be loaded")
+        return source
+
+    def _ingest_accepted_candidates(
+        self,
+        *,
+        scope: AccessScope,
+        request: DiscoverSourceRequest,
+        candidates: list[DiscoveredURLCandidate],
+        source: dict[str, Any] | None,
+    ) -> list[DiscoveredURLCandidate]:
+        ingested: list[DiscoveredURLCandidate] = []
+        for candidate in candidates:
+            if candidate.status != "accepted":
+                ingested.append(candidate)
+                continue
+            result = self.acquisition.ingest_url(
+                scope=scope,
+                url=candidate.url,
+                keywords=request.keywords,
+                collection_names=request.collections,
+            )
+            document = result.get("document")
+            document_id = int(document["id"]) if isinstance(document, Mapping) and document.get("id") else None
+            if result.get("reason_code") == "ok" and document_id is not None:
+                if source is not None:
+                    stored_document = self.store.get_document(scope, document_id, mode="metadata")
+                    self.store.link_source_document(
+                        scope=scope,
+                        source_id=int(source["id"]),
+                        document_id=document_id,
+                        source_item_uri=candidate.url,
+                        status="active",
+                        last_hash=str(stored_document.get("content_hash") or ""),
+                        metadata={"importer": "url_sitemap"},
+                    )
+                ingested.append(
+                    _replace_candidate(
+                        candidate,
+                        candidate.url,
+                        candidate.display_url,
+                        "ingested",
+                        "ok",
+                        document_id=document_id,
+                    )
+                )
+                continue
+            ingested.append(
+                _replace_candidate(
+                    candidate,
+                    candidate.url,
+                    candidate.display_url,
+                    "failed",
+                    str(result.get("reason_code") or "ingest_failed"),
+                )
+            )
+        return ingested
 
 
 class _LinkHTMLParser(HTMLParser):
@@ -234,8 +359,8 @@ def extract_page_links(base_url: str, body: bytes) -> list[str]:
     return _unique_links(links)
 
 
-def public_candidate(candidate: DiscoveredURLCandidate) -> dict[str, str]:
-    return {
+def public_candidate(candidate: DiscoveredURLCandidate) -> dict[str, Any]:
+    public = {
         "url": candidate.display_url,
         "status": candidate.status,
         "reason_code": candidate.reason_code,
@@ -243,6 +368,9 @@ def public_candidate(candidate: DiscoveredURLCandidate) -> dict[str, str]:
         "parent_url": candidate.parent_display_url,
         "safe_argument_hash": candidate.safe_argument_hash,
     }
+    if candidate.document_id is not None:
+        public["document_id"] = candidate.document_id
+    return public
 
 
 def _validate_discovery_request(
@@ -319,10 +447,8 @@ def _filter_candidates(
             )
             continue
         if settings.discovery_same_origin_only and _origin(candidate_url) != seed_origin:
-            decision = policy.evaluate(candidate_url)
-            if decision.status != "allowed":
-                filtered.append(_replace_candidate(candidate, candidate_url, display_url, "denied", "candidate_out_of_scope"))
-                continue
+            filtered.append(_replace_candidate(candidate, candidate_url, display_url, "denied", "candidate_out_of_scope"))
+            continue
         decision = policy.evaluate(candidate_url)
         if decision.status != "allowed":
             filtered.append(_replace_candidate(candidate, candidate_url, display_url, "denied", "candidate_out_of_scope"))
@@ -401,6 +527,8 @@ def _replace_candidate(
     display_url: str,
     status: CandidateStatus,
     reason_code: str,
+    *,
+    document_id: int | None = None,
 ) -> DiscoveredURLCandidate:
     return DiscoveredURLCandidate(
         url=url,
@@ -411,7 +539,23 @@ def _replace_candidate(
         parent_url=candidate.parent_url,
         parent_display_url=candidate.parent_display_url,
         safe_argument_hash=safe_argument_hash(url),
+        document_id=document_id,
     )
+
+
+def _public_source_for_response(source: dict[str, Any] | None) -> dict[str, Any] | None:
+    if source is None:
+        return None
+    public = dict(source)
+    if public.get("source_type") in {"url_page", "url_sitemap"}:
+        redacted_uri = public.get("redacted_source_url")
+        if not isinstance(redacted_uri, str) or not redacted_uri.strip():
+            redacted_uri = redacted_url_for_display(str(public.get("canonical_uri") or public.get("source_url") or ""))
+        public.pop("source_url", None)
+        public["canonical_uri"] = redacted_uri
+        public["display_uri"] = redacted_uri
+        public["redacted_source_url"] = redacted_uri
+    return public
 
 
 def _origin(url: str) -> tuple[str, str, int | None]:

--- a/apps/mcp-unified/src/mcp_unified/docs/discovery.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/discovery.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from typing import Literal
+from urllib.parse import urljoin, urlsplit, urlunsplit
+from xml.etree import ElementTree
+
+from .acquisition.policy import safe_argument_hash
+from .source_utils import redacted_url_for_display
+
+CandidateStatus = Literal["accepted", "duplicate", "denied", "skipped", "ingested", "failed"]
+
+
+@dataclass(frozen=True)
+class DiscoveredURLCandidate:
+    url: str
+    display_url: str
+    status: CandidateStatus
+    reason_code: str
+    source_kind: str
+    parent_url: str
+    parent_display_url: str
+    safe_argument_hash: str
+
+
+@dataclass(frozen=True)
+class SitemapParseResult:
+    status: str
+    reason_code: str
+    candidates: list[DiscoveredURLCandidate]
+    skipped: int = 0
+
+
+class _LinkHTMLParser(HTMLParser):
+    def __init__(self, base_url: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.base_url = base_url
+        self.links: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "a":
+            return
+        attr_map = {name.lower(): value for name, value in attrs if name}
+        rel = attr_map.get("rel") or ""
+        if "nofollow" in {item.strip().lower() for item in rel.split()}:
+            return
+        href = attr_map.get("href")
+        if not href:
+            return
+        resolved = _supported_joined_url(self.base_url, href)
+        if resolved:
+            self.links.append(resolved)
+
+
+def parse_sitemap_urlset(body: bytes, *, max_pages: int, parent_url: str = "") -> SitemapParseResult:
+    upper = body[:4096].upper()
+    if b"<!DOCTYPE" in upper:
+        return SitemapParseResult(status="denied", reason_code="sitemap_xml_forbidden_doctype", candidates=[])
+    if b"<!ENTITY" in upper:
+        return SitemapParseResult(status="denied", reason_code="sitemap_xml_forbidden_entity", candidates=[])
+    try:
+        root = ElementTree.fromstring(body)
+    except ElementTree.ParseError:
+        return SitemapParseResult(status="failed", reason_code="sitemap_parse_failed", candidates=[])
+
+    root_name = _local_name(root.tag)
+    if root_name == "sitemapindex":
+        return SitemapParseResult(status="denied", reason_code="sitemap_index_unsupported", candidates=[])
+    if root_name != "urlset":
+        return SitemapParseResult(status="failed", reason_code="sitemap_parse_failed", candidates=[])
+
+    locs = [
+        (loc.text or "").strip()
+        for url_node in root.iter()
+        if _local_name(url_node.tag) == "url"
+        for loc in list(url_node)
+        if _local_name(loc.tag) == "loc" and (loc.text or "").strip()
+    ]
+    selected = locs[: max(0, max_pages)]
+    parent_display = redacted_url_for_display(parent_url) if parent_url else ""
+    candidates = [
+        DiscoveredURLCandidate(
+            url=url,
+            display_url=redacted_url_for_display(url),
+            status="accepted",
+            reason_code="ok",
+            source_kind="sitemap",
+            parent_url=parent_url,
+            parent_display_url=parent_display,
+            safe_argument_hash=safe_argument_hash(url),
+        )
+        for url in selected
+    ]
+    return SitemapParseResult(
+        status="completed",
+        reason_code="ok",
+        candidates=candidates,
+        skipped=max(0, len(locs) - len(selected)),
+    )
+
+
+def extract_page_links(base_url: str, body: bytes) -> list[str]:
+    text = body.decode("utf-8", errors="replace")
+    links = _extract_links_with_beautifulsoup(base_url, text)
+    if links is None:
+        parser = _LinkHTMLParser(base_url)
+        parser.feed(text)
+        links = parser.links
+    return _unique_links(links)
+
+
+def public_candidate(candidate: DiscoveredURLCandidate) -> dict[str, str]:
+    return {
+        "url": candidate.display_url,
+        "status": candidate.status,
+        "reason_code": candidate.reason_code,
+        "source_kind": candidate.source_kind,
+        "parent_url": candidate.parent_display_url,
+        "safe_argument_hash": candidate.safe_argument_hash,
+    }
+
+
+def _extract_links_with_beautifulsoup(base_url: str, text: str) -> list[str] | None:
+    try:
+        bs4 = importlib.import_module("bs4")
+    except ImportError:
+        return None
+
+    soup = bs4.BeautifulSoup(text, "html.parser")
+    links: list[str] = []
+    for anchor in soup.find_all("a"):
+        rel = anchor.get("rel") or ()
+        rel_values = rel.split() if isinstance(rel, str) else tuple(str(item) for item in rel)
+        if "nofollow" in {item.strip().lower() for item in rel_values}:
+            continue
+        href = anchor.get("href")
+        if not href:
+            continue
+        resolved = _supported_joined_url(base_url, str(href))
+        if resolved:
+            links.append(resolved)
+    return links
+
+
+def _unique_links(links: list[str]) -> list[str]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for link in links:
+        stripped = _strip_fragment(link)
+        if stripped in seen:
+            continue
+        seen.add(stripped)
+        unique.append(stripped)
+    return unique
+
+
+def _supported_joined_url(base_url: str, href: str) -> str | None:
+    joined = urljoin(base_url, href.strip())
+    parts = urlsplit(joined)
+    if parts.scheme not in {"http", "https"} or not parts.netloc:
+        return None
+    return _strip_fragment(joined)
+
+
+def _strip_fragment(url: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path or "/", parts.query, ""))
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]

--- a/apps/mcp-unified/src/mcp_unified/docs/discovery.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/discovery.py
@@ -1,3 +1,5 @@
+"""Bounded source discovery for the standalone docs MCP corpus."""
+
 from __future__ import annotations
 
 import importlib
@@ -8,6 +10,7 @@ from typing import Any, Literal
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
 from defusedxml import ElementTree
+from defusedxml.common import DefusedXmlException
 from .acquisition.fetcher import URLFetcher
 from .acquisition.service import DocsAcquisitionService
 from .acquisition.policy import safe_argument_hash
@@ -23,6 +26,8 @@ _SITEMAP_CONTENT_TYPES = ("application/xml", "text/xml", "application/xhtml+xml"
 
 @dataclass(frozen=True)
 class DiscoveredURLCandidate:
+    """A discovered URL plus public-safe display metadata and status."""
+
     url: str
     display_url: str
     status: CandidateStatus
@@ -36,6 +41,8 @@ class DiscoveredURLCandidate:
 
 @dataclass(frozen=True)
 class SitemapParseResult:
+    """Result of parsing a sitemap urlset into candidate URLs."""
+
     status: str
     reason_code: str
     candidates: list[DiscoveredURLCandidate]
@@ -43,6 +50,8 @@ class SitemapParseResult:
 
 
 class DocsSourceDiscoveryService:
+    """Discover, register, and optionally ingest bounded documentation sources."""
+
     def __init__(
         self,
         *,
@@ -68,6 +77,8 @@ class DocsSourceDiscoveryService:
         self.acquisition = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
 
     def discover_source(self, *, scope: AccessScope, request: DiscoverSourceRequest) -> dict[str, Any]:
+        """Discover candidates for one sitemap or seed page request."""
+
         if not self.settings.enable_source_discovery:
             return _discovery_response(
                 status="denied",
@@ -104,7 +115,20 @@ class DocsSourceDiscoveryService:
             )
 
         kind = _resolve_kind(request.kind, request.url, fetched.headers)
-        candidates, warnings = self._candidates_for_fetched(kind=kind, request=request, fetched_body=fetched.body)
+        candidates, warnings, candidate_status = self._candidates_for_fetched(
+            kind=kind,
+            request=request,
+            fetched_body=fetched.body,
+        )
+        if candidate_status["reason_code"] != "ok":
+            return _discovery_response(
+                status=candidate_status["status"],
+                reason_code=candidate_status["reason_code"],
+                request=request,
+                candidates=candidates,
+                warnings=warnings,
+                source=None,
+            )
         candidates, filter_warnings = _filter_candidates(
             candidates,
             seed_url=fetched.canonical_url or request.url,
@@ -137,6 +161,8 @@ class DocsSourceDiscoveryService:
         url: str,
         max_pages: int,
     ) -> tuple[list[DiscoveredURLCandidate], list[str], dict[str, Any]]:
+        """Discover current candidates for a registered sitemap source."""
+
         fetched = self.fetcher.fetch(url)
         if fetched.status != "fetched":
             return [], [str(fetched.reason or "sitemap_fetch_failed")], {
@@ -171,7 +197,7 @@ class DocsSourceDiscoveryService:
         kind: str,
         request: DiscoverSourceRequest,
         fetched_body: bytes,
-    ) -> tuple[list[DiscoveredURLCandidate], list[str]]:
+    ) -> tuple[list[DiscoveredURLCandidate], list[str], dict[str, str]]:
         if kind == "sitemap":
             parsed = parse_sitemap_urlset(
                 fetched_body,
@@ -181,9 +207,15 @@ class DocsSourceDiscoveryService:
             warnings = [] if parsed.reason_code == "ok" else [parsed.reason_code]
             if parsed.skipped:
                 warnings.append("source_discovery_limit_exceeded")
-            return parsed.candidates, warnings
+            if parsed.reason_code != "ok":
+                return parsed.candidates, warnings, {"status": parsed.status, "reason_code": parsed.reason_code}
+            return parsed.candidates, warnings, {"status": "completed", "reason_code": "ok"}
         if kind == "page_links":
             parent_display = redacted_url_for_display(request.url)
+            discovered_urls: list[str] = []
+            if request.include_seed:
+                discovered_urls.append(request.url)
+            discovered_urls.extend(extract_page_links(request.url, fetched_body))
             candidates = [
                 DiscoveredURLCandidate(
                     url=url,
@@ -195,10 +227,13 @@ class DocsSourceDiscoveryService:
                     parent_display_url=parent_display,
                     safe_argument_hash=safe_argument_hash(url),
                 )
-                for url in extract_page_links(request.url, fetched_body)
+                for url in discovered_urls
             ]
-            return candidates, []
-        return [], ["source_discovery_kind_unsupported"]
+            return candidates, [], {"status": "completed", "reason_code": "ok"}
+        return [], ["source_discovery_kind_unsupported"], {
+            "status": "denied",
+            "reason_code": "source_discovery_kind_unsupported",
+        }
 
     def _apply_discovery(
         self,
@@ -283,13 +318,14 @@ class DocsSourceDiscoveryService:
             if result.get("reason_code") == "ok" and document_id is not None:
                 if source is not None:
                     stored_document = self.store.get_document(scope, document_id, mode="metadata")
+                    last_hash = str(stored_document.get("content_hash") or "") if stored_document else ""
                     self.store.link_source_document(
                         scope=scope,
                         source_id=int(source["id"]),
                         document_id=document_id,
                         source_item_uri=candidate.url,
                         status="active",
-                        last_hash=str(stored_document.get("content_hash") or ""),
+                        last_hash=last_hash,
                         metadata={"importer": "url_sitemap"},
                     )
                 ingested.append(
@@ -316,6 +352,8 @@ class DocsSourceDiscoveryService:
 
 
 class _LinkHTMLParser(HTMLParser):
+    """Small fallback link extractor used when BeautifulSoup is unavailable."""
+
     def __init__(self, base_url: str) -> None:
         super().__init__(convert_charrefs=True)
         self.base_url = base_url
@@ -337,6 +375,8 @@ class _LinkHTMLParser(HTMLParser):
 
 
 def parse_sitemap_urlset(body: bytes, *, max_pages: int, parent_url: str = "") -> SitemapParseResult:
+    """Parse a sitemap urlset without following sitemap indexes or external entities."""
+
     upper = body[:4096].upper()
     if b"<!DOCTYPE" in upper:
         return SitemapParseResult(status="denied", reason_code="sitemap_xml_forbidden_doctype", candidates=[])
@@ -344,6 +384,8 @@ def parse_sitemap_urlset(body: bytes, *, max_pages: int, parent_url: str = "") -
         return SitemapParseResult(status="denied", reason_code="sitemap_xml_forbidden_entity", candidates=[])
     try:
         root = ElementTree.fromstring(body)
+    except DefusedXmlException:
+        return SitemapParseResult(status="denied", reason_code="sitemap_parse_failed", candidates=[])
     except ElementTree.ParseError:
         return SitemapParseResult(status="failed", reason_code="sitemap_parse_failed", candidates=[])
 
@@ -384,6 +426,8 @@ def parse_sitemap_urlset(body: bytes, *, max_pages: int, parent_url: str = "") -
 
 
 def extract_page_links(base_url: str, body: bytes) -> list[str]:
+    """Extract unique HTTP(S) links from one HTML page body."""
+
     text = body.decode("utf-8", errors="replace")
     links = _extract_links_with_beautifulsoup(base_url, text)
     if links is None:
@@ -394,6 +438,8 @@ def extract_page_links(base_url: str, body: bytes) -> list[str]:
 
 
 def public_candidate(candidate: DiscoveredURLCandidate) -> dict[str, Any]:
+    """Return a candidate response with raw query-bearing URLs redacted."""
+
     public = {
         "url": candidate.display_url,
         "status": candidate.status,
@@ -443,13 +489,29 @@ def _validate_discovery_request(
             candidates=[],
             warnings=["max_pages must be positive"],
         )
-    if request.max_depth is not None and request.max_depth != settings.max_discovery_depth:
+    if request.max_depth is not None and (
+        request.max_depth > settings.max_discovery_depth or request.max_depth > 1
+    ):
         return _discovery_response(
             status="denied",
             reason_code="source_discovery_request_invalid",
             request=request,
             candidates=[],
             warnings=["max_depth_unsupported"],
+        )
+    apply_action = request.apply_action or settings.discovery_apply_default
+    if (
+        request.mode == "apply"
+        and apply_action in {"register", "register_and_ingest"}
+        and url_has_query(request.url)
+        and not settings.persist_url_query_strings
+    ):
+        return _discovery_response(
+            status="denied",
+            reason_code="candidate_query_not_persisted",
+            request=request,
+            candidates=[],
+            warnings=["source_url_query_not_persisted"],
         )
     return None
 
@@ -594,7 +656,14 @@ def _public_source_for_response(source: dict[str, Any] | None) -> dict[str, Any]
 
 def _origin(url: str) -> tuple[str, str, int | None]:
     parts = urlsplit(url)
-    return parts.scheme.lower(), (parts.hostname or "").lower(), parts.port
+    scheme = parts.scheme.lower()
+    try:
+        port = parts.port
+    except ValueError:
+        port = None
+    if (scheme == "http" and port == 80) or (scheme == "https" and port == 443):
+        port = None
+    return scheme, (parts.hostname or "").lower(), port
 
 
 def _merged_content_types(existing: tuple[str, ...], additions: tuple[str, ...]) -> tuple[str, ...]:
@@ -652,5 +721,7 @@ def _strip_fragment(url: str) -> str:
     return urlunsplit((parts.scheme, parts.netloc, parts.path or "/", parts.query, ""))
 
 
-def _local_name(tag: str) -> str:
+def _local_name(tag: Any) -> str:
+    if not isinstance(tag, str):
+        return ""
     return tag.rsplit("}", 1)[-1]

--- a/apps/mcp-unified/src/mcp_unified/docs/discovery.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/discovery.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
 import importlib
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
 from html.parser import HTMLParser
-from typing import Literal
+from typing import Any, Literal
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from xml.etree import ElementTree
 
+from .acquisition.fetcher import URLFetcher
+from .acquisition.service import DocsAcquisitionService
 from .acquisition.policy import safe_argument_hash
-from .source_utils import redacted_url_for_display
+from .acquisition.policy import SourcePolicy
+from .models import AccessScope, DiscoverSourceRequest
+from .settings import DocsSettings
+from .source_utils import redacted_url_for_display, url_has_query
+from .store.sqlite import DocsCatalogStore
 
 CandidateStatus = Literal["accepted", "duplicate", "denied", "skipped", "ingested", "failed"]
+_SITEMAP_CONTENT_TYPES = ("application/xml", "text/xml", "application/xhtml+xml")
 
 
 @dataclass(frozen=True)
@@ -31,6 +39,121 @@ class SitemapParseResult:
     reason_code: str
     candidates: list[DiscoveredURLCandidate]
     skipped: int = 0
+
+
+class DocsSourceDiscoveryService:
+    def __init__(
+        self,
+        *,
+        settings: DocsSettings,
+        store: DocsCatalogStore,
+        resolver: object | None = None,
+        transport: object | None = None,
+    ) -> None:
+        self.settings = settings
+        self.store = store
+        self.policy = SourcePolicy(
+            web_source_profile=settings.web_source_profile,
+            preapproved_domains=settings.preapproved_domains,
+            allowed_url_prefixes=settings.allowed_url_prefixes,
+            denied_domains=settings.denied_domains,
+            allow_arbitrary_public_domains=settings.allow_arbitrary_public_domains,
+        )
+        fetch_settings = replace(
+            settings,
+            allowed_content_types=_merged_content_types(settings.allowed_content_types, _SITEMAP_CONTENT_TYPES),
+        )
+        self.fetcher = URLFetcher(settings=fetch_settings, policy=self.policy, resolver=resolver, transport=transport)
+        self.acquisition = DocsAcquisitionService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    def discover_source(self, *, scope: AccessScope, request: DiscoverSourceRequest) -> dict[str, Any]:
+        if not self.settings.enable_source_discovery:
+            return _discovery_response(
+                status="denied",
+                reason_code="source_discovery_disabled",
+                request=request,
+                candidates=[],
+                warnings=[],
+            )
+        if not self.settings.enable_web_acquisition:
+            return _discovery_response(
+                status="denied",
+                reason_code="web_acquisition_disabled",
+                request=request,
+                candidates=[],
+                warnings=[],
+            )
+
+        validation = _validate_discovery_request(request, self.settings)
+        if validation is not None:
+            return validation
+
+        fetched = self.fetcher.fetch(request.url)
+        if fetched.status != "fetched":
+            return _discovery_response(
+                status=fetched.status,
+                reason_code=fetched.reason,
+                request=request,
+                candidates=[],
+                warnings=[],
+                source={
+                    "final_url": fetched.final_url,
+                    "safe_argument_hash": fetched.safe_argument_hash,
+                },
+            )
+
+        kind = _resolve_kind(request.kind, request.url, fetched.headers)
+        candidates, warnings = self._candidates_for_fetched(kind=kind, request=request, fetched_body=fetched.body)
+        candidates, filter_warnings = _filter_candidates(
+            candidates,
+            seed_url=fetched.canonical_url or request.url,
+            policy=self.policy,
+            settings=self.settings,
+            max_pages=_effective_discovery_page_limit(request, self.settings),
+        )
+        warnings.extend(filter_warnings)
+        return _discovery_response(
+            status="completed",
+            reason_code="ok",
+            request=request,
+            candidates=candidates,
+            warnings=warnings,
+        )
+
+    def _candidates_for_fetched(
+        self,
+        *,
+        kind: str,
+        request: DiscoverSourceRequest,
+        fetched_body: bytes,
+    ) -> tuple[list[DiscoveredURLCandidate], list[str]]:
+        if kind == "sitemap":
+            parsed = parse_sitemap_urlset(
+                fetched_body,
+                max_pages=_effective_discovery_page_limit(request, self.settings),
+                parent_url=request.url,
+            )
+            warnings = [] if parsed.reason_code == "ok" else [parsed.reason_code]
+            if parsed.skipped:
+                warnings.append("source_discovery_limit_exceeded")
+            return parsed.candidates, warnings
+        if kind == "page_links":
+            parent_display = redacted_url_for_display(request.url)
+            candidates = [
+                DiscoveredURLCandidate(
+                    url=url,
+                    display_url=redacted_url_for_display(url),
+                    status="accepted",
+                    reason_code="ok",
+                    source_kind="page_links",
+                    parent_url=request.url,
+                    parent_display_url=parent_display,
+                    safe_argument_hash=safe_argument_hash(url),
+                )
+                for url in extract_page_links(request.url, fetched_body)
+            ]
+            return candidates, []
+        return [], ["source_discovery_kind_unsupported"]
 
 
 class _LinkHTMLParser(HTMLParser):
@@ -120,6 +243,188 @@ def public_candidate(candidate: DiscoveredURLCandidate) -> dict[str, str]:
         "parent_url": candidate.parent_display_url,
         "safe_argument_hash": candidate.safe_argument_hash,
     }
+
+
+def _validate_discovery_request(
+    request: DiscoverSourceRequest,
+    settings: DocsSettings,
+) -> dict[str, Any] | None:
+    if request.kind not in {"auto", "sitemap", "page_links"}:
+        return _discovery_response(
+            status="denied",
+            reason_code="source_discovery_kind_unsupported",
+            request=request,
+            candidates=[],
+            warnings=[],
+        )
+    if request.mode not in {"dry_run", "apply"}:
+        return _discovery_response(
+            status="denied",
+            reason_code="source_discovery_request_invalid",
+            request=request,
+            candidates=[],
+            warnings=["invalid_mode"],
+        )
+    if request.apply_action is not None and request.apply_action not in {"register", "ingest", "register_and_ingest"}:
+        return _discovery_response(
+            status="denied",
+            reason_code="source_discovery_request_invalid",
+            request=request,
+            candidates=[],
+            warnings=["invalid_apply_action"],
+        )
+    if request.max_pages is not None and request.max_pages < 1:
+        return _discovery_response(
+            status="denied",
+            reason_code="source_discovery_limit_exceeded",
+            request=request,
+            candidates=[],
+            warnings=["max_pages must be positive"],
+        )
+    if request.max_depth is not None and request.max_depth != settings.max_discovery_depth:
+        return _discovery_response(
+            status="denied",
+            reason_code="source_discovery_request_invalid",
+            request=request,
+            candidates=[],
+            warnings=["max_depth_unsupported"],
+        )
+    return None
+
+
+def _filter_candidates(
+    candidates: list[DiscoveredURLCandidate],
+    *,
+    seed_url: str,
+    policy: SourcePolicy,
+    settings: DocsSettings,
+    max_pages: int,
+) -> tuple[list[DiscoveredURLCandidate], list[str]]:
+    seed_origin = _origin(seed_url)
+    seen: set[str] = set()
+    accepted = 0
+    filtered: list[DiscoveredURLCandidate] = []
+    warnings: list[str] = []
+    for candidate in candidates:
+        candidate_url = _strip_fragment(candidate.url)
+        display_url = redacted_url_for_display(candidate_url)
+        if candidate_url in seen:
+            filtered.append(_replace_candidate(candidate, candidate_url, display_url, "duplicate", "candidate_duplicate"))
+            continue
+        seen.add(candidate_url)
+
+        if url_has_query(candidate_url) and not settings.persist_url_query_strings:
+            filtered.append(
+                _replace_candidate(candidate, candidate_url, display_url, "skipped", "candidate_query_not_persisted")
+            )
+            continue
+        if settings.discovery_same_origin_only and _origin(candidate_url) != seed_origin:
+            decision = policy.evaluate(candidate_url)
+            if decision.status != "allowed":
+                filtered.append(_replace_candidate(candidate, candidate_url, display_url, "denied", "candidate_out_of_scope"))
+                continue
+        decision = policy.evaluate(candidate_url)
+        if decision.status != "allowed":
+            filtered.append(_replace_candidate(candidate, candidate_url, display_url, "denied", "candidate_out_of_scope"))
+            continue
+        if accepted >= max_pages:
+            warnings.append("source_discovery_limit_exceeded")
+            filtered.append(
+                _replace_candidate(candidate, candidate_url, display_url, "skipped", "source_discovery_limit_exceeded")
+            )
+            continue
+        accepted += 1
+        filtered.append(_replace_candidate(candidate, candidate_url, display_url, "accepted", "ok"))
+    return filtered, warnings
+
+
+def _discovery_response(
+    *,
+    status: str,
+    reason_code: str,
+    request: DiscoverSourceRequest,
+    candidates: list[DiscoveredURLCandidate],
+    warnings: list[str],
+    source: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "reason_code": reason_code,
+        "kind": request.kind,
+        "mode": request.mode,
+        "source": source,
+        "counts": _discovery_counts(candidates),
+        "candidates": [public_candidate(candidate) for candidate in candidates],
+        "warnings": warnings,
+    }
+
+
+def _discovery_counts(candidates: list[DiscoveredURLCandidate]) -> dict[str, int]:
+    counts = _zero_discovery_counts()
+    for candidate in candidates:
+        if candidate.status == "duplicate":
+            counts["duplicates"] += 1
+        elif candidate.status in counts:
+            counts[candidate.status] += 1
+    return counts
+
+
+def _zero_discovery_counts() -> dict[str, int]:
+    return {
+        "accepted": 0,
+        "duplicates": 0,
+        "denied": 0,
+        "skipped": 0,
+        "ingested": 0,
+        "failed": 0,
+    }
+
+
+def _effective_discovery_page_limit(request: DiscoverSourceRequest, settings: DocsSettings) -> int:
+    if request.max_pages is None:
+        return settings.max_discovery_pages
+    return min(request.max_pages, settings.max_discovery_pages)
+
+
+def _resolve_kind(requested_kind: str, url: str, headers: Mapping[str, str]) -> str:
+    if requested_kind != "auto":
+        return requested_kind
+    content_type = headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    if content_type in {"application/xml", "text/xml"} or urlsplit(url).path.endswith(".xml"):
+        return "sitemap"
+    return "page_links"
+
+
+def _replace_candidate(
+    candidate: DiscoveredURLCandidate,
+    url: str,
+    display_url: str,
+    status: CandidateStatus,
+    reason_code: str,
+) -> DiscoveredURLCandidate:
+    return DiscoveredURLCandidate(
+        url=url,
+        display_url=display_url,
+        status=status,
+        reason_code=reason_code,
+        source_kind=candidate.source_kind,
+        parent_url=candidate.parent_url,
+        parent_display_url=candidate.parent_display_url,
+        safe_argument_hash=safe_argument_hash(url),
+    )
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    parts = urlsplit(url)
+    return parts.scheme.lower(), (parts.hostname or "").lower(), parts.port
+
+
+def _merged_content_types(existing: tuple[str, ...], additions: tuple[str, ...]) -> tuple[str, ...]:
+    merged: list[str] = []
+    for value in (*existing, *additions):
+        if value not in merged:
+            merged.append(value)
+    return tuple(merged)
 
 
 def _extract_links_with_beautifulsoup(base_url: str, text: str) -> list[str] | None:

--- a/apps/mcp-unified/src/mcp_unified/docs/discovery.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/discovery.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass, replace
 from html.parser import HTMLParser
 from typing import Any, Literal
 from urllib.parse import urljoin, urlsplit, urlunsplit
-from xml.etree import ElementTree
 
+from defusedxml import ElementTree
 from .acquisition.fetcher import URLFetcher
 from .acquisition.service import DocsAcquisitionService
 from .acquisition.policy import safe_argument_hash

--- a/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
 from .acquisition.extract import available_extractors
 from .acquisition.service import DocsAcquisitionService
+from .discovery import DocsSourceDiscoveryService
 from .importers.local import DocsImportService
-from .models import AccessScope, ContextRequest, SearchFilters, SearchRequest, SyncSourceRequest
+from .models import AccessScope, ContextRequest, DiscoverSourceRequest, SearchFilters, SearchRequest, SyncSourceRequest
 from .retrieval.aliases import DocsAliasResolver
 from .retrieval.context import DocsContextBuilder
 from .retrieval.search import DocsRetrievalService
@@ -91,6 +92,11 @@ class DocsMCPToolProvider:
         self.source_sync = DocsSourceSyncService(settings=settings, store=self.store)
         self.acquisition = (
             DocsAcquisitionService(settings=settings, store=self.store) if settings.enable_web_acquisition else None
+        )
+        self.discovery = (
+            DocsSourceDiscoveryService(settings=settings, store=self.store)
+            if settings.enable_source_discovery and settings.enable_web_acquisition
+            else None
         )
 
     def tool_definitions(self) -> list[dict[str, Any]]:
@@ -232,6 +238,27 @@ class DocsMCPToolProvider:
                     "ingestion",
                 )
             )
+        if self.discovery is not None:
+            tools.append(
+                _tool(
+                    "docs.discover_source",
+                    "Discover bounded sitemap or page-link URL candidates and optionally register or ingest them.",
+                    {
+                        "url": {"type": "string"},
+                        "kind": {"type": "string"},
+                        "mode": {"type": "string"},
+                        "apply_action": {"type": "string"},
+                        "max_pages": {"type": "integer"},
+                        "max_depth": {"type": "integer"},
+                        "collections": {"type": "array"},
+                        "keywords": {"type": "array"},
+                        "title": {"type": "string"},
+                        "include_seed": {"type": "boolean"},
+                    },
+                    ["url"],
+                    "ingestion",
+                )
+            )
         return tools
 
     def execute(self, tool_name: str, arguments: dict[str, Any] | None, *, scope: AccessScope) -> Any:
@@ -312,6 +339,15 @@ class DocsMCPToolProvider:
                 collection_names=tuple(str(item) for item in args.get("collections") or ()),
                 title_override=_optional_str(args.get("title")),
             )
+        if tool_name == "docs.discover_source":
+            if not self.settings.enable_source_discovery:
+                return {"status": "denied", "reason_code": "source_discovery_disabled"}
+            if self.discovery is None:
+                return {"status": "denied", "reason_code": "web_acquisition_disabled"}
+            request, error = _discover_source_request_from_args(args)
+            if error is not None:
+                return error
+            return self.discovery.discover_source(scope=scope, request=request)
         if tool_name == "docs.sync_source":
             if not self.settings.enable_source_sync:
                 return {"status": "denied", "reason_code": "source_sync_disabled"}
@@ -443,12 +479,157 @@ def _sync_source_request_from_args(
     ), None
 
 
+def _discover_source_request_from_args(
+    args: dict[str, Any],
+) -> tuple[DiscoverSourceRequest, dict[str, str] | None]:
+    url = _optional_str(args.get("url"))
+    if url is None:
+        return DiscoverSourceRequest(url=""), _invalid_discovery_request("url")
+    kind, error = _optional_discovery_choice(
+        args.get("kind"),
+        "kind",
+        default="auto",
+        allowed={"auto", "sitemap", "page_links"},
+    )
+    if error is not None:
+        return DiscoverSourceRequest(url=url), error
+    mode, error = _optional_discovery_choice(
+        args.get("mode"),
+        "mode",
+        default="dry_run",
+        allowed={"dry_run", "apply"},
+    )
+    if error is not None:
+        return DiscoverSourceRequest(url=url), error
+    apply_action, error = _optional_discovery_choice_or_none(
+        args.get("apply_action"),
+        "apply_action",
+        allowed={"register", "ingest", "register_and_ingest"},
+    )
+    if error is not None:
+        return DiscoverSourceRequest(url=url), error
+    max_pages, error = _optional_discovery_positive_int(args.get("max_pages"), "max_pages")
+    if error is not None:
+        return DiscoverSourceRequest(url=url), error
+    max_depth, error = _optional_discovery_positive_int(args.get("max_depth"), "max_depth")
+    if error is not None:
+        return DiscoverSourceRequest(url=url), error
+    collections, error = _optional_string_tuple(args.get("collections"), "collections")
+    if error is not None:
+        return DiscoverSourceRequest(url=url), error
+    keywords, error = _optional_string_tuple(args.get("keywords"), "keywords")
+    if error is not None:
+        return DiscoverSourceRequest(url=url), error
+    include_seed, error = _optional_discovery_bool(args.get("include_seed"), "include_seed", default=False)
+    if error is not None:
+        return DiscoverSourceRequest(url=url), error
+
+    return DiscoverSourceRequest(
+        url=url,
+        kind=kind,
+        mode=mode,
+        apply_action=apply_action,
+        max_pages=max_pages,
+        max_depth=max_depth,
+        collections=collections,
+        keywords=keywords,
+        title=_optional_str(args.get("title")),
+        include_seed=include_seed,
+    ), None
+
+
 def _invalid_sync_request(field: str) -> dict[str, str]:
     return {
         "status": "denied",
         "reason_code": "source_sync_request_invalid",
         "field": field,
     }
+
+
+def _invalid_discovery_request(field: str) -> dict[str, str]:
+    return {
+        "status": "denied",
+        "reason_code": "source_discovery_request_invalid",
+        "field": field,
+    }
+
+
+def _optional_discovery_choice(
+    value: Any,
+    field: str,
+    *,
+    default: str,
+    allowed: set[str],
+) -> tuple[str, dict[str, str] | None]:
+    text = _optional_str(value)
+    if text is None:
+        return default, None
+    normalized = text.lower()
+    if normalized not in allowed:
+        return default, _invalid_discovery_request(field)
+    return normalized, None
+
+
+def _optional_discovery_choice_or_none(
+    value: Any,
+    field: str,
+    *,
+    allowed: set[str],
+) -> tuple[str | None, dict[str, str] | None]:
+    text = _optional_str(value)
+    if text is None:
+        return None, None
+    normalized = text.lower()
+    if normalized not in allowed:
+        return None, _invalid_discovery_request(field)
+    return normalized, None
+
+
+def _optional_discovery_positive_int(value: Any, field: str) -> tuple[int | None, dict[str, str] | None]:
+    if value is None:
+        return None, None
+    if isinstance(value, bool):
+        return None, _invalid_discovery_request(field)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None, None
+        try:
+            parsed = int(text, 10)
+        except ValueError:
+            return None, _invalid_discovery_request(field)
+    elif isinstance(value, int):
+        parsed = value
+    else:
+        return None, _invalid_discovery_request(field)
+
+    if parsed <= 0:
+        return None, _invalid_discovery_request(field)
+    return parsed, None
+
+
+def _optional_discovery_bool(value: Any, field: str, *, default: bool) -> tuple[bool, dict[str, str] | None]:
+    if value is None:
+        return default, None
+    if isinstance(value, bool):
+        return value, None
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if not normalized:
+            return default, None
+        if normalized in {"1", "true", "t", "yes", "y", "on"}:
+            return True, None
+        if normalized in {"0", "false", "f", "no", "n", "off"}:
+            return False, None
+    return default, _invalid_discovery_request(field)
+
+
+def _optional_string_tuple(value: Any, field: str) -> tuple[tuple[str, ...], dict[str, str] | None]:
+    if value is None:
+        return (), None
+    if isinstance(value, str) or isinstance(value, Mapping) or not isinstance(value, Iterable):
+        return (), _invalid_discovery_request(field)
+    return tuple(text for item in value if (text := str(item).strip())), None
 
 
 def _optional_choice(

--- a/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
@@ -8,7 +8,14 @@ from .acquisition.extract import available_extractors
 from .acquisition.service import DocsAcquisitionService
 from .discovery import DocsSourceDiscoveryService
 from .importers.local import DocsImportService
-from .models import AccessScope, ContextRequest, DiscoverSourceRequest, SearchFilters, SearchRequest, SyncSourceRequest
+from .models import (
+    AccessScope,
+    ContextRequest,
+    DiscoverSourceRequest,
+    SearchFilters,
+    SearchRequest,
+    SyncSourceRequest,
+)
 from .retrieval.aliases import DocsAliasResolver
 from .retrieval.context import DocsContextBuilder
 from .retrieval.search import DocsRetrievalService
@@ -62,6 +69,8 @@ def _source_sync_status(settings: DocsSettings) -> dict[str, Any]:
 
 
 def _source_discovery_status(settings: DocsSettings) -> dict[str, Any]:
+    """Report source discovery availability and configured bounds."""
+
     enabled = settings.enable_source_discovery
     available = enabled and settings.enable_web_acquisition
     disabled_reason = None if available else (
@@ -73,7 +82,7 @@ def _source_discovery_status(settings: DocsSettings) -> dict[str, Any]:
         "disabled_reason": disabled_reason,
         "supported_kinds": ["sitemap", "page_links"],
         "max_discovery_pages": settings.max_discovery_pages,
-        "max_discovery_depth": settings.max_discovery_depth,
+        "max_discovery_depth": min(settings.max_discovery_depth, 1),
         "max_discovery_sitemaps": settings.max_discovery_sitemaps,
         "discovery_apply_default": settings.discovery_apply_default,
         "discovery_same_origin_only": settings.discovery_same_origin_only,

--- a/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
@@ -60,6 +60,25 @@ def _source_sync_status(settings: DocsSettings) -> dict[str, Any]:
     }
 
 
+def _source_discovery_status(settings: DocsSettings) -> dict[str, Any]:
+    enabled = settings.enable_source_discovery
+    available = enabled and settings.enable_web_acquisition
+    disabled_reason = None if available else (
+        "web_acquisition_disabled" if enabled else "source_discovery_disabled"
+    )
+    return {
+        "enabled": enabled,
+        "available": available,
+        "disabled_reason": disabled_reason,
+        "supported_kinds": ["sitemap", "page_links"],
+        "max_discovery_pages": settings.max_discovery_pages,
+        "max_discovery_depth": settings.max_discovery_depth,
+        "max_discovery_sitemaps": settings.max_discovery_sitemaps,
+        "discovery_apply_default": settings.discovery_apply_default,
+        "discovery_same_origin_only": settings.discovery_same_origin_only,
+    }
+
+
 class DocsMCPToolProvider:
     def __init__(self, *, settings: DocsSettings, store: DocsCatalogStore | None = None) -> None:
         self.settings = settings
@@ -225,6 +244,7 @@ class DocsMCPToolProvider:
             status["web_source_profile"] = self.settings.web_source_profile
             status["web_policy"] = _web_policy_status(self.settings)
             status["source_sync"] = _source_sync_status(self.settings)
+            status["source_discovery"] = _source_discovery_status(self.settings)
             status["web_acquisition_unavailable_reason"] = (
                 None if self.acquisition is not None else "web_acquisition_disabled"
             )

--- a/apps/mcp-unified/src/mcp_unified/docs/models.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/models.py
@@ -97,6 +97,8 @@ class SyncSourceRequest:
 
 @dataclass(frozen=True)
 class DiscoverSourceRequest:
+    """Request one bounded sitemap or page-link discovery run."""
+
     url: str
     kind: DiscoveryKind = "auto"
     mode: DiscoveryMode = "dry_run"

--- a/apps/mcp-unified/src/mcp_unified/docs/models.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/models.py
@@ -12,6 +12,10 @@ SyncMode = Literal["dry_run", "apply"]
 StalePolicy = Literal["report", "tombstone"]
 SyncItemStatus = Literal["created", "updated", "unchanged", "missing", "tombstoned", "failed", "skipped"]
 SyncRunStatus = Literal["completed", "partial", "skipped", "denied", "failed"]
+DiscoveryKind = Literal["auto", "sitemap", "page_links"]
+DiscoveryMode = Literal["dry_run", "apply"]
+DiscoveryApplyAction = Literal["register", "ingest", "register_and_ingest"]
+DiscoveryCandidateStatus = Literal["accepted", "duplicate", "denied", "skipped", "ingested", "failed"]
 
 
 @dataclass(frozen=True)
@@ -89,6 +93,20 @@ class SyncSourceRequest:
     max_pages: int | None = None
     stale_policy: StalePolicy = "report"
     force: bool = False
+
+
+@dataclass(frozen=True)
+class DiscoverSourceRequest:
+    url: str
+    kind: DiscoveryKind = "auto"
+    mode: DiscoveryMode = "dry_run"
+    apply_action: DiscoveryApplyAction | None = None
+    max_pages: int | None = None
+    max_depth: int | None = None
+    collections: tuple[str, ...] = ()
+    keywords: tuple[str, ...] = ()
+    title: str | None = None
+    include_seed: bool = False
 
 
 @dataclass(frozen=True)

--- a/apps/mcp-unified/src/mcp_unified/docs/settings.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/settings.py
@@ -11,6 +11,7 @@ from .models import AccessScope
 
 SourceProfile = Literal["locked_down", "local_first", "online_capable"]
 StalePolicy = Literal["report", "tombstone"]
+DiscoveryApplyDefault = Literal["register", "ingest", "register_and_ingest"]
 
 _TRUE_VALUES = {"true", "1", "yes", "on"}
 _FALSE_VALUES = {"false", "0", "no", "off"}
@@ -122,6 +123,13 @@ def _coerce_stale_policy(value: object, field_name: str) -> StalePolicy:
     return cast(StalePolicy, text)
 
 
+def _coerce_discovery_apply_default(value: object, field_name: str) -> DiscoveryApplyDefault:
+    text = "register" if value is None else str(value).strip().lower()
+    if text not in {"register", "ingest", "register_and_ingest"}:
+        raise ValueError(f"{field_name} must be register, ingest, or register_and_ingest")
+    return cast(DiscoveryApplyDefault, text)
+
+
 @dataclass(frozen=True)
 class DocsSettings:
     db_path: Path
@@ -147,6 +155,12 @@ class DocsSettings:
     default_stale_policy: StalePolicy = "report"
     sitemap_sync_enabled: bool = False
     persist_url_query_strings: bool = False
+    enable_source_discovery: bool = False
+    max_discovery_pages: int = 25
+    max_discovery_depth: int = 1
+    max_discovery_sitemaps: int = 3
+    discovery_apply_default: DiscoveryApplyDefault = "register"
+    discovery_same_origin_only: bool = True
 
     @classmethod
     def from_mapping(cls, values: dict) -> "DocsSettings":
@@ -221,5 +235,29 @@ class DocsSettings:
             persist_url_query_strings=_coerce_bool(
                 values.get("persist_url_query_strings", False),
                 "persist_url_query_strings",
+            ),
+            enable_source_discovery=_coerce_bool(
+                values.get("enable_source_discovery", False),
+                "enable_source_discovery",
+            ),
+            max_discovery_pages=_coerce_positive_int(
+                values.get("max_discovery_pages", 25),
+                "max_discovery_pages",
+            ),
+            max_discovery_depth=_coerce_positive_int(
+                values.get("max_discovery_depth", 1),
+                "max_discovery_depth",
+            ),
+            max_discovery_sitemaps=_coerce_positive_int(
+                values.get("max_discovery_sitemaps", 3),
+                "max_discovery_sitemaps",
+            ),
+            discovery_apply_default=_coerce_discovery_apply_default(
+                values.get("discovery_apply_default", "register"),
+                "discovery_apply_default",
+            ),
+            discovery_same_origin_only=_coerce_bool(
+                values.get("discovery_same_origin_only", True),
+                "discovery_same_origin_only",
             ),
         )

--- a/apps/mcp-unified/src/mcp_unified/docs/settings.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/settings.py
@@ -124,6 +124,8 @@ def _coerce_stale_policy(value: object, field_name: str) -> StalePolicy:
 
 
 def _coerce_discovery_apply_default(value: object, field_name: str) -> DiscoveryApplyDefault:
+    """Coerce the default discovery apply action from config."""
+
     text = "register" if value is None else str(value).strip().lower()
     if text not in {"register", "ingest", "register_and_ingest"}:
         raise ValueError(f"{field_name} must be register, ingest, or register_and_ingest")

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from .acquisition.service import DocsAcquisitionService
+from .discovery import DiscoveredURLCandidate, DocsSourceDiscoveryService
 from .errors import DocsError
 from .importers.base import ParsedDocument, chunks_from_text
 from .importers.local import DocsImportService
@@ -47,6 +48,12 @@ class DocsSourceSyncService:
             resolver=resolver,
             transport=transport,
         )
+        self.discovery = DocsSourceDiscoveryService(
+            settings=settings,
+            store=store,
+            resolver=resolver,
+            transport=transport,
+        )
 
     def sync_source(self, *, scope: AccessScope, request: SyncSourceRequest) -> dict[str, Any]:
         if not self.settings.enable_source_sync:
@@ -80,6 +87,8 @@ class DocsSourceSyncService:
             return self._sync_local_directory(scope=scope, source=source, request=request)
         if source["source_type"] == "url_page":
             return self._sync_url_page(scope=scope, source=source, request=request)
+        if source["source_type"] == "url_sitemap":
+            return self._sync_url_sitemap(scope=scope, source=source, request=request)
         return self._denied(source=source, request=request, reason_code="source_sync_unsupported_type")
 
     def _get_source(self, *, scope: AccessScope, request: SyncSourceRequest) -> dict[str, Any] | None:
@@ -510,6 +519,224 @@ class DocsSourceSyncService:
             warnings=list(parsed.warnings),
         )
 
+    def _sync_url_sitemap(
+        self,
+        *,
+        scope: AccessScope,
+        source: dict[str, Any],
+        request: SyncSourceRequest,
+    ) -> dict[str, Any]:
+        if not self.settings.enable_web_acquisition:
+            return _response(
+                status="denied",
+                reason_code="web_acquisition_disabled",
+                source=source,
+                request=request,
+            )
+
+        source_url = str(source.get("source_url") or "").strip()
+        if not source_url:
+            return self._failed(
+                source=source,
+                request=request,
+                reason_code="source_url_missing",
+                warning="URL sitemap source does not include a source URL.",
+            )
+
+        max_pages = self._sitemap_page_limit(request)
+        candidates, warnings, discovery_status = self.discovery.discover_sitemap_candidates(
+            url=source_url,
+            max_pages=max_pages,
+        )
+        if discovery_status.get("status") != "completed":
+            reason_code = str(discovery_status.get("reason_code") or "sitemap_fetch_failed")
+            status = "denied" if discovery_status.get("status") in {"denied", "approval_required"} else "failed"
+            return _sync_response(
+                status=status,
+                reason_code=reason_code,
+                source=source,
+                request=request,
+                counts=dict(_ZERO_COUNTS),
+                items=[],
+                warnings=warnings,
+            )
+
+        mode = str(request.mode).strip().lower()
+        stale_policy = str(request.stale_policy).strip().lower()
+        source_id = int(source["id"])
+        counts = dict(_ZERO_COUNTS)
+        items: list[dict[str, Any]] = []
+        links = self.store.source_document_links(scope=scope, source_id=source_id)
+        links_by_uri = {str(link["source_item_uri"]): link for link in links}
+        accepted_candidates = [candidate for candidate in candidates if candidate.status == "accepted"]
+        current_uris = {candidate.url for candidate in accepted_candidates}
+        stale_links = [] if "source_discovery_limit_exceeded" in warnings else [
+            link
+            for link in links
+            if str(link["source_item_uri"]) not in current_uris and link.get("status") != "tombstoned"
+        ]
+        sync_item_count = len(accepted_candidates) + len(stale_links)
+        if sync_item_count > self.settings.max_sync_run_items:
+            return _sync_response(
+                status="denied",
+                reason_code="source_sync_limit_exceeded",
+                source=source,
+                request=request,
+                counts=dict(_ZERO_COUNTS),
+                items=[],
+                warnings=[f"sync_item_count={sync_item_count} exceeds max_sync_run_items={self.settings.max_sync_run_items}"],
+            )
+
+        default_keywords = _metadata_string_tuple(source.get("metadata"), "default_keywords")
+        default_collections = _metadata_string_tuple(source.get("metadata"), "default_collections")
+
+        for candidate in candidates:
+            if candidate.status != "accepted":
+                counts["skipped"] += 1
+                items.append(_sitemap_candidate_item(candidate, status="skipped"))
+                continue
+            link = links_by_uri.get(candidate.url)
+            if mode == "apply":
+                item = self._apply_sitemap_candidate(
+                    scope=scope,
+                    source_id=source_id,
+                    candidate=candidate,
+                    link=link,
+                    default_keywords=default_keywords,
+                    default_collections=default_collections,
+                    force=request.force,
+                )
+                counts[item["status"]] += 1
+                items.append(item)
+                continue
+
+            item_status = "created" if link is None or link.get("status") == "tombstoned" else "unchanged"
+            if request.force and item_status == "unchanged":
+                item_status = "updated"
+            counts[item_status] += 1
+            items.append(
+                _sitemap_candidate_item(
+                    candidate,
+                    status=item_status,
+                    document_id=int(link["document_id"]) if link is not None else None,
+                )
+            )
+
+        for link in stale_links:
+            item_uri = str(link["source_item_uri"])
+            if stale_policy == "tombstone":
+                counts["tombstoned"] += 1
+                item_status = "tombstoned"
+                if mode == "apply":
+                    self.store.tombstone_source_item(
+                        scope=scope,
+                        source_id=source_id,
+                        source_item_uri=item_uri,
+                    )
+                    self._tombstone_matching_url_page(scope=scope, source_item_uri=item_uri)
+            else:
+                counts["missing"] += 1
+                item_status = "missing"
+            items.append(
+                {
+                    "source_item_uri": redacted_url_for_display(item_uri),
+                    "status": item_status,
+                    "document_id": int(link["document_id"]),
+                    "canonical_uri": redacted_url_for_display(str(link.get("canonical_uri") or item_uri)),
+                    "title": link.get("title"),
+                }
+            )
+
+        run_status = "partial" if counts["failed"] else "completed"
+        reason_code = "partial_failure" if counts["failed"] else "ok"
+        if mode == "apply":
+            self.store.record_sync_run(
+                scope=scope,
+                source_id=source_id,
+                mode=mode,
+                status=run_status,
+                requested_limits={
+                    "max_documents": request.max_documents,
+                    "max_pages": request.max_pages,
+                    "effective_max_pages": max_pages,
+                    "effective_max_documents": self._document_limit(request),
+                },
+                counts=counts,
+                warnings=warnings,
+                error_code=None if reason_code == "ok" else reason_code,
+                metadata={"source_type": source["source_type"]},
+            )
+            source = self.store.get_source(scope=scope, source_id=source_id) or source
+
+        return _sync_response(
+            status=run_status,
+            reason_code=reason_code,
+            source=source,
+            request=request,
+            counts=counts,
+            items=items,
+            warnings=warnings,
+        )
+
+    def _apply_sitemap_candidate(
+        self,
+        *,
+        scope: AccessScope,
+        source_id: int,
+        candidate: DiscoveredURLCandidate,
+        link: dict[str, Any] | None,
+        default_keywords: tuple[str, ...],
+        default_collections: tuple[str, ...],
+        force: bool,
+    ) -> dict[str, Any]:
+        result = self.acquisition.ingest_url(
+            scope=scope,
+            url=candidate.url,
+            keywords=default_keywords,
+            collection_names=default_collections,
+        )
+        document = result.get("document")
+        document_id = int(document["id"]) if isinstance(document, dict) and document.get("id") else None
+        if result.get("reason_code") != "ok" or document_id is None:
+            return _sitemap_candidate_item(
+                candidate,
+                status="failed",
+                reason_code=str(result.get("reason_code") or "ingest_failed"),
+            )
+
+        stored_document = self.store.get_document(scope, document_id, mode="metadata")
+        self.store.link_source_document(
+            scope=scope,
+            source_id=source_id,
+            document_id=document_id,
+            source_item_uri=candidate.url,
+            status="active",
+            last_hash=str(stored_document.get("content_hash") or ""),
+            metadata={"importer": "url_sitemap"},
+        )
+        item_status = str(result.get("status") or "updated")
+        if force and link is not None and item_status == "unchanged":
+            item_status = "updated"
+        if item_status not in _ZERO_COUNTS:
+            item_status = "updated"
+        return _sitemap_candidate_item(
+            candidate,
+            status=item_status,
+            document_id=document_id,
+            canonical_uri=str(document.get("canonical_uri") or candidate.display_url),
+            title=str(document.get("title") or ""),
+        )
+
+    def _tombstone_matching_url_page(self, *, scope: AccessScope, source_item_uri: str) -> None:
+        page_source = self.store.get_source(scope=scope, canonical_uri=source_item_uri)
+        if page_source is None or page_source.get("source_type") != "url_page":
+            return
+        self.store.tombstone_source_item(
+            scope=scope,
+            source_id=int(page_source["id"]),
+            source_item_uri=source_item_uri,
+        )
+
     def _denied(self, *, source: dict[str, Any], request: SyncSourceRequest, reason_code: str) -> dict[str, Any]:
         return _response(status="skipped", reason_code=reason_code, source=source, request=request)
 
@@ -555,6 +782,14 @@ class DocsSourceSyncService:
 
     def _document_limit(self, request: SyncSourceRequest) -> int:
         limits = [self.settings.max_sync_documents, self.settings.max_sync_run_items]
+        if request.max_documents is not None:
+            limits.append(int(request.max_documents))
+        return min(limits)
+
+    def _sitemap_page_limit(self, request: SyncSourceRequest) -> int:
+        limits = [self.settings.max_sync_pages, self.settings.max_sync_run_items]
+        if request.max_pages is not None:
+            limits.append(int(request.max_pages))
         if request.max_documents is not None:
             limits.append(int(request.max_documents))
         return min(limits)
@@ -731,6 +966,27 @@ def _metadata_string_tuple(metadata: object, key: str) -> tuple[str, ...]:
     else:
         values = (value,)
     return tuple(str(item).strip() for item in values if str(item).strip())
+
+
+def _sitemap_candidate_item(
+    candidate: DiscoveredURLCandidate,
+    *,
+    status: str,
+    reason_code: str = "ok",
+    document_id: int | None = None,
+    canonical_uri: str | None = None,
+    title: str | None = None,
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "source_item_uri": candidate.display_url,
+        "status": status,
+        "reason_code": reason_code,
+        "canonical_uri": redacted_url_for_display(canonical_uri or candidate.display_url),
+        "title": title,
+    }
+    if document_id is not None:
+        item["document_id"] = document_id
+    return item
 
 
 def _existing_content_hash(store: DocsCatalogStore, scope: AccessScope, canonical_uri: str) -> str | None:

--- a/apps/mcp-unified/src/mcp_unified/docs/sync.py
+++ b/apps/mcp-unified/src/mcp_unified/docs/sync.py
@@ -593,7 +593,7 @@ class DocsSourceSyncService:
         for candidate in candidates:
             if candidate.status != "accepted":
                 counts["skipped"] += 1
-                items.append(_sitemap_candidate_item(candidate, status="skipped"))
+                items.append(_sitemap_candidate_item(candidate, status="skipped", reason_code=candidate.reason_code))
                 continue
             link = links_by_uri.get(candidate.url)
             if mode == "apply":
@@ -705,13 +705,14 @@ class DocsSourceSyncService:
             )
 
         stored_document = self.store.get_document(scope, document_id, mode="metadata")
+        last_hash = str(stored_document.get("content_hash") or "") if stored_document else ""
         self.store.link_source_document(
             scope=scope,
             source_id=source_id,
             document_id=document_id,
             source_item_uri=candidate.url,
             status="active",
-            last_hash=str(stored_document.get("content_hash") or ""),
+            last_hash=last_hash,
             metadata={"importer": "url_sitemap"},
         )
         item_status = str(result.get("status") or "updated")

--- a/backlog/tasks/task-12121 - Design-standalone-MCP-docs-Stage-4B-bounded-source-discovery.md
+++ b/backlog/tasks/task-12121 - Design-standalone-MCP-docs-Stage-4B-bounded-source-discovery.md
@@ -1,0 +1,65 @@
+---
+id: TASK-12121
+title: Design standalone MCP docs Stage 4B bounded source discovery
+status: In Progress
+labels:
+- mcp
+- docs
+- design
+priority: high
+documentation:
+- Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-catalog-design.md
+- Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-url-acquisition-design.md
+- Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
+- Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
+modified_files:
+- Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
+- backlog/tasks/task-12121 - Design-standalone-MCP-docs-Stage-4B-bounded-source-discovery.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write the Stage 4B design/spec for bounded source discovery in the standalone MCP docs corpus. Scope: sitemap and tightly bounded same-origin page discovery that registers candidate URL sources and feeds approved pages into the existing docs.ingest_url/docs.sync_source flow. Keep scraping optional and lazy-loaded with beautifulsoup4/trafilatura, preserve locked-down profiles, avoid browser automation and broad crawling, and keep mcp_unified.docs independent from tldw_Server_API runtime imports.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Stage 4B design defines source discovery goals, non-goals, and explicit boundaries versus Stage 4A sync_source.
+- [ ] #2 Spec defines tool contracts for bounded sitemap/page discovery and how accepted candidates become docs sources or ingested documents.
+- [ ] #3 Spec preserves optional web scraping dependencies and locked-down deployment profiles where URL acquisition/discovery can be disabled.
+- [ ] #4 Spec defines source policy, same-origin, URL normalization, robots/sitemap, caps, redaction, dedupe, and SSRF/privacy constraints.
+- [ ] #5 Spec keeps standalone MCP independent from tldw_Server_API runtime imports and excludes embeddings/vector/reranking/Media-RAG bridges.
+- [ ] #6 Spec includes implementation/testing strategy with fake transport/resolver tests and no live internet.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect merged standalone MCP docs Stage 2 and Stage 4A specs/code paths.
+2. Create the Stage 4B bounded source discovery design spec.
+3. Self-review for source-sync gaps, optional dependency boundaries, locked-down profile behavior, and host import boundaries.
+4. Run documentation verification and hand the draft to the user for review before implementation planning.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12121 - Design-standalone-MCP-docs-Stage-4B-bounded-source-discovery.md
+++ b/backlog/tasks/task-12121 - Design-standalone-MCP-docs-Stage-4B-bounded-source-discovery.md
@@ -45,13 +45,12 @@ Write the Stage 4B design/spec for bounded source discovery in the standalone MC
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Design review follow-up completed before implementation planning. Issues found and addressed: clarified optional BeautifulSoup/trafilatura usage; tightened query-bearing candidate response redaction with safe_argument_hash; clarified sitemap registration versus sitemap_sync_enabled repeated refresh; required sitemap source default keywords/collections to flow into page ingestion while preserving user-added organization; added tests for optional BeautifulSoup fallback, query redaction, and metadata preservation.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12121 - Design-standalone-MCP-docs-Stage-4B-bounded-source-discovery.md
+++ b/backlog/tasks/task-12121 - Design-standalone-MCP-docs-Stage-4B-bounded-source-discovery.md
@@ -1,17 +1,21 @@
 ---
 id: TASK-12121
 title: Design standalone MCP docs Stage 4B bounded source discovery
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-07-03 19:26
 labels:
 - mcp
 - docs
 - design
-priority: high
+dependencies: []
 documentation:
 - Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-catalog-design.md
 - Docs/superpowers/specs/2026-06-30-standalone-mcp-docs-url-acquisition-design.md
 - Docs/superpowers/specs/2026-07-01-standalone-mcp-docs-stage4a-sync-source-design.md
 - Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
+priority: high
 modified_files:
 - Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
 - backlog/tasks/task-12121 - Design-standalone-MCP-docs-Stage-4B-bounded-source-discovery.md
@@ -25,12 +29,12 @@ Write the Stage 4B design/spec for bounded source discovery in the standalone MC
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Stage 4B design defines source discovery goals, non-goals, and explicit boundaries versus Stage 4A sync_source.
-- [ ] #2 Spec defines tool contracts for bounded sitemap/page discovery and how accepted candidates become docs sources or ingested documents.
-- [ ] #3 Spec preserves optional web scraping dependencies and locked-down deployment profiles where URL acquisition/discovery can be disabled.
-- [ ] #4 Spec defines source policy, same-origin, URL normalization, robots/sitemap, caps, redaction, dedupe, and SSRF/privacy constraints.
-- [ ] #5 Spec keeps standalone MCP independent from tldw_Server_API runtime imports and excludes embeddings/vector/reranking/Media-RAG bridges.
-- [ ] #6 Spec includes implementation/testing strategy with fake transport/resolver tests and no live internet.
+- [x] #1 Stage 4B design defines source discovery goals, non-goals, and explicit boundaries versus Stage 4A sync_source.
+- [x] #2 Spec defines tool contracts for bounded sitemap/page discovery and how accepted candidates become docs sources or ingested documents.
+- [x] #3 Spec preserves optional web scraping dependencies and locked-down deployment profiles where URL acquisition/discovery can be disabled.
+- [x] #4 Spec defines source policy, same-origin, URL normalization, robots/sitemap, caps, redaction, dedupe, and SSRF/privacy constraints.
+- [x] #5 Spec keeps standalone MCP independent from tldw_Server_API runtime imports and excludes embeddings/vector/reranking/Media-RAG bridges.
+- [x] #6 Spec includes implementation/testing strategy with fake transport/resolver tests and no live internet.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,21 +48,24 @@ Write the Stage 4B design/spec for bounded source discovery in the standalone MC
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Design review follow-up completed before implementation planning. Issues found and addressed: clarified optional BeautifulSoup/trafilatura usage; tightened query-bearing candidate response redaction with safe_argument_hash; clarified sitemap registration versus sitemap_sync_enabled repeated refresh; required sitemap source default keywords/collections to flow into page ingestion while preserving user-added organization; added tests for optional BeautifulSoup fallback, query redaction, and metadata preservation.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 4B bounded source discovery design is approved for implementation planning. The spec defines docs.discover_source, bounded sitemap/page-link discovery, url_sitemap refresh through docs.sync_source, optional BeautifulSoup/trafilatura behavior, locked-down profile gates, query redaction, source metadata propagation, fake transport/resolver tests, and standalone import-boundary constraints. Verification was documentation-focused: git diff --check passed, ASCII scan passed, and Backlog rendering passed. Bandit was skipped because this design task changed only documentation and Backlog metadata.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12122 - Plan-standalone-MCP-docs-Stage-4B-source-discovery-implementation.md
+++ b/backlog/tasks/task-12122 - Plan-standalone-MCP-docs-Stage-4B-source-discovery-implementation.md
@@ -1,0 +1,66 @@
+---
+id: TASK-12122
+title: Plan standalone MCP docs Stage 4B source discovery implementation
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-07-03 19:38
+labels:
+- mcp
+- docs
+- planning
+dependencies: []
+documentation:
+- Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
+- Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+priority: high
+modified_files:
+- Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+- backlog/tasks/task-12121 - Design-standalone-MCP-docs-Stage-4B-bounded-source-discovery.md
+- backlog/tasks/task-12122 - Plan-standalone-MCP-docs-Stage-4B-source-discovery-implementation.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the implementation plan for Stage 4B bounded source discovery in the standalone MCP docs corpus. The plan should translate the approved design into test-first, reviewable implementation slices for docs.discover_source, sitemap/page-link discovery, url_sitemap sync_source refresh, optional BeautifulSoup/trafilatura behavior, policy/redaction/security tests, and host shim exposure without tldw_Server_API runtime imports.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan is saved under Docs/superpowers/plans with the required superpowers plan header.
+- [x] #2 Plan decomposes Stage 4B into test-first tasks with exact files, commands, and expected outcomes.
+- [x] #3 Plan preserves standalone MCP import boundaries and optional web dependency behavior.
+- [x] #4 Plan includes tests for source discovery policy, redaction, sitemap parsing, page-link extraction, metadata propagation, sync_source url_sitemap refresh, and host shim exposure.
+- [x] #5 Plan records verification and docs-only Bandit skip rationale.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Saved the Stage 4B source discovery implementation plan to Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md. The plan breaks implementation into eight test-first slices: settings/models/status, parser helpers, dry-run service, apply modes, MCP provider wiring, url_sitemap sync refresh, host shim/config safety, and full verification closeout.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the Stage 4B implementation plan for standalone MCP docs source discovery. The plan covers bounded docs.discover_source support, sitemap and page-link discovery, optional BeautifulSoup/trafilatura behavior without required dependencies, source policy and redaction handling, apply/register/ingest modes, url_sitemap sync_source refresh, host shim exposure, and required verification. Docs-only verification performed for this planning task: git diff --check, ASCII scan, and placeholder scan. Bandit is documented as skipped for this docs-only planning change and required for the later Python implementation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12124 - Implement-standalone-MCP-docs-Stage-4B-source-discovery.md
+++ b/backlog/tasks/task-12124 - Implement-standalone-MCP-docs-Stage-4B-source-discovery.md
@@ -29,6 +29,8 @@ modified_files:
 - tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
 - tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
 - backlog/tasks/task-12124 - Implement-standalone-MCP-docs-Stage-4B-source-discovery.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2598
 ---
 
 ## Description
@@ -61,7 +63,7 @@ Implemented Stage 4B source discovery from the approved plan using test-first sl
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 4B standalone MCP docs source discovery is implemented and verified. docs.discover_source is disabled by default and only advertised when web acquisition and source discovery are enabled. It supports bounded sitemap and page-link discovery with dry-run, register, ingest, and register_and_ingest flows. Registered url_sitemap sources refresh through docs.sync_source with dry-run/apply/stale handling. Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs -q -> 295 passed, 4 warnings; Bandit on apps/mcp-unified/src/mcp_unified/docs and tldw_Server_API/tests/MCP_unified/docs -> 0 findings; import-boundary test -> 6 passed; git diff --check -> clean.
+Stage 4B standalone MCP docs source discovery is implemented and verified. docs.discover_source is disabled by default and only advertised when web acquisition and source discovery are enabled. It supports bounded sitemap and page-link discovery with dry-run, register, ingest, and register_and_ingest flows. Registered url_sitemap sources refresh through docs.sync_source with dry-run/apply/stale handling. PR: https://github.com/rmusser01/tldw_server/pull/2598. Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs -q -> 295 passed, 4 warnings; Bandit on apps/mcp-unified/src/mcp_unified/docs and tldw_Server_API/tests/MCP_unified/docs -> 0 findings; import-boundary test -> 6 passed; git diff --check -> clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12124 - Implement-standalone-MCP-docs-Stage-4B-source-discovery.md
+++ b/backlog/tasks/task-12124 - Implement-standalone-MCP-docs-Stage-4B-source-discovery.md
@@ -1,0 +1,56 @@
+---
+id: TASK-12124
+title: Implement standalone MCP docs Stage 4B source discovery
+status: In Progress
+labels:
+- mcp
+- docs
+- implementation
+priority: high
+documentation:
+- Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
+- Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Stage 4B bounded source discovery for the standalone MCP docs corpus from the approved plan. Scope includes discovery settings/models/status, docs.discover_source, sitemap and page-link parsing, dry-run and apply modes, optional BeautifulSoup/trafilatura behavior without required dependencies, url_sitemap sync refresh, host shim exposure, policy/redaction/security tests, Bandit, and Backlog closeout.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Discovery settings, models, status surface, and provider advertisement follow the approved plan.
+- [ ] #2 docs.discover_source supports bounded sitemap/page-link dry-run and apply flows with policy, redaction, dedupe, and metadata propagation tests.
+- [ ] #3 Registered url_sitemap sources can refresh through docs.sync_source with dry-run/apply/stale handling tests.
+- [ ] #4 Standalone MCP import boundaries and optional dependency behavior remain covered by tests.
+- [ ] #5 Focused MCP docs tests, import-boundary tests, Bandit, diff hygiene, and Backlog closeout are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md inline using TDD. Commit after each task slice where tests are green.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12124 - Implement-standalone-MCP-docs-Stage-4B-source-discovery.md
+++ b/backlog/tasks/task-12124 - Implement-standalone-MCP-docs-Stage-4B-source-discovery.md
@@ -1,15 +1,34 @@
 ---
 id: TASK-12124
 title: Implement standalone MCP docs Stage 4B source discovery
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-07-03 23:26
 labels:
 - mcp
 - docs
 - implementation
-priority: high
+dependencies: []
 documentation:
 - Docs/superpowers/specs/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-design.md
 - Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+priority: high
+modified_files:
+- Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+- apps/mcp-unified/src/mcp_unified/docs/__init__.py
+- apps/mcp-unified/src/mcp_unified/docs/discovery.py
+- apps/mcp-unified/src/mcp_unified/docs/mcp_module.py
+- apps/mcp-unified/src/mcp_unified/docs/models.py
+- apps/mcp-unified/src/mcp_unified/docs/settings.py
+- apps/mcp-unified/src/mcp_unified/docs/sync.py
+- tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py
+- tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
+- tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py
+- tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py
+- tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
+- tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+- backlog/tasks/task-12124 - Implement-standalone-MCP-docs-Stage-4B-source-discovery.md
 ---
 
 ## Description
@@ -20,11 +39,11 @@ Implement Stage 4B bounded source discovery for the standalone MCP docs corpus f
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Discovery settings, models, status surface, and provider advertisement follow the approved plan.
-- [ ] #2 docs.discover_source supports bounded sitemap/page-link dry-run and apply flows with policy, redaction, dedupe, and metadata propagation tests.
-- [ ] #3 Registered url_sitemap sources can refresh through docs.sync_source with dry-run/apply/stale handling tests.
-- [ ] #4 Standalone MCP import boundaries and optional dependency behavior remain covered by tests.
-- [ ] #5 Focused MCP docs tests, import-boundary tests, Bandit, diff hygiene, and Backlog closeout are recorded.
+- [x] #1 Discovery settings, models, status surface, and provider advertisement follow the approved plan.
+- [x] #2 docs.discover_source supports bounded sitemap/page-link dry-run and apply flows with policy, redaction, dedupe, and metadata propagation tests.
+- [x] #3 Registered url_sitemap sources can refresh through docs.sync_source with dry-run/apply/stale handling tests.
+- [x] #4 Standalone MCP import boundaries and optional dependency behavior remain covered by tests.
+- [x] #5 Focused MCP docs tests, import-boundary tests, Bandit, diff hygiene, and Backlog closeout are recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -35,22 +54,22 @@ Execute Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-dis
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Stage 4B source discovery from the approved plan using test-first slices. Added safe discovery settings/status, DiscoverSourceRequest models, lazy optional page-link extraction with stdlib fallback, bounded sitemap/page-link discovery, dry-run and apply modes, url_sitemap registration and sync refresh, provider/host shim exposure, same-origin and prefix filtering, query redaction, metadata propagation, and import-boundary coverage. Bandit initially flagged stdlib ElementTree sitemap parsing; the parser now uses defusedxml.ElementTree, which is already a project dependency.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Stage 4B standalone MCP docs source discovery is implemented and verified. docs.discover_source is disabled by default and only advertised when web acquisition and source discovery are enabled. It supports bounded sitemap and page-link discovery with dry-run, register, ingest, and register_and_ingest flows. Registered url_sitemap sources refresh through docs.sync_source with dry-run/apply/stale handling. Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs -q -> 295 passed, 4 warnings; Bandit on apps/mcp-unified/src/mcp_unified/docs and tldw_Server_API/tests/MCP_unified/docs -> 0 findings; import-boundary test -> 6 passed; git diff --check -> clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12141 - Address-PR-2598-review-feedback.md
+++ b/backlog/tasks/task-12141 - Address-PR-2598-review-feedback.md
@@ -1,0 +1,66 @@
+---
+id: TASK-12141
+title: Address PR 2598 review feedback
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-07-04 17:57'
+labels:
+  - mcp
+  - docs
+  - review
+dependencies: []
+documentation:
+  - 'https://github.com/rmusser01/tldw_server/pull/2598'
+  - >-
+    Docs/superpowers/plans/2026-07-03-standalone-mcp-docs-stage4b-source-discovery-implementation-plan.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR 2598 on latest dev and address actionable review feedback for standalone MCP docs source discovery. Scope is limited to review items on sitemap/XML robustness, URL origin handling, source registration lifecycle, sync item reason reporting, small docstring/type/style comments, tests, Bandit, and PR push.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 PR branch is rebased on latest origin/dev and pushed.
+- [ ] #2 Actionable PR review issues are fixed in code/tests or explicitly documented as not applicable.
+- [ ] #3 Focused tests cover XML parse failure propagation, default-port origin equivalence, query sitemap registration denial, and sync skipped reason propagation.
+- [ ] #4 MCP docs tests, import-boundary tests, Bandit, and diff hygiene pass.
+- [ ] #5 Backlog task records final verification and PR status.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Use the existing PR branch. Rebase on origin/dev, inspect review threads, implement the smallest root-cause fixes with focused tests, run MCP docs tests plus Bandit, update this Backlog task, and force-push the rebased PR branch.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Bandit run for touched code when applicable or documented skip
+- [ ] #4 Final summary added
+- [ ] #5 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12141 - Address-PR-2598-review-feedback.md
+++ b/backlog/tasks/task-12141 - Address-PR-2598-review-feedback.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12141
 title: Address PR 2598 review feedback
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
 updated_date: '2026-07-04 17:57'
@@ -25,11 +25,11 @@ Rebase PR 2598 on latest dev and address actionable review feedback for standalo
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 PR branch is rebased on latest origin/dev and pushed.
-- [ ] #2 Actionable PR review issues are fixed in code/tests or explicitly documented as not applicable.
-- [ ] #3 Focused tests cover XML parse failure propagation, default-port origin equivalence, query sitemap registration denial, and sync skipped reason propagation.
-- [ ] #4 MCP docs tests, import-boundary tests, Bandit, and diff hygiene pass.
-- [ ] #5 Backlog task records final verification and PR status.
+- [x] #1 PR branch is rebased on latest origin/dev and pushed.
+- [x] #2 Actionable PR review issues are fixed in code/tests or explicitly documented as not applicable.
+- [x] #3 Focused tests cover XML parse failure propagation, default-port origin equivalence, query sitemap registration denial, and sync skipped reason propagation.
+- [x] #4 MCP docs tests, import-boundary tests, Bandit, and diff hygiene pass.
+- [x] #5 Backlog task records final verification and PR status.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -41,26 +41,20 @@ Use the existing PR branch. Rebase on origin/dev, inspect review threads, implem
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Rebased PR branch on origin/dev, inspected GitHub review threads, and fixed the actionable review items in the shared docs discovery/sync paths. Implemented controlled defusedxml exception handling, propagated sitemap parse failures from docs.discover_source, normalized default ports in same-origin checks, denied register/register_and_ingest for query-bearing sitemap seeds when query persistence is disabled, preserved skipped sitemap candidate reason codes, added safe missing-document hash handling, made include_seed functional for page-link discovery, reported the one-hop depth cap, and added small docstring/type/style fixes. Did not add docstrings to every pytest function because that is inconsistent with the existing test style and adds no safety.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-<!-- SECTION:FINAL_SUMMARY:END -->
-
+PR 2598 review feedback addressed and branch rebased on latest origin/dev. Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs -q -> 302 passed, 4 warnings; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py -q --tb=short -> 6 passed, 3 warnings; Bandit on apps/mcp-unified/src/mcp_unified/docs and tldw_Server_API/tests/MCP_unified/docs -> 0 findings; git diff --check -> clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Bandit run for touched code when applicable or documented skip
-- [ ] #4 Final summary added
-- [ ] #5 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Bandit run for touched code when applicable or documented skip
+- [x] #4 Final summary added
+- [x] #5 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
@@ -8,7 +8,7 @@ import pytest
 from mcp_unified.docs.acquisition.models import FetchResponse
 from mcp_unified.docs.acquisition.service import DocsAcquisitionService
 from mcp_unified.docs.mcp_module import DocsMCPToolProvider
-from mcp_unified.docs.models import AccessScope
+from mcp_unified.docs.models import AccessScope, DiscoverSourceRequest
 from mcp_unified.docs.settings import DocsSettings
 from mcp_unified.docs.store.sqlite import DocsCatalogStore
 from tldw_Server_API.tests.MCP_unified.docs.helpers import FakeResolver, FakeTransport
@@ -115,6 +115,96 @@ def test_provider_advertises_ingest_url_when_enabled(tmp_path: Path) -> None:
     assert "docs.ingest_url" in tools  # nosec B101
     assert tools["docs.ingest_url"]["metadata"]["category"] == "ingestion"  # nosec B101
     assert tools["docs.ingest_url"]["metadata"]["readOnlyHint"] is False  # nosec B101
+
+
+def test_provider_advertises_discover_source_when_enabled(tmp_path: Path) -> None:
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "enable_source_discovery": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": ("https://example.com/docs/",),
+        }
+    )
+    provider = DocsMCPToolProvider(settings=settings)
+
+    tools = {tool["name"]: tool for tool in provider.tool_definitions()}
+
+    assert "docs.discover_source" in tools  # nosec B101
+    assert tools["docs.discover_source"]["metadata"]["category"] == "ingestion"  # nosec B101
+    assert tools["docs.discover_source"]["metadata"]["readOnlyHint"] is False  # nosec B101
+
+
+def test_provider_omits_discover_source_when_disabled(tmp_path: Path) -> None:
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"))
+
+    names = {tool["name"] for tool in provider.tool_definitions()}
+
+    assert "docs.discover_source" not in names  # nosec B101
+
+
+def test_provider_stale_discover_source_call_is_disabled(tmp_path: Path) -> None:
+    provider = DocsMCPToolProvider(settings=DocsSettings(db_path=tmp_path / "docs.db"))
+
+    result = provider.execute("docs.discover_source", {"url": "https://example.com/sitemap.xml"}, scope=AccessScope())
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "source_discovery_disabled"  # nosec B101
+
+
+def test_provider_discover_source_delegates_to_discovery_service(tmp_path: Path) -> None:
+    class FakeDiscovery:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def discover_source(self, **kwargs):
+            self.calls.append(kwargs)
+            return {"status": "completed", "reason_code": "ok"}
+
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "enable_source_discovery": True,
+        }
+    )
+    provider = DocsMCPToolProvider(settings=settings)
+    discovery = FakeDiscovery()
+    provider.discovery = discovery
+    scope = AccessScope(owner_scope="owner-a", profile_scope="profile-a")
+
+    result = provider.execute(
+        "docs.discover_source",
+        {
+            "url": "https://example.com/sitemap.xml",
+            "kind": "sitemap",
+            "mode": "apply",
+            "apply_action": "register_and_ingest",
+            "max_pages": "3",
+            "max_depth": 1,
+            "collections": ["Reference"],
+            "keywords": ["docs"],
+            "title": "Example sitemap",
+            "include_seed": True,
+        },
+        scope=scope,
+    )
+
+    assert result["status"] == "completed"  # nosec B101
+    assert discovery.calls[0]["scope"] == scope  # nosec B101
+    request = discovery.calls[0]["request"]
+    assert isinstance(request, DiscoverSourceRequest)  # nosec B101
+    assert request.url == "https://example.com/sitemap.xml"  # nosec B101
+    assert request.kind == "sitemap"  # nosec B101
+    assert request.mode == "apply"  # nosec B101
+    assert request.apply_action == "register_and_ingest"  # nosec B101
+    assert request.max_pages == 3  # nosec B101
+    assert request.max_depth == 1  # nosec B101
+    assert request.collections == ("Reference",)  # nosec B101
+    assert request.keywords == ("docs",)  # nosec B101
+    assert request.title == "Example sitemap"  # nosec B101
+    assert request.include_seed is True  # nosec B101
 
 
 def test_provider_ingest_url_delegates_to_acquisition_service(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_mcp_provider.py
@@ -294,6 +294,29 @@ def test_provider_status_reports_web_acquisition_disabled(tmp_path: Path) -> Non
     assert status["source_sync"]["default_stale_policy"] == "report"  # nosec B101
     assert status["source_sync"]["max_sync_documents"] == 500  # nosec B101
     assert status["source_sync"]["sitemap_sync_enabled"] is False  # nosec B101
+    assert status["source_discovery"]["enabled"] is False  # nosec B101
+    assert status["source_discovery"]["available"] is False  # nosec B101
+    assert status["source_discovery"]["disabled_reason"] == "source_discovery_disabled"  # nosec B101
+    assert status["source_discovery"]["supported_kinds"] == ["sitemap", "page_links"]  # nosec B101
+
+
+def test_provider_status_reports_source_discovery_when_enabled(tmp_path: Path) -> None:
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "enable_source_discovery": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": ("https://example.com/docs/",),
+        }
+    )
+    provider = DocsMCPToolProvider(settings=settings)
+
+    status = provider.execute("docs.status", {}, scope=AccessScope())
+
+    assert status["source_discovery"]["enabled"] is True  # nosec B101
+    assert status["source_discovery"]["available"] is True  # nosec B101
+    assert status["source_discovery"]["max_discovery_pages"] == 25  # nosec B101
 
 
 def test_provider_status_reports_custom_web_policy(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_module_shim.py
@@ -52,6 +52,28 @@ async def test_docs_module_exposes_sync_source_without_media_or_rag(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_docs_module_exposes_discover_source_when_enabled(tmp_path: Path) -> None:
+    module = DocsModule(
+        ModuleConfig(
+            name="docs",
+            settings={
+                "db_path": str(tmp_path / "docs.db"),
+                "enable_web_acquisition": True,
+                "enable_source_discovery": True,
+                "web_source_profile": "locked_down",
+                "allowed_url_prefixes": ["https://example.com/docs/"],
+            },
+        )
+    )
+    await module.on_initialize()
+
+    tools = {tool["name"]: tool for tool in await module.get_tools()}
+
+    assert "docs.discover_source" in tools  # nosec B101
+    assert tools["docs.discover_source"]["metadata"]["category"] == "ingestion"  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_docs_module_executes_with_context_scope(tmp_path: Path) -> None:
     doc_path = tmp_path / "guide.md"
     doc_path.write_text("# Guide\n\nSQLite local docs.\n", encoding="utf-8")
@@ -160,6 +182,7 @@ def test_repo_docs_mcp_config_keeps_web_acquisition_disabled() -> None:
     assert len(docs_modules) == 1  # nosec B101
     settings = docs_modules[0]["settings"]
     assert settings["enable_web_acquisition"] is False  # nosec B101
+    assert settings.get("enable_source_discovery", False) is False  # nosec B101
     assert settings["web_source_profile"] == "locked_down"  # nosec B101
     assert settings["allow_arbitrary_public_domains"] is False  # nosec B101
     assert settings["preapproved_domains"] == []  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_settings.py
@@ -63,6 +63,17 @@ def test_from_mapping_uses_safe_source_sync_defaults() -> None:
     assert settings.persist_url_query_strings is False  # nosec B101
 
 
+def test_from_mapping_uses_safe_source_discovery_defaults() -> None:
+    settings = DocsSettings.from_mapping({})
+
+    assert settings.enable_source_discovery is False  # nosec B101
+    assert settings.max_discovery_pages == 25  # nosec B101
+    assert settings.max_discovery_depth == 1  # nosec B101
+    assert settings.max_discovery_sitemaps == 3  # nosec B101
+    assert settings.discovery_apply_default == "register"  # nosec B101
+    assert settings.discovery_same_origin_only is True  # nosec B101
+
+
 def test_from_mapping_parses_url_acquisition_values() -> None:
     settings = DocsSettings.from_mapping(
         {
@@ -116,6 +127,26 @@ def test_from_mapping_parses_source_sync_values() -> None:
     assert settings.persist_url_query_strings is True  # nosec B101
 
 
+def test_from_mapping_parses_source_discovery_values() -> None:
+    settings = DocsSettings.from_mapping(
+        {
+            "enable_source_discovery": "true",
+            "max_discovery_pages": "7",
+            "max_discovery_depth": "1",
+            "max_discovery_sitemaps": "2",
+            "discovery_apply_default": "register_and_ingest",
+            "discovery_same_origin_only": "false",
+        }
+    )
+
+    assert settings.enable_source_discovery is True  # nosec B101
+    assert settings.max_discovery_pages == 7  # nosec B101
+    assert settings.max_discovery_depth == 1  # nosec B101
+    assert settings.max_discovery_sitemaps == 2  # nosec B101
+    assert settings.discovery_apply_default == "register_and_ingest"  # nosec B101
+    assert settings.discovery_same_origin_only is False  # nosec B101
+
+
 def test_from_mapping_parses_default_scope() -> None:
     settings = DocsSettings.from_mapping({"default_scope": {"owner_scope": "owner-a", "profile_scope": "profile-a"}})
 
@@ -132,6 +163,12 @@ def test_from_mapping_rejects_unknown_web_source_profile(profile: str) -> None:
 def test_from_mapping_rejects_unknown_default_stale_policy(value: str) -> None:
     with pytest.raises(ValueError, match="default_stale_policy"):
         DocsSettings.from_mapping({"default_stale_policy": value})
+
+
+@pytest.mark.parametrize("value", ["", "crawl", "register+ingest"])
+def test_from_mapping_rejects_unknown_discovery_apply_default(value: str) -> None:
+    with pytest.raises(ValueError, match="discovery_apply_default"):
+        DocsSettings.from_mapping({"discovery_apply_default": value})
 
 
 @pytest.mark.parametrize("field", ["max_url_redirects", "max_url_body_bytes"])

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
@@ -214,3 +214,121 @@ def test_discover_sitemap_filters_scope_duplicates_and_query_leaks(tmp_path: Pat
     assert result["candidates"][0]["url"] == "https://example.com/docs/a"  # nosec B101
     assert "token=secret" not in serialized  # nosec B101
     assert "?token" not in serialized  # nosec B101
+
+
+def test_discover_sitemap_same_origin_setting_is_strict(tmp_path: Path) -> None:
+    body = b"<urlset><url><loc>https://docs.example.net/guide</loc></url></urlset>"
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    settings = _settings(
+        tmp_path,
+        allowed_url_prefixes=(
+            "https://example.com/sitemap.xml",
+            "https://example.com/docs/",
+            "https://docs.example.net/",
+        ),
+    )
+    strict_service = DocsSourceDiscoveryService(
+        settings=settings,
+        store=_store(tmp_path),
+        resolver=resolver,
+        transport=FakeTransport([FetchResponse(status_code=200, headers={"content-type": "application/xml"}, body_chunks=[body])]),
+    )
+
+    strict_result = strict_service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(url="https://example.com/sitemap.xml", kind="sitemap"),
+    )
+
+    assert strict_result["counts"]["denied"] == 1  # nosec B101
+    assert strict_result["candidates"][0]["reason_code"] == "candidate_out_of_scope"  # nosec B101
+
+    loose_service = DocsSourceDiscoveryService(
+        settings=DocsSettings.from_mapping({**settings.__dict__, "discovery_same_origin_only": False}),
+        store=_store(tmp_path),
+        resolver=resolver,
+        transport=FakeTransport([FetchResponse(status_code=200, headers={"content-type": "application/xml"}, body_chunks=[body])]),
+    )
+
+    loose_result = loose_service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(url="https://example.com/sitemap.xml", kind="sitemap"),
+    )
+
+    assert loose_result["counts"]["accepted"] == 1  # nosec B101
+
+
+def test_discover_sitemap_apply_register_creates_source_without_documents(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "application/xml"},
+                body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"],
+            )
+        ]
+    )
+    service = DocsSourceDiscoveryService(settings=_settings(tmp_path), store=store, resolver=resolver, transport=transport)
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(
+            url="https://example.com/sitemap.xml",
+            kind="sitemap",
+            mode="apply",
+            apply_action="register",
+            collections=("Reference",),
+            keywords=("docs",),
+            title="Example docs sitemap",
+        ),
+    )
+
+    assert result["status"] == "completed"  # nosec B101
+    assert result["source"]["source_type"] == "url_sitemap"  # nosec B101
+    assert "sitemap_sync_disabled" in result["warnings"]  # nosec B101
+    assert store.status()["counts"]["documents"] == 0  # nosec B101
+    sources = store.list_sources(scope=AccessScope())
+    assert sources[0]["metadata"]["default_collections"] == ["Reference"]  # nosec B101
+    assert sources[0]["metadata"]["default_keywords"] == ["docs"]  # nosec B101
+
+
+def test_discover_sitemap_apply_ingests_candidates_and_links_sitemap_source(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "application/xml"},
+                body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"],
+            ),
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "text/plain"},
+                body_chunks=[b"alpha reference body"],
+            ),
+        ]
+    )
+    settings = _settings(tmp_path, sitemap_sync_enabled=True)
+    service = DocsSourceDiscoveryService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(
+            url="https://example.com/sitemap.xml",
+            kind="sitemap",
+            mode="apply",
+            apply_action="register_and_ingest",
+            collections=("Reference",),
+            keywords=("docs",),
+        ),
+    )
+
+    assert result["counts"]["ingested"] == 1  # nosec B101
+    assert result["candidates"][0]["document_id"]  # nosec B101
+    assert store.search_chunks(scope=AccessScope(), query="alpha", limit=10)  # nosec B101
+    assert [item["name"] for item in store.list_collections(scope=AccessScope())] == ["Reference"]  # nosec B101
+    assert [item["keyword"] for item in store.list_keywords(scope=AccessScope())] == ["docs"]  # nosec B101
+    links = store.source_document_links(scope=AccessScope(), source_id=result["source"]["id"])
+    assert links[0]["source_item_uri"] == "https://example.com/docs/a"  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
@@ -1,9 +1,12 @@
+"""Tests for bounded standalone MCP docs source discovery."""
+
 from __future__ import annotations
 
 import importlib
 import json
 from pathlib import Path
 
+from defusedxml.common import DefusedXmlException
 import pytest
 
 from mcp_unified.docs.acquisition.models import FetchResponse
@@ -54,7 +57,7 @@ def test_extract_page_links_prefers_beautifulsoup_when_available(monkeypatch: py
     seen: list[str] = []
     original_import = importlib.import_module
 
-    def fake_import(name: str, package: str | None = None):
+    def fake_import(name: str, package: str | None = None) -> object:
         if name == "bs4":
             seen.append(name)
         return original_import(name, package)
@@ -86,6 +89,19 @@ def test_public_candidate_redacts_query_bearing_url() -> None:
     assert "token=secret" not in serialized  # nosec B101
     assert "https://example.com/page" in serialized  # nosec B101
     assert "hash" in serialized  # nosec B101
+
+
+def test_parse_sitemap_urlset_handles_defusedxml_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_parse(_: bytes) -> object:
+        raise DefusedXmlException("blocked")
+
+    monkeypatch.setattr("mcp_unified.docs.discovery.ElementTree.fromstring", fail_parse)
+
+    result = parse_sitemap_urlset(b"<urlset />", max_pages=10)
+
+    assert result.status == "denied"  # nosec B101
+    assert result.reason_code == "sitemap_parse_failed"  # nosec B101
+    assert result.candidates == []  # nosec B101
 
 
 def _store(tmp_path: Path) -> DocsCatalogStore:
@@ -160,6 +176,26 @@ def test_discover_sitemap_dry_run_returns_candidates_without_mutation(tmp_path: 
     assert store.list_sources(scope=AccessScope()) == []  # nosec B101
 
 
+def test_discover_sitemap_parse_failure_propagates_status(tmp_path: Path) -> None:
+    service = DocsSourceDiscoveryService(
+        settings=_settings(tmp_path),
+        store=_store(tmp_path),
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [FetchResponse(status_code=200, headers={"content-type": "application/xml"}, body_chunks=[b"<urlset>"])]
+        ),
+    )
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(url="https://example.com/sitemap.xml", kind="sitemap"),
+    )
+
+    assert result["status"] == "failed"  # nosec B101
+    assert result["reason_code"] == "sitemap_parse_failed"  # nosec B101
+    assert result["candidates"] == []  # nosec B101
+
+
 def test_discover_source_approval_required_does_not_resolve_or_fetch(tmp_path: Path) -> None:
     settings = _settings(
         tmp_path,
@@ -216,6 +252,35 @@ def test_discover_sitemap_filters_scope_duplicates_and_query_leaks(tmp_path: Pat
     assert "?token" not in serialized  # nosec B101
 
 
+def test_discover_sitemap_treats_default_https_port_as_same_origin(tmp_path: Path) -> None:
+    settings = _settings(
+        tmp_path,
+        allowed_url_prefixes=("https://example.com/sitemap.xml", "https://example.com:443/docs/"),
+    )
+    service = DocsSourceDiscoveryService(
+        settings=settings,
+        store=_store(tmp_path),
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [
+                FetchResponse(
+                    status_code=200,
+                    headers={"content-type": "application/xml"},
+                    body_chunks=[b"<urlset><url><loc>https://example.com:443/docs/a</loc></url></urlset>"],
+                )
+            ]
+        ),
+    )
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(url="https://example.com/sitemap.xml", kind="sitemap"),
+    )
+
+    assert result["counts"]["accepted"] == 1  # nosec B101
+    assert result["candidates"][0]["reason_code"] == "ok"  # nosec B101
+
+
 def test_discover_sitemap_same_origin_setting_is_strict(tmp_path: Path) -> None:
     body = b"<urlset><url><loc>https://docs.example.net/guide</loc></url></urlset>"
     resolver = FakeResolver({"example.com": ["93.184.216.34"]})
@@ -255,6 +320,94 @@ def test_discover_sitemap_same_origin_setting_is_strict(tmp_path: Path) -> None:
     )
 
     assert loose_result["counts"]["accepted"] == 1  # nosec B101
+
+
+def test_discover_sitemap_register_denies_query_seed_when_queries_not_persisted(tmp_path: Path) -> None:
+    transport = FakeTransport([FetchResponse(status_code=200, headers={"content-type": "application/xml"})])
+    service = DocsSourceDiscoveryService(
+        settings=_settings(
+            tmp_path,
+            allowed_url_prefixes=("https://example.com/sitemap.xml?token=secret",),
+            persist_url_query_strings=False,
+        ),
+        store=_store(tmp_path),
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=transport,
+    )
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(
+            url="https://example.com/sitemap.xml?token=secret",
+            kind="sitemap",
+            mode="apply",
+            apply_action="register",
+        ),
+    )
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "candidate_query_not_persisted"  # nosec B101
+    assert transport.calls == []  # nosec B101
+
+
+def test_discover_page_links_include_seed_when_requested(tmp_path: Path) -> None:
+    service = DocsSourceDiscoveryService(
+        settings=_settings(tmp_path, allowed_url_prefixes=("https://example.com/docs/",)),
+        store=_store(tmp_path),
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [
+                FetchResponse(
+                    status_code=200,
+                    headers={"content-type": "text/html"},
+                    body_chunks=[b'<a href="/docs/a">A</a>'],
+                )
+            ]
+        ),
+    )
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(
+            url="https://example.com/docs/index.html",
+            kind="page_links",
+            include_seed=True,
+        ),
+    )
+
+    assert [item["url"] for item in result["candidates"]] == [  # nosec B101
+        "https://example.com/docs/index.html",
+        "https://example.com/docs/a",
+    ]
+
+
+def test_discover_source_allows_depth_below_configured_cap(tmp_path: Path) -> None:
+    service = DocsSourceDiscoveryService(
+        settings=_settings(tmp_path, max_discovery_depth=2),
+        store=_store(tmp_path),
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [
+                FetchResponse(
+                    status_code=200,
+                    headers={"content-type": "application/xml"},
+                    body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"],
+                )
+            ]
+        ),
+    )
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(
+            url="https://example.com/sitemap.xml",
+            kind="sitemap",
+            max_depth=1,
+        ),
+    )
+
+    assert result["status"] == "completed"  # nosec B101
+    assert result["counts"]["accepted"] == 1  # nosec B101
 
 
 def test_discover_sitemap_apply_register_creates_source_without_documents(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
@@ -2,15 +2,22 @@ from __future__ import annotations
 
 import importlib
 import json
+from pathlib import Path
 
 import pytest
 
+from mcp_unified.docs.acquisition.models import FetchResponse
 from mcp_unified.docs.discovery import (
     DiscoveredURLCandidate,
+    DocsSourceDiscoveryService,
     extract_page_links,
     parse_sitemap_urlset,
     public_candidate,
 )
+from mcp_unified.docs.models import AccessScope, DiscoverSourceRequest
+from mcp_unified.docs.settings import DocsSettings
+from mcp_unified.docs.store.sqlite import DocsCatalogStore
+from tldw_Server_API.tests.MCP_unified.docs.helpers import FakeResolver, FakeTransport
 
 pytestmark = pytest.mark.unit
 
@@ -79,3 +86,131 @@ def test_public_candidate_redacts_query_bearing_url() -> None:
     assert "token=secret" not in serialized  # nosec B101
     assert "https://example.com/page" in serialized  # nosec B101
     assert "hash" in serialized  # nosec B101
+
+
+def _store(tmp_path: Path) -> DocsCatalogStore:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    return store
+
+
+def _settings(tmp_path: Path, **overrides: object) -> DocsSettings:
+    values: dict[str, object] = {
+        "db_path": str(tmp_path / "docs.db"),
+        "enable_web_acquisition": True,
+        "enable_source_discovery": True,
+        "web_source_profile": "locked_down",
+        "allowed_url_prefixes": ("https://example.com/docs/", "https://example.com/sitemap.xml"),
+    }
+    values.update(overrides)
+    return DocsSettings.from_mapping(values)
+
+
+def test_discover_source_disabled_returns_without_fetch(tmp_path: Path) -> None:
+    settings = _settings(tmp_path, enable_source_discovery=False)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport([FetchResponse(status_code=200, headers={"content-type": "text/xml"}, body_chunks=[b"never"])])
+    service = DocsSourceDiscoveryService(settings=settings, store=_store(tmp_path), resolver=resolver, transport=transport)
+
+    result = service.discover_source(scope=AccessScope(), request=DiscoverSourceRequest(url="https://example.com/sitemap.xml"))
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "source_discovery_disabled"  # nosec B101
+    assert resolver.calls == []  # nosec B101
+    assert transport.calls == []  # nosec B101
+
+
+def test_discover_source_requires_web_acquisition_without_fetch(tmp_path: Path) -> None:
+    settings = _settings(tmp_path, enable_web_acquisition=False)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport([FetchResponse(status_code=200, headers={"content-type": "text/xml"}, body_chunks=[b"never"])])
+    service = DocsSourceDiscoveryService(settings=settings, store=_store(tmp_path), resolver=resolver, transport=transport)
+
+    result = service.discover_source(scope=AccessScope(), request=DiscoverSourceRequest(url="https://example.com/sitemap.xml"))
+
+    assert result["status"] == "denied"  # nosec B101
+    assert result["reason_code"] == "web_acquisition_disabled"  # nosec B101
+    assert resolver.calls == []  # nosec B101
+    assert transport.calls == []  # nosec B101
+
+
+def test_discover_sitemap_dry_run_returns_candidates_without_mutation(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "application/xml"},
+                body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"],
+            )
+        ]
+    )
+    service = DocsSourceDiscoveryService(settings=_settings(tmp_path), store=store, resolver=resolver, transport=transport)
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(url="https://example.com/sitemap.xml", kind="sitemap"),
+    )
+
+    assert result["status"] == "completed"  # nosec B101
+    assert result["counts"]["accepted"] == 1  # nosec B101
+    assert result["candidates"][0]["url"] == "https://example.com/docs/a"  # nosec B101
+    assert store.status()["counts"]["documents"] == 0  # nosec B101
+    assert store.list_sources(scope=AccessScope()) == []  # nosec B101
+
+
+def test_discover_source_approval_required_does_not_resolve_or_fetch(tmp_path: Path) -> None:
+    settings = _settings(
+        tmp_path,
+        web_source_profile="local_first",
+        allowed_url_prefixes=(),
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport([FetchResponse(status_code=200, headers={"content-type": "application/xml"}, body_chunks=[b"never"])])
+    service = DocsSourceDiscoveryService(settings=settings, store=_store(tmp_path), resolver=resolver, transport=transport)
+
+    result = service.discover_source(scope=AccessScope(), request=DiscoverSourceRequest(url="https://example.com/sitemap.xml"))
+
+    assert result["status"] == "approval_required"  # nosec B101
+    assert result["reason_code"] == "source_approval_required"  # nosec B101
+    assert resolver.calls == []  # nosec B101
+    assert transport.calls == []  # nosec B101
+
+
+def test_discover_sitemap_filters_scope_duplicates_and_query_leaks(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "application/xml"},
+                body_chunks=[
+                    b"""
+                    <urlset>
+                      <url><loc>https://example.com/docs/a</loc></url>
+                      <url><loc>https://example.com/docs/a#fragment</loc></url>
+                      <url><loc>https://evil.example/docs/a</loc></url>
+                      <url><loc>https://example.com/docs/b?token=secret</loc></url>
+                    </urlset>
+                    """
+                ],
+            )
+        ]
+    )
+    service = DocsSourceDiscoveryService(settings=_settings(tmp_path), store=store, resolver=resolver, transport=transport)
+
+    result = service.discover_source(
+        scope=AccessScope(),
+        request=DiscoverSourceRequest(url="https://example.com/sitemap.xml", kind="sitemap"),
+    )
+    serialized = json.dumps(result, sort_keys=True)
+
+    assert result["counts"]["accepted"] == 1  # nosec B101
+    assert result["counts"]["duplicates"] == 1  # nosec B101
+    assert result["counts"]["denied"] == 1  # nosec B101
+    assert result["counts"]["skipped"] == 1  # nosec B101
+    assert result["candidates"][0]["url"] == "https://example.com/docs/a"  # nosec B101
+    assert "token=secret" not in serialized  # nosec B101
+    assert "?token" not in serialized  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_discovery.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+from mcp_unified.docs.discovery import (
+    DiscoveredURLCandidate,
+    extract_page_links,
+    parse_sitemap_urlset,
+    public_candidate,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_parse_sitemap_urlset_rejects_doctype() -> None:
+    body = b'<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><urlset />'
+
+    result = parse_sitemap_urlset(body, max_pages=10)
+
+    assert result.reason_code == "sitemap_xml_forbidden_doctype"  # nosec B101
+    assert result.candidates == []  # nosec B101
+
+
+def test_parse_sitemap_urlset_enforces_page_limit_before_candidates() -> None:
+    body = b"""
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://example.com/a</loc></url>
+      <url><loc>https://example.com/b</loc></url>
+      <url><loc>https://example.com/c</loc></url>
+    </urlset>
+    """
+
+    result = parse_sitemap_urlset(body, max_pages=2)
+
+    assert result.reason_code == "ok"  # nosec B101
+    assert [item.url for item in result.candidates] == [  # nosec B101
+        "https://example.com/a",
+        "https://example.com/b",
+    ]
+    assert result.skipped == 1  # nosec B101
+
+
+def test_extract_page_links_prefers_beautifulsoup_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+    original_import = importlib.import_module
+
+    def fake_import(name: str, package: str | None = None):
+        if name == "bs4":
+            seen.append(name)
+        return original_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    html = b'<a href="/docs/a">A</a><a rel="nofollow" href="/docs/b">B</a>'
+
+    links = extract_page_links("https://example.com/docs/index.html", html)
+
+    assert "https://example.com/docs/a" in links  # nosec B101
+    assert "https://example.com/docs/b" not in links  # nosec B101
+    assert seen == ["bs4"] or seen == []  # nosec B101
+
+
+def test_public_candidate_redacts_query_bearing_url() -> None:
+    candidate = DiscoveredURLCandidate(
+        url="https://example.com/page?token=secret",
+        display_url="https://example.com/page",
+        status="accepted",
+        reason_code="ok",
+        source_kind="sitemap",
+        parent_url="https://example.com/sitemap.xml?token=secret",
+        parent_display_url="https://example.com/sitemap.xml",
+        safe_argument_hash="hash",
+    )
+
+    serialized = json.dumps(public_candidate(candidate), sort_keys=True)
+
+    assert "token=secret" not in serialized  # nosec B101
+    assert "https://example.com/page" in serialized  # nosec B101
+    assert "hash" in serialized  # nosec B101

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -604,6 +604,285 @@ def test_provider_sync_source_returns_stable_unsupported_response_for_sitemap(tm
     assert result["counts"] == ZERO_SYNC_COUNTS  # nosec B101
 
 
+def test_url_sitemap_sync_apply_ingests_current_candidates(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_sitemap",
+        canonical_uri="https://example.com/sitemap.xml",
+        display_name="Example sitemap",
+        source_path=None,
+        source_url="https://example.com/sitemap.xml",
+        redacted_source_url="https://example.com/sitemap.xml",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={"default_keywords": ["docs"], "default_collections": ["Reference"]},
+    )
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "sitemap_sync_enabled": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": ("https://example.com/sitemap.xml", "https://example.com/docs/"),
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "application/xml"},
+                body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"],
+            ),
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "text/plain"},
+                body_chunks=[b"alpha sync body"],
+            ),
+        ]
+    )
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="apply"))
+
+    assert result["status"] == "completed"  # nosec B101
+    assert result["counts"]["created"] == 1  # nosec B101
+    assert store.search_chunks(scope=scope, query="alpha", limit=10)  # nosec B101
+    assert _document_count(store.list_keywords(scope), "docs") == 1  # nosec B101
+    assert _document_count(store.list_collections(scope), "Reference") == 1  # nosec B101
+
+
+def test_url_sitemap_sync_dry_run_does_not_mutate(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_sitemap",
+        canonical_uri="https://example.com/sitemap.xml",
+        display_name="Example sitemap",
+        source_path=None,
+        source_url="https://example.com/sitemap.xml",
+        redacted_source_url="https://example.com/sitemap.xml",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={"default_keywords": ["docs"], "default_collections": ["Reference"]},
+    )
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "sitemap_sync_enabled": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": ("https://example.com/sitemap.xml", "https://example.com/docs/"),
+        }
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    transport = FakeTransport(
+        [
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "application/xml"},
+                body_chunks=[b"<urlset><url><loc>https://example.com/docs/a</loc></url></urlset>"],
+            ),
+            FetchResponse(
+                status_code=200,
+                headers={"content-type": "text/plain"},
+                body_chunks=[b"alpha sync body"],
+            ),
+        ]
+    )
+    service = DocsSourceSyncService(settings=settings, store=store, resolver=resolver, transport=transport)
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="dry_run"))
+
+    assert result["status"] == "completed"  # nosec B101
+    assert result["counts"]["created"] == 1  # nosec B101
+    assert store.status()["counts"]["documents"] == 0  # nosec B101
+    assert store.source_document_links(scope=scope, source_id=source_id) == []  # nosec B101
+    assert store.status()["counts"]["sync_runs"] == 0  # nosec B101
+
+
+def test_url_sitemap_sync_tombstones_missing_links_only_in_apply_mode(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "sitemap_sync_enabled": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": (
+                "https://example.com/sitemap.xml",
+                "https://example.com/docs/old",
+                "https://example.com/docs/new",
+            ),
+        }
+    )
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_sitemap",
+        canonical_uri="https://example.com/sitemap.xml",
+        display_name="Example sitemap",
+        source_path=None,
+        source_url="https://example.com/sitemap.xml",
+        redacted_source_url="https://example.com/sitemap.xml",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    resolver = FakeResolver({"example.com": ["93.184.216.34"]})
+    acquisition = DocsAcquisitionService(
+        settings=settings,
+        store=store,
+        resolver=resolver,
+        transport=FakeTransport(
+            [FetchResponse(status_code=200, headers={"content-type": "text/plain"}, body_chunks=[b"old sitemap body"])]
+        ),
+    )
+    old_ingested = acquisition.ingest_url(scope=scope, url="https://example.com/docs/old")
+    old_doc = store.get_document(scope, old_ingested["document"]["id"], mode="metadata")
+    store.link_source_document(
+        scope=scope,
+        source_id=source_id,
+        document_id=old_ingested["document"]["id"],
+        source_item_uri="https://example.com/docs/old",
+        status="active",
+        last_hash=old_doc["content_hash"],
+        metadata={"importer": "url_sitemap"},
+    )
+    service = DocsSourceSyncService(
+        settings=settings,
+        store=store,
+        resolver=resolver,
+        transport=FakeTransport(
+            [
+                FetchResponse(
+                    status_code=200,
+                    headers={"content-type": "application/xml"},
+                    body_chunks=[b"<urlset><url><loc>https://example.com/docs/new</loc></url></urlset>"],
+                ),
+                FetchResponse(
+                    status_code=200,
+                    headers={"content-type": "text/plain"},
+                    body_chunks=[b"new sitemap body"],
+                ),
+            ]
+        ),
+    )
+
+    result = service.sync_source(
+        scope=scope,
+        request=SyncSourceRequest(source_id=source_id, mode="apply", stale_policy="tombstone"),
+    )
+    links = store.source_document_links(scope=scope, source_id=source_id)
+    old_links = [link for link in links if link["source_item_uri"] == "https://example.com/docs/old"]
+
+    assert result["counts"]["created"] == 1  # nosec B101
+    assert result["counts"]["tombstoned"] == 1  # nosec B101
+    assert old_links[0]["status"] == "tombstoned"  # nosec B101
+    assert store.search_chunks(scope=scope, query="old", limit=10) == []  # nosec B101
+    assert store.search_chunks(scope=scope, query="new", limit=10)  # nosec B101
+
+
+def test_url_sitemap_sync_does_not_tombstone_when_sitemap_view_is_limited(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_sitemap",
+        canonical_uri="https://example.com/sitemap.xml",
+        display_name="Example sitemap",
+        source_path=None,
+        source_url="https://example.com/sitemap.xml",
+        redacted_source_url="https://example.com/sitemap.xml",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    old_doc_id = store.upsert_document(
+        scope=scope,
+        title="Existing B",
+        document_type="html",
+        canonical_uri="https://example.com/docs/b",
+        source_path=None,
+        source_url="https://example.com/docs/b",
+        text="bravo sitemap body",
+        sections=[],
+        chunks=[{"text": "bravo sitemap body", "citation": "https://example.com/docs/b#1"}],
+        keywords=(),
+        collection_names=(),
+        metadata={},
+    )
+    old_doc = store.get_document(scope, old_doc_id, mode="metadata")
+    store.link_source_document(
+        scope=scope,
+        source_id=source_id,
+        document_id=old_doc_id,
+        source_item_uri="https://example.com/docs/b",
+        status="active",
+        last_hash=old_doc["content_hash"],
+        metadata={"importer": "url_sitemap"},
+    )
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "sitemap_sync_enabled": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": ("https://example.com/sitemap.xml", "https://example.com/docs/"),
+            "max_sync_pages": 1,
+        }
+    )
+    service = DocsSourceSyncService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [
+                FetchResponse(
+                    status_code=200,
+                    headers={"content-type": "application/xml"},
+                    body_chunks=[
+                        b"""
+                        <urlset>
+                          <url><loc>https://example.com/docs/a</loc></url>
+                          <url><loc>https://example.com/docs/b</loc></url>
+                        </urlset>
+                        """
+                    ],
+                ),
+                FetchResponse(
+                    status_code=200,
+                    headers={"content-type": "text/plain"},
+                    body_chunks=[b"alpha sitemap body"],
+                ),
+            ]
+        ),
+    )
+
+    result = service.sync_source(
+        scope=scope,
+        request=SyncSourceRequest(source_id=source_id, mode="apply", stale_policy="tombstone"),
+    )
+    old_links = [
+        link
+        for link in store.source_document_links(scope=scope, source_id=source_id)
+        if link["source_item_uri"] == "https://example.com/docs/b"
+    ]
+
+    assert result["counts"]["created"] == 1  # nosec B101
+    assert result["counts"]["tombstoned"] == 0  # nosec B101
+    assert "source_discovery_limit_exceeded" in result["warnings"]  # nosec B101
+    assert old_links[0]["status"] == "active"  # nosec B101
+    assert store.search_chunks(scope=scope, query="bravo", limit=10)  # nosec B101
+
+
 def test_local_file_sync_dry_run_does_not_mutate_document_or_run_rows(tmp_path: Path) -> None:
     root = tmp_path / "workspace"
     root.mkdir()

--- a/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
+++ b/tldw_Server_API/tests/MCP_unified/docs/test_docs_source_sync.py
@@ -706,6 +706,54 @@ def test_url_sitemap_sync_dry_run_does_not_mutate(tmp_path: Path) -> None:
     assert store.status()["counts"]["sync_runs"] == 0  # nosec B101
 
 
+def test_url_sitemap_sync_preserves_skipped_candidate_reason(tmp_path: Path) -> None:
+    store = DocsCatalogStore(tmp_path / "docs.db")
+    store.migrate()
+    scope = AccessScope()
+    source_id = store.upsert_source(
+        scope=scope,
+        source_type="url_sitemap",
+        canonical_uri="https://example.com/sitemap.xml",
+        display_name="Example sitemap",
+        source_path=None,
+        source_url="https://example.com/sitemap.xml",
+        redacted_source_url="https://example.com/sitemap.xml",
+        policy_profile="locked_down",
+        sync_enabled=True,
+        metadata={},
+    )
+    settings = DocsSettings.from_mapping(
+        {
+            "db_path": str(tmp_path / "docs.db"),
+            "enable_web_acquisition": True,
+            "sitemap_sync_enabled": True,
+            "web_source_profile": "locked_down",
+            "allowed_url_prefixes": ("https://example.com/sitemap.xml", "https://example.com/docs/"),
+            "persist_url_query_strings": False,
+        }
+    )
+    service = DocsSourceSyncService(
+        settings=settings,
+        store=store,
+        resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+        transport=FakeTransport(
+            [
+                FetchResponse(
+                    status_code=200,
+                    headers={"content-type": "application/xml"},
+                    body_chunks=[b"<urlset><url><loc>https://example.com/docs/a?token=secret</loc></url></urlset>"],
+                )
+            ]
+        ),
+    )
+
+    result = service.sync_source(scope=scope, request=SyncSourceRequest(source_id=source_id, mode="dry_run"))
+
+    assert result["counts"]["skipped"] == 1  # nosec B101
+    assert result["items"][0]["status"] == "skipped"  # nosec B101
+    assert result["items"][0]["reason_code"] == "candidate_query_not_persisted"  # nosec B101
+
+
 def test_url_sitemap_sync_tombstones_missing_links_only_in_apply_mode(tmp_path: Path) -> None:
     store = DocsCatalogStore(tmp_path / "docs.db")
     store.migrate()


### PR DESCRIPTION
## Summary
- Adds disabled-by-default standalone MCP docs source discovery settings, status, request models, and docs.discover_source provider/host exposure.
- Implements bounded sitemap and page-link discovery with dry-run, register, ingest, and register_and_ingest flows, including policy enforcement, redaction, dedupe, and metadata propagation.
- Adds url_sitemap sync_source refresh support and hardens sitemap XML parsing with defusedxml.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs -q -> 295 passed, 4 warnings
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r apps/mcp-unified/src/mcp_unified/docs tldw_Server_API/tests/MCP_unified/docs -f json -o /tmp/bandit_mcp_docs_stage4b_source_discovery.json -> 0 findings
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/docs/test_docs_import_boundaries.py -q --tb=short -> 6 passed
- [x] git diff --check -> clean

## Change summary
This PR adds a local-docs/source-discovery layer for the standalone MCP docs corpus without coupling it to tldw_server runtime services. Discovery is opt-in and bounded by config so locked-down deployments remain safe by default. The implementation reuses the existing URL policy/fetch/acquisition seams, keeps BeautifulSoup/trafilatura optional via lazy imports/fallbacks, and uses SQLite-backed docs/source records so agents can discover, register, ingest, and refresh general document collections for FTS/RAG workflows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds standalone, opt-in MCP docs source discovery via `docs.discover_source`. Enables bounded sitemap and page-link discovery with dry-run/apply, integrates `url_sitemap` sync refresh and apply-time ingestion, and hardens XML parsing.

- New Features
  - Added discovery settings, request/response models, service, and `docs.discover_source` provider/host exposure.
  - Supports `auto`/`sitemap`/`page_links`; `dry_run`/`apply`; apply actions `register`/`ingest`/`register_and_ingest`; bounded by `max_discovery_pages`, `max_discovery_depth`, `max_discovery_sitemaps`.
  - Enforces URL policy (allowed prefixes, same-origin), redaction, and dedupe; propagates metadata (collections, keywords, title).
  - Integrates with `docs.sync_source` for `url_sitemap` refresh and apply-time ingestion; keeps `beautifulsoup4`/`trafilatura` optional via lazy imports; SQLite-backed records.
  - Safe defaults: discovery disabled; low limits; `discovery_apply_default` is `register`.

- Bug Fixes
  - Hardened sitemap XML parsing with `defusedxml`; blocks DOCTYPE/unsafe constructs and applies strict size bounds.

<sup>Written for commit 5dc8ac6fb9fc1050bc67bce674e17e20cb64d4c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

