### PR TITLE
Define design-system CI gate tightening path

### DIFF
--- a/Docs/Design/tldw_web_design_system_baseline_reporting.md
+++ b/Docs/Design/tldw_web_design_system_baseline_reporting.md
@@ -10,6 +10,8 @@ and Backlog.md records execution evidence, but both must be refreshed from the
 verifier output rather than hand-counted.
 
 This document defines the reporting and cleanup workflow for migration PRs.
+The staged CI tightening path is defined in
+`Docs/Design/tldw_web_design_system_ci_gate_path.md`.
 
 ## Report Sections
 

--- a/Docs/Design/tldw_web_design_system_baseline_reporting.md
+++ b/Docs/Design/tldw_web_design_system_baseline_reporting.md
@@ -11,7 +11,7 @@ verifier output rather than hand-counted.
 
 This document defines the reporting and cleanup workflow for migration PRs.
 The staged CI tightening path is defined in
-`Docs/Design/tldw_web_design_system_ci_gate_path.md`.
+[tldw_web_design_system_ci_gate_path.md](tldw_web_design_system_ci_gate_path.md).
 
 ## Report Sections
 

--- a/Docs/Design/tldw_web_design_system_ci_gate_path.md
+++ b/Docs/Design/tldw_web_design_system_ci_gate_path.md
@@ -24,8 +24,12 @@ rows so migration PRs can shrink debt deliberately.
 
 1. **Report-only PR signal**
    - Owner: `.github/workflows/frontend-required.yml`
-   - Trigger: `apps/packages/ui/**`, `apps/tldw-frontend/**`, and design-system
-     docs/scripts.
+   - Trigger: `tldw_frontend_changed` from
+     [`Helper_Scripts/ci/path_classifier.py`](../../Helper_Scripts/ci/path_classifier.py),
+     currently covering `apps/tldw-frontend/**`, `apps/packages/ui/**`,
+     `apps/extension/**`, `apps/bun.lock`, and
+     `apps/tldw-frontend/package-lock.json`. Docs-only changes do not trigger
+     this signal unless the classifier is intentionally extended.
    - Behavior: install `apps` dependencies, run `bun run verify:design-system-state`
      from `apps/packages/ui`, and keep `continue-on-error: true`.
    - Exit criteria: at least one week of stable CI runtime and no false positives.
@@ -39,10 +43,13 @@ rows so migration PRs can shrink debt deliberately.
      baseline exceptions and no blocked findings.
 
 3. **Required stale-baseline cleanup**
-   - Owner: product-state guard script plus `frontend-required`.
+   - Owner:
+     [`apps/packages/ui/scripts/verify-design-system-product-state.mjs`](../../apps/packages/ui/scripts/verify-design-system-product-state.mjs)
+     plus `frontend-required`.
    - Behavior: make stale baseline rows fail CI.
    - Entry criteria: all open migration PRs use the stale-row cleanup workflow
-     in `tldw_web_design_system_baseline_reporting.md`.
+     in
+     [tldw_web_design_system_baseline_reporting.md](tldw_web_design_system_baseline_reporting.md).
 
 4. **Area-zero enforcement**
    - Owner: tracker issues under TASK-45.44 / GitHub epic #1655.

--- a/Docs/Design/tldw_web_design_system_ci_gate_path.md
+++ b/Docs/Design/tldw_web_design_system_ci_gate_path.md
@@ -1,0 +1,67 @@
+# tldw Web Design-System CI Gate Path
+
+Date: 2026-07-04
+
+## Purpose
+
+Move the product-state guard from local/report-mode usage into CI without
+blocking unrelated work on legacy baseline debt.
+
+The guard command is:
+
+```bash
+cd apps/packages/ui
+bun run verify:design-system-state
+```
+
+## Current Behavior
+
+`verify:design-system-state` fails on unbaselined product-state findings and
+invalid baseline rows. It reports active baseline exceptions and stale baseline
+rows so migration PRs can shrink debt deliberately.
+
+## Gate Stages
+
+1. **Report-only PR signal**
+   - Owner: `.github/workflows/frontend-required.yml`
+   - Trigger: `apps/packages/ui/**`, `apps/tldw-frontend/**`, and design-system
+     docs/scripts.
+   - Behavior: install `apps` dependencies, run `bun run verify:design-system-state`
+     from `apps/packages/ui`, and keep `continue-on-error: true`.
+   - Exit criteria: at least one week of stable CI runtime and no false positives.
+
+2. **Required new-finding gate**
+   - Owner: `frontend-required`.
+   - Behavior: remove `continue-on-error`; the existing verifier blocks new
+     unbaselined findings and invalid baseline rows while allowing current
+     baseline exceptions.
+   - Entry criteria: latest `dev` passes the verifier with only accepted
+     baseline exceptions and no blocked findings.
+
+3. **Required stale-baseline cleanup**
+   - Owner: product-state guard script plus `frontend-required`.
+   - Behavior: make stale baseline rows fail CI.
+   - Entry criteria: all open migration PRs use the stale-row cleanup workflow
+     in `tldw_web_design_system_baseline_reporting.md`.
+
+4. **Area-zero enforcement**
+   - Owner: tracker issues under TASK-45.44 / GitHub epic #1655.
+   - Behavior: once a product-area issue reaches zero exceptions, any new
+     baseline row for that area requires a new owner issue, replacement target,
+     and migration queue.
+
+## PR Requirements
+
+Design-system migration PRs must record:
+
+- verifier command and result,
+- before/after baseline count for the touched area,
+- stale baseline cleanup result,
+- PR link in the GitHub tracker issue,
+- Backlog task verification notes.
+
+## Non-Goals
+
+- Do not fail all CI on the current legacy baseline.
+- Do not add a new workflow when `frontend-required` can own the gate.
+- Do not add new dependencies for reporting.

--- a/backlog/tasks/task-45.44.15 - Define-design-system-CI-gate-tightening-path.md
+++ b/backlog/tasks/task-45.44.15 - Define-design-system-CI-gate-tightening-path.md
@@ -3,25 +3,24 @@ id: TASK-45.44.15
 title: Define design-system CI gate tightening path
 status: Done
 assignee: []
-created_date: '2026-05-14 03:20'
+created_date: 2026-05-14 03:20
 labels:
-  - design-system
-  - webui
-  - extension
-  - governance
+- design-system
+- webui
+- extension
+- governance
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1672'
-  - >-
-    Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
-  - Docs/Design/tldw_web_design_system_ci_gate_path.md
-  - 'https://github.com/rmusser01/tldw_server/pull/2626'
+- https://github.com/rmusser01/tldw_server/issues/1672
+- Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+- Docs/Design/tldw_web_design_system_ci_gate_path.md
+- https://github.com/rmusser01/tldw_server/pull/2626
 parent_task_id: TASK-45.44
 priority: medium
 modified_files:
-  - Docs/Design/tldw_web_design_system_ci_gate_path.md
-  - Docs/Design/tldw_web_design_system_baseline_reporting.md
-  - backlog/tasks/task-45.44.15 - Define-design-system-CI-gate-tightening-path.md
+- Docs/Design/tldw_web_design_system_ci_gate_path.md
+- Docs/Design/tldw_web_design_system_baseline_reporting.md
+- backlog/tasks/task-45.44.15 - Define-design-system-CI-gate-tightening-path.md
 ---
 
 ## Description
@@ -42,7 +41,10 @@ Mirror the linked GitHub governance issue. Closure requires a durable guard, doc
 - Added `Docs/Design/tldw_web_design_system_ci_gate_path.md` defining the staged path from report-only PR signal to required new-finding gate, stale-baseline cleanup, and area-zero enforcement.
 - Chose `frontend-required` as the future CI owner instead of adding a new workflow, because it already detects frontend changes and installs frontend dependencies.
 - Linked the CI gate path from `tldw_web_design_system_baseline_reporting.md` so migration PR instructions point at the durable artifact.
-- Verification: `git diff --check` passed.
+- Rebased PR #2626 onto `origin/dev` at `83428eff33`.
+- Addressed review feedback by tying the report-only trigger to the current `tldw_frontend_changed` classifier paths, documenting that docs-only changes do not trigger it, linking the concrete verifier script, and replacing plain document references with relative Markdown links.
+- Verification: `git diff --check` passed and all linked repository targets exist.
+- `bun run verify:design-system-state` runs but exits 1 on current `dev` debt: unbaselined product-state findings plus 14 stale baseline rows. This docs-only PR does not alter product-state source or baseline data.
 - Bandit is not applicable because this task changes only markdown documentation and Backlog metadata.
 - PR: https://github.com/rmusser01/tldw_server/pull/2626
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
@@ -50,7 +52,7 @@ Mirror the linked GitHub governance issue. Closure requires a durable guard, doc
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Defined the design-system CI gate tightening path in a durable design doc and linked it from the baseline reporting workflow. The path keeps current legacy debt non-blocking, adds a report-only PR signal first, then tightens to required new-finding, stale-baseline, and area-zero enforcement stages.
+Defined the design-system CI gate tightening path in a durable design doc and linked it from the baseline reporting workflow. Review remediation now anchors trigger behavior to the current path classifier, names the concrete verifier owner, and uses navigable document links. The branch was rebased onto current `dev`; the verifier's existing `dev` debt is recorded as an out-of-scope baseline blocker.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-45.44.15 - Define-design-system-CI-gate-tightening-path.md
+++ b/backlog/tasks/task-45.44.15 - Define-design-system-CI-gate-tightening-path.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.44.15
 title: Define design-system CI gate tightening path
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-14 03:20'
 labels:
@@ -14,8 +14,14 @@ references:
   - 'https://github.com/rmusser01/tldw_server/issues/1672'
   - >-
     Docs/superpowers/specs/2026-05-14-design-system-remaining-work-tracker-design.md
+  - Docs/Design/tldw_web_design_system_ci_gate_path.md
+  - 'https://github.com/rmusser01/tldw_server/pull/2626'
 parent_task_id: TASK-45.44
 priority: medium
+modified_files:
+  - Docs/Design/tldw_web_design_system_ci_gate_path.md
+  - Docs/Design/tldw_web_design_system_baseline_reporting.md
+  - backlog/tasks/task-45.44.15 - Define-design-system-CI-gate-tightening-path.md
 ---
 
 ## Description
@@ -26,16 +32,33 @@ Mirror the linked GitHub governance issue. Closure requires a durable guard, doc
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The linked GitHub issue owns public status.
-- [ ] #2 Backlog notes record PR links and verification evidence.
+- [x] #1 The linked GitHub issue owns public status.
+- [x] #2 Backlog notes record PR links and verification evidence.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `Docs/Design/tldw_web_design_system_ci_gate_path.md` defining the staged path from report-only PR signal to required new-finding gate, stale-baseline cleanup, and area-zero enforcement.
+- Chose `frontend-required` as the future CI owner instead of adding a new workflow, because it already detects frontend changes and installs frontend dependencies.
+- Linked the CI gate path from `tldw_web_design_system_baseline_reporting.md` so migration PR instructions point at the durable artifact.
+- Verification: `git diff --check` passed.
+- Bandit is not applicable because this task changes only markdown documentation and Backlog metadata.
+- PR: https://github.com/rmusser01/tldw_server/pull/2626
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Defined the design-system CI gate tightening path in a durable design doc and linked it from the baseline reporting workflow. The path keeps current legacy debt non-blocking, adds a report-only PR signal first, then tightens to required new-finding, stale-baseline, and area-zero enforcement stages.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Define the staged design-system product-state CI gate path requested by issue #1672. This adds a durable design doc, links it from baseline reporting, and closes the Backlog task with verification notes.

Why this shape:
- Reuses the existing `verify:design-system-state` command.
- Reuses `frontend-required` as the future CI owner instead of adding another workflow.
- Keeps current legacy baseline debt non-blocking until the report-only signal is stable.

## Verification

- `git diff --check`
- `rg -n "tldw_web_design_system_ci_gate_path|frontend-required|verify:design-system-state|continue-on-error" Docs/Design/tldw_web_design_system_ci_gate_path.md Docs/Design/tldw_web_design_system_baseline_reporting.md "backlog/tasks/task-45.44.15 - Define-design-system-CI-gate-tightening-path.md"`

Bandit skipped: docs/backlog-only change.

Closes #1672

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines a staged CI gate for the design-system product-state guard and links it from baseline reporting. Starts report-only and tightens to a required gate without blocking legacy baseline debt; aligns with #1672.

- New Features
  - Adds a durable doc with four stages (report-only, required new-finding, stale-baseline cleanup, area-zero), using the `tldw_frontend_changed` classifier for triggers; docs-only changes do not trigger; includes `continue-on-error` and entry/exit criteria.
  - Reuses `bun run verify:design-system-state` and makes `frontend-required` the CI owner; no new workflow added.
  - Links the doc from `tldw_web_design_system_baseline_reporting.md`, lists migration PR requirements, and updates the backlog task to Done.

<sup>Written for commit 59eca71b707023539d86f6edef846b3ebc1e3d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

