### PR TITLE
Harden integrations outbound egress policy

### DIFF
--- a/Docs/superpowers/plans/2026-07-04-audit-integrations-egress-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-07-04-audit-integrations-egress-remediation-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Regression Tests
+**Goal**: Capture the outbound-policy bypasses before changing production code.
+**Success Criteria**: Tests fail for direct workflow `pdf_url` download and tokenizer `_http_post` bypassing the central HTTP policy.
+**Tests**: Focused pytest cases in `tldw_Server_API/tests/Workflows/adapters/test_research_adapters.py` and `tldw_Server_API/tests/Writing/test_tokenizer_resolver_unit.py`.
+**Status**: Complete
+
+## Stage 2: Workflow Research HTTP Policy
+**Goal**: Route project-owned research adapter HTTP calls through the central HTTP helper layer.
+**Success Criteria**: Direct `pdf_url`, PubMed, Semantic Scholar, patent, and DOI requests use central egress/proxy/trust-env behavior while preserving existing response shapes.
+**Tests**: Research adapter regression tests plus existing focused research adapter tests.
+**Status**: Complete
+
+## Stage 3: Tokenizer Resolver HTTP Policy
+**Goal**: Replace raw tokenizer/counting `requests.post` use with the central sync HTTP helper path.
+**Success Criteria**: Tokenizer provider calls inherit central egress denial, redirect checks, proxy validation, and `trust_env=False` defaults; explicit local provider behavior remains testable.
+**Tests**: Tokenizer resolver regression tests plus existing unit tests for remote count/tokenizer adapters.
+**Status**: Complete
+
+## Stage 4: Verification And Task Record
+**Goal**: Prove the remediation and record it for repeatable audit follow-up.
+**Success Criteria**: Focused pytest passes, `git diff --check` passes, Bandit runs on touched production files, and `TASK-12138` records final verification.
+**Tests**: `python -m pytest` focused files, `git diff --check`, and Bandit on touched production files.
+**Status**: Complete

--- a/backlog/tasks/task-12138 - Harden-audit-Integrations-outbound-HTTP-policy.md
+++ b/backlog/tasks/task-12138 - Harden-audit-Integrations-outbound-HTTP-policy.md
@@ -1,0 +1,72 @@
+---
+id: TASK-12138
+title: Harden audit Integrations outbound HTTP policy
+status: Done
+created_date: 2026-07-04 01:32
+labels:
+- audit-remediation
+- security
+- integrations
+- egress
+priority: medium
+references:
+- AUDIT-2026-06-27-INTEGRATIONS-001
+- AUDIT-2026-06-27-INTEGRATIONS-002
+documentation:
+- Docs/superpowers/reviews/2026-06-27-repo-audit/domains/integrations-providers.md
+- Docs/superpowers/reviews/2026-06-27-repo-audit/remediation-backlog-draft.md
+modified_files:
+- Docs/superpowers/plans/2026-07-04-audit-integrations-egress-remediation-plan.md
+- tldw_Server_API/app/core/Workflows/adapters/research/search.py
+- tldw_Server_API/app/core/Workflows/adapters/research/bibliography.py
+- tldw_Server_API/app/core/LLM_Calls/tokenizer_resolver.py
+- tldw_Server_API/tests/Workflows/adapters/test_research_adapters.py
+- tldw_Server_API/tests/Writing/test_tokenizer_resolver_unit.py
+updated_date: 2026-07-04 01:42
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remediate comprehensive audit findings AUDIT-2026-06-27-INTEGRATIONS-001 and AUDIT-2026-06-27-INTEGRATIONS-002. Route workflow research adapter outbound calls and tokenizer resolver provider/token-count requests through the central outbound HTTP policy instead of raw clients, while preserving explicit local-provider behavior where supported.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workflow research adapter direct pdf_url downloads go through central egress/proxy/trust_env controls and deny private/loopback targets by policy.
+- [x] #2 Workflow research adapter first-party HTTP calls use central HTTP helpers or client factories rather than raw httpx clients.
+- [x] #3 Tokenizer resolver _http_post uses the central sync HTTP helper/client path instead of requests.post directly.
+- [x] #4 Regression tests cover private/loopback denial, direct pdf_url handling, central client/proxy defaults, and tokenizer base URL handling.
+- [x] #5 Focused pytest, diff check, and Bandit verification are recorded before finalizing.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regression tests for arxiv_download direct pdf_url egress denial and tokenizer _http_post central egress/proxy behavior.
+2. Replace workflow research raw httpx call sites with central async HTTP helpers or client factories, keeping existing response behavior.
+3. Replace tokenizer_resolver._http_post requests.post usage with the central sync fetch path.
+4. Run focused pytest, diff checks, and Bandit on touched production files; record results in the task final summary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented via isolated worktree codex/audit-integrations-egress-2026-07-04. Verification run: focused pytest for research adapter and tokenizer resolver tests passed (116 passed); git diff --check passed; Bandit on touched production files exited 0 and wrote /tmp/bandit_integrations_egress.json. Also confirmed targeted raw httpx.AsyncClient and requests.post patterns were removed from touched paths.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Routed workflow research adapter direct HTTP calls for direct arXiv PDF download, PubMed, Semantic Scholar, Google Patents, and DOI resolution through the central HTTP helper path with managed clients that inherit trust_env=False and central egress/proxy enforcement. Replaced tokenizer resolver raw requests.post usage with the central sync fetch helper. Added regression coverage for direct pdf_url central-helper use, private URL denial through central policy, tokenizer central fetch use, and tokenizer private URL denial. Updated legacy sanitizer tests to patch the new managed helper seam and documented the repeatable slice process in the plan file.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12146 - Harden-audit-Integrations-outbound-HTTP-policy.md
+++ b/backlog/tasks/task-12146 - Harden-audit-Integrations-outbound-HTTP-policy.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-12138
+id: TASK-12146
 title: Harden audit Integrations outbound HTTP policy
 status: Done
 created_date: 2026-07-04 01:32
@@ -12,6 +12,7 @@ priority: medium
 references:
 - AUDIT-2026-06-27-INTEGRATIONS-001
 - AUDIT-2026-06-27-INTEGRATIONS-002
+- https://github.com/rmusser01/tldw_server/pull/2604
 documentation:
 - Docs/superpowers/reviews/2026-06-27-repo-audit/domains/integrations-providers.md
 - Docs/superpowers/reviews/2026-06-27-repo-audit/remediation-backlog-draft.md
@@ -22,7 +23,7 @@ modified_files:
 - tldw_Server_API/app/core/LLM_Calls/tokenizer_resolver.py
 - tldw_Server_API/tests/Workflows/adapters/test_research_adapters.py
 - tldw_Server_API/tests/Writing/test_tokenizer_resolver_unit.py
-updated_date: 2026-07-04 01:42
+updated_date: 2026-07-04 19:08
 ---
 
 ## Description
@@ -53,12 +54,13 @@ Remediate comprehensive audit findings AUDIT-2026-06-27-INTEGRATIONS-001 and AUD
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Implemented via isolated worktree codex/audit-integrations-egress-2026-07-04. Verification run: focused pytest for research adapter and tokenizer resolver tests passed (116 passed); git diff --check passed; Bandit on touched production files exited 0 and wrote /tmp/bandit_integrations_egress.json. Also confirmed targeted raw httpx.AsyncClient and requests.post patterns were removed from touched paths.
+Latest-dev validation refresh (2026-07-04): original branch was stale at merge-base 800a81b5d7f8c941969c915274eb9f878bc2c207, then rebased cleanly onto origin/dev fd5c152b065c408e4e8ee5f08da41589f21cb7f5. Post-rebase merge-base matched origin/dev. Addressed PR review feedback by letting `_managed_afetch` accept an optional pre-existing async client and restoring PubMed search/summary to share one `create_async_client(timeout=30)` context while still calling central `afetch`. Added `test_pubmed_search_adapter_reuses_central_http_client`, which verifies one central client context and two fetch calls using the same client. Passed targeted PubMed reuse test (1 passed). Passed `.venv/bin/python -m pytest tldw_Server_API/tests/Workflows/adapters/test_research_adapters.py tldw_Server_API/tests/Writing/test_tokenizer_resolver_unit.py -q` with 117 passed. Passed Bandit over touched production files with 0 findings in `/tmp/bandit_integrations_egress_latest_dev.json`. Passed `git diff --check`. Raw-client scan over touched production files for `httpx.AsyncClient`, `httpx.Client`, `requests.`, `urllib.request`, and `urlopen(` returned no matches.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Routed workflow research adapter direct HTTP calls for direct arXiv PDF download, PubMed, Semantic Scholar, Google Patents, and DOI resolution through the central HTTP helper path with managed clients that inherit trust_env=False and central egress/proxy enforcement. Replaced tokenizer resolver raw requests.post usage with the central sync fetch helper. Added regression coverage for direct pdf_url central-helper use, private URL denial through central policy, tokenizer central fetch use, and tokenizer private URL denial. Updated legacy sanitizer tests to patch the new managed helper seam and documented the repeatable slice process in the plan file.
+Routed workflow research adapter direct HTTP calls for direct arXiv PDF download, PubMed, Semantic Scholar, Google Patents, and DOI resolution through the central HTTP helper path with managed clients that inherit trust_env=False and central egress/proxy enforcement. Replaced tokenizer resolver raw requests.post usage with the central sync fetch helper. Added regression coverage for direct pdf_url central-helper use, private URL denial through central policy, tokenizer central fetch use, tokenizer private URL denial, and PubMed shared-client reuse. Latest validation was refreshed after rebasing onto origin/dev fd5c152b065c408e4e8ee5f08da41589f21cb7f5: 117 focused tests passed, Bandit over touched production files reported 0 findings, `git diff --check` passed, and touched production files no longer contain the scanned raw-client patterns.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/LLM_Calls/tokenizer_resolver.py
+++ b/tldw_Server_API/app/core/LLM_Calls/tokenizer_resolver.py
@@ -6,6 +6,7 @@ import ipaddress
 import json
 import math
 import os
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import lru_cache
@@ -650,10 +651,17 @@ def strict_token_counting_enabled(default: bool = False) -> bool:
 
 def _http_post(*, url: str, payload: dict[str, Any], headers: dict[str, str], timeout: float) -> Any:
     try:
-        import requests  # type: ignore
+        from tldw_Server_API.app.core.http_client import fetch
     except Exception as exc:
         raise TokenizerUnavailable("Provider tokenizer HTTP client unavailable") from exc
-    return requests.post(url, json=payload, headers=headers, timeout=timeout)
+    return fetch(
+        method="POST",
+        url=url,
+        json=payload,
+        headers=headers,
+        timeout=timeout,
+        allow_redirects=True,
+    )
 
 
 def normalize_provider_for_tokenizer(provider: str) -> str:
@@ -883,10 +891,8 @@ def _runtime_probe_exact_resolution(
         )
     finally:
         if original_timeout is not None:
-            try:
+            with suppress(Exception):
                 setattr(encoding, "timeout_seconds", original_timeout)
-            except Exception:
-                pass
 
     return resolution
 

--- a/tldw_Server_API/app/core/Workflows/adapters/research/bibliography.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/research/bibliography.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from loguru import logger
 
+from tldw_Server_API.app.core.http_client import afetch, create_async_client
 from tldw_Server_API.app.core.testing import is_test_mode
 from tldw_Server_API.app.core.Workflows.adapters._common import _extract_openai_content
 from tldw_Server_API.app.core.Workflows.adapters._registry import registry
@@ -24,6 +25,12 @@ from tldw_Server_API.app.core.Workflows.adapters.research._config import (
     LiteratureReviewConfig,
     ReferenceParseConfig,
 )
+
+
+async def _managed_afetch(**kwargs: Any) -> Any:
+    timeout = kwargs.get("timeout")
+    async with create_async_client(timeout=timeout) as client:
+        return await afetch(client=client, **kwargs)
 
 
 @registry.register(
@@ -43,8 +50,6 @@ async def run_doi_resolve_adapter(config: dict[str, Any], context: dict[str, Any
       - metadata: dict - Paper metadata
       - resolved: bool
     """
-    import httpx
-
     from tldw_Server_API.app.core.Chat.prompt_template_manager import apply_template_to_string as _tmpl
 
     if callable(context.get("is_cancelled")) and context["is_cancelled"]():
@@ -91,32 +96,32 @@ async def run_doi_resolve_adapter(config: dict[str, Any], context: dict[str, Any
         }
 
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                f"https://doi.org/{doi}",
-                headers={"Accept": "application/vnd.citationstyles.csl+json"},
-                follow_redirects=True,
-                timeout=30,
-            )
-            response.raise_for_status()
-            data = response.json()
+        response = await _managed_afetch(
+            method="GET",
+            url=f"https://doi.org/{doi}",
+            headers={"Accept": "application/vnd.citationstyles.csl+json"},
+            allow_redirects=True,
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
 
-            metadata = {
-                "doi": doi,
-                "title": data.get("title", ""),
-                "authors": [
-                    f"{a.get('given', '')} {a.get('family', '')}".strip()
-                    for a in data.get("author", [])
-                ],
-                "container_title": data.get("container-title", ""),
-                "publisher": data.get("publisher", ""),
-                "issued": data.get("issued", {}).get("date-parts", [[]])[0],
-                "type": data.get("type", ""),
-                "abstract": data.get("abstract", ""),
-                "url": data.get("URL", ""),
-            }
+        metadata = {
+            "doi": doi,
+            "title": data.get("title", ""),
+            "authors": [
+                f"{a.get('given', '')} {a.get('family', '')}".strip()
+                for a in data.get("author", [])
+            ],
+            "container_title": data.get("container-title", ""),
+            "publisher": data.get("publisher", ""),
+            "issued": data.get("issued", {}).get("date-parts", [[]])[0],
+            "type": data.get("type", ""),
+            "abstract": data.get("abstract", ""),
+            "url": data.get("URL", ""),
+        }
 
-            return {"metadata": metadata, "resolved": True}
+        return {"metadata": metadata, "resolved": True}
 
     except Exception:
         logger.error("DOI resolve error")

--- a/tldw_Server_API/app/core/Workflows/adapters/research/search.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/research/search.py
@@ -33,7 +33,9 @@ from tldw_Server_API.app.core.Workflows.adapters.research._config import (
 )
 
 
-async def _managed_afetch(**kwargs: Any) -> Any:
+async def _managed_afetch(client: Any | None = None, **kwargs: Any) -> Any:
+    if client is not None:
+        return await afetch(client=client, **kwargs)
     timeout = kwargs.get("timeout")
     async with create_async_client(timeout=timeout) as client:
         return await afetch(client=client, **kwargs)
@@ -274,30 +276,43 @@ async def run_pubmed_search_adapter(config: dict[str, Any], context: dict[str, A
         # Use NCBI E-utilities
         base_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
 
-        # Search for IDs
-        search_url = f"{base_url}/esearch.fcgi"
-        search_params = {
-            "db": "pubmed",
-            "term": query,
-            "retmax": max_results,
-            "retmode": "json",
-        }
-        search_response = await _managed_afetch(method="GET", url=search_url, params=search_params, timeout=30)
-        search_data = search_response.json()
+        async with create_async_client(timeout=30) as client:
+            # Search for IDs
+            search_url = f"{base_url}/esearch.fcgi"
+            search_params = {
+                "db": "pubmed",
+                "term": query,
+                "retmax": max_results,
+                "retmode": "json",
+            }
+            search_response = await _managed_afetch(
+                client=client,
+                method="GET",
+                url=search_url,
+                params=search_params,
+                timeout=30,
+            )
+            search_data = search_response.json()
 
-        id_list = search_data.get("esearchresult", {}).get("idlist", [])
-        if not id_list:
-            return {"papers": [], "total_results": 0, "query": query}
+            id_list = search_data.get("esearchresult", {}).get("idlist", [])
+            if not id_list:
+                return {"papers": [], "total_results": 0, "query": query}
 
-        # Fetch details
-        fetch_url = f"{base_url}/esummary.fcgi"
-        fetch_params = {
-            "db": "pubmed",
-            "id": ",".join(id_list),
-            "retmode": "json",
-        }
-        fetch_response = await _managed_afetch(method="GET", url=fetch_url, params=fetch_params, timeout=30)
-        fetch_data = fetch_response.json()
+            # Fetch details
+            fetch_url = f"{base_url}/esummary.fcgi"
+            fetch_params = {
+                "db": "pubmed",
+                "id": ",".join(id_list),
+                "retmode": "json",
+            }
+            fetch_response = await _managed_afetch(
+                client=client,
+                method="GET",
+                url=fetch_url,
+                params=fetch_params,
+                timeout=30,
+            )
+            fetch_data = fetch_response.json()
 
         papers = []
         result_data = fetch_data.get("result", {})

--- a/tldw_Server_API/app/core/Workflows/adapters/research/search.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/research/search.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from loguru import logger
 
+from tldw_Server_API.app.core.http_client import afetch, create_async_client
 from tldw_Server_API.app.core.testing import is_test_mode as _is_test_mode
 from tldw_Server_API.app.core.Workflows.adapters._common import _resolve_artifacts_dir
 from tldw_Server_API.app.core.Workflows.adapters._registry import registry
@@ -30,6 +31,12 @@ from tldw_Server_API.app.core.Workflows.adapters.research._config import (
     PubmedSearchConfig,
     SemanticScholarSearchConfig,
 )
+
+
+async def _managed_afetch(**kwargs: Any) -> Any:
+    timeout = kwargs.get("timeout")
+    async with create_async_client(timeout=timeout) as client:
+        return await afetch(client=client, **kwargs)
 
 
 @registry.register(
@@ -191,13 +198,11 @@ async def run_arxiv_download_adapter(config: dict[str, Any], context: dict[str, 
             output_path = str(art_dir / filename)
             paper.download_pdf(dirpath=str(art_dir), filename=filename)
         else:
-            import httpx
-            async with httpx.AsyncClient() as client:
-                response = await client.get(pdf_url, follow_redirects=True, timeout=60)
-                response.raise_for_status()
-                filename = pdf_url.split("/")[-1] or "paper.pdf"
-                output_path = str(art_dir / filename)
-                Path(output_path).write_bytes(response.content)
+            response = await _managed_afetch(method="GET", url=pdf_url, allow_redirects=True, timeout=60)
+            response.raise_for_status()
+            filename = pdf_url.split("/")[-1] or "paper.pdf"
+            output_path = str(art_dir / filename)
+            Path(output_path).write_bytes(response.content)
 
         if callable(context.get("add_artifact")):
             context["add_artifact"](
@@ -233,8 +238,6 @@ async def run_pubmed_search_adapter(config: dict[str, Any], context: dict[str, A
       - papers: list[dict]
       - total_results: int
     """
-    import httpx
-
     from tldw_Server_API.app.core.Chat.prompt_template_manager import apply_template_to_string as _tmpl
 
     if callable(context.get("is_cancelled")) and context["is_cancelled"]():
@@ -271,47 +274,46 @@ async def run_pubmed_search_adapter(config: dict[str, Any], context: dict[str, A
         # Use NCBI E-utilities
         base_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
 
-        async with httpx.AsyncClient() as client:
-            # Search for IDs
-            search_url = f"{base_url}/esearch.fcgi"
-            search_params = {
-                "db": "pubmed",
-                "term": query,
-                "retmax": max_results,
-                "retmode": "json",
-            }
-            search_response = await client.get(search_url, params=search_params, timeout=30)
-            search_data = search_response.json()
+        # Search for IDs
+        search_url = f"{base_url}/esearch.fcgi"
+        search_params = {
+            "db": "pubmed",
+            "term": query,
+            "retmax": max_results,
+            "retmode": "json",
+        }
+        search_response = await _managed_afetch(method="GET", url=search_url, params=search_params, timeout=30)
+        search_data = search_response.json()
 
-            id_list = search_data.get("esearchresult", {}).get("idlist", [])
-            if not id_list:
-                return {"papers": [], "total_results": 0, "query": query}
+        id_list = search_data.get("esearchresult", {}).get("idlist", [])
+        if not id_list:
+            return {"papers": [], "total_results": 0, "query": query}
 
-            # Fetch details
-            fetch_url = f"{base_url}/esummary.fcgi"
-            fetch_params = {
-                "db": "pubmed",
-                "id": ",".join(id_list),
-                "retmode": "json",
-            }
-            fetch_response = await client.get(fetch_url, params=fetch_params, timeout=30)
-            fetch_data = fetch_response.json()
+        # Fetch details
+        fetch_url = f"{base_url}/esummary.fcgi"
+        fetch_params = {
+            "db": "pubmed",
+            "id": ",".join(id_list),
+            "retmode": "json",
+        }
+        fetch_response = await _managed_afetch(method="GET", url=fetch_url, params=fetch_params, timeout=30)
+        fetch_data = fetch_response.json()
 
-            papers = []
-            result_data = fetch_data.get("result", {})
-            for pmid in id_list:
-                if pmid in result_data:
-                    paper = result_data[pmid]
-                    papers.append({
-                        "pmid": pmid,
-                        "title": paper.get("title", ""),
-                        "authors": [a.get("name", "") for a in paper.get("authors", [])],
-                        "source": paper.get("source", ""),
-                        "pubdate": paper.get("pubdate", ""),
-                        "doi": paper.get("elocationid", ""),
-                    })
+        papers = []
+        result_data = fetch_data.get("result", {})
+        for pmid in id_list:
+            if pmid in result_data:
+                paper = result_data[pmid]
+                papers.append({
+                    "pmid": pmid,
+                    "title": paper.get("title", ""),
+                    "authors": [a.get("name", "") for a in paper.get("authors", [])],
+                    "source": paper.get("source", ""),
+                    "pubdate": paper.get("pubdate", ""),
+                    "doi": paper.get("elocationid", ""),
+                })
 
-            return {"papers": papers, "total_results": len(papers), "query": query}
+        return {"papers": papers, "total_results": len(papers), "query": query}
 
     except Exception:
         logger.error("PubMed search error")
@@ -337,8 +339,6 @@ async def run_semantic_scholar_search_adapter(config: dict[str, Any], context: d
       - papers: list[dict]
       - total_results: int
     """
-    import httpx
-
     from tldw_Server_API.app.core.Chat.prompt_template_manager import apply_template_to_string as _tmpl
 
     if callable(context.get("is_cancelled")) and context["is_cancelled"]():
@@ -374,32 +374,32 @@ async def run_semantic_scholar_search_adapter(config: dict[str, Any], context: d
     fields = config.get("fields") or ["title", "authors", "abstract", "year", "citationCount", "url"]
 
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                "https://api.semanticscholar.org/graph/v1/paper/search",
-                params={
-                    "query": query,
-                    "limit": max_results,
-                    "fields": ",".join(fields),
-                },
-                timeout=30,
-            )
-            response.raise_for_status()
-            data = response.json()
+        response = await _managed_afetch(
+            method="GET",
+            url="https://api.semanticscholar.org/graph/v1/paper/search",
+            params={
+                "query": query,
+                "limit": max_results,
+                "fields": ",".join(fields),
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
 
-            papers = []
-            for paper in data.get("data", []):
-                papers.append({
-                    "paper_id": paper.get("paperId"),
-                    "title": paper.get("title"),
-                    "authors": [a.get("name", "") for a in paper.get("authors", [])],
-                    "abstract": paper.get("abstract"),
-                    "year": paper.get("year"),
-                    "citation_count": paper.get("citationCount"),
-                    "url": paper.get("url"),
-                })
+        papers = []
+        for paper in data.get("data", []):
+            papers.append({
+                "paper_id": paper.get("paperId"),
+                "title": paper.get("title"),
+                "authors": [a.get("name", "") for a in paper.get("authors", [])],
+                "abstract": paper.get("abstract"),
+                "year": paper.get("year"),
+                "citation_count": paper.get("citationCount"),
+                "url": paper.get("url"),
+            })
 
-            return {"papers": papers, "total_results": data.get("total", len(papers)), "query": query}
+        return {"papers": papers, "total_results": data.get("total", len(papers)), "query": query}
 
     except Exception:
         logger.error("Semantic Scholar search error")
@@ -504,8 +504,6 @@ async def run_patent_search_adapter(config: dict[str, Any], context: dict[str, A
       - patents: list[dict]
       - total_results: int
     """
-    import httpx
-
     from tldw_Server_API.app.core.Chat.prompt_template_manager import apply_template_to_string as _tmpl
 
     if callable(context.get("is_cancelled")) and context["is_cancelled"]():
@@ -544,31 +542,30 @@ async def run_patent_search_adapter(config: dict[str, Any], context: dict[str, A
     try:
         import urllib.parse
 
-        async with httpx.AsyncClient() as client:
-            encoded_query = urllib.parse.quote(query)
-            url = f"https://patents.google.com/xhr/query?url=q%3D{encoded_query}&num={max_results}"
+        encoded_query = urllib.parse.quote(query)
+        url = f"https://patents.google.com/xhr/query?url=q%3D{encoded_query}&num={max_results}"
 
-            response = await client.get(url, timeout=30, headers={"Accept": "application/json"})
+        response = await _managed_afetch(method="GET", url=url, timeout=30, headers={"Accept": "application/json"})
 
-            if response.status_code == 200:
-                try:
-                    data = response.json()
-                    patents = []
-                    for result in data.get("results", {}).get("cluster", [])[:max_results]:
-                        patent = result.get("result", {}).get("patent", {})
-                        patents.append({
-                            "patent_id": patent.get("publication_number", ""),
-                            "title": patent.get("title", ""),
-                            "abstract": patent.get("abstract", ""),
-                            "assignee": patent.get("assignee", ""),
-                            "filing_date": patent.get("filing_date", ""),
-                            "publication_date": patent.get("publication_date", ""),
-                        })
-                    return {"patents": patents, "total_results": len(patents), "query": query}
-                except json.JSONDecodeError:
-                    pass
+        if response.status_code == 200:
+            try:
+                data = response.json()
+                patents = []
+                for result in data.get("results", {}).get("cluster", [])[:max_results]:
+                    patent = result.get("result", {}).get("patent", {})
+                    patents.append({
+                        "patent_id": patent.get("publication_number", ""),
+                        "title": patent.get("title", ""),
+                        "abstract": patent.get("abstract", ""),
+                        "assignee": patent.get("assignee", ""),
+                        "filing_date": patent.get("filing_date", ""),
+                        "publication_date": patent.get("publication_date", ""),
+                    })
+                return {"patents": patents, "total_results": len(patents), "query": query}
+            except json.JSONDecodeError:
+                pass
 
-            return {"patents": [], "total_results": 0, "query": query, "note": "google_patents_api_unavailable"}
+        return {"patents": [], "total_results": 0, "query": query, "note": "google_patents_api_unavailable"}
 
     except Exception:
         logger.error("Patent search error")

--- a/tldw_Server_API/tests/Workflows/adapters/test_research_adapters.py
+++ b/tldw_Server_API/tests/Workflows/adapters/test_research_adapters.py
@@ -29,34 +29,6 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-def _patch_module_import(monkeypatch, module_name: str, fake_module: object) -> None:
-    """Patch a locally imported optional module without replacing global package state."""
-    import builtins
-
-    real_import = builtins.__import__
-
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == module_name:
-            return fake_module
-        return real_import(name, globals, locals, fromlist, level)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-
-
-def _fake_httpx_module_with_error(message: str) -> object:
-    class _ExplodingClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        async def get(self, *args, **kwargs):
-            raise RuntimeError(message)
-
-    return types.SimpleNamespace(AsyncClient=lambda *args, **kwargs: _ExplodingClient())
-
-
 # =============================================================================
 # Deep Research Launch Adapter Tests
 # =============================================================================
@@ -1226,6 +1198,78 @@ async def test_arxiv_download_adapter_with_pdf_url(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_arxiv_download_adapter_uses_central_http_client_for_pdf_url(monkeypatch, tmp_path):
+    """Direct PDF URL downloads must use the central outbound HTTP helper."""
+    monkeypatch.setenv("TEST_MODE", "0")
+    monkeypatch.setenv("TLDW_TEST_MODE", "0")
+
+    from tldw_Server_API.app.core.Workflows.adapters.research import (
+        run_arxiv_download_adapter,
+        search as search_module,
+    )
+
+    calls: list[dict[str, object]] = []
+
+    class _FakeResponse:
+        content = b"%PDF-1.7\ncentral"
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+    async def _fake_afetch(**kwargs):
+        calls.append(dict(kwargs))
+        return _FakeResponse()
+
+    monkeypatch.setattr(search_module, "afetch", _fake_afetch, raising=False)
+    monkeypatch.setattr(search_module, "_resolve_artifacts_dir", lambda _step_run_id: tmp_path)
+
+    result = await run_arxiv_download_adapter(
+        {"pdf_url": "http://127.0.0.1:65535/paper.pdf"},
+        {"step_run_id": "arxiv-pdf-egress-test"},
+    )
+
+    assert result["downloaded"] is True
+    assert Path(result["pdf_path"]).read_bytes() == _FakeResponse.content
+    assert len(calls) == 1
+    assert calls[0]["method"] == "GET"
+    assert calls[0]["url"] == "http://127.0.0.1:65535/paper.pdf"
+    assert calls[0]["allow_redirects"] is True
+    assert calls[0]["timeout"] == 60
+    assert getattr(calls[0]["client"], "_trust_env", None) is False
+
+
+@pytest.mark.asyncio
+async def test_arxiv_download_adapter_private_pdf_url_denied_by_central_policy(monkeypatch, tmp_path):
+    """Private direct PDF URLs should fail through central egress before network I/O."""
+    monkeypatch.setenv("TEST_MODE", "0")
+    monkeypatch.setenv("TLDW_TEST_MODE", "0")
+
+    from tldw_Server_API.app.core.exceptions import EgressPolicyError
+    from tldw_Server_API.app.core.Workflows.adapters.research import (
+        run_arxiv_download_adapter,
+        search as search_module,
+    )
+
+    calls: list[str] = []
+
+    async def _fake_afetch(**kwargs):
+        calls.append(str(kwargs["url"]))
+        raise EgressPolicyError("private_network")
+
+    monkeypatch.setattr(search_module, "afetch", _fake_afetch, raising=False)
+    monkeypatch.setattr(search_module, "_resolve_artifacts_dir", lambda _step_run_id: tmp_path)
+
+    result = await run_arxiv_download_adapter(
+        {"pdf_url": "http://127.0.0.1:65535/paper.pdf"},
+        {"step_run_id": "arxiv-private-pdf-egress-test"},
+    )
+
+    assert result == {"error": "arXiv download failed", "downloaded": False}
+    assert calls == ["http://127.0.0.1:65535/paper.pdf"]
+
+
+@pytest.mark.asyncio
 async def test_arxiv_download_adapter_missing_id(monkeypatch):
     """Test arXiv download handles missing ID gracefully."""
     monkeypatch.setenv("TEST_MODE", "1")
@@ -1409,11 +1453,10 @@ async def test_pubmed_search_adapter_sanitizes_backend_errors(monkeypatch):
         search as search_module,
     )
 
-    _patch_module_import(
-        monkeypatch,
-        "httpx",
-        _fake_httpx_module_with_error("PubMed token at /private/pubmed-cache"),
-    )
+    async def _fake_managed_afetch(**_kwargs):
+        raise RuntimeError("PubMed token at /private/pubmed-cache")
+
+    monkeypatch.setattr(search_module, "_managed_afetch", _fake_managed_afetch)
 
     messages: list[str] = []
     sink_id = search_module.logger.add(lambda message: messages.append(str(message)), level="ERROR")
@@ -1529,11 +1572,10 @@ async def test_semantic_scholar_search_adapter_sanitizes_backend_errors(monkeypa
         search as search_module,
     )
 
-    _patch_module_import(
-        monkeypatch,
-        "httpx",
-        _fake_httpx_module_with_error("Semantic Scholar token at /private/s2-cache"),
-    )
+    async def _fake_managed_afetch(**_kwargs):
+        raise RuntimeError("Semantic Scholar token at /private/s2-cache")
+
+    monkeypatch.setattr(search_module, "_managed_afetch", _fake_managed_afetch)
 
     messages: list[str] = []
     sink_id = search_module.logger.add(lambda message: messages.append(str(message)), level="ERROR")
@@ -1761,11 +1803,10 @@ async def test_patent_search_adapter_sanitizes_backend_errors(monkeypatch):
         search as search_module,
     )
 
-    _patch_module_import(
-        monkeypatch,
-        "httpx",
-        _fake_httpx_module_with_error("Patent token at /private/patent-cache"),
-    )
+    async def _fake_managed_afetch(**_kwargs):
+        raise RuntimeError("Patent token at /private/patent-cache")
+
+    monkeypatch.setattr(search_module, "_managed_afetch", _fake_managed_afetch)
 
     messages: list[str] = []
     sink_id = search_module.logger.add(lambda message: messages.append(str(message)), level="ERROR")
@@ -1901,29 +1942,10 @@ async def test_doi_resolve_adapter_sanitizes_backend_errors(monkeypatch):
         run_doi_resolve_adapter,
     )
 
-    class ExplodingClient:
-        async def __aenter__(self):
-            return self
+    async def _fake_managed_afetch(**_kwargs):
+        raise RuntimeError("DOI backend exploded at /private/doi-cache")
 
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        async def get(self, *args, **kwargs):
-            raise RuntimeError("DOI backend exploded at /private/doi-cache")
-
-    class FakeHttpx:
-        AsyncClient = staticmethod(lambda *args, **kwargs: ExplodingClient())
-
-    import builtins
-
-    real_import = builtins.__import__
-
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "httpx":
-            return FakeHttpx
-        return real_import(name, globals, locals, fromlist, level)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(bibliography_module, "_managed_afetch", _fake_managed_afetch)
 
     messages: list[str] = []
     sink_id = bibliography_module.logger.add(lambda message: messages.append(str(message)), level="ERROR")

--- a/tldw_Server_API/tests/Workflows/adapters/test_research_adapters.py
+++ b/tldw_Server_API/tests/Workflows/adapters/test_research_adapters.py
@@ -1426,6 +1426,83 @@ async def test_pubmed_search_adapter_with_template(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_pubmed_search_adapter_reuses_central_http_client(monkeypatch):
+    """PubMed search and summary requests should share one central async client."""
+    monkeypatch.setenv("TEST_MODE", "0")
+    monkeypatch.setenv("TLDW_TEST_MODE", "0")
+
+    from tldw_Server_API.app.core.Workflows.adapters.research import (
+        run_pubmed_search_adapter,
+        search as search_module,
+    )
+
+    shared_client = object()
+    client_contexts: list[dict[str, object]] = []
+    fetch_calls: list[dict[str, object]] = []
+
+    class _FakeClientContext:
+        async def __aenter__(self):
+            client_contexts.append({"event": "enter"})
+            return shared_client
+
+        async def __aexit__(self, exc_type, exc, tb):
+            client_contexts.append({"event": "exit"})
+            return False
+
+    class _SearchResponse:
+        @staticmethod
+        def json():
+            return {"esearchresult": {"idlist": ["123", "456"]}}
+
+    class _SummaryResponse:
+        @staticmethod
+        def json():
+            return {
+                "result": {
+                    "123": {
+                        "title": "First",
+                        "authors": [{"name": "A. Author"}],
+                        "source": "Journal",
+                        "pubdate": "2024",
+                        "elocationid": "10.1/example",
+                    },
+                    "456": {
+                        "title": "Second",
+                        "authors": [{"name": "B. Author"}],
+                        "source": "Journal",
+                        "pubdate": "2025",
+                        "elocationid": "10.2/example",
+                    },
+                }
+            }
+
+    def _fake_create_async_client(**kwargs):
+        client_contexts.append({"event": "create", **kwargs})
+        return _FakeClientContext()
+
+    async def _fake_afetch(**kwargs):
+        fetch_calls.append(dict(kwargs))
+        if str(kwargs["url"]).endswith("/esearch.fcgi"):
+            return _SearchResponse()
+        return _SummaryResponse()
+
+    monkeypatch.setattr(search_module, "create_async_client", _fake_create_async_client)
+    monkeypatch.setattr(search_module, "afetch", _fake_afetch, raising=False)
+
+    result = await run_pubmed_search_adapter({"query": "cancer", "max_results": 2}, {})
+
+    assert [event["event"] for event in client_contexts] == ["create", "enter", "exit"]
+    assert client_contexts[0]["timeout"] == 30
+    assert len(fetch_calls) == 2
+    assert fetch_calls[0]["client"] is shared_client
+    assert fetch_calls[1]["client"] is shared_client
+    assert fetch_calls[0]["url"].endswith("/esearch.fcgi")
+    assert fetch_calls[1]["url"].endswith("/esummary.fcgi")
+    assert result["total_results"] == 2
+    assert [paper["pmid"] for paper in result["papers"]] == ["123", "456"]
+
+
+@pytest.mark.asyncio
 async def test_pubmed_search_adapter_cancelled(monkeypatch):
     """Test PubMed search respects cancellation."""
     monkeypatch.setenv("TEST_MODE", "1")

--- a/tldw_Server_API/tests/Writing/test_tokenizer_resolver_unit.py
+++ b/tldw_Server_API/tests/Writing/test_tokenizer_resolver_unit.py
@@ -113,6 +113,64 @@ def test_resolve_tokenizer_runtime_probe_downgrades_failed_provider_native(monke
     assert resolution.tokenizer == "tiktoken:cl100k_base"
 
 
+def test_tokenizer_http_post_uses_central_http_client(monkeypatch):
+    from tldw_Server_API.app.core import http_client
+    from tldw_Server_API.app.core.LLM_Calls import tokenizer_resolver as resolver
+
+    calls: list[dict[str, object]] = []
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, object]:
+            return {"tokens": [1, 2, 3]}
+
+    def _fake_fetch(**kwargs):
+        calls.append(dict(kwargs))
+        return _FakeResponse()
+
+    monkeypatch.setattr(http_client, "fetch", _fake_fetch)
+
+    response = resolver._http_post(
+        url="http://127.0.0.1:65535/tokenize",
+        payload={"content": "hello"},
+        headers={"X-Test": "1"},
+        timeout=7.0,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"tokens": [1, 2, 3]}
+    assert calls == [
+        {
+            "method": "POST",
+            "url": "http://127.0.0.1:65535/tokenize",
+            "json": {"content": "hello"},
+            "headers": {"X-Test": "1"},
+            "timeout": 7.0,
+            "allow_redirects": True,
+        }
+    ]
+
+
+def test_tokenizer_http_post_private_url_denied_by_central_policy(monkeypatch):
+    from tldw_Server_API.app.core import http_client
+    from tldw_Server_API.app.core.exceptions import EgressPolicyError
+    from tldw_Server_API.app.core.LLM_Calls import tokenizer_resolver as resolver
+
+    def _fake_fetch(**kwargs):  # noqa: ANN003, ARG001
+        raise EgressPolicyError("private_network")
+
+    monkeypatch.setattr(http_client, "fetch", _fake_fetch)
+
+    with pytest.raises(EgressPolicyError, match="private_network"):
+        resolver._http_post(
+            url="http://127.0.0.1:11434/api/tokenize",
+            payload={"content": "hello"},
+            headers={},
+            timeout=5.0,
+        )
+
+
 def test_resolve_tokenizer_openai_unavailable_error_not_masked_by_native_config(monkeypatch):
     from tldw_Server_API.app.core.LLM_Calls import tokenizer_resolver as resolver
 


### PR DESCRIPTION
Addresses AUDIT-2026-06-27-INTEGRATIONS-001 and AUDIT-2026-06-27-INTEGRATIONS-002 / TASK-12146.

Change summary:
- Routes workflow research adapter direct HTTP calls and tokenizer resolver provider/token-count requests through central HTTP helpers instead of raw clients.
- Preserves explicit local-provider behavior where supported.
- Restores PubMed search/summary connection reuse by sharing one central-policy async client across both requests.
- Renames the Backlog task from duplicate `TASK-12138` to `TASK-12146` to avoid collisions with current dev tasks.

Latest-dev validation:
- Fetched origin/dev and rebased this branch onto fd5c152b065c408e4e8ee5f08da41589f21cb7f5. Merge-base matched origin/dev before validation.
- Passed: `.venv/bin/python -m pytest tldw_Server_API/tests/Workflows/adapters/test_research_adapters.py::test_pubmed_search_adapter_reuses_central_http_client -q` (1 passed).
- Passed: `.venv/bin/python -m pytest tldw_Server_API/tests/Workflows/adapters/test_research_adapters.py tldw_Server_API/tests/Writing/test_tokenizer_resolver_unit.py -q` (117 passed).
- Passed: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Workflows/adapters/research/search.py tldw_Server_API/app/core/Workflows/adapters/research/bibliography.py tldw_Server_API/app/core/LLM_Calls/tokenizer_resolver.py -f json -o /tmp/bandit_integrations_egress_latest_dev.json` with 0 findings.
- Passed: `git diff --check`.
- Raw-client scan over touched production files for `httpx.AsyncClient`, `httpx.Client`, `requests.`, `urllib.request`, and `urlopen(` returned no matches.

Review notes:
- Addressed both client-reuse comments by adding optional-client support to `_managed_afetch`, wrapping PubMed requests in one `create_async_client(timeout=30)` context, and adding an adapter-level regression proving both `afetch` calls receive the same client.

Draft until the required human-authored Change summary is added.