### PR TITLE
Harden audio briefings and workspace artifact validation

### DIFF
--- a/backlog/tasks/task-12147 - Harden-audio-briefing-generation-before-Research-Workspace-reuse.md
+++ b/backlog/tasks/task-12147 - Harden-audio-briefing-generation-before-Research-Workspace-reuse.md
@@ -1,0 +1,49 @@
+---
+id: TASK-12147
+title: Harden audio briefing generation before Research Workspace reuse
+status: Done
+priority: High
+modified_files:
+- tldw_Server_API/app/core/Workflows/adapters/audio/multi_voice_tts.py
+- tldw_Server_API/app/core/Workflows/adapters/audio/_config.py
+- tldw_Server_API/app/core/Watchlists/audio_briefing_workflow.py
+- tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py
+- tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py
+references:
+- TASK-12148
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the existing audio briefing/TTS workflow so Research Workspace can reuse it without reporting partial assets as successful, while preserving explicit TTS provider selection for future briefing flows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 multi_voice_tts fails visibly when final audio concatenation fails instead of promoting a single segment as final output
+- [ ] #2 explicit TTS provider selection is propagated through Watchlists audio briefing inputs into the internal TTS generation call
+- [ ] #3 tests cover concat failure behavior and provider propagation without external HTTP calls
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented shared audio briefing hardening before Research Workspace reuse. multi_voice_tts now fails the workflow step on final concat failure instead of promoting a single section as the final artifact, allowing the existing single-voice fallback route to run. Watchlists audio briefing now preserves the resolved TTS provider through workflow inputs and into both multi-voice and fallback TTS steps. Verification: targeted red tests failed before implementation; focused regression tests passed; `python -m pytest tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py -q` passed 82 tests; `python -m pytest tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py::TestMultiVoiceTTSAdapter tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py -q` passed 44 tests; Bandit on touched implementation files reported zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12148 - Apply-shared-validation-gate-across-Research-Workspace-generated-artifact-pipelines.md
+++ b/backlog/tasks/task-12148 - Apply-shared-validation-gate-across-Research-Workspace-generated-artifact-pipelines.md
@@ -1,0 +1,44 @@
+---
+id: TASK-12148
+title: Apply shared validation gate across Research Workspace generated artifact pipelines
+status: To Do
+priority: High
+references:
+- TASK-12147
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add one reusable Research Workspace generated-content validation gate for quizzes, flashcards, audio summaries, adaptive data tables, slides, and mindmaps. The gate should reuse the existing claims/source-pack validation path and asset validators rather than copying bespoke checks into each pipeline.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 generated content pipelines can opt into the same source-pack claims validation contract
+- [ ] #2 artifact validators reject placeholder or invalid assets using shared checks instead of per-pipeline ad hoc strings
+- [ ] #3 user-facing metadata records whether validation ran, which validator/model was used, and any unresolved warnings
+- [ ] #4 tests cover at least one happy path and one invalid/placeholder asset for each generated artifact family
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12148 - Apply-shared-validation-gate-across-Research-Workspace-generated-artifact-pipelines.md
+++ b/backlog/tasks/task-12148 - Apply-shared-validation-gate-across-Research-Workspace-generated-artifact-pipelines.md
@@ -1,10 +1,17 @@
 ---
 id: TASK-12148
-title: Apply shared validation gate across Research Workspace generated artifact pipelines
-status: To Do
-priority: High
+title: >-
+  Apply shared validation gate across Research Workspace generated artifact
+  pipelines
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-05 00:54'
+labels: []
+dependencies: []
 references:
-- TASK-12147
+  - TASK-12147
+priority: high
 ---
 
 ## Description
@@ -15,30 +22,42 @@ Add one reusable Research Workspace generated-content validation gate for quizze
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 generated content pipelines can opt into the same source-pack claims validation contract
-- [ ] #2 artifact validators reject placeholder or invalid assets using shared checks instead of per-pipeline ad hoc strings
-- [ ] #3 user-facing metadata records whether validation ran, which validator/model was used, and any unresolved warnings
-- [ ] #4 tests cover at least one happy path and one invalid/placeholder asset for each generated artifact family
+- [x] #1 generated content pipelines can opt into the same source-pack claims validation contract
+- [x] #2 artifact validators reject placeholder or invalid assets using shared checks instead of per-pipeline ad hoc strings
+- [x] #3 user-facing metadata records whether validation ran, which validator/model was used, and any unresolved warnings
+- [x] #4 tests cover at least one happy path and one invalid/placeholder asset for each generated artifact family
 <!-- AC:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
+- Added shared workspace artifact export validator at tldw_Server_API/app/core/Workspaces/artifact_validation.py.
+- Export metadata now includes artifact_validation with gate status, validator id, claims-required flag, claims validator/model, unsupported claim count, and warnings.
+- Pipelines opt in by setting producer_metadata.claims_validation_required (or compatible aliases) and storing a claims report under review/version/producer metadata.
+- Placeholder checks cover quiz, flashcards, audio_summary, adaptive/data tables, slides/presentations, and mindmaps at the shared export boundary.
+- Verification: pytest tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q => 110 passed; Bandit touched Workspaces implementation => 0 findings.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented a shared Workspace artifact export validation gate for generated content families. The gate rejects placeholder/invalid generated artifacts, enforces opt-in claims-validation metadata when requested, rejects unresolved unsupported claims, and records artifact_validation metadata in exports. Covered quizzes, flashcards, audio summaries, adaptive/data tables, slides/presentations, and mindmaps with unit/property-style tests plus an API export regression. Verification passed: 110 Workspaces tests and Bandit on touched Workspaces implementation with 0 findings. No known blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12151 - Address-PR-2640-review-feedback.md
+++ b/backlog/tasks/task-12151 - Address-PR-2640-review-feedback.md
@@ -1,0 +1,43 @@
+---
+id: TASK-12151
+title: Address PR 2640 review feedback
+status: Done
+assignee: []
+created_date: '2026-07-05 01:03'
+updated_date: '2026-07-05 01:05'
+labels: []
+dependencies: []
+references:
+  - PR-2640
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix actionable inline review feedback on PR #2640 after rebasing on latest dev: numeric metadata booleans, warning-list copy/flattening, and self-contained accepted review-state validation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Addressed all three Gemini inline review comments on PR #2640.
+- Added regression coverage for numeric claims-validation flags, warning sequence copying/flattening, and self-contained accepted review-state validation.
+- Verification: focused review tests red before fix and green after fix; full Workspace artifact/API slice passed with 113 tests; audio adapter/watchlist slice passed with 112 tests; Bandit on touched PR implementation files reported 0 findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2640 on latest origin/dev and fixed all actionable inline review comments. The shared artifact validator now treats numeric metadata flags correctly, copies/flattens warning sequences, and rejects non-accepted artifacts directly. Verified with Workspaces tests, audio tests, and Bandit. No known blockers.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-12152 - Address-PR-2640-Qodo-review-feedback.md
+++ b/backlog/tasks/task-12152 - Address-PR-2640-Qodo-review-feedback.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12152
+title: Address PR 2640 Qodo review feedback
+status: Done
+assignee: []
+created_date: '2026-07-05 01:11'
+updated_date: '2026-07-05 01:16'
+labels: []
+dependencies: []
+references:
+  - PR-2640
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix Qodo review feedback on PR #2640: use project-specific adapter exception for multi-voice concat failure, allow non-Latin generated artifact content, and preserve explicit claims-validation statuses in export metadata.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented review fixes:
+- multi-voice concat failure now raises AdapterError("concat_failed") instead of RuntimeError.
+- generated artifact placeholder/empty checks treat non-Latin content as real content.
+- claims validation metadata preserves explicit statuses such as skipped.
+
+Verification:
+- python -m pytest tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py::TestMultiVoiceTTSAdapter::test_multi_voice_tts_concat_failure_returns_error_without_final_artifact tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py::test_non_latin_generated_artifact_content_is_not_treated_as_empty tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py::test_claims_validation_metadata_preserves_explicit_non_pass_status -q -> 3 passed.
+- python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q -> 115 passed.
+- python -m pytest tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py -q -> 112 passed.
+- python -m bandit -r touched files -f json -o /tmp/bandit_audio_workspace_pr_qodo.json -> 0 findings.
+- git diff --check -> clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all Qodo review comments found on PR #2640 by using AdapterError for concat failures, accepting real non-Latin generated content, and preserving explicit claims validation statuses. Added regression tests for each issue and verified focused, workspace, audio, Bandit, and diff-check gates.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-12153 - Address-PR-2640-CodeRabbit-outside-diff-feedback.md
+++ b/backlog/tasks/task-12153 - Address-PR-2640-CodeRabbit-outside-diff-feedback.md
@@ -1,0 +1,54 @@
+---
+id: TASK-12153
+title: Address PR 2640 CodeRabbit outside-diff feedback
+status: Done
+assignee: []
+created_date: '2026-07-05 01:25'
+updated_date: '2026-07-05 01:33'
+labels: []
+dependencies: []
+references:
+  - PR-2640
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix CodeRabbit outside-diff review feedback on PR #2640: document multi-voice provider config keys, remove duplicate fallback_provider config field, clean up temp files on concat failure, and raise adapter exceptions for missing/no generated sections so workflow failure handling runs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented CodeRabbit outside-diff review fixes:
+- Documented multi_voice_tts provider config keys in the adapter docstring.
+- Removed the duplicate MultiVoiceTTSConfig.fallback_provider field, keeping fallback provider as an optional hint.
+- Raised AdapterError for missing_sections and no_sections_generated so workflow failure handling can run.
+- Cleaned the per-step artifact directory before concat/no-generated-section failures.
+- Added regression coverage for optional fallback provider config, failure exceptions, concat cleanup, and silence-only failure output.
+- Stabilized the finite sampled placeholder property test by suppressing only the Hypothesis too_slow health check after suite-order startup noise was reproduced as non-assertive.
+
+Verification:
+- Focused CodeRabbit adapter tests -> 5 passed.
+- python -m pytest tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py -q -> 114 passed.
+- python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q -> 115 passed.
+- python -m bandit -r touched production files -f json -o /tmp/bandit_audio_workspace_pr_final.json -> 0 findings.
+- git diff --check -> clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed CodeRabbit outside-diff feedback on PR #2640 and verified the full relevant audio/workspace suites plus Bandit. The multi-voice TTS adapter now routes failure-shaped cases through AdapterError, cleans temporary artifacts on failure, documents provider config keys, and has a single fallback_provider config field with opt-in semantics.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/core/Watchlists/audio_briefing_workflow.py
+++ b/tldw_Server_API/app/core/Watchlists/audio_briefing_workflow.py
@@ -136,6 +136,7 @@ AUDIO_BRIEFING_WORKFLOW_DEF: dict[str, Any] = {
             "config": {
                 "sections": "{{ compose_script.sections }}",
                 "voice_assignments": "{{ compose_script.voice_assignments }}",
+                "default_provider": "{{ inputs.tts_provider }}",
                 "default_model": "{{ inputs.tts_model }}",
                 "default_voice": "{{ inputs.tts_voice }}",
                 "response_format": "mp3",
@@ -157,6 +158,7 @@ AUDIO_BRIEFING_WORKFLOW_DEF: dict[str, Any] = {
             "type": "tts",
             "config": {
                 "input": "{{ compose_script.text }}",
+                "provider": "{{ inputs.tts_provider }}",
                 "model": "{{ inputs.tts_model }}",
                 "voice": "{{ inputs.tts_voice }}",
                 "response_format": "mp3",
@@ -214,7 +216,7 @@ def _first_non_empty_pref(output_prefs: dict[str, Any], *keys: str) -> Any:
     return None
 
 
-def _resolve_workflow_tts_defaults(output_prefs: dict[str, Any]) -> tuple[str, str] | None:
+def _resolve_workflow_tts_defaults(output_prefs: dict[str, Any]) -> tuple[str | None, str, str] | None:
     """Resolve Watchlists audio prefs through the same defaults as /audio/speech."""
     provider = _first_non_empty_pref(output_prefs, "audio_provider", "tts_provider")
     model = _first_non_empty_pref(output_prefs, "audio_model", "tts_model")
@@ -229,11 +231,12 @@ def _resolve_workflow_tts_defaults(output_prefs: dict[str, Any]) -> tuple[str, s
         logger.warning("Audio briefing: failed to resolve TTS defaults (error_type={})", type(exc).__name__)
         return None
 
+    provider = str(resolved.provider or "").strip() or None
     model = str(resolved.model or "").strip()
     voice = str(resolved.voice or "").strip()
     if not model or not voice:
         return None
-    return model, voice
+    return provider, model, voice
 
 
 def _get_scheduler_queue_worker_count(scheduler: Any, queue_name: str) -> int | None:
@@ -275,7 +278,7 @@ def _build_workflow_inputs(
     tts_defaults = _resolve_workflow_tts_defaults(output_prefs)
     if tts_defaults is None:
         return None
-    tts_model, tts_voice = tts_defaults
+    tts_provider, tts_model, tts_voice = tts_defaults
 
     audio_cast = output_prefs.get("audio_cast")
     voice_map = output_prefs.get("voice_map")
@@ -286,6 +289,7 @@ def _build_workflow_inputs(
         "items": items,
         "target_audio_minutes": output_prefs.get("target_audio_minutes", 10),
         "audio_language": output_prefs.get("audio_language") or "en",
+        "tts_provider": tts_provider,
         "tts_model": tts_model,
         "tts_voice": tts_voice,
         "tts_speed": output_prefs.get("audio_speed") or 1.0,

--- a/tldw_Server_API/app/core/Workflows/adapters/audio/_config.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/audio/_config.py
@@ -138,7 +138,6 @@ class MultiVoiceTTSConfig(BaseAdapterConfig):
     pause_duration_seconds: float = Field(1.0, ge=0.0, le=5.0, description="Silence between sections")
     normalize: bool = Field(True, description="EBU R128 normalize final output")
     target_lufs: float = Field(-16.0, description="Target LUFS for normalization")
-    fallback_provider: str | None = Field("openai", description="Fallback TTS provider on failure")
     fallback_voice: str = Field("nova", description="Fallback voice for fallback provider")
     background_audio_uri: str | None = Field(
         None,

--- a/tldw_Server_API/app/core/Workflows/adapters/audio/_config.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/audio/_config.py
@@ -126,8 +126,11 @@ class MultiVoiceTTSConfig(BaseAdapterConfig):
 
     sections: list[dict[str, Any]] | None = Field(None, description="Sections [{voice, text}] from compose step")
     voice_assignments: dict[str, str] | None = Field(None, description="Voice marker -> Kokoro voice ID mapping")
+    default_provider: str | None = Field(None, description="Default TTS provider hint")
+    provider: str | None = Field(None, description="Legacy/default TTS provider hint")
     default_model: str = Field("kokoro", description="Default TTS model")
     default_voice: str = Field("af_heart", description="Fallback voice if assignment missing")
+    fallback_provider: str | None = Field(None, description="Optional fallback TTS provider hint")
     response_format: Literal["mp3", "wav", "opus", "flac", "aac"] = Field(
         "mp3", description="Output audio format"
     )

--- a/tldw_Server_API/app/core/Workflows/adapters/audio/multi_voice_tts.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/audio/multi_voice_tts.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from loguru import logger
 
+from tldw_Server_API.app.core.exceptions import AdapterError
 from tldw_Server_API.app.core.TTS.utils import clean_text_for_tts
 from tldw_Server_API.app.core.Workflows.adapters._common import (
     AsyncFileWriter,
@@ -567,7 +568,7 @@ async def run_multi_voice_tts_adapter(config: dict[str, Any], context: dict[str,
     else:
         concat_ok = await _concat_files(segment_files, concat_path, fmt)
         if not concat_ok:
-            raise RuntimeError("concat_failed")
+            raise AdapterError("concat_failed")
 
     # Normalize
     final_path = concat_path

--- a/tldw_Server_API/app/core/Workflows/adapters/audio/multi_voice_tts.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/audio/multi_voice_tts.py
@@ -83,6 +83,7 @@ async def _synthesize_section(
     fmt: str,
     speed: float,
     output_path: Path,
+    provider: str | None = None,
 ) -> int:
     """Synthesize a single text section, returning size in bytes."""
     from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
@@ -100,7 +101,7 @@ async def _synthesize_section(
     size_bytes = 0
     service = await get_tts_service_v2()
     async with AsyncFileWriter(output_path) as writer:
-        async for chunk in service.generate_speech(req):
+        async for chunk in service.generate_speech(req, provider=provider):
             if isinstance(chunk, (bytes, bytearray)):
                 await writer.write(chunk)
                 size_bytes += len(chunk)
@@ -420,6 +421,7 @@ async def run_multi_voice_tts_adapter(config: dict[str, Any], context: dict[str,
             voice_assignments = prev.get("voice_assignments") or {}
 
     default_model = str(config.get("default_model") or "kokoro")
+    default_provider = str(config.get("default_provider") or config.get("provider") or "").strip() or None
     default_voice = str(config.get("default_voice") or "af_heart")
     fmt = str(config.get("response_format") or "mp3").lower()
     ext = fmt if fmt in {"mp3", "wav", "opus", "flac", "aac"} else "mp3"
@@ -430,7 +432,7 @@ async def run_multi_voice_tts_adapter(config: dict[str, Any], context: dict[str,
     pause_duration = float(config.get("pause_duration_seconds", 1.0))
     do_normalize = bool(config.get("normalize", True))
     target_lufs = float(config.get("target_lufs", -16.0))
-    fallback_provider = config.get("fallback_provider")
+    fallback_provider = str(config.get("fallback_provider") or "").strip() or None
     fallback_voice = str(config.get("fallback_voice") or "nova")
     background_audio_uri = config.get("background_audio_uri")
     if isinstance(background_audio_uri, str):
@@ -491,7 +493,15 @@ async def run_multi_voice_tts_adapter(config: dict[str, Any], context: dict[str,
             continue
 
         try:
-            await _synthesize_section(clean_text, default_model, kokoro_voice, fmt, speed, section_path)
+            await _synthesize_section(
+                clean_text,
+                default_model,
+                kokoro_voice,
+                fmt,
+                speed,
+                section_path,
+                provider=default_provider,
+            )
             segment_files.append(section_path)
             speaker_segments.append(
                 {
@@ -510,7 +520,15 @@ async def run_multi_voice_tts_adapter(config: dict[str, Any], context: dict[str,
             # Fallback attempt
             if fallback_provider:
                 try:
-                    await _synthesize_section(clean_text, "tts-1", fallback_voice, fmt, speed, section_path)
+                    await _synthesize_section(
+                        clean_text,
+                        "tts-1",
+                        fallback_voice,
+                        fmt,
+                        speed,
+                        section_path,
+                        provider=fallback_provider,
+                    )
                     segment_files.append(section_path)
                     speaker_segments.append(
                         {
@@ -549,15 +567,7 @@ async def run_multi_voice_tts_adapter(config: dict[str, Any], context: dict[str,
     else:
         concat_ok = await _concat_files(segment_files, concat_path, fmt)
         if not concat_ok:
-            # Fallback: use the first file
-            if segment_files[0].exists():
-                source_path = segment_files[0]
-                source_path.rename(concat_path)
-                for segment in speaker_segments:
-                    if segment.get("path") == source_path:
-                        segment["path"] = concat_path
-            else:
-                return {"error": "concat_failed"}
+            raise RuntimeError("concat_failed")
 
     # Normalize
     final_path = concat_path

--- a/tldw_Server_API/app/core/Workflows/adapters/audio/multi_voice_tts.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/audio/multi_voice_tts.py
@@ -393,8 +393,11 @@ async def run_multi_voice_tts_adapter(config: dict[str, Any], context: dict[str,
     Config:
       - sections: list[{voice, text}] - Sections from compose step
       - voice_assignments: dict - Voice marker -> Kokoro voice ID
+      - default_provider: str | None = None - Preferred TTS provider for primary synthesis
+      - provider: str | None = None - Legacy alias for default_provider
       - default_model: str = "kokoro"
       - default_voice: str = "af_heart"
+      - fallback_provider: str | None = None - Provider used for per-section fallback synthesis
       - response_format: str = "mp3"
       - speed: float = 1.0
       - pause_duration_seconds: float = 1.0
@@ -413,7 +416,7 @@ async def run_multi_voice_tts_adapter(config: dict[str, Any], context: dict[str,
             sections = prev.get("sections") or []
 
     if not sections:
-        return {"error": "missing_sections"}
+        raise AdapterError("missing_sections")
 
     voice_assignments = config.get("voice_assignments") or {}
     if not voice_assignments:
@@ -553,8 +556,9 @@ async def run_multi_voice_tts_adapter(config: dict[str, Any], context: dict[str,
             if await _generate_silence(pause_duration, silence_path, fmt):
                 segment_files.append(silence_path)
 
-    if not segment_files:
-        return {"error": "no_sections_generated"}
+    if sections_generated == 0:
+        shutil.rmtree(out_dir, ignore_errors=True)
+        raise AdapterError("no_sections_generated")
 
     # Concatenate
     concat_path = out_dir / f"briefing_raw.{ext}"
@@ -568,6 +572,7 @@ async def run_multi_voice_tts_adapter(config: dict[str, Any], context: dict[str,
     else:
         concat_ok = await _concat_files(segment_files, concat_path, fmt)
         if not concat_ok:
+            shutil.rmtree(out_dir, ignore_errors=True)
             raise AdapterError("concat_failed")
 
     # Normalize

--- a/tldw_Server_API/app/core/Workspaces/artifact_validation.py
+++ b/tldw_Server_API/app/core/Workspaces/artifact_validation.py
@@ -1,0 +1,242 @@
+"""Shared validation checks for generated workspace artifacts."""
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from tldw_Server_API.app.core.exceptions import WorkspaceArtifactExportStateError
+
+_GENERATED_ARTIFACT_ALIASES: Mapping[str, tuple[str, ...]] = {
+    "quiz": ("quiz",),
+    "flashcards": ("flashcard",),
+    "audio_summary": ("audio_summary", "audio_brief", "audio_overview", "podcast"),
+    "adaptive_table": ("adaptive_table", "data_table", "adata_table"),
+    "slides": ("slides", "slide_deck", "presentation"),
+    "mindmap": ("mindmap", "mind_map"),
+}
+
+_EXACT_PLACEHOLDER_CONTENT = {
+    "invalid",
+    "placeholder",
+    "todo",
+    "tbd",
+}
+
+_PLACEHOLDER_PHRASES = (
+    "this is a test",
+    "slides go here",
+    "content goes here",
+    "quiz goes here",
+    "flashcards go here",
+    "audio summary goes here",
+    "table goes here",
+    "mindmap goes here",
+    "lorem ipsum",
+)
+
+_WRAPPER_RE = re.compile(r"[^a-z0-9]+")
+_FAIL_STATUSES = {"failed", "fail", "error", "rejected", "invalid"}
+_PASS_STATUSES = {"passed", "pass", "ok", "success", "succeeded", "valid"}
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _metadata_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "required", "on"}
+    return False
+
+
+def _normalize_type(value: Any) -> str:
+    return _WRAPPER_RE.sub("_", str(value or "").lower()).strip("_")
+
+
+def _artifact_family(artifact: Mapping[str, Any]) -> str | None:
+    normalized_type = _normalize_type(artifact.get("artifact_type"))
+    if not normalized_type:
+        return None
+    for family, aliases in _GENERATED_ARTIFACT_ALIASES.items():
+        if any(alias in normalized_type for alias in aliases):
+            return family
+    return None
+
+
+def _normalize_content(value: Any) -> str:
+    content = str(value or "").strip()
+    if content.startswith("```"):
+        lines = content.splitlines()
+        if lines:
+            lines = lines[1:]
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]
+        content = "\n".join(lines).strip()
+    return _WRAPPER_RE.sub(" ", content.lower()).strip()
+
+
+def _reject_placeholder_content(artifact: Mapping[str, Any], family: str | None) -> None:
+    if family is None:
+        return
+
+    content = str(artifact.get("content") or "")
+    normalized = _normalize_content(content)
+    if not normalized:
+        raise WorkspaceArtifactExportStateError("workspace_artifact_missing_content")
+
+    if normalized in _EXACT_PLACEHOLDER_CONTENT:
+        raise WorkspaceArtifactExportStateError("workspace_artifact_placeholder_content")
+
+    if len(normalized) <= 160 and any(phrase in normalized for phrase in _PLACEHOLDER_PHRASES):
+        raise WorkspaceArtifactExportStateError("workspace_artifact_placeholder_content")
+
+
+def _claims_validation_required(artifact: Mapping[str, Any]) -> bool:
+    producer_metadata = _as_mapping(artifact.get("producer_metadata"))
+    validation = _as_mapping(producer_metadata.get("validation"))
+    claims_validation = _as_mapping(producer_metadata.get("claims_validation"))
+    return any(
+        (
+            _metadata_bool(producer_metadata.get("claims_validation_required")),
+            _metadata_bool(producer_metadata.get("requires_claims_validation")),
+            _metadata_bool(producer_metadata.get("source_pack_claims_validation_required")),
+            _metadata_bool(validation.get("claims_required")),
+            _metadata_bool(validation.get("source_pack_claims_required")),
+            _metadata_bool(claims_validation.get("required")),
+        )
+    )
+
+
+def _walk_mapping(root: Mapping[str, Any], path: Sequence[str]) -> Mapping[str, Any]:
+    current: Any = root
+    for key in path:
+        current = _as_mapping(current).get(key)
+    return _as_mapping(current)
+
+
+def _has_claims_signal(report: Mapping[str, Any]) -> bool:
+    return any(
+        key in report
+        for key in (
+            "validator",
+            "validator_name",
+            "model",
+            "model_name",
+            "llm_model",
+            "unsupported_claim_count",
+            "unsupported_claims",
+            "warnings",
+            "status",
+        )
+    )
+
+
+def _find_claims_report(artifact: Mapping[str, Any]) -> Mapping[str, Any]:
+    paths = (
+        ("claims_validation",),
+        ("validation", "claims"),
+        ("post_verification",),
+        ("verification_summary",),
+    )
+    for root_name in ("review_metadata", "version_metadata", "producer_metadata"):
+        root = _as_mapping(artifact.get(root_name))
+        for path in paths:
+            report = _walk_mapping(root, path)
+            if _has_claims_signal(report):
+                return report
+    return {}
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
+def _unsupported_claim_count(report: Mapping[str, Any]) -> int | None:
+    count = _int_or_none(report.get("unsupported_claim_count"))
+    if count is not None:
+        return count
+    unsupported_claims = report.get("unsupported_claims")
+    if isinstance(unsupported_claims, Sequence) and not isinstance(unsupported_claims, (str, bytes)):
+        return len(unsupported_claims)
+    return None
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _claims_validation_metadata(
+    artifact: Mapping[str, Any],
+    report: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    if not report:
+        return None
+
+    producer_metadata = _as_mapping(artifact.get("producer_metadata"))
+    status = str(report.get("status") or "").strip().lower()
+    unsupported_count = _unsupported_claim_count(report)
+    return {
+        "status": status if status in _PASS_STATUSES else "passed",
+        "validator": (
+            report.get("validator")
+            or report.get("validator_name")
+            or producer_metadata.get("claims_validator")
+            or "claims_source_pack_v1"
+        ),
+        "model": (
+            report.get("model")
+            or report.get("model_name")
+            or report.get("llm_model")
+            or producer_metadata.get("claims_validator_model")
+        ),
+        "unsupported_claim_count": unsupported_count,
+        "warnings": _as_list(report.get("warnings") or report.get("unresolved_warnings")),
+    }
+
+
+def _reject_failed_claims_report(report: Mapping[str, Any]) -> None:
+    status = str(report.get("status") or "").strip().lower()
+    unsupported_count = _unsupported_claim_count(report)
+    if status in _FAIL_STATUSES or (unsupported_count is not None and unsupported_count > 0):
+        raise WorkspaceArtifactExportStateError("workspace_artifact_claims_validation_failed")
+
+
+def validate_workspace_artifact_for_export(artifact: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a workspace artifact immediately before export."""
+    family = _artifact_family(artifact)
+    _reject_placeholder_content(artifact, family)
+
+    claims_required = _claims_validation_required(artifact)
+    claims_report = _find_claims_report(artifact)
+    if claims_required and not claims_report:
+        raise WorkspaceArtifactExportStateError("workspace_artifact_claims_validation_missing")
+    if claims_report:
+        _reject_failed_claims_report(claims_report)
+
+    checks = ["accepted_review_state"]
+    if family is not None:
+        checks.extend(("content_present", "placeholder_rejected"))
+    if claims_required or claims_report:
+        checks.append("claims_validation")
+
+    return {
+        "status": "passed",
+        "validator": "workspace_artifact_export_v1",
+        "artifact_family": family,
+        "checks": checks,
+        "claims_validation_required": claims_required,
+        "claims_validation": _claims_validation_metadata(artifact, claims_report),
+    }

--- a/tldw_Server_API/app/core/Workspaces/artifact_validation.py
+++ b/tldw_Server_API/app/core/Workspaces/artifact_validation.py
@@ -47,6 +47,8 @@ def _as_mapping(value: Any) -> Mapping[str, Any]:
 def _metadata_bool(value: Any) -> bool:
     if isinstance(value, bool):
         return value
+    if isinstance(value, (int, float)):
+        return bool(value)
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "required", "on"}
     return False
@@ -173,8 +175,10 @@ def _unsupported_claim_count(report: Mapping[str, Any]) -> int | None:
 def _as_list(value: Any) -> list[Any]:
     if value is None:
         return []
-    if isinstance(value, list):
-        return value
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return list(value)
     return [value]
 
 
@@ -216,6 +220,9 @@ def _reject_failed_claims_report(report: Mapping[str, Any]) -> None:
 
 def validate_workspace_artifact_for_export(artifact: Mapping[str, Any]) -> dict[str, Any]:
     """Validate a workspace artifact immediately before export."""
+    if str(artifact.get("review_state") or "draft") != "accepted":
+        raise WorkspaceArtifactExportStateError("workspace_artifact_not_accepted")
+
     family = _artifact_family(artifact)
     _reject_placeholder_content(artifact, family)
 

--- a/tldw_Server_API/app/core/Workspaces/artifact_validation.py
+++ b/tldw_Server_API/app/core/Workspaces/artifact_validation.py
@@ -35,7 +35,7 @@ _PLACEHOLDER_PHRASES = (
     "lorem ipsum",
 )
 
-_WRAPPER_RE = re.compile(r"[^a-z0-9]+")
+_WRAPPER_RE = re.compile(r"[^\w]+", re.UNICODE)
 _FAIL_STATUSES = {"failed", "fail", "error", "rejected", "invalid"}
 _PASS_STATUSES = {"passed", "pass", "ok", "success", "succeeded", "valid"}
 
@@ -85,10 +85,10 @@ def _reject_placeholder_content(artifact: Mapping[str, Any], family: str | None)
         return
 
     content = str(artifact.get("content") or "")
-    normalized = _normalize_content(content)
-    if not normalized:
+    if not content.strip():
         raise WorkspaceArtifactExportStateError("workspace_artifact_missing_content")
 
+    normalized = _normalize_content(content)
     if normalized in _EXACT_PLACEHOLDER_CONTENT:
         raise WorkspaceArtifactExportStateError("workspace_artifact_placeholder_content")
 
@@ -193,7 +193,7 @@ def _claims_validation_metadata(
     status = str(report.get("status") or "").strip().lower()
     unsupported_count = _unsupported_claim_count(report)
     return {
-        "status": status if status in _PASS_STATUSES else "passed",
+        "status": status or "passed",
         "validator": (
             report.get("validator")
             or report.get("validator_name")

--- a/tldw_Server_API/app/core/Workspaces/workspace_artifact_exports.py
+++ b/tldw_Server_API/app/core/Workspaces/workspace_artifact_exports.py
@@ -11,6 +11,9 @@ from typing import Any
 import markdown
 
 from tldw_Server_API.app.core.exceptions import WorkspaceArtifactExportStateError
+from tldw_Server_API.app.core.Workspaces.artifact_validation import (
+    validate_workspace_artifact_for_export,
+)
 
 ALLOWED_WORKSPACE_ARTIFACT_EXPORT_FORMATS = ("md", "html", "json")
 
@@ -38,11 +41,18 @@ def _artifact_identity(artifact: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def _export_metadata(artifact: Mapping[str, Any], *, export_format: str, generated_at: str) -> dict[str, Any]:
+def _export_metadata(
+    artifact: Mapping[str, Any],
+    *,
+    export_format: str,
+    generated_at: str,
+    artifact_validation: Mapping[str, Any],
+) -> dict[str, Any]:
     """Collect traceability metadata that travels with an artifact export."""
     return {
         "artifact": _artifact_identity(artifact),
         "review_state": artifact.get("review_state") or "draft",
+        "artifact_validation": dict(artifact_validation),
         "producer_metadata": artifact.get("producer_metadata") or {},
         "source_lineage": artifact.get("source_lineage") or {},
         "review_metadata": artifact.get("review_metadata") or {},
@@ -159,7 +169,13 @@ def export_workspace_artifact_version(
         raise WorkspaceArtifactExportStateError("workspace_artifact_not_accepted")
 
     generated_at = generated_at or _utc_now_iso()
-    metadata = _export_metadata(artifact, export_format=export_format, generated_at=generated_at)
+    artifact_validation = validate_workspace_artifact_for_export(artifact)
+    metadata = _export_metadata(
+        artifact,
+        export_format=export_format,
+        generated_at=generated_at,
+        artifact_validation=artifact_validation,
+    )
     content_by_format = {
         "md": _render_markdown_export,
         "html": _render_html_export,

--- a/tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py
+++ b/tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py
@@ -65,6 +65,7 @@ class TestAudioBriefingWorkflowDefinition:
         )
         assert audio_cfg["background_audio_uri"] == "{{ inputs.background_audio_uri }}"
         assert audio_cfg["background_volume"] == "{{ inputs.background_volume }}"
+        assert audio_cfg["default_provider"] == "{{ inputs.tts_provider }}"
 
     def test_workflow_def_marks_single_voice_fallback_artifact(self):
         from tldw_Server_API.app.core.Watchlists.audio_briefing_workflow import (
@@ -83,6 +84,7 @@ class TestAudioBriefingWorkflowDefinition:
             "single_voice_fallback": True,
             "fallback_reason": "multi_voice_tts_failed",
         }
+        assert fallback_cfg["provider"] == "{{ inputs.tts_provider }}"
 
 
 class TestBuildWorkflowInputs:
@@ -821,6 +823,7 @@ class TestTriggerAudioBriefing:
         payload = scheduler.submit.call_args.kwargs["payload"]
         assert payload["inputs"]["tts_model"] == "configured-model"
         assert payload["inputs"]["tts_model"] != "kokoro"
+        assert payload["inputs"]["tts_provider"] == "configured_provider"
         assert payload["inputs"]["tts_voice"] == "Bella"
         resolver.assert_called_once_with(provider=None, model=None, voice="Bella")
 

--- a/tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py
+++ b/tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py
@@ -1887,6 +1887,7 @@ class TestMultiVoiceTTSAdapter:
         from tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts import (
             run_multi_voice_tts_adapter,
         )
+        from tldw_Server_API.app.core.exceptions import AdapterError
 
         monkeypatch.setenv("WORKFLOWS_ARTIFACTS_DIR", str(tmp_path / "artifacts"))
         artifacts: list[dict[str, Any]] = []
@@ -1920,7 +1921,7 @@ class TestMultiVoiceTTSAdapter:
                 return_value=False,
             ),
         ):
-            with pytest.raises(RuntimeError, match="concat_failed"):
+            with pytest.raises(AdapterError, match="concat_failed"):
                 await run_multi_voice_tts_adapter(config, base_context)
 
         assert artifacts == []

--- a/tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py
+++ b/tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py
@@ -1870,14 +1870,21 @@ class TestMultiVoiceTTSAdapter:
 
     @pytest.mark.asyncio
     async def test_multi_voice_tts_empty_sections_error(self, base_context):
-        """Test empty sections returns error."""
+        """Test empty sections route through adapter failure handling."""
         from tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts import (
             run_multi_voice_tts_adapter,
         )
+        from tldw_Server_API.app.core.exceptions import AdapterError
 
         config = {"sections": []}
-        result = await run_multi_voice_tts_adapter(config, base_context)
-        assert result.get("error") == "missing_sections"
+        with pytest.raises(AdapterError, match="missing_sections"):
+            await run_multi_voice_tts_adapter(config, base_context)
+
+    def test_multi_voice_tts_config_fallback_provider_is_optional(self):
+        """Fallback provider stays opt-in for internal per-section retries."""
+        from tldw_Server_API.app.core.Workflows.adapters.audio._config import MultiVoiceTTSConfig
+
+        assert MultiVoiceTTSConfig().fallback_provider is None
 
     @pytest.mark.asyncio
     async def test_multi_voice_tts_concat_failure_returns_error_without_final_artifact(
@@ -1925,6 +1932,49 @@ class TestMultiVoiceTTSAdapter:
                 await run_multi_voice_tts_adapter(config, base_context)
 
         assert artifacts == []
+        assert not (tmp_path / "artifacts" / "mvtts_test_123").exists()
+
+    @pytest.mark.asyncio
+    async def test_multi_voice_tts_silence_only_output_is_failure(self, base_context, tmp_path, monkeypatch):
+        """Silence gaps alone are not a valid generated briefing."""
+        from tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts import (
+            run_multi_voice_tts_adapter,
+        )
+        from tldw_Server_API.app.core.exceptions import AdapterError
+
+        monkeypatch.setenv("WORKFLOWS_ARTIFACTS_DIR", str(tmp_path / "artifacts"))
+
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
+            raise RuntimeError("TTS failed")
+
+        async def mock_silence(dur, path, fmt="mp3"):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"silence")
+            return True
+
+        config = {
+            "sections": [
+                {"voice": "HOST", "text": "First section."},
+                {"voice": "REPORTER", "text": "Second section."},
+            ],
+            "voice_assignments": {"HOST": "af_bella", "REPORTER": "am_adam"},
+            "normalize": False,
+        }
+
+        with (
+            patch(
+                "tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts._synthesize_section",
+                side_effect=mock_synthesize,
+            ),
+            patch(
+                "tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts._generate_silence",
+                side_effect=mock_silence,
+            ),
+        ):
+            with pytest.raises(AdapterError, match="no_sections_generated"):
+                await run_multi_voice_tts_adapter(config, base_context)
+
+        assert not (tmp_path / "artifacts" / "mvtts_test_123").exists()
 
     @pytest.mark.asyncio
     async def test_multi_voice_tts_passes_default_provider_to_synthesis(
@@ -2058,6 +2108,7 @@ class TestMultiVoiceTTSAdapter:
         from tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts import (
             run_multi_voice_tts_adapter,
         )
+        from tldw_Server_API.app.core.exceptions import AdapterError
 
         monkeypatch.setenv("WORKFLOWS_ARTIFACTS_DIR", str(tmp_path / "artifacts"))
 
@@ -2080,11 +2131,11 @@ class TestMultiVoiceTTSAdapter:
                 "tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts._synthesize_section",
                 side_effect=mock_synthesize,
             ):
-                result = await run_multi_voice_tts_adapter(config, base_context)
+                with pytest.raises(AdapterError, match="no_sections_generated"):
+                    await run_multi_voice_tts_adapter(config, base_context)
         finally:
             multi_voice_tts.logger.remove(sink_id)
 
-        assert result.get("error") == "no_sections_generated"
         joined = "\n".join(messages)
         assert "Section 0 TTS failed with kokoro/af_bella" in joined
         assert "Section 0 fallback TTS" in joined

--- a/tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py
+++ b/tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py
@@ -1811,7 +1811,7 @@ class TestMultiVoiceTTSAdapter:
 
         calls = []
 
-        async def mock_synthesize(text, model, voice, fmt, speed, output_path):
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
             calls.append({"text": text, "voice": voice, "model": model})
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"fake_audio_" + voice.encode())
@@ -1880,6 +1880,86 @@ class TestMultiVoiceTTSAdapter:
         assert result.get("error") == "missing_sections"
 
     @pytest.mark.asyncio
+    async def test_multi_voice_tts_concat_failure_returns_error_without_final_artifact(
+        self, sample_voice_assignments, base_context, tmp_path, monkeypatch
+    ):
+        """Concat failure must not promote one section as the final briefing."""
+        from tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts import (
+            run_multi_voice_tts_adapter,
+        )
+
+        monkeypatch.setenv("WORKFLOWS_ARTIFACTS_DIR", str(tmp_path / "artifacts"))
+        artifacts: list[dict[str, Any]] = []
+        base_context["add_artifact"] = lambda **kwargs: artifacts.append(kwargs)
+
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(f"audio-{voice}".encode("utf-8"))
+            return output_path.stat().st_size
+
+        config = {
+            "sections": [
+                {"voice": "HOST", "text": "Welcome to the briefing."},
+                {"voice": "REPORTER", "text": "The story details go here."},
+            ],
+            "voice_assignments": sample_voice_assignments,
+            "normalize": False,
+        }
+
+        with (
+            patch(
+                "tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts._synthesize_section",
+                side_effect=mock_synthesize,
+            ),
+            patch(
+                "tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts._generate_silence",
+                return_value=False,
+            ),
+            patch(
+                "tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts._concat_files",
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="concat_failed"):
+                await run_multi_voice_tts_adapter(config, base_context)
+
+        assert artifacts == []
+
+    @pytest.mark.asyncio
+    async def test_multi_voice_tts_passes_default_provider_to_synthesis(
+        self, base_context, tmp_path, monkeypatch
+    ):
+        """Explicit provider selection should reach the internal TTS service."""
+        from tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts import (
+            run_multi_voice_tts_adapter,
+        )
+
+        monkeypatch.setenv("WORKFLOWS_ARTIFACTS_DIR", str(tmp_path / "artifacts"))
+        providers: list[str | None] = []
+
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
+            providers.append(provider)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"audio")
+            return output_path.stat().st_size
+
+        config = {
+            "sections": [{"voice": "HOST", "text": "Welcome to the briefing."}],
+            "voice_assignments": {"HOST": "af_bella"},
+            "default_provider": "elevenlabs",
+            "normalize": False,
+        }
+
+        with patch(
+            "tldw_Server_API.app.core.Workflows.adapters.audio.multi_voice_tts._synthesize_section",
+            side_effect=mock_synthesize,
+        ):
+            result = await run_multi_voice_tts_adapter(config, base_context)
+
+        assert "error" not in result
+        assert providers == ["elevenlabs"]
+
+    @pytest.mark.asyncio
     async def test_multi_voice_tts_sections_from_prev(
         self, sample_sections, sample_voice_assignments, base_context, tmp_path, monkeypatch
     ):
@@ -1890,7 +1970,7 @@ class TestMultiVoiceTTSAdapter:
 
         monkeypatch.setenv("WORKFLOWS_ARTIFACTS_DIR", str(tmp_path / "artifacts"))
 
-        async def mock_synthesize(text, model, voice, fmt, speed, output_path):
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"audio")
             return 5
@@ -1944,7 +2024,7 @@ class TestMultiVoiceTTSAdapter:
 
         call_count = 0
 
-        async def mock_synthesize(text, model, voice, fmt, speed, output_path):
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -1980,7 +2060,7 @@ class TestMultiVoiceTTSAdapter:
 
         monkeypatch.setenv("WORKFLOWS_ARTIFACTS_DIR", str(tmp_path / "artifacts"))
 
-        async def mock_synthesize(text, model, voice, fmt, speed, output_path):
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
             if model == "kokoro":
                 raise RuntimeError("primary TTS token at /private/mvtts-primary-cache")
             raise RuntimeError("fallback TTS token at /private/mvtts-fallback-cache")
@@ -2039,7 +2119,7 @@ class TestMultiVoiceTTSAdapter:
         def mock_add_artifact(**kwargs):
             artifacts.append(kwargs)
 
-        async def mock_synthesize(text, model, voice, fmt, speed, output_path):
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"audio_data")
             return 10
@@ -2104,7 +2184,7 @@ class TestMultiVoiceTTSAdapter:
             {"voice": "HOST", "text": "That wraps up the briefing."},
         ]
 
-        async def mock_synthesize(text, model, voice, fmt, speed, output_path):
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(f"audio-{voice}".encode("utf-8"))
             return output_path.stat().st_size
@@ -2173,7 +2253,7 @@ class TestMultiVoiceTTSAdapter:
 
         calls = []
 
-        async def mock_synthesize(text, model, voice, fmt, speed, output_path):
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
             calls.append(voice)
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"audio")
@@ -2205,7 +2285,7 @@ class TestMultiVoiceTTSAdapter:
 
         observed_texts = []
 
-        async def mock_synthesize(text, model, voice, fmt, speed, output_path):
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
             observed_texts.append(text)
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"audio")
@@ -2243,7 +2323,7 @@ class TestMultiVoiceTTSAdapter:
 
         monkeypatch.setenv("WORKFLOWS_ARTIFACTS_DIR", str(tmp_path / "artifacts"))
 
-        async def mock_synthesize(text, model, voice, fmt, speed, output_path):
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"speech_audio")
             return len(b"speech_audio")
@@ -2290,7 +2370,7 @@ class TestMultiVoiceTTSAdapter:
 
         monkeypatch.setenv("WORKFLOWS_ARTIFACTS_DIR", str(tmp_path / "artifacts"))
 
-        async def mock_synthesize(text, model, voice, fmt, speed, output_path):
+        async def mock_synthesize(text, model, voice, fmt, speed, output_path, provider=None):
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(b"speech_audio")
             return len(b"speech_audio")

--- a/tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
@@ -121,6 +121,21 @@ def test_claims_required_artifact_rejects_missing_validation_report() -> None:
         validate_workspace_artifact_for_export(artifact)
 
 
+def test_numeric_claims_required_flag_is_enforced() -> None:
+    artifact = {
+        "artifact_type": "slides",
+        "review_state": "accepted",
+        "content": "# Findings\n- The source pack supports this answer.",
+        "producer_metadata": {"claims_validation_required": 1},
+    }
+
+    with pytest.raises(
+        WorkspaceArtifactExportStateError,
+        match="workspace_artifact_claims_validation_missing",
+    ):
+        validate_workspace_artifact_for_export(artifact)
+
+
 def test_short_real_content_that_mentions_invalid_is_allowed() -> None:
     artifact = {
         "artifact_type": "quiz",
@@ -131,6 +146,45 @@ def test_short_real_content_that_mentions_invalid_is_allowed() -> None:
     metadata = validate_workspace_artifact_for_export(artifact)
 
     assert metadata["status"] == "passed"
+
+
+def test_validation_metadata_copies_and_flattens_warning_sequences() -> None:
+    warnings = ["needs source review"]
+    artifact = {
+        "artifact_type": "slides",
+        "review_state": "accepted",
+        "content": "# Findings\n- The source pack supports this answer.",
+        "review_metadata": {
+            "verification_summary": {
+                "validator": "claims_source_pack_v1",
+                "unsupported_claim_count": 0,
+                "warnings": warnings,
+            }
+        },
+    }
+
+    metadata = validate_workspace_artifact_for_export(artifact)
+
+    assert metadata["claims_validation"]["warnings"] == ["needs source review"]
+    assert metadata["claims_validation"]["warnings"] is not warnings
+
+    artifact["review_metadata"]["verification_summary"]["warnings"] = ("first", "second")
+    metadata = validate_workspace_artifact_for_export(artifact)
+    assert metadata["claims_validation"]["warnings"] == ["first", "second"]
+
+
+def test_validator_rejects_non_accepted_artifacts_directly() -> None:
+    artifact = {
+        "artifact_type": "slides",
+        "review_state": "needs_revision",
+        "content": "# Findings\n- The source pack supports this answer.",
+    }
+
+    with pytest.raises(
+        WorkspaceArtifactExportStateError,
+        match="workspace_artifact_not_accepted",
+    ):
+        validate_workspace_artifact_for_export(artifact)
 
 
 def test_claims_required_artifact_rejects_unresolved_unsupported_claims() -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
@@ -148,6 +148,18 @@ def test_short_real_content_that_mentions_invalid_is_allowed() -> None:
     assert metadata["status"] == "passed"
 
 
+def test_non_latin_generated_artifact_content_is_not_treated_as_empty() -> None:
+    artifact = {
+        "artifact_type": "slides",
+        "review_state": "accepted",
+        "content": "# 調査結果\n- 出典に基づく要約です。",
+    }
+
+    metadata = validate_workspace_artifact_for_export(artifact)
+
+    assert metadata["status"] == "passed"
+
+
 def test_validation_metadata_copies_and_flattens_warning_sequences() -> None:
     warnings = ["needs source review"]
     artifact = {
@@ -171,6 +183,25 @@ def test_validation_metadata_copies_and_flattens_warning_sequences() -> None:
     artifact["review_metadata"]["verification_summary"]["warnings"] = ("first", "second")
     metadata = validate_workspace_artifact_for_export(artifact)
     assert metadata["claims_validation"]["warnings"] == ["first", "second"]
+
+
+def test_claims_validation_metadata_preserves_explicit_non_pass_status() -> None:
+    artifact = {
+        "artifact_type": "slides",
+        "review_state": "accepted",
+        "content": "# Findings\n- The source pack supports this answer.",
+        "review_metadata": {
+            "verification_summary": {
+                "validator": "claims_source_pack_v1",
+                "unsupported_claim_count": 0,
+                "status": "skipped",
+            }
+        },
+    }
+
+    metadata = validate_workspace_artifact_for_export(artifact)
+
+    assert metadata["claims_validation"]["status"] == "skipped"
 
 
 def test_validator_rejects_non_accepted_artifacts_directly() -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 import pytest
-from hypothesis import given, settings, strategies as st
+from hypothesis import HealthCheck, given, settings, strategies as st
 
 from tldw_Server_API.app.core.exceptions import WorkspaceArtifactExportStateError
 from tldw_Server_API.app.core.Workspaces.artifact_validation import (
@@ -49,7 +49,7 @@ def test_generated_artifact_placeholders_are_rejected(artifact_type: str, conten
         validate_workspace_artifact_for_export(artifact)
 
 
-@settings(max_examples=30)
+@settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
 @given(
     artifact_type=st.sampled_from(GENERATED_ARTIFACT_TYPES),
     content=st.sampled_from(PLACEHOLDER_CONTENT),

--- a/tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from tldw_Server_API.app.core.exceptions import WorkspaceArtifactExportStateError
+from tldw_Server_API.app.core.Workspaces.artifact_validation import (
+    validate_workspace_artifact_for_export,
+)
+from tldw_Server_API.app.core.Workspaces.workspace_artifact_exports import (
+    export_workspace_artifact_version,
+)
+
+
+GENERATED_ARTIFACT_TYPES = (
+    "quiz",
+    "flashcards",
+    "audio_summary",
+    "adaptive_table",
+    "slides",
+    "mindmap",
+)
+
+PLACEHOLDER_CONTENT = (
+    "slides go here",
+    "invalid",
+    "this is a test",
+)
+
+
+@pytest.mark.parametrize("artifact_type", GENERATED_ARTIFACT_TYPES)
+@pytest.mark.parametrize("content", PLACEHOLDER_CONTENT)
+def test_generated_artifact_placeholders_are_rejected(artifact_type: str, content: str) -> None:
+    artifact = {
+        "id": f"{artifact_type}-1",
+        "workspace_id": "ws-1",
+        "artifact_type": artifact_type,
+        "title": artifact_type,
+        "review_state": "accepted",
+        "content": content,
+    }
+
+    with pytest.raises(
+        WorkspaceArtifactExportStateError,
+        match="workspace_artifact_placeholder_content",
+    ):
+        validate_workspace_artifact_for_export(artifact)
+
+
+@settings(max_examples=30)
+@given(
+    artifact_type=st.sampled_from(GENERATED_ARTIFACT_TYPES),
+    content=st.sampled_from(PLACEHOLDER_CONTENT),
+    prefix=st.sampled_from(("", "  ", "# ", "```markdown\n")),
+    suffix=st.sampled_from(("", "  ", "\n", "\n```")),
+)
+def test_placeholder_rejection_is_case_and_wrapper_insensitive(
+    artifact_type: str,
+    content: str,
+    prefix: str,
+    suffix: str,
+) -> None:
+    artifact = {
+        "artifact_type": artifact_type,
+        "review_state": "accepted",
+        "content": f"{prefix}{content.upper()}{suffix}",
+    }
+
+    with pytest.raises(
+        WorkspaceArtifactExportStateError,
+        match="workspace_artifact_placeholder_content",
+    ):
+        validate_workspace_artifact_for_export(artifact)
+
+
+@pytest.mark.parametrize("artifact_type", GENERATED_ARTIFACT_TYPES)
+def test_substantive_generated_artifacts_pass_with_claims_metadata(artifact_type: str) -> None:
+    artifact = {
+        "id": f"{artifact_type}-1",
+        "workspace_id": "ws-1",
+        "artifact_type": artifact_type,
+        "title": artifact_type,
+        "review_state": "accepted",
+        "content": "# Findings\n- The source pack supports this answer with cited evidence.",
+        "producer_metadata": {
+            "claims_validation_required": True,
+            "claims_validator_model": "llama.cpp/local",
+        },
+        "review_metadata": {
+            "verification_summary": {
+                "validator": "claims_source_pack_v1",
+                "model": "llama.cpp/local",
+                "unsupported_claim_count": 0,
+            }
+        },
+    }
+
+    metadata = validate_workspace_artifact_for_export(artifact)
+
+    assert metadata["status"] == "passed"
+    assert metadata["claims_validation_required"] is True
+    assert metadata["claims_validation"]["validator"] == "claims_source_pack_v1"
+    assert metadata["claims_validation"]["model"] == "llama.cpp/local"
+    assert metadata["claims_validation"]["unsupported_claim_count"] == 0
+
+
+def test_claims_required_artifact_rejects_missing_validation_report() -> None:
+    artifact = {
+        "artifact_type": "slides",
+        "review_state": "accepted",
+        "content": "# Findings\n- The source pack supports this answer.",
+        "producer_metadata": {"claims_validation_required": True},
+    }
+
+    with pytest.raises(
+        WorkspaceArtifactExportStateError,
+        match="workspace_artifact_claims_validation_missing",
+    ):
+        validate_workspace_artifact_for_export(artifact)
+
+
+def test_short_real_content_that_mentions_invalid_is_allowed() -> None:
+    artifact = {
+        "artifact_type": "quiz",
+        "review_state": "accepted",
+        "content": "# Quiz\nWhich cited source says the claim is invalid?",
+    }
+
+    metadata = validate_workspace_artifact_for_export(artifact)
+
+    assert metadata["status"] == "passed"
+
+
+def test_claims_required_artifact_rejects_unresolved_unsupported_claims() -> None:
+    artifact = {
+        "artifact_type": "quiz",
+        "review_state": "accepted",
+        "content": "# Quiz\n1. Which result was supported by the source pack?",
+        "producer_metadata": {"claims_validation_required": True},
+        "review_metadata": {
+            "verification_summary": {
+                "validator": "claims_source_pack_v1",
+                "model": "llama.cpp/local",
+                "unsupported_claim_count": 1,
+            }
+        },
+    }
+
+    with pytest.raises(
+        WorkspaceArtifactExportStateError,
+        match="workspace_artifact_claims_validation_failed",
+    ):
+        validate_workspace_artifact_for_export(artifact)
+
+
+def test_export_metadata_includes_validation_result() -> None:
+    artifact = {
+        "id": "slides-1",
+        "workspace_id": "ws-1",
+        "artifact_type": "slides",
+        "title": "Supported Slides",
+        "review_state": "accepted",
+        "content": "# Findings\n- The source pack supports this answer.",
+        "producer_metadata": {"claims_validation_required": True},
+        "review_metadata": {
+            "verification_summary": {
+                "validator": "claims_source_pack_v1",
+                "model": "llama.cpp/local",
+                "unsupported_claim_count": 0,
+            }
+        },
+    }
+
+    payload = export_workspace_artifact_version(
+        artifact,
+        export_format="json",
+        generated_at="2026-07-05T00:00:00+00:00",
+    )
+    exported_json = json.loads(payload["content"])
+
+    validation = exported_json["metadata"]["artifact_validation"]
+    assert validation["status"] == "passed"
+    assert validation["claims_validation_required"] is True
+    assert validation["claims_validation"]["unsupported_claim_count"] == 0

--- a/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
@@ -2106,6 +2106,62 @@ def test_workspace_artifact_export_rejects_non_accepted_state(workspace_fastapi_
 
 
 @pytest.mark.integration
+def test_workspace_artifact_export_rejects_placeholder_generated_artifact(workspace_fastapi_app, db):
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    async def _user() -> User:
+        return User(
+            id=1,
+            username="testuser",
+            email="test@example.com",
+            is_active=True,
+            roles=["admin"],
+            is_admin=True,
+        )
+
+    def _db() -> CharactersRAGDB:
+        return db
+
+    workspace_fastapi_app.dependency_overrides[get_request_user] = _user
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = _db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        db.upsert_workspace("ws-export-api", "Workspace Exports")
+        db.add_workspace_artifact(
+            "ws-export-api",
+            {
+                "id": "slides-1",
+                "artifact_type": "slides",
+                "title": "Generated Slides",
+                "content": "slides go here",
+                "review_state": "accepted",
+                "source_lineage": {"sources": [{"source_id": "src-1"}]},
+            },
+        )
+
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.post(
+                "/api/v1/workspaces/ws-export-api/artifacts/slides-1/exports",
+                json={"format": "md"},
+            )
+            assert response.status_code == 409, response.text
+            assert response.json()["detail"] == "workspace_artifact_placeholder_content"
+
+            fetch_response = client.get("/api/v1/workspaces/ws-export-api/artifacts")
+            assert fetch_response.status_code == 200, fetch_response.text
+            assert fetch_response.json()[0]["export_refs"] == []
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_READ_RATE_LIMIT, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+
+@pytest.mark.integration
 def test_workspace_artifact_api_exposes_traceable_contract_fields(workspace_fastapi_app, db):
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 


### PR DESCRIPTION
## Summary
- Harden audio briefing TTS to use the configured provider through the internal TTS service, including provider/fallback propagation for multi-voice and single-voice fallback paths.
- Treat multi-voice concat failure as workflow failure so fallback can run instead of silently publishing the first segment as the final artifact.
- Add a shared Workspace artifact export validator for generated quizzes, flashcards, audio summaries, adaptive/data tables, slides/presentations, and mindmaps, with claims-validation opt-in metadata and placeholder rejection.

## Test Plan
- [x] `python -m pytest tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py -q` (112 passed)
- [x] `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q` (110 passed)
- [x] `python -m bandit -r tldw_Server_API/app/core/Workflows/adapters/audio/multi_voice_tts.py tldw_Server_API/app/core/Workflows/adapters/audio/_config.py tldw_Server_API/app/core/Watchlists/audio_briefing_workflow.py tldw_Server_API/app/core/Workspaces/artifact_validation.py tldw_Server_API/app/core/Workspaces/workspace_artifact_exports.py -f json -o /tmp/bandit_audio_workspace_pr.json` (0 findings)

## AI-authored PR note
This PR is materially AI-authored. Per repo policy, a human-owned Change summary must be added before the PR is ready to merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens audio briefing TTS to honor the selected provider and fail safely, and adds a shared Workspace export validator that blocks placeholders and enforces opt‑in claims checks. Exports now include `artifact_validation` metadata, and multi‑voice TTS cleans up and raises adapter errors on failure.

- **New Features**
  - Audio briefings: propagate `tts_provider` into multi‑voice synthesis and single‑voice fallback; support `default_provider`/`provider` alias and optional `fallback_provider` hints; pass provider to internal TTS calls. (TASK-12147)
  - Workspace exports: shared validator rejects placeholder content and records `artifact_validation` with claims status/model and warnings; export path invokes the validator for quizzes, flashcards, audio summaries, tables, slides, and mindmaps; opt‑in claims checks enforced. (TASK-12148)

- **Bug Fixes**
  - Multi‑voice: raise `AdapterError("missing_sections"|"no_sections_generated"|"concat_failed")`, treat silence‑only outputs as failures, and clean the step directory on failure so single‑voice fallback can run. (TASK-12147, TASK-12153)
  - Validator: require `accepted` review state; honor numeric claims‑required flags; copy/flatten warnings; preserve explicit non‑pass statuses (e.g., `skipped`); treat non‑Latin content as real. (TASK-12151, TASK-12152)

<sup>Written for commit f9ca9327135a9673a9fb1ace266b03756851e4f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

