### PR TITLE
Clean up MCP setup backlog bookkeeping

### DIFF
--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { FirstRunState } from "@/types/setup-onboarding";
@@ -902,17 +903,19 @@ describe("UnifiedSetupWizard", () => {
     const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
 
     render(
-      <UnifiedSetupWizard
-        initialState={initialStateForCompletedSteps([
-          "setup_path",
-          "privacy_security",
-          "providers",
-          "ingest_defaults",
-          "audio_defaults",
-          "optional_advanced",
-          "mcp_tools",
-        ])}
-      />,
+      <MemoryRouter>
+        <UnifiedSetupWizard
+          initialState={initialStateForCompletedSteps([
+            "setup_path",
+            "privacy_security",
+            "providers",
+            "ingest_defaults",
+            "audio_defaults",
+            "optional_advanced",
+            "mcp_tools",
+          ])}
+        />
+      </MemoryRouter>,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /back to mcp tools/i }));
@@ -926,42 +929,44 @@ describe("UnifiedSetupWizard", () => {
     const { UnifiedSetupWizard } = await import("../UnifiedSetupWizard");
 
     render(
-      <UnifiedSetupWizard
-        initialState={{
-          status: "in_progress",
-          completed_steps: [
-            "setup_path",
-            "privacy_security",
-            "providers",
-            "ingest_defaults",
-            "audio_defaults",
-            "optional_advanced",
-          ],
-          skipped_steps: [],
-          step_data: {
-            providers: {
-              acknowledged: true,
-              default_provider: "openai",
-              default_model: "gpt-4.1-mini",
-              default_provider_credential_configured: true,
+      <MemoryRouter>
+        <UnifiedSetupWizard
+          initialState={{
+            status: "in_progress",
+            completed_steps: [
+              "setup_path",
+              "privacy_security",
+              "providers",
+              "ingest_defaults",
+              "audio_defaults",
+              "optional_advanced",
+            ],
+            skipped_steps: [],
+            step_data: {
+              providers: {
+                acknowledged: true,
+                default_provider: "openai",
+                default_model: "gpt-4.1-mini",
+                default_provider_credential_configured: true,
+              },
+              mcp_tools: {
+                acknowledged: true,
+                validation_state: "not_run",
+                profile_id: 7,
+                assignment_id: 9,
+                selected_pack_ids: ["writing"],
+                selected_addon_ids: ["workspace_write"],
+                confirmed_addon_ids: ["workspace_write"],
+                effective_tool_count: 1,
+                effective_tools: ["notes.create"],
+                disabled_addons: [],
+              },
             },
-            mcp_tools: {
-              acknowledged: true,
-              validation_state: "not_run",
-              profile_id: 7,
-              assignment_id: 9,
-              selected_pack_ids: ["writing"],
-              selected_addon_ids: ["workspace_write"],
-              confirmed_addon_ids: ["workspace_write"],
-              effective_tool_count: 1,
-              effective_tools: ["notes.create"],
-              disabled_addons: [],
-            },
-          },
-          acknowledged_steps: [],
-          first_chat: { completed: false },
-        }}
-      />,
+            acknowledged_steps: [],
+            first_chat: { completed: false },
+          }}
+        />
+      </MemoryRouter>,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /back to mcp tools/i }));

--- a/backlog/tasks/task-12147 - Harden-audio-briefing-generation-before-Research-Workspace-reuse.md
+++ b/backlog/tasks/task-12147 - Harden-audio-briefing-generation-before-Research-Workspace-reuse.md
@@ -10,7 +10,7 @@ modified_files:
 - tldw_Server_API/tests/Workflows/adapters/test_audio_adapters.py
 - tldw_Server_API/tests/Watchlists/test_audio_briefing_workflow.py
 references:
-- TASK-12148
+- TASK-12166
 ---
 
 ## Description

--- a/backlog/tasks/task-12148 - Implement-first-run-MCP-tool-packs-setup.md
+++ b/backlog/tasks/task-12148 - Implement-first-run-MCP-tool-packs-setup.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12148
 title: Implement first-run MCP tool packs setup
-status: In Progress
+status: Done
 assignee: []
 created_date: 2026-07-04 23:41
 updated_date: 2026-07-05 02:54

--- a/backlog/tasks/task-12163 - Fix-UnifiedSetupWizard-MCP-tools-test-router-harness.md
+++ b/backlog/tasks/task-12163 - Fix-UnifiedSetupWizard-MCP-tools-test-router-harness.md
@@ -1,0 +1,48 @@
+---
+id: TASK-12163
+title: Fix UnifiedSetupWizard MCP tools test router harness
+status: Done
+labels:
+- tests
+- mcp
+- first-run
+- webui
+modified_files:
+- apps/packages/ui/src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx
+- backlog/tasks/task-12163 - Fix-UnifiedSetupWizard-MCP-tools-test-router-harness.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Close the validation failure found during the first-run MCP setup follow-up pass. The UnifiedSetupWizard tests render the MCP tools step without a React Router context, while McpToolsStep legitimately uses Link for MCP Hub handoff actions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The focused UnifiedSetupWizard MCP tools regressions pass with the same React Router context the app provides.
+- [x] #2 The broader first-run MCP onboarding and MCP Hub focused frontend validation suite passes.
+- [x] #3 Only test/backlog metadata changes are made unless product code is required by evidence.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+RED: the focused first-run MCP frontend validation suite failed with 2 UnifiedSetupWizard tests because McpToolsStep rendered React Router Link without a router context after navigating back from first chat. GREEN: wrapping those two wizard renders in MemoryRouter made the focused UnifiedSetupWizard file pass with 31 tests, then the broader first-run MCP onboarding/MCP Hub suite passed with 88 tests. Backend first-run MCP validation also passed with 72 selected tests before the frontend harness fix. Bandit not applicable because this slice touched only frontend test code and Backlog metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the validation harness issue found during the first-run MCP follow-up pass. The affected UnifiedSetupWizard tests now provide the same React Router context that the app provides when they render the MCP tools step after returning from first chat. Verification: backend focused first-run MCP pytest passed with 72 selected tests; UnifiedSetupWizard Vitest passed with 31 tests; broader first-run MCP onboarding and MCP Hub focused Vitest passed with 88 tests. Bandit skipped because no Python/runtime code changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12164 - Fix-active-Backlog-duplicate-task-ids-found-during-MCP-cleanup.md
+++ b/backlog/tasks/task-12164 - Fix-active-Backlog-duplicate-task-ids-found-during-MCP-cleanup.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12164
+title: Fix active Backlog duplicate task ids found during MCP cleanup
+status: Done
+labels:
+- backlog
+- cleanup
+- mcp
+modified_files:
+- backlog/tasks/task-12147 - Harden-audio-briefing-generation-before-Research-Workspace-reuse.md
+- backlog/tasks/task-12164 - Fix-active-Backlog-duplicate-task-ids-found-during-MCP-cleanup.md
+- backlog/tasks/task-12165 - Narrow-SQLite-memory-URI-filesystem-assertion.md
+- backlog/tasks/task-12166 - Apply-shared-validation-gate-across-Research-Workspace-generated-artifact-pipelines.md
+- backlog/tasks/task-12167 - Fix-PostgreSQL-setup-self-verify-timestamp-timezone-mismatch.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the active Backlog task-id collisions discovered while closing the first-run MCP setup stream. Preserve the canonical MCP first-run TASK-12148 record and renumber the unrelated duplicate records so id-based Backlog MCP/CLI lookups stop resolving the wrong task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The active TASK-12148 collision is resolved without changing the MCP first-run task id.
+- [x] #2 The active TASK-12160 collision is resolved without breaking direct Research Workspace WP2 documentation references.
+- [x] #3 Focused duplicate-id checks for TASK-12148 and TASK-12160 return one active file each after the fix.
+- [x] #4 The diff is limited to Backlog/Docs metadata and no runtime code changes are made.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Renumbered the unrelated active duplicate records while preserving ids with known downstream references. Kept TASK-12148 on the MCP first-run tool packs task and TASK-12160 on Research Workspace NotebookLM media outputs WP2. Moved SQLite memory URI assertion to TASK-12165, shared Research Workspace generated-artifact validation to TASK-12166, and PostgreSQL setup self-verify timestamp fix to TASK-12167. Updated TASK-12147's direct reference from TASK-12148 to TASK-12166. Verification: focused id scan returned one active file each for TASK-12148, TASK-12160, TASK-12165, TASK-12166, and TASK-12167; Backlog MCP task_view resolves TASK-12148 to the MCP first-run task and TASK-12160 to WP2; stale old-filename search returned no matches; git diff --check passed. Bandit not applicable because this changed only Backlog metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved the active Backlog id collisions found during MCP cleanup. The canonical MCP first-run setup task remains TASK-12148, Research Workspace WP2 remains TASK-12160, and the unrelated duplicate records were renumbered to TASK-12165 through TASK-12167 with the direct Research Workspace dependency reference updated. Verification confirmed the focused ids resolve uniquely and Backlog MCP lookup now returns the intended TASK-12148/TASK-12160 records. No runtime code changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12165 - Narrow-SQLite-memory-URI-filesystem-assertion.md
+++ b/backlog/tasks/task-12165 - Narrow-SQLite-memory-URI-filesystem-assertion.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-12148
+id: TASK-12165
 title: Narrow SQLite memory URI filesystem assertion
 status: Done
 assignee: []

--- a/backlog/tasks/task-12166 - Apply-shared-validation-gate-across-Research-Workspace-generated-artifact-pipelines.md
+++ b/backlog/tasks/task-12166 - Apply-shared-validation-gate-across-Research-Workspace-generated-artifact-pipelines.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-12148
+id: TASK-12166
 title: >-
   Apply shared validation gate across Research Workspace generated artifact
   pipelines

--- a/backlog/tasks/task-12167 - Fix-PostgreSQL-setup-self-verify-timestamp-timezone-mismatch.md
+++ b/backlog/tasks/task-12167 - Fix-PostgreSQL-setup-self-verify-timestamp-timezone-mismatch.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-12160
+id: TASK-12167
 title: Fix PostgreSQL setup self-verify timestamp timezone mismatch
 status: Done
 labels:

--- a/backlog/tasks/task-223.2 - PR-2-MCP-Hub-setup-polish-and-diagnostics.md
+++ b/backlog/tasks/task-223.2 - PR-2-MCP-Hub-setup-polish-and-diagnostics.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-223.2
 title: 'PR 2: MCP Hub setup polish and diagnostics'
-status: In Progress
+status: Done
 assignee: []
 created_date: 2026-05-10 06:13
 labels:


### PR DESCRIPTION
## Summary
- Mark completed MCP first-run/setup Backlog tasks as Done.
- Add router context to the UnifiedSetupWizard first-run MCP tests so the MCP Hub handoff Link renders under test.
- Renumber the active duplicate Backlog records that collided with TASK-12148/TASK-12160 while preserving the canonical MCP and WP2 ids.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Setup/test_first_run_mcp_tools_catalog.py tldw_Server_API/tests/Setup/test_first_run_mcp_tools_service.py tldw_Server_API/tests/integration/test_unified_first_run_setup_api.py -k mcp_tools -q
- bunx vitest run src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx --reporter=dot
- bunx vitest run src/services/tldw/__tests__/setup-onboarding.test.ts src/components/Option/Onboarding/__tests__/McpToolsStep.test.tsx src/components/Option/Onboarding/__tests__/UnifiedSetupWizard.test.tsx src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx src/components/Option/MCPHub/__tests__/McpHubPage.first-run-status.test.tsx src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx --reporter=dot
- git diff --check origin/dev..HEAD

Change summary: This PR closes stale task metadata after the MCP first-run work merged, fixes the smallest test-harness gap exposed by the follow-up validation pass, and removes the specific duplicate Backlog ids that broke id-based task lookup for the MCP cleanup stream. The duplicate-id repair intentionally preserves ids that already have live downstream references and renumbers only the unrelated duplicate task records.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up MCP first-run backlog bookkeeping and fixes the UnifiedSetupWizard MCP tests by providing a router context. This restores test stability and resolves duplicate Backlog task IDs while preserving canonical references.

- **Bug Fixes**
  - Wrapped `UnifiedSetupWizard` test renders in `MemoryRouter` so the MCP Hub handoff Link renders under test.

- **Refactors**
  - Resolved Backlog task-id collisions: preserved TASK-12148/TASK-12160, renumbered duplicates to TASK-12165–TASK-12167, and updated references.
  - Marked completed tasks as Done (e.g., TASK-12148, TASK-223.2) and added TASK-12163/TASK-12164 to record the fixes.

<sup>Written for commit 83d2fc812dd39684ac7fb8a6e7afd28f44c644ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

