### PR TITLE
Fix dark theme visual fidelity

### DIFF
--- a/Docs/superpowers/plans/2026-07-05-chat-notes-dark-theme-visual-fidelity-plan.md
+++ b/Docs/superpowers/plans/2026-07-05-chat-notes-dark-theme-visual-fidelity-plan.md
@@ -1,0 +1,50 @@
+# Chat, Extension Chat, Character Chat, and Notes Dark Theme Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans or follow this task list directly with TDD and rendered browser verification.
+
+**Goal:** Remove light-theme visual leaks from WebUI chat, extension chat, character-card chat, and Notes in dark mode.
+
+**Architecture:** Prefer shared token fixes in `apps/packages/ui/src/assets/tailwind-shared.css` and Ant Design theme bridging before local component patches. Only patch route/component files when a hardcoded light surface is confirmed in the target flow.
+
+**Tech Stack:** Next.js, React, Tailwind, Ant Design, Vitest, Playwright/Browser.
+
+---
+
+## Stage 1: Map and Reproduce
+**Goal:** Identify the exact light-theme leaks in the target dark-mode flows.
+**Success Criteria:** Screenshots or DOM/CSS evidence for `/chat`, `/chat?mode=character`, extension sidepanel chat/options, and `/notes`.
+**Tests:** Browser walkthrough with dark mode set before route load.
+**Status:** Complete
+
+## Stage 2: Add Minimal Regression Coverage
+**Goal:** Capture the shared dark-theme invariant that failed.
+**Success Criteria:** A focused test fails before the fix and checks relevant shared CSS/component output.
+**Tests:** Targeted Vitest or CSS contract test under `apps/tldw-frontend` or `apps/packages/ui`.
+**Status:** Complete
+
+## Stage 3: Fix Root Cause
+**Goal:** Replace confirmed light-only colors/classes with shared semantic tokens.
+**Success Criteria:** The target surfaces use `bg/surface/elevated/text/border` tokens in dark mode, with no new local theme abstraction.
+**Tests:** Targeted regression test passes.
+**Status:** Complete
+
+## Stage 4: Rendered Walkthrough
+**Goal:** Walk through menus/options in normal chat, character chat, extension chat, and Notes.
+**Success Criteria:** Desktop and one narrow viewport show no jarring light panels in dark mode; console has no relevant errors.
+**Tests:** Browser screenshots plus interaction checks for menus, selectors, modals, sidebars, and Notes overlays.
+**Status:** Complete
+
+## Stage 5: Final Verification
+**Goal:** Record focused verification and repo-required checks.
+**Success Criteria:** Targeted tests pass, Bandit is skipped with rationale for frontend-only changes, and `TASK-12171` has final notes.
+**Tests:** Focused test command, lint/build only if touched scope warrants it, browser QA evidence.
+**Status:** Complete
+
+Verification:
+- `npx playwright test e2e/smoke/dark-theme-visual-fidelity.spec.ts --reporter=line` passed.
+- `git diff --check -- apps/packages/ui/src/assets/tailwind-shared.css apps/tldw-frontend/e2e/smoke/dark-theme-visual-fidelity.spec.ts Docs/superpowers/plans/2026-07-05-chat-notes-dark-theme-visual-fidelity-plan.md "backlog/tasks/task-12171 - Fix-dark-theme-visual-drift-in-Chat-extension-chat-character-chat-and-Notes.md"` passed.
+- Bandit skipped: touched code is frontend CSS and Playwright TypeScript only.
+
+Notes:
+- Confirmed and fixed white Ant Select wrapper surfaces in Notes dark mode.
+- Confirmed and fixed low-contrast Ant button/radio-button text in Notes dark mode.

--- a/apps/packages/ui/src/assets/tailwind-shared.css
+++ b/apps/packages/ui/src/assets/tailwind-shared.css
@@ -372,11 +372,25 @@ body {
   border-color: rgb(var(--color-border)) !important;
 }
 
+.ant-table,
+.ant-table-wrapper .ant-table,
+.ant-table-container,
+.ant-table-content {
+  background-color: rgb(var(--color-surface)) !important;
+  color: rgb(var(--color-text)) !important;
+  border-color: rgb(var(--color-border)) !important;
+}
+
+.ant-popover,
+.ant-popover-container,
 .ant-popover-inner,
 .ant-dropdown-menu,
+.ant-notification-notice,
+.ant-notification-notice-wrapper,
 .ant-modal-container,
 .ant-modal-content,
 .ant-modal-header,
+.ant-drawer-section,
 .ant-drawer-content,
 .ant-drawer-header {
   background-color: rgb(var(--color-elevated)) !important;
@@ -387,11 +401,25 @@ body {
 .ant-card-head,
 .ant-modal-title,
 .ant-modal-body,
+.ant-notification-notice-title,
+.ant-notification-notice-message,
+.ant-notification-notice-description,
+.ant-notification-notice-close,
+.ant-table,
+.ant-table-cell,
+.ant-table-column-title,
+.ant-table-column-sorter,
+.ant-tag,
 .ant-drawer-title,
 .ant-typography:not(.ant-typography-danger):not(.ant-typography-success):not(.ant-typography-warning),
 .ant-form-item-label > label,
 .ant-checkbox-wrapper,
 .ant-radio-wrapper,
+.ant-radio-button-wrapper,
+.ant-btn:not(.ant-btn-primary):not(.ant-btn-dangerous):not(.ant-btn-link),
+.ant-dropdown-menu-item,
+.ant-dropdown-menu-submenu-title,
+.ant-dropdown-menu-title-content,
 .ant-tabs .ant-tabs-tab-btn,
 .ant-segmented,
 .ant-segmented-item-label {
@@ -402,6 +430,41 @@ body {
   border-color: rgb(var(--color-border)) !important;
 }
 
+.ant-table-thead > tr > th,
+.ant-table-thead > tr > td {
+  background-color: rgb(var(--color-surface-2)) !important;
+  border-color: rgb(var(--color-border)) !important;
+  color: rgb(var(--color-text)) !important;
+}
+
+.ant-table-tbody > tr > td,
+.ant-table-cell {
+  background-color: rgb(var(--color-surface)) !important;
+  border-color: rgb(var(--color-border)) !important;
+  color: rgb(var(--color-text)) !important;
+}
+
+.ant-table-column-sort {
+  background-color: rgb(var(--color-surface-2)) !important;
+}
+
+.ant-table-tbody > tr.ant-table-row:hover > td,
+.ant-table-tbody > tr > td.ant-table-cell-row-hover,
+.ant-table-tbody > tr.ant-table-row-selected > td,
+.ant-table-tbody > tr.ant-table-row-selected:hover > td {
+  background-color: rgb(var(--color-elevated)) !important;
+}
+
+.ant-tag {
+  background-color: rgb(var(--color-surface-2)) !important;
+  border-color: rgb(var(--color-border)) !important;
+  color: rgb(var(--color-text)) !important;
+}
+
+.ant-dropdown-menu-item-disabled,
+.ant-dropdown-menu-submenu-title-disabled,
+.ant-dropdown-menu-item-disabled .ant-dropdown-menu-title-content,
+.ant-dropdown-menu-submenu-title-disabled .ant-dropdown-menu-title-content,
 .ant-form-item-extra,
 .ant-form-item-explain,
 .ant-modal-close,
@@ -447,12 +510,18 @@ body {
 .ant-input-number-input,
 .ant-input-textarea,
 .ant-input-textarea textarea,
+.ant-select,
 .ant-select-selector,
 .ant-picker {
   background-color: rgb(var(--color-surface-2)) !important;
   border-color: rgb(var(--color-border)) !important;
   color: rgb(var(--color-text)) !important;
   transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.ant-select {
+  border-radius: 8px;
+  overflow: hidden;
 }
 
 .ant-input input,
@@ -623,6 +692,13 @@ body {
   background-color: rgb(var(--color-elevated)) !important;
 }
 
+.ant-dropdown-menu-item:hover,
+.ant-dropdown-menu-item-active,
+.ant-dropdown-menu-submenu-title:hover,
+.ant-dropdown-menu-submenu-title-active {
+  background-color: rgb(var(--color-surface-2)) !important;
+}
+
 .ant-btn-default:not(.ant-btn-dangerous) {
   background-color: rgb(var(--color-surface)) !important;
   border-color: rgb(var(--color-border)) !important;
@@ -662,6 +738,9 @@ body {
 .ant-select-disabled .ant-select-arrow,
 .ant-checkbox-wrapper-disabled,
 .ant-radio-wrapper-disabled,
+.ant-radio-button-wrapper-disabled,
+.ant-btn:disabled,
+.ant-btn.ant-btn-disabled,
 .ant-btn-default:disabled,
 .ant-btn-default.ant-btn-disabled {
   background-color: rgb(var(--color-surface-2) / 0.5) !important;

--- a/apps/tldw-frontend/e2e/smoke/dark-theme-visual-fidelity.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/dark-theme-visual-fidelity.spec.ts
@@ -1,0 +1,538 @@
+import { expect, test, seedAuth, SMOKE_LOAD_TIMEOUT } from "./smoke.setup"
+import type { Page, Route, TestInfo } from "@playwright/test"
+import { waitForAppShell } from "../utils/helpers"
+
+type LightSurfaceLeak = {
+  tag: string
+  className: string
+  testId: string
+  role: string
+  aria: string
+  text: string
+  backgroundColor: string
+  color: string
+  box: [number, number, number, number]
+}
+
+type LowContrastTextLeak = LightSurfaceLeak & {
+  effectiveBackgroundColor: string
+  contrast: number
+}
+
+const NOTE_FIXTURE = {
+  id: "note-a",
+  title: "Dark mode audit note",
+  content: "A note used to check menus and editor surfaces.",
+  version: 1,
+  keywords: [],
+  created_at: "2026-07-05T12:00:00Z",
+  updated_at: "2026-07-05T12:00:00Z",
+}
+
+const CHARACTER_FIXTURE = {
+  id: 7,
+  name: "Demo Archivist",
+  description: "A test character for visual QA.",
+  personality: "Concise",
+  version: 1,
+}
+
+const fulfillJson = async (route: Route, status: number, body: unknown) =>
+  route.fulfill({
+    status,
+    contentType: "application/json",
+    headers: {
+      "access-control-allow-origin": "*",
+      "access-control-allow-headers": "*",
+      "access-control-allow-methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
+    },
+    body: JSON.stringify(body),
+  })
+
+const installApiMocks = async (page: Page) => {
+  await page.route("**/*", async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const path = url.pathname
+    const method = request.method().toUpperCase()
+
+    if (method === "OPTIONS") {
+      await route.fulfill({
+        status: 204,
+        headers: {
+          "access-control-allow-origin": "*",
+          "access-control-allow-headers": "*",
+          "access-control-allow-methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
+        },
+      })
+      return
+    }
+
+    if (path === "/api/v1/health" || path === "/api/v1/health/live") {
+      await fulfillJson(route, 200, { status: "ok", checks: {} })
+      return
+    }
+
+    if (path === "/openapi.json") {
+      await fulfillJson(route, 200, {
+        openapi: "3.0.0",
+        info: { version: "visual-fidelity" },
+        paths: {
+          "/api/v1/chat/completions": {},
+          "/api/v1/characters": {},
+          "/api/v1/characters/query": {},
+          "/api/v1/characters/world-books": {},
+          "/api/v1/notes/": {},
+        },
+      })
+      return
+    }
+
+    if (path === "/api/v1/config/docs-info") {
+      await fulfillJson(route, 200, {
+        info: { version: "visual-fidelity" },
+        capabilities: { hasAudio: true, hasStt: true, hasTts: true },
+      })
+      return
+    }
+
+    if (path.startsWith("/api/v1/notifications")) {
+      await fulfillJson(
+        route,
+        200,
+        path.endsWith("/unread-count")
+          ? { unread_count: 0 }
+          : path.endsWith("/preferences")
+            ? {
+                reminder_enabled: false,
+                job_completed_enabled: false,
+                job_failed_enabled: false,
+              }
+            : { items: [], total: 0 }
+      )
+      return
+    }
+
+    if (path === "/api/v1/llm/providers") {
+      await fulfillJson(route, 200, {
+        providers: [{ id: "mock", name: "Mock Provider", status: "configured" }],
+      })
+      return
+    }
+
+    if (path === "/api/v1/llm/models") {
+      await fulfillJson(route, 200, ["mock:model"])
+      return
+    }
+
+    if (path === "/api/v1/llm/models/metadata") {
+      await fulfillJson(route, 200, {
+        models: [
+          {
+            id: "mock:model",
+            name: "Mock Model",
+            provider: "mock",
+            type: "chat",
+            output_modality: "text",
+            context_length: 8192,
+            capabilities: ["chat"],
+          },
+        ],
+        total: 1,
+      })
+      return
+    }
+
+    if (path.startsWith("/api/v1/characters/search")) {
+      await fulfillJson(route, 200, [CHARACTER_FIXTURE])
+      return
+    }
+
+    if (path === "/api/v1/characters" || path === "/api/v1/characters/") {
+      await fulfillJson(route, 200, [CHARACTER_FIXTURE])
+      return
+    }
+
+    if (path.startsWith("/api/v1/chat/conversations")) {
+      await fulfillJson(route, 200, method === "GET" ? { items: [] } : { success: true })
+      return
+    }
+
+    if (path === "/api/v1/chats" || path === "/api/v1/chats/") {
+      await fulfillJson(
+        route,
+        200,
+        method === "GET"
+          ? { chats: [], total: 0 }
+          : {
+              id: "audit-thread",
+              title: "Audit thread",
+              state: "active",
+              version: 1,
+              created_at: "2026-07-05T12:00:00Z",
+              updated_at: "2026-07-05T12:00:00Z",
+            }
+      )
+      return
+    }
+
+    if (/\/api\/v1\/chats\/[^/]+$/.test(path)) {
+      await fulfillJson(route, 200, {
+        id: "audit-thread",
+        title: "Audit thread",
+        state: "active",
+        version: 1,
+        created_at: "2026-07-05T12:00:00Z",
+        updated_at: "2026-07-05T12:00:00Z",
+      })
+      return
+    }
+
+    if (/\/api\/v1\/chats\/[^/]+\/messages$/.test(path)) {
+      await fulfillJson(route, 200, {
+        id: "audit-message",
+        role: "assistant",
+        content: "Mock assistant response for visual QA.",
+        created_at: "2026-07-05T12:00:00Z",
+        version: 1,
+      })
+      return
+    }
+
+    if (path === "/api/v1/chat/completions") {
+      await fulfillJson(route, 200, {
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: {
+              role: "assistant",
+              content: "Mock assistant response for visual QA.",
+            },
+          },
+        ],
+      })
+      return
+    }
+
+    if (path.startsWith("/api/v1/notes/title-settings")) {
+      await fulfillJson(route, 200, {
+        llm_enabled: false,
+        default_strategy: "heuristic",
+      })
+      return
+    }
+
+    if (path.startsWith("/api/v1/notes/search")) {
+      await fulfillJson(route, 200, { notes: [NOTE_FIXTURE], total: 1 })
+      return
+    }
+
+    if (path === "/api/v1/notes/" || path === "/api/v1/notes") {
+      await fulfillJson(
+        route,
+        200,
+        method === "GET" ? { notes: [NOTE_FIXTURE], total: 1 } : NOTE_FIXTURE
+      )
+      return
+    }
+
+    if (path === "/api/v1/notes/note-a") {
+      await fulfillJson(route, 200, { ...NOTE_FIXTURE, links: [] })
+      return
+    }
+
+    if (path.startsWith("/api/v1/notes/note-a/neighbors")) {
+      await fulfillJson(route, 200, { nodes: [], edges: [] })
+      return
+    }
+
+    if (path.startsWith("/api/v1/notes/keywords")) {
+      await fulfillJson(route, 200, { keywords: [], total: 0 })
+      return
+    }
+
+    if (path.startsWith("/api/v1/notes/collections")) {
+      await fulfillJson(route, 200, { collections: [], total: 0 })
+      return
+    }
+
+    if (path.startsWith("/api/v1/notes/moodboards")) {
+      await fulfillJson(route, 200, { moodboards: [], total: 0 })
+      return
+    }
+
+    if (path.startsWith("/api/v1/notes/trash")) {
+      await fulfillJson(route, 200, { notes: [], total: 0 })
+      return
+    }
+
+    if (path.startsWith("/api/v1/")) {
+      await fulfillJson(route, 200, {})
+      return
+    }
+
+    await route.continue()
+  })
+}
+
+const forceDarkMode = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("theme", "dark")
+    localStorage.setItem("tldw:themePreset", "default")
+    localStorage.setItem("playgroundComposerOptionsExpanded", "true")
+    localStorage.removeItem("__tldwServerCapabilitiesCacheV5")
+    sessionStorage.removeItem("__tldwServerCapabilitiesCacheV5")
+  })
+}
+
+const scanDarkVisualLeaks = async (
+  page: Page
+): Promise<{
+  lightSurfaces: LightSurfaceLeak[]
+  lowContrastText: LowContrastTextLeak[]
+}> =>
+  page.evaluate(() => {
+    const parseRgb = (value: string) => {
+      const match = value.match(/rgba?\(([^)]+)\)/)
+      if (!match) return null
+      const parts = match[1].split(",").map((part) => Number.parseFloat(part.trim()))
+      if (parts.length < 3) return null
+      return { r: parts[0], g: parts[1], b: parts[2], a: parts[3] ?? 1 }
+    }
+
+    const luminance = ({ r, g, b }: { r: number; g: number; b: number }) => {
+      const channels = [r, g, b].map((value) => {
+        const normalized = value / 255
+        return normalized <= 0.03928
+          ? normalized / 12.92
+          : Math.pow((normalized + 0.055) / 1.055, 2.4)
+      })
+      return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+    }
+
+    const directText = (element: Element) =>
+      Array.from(element.childNodes)
+        .filter((node) => node.nodeType === Node.TEXT_NODE)
+        .map((node) => node.textContent || "")
+        .join("")
+        .trim()
+        .replace(/\s+/g, " ")
+
+    const effectiveBackground = (element: Element) => {
+      let current: Element | null = element
+      while (current) {
+        const background = parseRgb(getComputedStyle(current).backgroundColor)
+        if (background && background.a >= 0.85) {
+          return {
+            value: getComputedStyle(current).backgroundColor,
+            rgb: background,
+          }
+        }
+        current = current.parentElement
+      }
+      return null
+    }
+
+    const isVisibleInViewport = (
+      rect: DOMRect,
+      style: CSSStyleDeclaration,
+      minWidth: number,
+      minHeight: number,
+      minArea = 0
+    ) =>
+      rect.width > minWidth &&
+      rect.height > minHeight &&
+      rect.width * rect.height >= minArea &&
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      Number.parseFloat(style.opacity) >= 0.1 &&
+      rect.bottom >= 0 &&
+      rect.right >= 0 &&
+      rect.left <= window.innerWidth &&
+      rect.top <= window.innerHeight
+
+    const lightSurfaces: LightSurfaceLeak[] = []
+    const lowContrastText: LowContrastTextLeak[] = []
+    for (const element of Array.from(document.querySelectorAll("body *"))) {
+      if (element.closest("[hidden], [aria-hidden='true'], .sr-only")) {
+        continue
+      }
+
+      const rect = element.getBoundingClientRect()
+      const style = getComputedStyle(element)
+
+      if (isVisibleInViewport(rect, style, 36, 18, 1_200)) {
+        const background = parseRgb(style.backgroundColor)
+        if (background && background.a >= 0.85 && luminance(background) >= 0.72) {
+          lightSurfaces.push({
+            tag: element.tagName.toLowerCase(),
+            className:
+              typeof element.className === "string" ? element.className.slice(0, 180) : "",
+            testId: element.getAttribute("data-testid") || "",
+            role: element.getAttribute("role") || "",
+            aria: element.getAttribute("aria-label") || "",
+            text: (element.textContent || "").trim().replace(/\s+/g, " ").slice(0, 100),
+            backgroundColor: style.backgroundColor,
+            color: style.color,
+            box: [
+              Math.round(rect.x),
+              Math.round(rect.y),
+              Math.round(rect.width),
+              Math.round(rect.height),
+            ],
+          })
+        }
+      }
+
+      const text = directText(element)
+      if (!text || !isVisibleInViewport(rect, style, 8, 8)) {
+        continue
+      }
+
+      const color = parseRgb(style.color)
+      const background = effectiveBackground(element)
+      if (!color || color.a < 0.85 || !background) continue
+
+      const foregroundLuminance = luminance(color)
+      const backgroundLuminance = luminance(background.rgb)
+      if (backgroundLuminance > 0.24) continue
+
+      const contrast =
+        (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+        (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+
+      if (foregroundLuminance < 0.18 && contrast < 3) {
+        lowContrastText.push({
+          tag: element.tagName.toLowerCase(),
+          className:
+            typeof element.className === "string" ? element.className.slice(0, 180) : "",
+          testId: element.getAttribute("data-testid") || "",
+          role: element.getAttribute("role") || "",
+          aria: element.getAttribute("aria-label") || "",
+          text: text.slice(0, 100),
+          backgroundColor: style.backgroundColor,
+          effectiveBackgroundColor: background.value,
+          color: style.color,
+          contrast: Number(contrast.toFixed(2)),
+          box: [
+            Math.round(rect.x),
+            Math.round(rect.y),
+            Math.round(rect.width),
+            Math.round(rect.height),
+          ],
+        })
+      }
+    }
+    return { lightSurfaces, lowContrastText }
+  })
+
+const expectNoDarkVisualLeaks = async (page: Page, label: string) => {
+  const { lightSurfaces, lowContrastText } = await scanDarkVisualLeaks(page)
+  expect(lightSurfaces, `${label} has light surfaces in dark mode`).toEqual([])
+  expect(lowContrastText, `${label} has low-contrast dark text in dark mode`).toEqual([])
+}
+
+const captureDarkScreenshot = async (
+  page: Page,
+  testInfo: TestInfo,
+  name: string
+) => {
+  const path = testInfo.outputPath(`${name}.png`)
+  await page.screenshot({ path, fullPage: false })
+  await testInfo.attach(name, { path, contentType: "image/png" })
+}
+
+const preparePage = async (page: Page) => {
+  await seedAuth(page)
+  await forceDarkMode(page)
+  await installApiMocks(page)
+}
+
+test("chat, character chat, extension sidepanel chat, characters, and notes stay visually dark", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(120_000)
+
+  await preparePage(page)
+  await page.setViewportSize({ width: 1440, height: 960 })
+
+  await page.goto("/chat", { waitUntil: "domcontentloaded", timeout: SMOKE_LOAD_TIMEOUT })
+  await waitForAppShell(page, SMOKE_LOAD_TIMEOUT)
+  await expect(page.getByTestId("chat-input")).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "chat-dark")
+  await expectNoDarkVisualLeaks(page, "Normal chat")
+
+  const moreToolsButton = page.getByRole("button", { name: "More tools" })
+  if ((await moreToolsButton.count()) > 0 && (await moreToolsButton.first().isVisible())) {
+    await moreToolsButton.first().click()
+    await expectNoDarkVisualLeaks(page, "Normal chat model menu")
+    await page.keyboard.press("Escape")
+  }
+
+  await page.goto("/chat?mode=character", {
+    waitUntil: "domcontentloaded",
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await waitForAppShell(page, SMOKE_LOAD_TIMEOUT)
+  await captureDarkScreenshot(page, testInfo, "character-chat-dark")
+  await expectNoDarkVisualLeaks(page, "Character chat")
+
+  await page.goto("/__debug__/sidepanel-chat", {
+    waitUntil: "domcontentloaded",
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await waitForAppShell(page, SMOKE_LOAD_TIMEOUT)
+  await captureDarkScreenshot(page, testInfo, "sidepanel-chat-dark")
+  await expectNoDarkVisualLeaks(page, "Extension sidepanel chat")
+
+  await page.goto("/characters", { waitUntil: "domcontentloaded", timeout: SMOKE_LOAD_TIMEOUT })
+  await waitForAppShell(page, SMOKE_LOAD_TIMEOUT)
+  await expect(page.getByTestId("characters-page")).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "characters-dark")
+  await expectNoDarkVisualLeaks(page, "Characters")
+
+  await page.getByRole("button", { name: /filters/i }).click()
+  await expect(page.locator("#characters-advanced-filters-panel")).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "characters-filters-dark")
+  await expectNoDarkVisualLeaks(page, "Characters filters")
+
+  await page.getByRole("button", { name: /display/i }).click()
+  await expect(page.locator(".ant-dropdown").first()).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "characters-display-menu-dark")
+  await expectNoDarkVisualLeaks(page, "Characters display menu")
+  await page.keyboard.press("Escape")
+  await expect(page.locator(".ant-dropdown").first()).toBeHidden({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+
+  await page.getByTestId("characters-new-button").click()
+  await expect(page.locator(".ant-drawer")).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "characters-create-drawer-dark")
+  await expectNoDarkVisualLeaks(page, "Characters create drawer")
+  await page.keyboard.press("Escape")
+
+  await page.goto("/notes", { waitUntil: "domcontentloaded", timeout: SMOKE_LOAD_TIMEOUT })
+  await waitForAppShell(page, SMOKE_LOAD_TIMEOUT)
+  await expect(page.getByTestId("notes-list-region")).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "notes-dark")
+  await expectNoDarkVisualLeaks(page, "Notes")
+
+  const overflow = page.getByTestId("notes-overflow-menu-button")
+  if ((await overflow.count()) > 0 && (await overflow.first().isVisible())) {
+    await overflow.first().click()
+    await expectNoDarkVisualLeaks(page, "Notes overflow menu")
+  }
+})

--- a/backlog/tasks/task-12171 - Fix-dark-theme-visual-drift-in-Chat-extension-chat-character-chat-and-Notes.md
+++ b/backlog/tasks/task-12171 - Fix-dark-theme-visual-drift-in-Chat-extension-chat-character-chat-and-Notes.md
@@ -1,0 +1,61 @@
+---
+id: TASK-12171
+title: 'Fix dark-theme visual drift in Chat, extension chat, character chat, and Notes'
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-05 18:31'
+labels:
+  - frontend
+  - theme
+  - webui
+  - extension
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Walk through the WebUI chat page, browser extension chat, character-card chat, and Notes page. Reproduce dark-theme light-surface leaks, apply the smallest token/component fixes, and verify the affected menus/options in rendered UI.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Normal chat dark-mode walkthrough has no large light-surface leaks.
+- [x] #2 Character chat dark-mode walkthrough has no large light-surface leaks.
+- [x] #3 Extension sidepanel chat dark-mode walkthrough has no large light-surface leaks.
+- [x] #4 Notes dark-mode walkthrough has no large light-surface leaks, including Ant Design select wrappers and overflow menu.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-07-05-chat-notes-dark-theme-visual-fidelity-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a focused Playwright smoke regression that seeds dark mode, mocks target API shapes, captures screenshots, and scans normal chat, character chat, extension sidepanel chat, Notes, and available overflow/tool menus for large light surfaces and low-contrast dark text. Fixed the confirmed Notes leaks by adding .ant-select to the shared Ant Design token bridge and covering Ant text buttons/radio-button wrappers in apps/packages/ui/src/assets/tailwind-shared.css.
+
+PR review follow-up: excluded Ant link buttons from the generic text-color override and collapsed the visual scanner into one DOM traversal per checkpoint with opacity and viewport-bound checks.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the dark-theme visual drift found during the walkthrough by bridging Ant Design Select wrapper surfaces, text-style buttons, disabled buttons, and radio-button wrappers to shared theme tokens. Verified with a red/green Playwright dark-theme visual-fidelity smoke pass and git diff --check on the touched files. Bandit skipped because the touched code is frontend CSS and Playwright TypeScript only. Remaining environment note: backend was unavailable, so the rendered walkthrough used route-level API mocks and the extension chat was verified through the sidepanel debug route.
+
+PR review follow-up excluded .ant-btn-link from the generic button color bridge and made the smoke scanner ignore transparent/off-viewport nodes while doing one DOM pass per checkpoint.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12172 - Verify-Characters-page-dark-theme-visual-fidelity.md
+++ b/backlog/tasks/task-12172 - Verify-Characters-page-dark-theme-visual-fidelity.md
@@ -1,0 +1,53 @@
+---
+id: TASK-12172
+title: Verify Characters page dark-theme visual fidelity
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-07-05 18:42
+labels:
+- frontend
+- theme
+- webui
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Walk through the WebUI Characters page in dark mode, check menus/options for light-theme or low-contrast visual drift, apply the smallest shared-token fix if needed, and record focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Characters page dark-mode walkthrough has no large light-surface leaks.
+- [x] #2 Characters page dark-mode walkthrough has no low-contrast dark text leaks.
+- [x] #3 Characters page primary visible controls and at least one page option/menu state are covered by focused visual regression.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extended the existing dark-theme visual-fidelity Playwright smoke to cover /characters, including the filters panel, Display dropdown, and New character drawer. Fixed confirmed shared Ant theme leaks in dropdown item text, popover wrappers, and drawer wrapper surfaces through apps/packages/ui/src/assets/tailwind-shared.css. Tightened the visual scan to ignore hidden, aria-hidden, and sr-only subtrees so non-visible helper markup does not produce false positives.
+
+PR review follow-up: added dark coverage for selected table rows, active dropdown items, and clipped Ant select wrappers to prevent rounded-corner leaks.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Characters dark-theme walkthrough has now been rerun against a live FastAPI backend on 127.0.0.1:8000 and Next WebUI on localhost:8080, with no API route mocks. The authenticated live pass covered the base Characters table, real character row/card selection, card More actions dropdown, filters panel, Manage tags modal, Display menu options (Comfortable/Compact/Dense/Keyboard shortcuts), and New character drawer. Live API calls included /api/v1/characters/query and /api/v1/characters/world-books with X-API-KEY present and returned 200. Fixed additional real-data light-theme leaks in Ant notification, table/header/body/sorted-column, and tag components through the shared CSS bridge. Verification: node /private/tmp/tldw-real-characters-dark-check.mjs passed with no visual leaks, no request failures, and no bad API statuses; npx playwright test e2e/smoke/dark-theme-visual-fidelity.spec.ts --reporter=line passed; git diff --check -- apps/packages/ui/src/assets/tailwind-shared.css passed. Whole-repo git diff --check remains blocked by unrelated Docs/Design/Tool-Calling.md trailing EOF blank line. Bandit skipped because touched repo code is frontend CSS only.
+
+PR review follow-up added selected-row and active-dropdown dark-state selectors, clipped the Ant select wrapper, and kept the visual scan bounded to visible viewport content.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Bridge Ant Design surfaces to dark theme tokens for chat, notes, and characters.
- Add a Playwright smoke covering chat, character chat, extension sidepanel chat, characters, and notes.
- Record Backlog task verification, including live-backend Characters coverage.

## Test Plan
- `git diff --cached --check`
- `npx playwright test e2e/smoke/dark-theme-visual-fidelity.spec.ts --reporter=line`

## Notes
- Bandit skipped because the touched repo code is frontend CSS and Playwright TypeScript only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dark theme visual drift across Chat, Character Chat (incl. extension sidepanel), Characters, and Notes by bridging Ant Design surfaces to shared dark tokens. Adds a Playwright smoke test that flags light panels and low-contrast text; satisfies TASK-12171 and TASK-12172.

- **Bug Fixes**
  - Bridged Ant Design table (header/body/cell/sort/hover/selected), modal/drawer/popover/notification containers, dropdown/select/tag, tabs/segmented, and default buttons/radio-button wrappers to `--color-*` tokens in `apps/packages/ui/src/assets/tailwind-shared.css` (incl. hover/disabled/close states); clipped `ant-select` radius/overflow and excluded `ant-btn-link` from generic text-color overrides.
  - Fixed light surfaces and low-contrast text in Notes and Characters flows, incl. dropdown active/disabled items, modal close hover, Characters filters/display/new drawer, and tag/notification wrappers.
  - Added e2e smoke `apps/tldw-frontend/e2e/smoke/dark-theme-visual-fidelity.spec.ts` that seeds dark mode, mocks APIs, captures screenshots, and scans for leaks across Chat, Character Chat, sidepanel, Characters, and Notes while ignoring hidden/off-viewport nodes.

<sup>Written for commit 95abd8071a71452ee5a144bd7d4128bfcc082b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

