### PR TITLE
Reject mismatched VZ guest agents before execution

### DIFF
--- a/backlog/tasks/task-12138 - Reject-new-VZ-Linux-VM-guest-agent-mismatch-before-execution.md
+++ b/backlog/tasks/task-12138 - Reject-new-VZ-Linux-VM-guest-agent-mismatch-before-execution.md
@@ -39,6 +39,7 @@ Close the VZ Linux guest-agent mismatch gap found in current code: newly-created
 - Added a focused regression for a newly-created session VM with mismatched guest metadata. The RED run failed because the command reached exec_guest and completed.
 - Added a create_vm gate that rejects explicit guest-agent mismatch before image-store clone prep, session-control persistence, or exec_guest. Unknown metadata remains allowed to preserve existing metadata-light guest behavior.
 - The guard sets should_terminate_vm before raising so the existing finally cleanup terminates the rejected VM.
+- Review follow-up: added marker, fixture type annotations, and docstrings to the new regression test/local helpers.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -47,6 +48,7 @@ Close the VZ Linux guest-agent mismatch gap found in current code: newly-created
 - Newly-created VZ Linux VMs with explicit guest-agent mismatch now fail closed before execution.
 - Mismatched newly-created session VMs are not stored for reuse and are terminated through the existing cleanup path.
 - Verification passed: focused regression pytest, related runner pytest selection, guest-agent helper pytest, py_compile, git diff --check, and Bandit on the touched runner file.
+- PR review hygiene comments were addressed in the regression test.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12138 - Reject-new-VZ-Linux-VM-guest-agent-mismatch-before-execution.md
+++ b/backlog/tasks/task-12138 - Reject-new-VZ-Linux-VM-guest-agent-mismatch-before-execution.md
@@ -1,0 +1,60 @@
+---
+id: TASK-12138
+title: Reject new VZ Linux VM guest-agent mismatch before execution
+status: Done
+labels:
+- sandbox
+- vz-linux
+- guest-agent
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Close the VZ Linux guest-agent mismatch gap found in current code: newly-created VMs with explicit guest-agent contract mismatch should fail closed before guest execution, should not store reusable session control, and should be terminated/cleaned up.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Add a focused failing runner test for newly-created VM guest-agent mismatch.
+- [x] #2 Reject explicit mismatch after create_vm and before exec_guest.
+- [x] #3 Do not store reusable session-control rows for mismatched newly-created VMs.
+- [x] #4 Terminate/cleanup the mismatched VM through the existing failure path.
+- [x] #5 Run focused pytest, py_compile or equivalent, diff check, and Bandit on touched production code.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- Write RED test in VZ Linux runner tests.
+- Implement the smallest runner guard using the existing guest-agent classifier and failure cleanup path.
+- Run focused verification and update task final summary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Verified current code before editing: existing session reuse already rejected explicit guest-agent mismatch, but the newly-created VM path executed before checking create_vm metadata.
+- Added a focused regression for a newly-created session VM with mismatched guest metadata. The RED run failed because the command reached exec_guest and completed.
+- Added a create_vm gate that rejects explicit guest-agent mismatch before image-store clone prep, session-control persistence, or exec_guest. Unknown metadata remains allowed to preserve existing metadata-light guest behavior.
+- The guard sets should_terminate_vm before raising so the existing finally cleanup terminates the rejected VM.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Newly-created VZ Linux VMs with explicit guest-agent mismatch now fail closed before execution.
+- Mismatched newly-created session VMs are not stored for reuse and are terminated through the existing cleanup path.
+- Verification passed: focused regression pytest, related runner pytest selection, guest-agent helper pytest, py_compile, git diff --check, and Bandit on the touched runner file.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -23,7 +23,7 @@ from ..policy import SandboxPolicyConfig
 from ..runtime_capabilities import RuntimePreflightResult
 from ..streams import get_hub
 from ..utils import coerce_optional_nonempty_string
-from ..vz_guest_agent import vz_linux_guest_agent_mismatched
+from ..vz_guest_agent import classify_vz_linux_guest_agent, vz_linux_guest_agent_mismatched
 from .resource_limits import log_limit_counters
 from .vz_common import _VZ_NONCRITICAL_EXCEPTIONS, VZBaseRunner, vz_host_facts
 
@@ -533,6 +533,15 @@ class VZLinuxRunner(VZBaseRunner):
                     }
                 )
                 vm_id = vm.vm_id
+                guest_agent = classify_vz_linux_guest_agent(vm.details)
+                if guest_agent.get("compatibility") == "mismatch":
+                    should_terminate_vm = True
+                    reasons = [
+                        str(reason)
+                        for reason in guest_agent.get("reasons", [])
+                        if str(reason).strip()
+                    ]
+                    raise RuntimeError(", ".join(reasons) or "vz_linux_guest_agent_mismatch")
                 if should_persist_run_manifest and image_store is not None and metadata_template_id:
                     image_store.prepare_run_clone(template_id=metadata_template_id, run_id=run_id)
                 should_terminate_vm = not session_mode

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -533,8 +533,8 @@ class VZLinuxRunner(VZBaseRunner):
                     }
                 )
                 vm_id = vm.vm_id
-                guest_agent = classify_vz_linux_guest_agent(vm.details)
-                if guest_agent.get("compatibility") == "mismatch":
+                guest_agent = classify_vz_linux_guest_agent(vm.details) if vm.details else None
+                if guest_agent and guest_agent.get("compatibility") == "mismatch":
                     should_terminate_vm = True
                     reasons = [
                         str(reason)

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -459,25 +459,35 @@ def test_vz_linux_session_create_vm_readiness_failure_does_not_persist_reuse_sta
             VZLinuxRunner._active_run_dir.pop(run_id, None)  # type: ignore[attr-defined]
 
 
+@pytest.mark.unit
 def test_vz_linux_session_create_vm_guest_agent_mismatch_fails_closed(
-    monkeypatch,
-    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
+    """Reject a newly-created session VM when helper metadata reports mismatch."""
+
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
     calls: list[str] = []
     stored: list[dict[str, object]] = []
     terminated: list[str] = []
 
     class _Store:
+        """Minimal session-control store for mismatch assertions."""
+
         def get_vz_session_control(self, session_id: str) -> None:
+            """Return no reusable VM for the tested session."""
             assert session_id == "sess-new-guest-agent-mismatch"
             return None
 
         def put_vz_session_control(self, **kwargs: object) -> None:
+            """Record unexpected session-control persistence."""
             stored.append(dict(kwargs))
 
     class _FakeHelper:
+        """Helper double that creates a VM with mismatched guest metadata."""
+
         def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            """Pretend the image template is valid."""
             calls.append("validate_template")
             return {
                 "template_id": "vz_linux:new-template",
@@ -486,6 +496,7 @@ def test_vz_linux_session_create_vm_guest_agent_mismatch_fails_closed(
             }
 
         def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            """Return a created VM whose guest metadata explicitly mismatches."""
             calls.append("create_vm")
             assert request["session_id"] == "sess-new-guest-agent-mismatch"
             assert request["session_mode"] is True
@@ -501,10 +512,12 @@ def test_vz_linux_session_create_vm_guest_agent_mismatch_fails_closed(
             )
 
         def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
+            """Fail the call-order assertion if the runner reaches guest execution."""
             calls.append("exec_guest")
             return HelperExecReply(exit_code=0, stdout=b"should-not-run\n")
 
         def terminate_vm(self, vm_id: str) -> bool:
+            """Record cleanup of the rejected VM."""
             calls.append("terminate_vm")
             terminated.append(vm_id)
             return True

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -459,6 +459,77 @@ def test_vz_linux_session_create_vm_readiness_failure_does_not_persist_reuse_sta
             VZLinuxRunner._active_run_dir.pop(run_id, None)  # type: ignore[attr-defined]
 
 
+def test_vz_linux_session_create_vm_guest_agent_mismatch_fails_closed(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    calls: list[str] = []
+    stored: list[dict[str, object]] = []
+    terminated: list[str] = []
+
+    class _Store:
+        def get_vz_session_control(self, session_id: str) -> None:
+            assert session_id == "sess-new-guest-agent-mismatch"
+            return None
+
+        def put_vz_session_control(self, **kwargs: object) -> None:
+            stored.append(dict(kwargs))
+
+    class _FakeHelper:
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            calls.append("validate_template")
+            return {
+                "template_id": "vz_linux:new-template",
+                "ready": True,
+                "reasons": [],
+            }
+
+        def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            calls.append("create_vm")
+            assert request["session_id"] == "sess-new-guest-agent-mismatch"
+            assert request["session_mode"] is True
+            return HelperVMReply(
+                vm_id="vm-new-guest-agent-mismatch",
+                state="created",
+                details={
+                    "guest_version": "0.9.0",
+                    "guest_workspace_root": "/var/empty",
+                    "guest_capabilities_known": "true",
+                    "guest_capabilities": "output_cap_v1",
+                },
+            )
+
+        def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
+            calls.append("exec_guest")
+            return HelperExecReply(exit_code=0, stdout=b"should-not-run\n")
+
+        def terminate_vm(self, vm_id: str) -> bool:
+            calls.append("terminate_vm")
+            terminated.append(vm_id)
+            return True
+
+    monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
+
+    status = VZLinuxRunner(session_control_store=_Store()).start_run(
+        run_id="vz-run-new-guest-agent-mismatch",
+        spec=RunSpec(
+            session_id="sess-new-guest-agent-mismatch",
+            runtime=RuntimeType.vz_linux,
+            base_image="ubuntu-24.04",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+        ),
+        session_workspace=str(tmp_path),
+    )
+
+    assert status.phase == RunPhase.failed
+    assert "vz_linux_guest_agent_workspace_mismatch" in status.message
+    assert calls == ["validate_template", "create_vm", "terminate_vm"]
+    assert stored == []
+    assert terminated == ["vm-new-guest-agent-mismatch"]
+
+
 def test_vz_linux_raw_template_path_ignores_unavailable_image_store(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
     broken_store_root = tmp_path / "not-a-directory"


### PR DESCRIPTION
## Summary
- reject explicit VZ Linux guest-agent mismatches immediately after create_vm metadata is available
- prevent mismatched newly-created session VMs from being stored or executed
- add regression coverage for the newly-created VM path

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py::test_vz_linux_session_create_vm_guest_agent_mismatch_fails_closed -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q -k "guest_agent_mismatch or create_vm_guest_agent_mismatch or session_reuse_guest_agent_mismatch or readiness_failure"
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_vz_guest_agent.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
- git diff --check
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py -f json -o /tmp/bandit_vz_guest_agent_create_gate.json

## Notes
- Human Change summary still required before merge if this PR is treated as AI-authored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject mismatched VZ Linux guest agents right after VM creation to fail closed before execution and avoid storing reusable session state. Addresses TASK-12138 and ensures mismatched VMs are terminated via the existing cleanup path.

- **Bug Fixes**
  - Added a gate after `create_vm` using `classify_vz_linux_guest_agent`; on "mismatch", sets `should_terminate_vm` and raises with reason messages.
  - Skips image-store clone, session-control persistence, and `exec_guest` on mismatch.
  - Added a focused regression test for the newly-created session path with markers and type hints.

<sup>Written for commit be0c23e322cb8139c6c37c98495196560370077a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

