### PR TITLE
Wire Chat Workspace inspector and status rails

### DIFF
--- a/Docs/superpowers/plans/2026-07-03-chat-workspace-status-rails-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-chat-workspace-status-rails-plan.md
@@ -1,0 +1,67 @@
+# Chat Workspace Status Rails Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete GitHub issue #2033 by making `/chat-workspace` inspector and status rails reflect real runtime, degraded, hydration, and failed-send states.
+
+**Architecture:** Keep the change inside the existing Chat Workspace component boundary. `WorkspaceChatPanel` remains the source of chat runtime state; `ChatWorkspacePage` lifts that state; `ChatWorkspaceConsole` passes it to `WorkspaceStatusStrip` and `InspectorRail`.
+
+**Tech Stack:** React, TypeScript, Vitest, Playwright.
+
+---
+
+## Stage 1: Runtime Contract
+
+**Goal:** Add failed-send state to the shared Chat Workspace runtime contract.
+**Success Criteria:** Send failures can be lifted from the chat panel and rendered outside the composer.
+**Tests:** `WorkspaceChatPanel.test.tsx` covers failed-send runtime reporting.
+**Status:** Complete
+
+- [x] Add `sendError` to `ChatWorkspaceRuntimeState`.
+- [x] Report `sendError` from `WorkspaceChatPanel`.
+- [x] Clear/report state through existing workspace and send transitions.
+
+## Stage 2: Inspector Rail
+
+**Goal:** Replace misleading placeholder inspector sections with real runtime and recovery state.
+**Success Criteria:** Inspector does not show inactive approval/task placeholders, and it explains backend, hydration, send failure, model, and persona states.
+**Tests:** `InspectorRail.test.tsx`.
+**Status:** Complete
+
+- [x] Add workspace-readiness and send-error props.
+- [x] Add deterministic runtime precedence.
+- [x] Add concise recovery copy.
+- [x] Remove placeholder approval/task-progress panels.
+
+## Stage 3: Status Strip
+
+**Goal:** Make the footer status strip match the actual ability to send workspace chat.
+**Success Criteria:** Hydration never renders as ready; failed sends and missing setup states surface as status pills.
+**Tests:** `WorkspaceStatusStrip.test.tsx`.
+**Status:** Complete
+
+- [x] Add workspace-readiness, send-error, model, and persona props.
+- [x] Add status precedence for server unavailable, workspace hydration, send failure, streaming, and ready.
+- [x] Add recovery/status pills for reconnect, workspace identity, model selection, and optional persona state.
+
+## Stage 4: Browser Evidence
+
+**Goal:** Extend existing live-backend browser proof to assert visible rail/status runtime state.
+**Success Criteria:** Playwright verifies streaming and send-failure status reaches the route UI.
+**Tests:** `apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts`.
+**Status:** Complete
+
+- [x] Assert status strip and inspector show streaming while stop generation is visible.
+- [x] Assert failed send shows status-strip failure and inspector retry recovery copy.
+- [x] Re-run Stage 5 Chat Workspace gate.
+
+## Stage 5: Review Remediation
+
+**Goal:** Address PR review comments after rebasing onto latest `dev`.
+**Success Criteria:** Runtime rail contracts avoid string sentinels, workspace readiness is required by rail callers, and stop generation proves delayed stream output does not land after abort.
+**Tests:** `InspectorRail.test.tsx`, `WorkspaceStatusStrip.test.tsx`, `WorkspaceChatPanel.test.tsx`, `apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts`.
+**Status:** Complete
+
+- [x] Pass selected model details through `InspectorRail` and add an explicit `hasModelSelected` runtime flag.
+- [x] Make `workspaceReady` required for `InspectorRail` and `WorkspaceStatusStrip`.
+- [x] Assert aborted workspace streams do not append delayed streamed output or leave streaming rail state visible.

--- a/Docs/superpowers/plans/2026-07-03-chat-workspace-status-rails-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-chat-workspace-status-rails-plan.md
@@ -71,9 +71,9 @@
 **Goal:** Address the final PR review findings with one readiness source of truth and browser-level offline transition evidence.
 **Success Criteria:** A persisted workspace ID cannot bypass store hydration, chat sending and both rails share the same readiness boolean, and active streaming rails switch coherently to server-unavailable state.
 **Tests:** `ChatWorkspacePage.test.tsx` and `apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts`.
-**Status:** In Progress
+**Status:** Complete
 
-- [ ] Add a failing page regression for a non-empty workspace ID while `storeHydrated` is false.
-- [ ] Derive readiness in `ChatWorkspacePage` from `storeHydrated` plus normalized workspace identity and pass it through `ChatWorkspaceConsole`.
-- [ ] Add a browser transition from active streaming to an unreachable connection and assert both rails suppress stale streaming state.
-- [ ] Re-run focused tests, TypeScript, lint/diff checks, and record verification in TASK-12135.
+- [x] Add a failing page regression for a non-empty workspace ID while `storeHydrated` is false.
+- [x] Derive readiness in `ChatWorkspacePage` from `storeHydrated` plus normalized workspace identity and pass it through `ChatWorkspaceConsole`.
+- [x] Add a browser transition from active streaming to an unreachable connection and assert both rails suppress stale streaming state.
+- [x] Re-run focused tests, TypeScript, lint/diff checks, and record verification in TASK-12135.

--- a/Docs/superpowers/plans/2026-07-03-chat-workspace-status-rails-plan.md
+++ b/Docs/superpowers/plans/2026-07-03-chat-workspace-status-rails-plan.md
@@ -65,3 +65,15 @@
 - [x] Pass selected model details through `InspectorRail` and add an explicit `hasModelSelected` runtime flag.
 - [x] Make `workspaceReady` required for `InspectorRail` and `WorkspaceStatusStrip`.
 - [x] Assert aborted workspace streams do not append delayed streamed output or leave streaming rail state visible.
+
+## Stage 6: Hydration and Offline Follow-up
+
+**Goal:** Address the final PR review findings with one readiness source of truth and browser-level offline transition evidence.
+**Success Criteria:** A persisted workspace ID cannot bypass store hydration, chat sending and both rails share the same readiness boolean, and active streaming rails switch coherently to server-unavailable state.
+**Tests:** `ChatWorkspacePage.test.tsx` and `apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts`.
+**Status:** In Progress
+
+- [ ] Add a failing page regression for a non-empty workspace ID while `storeHydrated` is false.
+- [ ] Derive readiness in `ChatWorkspacePage` from `storeHydrated` plus normalized workspace identity and pass it through `ChatWorkspaceConsole`.
+- [ ] Add a browser transition from active streaming to an unreachable connection and assert both rails suppress stale streaming state.
+- [ ] Re-run focused tests, TypeScript, lint/diff checks, and record verification in TASK-12135.

--- a/Docs/superpowers/specs/2026-07-13-chat-workspace-hydration-offline-follow-up-design.md
+++ b/Docs/superpowers/specs/2026-07-13-chat-workspace-hydration-offline-follow-up-design.md
@@ -1,0 +1,32 @@
+# Chat Workspace Hydration and Offline Follow-up Design
+
+## Scope
+
+Address the two remaining PR #2600 review findings without expanding the Chat Workspace runtime model:
+
+1. A persisted workspace ID must not make chat or its rails ready before the workspace store finishes hydration.
+2. Browser coverage must prove that the visible rails transition from connected/streaming to offline without leaving stale streaming status behind.
+
+## Design
+
+`ChatWorkspacePage` owns the readiness decision because it already reads workspace identity, connection state, and passes the send gate into `ChatWorkspaceConsole`. It will read `storeHydrated`, derive `workspaceReady` from both hydration and the normalized workspace ID, and pass that boolean into the console. The console will stop recomputing readiness from the ID so `WorkspaceChatPanel`, `WorkspaceStatusStrip`, and `InspectorRail` all consume the same decision.
+
+The existing live-backend Playwright test will transition the real browser-side connection store through its existing `window.__tldw_useConnectionStore` exposure. No production test hook or new runtime abstraction is needed. The test will begin during active streaming, set the connection to an unreachable error state, and assert that both rails show server-unavailable recovery state while no longer showing `Streaming`.
+
+## Error and State Precedence
+
+- Store hydration and workspace identity jointly gate chat readiness.
+- Backend unavailable continues to take precedence over hydration, send failure, and streaming in both rails.
+- The offline browser test changes only connection state; it does not alter or replace the chat stream implementation.
+
+## Testing
+
+- Vitest regression: a non-empty workspace ID with `storeHydrated: false` keeps the chat backend disabled and both rails in loading state; rerendering with hydration complete enables the backend.
+- Playwright regression: active streaming transitions to server-unavailable rail state after the real connection store becomes unreachable, and stale `Streaming` labels disappear.
+- Re-run the full Chat Workspace Vitest folder, focused live-backend smoke, TypeScript, diff checks, and touched-scope lint where supported.
+
+## Non-goals
+
+- No new readiness enum or selector abstraction.
+- No changes to global connection retry thresholds.
+- No changes to workspace persistence or hydration internals.

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspaceConsole.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspaceConsole.tsx
@@ -23,11 +23,13 @@ export type ChatWorkspaceConsoleProps = {
   browsedSourceId: string | null
   stagedSources: StagedWorkspaceSource[]
   selectedModelLabel: string
+  hasModelSelected: boolean
   selectedPersonaLabel: string | null
   assistantSource: ChatWorkspaceAssistantSource
   workspaceAssistantDegradedReason?: ChatWorkspaceRuntimeState[
     "workspaceAssistantDegradedReason"
   ]
+  sendError?: string | null
   effectiveAssistantDefault?: EffectiveWorkspaceAssistantDefault | null
   backendAvailable: boolean
   chatBackendAvailable: boolean
@@ -48,9 +50,11 @@ export const ChatWorkspaceConsole = ({
   browsedSourceId,
   stagedSources,
   selectedModelLabel,
+  hasModelSelected,
   selectedPersonaLabel,
   assistantSource,
   workspaceAssistantDegradedReason,
+  sendError,
   effectiveAssistantDefault,
   backendAvailable,
   chatBackendAvailable,
@@ -62,6 +66,7 @@ export const ChatWorkspaceConsole = ({
   onRuntimeStateChange
 }: ChatWorkspaceConsoleProps) => {
   const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId)
+  const workspaceReady = normalizedWorkspaceId !== null
   const stagedSourceIds = stagedSources.map((source) => source.sourceId)
   const inspectorSources = stagedSources.map((source) => ({
     sourceId: source.sourceId,
@@ -104,8 +109,13 @@ export const ChatWorkspaceConsole = ({
           </div>
           <WorkspaceStatusStrip
             backendAvailable={backendAvailable}
+            workspaceReady={workspaceReady}
             streaming={streaming}
+            sendError={sendError}
             stagedSourceCount={stagedSources.length}
+            hasModelSelected={hasModelSelected}
+            selectedPersonaLabel={selectedPersonaLabel}
+            assistantSource={assistantSource}
           />
         </main>
 
@@ -115,11 +125,14 @@ export const ChatWorkspaceConsole = ({
             stagedSourceCount={stagedSources.length}
             stagedSources={inspectorSources}
             selectedModelLabel={selectedModelLabel}
+            hasModelSelected={hasModelSelected}
             selectedPersonaLabel={selectedPersonaLabel}
             assistantSource={assistantSource}
             workspaceAssistantDegradedReason={workspaceAssistantDegradedReason}
             backendAvailable={backendAvailable}
+            workspaceReady={workspaceReady}
             streaming={streaming}
+            sendError={sendError}
           />
         </div>
       </div>

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspaceConsole.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspaceConsole.tsx
@@ -16,6 +16,7 @@ import { normalizeWorkspaceId } from "./workspaceIdentity"
 
 export type ChatWorkspaceConsoleProps = {
   workspaceId?: string | null
+  workspaceReady: boolean
   workspaceName: string
   sources: WorkspaceSource[]
   sourcesLoading?: boolean
@@ -43,6 +44,7 @@ export type ChatWorkspaceConsoleProps = {
 
 export const ChatWorkspaceConsole = ({
   workspaceId,
+  workspaceReady,
   workspaceName,
   sources,
   sourcesLoading,
@@ -66,7 +68,6 @@ export const ChatWorkspaceConsole = ({
   onRuntimeStateChange
 }: ChatWorkspaceConsoleProps) => {
   const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId)
-  const workspaceReady = normalizedWorkspaceId !== null
   const stagedSourceIds = stagedSources.map((source) => source.sourceId)
   const inspectorSources = stagedSources.map((source) => ({
     sourceId: source.sourceId,

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx
@@ -40,6 +40,7 @@ const createInitialRuntimeState = (
 
 export const ChatWorkspacePage = () => {
   const rawWorkspaceId = useWorkspaceStore((state) => state.workspaceId)
+  const storeHydrated = useWorkspaceStore((state) => state.storeHydrated)
   const workspaceName = useWorkspaceStore((state) => state.workspaceName)
   const sources = useWorkspaceStore((state) => state.sources)
   const effectiveAssistantDefault = useWorkspaceStore(
@@ -59,7 +60,7 @@ export const ChatWorkspacePage = () => {
     () => normalizeWorkspaceId(rawWorkspaceId),
     [rawWorkspaceId]
   )
-  const workspaceReady = workspaceId !== null
+  const workspaceReady = storeHydrated && workspaceId !== null
 
   const [workspaceContext, setWorkspaceContext] =
     React.useState<WorkspaceContextState>(() => ({
@@ -169,6 +170,7 @@ export const ChatWorkspacePage = () => {
       <h1 className="sr-only">Chat Workspace</h1>
       <ChatWorkspaceConsole
         workspaceId={workspaceId}
+        workspaceReady={workspaceReady}
         workspaceName={scopeLabel}
         sources={sources}
         sourcesLoading={sourcesLoading}

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx
@@ -26,7 +26,9 @@ const createInitialRuntimeState = (
 ): ChatWorkspaceRuntimeState => ({
   backendAvailable,
   streaming: false,
+  sendError: null,
   selectedModelLabel: "No model selected",
+  hasModelSelected: false,
   selectedPersonaLabel: null,
   assistantSource:
     effectiveAssistantDefault?.status === "unavailable" ? "unavailable" : "none",
@@ -174,11 +176,13 @@ export const ChatWorkspacePage = () => {
         browsedSourceId={browsedSourceId}
         stagedSources={stagedSources}
         selectedModelLabel={runtimeState.selectedModelLabel}
+        hasModelSelected={runtimeState.hasModelSelected}
         selectedPersonaLabel={runtimeState.selectedPersonaLabel}
         assistantSource={runtimeState.assistantSource}
         workspaceAssistantDegradedReason={
           runtimeState.workspaceAssistantDegradedReason
         }
+        sendError={runtimeState.sendError}
         effectiveAssistantDefault={effectiveAssistantDefault}
         backendAvailable={backendAvailable}
         chatBackendAvailable={backendAvailable && workspaceReady}

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/InspectorRail.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/InspectorRail.tsx
@@ -12,11 +12,14 @@ export type InspectorRailProps = {
   stagedSourceCount: number
   stagedSources: InspectorRailStagedSource[]
   selectedModelLabel: string
+  hasModelSelected: boolean
   selectedPersonaLabel: string | null
   assistantSource: ChatWorkspaceAssistantSource
   workspaceAssistantDegradedReason?: WorkspaceAssistantDefaultDegradedReason | null
   backendAvailable: boolean
+  workspaceReady: boolean
   streaming: boolean
+  sendError?: string | null
 }
 
 const panelClass = "rounded-md border border-border bg-surface px-3 py-2"
@@ -25,12 +28,45 @@ const valueClass = "mt-1 text-sm font-medium text-text"
 const mutedClass = "mt-1 text-xs text-text-muted"
 const READY_STATE_LABEL = getDesignSystemState("ready").label
 
-const getRuntimeLabel = (backendAvailable: boolean, streaming: boolean) => {
+const getRuntimeLabel = (
+  backendAvailable: boolean,
+  workspaceReady: boolean,
+  streaming: boolean,
+  sendError?: string | null
+) => {
   if (!backendAvailable) {
     return "Server unavailable"
   }
 
+  if (!workspaceReady) {
+    return "Loading workspace context"
+  }
+
+  if (sendError) {
+    return "Send failed"
+  }
+
   return streaming ? "Streaming" : READY_STATE_LABEL
+}
+
+const getRuntimeRecoveryCopy = (
+  backendAvailable: boolean,
+  workspaceReady: boolean,
+  sendError?: string | null
+) => {
+  if (!backendAvailable) {
+    return "Reconnect to the server before sending workspace chat."
+  }
+
+  if (!workspaceReady) {
+    return "Wait for workspace identity before sending."
+  }
+
+  if (sendError) {
+    return "Draft and staged context were preserved for retry."
+  }
+
+  return null
 }
 
 const degradedReasonLabels: Record<
@@ -58,17 +94,38 @@ export const InspectorRail = ({
   stagedSourceCount,
   stagedSources,
   selectedModelLabel,
+  hasModelSelected,
   selectedPersonaLabel,
   assistantSource,
   workspaceAssistantDegradedReason,
   backendAvailable,
-  streaming
+  workspaceReady,
+  streaming,
+  sendError
 }: InspectorRailProps) => {
-  const runtimeLabel = getRuntimeLabel(backendAvailable, streaming)
+  const runtimeLabel = getRuntimeLabel(
+    backendAvailable,
+    workspaceReady,
+    streaming,
+    sendError
+  )
+  const runtimeRecoveryCopy = getRuntimeRecoveryCopy(
+    backendAvailable,
+    workspaceReady,
+    sendError
+  )
   const assistantSourceLabel = getAssistantSourceLabel(assistantSource)
   const degradedReasonLabel = workspaceAssistantDegradedReason
     ? degradedReasonLabels[workspaceAssistantDegradedReason]
     : null
+  const modelRecoveryCopy =
+    !hasModelSelected
+      ? "Choose a model before sending."
+      : null
+  const personaRecoveryCopy =
+    assistantSource === "none"
+      ? "Persona is optional; workspace defaults apply when available."
+      : null
 
   return (
     <aside
@@ -119,23 +176,22 @@ export const InspectorRail = ({
             {assistantSourceLabel ? (
               <p className={mutedClass}>{assistantSourceLabel}</p>
             ) : null}
+            {modelRecoveryCopy ? (
+              <p className={mutedClass}>{modelRecoveryCopy}</p>
+            ) : null}
+            {personaRecoveryCopy ? (
+              <p className={mutedClass}>{personaRecoveryCopy}</p>
+            ) : null}
           </>
         )}
       </section>
 
       <section className={panelClass}>
-        <h2 className={headingClass}>Approvals</h2>
-        <p className={valueClass}>Not configured</p>
-      </section>
-
-      <section className={panelClass}>
-        <h2 className={headingClass}>Task Progress</h2>
-        <p className={valueClass}>No active task</p>
-      </section>
-
-      <section className={panelClass}>
         <h2 className={headingClass}>Runtime</h2>
         <p className={valueClass}>{runtimeLabel}</p>
+        {runtimeRecoveryCopy ? (
+          <p className={mutedClass}>{runtimeRecoveryCopy}</p>
+        ) : null}
       </section>
     </aside>
   )

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
@@ -200,7 +200,9 @@ export const WorkspaceChatPanel = ({
     onRuntimeStateChange?.({
       backendAvailable: chatBackendAvailable,
       streaming,
+      sendError,
       selectedModelLabel: selectedModel || "No model selected",
+      hasModelSelected: Boolean(selectedModel),
       selectedPersonaLabel: runtimeSelectedPersonaLabel,
       assistantSource,
       workspaceAssistantDegradedReason:
@@ -215,6 +217,7 @@ export const WorkspaceChatPanel = ({
     onRuntimeStateChange,
     runtimeSelectedPersonaLabel,
     selectedModel,
+    sendError,
     streaming
   ])
 

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceStatusStrip.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceStatusStrip.tsx
@@ -1,9 +1,15 @@
 import { getDesignSystemState } from "@/design-system"
+import type { ChatWorkspaceAssistantSource } from "./types"
 
 export type WorkspaceStatusStripProps = {
   backendAvailable: boolean
+  workspaceReady: boolean
   streaming: boolean
+  sendError?: string | null
   stagedSourceCount: number
+  hasModelSelected: boolean
+  selectedPersonaLabel?: string | null
+  assistantSource?: ChatWorkspaceAssistantSource
 }
 
 const statusPillClass =
@@ -11,16 +17,42 @@ const statusPillClass =
 
 const READY_STATE_LABEL = getDesignSystemState("ready").label
 
+const getRuntimeLabel = ({
+  backendAvailable,
+  workspaceReady,
+  streaming,
+  sendError
+}: Pick<
+  WorkspaceStatusStripProps,
+  "backendAvailable" | "workspaceReady" | "streaming" | "sendError"
+>) => {
+  if (!backendAvailable) return "Server unavailable"
+  if (workspaceReady === false) return "Loading workspace context"
+  if (sendError) return "Send failed"
+  if (streaming) return "Streaming"
+  return READY_STATE_LABEL
+}
+
 export const WorkspaceStatusStrip = ({
   backendAvailable,
+  workspaceReady,
   streaming,
-  stagedSourceCount
+  sendError,
+  stagedSourceCount,
+  hasModelSelected,
+  selectedPersonaLabel,
+  assistantSource
 }: WorkspaceStatusStripProps) => {
-  const runtimeLabel = !backendAvailable
-    ? "Server unavailable"
-    : streaming
-      ? "Streaming"
-      : READY_STATE_LABEL
+  const runtimeLabel = getRuntimeLabel({
+    backendAvailable,
+    workspaceReady,
+    streaming,
+    sendError
+  })
+  const hasPersona =
+    Boolean(selectedPersonaLabel) ||
+    assistantSource === "workspace" ||
+    assistantSource === "unavailable"
 
   return (
     <footer
@@ -31,6 +63,18 @@ export const WorkspaceStatusStrip = ({
         <span className={statusPillClass}>{runtimeLabel}</span>
         {stagedSourceCount > 0 ? (
           <span className={statusPillClass}>Context staged</span>
+        ) : null}
+        {!backendAvailable ? (
+          <span className={statusPillClass}>Reconnect server</span>
+        ) : null}
+        {backendAvailable && workspaceReady === false ? (
+          <span className={statusPillClass}>Wait for workspace identity</span>
+        ) : null}
+        {backendAvailable && workspaceReady && !hasModelSelected ? (
+          <span className={statusPillClass}>Select a model</span>
+        ) : null}
+        {backendAvailable && workspaceReady && !hasPersona ? (
+          <span className={statusPillClass}>No persona</span>
         ) : null}
       </div>
       <div className="flex min-w-0 flex-wrap items-center gap-2">

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx
@@ -101,6 +101,7 @@ vi.mock("../WorkspaceChatPanel", () => ({
         backendAvailable: chatPanelRuntimeState.backendAvailable,
         streaming: true,
         selectedModelLabel: "gpt-test",
+        hasModelSelected: true,
         selectedPersonaLabel: "Analyst",
         assistantSource: "explicit"
       })

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx
@@ -11,6 +11,7 @@ const chatPanelRuntimeState = vi.hoisted(() => ({
 const workspaceState = vi.hoisted((): { value: any } => ({
   value: {
     workspaceId: "workspace-1",
+    storeHydrated: true,
     workspaceName: "Default workspace",
     sources: [
       {
@@ -60,6 +61,7 @@ vi.mock("@/store/workspace", () => ({
     selector({
       sourcesLoading: false,
       sourcesError: null,
+      storeHydrated: true,
       ...workspaceActions,
       ...workspaceState.value
     })
@@ -128,6 +130,7 @@ describe("ChatWorkspacePage", () => {
     workspaceActions.focusSourceById.mockReturnValue(true)
     workspaceState.value = {
       workspaceId: "workspace-1",
+      storeHydrated: true,
       workspaceName: "Default workspace",
       sources: [
         {
@@ -260,6 +263,48 @@ describe("ChatWorkspacePage", () => {
     const panel = screen.getByTestId("workspace-chat-panel")
     expect(panel).toHaveAttribute("data-workspace-id", "null")
     expect(panel).toHaveAttribute("data-backend-available", "false")
+  })
+
+  it("keeps chat and rails loading until the workspace store hydrates", () => {
+    workspaceState.value = {
+      workspaceId: "workspace-1",
+      storeHydrated: false,
+      workspaceName: "Default workspace",
+      sources: []
+    }
+
+    const { rerender } = render(<ChatWorkspacePage />)
+
+    expect(screen.getByTestId("workspace-chat-panel")).toHaveAttribute(
+      "data-backend-available",
+      "false"
+    )
+    expect(
+      within(screen.getByLabelText("Chat workspace status")).getByText(
+        "Loading workspace context"
+      )
+    ).toBeInTheDocument()
+    expect(
+      within(
+        screen.getByRole("complementary", { name: /workspace inspector/i })
+      ).getByText("Loading workspace context")
+    ).toBeInTheDocument()
+
+    workspaceState.value = {
+      ...workspaceState.value,
+      storeHydrated: true
+    }
+    rerender(<ChatWorkspacePage />)
+
+    expect(screen.getByTestId("workspace-chat-panel")).toHaveAttribute(
+      "data-backend-available",
+      "true"
+    )
+    expect(
+      within(screen.getByLabelText("Chat workspace status")).getByText(
+        "Streaming"
+      )
+    ).toBeInTheDocument()
   })
 
   it("clears browsed and staged sources when the workspace changes", () => {

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/InspectorRail.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/InspectorRail.test.tsx
@@ -33,9 +33,11 @@ describe("InspectorRail", () => {
           { sourceId: "source-2", title: "Research Clip" }
         ]}
         selectedModelLabel="gpt-test"
+        hasModelSelected
         selectedPersonaLabel="Analyst"
         assistantSource="explicit"
         backendAvailable
+        workspaceReady
         streaming={false}
       />
     )
@@ -48,23 +50,28 @@ describe("InspectorRail", () => {
     expect(screen.getByText("Ready via registry")).toBeInTheDocument()
   })
 
-  it("labels inactive v1 panels honestly", () => {
+  it("explains backend recovery without inactive placeholder panels", () => {
     render(
       <InspectorRail
         scopeLabel="No workspace"
         stagedSourceCount={0}
         stagedSources={[]}
         selectedModelLabel="No model selected"
+        hasModelSelected={false}
         selectedPersonaLabel={null}
         assistantSource="none"
         backendAvailable={false}
         streaming={false}
+        workspaceReady
       />
     )
 
-    expect(screen.getByText("Not configured")).toBeInTheDocument()
-    expect(screen.getByText("No active task")).toBeInTheDocument()
     expect(screen.getByText("Server unavailable")).toBeInTheDocument()
+    expect(
+      screen.getByText("Reconnect to the server before sending workspace chat.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Approvals")).not.toBeInTheDocument()
+    expect(screen.queryByText("Task Progress")).not.toBeInTheDocument()
   })
 
   it("uses stable source metadata for duplicate staged source titles", () => {
@@ -77,9 +84,11 @@ describe("InspectorRail", () => {
           { sourceId: "source-2", title: "Meeting Notes" }
         ]}
         selectedModelLabel="gpt-test"
+        hasModelSelected
         selectedPersonaLabel={null}
         assistantSource="none"
         backendAvailable
+        workspaceReady
         streaming={false}
       />
     )
@@ -100,9 +109,11 @@ describe("InspectorRail", () => {
         stagedSourceCount={0}
         stagedSources={[]}
         selectedModelLabel="gpt-test"
+        hasModelSelected
         selectedPersonaLabel="Workspace Analyst"
         assistantSource="workspace"
         backendAvailable
+        workspaceReady
         streaming={false}
       />
     )
@@ -118,16 +129,65 @@ describe("InspectorRail", () => {
         stagedSourceCount={0}
         stagedSources={[]}
         selectedModelLabel="gpt-test"
+        hasModelSelected
         selectedPersonaLabel={null}
         assistantSource="unavailable"
         workspaceAssistantDegradedReason="persona_deleted"
         backendAvailable
         streaming={false}
+        workspaceReady
       />
     )
 
     expect(screen.getByText("Workspace default unavailable")).toBeInTheDocument()
     expect(screen.getByText("Persona deleted")).toBeInTheDocument()
     expect(screen.queryByText("No persona selected")).not.toBeInTheDocument()
+  })
+
+  it("shows workspace hydration as not ready even while the server is connected", () => {
+    render(
+      <InspectorRail
+        scopeLabel="Workspace"
+        stagedSourceCount={0}
+        stagedSources={[]}
+        selectedModelLabel="gpt-test"
+        hasModelSelected
+        selectedPersonaLabel={null}
+        assistantSource="none"
+        backendAvailable
+        streaming={false}
+        workspaceReady={false}
+      />
+    )
+
+    expect(screen.getByText("Loading workspace context")).toBeInTheDocument()
+    expect(
+      screen.getByText("Wait for workspace identity before sending.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Ready via registry")).not.toBeInTheDocument()
+  })
+
+  it("surfaces send failures and missing model recovery in the inspector", () => {
+    render(
+      <InspectorRail
+        scopeLabel="Default workspace"
+        stagedSourceCount={0}
+        stagedSources={[]}
+        selectedModelLabel="No model selected"
+        hasModelSelected={false}
+        selectedPersonaLabel={null}
+        assistantSource="none"
+        backendAvailable
+        streaming={false}
+        workspaceReady
+        sendError="Send failed"
+      />
+    )
+
+    expect(screen.getByText("Send failed")).toBeInTheDocument()
+    expect(screen.getByText("Choose a model before sending.")).toBeInTheDocument()
+    expect(
+      screen.getByText("Persona is optional; workspace defaults apply when available.")
+    ).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx
@@ -119,6 +119,7 @@ describe("WorkspaceChatPanel", () => {
     chatHookState.value.streaming = false
     chatHookState.value.isLoading = false
     chatHookState.value.isProcessing = false
+    chatHookState.value.selectedModel = "gpt-test"
     chatHookState.value.selectedAssistant = {
       kind: "persona",
       id: "p1",
@@ -455,6 +456,34 @@ describe("WorkspaceChatPanel", () => {
     expect(onClearStagedSources).not.toHaveBeenCalled()
   })
 
+  it("reports failed sends through runtime state", async () => {
+    chatHookState.onSubmit.mockResolvedValueOnce({
+      status: "failed",
+      errorMessage: "network"
+    })
+    const onRuntimeStateChange = vi.fn()
+
+    render(
+      <WorkspaceChatPanel
+        stagedSources={staged}
+        onClearStagedSources={vi.fn()}
+        backendAvailable
+        workspaceId="workspace-1"
+        onRuntimeStateChange={onRuntimeStateChange}
+      />
+    )
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Chat workspace message" }), {
+      target: { value: "Keep this draft" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send with staged context" }))
+
+    await screen.findByText("network")
+    expect(onRuntimeStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({ sendError: "network" })
+    )
+  })
+
   it("preserves draft and staged context without an error when submit is skipped", async () => {
     chatHookState.onSubmit.mockResolvedValueOnce({
       status: "skipped",
@@ -546,8 +575,31 @@ describe("WorkspaceChatPanel", () => {
       expect.objectContaining({
         streaming: false,
         selectedModelLabel: "gpt-test",
+        hasModelSelected: true,
         selectedPersonaLabel: "Analyst",
         assistantSource: "explicit"
+      })
+    )
+  })
+
+  it("reports missing model selection without relying on display text", () => {
+    chatHookState.value.selectedModel = ""
+    const onRuntimeStateChange = vi.fn()
+
+    render(
+      <WorkspaceChatPanel
+        stagedSources={staged}
+        onClearStagedSources={vi.fn()}
+        backendAvailable
+        workspaceId="workspace-1"
+        onRuntimeStateChange={onRuntimeStateChange}
+      />
+    )
+
+    expect(onRuntimeStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedModelLabel: "No model selected",
+        hasModelSelected: false
       })
     )
   })

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceStatusStrip.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceStatusStrip.test.tsx
@@ -22,7 +22,17 @@ vi.mock("@/design-system", async (importActual) => {
 
 describe("WorkspaceStatusStrip", () => {
   it("renders ready and keyboard hint state", () => {
-    render(<WorkspaceStatusStrip backendAvailable streaming={false} stagedSourceCount={0} />)
+    render(
+      <WorkspaceStatusStrip
+        backendAvailable
+        streaming={false}
+        stagedSourceCount={0}
+        workspaceReady
+        hasModelSelected
+        selectedPersonaLabel="Analyst"
+        assistantSource="explicit"
+      />
+    )
 
     expect(screen.getByText("Ready via registry")).toBeInTheDocument()
     expect(screen.getByText("Ctrl+K command")).toBeInTheDocument()
@@ -30,7 +40,17 @@ describe("WorkspaceStatusStrip", () => {
   })
 
   it("renders streaming and staged context states", () => {
-    render(<WorkspaceStatusStrip backendAvailable streaming stagedSourceCount={3} />)
+    render(
+      <WorkspaceStatusStrip
+        backendAvailable
+        streaming
+        stagedSourceCount={3}
+        workspaceReady
+        hasModelSelected
+        selectedPersonaLabel="Analyst"
+        assistantSource="explicit"
+      />
+    )
 
     expect(screen.getByText("Streaming")).toBeInTheDocument()
     expect(screen.getByText("Context staged")).toBeInTheDocument()
@@ -38,10 +58,57 @@ describe("WorkspaceStatusStrip", () => {
   })
 
   it("gives backend unavailable precedence over stale streaming state", () => {
-    render(<WorkspaceStatusStrip backendAvailable={false} streaming stagedSourceCount={3} />)
+    render(
+      <WorkspaceStatusStrip
+        backendAvailable={false}
+        streaming
+        stagedSourceCount={3}
+        workspaceReady
+        hasModelSelected
+        selectedPersonaLabel="Analyst"
+        assistantSource="explicit"
+      />
+    )
 
     expect(screen.getByText("Context staged")).toBeInTheDocument()
     expect(screen.getByText("Server unavailable")).toBeInTheDocument()
     expect(screen.queryByText("Streaming")).not.toBeInTheDocument()
+  })
+
+  it("shows workspace hydration before ready when sends are disabled", () => {
+    render(
+      <WorkspaceStatusStrip
+        backendAvailable
+        streaming={false}
+        stagedSourceCount={0}
+        workspaceReady={false}
+        hasModelSelected
+        selectedPersonaLabel={null}
+        assistantSource="none"
+      />
+    )
+
+    expect(screen.getByText("Loading workspace context")).toBeInTheDocument()
+    expect(screen.getByText("Wait for workspace identity")).toBeInTheDocument()
+    expect(screen.queryByText("Ready via registry")).not.toBeInTheDocument()
+  })
+
+  it("surfaces failed sends and missing model state", () => {
+    render(
+      <WorkspaceStatusStrip
+        backendAvailable
+        streaming={false}
+        stagedSourceCount={0}
+        workspaceReady
+        hasModelSelected={false}
+        selectedPersonaLabel={null}
+        assistantSource="none"
+        sendError="Send failed"
+      />
+    )
+
+    expect(screen.getByText("Send failed")).toBeInTheDocument()
+    expect(screen.getByText("Select a model")).toBeInTheDocument()
+    expect(screen.getByText("No persona")).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/types.ts
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/types.ts
@@ -28,7 +28,9 @@ export type ChatWorkspaceAssistantSource =
 export type ChatWorkspaceRuntimeState = {
   backendAvailable: boolean
   streaming: boolean
+  sendError?: string | null
   selectedModelLabel: string
+  hasModelSelected: boolean
   selectedPersonaLabel: string | null
   assistantSource: ChatWorkspaceAssistantSource
   workspaceAssistantDegradedReason?: WorkspaceAssistantDefaultDegradedReason | null

--- a/apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts
@@ -33,6 +33,13 @@ type BackendFixture = {
   ragSearches: CapturedRequest[]
 }
 
+type ConnectionStoreWindow = Window & {
+  __tldw_useConnectionStore?: {
+    getState: () => { state: Record<string, unknown> }
+    setState: (value: { state: Record<string, unknown> }) => void
+  }
+}
+
 const CORS_HEADERS = {
   "access-control-allow-origin": "*",
   "access-control-allow-headers": "*",
@@ -704,6 +711,62 @@ test.describe("Chat Workspace live-backend smoke coverage", () => {
         .getByRole("complementary", { name: "Chat workspace inspector" })
         .getByText("Streaming")
     ).toHaveCount(0)
+  })
+
+  test("switches active streaming rails to offline recovery state", async ({ page }) => {
+    await installBackendFixture(page, {
+      mode: "streaming",
+      streamDelayMs: 4_000
+    })
+    await seedChatWorkspaceState(page)
+    await openSeededChatWorkspace(page)
+
+    await page
+      .getByLabel("Chat workspace message")
+      .fill("Show offline recovery while streaming")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const statusStrip = page.getByLabel("Chat workspace status")
+    const inspector = page.getByRole("complementary", {
+      name: "Chat workspace inspector"
+    })
+    const stopButton = page.getByRole("button", { name: "Stop generating" })
+
+    await expect(stopButton).toBeVisible()
+    await expect(statusStrip.getByText("Streaming")).toBeVisible()
+    await expect(inspector.getByText("Streaming")).toBeVisible()
+    await page.waitForFunction(
+      () =>
+        typeof (window as ConnectionStoreWindow).__tldw_useConnectionStore
+          ?.getState === "function"
+    )
+    await page.evaluate(() => {
+      const store = (window as ConnectionStoreWindow).__tldw_useConnectionStore
+      if (!store) throw new Error("Connection store did not initialize")
+      const current = store.getState().state
+      store.setState({
+        state: {
+          ...current,
+          phase: "error",
+          isConnected: false,
+          isChecking: false,
+          errorKind: "unreachable",
+          consecutiveFailures: 3,
+          lastError: "offline",
+          lastStatusCode: 0,
+          lastCheckedAt: Date.now()
+        }
+      })
+    })
+
+    await expect(statusStrip.getByText("Server unavailable")).toBeVisible()
+    await expect(statusStrip.getByText("Reconnect server")).toBeVisible()
+    await expect(inspector.getByText("Server unavailable")).toBeVisible()
+    await expect(statusStrip.getByText("Streaming")).toHaveCount(0)
+    await expect(inspector.getByText("Streaming")).toHaveCount(0)
+
+    await stopButton.click()
+    await expect(stopButton).toBeHidden()
   })
 
   test("preserves draft and staged fallback context after send failure", async ({ page }) => {

--- a/apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/chat-workspace-live-backend.spec.ts
@@ -658,9 +658,10 @@ test.describe("Chat Workspace live-backend smoke coverage", () => {
   })
 
   test("shows stop generation while the workspace stream is active", async ({ page }) => {
+    const streamDelayMs = 1_000
     const fixture = await installBackendFixture(page, {
       mode: "streaming",
-      streamDelayMs: 4_000
+      streamDelayMs
     })
     await seedChatWorkspaceState(page)
     await openSeededChatWorkspace(page)
@@ -671,6 +672,14 @@ test.describe("Chat Workspace live-backend smoke coverage", () => {
 
     const stopButton = page.getByRole("button", { name: "Stop generating" })
     await expect(stopButton).toBeVisible()
+    await expect(
+      page.getByLabel("Chat workspace status").getByText("Streaming")
+    ).toBeVisible()
+    await expect(
+      page
+        .getByRole("complementary", { name: "Chat workspace inspector" })
+        .getByText("Streaming")
+    ).toBeVisible()
     await expect.poll(() => fixture.chatCreates.length).toBeGreaterThan(0)
     expect(fixture.chatCreates[0]?.body).toMatchObject({
       scope_type: "workspace",
@@ -684,6 +693,17 @@ test.describe("Chat Workspace live-backend smoke coverage", () => {
 
     await stopButton.click()
     await expect(stopButton).toBeHidden()
+    await expect(page.getByText("streamed workspace reply")).toHaveCount(0)
+    await page.waitForTimeout(streamDelayMs + 250)
+    await expect(page.getByText("streamed workspace reply")).toHaveCount(0)
+    await expect(
+      page.getByLabel("Chat workspace status").getByText("Streaming")
+    ).toHaveCount(0)
+    await expect(
+      page
+        .getByRole("complementary", { name: "Chat workspace inspector" })
+        .getByText("Streaming")
+    ).toHaveCount(0)
   })
 
   test("preserves draft and staged fallback context after send failure", async ({ page }) => {
@@ -709,6 +729,14 @@ test.describe("Chat Workspace live-backend smoke coverage", () => {
 
     await expect(
       page.getByRole("alert").filter({ hasText: "Stream completion failed" })
+    ).toBeVisible()
+    await expect(
+      page.getByLabel("Chat workspace status").getByText("Send failed")
+    ).toBeVisible()
+    await expect(
+      page
+        .getByRole("complementary", { name: "Chat workspace inspector" })
+        .getByText("Draft and staged context were preserved for retry.")
     ).toBeVisible()
     await expect(page.getByLabel("Chat workspace message")).toHaveValue(draft)
     await expect(

--- a/backlog/tasks/task-12135 - Implement-Chat-Workspace-inspector-and-status-runtime-state.md
+++ b/backlog/tasks/task-12135 - Implement-Chat-Workspace-inspector-and-status-runtime-state.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12135
+title: Implement Chat Workspace inspector and status runtime state
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-07-13 20:16'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/2033'
+  - 'https://github.com/rmusser01/tldw_server/issues/1239'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #2033 for /chat-workspace: replace placeholder inspector/status rail behavior with accurate runtime and workspace state, degraded/offline recovery copy, hydration/send-disabled safety, and focused component/browser coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-07-03-chat-workspace-status-rails-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+PR #2600 review remediation after rebase on latest origin/dev: added explicit hasModelSelected runtime state, made WorkspaceStatusStrip and InspectorRail require workspaceReady, verified selectedModelLabel is passed into InspectorRail, and strengthened stop-generation smoke coverage so delayed stream output does not land after abort. Verification: ChatWorkspace Vitest folder passed 8 files/74 tests; chat-workspace live-backend Playwright smoke passed 4/4; Stage 5 Chat Workspace release gate passed 1/1; git diff --check passed; UI package tsc --noEmit still fails on unrelated baseline outside Chat Workspace, and captured-log grep found no ChatWorkspace or rail errors; Bandit not applicable because no Python source changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented #2033 status/inspector runtime slice and PR #2600 review remediation: added sendError and explicit hasModelSelected runtime state, lifted failed-send state from WorkspaceChatPanel, passed workspace readiness and runtime setup state into WorkspaceStatusStrip and InspectorRail, required workspaceReady at rail boundaries, removed inactive approval/task-progress placeholder panels, added recovery copy for server unavailable/workspace hydration/send failure/missing model/no persona, and extended the live-backend smoke with visible streaming/failure rail assertions plus no-delayed-output stop-generation coverage. Verification: ChatWorkspace Vitest folder passed 8 files/74 tests; live-backend Playwright smoke passed 4/4; Stage 5 Chat Workspace release gate passed 1/1; git diff --check passed. UI package tsc --noEmit still fails on unrelated baseline errors outside touched Chat Workspace files; captured-log grep found no ChatWorkspace/InspectorRail/WorkspaceStatusStrip/WorkspaceChatPanel/ChatWorkspacePage errors. Bandit not applicable because no Python source changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12135 - Implement-Chat-Workspace-inspector-and-status-runtime-state.md
+++ b/backlog/tasks/task-12135 - Implement-Chat-Workspace-inspector-and-status-runtime-state.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-12135
 title: Implement Chat Workspace inspector and status runtime state
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-14 01:39'
+updated_date: '2026-07-14 01:58'
 labels: []
 dependencies: []
 references:
@@ -23,8 +23,8 @@ Implement GitHub issue #2033 for /chat-workspace: replace placeholder inspector/
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Chat Workspace remains non-ready and chat sends stay disabled while the workspace store is not hydrated, even when a workspace ID is present.
-- [ ] #2 Live-backend browser coverage verifies connected-to-offline rail transitions and suppresses stale streaming state.
+- [x] #1 Chat Workspace remains non-ready and chat sends stay disabled while the workspace store is not hydrated, even when a workspace ID is present.
+- [x] #2 Live-backend browser coverage verifies connected-to-offline rail transitions and suppresses stale streaming state.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -39,17 +39,19 @@ Docs/superpowers/plans/2026-07-03-chat-workspace-status-rails-plan.md
 PR #2600 review remediation after rebase on latest origin/dev: added explicit hasModelSelected runtime state, made WorkspaceStatusStrip and InspectorRail require workspaceReady, verified selectedModelLabel is passed into InspectorRail, and strengthened stop-generation smoke coverage so delayed stream output does not land after abort. Verification: ChatWorkspace Vitest folder passed 8 files/74 tests; chat-workspace live-backend Playwright smoke passed 4/4; Stage 5 Chat Workspace release gate passed 1/1; git diff --check passed; UI package tsc --noEmit still fails on unrelated baseline outside Chat Workspace, and captured-log grep found no ChatWorkspace or rail errors; Bandit not applicable because no Python source changed.
 
 2026-07-13 PR #2600 follow-up: addressing review findings for real storeHydrated readiness and the missing offline browser transition. Work will use TDD on the existing PR branch.
+
+2026-07-13 PR #2600 follow-up complete. TDD evidence: the new non-empty-ID/storeHydrated=false page test failed before the readiness fix, then passed after ChatWorkspacePage derived one readiness boolean from hydration plus normalized identity. Added live browser coverage that starts streaming, transitions the real connection store to unreachable, and verifies both rails show server recovery while suppressing stale streaming state. Fresh verification: Chat Workspace Vitest 8 files/75 tests passed; frontend tsc --noEmit passed; live-backend Playwright 5/5 passed; focused ESLint exited 0 with only the pre-existing PERSONA_ID warning; git diff --check passed. Bandit is not applicable because the touched implementation and tests are TypeScript/TSX only.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented #2033 status/inspector runtime slice and PR #2600 review remediation: added sendError and explicit hasModelSelected runtime state, lifted failed-send state from WorkspaceChatPanel, passed workspace readiness and runtime setup state into WorkspaceStatusStrip and InspectorRail, required workspaceReady at rail boundaries, removed inactive approval/task-progress placeholder panels, added recovery copy for server unavailable/workspace hydration/send failure/missing model/no persona, and extended the live-backend smoke with visible streaming/failure rail assertions plus no-delayed-output stop-generation coverage. Verification: ChatWorkspace Vitest folder passed 8 files/74 tests; live-backend Playwright smoke passed 4/4; Stage 5 Chat Workspace release gate passed 1/1; git diff --check passed. UI package tsc --noEmit still fails on unrelated baseline errors outside touched Chat Workspace files; captured-log grep found no ChatWorkspace/InspectorRail/WorkspaceStatusStrip/WorkspaceChatPanel/ChatWorkspacePage errors. Bandit not applicable because no Python source changed.
+Completed issue #2033 and both final PR #2600 review findings. Chat Workspace now lifts send/runtime state into accurate status and inspector rails, avoids placeholder approval/task UI, gates chat and rail readiness on both workspace-store hydration and a normalized workspace ID, and provides degraded/offline/send-failure recovery states. Unit coverage proves a persisted ID cannot enable sends or ready rails before hydration; live-backend browser coverage proves active streaming rails transition to server-unavailable state without stale streaming labels. Verification: 75/75 Chat Workspace unit tests, TypeScript, 5/5 live-backend browser tests, focused ESLint (no errors; one pre-existing warning), and git diff --check all passed. No Python changed, so Bandit was not applicable.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip

--- a/backlog/tasks/task-12135 - Implement-Chat-Workspace-inspector-and-status-runtime-state.md
+++ b/backlog/tasks/task-12135 - Implement-Chat-Workspace-inspector-and-status-runtime-state.md
@@ -4,12 +4,15 @@ title: Implement Chat Workspace inspector and status runtime state
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-07-13 20:16'
+updated_date: '2026-07-14 01:39'
 labels: []
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/issues/2033'
   - 'https://github.com/rmusser01/tldw_server/issues/1239'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-13-chat-workspace-hydration-offline-follow-up-design.md
 ---
 
 ## Description
@@ -20,6 +23,8 @@ Implement GitHub issue #2033 for /chat-workspace: replace placeholder inspector/
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [ ] #1 Chat Workspace remains non-ready and chat sends stay disabled while the workspace store is not hydrated, even when a workspace ID is present.
+- [ ] #2 Live-backend browser coverage verifies connected-to-offline rail transitions and suppresses stale streaming state.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -32,6 +37,8 @@ Docs/superpowers/plans/2026-07-03-chat-workspace-status-rails-plan.md
 
 <!-- SECTION:NOTES:BEGIN -->
 PR #2600 review remediation after rebase on latest origin/dev: added explicit hasModelSelected runtime state, made WorkspaceStatusStrip and InspectorRail require workspaceReady, verified selectedModelLabel is passed into InspectorRail, and strengthened stop-generation smoke coverage so delayed stream output does not land after abort. Verification: ChatWorkspace Vitest folder passed 8 files/74 tests; chat-workspace live-backend Playwright smoke passed 4/4; Stage 5 Chat Workspace release gate passed 1/1; git diff --check passed; UI package tsc --noEmit still fails on unrelated baseline outside Chat Workspace, and captured-log grep found no ChatWorkspace or rail errors; Bandit not applicable because no Python source changed.
+
+2026-07-13 PR #2600 follow-up: addressing review findings for real storeHydrated readiness and the missing offline browser transition. Work will use TDD on the existing PR branch.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary
- Lift Chat Workspace send-failure and workspace-readiness runtime state into the inspector/status rails.
- Replace inactive approval/task-progress placeholder panels with concrete runtime and recovery copy.
- Extend component coverage and the live-backend browser smoke for visible streaming/failure rail states.

## Test Plan
- `bunx vitest run src/components/Option/ChatWorkspace/__tests__ --maxWorkers=1`
- `npx playwright test e2e/smoke/chat-workspace-live-backend.spec.ts --project=chromium`
- `npx playwright test e2e/smoke/stage5-release-gate.spec.ts --project=chromium --grep "Chat Workspace"`
- `git diff --check`

## Typecheck Note
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json` still fails on unrelated existing test type errors outside this touched scope: `ChatGreetingPicker` greetingSelectionChecksum, `background-session-store` quickIngestBatches, `TldwChat.abort` spread args, and `character-export` tuple cast.

## Tracking
Closes #2033.
Refs #1239.

## Merge Gate
AI-authored PR: maintainer needs to add the required human-written Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the Chat Workspace inspector and status rails to real runtime state and gated readiness on workspace-store hydration plus workspace identity, with clear recovery for offline, missing model, and failed sends. Replaces placeholder panels and handles streaming→offline transitions without stale UI.

- **New Features**
  - Added `sendError` and `hasModelSelected` to runtime; `WorkspaceChatPanel` emits and state is lifted via `ChatWorkspacePage`/`ChatWorkspaceConsole`.
  - `ChatWorkspacePage` derives `workspaceReady` from `storeHydrated` + normalized ID and passes it down.
  - `WorkspaceStatusStrip` now requires `workspaceReady` and uses precedence: server unavailable → loading workspace context → send failed → streaming → ready; adds pills for reconnect, wait for workspace identity, select a model, no persona, and context staged.
  - `InspectorRail` now requires `workspaceReady`, shows runtime label and recovery copy (reconnect, wait, retry preserved), adds model/persona guidance, and removes Approvals/Task Progress.
  - Closes #2033 (refs #1239).

- **Tests**
  - Unit: hydration gating keeps chat/rails non-ready until hydrated; missing model; send failures; stable staged-source metadata.
  - E2E: visible streaming and send-failure rails; stop generation prevents delayed streamed output; active streaming transitions to offline and suppresses stale Streaming in both rails.

<sup>Written for commit 7a588924da76735b2f51c1bf637fc5f0632e6447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

