### PR TITLE
test(property): chunking reconstruction, markdown parser, structured-output (plan Task 7)

### DIFF
--- a/tldw_Server_API/tests/Chunking/test_chunking_overlap_properties.py
+++ b/tldw_Server_API/tests/Chunking/test_chunking_overlap_properties.py
@@ -8,6 +8,8 @@ from hypothesis import strategies as st
 from tldw_Server_API.app.core.Chunking.base import ChunkerConfig, ChunkingMethod
 from tldw_Server_API.app.core.Chunking.chunker import Chunker
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture(autouse=True)
 def testing_env():
@@ -61,7 +63,10 @@ def test_words_overlap_property(total_words, max_size, overlap):
 # chunk-size bound, and coverage. These complement the overlap-adjacency check
 # above; an off-by-one in the overlap stride breaks reconstruction.
 # --------------------------------------------------------------------------- #
-def _make_chunks(total_words, max_size, overlap):
+def _make_chunks(
+    total_words: int, max_size: int, overlap: int
+) -> tuple[list[str], list[str], int]:
+    """Chunk ``w0 w1 …`` by words; return ``(words, chunks, effective_overlap)``."""
     if overlap >= max_size:
         overlap = max(0, max_size - 1)
     words = [f"w{i}" for i in range(total_words)]
@@ -84,7 +89,7 @@ def _make_chunks(total_words, max_size, overlap):
     max_size=st.integers(min_value=1, max_value=40),
     overlap=st.integers(min_value=0, max_value=10),
 )
-def test_words_reconstruction_property(total_words, max_size, overlap):
+def test_words_reconstruction_property(total_words: int, max_size: int, overlap: int) -> None:
     """Streaming the chunk words in order and keeping each word's first
     occurrence must reconstruct the original sequence — no word is dropped or
     reordered. (A boundary chunk may legitimately repeat a word at very small
@@ -109,7 +114,7 @@ def test_words_reconstruction_property(total_words, max_size, overlap):
     max_size=st.integers(min_value=1, max_value=40),
     overlap=st.integers(min_value=0, max_value=10),
 )
-def test_words_chunk_size_bound(total_words, max_size, overlap):
+def test_words_chunk_size_bound(total_words: int, max_size: int, overlap: int) -> None:
     """No chunk exceeds max_size words, and every source word appears somewhere."""
     words, chunks, _overlap = _make_chunks(total_words, max_size, overlap)
     for chunk in chunks:

--- a/tldw_Server_API/tests/Chunking/test_chunking_overlap_properties.py
+++ b/tldw_Server_API/tests/Chunking/test_chunking_overlap_properties.py
@@ -1,9 +1,12 @@
 import os
-import pytest
-from hypothesis import given, strategies as st, settings as hyp_settings
 
-from tldw_Server_API.app.core.Chunking.chunker import Chunker
+import pytest
+from hypothesis import given
+from hypothesis import settings as hyp_settings
+from hypothesis import strategies as st
+
 from tldw_Server_API.app.core.Chunking.base import ChunkerConfig, ChunkingMethod
+from tldw_Server_API.app.core.Chunking.chunker import Chunker
 
 
 @pytest.fixture(autouse=True)
@@ -51,3 +54,67 @@ def test_words_overlap_property(total_words, max_size, overlap):
         b = chunks[i + 1].split()
         if len(a) >= overlap and len(b) >= overlap:
             assert a[-overlap:] == b[:overlap]
+
+
+# --------------------------------------------------------------------------- #
+# Additional word-chunking invariants (RA4, plan Task 7): reconstruction, the
+# chunk-size bound, and coverage. These complement the overlap-adjacency check
+# above; an off-by-one in the overlap stride breaks reconstruction.
+# --------------------------------------------------------------------------- #
+def _make_chunks(total_words, max_size, overlap):
+    if overlap >= max_size:
+        overlap = max(0, max_size - 1)
+    words = [f"w{i}" for i in range(total_words)]
+    cfg = ChunkerConfig(
+        default_method=ChunkingMethod.WORDS,
+        default_max_size=max_size,
+        default_overlap=overlap,
+        language="en",
+    )
+    ck = Chunker(config=cfg)
+    chunks = ck.chunk_text(
+        " ".join(words), method=ChunkingMethod.WORDS.value, max_size=max_size, overlap=overlap
+    )
+    return words, chunks, overlap
+
+
+@hyp_settings(deadline=None, max_examples=150)
+@given(
+    total_words=st.integers(min_value=1, max_value=200),
+    max_size=st.integers(min_value=1, max_value=40),
+    overlap=st.integers(min_value=0, max_value=10),
+)
+def test_words_reconstruction_property(total_words, max_size, overlap):
+    """Streaming the chunk words in order and keeping each word's first
+    occurrence must reconstruct the original sequence — no word is dropped or
+    reordered. (A boundary chunk may legitimately repeat a word at very small
+    max_size, so exact non-dup reconstruction is not asserted; the ordered-
+    first-occurrence view still fails on any off-by-one that skips/reorders.)"""
+    words, chunks, _overlap = _make_chunks(total_words, max_size, overlap)
+    assert chunks, "non-empty input produced no chunks"
+
+    seen: list[str] = []
+    seen_set: set[str] = set()
+    for chunk in chunks:
+        for word in chunk.split():
+            if word not in seen_set:
+                seen.append(word)
+                seen_set.add(word)
+    assert seen == words, "ordered chunk words do not reconstruct the source sequence"
+
+
+@hyp_settings(deadline=None, max_examples=150)
+@given(
+    total_words=st.integers(min_value=1, max_value=200),
+    max_size=st.integers(min_value=1, max_value=40),
+    overlap=st.integers(min_value=0, max_value=10),
+)
+def test_words_chunk_size_bound(total_words, max_size, overlap):
+    """No chunk exceeds max_size words, and every source word appears somewhere."""
+    words, chunks, _overlap = _make_chunks(total_words, max_size, overlap)
+    for chunk in chunks:
+        assert len(chunk.split()) <= max_size, "a chunk exceeded max_size words"
+    covered = set()
+    for chunk in chunks:
+        covered.update(chunk.split())
+    assert covered == set(words), "chunks did not cover every source word"

--- a/tldw_Server_API/tests/LLM_Calls/property/test_structured_output_properties.py
+++ b/tldw_Server_API/tests/LLM_Calls/property/test_structured_output_properties.py
@@ -1,0 +1,111 @@
+"""Property tests for structured-output JSON extraction (RA4, triage pick).
+
+``parse_structured_output`` extracts a JSON value from arbitrary model text
+(bare, fenced, or with surrounding prose). Its invariants:
+
+* totality — for any input it either returns a JSON-compatible value or raises
+  ``StructuredOutputNoPayloadError``; a raw ``JSONDecodeError`` never leaks
+* passthrough — an already-parsed dict/list is returned unchanged
+* serializable — any returned value round-trips through ``json.dumps``
+* round-trip — a JSON value embedded (bare or fenced) in text is recovered
+
+``extract_items`` normalizes parsed output into a list of item dicts; its
+lenient mode never raises on a parsed value and always yields a list.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from hypothesis import given
+from hypothesis import settings as hyp_settings
+from hypothesis import strategies as st
+
+from tldw_Server_API.app.core.exceptions import StructuredOutputSchemaError
+from tldw_Server_API.app.core.LLM_Calls.structured_output import (
+    StructuredOutputNoPayloadError,
+    extract_items,
+    parse_structured_output,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.property]
+
+_COMMON = hyp_settings(max_examples=200, deadline=None)
+
+# JSON values (objects/arrays at the top level are what the extractor targets)
+_json_scalars = st.none() | st.booleans() | st.integers() | st.text(max_size=20)
+_json_values = st.recursive(
+    _json_scalars,
+    lambda children: st.lists(children, max_size=4)
+    | st.dictionaries(st.text(min_size=1, max_size=8), children, max_size=4),
+    max_leaves=12,
+)
+_json_containers = st.one_of(
+    st.lists(_json_values, max_size=5),
+    st.dictionaries(st.text(min_size=1, max_size=8), _json_values, max_size=5),
+)
+
+
+class TestParseStructuredOutput:
+    @_COMMON
+    @given(payload=st.text(max_size=80))
+    def test_totality_on_arbitrary_text(self, payload: str) -> None:
+        """Only StructuredOutputNoPayloadError may be raised; no raw JSON error."""
+        try:
+            result = parse_structured_output(payload)
+        except StructuredOutputNoPayloadError:
+            return
+        # a returned value must always be JSON-serializable
+        json.dumps(result)
+
+    @_COMMON
+    @given(payload=st.none() | st.text(alphabet=" \t\n", max_size=10))
+    def test_empty_payloads_raise_no_payload(self, payload: Any) -> None:
+        with pytest.raises(StructuredOutputNoPayloadError):
+            parse_structured_output(payload)
+
+    @_COMMON
+    @given(value=_json_containers)
+    def test_dict_or_list_input_is_returned_unchanged(self, value: Any) -> None:
+        assert parse_structured_output(value) == value
+
+    @_COMMON
+    @given(value=_json_containers, fenced=st.booleans())
+    def test_round_trip_of_embedded_json(self, value: Any, fenced: bool) -> None:
+        """A JSON container serialized into text (bare or ```json fenced) is
+        recovered by the parser."""
+        as_text = json.dumps(value)
+        payload = f"```json\n{as_text}\n```" if fenced else as_text
+        parsed = parse_structured_output(payload)
+        assert parsed == value
+
+
+class TestExtractItems:
+    @_COMMON
+    @given(value=_json_containers)
+    def test_lenient_extract_returns_list_or_typed_schema_error(self, value: Any) -> None:
+        """extract_items either yields a list of item dicts or raises the typed
+        StructuredOutputSchemaError (e.g. a top-level list of non-objects) — it
+        never leaks an untyped exception."""
+        try:
+            result = extract_items(value)
+        except StructuredOutputSchemaError:
+            return
+        assert isinstance(result, list)
+        assert all(isinstance(item, dict) for item in result)
+
+    @_COMMON
+    @given(items=st.lists(st.dictionaries(st.text(min_size=1, max_size=6), _json_scalars, max_size=4), max_size=6))
+    def test_top_level_list_of_objects_is_preserved(self, items: list[dict]) -> None:
+        result = extract_items(items, allow_top_level_list=True)
+        assert result == items
+
+    @_COMMON
+    @given(
+        wrapper=st.text(min_size=1, max_size=8),
+        items=st.lists(st.dictionaries(st.text(min_size=1, max_size=6), _json_scalars, max_size=3), max_size=5),
+    )
+    def test_wrapped_items_are_unwrapped(self, wrapper: str, items: list[dict]) -> None:
+        result = extract_items({wrapper: items}, wrapper_key=wrapper)
+        assert result == items

--- a/tldw_Server_API/tests/LLM_Calls/property/test_structured_output_properties.py
+++ b/tldw_Server_API/tests/LLM_Calls/property/test_structured_output_properties.py
@@ -33,17 +33,27 @@ pytestmark = [pytest.mark.unit, pytest.mark.property]
 
 _COMMON = hyp_settings(max_examples=200, deadline=None)
 
-# JSON values (objects/arrays at the top level are what the extractor targets)
-_json_scalars = st.none() | st.booleans() | st.integers() | st.text(max_size=20)
+# JSON values (objects/arrays at the top level are what the extractor targets).
+# Backticks are excluded from generated text: a "```" inside a JSON string would
+# collide with the ```json fence in the round-trip test and spuriously fail —
+# the parser is not expected to recover JSON from a malformed markdown fence.
+def _safe_text(min_size: int = 0, max_size: int = 20) -> st.SearchStrategy[str]:
+    """Text without backticks (which would corrupt a ```json fence)."""
+    return st.text(
+        alphabet=st.characters(blacklist_characters="`"), min_size=min_size, max_size=max_size
+    )
+
+
+_json_scalars = st.none() | st.booleans() | st.integers() | _safe_text(max_size=20)
 _json_values = st.recursive(
     _json_scalars,
     lambda children: st.lists(children, max_size=4)
-    | st.dictionaries(st.text(min_size=1, max_size=8), children, max_size=4),
+    | st.dictionaries(_safe_text(min_size=1, max_size=8), children, max_size=4),
     max_leaves=12,
 )
 _json_containers = st.one_of(
     st.lists(_json_values, max_size=5),
-    st.dictionaries(st.text(min_size=1, max_size=8), _json_values, max_size=5),
+    st.dictionaries(_safe_text(min_size=1, max_size=8), _json_values, max_size=5),
 )
 
 
@@ -62,12 +72,14 @@ class TestParseStructuredOutput:
     @_COMMON
     @given(payload=st.none() | st.text(alphabet=" \t\n", max_size=10))
     def test_empty_payloads_raise_no_payload(self, payload: Any) -> None:
+        """None / whitespace-only payloads raise the typed no-payload error."""
         with pytest.raises(StructuredOutputNoPayloadError):
             parse_structured_output(payload)
 
     @_COMMON
     @given(value=_json_containers)
     def test_dict_or_list_input_is_returned_unchanged(self, value: Any) -> None:
+        """An already-parsed dict/list passes through untouched."""
         assert parse_structured_output(value) == value
 
     @_COMMON
@@ -96,16 +108,26 @@ class TestExtractItems:
         assert all(isinstance(item, dict) for item in result)
 
     @_COMMON
-    @given(items=st.lists(st.dictionaries(st.text(min_size=1, max_size=6), _json_scalars, max_size=4), max_size=6))
+    @given(
+        items=st.lists(
+            st.dictionaries(_safe_text(min_size=1, max_size=6), _json_scalars, max_size=4),
+            max_size=6,
+        )
+    )
     def test_top_level_list_of_objects_is_preserved(self, items: list[dict]) -> None:
+        """A top-level list of objects is returned as-is when allowed."""
         result = extract_items(items, allow_top_level_list=True)
         assert result == items
 
     @_COMMON
     @given(
-        wrapper=st.text(min_size=1, max_size=8),
-        items=st.lists(st.dictionaries(st.text(min_size=1, max_size=6), _json_scalars, max_size=3), max_size=5),
+        wrapper=_safe_text(min_size=1, max_size=8),
+        items=st.lists(
+            st.dictionaries(_safe_text(min_size=1, max_size=6), _json_scalars, max_size=3),
+            max_size=5,
+        ),
     )
     def test_wrapped_items_are_unwrapped(self, wrapper: str, items: list[dict]) -> None:
+        """Items under the wrapper key are unwrapped to a bare list."""
         result = extract_items({wrapper: items}, wrapper_key=wrapper)
         assert result == items

--- a/tldw_Server_API/tests/Notes_Tasks/property/test_markdown_parser_properties.py
+++ b/tldw_Server_API/tests/Notes_Tasks/property/test_markdown_parser_properties.py
@@ -1,0 +1,84 @@
+"""Property tests for the note markdown checklist parser (RA4, plan Task 7).
+
+``parse_note_checklists`` is parse-only (no renderer, so no round-trip). The
+real invariants: total (never raises on arbitrary content), deterministic,
+every item's locator offsets stay within the source and slice back to the raw
+line, and locators are monotone / occurrence-indexed consistently.
+"""
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import settings as hyp_settings
+from hypothesis import strategies as st
+
+from tldw_Server_API.app.core.Notes_Tasks.markdown_parser import parse_note_checklists
+
+pytestmark = [pytest.mark.unit, pytest.mark.property]
+
+_COMMON = hyp_settings(max_examples=200, deadline=None)
+
+# text likely to contain checklist lines, fences, indentation, unicode
+_line = st.one_of(
+    st.just("- [ ] todo item"),
+    st.just("- [x] done item"),
+    st.just("  - [ ] nested"),
+    st.just("* [ ] star bullet"),
+    st.just("```"),
+    st.just("plain paragraph"),
+    st.just(""),
+    st.text(max_size=40),
+)
+_content = st.lists(_line, max_size=30).map(lambda lines: "\n".join(lines))
+
+
+@_COMMON
+@given(content=_content)
+def test_parser_is_total(content: str) -> None:
+    result = parse_note_checklists(note_id="n1", note_version=1, content=content)
+    assert result is not None
+    assert isinstance(result.items, list)
+
+
+@_COMMON
+@given(content=_content)
+def test_parser_is_deterministic(content: str) -> None:
+    a = parse_note_checklists(note_id="n1", note_version=1, content=content)
+    b = parse_note_checklists(note_id="n1", note_version=1, content=content)
+    assert [i.locator for i in a.items] == [i.locator for i in b.items]
+    assert [i.text for i in a.items] == [i.text for i in b.items]
+
+
+@_COMMON
+@given(content=_content)
+def test_locator_offsets_stay_within_source_and_slice_the_raw_line(content: str) -> None:
+    result = parse_note_checklists(note_id="n1", note_version=1, content=content)
+    n = len(content)
+    for item in result.items:
+        loc = item.locator
+        assert 0 <= loc.start_offset <= loc.end_offset <= n, "offsets escape the source bounds"
+        # the span must slice back to exactly the raw line the item came from
+        assert content[loc.start_offset:loc.end_offset] == item.raw_line
+
+
+@_COMMON
+@given(content=_content)
+def test_locators_are_strictly_increasing(content: str) -> None:
+    result = parse_note_checklists(note_id="n1", note_version=1, content=content)
+    line_numbers = [i.locator.line_number for i in result.items]
+    start_offsets = [i.locator.start_offset for i in result.items]
+    assert line_numbers == sorted(line_numbers)
+    assert start_offsets == sorted(start_offsets)
+    # distinct items occupy distinct lines
+    assert len(set(line_numbers)) == len(line_numbers)
+
+
+@_COMMON
+@given(content=_content)
+def test_occurrence_index_increments_per_normalized_text(content: str) -> None:
+    result = parse_note_checklists(note_id="n1", note_version=1, content=content)
+    seen: dict[str, int] = {}
+    for item in result.items:
+        key = item.locator.normalized_text_hash
+        seen[key] = seen.get(key, 0) + 1
+        assert item.locator.occurrence_index == seen[key], "occurrence_index out of sequence"

--- a/tldw_Server_API/tests/Notes_Tasks/property/test_markdown_parser_properties.py
+++ b/tldw_Server_API/tests/Notes_Tasks/property/test_markdown_parser_properties.py
@@ -35,6 +35,7 @@ _content = st.lists(_line, max_size=30).map(lambda lines: "\n".join(lines))
 @_COMMON
 @given(content=_content)
 def test_parser_is_total(content: str) -> None:
+    """The parser never raises on arbitrary content and returns a result list."""
     result = parse_note_checklists(note_id="n1", note_version=1, content=content)
     assert result is not None
     assert isinstance(result.items, list)
@@ -43,15 +44,16 @@ def test_parser_is_total(content: str) -> None:
 @_COMMON
 @given(content=_content)
 def test_parser_is_deterministic(content: str) -> None:
+    """Parsing the same content twice yields an identical result (all fields)."""
     a = parse_note_checklists(note_id="n1", note_version=1, content=content)
     b = parse_note_checklists(note_id="n1", note_version=1, content=content)
-    assert [i.locator for i in a.items] == [i.locator for i in b.items]
-    assert [i.text for i in a.items] == [i.text for i in b.items]
+    assert a == b
 
 
 @_COMMON
 @given(content=_content)
 def test_locator_offsets_stay_within_source_and_slice_the_raw_line(content: str) -> None:
+    """Each item's locator offsets are in-bounds and slice back to its raw line."""
     result = parse_note_checklists(note_id="n1", note_version=1, content=content)
     n = len(content)
     for item in result.items:
@@ -64,6 +66,7 @@ def test_locator_offsets_stay_within_source_and_slice_the_raw_line(content: str)
 @_COMMON
 @given(content=_content)
 def test_locators_are_strictly_increasing(content: str) -> None:
+    """Item locators are in ascending line/offset order, one item per line."""
     result = parse_note_checklists(note_id="n1", note_version=1, content=content)
     line_numbers = [i.locator.line_number for i in result.items]
     start_offsets = [i.locator.start_offset for i in result.items]
@@ -76,6 +79,7 @@ def test_locators_are_strictly_increasing(content: str) -> None:
 @_COMMON
 @given(content=_content)
 def test_occurrence_index_increments_per_normalized_text(content: str) -> None:
+    """occurrence_index counts 1,2,3… within each group of same-text items."""
     result = parse_note_checklists(note_id="n1", note_version=1, content=content)
     seen: dict[str, int] = {}
     for item in result.items:


### PR DESCRIPTION
## Summary

Task 7 / PR 5 of `Docs/superpowers/plans/2026-07-04-test-suite-improvement-implementation-plan.md` — more RA4 property tests (contract/invariant gaps), each **mutation-verified**.

| File | Invariants | Mutation check |
|------|-----------|----------------|
| `Chunking/test_chunking_overlap_properties.py` (extended) | word-chunk reconstruction (ordered first-occurrence == source), chunk-size bound, coverage | off-by-one in the words stride that drops a word → **fails** ✓ |
| `Notes_Tasks/property/test_markdown_parser_properties.py` | `parse_note_checklists` totality, determinism, locator offsets within source AND slicing back to the raw line, strictly-increasing locators, occurrence-index sequencing | off-by-one in `end_offset` → span-slice property **fails** ✓ |
| `LLM_Calls/property/test_structured_output_properties.py` | `parse_structured_output` totality (only the typed no-payload error leaks; output always `json.dumps`-able), dict/list passthrough, bare/fenced JSON round-trip; `extract_items` yields list-of-dicts or the typed schema error | round-trip relies on correct extraction |

## Design notes
- **Chunking reconstruction tolerates a boundary duplicate.** Hypothesis found that at tiny `max_size` the chunker can repeat a word in the final chunk, so exact non-dup reconstruction is too strict. The ordered-first-occurrence view still fails on any *dropped or reordered* word (the off-by-one that matters), which the mutation confirms.
- **`extract_items` raises a typed error, not never.** Hypothesis found a top-level list of non-objects raises `StructuredOutputSchemaError`; the property asserts "list-of-dicts OR that typed error", never an untyped leak.

## Verification (local)
- 16 properties pass; `-m property` marker on the new files; ruff clean
- 3 mutation spot-checks confirmed (chunking words stride, markdown end_offset, and the structured-output round-trip)
- shard guard green (Config/Notes_Tasks/LLM_Calls dir-sharded — no ci.yml change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds property-based tests for word chunking, markdown checklist parsing, and structured-output JSON parsing to lock down key invariants and prevent regressions. Also stabilizes the structured-output round-trip to remove a CI flake.

- **New Tests**
  - Chunking (words): first-occurrence reconstruction, chunk-size bound, full coverage; preserves overlap adjacency; tolerates boundary duplicates; stride off-by-one mutation fails.
  - Markdown checklists: totality, determinism (full-result equality), locator offsets within source that slice back to the raw line, strictly increasing locators, occurrence-index sequencing; end_offset off-by-one mutation fails.
  - Structured output: totality with only `StructuredOutputNoPayloadError`, dict/list passthrough, bare/fenced JSON round-trip; `extract_items` returns list-of-dicts or raises `StructuredOutputSchemaError`.

- **Bug Fixes**
  - Fixed CI flake in structured-output tests by excluding backticks from generated JSON strings to avoid JSON fence collisions.
  - Test hygiene: added module-level `pytestmark = pytest.mark.unit` (chunking), kept `pytest.mark.property` in property dirs, and added hints/docstrings.

<sup>Written for commit 0e2d7354a83c6f6133b1022eaf267f07edc55cd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

