### PR TITLE
Auto publish MCP Unified version bumps

### DIFF
--- a/.github/workflows/mcp-unified-publish.yml
+++ b/.github/workflows/mcp-unified-publish.yml
@@ -1,6 +1,13 @@
 name: MCP Unified Publish Readiness
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - apps/mcp-unified/pyproject.toml
+      - apps/mcp-unified/src/mcp_unified/__init__.py
+      - .github/workflows/mcp-unified-publish.yml
   workflow_dispatch:
     inputs:
       target:
@@ -26,8 +33,156 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  detect-version-change:
+    name: Detect MCP Unified version publish candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      version_changed: ${{ steps.detect.outputs.version_changed }}
+      old_version: ${{ steps.detect.outputs.old_version }}
+      new_version: ${{ steps.detect.outputs.new_version }}
+      publish_candidate: ${{ steps.detect.outputs.publish_candidate }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect package version change
+        id: detect
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import ast
+          import os
+          import subprocess
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+          import tomllib
+
+          PYPROJECT = Path("apps/mcp-unified/pyproject.toml")
+          INIT_FILE = Path("apps/mcp-unified/src/mcp_unified/__init__.py")
+          PACKAGE_NAME = "mcp-unified"
+
+
+          def load_pyproject_version(text: str) -> str:
+              data = tomllib.loads(text)
+              version = data.get("project", {}).get("version")
+              if not isinstance(version, str) or not version:
+                  raise SystemExit("apps/mcp-unified/pyproject.toml is missing project.version")
+              return version
+
+
+          def load_init_version(path: Path) -> str:
+              tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+              for node in tree.body:
+                  if not isinstance(node, ast.Assign):
+                      continue
+                  for target in node.targets:
+                      if (
+                          isinstance(target, ast.Name)
+                          and target.id == "__version__"
+                          and isinstance(node.value, ast.Constant)
+                          and isinstance(node.value.value, str)
+                      ):
+                          return node.value.value
+              raise SystemExit(f"{path} is missing a string __version__ assignment")
+
+
+          def load_previous_version(before: str) -> str:
+              if not before or set(before) == {"0"}:
+                  return ""
+              try:
+                  text = subprocess.check_output(
+                      ["git", "show", f"{before}:{PYPROJECT.as_posix()}"],
+                      text=True,
+                  )
+              except subprocess.CalledProcessError:
+                  return ""
+              return load_pyproject_version(text)
+
+
+          def ensure_version_not_on_pypi(version: str) -> None:
+              url = f"https://pypi.org/pypi/{PACKAGE_NAME}/{version}/json"
+              request = urllib.request.Request(
+                  url,
+                  headers={"User-Agent": "tldw-server-mcp-unified-publish/1.0"},
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=15) as response:
+                      if response.status == 200:
+                          raise SystemExit(
+                              f"{PACKAGE_NAME} {version} already exists on PyPI; "
+                              "bump apps/mcp-unified/pyproject.toml before publishing"
+                          )
+                      raise SystemExit(
+                          f"unexpected PyPI response while checking {PACKAGE_NAME} {version}: "
+                          f"HTTP {response.status}"
+                      )
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 404:
+                      return
+                  raise SystemExit(
+                      f"could not verify PyPI version availability for {PACKAGE_NAME} {version}: "
+                      f"HTTP {exc.code}"
+                  ) from exc
+              except urllib.error.URLError as exc:
+                  raise SystemExit(
+                      f"could not verify PyPI version availability for {PACKAGE_NAME} {version}: "
+                      f"{exc.reason}"
+                  ) from exc
+
+
+          event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+          current_version = load_pyproject_version(PYPROJECT.read_text(encoding="utf-8"))
+          init_version = load_init_version(INIT_FILE)
+          if init_version != current_version:
+              raise SystemExit(
+                  f"{INIT_FILE} __version__={init_version!r} does not match "
+                  f"{PYPROJECT} project.version={current_version!r}"
+              )
+
+          old_version = ""
+          version_changed = False
+          publish_candidate = False
+          if event_name == "push":
+              old_version = load_previous_version(os.environ.get("GITHUB_EVENT_BEFORE", ""))
+              version_changed = current_version != old_version
+              publish_candidate = version_changed
+              if publish_candidate:
+                  ensure_version_not_on_pypi(current_version)
+
+          outputs = {
+              "old_version": old_version,
+              "new_version": current_version,
+              "version_changed": str(version_changed).lower(),
+              "publish_candidate": str(publish_candidate).lower(),
+          }
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              for key, value in outputs.items():
+                  output.write(f"{key}={value}\n")
+
+          print(
+              "MCP Unified publish detector:",
+              f"event={event_name}",
+              f"old_version={old_version or '<none>'}",
+              f"new_version={current_version}",
+              f"publish_candidate={publish_candidate}",
+          )
+          PY
+
   publish-plan:
     name: Build RC and publish dry-run plan
+    needs: detect-version-change
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-version-change.outputs.publish_candidate == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -99,8 +254,10 @@ jobs:
 
   publish-pypi:
     name: Upload MCP Unified to PyPI
-    needs: publish-plan
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH' }}
+    needs:
+      - detect-version-change
+      - publish-plan
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH') || (github.event_name == 'push' && needs.detect-version-change.outputs.publish_candidate == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -115,6 +272,53 @@ jobs:
         with:
           name: mcp-unified-publish-plan
           path: .artifacts/mcp-unified-rc
+
+      - name: Guard against duplicate PyPI version
+        env:
+          MCP_UNIFIED_PACKAGE_VERSION: ${{ needs.detect-version-change.outputs.new_version }}
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          import sys
+          import urllib.error
+          import urllib.request
+
+          package_name = "mcp-unified"
+          version = os.environ.get("MCP_UNIFIED_PACKAGE_VERSION", "").strip()
+          if not version:
+              raise SystemExit("MCP_UNIFIED_PACKAGE_VERSION is required before PyPI upload")
+
+          url = f"https://pypi.org/pypi/{package_name}/{version}/json"
+          request = urllib.request.Request(
+              url,
+              headers={"User-Agent": "tldw-server-mcp-unified-publish/1.0"},
+          )
+          try:
+              with urllib.request.urlopen(request, timeout=15) as response:
+                  if response.status == 200:
+                      raise SystemExit(
+                          f"{package_name} {version} already exists on PyPI; refusing duplicate upload"
+                      )
+                  raise SystemExit(
+                      f"unexpected PyPI response while checking {package_name} {version}: "
+                      f"HTTP {response.status}"
+                  )
+          except urllib.error.HTTPError as exc:
+              if exc.code == 404:
+                  print(f"{package_name} {version} is not present on PyPI; continuing")
+                  sys.exit(0)
+              raise SystemExit(
+                  f"could not verify PyPI version availability for {package_name} {version}: "
+                  f"HTTP {exc.code}"
+              ) from exc
+          except urllib.error.URLError as exc:
+              raise SystemExit(
+                  f"could not verify PyPI version availability for {package_name} {version}: "
+                  f"{exc.reason}"
+              ) from exc
+          PY
 
       - name: Publish MCP Unified to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
+++ b/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
@@ -121,7 +121,7 @@ Record that the release PR now includes guarded main-version auto-publish behavi
 - `apps/mcp-unified/README.md`
 - `apps/mcp-unified/src/mcp_unified/README.md`
 - `backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md`
-- `docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md`
+- Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
 
 - [ ] **Step 1: Run package validation**
 

--- a/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
+++ b/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
@@ -1,0 +1,153 @@
+# MCP Unified Main Version Auto Publish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish `mcp-unified` to PyPI automatically when a merged `main` commit changes the standalone package version.
+
+**Architecture:** Extend the existing MCP Unified publish workflow instead of adding a second workflow. A version-detection job compares the previous and current `apps/mcp-unified/pyproject.toml` versions, verifies `mcp_unified.__version__` is in sync, checks that the target version is not already on PyPI, then lets the existing RC and trusted-publishing path run for valid `main` version bumps.
+
+**Tech Stack:** GitHub Actions, Python 3.12, `tomllib`, stdlib `urllib`, existing `make mcp-unified-rc` and `make mcp-unified-publish-dry-run` targets, PyPI trusted publishing.
+
+---
+
+### Task 1: Add guarded main-push release detection
+
+**Files:**
+- Modify: `.github/workflows/mcp-unified-publish.yml`
+
+- [ ] **Step 1: Add push trigger**
+
+Add a `push` trigger for `main` scoped to release-relevant files:
+
+```yaml
+  push:
+    branches:
+      - main
+    paths:
+      - apps/mcp-unified/pyproject.toml
+      - apps/mcp-unified/src/mcp_unified/__init__.py
+      - .github/workflows/mcp-unified-publish.yml
+```
+
+- [ ] **Step 2: Add `detect-version-change` job**
+
+Create a job that checks out with `fetch-depth: 0`, reads the current package version, reads the prior version from `${{ github.event.before }}` for push events, and writes outputs:
+
+```text
+version_changed=true|false
+old_version=<old or empty>
+new_version=<current>
+publish_candidate=true|false
+```
+
+The job must:
+- skip publishing for manual dispatch unless manual inputs request it
+- fail if `apps/mcp-unified/src/mcp_unified/__init__.py` does not contain the same `__version__`
+- fail early if the current version already exists on PyPI
+- treat deleted/missing previous files as `version_changed=true` only for push events
+
+- [ ] **Step 3: Run YAML/lint sanity checks**
+
+Run:
+
+```bash
+python - <<'PY'
+import yaml
+from pathlib import Path
+yaml.safe_load(Path('.github/workflows/mcp-unified-publish.yml').read_text())
+PY
+```
+
+Expected: command exits successfully.
+
+### Task 2: Wire existing RC and PyPI publish jobs to the detector
+
+**Files:**
+- Modify: `.github/workflows/mcp-unified-publish.yml`
+
+- [ ] **Step 1: Gate `publish-plan`**
+
+Make `publish-plan` depend on `detect-version-change` and run when either:
+- the workflow is manually dispatched, or
+- a `main` push produced `publish_candidate=true`
+
+- [ ] **Step 2: Gate `publish-pypi`**
+
+Keep the existing manual PyPI condition and add the automatic condition:
+
+```text
+push to main AND publish_candidate=true
+```
+
+Keep `environment: pypi` and `id-token: write`.
+
+- [ ] **Step 3: Add final duplicate guard before upload**
+
+Before `pypa/gh-action-pypi-publish`, add a Python stdlib check against:
+
+```text
+https://pypi.org/pypi/mcp-unified/<version>/json
+```
+
+Expected:
+- `404` means safe to publish
+- `200` fails with a clear duplicate-version message
+- other/network errors fail closed
+
+### Task 3: Update release docs and task notes
+
+**Files:**
+- Modify: `apps/mcp-unified/README.md`
+- Modify: `apps/mcp-unified/src/mcp_unified/README.md`
+- Modify: `backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md`
+
+- [ ] **Step 1: Update README release text**
+
+Replace the manual-only PyPI language with:
+
+```text
+Merging a package version bump to main triggers the guarded PyPI publishing workflow.
+Manual TestPyPI and PyPI workflow dispatch remain available for release rehearsals and operator-driven publishes.
+```
+
+- [ ] **Step 2: Update Backlog task notes**
+
+Record that the release PR now includes guarded main-version auto-publish behavior.
+
+### Task 4: Verify and commit
+
+**Files:**
+- `.github/workflows/mcp-unified-publish.yml`
+- `apps/mcp-unified/README.md`
+- `apps/mcp-unified/src/mcp_unified/README.md`
+- `backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md`
+- `docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md`
+
+- [ ] **Step 1: Run package validation**
+
+Run:
+
+```bash
+make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run
+```
+
+Expected: `RC status: ok`.
+
+- [ ] **Step 2: Run targeted workflow syntax validation**
+
+Run the YAML parse check from Task 1.
+
+Expected: command exits successfully.
+
+- [ ] **Step 3: Run Bandit on touched Python if any**
+
+If only YAML/Markdown changes are made, record Bandit as skipped because no Python source changed.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add .github/workflows/mcp-unified-publish.yml apps/mcp-unified/README.md apps/mcp-unified/src/mcp_unified/README.md "backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md" docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
+git commit -m "Auto publish MCP Unified version bumps"
+```

--- a/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
+++ b/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
@@ -148,6 +148,6 @@ If only YAML/Markdown changes are made, record Bandit as skipped because no Pyth
 Run:
 
 ```bash
-git add .github/workflows/mcp-unified-publish.yml apps/mcp-unified/README.md apps/mcp-unified/src/mcp_unified/README.md "backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md" docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
+git add .github/workflows/mcp-unified-publish.yml apps/mcp-unified/README.md apps/mcp-unified/src/mcp_unified/README.md "backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md" Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
 git commit -m "Auto publish MCP Unified version bumps"
 ```

--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -74,10 +74,14 @@ Build artifacts and generate the TestPyPI upload plan without uploading:
 make mcp-unified-publish-dry-run
 ```
 
-Live TestPyPI or PyPI upload is not part of normal PR CI. It requires the manual
-workflow, an explicit confirmation input, and the RC helper's publish opt-in
-guard. Production PyPI uploads use the repository's configured trusted
-publishing environment rather than a long-lived PyPI token.
+Merging a package version bump to `main` triggers the guarded PyPI publishing
+workflow. The workflow runs the RC gate, verifies the version is not already on
+PyPI, and then uses the repository's configured trusted publishing environment
+rather than a long-lived PyPI token.
+
+Manual TestPyPI and PyPI workflow dispatch remain available for release
+rehearsals and operator-driven publishes. Manual live uploads require an
+explicit confirmation input and the RC helper's publish opt-in guard.
 
 ## Install From PyPI
 

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -74,10 +74,14 @@ Build artifacts and generate the TestPyPI upload plan without uploading:
 make mcp-unified-publish-dry-run
 ```
 
-Live TestPyPI or PyPI upload is not part of normal PR CI. It requires the manual
-workflow, an explicit confirmation input, and the RC helper's publish opt-in
-guard. Production PyPI uploads use the repository's configured trusted
-publishing environment rather than a long-lived PyPI token.
+Merging a package version bump to `main` triggers the guarded PyPI publishing
+workflow. The workflow runs the RC gate, verifies the version is not already on
+PyPI, and then uses the repository's configured trusted publishing environment
+rather than a long-lived PyPI token.
+
+Manual TestPyPI and PyPI workflow dispatch remain available for release
+rehearsals and operator-driven publishes. Manual live uploads require an
+explicit confirmation input and the RC helper's publish opt-in guard.
 
 ## Install From PyPI
 

--- a/backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md
+++ b/backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md
@@ -21,14 +21,19 @@ Prepare the standalone mcp-unified package for the next PyPI release after the d
 - [x] #1 mcp-unified package version is bumped from 0.1.1 to 0.2.0 before any publish attempt
 - [x] #2 local MCP Unified RC and publish dry-run checks pass from a clean release worktree
 - [ ] #3 TestPyPI publish is triggered only with explicit MCP_UNIFIED_PUBLISH confirmation and smoke-installed successfully
-- [ ] #4 PyPI publish is triggered only after TestPyPI smoke succeeds and final confirmation is explicit
+- [ ] #4 PyPI publish is triggered only after TestPyPI smoke succeeds and final confirmation is explicit, or automatically by a guarded main-branch package-version bump workflow
 - [ ] #5 post-publish PyPI smoke install verifies CLI entry points
+- [ ] #6 main-branch package-version bumps run guarded RC and PyPI duplicate checks before trusted publishing
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Verified release prep on the 0.2.0 worktree. Version bumped in apps/mcp-unified/pyproject.toml and apps/mcp-unified/src/mcp_unified/__init__.py. Ran package-boundary tests (47 passed), Ruff on touched package init, full make mcp-unified-rc (RC status ok), make mcp-unified-publish-dry-run (RC status ok), and Bandit on touched code (zero findings).
+
+Extending release task scope to include guarded automatic PyPI publish on main pushes where the mcp-unified package version changes. Manual TestPyPI remains available for rehearsal; automatic main publish must detect version changes, validate version sync, run the RC gate, and fail before upload if the version already exists on PyPI.
+
+Added guarded main-branch auto-publish workflow behavior and release documentation updates. Verified workflow YAML parsing and embedded Python compilation, make mcp-unified-publish-dry-run (RC status ok), make mcp-unified-rc (RC status ok), and git diff --check. Bandit skipped for this follow-up because no tracked Python source files changed; the new Python is inline GitHub Actions workflow code validated by compile checks.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -41,7 +46,7 @@ Verified release prep on the 0.2.0 worktree. Version bumped in apps/mcp-unified/
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
+- [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented


### PR DESCRIPTION
## Summary
- add guarded main-push detection for mcp-unified package version bumps
- auto-run the existing RC/publish workflow path for valid main version bumps
- keep manual TestPyPI/PyPI dispatch available and document the new release behavior

## Change summary
This keeps the existing release workflow as the single publishing path and adds the smallest guard needed for automatic PyPI publishing from main: compare the package version across the push, validate __version__ sync, run the RC gate, and refuse duplicate PyPI versions before trusted publishing. TestPyPI remains manual to avoid duplicate/churn noise.

## Verification
- workflow YAML parsed and embedded Python snippets compiled
- make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run
- make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-rc
- git diff --check
- Bandit skipped: no tracked Python source files changed; inline workflow Python was compile-checked

## Notes
- PR #2592 was already merged, so this is a focused follow-up PR for the auto-publish behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically publish the `mcp-unified` package to PyPI when a version bump is merged to `main`, reusing the existing RC/trusted publishing path. Adds strict guards to ensure version sync and prevent duplicate releases; manual TestPyPI/PyPI dispatch remains available.

- **New Features**
  - Add `push` trigger on `main` (scoped to `pyproject.toml`, `__init__.py`, and workflow).
  - New `detect-version-change` job: compares old/new versions, verifies `mcp_unified.__version__` matches `project.version`, and checks PyPI for existing versions.
  - Gate `publish-plan` and `publish-pypi` so they run on main pushes only when a valid version bump is detected; add a final duplicate-version check before upload.
  - Update READMEs to document auto-publish behavior; add an implementation plan doc and expand release task notes.

<sup>Written for commit 5db77e4d52e4129e54bf344123140742f79a5916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

