### PR TITLE
Harden weather provider outbound egress

### DIFF
--- a/Docs/Operations/Env_Vars.md
+++ b/Docs/Operations/Env_Vars.md
@@ -266,6 +266,7 @@ Notes:
 - `WEATHER_UNITS`: Unit system for weather summaries (`metric|imperial`, default `metric`).
 - `WEATHER_LANG`: OpenWeather language code for descriptions (default `en`).
 - `WEATHER_TIMEOUT_MS`: OpenWeather HTTP timeout in milliseconds (default `1500`).
+- `EGRESS_ALLOWLIST`: Comma-separated outbound host allowlist. Production's strict egress profile requires `api.openweathermap.org` in this list for live OpenWeather requests; retain any other outbound hosts your deployment needs.
 
 ## Chatbooks
 - `CHATBOOKS_JOBS_BACKEND`: Backend is fixed to "core"; this environment variable exists for compatibility and is ignored.

--- a/Docs/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md
+++ b/Docs/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md
@@ -76,7 +76,7 @@ default_location =        # fallback for /weather
 
 Built-in commands:
 - `/time [TZ]` → “Current time (America/New_York): 2025-11-10 20:15:00”
-- `/weather [location]` → “Boston: 42°F, clear skies” (requires provider config; otherwise “weather unavailable”). Configure `WEATHER_PROVIDER=openweather` and `OPENWEATHER_API_KEY` to enable live weather lookups.
+- `/weather [location]` → “Boston: 42°F, clear skies” (requires provider config; otherwise “weather unavailable”). Configure `WEATHER_PROVIDER=openweather` and `OPENWEATHER_API_KEY` to enable live weather lookups. Production deployments also need `api.openweathermap.org` in `EGRESS_ALLOWLIST` because the production egress profile is strict by default.
 - `/skills [filter]` → lists invocable skills for the current user (optional substring filter on name/description/argument hint).
 - `/skill <name> [args]` → executes an invocable skill and injects its output using the configured slash-command injection mode.
 

--- a/backlog/archive/tasks/task-12139 - Harden-audit-Integrations-weather-provider-egress-policy.md
+++ b/backlog/archive/tasks/task-12139 - Harden-audit-Integrations-weather-provider-egress-policy.md
@@ -18,7 +18,7 @@ documentation:
 modified_files:
 - tldw_Server_API/app/core/Integrations/weather_providers.py
 - tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
-updated_date: 2026-07-05 00:24
+updated_date: 2026-07-10 05:29
 ---
 
 ## Description
@@ -41,12 +41,15 @@ Implemented the AUDIT-2026-06-27-INTEGRATIONS-003 weather-provider egress remedi
 
 Current-dev refresh (2026-07-04): rebased `codex/audit-weather-egress-2026-07-04` onto `origin/dev` `09d9ec901e1d4548f7924f1c6bcefa963fadd9bd`; merge-base matches `origin/dev`. Current validation after the HTTP redirect hardening merge: `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q` passed with 36 tests; `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Integrations/weather_providers.py -f json -o /tmp/bandit_weather_egress_origin_dev_09d9ec.json` reported 0 findings over 257 LOC; `git diff --check HEAD~1..HEAD` passed. PR review feedback about spaces in the Backlog filename was evaluated as non-actionable because this repository's Backlog.md convention uses `task-id - title.md` filenames.
 2026-07-04 latest-dev refresh: rebased and validated PR #2610 on origin/dev 6b727b221e55646eba663a03571e38302f7fafc2. Tested head 2f2a02e8cdba. Verification: python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q => 36 passed, 80 warnings; bandit -r tldw_Server_API/app/core/Integrations/weather_providers.py => 0 findings over 257 LOC; git diff --check HEAD~1..HEAD => clean.
+2026-07-09 PR follow-up: reopened task to rebase PR #2610 onto current origin/dev and re-evaluate all review threads and CI failures before merge readiness.
+2026-07-09: This weather task ID collided with a different TASK-12139 added to dev. The weather remediation record is superseded by TASK-12945 and archived to preserve history without an ambiguous active ID.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Hardened weather provider egress handling and command-router coverage. Final refresh validated against origin/dev 6b727b221e55646eba663a03571e38302f7fafc2 with focused tests passing, Bandit clean on touched production scope, and whitespace check clean.
+Superseded by TASK-12945 after a latest-dev rebase exposed an active task ID collision.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/archive/tasks/task-12945 - Harden-audit-Integrations-weather-provider-egress-policy.md
+++ b/backlog/archive/tasks/task-12945 - Harden-audit-Integrations-weather-provider-egress-policy.md
@@ -1,0 +1,73 @@
+---
+id: TASK-12945
+title: Harden audit Integrations weather provider egress policy
+status: Done
+created_date: 2026-07-10 05:28
+labels:
+- audit
+- remediation
+- integrations
+- http-policy
+- pr-followup
+priority: medium
+references:
+- AUDIT-2026-06-27-INTEGRATIONS-003
+- https://github.com/rmusser01/tldw_server/pull/2610
+- Supersedes colliding weather task record TASK-12139
+documentation:
+- Docs/superpowers/reviews/2026-06-27-repo-audit/domains/integrations-providers.md
+- Docs/superpowers/reviews/2026-06-27-repo-audit/remediation-backlog-draft.md
+- Docs/Operations/Env_Vars.md
+- Docs/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md
+modified_files:
+- tldw_Server_API/app/core/Integrations/weather_providers.py
+- tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
+- Docs/Operations/Env_Vars.md
+- Docs/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md
+- tldw_Server_API/app/core/Integrations/README.md
+updated_date: 2026-07-10 05:35
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remediate AUDIT-2026-06-27-INTEGRATIONS-003 and complete PR #2610 follow-up by routing OpenWeather through central HTTP policy without redirecting credentials, documenting production egress configuration, and preserving sanitized provider behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Weather provider outbound requests use the central HTTP policy and never forward the OpenWeather API key across redirects.
+- [ ] #2 Tests cover central HTTP routing, redirect refusal, strict-profile allow/deny behavior, and sanitized errors.
+- [ ] #3 Production documentation explains the OpenWeather egress allowlist requirement.
+- [ ] #4 The PR uses a unique active Backlog task ID and preserves the superseded task history.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Stage 1: Rebase on latest dev and reconcile comments/checks. Stage 2: Add failing redirect and strict-policy regression tests. Stage 3: Apply the minimal redirect fix and update production configuration documentation. Stage 4: Run focused and security verification, independent review, push, and reconcile fresh PR checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created on 2026-07-09 because latest dev introduced a different active TASK-12139, colliding with the original weather remediation task. The original task record will be archived as superseded after this unique replacement is verified.
+TDD evidence (2026-07-09): added a real central-HTTP redirect regression using httpx.MockTransport plus a central-fetch call contract assertion. Before the production fix, the focused suite failed twice: the redirect target returned a successful forged weather payload and the central call omitted allow_redirects. The captured second request was https://example.com/capture?appid=secret-key&units=metric&lang=en&q=Boston. Adding allow_redirects=False produced one request to api.openweathermap.org and the 12-test weather suite passed. Added real strict-profile tests proving denial before network I/O without an allowlist and successful access when EGRESS_ALLOWLIST includes api.openweathermap.org. Updated operator and user documentation for the production allowlist requirement.
+2026-07-09: origin/dev advanced during verification and introduced unrelated active TASK-12945 records. This weather record is superseded by unique TASK-12946 and archived before the second rebase.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Superseded by TASK-12946 after a later latest-dev refresh exposed additional active TASK-12945 collisions.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Focused weather and command-router tests pass on latest dev.
+- [ ] #2 Ruff passes for touched Python files.
+- [ ] #3 Bandit reports no findings in touched production code.
+- [ ] #4 git diff --check passes.
+- [ ] #5 Independent specification and code-quality reviews have no unresolved actionable findings.
+- [ ] #6 PR review threads and fresh CI state are reconciled.
+<!-- DOD:END -->

--- a/backlog/tasks/task-12139 - Harden-audit-Integrations-weather-provider-egress-policy.md
+++ b/backlog/tasks/task-12139 - Harden-audit-Integrations-weather-provider-egress-policy.md
@@ -11,13 +11,14 @@ labels:
 priority: medium
 references:
 - AUDIT-2026-06-27-INTEGRATIONS-003
+- https://github.com/rmusser01/tldw_server/pull/2610
 documentation:
 - Docs/superpowers/reviews/2026-06-27-repo-audit/domains/integrations-providers.md
 - Docs/superpowers/reviews/2026-06-27-repo-audit/remediation-backlog-draft.md
 modified_files:
 - tldw_Server_API/app/core/Integrations/weather_providers.py
 - tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
-updated_date: 2026-07-04 01:58
+updated_date: 2026-07-05 00:24
 ---
 
 ## Description
@@ -36,13 +37,16 @@ Remediate AUDIT-2026-06-27-INTEGRATIONS-003 by routing weather-provider outbound
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Implemented the AUDIT-2026-06-27-INTEGRATIONS-003 weather-provider egress remediation. TDD evidence: `test_openweather_uses_central_http_fetch_for_requests` first failed because the provider still used the raw client path; after routing through central `fetch`, it passed. Added `test_openweather_central_policy_denial_returns_sanitized_error`; it first failed with `EgressPolicyError` bubbling out, then passed after adding central HTTP exception handling. Added a retry-preservation assertion that first failed on missing `retry`, then passed after using `RetryPolicy(attempts=1)` to preserve prior single-request weather timeout behavior. Verification: `python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q` passed with 36 passed; `python -m bandit -r tldw_Server_API/app/core/Integrations/weather_providers.py -f json -o /tmp/bandit_integrations_weather.json` produced 0 errors and 0 results; `git diff --check` passed; raw client scan for `http_client_factory`, `httpx.Client`, `httpx.AsyncClient`, and direct `requests` usage returned no matches in the touched weather files.
+Implemented the AUDIT-2026-06-27-INTEGRATIONS-003 weather-provider egress remediation. TDD evidence: `test_openweather_uses_central_http_fetch_for_requests` first failed because the provider still used the raw client path; after routing through central `fetch`, it passed. Added `test_openweather_central_policy_denial_returns_sanitized_error`; it first failed with `EgressPolicyError` bubbling out, then passed after adding central HTTP exception handling. Added a retry-preservation assertion that first failed on missing `retry`, then passed after using `RetryPolicy(attempts=1)` to preserve prior single-request weather timeout behavior.
+
+Current-dev refresh (2026-07-04): rebased `codex/audit-weather-egress-2026-07-04` onto `origin/dev` `09d9ec901e1d4548f7924f1c6bcefa963fadd9bd`; merge-base matches `origin/dev`. Current validation after the HTTP redirect hardening merge: `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q` passed with 36 tests; `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Integrations/weather_providers.py -f json -o /tmp/bandit_weather_egress_origin_dev_09d9ec.json` reported 0 findings over 257 LOC; `git diff --check HEAD~1..HEAD` passed. PR review feedback about spaces in the Backlog filename was evaluated as non-actionable because this repository's Backlog.md convention uses `task-id - title.md` filenames.
+2026-07-04 latest-dev refresh: rebased and validated PR #2610 on origin/dev 6b727b221e55646eba663a03571e38302f7fafc2. Tested head 2f2a02e8cdba. Verification: python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q => 36 passed, 80 warnings; bandit -r tldw_Server_API/app/core/Integrations/weather_providers.py => 0 findings over 257 LOC; git diff --check HEAD~1..HEAD => clean.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Routed OpenWeather API requests through the central synchronous HTTP helper, preserving the provider timeout as a single-attempt request and expanding sanitized handling to central HTTP policy/transport exceptions. Updated weather provider tests to patch the central fetch seam and added regressions for central fetch usage, sanitized policy denials, and unchanged validation-before-network behavior. This closes AUDIT-2026-06-27-INTEGRATIONS-003 for this focused branch.
+Hardened weather provider egress handling and command-router coverage. Final refresh validated against origin/dev 6b727b221e55646eba663a03571e38302f7fafc2 with focused tests passing, Bandit clean on touched production scope, and whitespace check clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12139 - Harden-audit-Integrations-weather-provider-egress-policy.md
+++ b/backlog/tasks/task-12139 - Harden-audit-Integrations-weather-provider-egress-policy.md
@@ -1,0 +1,54 @@
+---
+id: TASK-12139
+title: Harden audit Integrations weather provider egress policy
+status: Done
+created_date: 2026-07-04 01:50
+labels:
+- audit
+- remediation
+- integrations
+- http-policy
+priority: medium
+references:
+- AUDIT-2026-06-27-INTEGRATIONS-003
+documentation:
+- Docs/superpowers/reviews/2026-06-27-repo-audit/domains/integrations-providers.md
+- Docs/superpowers/reviews/2026-06-27-repo-audit/remediation-backlog-draft.md
+modified_files:
+- tldw_Server_API/app/core/Integrations/weather_providers.py
+- tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
+updated_date: 2026-07-04 01:58
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remediate AUDIT-2026-06-27-INTEGRATIONS-003 by routing weather-provider outbound API requests through the central HTTP defaults or an explicitly safe client configuration, while preserving existing provider behavior and sanitized error handling.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Weather provider outbound requests no longer use a raw client that bypasses central HTTP policy defaults.
+- [x] #2 Weather provider tests verify the request path uses central HTTP behavior or explicitly safe client configuration.
+- [x] #3 Existing weather provider input validation and sanitized error behavior remain intact.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the AUDIT-2026-06-27-INTEGRATIONS-003 weather-provider egress remediation. TDD evidence: `test_openweather_uses_central_http_fetch_for_requests` first failed because the provider still used the raw client path; after routing through central `fetch`, it passed. Added `test_openweather_central_policy_denial_returns_sanitized_error`; it first failed with `EgressPolicyError` bubbling out, then passed after adding central HTTP exception handling. Added a retry-preservation assertion that first failed on missing `retry`, then passed after using `RetryPolicy(attempts=1)` to preserve prior single-request weather timeout behavior. Verification: `python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q` passed with 36 passed; `python -m bandit -r tldw_Server_API/app/core/Integrations/weather_providers.py -f json -o /tmp/bandit_integrations_weather.json` produced 0 errors and 0 results; `git diff --check` passed; raw client scan for `http_client_factory`, `httpx.Client`, `httpx.AsyncClient`, and direct `requests` usage returned no matches in the touched weather files.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Routed OpenWeather API requests through the central synchronous HTTP helper, preserving the provider timeout as a single-attempt request and expanding sanitized handling to central HTTP policy/transport exceptions. Updated weather provider tests to patch the central fetch seam and added regressions for central fetch usage, sanitized policy denials, and unchanged validation-before-network behavior. This closes AUDIT-2026-06-27-INTEGRATIONS-003 for this focused branch.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Focused weather provider tests pass.
+- [x] #2 Bandit runs clean over touched production weather provider code.
+- [x] #3 git diff --check passes.
+- [x] #4 AUDIT-2026-06-27-INTEGRATIONS-003 closure evidence is recorded in the task notes.
+<!-- DOD:END -->

--- a/backlog/tasks/task-12946 - Harden-audit-Integrations-weather-provider-egress-policy.md
+++ b/backlog/tasks/task-12946 - Harden-audit-Integrations-weather-provider-egress-policy.md
@@ -1,0 +1,74 @@
+---
+id: TASK-12946
+title: Harden audit Integrations weather provider egress policy
+status: Done
+created_date: 2026-07-10 05:35
+labels:
+- audit
+- remediation
+- integrations
+- http-policy
+- pr-followup
+priority: medium
+references:
+- AUDIT-2026-06-27-INTEGRATIONS-003
+- https://github.com/rmusser01/tldw_server/pull/2610
+- Supersedes weather records TASK-12139 and TASK-12945 after latest-dev ID collisions
+documentation:
+- Docs/superpowers/reviews/2026-06-27-repo-audit/domains/integrations-providers.md
+- Docs/superpowers/reviews/2026-06-27-repo-audit/remediation-backlog-draft.md
+- Docs/Operations/Env_Vars.md
+- Docs/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md
+modified_files:
+- tldw_Server_API/app/core/Integrations/weather_providers.py
+- tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
+- Docs/Operations/Env_Vars.md
+- Docs/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md
+- tldw_Server_API/app/core/Integrations/README.md
+updated_date: 2026-07-10 06:07
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remediate AUDIT-2026-06-27-INTEGRATIONS-003 and complete PR #2610 follow-up by routing OpenWeather through central HTTP policy without redirecting credentials, documenting production egress configuration, and preserving sanitized provider behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Weather provider outbound requests use the central HTTP policy and never forward the OpenWeather API key across redirects.
+- [x] #2 Tests cover central HTTP routing, redirect refusal, strict-profile allow/deny behavior, and sanitized errors.
+- [x] #3 Production documentation explains the OpenWeather egress allowlist requirement.
+- [x] #4 The PR uses a unique active Backlog task ID and preserves superseded task history.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Stage 1: Rebase on latest dev and reconcile comments/checks. Stage 2: Add failing redirect and strict-policy regression tests. Stage 3: Apply the minimal redirect fix and update production configuration documentation. Stage 4: Run focused and security verification, independent review, push, and reconcile fresh PR checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created on 2026-07-09 after origin/dev advanced during verification and introduced unrelated active TASK-12945 records. Earlier weather records TASK-12139 and TASK-12945 are archived as superseded. TDD evidence: the real central-HTTP redirect regression failed before the fix after requesting https://example.com/capture?appid=secret-key&units=metric&lang=en&q=Boston; adding allow_redirects=False reduced execution to one OpenWeather request and made the 12-test weather suite pass. Strict-profile tests prove denial before network I/O without an allowlist and success when EGRESS_ALLOWLIST includes api.openweathermap.org. Production documentation now records that requirement.
+Latest-dev verification on 2026-07-09: branch rebased onto origin/dev 38bc70fd02ad4b55ed7ffc414642a936b6f28b0e and merge-base matched. Focused pytest command for weather providers plus command router passed 38 tests with 83 warnings. Ruff passed touched Python files. Bandit reported 0 findings, 0 skipped tests, and no errors over 258 production LOC. Both committed-range and working-tree git diff --check commands passed. Active TASK-12946 is unique; superseded weather records TASK-12139 and TASK-12945 are archived.
+Review gates: independent specification review approved after confirming merge-base 38bc70fd02 and TASK-12946 plan references. Independent final code-quality/security review approved with no actionable P0-P3 findings. Residual risk is limited to live DNS/TLS behavior because deterministic tests use an in-memory transport and pytest's DNS shortcut.
+PR refresh: force-pushed head 84bb98d57b5add518889cb271ef6c59d7ec43369, updated the PR body, and resolved the only review thread after its convention-based response. Fresh GitHub workflows were triggered with no failures, but repository-wide Actions capacity was unavailable: 113 runs queued and 0 in progress. This external queue state is recorded rather than misclassified as a branch failure; PR #2610 remains draft pending the required human-written Change summary and eventual CI execution.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2610 onto origin/dev 38bc70fd02, fixed the independently discovered cross-origin OpenWeather API-key redirect leak by disabling redirects, added real central-policy redirect and strict allow/deny tests, documented the production egress allowlist, and replaced colliding active task IDs with unique TASK-12946 while archiving superseded records. Focused tests passed 38/38, Ruff passed, Bandit reported zero findings over 258 production LOC, whitespace checks passed, independent spec and quality reviews approved, and the existing GitHub thread was resolved. Fresh GitHub checks are queued without failures because repository-wide Actions currently has no running capacity.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Focused weather and command-router tests pass on latest dev.
+- [x] #2 Ruff passes for touched Python files.
+- [x] #3 Bandit reports no findings in touched production code.
+- [x] #4 git diff --check passes.
+- [x] #5 Independent specification and code-quality reviews have no unresolved actionable findings.
+- [x] #6 PR review threads and fresh CI state are reconciled.
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Integrations/README.md
+++ b/tldw_Server_API/app/core/Integrations/README.md
@@ -46,8 +46,9 @@ Integrations currently contains the weather provider used by chat slash commands
 ### Security And Operations
 
 - The no-key client must not make outbound network requests.
+- OpenWeather requests use the central HTTP policy, do not follow redirects, and require `api.openweathermap.org` in `EGRESS_ALLOWLIST` when the strict production egress profile is active.
 - OpenWeather failures should return normalized unavailable/error metadata without leaking API keys.
-- The injectable HTTP client factory is the test boundary for timeout, status-code, and response-shape behavior.
+- Tests use the central HTTP helper or an in-memory transport as the boundary for policy, redirect, timeout, status-code, and response-shape behavior.
 
 ### Extension Checklist
 

--- a/tldw_Server_API/app/core/Integrations/weather_providers.py
+++ b/tldw_Server_API/app/core/Integrations/weather_providers.py
@@ -13,21 +13,28 @@ from typing import Any
 
 import httpx
 
+from tldw_Server_API.app.core.exceptions import (
+    EgressPolicyError,
+    NetworkError,
+    RetryExhaustedError,
+)
+from tldw_Server_API.app.core.http_client import RetryPolicy, fetch
+
 _WEATHER_NONCRITICAL_EXCEPTIONS = (
     AttributeError,
     ConnectionError,
+    EgressPolicyError,
     KeyError,
     LookupError,
+    NetworkError,
     OSError,
+    RetryExhaustedError,
     RuntimeError,
     TimeoutError,
     TypeError,
     ValueError,
     httpx.HTTPError,
 )
-
-# Test seam for controlled outbound behavior without patching httpx directly.
-http_client_factory = httpx.Client
 
 _MAX_LOCATION_CHARS = 120
 _MIN_LATITUDE = -90.0
@@ -217,8 +224,13 @@ class OpenWeatherClient(WeatherClient):
             )
 
         try:
-            with http_client_factory(timeout=self.timeout_seconds) as client:
-                response = client.get(self._BASE_URL, params=params)
+            response = fetch(
+                method="GET",
+                url=self._BASE_URL,
+                params=params,
+                retry=RetryPolicy(attempts=1),
+                timeout=self.timeout_seconds,
+            )
             if response.status_code >= 400:
                 return WeatherResult(
                     ok=False,

--- a/tldw_Server_API/app/core/Integrations/weather_providers.py
+++ b/tldw_Server_API/app/core/Integrations/weather_providers.py
@@ -230,6 +230,7 @@ class OpenWeatherClient(WeatherClient):
                 params=params,
                 retry=RetryPolicy(attempts=1),
                 timeout=self.timeout_seconds,
+                allow_redirects=False,
             )
             if response.status_code >= 400:
                 return WeatherResult(

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
@@ -1,6 +1,7 @@
 import httpx
 import pytest
 
+from tldw_Server_API.app.core.exceptions import EgressPolicyError
 from tldw_Server_API.app.core.Integrations import weather_providers
 
 
@@ -39,21 +40,10 @@ def test_openweather_http_error_response(monkeypatch):
         def json():
             return {}
 
-    class FakeClient:
-        def __init__(self, *args, **kwargs):
-            pass
+    def fake_fetch(**kwargs):
+        return FakeResponse()
 
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        @staticmethod
-        def get(*args, **kwargs):
-            return FakeResponse()
-
-    monkeypatch.setattr(weather_providers, "http_client_factory", FakeClient)
+    monkeypatch.setattr(weather_providers, "fetch", fake_fetch)
 
     result = client.get_current(location="Boston")
     assert not result.ok
@@ -65,21 +55,10 @@ def test_openweather_http_error_response(monkeypatch):
 def test_openweather_exception_path(monkeypatch):
     client = weather_providers.OpenWeatherClient(api_key="k")
 
-    class RaisingClient:
-        def __init__(self, *args, **kwargs):
-            pass
+    def fake_fetch(**kwargs):
+        raise httpx.ReadTimeout("timed out")
 
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        @staticmethod
-        def get(*args, **kwargs):
-            raise httpx.ReadTimeout("timed out")
-
-    monkeypatch.setattr(weather_providers, "http_client_factory", RaisingClient)
+    monkeypatch.setattr(weather_providers, "fetch", fake_fetch)
 
     result = client.get_current(location="Boston")
     assert not result.ok
@@ -91,21 +70,10 @@ def test_openweather_exception_path(monkeypatch):
 def test_openweather_exception_metadata_does_not_expose_raw_details(monkeypatch):
     client = weather_providers.OpenWeatherClient(api_key="secret-key")
 
-    class RaisingClient:
-        def __init__(self, *args, **kwargs):
-            pass
+    def fake_fetch(**kwargs):
+        raise httpx.RequestError("failed with appid=secret-key")
 
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        @staticmethod
-        def get(*args, **kwargs):
-            raise httpx.RequestError("failed with appid=secret-key")
-
-    monkeypatch.setattr(weather_providers, "http_client_factory", RaisingClient)
+    monkeypatch.setattr(weather_providers, "fetch", fake_fetch)
 
     result = client.get_current(location="Boston")
     combined = f"{result.summary} {result.metadata}"
@@ -117,14 +85,71 @@ def test_openweather_exception_metadata_does_not_expose_raw_details(monkeypatch)
 
 
 @pytest.mark.unit
+def test_openweather_central_policy_denial_returns_sanitized_error(monkeypatch):
+    client = weather_providers.OpenWeatherClient(api_key="secret-key")
+
+    def fake_fetch(**kwargs):
+        raise EgressPolicyError("blocked appid=secret-key")
+
+    monkeypatch.setattr(weather_providers, "fetch", fake_fetch)
+
+    result = client.get_current(location="Boston")
+    combined = f"{result.summary} {result.metadata}"
+    assert not result.ok
+    assert result.metadata.get("error") == "exception"
+    assert result.metadata.get("exception_type") == "EgressPolicyError"
+    assert "details" not in result.metadata
+    assert "secret-key" not in combined
+
+
+@pytest.mark.unit
+def test_openweather_uses_central_http_fetch_for_requests(monkeypatch):
+    client = weather_providers.OpenWeatherClient(api_key="k", units="metric")
+    calls = []
+
+    class FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {
+                "name": "Boston",
+                "sys": {"country": "US"},
+                "main": {"temp": 12.6},
+                "weather": [{"description": "clear sky"}],
+            }
+
+    def fake_fetch(**kwargs):
+        calls.append(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr(weather_providers, "fetch", fake_fetch, raising=False)
+
+    result = client.get_current(location="Boston")
+
+    assert result.ok
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["method"] == "GET"
+    assert call["url"] == weather_providers.OpenWeatherClient._BASE_URL
+    assert call["params"] == {
+        "appid": "k",
+        "units": "metric",
+        "lang": "en",
+        "q": "Boston",
+    }
+    assert call["timeout"] == client.timeout_seconds
+    assert call["retry"].attempts == 1
+
+
+@pytest.mark.unit
 def test_openweather_rejects_oversized_location_before_network(monkeypatch):
     client = weather_providers.OpenWeatherClient(api_key="k")
 
-    class FailingClient:
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError("network should not be used for invalid input")
+    def failing_fetch(**kwargs):
+        raise AssertionError("network should not be used for invalid input")
 
-    monkeypatch.setattr(weather_providers, "http_client_factory", FailingClient)
+    monkeypatch.setattr(weather_providers, "fetch", failing_fetch)
 
     result = client.get_current(location="x" * 300)
     assert not result.ok
@@ -135,11 +160,10 @@ def test_openweather_rejects_oversized_location_before_network(monkeypatch):
 def test_openweather_rejects_out_of_range_coordinates_before_network(monkeypatch):
     client = weather_providers.OpenWeatherClient(api_key="k")
 
-    class FailingClient:
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError("network should not be used for invalid input")
+    def failing_fetch(**kwargs):
+        raise AssertionError("network should not be used for invalid input")
 
-    monkeypatch.setattr(weather_providers, "http_client_factory", FailingClient)
+    monkeypatch.setattr(weather_providers, "fetch", failing_fetch)
 
     result = client.get_current(lat=95.0, lon=0.0)
     assert not result.ok
@@ -162,21 +186,10 @@ def test_openweather_success_response(monkeypatch):
                 "weather": [{"description": "clear sky"}],
             }
 
-    class FakeClient:
-        def __init__(self, *args, **kwargs):
-            pass
+    def fake_fetch(**kwargs):
+        return FakeResponse()
 
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        @staticmethod
-        def get(*args, **kwargs):
-            return FakeResponse()
-
-    monkeypatch.setattr(weather_providers, "http_client_factory", FakeClient)
+    monkeypatch.setattr(weather_providers, "fetch", fake_fetch)
 
     result = client.get_current(location="Boston")
     assert result.ok

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 
-from tldw_Server_API.app.core.exceptions import EgressPolicyError
+from tldw_Server_API.app.core import http_client
 from tldw_Server_API.app.core.Integrations import weather_providers
 
 
@@ -87,11 +87,14 @@ def test_openweather_exception_metadata_does_not_expose_raw_details(monkeypatch)
 @pytest.mark.unit
 def test_openweather_central_policy_denial_returns_sanitized_error(monkeypatch):
     client = weather_providers.OpenWeatherClient(api_key="secret-key")
-
-    def fake_fetch(**kwargs):
-        raise EgressPolicyError("blocked appid=secret-key")
-
-    monkeypatch.setattr(weather_providers, "fetch", fake_fetch)
+    monkeypatch.setenv("WORKFLOWS_EGRESS_PROFILE", "strict")
+    monkeypatch.delenv("WORKFLOWS_EGRESS_ALLOWLIST", raising=False)
+    monkeypatch.delenv("EGRESS_ALLOWLIST", raising=False)
+    monkeypatch.setattr(
+        http_client,
+        "_get_httpx_client",
+        lambda **kwargs: pytest.fail("strict policy denial must happen before network I/O"),
+    )
 
     result = client.get_current(location="Boston")
     combined = f"{result.summary} {result.metadata}"
@@ -100,6 +103,74 @@ def test_openweather_central_policy_denial_returns_sanitized_error(monkeypatch):
     assert result.metadata.get("exception_type") == "EgressPolicyError"
     assert "details" not in result.metadata
     assert "secret-key" not in combined
+
+
+@pytest.mark.unit
+def test_openweather_strict_policy_allows_documented_host(monkeypatch):
+    client = weather_providers.OpenWeatherClient(api_key="secret-key")
+    monkeypatch.setenv("WORKFLOWS_EGRESS_PROFILE", "strict")
+    monkeypatch.setenv("EGRESS_ALLOWLIST", "api.openweathermap.org")
+    monkeypatch.delenv("WORKFLOWS_EGRESS_ALLOWLIST", raising=False)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.openweathermap.org"
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "name": "Boston",
+                "sys": {"country": "US"},
+                "main": {"temp": 12.6},
+                "weather": [{"description": "clear sky"}],
+            },
+        )
+
+    transport_client = httpx.Client(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(http_client, "_get_httpx_client", lambda **kwargs: transport_client)
+    try:
+        result = client.get_current(location="Boston")
+    finally:
+        transport_client.close()
+
+    assert result.ok
+
+
+@pytest.mark.unit
+def test_openweather_does_not_follow_provider_redirects(monkeypatch):
+    client = weather_providers.OpenWeatherClient(api_key="secret-key")
+    monkeypatch.setenv("WORKFLOWS_EGRESS_PROFILE", "permissive")
+    monkeypatch.delenv("WORKFLOWS_EGRESS_ALLOWLIST", raising=False)
+    monkeypatch.delenv("EGRESS_ALLOWLIST", raising=False)
+    requested_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        if request.url.host == "api.openweathermap.org":
+            return httpx.Response(
+                302,
+                request=request,
+                headers={"Location": "https://example.com/capture"},
+            )
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "name": "Redirected",
+                "main": {"temp": 10},
+                "weather": [{"description": "unexpected"}],
+            },
+        )
+
+    transport_client = httpx.Client(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(http_client, "_get_httpx_client", lambda **kwargs: transport_client)
+    try:
+        result = client.get_current(location="Boston")
+    finally:
+        transport_client.close()
+
+    assert not result.ok
+    assert len(requested_urls) == 1
+    assert requested_urls[0].startswith("https://api.openweathermap.org/")
 
 
 @pytest.mark.unit
@@ -140,6 +211,7 @@ def test_openweather_uses_central_http_fetch_for_requests(monkeypatch):
     }
     assert call["timeout"] == client.timeout_seconds
     assert call["retry"].attempts == 1
+    assert call["allow_redirects"] is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Change summary

Human-written Change summary required before this AI-authored PR is merge-ready under `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## What changed

- Routes OpenWeather requests through the central HTTP policy.
- Disables provider redirects so the query-string API key cannot be forwarded to another origin.
- Preserves the prior one-attempt timeout and sanitized error behavior.
- Adds deterministic tests for redirect refusal and real strict-profile allow/deny behavior.
- Documents the production `EGRESS_ALLOWLIST=api.openweathermap.org` requirement.
- Moves superseded colliding weather task records to the Backlog archive; active tracking is `TASK-12946`.

## Latest dev refresh

- Base: `dev` at `38bc70fd02ad4b55ed7ffc414642a936b6f28b0e`.
- Head: `codex/audit-weather-egress-2026-07-04` at `e1ad3b60579b2ed535f2fa04226582674587aa54`.
- Merge-base verified equal to the base immediately before the final push.

## Review follow-up

- The filename-space suggestion remains non-actionable because `task-<id> - <title>.md` is the repository Backlog convention; the thread is resolved.
- Independent review found and this update fixes a cross-origin redirect credential leak.
- The original `TASK-12139` and interim `TASK-12945` weather records collided with newer `dev` records; both are archived and replaced by unique active `TASK-12946`.
- Independent specification and final code-quality/security reviews approved with no remaining actionable findings.

## Validation

- `python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q` -> 38 passed, 83 warnings.
- `python -m ruff check tldw_Server_API/app/core/Integrations/weather_providers.py tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py` -> passed.
- `python -m bandit -r tldw_Server_API/app/core/Integrations/weather_providers.py` -> 0 findings over 258 LOC.
- `git diff --check` -> clean.

## CI status

Fresh workflows were triggered for the final head and currently have no reported failures. At refresh time GitHub Actions was repository-wide queued (113 queued runs, 0 in progress), so this draft remains pending eventual runner capacity.
