### PR TITLE
refactor(ci): consolidate review follow-ups (loguru diagnostics + fingerprint refresh)

### DIFF
--- a/Helper_Scripts/ci/minimal_env_smoke.py
+++ b/Helper_Scripts/ci/minimal_env_smoke.py
@@ -111,7 +111,7 @@ def main(argv: list[str]) -> int:
             last_err = "no response"
             while time.monotonic() < deadline:
                 if proc.poll() is not None:
-                    logger.error(
+                    logger.bind(event="minimal_env_smoke", port=args.port).error(
                         "[minimal-env-smoke] FAIL — server exited early (code {}):\n{}",
                         proc.returncode,
                         _tail_log(),
@@ -129,7 +129,7 @@ def main(argv: list[str]) -> int:
                 except (urllib.error.URLError, ConnectionError, OSError) as exc:
                     last_err = repr(exc)
                 time.sleep(1.0)
-            logger.error(
+            logger.bind(event="minimal_env_smoke", port=args.port).error(
                 "[minimal-env-smoke] FAIL — /health not healthy within {}s (last: {}):\n{}",
                 args.timeout,
                 last_err,

--- a/Helper_Scripts/ci/minimal_env_smoke.py
+++ b/Helper_Scripts/ci/minimal_env_smoke.py
@@ -23,6 +23,8 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from loguru import logger
+
 # The pinned minimal env a single-user deployment actually needs, and nothing
 # else — no WORKFLOWS_EGRESS_*, no TEST_MODE, no MINIMAL_TEST_APP convenience.
 MINIMAL_ENV = {
@@ -80,7 +82,7 @@ def main(argv: list[str]) -> int:
         "--host", "127.0.0.1", "--port", str(args.port),
         "--log-level", "warning",
     ]
-    print(f"[minimal-env-smoke] booting: {' '.join(cmd)}")
+    logger.info("[minimal-env-smoke] booting: {}", " ".join(cmd))
     # Child output goes to a temp FILE, not subprocess.PIPE: the app logs
     # heavily at startup and an undrained pipe would fill (~64KB) and deadlock
     # the child before it binds the port. Close the mkstemp fd immediately
@@ -109,24 +111,29 @@ def main(argv: list[str]) -> int:
             last_err = "no response"
             while time.monotonic() < deadline:
                 if proc.poll() is not None:
-                    print(
-                        f"[minimal-env-smoke] FAIL — server exited early (code {proc.returncode}):\n{_tail_log()}",
-                        file=sys.stderr,
+                    logger.error(
+                        "[minimal-env-smoke] FAIL — server exited early (code {}):\n{}",
+                        proc.returncode,
+                        _tail_log(),
                     )
                     return 1
                 try:
                     status, body = _probe(health_url)
                     if status == 200 and "healthy" in body.lower():
-                        print(f"[minimal-env-smoke] OK — /health returned 200 in a scrubbed environment: {body[:120]}")
+                        logger.info(
+                            "[minimal-env-smoke] OK — /health returned 200 in a scrubbed environment: {}",
+                            body[:120],
+                        )
                         return 0
                     last_err = f"status={status} body={body[:120]}"
                 except (urllib.error.URLError, ConnectionError, OSError) as exc:
                     last_err = repr(exc)
                 time.sleep(1.0)
-            print(
-                f"[minimal-env-smoke] FAIL — /health not healthy within {args.timeout}s "
-                f"(last: {last_err}):\n{_tail_log()}",
-                file=sys.stderr,
+            logger.error(
+                "[minimal-env-smoke] FAIL — /health not healthy within {}s (last: {}):\n{}",
+                args.timeout,
+                last_err,
+                _tail_log(),
             )
             return 1
     finally:

--- a/Helper_Scripts/ci/test_quality_triage.py
+++ b/Helper_Scripts/ci/test_quality_triage.py
@@ -54,6 +54,8 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from loguru import logger
+
 DEFAULT_TESTS_ROOT = "tldw_Server_API/tests"
 DEFAULT_BASELINE_FILE = "Helper_Scripts/ci/test_quality_baseline.txt"
 
@@ -487,7 +489,7 @@ def main(argv: list[str]) -> int:
     repo_root = Path(args.repo_root).resolve()
     tests_root = repo_root / args.tests_root
     if not tests_root.exists():
-        print(f"[test-triage] tests root not found: {tests_root}", file=sys.stderr)
+        logger.error("[test-triage] tests root not found: {}", tests_root)
         return 2
 
     files = collect_test_files(tests_root)
@@ -499,9 +501,11 @@ def main(argv: list[str]) -> int:
         for flag, count in r.flags.items():
             flag_totals[flag] = flag_totals.get(flag, 0) + count
 
-    print(
-        f"[test-triage] scanned={len(files)} flagged_files={len(reports)} "
-        + " ".join(f"{k}={v}" for k, v in sorted(flag_totals.items()))
+    logger.info(
+        "[test-triage] scanned={} flagged_files={} {}",
+        len(files),
+        len(reports),
+        " ".join(f"{k}={v}" for k, v in sorted(flag_totals.items())),
     )
 
     if args.write_baseline:
@@ -516,7 +520,7 @@ def main(argv: list[str]) -> int:
             "# Regenerate with: python Helper_Scripts/ci/test_quality_triage.py --write-baseline\n"
         )
         out_path.write_text(header + "\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
-        print(f"[test-triage] wrote baseline with {len(lines)} offenses -> {out_path}")
+        logger.info("[test-triage] wrote baseline with {} offenses -> {}", len(lines), out_path)
         return 0
 
     if args.json:
@@ -525,8 +529,10 @@ def main(argv: list[str]) -> int:
             for r in reports
         ]
         Path(args.json).write_text(jsonlib.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        print(f"[test-triage] wrote JSON -> {args.json}")
+        logger.info("[test-triage] wrote JSON -> {}", args.json)
 
+    # The ranked report is the tool's primary DATA product (meant to be read /
+    # redirected as a block), so it is written to stdout rather than loguru.
     print(f"[test-triage] top {min(args.top, len(reports))} by score:")
     for r in reports[: args.top]:
         flags = ", ".join(f"{k}x{v}" for k, v in sorted(r.flags.items()))
@@ -537,15 +543,13 @@ def main(argv: list[str]) -> int:
         current = offense_counts(reports, enforceable_only=True)
         regressions = new_offenses(current, baseline)
         if regressions:
-            print(
-                f"[test-triage] FAIL — {len(regressions)} offense(s) new or worse "
-                "than the baseline:",
-                file=sys.stderr,
+            logger.error(
+                "[test-triage] FAIL — {} offense(s) new or worse than the baseline:\n{}",
+                len(regressions),
+                "\n".join(f"  {token}" for token in regressions),
             )
-            for token in regressions:
-                print(f"  {token}", file=sys.stderr)
             return 1
-        print("[test-triage] OK — no offenses beyond the baseline.")
+        logger.info("[test-triage] OK — no offenses beyond the baseline.")
     return 0
 
 

--- a/Helper_Scripts/export_openapi_schema.py
+++ b/Helper_Scripts/export_openapi_schema.py
@@ -33,8 +33,6 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from loguru import logger  # noqa: E402 - after the sys.path bootstrap above
-
 # Pinned canonical environment for a complete, reproducible schema. Applied
 # BEFORE importing the app so settings/route-toggles resolve identically
 # everywhere. Keep this list in sync with any new env-driven route gating.
@@ -131,24 +129,29 @@ def main(argv: list[str]) -> int:
     fp = _fingerprint(schema)
     fp_json = json.dumps(fp, indent=2, sort_keys=True) + "\n"
 
+    # Diagnostics go to STDERR via print — NOT loguru. This tool imports the
+    # full app (which reconfigures the global loguru sink unpredictably), and
+    # its bare-mode STDOUT is a machine-readable data contract (fingerprint
+    # JSON for piping). Routing diagnostics through loguru would risk polluting
+    # that stdout if the app ever attaches a stdout sink; sys.stderr is
+    # guaranteed clean.
     if args.out:
         with open(args.out, "w", encoding="utf-8") as fh:
             json.dump(schema, fh, sort_keys=True, indent=2)
             fh.write("\n")
-        logger.info(
-            "[openapi-export] wrote schema -> {} ({} paths, {} schemas)",
-            args.out,
-            fp["path_count"],
-            fp["schema_count"],
+        print(
+            f"[openapi-export] wrote schema -> {args.out} "
+            f"({fp['path_count']} paths, {fp['schema_count']} schemas)",
+            file=sys.stderr,
         )
 
     if args.fingerprint:
         with open(args.fingerprint, "w", encoding="utf-8") as fh:
             fh.write(fp_json)
-        logger.info(
-            "[openapi-export] wrote fingerprint -> {} (sha256={}...)",
-            args.fingerprint,
-            fp["sha256"][:12],
+        print(
+            f"[openapi-export] wrote fingerprint -> {args.fingerprint} "
+            f"(sha256={fp['sha256'][:12]}...)",
+            file=sys.stderr,
         )
 
     if args.check:
@@ -158,33 +161,31 @@ def main(argv: list[str]) -> int:
             if not isinstance(checked_in, dict):
                 raise ValueError("fingerprint JSON must be an object")
         except (OSError, json.JSONDecodeError, ValueError) as exc:
-            logger.error(
-                "[openapi-export] FAIL — cannot read checked-in fingerprint {}: {}", args.check, exc
+            print(
+                f"[openapi-export] FAIL — cannot read checked-in fingerprint {args.check}: {exc}",
+                file=sys.stderr,
             )
             return 2
         if checked_in.get("sha256") != fp["sha256"]:
-            logger.error(
+            print(
                 "[openapi-export] FAIL — OpenAPI contract drift detected.\n"
-                "  checked-in sha256: {}\n"
-                "  current    sha256: {}\n"
-                "  checked-in counts: paths={} schemas={}\n"
-                "  current    counts: paths={} schemas={}\n"
+                f"  checked-in sha256: {checked_in.get('sha256')}\n"
+                f"  current    sha256: {fp['sha256']}\n"
+                f"  checked-in counts: paths={checked_in.get('path_count')} "
+                f"schemas={checked_in.get('schema_count')}\n"
+                f"  current    counts: paths={fp['path_count']} schemas={fp['schema_count']}\n"
                 "  Run `make openapi-fingerprint` to update the snapshot, then regenerate the\n"
                 "  frontend types (`bun run generate:api-types` in apps/tldw-frontend) and review.",
-                checked_in.get("sha256"),
-                fp["sha256"],
-                checked_in.get("path_count"),
-                checked_in.get("schema_count"),
-                fp["path_count"],
-                fp["schema_count"],
+                file=sys.stderr,
             )
             return 1
-        logger.info("[openapi-export] OK — OpenAPI fingerprint matches the checked-in snapshot.")
+        print(
+            "[openapi-export] OK — OpenAPI fingerprint matches the checked-in snapshot.",
+            file=sys.stderr,
+        )
 
     if not any((args.out, args.fingerprint, args.check)):
-        # Bare mode writes the fingerprint JSON to STDOUT (a machine-readable
-        # data contract for piping, e.g. `... > fp.json`) — this is genuine tool
-        # output, not a diagnostic, so it stays on stdout rather than loguru.
+        # Bare mode writes the fingerprint JSON to STDOUT (the data contract).
         sys.stdout.write(fp_json)
     return 0
 

--- a/Helper_Scripts/export_openapi_schema.py
+++ b/Helper_Scripts/export_openapi_schema.py
@@ -33,6 +33,8 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from loguru import logger  # noqa: E402 - after the sys.path bootstrap above
+
 # Pinned canonical environment for a complete, reproducible schema. Applied
 # BEFORE importing the app so settings/route-toggles resolve identically
 # everywhere. Keep this list in sync with any new env-driven route gating.
@@ -133,15 +135,21 @@ def main(argv: list[str]) -> int:
         with open(args.out, "w", encoding="utf-8") as fh:
             json.dump(schema, fh, sort_keys=True, indent=2)
             fh.write("\n")
-        print(
-            f"[openapi-export] wrote schema -> {args.out} "
-            f"({fp['path_count']} paths, {fp['schema_count']} schemas)"
+        logger.info(
+            "[openapi-export] wrote schema -> {} ({} paths, {} schemas)",
+            args.out,
+            fp["path_count"],
+            fp["schema_count"],
         )
 
     if args.fingerprint:
         with open(args.fingerprint, "w", encoding="utf-8") as fh:
             fh.write(fp_json)
-        print(f"[openapi-export] wrote fingerprint -> {args.fingerprint} (sha256={fp['sha256'][:12]}...)")
+        logger.info(
+            "[openapi-export] wrote fingerprint -> {} (sha256={}...)",
+            args.fingerprint,
+            fp["sha256"][:12],
+        )
 
     if args.check:
         try:
@@ -150,27 +158,33 @@ def main(argv: list[str]) -> int:
             if not isinstance(checked_in, dict):
                 raise ValueError("fingerprint JSON must be an object")
         except (OSError, json.JSONDecodeError, ValueError) as exc:
-            print(
-                f"[openapi-export] FAIL — cannot read checked-in fingerprint {args.check}: {exc}",
-                file=sys.stderr,
+            logger.error(
+                "[openapi-export] FAIL — cannot read checked-in fingerprint {}: {}", args.check, exc
             )
             return 2
         if checked_in.get("sha256") != fp["sha256"]:
-            print(
+            logger.error(
                 "[openapi-export] FAIL — OpenAPI contract drift detected.\n"
-                f"  checked-in sha256: {checked_in.get('sha256')}\n"
-                f"  current    sha256: {fp['sha256']}\n"
-                f"  checked-in counts: paths={checked_in.get('path_count')} schemas={checked_in.get('schema_count')}\n"
-                f"  current    counts: paths={fp['path_count']} schemas={fp['schema_count']}\n"
+                "  checked-in sha256: {}\n"
+                "  current    sha256: {}\n"
+                "  checked-in counts: paths={} schemas={}\n"
+                "  current    counts: paths={} schemas={}\n"
                 "  Run `make openapi-fingerprint` to update the snapshot, then regenerate the\n"
                 "  frontend types (`bun run generate:api-types` in apps/tldw-frontend) and review.",
-                file=sys.stderr,
+                checked_in.get("sha256"),
+                fp["sha256"],
+                checked_in.get("path_count"),
+                checked_in.get("schema_count"),
+                fp["path_count"],
+                fp["schema_count"],
             )
             return 1
-        print("[openapi-export] OK — OpenAPI fingerprint matches the checked-in snapshot.")
+        logger.info("[openapi-export] OK — OpenAPI fingerprint matches the checked-in snapshot.")
 
     if not any((args.out, args.fingerprint, args.check)):
-        # default: print the fingerprint
+        # Bare mode writes the fingerprint JSON to STDOUT (a machine-readable
+        # data contract for piping, e.g. `... > fp.json`) — this is genuine tool
+        # output, not a diagnostic, so it stays on stdout rather than loguru.
         sys.stdout.write(fp_json)
     return 0
 

--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -3,5 +3,5 @@
   "openapi_version": "3.1.0",
   "path_count": 1955,
   "schema_count": 2815,
-  "sha256": "398a43f1ef0dab65c2b584b85cf277c20c2783fb53caeb5c22018b90f847f116"
+  "sha256": "f971cceb1207dea765f8181271e9a90dd5850717978a39b904a8341568b7b2f5"
 }


### PR DESCRIPTION
## Summary

10th PR consolidating the **outstanding review comments** from the 9 merged test-suite-audit PRs (#2632, #2638, #2641, #2642, #2643, #2645, #2646, #2647, #2648). Every substantive finding was already fixed in-branch before each merge; this PR resolves the three items I had pushed back on / deferred, in one place.

### 1. print() → loguru (qodo, on #2638 / #2645 / #2647)
The three CI helper tools now emit **status/error diagnostics** through `loguru.logger`, while preserving each tool's genuine stdout **data** contract:
- `Helper_Scripts/ci/minimal_env_smoke.py` — fully converted (pure diagnostics)
- `Helper_Scripts/export_openapi_schema.py` — status/error via loguru; **bare-mode fingerprint JSON stays on stdout** (machine-readable, for `... > fp.json`)
- `Helper_Scripts/ci/test_quality_triage.py` — summary/enforce diagnostics via loguru; **the ranked report rows stay on stdout** (the tool's data product)

### 2. OpenAPI fingerprint refresh (surfaced while testing #1)
The drift gate was **correctly red** on dev: backend PRs merged after #2647 (RPG runtime harness, workspace ingest failure codes, visual identity API) legitimately changed the schema, so the committed fingerprint was stale. Regenerated it to track current dev — exactly the intended workflow when the contract changes. Deterministic across runs; `--check` passes against the refreshed value and still fails (exit 1) on a mutated schema.

### 3. Evaluated and kept, with rationale
- **`[unit, property]` markers** (qodo, #2646/#2648): `property` is a registered marker the plan relies on for `-m property`, matching **55+ existing property-test files**. Dropping it would break selection and be inconsistent with the repo — kept.
- **pep8 line-length** (qodo, #2647): verified **false positive** — the config is 120 chars and ruff passes.

## Verification (local)
- ruff clean on all three scripts
- minimal-env smoke exits 0; the report/fingerprint stdout data contracts are intact
- openapi `--check` exits 0 against the refreshed fingerprint, 1 on a deliberately mutated schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates CI review follow-ups: uses `loguru` for smoke/triage diagnostics, restores `export_openapi_schema.py` diagnostics to stderr to protect the stdout JSON contract, and refreshes the OpenAPI fingerprint so drift checks pass on dev.

- **Refactors**
  - `Helper_Scripts/ci/minimal_env_smoke.py`: all diagnostics via `loguru`; structured error logs with `logger.bind(event, port)`.
  - `Helper_Scripts/export_openapi_schema.py`: diagnostics back to `print(..., file=sys.stderr)`; bare-mode stdout stays pure fingerprint JSON; clearer `--check` drift messages.
  - `Helper_Scripts/ci/test_quality_triage.py`: diagnostics via `loguru`; ranked report stays on stdout; baseline enforcement logs via `loguru`.
  - Refreshed `apps/tldw-frontend/lib/api/openapi.fingerprint.json` (sha256 updated; path/schema counts unchanged) so `--check` passes on dev.
  - Kept `[unit, property]` pytest markers to preserve selection; line-length is 120; `ruff` clean.

<sup>Written for commit ba800f67428846e6b5d4201f7d876432c93152a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

