### PR TITLE
Require media.create for media processing routes

### DIFF
--- a/backlog/tasks/task-12146 - Require-media.create-for-processing-endpoints.md
+++ b/backlog/tasks/task-12146 - Require-media.create-for-processing-endpoints.md
@@ -1,0 +1,76 @@
+---
+id: TASK-12146
+title: Require media.create for processing endpoints
+status: In Progress
+assignee: []
+created_date: 2026-07-04 17:04
+labels:
+- audit
+- remediation
+- media
+- security
+dependencies: []
+references:
+- AUDIT-2026-06-27-MEDIA-001
+documentation:
+- Docs/superpowers/reviews/2026-06-27-repo-audit/domains/media-ingestion-storage.md
+priority: high
+updated_date: 2026-07-04 17:12
+modified_files:
+- tldw_Server_API/app/api/v1/API_Deps/media_route_deps.py
+- tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
+- tldw_Server_API/app/api/v1/endpoints/media/process_code.py
+- tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
+- tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
+- tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
+- tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
+- tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
+- tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
+- tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+- tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remediate AUDIT-2026-06-27-MEDIA-001: processing-only media endpoints accept uploads, remote input, parsing, chunking, and analysis work while only authenticating callers. Align these write-like processing routes with the media.create permission and RBAC rate-limit boundary used by other ingestion routes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Processing-only media routes that accept user media or remote input require the media.create permission.
+- [x] #2 Processing-only media routes use the media.create RBAC rate-limit dependency where comparable ingestion routes do.
+- [x] #3 Regression tests assert callers without media.create receive 403 for representative processing endpoints.
+- [x] #4 Implementation remains on latest origin/dev and avoids changing unrelated media behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect current media processing route dependencies and existing media permission tests on latest dev.
+2. Add focused failing permission-denial tests for representative processing endpoints.
+3. Add or reuse a shared dependency bundle that applies RequirePermission(MEDIA_CREATE) and rbac_rate_limit('media.create') consistently.
+4. Run focused media permission tests, Bandit over touched production files, and git diff --check.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused media permission tests pass.
+- [x] #8 Bandit over touched production files reports no new issues.
+- [x] #9 git diff --check passes.
+- [ ] #10 Backlog task records latest-dev base, validation evidence, final summary, and PR link if opened.
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-07-04: Created remediation worktree from latest origin/dev fd5c152b065c408e4e8ee5f08da41589f21cb7f5 after a successful git fetch origin dev.
+2026-07-04: Red test confirmed MEDIA-001 on current dev. Command: /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py -q => 9 failed, 2 passed; missing media.create dependency on process-audios, process-pdfs, process-documents, process-ebooks, process-code, process-emails, mediawiki/ingest-dump, mediawiki/process-dump, plus representative request returned 401/400-class behavior instead of 403. After implementation: same command => 11 passed, 38 warnings. Expanded related command: /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py tldw_Server_API/tests/AuthNZ_Unit/test_media_add_permissions_claims.py tldw_Server_API/tests/Media_Ingestion_Modification/test_process_endpoints_contract_parity.py tldw_Server_API/tests/Media/test_media_router_resilient_imports.py -q => 16 passed, 48 warnings. Representative existing processing command: /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Media/test_process_code_and_uploads.py tldw_Server_API/tests/Media/test_json_document_processing.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_upload_failures.py -q => 21 passed, 558 warnings.
+2026-07-04: Final validation on latest origin/dev fd5c152b065c408e4e8ee5f08da41589f21cb7f5. Combined focused tests passed: /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py tldw_Server_API/tests/AuthNZ_Unit/test_media_add_permissions_claims.py tldw_Server_API/tests/Media_Ingestion_Modification/test_process_endpoints_contract_parity.py tldw_Server_API/tests/Media/test_media_router_resilient_imports.py tldw_Server_API/tests/Media/test_process_code_and_uploads.py tldw_Server_API/tests/Media/test_json_document_processing.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_upload_failures.py -q => 37 passed, 510 warnings. Bandit over touched production files wrote /tmp/bandit_media_processing_permissions.json and exited 0 with no findings. git diff --check exited 0. Untracked watchlist template files were present in the worktree and intentionally left unstaged because they are unrelated.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-12146 - Require-media.create-for-processing-endpoints.md
+++ b/backlog/tasks/task-12146 - Require-media.create-for-processing-endpoints.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12146
 title: Require media.create for processing endpoints
-status: In Progress
+status: Done
 assignee: []
 created_date: 2026-07-04 17:04
 labels:
@@ -15,7 +15,7 @@ references:
 documentation:
 - Docs/superpowers/reviews/2026-06-27-repo-audit/domains/media-ingestion-storage.md
 priority: high
-updated_date: 2026-07-04 17:12
+updated_date: 2026-07-05 00:26
 modified_files:
 - tldw_Server_API/app/api/v1/API_Deps/media_route_deps.py
 - tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
@@ -57,20 +57,31 @@ Remediate AUDIT-2026-06-27-MEDIA-001: processing-only media endpoints accept upl
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
+- [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 - [x] #7 Focused media permission tests pass.
 - [x] #8 Bandit over touched production files reports no new issues.
 - [x] #9 git diff --check passes.
-- [ ] #10 Backlog task records latest-dev base, validation evidence, final summary, and PR link if opened.
+- [x] #10 Backlog task records latest-dev base, validation evidence, final summary, and PR link if opened.
 <!-- DOD:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-2026-07-04: Created remediation worktree from latest origin/dev fd5c152b065c408e4e8ee5f08da41589f21cb7f5 after a successful git fetch origin dev.
-2026-07-04: Red test confirmed MEDIA-001 on current dev. Command: /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py -q => 9 failed, 2 passed; missing media.create dependency on process-audios, process-pdfs, process-documents, process-ebooks, process-code, process-emails, mediawiki/ingest-dump, mediawiki/process-dump, plus representative request returned 401/400-class behavior instead of 403. After implementation: same command => 11 passed, 38 warnings. Expanded related command: /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py tldw_Server_API/tests/AuthNZ_Unit/test_media_add_permissions_claims.py tldw_Server_API/tests/Media_Ingestion_Modification/test_process_endpoints_contract_parity.py tldw_Server_API/tests/Media/test_media_router_resilient_imports.py -q => 16 passed, 48 warnings. Representative existing processing command: /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Media/test_process_code_and_uploads.py tldw_Server_API/tests/Media/test_json_document_processing.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_upload_failures.py -q => 21 passed, 558 warnings.
-2026-07-04: Final validation on latest origin/dev fd5c152b065c408e4e8ee5f08da41589f21cb7f5. Combined focused tests passed: /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py tldw_Server_API/tests/AuthNZ_Unit/test_media_add_permissions_claims.py tldw_Server_API/tests/Media_Ingestion_Modification/test_process_endpoints_contract_parity.py tldw_Server_API/tests/Media/test_media_router_resilient_imports.py tldw_Server_API/tests/Media/test_process_code_and_uploads.py tldw_Server_API/tests/Media/test_json_document_processing.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_upload_failures.py -q => 37 passed, 510 warnings. Bandit over touched production files wrote /tmp/bandit_media_processing_permissions.json and exited 0 with no findings. git diff --check exited 0. Untracked watchlist template files were present in the worktree and intentionally left unstaged because they are unrelated.
+2026-07-04: Red test confirmed MEDIA-001 on then-current dev. Command: `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py -q` initially failed for missing `media.create` dependencies on processing-only media routes; after implementation the focused permission claims passed.
+
+Implemented a shared `media_create_dependencies()` helper and applied it to processing-only media routes that accept user media or remote input, aligning them with the `media.create` permission and RBAC rate-limit boundary. Added route-contract and representative 403 regression coverage.
+
+Current-dev refresh (2026-07-04): rebased `codex/audit-media-processing-permissions-2026-07-04` onto `origin/dev` `09d9ec901e1d4548f7924f1c6bcefa963fadd9bd`; merge-base matches `origin/dev`. Current validation: `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py -q` passed with 11 tests; `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/API_Deps/media_route_deps.py tldw_Server_API/app/api/v1/endpoints/media/process_audios.py tldw_Server_API/app/api/v1/endpoints/media/process_code.py tldw_Server_API/app/api/v1/endpoints/media/process_documents.py tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py tldw_Server_API/app/api/v1/endpoints/media/process_emails.py tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py tldw_Server_API/app/api/v1/endpoints/media/process_videos.py tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py -f json -o /tmp/bandit_media_processing_permissions_origin_dev_09d9ec.json` reported 0 findings over 3222 LOC; `git diff --check HEAD~1..HEAD` passed. The two untracked watchlist template files remain unrelated and intentionally unstaged.
+
+Draft PR: https://github.com/rmusser01/tldw_server/pull/2623. PR remains draft because AI-authored PRs require a human-written Change summary before merge.
+2026-07-04 latest-dev refresh: rebased and validated PR #2623 on origin/dev 6b727b221e55646eba663a03571e38302f7fafc2. Tested head 229de29981b2. Verification: python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py -q => 11 passed, 38 warnings; Bandit over media_route_deps.py and media processing endpoints => 0 findings over 3222 LOC; git diff --check HEAD~1..HEAD => clean. Two unrelated untracked watchlist template files remain intentionally unstaged.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Applied media-processing permission dependency coverage across the route family. Final refresh validated against origin/dev 6b727b221e55646eba663a03571e38302f7fafc2 with focused tests passing, Bandit clean on touched production scope, and whitespace check clean; unrelated untracked watchlist templates were left out of the PR.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/API_Deps/media_route_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/media_route_deps.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Depends
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
+from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
+
+
+def media_create_dependencies() -> list[Any]:
+    """Return the shared auth dependencies for media ingestion/processing writes."""
+    return [
+        Depends(RequirePermission(MEDIA_CREATE)),
+        Depends(rbac_rate_limit("media.create")),
+    ]

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
@@ -26,6 +26,7 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_audios_form,
 )
+from tldw_Server_API.app.api.v1.API_Deps.media_route_deps import media_create_dependencies
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     UsageEventLogger,
     get_usage_event_logger,
@@ -64,6 +65,7 @@ _propagate_billing_headers = propagate_billing_headers
     summary="Transcribe / chunk / analyse audio and return full artefacts (no DB write)",
     tags=["Media Processing (No DB)"],
     dependencies=[
+        *media_create_dependencies(),
         Depends(guard_storage_quota),
         Depends(require_within_limit(LimitCategory.STORAGE_MB, 1)),
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_code.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_code.py
@@ -14,6 +14,7 @@ from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storag
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_code_deps import get_process_code_form
+from tldw_Server_API.app.api.v1.API_Deps.media_route_deps import media_create_dependencies
 from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessCodeForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.code_utils import (
@@ -45,6 +46,7 @@ router = APIRouter()
     summary="Process code files (NO DB Persistence)",
     tags=["Media Processing (No DB)"],
     dependencies=[
+        *media_create_dependencies(),
         Depends(guard_storage_quota),
         Depends(require_within_limit(LimitCategory.STORAGE_MB, 1)),
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
@@ -17,6 +17,7 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_documents_form,
 )
+from tldw_Server_API.app.api.v1.API_Deps.media_route_deps import media_create_dependencies
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     UsageEventLogger,
     get_usage_event_logger,
@@ -73,6 +74,7 @@ ALLOWED_DOC_EXTENSIONS = [
     summary="Extract, chunk, analyse Documents (NO DB Persistence)",
     tags=["Media Processing (No DB)"],
     dependencies=[
+        *media_create_dependencies(),
         Depends(guard_storage_quota),
         Depends(require_within_limit(LimitCategory.STORAGE_MB, 1)),
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
@@ -23,6 +23,7 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_ebooks_form,
 )
+from tldw_Server_API.app.api.v1.API_Deps.media_route_deps import media_create_dependencies
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     UsageEventLogger,
     get_usage_event_logger,
@@ -138,6 +139,7 @@ def _process_single_ebook(
     summary="Extract, chunk, analyse EPUBs (NO DB Persistence)",
     tags=["Media Processing (No DB)"],
     dependencies=[
+        *media_create_dependencies(),
         Depends(guard_storage_quota),
         Depends(require_within_limit(LimitCategory.STORAGE_MB, 1)),
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
@@ -15,6 +15,7 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_emails_form,
 )
+from tldw_Server_API.app.api.v1.API_Deps.media_route_deps import media_create_dependencies
 from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessEmailsForm
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
@@ -41,7 +42,7 @@ router = APIRouter()
     "/process-emails",
     summary="Extract, chunk, analyse Emails (NO DB Persistence)",
     tags=["Media Processing (No DB)"],
-    dependencies=[Depends(guard_storage_quota)],
+    dependencies=[*media_create_dependencies(), Depends(guard_storage_quota)],
 )
 async def process_emails_endpoint(
     db: Any = Depends(get_media_db_for_user),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
@@ -20,6 +20,7 @@ from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storag
 from tldw_Server_API.app.api.v1.API_Deps.media_mediawiki_deps import (
     get_mediawiki_form_data,
 )
+from tldw_Server_API.app.api.v1.API_Deps.media_route_deps import media_create_dependencies
 from tldw_Server_API.app.api.v1.schemas.media_request_models import (
     MediaWikiDumpOptionsForm,
     ProcessedMediaWikiPage,
@@ -239,7 +240,11 @@ async def _process_mediawiki_dump(
     "/mediawiki/ingest-dump",
     summary="Ingest and process a MediaWiki XML dump, storing results to database and vector store.",
     tags=["MediaWiki Processing"],
-    dependencies=[Depends(guard_backpressure_and_quota), Depends(guard_storage_quota)],
+    dependencies=[
+        *media_create_dependencies(),
+        Depends(guard_backpressure_and_quota),
+        Depends(guard_storage_quota),
+    ],
     response_class=StreamingResponse,
     responses={
         status.HTTP_200_OK: {
@@ -274,7 +279,11 @@ async def ingest_mediawiki_dump_endpoint(
     "/mediawiki/process-dump",
     summary="Process a MediaWiki XML dump and return structured content without database storage.",
     tags=["MediaWiki Processing"],
-    dependencies=[Depends(guard_backpressure_and_quota), Depends(guard_storage_quota)],
+    dependencies=[
+        *media_create_dependencies(),
+        Depends(guard_backpressure_and_quota),
+        Depends(guard_storage_quota),
+    ],
     response_class=StreamingResponse,
     responses={
         status.HTTP_200_OK: {

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
@@ -24,6 +24,7 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_pdfs_form,
 )
+from tldw_Server_API.app.api.v1.API_Deps.media_route_deps import media_create_dependencies
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     UsageEventLogger,
     get_usage_event_logger,
@@ -75,6 +76,7 @@ ALLOWED_PDF_EXTENSIONS = [".pdf"]
     summary="Extract, chunk, analyse PDFs (NO DB Persistence)",
     tags=["Media Processing (No DB)"],
     dependencies=[
+        *media_create_dependencies(),
         Depends(guard_storage_quota),
         Depends(require_within_limit(LimitCategory.STORAGE_MB, 1)),
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
@@ -15,7 +15,7 @@ from fastapi import (
 )
 from loguru import logger
 from starlette.responses import JSONResponse
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import propagate_billing_headers, require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
@@ -24,6 +24,7 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_videos_form,
 )
+from tldw_Server_API.app.api.v1.API_Deps.media_route_deps import media_create_dependencies
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     UsageEventLogger,
     get_usage_event_logger,
@@ -31,9 +32,6 @@ from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
 from tldw_Server_API.app.api.v1.API_Deps.validations_deps import file_validator_instance
 from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessVideosForm
-from tldw_Server_API.app.core.AuthNZ.permissions import (
-    MEDIA_CREATE,
-)
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
     async_resolve_chunking_for_result,
@@ -62,8 +60,7 @@ router = APIRouter()
     summary="Transcribe / chunk / analyse videos and return the full artefacts (no DB write)",
     tags=["Media Processing (No DB)"],
     dependencies=[
-        Depends(RequirePermission(MEDIA_CREATE)),
-        Depends(rbac_rate_limit("media.create")),
+        *media_create_dependencies(),
         Depends(guard_storage_quota),
         Depends(require_within_limit(LimitCategory.STORAGE_MB, 1)),
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
@@ -8,8 +8,8 @@ from typing import Any, cast
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
+from tldw_Server_API.app.api.v1.API_Deps.media_route_deps import media_create_dependencies
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
@@ -17,7 +17,6 @@ from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     get_usage_event_logger,
 )
 from tldw_Server_API.app.api.v1.schemas.media_request_models import WebScrapingRequest
-from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
 from tldw_Server_API.app.services.web_scraping_service import process_web_scraping_task
 
 router = APIRouter()
@@ -48,8 +47,7 @@ def _resolve_process_web_scraping_task() -> WebScrapingTask:
 @router.post(
     "/process-web-scraping",
     dependencies=[
-        Depends(RequirePermission(MEDIA_CREATE)),
-        Depends(rbac_rate_limit("media.create")),
+        *media_create_dependencies(),
         Depends(require_within_limit(LimitCategory.STORAGE_MB, 1)),
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),
     ],

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterable
+
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.endpoints.media import (
+    process_audios,
+    process_code,
+    process_documents,
+    process_ebooks,
+    process_emails,
+    process_mediawiki,
+    process_pdfs,
+    process_videos,
+    process_web_scraping,
+)
+from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+
+
+PROCESSING_ROUTES = (
+    (process_videos.router, "/process-videos"),
+    (process_audios.router, "/process-audios"),
+    (process_pdfs.router, "/process-pdfs"),
+    (process_documents.router, "/process-documents"),
+    (process_ebooks.router, "/process-ebooks"),
+    (process_code.router, "/process-code"),
+    (process_emails.router, "/process-emails"),
+    (process_web_scraping.router, "/process-web-scraping"),
+    (process_mediawiki.router, "/mediawiki/ingest-dump"),
+    (process_mediawiki.router, "/mediawiki/process-dump"),
+)
+
+
+def _route_for_path(router, path: str) -> APIRoute:
+    for route in router.routes:
+        if isinstance(route, APIRoute) and route.path == path and "POST" in route.methods:
+            return route
+    raise AssertionError(f"POST route {path} not found")
+
+
+def _dependency_calls(route: APIRoute) -> Iterable[object]:
+    dependant = getattr(route, "dependant", None)
+    for dependency in getattr(dependant, "dependencies", []) or []:
+        call = getattr(dependency, "call", None)
+        if call is not None:
+            yield call
+
+
+def _required_permissions(route: APIRoute) -> set[str]:
+    permissions: set[str] = set()
+    for call in _dependency_calls(route):
+        if not callable(call):
+            continue
+        try:
+            closure_vars = inspect.getclosurevars(call)
+        except TypeError:
+            continue
+        for permission in closure_vars.nonlocals.get("perms", []) or []:
+            permissions.add(str(permission))
+    return permissions
+
+
+def _rate_limit_resources(route: APIRoute) -> set[str]:
+    return {
+        resource
+        for call in _dependency_calls(route)
+        if (resource := getattr(call, "_tldw_rate_limit_resource", None))
+    }
+
+
+@pytest.mark.parametrize(("router", "path"), PROCESSING_ROUTES)
+def test_media_processing_routes_require_media_create(router, path: str) -> None:
+    route = _route_for_path(router, path)
+
+    assert MEDIA_CREATE in _required_permissions(route)
+    assert "media.create" in _rate_limit_resources(route)
+
+
+def _principal_without_media_create() -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        roles=["user"],
+        permissions=[],
+        is_admin=False,
+    )
+
+
+def test_processing_endpoint_forbidden_without_media_create_claim(monkeypatch) -> None:
+    monkeypatch.setenv("STORAGE_QUOTA_ENFORCEMENT", "0")
+    principal = _principal_without_media_create()
+    app = FastAPI()
+    app.include_router(process_emails.router, prefix="/api/v1/media")
+
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:
+        request.state.auth = AuthContext(principal=principal)
+        return principal
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+
+    with TestClient(app) as client:
+        response = client.post("/api/v1/media/process-emails", data={})
+
+    assert response.status_code == 403
+    assert MEDIA_CREATE in response.json().get("detail", "")


### PR DESCRIPTION
## Change summary

Human-written Change summary required before this draft PR is merge-ready under `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## What changed

Applies the shared media.create permission/rate-limit dependency across processing-only media routes that accept user media or remote input.

Backlog tracking: `TASK-12146`.

## Latest dev refresh

- Base: `dev` at `6b727b221e55646eba663a03571e38302f7fafc2`.
- Head: `codex/audit-media-processing-permissions-2026-07-04` at `c4ca3e14f1383ee1bd52937394422b01f0e3c636`.
- Post-amend check verified the final Backlog-note amend changed only the task record for this PR; merge-base still equals `6b727b221e55646eba663a03571e38302f7fafc2`.

## Validation

- `python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_media_processing_permissions_claims.py -q` -> 11 passed, 38 warnings.
- Bandit over `media_route_deps.py` and the media processing endpoints -> 0 findings over 3222 LOC (`/tmp/bandit_media_processing_permissions_origin_dev_6b727b.json`).
- `git diff --check HEAD~1..HEAD` -> clean.
- Two unrelated untracked watchlist template files remain intentionally unstaged in the worktree.
