### PR TITLE
test(ci): singleton/lifecycle isolation guard plugin (plan Task 3)

### DIFF
--- a/audits/2026-07-04-singleton-inventory.md
+++ b/audits/2026-07-04-singleton-inventory.md
@@ -1,0 +1,49 @@
+# Process-Global Singleton Inventory
+
+**Date:** 2026-07-04
+**Context:** Task 3 of `Docs/superpowers/plans/2026-07-04-test-suite-improvement-implementation-plan.md`, targeting finding RA5 of `audits/2026-07-04-test-suite-audit-round2.md` — the top-severity (all-High) defect class of process-global state leaking across test modules (#2580 service/DB caches, #2581 drain/lifecycle singletons, #2585 app-module identity).
+
+The `tests/_plugins/singleton_guard.py` plugin watches the highest-risk subset of these at test-module boundaries (opt-in via `TLDW_SINGLETON_GUARD=warn|error`).
+
+## Watched by the guard (initial set)
+
+Ranked by mutability × cross-test reach × adjacency to the three known bugs.
+
+| # | Import path : global | Defect | Reader | Existing reset hook |
+|---|---|---|---|---|
+| 1 | `core/DB_Management/media_db/runtime/defaults:content_db_backend` | #2580 | identity | `reset_media_runtime_defaults()` |
+| 2 | `api/v1/API_Deps/ChaCha_Notes_DB_Deps:_chacha_db_instances` | #2580 | len | `shutdown_chacha_resources()` + autouse `reset_chacha_shutdown_state` |
+| 3 | `app.main` module identity | #2585 | `id(module)` | `restore_app_main()` (manual) |
+| 4 | `core/RAG/rag_service/semantic_cache:_SHARED_CACHES` | #2580 | len | `clear_shared_caches(namespace=None)` |
+| 5 | `core/Embeddings/connection_pool:_pool_manager` | #2581 | is-set | `close_all_pools()` |
+| 6 | `core/Embeddings/async_embeddings:_async_service_fallback` | #2581 | is-set | atexit only |
+| 7 | `core/Embeddings/request_batching:_batcher_fallback` | #2581 | is-set | `RequestBatcher.shutdown()` |
+
+## Full inventory (not all watched yet)
+
+The following are process-global mutable state that *could* leak; they are documented so the watchlist can be expanded as needed. Items marked **NO reset** are the highest-value future additions.
+
+**DB / service caches (#2580 class):**
+- `core/RAG/rag_service/advanced_cache:_shared_semantic_cache` — reset via `register_semantic_cache()` (no null-reset)
+- `core/Evaluations/unified_evaluation_service:_service_instance`, `db_adapter:_global_adapter` — **NO reset**; constructed with a `db_path` at first call
+- `core/Agent_Orchestration/db_factory` — `@lru_cache(maxsize=64)` DB-handle factory; `.cache_clear()` not wired to conftest
+- `core/RAG/rag_service/analytics_db:_analytics_db`, `agentic_execution:_STRUCT_DB` — **NO reset**
+- `core/Chat/provider_manager:_provider_manager`, `core/LLM_Calls/adapter_registry:_registry`, `embeddings_adapter_registry:_emb_registry` — **NO reset**
+- `core/Storage/__init__:_storage_backend_instance` — helper sets to None
+
+**Drain / lifecycle singletons (#2581 class):**
+- `core/TTS/tts_resource_manager:_resource_manager` — `close_resource_manager()` intentionally does *not* close the global
+- `core/TTS/tts_service_v2:_service_instance`, `voice_manager:_voice_manager`, `Scheduler/scheduler:_GLOBAL_SCHEDULER` — background tasks bound to first event loop
+- Resource-governor singletons `_rg_*_governor` across `Chat/`, `Embeddings/`, `Evaluations/`, `MCP_unified/auth/`, `Web_Scraping/`, `Usage/` rate limiters — **NO reset**
+- Daily-ledger singletons in `Usage/`, `Workflows/`, `Evaluations/`, `Resource_Governance/` — **NO reset**
+
+**Already-covered infrastructure (autouse reset in conftest, low risk):**
+- `core/config:_CONFIG_PARSER_CACHE` + `@lru_cache` fns — `clear_config_cache()` (autouse)
+- `core/http_client:{_AIOHTTP_SESSION_CACHE,_HTTPX_ASYNC_CLIENT_CACHE,_HTTPX_CLIENT_CACHE}` — `shutdown_http_client()`
+- App lifecycle `draining` flag lives on `app.state` (per-app-instance), reset by `reset_lifecycle_state()` — **not** a module global, so not the #2581 source
+
+## Verification (this PR)
+
+- **Mechanism:** 5 synthetic tests in `tests/Infrastructure/test_singleton_guard_mechanism.py` prove leak detection, false-positive avoidance (cleanup within a module), skipping unloaded modules, error-mode nonzero exit, and reader helpers.
+- **No false positives:** Config (166), Embeddings_isolated (117), and RAG (653) — 936 tests across many module boundaries — produced **zero** guard warnings, confirming the existing autouse reset fixtures cover these lanes. Error mode over a real-app lane exits 0.
+- The guard is opt-in and a no-op by default; it exists to catch *regressions* of the #2580/#2581/#2585 classes and to be pointed at broader lanes / more watched globals over time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -612,6 +612,12 @@ testpaths = ["tldw_Server_API/tests", "tldw_Server_API/app/core/MCP_unified/test
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+# NOTE: `plugins` is NOT a recognized `[tool.pytest.ini_options]` key — pytest
+# silently ignores it. The suite's plugins are actually loaded via
+# `pytest_plugins` in conftest.py (repo root) and
+# tldw_Server_API/tests/conftest.py. This list is kept only as documentation of
+# the intended plugin set; DO NOT register a new plugin here expecting it to
+# load — add it to a `pytest_plugins` tuple instead.
 plugins = [
     # Shared fixtures/plugins for the suite
     "tldw_Server_API.tests._plugins.authnz_fixtures",

--- a/tldw_Server_API/tests/Infrastructure/test_singleton_guard_mechanism.py
+++ b/tldw_Server_API/tests/Infrastructure/test_singleton_guard_mechanism.py
@@ -52,6 +52,70 @@ def test_guard_detects_leak_when_module_grows_a_watched_cache(
     assert "synthetic._cache" in guard.leaks[0]
 
 
+def test_guard_detects_singleton_becoming_live_from_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """None -> set is the #2580/#2581 signal (DB backend bound, drain singleton
+    became live) and must be flagged, not silently skipped."""
+    module_name = "tldw_singleton_guard_fake_none_to_set"
+    module = types.ModuleType(module_name)
+    module._instance = None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, module)
+    watch = sg.WatchedGlobal(
+        label="synthetic._instance",
+        module=module_name,
+        reader=sg._is_set_attr("_instance"),
+        why="synthetic singleton",
+    )
+    monkeypatch.setattr(sg, "WATCHLIST", [watch])
+
+    guard = sg.SingletonGuard(mode="warn")
+    guard.enter_module("mod_a")  # baseline: _instance is None (False)
+    module._instance = object()  # mod_a leaves a live singleton  # type: ignore[attr-defined]
+    guard.enter_module("mod_b")
+    guard.finish()
+
+    assert guard.leaks, "guard missed a None->set singleton leak"
+    assert "synthetic._instance" in guard.leaks[0]
+
+
+def test_guard_is_quiet_when_module_clears_state_it_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """set -> None (a module clearing its own singleton) is hygiene, not a leak."""
+    module_name = "tldw_singleton_guard_fake_set_to_none"
+    module = types.ModuleType(module_name)
+    module._instance = object()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, module)
+    watch = sg.WatchedGlobal(
+        label="synthetic._instance",
+        module=module_name,
+        reader=sg._is_set_attr("_instance"),
+        why="synthetic singleton",
+    )
+    monkeypatch.setattr(sg, "WATCHLIST", [watch])
+
+    guard = sg.SingletonGuard(mode="warn")
+    guard.enter_module("mod_a")  # baseline: live
+    module._instance = None  # mod_a cleaned up after itself  # type: ignore[attr-defined]
+    guard.enter_module("mod_b")
+    guard.finish()
+
+    assert not guard.leaks, f"clearing state was wrongly flagged: {guard.leaks}"
+
+
+def test_is_regression_only_flags_the_dangerous_direction() -> None:
+    """Unit coverage for the leak-direction rule."""
+    assert sg._is_regression(False, True) is True  # became live
+    assert sg._is_regression(True, False) is False  # cleared
+    assert sg._is_regression(0, 3) is True  # grew
+    assert sg._is_regression(3, 0) is False  # shrank
+    assert sg._is_regression(None, 12345) is True  # became set (id)
+    assert sg._is_regression(111, 222) is True  # rebound to a different object
+    assert sg._is_regression(12345, None) is False  # cleared (id -> None)
+    assert sg._is_regression(5, 5) is False  # unchanged
+
+
 def test_guard_is_quiet_when_module_cleans_up_after_itself(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Infrastructure/test_singleton_guard_mechanism.py
+++ b/tldw_Server_API/tests/Infrastructure/test_singleton_guard_mechanism.py
@@ -1,0 +1,120 @@
+"""Mechanism tests for the singleton-guard plugin.
+
+These prove the boundary-snapshot leak detector works, independent of which
+real globals are on the production watchlist — a synthetic module is placed in
+``sys.modules`` and a synthetic ``WatchedGlobal`` points at it.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management import media_db  # noqa: F401 - import sanity only
+from tldw_Server_API.tests._plugins import singleton_guard as sg
+
+pytestmark = pytest.mark.unit
+
+
+def _fake_module_with_cache(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module._cache = {}  # type: ignore[attr-defined]
+    return module
+
+
+def _install_watch(monkeypatch: pytest.MonkeyPatch, module_name: str) -> None:
+    watch = sg.WatchedGlobal(
+        label="synthetic._cache",
+        module=module_name,
+        reader=sg._len_attr("_cache"),
+        why="synthetic test cache",
+    )
+    monkeypatch.setattr(sg, "WATCHLIST", [watch])
+
+
+def test_guard_detects_leak_when_module_grows_a_watched_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "tldw_singleton_guard_fake_leaky"
+    fake = _fake_module_with_cache(module_name)
+    monkeypatch.setitem(sys.modules, module_name, fake)
+    _install_watch(monkeypatch, module_name)
+
+    guard = sg.SingletonGuard(mode="warn")
+    guard.enter_module("mod_a")  # baseline: cache empty
+    fake._cache["polluted"] = 1  # mod_a leaves state behind
+    guard.enter_module("mod_b")  # boundary: mod_a finalized here
+    guard.finish()
+
+    assert guard.leaks, "guard failed to detect a cross-module cache leak"
+    assert "mod_a" in guard.leaks[0]
+    assert "synthetic._cache" in guard.leaks[0]
+
+
+def test_guard_is_quiet_when_module_cleans_up_after_itself(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "tldw_singleton_guard_fake_clean"
+    fake = _fake_module_with_cache(module_name)
+    monkeypatch.setitem(sys.modules, module_name, fake)
+    _install_watch(monkeypatch, module_name)
+
+    guard = sg.SingletonGuard(mode="warn")
+    guard.enter_module("mod_a")
+    fake._cache["temp"] = 1
+    del fake._cache["temp"]  # cleaned up before the boundary
+    guard.enter_module("mod_b")
+    guard.finish()
+
+    assert not guard.leaks, f"guard reported a false positive: {guard.leaks}"
+
+
+def test_guard_ignores_modules_not_loaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A watched module absent from sys.modules contributes no snapshot/leak."""
+    _install_watch(monkeypatch, "tldw_module_that_is_not_imported_anywhere")
+
+    guard = sg.SingletonGuard(mode="warn")
+    guard.enter_module("mod_a")
+    guard.enter_module("mod_b")
+    guard.finish()
+
+    assert not guard.leaks
+
+
+def test_error_mode_forces_nonzero_exit_via_sessionfinish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "tldw_singleton_guard_fake_error"
+    fake = _fake_module_with_cache(module_name)
+    monkeypatch.setitem(sys.modules, module_name, fake)
+    _install_watch(monkeypatch, module_name)
+
+    guard = sg.SingletonGuard(mode="error")
+    guard.enter_module("mod_a")
+    fake._cache["x"] = 1
+    guard.enter_module("mod_b")
+
+    class _FakeConfig:
+        _singleton_guard = guard
+
+    class _FakeSession:
+        config = _FakeConfig()
+        exitstatus = 0
+
+    session = _FakeSession()
+    sg.pytest_sessionfinish(session, exitstatus=0)  # type: ignore[arg-type]
+
+    assert session.exitstatus == 1, "error mode did not force a nonzero exit"
+
+
+def test_reader_helpers_snapshot_expected_shapes() -> None:
+    module = types.ModuleType("tldw_reader_helper_probe")
+    module._instance = None  # type: ignore[attr-defined]
+    module._cache = {"a": 1}  # type: ignore[attr-defined]
+
+    assert sg._is_set_attr("_instance")(module) is False
+    module._instance = object()  # type: ignore[attr-defined]
+    assert sg._is_set_attr("_instance")(module) is True
+    assert sg._len_attr("_cache")(module) == 1
+    assert sg._len_attr("_missing")(module) is None

--- a/tldw_Server_API/tests/_plugins/singleton_guard.py
+++ b/tldw_Server_API/tests/_plugins/singleton_guard.py
@@ -1,0 +1,284 @@
+"""Singleton / lifecycle isolation guard.
+
+Detects process-global state that one test module leaves mutated for the
+*next* module to inherit — the failure class behind the audit's top-severity
+defects (audits/2026-07-04-test-suite-audit-round2.md, RA5):
+
+* #2580 — service-layer singleton caches registered against the wrong DB
+* #2581 — Embeddings/TTS drain state corrupting subsequent suites
+* #2585 — ``reload_app_main()`` swapping the cached app-module identity
+
+Mechanism (deliberately different from ``http_client_patch_guard``, which
+intercepts at patch time): a curated watchlist of known-dangerous globals is
+snapshotted at every test-module boundary. If a module ends with a watched
+global changed from how that module started it (and the change persists into
+the next module), the guard reports a leak, attributing it to the module that
+caused it.
+
+Only modules already present in ``sys.modules`` are inspected — the guard
+never force-imports anything, so it is cheap and free of import side effects.
+A module that a lane never loads simply has nothing to leak.
+
+Activation (opt-in) via the ``TLDW_SINGLETON_GUARD`` env var:
+
+* unset / ``"off"`` — disabled (default)
+* ``"warn"``        — emit a warning per leak (does not fail the run)
+* ``"error"``       — additionally force a non-zero session exit
+
+Register via ``pytest_plugins`` in ``tldw_Server_API/tests/conftest.py`` (the
+``http_client_patch_guard`` precedent) — NOT via the ``plugins`` key in
+``pyproject.toml``, which is not a real pytest option and is silently ignored.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+
+@dataclass(frozen=True)
+class WatchedGlobal:
+    """One process-global whose state the guard tracks across module boundaries."""
+
+    label: str
+    module: str
+    #: Reads a cheap, comparable snapshot from the imported module (int count,
+    #: bool presence, frozenset of keys, ...). Must never mutate.
+    reader: Callable[[Any], object]
+    #: Reason a change here is dangerous (shown in the leak report).
+    why: str
+
+
+def _len_attr(attr: str) -> Callable[[Any], object]:
+    """Reader: ``len(getattr(module, attr))`` when present, else None."""
+
+    def read(module: Any) -> object:
+        target = getattr(module, attr, None)
+        if target is None:
+            return None
+        try:
+            return len(target)
+        except TypeError:
+            return repr(target)
+
+    return read
+
+
+def _is_set_attr(attr: str) -> Callable[[Any], object]:
+    """Reader: whether ``module.attr`` is currently non-None (singleton set)."""
+
+    def read(module: Any) -> object:
+        return getattr(module, attr, None) is not None
+
+    return read
+
+
+def _call_len(func_name: str, cache_attr: str = "cache_info") -> Callable[[Any], object]:
+    """Reader: current size of an ``@lru_cache``-wrapped function."""
+
+    def read(module: Any) -> object:
+        func = getattr(module, func_name, None)
+        info = getattr(func, cache_attr, None)
+        if not callable(info):
+            return None
+        try:
+            return info().currsize
+        except Exception:
+            return None
+
+    return read
+
+
+def _identity_attr(attr: str) -> Callable[[Any], object]:
+    """Reader: ``id(module.attr)`` when set, else None.
+
+    Detects a same-named object being *rebound* to a different instance (a DB
+    backend swap) across a boundary, which ``_is_set_attr`` would miss.
+    """
+
+    def read(module: Any) -> object:
+        target = getattr(module, attr, None)
+        return id(target) if target is not None else None
+
+    return read
+
+
+def _module_self_id(module: Any) -> object:
+    """Reader: ``id`` of the watched module object itself.
+
+    Detects ``reload_app_main()`` swapping the app-main module in
+    ``sys.modules`` (#2585) — a changed id means other references are stale.
+    """
+    return id(module)
+
+
+# --------------------------------------------------------------------------- #
+# Curated watchlist — the known-dangerous globals from the audit inventory.
+# Ordered by defect adjacency. Add entries as new leak sources are found; each
+# should read a comparable snapshot cheaply and never mutate.
+# --------------------------------------------------------------------------- #
+WATCHLIST: list[WatchedGlobal] = [
+    # 1. Content DB backend — #2580 epicenter. A rebind (identity change)
+    #    across a boundary means a DB swap leaked into the next suite.
+    WatchedGlobal(
+        label="content_db_backend",
+        module="tldw_Server_API.app.core.DB_Management.media_db.runtime.defaults",
+        reader=_identity_attr("content_db_backend"),
+        why="content DB backend rebound without reset_media_runtime_defaults()",
+    ),
+    # 2. Per-user ChaCha DB cache — #2580. Live handles bound to USER_DB_BASE_DIR
+    #    carried across a boundary return wrong-DB handles.
+    WatchedGlobal(
+        label="_chacha_db_instances",
+        module="tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps",
+        reader=_len_attr("_chacha_db_instances"),
+        why="per-user ChaChaNotesDB handles left cached across suites",
+    ),
+    # 3. App-main module identity — #2585. reload_app_main() swaps this module;
+    #    a changed id means references held elsewhere are now stale.
+    WatchedGlobal(
+        label="app.main module identity",
+        module="tldw_Server_API.app.main",
+        reader=_module_self_id,
+        why="reload_app_main() swapped sys.modules['...app.main']",
+    ),
+    # 4. RAG shared semantic caches — #2580. A cache bound to a prior test's
+    #    DB/namespace staying visible to the next.
+    WatchedGlobal(
+        label="_SHARED_CACHES",
+        module="tldw_Server_API.app.core.RAG.rag_service.semantic_cache",
+        reader=_len_attr("_SHARED_CACHES"),
+        why="shared semantic caches left populated across suites",
+    ),
+    # 5-7. Embeddings drain singletons — #2581. None->set (or lingering after a
+    #      suite drained them) bleeds drained lifecycle state into the next.
+    WatchedGlobal(
+        label="_pool_manager",
+        module="tldw_Server_API.app.core.Embeddings.connection_pool",
+        reader=_is_set_attr("_pool_manager"),
+        why="embeddings connection-pool manager left live/drained across suites",
+    ),
+    WatchedGlobal(
+        label="_async_service_fallback",
+        module="tldw_Server_API.app.core.Embeddings.async_embeddings",
+        reader=_is_set_attr("_async_service_fallback"),
+        why="async embedding service singleton left live across suites",
+    ),
+    WatchedGlobal(
+        label="_batcher_fallback",
+        module="tldw_Server_API.app.core.Embeddings.request_batching",
+        reader=_is_set_attr("_batcher_fallback"),
+        why="request batcher singleton left live/drained across suites",
+    ),
+]
+
+
+@dataclass
+class _ModuleState:
+    name: str
+    start: dict[str, object] = field(default_factory=dict)
+
+
+class SingletonGuard:
+    """Snapshots the watchlist at module boundaries and reports leaks."""
+
+    def __init__(self, mode: str) -> None:
+        self.mode = mode  # "warn" | "error"
+        self._current: _ModuleState | None = None
+        self.leaks: list[str] = []
+
+    def _snapshot(self) -> dict[str, object]:
+        """Read every watched global that is currently importable/loaded."""
+        snap: dict[str, object] = {}
+        for w in WATCHLIST:
+            module = sys.modules.get(w.module)
+            if module is None:
+                continue  # not loaded on this lane -> nothing to leak yet
+            try:
+                snap[w.label] = w.reader(module)
+            except Exception:
+                # a flaky reader must never break the run
+                continue
+        return snap
+
+    def _finalize(self, state: _ModuleState) -> None:
+        """Compare a finishing module's end snapshot against its start."""
+        end = self._snapshot()
+        by_label = {w.label: w for w in WATCHLIST}
+        for label, end_val in end.items():
+            start_val = state.start.get(label)
+            if start_val is None or end_val is None:
+                continue
+            if end_val != start_val:
+                w = by_label.get(label)
+                why = f" — {w.why}" if w else ""
+                self.leaks.append(
+                    f"{state.name}: left '{label}' changed {start_val!r} -> {end_val!r}{why}"
+                )
+
+    def enter_module(self, name: str) -> None:
+        if self._current is not None and self._current.name == name:
+            return
+        if self._current is not None:
+            self._finalize(self._current)
+        self._current = _ModuleState(name=name, start=self._snapshot())
+
+    def finish(self) -> None:
+        if self._current is not None:
+            self._finalize(self._current)
+            self._current = None
+        if not self.leaks:
+            return
+        header = (
+            f"[singleton-guard] {len(self.leaks)} cross-module state leak(s) detected "
+            f"(mode={self.mode}):"
+        )
+        body = "\n".join(f"  - {leak}" for leak in self.leaks)
+        message = f"{header}\n{body}"
+        # Printed to stderr (not warnings.warn): sessionfinish runs AFTER pytest's
+        # warning summary is rendered, so a warning here would be invisible.
+        print(message, file=sys.stderr)  # noqa: T201 - guard diagnostic
+        if self.mode == "warn":
+            warnings.warn(
+                f"[singleton-guard] {len(self.leaks)} cross-module state leak(s); "
+                "see stderr for detail",
+                stacklevel=1,
+            )
+
+
+def _resolve_mode() -> str | None:
+    raw = (os.getenv("TLDW_SINGLETON_GUARD") or "").strip().lower()
+    if raw in ("warn", "error"):
+        return raw
+    return None
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    mode = _resolve_mode()
+    if mode is None:
+        return
+    guard = SingletonGuard(mode)
+    config._singleton_guard = guard  # type: ignore[attr-defined]
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    guard = getattr(item.config, "_singleton_guard", None)
+    if guard is None:
+        return
+    module = getattr(item, "module", None)
+    name = getattr(module, "__name__", None) or str(getattr(item, "fspath", "?"))
+    guard.enter_module(name)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    guard = getattr(session.config, "_singleton_guard", None)
+    if guard is None:
+        return
+    guard.finish()
+    if guard.mode == "error" and guard.leaks and exitstatus == 0:
+        session.exitstatus = 1

--- a/tldw_Server_API/tests/_plugins/singleton_guard.py
+++ b/tldw_Server_API/tests/_plugins/singleton_guard.py
@@ -178,6 +178,31 @@ WATCHLIST: list[WatchedGlobal] = [
 ]
 
 
+def _is_regression(start: object, end: object) -> bool:
+    """True when *end* holds MORE/DIFFERENT live state than *start*.
+
+    Only the dangerous direction is a leak — a module *clearing* its state
+    (``True -> False``, a shrinking count, ``set -> None``) is good hygiene,
+    not pollution:
+
+    * bool (is-set readers): ``False -> True`` is the leak (became live)
+    * int (len readers): growth is the leak
+    * identity ids / mixed None: becoming set or being rebound to a different
+      object is the leak; becoming ``None`` (cleared) is safe
+    """
+    if start == end:
+        return False
+    # bool is a subclass of int — check it first.
+    if isinstance(start, bool) or isinstance(end, bool):
+        return bool(end) and not bool(start)
+    if isinstance(start, int) and isinstance(end, int):
+        return end > start
+    # identity ids (or a None<->value transition): cleared is safe, set/rebind leaks
+    if end is None:
+        return False
+    return start != end
+
+
 @dataclass
 class _ModuleState:
     name: str
@@ -207,14 +232,21 @@ class SingletonGuard:
         return snap
 
     def _finalize(self, state: _ModuleState) -> None:
-        """Compare a finishing module's end snapshot against its start."""
+        """Compare a finishing module's end snapshot against its start.
+
+        Only labels present at *module start* are compared — a watched module
+        that first loaded mid-run is a lazy import, not inherited state. A key
+        maps to ``None`` only when the module was loaded but the global was
+        empty/unset; that is a real value, so a ``None -> set`` transition
+        (a singleton becoming live, a DB backend getting bound) IS a leak.
+        """
         end = self._snapshot()
         by_label = {w.label: w for w in WATCHLIST}
-        for label, end_val in end.items():
-            start_val = state.start.get(label)
-            if start_val is None or end_val is None:
-                continue
-            if end_val != start_val:
+        for label, start_val in state.start.items():
+            if label not in end:
+                continue  # module unloaded mid-run — nothing to inherit
+            end_val = end[label]
+            if _is_regression(start_val, end_val):
                 w = by_label.get(label)
                 why = f" — {w.why}" if w else ""
                 self.leaks.append(

--- a/tldw_Server_API/tests/conftest.py
+++ b/tldw_Server_API/tests/conftest.py
@@ -5,7 +5,11 @@ Registers shared test plugins and provides common fixtures.
 """
 from __future__ import annotations
 
-pytest_plugins = ["tldw_Server_API.tests._plugins.http_client_patch_guard"]
+pytest_plugins = [
+    "tldw_Server_API.tests._plugins.http_client_patch_guard",
+    # Opt-in via TLDW_SINGLETON_GUARD=warn|error; no-op otherwise.
+    "tldw_Server_API.tests._plugins.singleton_guard",
+]
 
 from collections.abc import Callable
 import os


### PR DESCRIPTION
## Summary

Task 3 / PR 6 of `Docs/superpowers/plans/2026-07-04-test-suite-improvement-implementation-plan.md`, targeting the audit's **top-severity, all-High** defect class (RA5): process-global state leaking across test modules — #2580 (service/DB caches registered against the wrong DB), #2581 (embeddings drain singletons), #2585 (`reload_app_main()` swapping `sys.modules`).

**`tests/_plugins/singleton_guard.py`** snapshots a curated watchlist of 7 highest-risk globals at every test-module boundary and reports any that a module leaves changed for the next module to inherit. It only inspects modules already in `sys.modules` (no forced imports → cheap, no side effects). Opt-in via `TLDW_SINGLETON_GUARD=warn|error`; **no-op by default**. Registered via `conftest.py` `pytest_plugins` (the `http_client_patch_guard` precedent) — and this PR annotates the dead `pyproject.toml` `plugins` key that silently ignores registrations.

The watchlist and the full not-yet-watched backlog (governor/ledger singletons with **no** reset hook) are documented in `audits/2026-07-04-singleton-inventory.md`, produced by a dedicated inventory pass over `app/core` + `app/services`.

## Verification (local)
- **Mechanism** (`tests/Infrastructure/test_singleton_guard_mechanism.py`, 5 tests): detects a real cross-module leak, stays quiet when a module cleans up after itself, skips unloaded modules, forces a nonzero exit in error mode, and the reader helpers snapshot correctly. **5/5 pass.**
- **Zero false positives** across Config (166), Embeddings_isolated (117), RAG (653) — 936 tests over many module boundaries produced no guard warnings (the existing autouse reset fixtures cover these lanes); error mode exits 0 on a real-app lane.
- No-op-by-default confirmed; shard-coverage guard and test-quality ratchet both green.

A note on one bug I caught during verification: `warnings.warn` in `pytest_sessionfinish` fires *after* pytest renders its warning summary, so it'd be invisible — warn/error output now prints to stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pytest guard to detect process-global singleton leaks between test modules. It snapshots 7 high-risk globals at module boundaries and now flags None→set and identity rebinds while ignoring cleanup, preventing DB/cache identity and embeddings lifecycle regressions (#2580, #2581, #2585).

- **New Features**
  - New plugin `tldw_Server_API/tests/_plugins/singleton_guard.py`; opt-in via `TLDW_SINGLETON_GUARD=warn|error` (default off).
  - Watches: content DB backend identity, per-user ChaCha DB cache, `app.main` module identity, RAG shared caches, and three Embeddings singletons.
  - Snapshots only modules already in `sys.modules`; diagnostics to stderr; error mode forces nonzero exit at session end.
  - Registered via `pytest_plugins` in `tldw_Server_API/tests/conftest.py`; `pyproject.toml` `plugins` key annotated as non-functional.
  - Mechanism tests and `audits/2026-07-04-singleton-inventory.md`; zero false positives across 936 tests; no-op by default.

- **Bug Fixes**
  - Detects None→set transitions and identity rebinds; treats set→None and count shrink as cleanup (not leaks).
  - Compares only labels present at module start to avoid lazy-import noise.
  - Mechanism coverage expanded to 8/8, including direction-of-change rules; stricter logic keeps error-mode exits at 0 on the Config lane.

<sup>Written for commit 3ec1a6978aa5bd80a9880dd6c542f15990336d45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

