### PR TITLE
Scope MediaWiki ingest to request user

### DIFF
--- a/backlog/tasks/task-12141 - Scope-MediaWiki-ingest-to-request-user.md
+++ b/backlog/tasks/task-12141 - Scope-MediaWiki-ingest-to-request-user.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12141
 title: Scope MediaWiki ingest to request user
-status: In Progress
+status: Done
 created_date: 2026-07-04 17:18
 labels:
 - audit
@@ -18,7 +18,7 @@ modified_files:
 - tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_db_persistence.py
 - tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_vector_storage.py
 - tldw_Server_API/tests/test_mediawiki_ephemeral_smoke.py
-updated_date: 2026-07-04 17:31
+updated_date: 2026-07-05 00:27
 ---
 
 ## Description
@@ -51,12 +51,16 @@ Implemented request-scoped MediaWiki ingest plumbing from latest fetched dev fd5
 
 Validation: focused red-green regressions passed after implementation; full MediaWiki test set passed: 34 passed, 88 warnings. Bandit on touched production files wrote /tmp/bandit_mediawiki_user_scope.json with 0 results. git diff --check exited 0.
 Draft PR created against dev: https://github.com/rmusser01/tldw_server/pull/2625.
+Review follow-up before the later rebase from origin/dev fd5c152b065c408e4e8ee5f08da41589f21cb7f5: addressed PR #2625 security-high inline review by making ingest_mediawiki_dump_endpoint fail closed when get_media_repository(db) returns None. This prevents a missing request-scoped repository from flowing into the MediaWiki importer path and risking fallback to singleton persistence. Added regression test_mediawiki_ingest_dump_rejects_missing_request_scoped_writer; red run failed because the endpoint entered the streaming importer with media_writer=None, then passed after the guard. Verification: new regression passed; focused MediaWiki suite passed with 35 passed and 90 warnings; Bandit over process_mediawiki.py and Media_Wiki.py exited 0 with 0 findings in /tmp/bandit_mediawiki_user_scope_review_latest_dev.json; git diff --check passed; branch merge-base matched origin/dev fd5c152b065c408e4e8ee5f08da41589f21cb7f5.
+Post-rebase validation on current origin/dev 4c1ca5d8358bff2a5a7fb5c75d60d1bd6728e702: rebased codex/audit-mediawiki-user-scope-2026-07-04 so merge-base equals current origin/dev. Fresh verification after rebase: focused MediaWiki suite passed (35 passed, 90 warnings); Bandit over tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py and tldw_Server_API/app/core/Ingestion_Media_Processing/MediaWiki/Media_Wiki.py scanned 1149 LOC and reported 0 findings in /tmp/bandit_mediawiki_user_scope_rebased_dev.json; git diff --check HEAD~1..HEAD passed.
+2026-07-04 current-dev refresh: rebased `codex/audit-mediawiki-user-scope-2026-07-04` onto `origin/dev` `09d9ec901e1d4548f7924f1c6bcefa963fadd9bd`; merge-base matches `origin/dev`. Validation: `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/test_mediawiki_ephemeral_smoke.py tldw_Server_API/tests/test_mediawiki_security.py tldw_Server_API/tests/test_mediawiki_compressed_open.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_db_persistence.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_vector_storage.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_lazy_config.py -q` passed with 35 tests; `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py tldw_Server_API/app/core/Ingestion_Media_Processing/MediaWiki/Media_Wiki.py -f json -o /tmp/bandit_mediawiki_user_scope_origin_dev_09d9ec.json` reported 0 findings over 1149 LOC; `git diff --check HEAD~1..HEAD` passed.
+2026-07-04 latest-dev refresh: rebased and validated PR #2625 on origin/dev 6b727b221e55646eba663a03571e38302f7fafc2. Tested head 7cfc5bce1d26. Verification: focused MediaWiki pytest suite => 35 passed, 90 warnings; bandit over process_mediawiki.py and Media_Wiki.py => 0 findings over 1149 LOC; git diff --check HEAD~1..HEAD => clean.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Scoped MediaWiki ingest-dump to request user resources by passing the request-scoped media repository and authenticated user id from the API endpoint into the core importer/vector storage path. Legacy direct importer calls retain fallback managed DB and SINGLE_USER_FIXED_ID behavior when no request-scoped values are supplied. Validation: full MediaWiki focused suite passed (34 passed, 88 warnings), Bandit touched production scan had 0 results, and git diff --check passed. Draft PR: https://github.com/rmusser01/tldw_server/pull/2625.
+Hardened MediaWiki ingestion user scoping and storage behavior. Final refresh validated against origin/dev 6b727b221e55646eba663a03571e38302f7fafc2 with focused MediaWiki tests passing, Bandit clean on touched production scope, and whitespace check clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12141 - Scope-MediaWiki-ingest-to-request-user.md
+++ b/backlog/tasks/task-12141 - Scope-MediaWiki-ingest-to-request-user.md
@@ -18,7 +18,7 @@ modified_files:
 - tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_db_persistence.py
 - tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_vector_storage.py
 - tldw_Server_API/tests/test_mediawiki_ephemeral_smoke.py
-updated_date: 2026-07-04 17:23
+updated_date: 2026-07-04 17:31
 ---
 
 ## Description
@@ -50,12 +50,13 @@ Remediate audit finding AUDIT-2026-06-27-MEDIA-002: the MediaWiki ingest-dump pa
 Implemented request-scoped MediaWiki ingest plumbing from latest fetched dev fd5c152b065c408e4e8ee5f08da41589f21cb7f5. Red tests first failed because import_mediawiki_dump lacked media_writer, process_single_item lacked vector_user_id, and the ingest endpoint did not pass either value. Production change adds optional media_writer/vector_user_id threading, endpoint get_media_db_for_user/get_request_user dependencies, and fallback preservation when no injected writer/user id is supplied.
 
 Validation: focused red-green regressions passed after implementation; full MediaWiki test set passed: 34 passed, 88 warnings. Bandit on touched production files wrote /tmp/bandit_mediawiki_user_scope.json with 0 results. git diff --check exited 0.
+Draft PR created against dev: https://github.com/rmusser01/tldw_server/pull/2625.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Scoped MediaWiki ingest-dump to request user resources by passing the request-scoped media repository and authenticated user id from the API endpoint into the core importer/vector storage path. Legacy direct importer calls retain fallback managed DB and SINGLE_USER_FIXED_ID behavior when no request-scoped values are supplied. Validation: full MediaWiki focused suite passed (34 passed, 88 warnings), Bandit touched production scan had 0 results, and git diff --check passed. Draft PR: https://github.com/rmusser01/tldw_server/pull/2625.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -63,5 +64,5 @@ Validation: focused red-green regressions passed after implementation; full Medi
 - [x] #1 Focused tests pass for the touched MediaWiki ingest/vector behavior.
 - [x] #2 Bandit runs on touched production files with no new findings.
 - [x] #3 git diff --check passes.
-- [ ] #4 Backlog task records touched files, validation results, and PR link.
+- [x] #4 Backlog task records touched files, validation results, and PR link.
 <!-- DOD:END -->

--- a/backlog/tasks/task-12141 - Scope-MediaWiki-ingest-to-request-user.md
+++ b/backlog/tasks/task-12141 - Scope-MediaWiki-ingest-to-request-user.md
@@ -1,0 +1,67 @@
+---
+id: TASK-12141
+title: Scope MediaWiki ingest to request user
+status: In Progress
+created_date: 2026-07-04 17:18
+labels:
+- audit
+- media-ingestion
+- security
+- authnz
+priority: High
+references:
+- AUDIT-2026-06-27-MEDIA-002
+- Docs/superpowers/reviews/2026-06-27-repo-audit/domains/media-ingestion-storage.md
+modified_files:
+- tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
+- tldw_Server_API/app/core/Ingestion_Media_Processing/MediaWiki/Media_Wiki.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_db_persistence.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_vector_storage.py
+- tldw_Server_API/tests/test_mediawiki_ephemeral_smoke.py
+updated_date: 2026-07-04 17:23
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remediate audit finding AUDIT-2026-06-27-MEDIA-002: the MediaWiki ingest-dump path can fall back to a singleton media database and shared vector namespace instead of using the authenticated request user's scoped media DB/vector identity.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MediaWiki ingest-dump writes through the request-scoped media database/repository rather than the singleton fallback database.
+- [x] #2 MediaWiki vector writes use the authenticated request user's namespace/id rather than SINGLE_USER_FIXED_ID when invoked from the API request path.
+- [x] #3 Legacy direct/core importer calls keep the existing fallback behavior when no request-scoped writer or user id is supplied.
+- [x] #4 Focused regression tests prove the endpoint/core path user scoping and prevent an unsafe managed_media_database call for request-scoped ingest.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for request-scoped MediaWiki ingest database and vector user behavior.
+2. Thread an optional media writer and vector user id from the ingest endpoint into the core importer.
+3. Preserve legacy fallback behavior for direct/core importer callers with no injected writer or vector user id.
+4. Validate with MediaWiki-focused tests, Bandit on touched production files, and git diff whitespace checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented request-scoped MediaWiki ingest plumbing from latest fetched dev fd5c152b065c408e4e8ee5f08da41589f21cb7f5. Red tests first failed because import_mediawiki_dump lacked media_writer, process_single_item lacked vector_user_id, and the ingest endpoint did not pass either value. Production change adds optional media_writer/vector_user_id threading, endpoint get_media_db_for_user/get_request_user dependencies, and fallback preservation when no injected writer/user id is supplied.
+
+Validation: focused red-green regressions passed after implementation; full MediaWiki test set passed: 34 passed, 88 warnings. Bandit on touched production files wrote /tmp/bandit_mediawiki_user_scope.json with 0 results. git diff --check exited 0.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Focused tests pass for the touched MediaWiki ingest/vector behavior.
+- [x] #2 Bandit runs on touched production files with no new findings.
+- [x] #3 git diff --check passes.
+- [ ] #4 Backlog task records touched files, validation results, and PR link.
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
@@ -272,6 +272,12 @@ async def ingest_mediawiki_dump_endpoint(
     persisting results to the primary database and vector store.
     """
     media_writer = get_media_repository(db)
+    if media_writer is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to initialize request-scoped media repository.",
+        )
+
     return await _process_mediawiki_dump(
         form_data=form_data,
         dump_file=dump_file,

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
@@ -6,6 +6,7 @@ import json
 import shutil
 from collections.abc import AsyncGenerator
 from pathlib import Path
+from typing import Any
 
 import aiofiles
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
@@ -17,6 +18,8 @@ from tldw_Server_API.app.api.v1.API_Deps.backpressure import (
     guard_backpressure_and_quota,
 )
 from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
+from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.API_Deps.media_mediawiki_deps import (
     get_mediawiki_form_data,
 )
@@ -34,6 +37,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.MediaWiki.Media_Wiki im
 from tldw_Server_API.app.core.Ingestion_Media_Processing.MediaWiki.Media_Wiki import (
     import_mediawiki_dump as core_import_mediawiki_dump,
 )
+from tldw_Server_API.app.core.DB_Management.media_db.api import get_media_repository
 from tldw_Server_API.app.core.Utils.Utils import sanitize_filename
 
 router = APIRouter()
@@ -118,6 +122,8 @@ async def _process_mediawiki_dump(
     store_to_db: bool,
     store_to_vector_db: bool,
     filter_item_results: bool,
+    media_writer: Any | None = None,
+    vector_user_id: str | None = None,
 ) -> StreamingResponse:
     """Shared ingestion/processing helper."""
     namespaces = _parse_namespaces(form_data.namespaces_str)
@@ -198,6 +204,8 @@ async def _process_mediawiki_dump(
                     api_name_vector_db=form_data.api_name_vector_db,
                     api_key_vector_db=form_data.api_key_vector_db,
                     allowed_dir=temp_dir_path,
+                    media_writer=media_writer,
+                    vector_user_id=vector_user_id,
                 ):
                     if filter_item_results and result_event.get("type") == "item_result":
                         page_data = result_event.get("data", {})
@@ -254,6 +262,8 @@ async def ingest_mediawiki_dump_endpoint(
         ...,
         description="MediaWiki XML dump file (.xml, .xml.bz2, .xml.gz).",
     ),
+    db: Any = Depends(get_media_db_for_user),
+    current_user: User = Depends(get_request_user),
 ) -> StreamingResponse:
     """
     MediaWiki ingest endpoint (streaming).
@@ -261,12 +271,15 @@ async def ingest_mediawiki_dump_endpoint(
     Streams ingestion events while processing a MediaWiki XML dump and
     persisting results to the primary database and vector store.
     """
+    media_writer = get_media_repository(db)
     return await _process_mediawiki_dump(
         form_data=form_data,
         dump_file=dump_file,
         store_to_db=True,
         store_to_vector_db=True,
         filter_item_results=False,
+        media_writer=media_writer,
+        vector_user_id=current_user.id_str,
     )
 
 

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/MediaWiki/Media_Wiki.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/MediaWiki/Media_Wiki.py
@@ -602,6 +602,7 @@ def _store_mediawiki_chunks_in_vector_db(
     revision_id: Optional[int],
     api_name_vector_db: Optional[str],
     api_key_vector_db: Optional[str],
+    vector_user_id: Optional[str] = None,
 ) -> tuple[bool, str]:
     if ChromaDBManager is None or create_embeddings_batch is None:
         return False, "Embeddings dependencies unavailable."
@@ -622,10 +623,12 @@ def _store_mediawiki_chunks_in_vector_db(
         "embedding_config": embedding_config,
     }
 
-    vector_user_id = settings.get("SINGLE_USER_FIXED_ID", 1)
+    resolved_vector_user_id = str(vector_user_id).strip() if vector_user_id is not None else ""
+    if not resolved_vector_user_id:
+        resolved_vector_user_id = str(settings.get("SINGLE_USER_FIXED_ID", 1))
     try:
         manager = ChromaDBManager(
-            user_id=str(vector_user_id),
+            user_id=resolved_vector_user_id,
             user_embedding_config=user_embedding_config,
         )
     except MEDIAWIKI_EMBEDDING_EXCEPTIONS as exc:
@@ -702,6 +705,7 @@ def process_single_item(
         api_name_vector_db: Optional[str] = None,
         api_key_vector_db: Optional[str] = None,
         media_writer: Any | None = None,
+        vector_user_id: Optional[str] = None,
 ) -> dict[str, Any]:
     try:
         logging.debug(
@@ -800,6 +804,7 @@ def process_single_item(
                 revision_id=item.get("revision_id"),
                 api_name_vector_db=api_name_vector_db,
                 api_key_vector_db=api_key_vector_db,
+                vector_user_id=vector_user_id,
             )
             if success:
                 processed_data["message"] += f" {message}"
@@ -943,6 +948,8 @@ def import_mediawiki_dump(
         api_name_vector_db: Optional[str] = None,
         api_key_vector_db: Optional[str] = None,
         allowed_dir: Optional[Path] = None,
+        media_writer: Any | None = None,
+        vector_user_id: Optional[str] = None,
 ) -> Iterator[dict[str, Any]]:
     try:
         # Sanitize wiki_name and validate file_path
@@ -975,8 +982,8 @@ def import_mediawiki_dump(
                "message": f"Found {total_pages} pages to process for '{wiki_name}'."}
 
         with contextlib.ExitStack() as stack:
-            shared_media_writer = None
-            if store_to_db:
+            shared_media_writer = media_writer
+            if store_to_db and shared_media_writer is None:
                 db_instance = stack.enter_context(
                     managed_media_database(client_id="mediawiki_import")
                 )
@@ -1013,6 +1020,7 @@ def import_mediawiki_dump(
                     api_name_vector_db=api_name_vector_db,
                     api_key_vector_db=api_key_vector_db,
                     media_writer=shared_media_writer,
+                    vector_user_id=vector_user_id,
                 )
 
                 if store_to_db and processed_item_details.get("status") == "Success" and processed_item_details.get(

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_db_persistence.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_db_persistence.py
@@ -192,6 +192,66 @@ def test_import_mediawiki_dump_reuses_single_managed_media_database(
     assert media_db.closed is True
 
 
+def test_import_mediawiki_dump_uses_injected_media_writer_without_managed_database(
+    monkeypatch,
+    tmp_path,
+):
+    class _FakeRepo:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def add_media_with_keywords(self, **kwargs):
+            self.calls.append(kwargs)
+            return 72, "wiki-uuid", "stored"
+
+    fake_repo = _FakeRepo()
+    checkpoint_saves: list[int] = []
+    dump_path = tmp_path / "dump.xml"
+    dump_path.write_text("<mediawiki />")
+    items = [
+        {
+            "title": "Request Page",
+            "content": "Scoped body",
+            "timestamp": datetime(2024, 1, 4, tzinfo=timezone.utc),
+            "namespace": 0,
+            "page_id": 125,
+            "revision_id": 458,
+        },
+    ]
+
+    monkeypatch.setattr(Media_Wiki, "sanitize_wiki_name", lambda name: name)
+    monkeypatch.setattr(Media_Wiki, "validate_file_path", lambda *args, **kwargs: dump_path)
+    monkeypatch.setattr(Media_Wiki, "count_pages", lambda *args, **kwargs: len(items))
+    monkeypatch.setattr(Media_Wiki, "parse_mediawiki_dump", lambda *args, **kwargs: iter(items))
+    monkeypatch.setattr(Media_Wiki, "optimized_chunking", lambda content, options: [{"text": content, "metadata": {}}])
+    monkeypatch.setattr(Media_Wiki, "load_checkpoint", lambda path: 0)
+    monkeypatch.setattr(Media_Wiki, "save_checkpoint", lambda path, page_id: checkpoint_saves.append(page_id))
+    monkeypatch.setattr(Media_Wiki, "get_safe_checkpoint_path", lambda wiki_name: tmp_path / f"{wiki_name}.json")
+    monkeypatch.setattr(
+        Media_Wiki,
+        "managed_media_database",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("request-scoped importer must not open fallback media DB")
+        ),
+        raising=False,
+    )
+
+    results = list(
+        Media_Wiki.import_mediawiki_dump(
+            file_path=str(dump_path),
+            wiki_name="ExampleWiki",
+            store_to_db=True,
+            store_to_vector_db=False,
+            allowed_dir=tmp_path,
+            media_writer=fake_repo,
+        )
+    )
+
+    assert results[-1]["type"] == "summary"
+    assert fake_repo.calls[0]["title"] == "Request Page"
+    assert checkpoint_saves == [125]
+
+
 def test_import_mediawiki_dump_sanitizes_unexpected_import_error(monkeypatch, tmp_path):
     dump_path = tmp_path / "dump.xml"
     dump_path.write_text("<mediawiki />")

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_vector_storage.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_mediawiki_vector_storage.py
@@ -72,3 +72,56 @@ def test_process_single_item_stores_vectors(monkeypatch):
     assert FakeManager.last_call is not None
     assert FakeManager.last_call["collection_name"].startswith("mediawiki_")
     assert FakeManager.last_call["metadatas"][0]["media_id"] == str(result["media_id"])
+
+
+def test_process_single_item_uses_request_user_for_vectors(monkeypatch):
+    class DummyDB:
+        def add_media_with_keywords(self, **_kwargs: Any):
+            return 124, "ok"
+
+    class FakeManager:
+        user_ids: List[str] = []
+
+        def __init__(self, user_id: str, user_embedding_config: Dict[str, Any]):
+            self.user_embedding_config = user_embedding_config
+            FakeManager.user_ids.append(user_id)
+
+        def store_in_chroma(
+            self,
+            collection_name: str,
+            texts: List[str],
+            embeddings: List[List[float]],
+            ids: List[str],
+            metadatas: List[Dict[str, Any]],
+            embedding_model_id_for_dim_check: str | None = None,
+        ) -> None:
+            return None
+
+    monkeypatch.setattr(mediawiki, "ChromaDBManager", FakeManager)
+    monkeypatch.setattr(
+        mediawiki,
+        "create_embeddings_batch",
+        lambda **kwargs: [[0.1, 0.2] for _ in kwargs["texts"]],
+    )
+
+    result = mediawiki.process_single_item(
+        content="Scoped vector body",
+        title="Scoped Page",
+        wiki_name="enwiki",
+        chunk_options={"max_size": 50},
+        item={
+            "timestamp": datetime.now(timezone.utc),
+            "page_id": 43,
+            "revision_id": 8,
+            "namespace": 0,
+        },
+        store_to_db=True,
+        store_to_vector_db=True,
+        api_name_vector_db="openai:text-embedding-3-small",
+        api_key_vector_db="test-key",
+        media_writer=DummyDB(),
+        vector_user_id="request-user-42",
+    )
+
+    assert result["status"] == "Success"
+    assert FakeManager.user_ids == ["request-user-42"]

--- a/tldw_Server_API/tests/test_mediawiki_ephemeral_smoke.py
+++ b/tldw_Server_API/tests/test_mediawiki_ephemeral_smoke.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.api.v1.endpoints.media import router as media_router
 from tldw_Server_API.app.api.v1.endpoints.media import process_mediawiki
+from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 
 
@@ -50,7 +51,13 @@ class _FailingAiofilesOpen:
         return False
 
 
-def _build_mediawiki_client(monkeypatch, tmp_path: Path) -> TestClient:
+def _build_mediawiki_client(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    user_id: int = 1,
+    media_db=None,
+) -> TestClient:
     # Force temp dirs outside CWD so allowed_dir enforcement is required
     monkeypatch.setenv("TMPDIR", str(tmp_path))
     monkeypatch.setenv("AUTH_MODE", "single_user")
@@ -60,9 +67,11 @@ def _build_mediawiki_client(monkeypatch, tmp_path: Path) -> TestClient:
     app.include_router(media_router, prefix="/api/v1/media")
 
     async def _override_user() -> User:
-        return User(id=1, username="tester", email=None, is_active=True, is_admin=True)
+        return User(id=user_id, username="tester", email=None, is_active=True, is_admin=True)
 
     app.dependency_overrides[get_request_user] = _override_user
+    if media_db is not None:
+        app.dependency_overrides[get_media_db_for_user] = lambda: media_db
     return TestClient(app, headers={"X-API-KEY": "test-api-key-12345"})
 
 
@@ -221,3 +230,40 @@ def test_mediawiki_process_dump_cleanup_failure_log_is_sanitized(monkeypatch, tm
     assert logger_stub.warnings == ["Failed to cleanup temporary directory"]
     assert logger_stub.warning_args == [()]
     assert logger_stub.warning_kwargs == [{}]
+
+
+@pytest.mark.integration
+def test_mediawiki_ingest_dump_passes_request_scoped_writer_and_vector_user(monkeypatch, tmp_path: Path):
+    fake_media_db = object()
+    fake_repo = object()
+    captured_kwargs = {}
+
+    def _fake_core_import(**kwargs):
+        captured_kwargs.update(kwargs)
+        return iter([{"type": "summary", "message": "Processed 1 page"}])
+
+    monkeypatch.setattr(process_mediawiki, "core_import_mediawiki_dump", _fake_core_import)
+    monkeypatch.setattr(
+        process_mediawiki,
+        "get_media_repository",
+        lambda db: fake_repo if db is fake_media_db else None,
+        raising=False,
+    )
+    client = _build_mediawiki_client(monkeypatch, tmp_path, user_id=42, media_db=fake_media_db)
+
+    response = client.post(
+        "/api/v1/media/mediawiki/ingest-dump",
+        files={"dump_file": ("mini.xml.gz", _gz_bytes(_mini_mediawiki_xml()), "application/gzip")},
+        data={
+            "wiki_name": "TestWiki",
+            "namespaces_str": "0",
+            "skip_redirects": "true",
+            "chunk_max_size": "500",
+            "api_name_vector_db": "",
+        },
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.text)["type"] == "summary"
+    assert captured_kwargs["media_writer"] is fake_repo
+    assert captured_kwargs["vector_user_id"] == "42"

--- a/tldw_Server_API/tests/test_mediawiki_ephemeral_smoke.py
+++ b/tldw_Server_API/tests/test_mediawiki_ephemeral_smoke.py
@@ -267,3 +267,35 @@ def test_mediawiki_ingest_dump_passes_request_scoped_writer_and_vector_user(monk
     assert json.loads(response.text)["type"] == "summary"
     assert captured_kwargs["media_writer"] is fake_repo
     assert captured_kwargs["vector_user_id"] == "42"
+
+
+@pytest.mark.integration
+def test_mediawiki_ingest_dump_rejects_missing_request_scoped_writer(monkeypatch, tmp_path: Path):
+    fake_media_db = object()
+
+    def _unexpected_core_import(**_kwargs):
+        raise AssertionError("MediaWiki ingest must not continue without a request-scoped writer")
+
+    monkeypatch.setattr(process_mediawiki, "core_import_mediawiki_dump", _unexpected_core_import)
+    monkeypatch.setattr(
+        process_mediawiki,
+        "get_media_repository",
+        lambda db: None,
+        raising=False,
+    )
+    client = _build_mediawiki_client(monkeypatch, tmp_path, user_id=42, media_db=fake_media_db)
+
+    response = client.post(
+        "/api/v1/media/mediawiki/ingest-dump",
+        files={"dump_file": ("mini.xml.gz", _gz_bytes(_mini_mediawiki_xml()), "application/gzip")},
+        data={
+            "wiki_name": "TestWiki",
+            "namespaces_str": "0",
+            "skip_redirects": "true",
+            "chunk_max_size": "500",
+            "api_name_vector_db": "",
+        },
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to initialize request-scoped media repository."


### PR DESCRIPTION
## Change summary

Human-written Change summary required before this draft PR is merge-ready under `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## What changed

Threads request-scoped media writer and vector user identity through MediaWiki ingest while preserving legacy direct-call fallback behavior.

Backlog tracking: `TASK-12141`.

## Latest dev refresh

- Base: `dev` at `6b727b221e55646eba663a03571e38302f7fafc2`.
- Head: `codex/audit-mediawiki-user-scope-2026-07-04` at `6eb82930575db4c6207aca7a5c85308c2aa9a426`.
- Post-amend check verified the final Backlog-note amend changed only the task record for this PR; merge-base still equals `6b727b221e55646eba663a03571e38302f7fafc2`.

## Validation

- Focused MediaWiki pytest suite -> 35 passed, 90 warnings.
- Bandit over `process_mediawiki.py` and `Media_Wiki.py` -> 0 findings over 1149 LOC (`/tmp/bandit_mediawiki_user_scope_origin_dev_6b727b.json`).
- `git diff --check HEAD~1..HEAD` -> clean.
