### PR TITLE
test(ci): isolation reproducer meta-tests + nightly shuffle (plan Task 4)

### DIFF
--- a/.github/workflows/test-order-shuffle-nightly.yml
+++ b/.github/workflows/test-order-shuffle-nightly.yml
@@ -1,0 +1,86 @@
+name: Test Order Shuffle (Nightly)
+
+# Surfaces order-dependence / cross-test state leaks (the #2580/#2581/#2585
+# class) by running high-risk lanes in randomized order via pytest-randomly.
+# NOT PR-blocking — informational until it is green 5 consecutive runs, then it
+# may be promoted to a required check.
+
+on:
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: "Fixed --randomly-seed (blank = random per run)"
+        required: false
+        default: ""
+  schedule:
+    - cron: '0 8 * * *'  # daily 08:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shuffle:
+    name: Shuffled order — ${{ matrix.lane.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        lane:
+          - name: embeddings-isolated
+            path: tldw_Server_API/tests/Embeddings_isolated
+          - name: rag
+            path: tldw_Server_API/tests/RAG
+          - name: infrastructure
+            path: tldw_Server_API/tests/Infrastructure
+    env:
+      PYTHONPATH: .
+      PYTEST_DISABLE_PLUGIN_AUTOLOAD: '1'
+      TEST_MODE: 'true'
+      DISABLE_HEAVY_STARTUP: '1'
+      # exercise the isolation guard while shuffling; warn (don't fail) so a
+      # leak surfaces as a diagnostic rather than a hard failure during rollout
+      TLDW_SINGLETON_GUARD: 'warn'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Python and deps (with uv)
+        uses: ./.github/actions/setup-python-deps
+        with:
+          python-version: '3.12'
+          use-uv: 'true'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
+          extras: dev
+
+      - name: Ensure shuffle/asyncio plugins installed
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-asyncio pytest-randomly
+
+      - name: Verify pytest-randomly import (autoload disabled)
+        run: |
+          python - <<'PY'
+          import importlib
+          importlib.import_module('pytest_randomly')
+          print('pytest_randomly import OK')
+          PY
+
+      - name: Run lane in randomized order
+        run: |
+          SEED_ARG=""
+          if [ -n "${{ github.event.inputs.seed }}" ]; then
+            # plugin is already loaded via -p pytest_randomly below; only pin the seed
+            SEED_ARG="--randomly-seed=${{ github.event.inputs.seed }}"
+          fi
+          pytest -q --disable-warnings \
+            -p pytest_asyncio.plugin \
+            -p pytest_randomly \
+            $SEED_ARG \
+            "${{ matrix.lane.path }}"

--- a/.github/workflows/test-order-shuffle-nightly.yml
+++ b/.github/workflows/test-order-shuffle-nightly.yml
@@ -59,11 +59,9 @@ jobs:
             uv.lock
           extras: dev
 
-      - name: Ensure shuffle/asyncio plugins installed
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-randomly
-
+      # pytest-randomly / pytest-asyncio come from the `dev` extras installed
+      # above (pytest-randomly is now a dev-dep in pyproject) — no extra pip
+      # install that would override the resolved environment.
       - name: Verify pytest-randomly import (autoload disabled)
         run: |
           python - <<'PY'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ dev = [
   "pytest-mock>=3.15.1",
   "pytest-timeout>=2.4.0",
   "pytest-benchmark>=5.2.3",
+  "pytest-randomly>=3.15.0",
   "black>=26.3.1",
   "mypy>=1.20.1",
   "ruff>=0.15.10",

--- a/tldw_Server_API/tests/Infrastructure/test_singleton_isolation.py
+++ b/tldw_Server_API/tests/Infrastructure/test_singleton_isolation.py
@@ -1,0 +1,123 @@
+"""Would-have-caught regression tests for the test-isolation defect class.
+
+Each test is a minimized reproducer of a specific process-global leak from
+audits/2026-07-04-test-suite-audit-round2.md (RA5). They assert that the
+*reset hook* restores isolation — so removing/weakening that hook makes the
+test fail (the "would have caught it" property).
+
+* #2580 — service/DB singleton caches registered against the wrong DB
+* #2581 — Embeddings drain singletons bleeding across suites
+* #2585 — reload_app_main() swapping the app-main module identity (STILL OPEN;
+          its meta-test is xfail-with-issue-link until the fix ships)
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# #2581 — Embeddings connection-pool manager drain singleton
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_embeddings_pool_manager_reset_yields_fresh_instance() -> None:
+    """The global pool manager must be nulled by its reset hook, so a suite
+    that drained it does not hand a drained manager to the next suite (#2581).
+
+    Reproducer: without ``cleanup_connection_pools()`` nulling ``_pool_manager``
+    the second ``get_pool_manager()`` returns the same (drained) object.
+    """
+    from tldw_Server_API.app.core.Embeddings import connection_pool as cp
+
+    first = cp.get_pool_manager()
+    assert cp._pool_manager is first
+    try:
+        await cp.cleanup_connection_pools()  # the reset hook
+        assert cp._pool_manager is None, "cleanup did not null the global manager"
+        second = cp.get_pool_manager()
+        assert second is not first, "drained manager leaked into the next acquisition"
+    finally:
+        await cp.cleanup_connection_pools()
+
+
+# --------------------------------------------------------------------------- #
+# #2580 — per-user ChaCha DB cache bound to USER_DB_BASE_DIR
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_chacha_db_cache_rebinds_to_new_base_dir_after_reset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A per-user DB handle cached under base dir A must not be reused after the
+    base dir changes to B; the reset hook clears the cache so the handle rebinds
+    to the new DB (#2580 — wrong-DB handle leak).
+    """
+    from tldw_Server_API.app.api.v1.API_Deps import ChaCha_Notes_DB_Deps as dep
+
+    base_a = tmp_path / "base_a"
+    base_b = tmp_path / "base_b"
+    base_a.mkdir()
+    base_b.mkdir()
+
+    await dep.shutdown_chacha_resources()
+    dep.reset_chacha_shutdown_state()
+    assert dep._get_chacha_cached_instance_count() == 0
+
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_a))
+    db_a = await dep.get_chacha_db_for_user_id(1)
+    path_a = db_a.db_path_str
+    assert dep._get_chacha_cached_instance_count() == 1
+    assert str(base_a) in path_a
+
+    # the reset hook — clears the per-user cache
+    await dep.shutdown_chacha_resources()
+    dep.reset_chacha_shutdown_state()
+    assert dep._get_chacha_cached_instance_count() == 0, "reset did not clear the DB cache"
+
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_b))
+    db_b = await dep.get_chacha_db_for_user_id(1)
+    path_b = db_b.db_path_str
+    try:
+        assert str(base_b) in path_b, "handle did not rebind to the new base dir"
+        assert path_a != path_b, "same DB handle leaked across a base-dir change (#2580)"
+    finally:
+        await dep.shutdown_chacha_resources()
+        dep.reset_chacha_shutdown_state()
+
+
+# --------------------------------------------------------------------------- #
+# #2585 — reload_app_main() swaps sys.modules['...app.main'] identity (OPEN)
+# --------------------------------------------------------------------------- #
+@pytest.mark.slow
+@pytest.mark.xfail(
+    reason="#2585 open: reload_app_main() swaps the app-main module identity and "
+    "there is no autouse restore, so references held before a reload go stale. "
+    "Flip to strict (remove xfail) when #2585 ships.",
+    strict=False,
+)
+def test_app_main_identity_is_stable_across_a_reload() -> None:
+    """DESIRED invariant (currently failing → xfail): a test that reloads the app
+    main module should not leave a different module identity behind for code that
+    imported it earlier. Restores app.main in ``finally`` so the meta-test never
+    pollutes the rest of the session.
+    """
+    from tldw_Server_API.tests.helpers.app_main_state import (
+        reload_app_main,
+        restore_app_main,
+        snapshot_app_main,
+    )
+
+    original = snapshot_app_main()
+    try:
+        reloaded = reload_app_main()
+        # The hazard: identity diverges. Asserting stability documents the fix
+        # target; while #2585 is open this fails and is xfail'd.
+        assert id(reloaded) == id(original), (
+            "reload_app_main swapped the app-main module identity (#2585)"
+        )
+    finally:
+        restore_app_main(original)
+        # sanity: session is left with the original module in place
+        assert sys.modules.get("tldw_Server_API.app.main") is original

--- a/tldw_Server_API/tests/Infrastructure/test_singleton_isolation.py
+++ b/tldw_Server_API/tests/Infrastructure/test_singleton_isolation.py
@@ -12,7 +12,7 @@ test fail (the "would have caught it" property).
 """
 from __future__ import annotations
 
-import sys
+from pathlib import Path
 
 import pytest
 
@@ -22,7 +22,6 @@ pytestmark = pytest.mark.unit
 # --------------------------------------------------------------------------- #
 # #2581 — Embeddings connection-pool manager drain singleton
 # --------------------------------------------------------------------------- #
-@pytest.mark.asyncio
 async def test_embeddings_pool_manager_reset_yields_fresh_instance() -> None:
     """The global pool manager must be nulled by its reset hook, so a suite
     that drained it does not hand a drained manager to the next suite (#2581).
@@ -46,9 +45,8 @@ async def test_embeddings_pool_manager_reset_yields_fresh_instance() -> None:
 # --------------------------------------------------------------------------- #
 # #2580 — per-user ChaCha DB cache bound to USER_DB_BASE_DIR
 # --------------------------------------------------------------------------- #
-@pytest.mark.asyncio
 async def test_chacha_db_cache_rebinds_to_new_base_dir_after_reset(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """A per-user DB handle cached under base dir A must not be reused after the
     base dir changes to B; the reset hook clears the cache so the handle rebinds
@@ -61,25 +59,26 @@ async def test_chacha_db_cache_rebinds_to_new_base_dir_after_reset(
     base_a.mkdir()
     base_b.mkdir()
 
-    await dep.shutdown_chacha_resources()
-    dep.reset_chacha_shutdown_state()
-    assert dep._get_chacha_cached_instance_count() == 0
-
-    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_a))
-    db_a = await dep.get_chacha_db_for_user_id(1)
-    path_a = db_a.db_path_str
-    assert dep._get_chacha_cached_instance_count() == 1
-    assert str(base_a) in path_a
-
-    # the reset hook — clears the per-user cache
-    await dep.shutdown_chacha_resources()
-    dep.reset_chacha_shutdown_state()
-    assert dep._get_chacha_cached_instance_count() == 0, "reset did not clear the DB cache"
-
-    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_b))
-    db_b = await dep.get_chacha_db_for_user_id(1)
-    path_b = db_b.db_path_str
+    # Whole body is guarded: any failed assertion still tears down cached handles.
     try:
+        await dep.shutdown_chacha_resources()
+        dep.reset_chacha_shutdown_state()
+        assert dep._get_chacha_cached_instance_count() == 0
+
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(base_a))
+        db_a = await dep.get_chacha_db_for_user_id(1)
+        path_a = db_a.db_path_str
+        assert dep._get_chacha_cached_instance_count() == 1
+        assert str(base_a) in path_a
+
+        # the reset hook — clears the per-user cache
+        await dep.shutdown_chacha_resources()
+        dep.reset_chacha_shutdown_state()
+        assert dep._get_chacha_cached_instance_count() == 0, "reset did not clear the DB cache"
+
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(base_b))
+        db_b = await dep.get_chacha_db_for_user_id(1)
+        path_b = db_b.db_path_str
         assert str(base_b) in path_b, "handle did not rebind to the new base dir"
         assert path_a != path_b, "same DB handle leaked across a base-dir change (#2580)"
     finally:
@@ -90,7 +89,6 @@ async def test_chacha_db_cache_rebinds_to_new_base_dir_after_reset(
 # --------------------------------------------------------------------------- #
 # #2585 — reload_app_main() swaps sys.modules['...app.main'] identity (OPEN)
 # --------------------------------------------------------------------------- #
-@pytest.mark.slow
 @pytest.mark.xfail(
     reason="#2585 open: reload_app_main() swaps the app-main module identity and "
     "there is no autouse restore, so references held before a reload go stale. "
@@ -100,24 +98,23 @@ async def test_chacha_db_cache_rebinds_to_new_base_dir_after_reset(
 def test_app_main_identity_is_stable_across_a_reload() -> None:
     """DESIRED invariant (currently failing → xfail): a test that reloads the app
     main module should not leave a different module identity behind for code that
-    imported it earlier. Restores app.main in ``finally`` so the meta-test never
-    pollutes the rest of the session.
+    imported it earlier. Uses ``import_app_main()`` (never None) and restores in
+    ``finally`` so the meta-test never pollutes the rest of the session.
     """
     from tldw_Server_API.tests.helpers.app_main_state import (
+        import_app_main,
         reload_app_main,
         restore_app_main,
-        snapshot_app_main,
     )
 
-    original = snapshot_app_main()
+    original = import_app_main()
+    assert original is not None
     try:
         reloaded = reload_app_main()
-        # The hazard: identity diverges. Asserting stability documents the fix
+        # The hazard: a fresh module object. Asserting identity documents the fix
         # target; while #2585 is open this fails and is xfail'd.
-        assert id(reloaded) == id(original), (
+        assert reloaded is original, (
             "reload_app_main swapped the app-main module identity (#2585)"
         )
     finally:
         restore_app_main(original)
-        # sanity: session is left with the original module in place
-        assert sys.modules.get("tldw_Server_API.app.main") is original

--- a/tldw_Server_API/tests/_plugins/singleton_reset_fixtures.py
+++ b/tldw_Server_API/tests/_plugins/singleton_reset_fixtures.py
@@ -1,0 +1,48 @@
+"""Opt-in reset fixtures for process-global singletons that lack a per-test hook.
+
+The audit inventory (audits/2026-07-04-singleton-inventory.md) found the
+Embeddings drain singletons have only an ``atexit`` shutdown — no per-test
+reset — so a suite that drains them could hand drained state to the next
+(#2581). These fixtures let a suite guarantee a clean slate.
+
+Kept OPT-IN (not autouse): the singleton guard currently reports zero leaks on
+the sampled lanes, so a suite-wide autouse reset would add teardown cost for no
+demonstrated benefit and risk resetting state a test legitimately set up.
+Promote to autouse only if the guard surfaces a real leak on a lane.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+async def _reset_embeddings_singletons() -> None:
+    """Best-effort null of the Embeddings drain singletons."""
+    try:
+        from tldw_Server_API.app.core.Embeddings import connection_pool as cp
+
+        await cp.cleanup_connection_pools()
+    except Exception:
+        pass
+    try:
+        from tldw_Server_API.app.core.Embeddings import async_embeddings as ae
+
+        ae._shutdown_async_embedding_service_sync()
+    except Exception:
+        pass
+    try:
+        from tldw_Server_API.app.core.Embeddings import request_batching as rb
+
+        batcher = rb._batcher_fallback
+        if batcher is not None:
+            await batcher.shutdown()
+        rb._batcher_fallback = None
+    except Exception:
+        pass
+
+
+@pytest.fixture
+async def reset_embeddings_singletons():
+    """Reset the Embeddings drain singletons before and after the test."""
+    await _reset_embeddings_singletons()
+    yield
+    await _reset_embeddings_singletons()

--- a/tldw_Server_API/tests/_plugins/singleton_reset_fixtures.py
+++ b/tldw_Server_API/tests/_plugins/singleton_reset_fixtures.py
@@ -12,32 +12,47 @@ Promote to autouse only if the guard surfaces a real leak on a lane.
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
+from loguru import logger
+
+# per-singleton await budget so a hung shutdown cannot stall the loop
+_SHUTDOWN_TIMEOUT_S = 5.0
 
 
 async def _reset_embeddings_singletons() -> None:
-    """Best-effort null of the Embeddings drain singletons."""
+    """Best-effort null of the Embeddings drain singletons.
+
+    Awaits the async shutdowns directly (never the atexit-oriented
+    ``_shutdown_async_embedding_service_sync`` helper, which blocks on
+    ``run_coroutine_threadsafe(...).result()`` and would stall a running event
+    loop). Failures are logged at debug, not silently swallowed.
+    """
     try:
         from tldw_Server_API.app.core.Embeddings import connection_pool as cp
 
-        await cp.cleanup_connection_pools()
-    except Exception:
-        pass
+        await asyncio.wait_for(cp.cleanup_connection_pools(), timeout=_SHUTDOWN_TIMEOUT_S)
+    except Exception as exc:
+        logger.debug(f"reset_embeddings_singletons: pool cleanup skipped: {exc!r}")
     try:
         from tldw_Server_API.app.core.Embeddings import async_embeddings as ae
 
-        ae._shutdown_async_embedding_service_sync()
-    except Exception:
-        pass
+        service = ae._async_service_fallback
+        if service is not None:
+            await asyncio.wait_for(service.shutdown(), timeout=_SHUTDOWN_TIMEOUT_S)
+        ae._async_service_fallback = None
+    except Exception as exc:
+        logger.debug(f"reset_embeddings_singletons: async service reset skipped: {exc!r}")
     try:
         from tldw_Server_API.app.core.Embeddings import request_batching as rb
 
         batcher = rb._batcher_fallback
         if batcher is not None:
-            await batcher.shutdown()
+            await asyncio.wait_for(batcher.shutdown(), timeout=_SHUTDOWN_TIMEOUT_S)
         rb._batcher_fallback = None
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug(f"reset_embeddings_singletons: batcher reset skipped: {exc!r}")
 
 
 @pytest.fixture

--- a/tldw_Server_API/tests/conftest.py
+++ b/tldw_Server_API/tests/conftest.py
@@ -9,6 +9,8 @@ pytest_plugins = [
     "tldw_Server_API.tests._plugins.http_client_patch_guard",
     # Opt-in via TLDW_SINGLETON_GUARD=warn|error; no-op otherwise.
     "tldw_Server_API.tests._plugins.singleton_guard",
+    # Opt-in `reset_embeddings_singletons` fixture (not autouse).
+    "tldw_Server_API.tests._plugins.singleton_reset_fixtures",
 ]
 
 from collections.abc import Callable


### PR DESCRIPTION
## Summary

Task 4 / PR 7 of `Docs/superpowers/plans/2026-07-04-test-suite-improvement-implementation-plan.md` — the would-have-caught regression tests for the top-severity isolation defect class (RA5), plus the tooling to keep it caught. Builds on the singleton guard from PR #2642.

### Reproducer meta-tests (`tests/Infrastructure/test_singleton_isolation.py`)
Each is a minimized reproducer that **fails when the reset hook is broken** (mutation-verified):

| Defect | Invariant | Mutation check |
|--------|-----------|----------------|
| #2581 embeddings pool-manager drain singleton | reset nulls the global → next acquisition is fresh | stop nulling → **fails** ✓ |
| #2580 per-user ChaCha DB cache | reset clears the cache → handle rebinds to a new `USER_DB_BASE_DIR` | stop clearing → **fails** ✓ |
| #2585 `reload_app_main()` identity | app-main identity stable across a reload | **STILL OPEN** → xfail-with-issue-link (flips to xpass, then strict, when the fix ships) |

### Reset fixture (`tests/_plugins/singleton_reset_fixtures.py`)
Opt-in `reset_embeddings_singletons` for the one gap the inventory found — the embeddings drain singletons have only an `atexit` shutdown, no per-test reset. Kept **opt-in, not autouse**: the guard reports zero leaks on sampled lanes, so a suite-wide autouse reset would add teardown cost for no demonstrated benefit.

### Nightly shuffle (`.github/workflows/test-order-shuffle-nightly.yml`)
`pytest-randomly` over Embeddings_isolated / RAG / Infrastructure with `TLDW_SINGLETON_GUARD=warn`. **Not PR-blocking**; the plan promotes it only after 5 consecutive green runs. `pytest-randomly` added as a dev-dep; loaded via the full module name `-p pytest_randomly` (the `randomly` alias is less reliable under `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`).

## Verification (local)
- 2 reproducers pass, 1 xfails on the open bug; both passing reproducers **mutation-verified** (break the reset → fail)
- `-p pytest_randomly` shuffles cleanly with autoload disabled (seed line printed)
- reset fixture nulls the pool manager as expected; shard-coverage + test-quality-triage guards green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add isolation reproducer tests and an opt-in embeddings reset fixture, plus a nightly shuffled test workflow to surface cross-test state leaks. Tightens cleanup (no event-loop stalls) and makes the app-main identity xfail precise to prevent RA5 regressions (#2580, #2581) and track #2585.

- **New Features**
  - Added minimized reproducers in `tests/Infrastructure/test_singleton_isolation.py`:
    - #2581 embeddings pool-manager must be nulled on reset.
    - #2580 per-user ChaCha DB cache must clear so handles rebind to a new `USER_DB_BASE_DIR` (now wrapped in try/finally for guaranteed teardown).
    - #2585 `reload_app_main()` identity is xfail until fixed; uses `import_app_main()` and asserts “reloaded is original”.
  - Introduced `reset_embeddings_singletons` opt-in fixture in `tests/_plugins/singleton_reset_fixtures.py`; awaits async shutdowns directly with a 5s timeout and logs at debug to avoid loop stalls (not autouse).
  - Nightly shuffled-order CI in `.github/workflows/test-order-shuffle-nightly.yml` for Embeddings_isolated / RAG / Infrastructure; uses `-p pytest_randomly` with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` and `TLDW_SINGLETON_GUARD=warn`. Relies on dev extras (no extra pip step) and verifies plugin import.

- **Dependencies**
  - Added `pytest-randomly` (dev).

<sup>Written for commit 2f160d611497dfa0cbca02a1a74cb7469e3b9db4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

