### PR TITLE
test(ci): env-absent defaults + minimal-env startup smoke (plan Task 5)

### DIFF
--- a/.github/workflows/backend-required.yml
+++ b/.github/workflows/backend-required.yml
@@ -113,3 +113,13 @@ jobs:
           pytest -q --disable-warnings -p pytest_asyncio.plugin \
             -m "unit and not e2e and not jobs" \
             tldw_Server_API/tests/unit
+
+      # Boots the app in a DEPLOYMENT-SHAPED (scrubbed) environment — no
+      # TEST_MODE, no conftest env forcing — and probes /health. Catches the
+      # "passes in CI with env vars, fails in a real deployment" class (#2590/
+      # e88c96500f). The script manages its own minimal child env, so no test
+      # env is set at the step level.
+      - name: Minimal-env startup smoke
+        if: needs.changes.outputs.backend_changed == 'true'
+        run: |
+          python Helper_Scripts/ci/minimal_env_smoke.py --timeout 150

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -795,6 +795,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py
               tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
+              tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
               tldw_Server_API/tests/ChaChaNotesDB/test_writing_playground_db.py
           - name: db-privileges
             paths: >-
@@ -2197,6 +2198,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py
               tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
+              tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
               tldw_Server_API/tests/ChaChaNotesDB/test_writing_playground_db.py
           - name: db-privileges
             paths: >-
@@ -3470,6 +3472,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py
               tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
+              tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
               tldw_Server_API/tests/ChaChaNotesDB/test_writing_playground_db.py
           - name: db-privileges
             paths: >-
@@ -4667,6 +4670,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py
               tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
+              tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
               tldw_Server_API/tests/ChaChaNotesDB/test_writing_playground_db.py
           - name: db-privileges
             paths: >-
@@ -5865,6 +5869,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py
               tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
+              tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py
               tldw_Server_API/tests/ChaChaNotesDB/test_writing_playground_db.py
           - name: db-privileges
             paths: >-

--- a/Helper_Scripts/ci/minimal_env_smoke.py
+++ b/Helper_Scripts/ci/minimal_env_smoke.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Boot the server in a deployment-shaped (scrubbed) environment and probe it.
+
+The test conftests force-set dozens of env vars at import time, so an in-pytest
+run never sees the no-override world a real single-user deployment runs in. This
+smoke boots ``tldw_Server_API.app.main:app`` as a subprocess with ONLY a pinned
+minimal env (empty otherwise), waits for ``/health`` to return 200, and exits
+nonzero if startup or the auth default drifts (the #2590/e88c96500f class).
+
+Run:
+    python Helper_Scripts/ci/minimal_env_smoke.py
+    python Helper_Scripts/ci/minimal_env_smoke.py --port 8123 --timeout 60
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# The pinned minimal env a single-user deployment actually needs, and nothing
+# else — no WORKFLOWS_EGRESS_*, no TEST_MODE, no MINIMAL_TEST_APP convenience.
+MINIMAL_ENV = {
+    "AUTH_MODE": "single_user",
+    # >=16 chars, non-placeholder (settings validation)
+    "SINGLE_USER_API_KEY": "smoke-minimal-env-key-0123456789",
+    # keep the boot fast and hermetic without leaning on TEST_MODE
+    "ULTRA_MINIMAL_APP": "1",
+    "AUTO_DOWNLOAD_MODELS": "false",
+    "DISABLE_AUTHNZ_SCHEDULER": "1",
+    "WORKFLOWS_SCHEDULER_ENABLED": "false",
+    "MPLBACKEND": "Agg",
+}
+
+
+def _child_env(repo_root: Path, port: int) -> dict[str, str]:
+    """A scrubbed environment: MINIMAL_ENV plus only what the OS needs to run."""
+    env: dict[str, str] = {"PYTHONPATH": str(repo_root), "PORT": str(port)}
+    for passthrough in ("PATH", "HOME", "LANG", "LC_ALL", "SYSTEMROOT", "TMPDIR", "VIRTUAL_ENV"):
+        value = os.environ.get(passthrough)
+        if value:
+            env[passthrough] = value
+    env.update(MINIMAL_ENV)
+    return env
+
+
+def _probe(url: str) -> tuple[int, str]:
+    with urllib.request.urlopen(url, timeout=3) as resp:  # noqa: S310 - localhost only
+        return resp.status, resp.read().decode("utf-8", "replace")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--port", type=int, default=8137)
+    parser.add_argument("--timeout", type=float, default=90.0, help="seconds to wait for /health")
+    parser.add_argument("--repo-root", default=".")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    health_url = f"http://127.0.0.1:{args.port}/health"
+
+    cmd = [
+        sys.executable, "-m", "uvicorn",
+        "tldw_Server_API.app.main:app",
+        "--host", "127.0.0.1", "--port", str(args.port),
+        "--log-level", "warning",
+    ]
+    print(f"[minimal-env-smoke] booting: {' '.join(cmd)}")
+    # Child output goes to a temp FILE, not subprocess.PIPE: the app logs
+    # heavily at startup and an undrained pipe would fill (~64KB) and deadlock
+    # the child before it binds the port.
+    log_file = Path(tempfile.mkstemp(prefix="minimal-env-smoke-", suffix=".log")[1])
+
+    def _tail_log(n: int = 25) -> str:
+        try:
+            return "\n".join(log_file.read_text("utf-8", "replace").splitlines()[-n:])
+        except OSError:
+            return "<no log captured>"
+
+    with log_file.open("w", encoding="utf-8") as sink:
+        proc = subprocess.Popen(  # noqa: S603 - fixed argv
+            cmd, cwd=str(repo_root), env=_child_env(repo_root, args.port),
+            stdout=sink, stderr=subprocess.STDOUT, text=True,
+        )
+        try:
+            deadline = time.monotonic() + args.timeout
+            last_err = "no response"
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    print(
+                        f"[minimal-env-smoke] FAIL — server exited early (code {proc.returncode}):\n{_tail_log()}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                try:
+                    status, body = _probe(health_url)
+                    if status == 200 and "healthy" in body.lower():
+                        print(f"[minimal-env-smoke] OK — /health returned 200 in a scrubbed environment: {body[:120]}")
+                        return 0
+                    last_err = f"status={status} body={body[:120]}"
+                except (urllib.error.URLError, ConnectionError, OSError) as exc:
+                    last_err = repr(exc)
+                time.sleep(1.0)
+            print(
+                f"[minimal-env-smoke] FAIL — /health not healthy within {args.timeout}s "
+                f"(last: {last_err}):\n{_tail_log()}",
+                file=sys.stderr,
+            )
+            return 1
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            log_file.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Helper_Scripts/ci/minimal_env_smoke.py
+++ b/Helper_Scripts/ci/minimal_env_smoke.py
@@ -39,7 +39,8 @@ MINIMAL_ENV = {
 
 
 def _child_env(repo_root: Path, port: int) -> dict[str, str]:
-    """A scrubbed environment: MINIMAL_ENV plus only what the OS needs to run."""
+    """Build the scrubbed child environment: MINIMAL_ENV plus only the OS
+    variables (PATH/HOME/...) the interpreter needs to run at all."""
     env: dict[str, str] = {"PYTHONPATH": str(repo_root), "PORT": str(port)}
     for passthrough in ("PATH", "HOME", "LANG", "LC_ALL", "SYSTEMROOT", "TMPDIR", "VIRTUAL_ENV"):
         value = os.environ.get(passthrough)
@@ -50,8 +51,17 @@ def _child_env(repo_root: Path, port: int) -> dict[str, str]:
 
 
 def _probe(url: str) -> tuple[int, str]:
-    with urllib.request.urlopen(url, timeout=3) as resp:  # noqa: S310 - localhost only
-        return resp.status, resp.read().decode("utf-8", "replace")
+    """GET *url* and return ``(status_code, body)``.
+
+    A non-2xx response (e.g. a 500 during a broken startup) raises
+    ``HTTPError``; catch it so the status and body still reach diagnostics
+    instead of being flattened into a generic connection error.
+    """
+    try:
+        with urllib.request.urlopen(url, timeout=3) as resp:  # noqa: S310 - localhost only
+            return resp.status, resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as err:
+        return err.code, err.read().decode("utf-8", "replace")
 
 
 def main(argv: list[str]) -> int:
@@ -73,21 +83,28 @@ def main(argv: list[str]) -> int:
     print(f"[minimal-env-smoke] booting: {' '.join(cmd)}")
     # Child output goes to a temp FILE, not subprocess.PIPE: the app logs
     # heavily at startup and an undrained pipe would fill (~64KB) and deadlock
-    # the child before it binds the port.
-    log_file = Path(tempfile.mkstemp(prefix="minimal-env-smoke-", suffix=".log")[1])
+    # the child before it binds the port. Close the mkstemp fd immediately
+    # (we reopen the path by name) to avoid leaking a descriptor.
+    fd, log_path = tempfile.mkstemp(prefix="minimal-env-smoke-", suffix=".log")
+    os.close(fd)
+    log_file = Path(log_path)
 
     def _tail_log(n: int = 25) -> str:
+        """Return the last *n* lines of the child's captured output."""
         try:
             return "\n".join(log_file.read_text("utf-8", "replace").splitlines()[-n:])
         except OSError:
             return "<no log captured>"
 
-    with log_file.open("w", encoding="utf-8") as sink:
-        proc = subprocess.Popen(  # noqa: S603 - fixed argv
-            cmd, cwd=str(repo_root), env=_child_env(repo_root, args.port),
-            stdout=sink, stderr=subprocess.STDOUT, text=True,
-        )
-        try:
+    proc: subprocess.Popen[str] | None = None
+    try:
+        # The `with` closes the sink before the finally unlinks it — required on
+        # Windows, where unlinking an open file raises PermissionError.
+        with log_file.open("w", encoding="utf-8") as sink:
+            proc = subprocess.Popen(  # noqa: S603 - fixed argv
+                cmd, cwd=str(repo_root), env=_child_env(repo_root, args.port),
+                stdout=sink, stderr=subprocess.STDOUT, text=True,
+            )
             deadline = time.monotonic() + args.timeout
             last_err = "no response"
             while time.monotonic() < deadline:
@@ -112,13 +129,14 @@ def main(argv: list[str]) -> int:
                 file=sys.stderr,
             )
             return 1
-        finally:
+    finally:
+        if proc is not None:
             proc.terminate()
             try:
                 proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 proc.kill()
-            log_file.unlink(missing_ok=True)
+        log_file.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/Makefile
+++ b/Makefile
@@ -492,7 +492,7 @@ lint-changed:
 # -----------------------------------------------------------------------------
 # Local CI — reproduce the gating GitHub checks before pushing
 # -----------------------------------------------------------------------------
-.PHONY: ci-local ci-local-full ci-local-lane test-triage
+.PHONY: ci-local ci-local-full ci-local-lane test-triage minimal-env-smoke
 
 # Prefer the project venv python ($(VENV_PYTHON)); fall back to $(PYTHON).
 CI_LOCAL_PYTHON ?= $(shell [ -x "$(VENV_PYTHON)" ] && echo "$(VENV_PYTHON)" || echo "$(PYTHON)")
@@ -512,6 +512,9 @@ ci-local-lane:       ## One area: make ci-local-lane LANE=tldw_Server_API/tests/
 
 test-triage:         ## Ranked test-quality triage report (see audits/2026-07-04-test-suite-audit-round2.md)
 	$(CI_LOCAL_PYTHON) Helper_Scripts/ci/test_quality_triage.py $(CI_ARGS)
+
+minimal-env-smoke:   ## Boot the app in a scrubbed env and probe /health (#2590-class guard)
+	$(CI_LOCAL_PYTHON) Helper_Scripts/ci/minimal_env_smoke.py $(CI_ARGS)
 
 # -----------------------------------------------------------------------------
 # Chat Streaming Load Harness (Scenario A starter)

--- a/tldw_Server_API/tests/Config/test_env_absent_defaults.py
+++ b/tldw_Server_API/tests/Config/test_env_absent_defaults.py
@@ -1,0 +1,143 @@
+"""Env-absent config defaults — the #2590/e88c96500f defect class (RA6).
+
+Real deployments frequently run with NO override env vars set. The test
+conftests force-set many env vars at import time, so the rest of the suite
+never exercises the no-env-var fallback path — which is exactly where the
+hardening-broke-the-fallback defects escaped.
+
+These tests bypass the conftest pollution entirely by passing an explicit
+empty ``env={}`` map to each typed config loader (all take
+``(config_parser, env=None)``), so they assert the true real-deployment
+defaults deterministically.
+"""
+from __future__ import annotations
+
+from configparser import ConfigParser
+
+import pytest
+
+from tldw_Server_API.app.core.config_sections.audio import load_audio_config
+from tldw_Server_API.app.core.config_sections.auth import load_auth_config
+from tldw_Server_API.app.core.config_sections.chat import load_chat_config
+from tldw_Server_API.app.core.config_sections.chunking import load_chunking_config
+from tldw_Server_API.app.core.config_sections.database import load_database_config
+from tldw_Server_API.app.core.config_sections.embeddings import load_embeddings_config
+from tldw_Server_API.app.core.config_sections.jobs import load_jobs_config
+from tldw_Server_API.app.core.config_sections.logging import load_logging_config
+from tldw_Server_API.app.core.config_sections.moderation import load_moderation_config
+from tldw_Server_API.app.core.config_sections.providers import load_providers_config
+from tldw_Server_API.app.core.config_sections.rag import load_rag_config
+from tldw_Server_API.app.core.config_sections.server import load_server_config
+from tldw_Server_API.app.core.config_sections.stt import load_stt_config
+
+pytestmark = pytest.mark.unit
+
+EMPTY_ENV: dict[str, str] = {}
+
+# (loader, config.txt section names it reads)
+_LOADERS = [
+    (load_auth_config, ["AuthNZ"]),
+    (load_server_config, ["API", "Server"]),
+    (load_database_config, ["Database"]),
+    (load_jobs_config, ["Jobs"]),
+    (load_rag_config, ["RAG"]),
+    (load_chat_config, ["Chat-Module"]),
+    (load_audio_config, ["TTS-Settings"]),
+    (load_stt_config, ["STT-Settings"]),
+    (load_embeddings_config, ["Embeddings"]),
+    (load_moderation_config, ["Moderation"]),
+    (load_providers_config, ["API"]),
+    (load_logging_config, ["Logging"]),
+]
+
+
+def _empty_parser() -> ConfigParser:
+    """A parser with every section the loaders may read, but no options set —
+    i.e. a fresh install with a bare config.txt."""
+    parser = ConfigParser()
+    for section in (
+        "AuthNZ", "API", "Server", "Database", "Jobs", "RAG", "Chat-Module",
+        "TTS-Settings", "STT-Settings", "Chunking", "Embeddings", "Moderation",
+        "Logging", "Providers",
+    ):
+        parser.add_section(section)
+    return parser
+
+
+@pytest.mark.parametrize("loader", [pair[0] for pair in _LOADERS], ids=[p[0].__name__ for p in _LOADERS])
+def test_config_loader_is_total_with_no_env(loader) -> None:
+    """Every typed loader must produce a config (never raise) when NO env vars
+    are set — the no-override real-deployment path.
+    """
+    result = loader(_empty_parser(), env=EMPTY_ENV)
+    assert result is not None
+
+
+def test_auth_defaults_to_single_user_with_no_env() -> None:
+    """With no AUTH_MODE/APP_MODE, auth defaults to the safe single-user mode."""
+    cfg = load_auth_config(_empty_parser(), env=EMPTY_ENV)
+    assert cfg.mode == "single_user"
+    assert cfg.single_user_fixed_id == 1
+
+
+def test_server_cors_is_not_disabled_by_default() -> None:
+    """CORS protection must be ON by default (disable_cors False) with no env —
+    a hardening regression here is the e88c96500f-class bug.
+    """
+    cfg = load_server_config(_empty_parser(), env=EMPTY_ENV)
+    assert cfg.disable_cors is False
+
+
+def test_chunking_loader_uses_typed_defaults_with_no_env() -> None:
+    """Chunking numeric/bool options fall back to their typed defaults, not
+    crash, when the env map is empty (exercises _parse_int/_parse_bool paths)."""
+    cfg = load_chunking_config(_empty_parser(), env=EMPTY_ENV)
+    # the typed loader must yield real ints/bools, never raw strings or None
+    assert isinstance(cfg.max_size, int) and cfg.max_size > 0
+    assert isinstance(cfg.overlap, int) and cfg.overlap >= 0
+    assert isinstance(cfg.adaptive, bool)
+    assert isinstance(cfg.multi_level, bool)
+
+
+def test_empty_env_matches_missing_env_map() -> None:
+    """Passing env={} must behave identically to env=None-under-empty-os-environ:
+    an explicit empty map is the faithful 'no overrides' signal."""
+    parser = _empty_parser()
+    for loader, _sections in _LOADERS:
+        explicit_empty = loader(parser, env={})
+        assert explicit_empty is not None
+
+
+# --------------------------------------------------------------------------- #
+# Auth-mode matrix: the loader must resolve each deployment mode from env,
+# via both AUTH_MODE (explicit) and APP_MODE (legacy) — the axes that actually
+# vary between single-user and multi-user deployments.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("env_map", "expected_mode"),
+    [
+        ({"AUTH_MODE": "single_user"}, "single_user"),
+        ({"AUTH_MODE": "multi_user"}, "multi_user"),
+        ({"AUTH_MODE": "garbage"}, "single_user"),  # invalid -> safe fallback
+        ({}, "single_user"),  # no env at all -> safe default
+    ],
+)
+def test_auth_mode_resolution_matrix(env_map: dict[str, str], expected_mode: str) -> None:
+    cfg = load_auth_config(_empty_parser(), env=env_map)
+    assert cfg.mode == expected_mode
+
+
+def test_app_mode_multi_is_the_last_resort_fallback() -> None:
+    """Documents the real precedence: APP_MODE is only consulted after both
+    AUTH_MODE and the config's auth_mode fail to yield a valid mode. Because
+    ConfigParser.get(..., fallback="single_user") always returns a valid value
+    for a missing section/option, the APP_MODE branch is reached only when the
+    config carries an explicitly INVALID auth_mode.
+    """
+    from configparser import ConfigParser
+
+    parser = ConfigParser()
+    parser.add_section("AuthNZ")
+    parser.set("AuthNZ", "auth_mode", "not_a_real_mode")  # invalid -> falls through
+    cfg = load_auth_config(parser, env={"APP_MODE": "multi"})
+    assert cfg.mode == "multi_user"

--- a/tldw_Server_API/tests/Security/test_egress_env_absent_defaults.py
+++ b/tldw_Server_API/tests/Security/test_egress_env_absent_defaults.py
@@ -1,0 +1,100 @@
+"""Env-absent egress policy defaults — the exact #2590/egress-bypass gap (RA6).
+
+The suite's conftest force-sets ``WORKFLOWS_EGRESS_BLOCK_PRIVATE=false`` and
+``WORKFLOWS_EGRESS_ALLOWED_PORTS=*``, so no test exercises the *secure*
+no-override defaults. The existing private-IP tests explicitly SET
+``WORKFLOWS_EGRESS_BLOCK_PRIVATE=true`` rather than removing it, so a hardening
+pass that flips the ``os.getenv(..., "true")`` fallback would not be caught.
+
+These tests scrub every egress env var and assert the real-deployment defaults:
+private IPs blocked, only ports 80/443 allowed, non-http(s) schemes rejected.
+``resolved_ips_override`` avoids real DNS.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Security import egress
+
+pytestmark = pytest.mark.unit
+
+# every egress env var the conftest (or a deployment) might set
+_EGRESS_ENV_VARS = (
+    egress.BLOCK_PRIVATE_ENV,
+    egress.ALLOWED_PORTS_ENV,
+    egress.ALLOWLIST_ENV,
+    egress.DENYLIST_ENV,
+    egress.GLOBAL_ALLOWLIST_ENV,
+    egress.GLOBAL_DENYLIST_ENV,
+    egress.WEBHOOK_ALLOWLIST_ENV,
+    egress.WEBHOOK_DENYLIST_ENV,
+    egress.PROFILENAME,
+    "ENVIRONMENT",
+    "APP_ENV",
+    "ENV",
+)
+
+
+def _scrub_egress_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _EGRESS_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_private_ip_blocked_by_default_with_no_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The core #2590 guard: with NO egress env vars set, a URL resolving to a
+    private/loopback IP must be denied. ``block_private_override`` is deliberately
+    NOT passed — the point is to exercise the ``getenv(..., "true")`` default.
+    """
+    _scrub_egress_env(monkeypatch)
+    result = egress.evaluate_url_policy(
+        "https://internal.example.com/steal",
+        resolved_ips_override=["127.0.0.1"],
+    )
+    assert result.allowed is False, "private IP was allowed with no egress env set (#2590 class)"
+    assert "private" in (result.reason or "").lower()
+
+
+def test_link_local_and_metadata_ip_blocked_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cloud-metadata SSRF target (169.254.169.254) must be blocked by default."""
+    _scrub_egress_env(monkeypatch)
+    result = egress.evaluate_url_policy(
+        "http://metadata.example/latest/meta-data",
+        resolved_ips_override=["169.254.169.254"],
+    )
+    assert result.allowed is False
+
+
+def test_public_ip_allowed_by_default_in_non_prod(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A public IP on port 443 should pass with no env (permissive non-prod
+    profile) — proving the block is targeted at private ranges, not a blanket deny.
+    """
+    _scrub_egress_env(monkeypatch)
+    result = egress.evaluate_url_policy(
+        "https://example.com/ok",
+        resolved_ips_override=["93.184.216.34"],
+    )
+    assert result.allowed is True, f"public URL wrongly denied by default: {result.reason}"
+
+
+def test_non_standard_port_rejected_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no WORKFLOWS_EGRESS_ALLOWED_PORTS, only 80/443 are allowed."""
+    _scrub_egress_env(monkeypatch)
+    result = egress.evaluate_url_policy(
+        "https://example.com:8080/ok",
+        resolved_ips_override=["93.184.216.34"],
+    )
+    assert result.allowed is False
+    assert "port" in (result.reason or "").lower()
+
+
+def test_non_http_scheme_rejected_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-http(s) schemes (file://, gopher://, ...) are rejected regardless of env."""
+    _scrub_egress_env(monkeypatch)
+    result = egress.evaluate_url_policy("file:///etc/passwd")
+    assert result.allowed is False
+
+
+def test_block_private_env_default_is_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Directly pin the secure fallback of the private-IP gate."""
+    monkeypatch.delenv(egress.BLOCK_PRIVATE_ENV, raising=False)
+    assert egress._should_block_private_env() is True


### PR DESCRIPTION
## Summary

Task 5 / PR 8 of `Docs/superpowers/plans/2026-07-04-test-suite-improvement-implementation-plan.md` — closes the env-matrix blindness (RA6) behind the #2590/e88c96500f defect class: hardening passes that broke the no-env-var fallback path, which the suite can't see because its conftest force-sets dozens of env vars at import.

### The concrete gap closed
No test scrubbed `WORKFLOWS_EGRESS_BLOCK_PRIVATE` and asserted private IPs are **blocked by default** — the existing egress tests explicitly *set* it to `true`, so a hardening pass flipping the `os.getenv(..., "true")` fallback would sail through. `tests/Security/test_egress_env_absent_defaults.py` scrubs the whole egress env and asserts the secure defaults (private/loopback + cloud-metadata blocked, only 80/443, non-http(s) rejected, public still allowed). **Mutation-verified**: flipping the default to `"false"` fails 2 tests.

### Config env-absent defaults
`tests/Config/test_env_absent_defaults.py`: every typed config loader is total on `env={}` (never crashes on the no-override path), plus secure-default assertions (auth→single_user, CORS not disabled, chunking real typed ints/bools) and an AUTH_MODE resolution matrix. Passing explicit `env={}` bypasses the conftest pollution deterministically.

### Minimal-env startup smoke
`Helper_Scripts/ci/minimal_env_smoke.py` (+ a `backend-required.yml` step, `make minimal-env-smoke`) boots the app as a subprocess in a **scrubbed** environment — no `TEST_MODE`, no conftest forcing, only a pinned minimal single-user set — and probes `/health`. This is the deployment-shaped world an in-pytest run can never reach.

### Incidental fix
Sharded `Workspaces/test_workspace_artifact_validation.py` — pre-existing dev drift (commit f9ca932713); the shard-coverage guard was already red on dev independent of this PR.

## Verification (local)
- 27 env-absent tests pass; egress private-block **mutation-verified**
- minimal-env smoke boots in a scrubbed env and `/health` returns 200 (exit 0). One real bug found and fixed building it: child output to a temp file, not `subprocess.PIPE` — the chatty startup fills the pipe buffer and deadlocks before binding the port.
- shard-coverage guard green

## Scope note
The auth-mode × DB-backend parametrization of the AuthNZ/Jobs/Chat suites (plan Step 1) is deferred — retrofitting existing suites is a large separate change. The env-absent defaults are the direct #2590 remediation; a lightweight AUTH_MODE matrix is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds env-absent default tests and a minimal-env startup smoke to catch regressions when no env vars are set (issue #2590). Improves the smoke script with safer cleanup and clearer failure output.

- New Features
  - Minimal-env startup smoke: `Helper_Scripts/ci/minimal_env_smoke.py` runs in `backend-required.yml` and via `make minimal-env-smoke`; boots with a scrubbed env (no `TEST_MODE`) and verifies `/health`.
  - Env-absent default tests: `tldw_Server_API/tests/Security/test_egress_env_absent_defaults.py` pins secure egress defaults (private/loopback and cloud metadata blocked; only ports 80/443; non-http(s) rejected; public allowed). `tldw_Server_API/tests/Config/test_env_absent_defaults.py` ensures typed loaders work with `env={}` and safe defaults (auth → single_user, CORS not disabled, typed ints/bools), plus an `AUTH_MODE` resolution matrix.

- Bug Fixes
  - Smoke robustness: log to a temp file (no PIPE deadlock), close `mkstemp` fd, single try/finally ensures cleanup (Windows-safe), tail logs on failures, and the probe catches `HTTPError` to surface non-2xx status/body.
  - CI: add `tldw_Server_API/tests/Workspaces/test_workspace_artifact_validation.py` to shards to restore the shard-coverage guard.

<sup>Written for commit eb32bc78cfd337b6cc18f946780d07017d826658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

