### PR TITLE
Add MCP resource discovery/read parity

### DIFF
--- a/Docs/superpowers/plans/2026-07-05-mcp-resource-discovery-read-parity-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-05-mcp-resource-discovery-read-parity-implementation-plan.md
@@ -1,0 +1,31 @@
+# MCP Resource Discovery and Read Parity Implementation Plan
+
+## Stage 1: External Runtime Resource Tests
+**Goal**: Prove external resources list/read through the runtime manager and adapter.
+**Success Criteria**: Tests cover redacted virtual resource descriptors, read routing, and stopped/missing errors.
+**Tests**: `test_gateway_external_runtime.py`, `test_gateway_fastapi_package.py`
+**Status**: Complete
+
+## Stage 2: Transport Resource Methods
+**Goal**: Add minimal `list_resources` and `read_resource` support to fake and stdio transports.
+**Success Criteria**: Stdio transport sends MCP `resources/list` and `resources/read` and normalizes malformed upstream data safely.
+**Tests**: Existing stdio smoke fixture or focused unit tests.
+**Status**: Complete
+
+## Stage 3: Runtime Integration
+**Goal**: Merge base and external resources in the gateway adapter.
+**Success Criteria**: External resources use virtual URIs, raw upstream URIs stay private, and reads route by virtual URI.
+**Tests**: Adapter and manager tests pass.
+**Status**: Complete
+
+## Stage 4: Bounded Readiness
+**Goal**: Add a small wait helper over existing runtime status.
+**Success Criteria**: Wait returns ready/unavailable server ids without spawning a monitor.
+**Tests**: Focused runtime test.
+**Status**: Complete
+
+## Stage 5: Verification
+**Goal**: Verify the touched scope and record results.
+**Success Criteria**: Focused pytest, Bandit on touched code, and `git diff --check` are clean or documented.
+**Tests**: Focused commands only.
+**Status**: Complete

--- a/Docs/superpowers/specs/2026-07-05-mcp-resource-discovery-read-parity-design.md
+++ b/Docs/superpowers/specs/2026-07-05-mcp-resource-discovery-read-parity-design.md
@@ -1,0 +1,29 @@
+# MCP Resource Discovery and Read Parity Design
+
+## Context
+
+`TASK-2290` covers Claude-style MCP resource discovery, resource reads, and bounded MCP server readiness checks. The current standalone gateway already routes `resources/list` and `resources/read` to a `GatewayRuntime`, and the tldw MCP protocol already supports internal module resources. External runtime support is tool-only.
+
+## Scope
+
+- Keep the existing JSON-RPC gateway paths for internal resources.
+- Add resource discovery/read methods to the external transport contract.
+- Expose running external server resources through the existing external runtime adapter.
+- Redact upstream resource identifiers from public resource metadata.
+- Add a bounded readiness helper over existing runtime status rows.
+
+## Design
+
+- External transports return plain MCP resource dictionaries and resource read payloads.
+- The runtime manager maps upstream resources to `external://{server_id}/{digest}` virtual URIs and stores the upstream URI in memory only.
+- Public descriptors include `external_server_id`, `source`, and safe title/description/mime metadata, but not the raw upstream URI.
+- Reads for `external://...` URIs go through the external runtime manager; all other URIs continue to delegate to the base runtime.
+- Missing, stopped, or unknown external resources raise `GatewayExternalRuntimeError` with stable reason codes.
+- Readiness waiting polls `list_runtime_servers()` until requested servers are healthy or the timeout expires.
+
+## Non-Goals
+
+- No new resource database.
+- No new setup UI.
+- No package install/update execution changes.
+- No local-file default pack changes.

--- a/apps/mcp-unified/src/mcp_unified/federation/stdio_transport.py
+++ b/apps/mcp-unified/src/mcp_unified/federation/stdio_transport.py
@@ -227,6 +227,61 @@ class StdioExternalTransport:
             )
         return tools
 
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Discover and normalize upstream MCP resource descriptors."""
+        await self._ensure_connected()
+        response = await self._request("resources/list", {})
+        result = response.get("result") or {}
+        if isinstance(result, dict):
+            raw_resources = result.get("resources") or []
+        elif isinstance(result, list):
+            raw_resources = result
+        else:
+            raw_resources = []
+
+        resources: list[dict[str, Any]] = []
+        for item in raw_resources:
+            if not isinstance(item, dict):
+                continue
+            uri = item.get("uri")
+            if not isinstance(uri, str) or not uri.strip():
+                continue
+            name = item.get("name")
+            if not isinstance(name, str):
+                name = ""
+            description = item.get("description")
+            if not isinstance(description, str):
+                description = ""
+            mime_type = item.get("mimeType")
+            if not isinstance(mime_type, str):
+                mime_type = None
+            metadata = item.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+            resources.append(
+                {
+                    "uri": uri,
+                    "name": name,
+                    "description": description,
+                    "mimeType": mime_type,
+                    "metadata": deepcopy(metadata),
+                }
+            )
+        return resources
+
+    async def read_resource(
+        self,
+        uri: str,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Read one upstream MCP resource."""
+        del context
+        await self._ensure_connected()
+        response = await self._request("resources/read", {"uri": uri})
+        result = response.get("result")
+        return deepcopy(result) if isinstance(result, dict) else {"contents": []}
+
     async def call_tool(
         self,
         tool_name: str,

--- a/apps/mcp-unified/src/mcp_unified/federation/transports.py
+++ b/apps/mcp-unified/src/mcp_unified/federation/transports.py
@@ -38,6 +38,19 @@ class ExternalFederationTransport(Protocol):
         """Return discovered external tool definitions."""
         ...
 
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Return discovered external resource descriptors."""
+        ...
+
+    async def read_resource(
+        self,
+        uri: str,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Read one upstream external resource."""
+        ...
+
     async def call_tool(
         self,
         tool_name: str,
@@ -60,6 +73,8 @@ class FakeExternalTransport:
         *,
         server_id: str,
         tools: list[ExternalToolDefinition] | None = None,
+        resources: list[dict[str, Any]] | None = None,
+        resource_results: dict[str, dict[str, Any]] | None = None,
         results: dict[str, ExternalToolCallResult] | None = None,
         health: dict[str, bool] | None = None,
     ) -> None:
@@ -69,8 +84,14 @@ class FakeExternalTransport:
         self.close_count = 0
         self.spawn_count = 0
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.resource_reads: list[str] = []
         self.runtime_auth_seen: BrokeredExternalCredential | None = None
         self._tools = [tool.copy() for tool in tools or []]
+        self._resources = [deepcopy(resource) for resource in resources or []]
+        self._resource_results = {
+            uri: deepcopy(result)
+            for uri, result in (resource_results or {}).items()
+        }
         self._results = {
             name: result.copy()
             for name, result in (results or {}).items()
@@ -99,6 +120,24 @@ class FakeExternalTransport:
     async def list_tools(self) -> list[ExternalToolDefinition]:
         """Return caller-owned fake tool definitions."""
         return [tool.copy() for tool in self._tools]
+
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Return caller-owned fake resource descriptors."""
+        return [deepcopy(resource) for resource in self._resources]
+
+    async def read_resource(
+        self,
+        uri: str,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Return a configured fake resource result."""
+        del context
+        self.resource_reads.append(uri)
+        result = self._resource_results.get(uri)
+        if result is None:
+            raise ValueError(f"Unknown fake external resource '{uri}'")
+        return deepcopy(result)
 
     async def call_tool(
         self,

--- a/apps/mcp-unified/src/mcp_unified/gateway/bootstrap.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/bootstrap.py
@@ -15,6 +15,7 @@ from mcp_unified.profiles.presets import duplicate_builtin_preset
 from mcp_unified.profiles.resolver import AssignmentBackedProfileResolver
 from mcp_unified.profiles.store import InMemoryProfileAssignmentStore, InMemoryProfileStore
 
+from .external_runtime_adapter import ExternalRuntimeGatewayRuntime
 from .profile_runtime import ProfileAwareGatewayRuntime
 from .runtime import GatewayRuntime
 
@@ -99,8 +100,14 @@ async def bootstrap_profile_gateway(
         assignment_store=assignments,
         fallback_default_profile_id=resolved_default_profile_id,
     )
+    resolved_backend: GatewayRuntime = backend
+    if external_runtime_manager is not None:
+        resolved_backend = ExternalRuntimeGatewayRuntime(
+            external_runtime_manager=external_runtime_manager,
+            base_runtime=backend,
+        )
     runtime = ProfileAwareGatewayRuntime(
-        backend,
+        resolved_backend,
         profile_resolver=resolver,
         policy_grant_store=policy_grant_store,
     )

--- a/apps/mcp-unified/src/mcp_unified/gateway/external_runtime.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/external_runtime.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import inspect
+import re
 import traceback
 from collections.abc import Callable, Iterable
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Protocol
+from urllib.parse import parse_qsl, urlsplit
 from uuid import uuid4
 
 from loguru import logger
@@ -64,6 +66,7 @@ _INSTALLER_SENSITIVE_KEY_TOKENS = (
 )
 _UNSAFE_INSTALLER_VALUE = object()
 _DEFAULT_INSTALLER_STATUS_TIMEOUT_SECONDS = 2.0
+_UNSCOPED_EFFECTIVE_POLICY = object()
 
 
 class GatewayExternalRuntimeError(RuntimeError):
@@ -444,12 +447,21 @@ class GatewayExternalRuntimeManager:
                 for name in sorted(self._virtual_tools)
             ]
 
-    async def list_virtual_resources(self) -> list[dict[str, Any]]:
+    async def list_virtual_resources(
+        self,
+        *,
+        effective_policy: Any = _UNSCOPED_EFFECTIVE_POLICY,
+    ) -> list[dict[str, Any]]:
         """Return caller-owned external resources for active servers."""
         async with self._lock:
             snapshots = [
                 (server_id, transport)
                 for server_id, transport in sorted(self._transports.items())
+                if self._resource_policy_allows_server(
+                    effective_policy,
+                    server_id,
+                    self._servers.get(server_id),
+                )
             ]
 
         for server_id, transport in snapshots:
@@ -474,12 +486,18 @@ class GatewayExternalRuntimeManager:
 
             async with self._lock:
                 if self._transports.get(server_id) is transport:
+                    self._last_errors[server_id] = None
                     self._replace_server_resources(server_id, resources)
 
         async with self._lock:
             return [
                 deepcopy(self._virtual_resources[uri]["descriptor"])
                 for uri in sorted(self._virtual_resources)
+                if self._resource_policy_allows_server(
+                    effective_policy,
+                    str(self._virtual_resources[uri]["server_id"]),
+                    self._servers.get(str(self._virtual_resources[uri]["server_id"])),
+                )
             ]
 
     async def read_virtual_resource(
@@ -487,6 +505,7 @@ class GatewayExternalRuntimeManager:
         uri: str,
         *,
         context: Any = None,
+        effective_policy: Any = _UNSCOPED_EFFECTIVE_POLICY,
     ) -> dict[str, Any]:
         """Read one active virtual external resource."""
         async with self._lock:
@@ -506,6 +525,46 @@ class GatewayExternalRuntimeManager:
                     reason_code="external_server_transport_unavailable",
                     server_id=server_id,
                 )
+            server = self._servers.get(server_id)
+            if server is None:
+                raise GatewayExternalRuntimeError(
+                    f"External server '{server_id}' is not active",
+                    reason_code="external_server_transport_unavailable",
+                    server_id=server_id,
+                )
+            server = server.model_copy(deep=True)
+            if (
+                effective_policy is not _UNSCOPED_EFFECTIVE_POLICY
+                and not self._has_resource_server_grant(effective_policy, server_id)
+            ):
+                raise FederationPolicyDenied(
+                    "external_server_not_granted",
+                    f"External server '{server_id}' is not allowed",
+                    payload={
+                        "reason_code": "external_server_not_granted",
+                        "server_id": server_id,
+                        "resource_uri": uri,
+                    },
+                )
+            if effective_policy is not _UNSCOPED_EFFECTIVE_POLICY:
+                missing_slots = self._missing_credential_slots(
+                    server=server,
+                    effective_policy=effective_policy,
+                )
+                if missing_slots:
+                    raise FederationPolicyDenied(
+                        "required_credential_grant_missing",
+                        (
+                            f"External server '{server_id}' requires credential grants for "
+                            f"{', '.join(missing_slots)}"
+                        ),
+                        payload={
+                            "reason_code": "required_credential_grant_missing",
+                            "server_id": server_id,
+                            "resource_uri": uri,
+                            "credential_slots": list(missing_slots),
+                        },
+                    )
 
         try:
             result = await transport.read_resource(upstream_uri, context=context)
@@ -985,19 +1044,127 @@ class GatewayExternalRuntimeManager:
         upstream_uri: str,
     ) -> dict[str, Any]:
         result = deepcopy(payload) if isinstance(payload, dict) else {"contents": []}
-        contents = result.get("contents")
-        if isinstance(contents, list):
-            rewritten: list[Any] = []
-            for item in contents:
-                if not isinstance(item, dict):
-                    rewritten.append(item)
-                    continue
-                item_copy = dict(item)
-                if item_copy.get("uri") == upstream_uri:
-                    item_copy["uri"] = virtual_uri
-                rewritten.append(item_copy)
-            result["contents"] = rewritten
-        return result
+        uri_prefix = GatewayExternalRuntimeManager._same_origin_uri_prefix(upstream_uri)
+        sensitive_values = GatewayExternalRuntimeManager._sensitive_uri_values(upstream_uri)
+        return GatewayExternalRuntimeManager._redact_resource_read_value(
+            result,
+            virtual_uri=virtual_uri,
+            upstream_uri=upstream_uri,
+            uri_prefix=uri_prefix,
+            sensitive_values=sensitive_values,
+        )
+
+    @staticmethod
+    def _redact_resource_read_value(
+        value: Any,
+        *,
+        virtual_uri: str,
+        upstream_uri: str,
+        uri_prefix: str | None,
+        sensitive_values: tuple[str, ...],
+        key: str | None = None,
+    ) -> Any:
+        if isinstance(value, dict):
+            return {
+                str(child_key): GatewayExternalRuntimeManager._redact_resource_read_value(
+                    child_value,
+                    virtual_uri=virtual_uri,
+                    upstream_uri=upstream_uri,
+                    uri_prefix=uri_prefix,
+                    sensitive_values=sensitive_values,
+                    key=str(child_key),
+                )
+                for child_key, child_value in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                GatewayExternalRuntimeManager._redact_resource_read_value(
+                    item,
+                    virtual_uri=virtual_uri,
+                    upstream_uri=upstream_uri,
+                    uri_prefix=uri_prefix,
+                    sensitive_values=sensitive_values,
+                )
+                for item in value
+            ]
+        if isinstance(value, str):
+            if GatewayExternalRuntimeManager._is_resource_uri_key(key):
+                return virtual_uri
+            redacted = value.replace(upstream_uri, virtual_uri)
+            if uri_prefix:
+                redacted = re.sub(
+                    rf"{re.escape(uri_prefix)}[^\s\"'<>)]*",
+                    virtual_uri,
+                    redacted,
+                )
+            for sensitive_value in sensitive_values:
+                redacted = redacted.replace(sensitive_value, "[redacted]")
+            return redacted
+        return value
+
+    @staticmethod
+    def _has_resource_server_grant(effective_policy: Any, server_id: str) -> bool:
+        """Return whether policy grants resource access to an external server."""
+
+        return any(
+            GatewayExternalRuntimeManager._grant_matches_server(grant, server_id)
+            for grant in GatewayExternalRuntimeManager._policy_dicts(
+                effective_policy,
+                "external_server_grants",
+            )
+        )
+
+    def _resource_policy_allows_server(
+        self,
+        effective_policy: Any,
+        server_id: str,
+        server: ExternalServerDefinition | None,
+    ) -> bool:
+        """Return whether resource discovery/read may touch this server."""
+
+        if effective_policy is _UNSCOPED_EFFECTIVE_POLICY:
+            return True
+        if not self._has_resource_server_grant(effective_policy, server_id):
+            return False
+        if server is None:
+            return False
+        return not self._missing_credential_slots(
+            server=server,
+            effective_policy=effective_policy,
+        )
+
+    @staticmethod
+    def _is_resource_uri_key(key: str | None) -> bool:
+        """Return whether a payload key is expected to carry a URI/URL value."""
+
+        if key is None:
+            return False
+        normalized = key.replace("_", "").replace("-", "").lower()
+        return normalized in {"uri", "url", "href", "sourceuri"} or normalized.endswith(
+            ("uri", "url")
+        )
+
+    @staticmethod
+    def _same_origin_uri_prefix(upstream_uri: str) -> str | None:
+        """Return the scheme/netloc prefix used to scrub related upstream URIs."""
+
+        parsed = urlsplit(upstream_uri)
+        if not parsed.scheme or not parsed.netloc:
+            return None
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    @staticmethod
+    def _sensitive_uri_values(upstream_uri: str) -> tuple[str, ...]:
+        """Return sensitive query values from the upstream URI for text redaction."""
+
+        parsed = urlsplit(upstream_uri)
+        sensitive_tokens = ("auth", "credential", "key", "password", "secret", "token")
+        values: list[str] = []
+        for key, value in parse_qsl(parsed.query, keep_blank_values=False):
+            key_text = key.lower()
+            if len(value) >= 4 and any(token in key_text for token in sensitive_tokens):
+                values.append(value)
+        return tuple(dict.fromkeys(values))
 
     async def _installer_status(
         self,

--- a/apps/mcp-unified/src/mcp_unified/gateway/external_runtime.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/external_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import traceback
 from collections.abc import Callable, Iterable
@@ -130,6 +131,7 @@ class GatewayExternalRuntimeManager:
         self._servers: dict[str, ExternalServerDefinition] = {}
         self._transports: dict[str, ExternalFederationTransport] = {}
         self._virtual_tools: dict[str, VirtualExternalTool] = {}
+        self._virtual_resources: dict[str, dict[str, Any]] = {}
         self._last_errors: dict[str, str | None] = {}
         self._lock = asyncio.Lock()
 
@@ -442,6 +444,127 @@ class GatewayExternalRuntimeManager:
                 for name in sorted(self._virtual_tools)
             ]
 
+    async def list_virtual_resources(self) -> list[dict[str, Any]]:
+        """Return caller-owned external resources for active servers."""
+        async with self._lock:
+            snapshots = [
+                (server_id, transport)
+                for server_id, transport in sorted(self._transports.items())
+            ]
+
+        for server_id, transport in snapshots:
+            try:
+                resources = await transport.list_resources()
+            except Exception as exc:  # noqa: BLE001 - resource discovery must be row-scoped.
+                async with self._lock:
+                    if self._transports.get(server_id) is transport:
+                        self._last_errors[server_id] = self._exception_summary(exc)
+                        self._clear_server_resources(server_id)
+                await self._audit_best_effort(
+                    "external_server.resource_discovery",
+                    payload={
+                        "reason_code": "external_server_resource_discovery_failed",
+                        "server_id": server_id,
+                        "error_type": type(exc).__name__,
+                    },
+                    target_type="external_server",
+                    target_id=server_id,
+                )
+                continue
+
+            async with self._lock:
+                if self._transports.get(server_id) is transport:
+                    self._replace_server_resources(server_id, resources)
+
+        async with self._lock:
+            return [
+                deepcopy(self._virtual_resources[uri]["descriptor"])
+                for uri in sorted(self._virtual_resources)
+            ]
+
+    async def read_virtual_resource(
+        self,
+        uri: str,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        """Read one active virtual external resource."""
+        async with self._lock:
+            entry = self._virtual_resources.get(uri)
+            if entry is None:
+                raise GatewayExternalRuntimeError(
+                    f"External resource '{uri}' was not found",
+                    reason_code="external_resource_not_found",
+                    server_id=self._server_id_from_virtual_resource_uri(uri),
+                )
+            server_id = str(entry["server_id"])
+            upstream_uri = str(entry["upstream_uri"])
+            transport = self._transports.get(server_id)
+            if transport is None:
+                raise GatewayExternalRuntimeError(
+                    f"External server '{server_id}' is not active",
+                    reason_code="external_server_transport_unavailable",
+                    server_id=server_id,
+                )
+
+        try:
+            result = await transport.read_resource(upstream_uri, context=context)
+        except Exception as exc:  # noqa: BLE001 - transport adapters define read errors.
+            raise GatewayExternalRuntimeError(
+                f"External resource '{uri}' failed during read",
+                reason_code="external_resource_read_failed",
+                server_id=server_id,
+            ) from exc
+        return self._resource_read_payload(result, virtual_uri=uri, upstream_uri=upstream_uri)
+
+    async def wait_for_servers(
+        self,
+        server_ids: list[str] | tuple[str, ...] | set[str] | None = None,
+        *,
+        timeout_seconds: float = 5.0,
+        poll_interval_seconds: float = 0.1,
+    ) -> dict[str, Any]:
+        """Wait briefly for external servers to report healthy runtime status."""
+        loop = asyncio.get_running_loop()
+        timeout = max(0.0, float(timeout_seconds))
+        poll_interval = max(0.001, float(poll_interval_seconds))
+        deadline = loop.time() + timeout
+        if isinstance(server_ids, str):
+            targets = {server_ids}
+        else:
+            targets = {str(server_id) for server_id in server_ids or () if str(server_id)}
+
+        while True:
+            rows = await self.list_runtime_servers()
+            by_id = {
+                str(row.get("id")): row
+                for row in rows.get("servers", [])
+                if row.get("id") is not None
+            }
+            current_targets = targets or set(by_id)
+            ready = sorted(
+                server_id
+                for server_id in current_targets
+                if by_id.get(server_id, {}).get("status") == "healthy"
+            )
+            unknown = sorted(current_targets - set(by_id))
+            unavailable = sorted(current_targets - set(ready) - set(unknown))
+            if not unavailable and not unknown:
+                return {
+                    "ok": True,
+                    "ready_servers": ready,
+                    "unavailable_servers": [],
+                    "unknown_servers": [],
+                }
+            if loop.time() >= deadline:
+                return {
+                    "ok": False,
+                    "ready_servers": ready,
+                    "unavailable_servers": unavailable,
+                    "unknown_servers": unknown,
+                }
+            await asyncio.sleep(min(poll_interval, max(0.0, deadline - loop.time())))
+
     async def has_virtual_tool(self, virtual_tool_name: str) -> bool:
         """Return whether an active virtual tool exists without copying the catalog."""
 
@@ -603,6 +726,7 @@ class GatewayExternalRuntimeManager:
         self._servers.pop(server_id, None)
         self._last_errors.pop(server_id, None)
         self._clear_server_tools(server_id)
+        self._clear_server_resources(server_id)
         return transport
 
     async def _close_stopped_transport(
@@ -787,6 +911,93 @@ class GatewayExternalRuntimeManager:
 
     def _count_tools_for_server(self, server_id: str) -> int:
         return sum(1 for tool in self._virtual_tools.values() if tool.server_id == server_id)
+
+    def _replace_server_resources(
+        self,
+        server_id: str,
+        resources: list[dict[str, Any]],
+    ) -> None:
+        self._clear_server_resources(server_id)
+        for resource in resources:
+            if not isinstance(resource, dict):
+                continue
+            upstream_uri = resource.get("uri")
+            if not isinstance(upstream_uri, str) or not upstream_uri.strip():
+                continue
+            virtual_uri = self._virtual_resource_uri(server_id, upstream_uri)
+            self._virtual_resources[virtual_uri] = {
+                "server_id": server_id,
+                "upstream_uri": upstream_uri,
+                "descriptor": self._virtual_resource_descriptor(
+                    server_id=server_id,
+                    virtual_uri=virtual_uri,
+                    resource=resource,
+                ),
+            }
+
+    def _clear_server_resources(self, server_id: str) -> None:
+        self._virtual_resources = {
+            uri: entry
+            for uri, entry in self._virtual_resources.items()
+            if entry["server_id"] != server_id
+        }
+
+    @staticmethod
+    def _virtual_resource_descriptor(
+        *,
+        server_id: str,
+        virtual_uri: str,
+        resource: dict[str, Any],
+    ) -> dict[str, Any]:
+        name = resource.get("name")
+        description = resource.get("description")
+        mime_type = resource.get("mimeType")
+        return {
+            "uri": virtual_uri,
+            "name": name if isinstance(name, str) else "",
+            "description": description if isinstance(description, str) else "",
+            "mimeType": mime_type if isinstance(mime_type, str) else None,
+            "metadata": {
+                "external_server_id": server_id,
+                "source": "external_runtime",
+            },
+        }
+
+    @staticmethod
+    def _virtual_resource_uri(server_id: str, upstream_uri: str) -> str:
+        digest = hashlib.sha256(upstream_uri.encode("utf-8")).hexdigest()[:24]
+        return f"external://{server_id}/{digest}"
+
+    @staticmethod
+    def _server_id_from_virtual_resource_uri(uri: str) -> str | None:
+        prefix = "external://"
+        if not uri.startswith(prefix):
+            return None
+        remainder = uri[len(prefix):]
+        server_id, _, _digest = remainder.partition("/")
+        return server_id or None
+
+    @staticmethod
+    def _resource_read_payload(
+        payload: dict[str, Any],
+        *,
+        virtual_uri: str,
+        upstream_uri: str,
+    ) -> dict[str, Any]:
+        result = deepcopy(payload) if isinstance(payload, dict) else {"contents": []}
+        contents = result.get("contents")
+        if isinstance(contents, list):
+            rewritten: list[Any] = []
+            for item in contents:
+                if not isinstance(item, dict):
+                    rewritten.append(item)
+                    continue
+                item_copy = dict(item)
+                if item_copy.get("uri") == upstream_uri:
+                    item_copy["uri"] = virtual_uri
+                rewritten.append(item_copy)
+            result["contents"] = rewritten
+        return result
 
     async def _installer_status(
         self,

--- a/apps/mcp-unified/src/mcp_unified/gateway/external_runtime.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/external_runtime.py
@@ -464,7 +464,7 @@ class GatewayExternalRuntimeManager:
                 )
             ]
 
-        for server_id, transport in snapshots:
+        async def discover(server_id: str, transport: ExternalFederationTransport) -> None:
             try:
                 resources = await transport.list_resources()
             except Exception as exc:  # noqa: BLE001 - resource discovery must be row-scoped.
@@ -482,12 +482,16 @@ class GatewayExternalRuntimeManager:
                     target_type="external_server",
                     target_id=server_id,
                 )
-                continue
+                return
 
             async with self._lock:
                 if self._transports.get(server_id) is transport:
                     self._last_errors[server_id] = None
                     self._replace_server_resources(server_id, resources)
+
+        await asyncio.gather(
+            *(discover(server_id, transport) for server_id, transport in snapshots)
+        )
 
         async with self._lock:
             return [
@@ -588,10 +592,13 @@ class GatewayExternalRuntimeManager:
         timeout = max(0.0, float(timeout_seconds))
         poll_interval = max(0.001, float(poll_interval_seconds))
         deadline = loop.time() + timeout
-        if isinstance(server_ids, str):
+        if server_ids is None:
+            async with self._lock:
+                targets = set(self._transports)
+        elif isinstance(server_ids, str):
             targets = {server_ids}
         else:
-            targets = {str(server_id) for server_id in server_ids or () if str(server_id)}
+            targets = {str(server_id) for server_id in server_ids if str(server_id)}
 
         while True:
             rows = await self.list_runtime_servers()
@@ -600,7 +607,7 @@ class GatewayExternalRuntimeManager:
                 for row in rows.get("servers", [])
                 if row.get("id") is not None
             }
-            current_targets = targets or set(by_id)
+            current_targets = set(targets)
             ready = sorted(
                 server_id
                 for server_id in current_targets

--- a/apps/mcp-unified/src/mcp_unified/gateway/external_runtime_adapter.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/external_runtime_adapter.py
@@ -90,9 +90,15 @@ class ExternalRuntimeGatewayRuntime:
 
         resources: list[dict[str, Any]] = []
         if self._base_runtime is None:
-            return await self._external_runtime_manager.list_virtual_resources()
+            return await self._external_runtime_manager.list_virtual_resources(
+                effective_policy=_effective_policy_from_context(context),
+            )
         resources.extend(await self._base_runtime.list_resources(context))
-        resources.extend(await self._external_runtime_manager.list_virtual_resources())
+        resources.extend(
+            await self._external_runtime_manager.list_virtual_resources(
+                effective_policy=_effective_policy_from_context(context),
+            )
+        )
         return resources
 
     async def read_resource(
@@ -103,10 +109,18 @@ class ExternalRuntimeGatewayRuntime:
         """Read external virtual resources or delegate to the base runtime."""
 
         if uri.startswith("external://"):
-            return await self._external_runtime_manager.read_virtual_resource(
-                uri,
-                context=context,
-            )
+            try:
+                return await self._external_runtime_manager.read_virtual_resource(
+                    uri,
+                    context=context,
+                    effective_policy=_effective_policy_from_context(context),
+                )
+            except FederationPolicyDenied as exc:
+                raise GatewayPolicyDenied(
+                    str(exc),
+                    reason_code=exc.reason_code,
+                    provenance=deepcopy(exc.payload),
+                ) from exc
         if self._base_runtime is None:
             raise ValueError(f"Unknown gateway resource: {uri}")
         return await self._base_runtime.read_resource(uri, context)

--- a/apps/mcp-unified/src/mcp_unified/gateway/external_runtime_adapter.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/external_runtime_adapter.py
@@ -86,19 +86,27 @@ class ExternalRuntimeGatewayRuntime:
         raise ValueError(f"Unknown gateway tool: {name}")
 
     async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
-        """Delegate resource listing to the base runtime when available."""
+        """Return local resources followed by active external virtual resources."""
 
+        resources: list[dict[str, Any]] = []
         if self._base_runtime is None:
-            return []
-        return await self._base_runtime.list_resources(context)
+            return await self._external_runtime_manager.list_virtual_resources()
+        resources.extend(await self._base_runtime.list_resources(context))
+        resources.extend(await self._external_runtime_manager.list_virtual_resources())
+        return resources
 
     async def read_resource(
         self,
         uri: str,
         context: GatewayRequestContext,
     ) -> dict[str, Any]:
-        """Delegate resource reads to the base runtime when available."""
+        """Read external virtual resources or delegate to the base runtime."""
 
+        if uri.startswith("external://"):
+            return await self._external_runtime_manager.read_virtual_resource(
+                uri,
+                context=context,
+            )
         if self._base_runtime is None:
             raise ValueError(f"Unknown gateway resource: {uri}")
         return await self._base_runtime.read_resource(uri, context)

--- a/apps/mcp-unified/src/mcp_unified/gateway/jsonrpc.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/jsonrpc.py
@@ -36,6 +36,7 @@ except ImportError:  # pragma: no cover - defensive fallback for future pydantic
     _pydantic_encoder = None
 
 from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
+from .external_runtime import GatewayExternalRuntimeError
 
 PROTOCOL_VERSION = "2024-11-05"
 JSONRPC_VERSION = "2.0"
@@ -407,6 +408,8 @@ async def handle_single_jsonrpc(
         )
     except GatewayPolicyDenied as exc:
         error = jsonrpc_error(POLICY_DENIED, str(exc), envelope.request_id, data=exc.to_error_data())
+    except GatewayExternalRuntimeError as exc:
+        error = jsonrpc_error(INVALID_PARAMS, str(exc), envelope.request_id, data=exc.to_payload())
     except ValueError as exc:
         error = jsonrpc_error(INVALID_PARAMS, str(exc), envelope.request_id)
     except NotImplementedError:

--- a/apps/mcp-unified/src/mcp_unified/gateway/profile_runtime.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/profile_runtime.py
@@ -282,18 +282,36 @@ class ProfileAwareGatewayRuntime:
         )
 
     async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
-        """Delegate resource discovery unchanged for this profile slice."""
+        """Return resources visible to the resolved profile."""
 
-        return await self._backend.list_resources(context)
+        profile_result = await self._resolve_profile(context)
+        if profile_result.status != "resolved" or profile_result.profile is None:
+            return []
+        policy_result = build_effective_policy_result(profile_result.profile)
+        if policy_result.status != "resolved" or policy_result.policy is None:
+            return []
+        return await self._backend.list_resources(
+            _context_with_effective_policy(context, policy_result.policy)
+        )
 
     async def read_resource(
         self,
         uri: str,
         context: GatewayRequestContext,
     ) -> dict[str, Any]:
-        """Delegate resource reads unchanged for this profile slice."""
+        """Read resources through the resolved profile policy."""
 
-        return await self._backend.read_resource(uri, context)
+        profile = await self._require_profile(context)
+        policy_result = build_effective_policy_result(profile)
+        if policy_result.status != "resolved" or policy_result.policy is None:
+            raise _policy_denied(
+                policy_result,
+                message=f"Gateway profile denied resource read: {policy_result.reason_code}",
+            )
+        return await self._backend.read_resource(
+            uri,
+            _context_with_effective_policy(context, policy_result.policy),
+        )
 
     async def list_prompts(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
         """Delegate prompt discovery unchanged for this profile slice."""

--- a/backlog/tasks/task-12148 - Implement-first-run-MCP-tool-packs-setup.md
+++ b/backlog/tasks/task-12148 - Implement-first-run-MCP-tool-packs-setup.md
@@ -1,20 +1,21 @@
 ---
 id: TASK-12148
 title: Implement first-run MCP tool packs setup
-status: In Progress
+status: Done
 assignee: []
-created_date: 2026-07-04 23:41
-updated_date: 2026-07-05 02:54
+created_date: '2026-07-04 23:41'
+updated_date: '2026-07-05 05:26'
 labels:
-- implementation
-- mcp
-- setup
-- first-run
+  - implementation
+  - mcp
+  - setup
+  - first-run
 dependencies:
-- TASK-12132
+  - TASK-12132
 references:
-- Docs/superpowers/plans/2026-07-04-first-run-mcp-tool-packs-implementation-plan.md
-- Docs/superpowers/specs/2026-07-04-first-run-mcp-tool-packs-design.md
+  - >-
+    Docs/superpowers/plans/2026-07-04-first-run-mcp-tool-packs-implementation-plan.md
+  - Docs/superpowers/specs/2026-07-04-first-run-mcp-tool-packs-design.md
 ---
 
 ## Description
@@ -52,12 +53,20 @@ Task 6 frontend MCP tools wizard step: added McpToolsStep and inserted mcp_tools
 Task 6 spec-review fixes: added a FirstChatStep backLabel prop so the first-run wizard can show Back to MCP tools while standalone/provider flows keep Back to providers; cleared MCP apply/validation results when pack/add-on/confirmation choices change after save; mapped conflict reasons, add-on ids, validation states, and external status values to local user-facing labels. Red check: focused Vitest failed before fixes on the missing backLabel behavior, stale saved selection controls, and raw profile_manually_changed/local_file_read/not_run/not_configured copy. Green verification: `bunx vitest run src/components/Option/Onboarding/__tests__/McpToolsStep.test.tsx src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx` from apps/packages/ui -> 3 files passed, 55 tests passed.
 
 Task 6 code-quality review fixes: passed saved mcp_tools step data into the MCP tools step, restored saved pack/add-on/confirmed add-on selections with an applied local state when returning from first chat, and added a synchronous pending guard for the MCP tools skip action. Added regression coverage for direct step hydration, wizard back-navigation hydration, and fast double-click skip protection. Focused UI verification: bunx vitest run src/components/Option/Onboarding/__tests__/McpToolsStep.test.tsx src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx passed with 58 tests.
+
+PR #2649 merged into dev. First-run MCP tool packs setup implementation and review follow-up landed; review threads were resolved and local focused verification was recorded in the PR.
+
+Task 7 MCP Hub follow-up status/recovery slice: added admin setup-onboarding client methods without noAuth, compact MCP Hub first-run recovery panel with user-facing status labels/recovery/profile routing, backend admin status detection for generated MCP profile hash mismatch, and focused UI/backend tests. Verification: frontend Vitest MCP Hub/status + setup-onboarding service -> 23 passed; backend admin MCP tools integration -> 5 passed; service recovery status target included in combined backend slice -> passed; Bandit touched backend scope -> 0 findings; git diff --check -> clean.
+Task 7 spec-review follow-up: fixed MCP Hub Review profile to create a real permission_profile drill target and passed drill targets into PermissionProfilesTab. PermissionProfilesTab now opens the matching profile edit form after profiles load and marks the drill handled. Verification: bunx vitest run src/components/Option/MCPHub/__tests__/McpHubPage.first-run-status.test.tsx src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx src/services/tldw/__tests__/setup-onboarding.test.ts -> 28 passed; git diff --check -> clean.
+Task 7 code-quality follow-up: recovery/manual-change status now requires first-run MCP provenance before running generated profile hash conflict checks, so a stale state pointing at a normal global profile is treated as no generated profile for conflict purposes. Added service regression coverage. Verification: focused regression target -> passed; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Setup/test_first_run_mcp_tools_service.py tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py -k "mcp_tools" -v -> 45 passed; Bandit touched backend service -> 0 findings; git diff --check -> clean.
+Final-review backend fixes: generated first-run MCP profiles now conflict on manual tool_patterns/tool_names, explicit replace strips those keys, completed catalog access requires SYSTEM_CONFIGURE/*, and validation skips external discovery unless external_network_read is selected. Verification: focused pytest 50 passed; git diff --check passed; Bandit results empty at /tmp/bandit_first_run_mcp_tools_final_review.json.
+Final-review external validation follow-up: validation now samples only external tools already present in the saved generated profile allowed_tools, preventing a refreshed tool discovered after apply from being executed or reported as passed outside the profile policy. Verification: focused validation regressions -> 3 passed; full focused backend suite -> 180 passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented first-run MCP tool packs setup end to end: backend catalog/apply/validate/admin recovery endpoints, safe MCP Hub generated default profile handling, optional onboarding MCP tools step, and MCP Hub recovery/status panel. Final verification on 66f4aa8f9f: backend focused suite 180 passed, frontend focused suite 94 passed, verify:openapi passed with existing reviewed exceptions, Bandit touched backend scope had zero findings, git diff --check clean, and final subagent re-review approved with no Critical/Important issues.
+Merged PR #2649 for first-run MCP tool packs setup. Backend setup endpoints, MCP Hub profile integration, onboarding UI, recovery/status UI, tests, Bandit, and review follow-up are complete.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -69,13 +78,3 @@ Implemented first-run MCP tool packs setup end to end: backend catalog/apply/val
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
-
-## Implementation Notes
-
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Task 7 MCP Hub follow-up status/recovery slice: added admin setup-onboarding client methods without noAuth, compact MCP Hub first-run recovery panel with user-facing status labels/recovery/profile routing, backend admin status detection for generated MCP profile hash mismatch, and focused UI/backend tests. Verification: frontend Vitest MCP Hub/status + setup-onboarding service -> 23 passed; backend admin MCP tools integration -> 5 passed; service recovery status target included in combined backend slice -> passed; Bandit touched backend scope -> 0 findings; git diff --check -> clean.
-Task 7 spec-review follow-up: fixed MCP Hub Review profile to create a real permission_profile drill target and passed drill targets into PermissionProfilesTab. PermissionProfilesTab now opens the matching profile edit form after profiles load and marks the drill handled. Verification: bunx vitest run src/components/Option/MCPHub/__tests__/McpHubPage.first-run-status.test.tsx src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx src/services/tldw/__tests__/setup-onboarding.test.ts -> 28 passed; git diff --check -> clean.
-Task 7 code-quality follow-up: recovery/manual-change status now requires first-run MCP provenance before running generated profile hash conflict checks, so a stale state pointing at a normal global profile is treated as no generated profile for conflict purposes. Added service regression coverage. Verification: focused regression target -> passed; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Setup/test_first_run_mcp_tools_service.py tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py -k "mcp_tools" -v -> 45 passed; Bandit touched backend service -> 0 findings; git diff --check -> clean.
-Final-review backend fixes: generated first-run MCP profiles now conflict on manual `tool_patterns`/`tool_names`, explicit replace strips those keys, completed catalog access requires SYSTEM_CONFIGURE/*, and validation skips external discovery unless `external_network_read` is selected. Verification: focused pytest 50 passed; git diff --check passed; Bandit results empty at /tmp/bandit_first_run_mcp_tools_final_review.json.
-Final-review external validation follow-up: validation now samples only external tools already present in the saved generated profile allowed_tools, preventing a refreshed tool discovered after apply from being executed or reported as passed outside the profile policy. Verification: focused validation regressions -> 3 passed; full focused backend suite -> 180 passed.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-12148 - Implement-first-run-MCP-tool-packs-setup.md
+++ b/backlog/tasks/task-12148 - Implement-first-run-MCP-tool-packs-setup.md
@@ -1,21 +1,20 @@
 ---
 id: TASK-12148
 title: Implement first-run MCP tool packs setup
-status: Done
+status: In Progress
 assignee: []
-created_date: '2026-07-04 23:41'
-updated_date: '2026-07-05 05:26'
+created_date: 2026-07-04 23:41
+updated_date: 2026-07-05 02:54
 labels:
-  - implementation
-  - mcp
-  - setup
-  - first-run
+- implementation
+- mcp
+- setup
+- first-run
 dependencies:
-  - TASK-12132
+- TASK-12132
 references:
-  - >-
-    Docs/superpowers/plans/2026-07-04-first-run-mcp-tool-packs-implementation-plan.md
-  - Docs/superpowers/specs/2026-07-04-first-run-mcp-tool-packs-design.md
+- Docs/superpowers/plans/2026-07-04-first-run-mcp-tool-packs-implementation-plan.md
+- Docs/superpowers/specs/2026-07-04-first-run-mcp-tool-packs-design.md
 ---
 
 ## Description
@@ -53,20 +52,12 @@ Task 6 frontend MCP tools wizard step: added McpToolsStep and inserted mcp_tools
 Task 6 spec-review fixes: added a FirstChatStep backLabel prop so the first-run wizard can show Back to MCP tools while standalone/provider flows keep Back to providers; cleared MCP apply/validation results when pack/add-on/confirmation choices change after save; mapped conflict reasons, add-on ids, validation states, and external status values to local user-facing labels. Red check: focused Vitest failed before fixes on the missing backLabel behavior, stale saved selection controls, and raw profile_manually_changed/local_file_read/not_run/not_configured copy. Green verification: `bunx vitest run src/components/Option/Onboarding/__tests__/McpToolsStep.test.tsx src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx` from apps/packages/ui -> 3 files passed, 55 tests passed.
 
 Task 6 code-quality review fixes: passed saved mcp_tools step data into the MCP tools step, restored saved pack/add-on/confirmed add-on selections with an applied local state when returning from first chat, and added a synchronous pending guard for the MCP tools skip action. Added regression coverage for direct step hydration, wizard back-navigation hydration, and fast double-click skip protection. Focused UI verification: bunx vitest run src/components/Option/Onboarding/__tests__/McpToolsStep.test.tsx src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx passed with 58 tests.
-
-PR #2649 merged into dev. First-run MCP tool packs setup implementation and review follow-up landed; review threads were resolved and local focused verification was recorded in the PR.
-
-Task 7 MCP Hub follow-up status/recovery slice: added admin setup-onboarding client methods without noAuth, compact MCP Hub first-run recovery panel with user-facing status labels/recovery/profile routing, backend admin status detection for generated MCP profile hash mismatch, and focused UI/backend tests. Verification: frontend Vitest MCP Hub/status + setup-onboarding service -> 23 passed; backend admin MCP tools integration -> 5 passed; service recovery status target included in combined backend slice -> passed; Bandit touched backend scope -> 0 findings; git diff --check -> clean.
-Task 7 spec-review follow-up: fixed MCP Hub Review profile to create a real permission_profile drill target and passed drill targets into PermissionProfilesTab. PermissionProfilesTab now opens the matching profile edit form after profiles load and marks the drill handled. Verification: bunx vitest run src/components/Option/MCPHub/__tests__/McpHubPage.first-run-status.test.tsx src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx src/services/tldw/__tests__/setup-onboarding.test.ts -> 28 passed; git diff --check -> clean.
-Task 7 code-quality follow-up: recovery/manual-change status now requires first-run MCP provenance before running generated profile hash conflict checks, so a stale state pointing at a normal global profile is treated as no generated profile for conflict purposes. Added service regression coverage. Verification: focused regression target -> passed; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Setup/test_first_run_mcp_tools_service.py tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py -k "mcp_tools" -v -> 45 passed; Bandit touched backend service -> 0 findings; git diff --check -> clean.
-Final-review backend fixes: generated first-run MCP profiles now conflict on manual tool_patterns/tool_names, explicit replace strips those keys, completed catalog access requires SYSTEM_CONFIGURE/*, and validation skips external discovery unless external_network_read is selected. Verification: focused pytest 50 passed; git diff --check passed; Bandit results empty at /tmp/bandit_first_run_mcp_tools_final_review.json.
-Final-review external validation follow-up: validation now samples only external tools already present in the saved generated profile allowed_tools, preventing a refreshed tool discovered after apply from being executed or reported as passed outside the profile policy. Verification: focused validation regressions -> 3 passed; full focused backend suite -> 180 passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Merged PR #2649 for first-run MCP tool packs setup. Backend setup endpoints, MCP Hub profile integration, onboarding UI, recovery/status UI, tests, Bandit, and review follow-up are complete.
+Implemented first-run MCP tool packs setup end to end: backend catalog/apply/validate/admin recovery endpoints, safe MCP Hub generated default profile handling, optional onboarding MCP tools step, and MCP Hub recovery/status panel. Final verification on 66f4aa8f9f: backend focused suite 180 passed, frontend focused suite 94 passed, verify:openapi passed with existing reviewed exceptions, Bandit touched backend scope had zero findings, git diff --check clean, and final subagent re-review approved with no Critical/Important issues.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -78,3 +69,13 @@ Merged PR #2649 for first-run MCP tool packs setup. Backend setup endpoints, MCP
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Task 7 MCP Hub follow-up status/recovery slice: added admin setup-onboarding client methods without noAuth, compact MCP Hub first-run recovery panel with user-facing status labels/recovery/profile routing, backend admin status detection for generated MCP profile hash mismatch, and focused UI/backend tests. Verification: frontend Vitest MCP Hub/status + setup-onboarding service -> 23 passed; backend admin MCP tools integration -> 5 passed; service recovery status target included in combined backend slice -> passed; Bandit touched backend scope -> 0 findings; git diff --check -> clean.
+Task 7 spec-review follow-up: fixed MCP Hub Review profile to create a real permission_profile drill target and passed drill targets into PermissionProfilesTab. PermissionProfilesTab now opens the matching profile edit form after profiles load and marks the drill handled. Verification: bunx vitest run src/components/Option/MCPHub/__tests__/McpHubPage.first-run-status.test.tsx src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx src/services/tldw/__tests__/setup-onboarding.test.ts -> 28 passed; git diff --check -> clean.
+Task 7 code-quality follow-up: recovery/manual-change status now requires first-run MCP provenance before running generated profile hash conflict checks, so a stale state pointing at a normal global profile is treated as no generated profile for conflict purposes. Added service regression coverage. Verification: focused regression target -> passed; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Setup/test_first_run_mcp_tools_service.py tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py -k "mcp_tools" -v -> 45 passed; Bandit touched backend service -> 0 findings; git diff --check -> clean.
+Final-review backend fixes: generated first-run MCP profiles now conflict on manual `tool_patterns`/`tool_names`, explicit replace strips those keys, completed catalog access requires SYSTEM_CONFIGURE/*, and validation skips external discovery unless `external_network_read` is selected. Verification: focused pytest 50 passed; git diff --check passed; Bandit results empty at /tmp/bandit_first_run_mcp_tools_final_review.json.
+Final-review external validation follow-up: validation now samples only external tools already present in the saved generated profile allowed_tools, preventing a refreshed tool discovered after apply from being executed or reported as passed outside the profile policy. Verification: focused validation regressions -> 3 passed; full focused backend suite -> 180 passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-2290 - Add-MCP-resource-discovery-and-read-tools-parity.md
+++ b/backlog/tasks/task-2290 - Add-MCP-resource-discovery-and-read-tools-parity.md
@@ -4,7 +4,7 @@ title: Add MCP resource discovery and read tools parity
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-05 05:43'
+updated_date: '2026-07-04 23:31'
 labels:
   - mcp
   - resources
@@ -46,12 +46,16 @@ Design and implement Claude-style ListMcpResourcesTool, ReadMcpResourceTool, and
 Started after TASK-12148 was closed. Existing TASK-581 already covers external server lifecycle runtime integration, so this task is scoped to resource parity over the current runtime surfaces.
 
 Verification: PYTHONPATH=apps/mcp-unified/src python -m pytest touched MCP resource/runtime test set -q (300 passed); git diff --check (clean); Bandit on touched implementation files wrote /tmp/bandit_mcp_resource_parity.json with zero findings. Note: the full stdio transport file requires PYTHONPATH=apps/mcp-unified/src in this worktree because the subprocess import boundary test uses the main checkout venv.
+
+Reopened for requested code-review fixes after PR #2653 review: profile grant enforcement, stable JSON-RPC errors, and stronger read payload URI redaction.
+
+Review fixes: rebased onto latest dev; wired configured gateway bootstrap through ExternalRuntimeGatewayRuntime; applied profile effective policy to resource list/read; denied external resource reads without external_server_grants or required credential_grants; pre-filtered resource discovery so ungranted servers are not contacted; recursively redacted upstream URI/token references in read payloads; mapped external resource runtime errors to stable JSON-RPC reason_code data; added websocket resource list/read parity; cleared resource-discovery last_error after successful rediscovery; removed stale TASK-12148 churn from the exact-base diff. Verification: focused red checks failed before fixes and passed after; PYTHONPATH=apps/mcp-unified/src python -m pytest touched MCP runtime/resource suite -q (308 passed); package-boundary regression passed; Bandit touched source scope including websocket adapter wrote /tmp/bandit_mcp_resource_parity_review_fixes.json with zero findings; git diff --check clean.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented MCP resource discovery/read parity for the standalone gateway external runtime and stdio transports. External resources are exposed as redacted external:// virtual URIs, reads route back to the owning active server, stopped/missing resources return stable runtime errors, and a bounded wait_for_servers helper reports ready/unavailable/unknown server ids. Added matching package and app-side stdio resource coverage plus design documentation.
+Implemented MCP resource discovery/read parity for the standalone gateway external runtime and stdio/websocket transports. External resources are exposed as redacted external:// virtual URIs, reads route back to the owning active server through profile policy, stopped/missing resources return stable runtime errors, and a bounded wait_for_servers helper reports ready/unavailable/unknown server ids without stale resource-discovery health state. Added matching package and app-side transport coverage plus design documentation.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2290 - Add-MCP-resource-discovery-and-read-tools-parity.md
+++ b/backlog/tasks/task-2290 - Add-MCP-resource-discovery-and-read-tools-parity.md
@@ -1,15 +1,24 @@
 ---
 id: TASK-2290
 title: Add MCP resource discovery and read tools parity
-status: To Do
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-05 05:43'
 labels:
-- mcp
-- resources
-- gateway
-- tools
-- agentic-execution
+  - mcp
+  - resources
+  - gateway
+  - tools
+  - agentic-execution
+dependencies: []
 references:
-- https://code.claude.com/docs/en/tools-reference
+  - 'https://code.claude.com/docs/en/tools-reference'
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-05-mcp-resource-discovery-read-parity-design.md
+  - >-
+    Docs/superpowers/plans/2026-07-05-mcp-resource-discovery-read-parity-implementation-plan.md
 ---
 
 ## Description
@@ -20,26 +29,37 @@ Design and implement Claude-style ListMcpResourcesTool, ReadMcpResourceTool, and
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Gateway resource list/read remains available for internal resources through the existing JSON-RPC gateway paths.
+- [x] #2 External runtime resources from running MCP servers are exposed as redacted, namespaced resource descriptors.
+- [x] #3 External resource reads route to the owning running server and return safe unavailable/not-found errors when the server or resource is missing.
+- [x] #4 The bounded wait-for-MCP-servers helper reports ready/unavailable servers without starting a new background monitor.
+- [x] #5 Focused pytest coverage, Bandit on touched code, and diff verification are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
+Started after TASK-12148 was closed. Existing TASK-581 already covers external server lifecycle runtime integration, so this task is scoped to resource parity over the current runtime surfaces.
+
+Verification: PYTHONPATH=apps/mcp-unified/src python -m pytest touched MCP resource/runtime test set -q (300 passed); git diff --check (clean); Bandit on touched implementation files wrote /tmp/bandit_mcp_resource_parity.json with zero findings. Note: the full stdio transport file requires PYTHONPATH=apps/mcp-unified/src in this worktree because the subprocess import boundary test uses the main checkout venv.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented MCP resource discovery/read parity for the standalone gateway external runtime and stdio transports. External resources are exposed as redacted external:// virtual URIs, reads route back to the owning active server, stopped/missing resources return stable runtime errors, and a bounded wait_for_servers helper reports ready/unavailable/unknown server ids. Added matching package and app-side stdio resource coverage plus design documentation.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2290 - Add-MCP-resource-discovery-and-read-tools-parity.md
+++ b/backlog/tasks/task-2290 - Add-MCP-resource-discovery-and-read-tools-parity.md
@@ -4,21 +4,19 @@ title: Add MCP resource discovery and read tools parity
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-04 23:31'
+updated_date: 2026-07-04 23:31
 labels:
-  - mcp
-  - resources
-  - gateway
-  - tools
-  - agentic-execution
+- mcp
+- resources
+- gateway
+- tools
+- agentic-execution
 dependencies: []
 references:
-  - 'https://code.claude.com/docs/en/tools-reference'
+- https://code.claude.com/docs/en/tools-reference
 documentation:
-  - >-
-    Docs/superpowers/specs/2026-07-05-mcp-resource-discovery-read-parity-design.md
-  - >-
-    Docs/superpowers/plans/2026-07-05-mcp-resource-discovery-read-parity-implementation-plan.md
+- Docs/superpowers/specs/2026-07-05-mcp-resource-discovery-read-parity-design.md
+- Docs/superpowers/plans/2026-07-05-mcp-resource-discovery-read-parity-implementation-plan.md
 ---
 
 ## Description
@@ -67,3 +65,9 @@ Implemented MCP resource discovery/read parity for the standalone gateway extern
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Latest PR #2653 review pass: origin/dev rebase was a no-op because the branch was already current. Addressed unresolved review threads by running external resource discovery concurrently, defaulting wait_for_servers(server_ids=None) to active transports only, changing the app-side base adapter read_resource default to ResourceNotFoundError, adding docstrings around the flagged gateway test helpers, strengthening merge-order/redaction assertions, and covering unknown-resource stdio read branches. Verification: focused red checks failed before implementation for concurrency/default wait/domain exception and passed after; focused MCP suite with manager coverage passed (333 passed); package boundary regression passed (1 passed); Bandit touched implementation scope wrote /tmp/bandit_mcp_resource_parity_latest_review.json with zero findings; git diff --check origin/dev...HEAD clean. Remaining PR metadata warning requires the human-authored Change summary mandated by Docs/ADR/004 and cannot be completed by an agent.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py
@@ -45,6 +45,19 @@ class ExternalMCPTransportAdapter(ABC):
     async def list_tools(self) -> list[ExternalToolDefinition]:
         """Discover external tools and return normalized definitions."""
 
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Discover external resources and return normalized descriptors."""
+        return []
+
+    async def read_resource(
+        self,
+        uri: str,
+        context: RequestContext | None = None,
+    ) -> dict[str, Any]:
+        """Read one external resource."""
+        del context
+        raise ValueError(f"Unknown external resource '{uri}'")
+
     @abstractmethod
     async def call_tool(
         self,

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py
@@ -11,6 +11,7 @@ from mcp_unified.federation.models import (
     ExternalToolCallResult,
     ExternalToolDefinition,
 )
+from tldw_Server_API.app.core.exceptions import ResourceNotFoundError
 
 if TYPE_CHECKING:  # pragma: no cover
     from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
@@ -56,7 +57,7 @@ class ExternalMCPTransportAdapter(ABC):
     ) -> dict[str, Any]:
         """Read one external resource."""
         del context
-        raise ValueError(f"Unknown external resource '{uri}'")
+        raise ResourceNotFoundError("external_resource", identifier=uri)
 
     @abstractmethod
     async def call_tool(

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/stdio_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/stdio_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 from typing import Any, Awaitable, Callable, Optional
 
 from loguru import logger
@@ -133,6 +134,60 @@ class StdioExternalMCPAdapter(ExternalMCPTransportAdapter):
                 )
             )
         return tools
+
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Discover external resources and return normalized descriptors."""
+        await self._ensure_connected()
+        response = await self._request("resources/list", {})
+        result = response.get("result") or {}
+        if isinstance(result, dict):
+            raw_resources = result.get("resources") or []
+        elif isinstance(result, list):
+            raw_resources = result
+        else:
+            raw_resources = []
+
+        resources: list[dict[str, Any]] = []
+        for item in raw_resources:
+            if not isinstance(item, dict):
+                continue
+            uri = item.get("uri")
+            if not isinstance(uri, str) or not uri.strip():
+                continue
+            name = item.get("name")
+            if not isinstance(name, str):
+                name = ""
+            description = item.get("description")
+            if not isinstance(description, str):
+                description = ""
+            mime_type = item.get("mimeType")
+            if not isinstance(mime_type, str):
+                mime_type = None
+            metadata = item.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+            resources.append(
+                {
+                    "uri": uri,
+                    "name": name,
+                    "description": description,
+                    "mimeType": mime_type,
+                    "metadata": deepcopy(metadata),
+                }
+            )
+        return resources
+
+    async def read_resource(
+        self,
+        uri: str,
+        context: Optional[Any] = None,
+    ) -> dict[str, Any]:
+        """Read one external resource."""
+        del context
+        await self._ensure_connected()
+        response = await self._request("resources/read", {"uri": uri})
+        result = response.get("result")
+        return deepcopy(result) if isinstance(result, dict) else {"contents": []}
 
     async def call_tool(
         self,

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/websocket_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/websocket_adapter.py
@@ -169,6 +169,74 @@ class WebSocketExternalMCPAdapter(ExternalMCPTransportAdapter):
 
         return tools
 
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Discover external resources and return normalized descriptors."""
+        await self._ensure_connected()
+        response = await self._jsonrpc_request("resources/list", {})
+
+        if response.get("error"):
+            raise RuntimeError(
+                f"External MCP resources/list failed for '{self.server_id}': "
+                f"{self._error_message(response['error'])}"
+            )
+
+        result = response.get("result") or {}
+        if isinstance(result, dict):
+            raw_resources = result.get("resources") or []
+        elif isinstance(result, list):
+            raw_resources = result
+        else:
+            raw_resources = []
+
+        resources: list[dict[str, Any]] = []
+        for item in raw_resources:
+            if not isinstance(item, dict):
+                continue
+            uri = item.get("uri")
+            if not isinstance(uri, str) or not uri.strip():
+                continue
+            name = item.get("name")
+            if not isinstance(name, str):
+                name = ""
+            description = item.get("description")
+            if not isinstance(description, str):
+                description = ""
+            mime_type = item.get("mimeType")
+            if not isinstance(mime_type, str):
+                mime_type = None
+            metadata = item.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+            resources.append(
+                {
+                    "uri": uri,
+                    "name": name,
+                    "description": description,
+                    "mimeType": mime_type,
+                    "metadata": dict(metadata),
+                }
+            )
+        return resources
+
+    async def read_resource(
+        self,
+        uri: str,
+        context: Optional[Any] = None,
+    ) -> dict[str, Any]:
+        """Read one external resource."""
+        del context
+        await self._ensure_connected()
+        response = await self._jsonrpc_request("resources/read", {"uri": uri})
+
+        if response.get("error"):
+            raise RuntimeError(
+                f"External MCP resources/read failed for '{self.server_id}': "
+                f"{self._error_message(response['error'])}"
+            )
+
+        result = response.get("result")
+        return dict(result) if isinstance(result, dict) else {"contents": []}
+
     async def call_tool(
         self,
         tool_name: str,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_external_server_manager.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_external_server_manager.py
@@ -20,6 +20,7 @@ from tldw_Server_API.app.core.MCP_unified.external_servers.transports.base impor
     adapter_supports_runtime_auth,
     call_tool_with_ephemeral_adapter,
 )
+from tldw_Server_API.app.core.exceptions import ResourceNotFoundError
 
 
 def _ensure(condition: bool, message: str) -> None:
@@ -154,6 +155,18 @@ def test_parse_virtual_tool_name_routing_contract() -> None:
         ExternalServerManager.parse_virtual_tool_name("docs.search")
     with pytest.raises(ValueError, match="must match 'ext.<server_id>.<tool_name>'"):
         ExternalServerManager.parse_virtual_tool_name("ext.docs")
+
+
+@pytest.mark.asyncio
+async def test_default_external_transport_read_resource_raises_domain_not_found() -> None:
+    """The default resource read path raises the project not-found exception."""
+    adapter = _FakeAdapter("docs", [])
+
+    with pytest.raises(ResourceNotFoundError) as exc_info:
+        await adapter.read_resource("resource://docs/missing")
+
+    assert exc_info.value.resource == "external_resource"
+    assert exc_info.value.identifier == "resource://docs/missing"
 
 
 def test_adapter_runtime_auth_compatibility_helper_handles_legacy_signature() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter_integration.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter_integration.py
@@ -229,6 +229,9 @@ async def test_stdio_adapter_subprocess_roundtrip_error_and_timeout(tmp_path: Pa
         resource = await adapter.read_resource("resource://docs/readme")
         assert resource["contents"][0]["text"] == "# Docs"
 
+        with pytest.raises(Exception):
+            await adapter.read_resource("resource://docs/missing")
+
         ok = await adapter.call_tool("docs.search", {"q": "hello"})
         assert ok.is_error is False
         assert ok.content == [{"type": "text", "text": "search:hello"}]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter_integration.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter_integration.py
@@ -70,6 +70,56 @@ for raw in sys.stdin:
         )
         continue
 
+    if method == "resources/list":
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "resources": [
+                        {
+                            "uri": "resource://docs/readme",
+                            "name": "Docs README",
+                            "description": "Documentation entry",
+                            "mimeType": "text/markdown",
+                            "metadata": {"category": "read"},
+                        },
+                        {"uri": "resource://docs/defaulted", "name": 7, "metadata": []},
+                    ]
+                },
+            }
+        )
+        continue
+
+    if method == "resources/read":
+        uri = str(params.get("uri") or "")
+        if uri == "resource://docs/readme":
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "contents": [
+                            {
+                                "uri": "resource://docs/readme",
+                                "mimeType": "text/markdown",
+                                "text": "# Docs",
+                            }
+                        ]
+                    },
+                }
+            )
+            continue
+
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32601, "message": f"unknown resource: {uri}"},
+            }
+        )
+        continue
+
     if method == "tools/call":
         tool_name = str(params.get("name") or "")
         arguments = params.get("arguments") or {}
@@ -158,6 +208,26 @@ async def test_stdio_adapter_subprocess_roundtrip_error_and_timeout(tmp_path: Pa
         assert [tool.name for tool in tools] == ["docs.search", "docs.defaulted"]
         assert tools[1].input_schema == {"type": "object"}
         assert tools[1].metadata == {}
+
+        resources = await adapter.list_resources()
+        assert resources == [
+            {
+                "uri": "resource://docs/readme",
+                "name": "Docs README",
+                "description": "Documentation entry",
+                "mimeType": "text/markdown",
+                "metadata": {"category": "read"},
+            },
+            {
+                "uri": "resource://docs/defaulted",
+                "name": "",
+                "description": "",
+                "mimeType": None,
+                "metadata": {},
+            },
+        ]
+        resource = await adapter.read_resource("resource://docs/readme")
+        assert resource["contents"][0]["text"] == "# Docs"
 
         ok = await adapter.call_tool("docs.search", {"q": "hello"})
         assert ok.is_error is False

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py
@@ -185,6 +185,77 @@ async def test_websocket_adapter_call_tool_maps_upstream_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_websocket_adapter_lists_and_reads_resources() -> None:
+    cfg = _server_config()
+    ws = _FakeWebSocket()
+    ws.enqueue({"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "stub"}}})
+
+    async def _connector(**kwargs):
+        return ws
+
+    adapter = WebSocketExternalMCPAdapter(cfg, ws_connector=_connector)
+    try:
+        await adapter.connect()
+        list_task = asyncio.create_task(adapter.list_resources())
+        await _wait_for_sent(ws, expected_count=2)
+        list_request_id = ws.sent_messages[1]["id"]
+        ws.enqueue(
+            {
+                "jsonrpc": "2.0",
+                "id": list_request_id,
+                "result": {
+                    "resources": [
+                        {
+                            "uri": "docs://one",
+                            "name": "Docs One",
+                            "description": "Reference",
+                            "mimeType": "text/plain",
+                            "metadata": {"scope": "read"},
+                        },
+                        {"uri": 7, "name": "invalid"},
+                    ]
+                },
+            }
+        )
+        resources = await list_task
+
+        read_task = asyncio.create_task(adapter.read_resource("docs://one"))
+        await _wait_for_sent(ws, expected_count=3)
+        read_request = ws.sent_messages[2]
+        ws.enqueue(
+            {
+                "jsonrpc": "2.0",
+                "id": read_request["id"],
+                "result": {
+                    "contents": [
+                        {
+                            "uri": "docs://one",
+                            "mimeType": "text/plain",
+                            "text": "hello",
+                        }
+                    ]
+                },
+            }
+        )
+        result = await read_task
+
+        assert resources == [
+            {
+                "uri": "docs://one",
+                "name": "Docs One",
+                "description": "Reference",
+                "mimeType": "text/plain",
+                "metadata": {"scope": "read"},
+            }
+        ]
+        assert read_request["method"] == "resources/read"
+        assert read_request["params"] == {"uri": "docs://one"}
+        assert result["contents"][0]["text"] == "hello"
+    finally:
+        await adapter.close()
+
+
+@pytest.mark.asyncio
 async def test_websocket_adapter_request_timeout_clears_pending() -> None:
     cfg = _server_config(request_seconds=0.1)
     ws = _FakeWebSocket()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -580,11 +580,18 @@ async def test_external_runtime_lists_and_reads_redacted_resources() -> None:
         ],
         resource_reads={
             upstream_uri: {
+                "uri": upstream_uri,
+                "sourceUri": f"{upstream_uri}#source",
+                "metadata": {"href": "secret://docs/related?token=do-not-leak"},
                 "contents": [
                     {
                         "uri": upstream_uri,
                         "mimeType": "text/plain",
-                        "text": "external contents",
+                        "text": f"external contents from {upstream_uri}",
+                    },
+                    {
+                        "type": "text",
+                        "text": "see secret://docs/related?token=do-not-leak",
                     }
                 ]
             }
@@ -610,9 +617,112 @@ async def test_external_runtime_lists_and_reads_redacted_resources() -> None:
     }
     assert "do-not-leak" not in public_payload
     assert upstream_uri not in public_payload
-    assert result["contents"][0]["text"] == "external contents"
+    private_payload = json.dumps(result, sort_keys=True)
+    assert "do-not-leak" not in private_payload
+    assert "secret://docs/" not in private_payload
     assert result["contents"][0]["uri"] == resource["uri"]
     assert transport.resource_reads == [upstream_uri]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_resource_listing_filters_ungranted_servers_before_discovery() -> None:
+    research_uri = "resource://research/one"
+    docs_uri = "resource://docs/one"
+    store = InMemoryExternalRegistryStore(
+        [
+            _server(id="research", name="Research"),
+            _server(id="docs", name="Docs"),
+        ]
+    )
+    research = RecordingExternalTransport(
+        server_id="research",
+        resources=[{"uri": research_uri, "name": "Research Doc"}],
+    )
+    docs = RecordingExternalTransport(
+        server_id="docs",
+        resources=[{"uri": docs_uri, "name": "Docs Doc"}],
+    )
+    transports = {"research": research, "docs": docs}
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: transports[server.id],
+    )
+    await manager.start_server("research")
+    await manager.start_server("docs")
+
+    resources = await manager.list_virtual_resources(
+        effective_policy={"external_server_grants": [{"server_id": "research"}]}
+    )
+
+    assert [resource["name"] for resource in resources] == ["Research Doc"]
+    assert research.list_resources_count == 1
+    assert docs.list_resources_count == 0
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_resource_read_requires_credential_grants_before_transport_call() -> None:
+    upstream_uri = "resource://docs/secret"
+    store = InMemoryExternalRegistryStore([_server(credential_slots=["api_key"])])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        resources=[{"uri": upstream_uri, "name": "Secret"}],
+        resource_reads={upstream_uri: {"contents": [{"uri": upstream_uri, "text": "secret"}]}},
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+    resources = await manager.list_virtual_resources()
+
+    with pytest.raises(FederationPolicyDenied) as exc_info:
+        await manager.read_virtual_resource(
+            resources[0]["uri"],
+            effective_policy={"external_server_grants": [{"server_id": "research"}]},
+        )
+
+    assert exc_info.value.reason_code == "required_credential_grant_missing"
+    assert transport.resource_reads == []
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_resource_discovery_success_clears_last_error() -> None:
+    upstream_uri = "resource://docs/one"
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        resources=[{"uri": upstream_uri, "name": "Doc"}],
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+
+    transport.fail_resources = True
+    assert await manager.list_virtual_resources() == []
+    degraded = await manager.wait_for_servers(
+        ["research"],
+        timeout_seconds=0.01,
+        poll_interval_seconds=0.001,
+    )
+
+    transport.fail_resources = False
+    resources = await manager.list_virtual_resources()
+    ready = await manager.wait_for_servers(
+        ["research"],
+        timeout_seconds=0.01,
+        poll_interval_seconds=0.001,
+    )
+
+    assert degraded["ok"] is False
+    assert resources[0]["name"] == "Doc"
+    assert ready == {
+        "ok": True,
+        "ready_servers": ["research"],
+        "unavailable_servers": [],
+        "unknown_servers": [],
+    }
 
 
 @pytest.mark.asyncio
@@ -660,7 +770,14 @@ async def test_external_runtime_adapter_merges_base_and_external_resources() -> 
         external_runtime_manager=manager,
         base_runtime=base_runtime,
     )
-    context = GatewayRequestContext(request_id="resources")
+    context = GatewayRequestContext(
+        request_id="resources",
+        metadata={
+            "_gateway_effective_policy": {
+                "external_server_grants": [{"server_id": "research"}],
+            }
+        },
+    )
 
     resources = await runtime.list_resources(context)
     external_uri = next(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -17,6 +17,8 @@ from mcp_unified.gateway.external_runtime import (
     GatewayExternalRuntimeError,
     GatewayExternalRuntimeManager,
 )
+from mcp_unified.gateway.external_runtime_adapter import ExternalRuntimeGatewayRuntime
+from mcp_unified.gateway.runtime import GatewayRequestContext
 from mcp_unified.interfaces.storage import ExternalRegistryStoreUnavailableError
 from mcp_unified.storage.models import AuditEvent, ExternalServerDefinition
 
@@ -124,6 +126,8 @@ class RecordingExternalTransport:
         *,
         server_id: str,
         tools: list[ExternalToolDefinition] | None = None,
+        resources: list[dict[str, Any]] | None = None,
+        resource_reads: dict[str, dict[str, Any]] | None = None,
         result: ExternalToolCallResult | None = None,
     ) -> None:
         self.server_id = server_id
@@ -131,12 +135,20 @@ class RecordingExternalTransport:
         self.connect_count = 0
         self.close_count = 0
         self.list_tools_count = 0
+        self.list_resources_count = 0
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.resource_reads: list[str] = []
         self.runtime_auth_seen: BrokeredExternalCredential | None = None
         self.fail_list = False
+        self.fail_resources = False
         self.fail_health = False
         self.fail_call = False
         self.tools = [tool.copy() for tool in tools or ()]
+        self.resources = [dict(resource) for resource in resources or ()]
+        self.resource_results = {
+            uri: dict(result)
+            for uri, result in (resource_reads or {}).items()
+        }
         self.result = result or ExternalToolCallResult(content={"ok": True})
 
     async def connect(self) -> None:
@@ -165,6 +177,21 @@ class RecordingExternalTransport:
         if self.fail_list:
             raise RuntimeError("discovery failed")
         return [tool.copy() for tool in self.tools]
+
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Return configured resources or raise a discovery failure."""
+        self.list_resources_count += 1
+        if self.fail_resources:
+            raise RuntimeError("resource discovery failed")
+        return [dict(resource) for resource in self.resources]
+
+    async def read_resource(self, uri: str, *, context: Any = None) -> dict[str, Any]:
+        """Record and return a configured resource read."""
+        del context
+        self.resource_reads.append(uri)
+        if uri not in self.resource_results:
+            raise RuntimeError("resource missing")
+        return dict(self.resource_results[uri])
 
     async def call_tool(
         self,
@@ -217,6 +244,63 @@ class BlockingConnectTransport(RecordingExternalTransport):
         self.connect_started.set()
         await self.allow_connect.wait()
         self.connected = True
+
+
+class BaseResourceRuntime:
+    """Base gateway runtime fake used by adapter resource tests."""
+
+    name = "base-runtime"
+    version = "0.0-test"
+
+    def __init__(self) -> None:
+        self.read_requests: list[str] = []
+
+    async def list_tools(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        del context
+        return []
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        del name, arguments, context
+        return {}
+
+    async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        del context
+        return [{"uri": "resource://local/doc", "name": "Local Doc"}]
+
+    async def read_resource(
+        self,
+        uri: str,
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        del context
+        self.read_requests.append(uri)
+        return {"contents": [{"uri": uri, "text": "local"}]}
+
+    async def list_prompts(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        del context
+        return []
+
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        del name, arguments, context
+        return {}
+
+    async def list_modules(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        del context
+        return []
+
+    async def get_modules_health(self, context: GatewayRequestContext) -> dict[str, Any]:
+        del context
+        return {"modules": []}
 
 
 class RecordingCredentialBroker:
@@ -474,6 +558,158 @@ async def test_external_runtime_start_discovers_tools_and_reports_healthy_status
         "external_server_started",
         "external_server_discovered",
     ]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_lists_and_reads_redacted_resources() -> None:
+    upstream_uri = "secret://docs/source?token=do-not-leak"
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        resources=[
+            {
+                "uri": upstream_uri,
+                "name": "Secret Doc",
+                "description": "Safe description",
+                "mimeType": "text/plain",
+                "metadata": {
+                    "category": "docs",
+                    "api_key": "do-not-leak",
+                },
+            }
+        ],
+        resource_reads={
+            upstream_uri: {
+                "contents": [
+                    {
+                        "uri": upstream_uri,
+                        "mimeType": "text/plain",
+                        "text": "external contents",
+                    }
+                ]
+            }
+        },
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+
+    resources = await manager.list_virtual_resources()
+    public_payload = json.dumps(resources, sort_keys=True)
+    resource = resources[0]
+    result = await manager.read_virtual_resource(resource["uri"])
+
+    assert resource["uri"].startswith("external://research/")
+    assert resource["name"] == "Secret Doc"
+    assert resource["mimeType"] == "text/plain"
+    assert resource["metadata"] == {
+        "external_server_id": "research",
+        "source": "external_runtime",
+    }
+    assert "do-not-leak" not in public_payload
+    assert upstream_uri not in public_payload
+    assert result["contents"][0]["text"] == "external contents"
+    assert result["contents"][0]["uri"] == resource["uri"]
+    assert transport.resource_reads == [upstream_uri]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_resource_read_reports_missing_or_stopped() -> None:
+    upstream_uri = "resource://docs/one"
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        resources=[{"uri": upstream_uri, "name": "Doc"}],
+        resource_reads={upstream_uri: {"contents": [{"uri": upstream_uri, "text": "ok"}]}},
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+    resources = await manager.list_virtual_resources()
+
+    with pytest.raises(GatewayExternalRuntimeError) as missing:
+        await manager.read_virtual_resource("external://research/missing")
+    assert missing.value.reason_code == "external_resource_not_found"
+
+    await manager.stop_server("research")
+    with pytest.raises(GatewayExternalRuntimeError) as stopped:
+        await manager.read_virtual_resource(resources[0]["uri"])
+    assert stopped.value.reason_code == "external_resource_not_found"
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_adapter_merges_base_and_external_resources() -> None:
+    upstream_uri = "resource://docs/one"
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(
+        server_id="research",
+        resources=[{"uri": upstream_uri, "name": "External Doc"}],
+        resource_reads={upstream_uri: {"contents": [{"uri": upstream_uri, "text": "external"}]}},
+    )
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+    base_runtime = BaseResourceRuntime()
+    runtime = ExternalRuntimeGatewayRuntime(
+        external_runtime_manager=manager,
+        base_runtime=base_runtime,
+    )
+    context = GatewayRequestContext(request_id="resources")
+
+    resources = await runtime.list_resources(context)
+    external_uri = next(
+        resource["uri"]
+        for resource in resources
+        if resource.get("metadata", {}).get("source") == "external_runtime"
+    )
+    external = await runtime.read_resource(external_uri, context)
+    local = await runtime.read_resource("resource://local/doc", context)
+
+    assert [resource["uri"] for resource in resources][:1] == ["resource://local/doc"]
+    assert external["contents"][0]["text"] == "external"
+    assert local["contents"][0]["text"] == "local"
+    assert base_runtime.read_requests == ["resource://local/doc"]
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_wait_for_servers_reports_ready_and_unavailable() -> None:
+    store = InMemoryExternalRegistryStore([_server()])
+    transport = RecordingExternalTransport(server_id="research")
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+
+    unavailable = await manager.wait_for_servers(
+        ["research"],
+        timeout_seconds=0.01,
+        poll_interval_seconds=0.001,
+    )
+    await manager.start_server("research")
+    ready = await manager.wait_for_servers(
+        ["research"],
+        timeout_seconds=0.01,
+        poll_interval_seconds=0.001,
+    )
+
+    assert unavailable == {
+        "ok": False,
+        "ready_servers": [],
+        "unavailable_servers": ["research"],
+        "unknown_servers": [],
+    }
+    assert ready == {
+        "ok": True,
+        "ready_servers": ["research"],
+        "unavailable_servers": [],
+        "unknown_servers": [],
+    }
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py
@@ -246,6 +246,28 @@ class BlockingConnectTransport(RecordingExternalTransport):
         self.connected = True
 
 
+class BlockingResourceListTransport(RecordingExternalTransport):
+    """Fake transport that pauses resource discovery until released."""
+
+    def __init__(
+        self,
+        *,
+        server_id: str,
+        resources: list[dict[str, Any]],
+        allow_list: asyncio.Event,
+    ) -> None:
+        super().__init__(server_id=server_id, resources=resources)
+        self.list_started = asyncio.Event()
+        self.allow_list = allow_list
+
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Wait for the test to release resource discovery."""
+        self.list_resources_count += 1
+        self.list_started.set()
+        await self.allow_list.wait()
+        return [dict(resource) for resource in self.resources]
+
+
 class BaseResourceRuntime:
     """Base gateway runtime fake used by adapter resource tests."""
 
@@ -253,9 +275,11 @@ class BaseResourceRuntime:
     version = "0.0-test"
 
     def __init__(self) -> None:
+        """Initialize request recording state."""
         self.read_requests: list[str] = []
 
     async def list_tools(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return no base tools for resource-focused tests."""
         del context
         return []
 
@@ -265,10 +289,12 @@ class BaseResourceRuntime:
         arguments: dict[str, Any],
         context: GatewayRequestContext,
     ) -> dict[str, Any]:
+        """Return an empty tool result for unused tool calls."""
         del name, arguments, context
         return {}
 
     async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return one local resource before external resources."""
         del context
         return [{"uri": "resource://local/doc", "name": "Local Doc"}]
 
@@ -277,11 +303,13 @@ class BaseResourceRuntime:
         uri: str,
         context: GatewayRequestContext,
     ) -> dict[str, Any]:
+        """Record the local read request and return local content."""
         del context
         self.read_requests.append(uri)
         return {"contents": [{"uri": uri, "text": "local"}]}
 
     async def list_prompts(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return no prompts for resource-focused tests."""
         del context
         return []
 
@@ -291,14 +319,17 @@ class BaseResourceRuntime:
         arguments: dict[str, Any],
         context: GatewayRequestContext,
     ) -> dict[str, Any]:
+        """Return an empty prompt payload for unused prompt calls."""
         del name, arguments, context
         return {}
 
     async def list_modules(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
+        """Return no modules for resource-focused tests."""
         del context
         return []
 
     async def get_modules_health(self, context: GatewayRequestContext) -> dict[str, Any]:
+        """Return an empty module health payload."""
         del context
         return {"modules": []}
 
@@ -562,6 +593,7 @@ async def test_external_runtime_start_discovers_tools_and_reports_healthy_status
 
 @pytest.mark.asyncio
 async def test_external_runtime_lists_and_reads_redacted_resources() -> None:
+    """External resources and read payloads expose only redacted virtual URIs."""
     upstream_uri = "secret://docs/source?token=do-not-leak"
     store = InMemoryExternalRegistryStore([_server()])
     transport = RecordingExternalTransport(
@@ -590,6 +622,7 @@ async def test_external_runtime_lists_and_reads_redacted_resources() -> None:
                         "text": f"external contents from {upstream_uri}",
                     },
                     {
+                        "uri": "secret://docs/related?token=do-not-leak",
                         "type": "text",
                         "text": "see secret://docs/related?token=do-not-leak",
                     }
@@ -621,11 +654,16 @@ async def test_external_runtime_lists_and_reads_redacted_resources() -> None:
     assert "do-not-leak" not in private_payload
     assert "secret://docs/" not in private_payload
     assert result["contents"][0]["uri"] == resource["uri"]
+    assert [content["uri"] for content in result["contents"]] == [
+        resource["uri"],
+        resource["uri"],
+    ]
     assert transport.resource_reads == [upstream_uri]
 
 
 @pytest.mark.asyncio
 async def test_external_runtime_resource_listing_filters_ungranted_servers_before_discovery() -> None:
+    """Resource discovery skips active servers outside the effective profile policy."""
     research_uri = "resource://research/one"
     docs_uri = "resource://docs/one"
     store = InMemoryExternalRegistryStore(
@@ -660,7 +698,47 @@ async def test_external_runtime_resource_listing_filters_ungranted_servers_befor
 
 
 @pytest.mark.asyncio
+async def test_external_runtime_resource_discovery_runs_active_servers_concurrently() -> None:
+    """Resource discovery starts all allowed active servers before awaiting completion."""
+    allow_list = asyncio.Event()
+    store = InMemoryExternalRegistryStore(
+        [
+            _server(id="research", name="Research"),
+            _server(id="docs", name="Docs"),
+        ]
+    )
+    research = BlockingResourceListTransport(
+        server_id="research",
+        resources=[{"uri": "resource://research/one", "name": "Research Doc"}],
+        allow_list=allow_list,
+    )
+    docs = BlockingResourceListTransport(
+        server_id="docs",
+        resources=[{"uri": "resource://docs/one", "name": "Docs Doc"}],
+        allow_list=allow_list,
+    )
+    transports = {"research": research, "docs": docs}
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda server: transports[server.id],
+    )
+    await manager.start_server("research")
+    await manager.start_server("docs")
+
+    list_task = asyncio.create_task(manager.list_virtual_resources())
+    try:
+        await asyncio.wait_for(research.list_started.wait(), timeout=0.2)
+        await asyncio.wait_for(docs.list_started.wait(), timeout=0.2)
+    finally:
+        allow_list.set()
+    resources = await asyncio.wait_for(list_task, timeout=0.2)
+
+    assert [resource["name"] for resource in resources] == ["Docs Doc", "Research Doc"]
+
+
+@pytest.mark.asyncio
 async def test_external_runtime_resource_read_requires_credential_grants_before_transport_call() -> None:
+    """External resource reads fail before transport calls when credentials are ungranted."""
     upstream_uri = "resource://docs/secret"
     store = InMemoryExternalRegistryStore([_server(credential_slots=["api_key"])])
     transport = RecordingExternalTransport(
@@ -687,6 +765,7 @@ async def test_external_runtime_resource_read_requires_credential_grants_before_
 
 @pytest.mark.asyncio
 async def test_external_runtime_resource_discovery_success_clears_last_error() -> None:
+    """A successful rediscovery clears the server's stale resource discovery error."""
     upstream_uri = "resource://docs/one"
     store = InMemoryExternalRegistryStore([_server()])
     transport = RecordingExternalTransport(
@@ -753,6 +832,7 @@ async def test_external_runtime_resource_read_reports_missing_or_stopped() -> No
 
 @pytest.mark.asyncio
 async def test_external_runtime_adapter_merges_base_and_external_resources() -> None:
+    """Gateway runtime lists base resources first, then external resources."""
     upstream_uri = "resource://docs/one"
     store = InMemoryExternalRegistryStore([_server()])
     transport = RecordingExternalTransport(
@@ -788,7 +868,10 @@ async def test_external_runtime_adapter_merges_base_and_external_resources() -> 
     external = await runtime.read_resource(external_uri, context)
     local = await runtime.read_resource("resource://local/doc", context)
 
-    assert [resource["uri"] for resource in resources][:1] == ["resource://local/doc"]
+    assert [resource["uri"] for resource in resources] == [
+        "resource://local/doc",
+        external_uri,
+    ]
     assert external["contents"][0]["text"] == "external"
     assert local["contents"][0]["text"] == "local"
     assert base_runtime.read_requests == ["resource://local/doc"]
@@ -796,6 +879,7 @@ async def test_external_runtime_adapter_merges_base_and_external_resources() -> 
 
 @pytest.mark.asyncio
 async def test_external_runtime_wait_for_servers_reports_ready_and_unavailable() -> None:
+    """Explicit server ids report unavailable before start and ready after start."""
     store = InMemoryExternalRegistryStore([_server()])
     transport = RecordingExternalTransport(server_id="research")
     manager = GatewayExternalRuntimeManager(
@@ -821,6 +905,35 @@ async def test_external_runtime_wait_for_servers_reports_ready_and_unavailable()
         "unavailable_servers": ["research"],
         "unknown_servers": [],
     }
+    assert ready == {
+        "ok": True,
+        "ready_servers": ["research"],
+        "unavailable_servers": [],
+        "unknown_servers": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_external_runtime_wait_for_servers_defaults_to_active_servers() -> None:
+    """Omitted server ids wait for active transports rather than all registry rows."""
+    store = InMemoryExternalRegistryStore(
+        [
+            _server(id="research", name="Research"),
+            _server(id="docs", name="Docs"),
+        ]
+    )
+    transport = RecordingExternalTransport(server_id="research")
+    manager = GatewayExternalRuntimeManager(
+        external_registry_store=store,
+        transport_factory=lambda _server: transport,
+    )
+    await manager.start_server("research")
+
+    ready = await manager.wait_for_servers(
+        timeout_seconds=0.01,
+        poll_interval_seconds=0.001,
+    )
+
     assert ready == {
         "ok": True,
         "ready_servers": ["research"],

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -255,9 +256,38 @@ async def _started_runtime(
 ) -> tuple[ExternalRuntimeGatewayRuntime, FakeExternalTransport]:
     """Create an adapter around a started external runtime manager."""
 
+    upstream_resource_uri = "secret://docs/source?token=do-not-leak"
     transport = FakeExternalTransport(
         server_id="research",
         tools=[_search_tool()],
+        resources=[
+            {
+                "uri": upstream_resource_uri,
+                "name": "Research Source",
+                "mimeType": "text/plain",
+            }
+        ],
+        resource_results={
+            upstream_resource_uri: {
+                "uri": upstream_resource_uri,
+                "contents": [
+                    {
+                        "uri": upstream_resource_uri,
+                        "mimeType": "text/plain",
+                        "text": "external resource",
+                    },
+                    {
+                        "uri": "secret://docs/related?token=do-not-leak",
+                        "mimeType": "text/plain",
+                        "text": "related",
+                    },
+                    {
+                        "type": "text",
+                        "text": f"see {upstream_resource_uri}#section",
+                    },
+                ],
+            }
+        },
         results={
             "search": ExternalToolCallResult(
                 content={"matches": ["paper-1"]},
@@ -439,6 +469,66 @@ async def test_profile_runtime_passes_external_grants_to_adapter() -> None:
     assert EFFECTIVE_POLICY_METADATA_KEY not in context.metadata
 
 
+async def test_profile_runtime_passes_external_resource_grants_to_adapter() -> None:
+    """Resolved profile grants should govern external resources."""
+
+    adapter, _transport = await _started_runtime()
+    profile_store = InMemoryProfileStore()
+    await profile_store.upsert_profile(
+        MCPProfile(
+            id="researcher",
+            name="Researcher",
+            external_server_grants=[{"server_id": "research"}],
+        )
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        adapter,
+        profile_store=profile_store,
+        default_profile_id="researcher",
+    )
+    context = GatewayRequestContext(request_id="profile-resource", user_id="user-1")
+
+    resources = await runtime.list_resources(context)
+    result = await runtime.read_resource(resources[0]["uri"], context)
+
+    payload = json.dumps(result, sort_keys=True)
+    assert resources[0]["metadata"]["external_server_id"] == "research"
+    assert result["contents"][0]["text"] == "external resource"
+    assert "do-not-leak" not in payload
+    assert "secret://docs/" not in payload
+    assert EFFECTIVE_POLICY_METADATA_KEY not in context.metadata
+
+
+async def test_profile_runtime_hides_external_resources_without_grant() -> None:
+    """Profiles without an external server grant cannot list or read resources."""
+
+    adapter, _transport = await _started_runtime()
+    granted_context = GatewayRequestContext(
+        request_id="granted",
+        metadata={
+            EFFECTIVE_POLICY_METADATA_KEY: {
+                "external_server_grants": [{"server_id": "research"}],
+            }
+        },
+    )
+    external_uri = (await adapter.list_resources(granted_context))[0]["uri"]
+    profile_store = InMemoryProfileStore()
+    await profile_store.upsert_profile(
+        MCPProfile(id="researcher", name="Researcher")
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        adapter,
+        profile_store=profile_store,
+        default_profile_id="researcher",
+    )
+    context = GatewayRequestContext(request_id="no-resource-grant", user_id="user-1")
+
+    assert await runtime.list_resources(context) == []
+    with pytest.raises(GatewayPolicyDenied) as exc_info:
+        await runtime.read_resource(external_uri, context)
+    assert exc_info.value.reason_code == "external_server_not_granted"
+
+
 async def test_profile_runtime_enriches_context_with_missing_metadata() -> None:
     """Profile policy metadata enrichment should tolerate a null metadata mapping."""
 
@@ -505,3 +595,24 @@ async def test_jsonrpc_maps_external_policy_denial_to_policy_error() -> None:
     assert response.error is not None
     assert response.error.code == -32001
     assert response.error.data["reason_code"] == "external_server_not_granted"
+
+
+async def test_jsonrpc_maps_external_resource_errors_to_stable_reason_codes() -> None:
+    """External resource runtime errors should keep their public reason code."""
+
+    runtime, _transport = await _started_runtime()
+    response = await handle_jsonrpc(
+        runtime,
+        {
+            "jsonrpc": "2.0",
+            "method": "resources/read",
+            "params": {"uri": "external://research/missing"},
+            "id": "missing-resource",
+        },
+        path="/mcp",
+    )
+
+    assert not isinstance(response, list)
+    assert response.error is not None
+    assert response.error.code == -32602
+    assert response.error.data["reason_code"] == "external_resource_not_found"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -4608,6 +4608,132 @@ def test_gateway_config_bootstrap_external_runtime_uses_injected_transport_facto
         asyncio.run(bootstrap.profile_store.aclose())
 
 
+def test_gateway_config_bootstrap_exposes_external_resources_through_runtime(
+    tmp_path: Path,
+) -> None:
+    """Configured external runtime should be visible through the bootstrapped runtime."""
+
+    from mcp_unified.federation.models import ExternalToolDefinition
+    from mcp_unified.gateway.config import (
+        GatewayExternalRuntimeBootstrapConfig,
+        GatewayProfileBootstrapConfig,
+        GatewayProfileStoreConfig,
+        bootstrap_profile_gateway_from_config,
+    )
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.storage.models import ExternalServerDefinition
+
+    upstream_uri = "secret://docs/source?token=do-not-leak"
+
+    class ResourceTransport:
+        transport_name = "resource"
+
+        def __init__(self, server_id: str) -> None:
+            self.server_id = server_id
+            self.connected = False
+
+        async def connect(self) -> None:
+            self.connected = True
+
+        async def close(self) -> None:
+            self.connected = False
+
+        async def health_check(self) -> dict[str, bool]:
+            return {
+                "configured": True,
+                "connected": self.connected,
+                "initialized": self.connected,
+            }
+
+        async def list_tools(self) -> list[ExternalToolDefinition]:
+            return [ExternalToolDefinition(name="search", description="Search")]
+
+        async def call_tool(
+            self,
+            tool_name: str,
+            arguments: dict[str, Any],
+            *,
+            context: Any = None,
+            runtime_auth: Any = None,
+        ) -> dict[str, Any]:
+            del tool_name, arguments, context, runtime_auth
+            return {"content": []}
+
+        async def list_resources(self) -> list[dict[str, Any]]:
+            return [{"uri": upstream_uri, "name": "Research Source"}]
+
+        async def read_resource(
+            self,
+            uri: str,
+            *,
+            context: Any = None,
+        ) -> dict[str, Any]:
+            del context
+            return {
+                "contents": [
+                    {
+                        "uri": uri,
+                        "mimeType": "text/plain",
+                        "text": f"read {uri}",
+                    }
+                ]
+            }
+
+    def factory(server: ExternalServerDefinition) -> ResourceTransport:
+        return ResourceTransport(server.id)
+
+    sqlite_path = tmp_path / "gateway.db"
+    bootstrap = asyncio.run(
+        bootstrap_profile_gateway_from_config(
+            _MultiToolGatewayRuntime(),
+            GatewayProfileBootstrapConfig(
+                store=GatewayProfileStoreConfig(kind="sqlite", sqlite_path=sqlite_path),
+                profiles=[
+                    {
+                        "id": "researcher",
+                        "name": "Researcher",
+                        "external_server_grants": [{"server_id": "research"}],
+                    }
+                ],
+                default_profile_id="researcher",
+                external_runtime=GatewayExternalRuntimeBootstrapConfig(enabled=True),
+            ),
+            external_transport_factory=factory,
+        )
+    )
+
+    try:
+        manager = bootstrap.external_runtime_manager
+        assert manager is not None
+        asyncio.run(
+            bootstrap.profile_store.create_server(
+                ExternalServerDefinition(
+                    id="research",
+                    name="Research",
+                    transport="stdio",
+                    command=["fake-mcp-server"],
+                )
+            )
+        )
+        asyncio.run(manager.start_server("research"))
+
+        context = GatewayRequestContext(request_id="config-resource", user_id="user-1")
+        resources = asyncio.run(bootstrap.runtime.list_resources(context))
+        external_uri = next(
+            resource["uri"]
+            for resource in resources
+            if resource.get("metadata", {}).get("external_server_id") == "research"
+        )
+        result = asyncio.run(bootstrap.runtime.read_resource(external_uri, context))
+
+        payload = json.dumps(result, sort_keys=True)
+        assert external_uri.startswith("external://research/")
+        assert "do-not-leak" not in payload
+        assert result["contents"][0]["uri"] == external_uri
+    finally:
+        asyncio.run(bootstrap.profile_store.aclose())
+
+
 def test_gateway_config_bootstrap_accepts_process_policy_mapping() -> None:
     """External runtime config validates and stores stdio process policy mappings."""
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
@@ -603,6 +603,9 @@ async def test_stdio_transport_connect_list_call_and_close(tmp_path: Path) -> No
         resource = await transport.read_resource("resource://docs/readme")
         assert resource["contents"][0]["text"] == "# Docs"
 
+        with pytest.raises(Exception):
+            await transport.read_resource("resource://docs/missing")
+
         ok = await transport.call_tool("docs.search", {"q": "hello"})
         assert ok.is_error is False
         assert ok.content == [{"type": "text", "text": "search:hello"}]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py
@@ -111,6 +111,50 @@ for raw in sys.stdin:
         })
         continue
 
+    if method == "resources/list":
+        send({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "resources": [
+                    {
+                        "uri": "resource://docs/readme",
+                        "name": "Docs README",
+                        "description": "Documentation entry",
+                        "mimeType": "text/markdown",
+                        "metadata": {"category": "read"},
+                    },
+                    {"uri": "resource://docs/defaulted", "name": 7, "metadata": []},
+                    {"uri": 42, "name": "invalid"},
+                ]
+            },
+        })
+        continue
+
+    if method == "resources/read":
+        uri = str(params.get("uri") or "")
+        if uri == "resource://docs/readme":
+            send({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "contents": [
+                        {
+                            "uri": "resource://docs/readme",
+                            "mimeType": "text/markdown",
+                            "text": "# Docs",
+                        }
+                    ]
+                },
+            })
+            continue
+        send({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": f"unknown resource: {uri}"},
+        })
+        continue
+
     if method == "tools/call":
         tool_name = str(params.get("name") or "")
         arguments = params.get("arguments") or {}
@@ -538,6 +582,26 @@ async def test_stdio_transport_connect_list_call_and_close(tmp_path: Path) -> No
         assert tools[1].description == ""
         assert tools[1].input_schema == {"type": "object"}
         assert tools[1].metadata == {}
+
+        resources = await transport.list_resources()
+        assert resources == [
+            {
+                "uri": "resource://docs/readme",
+                "name": "Docs README",
+                "description": "Documentation entry",
+                "mimeType": "text/markdown",
+                "metadata": {"category": "read"},
+            },
+            {
+                "uri": "resource://docs/defaulted",
+                "name": "",
+                "description": "",
+                "mimeType": None,
+                "metadata": {},
+            },
+        ]
+        resource = await transport.read_resource("resource://docs/readme")
+        assert resource["contents"][0]["text"] == "# Docs"
 
         ok = await transport.call_tool("docs.search", {"q": "hello"})
         assert ok.is_error is False


### PR DESCRIPTION
## Change summary

TODO: human-authored summary required before merge. Please explain what changed and why these implementation choices were made.

## AI-authored implementation summary

- Added external MCP resource list/read parity through the standalone gateway runtime using redacted `external://{server_id}/{digest}` virtual resource URIs.
- Added package and app-side stdio transport support for `resources/list` and `resources/read`.
- Added a bounded `wait_for_servers` helper over existing runtime status rows.
- Closed `TASK-12148` and `TASK-2290` with linked design/plan docs and verification notes.

## Test plan

- `PYTHONPATH=apps/mcp-unified/src python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_external_runtime_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_stdio_external_transport.py tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter_integration.py tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_federation_shell_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -k "not browser_ui and not e2e" -q`
- `git diff --check`
- `python -m bandit -r apps/mcp-unified/src/mcp_unified/federation/stdio_transport.py apps/mcp-unified/src/mcp_unified/federation/transports.py apps/mcp-unified/src/mcp_unified/gateway/external_runtime.py apps/mcp-unified/src/mcp_unified/gateway/external_runtime_adapter.py tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py tldw_Server_API/app/core/MCP_unified/external_servers/transports/stdio_adapter.py -f json -o /tmp/bandit_mcp_resource_parity.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP resource discovery/read parity for external servers in the standalone gateway with profile-aware policy and bootstrap wiring. External resources surface as redacted `external://` URIs; reads go to the owning server with stable JSON‑RPC reason codes. Closes `TASK-2290`.

- **New Features**
  - Expose external resources as `external://{server_id}/{digest}` and recursively redact upstream URIs and sensitive query tokens in read payloads.
  - Enforce the resolved profile’s policy: pre-filter discovery by grants, require `external_server_grants` and needed credential grants before reads, merge local+external resources, and route `external://` reads via the external manager.
  - Run discovery across allowed servers concurrently; add `wait_for_servers` to report ready/unavailable/unknown (defaults to active transports) and clear `last_error` after successful rediscovery.
  - Wire the external runtime into gateway bootstrap; map external runtime errors to JSON‑RPC with stable `reason_code`; implement `resources/list` and `resources/read` in `stdio` and websocket transports with safe normalization; default app transport `read_resource` raises domain not-found.

<sup>Written for commit 7bc7b6b9576ad8b527971e4b428697ab4ac8b467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

