### PR TITLE
feat(ci): OpenAPI contract drift gate (plan Task 8)

### DIFF
--- a/.github/workflows/backend-required.yml
+++ b/.github/workflows/backend-required.yml
@@ -123,3 +123,17 @@ jobs:
         if: needs.changes.outputs.backend_changed == 'true'
         run: |
           python Helper_Scripts/ci/minimal_env_smoke.py --timeout 150
+
+      # OpenAPI contract drift gate (RF1 / #2590 class): recompute the schema
+      # fingerprint and fail if it drifts from the checked-in snapshot. A
+      # backend Pydantic model change that alters the API without updating the
+      # snapshot (and regenerating the frontend types) fails here. Runs in the
+      # backend workflow because it is guaranteed to run on drift-causing PRs
+      # and has the server deps installed.
+      - name: OpenAPI contract drift gate
+        if: needs.changes.outputs.backend_changed == 'true'
+        env:
+          PYTHONPATH: .
+        run: |
+          python Helper_Scripts/export_openapi_schema.py \
+            --check apps/tldw-frontend/lib/api/openapi.fingerprint.json

--- a/Helper_Scripts/export_openapi_schema.py
+++ b/Helper_Scripts/export_openapi_schema.py
@@ -57,6 +57,8 @@ _NORMALIZED_VERSION = "0.0.0-fingerprint"
 
 
 def _apply_canonical_env() -> None:
+    """Pin the canonical environment (unset minimizers, fix auth/profile) so the
+    exported schema is identical across machines."""
     for key, value in _CANONICAL_ENV.items():
         if value == "":
             os.environ.pop(key, None)
@@ -65,28 +67,43 @@ def _apply_canonical_env() -> None:
 
 
 def _load_schema() -> dict:
+    """Import the app under the pinned env and return its OpenAPI schema with a
+    normalized version field (so a package bump is not read as API drift)."""
     _apply_canonical_env()
     # Import only after the env is pinned.
     from tldw_Server_API.app.main import app
 
     schema = app.openapi()
-    # Normalize the version so a bump is not read as drift.
     if isinstance(schema.get("info"), dict):
         schema = {**schema, "info": {**schema["info"], "version": _NORMALIZED_VERSION}}
     return schema
 
 
 def _canonical_json(schema: dict) -> str:
+    """Deterministic (sorted, compact) JSON serialization used for hashing."""
     return json.dumps(schema, sort_keys=True, separators=(",", ":"))
 
 
+def _schema_counts(schema: dict) -> tuple[int, int]:
+    """Return ``(path_count, schema_count)``, tolerating None/non-dict sections."""
+    paths = schema.get("paths") or {}
+    components = schema.get("components")
+    schemas = components.get("schemas") if isinstance(components, dict) else None
+    return (
+        len(paths) if isinstance(paths, dict) else 0,
+        len(schemas) if isinstance(schemas, dict) else 0,
+    )
+
+
 def _fingerprint(schema: dict) -> dict:
+    """Build the small drift fingerprint (sha256 + counts) that is checked in."""
+    path_count, schema_count = _schema_counts(schema)
     canonical = _canonical_json(schema)
     return {
         "sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
         "openapi_version": schema.get("openapi"),
-        "path_count": len(schema.get("paths", {})),
-        "schema_count": len(schema.get("components", {}).get("schemas", {})),
+        "path_count": path_count,
+        "schema_count": schema_count,
         "note": (
             "Regenerate with `make openapi-fingerprint`. A change here means the "
             "backend API contract drifted; regenerate the frontend types "
@@ -109,17 +126,17 @@ def main(argv: list[str]) -> int:
     args = parser.parse_args(argv)
 
     schema = _load_schema()
+    fp = _fingerprint(schema)
+    fp_json = json.dumps(fp, indent=2, sort_keys=True) + "\n"
 
     if args.out:
         with open(args.out, "w", encoding="utf-8") as fh:
             json.dump(schema, fh, sort_keys=True, indent=2)
             fh.write("\n")
-        print(f"[openapi-export] wrote schema -> {args.out} "
-              f"({len(schema.get('paths', {}))} paths, "
-              f"{len(schema.get('components', {}).get('schemas', {}))} schemas)")
-
-    fp = _fingerprint(schema)
-    fp_json = json.dumps(fp, indent=2, sort_keys=True) + "\n"
+        print(
+            f"[openapi-export] wrote schema -> {args.out} "
+            f"({fp['path_count']} paths, {fp['schema_count']} schemas)"
+        )
 
     if args.fingerprint:
         with open(args.fingerprint, "w", encoding="utf-8") as fh:
@@ -130,8 +147,13 @@ def main(argv: list[str]) -> int:
         try:
             with open(args.check, encoding="utf-8") as fh:
                 checked_in = json.load(fh)
-        except (OSError, json.JSONDecodeError) as exc:
-            print(f"[openapi-export] FAIL — cannot read checked-in fingerprint {args.check}: {exc}", file=sys.stderr)
+            if not isinstance(checked_in, dict):
+                raise ValueError("fingerprint JSON must be an object")
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            print(
+                f"[openapi-export] FAIL — cannot read checked-in fingerprint {args.check}: {exc}",
+                file=sys.stderr,
+            )
             return 2
         if checked_in.get("sha256") != fp["sha256"]:
             print(

--- a/Helper_Scripts/export_openapi_schema.py
+++ b/Helper_Scripts/export_openapi_schema.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Export the FastAPI OpenAPI schema deterministically + a drift fingerprint.
+
+The frontend hand-writes ``page.route()`` mocks and API clients with no link to
+the backend contract, so a Pydantic model change can silently break the wired
+system while both suites stay green (audits/2026-07-04-test-suite-audit-round2.md
+RF1, the #2590 class). This script is the backend half of the drift gate:
+
+* ``--out openapi.json``  — write the full canonical schema (feeds
+  ``openapi-typescript`` codegen).
+* ``--fingerprint PATH``  — write a tiny fingerprint (sha256 + counts) that is
+  checked in; CI recomputes it and fails on mismatch. A field rename changes
+  the sha256, so the gate fires.
+
+Determinism: a PINNED canonical environment is applied internally (the app has
+env-driven route toggles — MINIMAL_TEST_APP, route enable/disable, _TEST_MODE
+middleware — that would otherwise make the schema differ between machines), and
+the schema is serialized with ``sort_keys=True``. The version field is
+normalized so a package bump does not read as API drift.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+# Import THIS checkout's code, not a stray editable install that may point at a
+# different worktree. The repo root is two levels up (Helper_Scripts/<this>).
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Pinned canonical environment for a complete, reproducible schema. Applied
+# BEFORE importing the app so settings/route-toggles resolve identically
+# everywhere. Keep this list in sync with any new env-driven route gating.
+_CANONICAL_ENV = {
+    "AUTH_MODE": "single_user",
+    "SINGLE_USER_API_KEY": "openapi-export-fixed-key-0123456789",
+    "TEST_MODE": "true",
+    "DISABLE_HEAVY_STARTUP": "1",
+    # explicitly UNSET the minimizers so every router is registered
+    "MINIMAL_TEST_APP": "",
+    "ULTRA_MINIMAL_APP": "",
+    "ROUTES_ENABLE": "",
+    "ROUTES_DISABLE": "",
+    # pin the deployment profile so environment-derived toggles are stable
+    "ENVIRONMENT": "test",
+    "APP_ENV": "test",
+}
+
+# The schema version is intentionally excluded from the fingerprint: a package
+# version bump is not an API contract change.
+_NORMALIZED_VERSION = "0.0.0-fingerprint"
+
+
+def _apply_canonical_env() -> None:
+    for key, value in _CANONICAL_ENV.items():
+        if value == "":
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _load_schema() -> dict:
+    _apply_canonical_env()
+    # Import only after the env is pinned.
+    from tldw_Server_API.app.main import app
+
+    schema = app.openapi()
+    # Normalize the version so a bump is not read as drift.
+    if isinstance(schema.get("info"), dict):
+        schema = {**schema, "info": {**schema["info"], "version": _NORMALIZED_VERSION}}
+    return schema
+
+
+def _canonical_json(schema: dict) -> str:
+    return json.dumps(schema, sort_keys=True, separators=(",", ":"))
+
+
+def _fingerprint(schema: dict) -> dict:
+    canonical = _canonical_json(schema)
+    return {
+        "sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+        "openapi_version": schema.get("openapi"),
+        "path_count": len(schema.get("paths", {})),
+        "schema_count": len(schema.get("components", {}).get("schemas", {})),
+        "note": (
+            "Regenerate with `make openapi-fingerprint`. A change here means the "
+            "backend API contract drifted; regenerate the frontend types "
+            "(`bun run generate:api-types` in apps/tldw-frontend) and review."
+        ),
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--out", default=None, help="Write the full canonical OpenAPI JSON here.")
+    parser.add_argument("--fingerprint", default=None, help="Write the drift fingerprint JSON here.")
+    parser.add_argument(
+        "--check",
+        default=None,
+        help="Compare a freshly computed fingerprint against this checked-in file; exit 1 on drift.",
+    )
+    args = parser.parse_args(argv)
+
+    schema = _load_schema()
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            json.dump(schema, fh, sort_keys=True, indent=2)
+            fh.write("\n")
+        print(f"[openapi-export] wrote schema -> {args.out} "
+              f"({len(schema.get('paths', {}))} paths, "
+              f"{len(schema.get('components', {}).get('schemas', {}))} schemas)")
+
+    fp = _fingerprint(schema)
+    fp_json = json.dumps(fp, indent=2, sort_keys=True) + "\n"
+
+    if args.fingerprint:
+        with open(args.fingerprint, "w", encoding="utf-8") as fh:
+            fh.write(fp_json)
+        print(f"[openapi-export] wrote fingerprint -> {args.fingerprint} (sha256={fp['sha256'][:12]}...)")
+
+    if args.check:
+        try:
+            with open(args.check, encoding="utf-8") as fh:
+                checked_in = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"[openapi-export] FAIL — cannot read checked-in fingerprint {args.check}: {exc}", file=sys.stderr)
+            return 2
+        if checked_in.get("sha256") != fp["sha256"]:
+            print(
+                "[openapi-export] FAIL — OpenAPI contract drift detected.\n"
+                f"  checked-in sha256: {checked_in.get('sha256')}\n"
+                f"  current    sha256: {fp['sha256']}\n"
+                f"  checked-in counts: paths={checked_in.get('path_count')} schemas={checked_in.get('schema_count')}\n"
+                f"  current    counts: paths={fp['path_count']} schemas={fp['schema_count']}\n"
+                "  Run `make openapi-fingerprint` to update the snapshot, then regenerate the\n"
+                "  frontend types (`bun run generate:api-types` in apps/tldw-frontend) and review.",
+                file=sys.stderr,
+            )
+            return 1
+        print("[openapi-export] OK — OpenAPI fingerprint matches the checked-in snapshot.")
+
+    if not any((args.out, args.fingerprint, args.check)):
+        # default: print the fingerprint
+        sys.stdout.write(fp_json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Makefile
+++ b/Makefile
@@ -492,7 +492,7 @@ lint-changed:
 # -----------------------------------------------------------------------------
 # Local CI — reproduce the gating GitHub checks before pushing
 # -----------------------------------------------------------------------------
-.PHONY: ci-local ci-local-full ci-local-lane test-triage minimal-env-smoke
+.PHONY: ci-local ci-local-full ci-local-lane test-triage minimal-env-smoke openapi-fingerprint openapi-drift-check
 
 # Prefer the project venv python ($(VENV_PYTHON)); fall back to $(PYTHON).
 CI_LOCAL_PYTHON ?= $(shell [ -x "$(VENV_PYTHON)" ] && echo "$(VENV_PYTHON)" || echo "$(PYTHON)")
@@ -515,6 +515,12 @@ test-triage:         ## Ranked test-quality triage report (see audits/2026-07-04
 
 minimal-env-smoke:   ## Boot the app in a scrubbed env and probe /health (#2590-class guard)
 	$(CI_LOCAL_PYTHON) Helper_Scripts/ci/minimal_env_smoke.py $(CI_ARGS)
+
+openapi-fingerprint: ## Refresh the checked-in OpenAPI drift fingerprint
+	$(CI_LOCAL_PYTHON) Helper_Scripts/export_openapi_schema.py --fingerprint apps/tldw-frontend/lib/api/openapi.fingerprint.json
+
+openapi-drift-check: ## Fail if the OpenAPI contract drifted from the checked-in fingerprint
+	$(CI_LOCAL_PYTHON) Helper_Scripts/export_openapi_schema.py --check apps/tldw-frontend/lib/api/openapi.fingerprint.json
 
 # -----------------------------------------------------------------------------
 # Chat Streaming Load Harness (Scenario A starter)

--- a/apps/bun.lock
+++ b/apps/bun.lock
@@ -310,6 +310,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "globals": "^16.5.0",
         "jsdom": "^27.3.0",
+        "openapi-typescript": "^7.13.0",
         "playwright": "^1.58.0",
         "postcss": "^8.5.6",
         "postcss-import": "^16.1.1",
@@ -998,6 +999,12 @@
 
     "@rc-component/virtual-list": ["@rc-component/virtual-list@1.0.2", "", { "dependencies": { "@babel/runtime": "^7.20.0", "@rc-component/resize-observer": "^1.0.1", "@rc-component/util": "^1.4.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ=="],
 
+    "@redocly/ajv": ["@redocly/ajv@8.11.2", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js-replace": "^1.0.1" } }, "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg=="],
+
+    "@redocly/config": ["@redocly/config@0.22.0", "", {}, "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ=="],
+
+    "@redocly/openapi-core": ["@redocly/openapi-core@1.34.17", "", { "dependencies": { "@redocly/ajv": "8.11.2", "@redocly/config": "0.22.0", "colorette": "1.4.0", "https-proxy-agent": "7.0.6", "js-levenshtein": "1.1.6", "js-yaml": "4.2.0", "minimatch": "5.1.9", "pluralize": "8.0.0", "yaml-ast-parser": "0.0.43" } }, "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig=="],
+
     "@remirror/core-constants": ["@remirror/core-constants@3.0.0", "", {}, "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="],
 
     "@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
@@ -1588,6 +1595,8 @@
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
+    "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
+
     "ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -1748,6 +1757,8 @@
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
+
     "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
 
     "character-entities": ["character-entities@1.2.4", "", {}, "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="],
@@ -1804,7 +1815,7 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+    "colorette": ["colorette@1.4.0", "", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
@@ -2382,6 +2393,8 @@
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
+    "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
+
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
@@ -2523,6 +2536,8 @@
     "jest-worker": ["jest-worker@27.5.1", "", { "dependencies": { "@types/node": "*", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg=="],
 
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+
+    "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
@@ -2912,6 +2927,8 @@
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
+    "openapi-typescript": ["openapi-typescript@7.13.0", "", { "dependencies": { "@redocly/openapi-core": "^1.34.6", "ansi-colors": "^4.1.3", "change-case": "^5.4.4", "parse-json": "^8.3.0", "supports-color": "^10.2.2", "yargs-parser": "^21.1.1" }, "peerDependencies": { "typescript": "^5.x" }, "bin": { "openapi-typescript": "bin/cli.js" } }, "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ=="],
+
     "opencollective-postinstall": ["opencollective-postinstall@2.0.3", "", { "bin": { "opencollective-postinstall": "index.js" } }, "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -2946,7 +2963,7 @@
 
     "parse-imports-exports": ["parse-imports-exports@0.2.4", "", { "dependencies": { "parse-statements": "1.0.11" } }, "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ=="],
 
-    "parse-json": ["parse-json@7.1.1", "", { "dependencies": { "@babel/code-frame": "^7.21.4", "error-ex": "^1.3.2", "json-parse-even-better-errors": "^3.0.0", "lines-and-columns": "^2.0.3", "type-fest": "^3.8.0" } }, "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw=="],
+    "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
     "parse-statements": ["parse-statements@1.0.11", "", {}, "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA=="],
 
@@ -3009,6 +3026,8 @@
     "playwright": ["playwright@1.58.0", "", { "dependencies": { "playwright-core": "1.58.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ=="],
 
     "playwright-core": ["playwright-core@1.58.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw=="],
+
+    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 
@@ -3426,7 +3445,7 @@
 
     "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
-    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
@@ -3576,6 +3595,8 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "uri-js-replace": ["uri-js-replace@1.0.1", "", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
+
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
@@ -3704,6 +3725,8 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
+
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
@@ -3796,6 +3819,10 @@
 
     "@rc-component/util/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
+    "@redocly/openapi-core/js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+
+    "@redocly/openapi-core/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
     "@rollup/plugin-commonjs/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
@@ -3859,6 +3886,8 @@
     "c12/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "c12/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -3962,6 +3991,8 @@
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
+    "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
@@ -3969,6 +4000,8 @@
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "linkedom/html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "listr2/colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "localforage/lie": ["lie@3.1.1", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw=="],
 
@@ -4025,10 +4058,6 @@
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "package-json/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "parse-json/lines-and-columns": ["lines-and-columns@2.0.4", "", {}, "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A=="],
-
-    "parse-json/type-fest": ["type-fest@3.13.1", "", {}, "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -4166,6 +4195,8 @@
 
     "web-ext-run/@babel/runtime": ["@babel/runtime@7.28.2", "", {}, "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA=="],
 
+    "web-ext-run/parse-json": ["parse-json@7.1.1", "", { "dependencies": { "@babel/code-frame": "^7.21.4", "error-ex": "^1.3.2", "json-parse-even-better-errors": "^3.0.0", "lines-and-columns": "^2.0.3", "type-fest": "^3.8.0" } }, "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw=="],
+
     "webpack/es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
     "webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
@@ -4215,6 +4246,8 @@
     "@sentry/bundler-plugin-core/unplugin/webpack-virtual-modules": ["webpack-virtual-modules@0.5.0", "", {}, "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw=="],
 
     "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "@sentry/nextjs/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "@sentry/webpack-plugin/unplugin/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
@@ -4355,6 +4388,10 @@
     "vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vitest/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "web-ext-run/parse-json/lines-and-columns": ["lines-and-columns@2.0.4", "", {}, "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A=="],
+
+    "web-ext-run/parse-json/type-fest": ["type-fest@3.13.1", "", {}, "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="],
 
     "webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 

--- a/apps/tldw-frontend/.gitignore
+++ b/apps/tldw-frontend/.gitignore
@@ -46,3 +46,7 @@ next-env.d.ts
 # Generated files
 # PDF.js worker is copied from node_modules during postinstall
 /public/pdf.worker.min.mjs
+
+# OpenAPI codegen artifacts (regenerated via `bun run generate:api-types`);
+# only lib/api/openapi.fingerprint.json is committed (see lib/api/README.md)
+/lib/api/generated/

--- a/apps/tldw-frontend/lib/api/README.md
+++ b/apps/tldw-frontend/lib/api/README.md
@@ -1,0 +1,42 @@
+# Backend API contract sync
+
+This directory links the frontend to the backend's OpenAPI contract so a
+backend model change can't silently drift from the frontend's view of the API
+(the RF1 / #2590 defect class from `audits/2026-07-04-test-suite-audit-round2.md`).
+
+## Files
+
+- **`openapi.fingerprint.json`** — committed. A small sha256 + counts of the
+  canonical backend schema. The CI drift gate (`backend-required.yml` →
+  "OpenAPI contract drift gate") recomputes it and fails if it differs, forcing
+  a backend contract change to be acknowledged.
+- **`generated/`** — gitignored build artifacts: the full `openapi.json` (~5MB)
+  and `schema.d.ts` (~6MB, from `openapi-typescript`). Not committed because
+  they regenerate deterministically and would bloat the repo with unreviewable
+  diffs.
+
+## When the drift gate fails
+
+The backend API contract changed. Regenerate and review:
+
+```bash
+# from apps/tldw-frontend (venv with server deps importable)
+bun run generate:api-types
+# review the fingerprint change, update any affected frontend types/mocks,
+# then commit the updated openapi.fingerprint.json
+```
+
+Or just refresh the fingerprint from the repo root: `make openapi-fingerprint`.
+
+## Using the generated types
+
+After `bun run generate:api-types`, import from the generated schema:
+
+```ts
+import type { paths, components } from "@/lib/api/generated/schema";
+type RoleResponse = components["schemas"]["RoleResponse"];
+```
+
+Decision (see the implementation plan): OpenAPI-generated TypeScript, not
+mirrored zod schemas — the backend already emits OpenAPI 3 from FastAPI, so
+codegen is zero-runtime-cost and single-source-of-truth.

--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -1,0 +1,7 @@
+{
+  "note": "Regenerate with `make openapi-fingerprint`. A change here means the backend API contract drifted; regenerate the frontend types (`bun run generate:api-types` in apps/tldw-frontend) and review.",
+  "openapi_version": "3.1.0",
+  "path_count": 1955,
+  "schema_count": 2815,
+  "sha256": "398a43f1ef0dab65c2b584b85cf277c20c2783fb53caeb5c22018b90f847f116"
+}

--- a/apps/tldw-frontend/package.json
+++ b/apps/tldw-frontend/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "scripts": {
     "postinstall": "node scripts/copy-pdf-worker.mjs",
+    "generate:api-types": "node scripts/generate-api-types.mjs",
     "dev": "next dev",
     "dev:webpack": "next dev --webpack",
     "build": "node scripts/build-with-profile.mjs --bundler=turbopack && node scripts/verify-shared-token-sync.mjs --dir .next",
@@ -141,6 +142,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
+    "openapi-typescript": "^7.13.0",
     "@eslint/js": "^9.39.2",
     "@next/eslint-plugin-next": "^16.1.0",
     "@playwright/test": "^1.51.1",

--- a/apps/tldw-frontend/scripts/generate-api-types.mjs
+++ b/apps/tldw-frontend/scripts/generate-api-types.mjs
@@ -30,7 +30,7 @@ const fingerprint = resolve(frontendRoot, "lib/api/openapi.fingerprint.json");
 
 mkdirSync(generatedDir, { recursive: true });
 
-const python = process.env.PYTHON || "python";
+const python = process.env.PYTHON || (process.platform === "win32" ? "python" : "python3");
 
 console.log("[generate-api-types] exporting canonical OpenAPI schema + fingerprint…");
 execFileSync(
@@ -46,7 +46,8 @@ execFileSync(
 );
 
 console.log("[generate-api-types] generating schema.d.ts via openapi-typescript…");
-execFileSync("bunx", ["openapi-typescript", openapiJson, "-o", schemaDts], {
+// `bun x` (not `bunx`) — the standalone `bunx` shim can ENOENT on Windows.
+execFileSync("bun", ["x", "openapi-typescript", openapiJson, "-o", schemaDts], {
   cwd: frontendRoot,
   stdio: "inherit",
 });

--- a/apps/tldw-frontend/scripts/generate-api-types.mjs
+++ b/apps/tldw-frontend/scripts/generate-api-types.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Regenerate the typed OpenAPI view for the frontend.
+ *
+ * 1. Runs the backend exporter (Helper_Scripts/export_openapi_schema.py) to
+ *    produce a canonical openapi.json AND refresh the checked-in fingerprint.
+ * 2. Runs openapi-typescript over that JSON to emit lib/api/generated/schema.d.ts.
+ *
+ * The full openapi.json (~5MB) and schema.d.ts (~6MB) are build artifacts and
+ * are gitignored (lib/api/generated/). Only the tiny openapi.fingerprint.json is
+ * committed — the CI drift gate keys off that. Run this whenever the backend
+ * API contract changes and the drift gate fails.
+ *
+ * Requires a Python environment with the server deps importable (run from repo
+ * root or with the venv active).
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const frontendRoot = resolve(here, "..");
+const repoRoot = resolve(frontendRoot, "..", "..");
+
+const generatedDir = resolve(frontendRoot, "lib/api/generated");
+const openapiJson = resolve(generatedDir, "openapi.json");
+const schemaDts = resolve(generatedDir, "schema.d.ts");
+const fingerprint = resolve(frontendRoot, "lib/api/openapi.fingerprint.json");
+
+mkdirSync(generatedDir, { recursive: true });
+
+const python = process.env.PYTHON || "python";
+
+console.log("[generate-api-types] exporting canonical OpenAPI schema + fingerprint…");
+execFileSync(
+  python,
+  [
+    "Helper_Scripts/export_openapi_schema.py",
+    "--out",
+    openapiJson,
+    "--fingerprint",
+    fingerprint,
+  ],
+  { cwd: repoRoot, stdio: "inherit", env: { ...process.env, PYTHONPATH: repoRoot } },
+);
+
+console.log("[generate-api-types] generating schema.d.ts via openapi-typescript…");
+execFileSync("bunx", ["openapi-typescript", openapiJson, "-o", schemaDts], {
+  cwd: frontendRoot,
+  stdio: "inherit",
+});
+
+console.log(`[generate-api-types] done -> ${schemaDts}`);
+console.log("[generate-api-types] committed artifact: lib/api/openapi.fingerprint.json");


### PR DESCRIPTION
## Summary

Task 8 / PR 9 of `Docs/superpowers/plans/2026-07-04-test-suite-improvement-implementation-plan.md` — closes the RF1 / #2590 defect class: the frontend's view of the API silently drifting from the backend contract (hand-written `page.route()` mocks, no shared schema). A backend Pydantic model change now fails CI.

**How it works**
- `Helper_Scripts/export_openapi_schema.py` generates the FastAPI schema under a **pinned canonical env** (route toggles + version normalized so a package bump isn't read as drift), with `--fingerprint` (a tiny sha256+counts snapshot) and `--check` (fail on drift). It's **self-locating** — inserts its own repo root at `sys.path[0]` so it exports THIS checkout, not a stray editable install.
- `apps/tldw-frontend/lib/api/openapi.fingerprint.json` is the committed snapshot the gate keys off.
- `backend-required.yml` gains an **"OpenAPI contract drift gate"** step, gated on `backend_changed` — placed in the backend workflow because it's guaranteed to run on drift-causing PRs and has the server deps.
- `openapi-typescript` dev-dep + `scripts/generate-api-types.mjs` (`bun run generate:api-types`) regenerate the schema, refresh the fingerprint, and emit `lib/api/generated/schema.d.ts` for typed frontend access.

**Scope decision (documented in `lib/api/README.md`)**
Per the plan: openapi-typescript codegen, not mirrored zod. But the full `openapi.json` (~5MB) and `schema.d.ts` (~6MB) are **gitignored build artifacts**, not committed — the gate keys off the tiny fingerprint instead. Same drift-detection value (any contract change fails CI), no repo bloat or unreviewable 5MB diffs.

## Verification (local)
- Fingerprint reproducible across runs **and invocation contexts** (this caught a real bug: without `sys.path` self-location, a stray editable install exported a *different* worktree → the self-location fix resolves it)
- **Renaming a Pydantic response field fails the gate** (`exit 1`); reverting passes (`exit 0`) — the plan's exact verification
- Full codegen flow runs end-to-end; generated/ correctly gitignored; shard guard green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI gate to detect OpenAPI contract drift and block backend changes that alter the API without updating the frontend types. Addresses RF1 / #2590 by fingerprinting the canonical FastAPI schema and verifying it in backend CI.

- **New Features**
  - Deterministic, hardened schema exporter `Helper_Scripts/export_openapi_schema.py` (pinned env, version normalized, self-locating; tolerates None/non-dict sections; validates fingerprint JSON) that writes the full schema and a small fingerprint.
  - Backend workflow adds an “OpenAPI contract drift gate” that recomputes and compares the fingerprint against `apps/tldw-frontend/lib/api/openapi.fingerprint.json` when backend code changes.
  - Frontend codegen via `bun run generate:api-types` (uses `openapi-typescript`) emits `lib/api/generated/schema.d.ts` and refreshes the fingerprint; artifacts are gitignored. Cross-platform defaults: `python3` on non-Windows and `bun x` to avoid Windows ENOENT.
  - Make targets: `openapi-fingerprint` and `openapi-drift-check` for local verification.

- **Migration**
  - If the gate fails: from `apps/tldw-frontend`, run `bun run generate:api-types`, update any affected types/mocks, and commit the updated `openapi.fingerprint.json`.
  - Alternatively, from repo root run `make openapi-fingerprint` to refresh the snapshot.

<sup>Written for commit 51230d2b1c90ef8e4c58e75b82fc1abeba0a3939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

