### PR TITLE
fix: address review comments from PRs #2604 and #2619

### DIFF
--- a/Docs/superpowers/plans/2026-07-04-audit-integrations-egress-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-07-04-audit-integrations-egress-remediation-plan.md
@@ -18,6 +18,6 @@
 
 ## Stage 4: Verification And Task Record
 **Goal**: Prove the remediation and record it for repeatable audit follow-up.
-**Success Criteria**: Focused pytest passes, `git diff --check` passes, Bandit runs on touched production files, and `TASK-12138` records final verification.
+**Success Criteria**: Focused pytest passes, `git diff --check` passes, Bandit runs on touched production files, and `TASK-12146` records final verification.
 **Tests**: `python -m pytest` focused files, `git diff --check`, and Bandit on touched production files.
 **Status**: Complete

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -1276,16 +1276,16 @@ async def acp_session_stream(
         # available; otherwise fall back to the existing path.
         bus = get_session_event_bus(session_id)
         if bus is not None and last_sequence > 0:
-            from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import WSBroadcaster
-
-            reconnect_conn_id = f"ws-{session_id}-{id(stream)}"
-            reconnect_broadcaster = WSBroadcaster(consumer_id=f"ws_broadcaster:{reconnect_conn_id}")
-            await reconnect_broadcaster.start(bus)
+            from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import (
+                start_reconnect_replay,
+            )
 
             async def _ws_send_str(msg: str) -> None:
                 await stream.send_json(json.loads(msg))
 
-            await reconnect_broadcaster.add_connection(
+            reconnect_conn_id = f"ws-{session_id}-{id(stream)}"
+            reconnect_broadcaster = await start_reconnect_replay(
+                bus,
                 conn_id=reconnect_conn_id,
                 send_callback=_ws_send_str,
                 from_sequence=last_sequence,
@@ -1336,11 +1336,12 @@ async def acp_session_stream(
         logger.exception("WebSocket error for ACP session {}", session_id)
     finally:
         if reconnect_broadcaster is not None:
-            if reconnect_conn_id is not None:
-                with contextlib.suppress(_ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS):
-                    reconnect_broadcaster.remove_connection(reconnect_conn_id)
-            with contextlib.suppress(_ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS):
-                await reconnect_broadcaster.stop()
+            from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import (
+                stop_reconnect_replay,
+            )
+
+            # logs (never silently suppresses) cleanup failures
+            await stop_reconnect_replay(reconnect_broadcaster, reconnect_conn_id)
         # Unregister WebSocket
         if send_callback is not None:
             try:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
@@ -57,6 +57,15 @@ class WSBroadcaster(EventConsumer):
     consumer_id: str = "ws_broadcaster"
 
     def __init__(self, consumer_id: str | None = None) -> None:
+        """Initialize the broadcaster.
+
+        Args:
+            consumer_id: Optional unique identifier used when subscribing to
+                the session event bus. Defaults to the class-level
+                ``"ws_broadcaster"``. Pass a unique value (e.g. per
+                reconnect-replay connection) so concurrent broadcasters on the
+                same bus do not overwrite each other's subscriptions.
+        """
         self.consumer_id = consumer_id or self.consumer_id
         self._connections: dict[str, _ConnectionInfo] = {}
         self._bus: SessionEventBus | None = None
@@ -195,3 +204,52 @@ def _passes_filter(kind: AgentEventKind, verbosity: str) -> bool:
         return kind in _SUMMARY_KINDS
     # Unknown verbosity -- default to full
     return True
+
+
+async def start_reconnect_replay(
+    bus: SessionEventBus,
+    *,
+    conn_id: str,
+    send_callback: SendCallback,
+    from_sequence: int,
+) -> WSBroadcaster:
+    """Create and start a dedicated broadcaster that replays missed events.
+
+    Used on WebSocket reconnect: a per-connection broadcaster (unique
+    ``consumer_id`` so concurrent reconnects don't clobber each other's bus
+    subscriptions) is subscribed to *bus* and replays buffered events from
+    *from_sequence* to *send_callback*. Callers must pair this with
+    :func:`stop_reconnect_replay` on disconnect.
+    """
+    broadcaster = WSBroadcaster(consumer_id=f"ws_broadcaster:{conn_id}")
+    await broadcaster.start(bus)
+    await broadcaster.add_connection(
+        conn_id=conn_id,
+        send_callback=send_callback,
+        from_sequence=from_sequence,
+    )
+    return broadcaster
+
+
+async def stop_reconnect_replay(broadcaster: WSBroadcaster, conn_id: str | None) -> None:
+    """Tear down a reconnect-replay broadcaster created by :func:`start_reconnect_replay`.
+
+    Cleanup failures are logged (never silently suppressed) but do not
+    propagate: this runs in disconnect paths where raising would mask the
+    original connection error.
+    """
+    if conn_id is not None:
+        try:
+            broadcaster.remove_connection(conn_id)
+        except Exception as exc:
+            logger.warning(
+                "Failed to remove reconnect replay connection {}: {}", conn_id, exc
+            )
+    try:
+        await broadcaster.stop()
+    except Exception as exc:
+        logger.warning(
+            "Failed to stop reconnect replay broadcaster {}: {}",
+            broadcaster.consumer_id,
+            exc,
+        )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
@@ -219,15 +219,48 @@ async def start_reconnect_replay(
     ``consumer_id`` so concurrent reconnects don't clobber each other's bus
     subscriptions) is subscribed to *bus* and replays buffered events from
     *from_sequence* to *send_callback*. Callers must pair this with
-    :func:`stop_reconnect_replay` on disconnect.
+    :func:`stop_reconnect_replay` on disconnect. If registration or replay
+    fails after the broadcaster started, the broadcaster is stopped before
+    the error propagates, so no bus subscription leaks.
+
+    Args:
+        bus: Session event bus to subscribe the replay broadcaster to.
+        conn_id: Unique connection identifier; also seeds the broadcaster's
+            ``consumer_id`` (``ws_broadcaster:<conn_id>``).
+        send_callback: Awaitable callback that delivers each serialized event
+            to the reconnected WebSocket.
+        from_sequence: Sequence number after which buffered events are
+            replayed to the new connection.
+
+    Returns:
+        The started :class:`WSBroadcaster`, already registered with the
+        connection and mid-replay/live on the bus.
+
+    Raises:
+        Exception: Whatever :meth:`WSBroadcaster.start` or
+            :meth:`WSBroadcaster.add_connection` raises; the broadcaster is
+            stopped (best-effort) first.
     """
     broadcaster = WSBroadcaster(consumer_id=f"ws_broadcaster:{conn_id}")
     await broadcaster.start(bus)
-    await broadcaster.add_connection(
-        conn_id=conn_id,
-        send_callback=send_callback,
-        from_sequence=from_sequence,
-    )
+    try:
+        await broadcaster.add_connection(
+            conn_id=conn_id,
+            send_callback=send_callback,
+            from_sequence=from_sequence,
+        )
+    except Exception:
+        # replay/send can fail mid-registration; without this stop() the
+        # bus subscription and consume task would leak (caller never gets
+        # the broadcaster reference to clean up)
+        try:
+            await broadcaster.stop()
+        except Exception as stop_exc:
+            logger.bind(conn_id=conn_id, consumer_id=broadcaster.consumer_id).warning(
+                "Failed to stop reconnect replay broadcaster after registration error: {}",
+                stop_exc,
+            )
+        raise
     return broadcaster
 
 
@@ -237,19 +270,26 @@ async def stop_reconnect_replay(broadcaster: WSBroadcaster, conn_id: str | None)
     Cleanup failures are logged (never silently suppressed) but do not
     propagate: this runs in disconnect paths where raising would mask the
     original connection error.
+
+    Args:
+        broadcaster: The broadcaster returned by :func:`start_reconnect_replay`.
+        conn_id: Connection identifier to unregister first, or ``None`` to
+            skip connection removal and only stop the broadcaster.
     """
     if conn_id is not None:
         try:
             broadcaster.remove_connection(conn_id)
         except Exception as exc:
-            logger.warning(
-                "Failed to remove reconnect replay connection {}: {}", conn_id, exc
-            )
+            logger.bind(
+                action="reconnect_replay_cleanup",
+                conn_id=conn_id,
+                consumer_id=broadcaster.consumer_id,
+            ).warning("Failed to remove reconnect replay connection: {}", exc)
     try:
         await broadcaster.stop()
     except Exception as exc:
-        logger.warning(
-            "Failed to stop reconnect replay broadcaster {}: {}",
-            broadcaster.consumer_id,
-            exc,
-        )
+        logger.bind(
+            action="reconnect_replay_cleanup",
+            conn_id=conn_id,
+            consumer_id=broadcaster.consumer_id,
+        ).warning("Failed to stop reconnect replay broadcaster: {}", exc)

--- a/tldw_Server_API/app/core/LLM_Calls/tokenizer_resolver.py
+++ b/tldw_Server_API/app/core/LLM_Calls/tokenizer_resolver.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import parse_qsl, quote, quote_plus, urlparse
 
+from loguru import logger
+
 from tldw_Server_API.app.core.config import load_comprehensive_config
 from tldw_Server_API.app.core.custom_openai_providers import (
     custom_openai_config_option_names,
@@ -654,13 +656,17 @@ def _http_post(*, url: str, payload: dict[str, Any], headers: dict[str, str], ti
         from tldw_Server_API.app.core.http_client import fetch
     except Exception as exc:
         raise TokenizerUnavailable("Provider tokenizer HTTP client unavailable") from exc
+    # allow_redirects=False: these POSTs carry provider credentials
+    # (Authorization / x-api-key); following a cross-origin redirect would
+    # resend the secrets to the redirect target. Provider tokenizer APIs
+    # never legitimately redirect.
     return fetch(
         method="POST",
         url=url,
         json=payload,
         headers=headers,
         timeout=timeout,
-        allow_redirects=True,
+        allow_redirects=False,
     )
 
 
@@ -891,8 +897,12 @@ def _runtime_probe_exact_resolution(
         )
     finally:
         if original_timeout is not None:
-            with suppress(Exception):
+            try:
                 setattr(encoding, "timeout_seconds", original_timeout)
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to restore tokenizer encoding timeout_seconds={original_timeout!r}: {exc}"
+                )
 
     return resolution
 

--- a/tldw_Server_API/app/core/Workflows/adapters/research/search.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/research/search.py
@@ -11,6 +11,7 @@ This module includes adapters for academic search operations:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import tempfile
 import time
@@ -204,7 +205,8 @@ async def run_arxiv_download_adapter(config: dict[str, Any], context: dict[str, 
             response.raise_for_status()
             filename = pdf_url.split("/")[-1] or "paper.pdf"
             output_path = str(art_dir / filename)
-            Path(output_path).write_bytes(response.content)
+            # blocking file write must not stall the event loop
+            await asyncio.to_thread(Path(output_path).write_bytes, response.content)
 
         if callable(context.get("add_artifact")):
             context["add_artifact"](

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_websocket.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_websocket.py
@@ -291,8 +291,9 @@ async def test_acp_session_stream_start_failure_skips_unset_callback_cleanup(mon
         pytest.fail(f"Expected exactly one stream.stop() call, got {lifecycle['stop_calls']}")
 
 
-@pytest.mark.asyncio
-async def test_acp_session_stream_reconnect_cleans_up_replay_broadcaster(monkeypatch):
+async def test_acp_session_stream_reconnect_cleans_up_replay_broadcaster(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Reconnect replay broadcasters must not leave event-bus subscribers behind."""
     import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
 
@@ -310,7 +311,7 @@ async def test_acp_session_stream_reconnect_cleans_up_replay_broadcaster(monkeyp
     streams: list[Any] = []
 
     class _DisconnectingStream:
-        def __init__(self, *args, **kwargs) -> None:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
             self.sent_payloads: list[dict[str, Any]] = []
             self.stop_calls = 0
             streams.append(self)
@@ -331,16 +332,23 @@ async def test_acp_session_stream_reconnect_cleans_up_replay_broadcaster(monkeyp
         async def close(self, code: int = 1000) -> None:
             return None
 
-    async def _fake_authenticate_ws(websocket, token=None, api_key=None, required_scope="read"):
+    async def _fake_authenticate_ws(
+        websocket: Any,
+        token: str | None = None,
+        api_key: str | None = None,
+        required_scope: str = "read",
+    ) -> int:
         return 1
 
-    async def _fake_get_runner_client():
+    async def _fake_get_runner_client() -> MockRunnerClient:
         return stub_client
 
-    async def _fake_resolve_persona_id(client, *, session_id: str, user_id: int):
+    async def _fake_resolve_persona_id(client: Any, *, session_id: str, user_id: int) -> None:
         return None
 
-    def _fake_acquire_quota(*, user_id: int, session_id: str, persona_id: str | None):
+    def _fake_acquire_quota(
+        *, user_id: int, session_id: str, persona_id: str | None
+    ) -> tuple[str, None]:
         return "quota-token", None
 
     def _fake_release_quota(token: str) -> None:
@@ -981,7 +989,12 @@ class TestACPRunnerClientPermissions:
 
     @pytest.mark.asyncio
     async def test_determine_permission_tier_batch(self):
-        """Test that write operations get batch tier."""
+        """Batch tier is the fallback for tools that are neither destructive nor read-only.
+
+        Write/modify operations were promoted to the stricter "individual"
+        tier by the ACP runner security hardening (see permission_tiers.py);
+        this test previously pinned the pre-hardening behavior.
+        """
         from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import ACPRunnerClient
 
         mock_config = MagicMock()
@@ -993,10 +1006,13 @@ class TestACPRunnerClientPermissions:
 
         client = ACPRunnerClient(mock_config)
 
-        # Write operations should be batch
-        assert client._determine_permission_tier("fs.write") == "batch"
+        # Write/modify operations are individual tier post-hardening
+        assert client._determine_permission_tier("fs.write") == "individual"
+        assert client._determine_permission_tier("modify_file") == "individual"
+
+        # Tools matching neither the individual nor auto token sets fall back to batch
         assert client._determine_permission_tier("git.commit") == "batch"
-        assert client._determine_permission_tier("modify_file") == "batch"
+        assert client._determine_permission_tier("fs.chmod") == "batch"
 
     @pytest.mark.asyncio
     async def test_permission_request_message_includes_runtime_policy_metadata(self):

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
@@ -15,6 +15,8 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster imp
     WSBroadcaster,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _make_event(kind: AgentEventKind, session_id: str = "sess-1") -> AgentEvent:
     return AgentEvent(session_id=session_id, kind=kind, payload={"data": kind.value})
@@ -56,8 +58,7 @@ async def test_ws_broadcaster_delivers_events_full_verbosity():
     assert received[2]["kind"] == "completion"
 
 
-@pytest.mark.asyncio
-async def test_ws_broadcaster_allows_unique_consumer_ids():
+async def test_ws_broadcaster_allows_unique_consumer_ids() -> None:
     """Distinct broadcasters should not overwrite each other's bus subscription."""
     bus = SessionEventBus(session_id="sess-unique-consumers")
     first = WSBroadcaster(consumer_id="ws_broadcaster:conn-1")

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
@@ -78,6 +78,31 @@ async def test_ws_broadcaster_allows_unique_consumer_ids() -> None:
     assert bus._subscribers == {}
 
 
+async def test_start_reconnect_replay_cleans_up_when_registration_fails() -> None:
+    """A failing replay send must not leak the bus subscription or consume task."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import (
+        start_reconnect_replay,
+    )
+
+    session_id = "sess-replay-fail"
+    bus = SessionEventBus(session_id=session_id)
+    await bus.publish(_make_event(AgentEventKind.COMPLETION, session_id=session_id))
+
+    async def failing_send(msg: str) -> None:
+        raise RuntimeError("send failed during replay")
+
+    with pytest.raises(RuntimeError, match="send failed during replay"):
+        await start_reconnect_replay(
+            bus,
+            conn_id="conn-replay-fail",
+            send_callback=failing_send,
+            from_sequence=1,
+        )
+
+    # the broadcaster must have been stopped: no leaked subscriber
+    assert bus._subscribers == {}
+
+
 @pytest.mark.asyncio
 async def test_ws_broadcaster_summary_filters_thinking():
     """Summary verbosity should drop thinking/tool_call/etc., keep completion."""

--- a/tldw_Server_API/tests/Writing/test_tokenizer_resolver_unit.py
+++ b/tldw_Server_API/tests/Writing/test_tokenizer_resolver_unit.py
@@ -147,7 +147,9 @@ def test_tokenizer_http_post_uses_central_http_client(monkeypatch):
             "json": {"content": "hello"},
             "headers": {"X-Test": "1"},
             "timeout": 7.0,
-            "allow_redirects": True,
+            # redirects disabled: these POSTs carry provider credentials and
+            # must not follow cross-origin redirects (PR #2604 review)
+            "allow_redirects": False,
         }
     ]
 


### PR DESCRIPTION
## Summary

Follow-up addressing every unresolved reviewer comment from the two audit-fix PRs merged earlier today (the client-reuse and trivial-test comments were already fixed in-branch before merge; the `nonlocal` suggestion on #2619 was correctly rejected by the author).

### From PR #2604 (egress hardening)
- **Blocking I/O in async** (qodo, `search.py:207`): `run_arxiv_download_adapter` now offloads `Path.write_bytes` via `asyncio.to_thread`. (The `import arxiv` branch's blocking library calls are pre-existing and out of scope.)
- **Redirect leaks auth headers** (qodo, `tokenizer_resolver.py:664`, security): `_http_post` now sends `allow_redirects=False` — these POSTs carry `Authorization`/`x-api-key` and the central redirect loop doesn't strip headers cross-origin. Regression test contract updated. The central fix (strip/partition sensitive headers on cross-origin redirects in `http_client` fetch/afetch) is qodo's preferred Option B and remains open — larger change, deserves its own PR.
- **Silent suppress in finally** (qodo, `tokenizer_resolver.py:895`): restoring `encoding.timeout_seconds` now logs a warning on failure instead of `suppress(Exception)`.
- **Wrong task id** (qodo, plan doc): `TASK-12138` → `TASK-12146`.

### From PR #2619 (ACP reconnect cleanup)
- **Workflow logic in endpoint** (qodo, architecture): reconnect-replay lifecycle extracted to core — `ws_broadcaster.start_reconnect_replay()` / `stop_reconnect_replay()`; the endpoint just calls them.
- **Cleanup suppresses exceptions** (qodo, `agent_client_protocol.py:1343`): teardown failures are now logged in `stop_reconnect_replay`, never silently dropped.
- **Missing docstring** (qodo): `WSBroadcaster.__init__` documents `consumer_id`.
- **Disallowed `asyncio` marker + missing type hints on new tests** (qodo): dropped redundant `@pytest.mark.asyncio` from the new tests (`asyncio_mode=auto`), added module-level `pytestmark = pytest.mark.unit` to `test_ws_broadcaster.py`, completed type hints on the new test helpers.

### Bonus
- `test_determine_permission_tier_batch` was red on dev: it pinned pre-hardening behavior (`write` → batch). Updated for the hardened contract (`write`/`modify` → individual; true fallback tools → batch).

## Verification
- `tests/Agent_Client_Protocol/`: **963/963 pass** locally
- `test_tokenizer_resolver_unit.py` + `test_research_adapters.py`: **117/117 pass**
- Local runs use `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` + `-p pytest_asyncio.plugin` per repo convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-up to #2604 (egress hardening) and #2619 (ACP reconnect) that closes remaining review comments. Prevents credential leaks on redirects, removes event-loop blocking I/O, and hardens reconnect replay with lifecycle helpers, error cleanup, and clearer logs/tests. Updates plan doc to reference TASK-12146 for audit verification.

- **Bug Fixes**
  - Tokenizer POST: `allow_redirects=False` to avoid sending auth headers on redirects; tests updated.
  - ArXiv download: offload `Path.write_bytes` via `asyncio.to_thread` to avoid event-loop stalls.
  - Tokenizer timeout restore now logs failures instead of suppressing errors.
  - Reconnect replay: `start_reconnect_replay` now stops the broadcaster if `add_connection` fails mid-replay to prevent leaked bus subscriptions; regression test added.
  - Permission tier tests updated to hardened policy: write/modify → individual; true fallbacks → batch.
  - Plan doc traceability: `TASK-12146`.

- **Refactors**
  - Extracted reconnect replay lifecycle to core: `start_reconnect_replay` / `stop_reconnect_replay`; endpoint now only calls them.
  - Cleanup paths now log teardown failures with bound `action`/`conn_id`/`consumer_id` (no silent suppress).
  - `WSBroadcaster.__init__` documents `consumer_id`; tests drop redundant `@pytest.mark.asyncio`, add unit marker, and complete type hints.

<sup>Written for commit dd8660b6675fa2a1c998dfc2a2031d1cf519a757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

