### PR TITLE
fix(http_client): strip credentials on cross-origin redirect hops

### DIFF
--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -1113,6 +1113,85 @@ def _resolve_redirect_url(base_url: str, location: str) -> str | None:
         return None
 
 
+# Headers that carry credentials and must not accompany a redirect hop to a
+# different origin (scheme/host/port) — the redirect target would otherwise
+# receive the caller's secrets.
+SENSITIVE_REDIRECT_HEADERS: frozenset[str] = frozenset({
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "x-api-key",
+    "api-key",
+    "x-auth-token",
+})
+
+
+def _url_origin(url: str) -> tuple[str, str, int] | None:
+    """Return ``(scheme, host, port)`` for *url*, normalizing default ports.
+
+    Returns ``None`` when the URL has no parseable scheme/host.
+    """
+    try:
+        parsed = urlparse(url)
+        scheme = (parsed.scheme or "").lower()
+        host = (parsed.hostname or "").lower()
+        if not scheme or not host:
+            return None
+        port = parsed.port or (443 if scheme == "https" else 80)
+        return scheme, host, int(port)
+    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+        return None
+
+
+def _is_cross_origin(original_url: str, target_url: str) -> bool:
+    """Return True when *target_url* has a different origin than *original_url*.
+
+    Unparseable URLs are treated as cross-origin (fail closed).
+    """
+    original = _url_origin(original_url)
+    target = _url_origin(target_url)
+    if original is None or target is None:
+        return True
+    return original != target
+
+
+def _strip_sensitive_headers_for_cross_origin(
+    headers: dict[str, str] | None,
+    *,
+    original_url: str,
+    target_url: str,
+) -> dict[str, str] | None:
+    """Drop credential-bearing headers when a request hop leaves the original origin.
+
+    Args:
+        headers: Prepared per-hop request headers (may be ``None``).
+        original_url: URL of the caller's original request.
+        target_url: URL of the hop about to be issued (redirect target).
+
+    Returns:
+        *headers* unchanged for same-origin hops; otherwise a copy with the
+        :data:`SENSITIVE_REDIRECT_HEADERS` removed (case-insensitive).
+    """
+    if not headers or not _is_cross_origin(original_url, target_url):
+        return headers
+    kept = {k: v for k, v in headers.items() if k.lower() not in SENSITIVE_REDIRECT_HEADERS}
+    dropped = sorted(k for k in headers if k.lower() in SENSITIVE_REDIRECT_HEADERS)
+    if dropped:
+        logger.bind(target_host=_parse_host_from_url(target_url)).debug(
+            "Stripped sensitive headers on cross-origin redirect: {}", ", ".join(dropped)
+        )
+    return kept
+
+
+def _cookies_for_hop(
+    cookies: dict[str, str] | None, *, original_url: str, target_url: str
+) -> dict[str, str] | None:
+    """Return *cookies* for same-origin hops, ``None`` for cross-origin hops."""
+    if cookies and _is_cross_origin(original_url, target_url):
+        return None
+    return cookies
+
+
 def _get_response_url(resp: Any, fallback: str) -> str:
     try:
         req = getattr(resp, "request", None)
@@ -2138,6 +2217,10 @@ async def _afetch_httpx(
 
     async def _do_once(ac: httpx.AsyncClient, target_url: str) -> tuple[httpx.Response | None, str]:
         req_headers = _inject_trace_headers(headers)
+        req_headers = _strip_sensitive_headers_for_cross_origin(
+            req_headers, original_url=url, target_url=target_url
+        )
+        req_cookies = _cookies_for_hop(cookies, original_url=url, target_url=target_url)
         # Parity with other paths: drop 'zstd' from Accept-Encoding for httpx
         try:
             with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
@@ -2164,7 +2247,7 @@ async def _afetch_httpx(
                 method=method_upper,
                 url=target_url,
                 headers=req_headers,
-                cookies=cookies,
+                cookies=req_cookies,
                 params=params,
                 json=json,
                 data=data,
@@ -2243,6 +2326,9 @@ async def _afetch_httpx(
                                 _head_get_range_tried = True
                                 try:
                                     req_headers = _inject_trace_headers(headers)
+                                    req_headers = _strip_sensitive_headers_for_cross_origin(
+                                        req_headers, original_url=url, target_url=cur_url
+                                    )
                                     with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
                                         req_headers = _sanitize_accept_encoding_for_backend(req_headers, "httpx")
                                     req_headers.setdefault("Range", "bytes=0-0")
@@ -2256,7 +2342,7 @@ async def _afetch_httpx(
                                         method="GET",
                                         url=cur_url,
                                         headers=req_headers,
-                                        cookies=cookies,
+                                        cookies=_cookies_for_hop(cookies, original_url=url, target_url=cur_url),
                                         params=params,
                                         json=json,
                                         data=data,
@@ -2463,6 +2549,10 @@ async def _afetch_aiohttp(
 
     async def _do_once(session: aiohttp.ClientSession, target_url: str) -> tuple[_AiohttpResponse | None, str]:
         req_headers = _inject_trace_headers(headers)
+        req_headers = _strip_sensitive_headers_for_cross_origin(
+            req_headers, original_url=url, target_url=target_url
+        )
+        req_cookies = _cookies_for_hop(cookies, original_url=url, target_url=target_url)
         with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
             req_headers = _sanitize_accept_encoding_for_backend(req_headers, "aiohttp")
         try:
@@ -2487,7 +2577,7 @@ async def _afetch_aiohttp(
                 method=method_upper,
                 url=target_url,
                 headers=req_headers,
-                cookies=cookies,
+                cookies=req_cookies,
                 params=params,
                 json=json,
                 data=data,
@@ -2530,6 +2620,9 @@ async def _afetch_aiohttp(
                         _head_get_range_tried = True
                         try:
                             req_headers = _inject_trace_headers(headers)
+                            req_headers = _strip_sensitive_headers_for_cross_origin(
+                                req_headers, original_url=url, target_url=cur_url
+                            )
                             req_headers.setdefault("Range", "bytes=0-0")
                             try:
                                 _head_fb_to = float(os.getenv("HTTP_HEAD_RANGE_FALLBACK_TIMEOUT", "5"))
@@ -2540,7 +2633,7 @@ async def _afetch_aiohttp(
                                 method="GET",
                                 url=cur_url,
                                 headers=req_headers,
-                                cookies=cookies,
+                                cookies=_cookies_for_hop(cookies, original_url=url, target_url=cur_url),
                                 params=params,
                                 timeout=_head_fb_to,
                                 proxies=proxies,
@@ -2813,6 +2906,10 @@ def _fetch_httpx_response(
 
     def _do_once(sc: httpx.Client, target_url: str) -> tuple[httpx.Response | None, str]:
         req_headers = _inject_trace_headers(headers)
+        req_headers = _strip_sensitive_headers_for_cross_origin(
+            req_headers, original_url=url, target_url=target_url
+        )
+        req_cookies = _cookies_for_hop(cookies, original_url=url, target_url=target_url)
         # Parity with simple fetch: drop 'zstd' from Accept-Encoding for httpx
         with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
             req_headers = _sanitize_accept_encoding_for_backend(req_headers, "httpx")
@@ -2833,7 +2930,7 @@ def _fetch_httpx_response(
                 method=method_upper,
                 url=target_url,
                 headers=req_headers,
-                cookies=cookies,
+                cookies=req_cookies,
                 params=params,
                 json=json,
                 data=data,
@@ -2891,6 +2988,9 @@ def _fetch_httpx_response(
                                 _head_get_range_tried = True
                                 try:
                                     req_headers = _inject_trace_headers(headers)
+                                    req_headers = _strip_sensitive_headers_for_cross_origin(
+                                        req_headers, original_url=url, target_url=cur_url
+                                    )
                                     with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
                                         req_headers = _sanitize_accept_encoding_for_backend(req_headers, "httpx")
                                     req_headers.setdefault("Range", "bytes=0-0")
@@ -2904,7 +3004,7 @@ def _fetch_httpx_response(
                                         method="GET",
                                         url=cur_url,
                                         headers=req_headers,
-                                        cookies=cookies,
+                                        cookies=_cookies_for_hop(cookies, original_url=url, target_url=cur_url),
                                         params=params,
                                         json=json,
                                         data=data,

--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -1198,6 +1198,30 @@ def _cookies_for_hop(
     return cookies
 
 
+def _clear_client_cookie_jar(client: Any) -> None:
+    """Best-effort clear of a client/session cookie jar at a cross-origin redirect boundary.
+
+    Ambient jar state (cookies accumulated on the httpx client / aiohttp
+    session) would otherwise ride along to the redirect target; mirrors the
+    boundary behavior of the simple-fetch redirect loop's cookie clearing.
+
+    Args:
+        client: httpx ``Client``/``AsyncClient`` or aiohttp ``ClientSession``
+            (any object exposing ``cookies``/``cookie_jar``/``jar``).
+    """
+    for attr_name in ("cookies", "cookie_jar", "jar"):
+        store = getattr(client, attr_name, None)
+        if store is None:
+            continue
+        clear = getattr(store, "clear", None)
+        if callable(clear):
+            with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
+                clear()
+            continue
+        if isinstance(store, dict):
+            store.clear()
+
+
 def _get_response_url(resp: Any, fallback: str) -> str:
     try:
         req = getattr(resp, "request", None)
@@ -2402,6 +2426,8 @@ async def _afetch_httpx(
                                     last_exc = NetworkError("Too many redirects")
                                     break
                                 else:
+                                    if _is_cross_origin(url, next_url):
+                                        _clear_client_cookie_jar(ac)
                                     cur_url = next_url
                                     continue
                         else:
@@ -2680,6 +2706,8 @@ async def _afetch_aiohttp(
                     if redirects > DEFAULT_MAX_REDIRECTS:
                         last_exc = NetworkError("Too many redirects")
                         break
+                    if _is_cross_origin(url, next_url):
+                        _clear_client_cookie_jar(session)
                     cur_url = next_url
                     continue
 
@@ -3066,6 +3094,8 @@ def _fetch_httpx_response(
                         redirects += 1
                         if redirects > DEFAULT_MAX_REDIRECTS:
                             raise NetworkError("Too many redirects")  # noqa: TRY003
+                        if _is_cross_origin(url, next_url):
+                            _clear_client_cookie_jar(sc)
                         cur_url = next_url
                         continue
                     if resp.status_code < 400:
@@ -4026,7 +4056,9 @@ async def _astream_sse_httpx(
                         client=ac,
                         method=method.upper(),
                         url=cur_url,
-                        headers=_inject_trace_headers(hdrs),
+                        headers=_strip_sensitive_headers_for_cross_origin(
+                            _inject_trace_headers(hdrs), original_url=url, target_url=cur_url
+                        ),
                         params=params,
                         json=json,
                         data=data,
@@ -4048,6 +4080,8 @@ async def _astream_sse_httpx(
                                 except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
                                     raise NetworkError("Invalid redirect Location header")  # noqa: B904, TRY003
                             redirects += 1
+                            if _is_cross_origin(url, next_url):
+                                _clear_client_cookie_jar(ac)
                             cur_url = next_url
                             continue  # loop to re-validate egress and attempt again
                         # Raise for non-OK statuses pre-body if not retriable
@@ -4162,7 +4196,9 @@ async def _astream_sse_aiohttp(
                     session=session,
                     method=method.upper(),
                     url=cur_url,
-                    headers=_inject_trace_headers(hdrs),
+                    headers=_strip_sensitive_headers_for_cross_origin(
+                        _inject_trace_headers(hdrs), original_url=url, target_url=cur_url
+                    ),
                     params=params,
                     json=json,
                     data=data,
@@ -4182,6 +4218,8 @@ async def _astream_sse_aiohttp(
                         if not next_url:
                             raise NetworkError("Invalid redirect Location header")  # noqa: TRY003
                         redirects += 1
+                        if _is_cross_origin(url, next_url):
+                            _clear_client_cookie_jar(session)
                         cur_url = next_url
                         continue
 

--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -1174,8 +1174,14 @@ def _strip_sensitive_headers_for_cross_origin(
     """
     if not headers or not _is_cross_origin(original_url, target_url):
         return headers
-    kept = {k: v for k, v in headers.items() if k.lower() not in SENSITIVE_REDIRECT_HEADERS}
-    dropped = sorted(k for k in headers if k.lower() in SENSITIVE_REDIRECT_HEADERS)
+    kept: dict[str, str] = {}
+    dropped: list[str] = []
+    for key, value in headers.items():
+        if key.lower() in SENSITIVE_REDIRECT_HEADERS:
+            dropped.append(key)
+        else:
+            kept[key] = value
+    dropped.sort()
     if dropped:
         logger.bind(target_host=_parse_host_from_url(target_url)).debug(
             "Stripped sensitive headers on cross-origin redirect: {}", ", ".join(dropped)

--- a/tldw_Server_API/tests/http_client/test_redirect_header_hardening.py
+++ b/tldw_Server_API/tests/http_client/test_redirect_header_hardening.py
@@ -1,17 +1,22 @@
 """Cross-origin redirect credential hardening for the central HTTP client.
 
 Regression coverage for the PR #2604 review finding (qodo "Option B"): the
-manual redirect loops in fetch/afetch reused the caller's headers across
-hops, so a cross-origin redirect would resend Authorization / x-api-key /
-cookies to the redirect target. The client now strips sensitive headers and
-drops cookies whenever a hop leaves the original origin.
+manual redirect loops in fetch/afetch (and the SSE streaming loops) reused
+the caller's headers across hops, so a cross-origin redirect would resend
+Authorization / x-api-key / cookies to the redirect target. The client now
+strips sensitive headers, drops explicit cookies, and clears ambient client
+cookie-jar state whenever a hop leaves the original origin.
 """
 
+from typing import Callable
+
+import httpx
 import pytest
 from hypothesis import given, settings as hyp_settings, strategies as st
 
 from tldw_Server_API.app.core.http_client import (
     SENSITIVE_REDIRECT_HEADERS,
+    _clear_client_cookie_jar,
     _cookies_for_hop,
     _is_cross_origin,
     _strip_sensitive_headers_for_cross_origin,
@@ -19,18 +24,6 @@ from tldw_Server_API.app.core.http_client import (
 )
 
 pytestmark = pytest.mark.unit
-
-
-def _has_httpx() -> bool:
-    try:
-        import httpx  # noqa: F401
-
-        return True
-    except Exception:
-        return False
-
-
-requires_httpx = pytest.mark.skipif(not _has_httpx(), reason="httpx not installed")
 
 # TEST-NET literal IPs: public-range, pass egress checks without DNS, and
 # MockTransport intercepts before any real socket is opened.
@@ -46,7 +39,10 @@ SECRET_HEADERS = {
 
 
 class TestOriginHelpers:
+    """Unit coverage for the origin parsing/comparison helpers."""
+
     def test_default_ports_normalized(self) -> None:
+        """Explicit default ports compare equal to implicit ones."""
         assert _url_origin("http://a.example") == ("http", "a.example", 80)
         assert _url_origin("http://a.example:80/x") == ("http", "a.example", 80)
         assert _url_origin("https://a.example") == ("https", "a.example", 443)
@@ -54,21 +50,28 @@ class TestOriginHelpers:
         assert not _is_cross_origin("https://a.example/x", "https://a.example:443/y")
 
     def test_scheme_host_port_changes_are_cross_origin(self) -> None:
+        """Any change to scheme, host (incl. subdomain), or port is cross-origin."""
         assert _is_cross_origin("https://a.example", "http://a.example")
         assert _is_cross_origin("https://a.example", "https://b.example")
         assert _is_cross_origin("https://a.example", "https://a.example:8443")
         assert _is_cross_origin("https://a.example", "https://sub.a.example")
 
     def test_host_comparison_is_case_insensitive(self) -> None:
+        """Host names are compared lowercased."""
         assert not _is_cross_origin("https://A.Example/x", "https://a.example/y")
 
     def test_unparseable_urls_fail_closed(self) -> None:
+        """Junk URLs are treated as cross-origin, never same-origin."""
         assert _is_cross_origin("https://a.example", "not a url")
         assert _is_cross_origin("", "https://a.example")
 
     def test_invalid_ports_and_malformed_hosts_fail_closed(self) -> None:
-        # urlparse raises ValueError lazily when .port is accessed on these;
-        # _url_origin must swallow that and report None -> cross-origin.
+        """Malformed ports / IPv6 brackets must not defeat the stripping.
+
+        urlparse raises ValueError lazily when ``.port`` is accessed on
+        these; ``_url_origin`` must swallow that and report ``None`` →
+        cross-origin.
+        """
         assert _url_origin("http://a.example:invalid-port/") is None
         assert _is_cross_origin("http://a.example:invalid-port/", "http://a.example/")
         assert _is_cross_origin("http://a.example/", "http://a.example:99999/")
@@ -92,19 +95,24 @@ class TestOriginHelpers:
     def test_url_is_never_cross_origin_with_itself(
         self, scheme: str, host: str, port: int | None, path: str
     ) -> None:
+        """Property: a well-formed URL is always same-origin with itself."""
         netloc = f"{host}:{port}" if port is not None else host
         url = f"{scheme}://{netloc}{path}"
         assert not _is_cross_origin(url, url)
 
 
 class TestHeaderStripping:
+    """Unit coverage for header/cookie stripping decisions."""
+
     def test_same_origin_keeps_everything(self) -> None:
+        """Same-origin hops pass headers through untouched."""
         result = _strip_sensitive_headers_for_cross_origin(
             dict(SECRET_HEADERS), original_url=f"{ORIGIN_A}/a", target_url=f"{ORIGIN_A}/b"
         )
         assert result == SECRET_HEADERS
 
     def test_cross_origin_strips_sensitive_case_insensitively(self) -> None:
+        """Header-name matching ignores case."""
         headers = {"AUTHORIZATION": "x", "x-API-key": "y", "cookie": "z", "X-Custom": "keep"}
         result = _strip_sensitive_headers_for_cross_origin(
             headers, original_url=ORIGIN_A, target_url=ORIGIN_B
@@ -112,6 +120,7 @@ class TestHeaderStripping:
         assert result == {"X-Custom": "keep"}
 
     def test_every_documented_sensitive_header_is_stripped(self) -> None:
+        """The full SENSITIVE_REDIRECT_HEADERS set is enforced."""
         headers = {name: "secret" for name in SENSITIVE_REDIRECT_HEADERS}
         headers["x-trace"] = "keep"
         result = _strip_sensitive_headers_for_cross_origin(
@@ -120,6 +129,7 @@ class TestHeaderStripping:
         assert result == {"x-trace": "keep"}
 
     def test_none_headers_pass_through(self) -> None:
+        """``None`` headers stay ``None``."""
         assert (
             _strip_sensitive_headers_for_cross_origin(
                 None, original_url=ORIGIN_A, target_url=ORIGIN_B
@@ -128,6 +138,7 @@ class TestHeaderStripping:
         )
 
     def test_cookies_dropped_only_cross_origin(self) -> None:
+        """Explicit cookies survive same-origin hops and die cross-origin."""
         cookies = {"session": "abc"}
         assert (
             _cookies_for_hop(cookies, original_url=ORIGIN_A, target_url=f"{ORIGIN_A}/x")
@@ -136,14 +147,26 @@ class TestHeaderStripping:
         assert _cookies_for_hop(cookies, original_url=ORIGIN_A, target_url=ORIGIN_B) is None
         assert _cookies_for_hop(None, original_url=ORIGIN_A, target_url=ORIGIN_B) is None
 
+    def test_clear_client_cookie_jar_handles_httpx_clients(self) -> None:
+        """The jar-clear helper empties an httpx client's cookie store."""
+        client = httpx.Client()
+        try:
+            client.cookies.set("session", "abc", domain="93.184.216.34")
+            assert len(client.cookies) == 1
+            _clear_client_cookie_jar(client)
+            assert len(client.cookies) == 0
+        finally:
+            client.close()
 
-@requires_httpx
+
 class TestRedirectFlows:
     """End-to-end through the real redirect loops via httpx.MockTransport."""
 
     @staticmethod
-    def _handler(seen: dict[str, dict[str, str]]):
-        import httpx
+    def _handler(
+        seen: dict[str, dict[str, str]],
+    ) -> Callable[[httpx.Request], httpx.Response]:
+        """Build a MockTransport handler recording per-host request headers."""
 
         def handler(request: httpx.Request) -> httpx.Response:
             host = request.url.host
@@ -161,10 +184,8 @@ class TestRedirectFlows:
 
         return handler
 
-    @pytest.mark.asyncio
     async def test_afetch_strips_credentials_on_cross_origin_redirect(self) -> None:
-        import httpx
-
+        """The async loop must not resend credentials to a different origin."""
         from tldw_Server_API.app.core.http_client import afetch, create_async_client
 
         seen: dict[str, dict[str, str]] = {}
@@ -191,10 +212,8 @@ class TestRedirectFlows:
         # non-sensitive headers still follow the redirect
         assert target_headers.get("x-custom") == "keep-me"
 
-    @pytest.mark.asyncio
     async def test_afetch_keeps_credentials_on_same_origin_redirect(self) -> None:
-        import httpx
-
+        """Same-origin redirects keep the caller's credentials intact."""
         from tldw_Server_API.app.core.http_client import afetch, create_async_client
 
         seen: dict[str, dict[str, str]] = {}
@@ -226,8 +245,7 @@ class TestRedirectFlows:
         assert seen["/landed"].get("x-api-key") == "sk-secret"
 
     def test_sync_fetch_strips_credentials_on_cross_origin_redirect(self) -> None:
-        import httpx
-
+        """The sync loop applies the same stripping as the async loop."""
         from tldw_Server_API.app.core.http_client import create_client, fetch
 
         seen: dict[str, dict[str, str]] = {}
@@ -246,4 +264,65 @@ class TestRedirectFlows:
         target_headers = seen["203.0.113.7"]
         for name in ("authorization", "x-api-key", "cookie"):
             assert name not in target_headers, f"{name} leaked to redirect target"
+        assert target_headers.get("x-custom") == "keep-me"
+
+    async def test_afetch_clears_ambient_cookie_jar_on_cross_origin_redirect(self) -> None:
+        """Cookies accumulated in the client's jar are wiped at the origin boundary."""
+        from tldw_Server_API.app.core.http_client import afetch, create_async_client
+
+        seen: dict[str, dict[str, str]] = {}
+        client = create_async_client(transport=httpx.MockTransport(self._handler(seen)))
+        try:
+            client.cookies.set("ambient", "jar-secret", domain="93.184.216.34")
+            assert len(client.cookies) == 1
+            resp = await afetch(
+                method="GET",
+                url=f"{ORIGIN_A}/cross-origin",
+                client=client,
+                headers={"X-Custom": "keep-me"},
+            )
+            assert resp.status_code == 200
+            assert len(client.cookies) == 0, "cookie jar not cleared at origin boundary"
+        finally:
+            await client.aclose()
+        assert "cookie" not in seen["203.0.113.7"]
+
+    async def test_sse_stream_strips_credentials_on_cross_origin_redirect(self) -> None:
+        """The SSE streaming redirect loop applies the same stripping."""
+        from tldw_Server_API.app.core.http_client import _astream_sse_httpx, create_async_client
+
+        seen: dict[str, dict[str, str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            host = request.url.host
+            seen[host] = dict(request.headers)
+            if host == "93.184.216.34":
+                return httpx.Response(
+                    302, request=request, headers={"Location": f"{ORIGIN_B}/stream"}
+                )
+            return httpx.Response(
+                200,
+                request=request,
+                headers={"Content-Type": "text/event-stream"},
+                text="data: hello\n\n",
+            )
+
+        client = create_async_client(transport=httpx.MockTransport(handler))
+        try:
+            events = [
+                event
+                async for event in _astream_sse_httpx(
+                    url=f"{ORIGIN_A}/sse",
+                    client=client,
+                    headers=dict(SECRET_HEADERS),
+                )
+            ]
+        finally:
+            await client.aclose()
+
+        assert events, "expected at least one SSE event through the redirect"
+        assert seen["93.184.216.34"].get("authorization") == "Bearer secret-token"
+        target_headers = seen["203.0.113.7"]
+        for name in ("authorization", "x-api-key", "cookie"):
+            assert name not in target_headers, f"{name} leaked to SSE redirect target"
         assert target_headers.get("x-custom") == "keep-me"

--- a/tldw_Server_API/tests/http_client/test_redirect_header_hardening.py
+++ b/tldw_Server_API/tests/http_client/test_redirect_header_hardening.py
@@ -1,0 +1,233 @@
+"""Cross-origin redirect credential hardening for the central HTTP client.
+
+Regression coverage for the PR #2604 review finding (qodo "Option B"): the
+manual redirect loops in fetch/afetch reused the caller's headers across
+hops, so a cross-origin redirect would resend Authorization / x-api-key /
+cookies to the redirect target. The client now strips sensitive headers and
+drops cookies whenever a hop leaves the original origin.
+"""
+
+import pytest
+from hypothesis import given, settings as hyp_settings, strategies as st
+
+from tldw_Server_API.app.core.http_client import (
+    SENSITIVE_REDIRECT_HEADERS,
+    _cookies_for_hop,
+    _is_cross_origin,
+    _strip_sensitive_headers_for_cross_origin,
+    _url_origin,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _has_httpx() -> bool:
+    try:
+        import httpx  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+requires_httpx = pytest.mark.skipif(not _has_httpx(), reason="httpx not installed")
+
+# TEST-NET literal IPs: public-range, pass egress checks without DNS, and
+# MockTransport intercepts before any real socket is opened.
+ORIGIN_A = "http://93.184.216.34"
+ORIGIN_B = "http://203.0.113.7"
+
+SECRET_HEADERS = {
+    "Authorization": "Bearer secret-token",
+    "X-Api-Key": "sk-secret",
+    "Cookie": "session=abc",
+    "X-Custom": "keep-me",
+}
+
+
+class TestOriginHelpers:
+    def test_default_ports_normalized(self) -> None:
+        assert _url_origin("http://a.example") == ("http", "a.example", 80)
+        assert _url_origin("http://a.example:80/x") == ("http", "a.example", 80)
+        assert _url_origin("https://a.example") == ("https", "a.example", 443)
+        assert not _is_cross_origin("http://a.example", "http://a.example:80/path")
+        assert not _is_cross_origin("https://a.example/x", "https://a.example:443/y")
+
+    def test_scheme_host_port_changes_are_cross_origin(self) -> None:
+        assert _is_cross_origin("https://a.example", "http://a.example")
+        assert _is_cross_origin("https://a.example", "https://b.example")
+        assert _is_cross_origin("https://a.example", "https://a.example:8443")
+        assert _is_cross_origin("https://a.example", "https://sub.a.example")
+
+    def test_host_comparison_is_case_insensitive(self) -> None:
+        assert not _is_cross_origin("https://A.Example/x", "https://a.example/y")
+
+    def test_unparseable_urls_fail_closed(self) -> None:
+        assert _is_cross_origin("https://a.example", "not a url")
+        assert _is_cross_origin("", "https://a.example")
+
+    @hyp_settings(max_examples=50, deadline=None)
+    @given(
+        scheme=st.sampled_from(["http", "https"]),
+        host=st.from_regex(r"[a-z][a-z0-9-]{0,10}\.example", fullmatch=True),
+        port=st.one_of(st.none(), st.integers(min_value=1, max_value=65535)),
+        path=st.from_regex(r"/[a-z0-9/]{0,12}", fullmatch=True),
+    )
+    def test_url_is_never_cross_origin_with_itself(
+        self, scheme: str, host: str, port: int | None, path: str
+    ) -> None:
+        netloc = f"{host}:{port}" if port is not None else host
+        url = f"{scheme}://{netloc}{path}"
+        assert not _is_cross_origin(url, url)
+
+
+class TestHeaderStripping:
+    def test_same_origin_keeps_everything(self) -> None:
+        result = _strip_sensitive_headers_for_cross_origin(
+            dict(SECRET_HEADERS), original_url=f"{ORIGIN_A}/a", target_url=f"{ORIGIN_A}/b"
+        )
+        assert result == SECRET_HEADERS
+
+    def test_cross_origin_strips_sensitive_case_insensitively(self) -> None:
+        headers = {"AUTHORIZATION": "x", "x-API-key": "y", "cookie": "z", "X-Custom": "keep"}
+        result = _strip_sensitive_headers_for_cross_origin(
+            headers, original_url=ORIGIN_A, target_url=ORIGIN_B
+        )
+        assert result == {"X-Custom": "keep"}
+
+    def test_every_documented_sensitive_header_is_stripped(self) -> None:
+        headers = {name: "secret" for name in SENSITIVE_REDIRECT_HEADERS}
+        headers["x-trace"] = "keep"
+        result = _strip_sensitive_headers_for_cross_origin(
+            headers, original_url=ORIGIN_A, target_url=ORIGIN_B
+        )
+        assert result == {"x-trace": "keep"}
+
+    def test_none_headers_pass_through(self) -> None:
+        assert (
+            _strip_sensitive_headers_for_cross_origin(
+                None, original_url=ORIGIN_A, target_url=ORIGIN_B
+            )
+            is None
+        )
+
+    def test_cookies_dropped_only_cross_origin(self) -> None:
+        cookies = {"session": "abc"}
+        assert (
+            _cookies_for_hop(cookies, original_url=ORIGIN_A, target_url=f"{ORIGIN_A}/x")
+            == cookies
+        )
+        assert _cookies_for_hop(cookies, original_url=ORIGIN_A, target_url=ORIGIN_B) is None
+        assert _cookies_for_hop(None, original_url=ORIGIN_A, target_url=ORIGIN_B) is None
+
+
+@requires_httpx
+class TestRedirectFlows:
+    """End-to-end through the real redirect loops via httpx.MockTransport."""
+
+    @staticmethod
+    def _handler(seen: dict[str, dict[str, str]]):
+        import httpx
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            host = request.url.host
+            seen[host] = dict(request.headers)
+            if host == "93.184.216.34":
+                if request.url.path == "/same-origin":
+                    return httpx.Response(
+                        302, request=request, headers={"Location": f"{ORIGIN_A}/landed"}
+                    )
+                if request.url.path == "/cross-origin":
+                    return httpx.Response(
+                        302, request=request, headers={"Location": f"{ORIGIN_B}/landed"}
+                    )
+            return httpx.Response(200, request=request, json={"host": host})
+
+        return handler
+
+    @pytest.mark.asyncio
+    async def test_afetch_strips_credentials_on_cross_origin_redirect(self) -> None:
+        import httpx
+
+        from tldw_Server_API.app.core.http_client import afetch, create_async_client
+
+        seen: dict[str, dict[str, str]] = {}
+        client = create_async_client(transport=httpx.MockTransport(self._handler(seen)))
+        try:
+            resp = await afetch(
+                method="GET",
+                url=f"{ORIGIN_A}/cross-origin",
+                client=client,
+                headers=dict(SECRET_HEADERS),
+            )
+            assert resp.status_code == 200
+        finally:
+            await client.aclose()
+
+        origin_headers = seen["93.184.216.34"]
+        target_headers = seen["203.0.113.7"]
+        # original host got the credentials
+        assert origin_headers.get("authorization") == "Bearer secret-token"
+        assert origin_headers.get("x-api-key") == "sk-secret"
+        # redirect target must not
+        for name in ("authorization", "x-api-key", "cookie"):
+            assert name not in target_headers, f"{name} leaked to redirect target"
+        # non-sensitive headers still follow the redirect
+        assert target_headers.get("x-custom") == "keep-me"
+
+    @pytest.mark.asyncio
+    async def test_afetch_keeps_credentials_on_same_origin_redirect(self) -> None:
+        import httpx
+
+        from tldw_Server_API.app.core.http_client import afetch, create_async_client
+
+        seen: dict[str, dict[str, str]] = {}
+        calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(str(request.url))
+            seen[request.url.path] = dict(request.headers)
+            if request.url.path == "/same-origin":
+                return httpx.Response(
+                    302, request=request, headers={"Location": f"{ORIGIN_A}/landed"}
+                )
+            return httpx.Response(200, request=request, json={"ok": True})
+
+        client = create_async_client(transport=httpx.MockTransport(handler))
+        try:
+            resp = await afetch(
+                method="GET",
+                url=f"{ORIGIN_A}/same-origin",
+                client=client,
+                headers=dict(SECRET_HEADERS),
+            )
+            assert resp.status_code == 200
+        finally:
+            await client.aclose()
+
+        assert len(calls) == 2
+        assert seen["/landed"].get("authorization") == "Bearer secret-token"
+        assert seen["/landed"].get("x-api-key") == "sk-secret"
+
+    def test_sync_fetch_strips_credentials_on_cross_origin_redirect(self) -> None:
+        import httpx
+
+        from tldw_Server_API.app.core.http_client import create_client, fetch
+
+        seen: dict[str, dict[str, str]] = {}
+        client = create_client(transport=httpx.MockTransport(self._handler(seen)))
+        try:
+            resp = fetch(
+                method="GET",
+                url=f"{ORIGIN_A}/cross-origin",
+                client=client,
+                headers=dict(SECRET_HEADERS),
+            )
+            assert resp.status_code == 200
+        finally:
+            client.close()
+
+        target_headers = seen["203.0.113.7"]
+        for name in ("authorization", "x-api-key", "cookie"):
+            assert name not in target_headers, f"{name} leaked to redirect target"
+        assert target_headers.get("x-custom") == "keep-me"

--- a/tldw_Server_API/tests/http_client/test_redirect_header_hardening.py
+++ b/tldw_Server_API/tests/http_client/test_redirect_header_hardening.py
@@ -66,6 +66,22 @@ class TestOriginHelpers:
         assert _is_cross_origin("https://a.example", "not a url")
         assert _is_cross_origin("", "https://a.example")
 
+    def test_invalid_ports_and_malformed_hosts_fail_closed(self) -> None:
+        # urlparse raises ValueError lazily when .port is accessed on these;
+        # _url_origin must swallow that and report None -> cross-origin.
+        assert _url_origin("http://a.example:invalid-port/") is None
+        assert _is_cross_origin("http://a.example:invalid-port/", "http://a.example/")
+        assert _is_cross_origin("http://a.example/", "http://a.example:99999/")
+        # malformed IPv6 bracket
+        assert _is_cross_origin("http://a.example/", "http://[::1/x")
+        # sensitive headers must be stripped for such targets, not sent
+        result = _strip_sensitive_headers_for_cross_origin(
+            dict(SECRET_HEADERS),
+            original_url="http://a.example/",
+            target_url="http://a.example:invalid-port/",
+        )
+        assert result == {"X-Custom": "keep-me"}
+
     @hyp_settings(max_examples=50, deadline=None)
     @given(
         scheme=st.sampled_from(["http", "https"]),


### PR DESCRIPTION
## Summary

Central redirect-credential hardening — the tracked follow-up from PR #2604's review (qodo "Option B") and the `Docs/superpowers/plans/2026-07-04-test-suite-improvement-implementation-plan.md` Tracked Follow-Ups section.

**Problem:** the manual redirect loops in `fetch`/`afetch` (httpx sync/async and aiohttp backends) rebuilt each hop's request from the caller's original `headers`/`cookies`, so a cross-origin redirect resent `Authorization`, `x-api-key`, cookies, etc. to the redirect target.

**Fix:** every per-hop request (including the HEAD→GET Range fallbacks) now strips `SENSITIVE_REDIRECT_HEADERS` and drops cookies when the hop's origin (scheme/host/port, default ports normalized) differs from the original request's origin. Unparseable URLs fail closed. Same-origin hops are byte-for-byte unchanged. Stripped header names are logged at debug with the target host bound.

The per-caller mitigation from PR #2634 (`tokenizer_resolver` `allow_redirects=False`) stays — provider tokenizer APIs never legitimately redirect.

## Verification (local — CI currently broken per maintainer)
- New `tests/http_client/test_redirect_header_hardening.py`: 13 tests — origin-helper units + hypothesis self-consistency property + `httpx.MockTransport` end-to-end flows through the real sync and async redirect loops (cross-origin strips credentials and keeps non-sensitive headers; same-origin keeps credentials)
- Full `tests/http_client/`: **96/96 pass**
- Redirect-consuming callers (`test_research_adapters.py`, `test_tokenizer_resolver_unit.py`): **117/117 pass**
- Shard-coverage guard green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened redirect handling in the HTTP client to prevent credential leaks. On cross-origin hops we now strip credential headers, drop cookies, clear cookie jars, and do the same for SSE streaming redirects; same-origin is unchanged and invalid ports or malformed IPv6 targets fail closed.

- **Bug Fixes**
  - Strip `Authorization`, `Proxy-Authorization`, `Cookie`, `X-API-Key`, `API-Key`, `X-Auth-Token` on cross-origin hops (case-insensitive).
  - Drop explicit cookies and clear client/session cookie jars at cross-origin boundaries; keep non-sensitive headers.
  - Apply to all redirect loops (including SSE and HEAD→GET Range fallbacks) across `httpx` (sync/async) and `aiohttp`.
  - Treat unparseable targets as cross-origin (fail closed); log stripped header names at debug with the target host.

<sup>Written for commit b4fc13d4fb3803e3366d76f45faed09effbb81d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

