### PR TITLE
Add cooking recipe card tool-result UI

### DIFF
--- a/Docs/superpowers/plans/2026-07-05-cooking-recipe-card-tool-result-ui.md
+++ b/Docs/superpowers/plans/2026-07-05-cooking-recipe-card-tool-result-ui.md
@@ -1,0 +1,1129 @@
+# Cooking Recipe Card Tool-Result UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only `cooking.recipe_card.render` MCP tool whose structured tool result renders as a shared recipe card UI in WebUI and extension chat.
+
+**Architecture:** Implement one backend MCP module that validates recipe card input and returns a namespaced `tldw_ui` payload. Add a small shared frontend parser and `RecipeCard` component, then integrate it into the existing `ToolCallBlock` fallback path without touching OpenUI or adding generic UI rendering.
+
+**Tech Stack:** FastAPI-side MCP Unified modules in Python, pytest/pytest-asyncio, React 18, TypeScript, Vitest, Testing Library, Tailwind classes, lucide-react.
+
+---
+
+## Spec
+
+Approved design spec:
+
+- `Docs/superpowers/specs/2026-07-05-cooking-recipe-card-tool-result-ui-design.md`
+
+Backlog:
+
+- `TASK-12150`
+
+## Scope Check
+
+This is one reviewable feature with two coupled slices:
+
+- backend tool result producer
+- frontend typed tool-result renderer
+
+Do not split into a generic `ui.render` system, OpenUI changes, timers, grocery export, recipe persistence, or notification work.
+
+## File Structure
+
+Backend:
+
+- Create `tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py`
+  - Owns `CookingModule`, `cooking.recipe_card.render`, validation helpers, and output normalization.
+- Modify `tldw_Server_API/Config_Files/mcp_modules.yaml`
+  - Adds enabled read-only `cooking` module entry.
+- Create `tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py`
+  - Unit tests for tool schema, happy path, bounds, invalid input, unknown tool.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py`
+  - Adds checked-in YAML coverage proving the safe `cooking` module is present and enabled while high-risk modules stay disabled.
+
+Frontend:
+
+- Create `apps/packages/ui/src/types/recipe-card.ts`
+  - Shared TypeScript types for the normalized recipe card payload.
+- Create `apps/packages/ui/src/utils/recipe-card-ui.ts`
+  - Safe parser for `ToolCallResult.content`; returns `RecipeCardPayload | null`.
+- Create `apps/packages/ui/src/utils/__tests__/recipe-card-ui.test.ts`
+  - Parser tests for valid payload, malformed JSON, unsupported version, error results, oversized arrays.
+- Create `apps/packages/ui/src/components/Common/RecipeCard/RecipeCard.tsx`
+  - Shared compact recipe card and local serving stepper.
+- Create `apps/packages/ui/src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx`
+  - Component behavior tests.
+- Modify `apps/packages/ui/src/components/Sidepanel/Chat/ToolCallBlock.tsx`
+  - Adds label/icon for `cooking.recipe_card.render` and renders `RecipeCard` for valid non-error recipe tool results.
+- Create `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx`
+  - Integration tests for recipe rendering and fallback behavior.
+- Create `apps/packages/ui/src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts`
+  - Source/contract guard that WebUI and extension chat pass persisted `toolResults` into message rendering.
+
+Verification:
+
+- Backend targeted pytest.
+- Frontend targeted Vitest.
+- Bandit on touched backend module.
+- Optional browser screenshot after implementation if the dev server is already available or can be started.
+
+---
+
+### Task 1: Backend Cooking Module Contract Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py`
+- Later implementation: `tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py`
+
+- [ ] **Step 1: Write failing tests for tool metadata and happy path**
+
+Create `test_cooking_module.py` with:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.cooking_module import (
+    CookingModule,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _module() -> CookingModule:
+    return CookingModule(ModuleConfig(name="Cooking"))
+
+
+def _recipe_args() -> dict:
+    return {
+        "title": "Cajun Alfredo Sauce",
+        "servings": {"value": 2, "label": "2 servings"},
+        "ingredients": [
+            {
+                "display": "3 tbsp butter",
+                "name": "butter",
+                "quantity": 3,
+                "unit": "tbsp",
+                "scalable": True,
+            },
+            {"display": "salt to taste", "scalable": False},
+        ],
+        "steps": [{"display": "Melt butter.", "timer_seconds": None}],
+        "summary": "Rich sauce for pasta.",
+        "notes": ["Add pasta water slowly."],
+    }
+
+
+async def test_get_tools_exposes_recipe_card_contract() -> None:
+    tools = await _module().get_tools()
+
+    assert [tool["name"] for tool in tools] == ["cooking.recipe_card.render"]  # nosec B101
+    tool = tools[0]
+    assert tool["inputSchema"]["required"] == ["title", "servings", "ingredients", "steps"]  # nosec B101
+    assert tool["metadata"]["readOnlyHint"] is True  # nosec B101
+    assert tool["metadata"]["category"] == "cooking"  # nosec B101
+
+
+async def test_render_recipe_card_returns_tldw_ui_envelope() -> None:
+    result = await _module().execute_tool("cooking.recipe_card.render", _recipe_args())
+
+    assert set(result) == {"tldw_ui"}  # nosec B101
+    envelope = result["tldw_ui"]
+    assert envelope["kind"] == "recipe_card"  # nosec B101
+    assert envelope["version"] == 1  # nosec B101
+    recipe = envelope["recipe"]
+    assert recipe["title"] == "Cajun Alfredo Sauce"  # nosec B101
+    assert recipe["ingredients"][0]["display"] == "3 tbsp butter"  # nosec B101
+    assert recipe["ingredients"][0]["quantity"] == 3  # nosec B101
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError` for `cooking_module`.
+
+- [ ] **Step 3: Commit only if this task is split into its own branch checkpoint**
+
+Skip a commit here if implementing Task 2 immediately in the same working set.
+
+---
+
+### Task 2: Backend Cooking Module Implementation
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py`
+
+- [ ] **Step 1: Implement minimal module shell and constants**
+
+Use the existing `TemplateModule` pattern. Keep validation local to this module.
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import BaseModule, create_tool_definition
+
+TOOL_RECIPE_CARD = "cooking.recipe_card.render"
+UI_KIND_RECIPE_CARD = "recipe_card"
+UI_VERSION = 1
+
+MAX_TITLE_CHARS = 120
+MAX_SUMMARY_CHARS = 300
+MAX_NOTE_CHARS = 300
+MAX_NOTES = 8
+MAX_INGREDIENTS = 60
+MAX_INGREDIENT_DISPLAY_CHARS = 180
+MAX_STEPS = 40
+MAX_STEP_DISPLAY_CHARS = 600
+MAX_TIMER_SECONDS = 86400
+MAX_SERVINGS = 50
+
+
+class CookingModule(BaseModule):
+    """Read-only cooking UI helpers for MCP tool-call rendering."""
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return [
+            create_tool_definition(
+                name=TOOL_RECIPE_CARD,
+                description=(
+                    "Validate structured recipe data and return a tldw recipe "
+                    "card UI payload. Use when an answer includes a cooking "
+                    "recipe that should render as an inline recipe card."
+                ),
+                parameters=_recipe_card_parameters(),
+                metadata={
+                    "category": "cooking",
+                    "readOnlyHint": True,
+                    "auth_required": False,
+                    "capabilities": ["ui.recipe_card", "cooking.recipe"],
+                },
+            )
+        ]
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> Any:
+        if tool_name != TOOL_RECIPE_CARD:
+            return {"ok": False, "reason_code": "unknown_tool", "error": f"Unknown tool: {tool_name}"}
+        try:
+            recipe = _normalize_recipe(self.sanitize_input(arguments))
+        except ValueError as exc:
+            return {"ok": False, "reason_code": "invalid_arguments", "error": str(exc)}
+        return {"tldw_ui": {"kind": UI_KIND_RECIPE_CARD, "version": UI_VERSION, "recipe": recipe}}
+```
+
+- [ ] **Step 2: Add JSON schema function**
+
+Keep the schema explicit. Do not add a dependency.
+
+```python
+def _recipe_card_parameters() -> dict[str, Any]:
+    return {
+        "properties": {
+            "title": {"type": "string", "minLength": 1, "maxLength": MAX_TITLE_CHARS},
+            "servings": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "number", "minimum": 1, "maximum": MAX_SERVINGS},
+                    "label": {"type": "string", "maxLength": 80},
+                },
+                "required": ["value"],
+            },
+            "ingredients": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": MAX_INGREDIENTS,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "display": {"type": "string", "minLength": 1, "maxLength": MAX_INGREDIENT_DISPLAY_CHARS},
+                        "name": {"type": "string", "maxLength": 120},
+                        "quantity": {"type": "number"},
+                        "unit": {"type": "string", "maxLength": 32},
+                        "note": {"type": ["string", "null"], "maxLength": 160},
+                        "scalable": {"type": "boolean"},
+                    },
+                    "required": ["display"],
+                },
+            },
+            "steps": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": MAX_STEPS,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "display": {"type": "string", "minLength": 1, "maxLength": MAX_STEP_DISPLAY_CHARS},
+                        "timer_seconds": {"type": ["integer", "null"], "minimum": 1, "maximum": MAX_TIMER_SECONDS},
+                    },
+                    "required": ["display"],
+                },
+            },
+            "summary": {"type": ["string", "null"], "maxLength": MAX_SUMMARY_CHARS},
+            "notes": {
+                "type": "array",
+                "maxItems": MAX_NOTES,
+                "items": {"type": "string", "maxLength": MAX_NOTE_CHARS},
+            },
+        },
+        "required": ["title", "servings", "ingredients", "steps"],
+    }
+```
+
+- [ ] **Step 3: Add normalization helpers**
+
+Implement boring validators. Preserve `display` as authoritative.
+
+```python
+def _clean_text(value: Any, *, field: str, max_chars: int, required: bool = True) -> str | None:
+    if value is None:
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    text = value.strip()
+    if required and not text:
+        raise ValueError(f"{field} is required")
+    if len(text) > max_chars:
+        raise ValueError(f"{field} exceeds {max_chars} characters")
+    return text or None
+```
+
+Add `_normalize_servings`, `_normalize_ingredients`, `_normalize_steps`, and `_normalize_recipe` with the limits from the spec.
+
+- [ ] **Step 4: Run backend tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add invalid-input tests**
+
+Add parametrized tests for:
+
+- empty title
+- servings `0`
+- more than 60 ingredients
+- ingredient missing `display`
+- more than 40 steps
+- step text longer than 600 characters
+- timer over 86400
+- unknown tool
+
+Expected assertion shape:
+
+```python
+result = await _module().execute_tool("cooking.recipe_card.render", bad_args)
+assert result["ok"] is False  # nosec B101
+assert result["reason_code"] == "invalid_arguments"  # nosec B101
+```
+
+- [ ] **Step 6: Run full backend module test**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit backend module slice**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py
+git commit -m "feat: add cooking recipe card MCP tool"
+```
+
+---
+
+### Task 3: MCP Config Registration
+
+**Files:**
+- Modify: `tldw_Server_API/Config_Files/mcp_modules.yaml`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py`
+
+- [ ] **Step 1: Add failing config tests**
+
+In `test_basic_functionality.py`, extend the existing YAML defaults test:
+
+```python
+def test_default_mcp_modules_yaml_includes_safe_cooking_module():
+    import yaml
+    from pathlib import Path
+
+    data = yaml.safe_load(Path("tldw_Server_API/Config_Files/mcp_modules.yaml").read_text(encoding="utf-8"))
+    modules = {entry["id"]: entry for entry in data["modules"]}
+
+    assert modules["cooking"]["enabled"] is True  # nosec B101
+    assert modules["cooking"]["class"].endswith("cooking_module:CookingModule")  # nosec B101
+```
+
+In `test_cooking_module.py`, add a normal server registration test:
+
+```python
+async def test_server_registers_cooking_module_from_default_yaml(monkeypatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    server = MCPServer()
+    registrations = []
+
+    async def _register_module(module_id, cls, config):
+        registrations.append((module_id, cls, config))
+
+    monkeypatch.setattr(server.module_registry, "register_module", _register_module)
+    monkeypatch.delenv("MCP_MODULES_CONFIG", raising=False)
+    monkeypatch.delenv("MCP_MODULES", raising=False)
+
+    await server._register_default_modules()
+
+    cooking = next(item for item in registrations if item[0] == "cooking")
+    assert cooking[1].__name__ == "CookingModule"  # nosec B101
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::test_default_mcp_modules_yaml_includes_safe_cooking_module \
+  tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py::test_server_registers_cooking_module_from_default_yaml \
+  -q
+```
+
+Expected: FAIL because YAML lacks `cooking`.
+
+- [ ] **Step 3: Add YAML module entry**
+
+Add to `tldw_Server_API/Config_Files/mcp_modules.yaml` near other safe read-only/user-facing modules:
+
+```yaml
+  - id: cooking
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.cooking_module:CookingModule
+    enabled: true
+    name: Cooking
+    version: "1.0.0"
+    department: utility
+    max_concurrent: 20
+    description: Read-only cooking recipe card UI payload tools
+    settings: {}
+```
+
+- [ ] **Step 4: Run targeted registration tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::test_default_mcp_modules_yaml_includes_safe_cooking_module \
+  tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py::test_server_registers_cooking_module_from_default_yaml \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run related MCP tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::test_default_mcp_modules_yaml_disables_local_file_and_process_modules \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::test_default_mcp_modules_yaml_includes_safe_cooking_module \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit config slice**
+
+```bash
+git add tldw_Server_API/Config_Files/mcp_modules.yaml \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py
+git commit -m "feat: register cooking MCP module"
+```
+
+---
+
+### Task 4: Frontend Recipe Payload Parser
+
+**Files:**
+- Create: `apps/packages/ui/src/types/recipe-card.ts`
+- Create: `apps/packages/ui/src/utils/recipe-card-ui.ts`
+- Create: `apps/packages/ui/src/utils/__tests__/recipe-card-ui.test.ts`
+
+- [ ] **Step 1: Write parser tests first**
+
+Create `recipe-card-ui.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { parseRecipeCardToolResult } from "../recipe-card-ui"
+
+const validContent = JSON.stringify({
+  tldw_ui: {
+    kind: "recipe_card",
+    version: 1,
+    recipe: {
+      title: "Cajun Alfredo Sauce",
+      servings: { value: 2, label: "2 servings" },
+      ingredients: [
+        {
+          display: "3 tbsp butter",
+          name: "butter",
+          quantity: 3,
+          unit: "tbsp",
+          scalable: true
+        },
+        { display: "salt to taste", scalable: false }
+      ],
+      steps: [{ display: "Melt butter.", timer_seconds: null }],
+      summary: null,
+      notes: []
+    }
+  }
+})
+
+describe("parseRecipeCardToolResult", () => {
+  it("parses a valid recipe card payload", () => {
+    const parsed = parseRecipeCardToolResult({ content: validContent })
+    expect(parsed?.recipe.title).toBe("Cajun Alfredo Sauce")
+    expect(parsed?.recipe.ingredients[0].quantity).toBe(3)
+  })
+
+  it("returns null for errors, malformed JSON, and unsupported versions", () => {
+    expect(parseRecipeCardToolResult({ content: validContent, error: true })).toBeNull()
+    expect(parseRecipeCardToolResult({ content: "not json" })).toBeNull()
+    expect(
+      parseRecipeCardToolResult({
+        content: JSON.stringify({ tldw_ui: { kind: "recipe_card", version: 2, recipe: {} } })
+      })
+    ).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run parser tests to verify failure**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/utils/__tests__/recipe-card-ui.test.ts
+```
+
+Expected: FAIL because files do not exist.
+
+- [ ] **Step 3: Add shared types**
+
+Create `recipe-card.ts`:
+
+```ts
+export type RecipeCardIngredient = {
+  display: string
+  name?: string
+  quantity?: number
+  unit?: string
+  note?: string | null
+  scalable?: boolean
+}
+
+export type RecipeCardStep = {
+  display: string
+  timer_seconds?: number | null
+}
+
+export type RecipeCardPayload = {
+  kind: "recipe_card"
+  version: 1
+  recipe: {
+    title: string
+    servings: {
+      value: number
+      label?: string
+    }
+    ingredients: RecipeCardIngredient[]
+    steps: RecipeCardStep[]
+    summary?: string | null
+    notes?: string[]
+  }
+}
+```
+
+- [ ] **Step 4: Implement parser with caps**
+
+Create `recipe-card-ui.ts`. Keep this dependency-free.
+
+```ts
+import type { ToolCallResult } from "@/types/tool-calls"
+import type { RecipeCardPayload } from "@/types/recipe-card"
+
+const MAX_INGREDIENTS = 60
+const MAX_STEPS = 40
+
+export const parseRecipeCardToolResult = (
+  result?: Pick<ToolCallResult, "content" | "error">
+): RecipeCardPayload | null => {
+  if (!result || result.error) return null
+  try {
+    const parsed = JSON.parse(result.content)
+    const ui = parsed?.tldw_ui
+    if (!ui || ui.kind !== "recipe_card" || ui.version !== 1) return null
+    const recipe = ui.recipe
+    if (!recipe || typeof recipe.title !== "string") return null
+    if (!Array.isArray(recipe.ingredients) || recipe.ingredients.length === 0) return null
+    if (!Array.isArray(recipe.steps) || recipe.steps.length === 0) return null
+    if (recipe.ingredients.length > MAX_INGREDIENTS || recipe.steps.length > MAX_STEPS) return null
+    return ui as RecipeCardPayload
+  } catch {
+    return null
+  }
+}
+```
+
+Add stricter string/number checks after the first passing test. Do not parse ingredient strings.
+
+- [ ] **Step 5: Run parser tests**
+
+```bash
+bunx vitest run src/utils/__tests__/recipe-card-ui.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Add bounds tests**
+
+Add tests for:
+
+- missing `tldw_ui`
+- wrong `kind`
+- empty ingredients
+- too many ingredients
+- too many steps
+- non-string ingredient display
+- invalid servings value
+
+- [ ] **Step 7: Run parser tests again**
+
+```bash
+bunx vitest run src/utils/__tests__/recipe-card-ui.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit parser slice**
+
+```bash
+git add apps/packages/ui/src/types/recipe-card.ts \
+  apps/packages/ui/src/utils/recipe-card-ui.ts \
+  apps/packages/ui/src/utils/__tests__/recipe-card-ui.test.ts
+git commit -m "feat: parse recipe card tool results"
+```
+
+---
+
+### Task 5: Shared RecipeCard Component
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Common/RecipeCard/RecipeCard.tsx`
+- Create: `apps/packages/ui/src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx`
+
+- [ ] **Step 1: Write component tests**
+
+Create `RecipeCard.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+import { RecipeCard } from "../RecipeCard"
+import type { RecipeCardPayload } from "@/types/recipe-card"
+
+const payload: RecipeCardPayload = {
+  kind: "recipe_card",
+  version: 1,
+  recipe: {
+    title: "Cajun Alfredo Sauce",
+    servings: { value: 2, label: "2 servings" },
+    ingredients: [
+      { display: "3 tbsp butter", quantity: 3, unit: "tbsp", name: "butter", scalable: true },
+      { display: "salt to taste", scalable: false }
+    ],
+    steps: [
+      { display: "Melt butter.", timer_seconds: null },
+      { display: "Simmer for 5 minutes.", timer_seconds: 300 }
+    ],
+    notes: []
+  }
+}
+
+describe("RecipeCard", () => {
+  it("renders recipe title, counts, ingredients, and steps", () => {
+    render(<RecipeCard payload={payload} />)
+    expect(screen.getByText("Cajun Alfredo Sauce")).toBeInTheDocument()
+    expect(screen.getByText("2 ingredients")).toBeInTheDocument()
+    expect(screen.getByText("2 steps")).toBeInTheDocument()
+    expect(screen.getByText("3 tbsp butter")).toBeInTheDocument()
+    expect(screen.getByText("salt to taste")).toBeInTheDocument()
+  })
+
+  it("scales only structured scalable ingredients", async () => {
+    const user = userEvent.setup()
+    render(<RecipeCard payload={payload} />)
+    await user.click(screen.getByRole("button", { name: "Increase servings" }))
+    expect(screen.getByText("4 servings")).toBeInTheDocument()
+    expect(screen.getByText("6 tbsp butter")).toBeInTheDocument()
+    expect(screen.getByText("salt to taste")).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run component tests to verify failure**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx
+```
+
+Expected: FAIL because component does not exist.
+
+- [ ] **Step 3: Implement `RecipeCard`**
+
+Use lucide icons, native buttons, and text rendering only. Avoid nested cards. Example structure:
+
+```tsx
+import React from "react"
+import { ChefHat, ListChecks, Minus, Plus } from "lucide-react"
+import { classNames } from "@/libs/class-name"
+import type { RecipeCardPayload, RecipeCardIngredient } from "@/types/recipe-card"
+
+type RecipeCardProps = {
+  payload: RecipeCardPayload
+  className?: string
+}
+
+export const RecipeCard: React.FC<RecipeCardProps> = ({ payload, className }) => {
+  const { recipe } = payload
+  const baseServings = recipe.servings.value
+  const [servings, setServings] = React.useState(baseServings)
+  const factor = servings / baseServings
+
+  return (
+    <section className={classNames("rounded-md border border-border bg-surface px-3 py-3", className)}>
+      <div className="flex items-start gap-2">
+        <ChefHat className="mt-0.5 size-4 text-primary" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold text-text">{recipe.title}</h3>
+          <p className="text-xs text-text-muted">
+            {recipe.ingredients.length} ingredients - {recipe.steps.length} steps
+          </p>
+        </div>
+      </div>
+      {/* servings controls, ingredients, cooking mode */}
+    </section>
+  )
+}
+```
+
+Use simple pluralization inline. Do not add a new i18n namespace in this slice.
+
+- [ ] **Step 4: Add scaling helper inside component file**
+
+```ts
+const formatQuantity = (value: number) =>
+  Number.isInteger(value) ? String(value) : String(Math.round(value * 100) / 100)
+
+const formatIngredient = (ingredient: RecipeCardIngredient, factor: number) => {
+  if (
+    ingredient.scalable &&
+    typeof ingredient.quantity === "number" &&
+    Number.isFinite(ingredient.quantity) &&
+    ingredient.unit &&
+    ingredient.name
+  ) {
+    const scaled = ingredient.quantity * factor
+    return `${formatQuantity(scaled)} ${ingredient.unit} ${ingredient.name}`
+  }
+  return ingredient.display
+}
+```
+
+- [ ] **Step 5: Implement inline cooking mode**
+
+Add a `Cooking mode` button that toggles a compact ordered step view. It does not start timers. Durations render as text.
+
+```tsx
+const [showSteps, setShowSteps] = React.useState(false)
+
+<button type="button" onClick={() => setShowSteps((value) => !value)}>
+  <ListChecks className="size-4" aria-hidden="true" />
+  Cooking mode
+</button>
+```
+
+- [ ] **Step 6: Run component tests**
+
+```bash
+bunx vitest run src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit component slice**
+
+```bash
+git add apps/packages/ui/src/components/Common/RecipeCard/RecipeCard.tsx \
+  apps/packages/ui/src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx
+git commit -m "feat: add recipe card component"
+```
+
+---
+
+### Task 6: ToolCallBlock Integration
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/ToolCallBlock.tsx`
+- Create: `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx`
+
+- [ ] **Step 1: Write integration tests**
+
+Create `ToolCallBlock.recipe-card.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { ToolCallBlock } from "../ToolCallBlock"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+const toolCall = {
+  id: "call_recipe",
+  type: "function" as const,
+  function: {
+    name: "cooking.recipe_card.render",
+    arguments: JSON.stringify({ title: "Cajun Alfredo Sauce" })
+  }
+}
+
+const recipeResult = {
+  tool_call_id: "call_recipe",
+  content: JSON.stringify({
+    tldw_ui: {
+      kind: "recipe_card",
+      version: 1,
+      recipe: {
+        title: "Cajun Alfredo Sauce",
+        servings: { value: 2, label: "2 servings" },
+        ingredients: [{ display: "3 tbsp butter", quantity: 3, unit: "tbsp", name: "butter", scalable: true }],
+        steps: [{ display: "Melt butter.", timer_seconds: null }],
+        summary: null,
+        notes: []
+      }
+    }
+  })
+}
+
+describe("ToolCallBlock recipe card rendering", () => {
+  it("renders a valid recipe card tool result without expanding raw JSON", () => {
+    render(<ToolCallBlock toolCalls={[toolCall]} results={[recipeResult]} />)
+    expect(screen.getByText("Recipe Card")).toBeInTheDocument()
+    expect(screen.getByText("Cajun Alfredo Sauce")).toBeInTheDocument()
+    expect(screen.queryByText(/\"tldw_ui\"/)).not.toBeInTheDocument()
+  })
+
+  it("falls back for failed recipe tool results", () => {
+    render(<ToolCallBlock toolCalls={[toolCall]} results={[{ ...recipeResult, error: true }]} />)
+    expect(screen.queryByText("Cajun Alfredo Sauce")).not.toBeInTheDocument()
+    expect(screen.getByText("Error")).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx
+```
+
+Expected: FAIL because recipe rendering is not integrated.
+
+- [ ] **Step 3: Add label/icon mapping**
+
+Modify imports and maps in `ToolCallBlock.tsx`:
+
+```ts
+import { ChefHat, ... } from "lucide-react"
+
+const TOOL_ICONS = {
+  ...,
+  "cooking.recipe_card.render": ChefHat
+}
+
+const TOOL_LABELS = {
+  ...,
+  "cooking.recipe_card.render": "Recipe Card"
+}
+```
+
+- [ ] **Step 4: Integrate parser and component**
+
+Inside `toolCalls.map`, compute:
+
+```ts
+const recipePayload = parseRecipeCardToolResult(result)
+```
+
+Render special body when present:
+
+```tsx
+{recipePayload && (
+  <div className="border-t border-border/40 px-2 py-2">
+    <RecipeCard payload={recipePayload} />
+  </div>
+)}
+```
+
+Keep the existing expanded generic content for arguments and fallback results. For recipe payloads, expanded content may show arguments only; do not duplicate raw `tldw_ui` JSON unless the recipe parser returned `null`.
+
+- [ ] **Step 5: Run integration tests**
+
+```bash
+bunx vitest run src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run parser and component tests together**
+
+```bash
+bunx vitest run \
+  src/utils/__tests__/recipe-card-ui.test.ts \
+  src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx \
+  src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit integration slice**
+
+```bash
+git add apps/packages/ui/src/components/Sidepanel/Chat/ToolCallBlock.tsx \
+  apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx
+git commit -m "feat: render recipe card tool results"
+```
+
+---
+
+### Task 7: Tool Result Replay Guard
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts`
+- Modify only if needed:
+  - `apps/packages/ui/src/components/Option/Playground/PlaygroundChat.tsx`
+  - `apps/packages/ui/src/components/Sidepanel/Chat/body.tsx`
+  - relevant message/store adapters found during implementation
+
+- [ ] **Step 1: Write a guard for the two MVP surfaces**
+
+Create a source guard that documents the replay dependency:
+
+```ts
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const readSource = (relativePath: string) =>
+  fs.readFileSync(path.resolve(__dirname, relativePath), "utf8")
+
+describe("tool result replay wiring", () => {
+  it("passes persisted toolResults through WebUI chat messages", () => {
+    const source = readSource("../../../Option/Playground/PlaygroundChat.tsx")
+    expect(source).toContain("toolResults={message?.toolResults}")
+  })
+
+  it("passes persisted toolResults through extension sidepanel messages", () => {
+    const source = readSource("../../../Sidepanel/Chat/body.tsx")
+    expect(source).toContain("toolResults={message?.toolResults}")
+  })
+})
+```
+
+- [ ] **Step 2: Run guard**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts
+```
+
+Expected: PASS if existing wiring is intact.
+
+- [ ] **Step 3: If the guard fails, add the smallest adapter**
+
+Only touch message plumbing if a target surface drops `toolResults`. Keep the change local. Do not redesign chat persistence in this feature.
+
+- [ ] **Step 4: Run the guard and integration tests**
+
+```bash
+bunx vitest run \
+  src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts \
+  src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit replay guard**
+
+```bash
+git add apps/packages/ui/src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts
+git commit -m "test: guard recipe card tool result replay"
+```
+
+---
+
+### Task 8: Verification And Hardening
+
+**Files:**
+- Update if needed: files touched in earlier tasks only.
+- Update: `backlog/tasks/task-12150 - Design-cooking-recipe-card-tool-result-UI.md`
+
+- [ ] **Step 1: Run backend targeted tests**
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::test_default_mcp_modules_yaml_disables_local_file_and_process_modules \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::test_default_mcp_modules_yaml_includes_safe_cooking_module \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend targeted tests**
+
+From `apps/packages/ui`:
+
+```bash
+bunx vitest run \
+  src/utils/__tests__/recipe-card-ui.test.ts \
+  src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx \
+  src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx \
+  src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Bandit on touched backend code**
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py \
+  -f json -o /tmp/bandit_cooking_recipe_card.json
+```
+
+Expected: PASS or only non-actionable findings outside changed code. Fix any new finding in `cooking_module.py`.
+
+- [ ] **Step 4: Run TypeScript typecheck if targeted tests pass**
+
+From `apps/tldw-frontend`:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS. If this is too slow or blocked by existing unrelated errors, record the failure and run the targeted Vitest suite as the required frontend verification.
+
+- [ ] **Step 5: Visual smoke check**
+
+If a dev server is already running, open a page with a fixture or temporary test harness that renders `ToolCallBlock` with a recipe payload. Verify:
+
+- the recipe card is visible without opening raw JSON
+- the card fits a narrow sidepanel width
+- serving controls do not shift layout badly
+- cooking mode expands inline
+
+If no dev server is available, rely on the Testing Library coverage and document that browser visual QA was not run.
+
+- [ ] **Step 6: Update Backlog task**
+
+Record:
+
+- files changed
+- test commands and results
+- Bandit result path
+- any skipped visual QA reason
+
+- [ ] **Step 7: Final commit**
+
+If earlier tasks were not committed individually, commit all remaining implementation files:
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py \
+  tldw_Server_API/Config_Files/mcp_modules.yaml \
+  tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  apps/packages/ui/src/types/recipe-card.ts \
+  apps/packages/ui/src/utils/recipe-card-ui.ts \
+  apps/packages/ui/src/utils/__tests__/recipe-card-ui.test.ts \
+  apps/packages/ui/src/components/Common/RecipeCard/RecipeCard.tsx \
+  apps/packages/ui/src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx \
+  apps/packages/ui/src/components/Sidepanel/Chat/ToolCallBlock.tsx \
+  apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx \
+  apps/packages/ui/src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts \
+  "backlog/tasks/task-12150 - Design-cooking-recipe-card-tool-result-UI.md"
+git commit -m "feat: render cooking recipe card tool results"
+```
+
+---
+
+## Final Verification Checklist
+
+- [ ] `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py -q`
+- [ ] `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::test_default_mcp_modules_yaml_includes_safe_cooking_module -q`
+- [ ] `bunx vitest run src/utils/__tests__/recipe-card-ui.test.ts src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts`
+- [ ] `python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py -f json -o /tmp/bandit_cooking_recipe_card.json`
+- [ ] Typecheck or documented targeted-test fallback
+- [ ] Browser visual QA or documented skip
+- [ ] Backlog `TASK-12150` updated

--- a/Docs/superpowers/specs/2026-07-05-cooking-recipe-card-tool-result-ui-design.md
+++ b/Docs/superpowers/specs/2026-07-05-cooking-recipe-card-tool-result-ui-design.md
@@ -1,0 +1,356 @@
+# Cooking Recipe Card Tool-Result UI Design
+
+Date: 2026-07-05
+Status: Human-reviewed after spec reviewer timeout
+Backlog: TASK-12150
+
+## Summary
+
+Add a small, typed UI affordance for cooking recipes by letting the model call a read-only backend MCP tool named `cooking.recipe_card.render`. The tool validates model-provided recipe card data and returns a namespaced `tldw_ui` envelope. WebUI and the browser extension render that envelope with a shared recipe card component when it appears in a tool result.
+
+This is not a frontend recipe detector and not a generic UI rendering protocol. The model decides when a recipe card is useful by calling the tool. The frontend decides only whether a known, valid `tldw_ui` payload can be rendered specially. Unknown or invalid tool results continue through the existing generic tool-call display.
+
+## Goals
+
+- Give recipe answers a richer inline UI without requiring users to switch modes.
+- Let the model opt in through normal tool calling instead of frontend text heuristics.
+- Keep the payload typed, bounded, namespaced, and safe to replay from saved chat history.
+- Share the renderer between WebUI chat and extension sidepanel chat.
+- Reuse the existing MCP tool and tool-call UI paths.
+- Keep the first slice useful without durable timers, grocery export, or recipe storage.
+
+## Non-Goals
+
+- Do not add a generic `ui.render` tool in v1.
+- Do not enable or extend the existing OpenUI dynamic UI path for this feature.
+- Do not infer recipes from assistant prose in the frontend.
+- Do not persist recipes in a dedicated recipe database.
+- Do not add notification permissions, background timers, or OS-level alarms.
+- Do not add grocery list export, nutrition analysis, or source crawling.
+- Do not change existing dynamic UI surface gating.
+
+## Current Context
+
+The repository already has three relevant paths:
+
+- MCP Unified modules define tools with `create_tool_definition(...)` and metadata such as `readOnlyHint`.
+- `/api/v1/tools` delegates list and execute operations through `ToolExecutor`, which wraps MCP `tools/list` and `tools/call`.
+- Chat message rendering already shows assistant tool calls through the shared `ToolCallBlock` used by WebUI and extension chat surfaces.
+
+The frontend also has an OpenUI dynamic UI feature, but it is intentionally surface-gated. Web chat can render OpenUI while the extension sidepanel and workspace surfaces fall back. Cooking cards should not use that path. A typed renderer inside the existing tool-call display path is smaller, safer, and easier to share.
+
+## Recommended Approach
+
+Add one domain-specific MCP tool:
+
+```text
+cooking.recipe_card.render
+```
+
+The tool is read-only and side-effect free. It accepts structured recipe data from the model, validates it, normalizes it into a stable envelope, and returns JSON content containing:
+
+```json
+{
+  "tldw_ui": {
+    "kind": "recipe_card",
+    "version": 1,
+    "recipe": {}
+  }
+}
+```
+
+The frontend adds a tiny typed UI result parser. When a tool result parses as a supported `tldw_ui` envelope, it renders the matching shared component. When parsing fails, the existing generic tool result UI remains the fallback.
+
+## Alternatives Considered
+
+### Generic `ui.render` Tool
+
+Pros:
+
+- One tool could eventually cover recipes, checklists, itineraries, tables, and other structured UI.
+- The frontend could grow a general typed UI renderer registry.
+
+Cons:
+
+- It creates a UI protocol before there is enough evidence for one.
+- Permission and safety semantics are vaguer than a domain-specific read-only cooking tool.
+- The model would have a broader tool that invites unrelated UI payloads.
+
+Decision: defer. A future `ui.render` can absorb proven envelopes after at least two or three specific renderers exist.
+
+### Reuse OpenUI Dynamic UI
+
+Pros:
+
+- Existing dynamic UI envelope, renderer, and action bridge already exist.
+- Could produce more flexible visual layouts.
+
+Cons:
+
+- OpenUI is intentionally disabled on extension and workspace surfaces.
+- Model-generated UI source is harder to validate than a recipe schema.
+- The feature needs one known card, not arbitrary component source.
+
+Decision: do not use OpenUI for cooking cards.
+
+### Frontend Recipe Detector
+
+Pros:
+
+- No backend tool needed.
+- Could display cards when the assistant forgets to call a tool.
+
+Cons:
+
+- Brittle prose parsing.
+- Surprising UI triggers.
+- Harder to explain and test than explicit tool use.
+
+Decision: do not detect recipes from prose in v1.
+
+## Backend Design
+
+### Tool Module
+
+Add a small MCP module or register the tool in the nearest existing UI/helper module if implementation planning finds one. The tool definition should include:
+
+- name: `cooking.recipe_card.render`
+- description: explains that it validates and returns a recipe card UI payload
+- metadata:
+  - `readOnlyHint: true`
+  - category such as `ui` or `cooking`
+  - no write/destructive/network capabilities
+
+The tool does not call external services, read local files, write databases, or modify user state.
+
+Implementation must also wire the module into normal MCP discovery, not only unit-test it directly. The default path is `tldw_Server_API/Config_Files/mcp_modules.yaml`, which is loaded by the MCP server module autoloader. If implementation planning chooses a new `CookingModule`, the plan must add the module config entry and a test proving `tools/list` exposes `cooking.recipe_card.render` through the normal server configuration path.
+
+### Input Contract
+
+Expected input:
+
+```json
+{
+  "title": "Cajun Alfredo Sauce",
+  "servings": {
+    "value": 2,
+    "label": "2 servings"
+  },
+  "ingredients": [
+    {
+      "display": "3 tbsp butter",
+      "name": "butter",
+      "quantity": 3,
+      "unit": "tbsp",
+      "note": null,
+      "scalable": true
+    }
+  ],
+  "steps": [
+    {
+      "display": "Melt butter in a pan over medium heat.",
+      "timer_seconds": null
+    }
+  ],
+  "summary": "Rich Cajun-style Alfredo sauce for pasta.",
+  "notes": [
+    "Add pasta water slowly until the sauce loosens."
+  ]
+}
+```
+
+Only `title`, `servings`, `ingredients`, and `steps` are required. Each ingredient keeps `display` as the authoritative text. Numeric scaling is optional and used only when `quantity`, `unit`, and `scalable` are present and safe.
+
+### Output Contract
+
+The tool returns one canonical envelope:
+
+```json
+{
+  "tldw_ui": {
+    "kind": "recipe_card",
+    "version": 1,
+    "recipe": {
+      "title": "Cajun Alfredo Sauce",
+      "servings": {
+        "value": 2,
+        "label": "2 servings"
+      },
+      "ingredients": [],
+      "steps": [],
+      "summary": null,
+      "notes": []
+    }
+  }
+}
+```
+
+The namespaced `tldw_ui` wrapper avoids collisions with ordinary tool JSON. The `version` field lets the frontend reject or fall back on unsupported future shapes.
+
+### Validation Limits
+
+Implementation should set boring, explicit limits:
+
+- title: 1 to 120 characters
+- summary: 0 to 300 characters
+- notes: at most 8 items, 300 characters each
+- ingredients: 1 to 60 items
+- ingredient display: 1 to 180 characters
+- steps: 1 to 40 items
+- step display: 1 to 600 characters
+- servings value: integer or decimal from 1 to 50
+- timer seconds: optional, 1 to 86400
+
+If the payload exceeds limits or fails schema validation, the tool returns a normal tool error. The frontend then shows the generic tool error/result path rather than a partial recipe card.
+
+## Frontend Design
+
+### Typed Parser
+
+Add a shared parser for tool result content:
+
+- parse string content as JSON when possible
+- require a top-level `tldw_ui`
+- require `kind === "recipe_card"`
+- require `version === 1`
+- validate core recipe fields and caps before rendering
+- return `null` on mismatch
+
+This parser should never throw to React render paths. Bad payloads fall back to the current generic tool-call UI.
+
+### Renderer Placement
+
+Keep the existing `ToolCallBlock` behavior as the default. Add one check before the generic formatted-result body:
+
+1. Parse the tool result with the typed UI parser.
+2. If the result is not an error and it returns a recipe card payload, render `RecipeCard`.
+3. Otherwise render the existing generic result block.
+
+This keeps the feature local to tool-result rendering and avoids changing message metadata, dynamic UI envelopes, or chat completion transport.
+
+Also add a cooking label and icon mapping for `cooking.recipe_card.render` so collapsed, loading, error, and fallback states read as intentional even when the special renderer is not active.
+
+### Shared Component
+
+Add a shared `RecipeCard` component under the existing shared UI package so WebUI and extension sidepanel can use the same rendering. It should be compact enough for chat:
+
+- title
+- ingredient and step counts
+- servings stepper
+- ingredients list
+- steps list
+- `Cooking mode` button
+
+The first `Cooking mode` behavior is an inline expanded step view. It can focus one step at a time and show any provided duration as text. It should not start reliable alarm timers in v1.
+
+### Ingredient Scaling
+
+The serving stepper changes local display state only. It should:
+
+- keep original `display` text available
+- scale only ingredients with numeric `quantity`, known `unit`, and `scalable: true`
+- leave non-scalable ingredients unchanged
+- avoid trying to parse freeform strings on the frontend
+
+Examples that should remain unchanged unless explicitly structured:
+
+- `1 can evaporated milk`
+- `salt to taste`
+- `half an onion`
+- `reserved pasta water as needed`
+
+### Visual Treatment
+
+The card should match the existing restrained product UI:
+
+- no nested cards
+- no decorative blobs or hero treatment
+- compact header, subdued metadata, clear affordances
+- accessible buttons for servings and cooking mode
+- responsive layout that fits the extension sidepanel width
+
+The screenshot is a reference for the information hierarchy, not a directive to copy Claude's visual styling.
+
+## Data Flow
+
+1. User asks for a recipe or cooking idea.
+2. Model chooses to call `cooking.recipe_card.render` with structured recipe data.
+3. Backend MCP tool validates and returns the `tldw_ui` recipe envelope.
+4. Chat stores the assistant tool call and tool result durably enough for later message replay.
+5. Frontend receives the message history.
+6. `ToolCallBlock` sees the tool result, parses the envelope, and renders `RecipeCard`.
+7. Saved chats replay the same card from the persisted tool result.
+
+No extra frontend detector or post-processing pass is needed.
+
+Implementation planning must verify this persistence path before building the renderer. If a target chat surface does not currently persist `toolResults`, the implementation must add the smallest adapter needed for that surface or exclude that surface from the first slice explicitly. The intended MVP includes WebUI chat and extension sidepanel replay.
+
+## Error Handling
+
+- Invalid tool input returns a tool error with a concise validation message.
+- Tool results marked as errors never render recipe UI.
+- Unsupported `tldw_ui.version` falls back to generic JSON display.
+- Unknown `tldw_ui.kind` falls back to generic JSON display.
+- Renderer parse failures fall back without throwing.
+- Missing optional fields render as absent UI, not as placeholder copy.
+
+## Security And Privacy
+
+- Treat tool output as untrusted because it originates from model-provided data.
+- Render all strings as text, never as raw HTML.
+- Do not persist recipe data outside the normal chat/tool-result storage.
+- Do not request browser notification permissions in v1.
+- Do not let the cooking tool access files, network, databases, or credentials.
+- Keep explicit schema and display caps on both backend and frontend boundaries.
+
+## Testing Plan
+
+Backend:
+
+- tool appears in MCP tool list with read-only metadata
+- tool appears through normal MCP module configuration, not only direct module construction
+- valid minimal recipe returns a `tldw_ui.kind = "recipe_card"` envelope
+- valid full recipe preserves display strings and structured quantities
+- too many ingredients or steps returns a validation error
+- invalid servings and overlong strings return validation errors
+
+Frontend:
+
+- valid recipe tool result renders `RecipeCard`
+- failed recipe tool result renders the generic error/result path, not `RecipeCard`
+- unknown tool result still renders the generic tool-call block
+- malformed JSON falls back to generic display
+- unsupported `tldw_ui.version` falls back
+- serving stepper scales only structured scalable ingredients
+- non-scalable ingredients keep original display text
+- `cooking.recipe_card.render` has an intentional label/icon in collapsed and fallback states
+- extension-width render does not overflow core controls
+
+## Implementation Boundaries
+
+Implementation planning should start from existing code paths:
+
+- MCP tool registration under `tldw_Server_API/app/core/MCP_unified/modules/implementations/`
+- MCP module config wiring under `tldw_Server_API/Config_Files/mcp_modules.yaml`
+- shared tool-call rendering under `apps/packages/ui/src/components/Sidepanel/Chat/ToolCallBlock.tsx`
+- shared UI types/utilities under `apps/packages/ui/src/types` or `apps/packages/ui/src/utils`
+
+The final file placement can follow nearby patterns after reading the exact module registry and frontend export structure.
+
+## Rollout
+
+Ship behind normal tool availability. No separate feature flag is required unless implementation planning finds that MCP tool exposure is globally on by default in places where this would be noisy.
+
+The feature is safe to merge in slices:
+
+1. Backend MCP tool and validation tests.
+2. Frontend parser and renderer tests.
+3. Shared card UI and chat integration.
+4. Visual/browser verification for WebUI and extension widths.
+
+## Decisions For Implementation Planning
+
+- Prefer a new `cooking` MCP module unless implementation planning finds an existing UI/helper module that already owns typed presentation payloads.
+- Verify chat tool-result persistence before frontend integration. Replay is part of the MVP for WebUI chat and extension sidepanel.
+- Verify both target surfaces expose tool results to `ToolCallBlock`; add the smallest adapter needed if one does not.
+- Start with the tool description as the model-facing hint. Add prompt guidance only if manual or automated testing shows models do not discover the tool reliably.

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const uiRoot = path.resolve(__dirname, "../../../..")
+
+const readSource = (relativePath: string) =>
+  fs.readFileSync(path.resolve(uiRoot, relativePath), "utf8")
+
+describe("tool result replay wiring", () => {
+  it("passes persisted toolResults through WebUI chat messages", () => {
+    const source = readSource("components/Option/Playground/PlaygroundChat.tsx")
+
+    expect(source).toContain("toolResults={message?.toolResults}")
+  })
+
+  it("passes message toolResults into ToolCallBlock", () => {
+    const source = readSource("components/Common/Playground/Message.tsx")
+
+    expect(source).toContain("<ToolCallBlock")
+    expect(source).toContain("results={props.toolResults}")
+  })
+
+  it("passes persisted toolResults through extension sidepanel messages", () => {
+    const source = readSource("components/Sidepanel/Chat/body.tsx")
+
+    expect(source).toContain("toolResults={message?.toolResults}")
+  })
+
+  it("keeps toolResults available in compare clusters", () => {
+    const source = readSource(
+      "components/Option/Playground/PlaygroundCompareCluster.tsx"
+    )
+
+    expect(source).toMatch(
+      /toolResults=\{(?:message|userMessage)\?\.toolResults\}/
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Common/RecipeCard/RecipeCard.tsx
+++ b/apps/packages/ui/src/components/Common/RecipeCard/RecipeCard.tsx
@@ -1,0 +1,146 @@
+import React from "react"
+import { ChefHat, ListChecks, Minus, Plus } from "lucide-react"
+
+import { classNames } from "@/libs/class-name"
+import type { RecipeCardIngredient, RecipeCardPayload } from "@/types/recipe-card"
+
+type RecipeCardProps = {
+  payload: RecipeCardPayload
+  className?: string
+}
+
+const formatQuantity = (value: number) =>
+  Number.isInteger(value) ? String(value) : String(Math.round(value * 100) / 100)
+
+const durationText = (seconds: number) =>
+  seconds >= 60 && seconds % 60 === 0 ? `${seconds / 60} min` : `${seconds} sec`
+
+const formatServingsLabel = (value: number) =>
+  `${formatQuantity(value)} ${value === 1 ? "serving" : "servings"}`
+
+const ingredientText = (
+  ingredient: RecipeCardIngredient,
+  factor: number
+) => {
+  if (
+    ingredient.scalable === true &&
+    Number.isFinite(ingredient.quantity) &&
+    ingredient.unit &&
+    ingredient.name
+  ) {
+    const note = ingredient.note ? ` (${ingredient.note})` : ""
+    return `${formatQuantity((ingredient.quantity as number) * factor)} ${ingredient.unit} ${ingredient.name}${note}`
+  }
+  return ingredient.display
+}
+
+export function RecipeCard({ payload, className = "" }: RecipeCardProps) {
+  const { recipe } = payload
+  const [servings, setServings] = React.useState(recipe.servings.value)
+  const [isCookingMode, setIsCookingMode] = React.useState(false)
+  const factor = servings / recipe.servings.value
+  const servingLabel = formatServingsLabel(servings)
+
+  return (
+    <section
+      className={classNames(
+        "w-full max-w-full rounded-lg border border-border bg-surface px-3 py-3 text-sm text-text shadow-sm",
+        className
+      )}
+      aria-label={recipe.title}
+    >
+      <header className="flex items-start gap-2">
+        <ChefHat className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <h3 className="break-words text-sm font-semibold leading-5 text-text">
+            {recipe.title}
+          </h3>
+          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-text-muted">
+            <span>{recipe.ingredients.length} ingredients</span>
+            <span>{recipe.steps.length} steps</span>
+          </div>
+        </div>
+      </header>
+
+      {recipe.summary ? (
+        <p className="mt-2 break-words text-xs leading-5 text-text-muted">
+          {recipe.summary}
+        </p>
+      ) : null}
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-text-muted">{servingLabel}</span>
+        <div className="flex items-center rounded-md border border-border">
+          <button
+            type="button"
+            aria-label="Decrease servings"
+            className="flex h-7 w-8 items-center justify-center text-text-muted hover:bg-surface2 hover:text-text disabled:opacity-40"
+            disabled={servings <= 1}
+            onClick={() => setServings((value) => Math.max(1, value - 1))}
+          >
+            <Minus className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            aria-label="Increase servings"
+            className="flex h-7 w-8 items-center justify-center border-l border-border text-text-muted hover:bg-surface2 hover:text-text disabled:opacity-40"
+            disabled={servings >= 50}
+            onClick={() => setServings((value) => Math.min(50, value + 1))}
+          >
+            <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        </div>
+        <button
+          type="button"
+          className={classNames(
+            "ml-auto inline-flex min-h-[28px] items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
+            isCookingMode
+              ? "border-primary/50 bg-primary/10 text-primary"
+              : "border-border text-text hover:bg-surface2"
+          )}
+          aria-pressed={isCookingMode}
+          onClick={() => setIsCookingMode((value) => !value)}
+        >
+          <ListChecks className="h-3.5 w-3.5" aria-hidden="true" />
+          Cooking mode
+        </button>
+      </div>
+
+      <ul className="mt-3 space-y-1.5">
+        {recipe.ingredients.map((ingredient, index) => (
+          <li key={`${ingredient.display}-${index}`} className="break-words leading-5">
+            {ingredientText(ingredient, factor)}
+          </li>
+        ))}
+      </ul>
+
+      {recipe.notes?.length ? (
+        <ul className="mt-3 space-y-1 border-t border-border pt-2 text-xs text-text-muted">
+          {recipe.notes.map((note, index) => (
+            <li key={`${note}-${index}`} className="break-words">
+              {note}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {isCookingMode ? (
+        <ol className="mt-3 space-y-2 border-t border-border pt-3">
+          {recipe.steps.map((step, index) => (
+            <li key={`${step.display}-${index}`} className="flex gap-2 leading-5">
+              <span className="text-xs font-semibold text-text-muted">{index + 1}.</span>
+              <span className="min-w-0 flex-1 break-words">{step.display}</span>
+              {step.timer_seconds ? (
+                <span className="shrink-0 text-xs text-text-muted">
+                  {durationText(step.timer_seconds)}
+                </span>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      ) : null}
+    </section>
+  )
+}
+
+export default RecipeCard

--- a/apps/packages/ui/src/components/Common/RecipeCard/RecipeCard.tsx
+++ b/apps/packages/ui/src/components/Common/RecipeCard/RecipeCard.tsx
@@ -41,6 +41,10 @@ export function RecipeCard({ payload, className = "" }: RecipeCardProps) {
   const factor = servings / recipe.servings.value
   const servingLabel = formatServingsLabel(servings)
 
+  React.useEffect(() => {
+    setServings(recipe.servings.value)
+  }, [recipe.servings.value])
+
   return (
     <section
       className={classNames(

--- a/apps/packages/ui/src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx
+++ b/apps/packages/ui/src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx
@@ -63,6 +63,28 @@ describe("RecipeCard", () => {
     expect(screen.getByText("1 serving")).toBeInTheDocument()
   })
 
+  it("resyncs servings when a new recipe payload changes the base serving count", async () => {
+    const { rerender } = render(<RecipeCard payload={payload} />)
+
+    await userEvent.click(screen.getByRole("button", { name: "Increase servings" }))
+    expect(screen.getByText("3 servings")).toBeInTheDocument()
+
+    rerender(
+      <RecipeCard
+        payload={{
+          ...payload,
+          recipe: {
+            ...payload.recipe,
+            title: "Garlic Alfredo Sauce",
+            servings: { value: 4, label: "4 servings" }
+          }
+        }}
+      />
+    )
+
+    expect(await screen.findByText("4 servings")).toBeInTheDocument()
+  })
+
   it("toggles cooking mode steps and duration text", async () => {
     render(<RecipeCard payload={payload} />)
 

--- a/apps/packages/ui/src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx
+++ b/apps/packages/ui/src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+
+import { RecipeCard } from "../RecipeCard"
+import type { RecipeCardPayload } from "@/types/recipe-card"
+
+const payload: RecipeCardPayload = {
+  kind: "recipe_card",
+  version: 1,
+  recipe: {
+    title: "Cajun Alfredo Sauce",
+    servings: { value: 2, label: "2 servings" },
+    ingredients: [
+      {
+        display: "3 tbsp butter",
+        name: "butter",
+        quantity: 3,
+        unit: "tbsp",
+        scalable: true
+      },
+      { display: "salt to taste", scalable: false }
+    ],
+    steps: [
+      { display: "Melt butter.", timer_seconds: 300 },
+      { display: "Season to taste.", timer_seconds: 90 }
+    ],
+    summary: "Rich sauce for pasta.",
+    notes: ["Add pasta water slowly."]
+  }
+}
+
+describe("RecipeCard", () => {
+  it("renders title, counts, and ingredients", () => {
+    render(<RecipeCard payload={payload} />)
+
+    expect(screen.getByText("Cajun Alfredo Sauce")).toBeInTheDocument()
+    expect(screen.getByText("2 ingredients")).toBeInTheDocument()
+    expect(screen.getByText("2 steps")).toBeInTheDocument()
+    expect(screen.getByText("3 tbsp butter")).toBeInTheDocument()
+    expect(screen.getByText("salt to taste")).toBeInTheDocument()
+  })
+
+  it("increases servings and scales only structured scalable ingredients", async () => {
+    render(<RecipeCard payload={payload} />)
+
+    await userEvent.click(screen.getByRole("button", { name: "Increase servings" }))
+
+    expect(screen.getByText("3 servings")).toBeInTheDocument()
+    expect(screen.getByText("4.5 tbsp butter")).toBeInTheDocument()
+    expect(screen.getByText("salt to taste")).toBeInTheDocument()
+  })
+
+  it("does not decrease below 1 serving", async () => {
+    render(<RecipeCard payload={payload} />)
+    const decrease = screen.getByRole("button", { name: "Decrease servings" })
+
+    await userEvent.click(decrease)
+    await userEvent.click(decrease)
+
+    expect(screen.getByText("1 serving")).toBeInTheDocument()
+  })
+
+  it("toggles cooking mode steps and duration text", async () => {
+    render(<RecipeCard payload={payload} />)
+
+    expect(screen.queryByText("Melt butter.")).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole("button", { name: "Cooking mode" }))
+
+    expect(screen.getByText("Melt butter.")).toBeInTheDocument()
+    expect(screen.getByText("5 min")).toBeInTheDocument()
+    expect(screen.getByText("90 sec")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ToolCallBlock.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ToolCallBlock.tsx
@@ -30,6 +30,8 @@ interface ToolCallBlockProps {
   className?: string
 }
 
+const RECIPE_CARD_TOOL_NAME = "cooking.recipe_card.render"
+
 // Map tool names to icons
 const TOOL_ICONS: Record<string, React.FC<{ className?: string }>> = {
   fs_list: FolderOpen,
@@ -49,7 +51,7 @@ const TOOL_ICONS: Record<string, React.FC<{ className?: string }>> = {
   exec_run: Terminal,
   web_search: Globe,
   web_fetch: Globe,
-  "cooking.recipe_card.render": ChefHat
+  [RECIPE_CARD_TOOL_NAME]: ChefHat
 }
 
 // Fallback display names
@@ -71,7 +73,7 @@ const TOOL_LABELS: Record<string, string> = {
   exec_run: "Run Command",
   web_search: "Web Search",
   web_fetch: "Fetch URL",
-  "cooking.recipe_card.render": "Recipe Card"
+  [RECIPE_CARD_TOOL_NAME]: "Recipe Card"
 }
 
 // Format tool arguments for compact display
@@ -216,7 +218,7 @@ export const ToolCallBlock: React.FC<ToolCallBlockProps> = ({
         const argsPreview = formatArgsPreview(call.function.name, call.function.arguments)
         const result = resultsMap.get(call.id)
         const recipePayload =
-          call.function.name === "cooking.recipe_card.render"
+          call.function.name === RECIPE_CARD_TOOL_NAME
             ? parseRecipeCardToolResult(result)
             : null
 

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ToolCallBlock.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ToolCallBlock.tsx
@@ -16,10 +16,13 @@ import {
   Globe,
   Wrench,
   ChevronDown,
-  ChevronRight
+  ChevronRight,
+  ChefHat
 } from "lucide-react"
 import { classNames } from "@/libs/class-name"
+import { RecipeCard } from "@/components/Common/RecipeCard/RecipeCard"
 import type { ToolCall, ToolCallResult } from "@/types/tool-calls"
+import { parseRecipeCardToolResult } from "@/utils/recipe-card-ui"
 
 interface ToolCallBlockProps {
   toolCalls: ToolCall[]
@@ -45,7 +48,8 @@ const TOOL_ICONS: Record<string, React.FC<{ className?: string }>> = {
   git_commit: GitBranch,
   exec_run: Terminal,
   web_search: Globe,
-  web_fetch: Globe
+  web_fetch: Globe,
+  "cooking.recipe_card.render": ChefHat
 }
 
 // Fallback display names
@@ -66,7 +70,8 @@ const TOOL_LABELS: Record<string, string> = {
   git_commit: "Commit",
   exec_run: "Run Command",
   web_search: "Web Search",
-  web_fetch: "Fetch URL"
+  web_fetch: "Fetch URL",
+  "cooking.recipe_card.render": "Recipe Card"
 }
 
 // Format tool arguments for compact display
@@ -210,6 +215,10 @@ export const ToolCallBlock: React.FC<ToolCallBlockProps> = ({
         const isExpanded = expandedIds.has(call.id)
         const argsPreview = formatArgsPreview(call.function.name, call.function.arguments)
         const result = resultsMap.get(call.id)
+        const recipePayload =
+          call.function.name === "cooking.recipe_card.render"
+            ? parseRecipeCardToolResult(result)
+            : null
 
         return (
           <div
@@ -276,16 +285,22 @@ export const ToolCallBlock: React.FC<ToolCallBlockProps> = ({
                     <div className="text-[10px] uppercase tracking-wide text-text-muted mb-1">
                       {t("common:result", "Result")}
                     </div>
-                    <pre
-                      className={classNames(
-                        "text-xs rounded p-2 overflow-x-auto max-h-48",
-                        result.error
-                          ? "bg-danger/10 text-danger"
-                          : "bg-surface"
-                      )}
-                    >
-                      {formatResult(result.content)}
-                    </pre>
+                    {recipePayload ? (
+                      <div className="max-h-96 overflow-y-auto overflow-x-hidden">
+                        <RecipeCard payload={recipePayload} />
+                      </div>
+                    ) : (
+                      <pre
+                        className={classNames(
+                          "text-xs rounded p-2 overflow-x-auto max-h-48",
+                          result.error
+                            ? "bg-danger/10 text-danger"
+                            : "bg-surface"
+                        )}
+                      >
+                        {formatResult(result.content)}
+                      </pre>
+                    )}
                   </div>
                 )}
               </div>

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { ToolCallBlock } from "../ToolCallBlock"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallback?: string | {
+        defaultValue?: string
+      }
+    ) => {
+      if (typeof fallback === "string") return fallback
+      return fallback?.defaultValue || key
+    }
+  })
+}))
+
+const recipeToolCall = {
+  id: "call_recipe",
+  type: "function" as const,
+  function: {
+    name: "cooking.recipe_card.render",
+    arguments: "{}"
+  }
+}
+
+const recipePayload = {
+  tldw_ui: {
+    kind: "recipe_card",
+    version: 1,
+    recipe: {
+      title: "Cajun Alfredo Sauce",
+      servings: { value: 2, label: "2 servings" },
+      ingredients: [
+        {
+          display: "3 tbsp butter",
+          quantity: 3,
+          unit: "tbsp",
+          name: "butter",
+          scalable: true
+        }
+      ],
+      steps: [{ display: "Melt butter.", timer_seconds: null }],
+      summary: null,
+      notes: []
+    }
+  }
+}
+
+describe("ToolCallBlock recipe card rendering", () => {
+  it("renders a valid recipe card tool result instead of raw JSON", async () => {
+    render(
+      <ToolCallBlock
+        toolCalls={[recipeToolCall]}
+        results={[
+          {
+            tool_call_id: "call_recipe",
+            content: JSON.stringify(recipePayload)
+          }
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /Recipe Card/i }))
+
+    expect(screen.getByText("Recipe Card")).toBeInTheDocument()
+    expect(screen.getByText("Cajun Alfredo Sauce")).toBeInTheDocument()
+    expect(screen.getByText("3 tbsp butter")).toBeInTheDocument()
+    expect(screen.queryByText(/"tldw_ui"/)).not.toBeInTheDocument()
+  })
+
+  it("falls back to generic error output for failed recipe tool results", async () => {
+    render(
+      <ToolCallBlock
+        toolCalls={[recipeToolCall]}
+        results={[
+          {
+            tool_call_id: "call_recipe",
+            content: JSON.stringify({
+              ok: false,
+              error: "invalid recipe"
+            }),
+            error: true
+          }
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /Recipe Card/i }))
+
+    expect(screen.queryByText("Cajun Alfredo Sauce")).not.toBeInTheDocument()
+    expect(screen.getByText("Error: invalid recipe")).toBeInTheDocument()
+  })
+
+  it("falls back to generic output for malformed recipe JSON", async () => {
+    render(
+      <ToolCallBlock
+        toolCalls={[recipeToolCall]}
+        results={[
+          {
+            tool_call_id: "call_recipe",
+            content: "{"
+          }
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /Recipe Card/i }))
+
+    expect(screen.queryByText("Cajun Alfredo Sauce")).not.toBeInTheDocument()
+    expect(screen.getByText("{")).toBeInTheDocument()
+  })
+
+  it("keeps valid recipe-shaped JSON generic for unknown tools", async () => {
+    render(
+      <ToolCallBlock
+        toolCalls={[
+          {
+            ...recipeToolCall,
+            function: {
+              name: "other_tool",
+              arguments: "{}"
+            }
+          }
+        ]}
+        results={[
+          {
+            tool_call_id: "call_recipe",
+            content: JSON.stringify(recipePayload)
+          }
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /other tool/i }))
+
+    expect(screen.queryByRole("region", { name: "Cajun Alfredo Sauce" })).not.toBeInTheDocument()
+    expect(screen.getByText(/"tldw_ui"/)).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/types/recipe-card.ts
+++ b/apps/packages/ui/src/types/recipe-card.ts
@@ -1,8 +1,8 @@
 export type RecipeCardIngredient = {
   display: string
-  name?: string
-  quantity?: number
-  unit?: string
+  name?: string | null
+  quantity?: number | null
+  unit?: string | null
   note?: string | null
   scalable?: boolean
 }

--- a/apps/packages/ui/src/types/recipe-card.ts
+++ b/apps/packages/ui/src/types/recipe-card.ts
@@ -1,0 +1,26 @@
+export type RecipeCardIngredient = {
+  display: string
+  name?: string
+  quantity?: number
+  unit?: string
+  note?: string | null
+  scalable?: boolean
+}
+
+export type RecipeCardStep = {
+  display: string
+  timer_seconds?: number | null
+}
+
+export type RecipeCardPayload = {
+  kind: "recipe_card"
+  version: 1
+  recipe: {
+    title: string
+    servings: { value: number; label?: string }
+    ingredients: RecipeCardIngredient[]
+    steps: RecipeCardStep[]
+    summary?: string | null
+    notes?: string[]
+  }
+}

--- a/apps/packages/ui/src/utils/__tests__/recipe-card-ui.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/recipe-card-ui.test.ts
@@ -38,6 +38,31 @@ describe("parseRecipeCardToolResult", () => {
     expect(parsed?.recipe.ingredients[0].quantity).toBe(3)
   })
 
+  it("accepts backend-normalized null optional ingredient fields", () => {
+    const parsed = parseRecipeCardToolResult(
+      resultWith({
+        ...validPayload,
+        tldw_ui: {
+          ...validPayload.tldw_ui,
+          recipe: {
+            ...validPayload.tldw_ui.recipe,
+            ingredients: [
+              {
+                display: "salt to taste",
+                name: null,
+                quantity: null,
+                unit: null,
+                note: null
+              }
+            ]
+          }
+        }
+      })
+    )
+
+    expect(parsed?.recipe.ingredients[0].display).toBe("salt to taste")
+  })
+
   it("returns null for error results", () => {
     expect(
       parseRecipeCardToolResult({

--- a/apps/packages/ui/src/utils/__tests__/recipe-card-ui.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/recipe-card-ui.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest"
+
+import { parseRecipeCardToolResult } from "../recipe-card-ui"
+
+const validPayload = {
+  tldw_ui: {
+    kind: "recipe_card",
+    version: 1,
+    recipe: {
+      title: "Cajun Alfredo Sauce",
+      servings: { value: 2, label: "2 servings" },
+      ingredients: [
+        {
+          display: "3 tbsp butter",
+          name: "butter",
+          quantity: 3,
+          unit: "tbsp",
+          scalable: true
+        },
+        { display: "salt to taste", scalable: false }
+      ],
+      steps: [{ display: "Melt butter.", timer_seconds: null }],
+      summary: "Rich sauce for pasta.",
+      notes: ["Add pasta water slowly."]
+    }
+  }
+}
+
+const resultWith = (content: unknown) => ({
+  content: typeof content === "string" ? content : JSON.stringify(content)
+})
+
+describe("parseRecipeCardToolResult", () => {
+  it("parses a valid payload and preserves title and quantity", () => {
+    const parsed = parseRecipeCardToolResult(resultWith(validPayload))
+
+    expect(parsed?.recipe.title).toBe("Cajun Alfredo Sauce")
+    expect(parsed?.recipe.ingredients[0].quantity).toBe(3)
+  })
+
+  it("returns null for error results", () => {
+    expect(
+      parseRecipeCardToolResult({
+        content: JSON.stringify(validPayload),
+        error: true
+      })
+    ).toBeNull()
+  })
+
+  it("returns null for malformed JSON", () => {
+    expect(parseRecipeCardToolResult({ content: "{" })).toBeNull()
+  })
+
+  it("returns null for unsupported version", () => {
+    expect(
+      parseRecipeCardToolResult(
+        resultWith({ ...validPayload, tldw_ui: { ...validPayload.tldw_ui, version: 2 } })
+      )
+    ).toBeNull()
+  })
+
+  it("returns null for missing tldw_ui", () => {
+    expect(parseRecipeCardToolResult(resultWith({ recipe: validPayload.tldw_ui.recipe }))).toBeNull()
+  })
+
+  it("returns null for wrong kind", () => {
+    expect(
+      parseRecipeCardToolResult(
+        resultWith({
+          ...validPayload,
+          tldw_ui: { ...validPayload.tldw_ui, kind: "shopping_list" }
+        })
+      )
+    ).toBeNull()
+  })
+
+  it("returns null for empty ingredients", () => {
+    expect(
+      parseRecipeCardToolResult(
+        resultWith({
+          ...validPayload,
+          tldw_ui: {
+            ...validPayload.tldw_ui,
+            recipe: { ...validPayload.tldw_ui.recipe, ingredients: [] }
+          }
+        })
+      )
+    ).toBeNull()
+  })
+
+  it("returns null for too many ingredients", () => {
+    expect(
+      parseRecipeCardToolResult(
+        resultWith({
+          ...validPayload,
+          tldw_ui: {
+            ...validPayload.tldw_ui,
+            recipe: {
+              ...validPayload.tldw_ui.recipe,
+              ingredients: Array.from({ length: 61 }, (_, index) => ({
+                display: `ingredient ${index}`
+              }))
+            }
+          }
+        })
+      )
+    ).toBeNull()
+  })
+
+  it("returns null for too many steps", () => {
+    expect(
+      parseRecipeCardToolResult(
+        resultWith({
+          ...validPayload,
+          tldw_ui: {
+            ...validPayload.tldw_ui,
+            recipe: {
+              ...validPayload.tldw_ui.recipe,
+              steps: Array.from({ length: 41 }, (_, index) => ({
+                display: `step ${index}`
+              }))
+            }
+          }
+        })
+      )
+    ).toBeNull()
+  })
+
+  it("returns null for non-string ingredient display", () => {
+    expect(
+      parseRecipeCardToolResult(
+        resultWith({
+          ...validPayload,
+          tldw_ui: {
+            ...validPayload.tldw_ui,
+            recipe: {
+              ...validPayload.tldw_ui.recipe,
+              ingredients: [{ display: 3 }]
+            }
+          }
+        })
+      )
+    ).toBeNull()
+  })
+
+  it("returns null for invalid servings value", () => {
+    expect(
+      parseRecipeCardToolResult(
+        resultWith({
+          ...validPayload,
+          tldw_ui: {
+            ...validPayload.tldw_ui,
+            recipe: {
+              ...validPayload.tldw_ui.recipe,
+              servings: { value: 0 }
+            }
+          }
+        })
+      )
+    ).toBeNull()
+  })
+
+  it("returns null for invalid ingredient quantities", () => {
+    expect(
+      parseRecipeCardToolResult(
+        resultWith({
+          ...validPayload,
+          tldw_ui: {
+            ...validPayload.tldw_ui,
+            recipe: {
+              ...validPayload.tldw_ui.recipe,
+              ingredients: [{ display: "bad butter", quantity: -1 }]
+            }
+          }
+        })
+      )
+    ).toBeNull()
+  })
+})

--- a/apps/packages/ui/src/utils/recipe-card-ui.ts
+++ b/apps/packages/ui/src/utils/recipe-card-ui.ts
@@ -1,0 +1,103 @@
+import type { RecipeCardPayload } from "@/types/recipe-card"
+import type { ToolCallResult } from "@/types/tool-calls"
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isString = (value: unknown, max: number, allowEmpty = false) =>
+  typeof value === "string" &&
+  value.length <= max &&
+  (allowEmpty || value.trim().length > 0)
+
+const isOptionalString = (value: unknown, max: number) =>
+  value === undefined || isString(value, max, true)
+
+const isOptionalStringOrNull = (value: unknown, max: number) =>
+  value === undefined || value === null || isString(value, max, true)
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value)
+
+const isIngredientQuantity = (value: unknown): value is number =>
+  isFiniteNumber(value) && value > 0 && value <= 100000
+
+const isValidIngredient = (ingredient: unknown) => {
+  if (!isObject(ingredient) || !isString(ingredient.display, 180)) return false
+  if (!isOptionalString(ingredient.name, 120)) return false
+  if (ingredient.quantity !== undefined && !isIngredientQuantity(ingredient.quantity)) {
+    return false
+  }
+  if (!isOptionalString(ingredient.unit, 32)) return false
+  if (!isOptionalStringOrNull(ingredient.note, 160)) return false
+  return ingredient.scalable === undefined || typeof ingredient.scalable === "boolean"
+}
+
+const isValidStep = (step: unknown) => {
+  if (!isObject(step) || !isString(step.display, 600)) return false
+  const timer = step.timer_seconds
+  return (
+    timer === undefined ||
+    timer === null ||
+    (Number.isInteger(timer) && timer >= 1 && timer <= 86400)
+  )
+}
+
+const isValidRecipe = (recipe: unknown) => {
+  if (!isObject(recipe) || !isString(recipe.title, 120)) return false
+  if (!isObject(recipe.servings)) return false
+  if (
+    !isFiniteNumber(recipe.servings.value) ||
+    recipe.servings.value < 1 ||
+    recipe.servings.value > 50 ||
+    !isOptionalString(recipe.servings.label, 80)
+  ) {
+    return false
+  }
+  if (
+    !Array.isArray(recipe.ingredients) ||
+    recipe.ingredients.length < 1 ||
+    recipe.ingredients.length > 60 ||
+    !recipe.ingredients.every(isValidIngredient)
+  ) {
+    return false
+  }
+  if (
+    !Array.isArray(recipe.steps) ||
+    recipe.steps.length < 1 ||
+    recipe.steps.length > 40 ||
+    !recipe.steps.every(isValidStep)
+  ) {
+    return false
+  }
+  if (!isOptionalStringOrNull(recipe.summary, 300)) return false
+  return (
+    recipe.notes === undefined ||
+    (Array.isArray(recipe.notes) &&
+      recipe.notes.length <= 8 &&
+      recipe.notes.every((note) => isString(note, 300, true)))
+  )
+}
+
+export const parseRecipeCardToolResult = (
+  result?: Pick<ToolCallResult, "content" | "error">
+): RecipeCardPayload | null => {
+  if (!result || result.error === true) return null
+
+  try {
+    const parsed = JSON.parse(result.content) as unknown
+    if (!isObject(parsed) || !isObject(parsed.tldw_ui)) return null
+
+    const payload = parsed.tldw_ui
+    if (
+      payload.kind !== "recipe_card" ||
+      payload.version !== 1 ||
+      !isValidRecipe(payload.recipe)
+    ) {
+      return null
+    }
+
+    return payload as RecipeCardPayload
+  } catch {
+    return null
+  }
+}

--- a/apps/packages/ui/src/utils/recipe-card-ui.ts
+++ b/apps/packages/ui/src/utils/recipe-card-ui.ts
@@ -1,4 +1,8 @@
-import type { RecipeCardPayload } from "@/types/recipe-card"
+import type {
+  RecipeCardIngredient,
+  RecipeCardPayload,
+  RecipeCardStep
+} from "@/types/recipe-card"
 import type { ToolCallResult } from "@/types/tool-calls"
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
@@ -21,7 +25,7 @@ const isFiniteNumber = (value: unknown): value is number =>
 const isIngredientQuantity = (value: unknown): value is number =>
   isFiniteNumber(value) && value > 0 && value <= 100000
 
-const isValidIngredient = (ingredient: unknown) => {
+const isValidIngredient = (ingredient: unknown): ingredient is RecipeCardIngredient => {
   if (!isObject(ingredient) || !isString(ingredient.display, 180)) return false
   if (!isOptionalStringOrNull(ingredient.name, 120)) return false
   if (
@@ -36,7 +40,7 @@ const isValidIngredient = (ingredient: unknown) => {
   return ingredient.scalable === undefined || typeof ingredient.scalable === "boolean"
 }
 
-const isValidStep = (step: unknown) => {
+const isValidStep = (step: unknown): step is RecipeCardStep => {
   if (!isObject(step) || !isString(step.display, 600)) return false
   const timer = step.timer_seconds
   return (
@@ -49,7 +53,7 @@ const isValidStep = (step: unknown) => {
   )
 }
 
-const isValidRecipe = (recipe: unknown) => {
+const isValidRecipe = (recipe: unknown): recipe is RecipeCardPayload["recipe"] => {
   if (!isObject(recipe) || !isString(recipe.title, 120)) return false
   if (!isObject(recipe.servings)) return false
   if (
@@ -109,5 +113,5 @@ export const parseRecipeCardToolResult = (
     return null
   }
 
-  return payload as RecipeCardPayload
+  return { kind: "recipe_card", version: 1, recipe: payload.recipe }
 }

--- a/apps/packages/ui/src/utils/recipe-card-ui.ts
+++ b/apps/packages/ui/src/utils/recipe-card-ui.ts
@@ -23,11 +23,15 @@ const isIngredientQuantity = (value: unknown): value is number =>
 
 const isValidIngredient = (ingredient: unknown) => {
   if (!isObject(ingredient) || !isString(ingredient.display, 180)) return false
-  if (!isOptionalString(ingredient.name, 120)) return false
-  if (ingredient.quantity !== undefined && !isIngredientQuantity(ingredient.quantity)) {
+  if (!isOptionalStringOrNull(ingredient.name, 120)) return false
+  if (
+    ingredient.quantity !== undefined &&
+    ingredient.quantity !== null &&
+    !isIngredientQuantity(ingredient.quantity)
+  ) {
     return false
   }
-  if (!isOptionalString(ingredient.unit, 32)) return false
+  if (!isOptionalStringOrNull(ingredient.unit, 32)) return false
   if (!isOptionalStringOrNull(ingredient.note, 160)) return false
   return ingredient.scalable === undefined || typeof ingredient.scalable === "boolean"
 }
@@ -86,21 +90,24 @@ export const parseRecipeCardToolResult = (
 ): RecipeCardPayload | null => {
   if (!result || result.error === true) return null
 
+  let parsed: unknown
   try {
-    const parsed = JSON.parse(result.content) as unknown
-    if (!isObject(parsed) || !isObject(parsed.tldw_ui)) return null
-
-    const payload = parsed.tldw_ui
-    if (
-      payload.kind !== "recipe_card" ||
-      payload.version !== 1 ||
-      !isValidRecipe(payload.recipe)
-    ) {
-      return null
-    }
-
-    return payload as RecipeCardPayload
-  } catch {
+    parsed = JSON.parse(result.content) as unknown
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error
     return null
   }
+
+  if (!isObject(parsed) || !isObject(parsed.tldw_ui)) return null
+
+  const payload = parsed.tldw_ui
+  if (
+    payload.kind !== "recipe_card" ||
+    payload.version !== 1 ||
+    !isValidRecipe(payload.recipe)
+  ) {
+    return null
+  }
+
+  return payload as RecipeCardPayload
 }

--- a/apps/packages/ui/src/utils/recipe-card-ui.ts
+++ b/apps/packages/ui/src/utils/recipe-card-ui.ts
@@ -38,7 +38,10 @@ const isValidStep = (step: unknown) => {
   return (
     timer === undefined ||
     timer === null ||
-    (Number.isInteger(timer) && timer >= 1 && timer <= 86400)
+    (typeof timer === "number" &&
+      Number.isInteger(timer) &&
+      timer >= 1 &&
+      timer <= 86400)
   )
 }
 

--- a/backlog/tasks/task-12150 - Design-cooking-recipe-card-tool-result-UI.md
+++ b/backlog/tasks/task-12150 - Design-cooking-recipe-card-tool-result-UI.md
@@ -1,16 +1,16 @@
 ---
 id: TASK-12150
 title: Design cooking recipe card tool-result UI
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-05 14:49'
 labels:
-- design
-- mcp
-- frontend
-priority: Medium
-modified_files:
-- Docs/superpowers/specs/2026-07-05-cooking-recipe-card-tool-result-ui-design.md
-- Docs/superpowers/plans/2026-07-05-cooking-recipe-card-tool-result-ui.md
-- backlog/tasks/task-12150 - Design-cooking-recipe-card-tool-result-UI.md
+  - design
+  - mcp
+  - frontend
+dependencies: []
+priority: medium
 ---
 
 ## Description
@@ -31,22 +31,40 @@ Implementation plan written at Docs/superpowers/plans/2026-07-05-cooking-recipe-
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+<!-- SECTION:NOTES:BEGIN -->
+Implemented on branch codex/cooking-recipe-card-tool-ui.
 
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Files changed:
+- Backend MCP tool: tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py
+- MCP registration/surface: tldw_Server_API/Config_Files/mcp_modules.yaml; tldw_Server_API/app/core/MCP_unified/module_surface.py
+- Backend tests: tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py; tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+- Frontend parser/types: apps/packages/ui/src/types/recipe-card.ts; apps/packages/ui/src/utils/recipe-card-ui.ts; apps/packages/ui/src/utils/__tests__/recipe-card-ui.test.ts
+- Shared component: apps/packages/ui/src/components/Common/RecipeCard/RecipeCard.tsx; apps/packages/ui/src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx
+- Tool rendering/replay guard: apps/packages/ui/src/components/Sidepanel/Chat/ToolCallBlock.tsx; apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx; apps/packages/ui/src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts
+
+Key decisions kept from the approved spec: domain-specific read-only MCP tool only; no OpenUI changes; no frontend prose detection; no persistent recipe database; no timers/notifications beyond inline cooking-mode display.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Design spec and implementation plan are written and locally reviewed. Independent spec review could not complete after three timed-out subagent attempts; plan subagent review was not retried because the review path had already failed repeatedly and the user instructed continuation. Local checks passed: plan and spec have no TODO/TBD/FIXME markers, and both are ASCII-only. Awaiting execution choice.
+Implemented a read-only cooking.recipe_card.render MCP tool that validates recipe data and returns a namespaced tldw_ui recipe_card payload. Registered it in the default MCP module config and classified it as read-only in module surface reporting. Added a shared frontend parser and RecipeCard component, then integrated rendering into ToolCallBlock for cooking tool results only, with generic fallback for errors, malformed JSON, unsupported payloads, and unknown tools. Added replay guards for WebUI, extension sidepanel, compare clusters, and Message-to-ToolCallBlock handoff.
+
+Verification recorded:
+- Backend targeted pytest: 17 passed.
+- Frontend targeted Vitest suite: 24 passed.
+- Bandit on cooking_module.py: zero findings, output /tmp/bandit_cooking_recipe_card.json.
+- Typecheck attempted after temporarily repairing local antd symlink; our recipe parser TS issue was fixed, remaining failures are existing unrelated errors in AudioStudio, ScheduledTasks, Skills, service clients, and e2e fixtures.
+
+Visual browser QA was not run; coverage is via focused component/integration tests and replay source guards.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12150 - Design-cooking-recipe-card-tool-result-UI.md
+++ b/backlog/tasks/task-12150 - Design-cooking-recipe-card-tool-result-UI.md
@@ -1,0 +1,52 @@
+---
+id: TASK-12150
+title: Design cooking recipe card tool-result UI
+status: In Progress
+labels:
+- design
+- mcp
+- frontend
+priority: Medium
+modified_files:
+- Docs/superpowers/specs/2026-07-05-cooking-recipe-card-tool-result-ui-design.md
+- Docs/superpowers/plans/2026-07-05-cooking-recipe-card-tool-result-ui.md
+- backlog/tasks/task-12150 - Design-cooking-recipe-card-tool-result-UI.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write and review a design spec for a read-only MCP tool that emits a typed recipe card UI payload and a shared frontend renderer for WebUI/browser extension chat tool results.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implementation plan written at Docs/superpowers/plans/2026-07-05-cooking-recipe-card-tool-result-ui.md. Plan slices: backend CookingModule contract tests and implementation; mcp_modules.yaml registration and config tests; frontend recipe-card payload parser; shared RecipeCard component; ToolCallBlock integration; tool-result replay guard; targeted pytest/Vitest/Bandit/typecheck/visual verification. Design spec remains at Docs/superpowers/specs/2026-07-05-cooking-recipe-card-tool-result-ui-design.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Design spec and implementation plan are written and locally reviewed. Independent spec review could not complete after three timed-out subagent attempts; plan subagent review was not retried because the review path had already failed repeatedly and the user instructed continuation. Local checks passed: plan and spec have no TODO/TBD/FIXME markers, and both are ASCII-only. Awaiting execution choice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/mcp_modules.yaml
+++ b/tldw_Server_API/Config_Files/mcp_modules.yaml
@@ -98,6 +98,16 @@ modules:
         #     key: search_knowledge
         #     title: Search Knowledge
 
+  - id: cooking
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.cooking_module:CookingModule
+    enabled: true
+    name: Cooking
+    version: "1.0.0"
+    department: utility
+    max_concurrent: 20
+    description: Read-only cooking recipe card UI payload tools
+    settings: {}
+
   - id: persona_visuals
     class: tldw_Server_API.app.core.MCP_unified.modules.implementations.persona_visuals_module:PersonaVisualsModule
     enabled: false

--- a/tldw_Server_API/app/core/MCP_unified/module_surface.py
+++ b/tldw_Server_API/app/core/MCP_unified/module_surface.py
@@ -9,6 +9,7 @@ MODULE_RISK_TIERS: dict[str, tuple[str, str]] = {
     "media": ("read_only", "Search and retrieve existing media records."),
     "knowledge": ("read_only", "Search and retrieve knowledge records."),
     "rag": ("read_only", "Run grounded retrieval and answer generation over configured knowledge sources."),
+    "cooking": ("read_only", "Render validated cooking recipe card payloads."),
     "chats": ("read_only", "Read chat/session context."),
     "prompts": ("read_only", "Read prompt library entries."),
     "prompts_catalog": ("read_only", "Expose configured prompt catalogs."),

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
 from typing import Any
 
 from ..base import BaseModule, create_tool_definition
@@ -15,15 +16,19 @@ class CookingModule(BaseModule):
     """Read-only cooking helpers for typed UI payloads."""
 
     async def on_initialize(self) -> None:
+        """Initialize the stateless cooking module."""
         return None
 
     async def on_shutdown(self) -> None:
+        """Shut down the stateless cooking module."""
         return None
 
     async def check_health(self) -> dict[str, bool]:
+        """Report health for the stateless cooking module."""
         return {"initialized": True, "dependencies_ok": True}
 
     async def get_tools(self) -> list[dict[str, Any]]:
+        """Return the recipe card render tool contract."""
         return [
             create_tool_definition(
                 name=TOOL_NAME,
@@ -48,7 +53,11 @@ class CookingModule(BaseModule):
                                 "properties": {
                                     "display": {"type": "string", "minLength": 1, "maxLength": 180},
                                     "name": {"type": "string", "maxLength": 120},
-                                    "quantity": {"type": "number"},
+                                    "quantity": {
+                                        "type": "number",
+                                        "exclusiveMinimum": 0,
+                                        "maximum": 100000,
+                                    },
                                     "unit": {"type": "string", "maxLength": 32},
                                     "note": {"type": ["string", "null"], "maxLength": 160},
                                     "scalable": {"type": "boolean"},
@@ -75,7 +84,7 @@ class CookingModule(BaseModule):
                         },
                         "summary": {"type": ["string", "null"], "maxLength": 300},
                         "notes": {
-                            "type": "array",
+                            "type": ["array", "null"],
                             "maxItems": 8,
                             "items": {"type": "string", "maxLength": 300},
                         },
@@ -92,12 +101,13 @@ class CookingModule(BaseModule):
         arguments: dict[str, Any],
         context: Any | None = None,
     ) -> Any:
+        """Execute a cooking tool and return a typed UI payload or structured error."""
         del context
         if tool_name != TOOL_NAME:
             return _error("unknown_tool", f"Unknown tool: {tool_name}")
 
         try:
-            recipe = _normalize_recipe(self.sanitize_input(arguments))
+            recipe = _normalize_recipe(arguments)
         except ValueError as exc:
             return _error("invalid_arguments", str(exc))
 
@@ -105,10 +115,12 @@ class CookingModule(BaseModule):
 
 
 def _error(reason_code: str, message: str) -> dict[str, Any]:
+    """Build a structured tool error response."""
     return {"ok": False, "reason_code": reason_code, "error": message}
 
 
 def _normalize_recipe(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Validate and normalize recipe arguments into the UI payload shape."""
     if not isinstance(arguments, dict):
         raise ValueError("arguments must be an object")
 
@@ -119,7 +131,8 @@ def _normalize_recipe(arguments: dict[str, Any]) -> dict[str, Any]:
     summary = arguments.get("summary")
     if summary is not None:
         summary = _string(summary, "summary", max_len=300)
-    notes = _items(arguments.get("notes", []), "notes", 0, 8, _note)
+    notes_value = arguments.get("notes")
+    notes = _items(notes_value, "notes", 0, 8, _note) if notes_value is not None else []
 
     return {
         "title": title,
@@ -132,6 +145,7 @@ def _normalize_recipe(arguments: dict[str, Any]) -> dict[str, Any]:
 
 
 def _servings(value: Any) -> dict[str, Any]:
+    """Normalize servings metadata and default the human label."""
     if not isinstance(value, dict):
         raise ValueError("servings must be an object")
     serving_value = _number(value.get("value"), "servings.value", min_value=1, max_value=50)
@@ -144,11 +158,14 @@ def _servings(value: Any) -> dict[str, Any]:
 
 
 def _ingredient(value: Any) -> dict[str, Any]:
+    """Normalize one ingredient row."""
     if not isinstance(value, dict):
         raise ValueError("ingredient must be an object")
     quantity = value.get("quantity")
     if quantity is not None:
-        quantity = _number(quantity, "ingredient.quantity")
+        quantity = _number(quantity, "ingredient.quantity", max_value=100000)
+        if quantity <= 0:
+            raise ValueError("ingredient.quantity must be greater than 0")
     scalable = value.get("scalable", False)
     if not isinstance(scalable, bool):
         raise ValueError("ingredient.scalable must be a boolean")
@@ -163,6 +180,7 @@ def _ingredient(value: Any) -> dict[str, Any]:
 
 
 def _step(value: Any) -> dict[str, Any]:
+    """Normalize one cooking step."""
     if not isinstance(value, dict):
         raise ValueError("step must be an object")
     timer_seconds = value.get("timer_seconds")
@@ -178,10 +196,18 @@ def _step(value: Any) -> dict[str, Any]:
 
 
 def _note(value: Any) -> str:
+    """Normalize one recipe note."""
     return _string(value, "note", max_len=300)
 
 
-def _items(value: Any, field: str, min_len: int, max_len: int, normalize) -> list[Any]:
+def _items(
+    value: Any,
+    field: str,
+    min_len: int,
+    max_len: int,
+    normalize: Callable[[Any], Any],
+) -> list[Any]:
+    """Normalize a bounded list field."""
     if not isinstance(value, list):
         raise ValueError(f"{field} must be an array")
     if not min_len <= len(value) <= max_len:
@@ -190,12 +216,14 @@ def _items(value: Any, field: str, min_len: int, max_len: int, normalize) -> lis
 
 
 def _optional_string(value: Any, field: str, max_len: int) -> str | None:
+    """Normalize an optional string field."""
     if value is None:
         return None
     return _string(value, field, max_len=max_len)
 
 
 def _string(value: Any, field: str, *, min_len: int = 0, max_len: int) -> str:
+    """Validate and trim a bounded string."""
     if not isinstance(value, str):
         raise ValueError(f"{field} must be a string")
     text = value.strip()
@@ -211,6 +239,7 @@ def _number(
     min_value: float | None = None,
     max_value: float | None = None,
 ) -> int | float:
+    """Validate a finite numeric field with optional inclusive bounds."""
     if not isinstance(value, int | float) or isinstance(value, bool) or not math.isfinite(value):
         raise ValueError(f"{field} must be a finite number")
     if min_value is not None and value < min_value:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py
@@ -1,0 +1,220 @@
+"""Cooking UI payload tools for Unified MCP."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from ..base import BaseModule, create_tool_definition
+
+
+TOOL_NAME = "cooking.recipe_card.render"
+
+
+class CookingModule(BaseModule):
+    """Read-only cooking helpers for typed UI payloads."""
+
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"initialized": True, "dependencies_ok": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return [
+            create_tool_definition(
+                name=TOOL_NAME,
+                description="Render a typed recipe card UI payload.",
+                parameters={
+                    "properties": {
+                        "title": {"type": "string", "minLength": 1, "maxLength": 120},
+                        "servings": {
+                            "type": "object",
+                            "properties": {
+                                "value": {"type": "number", "minimum": 1, "maximum": 50},
+                                "label": {"type": "string", "maxLength": 80},
+                            },
+                            "required": ["value"],
+                        },
+                        "ingredients": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 60,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "display": {"type": "string", "minLength": 1, "maxLength": 180},
+                                    "name": {"type": "string", "maxLength": 120},
+                                    "quantity": {"type": "number"},
+                                    "unit": {"type": "string", "maxLength": 32},
+                                    "note": {"type": ["string", "null"], "maxLength": 160},
+                                    "scalable": {"type": "boolean"},
+                                },
+                                "required": ["display"],
+                            },
+                        },
+                        "steps": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 40,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "display": {"type": "string", "minLength": 1, "maxLength": 600},
+                                    "timer_seconds": {
+                                        "type": ["integer", "null"],
+                                        "minimum": 1,
+                                        "maximum": 86400,
+                                    },
+                                },
+                                "required": ["display"],
+                            },
+                        },
+                        "summary": {"type": ["string", "null"], "maxLength": 300},
+                        "notes": {
+                            "type": "array",
+                            "maxItems": 8,
+                            "items": {"type": "string", "maxLength": 300},
+                        },
+                    },
+                    "required": ["title", "servings", "ingredients", "steps"],
+                },
+                metadata={"readOnlyHint": True, "category": "cooking"},
+            )
+        ]
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> Any:
+        del context
+        if tool_name != TOOL_NAME:
+            return _error("unknown_tool", f"Unknown tool: {tool_name}")
+
+        try:
+            recipe = _normalize_recipe(self.sanitize_input(arguments))
+        except ValueError as exc:
+            return _error("invalid_arguments", str(exc))
+
+        return {"tldw_ui": {"kind": "recipe_card", "version": 1, "recipe": recipe}}
+
+
+def _error(reason_code: str, message: str) -> dict[str, Any]:
+    return {"ok": False, "reason_code": reason_code, "error": message}
+
+
+def _normalize_recipe(arguments: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(arguments, dict):
+        raise ValueError("arguments must be an object")
+
+    title = _string(arguments.get("title"), "title", min_len=1, max_len=120)
+    servings = _servings(arguments.get("servings"))
+    ingredients = _items(arguments.get("ingredients"), "ingredients", 1, 60, _ingredient)
+    steps = _items(arguments.get("steps"), "steps", 1, 40, _step)
+    summary = arguments.get("summary")
+    if summary is not None:
+        summary = _string(summary, "summary", max_len=300)
+    notes = _items(arguments.get("notes", []), "notes", 0, 8, _note)
+
+    return {
+        "title": title,
+        "servings": servings,
+        "ingredients": ingredients,
+        "steps": steps,
+        "summary": summary,
+        "notes": notes,
+    }
+
+
+def _servings(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("servings must be an object")
+    serving_value = _number(value.get("value"), "servings.value", min_value=1, max_value=50)
+    label = value.get("label")
+    if label is None:
+        label = f"{serving_value:g} serving" if serving_value == 1 else f"{serving_value:g} servings"
+    else:
+        label = _string(label, "servings.label", max_len=80)
+    return {"value": serving_value, "label": label}
+
+
+def _ingredient(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("ingredient must be an object")
+    quantity = value.get("quantity")
+    if quantity is not None:
+        quantity = _number(quantity, "ingredient.quantity")
+    scalable = value.get("scalable", False)
+    if not isinstance(scalable, bool):
+        raise ValueError("ingredient.scalable must be a boolean")
+    return {
+        "display": _string(value.get("display"), "ingredient.display", min_len=1, max_len=180),
+        "name": _optional_string(value.get("name"), "ingredient.name", 120),
+        "quantity": quantity,
+        "unit": _optional_string(value.get("unit"), "ingredient.unit", 32),
+        "note": _optional_string(value.get("note"), "ingredient.note", 160),
+        "scalable": scalable,
+    }
+
+
+def _step(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("step must be an object")
+    timer_seconds = value.get("timer_seconds")
+    if timer_seconds is not None:
+        if not isinstance(timer_seconds, int) or isinstance(timer_seconds, bool):
+            raise ValueError("step.timer_seconds must be an integer")
+        if not 1 <= timer_seconds <= 86400:
+            raise ValueError("step.timer_seconds must be between 1 and 86400")
+    return {
+        "display": _string(value.get("display"), "step.display", min_len=1, max_len=600),
+        "timer_seconds": timer_seconds,
+    }
+
+
+def _note(value: Any) -> str:
+    return _string(value, "note", max_len=300)
+
+
+def _items(value: Any, field: str, min_len: int, max_len: int, normalize) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be an array")
+    if not min_len <= len(value) <= max_len:
+        raise ValueError(f"{field} must contain between {min_len} and {max_len} items")
+    return [normalize(item) for item in value]
+
+
+def _optional_string(value: Any, field: str, max_len: int) -> str | None:
+    if value is None:
+        return None
+    return _string(value, field, max_len=max_len)
+
+
+def _string(value: Any, field: str, *, min_len: int = 0, max_len: int) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    text = value.strip()
+    if not min_len <= len(text) <= max_len:
+        raise ValueError(f"{field} must be between {min_len} and {max_len} characters")
+    return text
+
+
+def _number(
+    value: Any,
+    field: str,
+    *,
+    min_value: float | None = None,
+    max_value: float | None = None,
+) -> int | float:
+    if not isinstance(value, int | float) or isinstance(value, bool) or not math.isfinite(value):
+        raise ValueError(f"{field} must be a finite number")
+    if min_value is not None and value < min_value:
+        raise ValueError(f"{field} must be at least {min_value:g}")
+    if max_value is not None and value > max_value:
+        raise ValueError(f"{field} must be at most {max_value:g}")
+    return value

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
@@ -119,6 +119,7 @@ def test_describe_module_surface_groups_enabled_modules_by_risk():
     from tldw_Server_API.app.core.MCP_unified.module_surface import describe_module_surface
 
     modules = {
+        "cooking": {"enabled": True, "status": "healthy"},
         "media": {"enabled": True, "status": "healthy"},
         "filesystem": {"enabled": True, "status": "healthy"},
         "git": {"enabled": True, "status": "healthy"},
@@ -137,7 +138,10 @@ def test_describe_module_surface_groups_enabled_modules_by_risk():
     assert "local_process" in surface["tiers"]
     assert "external_network" in surface["tiers"]
     assert "unknown" not in surface["tiers"]
-    assert [module["id"] for module in surface["tiers"]["read_only"]["modules"]] == ["media"]
+    assert [module["id"] for module in surface["tiers"]["read_only"]["modules"]] == [
+        "cooking",
+        "media",
+    ]
     assert [module["id"] for module in surface["tiers"]["local_files"]["modules"]] == ["filesystem"]
     assert [module["id"] for module in surface["tiers"]["local_process"]["modules"]] == [
         "browser_cdp",
@@ -149,7 +153,7 @@ def test_describe_module_surface_groups_enabled_modules_by_risk():
         "web_research",
         "web_search",
     ]
-    assert surface["enabled_count"] == 8
+    assert surface["enabled_count"] == 9
 
 
 def test_describe_module_surface_reports_disabled_available_high_risk_modules():
@@ -198,6 +202,18 @@ def test_default_mcp_modules_yaml_disables_local_file_and_process_modules():
     assert modules["filesystem"]["enabled"] is False
     assert modules["run_command"]["enabled"] is False
     assert modules["codegraph"]["enabled"] is False
+
+
+def test_default_mcp_modules_yaml_includes_safe_cooking_module():
+    """Checked-in defaults should expose the read-only cooking module."""
+    import yaml
+    from pathlib import Path
+
+    data = yaml.safe_load(Path("tldw_Server_API/Config_Files/mcp_modules.yaml").read_text(encoding="utf-8"))
+    modules = {entry["id"]: entry for entry in data["modules"]}
+
+    assert modules["cooking"]["enabled"] is True  # nosec B101
+    assert modules["cooking"]["class"].endswith("cooking_module:CookingModule")  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py
@@ -1,3 +1,7 @@
+"""Tests for the cooking recipe-card MCP module."""
+
+from typing import Any
+
 import pytest
 
 from tldw_Server_API.app.core.MCP_unified import MCPServer
@@ -10,10 +14,12 @@ pytestmark = pytest.mark.unit
 
 
 def _module() -> CookingModule:
+    """Create a cooking module with minimal config."""
     return CookingModule(ModuleConfig(name="cooking"))
 
 
-def _minimal_recipe() -> dict:
+def _minimal_recipe() -> dict[str, Any]:
+    """Return the smallest valid recipe arguments."""
     return {
         "title": "Toast",
         "servings": {"value": 2},
@@ -24,24 +30,32 @@ def _minimal_recipe() -> dict:
 
 @pytest.mark.asyncio
 async def test_get_tools_exposes_recipe_card_render_contract() -> None:
+    """The cooking tool advertises the bounded recipe-card schema."""
     tools = await _module().get_tools()
 
     assert [tool["name"] for tool in tools] == ["cooking.recipe_card.render"]  # nosec B101
     tool = tools[0]
     assert tool["inputSchema"]["required"] == ["title", "servings", "ingredients", "steps"]  # nosec B101
+    quantity_schema = tool["inputSchema"]["properties"]["ingredients"]["items"]["properties"]["quantity"]
+    assert quantity_schema["exclusiveMinimum"] == 0  # nosec B101
+    assert quantity_schema["maximum"] == 100000  # nosec B101
+    assert tool["inputSchema"]["properties"]["notes"]["type"] == ["array", "null"]  # nosec B101
     assert tool["metadata"]["readOnlyHint"] is True  # nosec B101
     assert tool["metadata"]["category"] == "cooking"  # nosec B101
 
 
 @pytest.mark.asyncio
 async def test_server_registers_cooking_module_from_default_yaml(monkeypatch) -> None:
+    """The default MCP module config registers the cooking module."""
     monkeypatch.delenv("MCP_MODULES_CONFIG", raising=False)
     monkeypatch.delenv("MCP_MODULES", raising=False)
 
-    registrations = {}
+    registrations: dict[str, type[Any]] = {}
     server = MCPServer()
 
-    async def _register_module(module_id, cls, config):
+    async def _register_module(module_id: str, cls: type[Any], config: ModuleConfig) -> None:
+        """Capture default module registrations."""
+        del config
         registrations[module_id] = cls
 
     monkeypatch.setattr(server.module_registry, "register_module", _register_module)
@@ -53,6 +67,7 @@ async def test_server_registers_cooking_module_from_default_yaml(monkeypatch) ->
 
 @pytest.mark.asyncio
 async def test_full_recipe_returns_recipe_card_payload() -> None:
+    """A complete recipe returns a typed tldw_ui recipe-card payload."""
     result = await _module().execute_tool(
         "cooking.recipe_card.render",
         {
@@ -86,6 +101,7 @@ async def test_full_recipe_returns_recipe_card_payload() -> None:
 
 @pytest.mark.asyncio
 async def test_minimal_recipe_normalizes_optional_fields() -> None:
+    """Missing optional fields normalize to stable empty/null values."""
     result = await _module().execute_tool("cooking.recipe_card.render", _minimal_recipe())
 
     recipe = result["tldw_ui"]["recipe"]
@@ -95,21 +111,48 @@ async def test_minimal_recipe_normalizes_optional_fields() -> None:
 
 
 @pytest.mark.asyncio
+async def test_null_notes_normalize_to_empty_list() -> None:
+    """Explicit JSON null notes are accepted as no notes."""
+    arguments = _minimal_recipe()
+    arguments["notes"] = None
+
+    result = await _module().execute_tool("cooking.recipe_card.render", arguments)
+
+    assert result["tldw_ui"]["recipe"]["notes"] == []  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_recipe_text_allows_sql_comment_like_substrings() -> None:
+    """Free-form recipe text may contain characters rejected by SQL sanitizers."""
+    arguments = _minimal_recipe()
+    arguments["title"] = "Toast -- broiler style"
+    arguments["ingredients"] = [{"display": "1 tbsp sauce /* optional */"}]
+
+    result = await _module().execute_tool("cooking.recipe_card.render", arguments)
+
+    assert result["tldw_ui"]["recipe"]["title"] == "Toast -- broiler style"  # nosec B101
+    assert result["tldw_ui"]["recipe"]["ingredients"][0]["display"] == "1 tbsp sauce /* optional */"  # nosec B101
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "override",
     [
         {"title": ""},
         {"title": "   "},
-        {"title": "Toast -- comment"},
         {"servings": {"value": 0}},
         {"ingredients": [{"display": "salt"}] * 61},
         {"ingredients": [{"name": "salt"}]},
+        {"ingredients": [{"display": "salt", "quantity": 0}]},
+        {"ingredients": [{"display": "salt", "quantity": -1}]},
+        {"ingredients": [{"display": "salt", "quantity": 100001}]},
         {"steps": [{"display": "stir"}] * 41},
         {"steps": [{"display": "x" * 601}]},
         {"steps": [{"display": "Wait.", "timer_seconds": 86401}]},
     ],
 )
-async def test_invalid_arguments_return_structured_error(override: dict) -> None:
+async def test_invalid_arguments_return_structured_error(override: dict[str, Any]) -> None:
+    """Invalid recipe arguments return a structured tool error."""
     arguments = _minimal_recipe()
     arguments.update(override)
 
@@ -122,6 +165,7 @@ async def test_invalid_arguments_return_structured_error(override: dict) -> None
 
 @pytest.mark.asyncio
 async def test_unknown_tool_returns_structured_error() -> None:
+    """Unknown cooking tool names return a structured tool error."""
     result = await _module().execute_tool("cooking.nope", {})
 
     assert result["ok"] is False  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py
@@ -1,0 +1,110 @@
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.cooking_module import (
+    CookingModule,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _module() -> CookingModule:
+    return CookingModule(ModuleConfig(name="cooking"))
+
+
+def _minimal_recipe() -> dict:
+    return {
+        "title": "Toast",
+        "servings": {"value": 2},
+        "ingredients": [{"display": "2 slices bread"}],
+        "steps": [{"display": "Toast the bread."}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_tools_exposes_recipe_card_render_contract() -> None:
+    tools = await _module().get_tools()
+
+    assert [tool["name"] for tool in tools] == ["cooking.recipe_card.render"]  # nosec B101
+    tool = tools[0]
+    assert tool["inputSchema"]["required"] == ["title", "servings", "ingredients", "steps"]  # nosec B101
+    assert tool["metadata"]["readOnlyHint"] is True  # nosec B101
+    assert tool["metadata"]["category"] == "cooking"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_full_recipe_returns_recipe_card_payload() -> None:
+    result = await _module().execute_tool(
+        "cooking.recipe_card.render",
+        {
+            "title": "Cajun Alfredo Sauce",
+            "servings": {"value": 2, "label": "2 servings"},
+            "ingredients": [
+                {
+                    "display": "3 tbsp butter",
+                    "name": "butter",
+                    "quantity": 3,
+                    "unit": "tbsp",
+                    "note": None,
+                    "scalable": True,
+                }
+            ],
+            "steps": [
+                {"display": "Melt butter in a pan over medium heat.", "timer_seconds": None}
+            ],
+            "summary": "Rich Cajun-style Alfredo sauce for pasta.",
+            "notes": ["Add pasta water slowly until the sauce loosens."],
+        },
+    )
+
+    recipe = result["tldw_ui"]["recipe"]
+    assert result["tldw_ui"]["kind"] == "recipe_card"  # nosec B101
+    assert result["tldw_ui"]["version"] == 1  # nosec B101
+    assert recipe["title"] == "Cajun Alfredo Sauce"  # nosec B101
+    assert recipe["ingredients"][0]["display"] == "3 tbsp butter"  # nosec B101
+    assert recipe["ingredients"][0]["quantity"] == 3  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_minimal_recipe_normalizes_optional_fields() -> None:
+    result = await _module().execute_tool("cooking.recipe_card.render", _minimal_recipe())
+
+    recipe = result["tldw_ui"]["recipe"]
+    assert recipe["summary"] is None  # nosec B101
+    assert recipe["notes"] == []  # nosec B101
+    assert recipe["servings"]["label"] == "2 servings"  # nosec B101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"title": ""},
+        {"title": "   "},
+        {"title": "Toast -- comment"},
+        {"servings": {"value": 0}},
+        {"ingredients": [{"display": "salt"}] * 61},
+        {"ingredients": [{"name": "salt"}]},
+        {"steps": [{"display": "stir"}] * 41},
+        {"steps": [{"display": "x" * 601}]},
+        {"steps": [{"display": "Wait.", "timer_seconds": 86401}]},
+    ],
+)
+async def test_invalid_arguments_return_structured_error(override: dict) -> None:
+    arguments = _minimal_recipe()
+    arguments.update(override)
+
+    result = await _module().execute_tool("cooking.recipe_card.render", arguments)
+
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "invalid_arguments"  # nosec B101
+    assert result["error"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_returns_structured_error() -> None:
+    result = await _module().execute_tool("cooking.nope", {})
+
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "unknown_tool"  # nosec B101
+    assert result["error"] == "Unknown tool: cooking.nope"  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tldw_Server_API.app.core.MCP_unified import MCPServer
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.cooking_module import (
     CookingModule,
@@ -30,6 +31,24 @@ async def test_get_tools_exposes_recipe_card_render_contract() -> None:
     assert tool["inputSchema"]["required"] == ["title", "servings", "ingredients", "steps"]  # nosec B101
     assert tool["metadata"]["readOnlyHint"] is True  # nosec B101
     assert tool["metadata"]["category"] == "cooking"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_server_registers_cooking_module_from_default_yaml(monkeypatch) -> None:
+    monkeypatch.delenv("MCP_MODULES_CONFIG", raising=False)
+    monkeypatch.delenv("MCP_MODULES", raising=False)
+
+    registrations = {}
+    server = MCPServer()
+
+    async def _register_module(module_id, cls, config):
+        registrations[module_id] = cls
+
+    monkeypatch.setattr(server.module_registry, "register_module", _register_module)
+
+    await server._register_default_modules()
+
+    assert registrations["cooking"].__name__ == "CookingModule"  # nosec B101
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds a read-only `cooking.recipe_card.render` MCP tool that returns a bounded `tldw_ui.recipe_card` payload.
- Registers the cooking module as a safe default and classifies it as read-only in the MCP module surface.
- Adds typed frontend parsing, recipe card rendering, tool-call gating, and replay guards for chat/tool-result surfaces.
- Rebases the branch onto current `dev` and addresses Gemini/Qodo/CodeRabbit review feedback around null optionals, quantity bounds, sanitizer false rejects, docstrings/type hints, parser predicates/error handling, recipe serving resync, and recipe tool-name reuse.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_cooking_module.py tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::test_describe_module_surface_groups_enabled_modules_by_risk tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::test_default_mcp_modules_yaml_disables_local_file_and_process_modules tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py::test_default_mcp_modules_yaml_includes_safe_cooking_module -q` - 21 passed
- `bun run test -- src/utils/__tests__/recipe-card-ui.test.ts src/components/Common/RecipeCard/__tests__/RecipeCard.test.tsx src/components/Sidepanel/Chat/__tests__/ToolCallBlock.recipe-card.test.tsx src/components/Common/Playground/__tests__/tool-results-replay.guard.test.ts` - 26 passed
- `bun run typecheck` from `apps/tldw-frontend` - passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/cooking_module.py -f json -o /tmp/bandit_cooking_recipe_card_rereview.json` - zero findings
- `git diff --check` - passed

## Known gaps
- Browser visual QA was not run.
- GitHub checks are running after the latest rebase/push.

## Merge note
Per repo policy, this AI-authored PR still needs the human requester to add a human-written `Change summary` explaining what changed and why before merge.
