### PR TITLE
Add regression coverage for llama provider alias

### DIFF
--- a/backlog/tasks/task-12120 - Fix-llama-provider-alias-rejection-in-chat-completions.md
+++ b/backlog/tasks/task-12120 - Fix-llama-provider-alias-rejection-in-chat-completions.md
@@ -1,0 +1,52 @@
+---
+id: TASK-12120
+title: Fix llama provider alias rejection in chat completions
+status: Done
+labels:
+- bug
+- webui
+- chat
+priority: High
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The WebUI provider catalog exposes the configured llama.cpp endpoint as provider name `llama`, but chat completion request validation rejects `api_provider: "llama"` before adapter alias resolution. This breaks WebUI chat sends against a configured llama.cpp server with a 422 validation error.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `api_provider: "llama"` is accepted for chat completions and normalized to the llama.cpp provider used by backend routing.
+- [x] #2 Existing canonical `api_provider: "llama.cpp"` behavior remains unchanged.
+- [x] #3 A regression test covers the alias path that the WebUI uses.
+- [x] #4 Focused tests and security checks pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- `origin/dev` already contains provider alias normalization via `normalize_catalog_provider_for_chat`.
+- Added focused request-schema coverage for the WebUI `api_provider: "llama"` alias path so the regression is caught before the endpoint returns HTTP 422.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Added schema regression coverage for the WebUI `api_provider: "llama"` request path.
+- Verified `api_provider: "llama"` returns HTTP 200 against the PR worktree backend and live llama.cpp server at `127.0.0.1:9099`, with response content `alias ok`.
+- Verification:
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py -q` (`25 passed`)
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py -f json -o /tmp/bandit_task_12120.json` (`0 results`)
+  - Local curl to `POST /api/v1/chat/completions` with `api_provider: "llama"` returned `HTTP/1.1 200 OK`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12120 - Fix-llama-provider-alias-rejection-in-chat-completions.md
+++ b/backlog/tasks/task-12120 - Fix-llama-provider-alias-rejection-in-chat-completions.md
@@ -39,9 +39,9 @@ The WebUI provider catalog exposes the configured llama.cpp endpoint as provider
 - Added provider/model resolution coverage for the WebUI `model: "llama:<model>"` request path and normalized it to the llama.cpp adapter.
 - Verified `api_provider: "llama"` returns HTTP 200 against the PR worktree backend and live llama.cpp server at `127.0.0.1:9099`, with response content `alias ok`.
 - Verification:
-  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py::test_resolve_provider_and_model_normalizes_llama_colon_model_prefix -q` failed before the fix with `metrics_provider == "openai"`.
-  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py -q` (`31 passed`)
-  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Chat/chat_service.py tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py -f json -o /tmp/bandit_task_12120.json` (`0 results`)
+  - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py::test_resolve_provider_and_model_normalizes_llama_colon_model_prefix -q` failed before the fix with `metrics_provider == "openai"`.
+  - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py -q` (`31 passed`)
+  - `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Chat/chat_service.py tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py -f json -o /tmp/bandit_task_12120.json` (`0 results`)
   - Local curl to `POST /api/v1/chat/completions` with `api_provider: "llama"` returned `HTTP/1.1 200 OK`.
   - Local curl to `POST /api/v1/chat/completions` with `model: "llama:<gguf>"` and no `api_provider` returned `HTTP/1.1 200 OK` against the PR worktree backend and live llama.cpp server, with response content `colon alias ok`.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-12120 - Fix-llama-provider-alias-rejection-in-chat-completions.md
+++ b/backlog/tasks/task-12120 - Fix-llama-provider-alias-rejection-in-chat-completions.md
@@ -12,15 +12,16 @@ priority: High
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-The WebUI provider catalog exposes the configured llama.cpp endpoint as provider name `llama`, but chat completion request validation rejects `api_provider: "llama"` before adapter alias resolution. This breaks WebUI chat sends against a configured llama.cpp server with a 422 validation error.
+The WebUI provider catalog exposes the configured llama.cpp endpoint as provider name `llama`, but chat completion request validation rejects `api_provider: "llama"` before adapter alias resolution. A second frontend path sends provider-qualified model ids such as `llama:<model>` without `api_provider`; backend execution previously treated that as the default provider and returned a generation failure instead of routing to llama.cpp. Both paths break WebUI chat sends against a configured llama.cpp server.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 `api_provider: "llama"` is accepted for chat completions and normalized to the llama.cpp provider used by backend routing.
-- [x] #2 Existing canonical `api_provider: "llama.cpp"` behavior remains unchanged.
-- [x] #3 A regression test covers the alias path that the WebUI uses.
-- [x] #4 Focused tests and security checks pass for the touched scope.
+- [x] #2 Frontend provider-qualified `model: "llama:<model>"` requests are normalized to provider `llama.cpp` and model `<model>`.
+- [x] #3 Existing canonical `api_provider: "llama.cpp"` behavior remains unchanged.
+- [x] #4 Regression tests cover the alias paths that the WebUI uses.
+- [x] #5 Focused tests and security checks pass for the touched scope.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -28,17 +29,21 @@ The WebUI provider catalog exposes the configured llama.cpp endpoint as provider
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - `origin/dev` already contains provider alias normalization via `normalize_catalog_provider_for_chat`.
 - Added focused request-schema coverage for the WebUI `api_provider: "llama"` alias path so the regression is caught before the endpoint returns HTTP 422.
+- Added backend provider/model normalization for provider-qualified model ids. Slash-qualified model ids keep the existing behavior; colon-qualified model ids are split only when the prefix normalizes to a registered chat provider.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 - Added schema regression coverage for the WebUI `api_provider: "llama"` request path.
+- Added provider/model resolution coverage for the WebUI `model: "llama:<model>"` request path and normalized it to the llama.cpp adapter.
 - Verified `api_provider: "llama"` returns HTTP 200 against the PR worktree backend and live llama.cpp server at `127.0.0.1:9099`, with response content `alias ok`.
 - Verification:
-  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py -q` (`25 passed`)
-  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py -f json -o /tmp/bandit_task_12120.json` (`0 results`)
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py::test_resolve_provider_and_model_normalizes_llama_colon_model_prefix -q` failed before the fix with `metrics_provider == "openai"`.
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py -q` (`31 passed`)
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Chat/chat_service.py tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py -f json -o /tmp/bandit_task_12120.json` (`0 results`)
   - Local curl to `POST /api/v1/chat/completions` with `api_provider: "llama"` returned `HTTP/1.1 200 OK`.
+  - Local curl to `POST /api/v1/chat/completions` with `model: "llama:<gguf>"` and no `api_provider` returned `HTTP/1.1 200 OK` against the PR worktree backend and live llama.cpp server, with response content `colon alias ok`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Chat/chat_service.py
+++ b/tldw_Server_API/app/core/Chat/chat_service.py
@@ -234,6 +234,12 @@ _PROVIDER_MODEL_CONFIG_FIELDS.update(
     }
 )
 
+_INLINE_MODEL_PROVIDER_NAMES = frozenset(
+    normalize_catalog_provider_for_chat(provider_name)
+    for provider_name in _adapter_registry.ChatProviderRegistry.DEFAULT_ADAPTERS
+)
+_NAMESPACED_MODEL_PROVIDERS = {"openrouter", "huggingface", "novita", "poe", "together"}
+
 _OPENROUTER_MODEL_DISCOVERY_TIMEOUT_SECONDS = 5.0
 _DEFAULT_ASSISTANT_SYSTEM_PROMPT = "You are a helpful AI assistant."
 
@@ -1223,6 +1229,26 @@ def infer_provider_from_model_catalog(
     return current_provider, debug
 
 
+def _split_inline_provider_model(model_str: str) -> tuple[str | None, str | None, str | None]:
+    """Split frontend provider-qualified model ids into provider/model parts."""
+    model_value = (model_str or "").strip()
+    if not model_value:
+        return None, None, None
+
+    if "/" in model_value:
+        model_provider, model_name = model_value.split("/", 1)
+        return model_provider.strip(), model_name.strip(), "/"
+
+    if ":" not in model_value:
+        return None, None, None
+
+    model_provider, model_name = model_value.split(":", 1)
+    normalized_provider = normalize_catalog_provider_for_chat(model_provider.strip().lower())
+    if normalized_provider not in _INLINE_MODEL_PROVIDER_NAMES:
+        return None, None, None
+    return model_provider.strip(), model_name.strip(), ":"
+
+
 def invalidate_model_alias_caches() -> None:
     """Invalidate cached model list and alias overrides for hot-reload.
 
@@ -1333,17 +1359,11 @@ def parse_provider_model_for_metrics(
     """
     model_str = getattr(request_data, "model", None) or "unknown"
     api_provider = getattr(request_data, "api_provider", None)
-    if "/" in model_str:
-        parts = model_str.split("/", 1)
-        if len(parts) == 2:
-            model_provider, model_name = parts
-            raw_provider = api_provider or model_provider
-            provider = normalize_catalog_provider_for_chat((raw_provider or "").strip().lower())
-            model = model_name
-        else:
-            raw_provider = api_provider or default_provider
-            provider = normalize_catalog_provider_for_chat((raw_provider or "").strip().lower())
-            model = model_str
+    model_provider, model_name, _ = _split_inline_provider_model(model_str)
+    if model_provider is not None and model_name is not None:
+        raw_provider = api_provider or model_provider
+        provider = normalize_catalog_provider_for_chat((raw_provider or "").strip().lower())
+        model = model_name
     else:
         raw_provider = api_provider or default_provider
         provider = normalize_catalog_provider_for_chat((raw_provider or "").strip().lower())
@@ -1375,10 +1395,8 @@ def normalize_request_provider_and_model(
         # prefer that; else honor api_provider, then default_provider.
         inline_provider: str | None = None
         inline_model_part: str | None = None
-        if "/" in model_str:
-            parts_for_alias = model_str.split("/", 1)
-            if len(parts_for_alias) == 2:
-                inline_provider, inline_model_part = parts_for_alias[0].strip(), parts_for_alias[1].strip()
+        inline_separator: str | None = None
+        inline_provider, inline_model_part, inline_separator = _split_inline_provider_model(model_str)
         provider_for_mapping = normalize_catalog_provider_for_chat(
             ((inline_provider or api_provider or default_provider) or "").strip().lower()
         )
@@ -1418,7 +1436,7 @@ def normalize_request_provider_and_model(
             allow_cross = _shared_is_truthy(os.getenv("CHAT_ALLOW_CROSS_PROVIDER_ALIASING", "0"))
             if inline_provider:
                 # Preserve inline provider prefix until final normalization below
-                combined = f"{inline_provider}/{resolved}"
+                combined = f"{inline_provider}{inline_separator or '/'}{resolved}"
                 request_data.model = combined
                 model_str = combined
             else:
@@ -1444,31 +1462,29 @@ def normalize_request_provider_and_model(
     provider = normalize_catalog_provider_for_chat(
         ((api_provider or default_provider) or "").strip().lower()
     )
-    if "/" in model_str:
-        parts = model_str.split("/", 1)
-        if len(parts) == 2:
-            model_provider, actual_model = parts
-            inline_provider_lower = normalize_catalog_provider_for_chat(
-                model_provider.strip().lower()
-            )
-            # If the api_provider was not explicitly set, allow inline provider to select it
-            if not api_provider:
-                provider = inline_provider_lower
-                # In this case, strip the inline provider prefix from the model
-                request_data.model = actual_model
-            else:
-                # api_provider is explicitly set on the request. For some providers,
-                # many valid model IDs include a namespace
-                # (e.g., "openai/gpt-4o-mini", "z-ai/glm-4.6"). Preserve the full
-                # namespaced model id unless the inline namespace matches "openrouter".
-                if provider in {"openrouter", "huggingface", "novita", "poe", "together"}:
-                    if provider == "openrouter" and inline_provider_lower == "openrouter":
-                        request_data.model = actual_model
-                    else:
-                        request_data.model = model_str
-                else:
-                    # Non-OpenRouter providers do not use namespaced model ids; strip prefix
+    model_provider, actual_model, inline_separator = _split_inline_provider_model(model_str)
+    if model_provider is not None and actual_model is not None:
+        inline_provider_lower = normalize_catalog_provider_for_chat(
+            model_provider.strip().lower()
+        )
+        # If the api_provider was not explicitly set, allow inline provider to select it
+        if not api_provider:
+            provider = inline_provider_lower
+            # In this case, strip the inline provider prefix from the model
+            request_data.model = actual_model
+        else:
+            # api_provider is explicitly set on the request. For some providers,
+            # many valid model IDs include a namespace
+            # (e.g., "openai/gpt-4o-mini", "z-ai/glm-4.6"). Preserve slash
+            # namespaces unless the inline namespace is the provider itself.
+            if provider in _NAMESPACED_MODEL_PROVIDERS and inline_separator == "/":
+                if provider == "openrouter" and inline_provider_lower == "openrouter":
                     request_data.model = actual_model
+                else:
+                    request_data.model = model_str
+            else:
+                # Non-namespaced providers do not use provider-qualified model ids; strip prefix
+                request_data.model = actual_model
     return provider
 
 

--- a/tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py
@@ -107,6 +107,17 @@ def test_chat_completion_request_valid_api_provider():
 
 
 @pytest.mark.unit
+def test_chat_completion_request_normalizes_llama_provider_alias():
+    req = ChatCompletionRequest(
+        model="gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf",
+        messages=[ChatCompletionUserMessageParam(role="user", content="hi")],
+        api_provider="llama",
+    )
+
+    assert req.api_provider == "llama.cpp"
+
+
+@pytest.mark.unit
 def test_supported_api_endpoints_uses_python310_safe_runtime_validation():
     assert SUPPORTED_API_ENDPOINTS is str
 

--- a/tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py
@@ -107,7 +107,8 @@ def test_chat_completion_request_valid_api_provider():
 
 
 @pytest.mark.unit
-def test_chat_completion_request_normalizes_llama_provider_alias():
+def test_chat_completion_request_normalizes_llama_provider_alias() -> None:
+    """Catalog provider id `llama` should validate as canonical `llama.cpp`."""
     req = ChatCompletionRequest(
         model="gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf",
         messages=[ChatCompletionUserMessageParam(role="user", content="hi")],

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py
@@ -70,6 +70,31 @@ def test_resolve_provider_and_model_normalizes_llamacpp_catalog_alias() -> None:
 
 
 @pytest.mark.unit
+def test_resolve_provider_and_model_normalizes_llama_colon_model_prefix() -> None:
+    """Frontend provider-qualified model ids should route to llama.cpp."""
+    request = ChatCompletionRequest(
+        model="llama:gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    metrics_provider, metrics_model, selected_provider, selected_model, debug_info = (
+        resolve_provider_and_model(
+            request_data=request,
+            metrics_default_provider="openai",
+            normalize_default_provider="openai",
+        )
+    )
+
+    assert metrics_provider == "llama.cpp"
+    assert metrics_model == "gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf"
+    assert selected_provider == "llama.cpp"
+    assert selected_model == "gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf"
+    assert request.model == "gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf"
+    assert debug_info["raw"]["model"] == "llama:gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf"
+    assert debug_info["normalized"]["provider"] == "llama.cpp"
+
+
+@pytest.mark.unit
 def test_resolve_provider_and_model_catalog_unique_match_when_provider_not_explicit(monkeypatch):
     request = ChatCompletionRequest(
         model="deepseek-chat",


### PR DESCRIPTION
## Summary
- Normalize frontend provider-qualified model ids such as `llama:<model>` to provider `llama.cpp` and model `<model>` before chat execution.
- Keep existing slash-qualified provider/model behavior, while only splitting colon-qualified ids when the prefix is a registered chat provider.
- Retain request-schema regression coverage for `api_provider: "llama"` and add provider/model resolution coverage for the actual frontend `model: "llama:<model>"` payload.
- Update TASK-12120 with both failure modes and live verification notes.

## Context
The first failure mode was HTTP 422 for `api_provider: "llama"`. `dev` already had alias normalization for that path, so this PR pinned it with schema coverage.

The repeated live UI failure also happens after selecting the llama.cpp model in the frontend: the UI sends `model: "llama:<gguf>"` with no `api_provider`. The backend previously treated that as the default provider and failed generation instead of routing to llama.cpp. This PR fixes that execution path.

## Verification
- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py::test_resolve_provider_and_model_normalizes_llama_colon_model_prefix -q` failed before the fix with `metrics_provider == "openai"`.
- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_provider_model_resolution.py tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py -q` -> 31 passed.
- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Chat/chat_service.py tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py -f json -o /tmp/bandit_task_12120.json` -> 0 results.
- Local PR-worktree backend + live llama.cpp at `127.0.0.1:9099`: `POST /api/v1/chat/completions` with `api_provider: "llama"` returned HTTP 200 and content `alias ok`.
- Local PR-worktree backend + live llama.cpp at `127.0.0.1:9099`: `POST /api/v1/chat/completions` with `model: "llama:<gguf>"` and no `api_provider` returned HTTP 200 and content `colon alias ok`.

## Merge Note
AI-generated PR merge policy still requires a human-written Change summary before merge.
