### PR TITLE
Redact RAG query text from info logs

### DIFF
--- a/backlog/tasks/task-12141 - Fix-audit-RAG-raw-query-info-logging.md
+++ b/backlog/tasks/task-12141 - Fix-audit-RAG-raw-query-info-logging.md
@@ -1,0 +1,59 @@
+---
+id: TASK-12141
+title: Fix audit RAG raw query info logging
+status: Done
+created_date: 2026-07-04 03:25
+labels:
+- audit
+- remediation
+- rag
+- logging
+- security
+priority: medium
+references:
+- AUDIT-2026-06-27-CHAT-002
+documentation:
+- Docs/superpowers/reviews/2026-06-27-repo-audit/domains/chat-rag-llm.md
+- Docs/superpowers/reviews/2026-06-27-repo-audit/remediation-backlog-draft.md
+modified_files:
+- tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+- tldw_Server_API/tests/RAG/test_rag_query_logging.py
+updated_date: 2026-07-04 03:29
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remediate AUDIT-2026-06-27-CHAT-002 by replacing info-level RAG logs that include raw user queries with hash/length metadata and tests preventing raw query leakage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Unified RAG search info logs do not include raw query text.
+- [x] #2 Advanced RAG search info logs do not include raw query text.
+- [x] #3 RAG request logs include non-security query hash and query length metadata for correlation.
+- [x] #4 Focused tests assert sensitive query content is absent from rendered info logs.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `_log_rag_search_request()` to log a non-security MD5 query hash and query length instead of raw query text.
+- Replaced raw info-level query logging in unified and advanced RAG search paths; simple search now reuses the same helper.
+- Added focused unit coverage asserting sensitive query fragments and private paths are absent from rendered info logs while hash/length metadata remains present.
+- Verification: `python -m pytest tldw_Server_API/tests/RAG/test_rag_query_logging.py -q` passed with 2 tests; Bandit over `tldw_Server_API/app/api/v1/endpoints/rag_unified.py` reported 0 findings; `git diff --check` passed; targeted source scan found no old unified/advanced raw-query info log patterns.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed AUDIT-2026-06-27-CHAT-002 by routing RAG request info logs through a shared hash/length helper and removing raw query text from unified and advanced search logs. Focused tests now prevent sensitive query fragments from appearing in rendered info logs.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Focused RAG query logging tests pass.
+- [x] #2 Bandit runs clean over touched production code.
+- [x] #3 git diff --check passes.
+- [x] #4 AUDIT-2026-06-27-CHAT-002 closure evidence is recorded in task notes.
+<!-- DOD:END -->

--- a/backlog/tasks/task-12143 - Fix-audit-RAG-raw-query-info-logging.md
+++ b/backlog/tasks/task-12143 - Fix-audit-RAG-raw-query-info-logging.md
@@ -1,8 +1,8 @@
 ---
-id: TASK-12141
+id: TASK-12143
 title: Fix audit RAG raw query info logging
 status: Done
-created_date: 2026-07-04 03:25
+created_date: 2026-07-04 18:20
 labels:
 - audit
 - remediation
@@ -12,13 +12,14 @@ labels:
 priority: medium
 references:
 - AUDIT-2026-06-27-CHAT-002
+- https://github.com/rmusser01/tldw_server/pull/2614
 documentation:
 - Docs/superpowers/reviews/2026-06-27-repo-audit/domains/chat-rag-llm.md
 - Docs/superpowers/reviews/2026-06-27-repo-audit/remediation-backlog-draft.md
 modified_files:
 - tldw_Server_API/app/api/v1/endpoints/rag_unified.py
 - tldw_Server_API/tests/RAG/test_rag_query_logging.py
-updated_date: 2026-07-04 03:29
+updated_date: 2026-07-04 18:23
 ---
 
 ## Description
@@ -42,6 +43,9 @@ Remediate AUDIT-2026-06-27-CHAT-002 by replacing info-level RAG logs that includ
 - Replaced raw info-level query logging in unified and advanced RAG search paths; simple search now reuses the same helper.
 - Added focused unit coverage asserting sensitive query fragments and private paths are absent from rendered info logs while hash/length metadata remains present.
 - Verification: `python -m pytest tldw_Server_API/tests/RAG/test_rag_query_logging.py -q` passed with 2 tests; Bandit over `tldw_Server_API/app/api/v1/endpoints/rag_unified.py` reported 0 findings; `git diff --check` passed; targeted source scan found no old unified/advanced raw-query info log patterns.
+- 2026-07-04 latest-dev refresh: rebased `codex/audit-rag-query-logging-2026-07-04` onto `origin/dev` `fd5c152b065c408e4e8ee5f08da41589f21cb7f5`; merge-base matches `origin/dev`.
+- Latest-dev validation: `.venv/bin/python -m pytest tldw_Server_API/tests/RAG/test_rag_query_logging.py -q` passed with 2 tests; `.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/rag_unified.py -f json -o /tmp/bandit_rag_query_logging_latest.json` reported 0 findings; `git diff --check` passed; targeted raw-query logger scan found no old unified/advanced/simple raw-query info log patterns.
+- Tracking hygiene: moved this RAG audit record from duplicate `TASK-12141` to `TASK-12143` so it does not collide with another active audit PR.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12143 - Fix-audit-RAG-raw-query-info-logging.md
+++ b/backlog/tasks/task-12143 - Fix-audit-RAG-raw-query-info-logging.md
@@ -19,7 +19,7 @@ documentation:
 modified_files:
 - tldw_Server_API/app/api/v1/endpoints/rag_unified.py
 - tldw_Server_API/tests/RAG/test_rag_query_logging.py
-updated_date: 2026-07-04 18:23
+updated_date: 2026-07-05 00:25
 ---
 
 ## Description
@@ -42,16 +42,17 @@ Remediate AUDIT-2026-06-27-CHAT-002 by replacing info-level RAG logs that includ
 - Added `_log_rag_search_request()` to log a non-security MD5 query hash and query length instead of raw query text.
 - Replaced raw info-level query logging in unified and advanced RAG search paths; simple search now reuses the same helper.
 - Added focused unit coverage asserting sensitive query fragments and private paths are absent from rendered info logs while hash/length metadata remains present.
-- Verification: `python -m pytest tldw_Server_API/tests/RAG/test_rag_query_logging.py -q` passed with 2 tests; Bandit over `tldw_Server_API/app/api/v1/endpoints/rag_unified.py` reported 0 findings; `git diff --check` passed; targeted source scan found no old unified/advanced raw-query info log patterns.
-- 2026-07-04 latest-dev refresh: rebased `codex/audit-rag-query-logging-2026-07-04` onto `origin/dev` `fd5c152b065c408e4e8ee5f08da41589f21cb7f5`; merge-base matches `origin/dev`.
-- Latest-dev validation: `.venv/bin/python -m pytest tldw_Server_API/tests/RAG/test_rag_query_logging.py -q` passed with 2 tests; `.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/rag_unified.py -f json -o /tmp/bandit_rag_query_logging_latest.json` reported 0 findings; `git diff --check` passed; targeted raw-query logger scan found no old unified/advanced/simple raw-query info log patterns.
 - Tracking hygiene: moved this RAG audit record from duplicate `TASK-12141` to `TASK-12143` so it does not collide with another active audit PR.
+- Review follow-up: kept Loguru `{}` placeholder logging because this file imports Loguru and that formatting style is supported; added defensive query coercion for non-string helper input with regression coverage.
+- Current-dev refresh: rebased `codex/audit-rag-query-logging-2026-07-04` onto `origin/dev` `09d9ec901e1d4548f7924f1c6bcefa963fadd9bd`; merge-base matches `origin/dev`.
+- Current-dev validation: `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/RAG/test_rag_query_logging.py -q` passed with 3 tests; `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/rag_unified.py -f json -o /tmp/bandit_rag_query_logging_origin_dev_09d9ec.json` reported 0 findings over 1900 LOC; `git diff --check HEAD~1..HEAD` passed.
+2026-07-04 latest-dev refresh: rebased and validated PR #2614 on origin/dev 6b727b221e55646eba663a03571e38302f7fafc2. Tested head beb6e22200b3. Verification: python -m pytest tldw_Server_API/tests/RAG/test_rag_query_logging.py -q => 3 passed, 15 warnings; bandit -r tldw_Server_API/app/api/v1/endpoints/rag_unified.py => 0 findings over 1900 LOC; git diff --check HEAD~1..HEAD => clean.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed AUDIT-2026-06-27-CHAT-002 by routing RAG request info logs through a shared hash/length helper and removing raw query text from unified and advanced search logs. Focused tests now prevent sensitive query fragments from appearing in rendered info logs.
+Hardened RAG query logging to avoid sensitive-query exposure while preserving request tracing. Final refresh validated against origin/dev 6b727b221e55646eba663a03571e38302f7fafc2 with focused tests passing, Bandit clean on touched production scope, and whitespace check clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -97,8 +97,8 @@ _RAG_STREAM_DIAGNOSTIC_KEYS = frozenset({"error", "errors", "exception", "traceb
 _PUBLIC_RAG_STREAM_DIAGNOSTIC = "RAG processing diagnostic omitted"
 
 
-def _log_rag_search_request(label: str, query: str | None, **metadata: Any) -> None:
-    query_text = query or ""
+def _log_rag_search_request(label: str, query: object | None, **metadata: Any) -> None:
+    query_text = str(query) if query is not None else ""
     query_hash = hashlib.md5(
         query_text.encode("utf-8"),
         usedforsecurity=False,

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -97,6 +97,27 @@ _RAG_STREAM_DIAGNOSTIC_KEYS = frozenset({"error", "errors", "exception", "traceb
 _PUBLIC_RAG_STREAM_DIAGNOSTIC = "RAG processing diagnostic omitted"
 
 
+def _log_rag_search_request(label: str, query: str | None, **metadata: Any) -> None:
+    query_text = query or ""
+    query_hash = hashlib.md5(
+        query_text.encode("utf-8"),
+        usedforsecurity=False,
+    ).hexdigest()[:8]
+    metadata_text = " ".join(
+        f"{key}={value}" for key, value in metadata.items() if value is not None
+    )
+    if metadata_text:
+        logger.info(
+            "{}: query_hash={} len={} {}",
+            label,
+            query_hash,
+            len(query_text),
+            metadata_text,
+        )
+    else:
+        logger.info("{}: query_hash={} len={}", label, query_hash, len(query_text))
+
+
 def _copy_rag_request_with_updates(
     request: UnifiedRAGRequest,
     updates: dict[str, Any],
@@ -1113,7 +1134,11 @@ async def unified_search_endpoint(
     """
     try:
         request = _apply_media_collection_scope(request, collections_db)
-        logger.info(f"Unified RAG search: query='{request.query}', user={current_user.username if current_user else 'anonymous'}")
+        _log_rag_search_request(
+            "Unified RAG search",
+            request.query,
+            user=current_user.username if current_user else "anonymous",
+        )
         # Topic monitoring (non-blocking) for query text
         try:
             from tldw_Server_API.app.core.Monitoring.topic_monitoring_service import get_topic_monitoring_service
@@ -1547,8 +1572,7 @@ async def simple_search_endpoint(
     """
     try:
         try:
-            _qh = hashlib.md5((query or "").encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
-            logger.info(f"Simple search: query_hash={_qh} len={len(query or '')}")
+            _log_rag_search_request("Simple search", query)
         except (AttributeError, TypeError, ValueError):
             logger.info("Simple search request received")
         # Topic monitoring (non-blocking)
@@ -1938,7 +1962,7 @@ async def advanced_search_endpoint(
     Advanced search with common features enabled.
     """
     try:
-        logger.info(f"Advanced search: query='{query}'")
+        _log_rag_search_request("Advanced search", query)
         # Topic monitoring (non-blocking)
         try:
             from tldw_Server_API.app.core.Monitoring.topic_monitoring_service import get_topic_monitoring_service

--- a/tldw_Server_API/tests/RAG/test_rag_query_logging.py
+++ b/tldw_Server_API/tests/RAG/test_rag_query_logging.py
@@ -48,3 +48,12 @@ def test_rag_search_request_log_omits_raw_query(monkeypatch, label, metadata):
     assert f"len={len(query)}" in rendered
     for key, value in metadata.items():
         assert f"{key}={value}" in rendered
+
+
+def test_rag_search_request_log_handles_non_string_query(monkeypatch):
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(rag_unified, "logger", logger_stub)
+
+    rag_unified._log_rag_search_request("Unified RAG search", 42)
+
+    assert logger_stub.infos == ["Unified RAG search: query_hash=a1d0c6e8 len=2"]

--- a/tldw_Server_API/tests/RAG/test_rag_query_logging.py
+++ b/tldw_Server_API/tests/RAG/test_rag_query_logging.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints import rag_unified
+
+
+class _LoggerStub:
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+
+    def info(self, message: str, *args: Any, **kwargs: Any) -> None:
+        try:
+            rendered = message.format(*args, **kwargs)
+        except (IndexError, KeyError, ValueError):
+            rendered = f"{message} args={args!r} kwargs={kwargs!r}"
+        self.infos.append(rendered)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("label", "metadata"),
+    [
+        ("Unified RAG search", {"user": "alice"}),
+        ("Advanced search", {}),
+    ],
+)
+def test_rag_search_request_log_omits_raw_query(monkeypatch, label, metadata):
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(rag_unified, "logger", logger_stub)
+    query = "summarize secret token sk-live-private and /private/customer.db"
+
+    rag_unified._log_rag_search_request(label, query, **metadata)
+
+    rendered = "\n".join(logger_stub.infos)
+    expected_hash = hashlib.md5(
+        query.encode("utf-8"),
+        usedforsecurity=False,
+    ).hexdigest()[:8]
+
+    assert query not in rendered
+    assert "sk-live-private" not in rendered
+    assert "/private/customer.db" not in rendered
+    assert f"query_hash={expected_hash}" in rendered
+    assert f"len={len(query)}" in rendered
+    for key, value in metadata.items():
+        assert f"{key}={value}" in rendered


### PR DESCRIPTION
## Change summary

Human-written Change summary required before this draft PR is merge-ready under `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## What changed

Replaces raw RAG query info logs with query hash/length metadata and tests that sensitive query fragments are not emitted.

Backlog tracking: `TASK-12143`.

## Latest dev refresh

- Base: `dev` at `6b727b221e55646eba663a03571e38302f7fafc2`.
- Head: `codex/audit-rag-query-logging-2026-07-04` at `0202770ea6dc7f1614e8547e1f845de053ccf24e`.
- Post-amend check verified the final Backlog-note amend changed only the task record for this PR; merge-base still equals `6b727b221e55646eba663a03571e38302f7fafc2`.

## Validation

- `python -m pytest tldw_Server_API/tests/RAG/test_rag_query_logging.py -q` -> 3 passed, 15 warnings.
- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/rag_unified.py -f json -o /tmp/bandit_rag_query_logging_origin_dev_6b727b.json` -> 0 findings over 1900 LOC.
- `git diff --check HEAD~1..HEAD` -> clean.
