### PR TITLE
Fix chat system prompts modal editing

### DIFF
--- a/apps/packages/ui/src/assets/tailwind-shared.css
+++ b/apps/packages/ui/src/assets/tailwind-shared.css
@@ -374,6 +374,7 @@ body {
 
 .ant-popover-inner,
 .ant-dropdown-menu,
+.ant-modal-container,
 .ant-modal-content,
 .ant-modal-header,
 .ant-drawer-content,
@@ -385,6 +386,7 @@ body {
 
 .ant-card-head,
 .ant-modal-title,
+.ant-modal-body,
 .ant-drawer-title,
 .ant-typography:not(.ant-typography-danger):not(.ant-typography-success):not(.ant-typography-warning),
 .ant-form-item-label > label,
@@ -402,10 +404,17 @@ body {
 
 .ant-form-item-extra,
 .ant-form-item-explain,
+.ant-modal-close,
+.ant-modal-close-x,
 .ant-typography-secondary,
 .ant-typography .ant-typography-secondary,
 .ant-tabs .ant-tabs-tab:not(.ant-tabs-tab-active) .ant-tabs-tab-btn {
   color: rgb(var(--color-text-muted)) !important;
+}
+
+.ant-modal-close:hover {
+  background-color: rgb(var(--color-surface-2)) !important;
+  color: rgb(var(--color-text)) !important;
 }
 
 .ant-tabs .ant-tabs-tab:hover .ant-tabs-tab-btn,

--- a/apps/packages/ui/src/assets/tailwind-shared.css
+++ b/apps/packages/ui/src/assets/tailwind-shared.css
@@ -412,8 +412,15 @@ body {
   color: rgb(var(--color-text-muted)) !important;
 }
 
-.ant-modal-close:hover {
+.ant-modal-close:hover,
+.ant-modal-close:focus-visible {
   background-color: rgb(var(--color-surface-2)) !important;
+}
+
+.ant-modal-close:hover,
+.ant-modal-close:hover .ant-modal-close-x,
+.ant-modal-close:focus-visible,
+.ant-modal-close:focus-visible .ant-modal-close-x {
   color: rgb(var(--color-text)) !important;
 }
 

--- a/apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
@@ -843,7 +843,11 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
               {formattingGuideControl}
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <SystemPromptTemplatesButton onSelect={onTemplateSelect} />
+              <SystemPromptTemplatesButton
+                onSelect={onTemplateSelect}
+                systemPrompt={systemPrompt}
+                onSystemPromptChange={setSystemPrompt}
+              />
               {messages.length > 0 && (
                 <SessionCostEstimation
                   modelId={selectedModel}
@@ -968,7 +972,11 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
           {tabsCountBadge}
           {filesCountBadge}
           <ParameterPresets compact />
-          <SystemPromptTemplatesButton onSelect={onTemplateSelect} />
+          <SystemPromptTemplatesButton
+            onSelect={onTemplateSelect}
+            systemPrompt={systemPrompt}
+            onSystemPromptChange={setSystemPrompt}
+          />
           {formattingGuideControl}
         </div>
       </div>
@@ -1066,6 +1074,8 @@ export const ComposerToolbar = React.memo(function ComposerToolbar(
         open={systemPromptsOpen}
         onClose={() => setSystemPromptsOpen(false)}
         onSelect={handleMobileTemplateSelect}
+        systemPrompt={systemPrompt}
+        onSystemPromptChange={setSystemPrompt}
       />
       <Modal
         title={t("playground:presets.title", "Generation style") as string}

--- a/apps/packages/ui/src/components/Option/Playground/SystemPromptTemplates.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/SystemPromptTemplates.tsx
@@ -370,6 +370,16 @@ export const SystemPromptTemplatesModal: React.FC<Props> = ({
   const [searchQuery, setSearchQuery] = React.useState("");
   const [activeCategory, setActiveCategory] = React.useState<string>("all");
   const [copiedId, setCopiedId] = React.useState<string | null>(null);
+  const [localSystemPrompt, setLocalSystemPrompt] = React.useState(
+    systemPrompt || "",
+  );
+  const committedSystemPromptRef = React.useRef(systemPrompt || "");
+
+  React.useEffect(() => {
+    const nextSystemPrompt = systemPrompt || "";
+    committedSystemPromptRef.current = nextSystemPrompt;
+    setLocalSystemPrompt(nextSystemPrompt);
+  }, [systemPrompt]);
 
   const filteredTemplates = React.useMemo(() => {
     let templates = PROMPT_TEMPLATES;
@@ -402,6 +412,19 @@ export const SystemPromptTemplatesModal: React.FC<Props> = ({
     }
   };
 
+  const commitSystemPrompt = React.useCallback(() => {
+    if (!onSystemPromptChange) return;
+    if (localSystemPrompt !== committedSystemPromptRef.current) {
+      committedSystemPromptRef.current = localSystemPrompt;
+      onSystemPromptChange(localSystemPrompt);
+    }
+  }, [localSystemPrompt, onSystemPromptChange]);
+
+  const handleClose = React.useCallback(() => {
+    commitSystemPrompt();
+    onClose();
+  }, [commitSystemPrompt, onClose]);
+
   const handleSelect = (template: PromptTemplate) => {
     onSelect(template);
     onClose();
@@ -429,7 +452,7 @@ export const SystemPromptTemplatesModal: React.FC<Props> = ({
         </div>
       }
       open={open}
-      onCancel={onClose}
+      onCancel={handleClose}
       footer={null}
       width={700}
       className="prompt-templates-modal"
@@ -447,8 +470,9 @@ export const SystemPromptTemplatesModal: React.FC<Props> = ({
                   "Current system prompt",
                 ) as string
               }
-              value={systemPrompt || ""}
-              onChange={(e) => onSystemPromptChange(e.target.value)}
+              value={localSystemPrompt}
+              onChange={(e) => setLocalSystemPrompt(e.target.value)}
+              onBlur={commitSystemPrompt}
               rows={4}
               placeholder={t(
                 "playground:templates.currentPromptPlaceholder",

--- a/apps/packages/ui/src/components/Option/Playground/SystemPromptTemplates.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/SystemPromptTemplates.tsx
@@ -355,12 +355,16 @@ type Props = {
   open: boolean;
   onClose: () => void;
   onSelect: (template: PromptTemplate) => void;
+  systemPrompt?: string;
+  onSystemPromptChange?: (prompt: string) => void;
 };
 
 export const SystemPromptTemplatesModal: React.FC<Props> = ({
   open,
   onClose,
   onSelect,
+  systemPrompt,
+  onSystemPromptChange,
 }) => {
   const { t } = useTranslation(["playground", "common"]);
   const [searchQuery, setSearchQuery] = React.useState("");
@@ -431,7 +435,34 @@ export const SystemPromptTemplatesModal: React.FC<Props> = ({
       className="prompt-templates-modal"
     >
       <div className="space-y-4">
+        {onSystemPromptChange ? (
+          <label className="block space-y-1.5">
+            <span className="text-xs font-medium text-text-muted">
+              {t("playground:templates.currentPrompt", "Current system prompt")}
+            </span>
+            <Input.TextArea
+              aria-label={
+                t(
+                  "playground:templates.currentPrompt",
+                  "Current system prompt",
+                ) as string
+              }
+              value={systemPrompt || ""}
+              onChange={(e) => onSystemPromptChange(e.target.value)}
+              rows={4}
+              placeholder={t(
+                "playground:templates.currentPromptPlaceholder",
+                "Write or edit the system prompt for this chat...",
+              )}
+            />
+          </label>
+        ) : null}
+
         <Input
+          aria-label={t(
+            "playground:templates.search",
+            "Search system prompts...",
+          )}
           placeholder={t(
             "playground:templates.search",
             "Search system prompts...",
@@ -525,11 +556,15 @@ export const SystemPromptTemplatesModal: React.FC<Props> = ({
 
 type TemplatesButtonProps = {
   onSelect: (template: PromptTemplate) => void;
+  systemPrompt?: string;
+  onSystemPromptChange?: (prompt: string) => void;
   className?: string;
 };
 
 export const SystemPromptTemplatesButton: React.FC<TemplatesButtonProps> = ({
   onSelect,
+  systemPrompt,
+  onSystemPromptChange,
   className,
 }) => {
   const { t } = useTranslation(["playground"]);
@@ -553,6 +588,8 @@ export const SystemPromptTemplatesButton: React.FC<TemplatesButtonProps> = ({
         open={open}
         onClose={() => setOpen(false)}
         onSelect={onSelect}
+        systemPrompt={systemPrompt}
+        onSystemPromptChange={onSystemPromptChange}
       />
     </>
   );

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/SystemPromptTemplates.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/SystemPromptTemplates.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { SystemPromptTemplatesModal } from "../SystemPromptTemplates"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+vi.mock("antd", async () => {
+  const React = await import("react")
+
+  const Input = (props: any) => (
+    <input
+      aria-label={props["aria-label"] ?? props.placeholder}
+      placeholder={props.placeholder}
+      value={props.value}
+      onChange={props.onChange}
+    />
+  )
+
+  Input.TextArea = (props: any) => (
+    <textarea
+      aria-label={props["aria-label"] ?? props.placeholder}
+      placeholder={props.placeholder}
+      value={props.value}
+      onChange={props.onChange}
+    />
+  )
+
+  return {
+    Modal: ({
+      open,
+      title,
+      children
+    }: {
+      open?: boolean
+      title?: React.ReactNode
+      children: React.ReactNode
+    }) =>
+      open ? (
+        <section role="dialog" aria-label={String(title || "Dialog")}>
+          {children}
+        </section>
+      ) : null,
+    Input,
+    Tabs: ({
+      items
+    }: {
+      items: Array<{ key: string; label: React.ReactNode }>
+    }) => (
+      <div>
+        {items.map((item) => (
+          <button key={item.key} type="button">
+            {item.label}
+          </button>
+        ))}
+      </div>
+    ),
+    Empty: ({ description }: { description?: React.ReactNode }) => (
+      <div>{description}</div>
+    ),
+    Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>
+  }
+})
+
+describe("SystemPromptTemplatesModal", () => {
+  it("shows an editable current system prompt above template search", async () => {
+    const user = userEvent.setup()
+    const onSystemPromptChange = vi.fn()
+
+    const Wrapper = () => {
+      const [systemPrompt, setSystemPrompt] =
+        React.useState("Stay in character.")
+
+      return (
+        <SystemPromptTemplatesModal
+          open
+          onClose={vi.fn()}
+          onSelect={vi.fn()}
+          systemPrompt={systemPrompt}
+          onSystemPromptChange={(nextPrompt) => {
+            setSystemPrompt(nextPrompt)
+            onSystemPromptChange(nextPrompt)
+          }}
+        />
+      )
+    }
+
+    render(<Wrapper />)
+
+    const editor = screen.getByLabelText(/current system prompt/i)
+    const search = screen.getByLabelText(/search system prompts/i)
+
+    expect(editor.compareDocumentPosition(search)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+
+    await user.clear(editor)
+    await user.type(editor, "Speak plainly.")
+
+    expect(onSystemPromptChange).toHaveBeenLastCalledWith("Speak plainly.")
+    expect(editor).toHaveValue("Speak plainly.")
+  })
+})

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/SystemPromptTemplates.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/SystemPromptTemplates.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import React from "react"
 import { describe, expect, it, vi } from "vitest"
@@ -29,6 +29,7 @@ vi.mock("antd", async () => {
       placeholder={props.placeholder}
       value={props.value}
       onChange={props.onChange}
+      onBlur={props.onBlur}
     />
   )
 
@@ -103,7 +104,11 @@ describe("SystemPromptTemplatesModal", () => {
     await user.clear(editor)
     await user.type(editor, "Speak plainly.")
 
-    expect(onSystemPromptChange).toHaveBeenLastCalledWith("Speak plainly.")
     expect(editor).toHaveValue("Speak plainly.")
+    expect(onSystemPromptChange).not.toHaveBeenCalled()
+
+    fireEvent.blur(editor)
+
+    expect(onSystemPromptChange).toHaveBeenLastCalledWith("Speak plainly.")
   })
 })

--- a/backlog/tasks/task-12153 - Show-editable-current-system-prompt-in-chat-composer-modal.md
+++ b/backlog/tasks/task-12153 - Show-editable-current-system-prompt-in-chat-composer-modal.md
@@ -1,0 +1,49 @@
+---
+id: TASK-12153
+title: Show editable current system prompt in chat composer modal
+status: Done
+labels:
+- ui
+- chat
+- prompt-select
+modified_files:
+- apps/packages/ui/src/components/Option/Playground/SystemPromptTemplates.tsx
+- apps/packages/ui/src/components/Option/Playground/ComposerToolbar.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/SystemPromptTemplates.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update the chat composer System Prompts modal used by the WebUI and browser extension so the current system prompt is visible in an editable text box above the prompt search/select controls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+The chat composer System Prompts modal now shows the current system prompt in an editable textarea above template search/select when opened from composer controls. Editing the textbox updates the existing systemPrompt state; saved template selection remains unchanged.
+
+Verification: focused Vitest coverage passed for SystemPromptTemplates, ComposerToolbar desktop/mobile, and PromptSelect modal tests; extension compile passed; git diff whitespace check passed. Full WebUI/shared UI typechecks remain blocked by pre-existing unrelated TypeScript errors. Rendered verification passed on an isolated WebUI stack after avoiding the existing occupied frontend/backend ports.
+
+Bandit: not applicable; touched files are TypeScript/TSX UI files only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12155 - Fix-System-Prompts-modal-dark-theme-colors.md
+++ b/backlog/tasks/task-12155 - Fix-System-Prompts-modal-dark-theme-colors.md
@@ -1,0 +1,48 @@
+---
+id: TASK-12155
+title: Fix System Prompts modal dark theme colors
+status: Done
+labels:
+- webui
+- extension
+- ui
+- theme
+priority: Medium
+modified_files:
+- apps/packages/ui/src/assets/tailwind-shared.css
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The System Prompts modal opened from the chat composer renders AntD modal chrome with light-theme colors while the chat UI is in dark mode. Scope the fix to the modal/theme styling and verify on an isolated frontend/backend stack.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 System Prompts modal content, title, tabs, close control, and prompt cards use the active dark theme colors in the WebUI.
+- [ ] #2 The existing editable current system prompt field remains visible above search and the prompt template selector.
+- [ ] #3 The fix works in the shared UI surface used by WebUI and browser extension without changing unrelated theme behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the System Prompts modal dark-theme mix by extending the shared AntD theme bridge to cover .ant-modal-container, .ant-modal-body, and the modal close control. Verified on the isolated WebUI stack at 127.0.0.1:3123 with mock backend 127.0.0.1:18081: modal container resolved to rgb(35, 40, 50), text to rgb(231, 233, 238), prompt cards inherited dark text correctly, and the editable Current system prompt textarea accepted input above search. Checks: git diff --check passed; focused Vitest run passed (4 files, 50 tests); apps/extension bun run compile passed; Bandit skipped because touched code is CSS/TS frontend only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12170 - Rebase-PR-2666-on-dev-and-address-review-feedback.md
+++ b/backlog/tasks/task-12170 - Rebase-PR-2666-on-dev-and-address-review-feedback.md
@@ -1,0 +1,50 @@
+---
+id: TASK-12170
+title: Rebase PR 2666 on dev and address review feedback
+status: Done
+labels:
+- webui
+- extension
+- review-feedback
+modified_files:
+- apps/packages/ui/src/assets/tailwind-shared.css
+- apps/packages/ui/src/components/Option/Playground/SystemPromptTemplates.tsx
+- apps/packages/ui/src/components/Option/Playground/__tests__/SystemPromptTemplates.test.tsx
+- backlog/tasks/task-12170 - Rebase-PR-2666-on-dev-and-address-review-feedback.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track the PR #2666 follow-up work: rebase onto latest dev, address inline review comments on the System Prompts modal, verify the frontend checks, and update the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR #2666 is based on the latest fetched origin/dev.
+- [x] #2 System Prompts modal editor no longer updates ComposerToolbar on every keystroke.
+- [x] #3 Modal close button hover and keyboard focus styles recolor the inner Ant close icon.
+- [x] #4 Focused frontend checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Rebased the branch onto origin/dev before applying review feedback. Buffered the current system prompt editor in modal-local state and committed changes on blur/cancel, with a committed-value ref to avoid duplicate parent callbacks. Updated the Ant modal close bridge to style hover and focus-visible states on both the close button and .ant-modal-close-x.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2666 onto the latest fetched origin/dev and addressed the inline review comments. The System Prompts modal now buffers textarea edits locally and commits them on blur/cancel instead of calling the composer parent on every keystroke, and the close-button styling now covers hover/focus-visible for the inner Ant close icon. Verification: git diff --check passed; focused Vitest passed (4 files, 50 tests); apps/extension bun run compile passed; apps/tldw-frontend bun run typecheck passed. Bandit was not run because the touched implementation is frontend TS/TSX/CSS plus Backlog markdown.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Show the current chat system prompt in an editable textarea at the top of the System Prompts modal.
- Wire composer System Prompts buttons to the existing systemPrompt state across desktop, pro, and mobile/overflow paths.
- Extend the shared AntD theme bridge so the System Prompts modal uses dark-theme modal container/body/close colors.

## Test Plan
- [x] `bunx vitest run src/components/Option/Playground/__tests__/SystemPromptTemplates.test.tsx src/components/Option/Playground/__tests__/ComposerToolbar.test.tsx src/components/Option/Playground/__tests__/ComposerToolbar.role-play-mobile.test.tsx src/components/Common/__tests__/PromptSelect.system-prompt-modal.test.tsx`
- [x] `bun run compile` in `apps/extension`
- [x] `git diff --cached --check`
- [x] Rendered check on isolated stack: WebUI `127.0.0.1:3123`, mock backend `127.0.0.1:18081`

## Notes
- Broad WebUI/package TypeScript checks are still blocked by unrelated existing TS errors; investigated separately after PR creation.
- Bandit not applicable: touched code is frontend TS/TSX/CSS only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat System Prompts modal editing and dark-theme styling by adding an editable “current system prompt” at the top and committing changes on blur/close (not every keystroke). Addresses TASK-12153, TASK-12155, TASK-12170.

- **New Features**
  - Show current system prompt in an editable textarea above template search, wired across desktop and mobile composer.

- **Bug Fixes**
  - Buffer edits locally and sync to the composer on blur or modal close (no per-keystroke updates).
  - Apply dark theme colors to `.ant-modal-container`, `.ant-modal-body`, title/text, and close button hover/focus (including `.ant-modal-close-x`).

<sup>Written for commit eef24429b328887d6ffa46380e1b3cb1401525d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

