### PR TITLE
Fix PostgreSQL setup self-verify timestamp mismatch

### DIFF
--- a/backlog/tasks/task-12160 - Fix-PostgreSQL-setup-self-verify-timestamp-timezone-mismatch.md
+++ b/backlog/tasks/task-12160 - Fix-PostgreSQL-setup-self-verify-timestamp-timezone-mismatch.md
@@ -1,0 +1,54 @@
+---
+id: TASK-12160
+title: Fix PostgreSQL setup self-verify timestamp timezone mismatch
+status: Done
+labels:
+- bug
+- postgres
+- authnz
+references:
+- https://github.com/rmusser01/tldw_server/issues/2651
+modified_files:
+- tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+- tldw_Server_API/app/services/startup_auth.py
+- tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_user_timestamps.py
+- tldw_Server_API/tests/AuthNZ_Postgres/test_user_timestamp_timezones_pg.py
+- tldw_Server_API/tests/Services/test_startup_auth.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix GitHub issue #2651: first-time setup self-verification fails on PostgreSQL with asyncpg DataError "can't subtract offset-naive and offset-aware datetimes" when marking the account verified.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Root cause documented against the setup self-verify/auth service path.
+- [ ] #2 Latest dev checked for whether the issue is already fixed.
+- [ ] #3 Regression test covers aware UTC datetimes being written through mark_user_verified against PostgreSQL timestamp columns or normalized parameters.
+- [ ] #4 Minimal pragmatic fix implemented without broad schema churn.
+- [ ] #5 Targeted tests, Bandit on touched scope, and relevant verification commands recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Root cause: setup self-verify passes an aware UTC datetime into auth_service.mark_user_verified, but legacy PostgreSQL users.updated_at columns may be timestamp without time zone, which asyncpg rejects. Latest dev had new embedded bootstrap schemas using TIMESTAMPTZ, but no startup repair for existing/fixture schemas, so the issue was not fully fixed. Fix: add an idempotent PostgreSQL startup ensure that converts legacy users timestamp columns to TIMESTAMPTZ using UTC, and wire it before other PG AuthNZ extras. Tests: unit coverage for the new migration SQL and startup wiring, plus a PostgreSQL regression that starts from a TIMESTAMP users.updated_at column and verifies mark_user_verified accepts an aware UTC datetime after repair. Verification: targeted unit suite passed, forced PostgreSQL regression passed, production-code Bandit passed; full touched-scope Bandit only reported pytest assert B101 findings in tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -34,6 +34,39 @@ _BUDGET_FIELD_KEYS = {
     "budget_month_tokens",
 }
 
+_ENSURE_USER_TIMESTAMP_TIMEZONES_SQL = """
+DO $$
+DECLARE
+    col_name text;
+BEGIN
+    FOREACH col_name IN ARRAY ARRAY[
+        'created_at',
+        'updated_at',
+        'last_login',
+        'locked_until',
+        'email_verified_at',
+        'password_changed_at'
+    ]
+    LOOP
+        IF EXISTS (
+            SELECT 1
+            FROM information_schema.columns c
+            WHERE c.table_schema = current_schema()
+              AND c.table_name = 'users'
+              AND c.column_name = col_name
+              AND c.data_type = 'timestamp without time zone'
+        ) THEN
+            EXECUTE format(
+                'ALTER TABLE users ALTER COLUMN %I TYPE TIMESTAMPTZ USING %I AT TIME ZONE ''UTC''',
+                col_name,
+                col_name
+            );
+        END IF;
+    END LOOP;
+END
+$$
+"""
+
 
 _CREATE_TOOL_CATALOGS = [
     # tool_catalogs
@@ -2621,6 +2654,20 @@ async def ensure_mcp_prompt_read_permission_pg(pool: DatabasePool | None = None)
         return True
     except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
         logger.warning(f"Failed to ensure PostgreSQL MCP prompts.read permission: {exc}")
+        return False
+
+
+async def ensure_user_timestamp_timezones_pg(pool: DatabasePool | None = None) -> bool:
+    """Ensure legacy PostgreSQL users timestamp columns accept aware UTC datetimes."""
+    try:
+        db_pool = pool or await get_db_pool()
+        if getattr(db_pool, "pool", None) is None:
+            return False
+        await db_pool.execute(_ENSURE_USER_TIMESTAMP_TIMEZONES_SQL)
+        logger.info("Ensured PostgreSQL users timestamp columns use TIMESTAMPTZ")
+        return True
+    except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(f"Failed to ensure PostgreSQL users timestamp time zones: {exc}")
         return False
 
 

--- a/tldw_Server_API/app/services/startup_auth.py
+++ b/tldw_Server_API/app/services/startup_auth.py
@@ -88,10 +88,12 @@ async def _ensure_pg_extras(db_pool: object) -> None:
             ensure_privilege_snapshots_table_pg,
             ensure_tool_catalogs_tables_pg,
             ensure_usage_tables_pg,
+            ensure_user_timestamp_timezones_pg,
             ensure_virtual_key_counters_pg,
         )
 
         pg_ensures = [
+            ("users timestamp time zones", ensure_user_timestamp_timezones_pg),
             ("AuthNZ core tables", ensure_authnz_core_tables_pg),
             ("generated_files table", ensure_generated_files_table_pg),
             ("tool catalogs tables", ensure_tool_catalogs_tables_pg),

--- a/tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_user_timestamps.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_user_timestamps.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+class _StubPostgresPool:
+    def __init__(self) -> None:
+        self.pool = object()
+        self.executed_sql: list[str] = []
+
+    async def execute(self, query: str, *args):  # noqa: ANN001, ANN002
+        self.executed_sql.append(query)
+        return None
+
+
+class _StubNonPostgresPool:
+    pool = None
+
+
+@pytest.mark.asyncio
+async def test_ensure_user_timestamp_timezones_pg_skips_non_postgres() -> None:
+    from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+        ensure_user_timestamp_timezones_pg,
+    )
+
+    ok = await ensure_user_timestamp_timezones_pg(_StubNonPostgresPool())
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_user_timestamp_timezones_pg_emits_utc_repairs() -> None:
+    from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+        ensure_user_timestamp_timezones_pg,
+    )
+
+    pool = _StubPostgresPool()
+
+    ok = await ensure_user_timestamp_timezones_pg(pool)
+
+    assert ok is True
+    ddl = "\n".join(pool.executed_sql)
+    assert "ALTER TABLE users" in ddl
+    assert "updated_at" in ddl
+    assert "TYPE TIMESTAMPTZ" in ddl
+    assert "AT TIME ZONE" in ddl
+    assert "UTC" in ddl

--- a/tldw_Server_API/tests/AuthNZ_Postgres/test_user_timestamp_timezones_pg.py
+++ b/tldw_Server_API/tests/AuthNZ_Postgres/test_user_timestamp_timezones_pg.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_user_timestamp_repair_allows_aware_setup_self_verify(test_db_pool) -> None:
+    from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+        ensure_user_timestamp_timezones_pg,
+    )
+    from tldw_Server_API.app.services.auth_service import mark_user_verified
+
+    username = f"pg-setup-{uuid.uuid4().hex[:8]}"
+    await test_db_pool.execute(
+        """
+        INSERT INTO users (uuid, username, email, password_hash, is_active)
+        VALUES ($1, $2, $3, $4, TRUE)
+        """,
+        str(uuid.uuid4()),
+        username,
+        f"{username}@example.com",
+        "hash",
+    )
+    user_id = await test_db_pool.fetchval("SELECT id FROM users WHERE username = $1", username)
+    before_type = await test_db_pool.fetchval(
+        """
+        SELECT data_type
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'users'
+          AND column_name = 'updated_at'
+        """
+    )
+
+    assert before_type == "timestamp without time zone"
+
+    assert await ensure_user_timestamp_timezones_pg(test_db_pool) is True
+    after_type = await test_db_pool.fetchval(
+        """
+        SELECT data_type
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'users'
+          AND column_name = 'updated_at'
+        """
+    )
+    assert after_type == "timestamp with time zone"
+
+    await mark_user_verified(
+        test_db_pool,
+        user_id=int(user_id),
+        now_utc=datetime(2026, 7, 5, 5, 25, 52, tzinfo=timezone.utc),
+    )
+
+    row = await test_db_pool.fetchrow(
+        "SELECT is_verified, updated_at FROM users WHERE id = $1",
+        user_id,
+    )
+    assert row["is_verified"] is True
+    assert row["updated_at"].tzinfo is not None

--- a/tldw_Server_API/tests/Services/test_startup_auth.py
+++ b/tldw_Server_API/tests/Services/test_startup_auth.py
@@ -145,6 +145,7 @@ async def test_init_auth_services_runs_pg_extras_when_pool_present(
     _install_module(
         monkeypatch,
         "tldw_Server_API.app.core.AuthNZ.pg_migrations_extra",
+        ensure_user_timestamp_timezones_pg=_make_pg_ensure("user_timestamps"),
         ensure_authnz_core_tables_pg=_make_pg_ensure("authnz_core"),
         ensure_generated_files_table_pg=_make_pg_ensure("generated_files"),
         ensure_tool_catalogs_tables_pg=_make_pg_ensure("tool_catalogs"),
@@ -161,6 +162,7 @@ async def test_init_auth_services_runs_pg_extras_when_pool_present(
 
     assert result is db_pool
     assert pg_calls == [
+        "user_timestamps",
         "authnz_core",
         "generated_files",
         "tool_catalogs",


### PR DESCRIPTION
## Summary
- Adds an idempotent PostgreSQL startup repair for legacy `users` timestamp columns, converting `timestamp without time zone` columns to `TIMESTAMPTZ` with UTC interpretation.
- Wires the repair before the existing AuthNZ PostgreSQL extras so `/api/v1/setup/self-verify` can safely bind aware UTC datetimes through `mark_user_verified`.
- Adds unit coverage for the repair SQL/startup wiring and a PostgreSQL regression covering the original asyncpg failure path.

## Change summary
AI-authored draft. Per project policy, a human maintainer should replace or confirm this section before marking the PR ready for merge.

## Test Plan
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_auth_service_backend_agnostic.py tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_user_timestamps.py tldw_Server_API/tests/Services/test_startup_auth.py -q`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && TLDW_TEST_POSTGRES_REQUIRED=1 python -m pytest tldw_Server_API/tests/AuthNZ_Postgres/test_user_timestamp_timezones_pg.py -q -rs`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py tldw_Server_API/app/services/startup_auth.py -f json -o /tmp/bandit_issue_2651_app_pr.json`
- `git diff --check`

Fixes #2651


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PostgreSQL setup self-verify failures by converting legacy `users` timestamp columns to TIMESTAMPTZ (UTC) at startup. This lets `/api/v1/setup/self-verify` mark users verified with aware UTC datetimes without asyncpg errors (fixes #2651).

- **Bug Fixes**
  - Added an idempotent startup repair to alter `users` timestamps to TIMESTAMPTZ using UTC.
  - Runs this repair before other PostgreSQL AuthNZ extras.
  - Added unit tests for the repair SQL and startup ordering.
  - Added a PostgreSQL regression test that reproduces the original failure and verifies the fix.

<sup>Written for commit d25fb10616ee95ed478acbc2ceaab273b9e73c79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

