### PR TITLE
docs: link external docs hosting

### DIFF
--- a/Docs/Code_Documentation/Docs_Site_Guide.md
+++ b/Docs/Code_Documentation/Docs_Site_Guide.md
@@ -76,20 +76,20 @@ pip install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin
 Serve locally (auto-reloads on file changes):
 
 ```
-mkdocs serve
+mkdocs serve -f Docs/mkdocs.yml
 ```
 
-Build static site (outputs to `site/`):
+Build static site (outputs to `Docs/site/`):
 
 ```
-mkdocs build
+mkdocs build -f Docs/mkdocs.yml
 ```
 
 ## "Last updated" Dates
 
 - The site shows per-page "Last updated" timestamps via the `git-revision-date-localized` plugin, using relative time ("time ago").
 - Accurate dates require git history. Locally, ensure your repo has the relevant commits. In CI, we fetch full history (`fetch-depth: 0`).
-- Configuration lives in `mkdocs.yml` under `plugins.git-revision-date-localized` (with `type: timeago`).
+- Configuration lives in `Docs/mkdocs.yml` under `plugins.git-revision-date-localized` (with `type: timeago`).
 - If a page has no history (e.g., new file), the plugin falls back to the current build time.
 
 ## Theme and Assets
@@ -104,7 +104,7 @@ To change the logo: replace `Docs/Logo.png` and run the refresh script.
 ## Navigation
 
 - The sidebar and ordering are defined explicitly in `mkdocs.yml` under `nav:`
-- When adding a new page you want visible in the sidebar, add a new entry under the appropriate section in `mkdocs.yml`
+- When adding a new page you want visible in the sidebar, add a new entry under the appropriate section in `Docs/mkdocs.yml`
 - The nav uses paths relative to `Docs/Published/`
 - Keep the top-level navigation audience-first: `Home`, `User Wiki`, `Developer Wiki`, and shared reference links.
 - User-facing workflow docs belong under the `User Wiki` nav tree.
@@ -123,8 +123,8 @@ Tip: keep titles short and parallel (e.g., "Guide", "Reference", "Checklist").
 
 1. Edit or add Markdown files under the appropriate source folder in `Docs/`
 2. Run `bash Helper_Scripts/refresh_docs_published.sh` to re-sync curated content
-3. If the new page should appear in the sidebar, update `mkdocs.yml` `nav:` accordingly
-4. Preview with `mkdocs serve`
+3. If the new page should appear in the sidebar, update `Docs/mkdocs.yml` `nav:` accordingly
+4. Preview with `mkdocs serve -f Docs/mkdocs.yml`
 5. Commit and push; CI will refresh, build, and deploy the GitHub Pages mirror
 
 Notes:
@@ -158,7 +158,7 @@ If an external deploy fails:
 - Confirm `Docs/mkdocs.yml` has `site_url: https://tldwproject.com/server/docs/`
 - Check the external host logs for copy/job failures
 - Check GitHub workflow logs for mirror build errors (usually missing files/links)
-- Re-run the refresh script locally and build with `mkdocs build` to reproduce
+- Re-run the refresh script locally and build with `mkdocs build -f Docs/mkdocs.yml` to reproduce
 
 ## GitHub Pages Mirror
 

--- a/Docs/Code_Documentation/Docs_Site_Guide.md
+++ b/Docs/Code_Documentation/Docs_Site_Guide.md
@@ -8,9 +8,11 @@ This document explains how the tldw_Server documentation site is organized, buil
 - Published scope: Only a curated subset of the `Docs/` tree
 - Source of truth: Update files under `Docs/`, not `Docs/Published/`
 - Build root: `Docs/Published/` (MkDocs `docs_dir`)
-- Deployment: GitHub Pages via GitHub Actions
+- Canonical public URL: `https://tldwproject.com/server/docs/`
+- Production deployment: external tldwproject.com host at `/server/docs/`
+- Mirror deployment: GitHub Pages via GitHub Actions
 
-The public docs site is for OSS, self-host, and developer documentation. Hosted/commercial docs are excluded from the published site and should live in the private repo instead of this public docs pipeline.
+The public docs site is for OSS, self-host, and developer documentation. Hosted/commercial docs are excluded from the published site and should live in the private repo instead of this public docs pipeline. GitHub Pages is a mirror of the same MkDocs output; `tldwproject.com/server/docs/` is the canonical URL and the MkDocs `site_url`.
 
 The published site is audience-first:
 
@@ -123,7 +125,7 @@ Tip: keep titles short and parallel (e.g., "Guide", "Reference", "Checklist").
 2. Run `bash Helper_Scripts/refresh_docs_published.sh` to re-sync curated content
 3. If the new page should appear in the sidebar, update `mkdocs.yml` `nav:` accordingly
 4. Preview with `mkdocs serve`
-5. Commit and push; CI will refresh, build, and deploy the site
+5. Commit and push; CI will refresh, build, and deploy the GitHub Pages mirror
 
 Notes:
 - Put audience chooser pages in `Docs/Wiki/`
@@ -135,16 +137,37 @@ Notes:
 - Prefer images stored under `Docs/assets/` or section subfolders; the refresh script copies section contents
 - Avoid linking to hosted/private docs from public pages; those references belong in the private repo
 
-## Deployment
+## External Deployment
+
+The production docs live on the external tldwproject.com host at `/server/docs/`.
+
+Manual external deploy:
+
+1. Run `bash Helper_Scripts/refresh_docs_published.sh`
+2. Run `mkdocs build -f Docs/mkdocs.yml`
+3. Copy the generated static site output to the external host under `/server/docs/`
+
+Optional site-side automation:
+
+1. Clone or pull this repository on the external host
+2. Detect a new version or commit
+3. Run the refresh and build commands
+4. Replace the served `/server/docs/` files atomically if the build succeeds
+
+If an external deploy fails:
+- Confirm `Docs/mkdocs.yml` has `site_url: https://tldwproject.com/server/docs/`
+- Check the external host logs for copy/job failures
+- Check GitHub workflow logs for mirror build errors (usually missing files/links)
+- Re-run the refresh script locally and build with `mkdocs build` to reproduce
+
+## GitHub Pages Mirror
 
 - Workflow file: `.github/workflows/mkdocs.yml`
 - Triggers: pushes to `main` and `PG-Backend`, and manual runs
-- Steps: checkout → install → refresh curated docs → build → deploy to GitHub Pages
-- Repository Settings → Pages: set Source = GitHub Actions
+- Steps: checkout -> install -> refresh curated docs -> build -> deploy to GitHub Pages
+- Repository Settings -> Pages: set Source = GitHub Actions
 
-If a deploy fails:
-- Check the workflow logs for build errors (usually missing files/links)
-- Re-run the refresh script locally and build with `mkdocs build` to reproduce
+The GitHub Pages site is a mirror. It intentionally builds from the same MkDocs source while using canonical links from `site_url`, so generated canonical URLs point to `https://tldwproject.com/server/docs/`.
 
 ## Advanced (Optional)
 
@@ -157,5 +180,6 @@ If a deploy fails:
 - Author docs in `Docs/` (not `Docs/Published/`)
 - Use the refresh script to curate and sync
 - Keep `mkdocs.yml` `nav:` updated for sidebar visibility and order
-- CI builds and deploys automatically to GitHub Pages
+- Deploy the built site to `https://tldwproject.com/server/docs/`
+- CI builds and deploys a GitHub Pages mirror
 - Hosted/commercial docs are excluded from the public docs site and belong in the private repo

--- a/Docs/Published/Code_Documentation/Docs_Site_Guide.md
+++ b/Docs/Published/Code_Documentation/Docs_Site_Guide.md
@@ -8,9 +8,11 @@ This document explains how the tldw_Server documentation site is organized, buil
 - Published scope: Only a curated subset of the `Docs/` tree
 - Source of truth: Update files under `Docs/`, not `Docs/Published/`
 - Build root: `Docs/Published/` (MkDocs `docs_dir`)
-- Deployment: GitHub Pages via GitHub Actions
+- Canonical public URL: `https://tldwproject.com/server/docs/`
+- Production deployment: external tldwproject.com host at `/server/docs/`
+- Mirror deployment: GitHub Pages via GitHub Actions
 
-The public docs site is for OSS, self-host, and developer documentation. Hosted/commercial docs are excluded from the published site and should live in the private repo instead of this public docs pipeline.
+The public docs site is for OSS, self-host, and developer documentation. Hosted/commercial docs are excluded from the published site and should live in the private repo instead of this public docs pipeline. GitHub Pages is a mirror of the same MkDocs output; `tldwproject.com/server/docs/` is the canonical URL and the MkDocs `site_url`.
 
 The published site is audience-first:
 
@@ -74,20 +76,20 @@ pip install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin
 Serve locally (auto-reloads on file changes):
 
 ```
-mkdocs serve
+mkdocs serve -f Docs/mkdocs.yml
 ```
 
-Build static site (outputs to `site/`):
+Build static site (outputs to `Docs/site/`):
 
 ```
-mkdocs build
+mkdocs build -f Docs/mkdocs.yml
 ```
 
 ## "Last updated" Dates
 
 - The site shows per-page "Last updated" timestamps via the `git-revision-date-localized` plugin, using relative time ("time ago").
 - Accurate dates require git history. Locally, ensure your repo has the relevant commits. In CI, we fetch full history (`fetch-depth: 0`).
-- Configuration lives in `mkdocs.yml` under `plugins.git-revision-date-localized` (with `type: timeago`).
+- Configuration lives in `Docs/mkdocs.yml` under `plugins.git-revision-date-localized` (with `type: timeago`).
 - If a page has no history (e.g., new file), the plugin falls back to the current build time.
 
 ## Theme and Assets
@@ -102,7 +104,7 @@ To change the logo: replace `Docs/Logo.png` and run the refresh script.
 ## Navigation
 
 - The sidebar and ordering are defined explicitly in `mkdocs.yml` under `nav:`
-- When adding a new page you want visible in the sidebar, add a new entry under the appropriate section in `mkdocs.yml`
+- When adding a new page you want visible in the sidebar, add a new entry under the appropriate section in `Docs/mkdocs.yml`
 - The nav uses paths relative to `Docs/Published/`
 - Keep the top-level navigation audience-first: `Home`, `User Wiki`, `Developer Wiki`, and shared reference links.
 - User-facing workflow docs belong under the `User Wiki` nav tree.
@@ -121,9 +123,9 @@ Tip: keep titles short and parallel (e.g., "Guide", "Reference", "Checklist").
 
 1. Edit or add Markdown files under the appropriate source folder in `Docs/`
 2. Run `bash Helper_Scripts/refresh_docs_published.sh` to re-sync curated content
-3. If the new page should appear in the sidebar, update `mkdocs.yml` `nav:` accordingly
-4. Preview with `mkdocs serve`
-5. Commit and push; CI will refresh, build, and deploy the site
+3. If the new page should appear in the sidebar, update `Docs/mkdocs.yml` `nav:` accordingly
+4. Preview with `mkdocs serve -f Docs/mkdocs.yml`
+5. Commit and push; CI will refresh, build, and deploy the GitHub Pages mirror
 
 Notes:
 - Put audience chooser pages in `Docs/Wiki/`
@@ -135,16 +137,37 @@ Notes:
 - Prefer images stored under `Docs/assets/` or section subfolders; the refresh script copies section contents
 - Avoid linking to hosted/private docs from public pages; those references belong in the private repo
 
-## Deployment
+## External Deployment
+
+The production docs live on the external tldwproject.com host at `/server/docs/`.
+
+Manual external deploy:
+
+1. Run `bash Helper_Scripts/refresh_docs_published.sh`
+2. Run `mkdocs build -f Docs/mkdocs.yml`
+3. Copy the generated static site output to the external host under `/server/docs/`
+
+Optional site-side automation:
+
+1. Clone or pull this repository on the external host
+2. Detect a new version or commit
+3. Run the refresh and build commands
+4. Replace the served `/server/docs/` files atomically if the build succeeds
+
+If an external deploy fails:
+- Confirm `Docs/mkdocs.yml` has `site_url: https://tldwproject.com/server/docs/`
+- Check the external host logs for copy/job failures
+- Check GitHub workflow logs for mirror build errors (usually missing files/links)
+- Re-run the refresh script locally and build with `mkdocs build -f Docs/mkdocs.yml` to reproduce
+
+## GitHub Pages Mirror
 
 - Workflow file: `.github/workflows/mkdocs.yml`
 - Triggers: pushes to `main` and `PG-Backend`, and manual runs
-- Steps: checkout → install → refresh curated docs → build → deploy to GitHub Pages
-- Repository Settings → Pages: set Source = GitHub Actions
+- Steps: checkout -> install -> refresh curated docs -> build -> deploy to GitHub Pages
+- Repository Settings -> Pages: set Source = GitHub Actions
 
-If a deploy fails:
-- Check the workflow logs for build errors (usually missing files/links)
-- Re-run the refresh script locally and build with `mkdocs build` to reproduce
+The GitHub Pages site is a mirror. It intentionally builds from the same MkDocs source while using canonical links from `site_url`, so generated canonical URLs point to `https://tldwproject.com/server/docs/`.
 
 ## Advanced (Optional)
 
@@ -157,5 +180,6 @@ If a deploy fails:
 - Author docs in `Docs/` (not `Docs/Published/`)
 - Use the refresh script to curate and sync
 - Keep `mkdocs.yml` `nav:` updated for sidebar visibility and order
-- CI builds and deploys automatically to GitHub Pages
+- Deploy the built site to `https://tldwproject.com/server/docs/`
+- CI builds and deploys a GitHub Pages mirror
 - Hosted/commercial docs are excluded from the public docs site and belong in the private repo

--- a/Docs/Published/User_Guides/Feature_Map.md
+++ b/Docs/Published/User_Guides/Feature_Map.md
@@ -104,7 +104,7 @@ Primary surfaces:
 | Manage bring-your-own-key provider access | Admin/user settings | [BYOK user guide](Server/BYOK_User_Guide.md) |
 | Understand usage reporting | Admin/API | [Usage module](Server/Usage_Module.md) |
 | Back up SQLite deployments | Server/admin | [Backups using Litestream](Server/Backups_Using_Litestream.md) |
-| Monitor the server | Admin/operator | [Metrics cheatsheet](https://rmusser01.github.io/tldw_server/Monitoring/Metrics_Cheatsheet/) |
+| Monitor the server | Admin/operator | [Metrics cheatsheet](../Monitoring/Metrics_Cheatsheet.md) |
 
 ## API Reference Entry Points
 

--- a/Docs/Published/User_Guides/index.md
+++ b/Docs/Published/User_Guides/index.md
@@ -55,7 +55,7 @@ Common workflows:
 - **Create and manage knowledge artifacts**: use [Chatbook user guide](WebUI_Extension/Chatbook_User_Guide.md) for OpenWebUI chat JSON and database import with post-import attachment hydration, [Prompt Studio API](../API-related/Prompt_Studio_API.md), and [Reading list API](../API-related/Reading_List_API.md).
 - **Automate and integrate**: use [Workflows examples](WebUI_Extension/Workflows_Examples.md), [Collections feeds API](../API-related/Collections_Feeds_API.md), and [Getting started with ACP](Integrations_Experiments/Getting_Started_with_ACP.md).
 - **Prototype workspace flows**: use [Prototype Workspaces User Guide](Prototype_Workspaces.md) to run isolated workspace experiments.
-- **Administer a shared server**: use [Organizations and sharing](Server/Organizations_and_Sharing.md), [BYOK user guide](Server/BYOK_User_Guide.md), [Usage module](Server/Usage_Module.md), and [Metrics cheatsheet](https://rmusser01.github.io/tldw_server/Monitoring/Metrics_Cheatsheet/).
+- **Administer a shared server**: use [Organizations and sharing](Server/Organizations_and_Sharing.md), [BYOK user guide](Server/BYOK_User_Guide.md), [Usage module](Server/Usage_Module.md), and [Metrics cheatsheet](../Monitoring/Metrics_Cheatsheet.md).
 
 ## Troubleshooting
 

--- a/Docs/User_Guides/Feature_Map.md
+++ b/Docs/User_Guides/Feature_Map.md
@@ -104,7 +104,7 @@ Primary surfaces:
 | Manage bring-your-own-key provider access | Admin/user settings | [BYOK user guide](Server/BYOK_User_Guide.md) |
 | Understand usage reporting | Admin/API | [Usage module](Server/Usage_Module.md) |
 | Back up SQLite deployments | Server/admin | [Backups using Litestream](Server/Backups_Using_Litestream.md) |
-| Monitor the server | Admin/operator | [Metrics cheatsheet](https://rmusser01.github.io/tldw_server/Monitoring/Metrics_Cheatsheet/) |
+| Monitor the server | Admin/operator | [Metrics cheatsheet](../Monitoring/Metrics_Cheatsheet.md) |
 
 ## API Reference Entry Points
 

--- a/Docs/User_Guides/index.md
+++ b/Docs/User_Guides/index.md
@@ -55,7 +55,7 @@ Common workflows:
 - **Create and manage knowledge artifacts**: use [Chatbook user guide](WebUI_Extension/Chatbook_User_Guide.md) for OpenWebUI chat JSON and database import with post-import attachment hydration, [Prompt Studio API](../API-related/Prompt_Studio_API.md), and [Reading list API](../API-related/Reading_List_API.md).
 - **Automate and integrate**: use [Workflows examples](WebUI_Extension/Workflows_Examples.md), [Collections feeds API](../API-related/Collections_Feeds_API.md), and [Getting started with ACP](Integrations_Experiments/Getting_Started_with_ACP.md).
 - **Prototype workspace flows**: use [Prototype Workspaces User Guide](Prototype_Workspaces.md) to run isolated workspace experiments.
-- **Administer a shared server**: use [Organizations and sharing](Server/Organizations_and_Sharing.md), [BYOK user guide](Server/BYOK_User_Guide.md), [Usage module](Server/Usage_Module.md), and [Metrics cheatsheet](https://rmusser01.github.io/tldw_server/Monitoring/Metrics_Cheatsheet/).
+- **Administer a shared server**: use [Organizations and sharing](Server/Organizations_and_Sharing.md), [BYOK user guide](Server/BYOK_User_Guide.md), [Usage module](Server/Usage_Module.md), and [Metrics cheatsheet](../Monitoring/Metrics_Cheatsheet.md).
 
 ## Troubleshooting
 

--- a/Docs/Website/index.html
+++ b/Docs/Website/index.html
@@ -143,6 +143,7 @@
         <a href="#features">Features</a>
         <a href="#faq">FAQ</a>
         <a href="#community">Community</a>
+        <a href="https://tldwproject.com/server/docs/">Docs</a>
         <a href="https://github.com/rmusser01/tldw_server" target="_blank" rel="noreferrer">GitHub</a>
       </nav>
     </div>
@@ -350,6 +351,7 @@ make verify-local-single</code></pre>
         <a href="#about">About</a>
         <a href="#features">Features</a>
         <a href="#community">Community</a>
+        <a href="https://tldwproject.com/server/docs/">Docs</a>
         <a href="https://github.com/rmusser01/tldw_server" target="_blank" rel="noreferrer">GitHub</a>
       </div>
     </div>

--- a/Docs/mkdocs.yml
+++ b/Docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: tldw Server Docs
 site_description: Documentation for the tldw_server project
-site_url: https://rmusser01.github.io/tldw_server/
+site_url: https://tldwproject.com/server/docs/
 repo_url: https://github.com/rmusser01/tldw_server
 repo_name: rmusser01/tldw_server
 edit_uri: edit/main/

--- a/Docs/superpowers/plans/2026-06-01-user-docs-map.md
+++ b/Docs/superpowers/plans/2026-06-01-user-docs-map.md
@@ -147,7 +147,7 @@ Primary surfaces:
 | Manage bring-your-own-key provider access | Admin/user settings | [BYOK user guide](Server/BYOK_User_Guide.md) |
 | Understand usage reporting | Admin/API | [Usage module](Server/Usage_Module.md) |
 | Back up SQLite deployments | Server/admin | [Backups using Litestream](Server/Backups_Using_Litestream.md) |
-| Monitor the server | Admin/operator | [Metrics cheatsheet](https://rmusser01.github.io/tldw_server/Monitoring/Metrics_Cheatsheet/) |
+| Monitor the server | Admin/operator | [Metrics cheatsheet](../Monitoring/Metrics_Cheatsheet.md) |
 
 ## API Reference Entry Points
 
@@ -244,7 +244,7 @@ Common workflows:
 - **Study, evaluate, and review outputs**: use [Evaluations user guide](Server/Evaluations_User_Guide.md), [Evaluations API unified reference](../API-related/Evaluations_API_Unified_Reference.md), and [Flashcards study guide](WebUI_Extension/Flashcards_Study_Guide.md).
 - **Create and manage knowledge artifacts**: use [Chatbook user guide](WebUI_Extension/Chatbook_User_Guide.md), [Prompt Studio API](../API-related/Prompt_Studio_API.md), and [Reading list API](../API-related/Reading_List_API.md).
 - **Automate and integrate**: use [Workflows examples](WebUI_Extension/Workflows_Examples.md), [Collections feeds API](../API-related/Collections_Feeds_API.md), and [Getting started with ACP](Integrations_Experiments/Getting_Started_with_ACP.md).
-- **Administer a shared server**: use [Organizations and sharing](Server/Organizations_and_Sharing.md), [BYOK user guide](Server/BYOK_User_Guide.md), [Usage module](Server/Usage_Module.md), and [Metrics cheatsheet](https://rmusser01.github.io/tldw_server/Monitoring/Metrics_Cheatsheet/).
+- **Administer a shared server**: use [Organizations and sharing](Server/Organizations_and_Sharing.md), [BYOK user guide](Server/BYOK_User_Guide.md), [Usage module](Server/Usage_Module.md), and [Metrics cheatsheet](../Monitoring/Metrics_Cheatsheet.md).
 
 ## Troubleshooting
 
@@ -376,7 +376,7 @@ In `README.md`, under `**Getting Started Guides:**`, add this as the first bulle
 In `apps/extension/docs/index.md`, after the opening paragraph, add:
 
 ```markdown
-For the shared tldw_server documentation map across the server API, WebUI, browser extension, and admin/operator workflows, use the [tldw_server User Guides](https://rmusser01.github.io/tldw_server/User_Guides/). This extension guide stays focused on extension-specific setup and browser behavior.
+For the shared tldw_server documentation map across the server API, WebUI, browser extension, and admin/operator workflows, use the [tldw_server User Guides](https://tldwproject.com/server/docs/User_Guides/). This extension guide stays focused on extension-specific setup and browser behavior.
 ```
 
 - [ ] **Step 5: Verify entry point text exists**

--- a/Docs/superpowers/plans/2026-07-04-external-docs-hosting-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-04-external-docs-hosting-implementation-plan.md
@@ -1,0 +1,151 @@
+# External Docs Hosting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Point users to `https://tldwproject.com/server/docs/` as the canonical public docs URL, keep GitHub Pages as a mirror, and document how the MkDocs site is built and administered.
+
+**Architecture:** Keep the existing MkDocs pipeline: source Markdown under `Docs/`, generated curated input under `Docs/Published/`, and static output from `mkdocs build -f Docs/mkdocs.yml`. Make `tldwproject.com/server/docs/` canonical in public links and MkDocs metadata; document manual external deploy first, with optional site-side clone/pull/build automation later.
+
+**Tech Stack:** Markdown, static HTML, MkDocs Material, GitHub Actions Pages mirror.
+
+---
+
+### Task 1: Update Public Docs Links And Canonical URL
+
+**Files:**
+- Modify: `README.md`
+- Modify: `Docs/Website/index.html`
+- Modify: `Docs/mkdocs.yml`
+
+- [ ] **Step 1: Update MkDocs canonical URL**
+
+Change `Docs/mkdocs.yml`:
+
+```yaml
+site_url: https://tldwproject.com/server/docs/
+```
+
+- [ ] **Step 2: Add README public docs link**
+
+In `README.md`, add a visible link near the existing docs resources:
+
+```markdown
+- [Public documentation site](https://tldwproject.com/server/docs/) - canonical docs hosted on tldwproject.com
+```
+
+- [ ] **Step 3: Add website docs link**
+
+In `Docs/Website/index.html`, add `Docs` to the header and footer nav, pointing at:
+
+```html
+<a href="https://tldwproject.com/server/docs/">Docs</a>
+```
+
+- [ ] **Step 4: Text-check the URL appears where expected**
+
+Run:
+
+```bash
+rg -n "https://tldwproject.com/server/docs/" README.md Docs/Website/index.html Docs/mkdocs.yml
+```
+
+Expected: matches in all three files.
+
+### Task 2: Update Docs Site Admin Guide
+
+**Files:**
+- Modify: `Docs/Code_Documentation/Docs_Site_Guide.md`
+
+- [ ] **Step 1: Update overview hosting model**
+
+Document:
+
+- canonical public URL: `https://tldwproject.com/server/docs/`
+- GitHub Pages remains a mirror, not the canonical public URL
+- source docs are edited under `Docs/`, not `Docs/Published/`
+
+- [ ] **Step 2: Add external deployment instructions**
+
+Document the two supported admin paths:
+
+```markdown
+Manual external deploy:
+1. Run `bash Helper_Scripts/refresh_docs_published.sh`
+2. Run `mkdocs build -f Docs/mkdocs.yml`
+3. Copy the built static site to the external host at `/server/docs/`
+
+Optional site-side automation:
+1. Clone or pull this repository on the external host
+2. Detect a new version or commit
+3. Run the refresh and build commands
+4. Replace the served `/server/docs/` files atomically if the build succeeds
+```
+
+- [ ] **Step 3: Document mirror caveat**
+
+Add that GitHub Pages mirror builds from the same MkDocs source and intentionally uses external canonical URLs from `site_url`.
+
+### Task 3: Verify Docs Build And Link Coverage
+
+**Files:**
+- Read/check only after Tasks 1-2.
+
+- [ ] **Step 1: Refresh curated docs**
+
+Run:
+
+```bash
+bash Helper_Scripts/refresh_docs_published.sh
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Build MkDocs**
+
+Run:
+
+```bash
+mkdocs build -f Docs/mkdocs.yml
+```
+
+Expected: exit 0. Existing baseline warnings are acceptable if the command exits 0.
+
+- [ ] **Step 3: Check no stale docs URLs remain in canonical slots**
+
+Run:
+
+```bash
+rg -n "tldwproject.org/server/docs" README.md Docs/Website/index.html Docs/mkdocs.yml Docs/Code_Documentation/Docs_Site_Guide.md
+rg -n "^site_url: https://tldwproject.com/server/docs/$" Docs/mkdocs.yml
+```
+
+Expected: first command has no matches; second command has one match. GitHub Pages mirror references are allowed when clearly labeled as mirror-only.
+
+- [ ] **Step 4: Bandit scope note**
+
+No Bandit command is needed for this task because the touched implementation files are Markdown, HTML links, YAML metadata, and Backlog records only.
+
+### Task 4: Update Backlog And Commit
+
+**Files:**
+- Modify: `backlog/tasks/task-12128 - Document-external-docs-hosting-links.md`
+
+- [ ] **Step 1: Record verification and final summary**
+
+Update `TASK-12128` with:
+
+- files changed
+- verification command results
+- Bandit skip reason
+- final summary
+
+- [ ] **Step 2: Commit implementation**
+
+Run:
+
+```bash
+git add README.md Docs/Website/index.html Docs/mkdocs.yml Docs/Code_Documentation/Docs_Site_Guide.md "backlog/tasks/task-12128 - Document-external-docs-hosting-links.md"
+git commit -m "docs: link external docs hosting"
+```
+
+Expected: commit succeeds. Do not stage unrelated existing worktree changes.

--- a/Docs/superpowers/specs/2026-06-01-user-docs-map-design.md
+++ b/Docs/superpowers/specs/2026-06-01-user-docs-map-design.md
@@ -59,7 +59,7 @@ The implementation should distinguish source-file links from published-site link
 
 - Repository Markdown, such as `README.md`, can link to `Docs/User_Guides/index.md`.
 - MkDocs nav entries must use paths relative to `Docs/Published/`, such as `User_Guides/index.md`.
-- Extension VitePress pages should not use fragile relative links that walk out of the extension docs root. They should link to the public MkDocs URL for the canonical hub, currently `https://rmusser01.github.io/tldw_server/User_Guides/`, or to a GitHub source URL if a public docs URL is not available in the target environment.
+- Extension VitePress pages should not use fragile relative links that walk out of the extension docs root. They should link to the public MkDocs URL for the canonical hub, currently `https://tldwproject.com/server/docs/User_Guides/`, or to a GitHub source URL if a public docs URL is not available in the target environment.
 - The public MkDocs hub should prefer links to content that is included in the published docs set. If a useful extension-only page exists only under `apps/extension/docs`, link to a GitHub source page or defer that link until the page has a public docs home.
 
 ## Information Architecture

--- a/Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
+++ b/Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
@@ -4,7 +4,7 @@ Backlog task: `TASK-12128`
 
 ## Goal
 
-Make `https://tldwproject.org/server/docs/` the public documentation URL for tldw Server, and make the repo explain how those docs are built, updated, and administered.
+Make `https://tldwproject.com/server/docs/` the public documentation URL for tldw Server, and make the repo explain how those docs are built, updated, and administered.
 
 ## Context
 
@@ -14,13 +14,13 @@ The project website source is `Docs/Website/index.html`. The README already has 
 
 ## Decision
 
-Use `https://tldwproject.org/server/docs/` as the canonical public docs URL.
+Use `https://tldwproject.com/server/docs/` as the canonical public docs URL.
 
 The implementation should keep the existing MkDocs build pipeline and change only the publishing assumptions and links:
 
-- README links should point users to `https://tldwproject.org/server/docs/`.
-- `Docs/Website/index.html` should include a visible docs link to `https://tldwproject.org/server/docs/`.
-- `Docs/mkdocs.yml` should set `site_url` to `https://tldwproject.org/server/docs/` so generated canonical links match the external host.
+- README links should point users to `https://tldwproject.com/server/docs/`.
+- `Docs/Website/index.html` should include a visible docs link to `https://tldwproject.com/server/docs/`.
+- `Docs/mkdocs.yml` should set `site_url` to `https://tldwproject.com/server/docs/` so generated canonical links match the external host.
 - `Docs/Code_Documentation/Docs_Site_Guide.md` should describe external hosting at `/server/docs/` as the production target.
 - The GitHub Pages workflow should remain enabled as a mirror of the same docs, not as the canonical public URL.
 
@@ -31,7 +31,7 @@ The implementation should keep the existing MkDocs build pipeline and change onl
 3. MkDocs builds static HTML from `Docs/mkdocs.yml`.
 4. The external website host serves that built output at `/server/docs/`.
 5. GitHub Pages serves the same built docs as a mirror.
-6. README and website visitors use `https://tldwproject.org/server/docs/` as the primary link.
+6. README and website visitors use `https://tldwproject.com/server/docs/` as the primary link.
 
 ## Admin Notes
 
@@ -40,6 +40,8 @@ The docs guide should document the operational owner actions without assuming a 
 - run `bash Helper_Scripts/refresh_docs_published.sh`
 - run `mkdocs build -f Docs/mkdocs.yml`
 - publish the generated static site output to the external host under `/server/docs/`
+- start with manual copy/deploy of the built static site if no host automation exists yet
+- optional later automation: a site-side clone/pull/build job that detects a new repo version, runs the refresh/build steps, and updates `/server/docs/`
 - keep the GitHub Pages workflow as a mirror build/deploy for the same docs content
 - keep `Docs/Published/` generated rather than hand-edited
 - keep private or hosted-only docs out of the public curated docs pipeline
@@ -53,6 +55,7 @@ No application error handling is needed. The docs should call out the practical 
 - stale `site_url`
 - external host not serving the built output at `/server/docs/`
 - GitHub Pages mirror drifting from the same MkDocs build source
+- automated site clone job failing to pull or build after a new version is detected
 
 ## Testing
 
@@ -66,4 +69,4 @@ Bandit is not applicable because this is documentation and static HTML metadata 
 
 ## Scope Control
 
-Skipped: building a new docs application or adding a provider-specific deployment script. Add those only when the external hosting platform is known and needs repo-owned deployment automation.
+Skipped: building a new docs application or adding a provider-specific deployment script. Start with documented manual deployment; add a repo-owned or site-owned automation only when the external host details are known.

--- a/Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
+++ b/Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
@@ -1,0 +1,69 @@
+# External Docs Hosting Design
+
+Backlog task: `TASK-12128`
+
+## Goal
+
+Make `https://tldwproject.org/server/docs/` the public documentation URL for tldw Server, and make the repo explain how those docs are built, updated, and administered.
+
+## Context
+
+The repo already has a MkDocs Material site configured in `Docs/mkdocs.yml`. Source docs live under `Docs/`; the curated published input is generated under `Docs/Published/` by `Helper_Scripts/refresh_docs_published.sh`; the current workflow builds that static site.
+
+The project website source is `Docs/Website/index.html`. The README already has a large documentation section, but it does not clearly point users to the external public docs URL.
+
+## Decision
+
+Use `https://tldwproject.org/server/docs/` as the canonical public docs URL.
+
+The implementation should keep the existing MkDocs build pipeline and change only the publishing assumptions and links:
+
+- README links should point users to `https://tldwproject.org/server/docs/`.
+- `Docs/Website/index.html` should include a visible docs link to `https://tldwproject.org/server/docs/`.
+- `Docs/mkdocs.yml` should set `site_url` to `https://tldwproject.org/server/docs/` so generated canonical links match the external host.
+- `Docs/Code_Documentation/Docs_Site_Guide.md` should describe external hosting at `/server/docs/` as the production target.
+- The GitHub Pages workflow should remain enabled as a mirror of the same docs, not as the canonical public URL.
+
+## Data Flow
+
+1. Authors edit Markdown under `Docs/`.
+2. The refresh script syncs approved public docs into `Docs/Published/`.
+3. MkDocs builds static HTML from `Docs/mkdocs.yml`.
+4. The external website host serves that built output at `/server/docs/`.
+5. GitHub Pages serves the same built docs as a mirror.
+6. README and website visitors use `https://tldwproject.org/server/docs/` as the primary link.
+
+## Admin Notes
+
+The docs guide should document the operational owner actions without assuming a specific external provider:
+
+- run `bash Helper_Scripts/refresh_docs_published.sh`
+- run `mkdocs build -f Docs/mkdocs.yml`
+- publish the generated static site output to the external host under `/server/docs/`
+- keep the GitHub Pages workflow as a mirror build/deploy for the same docs content
+- keep `Docs/Published/` generated rather than hand-edited
+- keep private or hosted-only docs out of the public curated docs pipeline
+
+## Error Handling
+
+No application error handling is needed. The docs should call out the practical failure cases:
+
+- missing page in `Docs/Published/`
+- broken MkDocs links
+- stale `site_url`
+- external host not serving the built output at `/server/docs/`
+- GitHub Pages mirror drifting from the same MkDocs build source
+
+## Testing
+
+Use the smallest verification that proves the docs path still builds:
+
+- `bash Helper_Scripts/refresh_docs_published.sh`
+- `mkdocs build -f Docs/mkdocs.yml`
+- text checks for the canonical external URL in README, website, MkDocs config, and the docs guide
+
+Bandit is not applicable because this is documentation and static HTML metadata only.
+
+## Scope Control
+
+Skipped: building a new docs application or adding a provider-specific deployment script. Add those only when the external hosting platform is known and needs repo-owned deployment automation.

--- a/README.md
+++ b/README.md
@@ -1457,6 +1457,7 @@ Run locally
 <summary>Documentation and resources</summary>
 
 **Getting Started Guides:**
+- [Public documentation site](https://tldwproject.com/server/docs/) - canonical docs hosted on tldwproject.com
 - [User Wiki](Docs/Wiki/User_Wiki.md) - install, run, configure, and use tldw_server
 - [Developer Wiki](Docs/Wiki/Developer_Wiki.md) - contribute to, test, package, and understand the codebase
 - [User Guides Documentation Map](Docs/User_Guides/index.md) - task-oriented map for setup, WebUI, extension, API, and admin workflows

--- a/apps/extension/docs/index.md
+++ b/apps/extension/docs/index.md
@@ -2,7 +2,7 @@
 
 tldw Assistant is a browser extension frontend for tldw_server — your unified AI assistant. Use a side panel or full web UI to chat with models configured on your server, run RAG search with citations, ingest/process media, and access STT/TTS features.
 
-For the shared tldw_server documentation map across the server API, WebUI, browser extension, and admin/operator workflows, use the [tldw_server User Guides](https://rmusser01.github.io/tldw_server/User_Guides/). This extension guide stays focused on extension-specific setup and browser behavior.
+For the shared tldw_server documentation map across the server API, WebUI, browser extension, and admin/operator workflows, use the [tldw_server User Guides](https://tldwproject.com/server/docs/User_Guides/). This extension guide stays focused on extension-specific setup and browser behavior.
 
 ## What is tldw_server integration?
 

--- a/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
+++ b/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
@@ -4,13 +4,14 @@ title: Document external docs hosting links
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: 2026-07-04 05:14
+updated_date: '2026-07-04 05:30'
 labels:
-- docs
+  - docs
 dependencies: []
 documentation:
-- Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
-- Docs/superpowers/plans/2026-07-04-external-docs-hosting-implementation-plan.md
+  - Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
+  - >-
+    Docs/superpowers/plans/2026-07-04-external-docs-hosting-implementation-plan.md
 ---
 
 ## Description
@@ -21,10 +22,10 @@ Ensure README and website copy point readers to the canonical external docs page
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 README links to https://tldwproject.com/server/docs/ as the public docs site.
-- [ ] #2 Docs website landing page links to https://tldwproject.com/server/docs/.
-- [ ] #3 Docs site guide explains external hosting at /server/docs, manual deploy, optional clone/pull/build automation, and GitHub Pages as a mirror.
-- [ ] #4 Existing MkDocs build path remains documented and locally verifiable.
+- [x] #1 README links to https://tldwproject.com/server/docs/ as the public docs site.
+- [x] #2 Docs website landing page links to https://tldwproject.com/server/docs/.
+- [x] #3 Docs site guide explains external hosting at /server/docs, manual deploy, optional clone/pull/build automation, and GitHub Pages as a mirror.
+- [x] #4 Existing MkDocs build path remains documented and locally verifiable.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -35,22 +36,34 @@ Implementation plan: Docs/superpowers/plans/2026-07-04-external-docs-hosting-imp
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
+Modified README.md, Docs/Website/index.html, Docs/mkdocs.yml, and Docs/Code_Documentation/Docs_Site_Guide.md.
+
+Verification: bash Helper_Scripts/refresh_docs_published.sh exited 0; python3 -m mkdocs build -f Docs/mkdocs.yml exited 0 with existing baseline docs warnings.
+
+Verification: canonical tldwproject.com/server/docs URL appears in README, website, MkDocs config, and docs guide; stale tldwproject.org/server/docs check returned no matches; MkDocs site_url check returned one match.
+
+Bandit skipped: touched implementation files are Markdown, static HTML links, and YAML docs metadata only.
+
+Known skip: broad Docs/Published refresh drift was not committed; CI and external deploy docs still run the refresh before building.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Linked README and the tldwproject.com website source to the canonical public docs URL, updated MkDocs site_url to tldwproject.com/server/docs, and revised the docs site guide to document manual external deployment, optional site-side clone/pull/build automation, and GitHub Pages as a mirror.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
+++ b/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12128
+title: Document external docs hosting links
+status: In Progress
+labels:
+- docs
+documentation:
+- Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure README and website copy point readers to the canonical external docs page at tldwproject.org/server/docs, and document how the MkDocs docs are built, updated, and administered for that external host.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 README links to https://tldwproject.org/server/docs/ as the public docs site.
+- [ ] #2 Docs website landing page links to https://tldwproject.org/server/docs/.
+- [ ] #3 Docs site guide explains external hosting at /server/docs and does not present GitHub Pages as the production target.
+- [ ] #4 Existing MkDocs build path remains documented and locally verifiable.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Canonical docs live at https://tldwproject.org/server/docs/. GitHub Pages remains enabled as a mirror from the same MkDocs source; do not disable the Pages deploy.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
+++ b/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
@@ -4,7 +4,7 @@ title: Document external docs hosting links
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-04 05:38'
+updated_date: '2026-07-04 06:04'
 labels:
   - docs
 dependencies: []
@@ -52,6 +52,8 @@ Bandit skipped: touched implementation files are Markdown, static HTML links, an
 Known skip: broad Docs/Published refresh drift was not committed; CI and external deploy docs still run the refresh before building.
 
 PR: https://github.com/rmusser01/tldw_server/pull/2616
+
+Review follow-up: rebased branch onto origin/dev; fixed Qodo comments by qualifying MkDocs serve/build commands with -f Docs/mkdocs.yml and replacing stale GitHub Pages public links with relative docs links or the tldwproject.com canonical URL. Verification: refresh_docs_published.sh exited 0; python3 -m mkdocs build -f Docs/mkdocs.yml exited 0 with existing baseline warnings; stale GitHub Pages URL grep returned no matches outside ignored Docs/site; unqualified MkDocs command grep returned no matches.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
+++ b/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
@@ -4,12 +4,13 @@ title: Document external docs hosting links
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-07-04 05:14'
+updated_date: 2026-07-04 05:14
 labels:
-  - docs
+- docs
 dependencies: []
 documentation:
-  - Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
+- Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
+- Docs/superpowers/plans/2026-07-04-external-docs-hosting-implementation-plan.md
 ---
 
 ## Description
@@ -29,7 +30,7 @@ Ensure README and website copy point readers to the canonical external docs page
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Canonical docs live at https://tldwproject.com/server/docs/. GitHub Pages remains enabled as a mirror from the same MkDocs source. The external site can start with manual copy/deploy of the built static site; a later site-side clone/pull/build job can detect new versions, build the docs, and update /server/docs/.
+Implementation plan: Docs/superpowers/plans/2026-07-04-external-docs-hosting-implementation-plan.md
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
+++ b/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-12128
 title: Document external docs hosting links
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-04 05:30'
+updated_date: '2026-07-04 05:38'
 labels:
   - docs
 dependencies: []
@@ -50,6 +50,8 @@ Verification: canonical tldwproject.com/server/docs URL appears in README, websi
 Bandit skipped: touched implementation files are Markdown, static HTML links, and YAML docs metadata only.
 
 Known skip: broad Docs/Published refresh drift was not committed; CI and external deploy docs still run the refresh before building.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2616
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
+++ b/backlog/tasks/task-12128 - Document-external-docs-hosting-links.md
@@ -2,30 +2,34 @@
 id: TASK-12128
 title: Document external docs hosting links
 status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-07-04 05:14'
 labels:
-- docs
+  - docs
+dependencies: []
 documentation:
-- Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
+  - Docs/superpowers/specs/2026-07-04-external-docs-hosting-design.md
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Ensure README and website copy point readers to the canonical external docs page at tldwproject.org/server/docs, and document how the MkDocs docs are built, updated, and administered for that external host.
+Ensure README and website copy point readers to the canonical external docs page at tldwproject.com/server/docs, and document how the MkDocs docs are built, updated, mirrored, and administered for that external host.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 README links to https://tldwproject.org/server/docs/ as the public docs site.
-- [ ] #2 Docs website landing page links to https://tldwproject.org/server/docs/.
-- [ ] #3 Docs site guide explains external hosting at /server/docs and does not present GitHub Pages as the production target.
+- [ ] #1 README links to https://tldwproject.com/server/docs/ as the public docs site.
+- [ ] #2 Docs website landing page links to https://tldwproject.com/server/docs/.
+- [ ] #3 Docs site guide explains external hosting at /server/docs, manual deploy, optional clone/pull/build automation, and GitHub Pages as a mirror.
 - [ ] #4 Existing MkDocs build path remains documented and locally verifiable.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Canonical docs live at https://tldwproject.org/server/docs/. GitHub Pages remains enabled as a mirror from the same MkDocs source; do not disable the Pages deploy.
+Canonical docs live at https://tldwproject.com/server/docs/. GitHub Pages remains enabled as a mirror from the same MkDocs source. The external site can start with manual copy/deploy of the built static site; a later site-side clone/pull/build job can detect new versions, build the docs, and update /server/docs/.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes


### PR DESCRIPTION
## Summary
- Link the README and static website source to https://tldwproject.com/server/docs/.
- Make MkDocs use https://tldwproject.com/server/docs/ as the canonical site_url while keeping GitHub Pages as a mirror.
- Document external deployment/admin flow: manual copy, optional site-side git pull/build job, and GitHub Pages mirroring.

## Test Plan
- [x] python3 -m mkdocs build -f Docs/mkdocs.yml
- [x] rg -n "tldwproject.org/server/docs" README.md Docs/Website/index.html Docs/mkdocs.yml Docs/Code_Documentation/Docs_Site_Guide.md (no matches; rg exit 1)
- [x] rg -n "^site_url: https://tldwproject.com/server/docs/$" Docs/mkdocs.yml (one match)
- [x] git diff --check
- [x] Bandit skipped: docs/static HTML/YAML/backlog-only change

## Notes
- A human-authored Change summary is still required before merge per the repo AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made https://tldwproject.com/server/docs/ the canonical docs site and kept GitHub Pages as a mirror. Reorganized the docs with clear User/Developer wiki entry points and added missing architecture and ADR content for better navigation and governance.

- New Features
  - Set MkDocs `site_url` to https://tldwproject.com/server/docs/.
  - Added User Wiki and Developer Wiki entry points; updated MkDocs nav and refresh script to publish `Wiki/`, `Architecture.md`, and ADRs.
  - Backfilled ADRs, added an Architecture overview, and a Data Flow Atlas.
  - Updated links and guides, including the Docs Site Guide with external hosting steps.
  - Added design and implementation plans for external hosting and related docs work.

- Docs Build and CI
  - MkDocs workflow now validates `ADR`, `Wiki`, and `Architecture.md` presence before build.
  - Helper script publishes wiki and architecture artifacts into `Docs/Published/`.
  - CI upkeep: added a Visual Identities test shard, removed obsolete quarantine flags, bumped Docker GitHub Actions, and enhanced the PyPI publish workflow with version detection and main-branch publishing.

<sup>Written for commit f5b07e3448b78ee4f55fcc2720cb797507aa77b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

