### PR TITLE
Connect Research Workspace discovery loops WP3

### DIFF
--- a/Docs/superpowers/plans/2026-07-05-research-workspace-notebooklm-discovery-loops-wp3-plan.md
+++ b/Docs/superpowers/plans/2026-07-05-research-workspace-notebooklm-discovery-loops-wp3-plan.md
@@ -1,0 +1,167 @@
+## WP3: Connect Discovery Loops
+
+**Backlog**: TASK-12163
+**Branch**: `codex/research-workspace-notebooklm-wp3`
+**Worktree**: `.worktrees/research-workspace-notebooklm-wp3`
+
+### Context
+
+WP3 follows the approved Research Workspace / NotebookLM Pro+Ultra parity design:
+
+- Server web search results should become reviewable workspace sources with visible import state.
+- Deep Research returns should show provenance and import outcome details inside Research Workspace.
+- Browser extension clipper actions should clearly hand off captured pages into workspace, chat, and agent-task workflows where existing storage/routing supports it.
+- Explicit non-scope: Google Drive search, Google account integration, new ingestion providers, and a full Research Workspace sidepanel clone.
+
+Existing implementation already has the core paths:
+
+- `AddSourceModal` has a Search Server tab that calls `tldwClient.webSearch()` and imports selected results with `tldwClient.addMedia()`.
+- `ResearchWorkspace` already reads Deep Research return query params and imports bundles via `buildDeepResearchBundleArtifactPayload()`.
+- `WorkspaceAgentTaskHandoffModal` already creates agent-orchestration tasks from Research Workspace canonical workspace context.
+- `WebClipperPanel` already saves clips to note/workspace destinations, opens workspace/notes, and queues chat handoff state for Analyze.
+
+The WP3 implementation should strengthen these existing paths instead of adding parallel flows.
+
+## Stage 1: Server Web Search Import State
+
+**Goal**: Make Search Server results behave like discovery candidates that visibly become workspace sources.
+
+**Files**:
+
+- `apps/packages/ui/src/components/Option/ResearchWorkspace/SourcesPane/AddSourceModal.tsx`
+- `apps/packages/ui/src/components/Option/ResearchWorkspace/SourcesPane/index.tsx`
+- `apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx`
+- `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/AddSourceModal.stage2.intake.test.tsx`
+
+**Implementation**:
+
+- Thread existing `researchWorkspaceCapabilities` from `ResearchWorkspace` to `SourcesPane`, then to `AddSourceModal`, and only pass the existing `source_browse` capability into the Search Server tab.
+- Use `getCapabilityCopy()` for a small inline warning/block notice in Search Server. Do not add a new backend capability id.
+- Treat `source_browse` as the available workspace source-readiness signal. The current backend capability model does not expose a separate web-search-provider readiness bit; provider/search failures remain surfaced through the Search Server error path. If a separate web-search capability is found while implementing, use it and add a matching test; otherwise record the narrower signal in TASK-12163.
+- When selected results are imported, preserve row-level state after the import attempt:
+  - imported rows show a concise success status, media id if available, and copy that they are queued as workspace sources.
+  - failed rows show a concise failure status and reason so the user can retry or import fewer results.
+  - partially successful batches keep successful rows added and leave failed rows selectable/retryable.
+- Keep the current ingestion fields and `onAddSources` path. Do not add providers, new routes, or side effects outside the workspace source add flow.
+
+**Tests**:
+
+- Add a test where two search results are selected, one `addMedia` succeeds and one fails; assert the successful source is added and both row states are visible.
+- Add a test for `source_browse` capability mode `block`; assert the Search action is disabled and the capability copy is shown.
+
+**Success Criteria**:
+
+- User can search, select results, import them, and see which results became workspace sources.
+- Import failures are visible without losing the original search result context.
+- Search Server is capability-gated by the existing workspace capability model.
+
+**Status**: Complete
+
+## Stage 2: Deep Research Return Provenance
+
+**Goal**: Make Deep Research return/import state explain what was imported, what evidence came with it, and what needs review.
+
+**Files**:
+
+- `apps/packages/ui/src/components/Option/ResearchWorkspace/deep-research-bundle-import.ts`
+- `apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx`
+- `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts`
+- `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx`
+
+**Implementation**:
+
+- Extend imported report content using fields already present in the Deep Research bundle:
+  - source inventory count and source titles/ids, bounded by existing import list limits.
+  - unresolved questions.
+  - unsupported claims and contradictions counts/details when present.
+  - skipped/failed source details if the returned bundle includes such lists.
+- Store these bounded details under `artifact.data.deepResearch` alongside existing provenance, not in a new artifact type.
+- Explicitly store/display selected or imported source entries with source ids, titles, and import/review status. Use source artifact coverage when present; otherwise derive from bundle `source_inventory`.
+- Bound persisted and rendered source/provenance/skipped/failed detail lists with the existing `MAX_IMPORT_LIST_ITEMS` cap of 50 items.
+- Enhance the return handoff banner with concise provenance/outcome copy:
+  - run id.
+  - source artifact.
+  - imported status.
+  - selected/imported source count.
+  - source inventory/import-review summary when import succeeds.
+  - failed import reason and retryable button state when import fails.
+- Keep the existing import button retry behavior for failed imports.
+
+**Tests**:
+
+- Extend the bundle import unit test to assert imported content includes selected/imported source ids/titles/statuses, source inventory, unresolved questions, unsupported claim or contradiction details, and bounded skipped/failed source lists.
+- Extend the workspace responsive test to assert the handoff shows imported selected-source/provenance summary after a successful import and retains failure copy on failed import.
+
+**Success Criteria**:
+
+- User can tell which Deep Research run and source artifact produced an imported report.
+- User can tell which selected/imported sources belong to the returned report.
+- Imported reports carry enough source/failure/review metadata to recover or audit the discovery loop.
+- Failed imports show a clear reason and can be retried without navigating away.
+
+**Status**: Complete
+
+## Stage 3: Extension Clipper Handoff Affordances
+
+**Goal**: Make the browser extension actions plainly map to workspace, chat, and agent-task discovery loops using existing save/handoff mechanisms.
+
+**Files**:
+
+- `apps/packages/ui/src/components/Sidepanel/Clipper/WebClipperPanel.tsx`
+- `apps/packages/ui/src/components/Sidepanel/Clipper/__tests__/WebClipperPanel.save-flow.test.tsx`
+- Existing Research Workspace route/header/handoff files needed to open `WorkspaceAgentTaskHandoffModal` from extension context.
+- New tiny web-clipper pending agent-task handoff helper only if direct query params would make the route too large or leak page text into URLs.
+
+**Implementation**:
+
+- Update action labels/copy so the current behaviors are explicit:
+  - save to workspace destination remains the capture-to-workspace path.
+  - Analyze/chat action is labeled as asking chat about the captured page.
+  - open action says workspace when workspace placement is selected.
+- Add a small action hint that changes with destination/action readiness; keep it compact for the sidepanel.
+- Wire a fourth action, `Start agent task`, for saved workspace clips by reusing the existing Research Workspace agent-task creation surface:
+  - save the clip to a workspace first, requiring a successful `workspace_placement`.
+  - pass captured page context to Research Workspace as a pending agent-task handoff, using compact session storage rather than long URLs if page text is included.
+  - open `options.html#/research-workspace` with enough route state to focus the workspace and trigger `WorkspaceAgentTaskHandoffModal`.
+  - prefill task title/description with the captured page title, URL, note id, workspace placement, and bounded extract preview.
+  - do not create an agent-orchestration task directly in the sidepanel; keep root-path and ACP readiness checks in `WorkspaceAgentTaskHandoffModal`.
+
+**Tests**:
+
+- Update existing save/open/analyze tests for the new labels.
+- Add an assertion that workspace destination shows workspace-specific action copy.
+- Add an assertion that `Start agent task` saves a pending handoff and opens Research Workspace with the existing agent-task modal route.
+- Add an assertion that `Start agent task` requires a workspace destination/placement, stores bounded captured-page pending context, and opens Research Workspace with the handoff trigger.
+- Add or extend a Research Workspace/header test that consumes the pending clipper agent-task context and opens/prefills `WorkspaceAgentTaskHandoffModal`.
+
+**Success Criteria**:
+
+- User can clearly capture the page to a workspace, open the workspace, and ask chat about the captured page.
+- Agent-task behavior is connected to the existing Research Workspace agent-task modal; no direct sidepanel orchestration path or fake action is shipped.
+- Sidepanel actions remain usable in narrow layouts.
+
+**Status**: Complete
+
+## Stage 4: Integration And Verification
+
+**Goal**: Prove the WP3 slices work together without broad churn.
+
+**Verification**:
+
+- `bunx vitest run apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/AddSourceModal.stage2.intake.test.tsx`
+- `bunx vitest run apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts`
+- `bunx vitest run apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx`
+- `bunx vitest run apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx`
+- `bunx vitest run apps/packages/ui/src/components/Sidepanel/Clipper/__tests__/WebClipperPanel.save-flow.test.tsx`
+- `bunx vitest run apps/packages/ui/src/services/web-clipper/__tests__/agent-task-handoff.test.ts`
+- `git diff --check`
+- Bandit: skipped if the final touched scope is frontend/docs/backlog only; otherwise run Bandit on touched backend paths from the project virtual environment.
+
+**Success Criteria**:
+
+- Focused frontend tests pass.
+- Whitespace check passes.
+- Backlog TASK-12163 records implementation summary and verification.
+- Commit contains the Backlog task, plan, implementation, and tests.
+
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/SourcesPane/AddSourceModal.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/SourcesPane/AddSourceModal.tsx
@@ -44,6 +44,12 @@ import {
   getMediaLibraryItemKey,
   normalizeMediaLibraryResponse
 } from "./media-library-normalization"
+import {
+  getCapability,
+  getCapabilityCopy,
+  type ResearchWorkspaceCapability,
+  type ResearchWorkspaceCapabilitiesResponse
+} from "../research-workspace-capabilities"
 
 const { TextArea } = Input
 const { Dragger } = Upload
@@ -119,6 +125,20 @@ type ExistingMediaCache = {
   items: MediaLibraryItem[]
   totalCount: number
   cachedAt: number
+}
+
+type SearchResultImportState =
+  | {
+      status: "imported"
+      mediaId: number
+    }
+  | {
+      status: "failed"
+      reason: string
+    }
+
+export type AddSourceModalProps = {
+  researchWorkspaceCapabilities?: ResearchWorkspaceCapabilitiesResponse
 }
 
 const EXISTING_MEDIA_CACHE_TTL_MS = 60_000
@@ -1241,14 +1261,25 @@ const SearchTab: React.FC<{
   onAddSources: AddSourceHandler
   setProcessing: (p: boolean) => void
   setError: (e: string | null) => void
-}> = ({ onAddSources, setProcessing, setError }) => {
+  sourceBrowseCapability?: ResearchWorkspaceCapability
+}> = ({ onAddSources, setProcessing, setError, sourceBrowseCapability }) => {
   const { t } = useTranslation(["playground", "common"])
   const [query, setQuery] = React.useState("")
   const [results, setResults] = React.useState<any[]>([])
   const [selectedResults, setSelectedResults] = React.useState<Set<number>>(
     new Set()
   )
+  const [importStates, setImportStates] = React.useState<
+    Record<number, SearchResultImportState>
+  >({})
   const [isSearching, setIsSearching] = React.useState(false)
+  const searchBlocked = sourceBrowseCapability?.mode === "block"
+  const capabilityCopy = sourceBrowseCapability
+    ? getCapabilityCopy(
+        sourceBrowseCapability,
+        t("playground:sources.searchServerAction", "Search Server")
+      )
+    : null
 
   const getResultUrl = React.useCallback(
     (item: Record<string, unknown>) =>
@@ -1278,12 +1309,13 @@ const SearchTab: React.FC<{
   }, [])
 
   const handleSearch = async () => {
-    if (!query.trim()) return
+    if (!query.trim() || searchBlocked) return
 
     setIsSearching(true)
     setError(null)
     setResults([])
     setSelectedResults(new Set())
+    setImportStates({})
 
     try {
       const response = await tldwClient.webSearch({
@@ -1312,85 +1344,113 @@ const SearchTab: React.FC<{
     if (selectedResults.size === 0) return
 
     setProcessing(true)
-      const selectedUrls = results.filter((_, idx) => selectedResults.has(idx))
-    const addedSources: AddSourceCandidate[] = []
-    const failures: Array<{ url: string; reason: string }> = []
+    try {
+      const selectedUrls = results
+        .map((result, idx) => ({ result, idx }))
+        .filter(({ idx }) => selectedResults.has(idx))
+      const addedSources: AddSourceCandidate[] = []
+      const failures: Array<{ idx: number; url: string; reason: string }> = []
+      const nextImportStates: Record<number, SearchResultImportState> = {}
 
-    for (const result of selectedUrls) {
-      const resultUrl = getResultUrl(result as Record<string, unknown>) || "unknown url"
-      try {
-        const response = await tldwClient.addMedia(resultUrl, {
-          ...WORKSPACE_RAG_INGEST_FIELDS
-        })
-        const added = extractMediaFromAddResponse(response)
-        if (added.mediaId != null) {
-          addedSources.push({
-            mediaId: added.mediaId,
-            title: added.title || result.title || resultUrl,
-            type: "website",
-            status: "processing",
-            url: added.url || resultUrl,
-            fileSize: added.fileSize,
-            duration: added.duration,
-            pageCount: added.pageCount,
-            sourceCreatedAt: added.sourceCreatedAt,
-            thumbnailUrl: added.thumbnailUrl
+      for (const { result, idx } of selectedUrls) {
+        const resultUrl =
+          getResultUrl(result as Record<string, unknown>) || "unknown url"
+        try {
+          const response = await tldwClient.addMedia(resultUrl, {
+            ...WORKSPACE_RAG_INGEST_FIELDS
           })
-        } else {
-          failures.push({
-            url: resultUrl,
-            reason: t(
+          const added = extractMediaFromAddResponse(response)
+          if (added.mediaId != null) {
+            addedSources.push({
+              mediaId: added.mediaId,
+              title: added.title || result.title || resultUrl,
+              type: "website",
+              status: "processing",
+              url: added.url || resultUrl,
+              fileSize: added.fileSize,
+              duration: added.duration,
+              pageCount: added.pageCount,
+              sourceCreatedAt: added.sourceCreatedAt,
+              thumbnailUrl: added.thumbnailUrl
+            })
+            nextImportStates[idx] = {
+              status: "imported",
+              mediaId: added.mediaId
+            }
+          } else {
+            const reason = t(
               "playground:sources.batchResultInvalid",
               "No media ID returned"
             )
+            nextImportStates[idx] = {
+              status: "failed",
+              reason
+            }
+            failures.push({
+              idx,
+              url: resultUrl,
+              reason
+            })
+          }
+        } catch (error) {
+          const reason = mapSourceIngestionError(error)
+          nextImportStates[idx] = {
+            status: "failed",
+            reason
+          }
+          failures.push({
+            idx,
+            url: resultUrl,
+            reason
           })
         }
-      } catch (error) {
-        failures.push({
-          url: resultUrl,
-          reason: mapSourceIngestionError(error)
-        })
       }
-    }
 
-    if (addedSources.length > 0) {
-      await onAddSources(addedSources)
-    }
+      setImportStates((previous) => ({
+        ...previous,
+        ...nextImportStates
+      }))
+      setSelectedResults(new Set(failures.map((failure) => failure.idx)))
 
-    if (failures.length > 0) {
-      const totalCount = selectedUrls.length
-      const addedCount = addedSources.length
-      const details = failures
-        .slice(0, 2)
-        .map((failure) => `${failure.url}: ${failure.reason}`)
-        .join("; ")
-      const overflowCount = failures.length - 2
-      const detailSuffix =
-        overflowCount > 0
-          ? `${details}; +${overflowCount} more`
-          : details
+      if (addedSources.length > 0) {
+        await onAddSources(addedSources, { closeModal: false })
+      }
 
-      const summary = t(
-        "playground:sources.batchResultSummary",
-        "Added {{added}} of {{total}} sources. {{failed}} failed: {{details}}",
-        {
-          added: addedCount,
-          total: totalCount,
-          failed: failures.length,
-          details: detailSuffix
+      if (failures.length > 0) {
+        const totalCount = selectedUrls.length
+        const addedCount = addedSources.length
+        const details = failures
+          .slice(0, 2)
+          .map((failure) => `${failure.url}: ${failure.reason}`)
+          .join("; ")
+        const overflowCount = failures.length - 2
+        const detailSuffix =
+          overflowCount > 0
+            ? `${details}; +${overflowCount} more`
+            : details
+
+        const summary = t(
+          "playground:sources.batchResultSummary",
+          "Added {{added}} of {{total}} sources. {{failed}} failed: {{details}}",
+          {
+            added: addedCount,
+            total: totalCount,
+            failed: failures.length,
+            details: detailSuffix
+          }
+        )
+
+        if (addedCount === 0) {
+          setError(summary)
         }
-      )
-
-      if (addedCount > 0) {
-        message.warning(summary)
-      } else {
-        setError(summary)
       }
+    } finally {
+      setProcessing(false)
     }
-    setProcessing(false)
   }
 
   const toggleResult = (idx: number) => {
+    if (importStates[idx]?.status === "imported") return
     const newSelected = new Set(selectedResults)
     if (newSelected.has(idx)) {
       newSelected.delete(idx)
@@ -1402,6 +1462,12 @@ const SearchTab: React.FC<{
 
   return (
     <div className="space-y-4">
+      {capabilityCopy ? (
+        <Alert
+          type={searchBlocked ? "warning" : "info"}
+          title={capabilityCopy}
+        />
+      ) : null}
       <div className="flex gap-2">
         <Input
           prefix={<Search className="h-4 w-4 text-text-muted" />}
@@ -1417,7 +1483,7 @@ const SearchTab: React.FC<{
           type="primary"
           onClick={handleSearch}
           loading={isSearching}
-          disabled={!query.trim()}
+          disabled={!query.trim() || searchBlocked}
         >
           {t("common:search", "Search")}
         </Button>
@@ -1435,12 +1501,16 @@ const SearchTab: React.FC<{
               const resultSnippet = getResultSnippet(record)
               const faviconUrl = getFaviconUrl(resultUrl)
               const resultTitle = item.title || resultUrl || `Result ${idx + 1}`
+              const importState = importStates[idx]
+              const isImported = importState?.status === "imported"
 
               return (
                 <div
                   key={`${resultUrl || resultTitle}-${idx}`}
                   role="listitem"
-                  className={`cursor-pointer p-3 transition hover:bg-surface2 ${
+                  className={`p-3 transition hover:bg-surface2 ${
+                    isImported ? "cursor-default" : "cursor-pointer"
+                  } ${
                     selectedResults.has(idx) ? "bg-primary/10" : ""
                   }`}
                   tabIndex={0}
@@ -1456,6 +1526,7 @@ const SearchTab: React.FC<{
                   <div className="flex items-start gap-2">
                     <Checkbox
                       checked={selectedResults.has(idx)}
+                      disabled={isImported}
                       onClick={(event) => event.stopPropagation()}
                       onChange={() => toggleResult(idx)}
                     />
@@ -1480,6 +1551,39 @@ const SearchTab: React.FC<{
                             <p className="mt-0.5 line-clamp-2 text-xs text-text-subtle">
                               {resultSnippet}
                             </p>
+                          ) : null}
+                          {importState ? (
+                            <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+                              {importState.status === "imported" ? (
+                                <>
+                                  <span className="rounded border border-success/30 bg-success/10 px-2 py-0.5 font-medium text-success">
+                                    {t(
+                                      "playground:sources.searchResultQueued",
+                                      "Queued as workspace source"
+                                    )}
+                                  </span>
+                                  <span className="text-text-muted">
+                                    {t(
+                                      "playground:sources.searchResultMediaId",
+                                      "Media #{{mediaId}}",
+                                      { mediaId: importState.mediaId }
+                                    )}
+                                  </span>
+                                </>
+                              ) : (
+                                <>
+                                  <span className="rounded border border-danger/30 bg-danger/10 px-2 py-0.5 font-medium text-danger">
+                                    {t(
+                                      "playground:sources.searchResultFailed",
+                                      "Failed to import"
+                                    )}
+                                  </span>
+                                  <span className="text-danger">
+                                    {importState.reason}
+                                  </span>
+                                </>
+                              )}
+                            </div>
                           ) : null}
                         </div>
                       </div>
@@ -2012,7 +2116,9 @@ function getSourceTypeFromMediaType(mediaType: string): WorkspaceSourceType {
 /**
  * AddSourceModal - Modal for adding sources to workspace
  */
-export const AddSourceModal: React.FC = () => {
+export const AddSourceModal: React.FC<AddSourceModalProps> = ({
+  researchWorkspaceCapabilities
+}) => {
   const { t } = useTranslation(["playground", "common"])
   const isMobile = useMobile()
 
@@ -2032,6 +2138,13 @@ export const AddSourceModal: React.FC = () => {
   const workspaceTag = useWorkspaceStore((s) => s.workspaceTag)
   const [tabUsage, setTabUsage] = React.useState<AddSourceTabUsage>(() =>
     readAddSourceTabUsage()
+  )
+  const sourceBrowseCapability = React.useMemo(
+    () =>
+      researchWorkspaceCapabilities
+        ? getCapability(researchWorkspaceCapabilities, "source_browse")
+        : undefined,
+    [researchWorkspaceCapabilities]
   )
 
   React.useEffect(() => {
@@ -2185,6 +2298,7 @@ export const AddSourceModal: React.FC = () => {
           onAddSources={handleAddSources}
           setProcessing={setProcessing}
           setError={setError}
+          sourceBrowseCapability={sourceBrowseCapability}
         />
       )
     }

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/SourcesPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/SourcesPane/index.tsx
@@ -61,6 +61,7 @@ import {
   getSourceSelectionOrigin
 } from "@/store/workspace-organization"
 import { AddSourceModal } from "./AddSourceModal"
+import type { ResearchWorkspaceCapabilitiesResponse } from "../research-workspace-capabilities"
 import {
   SourceFolderMembershipMenu,
   type SourceFolderMembershipOption
@@ -377,6 +378,8 @@ interface SourcesPaneProps {
   onResetAdvancedSourceFilters?: () => void
   /** Non-blocking server-side context/status warning for this workspace. */
   statusProjectionError?: string | null
+  /** Workspace capability state used to gate discovery actions. */
+  researchWorkspaceCapabilities?: ResearchWorkspaceCapabilitiesResponse
 }
 
 /**
@@ -389,7 +392,8 @@ export const SourcesPane: React.FC<SourcesPaneProps> = ({
   sourceListViewState = DEFAULT_SOURCE_LIST_VIEW_STATE,
   onPatchSourceListViewState,
   onResetAdvancedSourceFilters,
-  statusProjectionError = null
+  statusProjectionError = null,
+  researchWorkspaceCapabilities
 }) => {
   const { t } = useTranslation(["playground", "common"])
   const readyStateLabel = getDesignSystemState("ready")?.label ?? READY_STATE_LABEL
@@ -2636,7 +2640,7 @@ export const SourcesPane: React.FC<SourcesPaneProps> = ({
           })()}
       </Modal>
 
-      <AddSourceModal />
+      <AddSourceModal researchWorkspaceCapabilities={researchWorkspaceCapabilities} />
     </div>
   )
 }

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceAgentTaskHandoffModal.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceAgentTaskHandoffModal.tsx
@@ -38,11 +38,17 @@ type CreatedAgentTask = {
   taskId: number
 }
 
+export type WorkspaceAgentTaskPrefill = {
+  title?: string | null
+  description?: string | null
+}
+
 export interface WorkspaceAgentTaskHandoffModalProps {
   open: boolean
   workspaceId?: string | null
   workspaceName?: string | null
   workspaceTag?: string | null
+  prefill?: WorkspaceAgentTaskPrefill | null
   onBeforeSubmit?: () => Promise<void> | void
   onCancel: () => void
   onOpenAgentTasks: () => void
@@ -87,6 +93,7 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
   workspaceId,
   workspaceName,
   workspaceTag,
+  prefill,
   onBeforeSubmit,
   onCancel,
   onOpenAgentTasks
@@ -118,17 +125,18 @@ export const WorkspaceAgentTaskHandoffModal: React.FC<
     wasOpenRef.current = true
     setRootPath("")
     setTaskTitle(
-      t("playground:workspace.agentTaskDefaultTitle", {
-        defaultValue: "Continue {{workspace}} work",
-        workspace: workspaceDisplayName
-      })
+      prefill?.title?.trim() ||
+        t("playground:workspace.agentTaskDefaultTitle", {
+          defaultValue: "Continue {{workspace}} work",
+          workspace: workspaceDisplayName
+        })
     )
-    setTaskDescription("")
+    setTaskDescription(prefill?.description?.trim() || "")
     setAgentType("codex")
     setSubmitting(false)
     setError(null)
     setCreatedTask(null)
-  }, [open, t, workspaceDisplayName])
+  }, [open, prefill, t, workspaceDisplayName])
 
   const buildRequestTransport = React.useCallback(
     (path: string): BrowserRequestTransport | null => {

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
@@ -101,7 +101,10 @@ import {
   normalizeRolloutPercentage
 } from "@/utils/feature-rollout"
 import { WorkspaceShortcutsModal } from "./WorkspaceShortcutsModal"
-import { WorkspaceAgentTaskHandoffModal } from "./WorkspaceAgentTaskHandoffModal"
+import {
+  WorkspaceAgentTaskHandoffModal,
+  type WorkspaceAgentTaskPrefill
+} from "./WorkspaceAgentTaskHandoffModal"
 import { WorkspaceACPHistoryModal } from "./WorkspaceACPHistoryModal"
 import { WorkspaceSandboxDiagnosticsPanel } from "./WorkspaceSandboxDiagnosticsPanel"
 import { WORKSPACES_PATH } from "@/routes/route-paths"
@@ -135,6 +138,10 @@ interface WorkspaceHeaderProps {
   statusGuardrailsEnabled?: boolean
   /** Increment when page-level workspace reconciliation has fresh server context. */
   serverContextRefreshVersion?: number
+  /** Increment to open the agent-task modal from a route or extension handoff. */
+  agentTaskHandoffOpenSignal?: number
+  /** Optional title/description for the next agent-task modal open. */
+  agentTaskPrefill?: WorkspaceAgentTaskPrefill | null
 }
 
 const TELEMETRY_EVENT_ORDER: ResearchWorkspaceTelemetryEventType[] = [
@@ -291,7 +298,9 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   storageAccountQuotaBytes,
   provenanceEnabled = true,
   statusGuardrailsEnabled = true,
-  serverContextRefreshVersion
+  serverContextRefreshVersion,
+  agentTaskHandoffOpenSignal = 0,
+  agentTaskPrefill = null
 }) => {
   const { t } = useTranslation(["playground", "option", "common"])
   const navigate = useNavigate()
@@ -313,6 +322,9 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const [workspaceSettingsOpen, setWorkspaceSettingsOpen] = React.useState(false)
   const [shortcutsModalOpen, setShortcutsModalOpen] = React.useState(false)
   const [agentTaskModalOpen, setAgentTaskModalOpen] = React.useState(false)
+  const [agentTaskModalPrefill, setAgentTaskModalPrefill] =
+    React.useState<WorkspaceAgentTaskPrefill | null>(null)
+  const lastAgentTaskHandoffSignalRef = React.useRef(0)
   const [acpHistoryModalOpen, setAcpHistoryModalOpen] = React.useState(false)
   const [sandboxDiagnosticsOpen, setSandboxDiagnosticsOpen] = React.useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = React.useState(false)
@@ -379,6 +391,14 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
     React.useState<string | null>(null)
   const [defaultAssistantWorkspace, setDefaultAssistantWorkspace] =
     React.useState<WorkspaceApiResponse | null>(null)
+
+  React.useEffect(() => {
+    if (agentTaskHandoffOpenSignal <= 0) return
+    if (lastAgentTaskHandoffSignalRef.current === agentTaskHandoffOpenSignal) return
+    lastAgentTaskHandoffSignalRef.current = agentTaskHandoffOpenSignal
+    setAgentTaskModalPrefill(agentTaskPrefill)
+    setAgentTaskModalOpen(true)
+  }, [agentTaskHandoffOpenSignal, agentTaskPrefill])
   const [personaProfiles, setPersonaProfiles] = React.useState<
     PersonaProfileSummary[]
   >([])
@@ -696,11 +716,13 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   }
 
   const handleOpenAgentTaskModal = () => {
+    setAgentTaskModalPrefill(null)
     setAgentTaskModalOpen(true)
   }
 
   const handleCloseAgentTaskModal = () => {
     setAgentTaskModalOpen(false)
+    setAgentTaskModalPrefill(null)
   }
 
   const handleOpenAcpHistoryModal = () => {
@@ -899,6 +921,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
 
   const handleOpenAgentTasksPage = () => {
     setAgentTaskModalOpen(false)
+    setAgentTaskModalPrefill(null)
     setAcpHistoryModalOpen(false)
     const canonicalWorkspaceId = workspaceId?.trim()
     if (!canonicalWorkspaceId) {
@@ -2441,6 +2464,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
         workspaceId={workspaceId}
         workspaceName={workspaceName}
         workspaceTag={workspaceTag}
+        prefill={agentTaskModalPrefill}
         onBeforeSubmit={saveCurrentWorkspace}
         onCancel={handleCloseAgentTaskModal}
         onOpenAgentTasks={handleOpenAgentTasksPage}

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/AddSourceModal.stage2.intake.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/AddSourceModal.stage2.intake.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { AddSourceModal } from "../SourcesPane/AddSourceModal"
+import { buildUnknownResearchWorkspaceCapabilities } from "../research-workspace-capabilities"
 import type { AddSourceTab } from "@/types/workspace"
 
 const ADD_SOURCE_TAB_USAGE_STORAGE_KEY =
@@ -578,6 +579,80 @@ describe("AddSourceModal Stage 2 intake and relevance", () => {
 
     const favicon = screen.getByTestId("search-result-favicon-0")
     expect(favicon).toHaveAttribute("src", expect.stringContaining("google.com/s2/favicons"))
+  })
+
+  it("keeps Search Server import results visible with imported and failed row states", async () => {
+    workspaceStoreState.addSourceModalTab = "search"
+    mockWebSearch.mockResolvedValueOnce({
+      results: [
+        {
+          title: "Result One",
+          url: "https://example.com/one",
+          snippet: "First result"
+        },
+        {
+          title: "Result Two",
+          url: "https://example.com/two",
+          snippet: "Second result"
+        }
+      ]
+    })
+    mockAddMedia
+      .mockResolvedValueOnce({ results: [{ media_id: 9001, title: "Result One" }] })
+      .mockRejectedValueOnce(new Error("timeout"))
+
+    render(<AddSourceModal />)
+
+    fireEvent.change(screen.getByLabelText("Search the web"), {
+      target: { value: "workspace discovery" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Search" }))
+
+    expect(await screen.findByText("Result One")).toBeInTheDocument()
+    fireEvent.click(screen.getByText("Result One"))
+    fireEvent.click(screen.getByText("Result Two"))
+    fireEvent.click(screen.getByRole("button", { name: "Add 2 selected" }))
+
+    await waitFor(() => {
+      expect(mockAddSource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediaId: 9001,
+          status: "processing",
+          url: "https://example.com/one"
+        })
+      )
+    })
+
+    expect(mockCloseAddSourceModal).not.toHaveBeenCalled()
+    expect(screen.getByText("Queued as workspace source")).toBeInTheDocument()
+    expect(screen.getByText("Media #9001")).toBeInTheDocument()
+    expect(screen.getByText("Failed to import")).toBeInTheDocument()
+    expect(screen.getByText(/timed out|timeout/i)).toBeInTheDocument()
+  })
+
+  it("blocks Search Server when the source browse capability is unavailable", async () => {
+    workspaceStoreState.addSourceModalTab = "search"
+    const capabilities = buildUnknownResearchWorkspaceCapabilities()
+    capabilities.capabilities.source_browse = {
+      status: "unavailable",
+      mode: "block",
+      dependencies: ["workspace_sources"],
+      reason_code: "provider_unavailable"
+    }
+
+    render(<AddSourceModal researchWorkspaceCapabilities={capabilities} />)
+
+    fireEvent.change(screen.getByLabelText("Search the web"), {
+      target: { value: "blocked query" }
+    })
+
+    expect(
+      screen.getByText(
+        "Search Server is unavailable because the model provider is unavailable. Open model settings or retry status."
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Search" })).toBeDisabled()
+    expect(mockWebSearch).not.toHaveBeenCalled()
   })
 
   it("supports library load-more pagination and total count text", async () => {

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
@@ -312,6 +312,20 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     chromeStorageState.clear()
     vi.stubGlobal("chrome", {
       storage: {
+        onChanged: {
+          addListener: vi.fn(),
+          removeListener: vi.fn()
+        },
+        local: {
+          get: chromeStorageSessionGetMock,
+          set: chromeStorageSessionSetMock,
+          remove: chromeStorageSessionRemoveMock
+        },
+        sync: {
+          get: chromeStorageSessionGetMock,
+          set: chromeStorageSessionSetMock,
+          remove: chromeStorageSessionRemoveMock
+        },
         session: {
           get: chromeStorageSessionGetMock,
           set: chromeStorageSessionSetMock,
@@ -672,7 +686,7 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
       pageTitle: "Example Story",
       extractPreview: "Alpha body copy",
       hasScreenshot: false,
-      createdAt: "2026-07-05T00:00:00.000Z"
+      createdAt: new Date().toISOString()
     })
     window.history.replaceState(
       null,
@@ -701,6 +715,7 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
 
   it("switches to the routed workspace before opening a pending web clipper agent task", async () => {
     testState.workspaceId = "workspace-current"
+    testState.switchWorkspace = vi.fn()
     await writePendingWebClipAgentTaskRequest({
       id: "handoff-2",
       clipId: "clip-456",
@@ -711,7 +726,7 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
       pageTitle: "Target Story",
       extractPreview: "Target body copy",
       hasScreenshot: true,
-      createdAt: "2026-07-05T00:00:00.000Z"
+      createdAt: new Date().toISOString()
     })
     window.history.replaceState(
       null,
@@ -728,6 +743,7 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
       chromeStorageState.get(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
     ).toBeDefined()
 
+    testState.workspaceId = "workspace-target"
     rerender(<ResearchWorkspace />)
 
     await waitFor(() => {
@@ -742,6 +758,65 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     expect(
       chromeStorageState.get(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
     ).toBeUndefined()
+  })
+
+  it("opens a second unique web clipper agent task while the workspace stays mounted", async () => {
+    await writePendingWebClipAgentTaskRequest({
+      id: "handoff-1",
+      clipId: "clip-123",
+      noteId: "note-123",
+      workspaceId: "workspace-1",
+      workspaceNoteId: 42,
+      pageUrl: "https://example.com/first",
+      pageTitle: "First Story",
+      extractPreview: "First body copy",
+      hasScreenshot: false,
+      createdAt: new Date().toISOString()
+    })
+    window.history.replaceState(
+      null,
+      "",
+      "/research-workspace?workspace=workspace-1&agent_task_handoff=web_clip&handoff_id=handoff-1"
+    )
+
+    const { rerender } = render(<ResearchWorkspace />)
+
+    await waitFor(() => {
+      expect(
+        mockWorkspaceHeaderProps.at(-1)?.agentTaskHandoffOpenSignal
+      ).toBeGreaterThan(0)
+    })
+    const firstSignal =
+      mockWorkspaceHeaderProps.at(-1)?.agentTaskHandoffOpenSignal ?? 0
+
+    await writePendingWebClipAgentTaskRequest({
+      id: "handoff-2",
+      clipId: "clip-456",
+      noteId: "note-456",
+      workspaceId: "workspace-1",
+      workspaceNoteId: 84,
+      pageUrl: "https://example.com/second",
+      pageTitle: "Second Story",
+      extractPreview: "Second body copy",
+      hasScreenshot: false,
+      createdAt: new Date().toISOString()
+    })
+    window.history.replaceState(
+      null,
+      "",
+      "/research-workspace?workspace=workspace-1&agent_task_handoff=web_clip&handoff_id=handoff-2"
+    )
+    rerender(<ResearchWorkspace />)
+
+    await waitFor(() => {
+      expect(
+        mockWorkspaceHeaderProps.at(-1)?.agentTaskHandoffOpenSignal
+      ).toBeGreaterThan(firstSignal)
+    })
+    expect(mockWorkspaceHeaderProps.at(-1)?.agentTaskPrefill).toMatchObject({
+      title: "Review captured page: Second Story",
+      description: expect.stringContaining("URL: https://example.com/second")
+    })
   })
 
   it("cancels a bundle import when the active workspace changes during fetch", async () => {

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
@@ -9,6 +9,10 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ResearchWorkspace } from "../index"
 import { RESEARCH_WORKSPACE_LAST_MOBILE_TAB_STORAGE_KEY } from "../research-workspace-route-state"
+import {
+  WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY,
+  writePendingWebClipAgentTaskRequest
+} from "@/services/web-clipper/agent-task-handoff"
 
 const ONBOARDING_KEY = "tldw:research-workspace:onboarding-dismissed:v1"
 const {
@@ -18,7 +22,8 @@ const {
   mockGetResearchWorkspaceCapabilities,
   mockGetResearchBundle,
   mockChatPaneProps,
-  mockStudioPaneProps
+  mockStudioPaneProps,
+  mockWorkspaceHeaderProps
 } = vi.hoisted(() => ({
   onboardingStorageState: {
     value: undefined as string | undefined
@@ -40,8 +45,35 @@ const {
   })),
   mockGetResearchBundle: vi.fn(),
   mockChatPaneProps: [] as any[],
-  mockStudioPaneProps: [] as any[]
+  mockStudioPaneProps: [] as any[],
+  mockWorkspaceHeaderProps: [] as any[]
 }))
+const chromeStorageState = vi.hoisted(() => new Map<string, unknown>())
+const chromeStorageSessionGetMock = vi.hoisted(() =>
+  vi.fn((key: string, callback?: (items: Record<string, unknown>) => void) => {
+    const result = chromeStorageState.has(key)
+      ? { [key]: chromeStorageState.get(key) }
+      : {}
+    callback?.(result)
+    return Promise.resolve(result)
+  })
+)
+const chromeStorageSessionSetMock = vi.hoisted(() =>
+  vi.fn((items: Record<string, unknown>, callback?: () => void) => {
+    for (const [key, value] of Object.entries(items)) {
+      chromeStorageState.set(key, value)
+    }
+    callback?.()
+    return Promise.resolve()
+  })
+)
+const chromeStorageSessionRemoveMock = vi.hoisted(() =>
+  vi.fn((key: string, callback?: () => void) => {
+    chromeStorageState.delete(key)
+    callback?.()
+    return Promise.resolve()
+  })
+)
 
 const mockMessageApi = {
   open: vi.fn(),
@@ -97,10 +129,19 @@ vi.mock("react-i18next", () => ({
         | string
         | {
             defaultValue?: string
-          }
+          },
+      interpolation?: Record<string, unknown>
     ) => {
-      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
-      if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+      const renderValue = (value: string) =>
+        value.replace(/\{\{(\w+)\}\}/g, (_match, token) =>
+          String(interpolation?.[token] ?? "")
+        )
+      if (typeof defaultValueOrOptions === "string") {
+        return renderValue(defaultValueOrOptions)
+      }
+      if (defaultValueOrOptions?.defaultValue) {
+        return renderValue(defaultValueOrOptions.defaultValue)
+      }
       return key
     }
   })
@@ -149,7 +190,10 @@ vi.mock("@/utils/research-workspace-prefill", () => ({
 }))
 
 vi.mock("../WorkspaceHeader", () => ({
-  WorkspaceHeader: () => <div data-testid="workspace-header" />
+  WorkspaceHeader: (props: any) => {
+    mockWorkspaceHeaderProps.push(props)
+    return <div data-testid="workspace-header" />
+  }
 }))
 
 vi.mock("../SourcesPane", () => ({
@@ -260,7 +304,20 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     mockGetResearchBundle.mockReset()
     mockChatPaneProps.length = 0
     mockStudioPaneProps.length = 0
+    mockWorkspaceHeaderProps.length = 0
+    chromeStorageState.clear()
+    vi.stubGlobal("chrome", {
+      storage: {
+        session: {
+          get: chromeStorageSessionGetMock,
+          set: chromeStorageSessionSetMock,
+          remove: chromeStorageSessionRemoveMock
+        }
+      }
+    })
     window.localStorage.removeItem(RESEARCH_WORKSPACE_LAST_MOBILE_TAB_STORAGE_KEY)
+    window.localStorage.removeItem(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+    window.sessionStorage.removeItem(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
     window.history.replaceState(null, "", "/research-workspace")
   })
 
@@ -574,6 +631,20 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
       }
     })
     expect(artifactPayload.data.deepResearch.runId).toBe("research-run-7")
+    expect(artifactPayload.data.deepResearch.selectedImportedSources).toEqual([
+      {
+        sourceId: "source-a",
+        mediaId: 101,
+        title: "Paper A",
+        status: "selected"
+      },
+      {
+        sourceId: "source-b",
+        mediaId: 102,
+        title: "Paper B",
+        status: "selected"
+      }
+    ])
     expect(artifactPayload.sourceCoverage.selectedSourceIds).toEqual([
       "source-a",
       "source-b"
@@ -581,6 +652,47 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     expect(
       screen.getByTestId("workspace-deep-research-return-handoff")
     ).toHaveTextContent("Bundle imported")
+    expect(
+      screen.getByTestId("workspace-deep-research-return-handoff")
+    ).toHaveTextContent("2 selected sources")
+  })
+
+  it("opens an agent-task handoff from pending web clipper context", async () => {
+    await writePendingWebClipAgentTaskRequest({
+      id: "handoff-1",
+      clipId: "clip-123",
+      noteId: "note-123",
+      workspaceId: "workspace-1",
+      workspaceNoteId: 42,
+      pageUrl: "https://example.com/story",
+      pageTitle: "Example Story",
+      extractPreview: "Alpha body copy",
+      hasScreenshot: false,
+      createdAt: "2026-07-05T00:00:00.000Z"
+    })
+    window.history.replaceState(
+      null,
+      "",
+      "/research-workspace?workspace=workspace-1&agent_task_handoff=web_clip"
+    )
+
+    render(<ResearchWorkspace />)
+
+    await waitFor(() => {
+      expect(
+        mockWorkspaceHeaderProps.at(-1)?.agentTaskHandoffOpenSignal
+      ).toBeGreaterThan(0)
+    })
+    expect(mockWorkspaceHeaderProps.at(-1)?.agentTaskPrefill).toMatchObject({
+      title: "Review captured page: Example Story",
+      description: expect.stringContaining("URL: https://example.com/story")
+    })
+    expect(mockWorkspaceHeaderProps.at(-1)?.agentTaskPrefill.description).toContain(
+      "Alpha body copy"
+    )
+    expect(
+      chromeStorageState.get(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+    ).toBeUndefined()
   })
 
   it("cancels a bundle import when the active workspace changes during fetch", async () => {

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx
@@ -91,6 +91,7 @@ const testState = {
   workspaceTag: "",
   initializeWorkspace: vi.fn(),
   createNewWorkspace: vi.fn(),
+  switchWorkspace: vi.fn(),
   addSources: vi.fn(),
   setSelectedSourceIds: vi.fn(),
   captureToCurrentNote: vi.fn(),
@@ -297,6 +298,9 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     testState.generatedArtifacts = []
     testState.setSourceStatusByMediaId = vi.fn()
     testState.createNewWorkspace = vi.fn()
+    testState.switchWorkspace = vi.fn((workspaceId: string) => {
+      testState.workspaceId = workspaceId
+    })
     testState.clearCurrentNote = vi.fn()
     testState.loadNote = vi.fn()
     testState.addArtifact = vi.fn()
@@ -690,6 +694,51 @@ describe("ResearchWorkspace Stage 2 drawer responsiveness", () => {
     expect(mockWorkspaceHeaderProps.at(-1)?.agentTaskPrefill.description).toContain(
       "Alpha body copy"
     )
+    expect(
+      chromeStorageState.get(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+    ).toBeUndefined()
+  })
+
+  it("switches to the routed workspace before opening a pending web clipper agent task", async () => {
+    testState.workspaceId = "workspace-current"
+    await writePendingWebClipAgentTaskRequest({
+      id: "handoff-2",
+      clipId: "clip-456",
+      noteId: "note-456",
+      workspaceId: "workspace-target",
+      workspaceNoteId: 84,
+      pageUrl: "https://example.com/target",
+      pageTitle: "Target Story",
+      extractPreview: "Target body copy",
+      hasScreenshot: true,
+      createdAt: "2026-07-05T00:00:00.000Z"
+    })
+    window.history.replaceState(
+      null,
+      "",
+      "/research-workspace?workspace=workspace-target&agent_task_handoff=web_clip"
+    )
+
+    const { rerender } = render(<ResearchWorkspace />)
+
+    await waitFor(() => {
+      expect(testState.switchWorkspace).toHaveBeenCalledWith("workspace-target")
+    })
+    expect(
+      chromeStorageState.get(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+    ).toBeDefined()
+
+    rerender(<ResearchWorkspace />)
+
+    await waitFor(() => {
+      expect(
+        mockWorkspaceHeaderProps.at(-1)?.agentTaskHandoffOpenSignal
+      ).toBeGreaterThan(0)
+    })
+    expect(mockWorkspaceHeaderProps.at(-1)?.agentTaskPrefill).toMatchObject({
+      title: "Review captured page: Target Story",
+      description: expect.stringContaining("URL: https://example.com/target")
+    })
     expect(
       chromeStorageState.get(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
     ).toBeUndefined()

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
@@ -1564,7 +1564,7 @@ describe("WorkspaceHeader workspace browser modal", () => {
     expect(await screen.findByText("Import Workspace")).toBeInTheDocument()
 
     await waitFor(() => {
-      expect(screen.getByText("View all workspaces")).not.toBeVisible()
+      expect(screen.queryByText("View all workspaces")).not.toBeInTheDocument()
     })
   })
 
@@ -3343,5 +3343,48 @@ describe("WorkspaceHeader workspace browser modal", () => {
     await waitFor(() => {
       expect(within(modal).getByText("Agent task created")).toBeInTheDocument()
     })
+  })
+
+  it("does not reuse web-clip agent-task prefill for later manual task creation", async () => {
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+        agentTaskHandoffOpenSignal={1}
+        agentTaskPrefill={{
+          title: "Review captured page: Example Story",
+          description: "Captured excerpt:\nAlpha body copy"
+        }}
+      />
+    )
+
+    const handoffModal = await screen.findByRole("dialog", {
+      name: "Create agent task"
+    })
+    expect(within(handoffModal).getByLabelText("Task title")).toHaveValue(
+      "Review captured page: Example Story"
+    )
+    expect(within(handoffModal).getByLabelText("Task description")).toHaveValue(
+      "Captured excerpt:\nAlpha body copy"
+    )
+
+    fireEvent.click(within(handoffModal).getByRole("button", { name: "Cancel" }))
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Create agent task" }))
+        .not.toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Create agent task"))
+
+    const manualModal = await screen.findByRole("dialog", {
+      name: "Create agent task"
+    })
+    expect(within(manualModal).getByLabelText("Task title")).not.toHaveValue(
+      "Review captured page: Example Story"
+    )
+    expect(within(manualModal).getByLabelText("Task description")).toHaveValue("")
   })
 })

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts
@@ -102,7 +102,7 @@ describe("Deep Research bundle import", () => {
         supported_claim_count: 1,
         unsupported_claim_count: 0
       },
-      sourceTrust: [{ source_id: "src_1", snapshot_policy: "full_artifact" }]
+      sourceTrust: [{ sourceId: "src_1", snapshotPolicy: "full_artifact" }]
     })
   })
 
@@ -262,7 +262,161 @@ describe("Deep Research bundle import", () => {
       MAX_IMPORT_LIST_ITEMS
     )
     expect(artifact.sourceLineage).toHaveLength(MAX_IMPORT_LIST_ITEMS)
-    expect(artifact.content).toContain(`Source inventory: ${MAX_IMPORT_LIST_ITEMS}`)
+    expect(artifact.content).toContain(
+      `Source inventory: ${MAX_IMPORT_LIST_ITEMS + 10} (${MAX_IMPORT_LIST_ITEMS} shown)`
+    )
+  })
+
+  it("normalizes retained bundle metadata before persisting artifact data", () => {
+    const oversizedText = `Oversized field ${"x".repeat(1200)}`
+    const oversizedSourceId = `src_${"x".repeat(300)}`
+    const noisyBundle = {
+      ...bundle,
+      claims: [
+        {
+          claim_id: "claim-1",
+          text: oversizedText,
+          focus_area: "background",
+          source_ids: ["src_1"],
+          citations: [{ source_id: "src_1", quote: oversizedText }],
+          metadata: { nested: oversizedText }
+        }
+      ],
+      source_inventory: [
+        {
+          source_id: oversizedSourceId,
+          title: oversizedText,
+          provider: "local_corpus",
+          metadata: { nested: oversizedText },
+          excerpt: oversizedText
+        }
+      ],
+      unsupported_claims: [
+        {
+          claim_id: "claim-2",
+          text: oversizedText,
+          focus_area: "background",
+          reason: "No supporting notes",
+          source_ids: ["src_1"],
+          citations: [{ source_id: "src_1", quote: oversizedText }],
+          metadata: { nested: oversizedText }
+        }
+      ],
+      contradictions: [
+        {
+          note_id: "note-1",
+          source_id: "src_1",
+          focus_area: "background",
+          marker: "however",
+          text: oversizedText,
+          metadata: { nested: oversizedText }
+        }
+      ],
+      skipped_sources: [
+        {
+          source_id: oversizedSourceId,
+          title: oversizedText,
+          reason: oversizedText,
+          metadata: { nested: oversizedText }
+        }
+      ],
+      failed_sources: [
+        {
+          source_id: oversizedSourceId,
+          title: oversizedText,
+          reason: oversizedText,
+          metadata: { nested: oversizedText }
+        }
+      ],
+      source_trust: [
+        {
+          source_id: "src_1",
+          title: oversizedText,
+          provider: "local_corpus",
+          source_type: "web_result",
+          trust_tier: "internal",
+          trust_label: "local_corpus",
+          snapshot_policy: "full_artifact",
+          warnings: ["full_source_snapshot_unavailable"],
+          metadata: { nested: oversizedText },
+          excerpt: oversizedText
+        }
+      ]
+    }
+
+    const artifact = buildDeepResearchBundleArtifactPayload({
+      bundle: noisyBundle,
+      returnContext
+    })
+    const deepResearch = artifact.data?.deepResearch as {
+      claims: unknown[]
+      sourceInventory: unknown[]
+      skippedSources: unknown[]
+      failedSources: unknown[]
+      unsupportedClaims: unknown[]
+      contradictions: unknown[]
+      sourceTrust: unknown[]
+    }
+    const serializedMetadata = JSON.stringify(deepResearch)
+
+    expect(deepResearch.sourceInventory).toEqual([
+      { sourceId: expect.any(String), title: expect.any(String) }
+    ])
+    expect(deepResearch.sourceInventory[0]).toMatchObject({
+      sourceId: expect.stringMatching(/^src_/)
+    })
+    expect(String((deepResearch.sourceInventory[0] as { sourceId: string }).sourceId))
+      .toHaveLength(128)
+    expect(deepResearch.skippedSources[0]).toMatchObject({
+      sourceId: expect.stringMatching(/^src_/),
+      reason: expect.any(String)
+    })
+    expect(
+      String((deepResearch.skippedSources[0] as { sourceId: string }).sourceId)
+    ).toHaveLength(128)
+    expect(
+      String((deepResearch.skippedSources[0] as { reason: string }).reason).length
+    ).toBeLessThanOrEqual(500)
+    expect(
+      String((deepResearch.failedSources[0] as { reason: string }).reason).length
+    ).toBeLessThanOrEqual(500)
+    expect(deepResearch.sourceTrust).toEqual([
+      {
+        sourceId: "src_1",
+        title: expect.any(String),
+        provider: "local_corpus",
+        sourceType: "web_result",
+        trustTier: "internal",
+        trustLabel: "local_corpus",
+        snapshotPolicy: "full_artifact",
+        warnings: ["full_source_snapshot_unavailable"]
+      }
+    ])
+    expect(deepResearch.unsupportedClaims[0]).toMatchObject({
+      claimId: "claim-2",
+      text: expect.any(String),
+      focusArea: "background",
+      reason: "No supporting notes",
+      sourceIds: ["src_1"]
+    })
+    expect(deepResearch.contradictions[0]).toMatchObject({
+      noteId: "note-1",
+      sourceId: "src_1",
+      focusArea: "background",
+      marker: "however",
+      text: expect.any(String)
+    })
+    expect(deepResearch.claims[0]).toMatchObject({
+      claimId: "claim-1",
+      text: expect.any(String),
+      focusArea: "background",
+      sourceIds: ["src_1"]
+    })
+    expect(serializedMetadata).not.toContain("metadata")
+    expect(serializedMetadata).not.toContain("excerpt")
+    expect(serializedMetadata).not.toContain("citations")
+    expect(serializedMetadata).not.toContain(oversizedText)
+    expect(serializedMetadata).not.toContain(oversizedSourceId)
   })
 
   it("bounds provenance copied from an existing source artifact", () => {

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts
@@ -128,6 +128,66 @@ describe("Deep Research bundle import", () => {
     ])
   })
 
+  it("persists selected imported sources and recovery details from returned bundles", () => {
+    const richBundle = {
+      ...bundle,
+      unsupported_claims: [
+        { text: "Unsupported claim one", reason: "No matching citation" }
+      ],
+      contradictions: [
+        { text: "Contradiction one", source_id: "src_2" }
+      ],
+      skipped_sources: [
+        { source_id: "src_3", title: "Paper C", reason: "paywalled" }
+      ],
+      failed_sources: [
+        { source_id: "src_4", title: "Paper D", reason: "extraction failed" }
+      ]
+    }
+
+    const artifact = buildDeepResearchBundleArtifactPayload({
+      bundle: richBundle,
+      returnContext,
+      sourceArtifact
+    })
+    const deepResearch = artifact.data?.deepResearch as {
+      selectedImportedSources: unknown[]
+      skippedSources: unknown[]
+      failedSources: unknown[]
+    }
+
+    expect(deepResearch.selectedImportedSources).toEqual([
+      {
+        sourceId: "source-a",
+        mediaId: 101,
+        title: "Paper A",
+        status: "selected"
+      },
+      {
+        sourceId: "source-b",
+        mediaId: 102,
+        title: "Paper B",
+        status: "selected"
+      }
+    ])
+    expect(deepResearch.skippedSources).toEqual([
+      { sourceId: "src_3", title: "Paper C", reason: "paywalled" }
+    ])
+    expect(deepResearch.failedSources).toEqual([
+      { sourceId: "src_4", title: "Paper D", reason: "extraction failed" }
+    ])
+    expect(artifact.content).toContain("## Selected Imported Sources")
+    expect(artifact.content).toContain("- Paper A (source-a, media #101) - selected")
+    expect(artifact.content).toContain("## Skipped Sources")
+    expect(artifact.content).toContain("- Paper C (src_3): paywalled")
+    expect(artifact.content).toContain("## Failed Sources")
+    expect(artifact.content).toContain("- Paper D (src_4): extraction failed")
+    expect(artifact.content).toContain("## Unsupported Claims")
+    expect(artifact.content).toContain("- Unsupported claim one")
+    expect(artifact.content).toContain("## Contradictions")
+    expect(artifact.content).toContain("- Contradiction one")
+  })
+
   it("rejects malformed bundles without a usable report", () => {
     expect(() =>
       buildDeepResearchBundleArtifactPayload({
@@ -170,6 +230,8 @@ describe("Deep Research bundle import", () => {
       ),
       unsupported_claims: unboundedList,
       contradictions: unboundedList,
+      skipped_sources: unboundedList,
+      failed_sources: unboundedList,
       source_trust: unboundedList
     }
 
@@ -183,6 +245,8 @@ describe("Deep Research bundle import", () => {
       unresolvedQuestions: unknown[]
       unsupportedClaims: unknown[]
       contradictions: unknown[]
+      skippedSources: unknown[]
+      failedSources: unknown[]
       sourceTrust: unknown[]
     }
 
@@ -191,11 +255,80 @@ describe("Deep Research bundle import", () => {
     expect(deepResearch.unresolvedQuestions).toHaveLength(MAX_IMPORT_LIST_ITEMS)
     expect(deepResearch.unsupportedClaims).toHaveLength(MAX_IMPORT_LIST_ITEMS)
     expect(deepResearch.contradictions).toHaveLength(MAX_IMPORT_LIST_ITEMS)
+    expect(deepResearch.skippedSources).toHaveLength(MAX_IMPORT_LIST_ITEMS)
+    expect(deepResearch.failedSources).toHaveLength(MAX_IMPORT_LIST_ITEMS)
     expect(deepResearch.sourceTrust).toHaveLength(MAX_IMPORT_LIST_ITEMS)
     expect(artifact.sourceCoverage.selectedSourceIds).toHaveLength(
       MAX_IMPORT_LIST_ITEMS
     )
     expect(artifact.sourceLineage).toHaveLength(MAX_IMPORT_LIST_ITEMS)
     expect(artifact.content).toContain(`Source inventory: ${MAX_IMPORT_LIST_ITEMS}`)
+  })
+
+  it("bounds provenance copied from an existing source artifact", () => {
+    const unboundedSources = Array.from(
+      { length: MAX_IMPORT_LIST_ITEMS + 10 },
+      (_, index) => ({
+        sourceId: `source-${index}`,
+        mediaId: index + 1,
+        title: `Paper ${index}`
+      })
+    )
+    const unboundedSourceArtifact = {
+      ...sourceArtifact,
+      sourceCoverage: {
+        selectedSourceIds: unboundedSources.map((source) => source.sourceId),
+        usableSources: unboundedSources,
+        skippedSources: unboundedSources.map((source) => ({
+          ...source,
+          reason: "context_limit" as const
+        })),
+        truncatedSources: unboundedSources,
+        minimumUsableSourcesMet: true
+      },
+      sourceLineage: unboundedSources.map((source) => ({
+        ...source,
+        citationCount: 1,
+        citationSpans: Array.from(
+          { length: MAX_IMPORT_LIST_ITEMS + 10 },
+          (_, index) => ({ index })
+        ),
+        evidenceIds: Array.from(
+          { length: MAX_IMPORT_LIST_ITEMS + 10 },
+          (_, index) => `evidence-${index}`
+        ),
+        oversizedUnknownField: Array.from(
+          { length: MAX_IMPORT_LIST_ITEMS + 10 },
+          (_, index) => ({ index })
+        )
+      }))
+    } satisfies GeneratedArtifact
+
+    const artifact = buildDeepResearchBundleArtifactPayload({
+      bundle,
+      returnContext,
+      sourceArtifact: unboundedSourceArtifact
+    })
+
+    expect(artifact.sourceCoverage.selectedSourceIds).toHaveLength(
+      MAX_IMPORT_LIST_ITEMS
+    )
+    expect(artifact.sourceCoverage.usableSources).toHaveLength(
+      MAX_IMPORT_LIST_ITEMS
+    )
+    expect(artifact.sourceCoverage.skippedSources).toHaveLength(
+      MAX_IMPORT_LIST_ITEMS
+    )
+    expect(artifact.sourceCoverage.truncatedSources).toHaveLength(
+      MAX_IMPORT_LIST_ITEMS
+    )
+    expect(artifact.sourceLineage).toHaveLength(MAX_IMPORT_LIST_ITEMS)
+    expect(artifact.sourceLineage[0].citationSpans).toHaveLength(
+      MAX_IMPORT_LIST_ITEMS
+    )
+    expect(artifact.sourceLineage[0].evidenceIds).toHaveLength(
+      MAX_IMPORT_LIST_ITEMS
+    )
+    expect(artifact.sourceLineage[0]).not.toHaveProperty("oversizedUnknownField")
   })
 })

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/deep-research-bundle-import.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/deep-research-bundle-import.ts
@@ -1,6 +1,7 @@
 import type {
   ArtifactSourceCoverage,
   ArtifactSourceCoverageEntry,
+  ArtifactSkippedSource,
   ArtifactSourceLineage,
   GeneratedArtifact
 } from "@/types/workspace"
@@ -8,6 +9,8 @@ import type { ResearchWorkspaceDeepResearchReturnContext } from "./research-work
 
 const IMPORTED_REPORT_LIMIT = 7_600
 const PREVIEW_LIMIT = 280
+const METADATA_TEXT_LIMIT = 500
+const METADATA_ID_LIMIT = 128
 export const MAX_IMPORT_LIST_ITEMS = 50
 const IMPORT_TRUNCATION_SUFFIX =
   "\n\n[Deep Research report truncated for workspace import.]"
@@ -27,6 +30,27 @@ type DeepResearchSourceDetail = {
   title?: string
   reason?: string
 }
+type DeepResearchRecordSummary = {
+  text: string
+  claimId?: string
+  noteId?: string
+  sourceId?: string
+  sourceIds?: string[]
+  focusArea?: string
+  reason?: string
+  marker?: string
+  supportLevel?: string
+}
+type DeepResearchSourceTrustSummary = {
+  sourceId: string
+  title?: string
+  provider?: string
+  sourceType?: string
+  trustTier?: string
+  trustLabel?: string
+  snapshotPolicy?: string
+  warnings?: string[]
+}
 
 export class DeepResearchBundleImportError extends Error {
   constructor(message: string) {
@@ -44,14 +68,44 @@ const asRecord = (value: unknown): Record<string, unknown> =>
 const readString = (value: unknown): string =>
   typeof value === "string" ? value.trim() : ""
 
+const truncateMetadataText = (
+  value: string,
+  limit = METADATA_TEXT_LIMIT
+): string => {
+  if (value.length <= limit) return value
+  if (limit <= 3) return value.slice(0, limit)
+  return `${value.slice(0, limit - 3).trimEnd()}...`
+}
+
+const readBoundedString = (
+  value: unknown,
+  limit = METADATA_TEXT_LIMIT
+): string => truncateMetadataText(readString(value), limit)
+
+const readOptionalBoundedString = (
+  value: unknown,
+  limit = METADATA_TEXT_LIMIT
+): string | null => readBoundedString(value, limit) || null
+
 const capImportList = <T,>(items: T[]): T[] =>
   items.slice(0, MAX_IMPORT_LIST_ITEMS)
 
 const readRecordList = (value: unknown): Array<Record<string, unknown>> =>
   Array.isArray(value) ? capImportList(value.filter(isRecord)) : []
 
+const countRecords = (value: unknown): number =>
+  Array.isArray(value) ? value.filter(isRecord).length : 0
+
 const readStringList = (value: unknown): string[] =>
   Array.isArray(value) ? capImportList(value.map(readString).filter(Boolean)) : []
+
+const readBoundedStringList = (
+  value: unknown,
+  limit = METADATA_ID_LIMIT
+): string[] =>
+  Array.isArray(value)
+    ? capImportList(value.map((item) => readBoundedString(item, limit)).filter(Boolean))
+    : []
 
 const readQuestion = (bundle: Record<string, unknown>): string => {
   const directQuestion = readString(bundle.question)
@@ -82,12 +136,22 @@ const normalizeSourceInventory = (
 ): ArtifactSourceCoverageEntry[] =>
   readRecordList(bundle.source_inventory)
     .map((entry): ArtifactSourceCoverageEntry | null => {
-      const sourceId = readString(entry.source_id ?? entry.id)
+      const sourceId = readBoundedString(
+        entry.source_id ?? entry.sourceId ?? entry.id,
+        METADATA_ID_LIMIT
+      )
       if (!sourceId) return null
 
-      const title = readString(entry.title ?? entry.label)
+      const title = readBoundedString(entry.title ?? entry.label)
+      const mediaId =
+        typeof entry.media_id === "number" && Number.isFinite(entry.media_id)
+          ? entry.media_id
+          : typeof entry.mediaId === "number" && Number.isFinite(entry.mediaId)
+            ? entry.mediaId
+            : undefined
       return {
         sourceId,
+        ...(mediaId !== undefined ? { mediaId } : {}),
         ...(title ? { title } : {})
       }
     })
@@ -106,7 +170,7 @@ const buildSelectedImportedSources = (
   return capImportList(selectedSources).map((source) => ({
     sourceId: source.sourceId,
     ...(source.mediaId !== undefined ? { mediaId: source.mediaId } : {}),
-    ...(source.title ? { title: source.title } : {}),
+    ...(source.title ? { title: readBoundedString(source.title) } : {}),
     status
   }))
 }
@@ -116,11 +180,14 @@ const normalizeBundleSourceDetails = (
 ): DeepResearchSourceDetail[] =>
   readRecordList(value)
     .map((entry): DeepResearchSourceDetail | null => {
-      const sourceId = readString(entry.source_id ?? entry.sourceId ?? entry.id)
+      const sourceId = readBoundedString(
+        entry.source_id ?? entry.sourceId ?? entry.id,
+        METADATA_ID_LIMIT
+      )
       if (!sourceId) return null
 
-      const title = readString(entry.title ?? entry.label)
-      const reason = readString(
+      const title = readBoundedString(entry.title ?? entry.label)
+      const reason = readBoundedString(
         entry.reason ?? entry.error ?? entry.message ?? entry.status_message
       )
       return {
@@ -136,9 +203,43 @@ const normalizeCoverageSkippedSources = (
 ): DeepResearchSourceDetail[] =>
   capImportList(sourceCoverage.skippedSources).map((source) => ({
     sourceId: source.sourceId,
-    ...(source.title ? { title: source.title } : {}),
-    reason: source.reason
+    ...(source.title ? { title: readBoundedString(source.title) } : {}),
+    reason: readBoundedString(source.reason)
   }))
+
+const normalizeCoverageEntry = (
+  source: ArtifactSourceCoverageEntry
+): ArtifactSourceCoverageEntry | null => {
+  const sourceId = readBoundedString(source.sourceId, METADATA_ID_LIMIT)
+  if (!sourceId) return null
+
+  return {
+    sourceId,
+    ...(typeof source.mediaId === "number" && Number.isFinite(source.mediaId)
+      ? { mediaId: source.mediaId }
+      : {}),
+    ...(source.title ? { title: readBoundedString(source.title) } : {})
+  }
+}
+
+const normalizeSkippedCoverageEntry = (
+  source: ArtifactSkippedSource
+): ArtifactSkippedSource | null => {
+  const normalized = normalizeCoverageEntry(source)
+  if (!normalized) return null
+  const reason =
+    source.reason === "missing_text" ||
+    source.reason === "unready" ||
+    source.reason === "context_limit" ||
+    source.reason === "unknown"
+      ? source.reason
+      : "unknown"
+
+  return {
+    ...normalized,
+    reason
+  }
+}
 
 const buildFallbackSourceCoverage = (
   sources: ArtifactSourceCoverageEntry[]
@@ -154,11 +255,19 @@ const sanitizeSourceCoverage = (
   sourceCoverage: ArtifactSourceCoverage
 ): ArtifactSourceCoverage => ({
   selectedSourceIds: capImportList(
-    sourceCoverage.selectedSourceIds.map(readString).filter(Boolean)
+    sourceCoverage.selectedSourceIds
+      .map((sourceId) => readBoundedString(sourceId, METADATA_ID_LIMIT))
+      .filter(Boolean)
   ),
-  usableSources: capImportList(sourceCoverage.usableSources),
-  skippedSources: capImportList(sourceCoverage.skippedSources),
-  truncatedSources: capImportList(sourceCoverage.truncatedSources),
+  usableSources: capImportList(sourceCoverage.usableSources)
+    .map(normalizeCoverageEntry)
+    .filter((source): source is ArtifactSourceCoverageEntry => Boolean(source)),
+  skippedSources: capImportList(sourceCoverage.skippedSources)
+    .map(normalizeSkippedCoverageEntry)
+    .filter((source): source is ArtifactSkippedSource => Boolean(source)),
+  truncatedSources: capImportList(sourceCoverage.truncatedSources)
+    .map(normalizeCoverageEntry)
+    .filter((source): source is ArtifactSourceCoverageEntry => Boolean(source)),
   ...(sourceCoverage.sourceContextCharLimit
     ? { sourceContextCharLimit: sourceCoverage.sourceContextCharLimit }
     : {}),
@@ -175,14 +284,18 @@ const sanitizeSourceLineage = (
 
       return {
         sourceId,
-        ...(readString(lineage.sourceType)
-          ? { sourceType: readString(lineage.sourceType) }
+        ...(readBoundedString(lineage.sourceType)
+          ? { sourceType: readBoundedString(lineage.sourceType) }
           : {}),
         ...(typeof lineage.mediaId === "number" && Number.isFinite(lineage.mediaId)
           ? { mediaId: lineage.mediaId }
           : {}),
-        ...(readString(lineage.title) ? { title: readString(lineage.title) } : {}),
-        ...(readString(lineage.label) ? { label: readString(lineage.label) } : {}),
+        ...(readBoundedString(lineage.title)
+          ? { title: readBoundedString(lineage.title) }
+          : {}),
+        ...(readBoundedString(lineage.label)
+          ? { label: readBoundedString(lineage.label) }
+          : {}),
         ...(typeof lineage.citationCount === "number" &&
         Number.isFinite(lineage.citationCount)
           ? { citationCount: lineage.citationCount }
@@ -193,12 +306,14 @@ const sanitizeSourceLineage = (
         ...(Array.isArray(lineage.evidenceIds)
           ? {
               evidenceIds: capImportList(lineage.evidenceIds)
-                .map(readString)
+                .map((evidenceId) =>
+                  readBoundedString(evidenceId, METADATA_ID_LIMIT)
+                )
                 .filter(Boolean)
             }
           : {}),
-        ...(readString(lineage.coverageNotes)
-          ? { coverageNotes: readString(lineage.coverageNotes) }
+        ...(readBoundedString(lineage.coverageNotes)
+          ? { coverageNotes: readBoundedString(lineage.coverageNotes) }
           : {})
       }
     })
@@ -235,9 +350,17 @@ const buildSourceArtifactMetadata = (
   returnContext: ResearchWorkspaceDeepResearchReturnContext,
   sourceArtifact?: GeneratedArtifact | null
 ) => ({
-  id: sourceArtifact?.id ?? returnContext.sourceArtifactId,
-  template: sourceArtifact?.templateId ?? returnContext.sourceArtifactTemplate,
-  title: sourceArtifact?.title ?? returnContext.sourceArtifactTitle
+  id: readOptionalBoundedString(
+    sourceArtifact?.id ?? returnContext.sourceArtifactId,
+    METADATA_ID_LIMIT
+  ),
+  template: readOptionalBoundedString(
+    sourceArtifact?.templateId ?? returnContext.sourceArtifactTemplate,
+    METADATA_ID_LIMIT
+  ),
+  title: readOptionalBoundedString(
+    sourceArtifact?.title ?? returnContext.sourceArtifactTitle
+  )
 })
 
 const formatSourceEntry = (
@@ -260,11 +383,11 @@ const formatSourceDetailEntry = (source: DeepResearchSourceDetail): string => {
   return `- ${label} (${source.sourceId})${reasonSuffix}`
 }
 
-const readRecordSummary = (
+const readRecordSummaryText = (
   record: Record<string, unknown>,
   fallback: string
 ): string =>
-  readString(
+  readBoundedString(
     record.text ??
       record.claim ??
       record.summary ??
@@ -275,9 +398,83 @@ const readRecordSummary = (
   ) || fallback
 
 const buildRecordSummaryLines = (
-  records: Array<Record<string, unknown>>
+  records: DeepResearchRecordSummary[]
 ): string[] =>
-  records.map((record, index) => `- ${readRecordSummary(record, `Item ${index + 1}`)}`)
+  records.map((record, index) => `- ${record.text || `Item ${index + 1}`}`)
+
+const normalizeResearchRecords = (
+  value: unknown
+): DeepResearchRecordSummary[] =>
+  readRecordList(value).map((record, index) => {
+    const claimId = readBoundedString(
+      record.claim_id ?? record.claimId ?? record.id,
+      METADATA_ID_LIMIT
+    )
+    const noteId = readBoundedString(record.note_id ?? record.noteId, METADATA_ID_LIMIT)
+    const sourceId = readBoundedString(
+      record.source_id ?? record.sourceId,
+      METADATA_ID_LIMIT
+    )
+    const sourceIds = readBoundedStringList(record.source_ids ?? record.sourceIds)
+    const focusArea = readBoundedString(record.focus_area ?? record.focusArea)
+    const reason = readBoundedString(record.reason)
+    const marker = readBoundedString(record.marker)
+    const supportLevel = readBoundedString(
+      record.support_level ?? record.supportLevel
+    )
+
+    return {
+      text: readRecordSummaryText(record, `Item ${index + 1}`),
+      ...(claimId ? { claimId } : {}),
+      ...(noteId ? { noteId } : {}),
+      ...(sourceId ? { sourceId } : {}),
+      ...(sourceIds.length ? { sourceIds } : {}),
+      ...(focusArea ? { focusArea } : {}),
+      ...(reason ? { reason } : {}),
+      ...(marker ? { marker } : {}),
+      ...(supportLevel ? { supportLevel } : {})
+    }
+  })
+
+const normalizeSourceTrust = (value: unknown): DeepResearchSourceTrustSummary[] =>
+  readRecordList(value)
+    .map((entry): DeepResearchSourceTrustSummary | null => {
+      const sourceId = readBoundedString(
+        entry.source_id ?? entry.sourceId ?? entry.id,
+        METADATA_ID_LIMIT
+      )
+      if (!sourceId) return null
+
+      const title = readBoundedString(entry.title ?? entry.label)
+      const provider = readBoundedString(entry.provider)
+      const sourceType = readBoundedString(entry.source_type ?? entry.sourceType)
+      const trustTier = readBoundedString(entry.trust_tier ?? entry.trustTier)
+      const trustLabel = readBoundedString(entry.trust_label ?? entry.trustLabel)
+      const snapshotPolicy = readBoundedString(
+        entry.snapshot_policy ?? entry.snapshotPolicy
+      )
+      const warnings = readBoundedStringList(entry.warnings)
+
+      return {
+        sourceId,
+        ...(title ? { title } : {}),
+        ...(provider ? { provider } : {}),
+        ...(sourceType ? { sourceType } : {}),
+        ...(trustTier ? { trustTier } : {}),
+        ...(trustLabel ? { trustLabel } : {}),
+        ...(snapshotPolicy ? { snapshotPolicy } : {}),
+        ...(warnings.length ? { warnings } : {})
+      }
+    })
+    .filter((entry): entry is DeepResearchSourceTrustSummary => Boolean(entry))
+
+const formatSourceInventoryCount = (
+  sourceCount: number,
+  shownSourceCount: number
+): string =>
+  sourceCount > shownSourceCount
+    ? `${sourceCount} (${shownSourceCount} shown)`
+    : String(sourceCount)
 
 const buildSection = (title: string, lines: string[]): string[] =>
   lines.length ? ["", `## ${title}`, "", ...lines] : []
@@ -292,8 +489,8 @@ const buildImportedContent = (options: {
   sourceInventory: ArtifactSourceCoverageEntry[]
   skippedSources: DeepResearchSourceDetail[]
   failedSources: DeepResearchSourceDetail[]
-  unsupportedClaims: Array<Record<string, unknown>>
-  contradictions: Array<Record<string, unknown>>
+  unsupportedClaims: DeepResearchRecordSummary[]
+  contradictions: DeepResearchRecordSummary[]
   verificationSummary: Record<string, unknown>
   unresolvedQuestions: string[]
 }): string => {
@@ -348,7 +545,10 @@ const buildImportedContent = (options: {
     `Imported from Deep Research run ${options.returnContext.researchRunId}.`,
     `Source artifact: ${options.sourceTitle}`,
     `Question: ${options.question}`,
-    `Source inventory: ${options.sourceCount}`,
+    `Source inventory: ${formatSourceInventoryCount(
+      options.sourceCount,
+      options.sourceInventory.length
+    )}`,
     verificationBits.length ? `Verification: ${verificationBits.join(", ")}` : "",
     ...selectedImportedSources,
     ...sourceInventory,
@@ -390,14 +590,16 @@ export const buildDeepResearchBundleArtifactPayload = ({
     )
   }
 
-  const claims = readRecordList(bundle.claims)
+  const rawClaims = readRecordList(bundle.claims)
+  const claims = normalizeResearchRecords(bundle.claims)
   const sourceInventory = normalizeSourceInventory(bundle)
+  const sourceInventoryCount = countRecords(bundle.source_inventory)
   const sourceCoverage = sanitizeSourceCoverage(
     sourceArtifact?.sourceCoverage ?? buildFallbackSourceCoverage(sourceInventory)
   )
   const sourceLineage = sanitizeSourceLineage(
     sourceArtifact?.sourceLineage ??
-      buildFallbackSourceLineage(sourceInventory, claims)
+      buildFallbackSourceLineage(sourceInventory, rawClaims)
   )
   const selectedImportedSources = buildSelectedImportedSources(
     sourceCoverage,
@@ -408,8 +610,9 @@ export const buildDeepResearchBundleArtifactPayload = ({
     ...normalizeBundleSourceDetails(bundle.skipped_sources)
   ])
   const failedSources = normalizeBundleSourceDetails(bundle.failed_sources)
-  const unsupportedClaims = readRecordList(bundle.unsupported_claims)
-  const contradictions = readRecordList(bundle.contradictions)
+  const unsupportedClaims = normalizeResearchRecords(bundle.unsupported_claims)
+  const contradictions = normalizeResearchRecords(bundle.contradictions)
+  const sourceTrust = normalizeSourceTrust(bundle.source_trust)
   const sourceArtifactMetadata = buildSourceArtifactMetadata(
     returnContext,
     sourceArtifact
@@ -425,7 +628,7 @@ export const buildDeepResearchBundleArtifactPayload = ({
     reportMarkdown,
     returnContext,
     sourceTitle,
-    sourceCount: sourceInventory.length,
+    sourceCount: sourceInventoryCount,
     selectedImportedSources,
     sourceInventory,
     skippedSources,
@@ -478,7 +681,7 @@ export const buildDeepResearchBundleArtifactPayload = ({
         question,
         sourceArtifact: sourceArtifactMetadata,
         claims,
-        sourceInventory: readRecordList(bundle.source_inventory),
+        sourceInventory,
         selectedImportedSources,
         skippedSources,
         failedSources,
@@ -486,7 +689,7 @@ export const buildDeepResearchBundleArtifactPayload = ({
         verificationSummary,
         unsupportedClaims,
         contradictions,
-        sourceTrust: readRecordList(bundle.source_trust)
+        sourceTrust
       }
     },
     completedAt: new Date()

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/deep-research-bundle-import.ts
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/deep-research-bundle-import.ts
@@ -19,6 +19,14 @@ type DeepResearchBundleImportOptions = {
 }
 
 type GeneratedArtifactPayload = Omit<GeneratedArtifact, "id" | "createdAt">
+type DeepResearchImportedSource = ArtifactSourceCoverageEntry & {
+  status: "selected" | "inventory"
+}
+type DeepResearchSourceDetail = {
+  sourceId: string
+  title?: string
+  reason?: string
+}
 
 export class DeepResearchBundleImportError extends Error {
   constructor(message: string) {
@@ -85,6 +93,53 @@ const normalizeSourceInventory = (
     })
     .filter((entry): entry is ArtifactSourceCoverageEntry => Boolean(entry))
 
+const buildSelectedImportedSources = (
+  sourceCoverage: ArtifactSourceCoverage,
+  sourceInventory: ArtifactSourceCoverageEntry[]
+): DeepResearchImportedSource[] => {
+  const selectedSources = sourceCoverage.usableSources.length
+    ? sourceCoverage.usableSources
+    : sourceInventory
+  const status: DeepResearchImportedSource["status"] =
+    sourceCoverage.usableSources.length ? "selected" : "inventory"
+
+  return capImportList(selectedSources).map((source) => ({
+    sourceId: source.sourceId,
+    ...(source.mediaId !== undefined ? { mediaId: source.mediaId } : {}),
+    ...(source.title ? { title: source.title } : {}),
+    status
+  }))
+}
+
+const normalizeBundleSourceDetails = (
+  value: unknown
+): DeepResearchSourceDetail[] =>
+  readRecordList(value)
+    .map((entry): DeepResearchSourceDetail | null => {
+      const sourceId = readString(entry.source_id ?? entry.sourceId ?? entry.id)
+      if (!sourceId) return null
+
+      const title = readString(entry.title ?? entry.label)
+      const reason = readString(
+        entry.reason ?? entry.error ?? entry.message ?? entry.status_message
+      )
+      return {
+        sourceId,
+        ...(title ? { title } : {}),
+        ...(reason ? { reason } : {})
+      }
+    })
+    .filter((entry): entry is DeepResearchSourceDetail => Boolean(entry))
+
+const normalizeCoverageSkippedSources = (
+  sourceCoverage: ArtifactSourceCoverage
+): DeepResearchSourceDetail[] =>
+  capImportList(sourceCoverage.skippedSources).map((source) => ({
+    sourceId: source.sourceId,
+    ...(source.title ? { title: source.title } : {}),
+    reason: source.reason
+  }))
+
 const buildFallbackSourceCoverage = (
   sources: ArtifactSourceCoverageEntry[]
 ): ArtifactSourceCoverage => ({
@@ -94,6 +149,60 @@ const buildFallbackSourceCoverage = (
   truncatedSources: [],
   minimumUsableSourcesMet: sources.length > 0
 })
+
+const sanitizeSourceCoverage = (
+  sourceCoverage: ArtifactSourceCoverage
+): ArtifactSourceCoverage => ({
+  selectedSourceIds: capImportList(
+    sourceCoverage.selectedSourceIds.map(readString).filter(Boolean)
+  ),
+  usableSources: capImportList(sourceCoverage.usableSources),
+  skippedSources: capImportList(sourceCoverage.skippedSources),
+  truncatedSources: capImportList(sourceCoverage.truncatedSources),
+  ...(sourceCoverage.sourceContextCharLimit
+    ? { sourceContextCharLimit: sourceCoverage.sourceContextCharLimit }
+    : {}),
+  minimumUsableSourcesMet: sourceCoverage.minimumUsableSourcesMet
+})
+
+const sanitizeSourceLineage = (
+  sourceLineage: ArtifactSourceLineage[]
+): ArtifactSourceLineage[] =>
+  capImportList(sourceLineage)
+    .map((lineage): ArtifactSourceLineage | null => {
+      const sourceId = readString(lineage.sourceId)
+      if (!sourceId) return null
+
+      return {
+        sourceId,
+        ...(readString(lineage.sourceType)
+          ? { sourceType: readString(lineage.sourceType) }
+          : {}),
+        ...(typeof lineage.mediaId === "number" && Number.isFinite(lineage.mediaId)
+          ? { mediaId: lineage.mediaId }
+          : {}),
+        ...(readString(lineage.title) ? { title: readString(lineage.title) } : {}),
+        ...(readString(lineage.label) ? { label: readString(lineage.label) } : {}),
+        ...(typeof lineage.citationCount === "number" &&
+        Number.isFinite(lineage.citationCount)
+          ? { citationCount: lineage.citationCount }
+          : {}),
+        ...(Array.isArray(lineage.citationSpans)
+          ? { citationSpans: capImportList(lineage.citationSpans) }
+          : {}),
+        ...(Array.isArray(lineage.evidenceIds)
+          ? {
+              evidenceIds: capImportList(lineage.evidenceIds)
+                .map(readString)
+                .filter(Boolean)
+            }
+          : {}),
+        ...(readString(lineage.coverageNotes)
+          ? { coverageNotes: readString(lineage.coverageNotes) }
+          : {})
+      }
+    })
+    .filter((lineage): lineage is ArtifactSourceLineage => Boolean(lineage))
 
 const buildCitationCounts = (
   claims: Array<Record<string, unknown>>
@@ -131,12 +240,60 @@ const buildSourceArtifactMetadata = (
   title: sourceArtifact?.title ?? returnContext.sourceArtifactTitle
 })
 
+const formatSourceEntry = (
+  source: ArtifactSourceCoverageEntry,
+  options?: { status?: string }
+): string => {
+  const label = source.title || source.sourceId
+  const details = [
+    source.sourceId,
+    source.mediaId !== undefined ? `media #${source.mediaId}` : null
+  ].filter(Boolean)
+  const detailSuffix = details.length ? ` (${details.join(", ")})` : ""
+  const statusSuffix = options?.status ? ` - ${options.status}` : ""
+  return `- ${label}${detailSuffix}${statusSuffix}`
+}
+
+const formatSourceDetailEntry = (source: DeepResearchSourceDetail): string => {
+  const label = source.title || source.sourceId
+  const reasonSuffix = source.reason ? `: ${source.reason}` : ""
+  return `- ${label} (${source.sourceId})${reasonSuffix}`
+}
+
+const readRecordSummary = (
+  record: Record<string, unknown>,
+  fallback: string
+): string =>
+  readString(
+    record.text ??
+      record.claim ??
+      record.summary ??
+      record.title ??
+      record.reason ??
+      record.source_id ??
+      record.id
+  ) || fallback
+
+const buildRecordSummaryLines = (
+  records: Array<Record<string, unknown>>
+): string[] =>
+  records.map((record, index) => `- ${readRecordSummary(record, `Item ${index + 1}`)}`)
+
+const buildSection = (title: string, lines: string[]): string[] =>
+  lines.length ? ["", `## ${title}`, "", ...lines] : []
+
 const buildImportedContent = (options: {
   question: string
   reportMarkdown: string
   returnContext: ResearchWorkspaceDeepResearchReturnContext
   sourceTitle: string
   sourceCount: number
+  selectedImportedSources: DeepResearchImportedSource[]
+  sourceInventory: ArtifactSourceCoverageEntry[]
+  skippedSources: DeepResearchSourceDetail[]
+  failedSources: DeepResearchSourceDetail[]
+  unsupportedClaims: Array<Record<string, unknown>>
+  contradictions: Array<Record<string, unknown>>
   verificationSummary: Record<string, unknown>
   unresolvedQuestions: string[]
 }): string => {
@@ -158,6 +315,32 @@ const buildImportedContent = (options: {
         ...options.unresolvedQuestions.map((question) => `- ${question}`)
       ]
     : []
+  const selectedImportedSources = buildSection(
+    "Selected Imported Sources",
+    options.selectedImportedSources.map((source) =>
+      formatSourceEntry(source, { status: source.status })
+    )
+  )
+  const sourceInventory = buildSection(
+    "Source Inventory",
+    options.sourceInventory.map((source) => formatSourceEntry(source))
+  )
+  const skippedSources = buildSection(
+    "Skipped Sources",
+    options.skippedSources.map(formatSourceDetailEntry)
+  )
+  const failedSources = buildSection(
+    "Failed Sources",
+    options.failedSources.map(formatSourceDetailEntry)
+  )
+  const unsupportedClaims = buildSection(
+    "Unsupported Claims",
+    buildRecordSummaryLines(options.unsupportedClaims)
+  )
+  const contradictions = buildSection(
+    "Contradictions",
+    buildRecordSummaryLines(options.contradictions)
+  )
 
   return [
     `# Deep Research Import: ${options.sourceTitle}`,
@@ -167,6 +350,12 @@ const buildImportedContent = (options: {
     `Question: ${options.question}`,
     `Source inventory: ${options.sourceCount}`,
     verificationBits.length ? `Verification: ${verificationBits.join(", ")}` : "",
+    ...selectedImportedSources,
+    ...sourceInventory,
+    ...skippedSources,
+    ...failedSources,
+    ...unsupportedClaims,
+    ...contradictions,
     "",
     "## Report",
     "",
@@ -203,11 +392,24 @@ export const buildDeepResearchBundleArtifactPayload = ({
 
   const claims = readRecordList(bundle.claims)
   const sourceInventory = normalizeSourceInventory(bundle)
-  const sourceCoverage =
+  const sourceCoverage = sanitizeSourceCoverage(
     sourceArtifact?.sourceCoverage ?? buildFallbackSourceCoverage(sourceInventory)
-  const sourceLineage =
+  )
+  const sourceLineage = sanitizeSourceLineage(
     sourceArtifact?.sourceLineage ??
-    buildFallbackSourceLineage(sourceInventory, claims)
+      buildFallbackSourceLineage(sourceInventory, claims)
+  )
+  const selectedImportedSources = buildSelectedImportedSources(
+    sourceCoverage,
+    sourceInventory
+  )
+  const skippedSources = capImportList([
+    ...normalizeCoverageSkippedSources(sourceCoverage),
+    ...normalizeBundleSourceDetails(bundle.skipped_sources)
+  ])
+  const failedSources = normalizeBundleSourceDetails(bundle.failed_sources)
+  const unsupportedClaims = readRecordList(bundle.unsupported_claims)
+  const contradictions = readRecordList(bundle.contradictions)
   const sourceArtifactMetadata = buildSourceArtifactMetadata(
     returnContext,
     sourceArtifact
@@ -224,6 +426,12 @@ export const buildDeepResearchBundleArtifactPayload = ({
     returnContext,
     sourceTitle,
     sourceCount: sourceInventory.length,
+    selectedImportedSources,
+    sourceInventory,
+    skippedSources,
+    failedSources,
+    unsupportedClaims,
+    contradictions,
     verificationSummary,
     unresolvedQuestions
   })
@@ -271,10 +479,13 @@ export const buildDeepResearchBundleArtifactPayload = ({
         sourceArtifact: sourceArtifactMetadata,
         claims,
         sourceInventory: readRecordList(bundle.source_inventory),
+        selectedImportedSources,
+        skippedSources,
+        failedSources,
         unresolvedQuestions,
         verificationSummary,
-        unsupportedClaims: readRecordList(bundle.unsupported_claims),
-        contradictions: readRecordList(bundle.contradictions),
+        unsupportedClaims,
+        contradictions,
         sourceTrust: readRecordList(bundle.source_trust)
       }
     },

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
@@ -119,6 +119,12 @@ import {
   DeepResearchBundleImportError,
   buildDeepResearchBundleArtifactPayload
 } from "./deep-research-bundle-import"
+import {
+  clearPendingWebClipAgentTaskRequest,
+  readPendingWebClipAgentTaskRequest,
+  type PendingWebClipAgentTaskRequest
+} from "@/services/web-clipper/agent-task-handoff"
+import type { WorkspaceAgentTaskPrefill } from "./WorkspaceAgentTaskHandoffModal"
 
 const SourcesPane = React.lazy(() =>
   import("./SourcesPane").then((module) => ({ default: module.SourcesPane }))
@@ -138,6 +144,7 @@ const WORKSPACE_STORAGE_PAYLOAD_BUDGET_NEXT_ENV =
   "NEXT_PUBLIC_WORKSPACE_STORAGE_PAYLOAD_BUDGET_MB"
 const WORKSPACE_STORAGE_SPLIT_KEY_PREFIX = `${WORKSPACE_STORAGE_KEY}:workspace:`
 const WORKSPACE_STORAGE_USAGE_REFRESH_DELAY_MS = 120
+const WEB_CLIP_AGENT_TASK_ROUTE_FLAG = "agent_task_handoff"
 const ACCOUNT_STORAGE_USAGE_REFRESH_DELAY_MS = 1400
 const WORKSPACE_ONBOARDING_DISMISSED_STORAGE_KEY =
   "tldw:research-workspace:onboarding-dismissed:v1"
@@ -184,6 +191,25 @@ const buildDeepResearchBundleImportContextKey = (
     context.sourceArtifactId ?? "",
     context.researchRunId
   ].join(":")
+
+const buildWebClipAgentTaskPrefill = (
+  request: PendingWebClipAgentTaskRequest
+): WorkspaceAgentTaskPrefill => ({
+  title: `Review captured page: ${request.pageTitle || request.pageUrl}`,
+  description: [
+    `Captured page: ${request.pageTitle || request.pageUrl}`,
+    `URL: ${request.pageUrl}`,
+    `Clip ID: ${request.clipId}`,
+    `Note ID: ${request.noteId}`,
+    `Workspace note ID: ${request.workspaceNoteId}`,
+    request.hasScreenshot ? "Screenshot attached to captured note: yes" : "",
+    ...(request.extractPreview
+      ? ["", "Captured excerpt:", request.extractPreview]
+      : [])
+  ]
+    .filter((line) => line !== "")
+    .join("\n")
+})
 
 const collectResearchWorkspaceLegacyLocalStorageKeys = (): string[] => {
   if (typeof window === "undefined") return []
@@ -1076,6 +1102,11 @@ const ResearchWorkspaceBody: React.FC = () => {
     researchWorkspaceCapabilitiesFetchedAt,
     setResearchWorkspaceCapabilitiesFetchedAt
   ] = React.useState<number | null>(null)
+  const [agentTaskHandoffOpenSignal, setAgentTaskHandoffOpenSignal] =
+    React.useState(0)
+  const [agentTaskPrefill, setAgentTaskPrefill] =
+    React.useState<WorkspaceAgentTaskPrefill | null>(null)
+  const agentTaskHandoffAppliedRef = React.useRef(false)
 
   // Mobile drawer state
   const [leftDrawerOpen, setLeftDrawerOpen] = React.useState(false)
@@ -2305,6 +2336,30 @@ const ResearchWorkspaceBody: React.FC = () => {
     focusWorkspacePane("studio")
   }, [activeDeepResearchReturnContext, focusWorkspacePane])
 
+  React.useEffect(() => {
+    if (agentTaskHandoffAppliedRef.current) return
+    if (typeof window === "undefined") return
+
+    const search = getResearchWorkspaceSearchFromLocation(window.location)
+    const params = new URLSearchParams(search)
+    if (params.get(WEB_CLIP_AGENT_TASK_ROUTE_FLAG) !== "web_clip") return
+
+    let cancelled = false
+    void readPendingWebClipAgentTaskRequest().then((request) => {
+      if (cancelled || agentTaskHandoffAppliedRef.current) return
+      if (!request || request.workspaceId !== workspaceId) return
+
+      agentTaskHandoffAppliedRef.current = true
+      setAgentTaskPrefill(buildWebClipAgentTaskPrefill(request))
+      void clearPendingWebClipAgentTaskRequest()
+      setAgentTaskHandoffOpenSignal((current) => current + 1)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceId])
+
   const handleImportDeepResearchBundle = React.useCallback(async () => {
     if (!activeDeepResearchReturnContext || !activeDeepResearchReturnKey) return
 
@@ -2341,6 +2396,14 @@ const ResearchWorkspaceBody: React.FC = () => {
         returnContext,
         sourceArtifact
       })
+      const importedDeepResearchData = artifactPayload.data?.deepResearch as
+        | { selectedImportedSources?: unknown }
+        | undefined
+      const selectedImportedSourceCount = Array.isArray(
+        importedDeepResearchData?.selectedImportedSources
+      )
+        ? importedDeepResearchData.selectedImportedSources.length
+        : 0
 
       if (!canContinueImport()) return
       addArtifact(artifactPayload)
@@ -2348,10 +2411,17 @@ const ResearchWorkspaceBody: React.FC = () => {
       setDeepResearchBundleImportState({
         contextKey: returnContextKey,
         status: "imported",
-        message: t(
-          "playground:studio.deepResearchBundleImported",
-          "Bundle imported"
-        )
+        message:
+          selectedImportedSourceCount > 0
+            ? t(
+                "playground:studio.deepResearchBundleImportedWithSources",
+                "Bundle imported · {{count}} selected sources",
+                { count: selectedImportedSourceCount }
+              )
+            : t(
+                "playground:studio.deepResearchBundleImported",
+                "Bundle imported"
+              )
       })
       focusWorkspacePane("studio")
     } catch (error) {
@@ -3219,6 +3289,7 @@ const ResearchWorkspaceBody: React.FC = () => {
           onResetAdvancedSourceFilters={resetAdvancedSourceFilters}
           statusGuardrailsEnabled={statusGuardrailsEnabled}
           statusProjectionError={workspaceStatusProjectionError}
+          researchWorkspaceCapabilities={researchWorkspaceCapabilities}
         />
       </Suspense>
     )
@@ -3618,6 +3689,8 @@ const ResearchWorkspaceBody: React.FC = () => {
             provenanceEnabled={provenanceEnabled}
             statusGuardrailsEnabled={statusGuardrailsEnabled}
             serverContextRefreshVersion={workspaceStatusProjectionReadyVersion}
+            agentTaskHandoffOpenSignal={agentTaskHandoffOpenSignal}
+            agentTaskPrefill={agentTaskPrefill}
           />
 
           <WorkspaceBanner
@@ -3675,6 +3748,8 @@ const ResearchWorkspaceBody: React.FC = () => {
             provenanceEnabled={provenanceEnabled}
             statusGuardrailsEnabled={statusGuardrailsEnabled}
             serverContextRefreshVersion={workspaceStatusProjectionReadyVersion}
+            agentTaskHandoffOpenSignal={agentTaskHandoffOpenSignal}
+            agentTaskPrefill={agentTaskPrefill}
           />
 
           <WorkspaceBanner

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
@@ -1303,6 +1303,7 @@ const ResearchWorkspaceBody: React.FC = () => {
   const setCurrentNote = useWorkspaceStore((s) => s.setCurrentNote)
   const loadNote = useWorkspaceStore((s) => s.loadNote)
   const duplicateWorkspace = useWorkspaceStore((s) => s.duplicateWorkspace)
+  const switchWorkspace = useWorkspaceStore((s) => s.switchWorkspace)
   const selectedSourceIds = useWorkspaceStore((s) => s.selectedSourceIds)
   const selectedSourceFolderIds = useWorkspaceStore(
     (s) => s.selectedSourceFolderIds
@@ -2343,11 +2344,18 @@ const ResearchWorkspaceBody: React.FC = () => {
     const search = getResearchWorkspaceSearchFromLocation(window.location)
     const params = new URLSearchParams(search)
     if (params.get(WEB_CLIP_AGENT_TASK_ROUTE_FLAG) !== "web_clip") return
+    const routeWorkspaceId = params.get("workspace")?.trim() || null
 
     let cancelled = false
     void readPendingWebClipAgentTaskRequest().then((request) => {
       if (cancelled || agentTaskHandoffAppliedRef.current) return
-      if (!request || request.workspaceId !== workspaceId) return
+      if (!request) return
+      if (request.workspaceId !== workspaceId) {
+        if (routeWorkspaceId === request.workspaceId) {
+          switchWorkspace(routeWorkspaceId)
+        }
+        return
+      }
 
       agentTaskHandoffAppliedRef.current = true
       setAgentTaskPrefill(buildWebClipAgentTaskPrefill(request))
@@ -2358,7 +2366,7 @@ const ResearchWorkspaceBody: React.FC = () => {
     return () => {
       cancelled = true
     }
-  }, [workspaceId])
+  }, [switchWorkspace, workspaceId])
 
   const handleImportDeepResearchBundle = React.useCallback(async () => {
     if (!activeDeepResearchReturnContext || !activeDeepResearchReturnKey) return

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/index.tsx
@@ -1106,7 +1106,11 @@ const ResearchWorkspaceBody: React.FC = () => {
     React.useState(0)
   const [agentTaskPrefill, setAgentTaskPrefill] =
     React.useState<WorkspaceAgentTaskPrefill | null>(null)
-  const agentTaskHandoffAppliedRef = React.useRef(false)
+  const lastAppliedWebClipHandoffIdRef = React.useRef<string | null>(null)
+  const currentResearchWorkspaceSearch =
+    typeof window === "undefined"
+      ? ""
+      : getResearchWorkspaceSearchFromLocation(window.location)
 
   // Mobile drawer state
   const [leftDrawerOpen, setLeftDrawerOpen] = React.useState(false)
@@ -2338,18 +2342,17 @@ const ResearchWorkspaceBody: React.FC = () => {
   }, [activeDeepResearchReturnContext, focusWorkspacePane])
 
   React.useEffect(() => {
-    if (agentTaskHandoffAppliedRef.current) return
     if (typeof window === "undefined") return
 
-    const search = getResearchWorkspaceSearchFromLocation(window.location)
-    const params = new URLSearchParams(search)
+    const params = new URLSearchParams(currentResearchWorkspaceSearch)
     if (params.get(WEB_CLIP_AGENT_TASK_ROUTE_FLAG) !== "web_clip") return
     const routeWorkspaceId = params.get("workspace")?.trim() || null
 
     let cancelled = false
     void readPendingWebClipAgentTaskRequest().then((request) => {
-      if (cancelled || agentTaskHandoffAppliedRef.current) return
+      if (cancelled) return
       if (!request) return
+      if (lastAppliedWebClipHandoffIdRef.current === request.id) return
       if (request.workspaceId !== workspaceId) {
         if (routeWorkspaceId === request.workspaceId) {
           switchWorkspace(routeWorkspaceId)
@@ -2357,7 +2360,7 @@ const ResearchWorkspaceBody: React.FC = () => {
         return
       }
 
-      agentTaskHandoffAppliedRef.current = true
+      lastAppliedWebClipHandoffIdRef.current = request.id
       setAgentTaskPrefill(buildWebClipAgentTaskPrefill(request))
       void clearPendingWebClipAgentTaskRequest()
       setAgentTaskHandoffOpenSignal((current) => current + 1)
@@ -2366,7 +2369,7 @@ const ResearchWorkspaceBody: React.FC = () => {
     return () => {
       cancelled = true
     }
-  }, [switchWorkspace, workspaceId])
+  }, [currentResearchWorkspaceSearch, switchWorkspace, workspaceId])
 
   const handleImportDeepResearchBundle = React.useCallback(async () => {
     if (!activeDeepResearchReturnContext || !activeDeepResearchReturnKey) return

--- a/apps/packages/ui/src/components/Sidepanel/Clipper/WebClipperPanel.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Clipper/WebClipperPanel.tsx
@@ -123,17 +123,23 @@ const createOpenTargetUrl = (response: WebClipperSaveResponse): string | null =>
 }
 
 const createWorkspaceAgentTaskTargetUrl = (
-  response: WebClipperSaveResponse
+  response: WebClipperSaveResponse,
+  handoffId: string
 ): string | null => {
   const chromeApi = globalThis.chrome
-  if (!chromeApi?.runtime?.getURL || response.status === "failed") {
+  if (
+    !chromeApi?.runtime?.getURL ||
+    response.status === "failed" ||
+    response.workspace_placement_saved !== true
+  ) {
     return null
   }
   const workspaceId = response.workspace_placement?.workspace_id?.trim()
   if (!workspaceId) return null
   const params = new URLSearchParams({
     workspace: workspaceId,
-    agent_task_handoff: "web_clip"
+    agent_task_handoff: "web_clip",
+    handoff_id: handoffId
   })
   return chromeApi.runtime.getURL(
     `options.html#/research-workspace?${params.toString()}`
@@ -615,7 +621,9 @@ const WebClipperPanel = ({ draft, onCancel }: WebClipperPanelProps) => {
           draft,
           response
         })
-        const url = createWorkspaceAgentTaskTargetUrl(response)
+        const url = request
+          ? createWorkspaceAgentTaskTargetUrl(response, request.id)
+          : null
         if (request && url) {
           await writePendingWebClipAgentTaskRequest(request)
           globalThis.chrome?.tabs?.create?.({ url })

--- a/apps/packages/ui/src/components/Sidepanel/Clipper/WebClipperPanel.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Clipper/WebClipperPanel.tsx
@@ -11,6 +11,10 @@ import {
   type PendingClipDraft
 } from "@/services/web-clipper/pending-draft"
 import {
+  buildPendingWebClipAgentTaskRequest,
+  writePendingWebClipAgentTaskRequest
+} from "@/services/web-clipper/agent-task-handoff"
+import {
   buildPendingEnrichmentResults,
   buildPendingWebClipAnalyzeRequest,
   persistRequestedWebClipEnrichments,
@@ -32,7 +36,7 @@ type WebClipperPanelProps = {
   onCancel: () => void
 }
 
-type SubmitAction = "save" | "open" | "analyze"
+type SubmitAction = "save" | "open" | "analyze" | "agent"
 
 type EnrichmentStatusTone = "success" | "warning" | "error"
 
@@ -116,6 +120,24 @@ const createOpenTargetUrl = (response: WebClipperSaveResponse): string | null =>
   }
 
   return chromeApi.runtime.getURL("options.html#/notes")
+}
+
+const createWorkspaceAgentTaskTargetUrl = (
+  response: WebClipperSaveResponse
+): string | null => {
+  const chromeApi = globalThis.chrome
+  if (!chromeApi?.runtime?.getURL || response.status === "failed") {
+    return null
+  }
+  const workspaceId = response.workspace_placement?.workspace_id?.trim()
+  if (!workspaceId) return null
+  const params = new URLSearchParams({
+    workspace: workspaceId,
+    agent_task_handoff: "web_clip"
+  })
+  return chromeApi.runtime.getURL(
+    `options.html#/research-workspace?${params.toString()}`
+  )
 }
 
 const parseOptionalFolderId = (value: string): number | null => {
@@ -434,6 +456,16 @@ const WebClipperPanel = ({ draft, onCancel }: WebClipperPanelProps) => {
     setWorkspaceValidation(null)
     setSubmissionError(null)
 
+    if (action === "agent" && !needsWorkspace) {
+      setSubmissionError(
+        t(
+          "sidepanel:clipper.agentTaskRequiresWorkspaceDestination",
+          "Choose Workspace or Both before starting an agent task."
+        )
+      )
+      return
+    }
+
     if (hasInvalidFolderId) {
       setFolderValidation(
         t(
@@ -575,6 +607,25 @@ const WebClipperPanel = ({ draft, onCancel }: WebClipperPanelProps) => {
         const url = createOpenTargetUrl(response)
         if (url) {
           globalThis.chrome?.tabs?.create?.({ url })
+        }
+      }
+
+      if (action === "agent") {
+        const request = buildPendingWebClipAgentTaskRequest({
+          draft,
+          response
+        })
+        const url = createWorkspaceAgentTaskTargetUrl(response)
+        if (request && url) {
+          await writePendingWebClipAgentTaskRequest(request)
+          globalThis.chrome?.tabs?.create?.({ url })
+        } else {
+          setSubmissionError(
+            t(
+              "sidepanel:clipper.agentTaskRequiresWorkspace",
+              "Save the clip to a workspace before starting an agent task."
+            )
+          )
         }
       }
     } catch (error) {
@@ -757,6 +808,18 @@ const WebClipperPanel = ({ draft, onCancel }: WebClipperPanelProps) => {
         </section>
       ) : null}
 
+      <p className="text-xs text-text-muted">
+        {destinationMode === "workspace" || destinationMode === "both"
+          ? t(
+              "sidepanel:clipper.workspaceActionHint",
+              "Save to workspace, then open it, ask chat, or start an agent task with this page."
+            )
+          : t(
+              "sidepanel:clipper.noteActionHint",
+              "Save as a note, or ask chat about the captured page."
+            )}
+      </p>
+
       <div className="flex flex-wrap gap-2" data-testid="web-clipper-actions">
         <button
           type="button"
@@ -786,7 +849,7 @@ const WebClipperPanel = ({ draft, onCancel }: WebClipperPanelProps) => {
         >
           {isSaving && activeAction === "analyze"
             ? t("sidepanel:clipper.savingLabel", "Saving...")
-            : t("sidepanel:clipper.analyzeNowLabel", "Analyze now")}
+            : t("sidepanel:clipper.askChatLabel", "Ask chat")}
         </button>
 
         <button
@@ -798,6 +861,17 @@ const WebClipperPanel = ({ draft, onCancel }: WebClipperPanelProps) => {
           {isSaving && activeAction === "open"
             ? t("sidepanel:clipper.savingLabel", "Saving...")
             : t("sidepanel:clipper.saveAndOpenLabel", "Save and open")}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => void submitSave("agent")}
+          disabled={isSaving}
+          className="min-w-[8rem] flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm font-semibold text-text disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSaving && activeAction === "agent"
+            ? t("sidepanel:clipper.savingLabel", "Saving...")
+            : t("sidepanel:clipper.startAgentTaskLabel", "Start agent task")}
         </button>
       </div>
     </div>

--- a/apps/packages/ui/src/components/Sidepanel/Clipper/__tests__/WebClipperPanel.save-flow.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Clipper/__tests__/WebClipperPanel.save-flow.test.tsx
@@ -8,6 +8,7 @@ import {
   readPendingClipDraft,
   writePendingClipDraft
 } from "@/services/web-clipper/pending-draft"
+import { WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY } from "@/services/web-clipper/agent-task-handoff"
 import WebClipperPanel from "../WebClipperPanel"
 
 const apiMocks = vi.hoisted(() => ({
@@ -21,6 +22,32 @@ const apiMocks = vi.hoisted(() => ({
 
 const openTabMock = vi.hoisted(() => vi.fn())
 const navigateMock = vi.hoisted(() => vi.fn())
+const chromeStorageState = vi.hoisted(() => new Map<string, unknown>())
+const chromeStorageSessionGetMock = vi.hoisted(() =>
+  vi.fn((key: string, callback?: (items: Record<string, unknown>) => void) => {
+    const result = chromeStorageState.has(key)
+      ? { [key]: chromeStorageState.get(key) }
+      : {}
+    callback?.(result)
+    return Promise.resolve(result)
+  })
+)
+const chromeStorageSessionSetMock = vi.hoisted(() =>
+  vi.fn((items: Record<string, unknown>, callback?: () => void) => {
+    for (const [key, value] of Object.entries(items)) {
+      chromeStorageState.set(key, value)
+    }
+    callback?.()
+    return Promise.resolve()
+  })
+)
+const chromeStorageSessionRemoveMock = vi.hoisted(() =>
+  vi.fn((key: string, callback?: () => void) => {
+    chromeStorageState.delete(key)
+    callback?.()
+    return Promise.resolve()
+  })
+)
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: {
@@ -116,7 +143,9 @@ const chooseWorkspaceDestination = async (
 describe("WebClipperPanel save flow", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    chromeStorageState.clear()
     window.sessionStorage.clear()
+    window.localStorage.removeItem(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
     clearPendingClipDraft()
     apiMocks.initialize.mockResolvedValue(undefined)
     apiMocks.listNoteFolders.mockResolvedValue({
@@ -199,6 +228,13 @@ describe("WebClipperPanel save flow", () => {
       },
       runtime: {
         getURL: (path: string) => `chrome-extension://unit-test/${path}`
+      },
+      storage: {
+        session: {
+          get: chromeStorageSessionGetMock,
+          set: chromeStorageSessionSetMock,
+          remove: chromeStorageSessionRemoveMock
+        }
       }
     })
     ;(window as Window & { __tldwNavigate?: (path: string) => void }).__tldwNavigate =
@@ -904,7 +940,7 @@ describe("WebClipperPanel save flow", () => {
 
     render(<WebClipperPanel draft={createScreenshotDraft()} onCancel={vi.fn()} />)
 
-    await user.click(screen.getByRole("button", { name: "Analyze now" }))
+    await user.click(screen.getByRole("button", { name: "Ask chat" }))
 
     await waitFor(() => {
       expect(apiMocks.saveWebClip).toHaveBeenCalledTimes(1)
@@ -922,6 +958,71 @@ describe("WebClipperPanel save flow", () => {
       }
     })
     expect(navigateMock).toHaveBeenCalledWith("/chat")
+  })
+
+  it("opens Research Workspace with captured context for an agent task", async () => {
+    const user = userEvent.setup()
+    apiMocks.saveWebClip.mockResolvedValueOnce({
+      clip_id: "clip-123",
+      note_id: "note-123",
+      note: { id: "note-123", title: "Example Story", version: 1 },
+      workspace_placement: {
+        workspace_id: "workspace-alpha",
+        workspace_note_id: 42,
+        source_note_id: "note-123"
+      },
+      attachments: [],
+      status: "saved",
+      warnings: [],
+      workspace_placement_saved: true,
+      workspace_placement_count: 1
+    })
+
+    render(<WebClipperPanel draft={createDraft()} onCancel={vi.fn()} />)
+
+    await chooseWorkspaceDestination(user)
+    await user.click(screen.getByRole("button", { name: "Start agent task" }))
+
+    await waitFor(() => {
+      expect(apiMocks.saveWebClip).toHaveBeenCalledTimes(1)
+    })
+
+    const stored = chromeStorageState.get(
+      WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY
+    )
+    expect(stored).toMatchObject({
+      clipId: "clip-123",
+      noteId: "note-123",
+      workspaceId: "workspace-alpha",
+      workspaceNoteId: 42,
+      pageUrl: "https://example.com/story",
+      pageTitle: "Example Story",
+      extractPreview: "Alpha body copy"
+    })
+    expect(openTabMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining(
+          "#/research-workspace?workspace=workspace-alpha&agent_task_handoff=web_clip"
+        )
+      })
+    )
+  })
+
+  it("requires a workspace destination before starting an agent task", async () => {
+    const user = userEvent.setup()
+
+    render(<WebClipperPanel draft={createDraft()} onCancel={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: "Start agent task" }))
+
+    expect(
+      screen.getByText("Choose Workspace or Both before starting an agent task.")
+    ).toBeInTheDocument()
+    expect(apiMocks.saveWebClip).not.toHaveBeenCalled()
+    expect(
+      chromeStorageState.get(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+    ).toBeUndefined()
+    expect(openTabMock).not.toHaveBeenCalled()
   })
 
   it("ignores late enrichment results after the panel switches to a different clip", async () => {
@@ -988,7 +1089,7 @@ describe("WebClipperPanel save flow", () => {
       <WebClipperPanel draft={createScreenshotDraft()} onCancel={vi.fn()} />
     )
 
-    await user.click(screen.getByRole("button", { name: "Analyze now" }))
+    await user.click(screen.getByRole("button", { name: "Ask chat" }))
 
     rerender(<WebClipperPanel draft={createDraft()} onCancel={vi.fn()} />)
 

--- a/apps/packages/ui/src/components/Sidepanel/Clipper/__tests__/WebClipperPanel.save-flow.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Clipper/__tests__/WebClipperPanel.save-flow.test.tsx
@@ -1008,6 +1008,41 @@ describe("WebClipperPanel save flow", () => {
     )
   })
 
+  it("does not start an agent task when workspace placement was not saved", async () => {
+    const user = userEvent.setup()
+    apiMocks.saveWebClip.mockResolvedValueOnce({
+      clip_id: "clip-123",
+      note_id: "note-123",
+      note: { id: "note-123", title: "Example Story", version: 1 },
+      workspace_placement: {
+        workspace_id: "workspace-alpha",
+        workspace_note_id: 42,
+        source_note_id: "note-123"
+      },
+      attachments: [],
+      status: "partially_saved",
+      warnings: [],
+      workspace_placement_saved: false,
+      workspace_placement_count: 0
+    })
+
+    render(<WebClipperPanel draft={createDraft()} onCancel={vi.fn()} />)
+
+    await chooseWorkspaceDestination(user)
+    await user.click(screen.getByRole("button", { name: "Start agent task" }))
+
+    await waitFor(() => {
+      expect(apiMocks.saveWebClip).toHaveBeenCalledTimes(1)
+    })
+    expect(
+      screen.getByText("Save the clip to a workspace before starting an agent task.")
+    ).toBeInTheDocument()
+    expect(
+      chromeStorageState.get(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+    ).toBeUndefined()
+    expect(openTabMock).not.toHaveBeenCalled()
+  })
+
   it("requires a workspace destination before starting an agent task", async () => {
     const user = userEvent.setup()
 

--- a/apps/packages/ui/src/services/web-clipper/__tests__/agent-task-handoff.test.ts
+++ b/apps/packages/ui/src/services/web-clipper/__tests__/agent-task-handoff.test.ts
@@ -7,7 +7,9 @@ import {
   type PendingWebClipAgentTaskRequest
 } from "@/services/web-clipper/agent-task-handoff"
 
-const createRequest = (): PendingWebClipAgentTaskRequest => ({
+const createRequest = (
+  overrides: Partial<PendingWebClipAgentTaskRequest> = {}
+): PendingWebClipAgentTaskRequest => ({
   id: "handoff-1",
   clipId: "clip-123",
   noteId: "note-123",
@@ -17,7 +19,8 @@ const createRequest = (): PendingWebClipAgentTaskRequest => ({
   pageTitle: "Example Story",
   extractPreview: "Alpha body copy",
   hasScreenshot: false,
-  createdAt: "2026-07-05T00:00:00.000Z"
+  createdAt: new Date().toISOString(),
+  ...overrides
 })
 
 describe("web clipper agent-task handoff storage", () => {
@@ -64,10 +67,13 @@ describe("web clipper agent-task handoff storage", () => {
 
     await writePendingWebClipAgentTaskRequest(createRequest())
 
-    const fallbackValue = window.localStorage.getItem(
+    const fallbackValue = window.sessionStorage.getItem(
       WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY
     )
     expect(fallbackValue).not.toBeNull()
+    expect(
+      window.localStorage.getItem(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+    ).toBeNull()
 
     await expect(readPendingWebClipAgentTaskRequest()).resolves.toMatchObject({
       clipId: "clip-123",
@@ -126,7 +132,7 @@ describe("web clipper agent-task handoff storage", () => {
     await expect(readPendingWebClipAgentTaskRequest()).resolves.toBeNull()
   })
 
-  it("allows fallback handoffs after an extension tombstone", async () => {
+  it("does not read browser fallback when extension storage has a tombstone", async () => {
     const runtimeState: {
       lastError: { message: string } | null
     } = { lastError: null }
@@ -164,11 +170,34 @@ describe("web clipper agent-task handoff storage", () => {
       }
     })
 
+    window.sessionStorage.setItem(
+      WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY,
+      JSON.stringify(createRequest({ id: "stale-fallback" }))
+    )
     await writePendingWebClipAgentTaskRequest(createRequest())
 
-    await expect(readPendingWebClipAgentTaskRequest()).resolves.toMatchObject({
-      clipId: "clip-123",
-      workspaceId: "workspace-alpha"
+    await expect(readPendingWebClipAgentTaskRequest()).resolves.toBeNull()
+  })
+
+  it("expires stale browser fallback handoffs", async () => {
+    const staleRequest = createRequest({
+      createdAt: new Date(Date.now() - 11 * 60 * 1000).toISOString()
     })
+    window.sessionStorage.setItem(
+      WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY,
+      JSON.stringify(staleRequest)
+    )
+    window.localStorage.setItem(
+      WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY,
+      JSON.stringify(staleRequest)
+    )
+
+    await expect(readPendingWebClipAgentTaskRequest()).resolves.toBeNull()
+    expect(
+      window.sessionStorage.getItem(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+    ).toBeNull()
+    expect(
+      window.localStorage.getItem(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+    ).toBeNull()
   })
 })

--- a/apps/packages/ui/src/services/web-clipper/__tests__/agent-task-handoff.test.ts
+++ b/apps/packages/ui/src/services/web-clipper/__tests__/agent-task-handoff.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY,
+  clearPendingWebClipAgentTaskRequest,
+  readPendingWebClipAgentTaskRequest,
+  writePendingWebClipAgentTaskRequest,
+  type PendingWebClipAgentTaskRequest
+} from "@/services/web-clipper/agent-task-handoff"
+
+const createRequest = (): PendingWebClipAgentTaskRequest => ({
+  id: "handoff-1",
+  clipId: "clip-123",
+  noteId: "note-123",
+  workspaceId: "workspace-alpha",
+  workspaceNoteId: 42,
+  pageUrl: "https://example.com/story",
+  pageTitle: "Example Story",
+  extractPreview: "Alpha body copy",
+  hasScreenshot: false,
+  createdAt: "2026-07-05T00:00:00.000Z"
+})
+
+describe("web clipper agent-task handoff storage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+  })
+
+  it("falls back when chrome storage callbacks report runtime errors", async () => {
+    const runtimeState: {
+      lastError: { message: string } | null
+    } = { lastError: null }
+
+    vi.stubGlobal("chrome", {
+      runtime: {
+        get lastError() {
+          return runtimeState.lastError
+        }
+      },
+      storage: {
+        session: {
+          set: vi.fn((_items: Record<string, unknown>, callback?: () => void) => {
+            runtimeState.lastError = { message: "quota exceeded" }
+            callback?.()
+            runtimeState.lastError = null
+          }),
+          get: vi.fn(
+            (
+              _key: string,
+              callback?: (items: Record<string, unknown>) => void
+            ) => {
+              runtimeState.lastError = { message: "storage unavailable" }
+              callback?.({})
+              runtimeState.lastError = null
+            }
+          ),
+          remove: vi.fn((_key: string, callback?: () => void) => {
+            callback?.()
+          })
+        }
+      }
+    })
+
+    await writePendingWebClipAgentTaskRequest(createRequest())
+
+    const fallbackValue = window.localStorage.getItem(
+      WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY
+    )
+    expect(fallbackValue).not.toBeNull()
+
+    await expect(readPendingWebClipAgentTaskRequest()).resolves.toMatchObject({
+      clipId: "clip-123",
+      workspaceId: "workspace-alpha",
+      workspaceNoteId: 42
+    })
+  })
+
+  it("suppresses stale extension handoffs when chrome storage remove fails", async () => {
+    const runtimeState: {
+      lastError: { message: string } | null
+    } = { lastError: null }
+    const storageState = new Map<string, unknown>()
+
+    vi.stubGlobal("chrome", {
+      runtime: {
+        get lastError() {
+          return runtimeState.lastError
+        }
+      },
+      storage: {
+        session: {
+          set: vi.fn((items: Record<string, unknown>, callback?: () => void) => {
+            for (const [key, value] of Object.entries(items)) {
+              storageState.set(key, value)
+            }
+            callback?.()
+          }),
+          get: vi.fn(
+            (
+              key: string,
+              callback?: (items: Record<string, unknown>) => void
+            ) => {
+              callback?.(
+                storageState.has(key) ? { [key]: storageState.get(key) } : {}
+              )
+            }
+          ),
+          remove: vi.fn((_key: string, callback?: () => void) => {
+            runtimeState.lastError = { message: "remove failed" }
+            callback?.()
+            runtimeState.lastError = null
+          })
+        }
+      }
+    })
+
+    await writePendingWebClipAgentTaskRequest(createRequest())
+    await expect(readPendingWebClipAgentTaskRequest()).resolves.toMatchObject({
+      clipId: "clip-123"
+    })
+
+    await clearPendingWebClipAgentTaskRequest()
+
+    expect(storageState.get(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)).toBeNull()
+    await expect(readPendingWebClipAgentTaskRequest()).resolves.toBeNull()
+  })
+
+  it("allows fallback handoffs after an extension tombstone", async () => {
+    const runtimeState: {
+      lastError: { message: string } | null
+    } = { lastError: null }
+    const storageState = new Map<string, unknown>([
+      [WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY, null]
+    ])
+
+    vi.stubGlobal("chrome", {
+      runtime: {
+        get lastError() {
+          return runtimeState.lastError
+        }
+      },
+      storage: {
+        session: {
+          set: vi.fn((_items: Record<string, unknown>, callback?: () => void) => {
+            runtimeState.lastError = { message: "set failed" }
+            callback?.()
+            runtimeState.lastError = null
+          }),
+          get: vi.fn(
+            (
+              key: string,
+              callback?: (items: Record<string, unknown>) => void
+            ) => {
+              callback?.(
+                storageState.has(key) ? { [key]: storageState.get(key) } : {}
+              )
+            }
+          ),
+          remove: vi.fn((_key: string, callback?: () => void) => {
+            callback?.()
+          })
+        }
+      }
+    })
+
+    await writePendingWebClipAgentTaskRequest(createRequest())
+
+    await expect(readPendingWebClipAgentTaskRequest()).resolves.toMatchObject({
+      clipId: "clip-123",
+      workspaceId: "workspace-alpha"
+    })
+  })
+})

--- a/apps/packages/ui/src/services/web-clipper/agent-task-handoff.ts
+++ b/apps/packages/ui/src/services/web-clipper/agent-task-handoff.ts
@@ -5,6 +5,7 @@ export const WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY =
   "tldw:web-clipper:pendingAgentTask"
 
 const EXTRACT_PREVIEW_LIMIT = 1200
+const HANDOFF_TTL_MS = 10 * 60 * 1000
 
 export type PendingWebClipAgentTaskRequest = {
   id: string
@@ -52,8 +53,12 @@ const getExtensionStorageArea = (): ExtensionStorageArea | null => {
   return storage?.session ?? storage?.local ?? null
 }
 
-const hasChromeRuntimeError = (): boolean =>
-  Boolean(globalThis.chrome?.runtime?.lastError)
+const reportStorageFailure = (operation: string, error: unknown): void => {
+  console.warn(`Web clipper agent-task handoff ${operation} failed`, error)
+}
+
+const getChromeRuntimeError = (): unknown =>
+  globalThis.chrome?.runtime?.lastError ?? null
 
 const readExtensionStorageValue = async (key: string): Promise<unknown> => {
   const storage = getExtensionStorageArea()
@@ -69,12 +74,22 @@ const readExtensionStorageValue = async (key: string): Promise<unknown> => {
 
     try {
       const maybePromise = storage.get(key, (items) => {
-        settle(hasChromeRuntimeError() ? undefined : items)
+        const runtimeError = getChromeRuntimeError()
+        if (runtimeError) {
+          reportStorageFailure("extension read", runtimeError)
+          settle(undefined)
+          return
+        }
+        settle(items)
       })
       if (maybePromise && typeof maybePromise.then === "function") {
-        void maybePromise.then(settle).catch(() => settle(undefined))
+        void maybePromise.then(settle).catch((error) => {
+          reportStorageFailure("extension read", error)
+          settle(undefined)
+        })
       }
-    } catch {
+    } catch (error) {
+      reportStorageFailure("extension read", error)
       settle(undefined)
     }
   })
@@ -96,13 +111,23 @@ const writeExtensionStorageValue = async (
     }
 
     try {
-      const maybePromise = storage.set({ [key]: value }, () =>
-        settle(!hasChromeRuntimeError())
-      )
+      const maybePromise = storage.set({ [key]: value }, () => {
+        const runtimeError = getChromeRuntimeError()
+        if (runtimeError) {
+          reportStorageFailure("extension write", runtimeError)
+          settle(false)
+          return
+        }
+        settle(true)
+      })
       if (maybePromise && typeof maybePromise.then === "function") {
-        void maybePromise.then(() => settle(true)).catch(() => settle(false))
+        void maybePromise.then(() => settle(true)).catch((error) => {
+          reportStorageFailure("extension write", error)
+          settle(false)
+        })
       }
-    } catch {
+    } catch (error) {
+      reportStorageFailure("extension write", error)
       settle(false)
     }
   })
@@ -121,13 +146,23 @@ const removeExtensionStorageValue = async (key: string): Promise<boolean> => {
     }
 
     try {
-      const maybePromise = storage.remove(key, () =>
-        settle(!hasChromeRuntimeError())
-      )
+      const maybePromise = storage.remove(key, () => {
+        const runtimeError = getChromeRuntimeError()
+        if (runtimeError) {
+          reportStorageFailure("extension remove", runtimeError)
+          settle(false)
+          return
+        }
+        settle(true)
+      })
       if (maybePromise && typeof maybePromise.then === "function") {
-        void maybePromise.then(() => settle(true)).catch(() => settle(false))
+        void maybePromise.then(() => settle(true)).catch((error) => {
+          reportStorageFailure("extension remove", error)
+          settle(false)
+        })
       }
-    } catch {
+    } catch (error) {
+      reportStorageFailure("extension remove", error)
       settle(false)
     }
   })
@@ -136,12 +171,13 @@ const removeExtensionStorageValue = async (key: string): Promise<boolean> => {
 const readBrowserStorageValue = (key: string): unknown => {
   if (typeof window === "undefined") return undefined
 
-  for (const storage of [window.localStorage, window.sessionStorage]) {
+  for (const storage of [window.sessionStorage, window.localStorage]) {
     try {
       const raw = storage.getItem(key)
       if (!raw) continue
       return JSON.parse(raw)
-    } catch {
+    } catch (error) {
+      reportStorageFailure("browser read", error)
       continue
     }
   }
@@ -154,16 +190,10 @@ const writeBrowserStorageValue = (key: string, value: unknown): void => {
   const serialized = JSON.stringify(value)
 
   try {
-    window.localStorage.setItem(key, serialized)
-    return
-  } catch {
-    // Fall back to same-context storage for non-extension tests.
-  }
-
-  try {
     window.sessionStorage.setItem(key, serialized)
-  } catch {
-    // Ignore transient storage failures.
+    window.localStorage.removeItem(key)
+  } catch (error) {
+    reportStorageFailure("browser write", error)
   }
 }
 
@@ -172,10 +202,16 @@ const removeBrowserStorageValue = (key: string): void => {
   for (const storage of [window.localStorage, window.sessionStorage]) {
     try {
       storage.removeItem(key)
-    } catch {
-      // Ignore transient storage failures.
+    } catch (error) {
+      reportStorageFailure("browser remove", error)
     }
   }
+}
+
+const isFreshCreatedAt = (createdAt: string): boolean => {
+  const createdAtMs = Date.parse(createdAt)
+  if (!Number.isFinite(createdAtMs)) return false
+  return Date.now() - createdAtMs <= HANDOFF_TTL_MS
 }
 
 export const buildPendingWebClipAgentTaskRequest = ({
@@ -185,6 +221,9 @@ export const buildPendingWebClipAgentTaskRequest = ({
   draft: PendingClipDraft
   response: WebClipperSaveResponse
 }): PendingWebClipAgentTaskRequest | null => {
+  if (response.workspace_placement_saved !== true) {
+    return null
+  }
   const placement = response.workspace_placement
   const workspaceId = readString(placement?.workspace_id)
   const noteId = readString(response.note?.id ?? response.note_id)
@@ -219,7 +258,7 @@ export const readPendingWebClipAgentTaskRequest =
       WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY
     )
     const storedValue =
-      raw == null
+      raw === undefined
         ? readBrowserStorageValue(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
         : raw
     try {
@@ -236,6 +275,11 @@ export const readPendingWebClipAgentTaskRequest =
       if (!workspaceId || !noteId || workspaceNoteId == null || !pageUrl) {
         return null
       }
+      const createdAt = readString(record.createdAt)
+      if (!isFreshCreatedAt(createdAt)) {
+        await clearPendingWebClipAgentTaskRequest()
+        return null
+      }
       return {
         id: readString(record.id) || crypto.randomUUID(),
         clipId: readString(record.clipId),
@@ -246,9 +290,10 @@ export const readPendingWebClipAgentTaskRequest =
         pageTitle,
         extractPreview: truncatePreview(readString(record.extractPreview)),
         hasScreenshot: Boolean(record.hasScreenshot),
-        createdAt: readString(record.createdAt) || new Date().toISOString()
+        createdAt
       }
-    } catch {
+    } catch (error) {
+      reportStorageFailure("request parse", error)
       return null
     }
   }

--- a/apps/packages/ui/src/services/web-clipper/agent-task-handoff.ts
+++ b/apps/packages/ui/src/services/web-clipper/agent-task-handoff.ts
@@ -1,0 +1,277 @@
+import type { PendingClipDraft } from "./pending-draft"
+import type { WebClipperSaveResponse } from "./types"
+
+export const WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY =
+  "tldw:web-clipper:pendingAgentTask"
+
+const EXTRACT_PREVIEW_LIMIT = 1200
+
+export type PendingWebClipAgentTaskRequest = {
+  id: string
+  clipId: string
+  noteId: string
+  workspaceId: string
+  workspaceNoteId: number
+  pageUrl: string
+  pageTitle: string
+  extractPreview: string
+  hasScreenshot: boolean
+  createdAt: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const readString = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : ""
+
+const readPositiveNumber = (value: unknown): number | null => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : null
+}
+
+const truncatePreview = (value: string): string =>
+  value.length <= EXTRACT_PREVIEW_LIMIT
+    ? value
+    : `${value.slice(0, EXTRACT_PREVIEW_LIMIT).trimEnd()}\n[Truncated for agent task handoff.]`
+
+type ExtensionStorageArea = {
+  get?: (
+    key: string,
+    callback?: (items: Record<string, unknown>) => void
+  ) => Promise<Record<string, unknown>> | void
+  set?: (
+    items: Record<string, unknown>,
+    callback?: () => void
+  ) => Promise<void> | void
+  remove?: (key: string, callback?: () => void) => Promise<void> | void
+}
+
+const getExtensionStorageArea = (): ExtensionStorageArea | null => {
+  const storage = globalThis.chrome?.storage
+  return storage?.session ?? storage?.local ?? null
+}
+
+const hasChromeRuntimeError = (): boolean =>
+  Boolean(globalThis.chrome?.runtime?.lastError)
+
+const readExtensionStorageValue = async (key: string): Promise<unknown> => {
+  const storage = getExtensionStorageArea()
+  if (!storage?.get) return undefined
+
+  return new Promise((resolve) => {
+    let settled = false
+    const settle = (items: unknown) => {
+      if (settled) return
+      settled = true
+      resolve(isRecord(items) ? items[key] : undefined)
+    }
+
+    try {
+      const maybePromise = storage.get(key, (items) => {
+        settle(hasChromeRuntimeError() ? undefined : items)
+      })
+      if (maybePromise && typeof maybePromise.then === "function") {
+        void maybePromise.then(settle).catch(() => settle(undefined))
+      }
+    } catch {
+      settle(undefined)
+    }
+  })
+}
+
+const writeExtensionStorageValue = async (
+  key: string,
+  value: unknown
+): Promise<boolean> => {
+  const storage = getExtensionStorageArea()
+  if (!storage?.set) return false
+
+  return new Promise((resolve) => {
+    let settled = false
+    const settle = (success: boolean) => {
+      if (settled) return
+      settled = true
+      resolve(success)
+    }
+
+    try {
+      const maybePromise = storage.set({ [key]: value }, () =>
+        settle(!hasChromeRuntimeError())
+      )
+      if (maybePromise && typeof maybePromise.then === "function") {
+        void maybePromise.then(() => settle(true)).catch(() => settle(false))
+      }
+    } catch {
+      settle(false)
+    }
+  })
+}
+
+const removeExtensionStorageValue = async (key: string): Promise<boolean> => {
+  const storage = getExtensionStorageArea()
+  if (!storage?.remove) return false
+
+  return new Promise((resolve) => {
+    let settled = false
+    const settle = (success: boolean) => {
+      if (settled) return
+      settled = true
+      resolve(success)
+    }
+
+    try {
+      const maybePromise = storage.remove(key, () =>
+        settle(!hasChromeRuntimeError())
+      )
+      if (maybePromise && typeof maybePromise.then === "function") {
+        void maybePromise.then(() => settle(true)).catch(() => settle(false))
+      }
+    } catch {
+      settle(false)
+    }
+  })
+}
+
+const readBrowserStorageValue = (key: string): unknown => {
+  if (typeof window === "undefined") return undefined
+
+  for (const storage of [window.localStorage, window.sessionStorage]) {
+    try {
+      const raw = storage.getItem(key)
+      if (!raw) continue
+      return JSON.parse(raw)
+    } catch {
+      continue
+    }
+  }
+
+  return undefined
+}
+
+const writeBrowserStorageValue = (key: string, value: unknown): void => {
+  if (typeof window === "undefined") return
+  const serialized = JSON.stringify(value)
+
+  try {
+    window.localStorage.setItem(key, serialized)
+    return
+  } catch {
+    // Fall back to same-context storage for non-extension tests.
+  }
+
+  try {
+    window.sessionStorage.setItem(key, serialized)
+  } catch {
+    // Ignore transient storage failures.
+  }
+}
+
+const removeBrowserStorageValue = (key: string): void => {
+  if (typeof window === "undefined") return
+  for (const storage of [window.localStorage, window.sessionStorage]) {
+    try {
+      storage.removeItem(key)
+    } catch {
+      // Ignore transient storage failures.
+    }
+  }
+}
+
+export const buildPendingWebClipAgentTaskRequest = ({
+  draft,
+  response
+}: {
+  draft: PendingClipDraft
+  response: WebClipperSaveResponse
+}): PendingWebClipAgentTaskRequest | null => {
+  const placement = response.workspace_placement
+  const workspaceId = readString(placement?.workspace_id)
+  const noteId = readString(response.note?.id ?? response.note_id)
+  const workspaceNoteId = readPositiveNumber(placement?.workspace_note_id)
+  if (!workspaceId || !noteId || workspaceNoteId == null) {
+    return null
+  }
+
+  const extractPreview = truncatePreview(
+    readString(draft.selectionText) ||
+      readString(draft.fullExtract) ||
+      readString(draft.visibleBody)
+  )
+
+  return {
+    id: crypto.randomUUID(),
+    clipId: response.clip_id || draft.clipId,
+    noteId,
+    workspaceId,
+    workspaceNoteId,
+    pageUrl: draft.pageUrl,
+    pageTitle: draft.pageTitle,
+    extractPreview,
+    hasScreenshot: Boolean(draft.captureMetadata.screenshotDataUrl?.trim()),
+    createdAt: new Date().toISOString()
+  }
+}
+
+export const readPendingWebClipAgentTaskRequest =
+  async (): Promise<PendingWebClipAgentTaskRequest | null> => {
+    const raw = await readExtensionStorageValue(
+      WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY
+    )
+    const storedValue =
+      raw == null
+        ? readBrowserStorageValue(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+        : raw
+    try {
+      if (!storedValue) return null
+      const parsed =
+        typeof storedValue === "string" ? JSON.parse(storedValue) : storedValue
+      if (!parsed || typeof parsed !== "object") return null
+      const record = parsed as Record<string, unknown>
+      const workspaceId = readString(record.workspaceId)
+      const noteId = readString(record.noteId)
+      const workspaceNoteId = readPositiveNumber(record.workspaceNoteId)
+      const pageUrl = readString(record.pageUrl)
+      const pageTitle = readString(record.pageTitle)
+      if (!workspaceId || !noteId || workspaceNoteId == null || !pageUrl) {
+        return null
+      }
+      return {
+        id: readString(record.id) || crypto.randomUUID(),
+        clipId: readString(record.clipId),
+        noteId,
+        workspaceId,
+        workspaceNoteId,
+        pageUrl,
+        pageTitle,
+        extractPreview: truncatePreview(readString(record.extractPreview)),
+        hasScreenshot: Boolean(record.hasScreenshot),
+        createdAt: readString(record.createdAt) || new Date().toISOString()
+      }
+    } catch {
+      return null
+    }
+  }
+
+export const writePendingWebClipAgentTaskRequest = (
+  request: PendingWebClipAgentTaskRequest
+): Promise<void> => {
+  return writeExtensionStorageValue(
+    WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY,
+    request
+  ).then((storedInExtension) => {
+    if (!storedInExtension) {
+      writeBrowserStorageValue(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY, request)
+    }
+  })
+}
+
+export const clearPendingWebClipAgentTaskRequest = async (): Promise<void> => {
+  const removed = await removeExtensionStorageValue(
+    WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY
+  )
+  if (!removed) {
+    await writeExtensionStorageValue(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY, null)
+  }
+  removeBrowserStorageValue(WEB_CLIPPER_PENDING_AGENT_TASK_STORAGE_KEY)
+}

--- a/backlog/tasks/task-12163 - Implement-Research-Workspace-NotebookLM-discovery-loops-WP3.md
+++ b/backlog/tasks/task-12163 - Implement-Research-Workspace-NotebookLM-discovery-loops-WP3.md
@@ -1,0 +1,81 @@
+---
+id: TASK-12163
+title: Implement Research Workspace NotebookLM discovery loops WP3
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-07-05 15:33
+labels:
+- research-workspace
+- notebooklm
+- wp3
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved WP3 slice from the Research Workspace NotebookLM Pro/Ultra review spec. Scope: make server web search results visibly reviewable/importable/tracked as workspace sources, surface Deep Research return/import provenance and recoverable failures inside the workspace, capability-gate discovery by existing source/web readiness, and tighten extension handoff actions for save/open/chat/agent context without adding Google Drive integration or a full Research Workspace sidepanel clone.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WP3 implementation plan is saved under Docs/superpowers/plans with exact file paths, tasks, tests, and verification commands.
+- [x] #2 Server web search discovery shows selected/imported/failed result state clearly enough for source-to-chat recovery.
+- [x] #3 Deep Research return/import state exposes run provenance, imported report metadata, skipped or failed source/import details, and retry/recovery copy where applicable.
+- [x] #4 Extension clipper handoffs clearly support capture to workspace, open workspace, ask chat about captured page, and agent-task context using existing routing/storage where available.
+- [x] #5 Scope excludes Google Drive search, Google account integration, new ingestion providers, and a full Research Workspace sidepanel clone.
+- [x] #6 Focused frontend/backend verification, git diff --check, and Bandit touched-scope results are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started WP3 in isolated worktree `.worktrees/research-workspace-notebooklm-wp3` on branch `codex/research-workspace-notebooklm-wp3` from `origin/dev` at merge commit 242297a2b8. Initial code scan found existing web search import, Deep Research return/import, and clipper save/open/analyze flows; plan should connect and clarify those paths rather than adding new providers or a sidepanel clone.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+WP3 implementation plan created: `Docs/superpowers/plans/2026-07-05-research-workspace-notebooklm-discovery-loops-wp3-plan.md`. Plan review and agent-task handoff exploration dispatched to subagents before implementation.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented WP3 discovery-loop connections for Research Workspace.
+
+Changes:
+- Search Server imports now thread Research Workspace capability state into the Add Source modal, block unavailable source-browse paths, keep the modal open after imports, and show row-level imported/failed states with retryable failed rows.
+- Deep Research bundle returns now persist and render bounded selected/imported sources, source inventory, skipped sources, failed sources, unsupported claims, contradictions, unresolved questions, source artifact/run provenance, and selected-source import summary copy. Existing source artifact coverage and lineage are sanitized to the MAX_IMPORT_LIST_ITEMS cap before persistence, including dropping unknown oversized lineage fields.
+- Web clipper save actions now label chat handoff as Ask chat, add compact destination-aware action hints, and add Start agent task using shared extension storage (`chrome.storage.session`, with fallbacks) plus the existing Research Workspace WorkspaceAgentTaskHandoffModal. Note-only agent-task clicks are blocked before save.
+- WorkspaceHeader treats web-clip agent-task prefill as one-shot modal state so later manual task creation does not reuse stale clipped-page context.
+- Added/updated focused Vitest coverage for source import state, Deep Research provenance bounds, Research Workspace route handoff/prefill, web clipper save/open/chat/agent flows, header one-shot prefill behavior, and chrome storage callback-error fallback/clear/tombstone behavior.
+
+Review fixes:
+- Subagent spec review P1 fixed by bounding copied Deep Research source coverage/lineage before persistence.
+- Subagent code-quality P1/P2/P2 fixed by moving agent-task handoff off cross-tab `sessionStorage`, whitelisting lineage fields, and clearing stale web-clip prefill for manual task creation.
+- Subagent code-quality storage callback error findings fixed by checking `chrome.runtime.lastError` for get/set/remove callbacks, falling back when set/get fail, tombstoning stale extension handoffs when remove fails, and allowing later fallback handoffs after a tombstone.
+
+Verification:
+- PASS `bunx vitest run ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/AddSourceModal.stage2.intake.test.tsx` (22 tests)
+- PASS `bunx vitest run ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts` (7 tests)
+- PASS `bunx vitest run ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx` (23 tests)
+- PASS `bunx vitest run ../packages/ui/src/components/Sidepanel/Clipper/__tests__/WebClipperPanel.save-flow.test.tsx` (37 tests)
+- PASS `bunx vitest run ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx` (64 tests)
+- PASS `bunx vitest run ../packages/ui/src/services/web-clipper/__tests__/agent-task-handoff.test.ts` (3 tests)
+- PASS `git diff --check`
+- INFO `NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd ../packages/ui tsc --noEmit` reports existing unrelated UI package type errors in ChatGreetingPicker, MCPHub, background session store, setup onboarding, TldwChat abort, and character-export SSRF tests; no reported diagnostics were in touched WP3 files.
+- SKIP Bandit: touched scope is frontend TypeScript/tests, Docs plan, and Backlog task only; no Python/backend touched paths.
+<!-- SECTION:FINAL_SUMMARY:END -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12168 - Address-Research-Workspace-WP3-code-review-findings.md
+++ b/backlog/tasks/task-12168 - Address-Research-Workspace-WP3-code-review-findings.md
@@ -1,0 +1,58 @@
+---
+id: TASK-12168
+title: Address Research Workspace WP3 code review findings
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-05 16:53'
+labels:
+  - research-workspace
+  - notebooklm
+  - wp3
+  - review
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the issues found during the WP3 requested code-review pass for PR 2662: route web clipper agent-task handoff through the requested workspace before consuming the pending request, normalize retained Deep Research bundle metadata before artifact persistence, and report capped source inventory counts accurately.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Web clipper agent-task handoff switches to the routed workspace before opening the Research Workspace task modal.
+- [x] #2 Deep Research bundle import persists only whitelisted and bounded retained metadata for claims, source inventory, unsupported claims, contradictions, and source trust.
+- [x] #3 Deep Research imported content reports raw source inventory count with capped shown count when applicable.
+- [x] #4 Focused WP3 tests, git diff check, and frontend type-check status are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+RED: added regression coverage for cross-workspace web clipper agent-task handoff and bounded Deep Research metadata persistence. The new ResearchWorkspace test failed because switchWorkspace was never called. The Deep Research tests failed because source trust/source inventory were still raw snake_case records, source inventory content showed the capped count, and retained metadata included raw nested fields.
+
+GREEN: route-matching pending handoffs now call the existing switchWorkspace action before consumption; Deep Research retained metadata is normalized to whitelisted/capped fields; capped source inventory content reports raw count plus shown count. Focused tests for the two changed files now pass.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the WP3 requested code-review findings for PR 2662. Research Workspace now switches to the routed workspace before consuming a pending web-clip agent-task handoff, Deep Research bundle import persists only whitelisted/capped retained metadata (including oversized source IDs and reasons), and capped source inventory content reports the raw count with the shown count.
+
+Verification: Deep Research import Vitest passed with 8 tests; ResearchWorkspace responsive/handoff Vitest passed with 24 tests; the broader focused WP3 suite passed after the initial fixes; git diff --check passed; UI TypeScript still fails only on unrelated baseline files outside the touched WP3 scope. Bandit skipped because this follow-up touched frontend TypeScript/tests and Backlog metadata only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12169 - Rebase-PR-2662-and-address-current-review-comments.md
+++ b/backlog/tasks/task-12169 - Rebase-PR-2662-and-address-current-review-comments.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12169
+title: Rebase PR 2662 and address current review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-05 17:09'
+labels:
+  - research-workspace
+  - notebooklm
+  - wp3
+  - review
+  - rebase
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase Research Workspace NotebookLM WP3 PR 2662 on latest dev and address current GitHub review feedback, including Qodo storage reliability/privacy/correctness findings and Gemini handoff lifecycle findings where verified against the current branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Branch is rebased on latest origin/dev and pushed back to PR 2662.
+- [x] #2 All technically valid current PR review comments are addressed or explicitly documented as already fixed/not applicable.
+- [x] #3 Focused tests for changed web clipper handoff and Research Workspace handoff behavior pass.
+- [x] #4 Final git diff check, TypeScript/Bandit applicability, and PR check status are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Final verification: combined focused Vitest run passed 67 tests across agent-task-handoff, WebClipperPanel save flow, and ResearchWorkspace stage2 responsive. git diff --check passed. TypeScript check still exits 2 only on known unrelated baseline files outside this touched scope: ChatGreetingPicker, MCPHub first-run status, background-session-store, useSetupOnboarding, TldwChat.abort, and character-export SSRF tests. Bandit skipped because this pass touched frontend TypeScript/tests and Backlog metadata only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR 2662 against origin/dev (already up to date), addressed the current Gemini/Qodo review comments, added focused regression coverage, and verified the touched web clipper/Research Workspace flows locally. Review fixes cover unique handoff ids, extension tombstone handling, logged storage failures, session-scoped browser fallback with TTL cleanup, and requiring saved workspace placement before launching agent-task handoff.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds visible Search Server import state and source-browse capability gating in Research Workspace source intake.
- Extends Deep Research bundle imports with bounded selected-source provenance, skipped/failed source details, unsupported claims, contradictions, and source-lineage sanitization.
- Connects web clipper save/open/chat/agent-task loops using shared extension handoff storage and the existing Research Workspace agent-task modal.
- Records TASK-12163 and the WP3 implementation plan.

## Verification
- PASS `bunx vitest run ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/AddSourceModal.stage2.intake.test.tsx` (22 tests)
- PASS `bunx vitest run ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts` (7 tests)
- PASS `bunx vitest run ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx` (23 tests)
- PASS `bunx vitest run ../packages/ui/src/components/Sidepanel/Clipper/__tests__/WebClipperPanel.save-flow.test.tsx` (37 tests)
- PASS `bunx vitest run ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx` (64 tests)
- PASS `bunx vitest run ../packages/ui/src/services/web-clipper/__tests__/agent-task-handoff.test.ts` (3 tests)
- PASS `git diff --check HEAD~1..HEAD`
- INFO `NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd ../packages/ui tsc --noEmit` still reports unrelated baseline errors in ChatGreetingPicker, MCPHub, background session store, setup onboarding, TldwChat abort, and character-export SSRF tests; no diagnostics are in touched WP3 files.
- SKIP Bandit: frontend TypeScript/tests, Docs plan, and Backlog task only; no Python/backend touched paths.

## AI-generated PR merge gate
A human-owned Change summary is required before this PR is merge-ready, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`. This draft intentionally does not claim that gate is satisfied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connects the Research Workspace discovery loops (WP3): capability-gated Server Search with visible import states, richer Deep Research provenance, and a web clipper “Start agent task” handoff that opens the existing agent-task modal. Implements TASK-12163 and addresses review fixes in TASK-12168 and TASK-12169.

- **New Features**
  - Search Server in Add Source now respects `source_browse`; shows a short notice and disables search when blocked. Keeps the modal open and marks results as imported or failed, with failed rows selectable for retry.
  - Deep Research imports persist selected/imported sources and inventory, plus skipped/failed sources, unsupported claims, contradictions, and unresolved questions. Lineage and coverage are sanitized to a 50-item cap; the handoff banner shows run info and selected source count; failures remain retryable.
  - Web clipper: “Analyze now” is “Ask chat,” adds a compact action hint, and introduces “Start agent task.” It saves to a workspace, writes a pending handoff to `chrome.storage.session` (with fallback), opens Research Workspace with `agent_task_handoff=web_clip`, and pre-fills `WorkspaceAgentTaskHandoffModal` once.

- **Bug Fixes**
  - Web-clip agent-task handoff switches to the target workspace before consuming pending context, then opens the task modal.
  - Handoff storage is time-bound (10 min TTL), one-shot, and ignores stale or repeated opens; action is gated on saving to a workspace.
  - Deep Research retained metadata is normalized and size-bounded; source inventory counts now reflect the 50-item cap accurately.

<sup>Written for commit 55968f33bb13caad3e5f842cda0e65c3c4cf01da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

