### PR TITLE
chore: stop tracking node_modules symlinks

### DIFF
--- a/apps/packages/ui/node_modules/.bin/katex
+++ b/apps/packages/ui/node_modules/.bin/katex
@@ -1,1 +1,0 @@
-../katex/cli.js

--- a/apps/packages/ui/node_modules/.bin/marked
+++ b/apps/packages/ui/node_modules/.bin/marked
@@ -1,1 +1,0 @@
-../marked/bin/marked.js

--- a/apps/packages/ui/node_modules/.bin/vitest
+++ b/apps/packages/ui/node_modules/.bin/vitest
@@ -1,1 +1,0 @@
-../vitest/vitest.mjs

--- a/apps/packages/ui/node_modules/.bin/wxt
+++ b/apps/packages/ui/node_modules/.bin/wxt
@@ -1,1 +1,0 @@
-../wxt/bin/wxt.mjs

--- a/apps/packages/ui/node_modules/.bin/wxt-publish-extension
+++ b/apps/packages/ui/node_modules/.bin/wxt-publish-extension
@@ -1,1 +1,0 @@
-../wxt/bin/wxt-publish-extension.cjs

--- a/apps/packages/ui/node_modules/.bin/xlsx
+++ b/apps/packages/ui/node_modules/.bin/xlsx
@@ -1,1 +1,0 @@
-../xlsx/bin/xlsx.njs

--- a/apps/packages/ui/node_modules/@ant-design/cssinjs
+++ b/apps/packages/ui/node_modules/@ant-design/cssinjs
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@ant-design+cssinjs@2.0.3+6dbf9a050bc9aadb/node_modules/@ant-design/cssinjs

--- a/apps/packages/ui/node_modules/@ant-design/icons
+++ b/apps/packages/ui/node_modules/@ant-design/icons
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@ant-design+icons@6.1.0+6dbf9a050bc9aadb/node_modules/@ant-design/icons

--- a/apps/packages/ui/node_modules/@dnd-kit/collision
+++ b/apps/packages/ui/node_modules/@dnd-kit/collision
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@dnd-kit+collision@0.1.21/node_modules/@dnd-kit/collision

--- a/apps/packages/ui/node_modules/@dnd-kit/dom
+++ b/apps/packages/ui/node_modules/@dnd-kit/dom
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@dnd-kit+dom@0.1.21/node_modules/@dnd-kit/dom

--- a/apps/packages/ui/node_modules/@dnd-kit/helpers
+++ b/apps/packages/ui/node_modules/@dnd-kit/helpers
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@dnd-kit+helpers@0.1.21/node_modules/@dnd-kit/helpers

--- a/apps/packages/ui/node_modules/@dnd-kit/react
+++ b/apps/packages/ui/node_modules/@dnd-kit/react
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@dnd-kit+react@0.1.21+6dbf9a050bc9aadb/node_modules/@dnd-kit/react

--- a/apps/packages/ui/node_modules/@heroicons/react
+++ b/apps/packages/ui/node_modules/@heroicons/react
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@heroicons+react@2.2.0+f4eacebf2041cd4f/node_modules/@heroicons/react

--- a/apps/packages/ui/node_modules/@monaco-editor/react
+++ b/apps/packages/ui/node_modules/@monaco-editor/react
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@monaco-editor+react@4.7.0+e8b56836a3799637/node_modules/@monaco-editor/react

--- a/apps/packages/ui/node_modules/@mozilla/readability
+++ b/apps/packages/ui/node_modules/@mozilla/readability
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@mozilla+readability@0.6.0/node_modules/@mozilla/readability

--- a/apps/packages/ui/node_modules/@plasmohq/storage
+++ b/apps/packages/ui/node_modules/@plasmohq/storage
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@plasmohq+storage@1.15.0+f4eacebf2041cd4f/node_modules/@plasmohq/storage

--- a/apps/packages/ui/node_modules/@tanstack/react-query
+++ b/apps/packages/ui/node_modules/@tanstack/react-query
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@tanstack+react-query@5.90.20+f4eacebf2041cd4f/node_modules/@tanstack/react-query

--- a/apps/packages/ui/node_modules/@tanstack/react-virtual
+++ b/apps/packages/ui/node_modules/@tanstack/react-virtual
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@tanstack+react-virtual@3.13.18+6dbf9a050bc9aadb/node_modules/@tanstack/react-virtual

--- a/apps/packages/ui/node_modules/@testing-library/jest-dom
+++ b/apps/packages/ui/node_modules/@testing-library/jest-dom
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@testing-library+jest-dom@6.9.1/node_modules/@testing-library/jest-dom

--- a/apps/packages/ui/node_modules/@testing-library/react
+++ b/apps/packages/ui/node_modules/@testing-library/react
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@testing-library+react@16.3.2+e79794b3bc7ff534/node_modules/@testing-library/react

--- a/apps/packages/ui/node_modules/@testing-library/user-event
+++ b/apps/packages/ui/node_modules/@testing-library/user-event
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@testing-library+user-event@14.6.1+08996f9534b2833c/node_modules/@testing-library/user-event

--- a/apps/packages/ui/node_modules/@tiptap/core
+++ b/apps/packages/ui/node_modules/@tiptap/core
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@tiptap+core@3.22.1+c79d51da8b4a98f1/node_modules/@tiptap/core

--- a/apps/packages/ui/node_modules/@tiptap/extension-character-count
+++ b/apps/packages/ui/node_modules/@tiptap/extension-character-count
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@tiptap+extension-character-count@3.22.1+41955a45cc78f033/node_modules/@tiptap/extension-character-count

--- a/apps/packages/ui/node_modules/@tiptap/extension-placeholder
+++ b/apps/packages/ui/node_modules/@tiptap/extension-placeholder
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@tiptap+extension-placeholder@3.22.1+41955a45cc78f033/node_modules/@tiptap/extension-placeholder

--- a/apps/packages/ui/node_modules/@tiptap/pm
+++ b/apps/packages/ui/node_modules/@tiptap/pm
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@tiptap+pm@3.22.1/node_modules/@tiptap/pm

--- a/apps/packages/ui/node_modules/@tiptap/react
+++ b/apps/packages/ui/node_modules/@tiptap/react
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@tiptap+react@3.22.1+707c590a3abfbdde/node_modules/@tiptap/react

--- a/apps/packages/ui/node_modules/@tiptap/starter-kit
+++ b/apps/packages/ui/node_modules/@tiptap/starter-kit
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@tiptap+starter-kit@3.22.1/node_modules/@tiptap/starter-kit

--- a/apps/packages/ui/node_modules/@types/react
+++ b/apps/packages/ui/node_modules/@types/react
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@types+react@18.3.27/node_modules/@types/react

--- a/apps/packages/ui/node_modules/@types/react-dom
+++ b/apps/packages/ui/node_modules/@types/react-dom
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@types+react-dom@18.3.7+e9c64bd7cbf321c8/node_modules/@types/react-dom

--- a/apps/packages/ui/node_modules/@xterm/addon-fit
+++ b/apps/packages/ui/node_modules/@xterm/addon-fit
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@xterm+addon-fit@0.11.0/node_modules/@xterm/addon-fit

--- a/apps/packages/ui/node_modules/@xyflow/react
+++ b/apps/packages/ui/node_modules/@xyflow/react
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@xyflow+react@12.10.0+95d60cde8d9343f0/node_modules/@xyflow/react

--- a/apps/packages/ui/node_modules/antd
+++ b/apps/packages/ui/node_modules/antd
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/antd@6.2.1+6dbf9a050bc9aadb/node_modules/antd

--- a/apps/packages/ui/node_modules/axe-core
+++ b/apps/packages/ui/node_modules/axe-core
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/axe-core@4.11.1/node_modules/axe-core

--- a/apps/packages/ui/node_modules/axios
+++ b/apps/packages/ui/node_modules/axios
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/axios@1.13.2/node_modules/axios

--- a/apps/packages/ui/node_modules/cheerio
+++ b/apps/packages/ui/node_modules/cheerio
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/cheerio@1.2.0/node_modules/cheerio

--- a/apps/packages/ui/node_modules/cytoscape
+++ b/apps/packages/ui/node_modules/cytoscape
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/cytoscape@3.33.1/node_modules/cytoscape

--- a/apps/packages/ui/node_modules/cytoscape-dagre
+++ b/apps/packages/ui/node_modules/cytoscape-dagre
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/cytoscape-dagre@2.5.0+858e1abf508018ad/node_modules/cytoscape-dagre

--- a/apps/packages/ui/node_modules/dayjs
+++ b/apps/packages/ui/node_modules/dayjs
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/dayjs@1.11.19/node_modules/dayjs

--- a/apps/packages/ui/node_modules/dexie
+++ b/apps/packages/ui/node_modules/dexie
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/dexie@4.2.1/node_modules/dexie

--- a/apps/packages/ui/node_modules/dexie-react-hooks
+++ b/apps/packages/ui/node_modules/dexie-react-hooks
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/dexie-react-hooks@1.1.7+596f889e89ee6e68/node_modules/dexie-react-hooks

--- a/apps/packages/ui/node_modules/dompurify
+++ b/apps/packages/ui/node_modules/dompurify
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/dompurify@3.3.1/node_modules/dompurify

--- a/apps/packages/ui/node_modules/epubjs
+++ b/apps/packages/ui/node_modules/epubjs
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/epubjs@0.3.93/node_modules/epubjs

--- a/apps/packages/ui/node_modules/gpt-tokenizer
+++ b/apps/packages/ui/node_modules/gpt-tokenizer
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/gpt-tokenizer@3.4.0/node_modules/gpt-tokenizer

--- a/apps/packages/ui/node_modules/html2canvas
+++ b/apps/packages/ui/node_modules/html2canvas
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/html2canvas@1.4.1/node_modules/html2canvas

--- a/apps/packages/ui/node_modules/i18next
+++ b/apps/packages/ui/node_modules/i18next
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/i18next@25.8.0+1fb4c65d43e298b9/node_modules/i18next

--- a/apps/packages/ui/node_modules/i18next-icu
+++ b/apps/packages/ui/node_modules/i18next-icu
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/i18next-icu@2.4.2+2b2d09cbc8397d30/node_modules/i18next-icu

--- a/apps/packages/ui/node_modules/jsdom
+++ b/apps/packages/ui/node_modules/jsdom
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/jsdom@28.1.0+123fd722184cdea3/node_modules/jsdom

--- a/apps/packages/ui/node_modules/jszip
+++ b/apps/packages/ui/node_modules/jszip
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/jszip@3.10.1/node_modules/jszip

--- a/apps/packages/ui/node_modules/katex
+++ b/apps/packages/ui/node_modules/katex
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/katex@0.16.27/node_modules/katex

--- a/apps/packages/ui/node_modules/lucide-react
+++ b/apps/packages/ui/node_modules/lucide-react
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/lucide-react@0.562.0+f4eacebf2041cd4f/node_modules/lucide-react

--- a/apps/packages/ui/node_modules/marked
+++ b/apps/packages/ui/node_modules/marked
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/marked@15.0.12/node_modules/marked

--- a/apps/packages/ui/node_modules/mermaid
+++ b/apps/packages/ui/node_modules/mermaid
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/mermaid@11.12.2/node_modules/mermaid

--- a/apps/packages/ui/node_modules/pdfjs-dist
+++ b/apps/packages/ui/node_modules/pdfjs-dist
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/pdfjs-dist@4.10.38/node_modules/pdfjs-dist

--- a/apps/packages/ui/node_modules/prism-react-renderer
+++ b/apps/packages/ui/node_modules/prism-react-renderer
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/prism-react-renderer@2.4.1+f4eacebf2041cd4f/node_modules/prism-react-renderer

--- a/apps/packages/ui/node_modules/property-information
+++ b/apps/packages/ui/node_modules/property-information
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/property-information@6.5.0/node_modules/property-information

--- a/apps/packages/ui/node_modules/react
+++ b/apps/packages/ui/node_modules/react
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/react@18.3.1/node_modules/react

--- a/apps/packages/ui/node_modules/react-dom
+++ b/apps/packages/ui/node_modules/react-dom
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/react-dom@18.3.1+f4eacebf2041cd4f/node_modules/react-dom

--- a/apps/packages/ui/node_modules/react-i18next
+++ b/apps/packages/ui/node_modules/react-i18next
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/react-i18next@16.5.3+1692c15af4819631/node_modules/react-i18next

--- a/apps/packages/ui/node_modules/react-icons
+++ b/apps/packages/ui/node_modules/react-icons
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/react-icons@5.5.0+f4eacebf2041cd4f/node_modules/react-icons

--- a/apps/packages/ui/node_modules/react-joyride
+++ b/apps/packages/ui/node_modules/react-joyride
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/react-joyride@2.9.3+95d60cde8d9343f0/node_modules/react-joyride

--- a/apps/packages/ui/node_modules/react-markdown
+++ b/apps/packages/ui/node_modules/react-markdown
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/react-markdown@10.1.0+9cdd050739dc4c16/node_modules/react-markdown

--- a/apps/packages/ui/node_modules/react-pdf
+++ b/apps/packages/ui/node_modules/react-pdf
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/react-pdf@9.2.1+95d60cde8d9343f0/node_modules/react-pdf

--- a/apps/packages/ui/node_modules/react-router-dom
+++ b/apps/packages/ui/node_modules/react-router-dom
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/react-router-dom@6.30.3+6dbf9a050bc9aadb/node_modules/react-router-dom

--- a/apps/packages/ui/node_modules/react-toastify
+++ b/apps/packages/ui/node_modules/react-toastify
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/react-toastify@10.0.6+6dbf9a050bc9aadb/node_modules/react-toastify

--- a/apps/packages/ui/node_modules/rehype-katex
+++ b/apps/packages/ui/node_modules/rehype-katex
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/rehype-katex@7.0.1/node_modules/rehype-katex

--- a/apps/packages/ui/node_modules/remark-gfm
+++ b/apps/packages/ui/node_modules/remark-gfm
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/remark-gfm@4.0.1/node_modules/remark-gfm

--- a/apps/packages/ui/node_modules/remark-math
+++ b/apps/packages/ui/node_modules/remark-math
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/remark-math@6.0.0/node_modules/remark-math

--- a/apps/packages/ui/node_modules/turndown
+++ b/apps/packages/ui/node_modules/turndown
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/turndown@7.2.2/node_modules/turndown

--- a/apps/packages/ui/node_modules/vitest
+++ b/apps/packages/ui/node_modules/vitest
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/vitest@4.0.18+0560a95e2bbfec09/node_modules/vitest

--- a/apps/packages/ui/node_modules/wxt
+++ b/apps/packages/ui/node_modules/wxt
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/wxt@0.20.13+ef3bba8848567a1c/node_modules/wxt

--- a/apps/packages/ui/node_modules/xlsx
+++ b/apps/packages/ui/node_modules/xlsx
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/xlsx@0.18.5/node_modules/xlsx

--- a/apps/packages/ui/node_modules/xterm
+++ b/apps/packages/ui/node_modules/xterm
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/xterm@5.3.0/node_modules/xterm

--- a/apps/packages/ui/node_modules/zustand
+++ b/apps/packages/ui/node_modules/zustand
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/zustand@5.0.10+324ccb968d86c5f8/node_modules/zustand

--- a/apps/packages/voice-assistant-sdk/node_modules/.bin/tsc
+++ b/apps/packages/voice-assistant-sdk/node_modules/.bin/tsc
@@ -1,1 +1,0 @@
-../typescript/bin/tsc

--- a/apps/packages/voice-assistant-sdk/node_modules/.bin/tsserver
+++ b/apps/packages/voice-assistant-sdk/node_modules/.bin/tsserver
@@ -1,1 +1,0 @@
-../typescript/bin/tsserver

--- a/apps/packages/voice-assistant-sdk/node_modules/@types/audioworklet
+++ b/apps/packages/voice-assistant-sdk/node_modules/@types/audioworklet
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@types+audioworklet@0.0.60/node_modules/@types/audioworklet

--- a/apps/packages/voice-assistant-sdk/node_modules/@types/dom-webcodecs
+++ b/apps/packages/voice-assistant-sdk/node_modules/@types/dom-webcodecs
@@ -1,1 +1,0 @@
-../../../../node_modules/.bun/@types+dom-webcodecs@0.1.18/node_modules/@types/dom-webcodecs

--- a/apps/packages/voice-assistant-sdk/node_modules/eventemitter3
+++ b/apps/packages/voice-assistant-sdk/node_modules/eventemitter3
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/eventemitter3@5.0.4/node_modules/eventemitter3

--- a/apps/packages/voice-assistant-sdk/node_modules/react
+++ b/apps/packages/voice-assistant-sdk/node_modules/react
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/react@18.3.1/node_modules/react

--- a/apps/packages/voice-assistant-sdk/node_modules/typescript
+++ b/apps/packages/voice-assistant-sdk/node_modules/typescript
@@ -1,1 +1,0 @@
-../../../node_modules/.bun/typescript@5.9.3/node_modules/typescript

--- a/backlog/tasks/task-12129 - Remove-tracked-node-modules-symlinks.md
+++ b/backlog/tasks/task-12129 - Remove-tracked-node-modules-symlinks.md
@@ -28,6 +28,8 @@ No `.gitignore` change was needed because `.gitignore` already contains `/apps/*
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Removed the tracked node_modules symlink entries only. Verification: git ls-files -s -- ':(glob)**/node_modules/**' returned no output. Bandit skipped because this was non-code dependency artifact cleanup.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2624
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12129 - Remove-tracked-node-modules-symlinks.md
+++ b/backlog/tasks/task-12129 - Remove-tracked-node-modules-symlinks.md
@@ -1,0 +1,41 @@
+---
+id: TASK-12129
+title: Remove tracked node_modules symlinks
+status: Done
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Clean up tracked node_modules symlink entries so dependency installs are not represented in git. Scope is limited to node_modules entries only.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] No tracked `node_modules` paths remain in git.
+- [x] Existing ignore rules cover `node_modules` paths so they are not re-added.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Removed tracked symlink entries under `apps/packages/ui/node_modules` and `apps/packages/voice-assistant-sdk/node_modules` with `git rm -r`.
+
+No `.gitignore` change was needed because `.gitignore` already contains `/apps/**/node_modules/`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed the tracked node_modules symlink entries only. Verification: git ls-files -s -- ':(glob)**/node_modules/**' returned no output. Bandit skipped because this was non-code dependency artifact cleanup.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Remove tracked node_modules symlink entries under apps/packages/ui and apps/packages/voice-assistant-sdk.
- Add TASK-12129 documenting the artifact cleanup and verification.

## Change summary
TODO: human requester must replace this before marking ready/merge-ready, per AI-generated PR policy.

## Test Plan
- `git ls-files -s -- ':(glob)**/node_modules/**'` returned no output
- `git status --short` returned no output in the PR worktree
- Bandit not run: non-code artifact cleanup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed tracked `node_modules` symlink entries under `apps/packages/ui` and `apps/packages/voice-assistant-sdk` to keep dependency artifacts out of git and reduce churn. Aligns with TASK-12129: no tracked `node_modules` remain, existing ignore rules prevent re-adding, and a backlog task doc was added to record the cleanup and verification.

<sup>Written for commit 10c9c0ac6d4e1e9396cc57b2edfce8da0a71c426. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

