### PR TITLE
test: add Chatbooks dark theme visual coverage

### DIFF
--- a/apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Chatbooks/ChatbooksPlaygroundPage.tsx
@@ -1828,6 +1828,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
             <Switch checked={includeMedia} onChange={setIncludeMedia} />
             <Text>{t("settings:chatbooksPlayground.includeMedia", "Include media")}</Text>
             <Select
+              aria-label={t("settings:chatbooksPlayground.mediaQuality", "Media quality")}
               value={mediaQuality}
               onChange={setMediaQuality}
               options={[
@@ -1983,6 +1984,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
           <Space wrap>
             <Text>{t("settings:chatbooksPlayground.importSource", "Source")}</Text>
             <Select
+              aria-label={t("settings:chatbooksPlayground.importSource", "Import source")}
               value={importSourceFormat}
               onChange={(value) => setImportSourceFormat(value as ImportSourceFormat)}
               className="min-w-[220px]"
@@ -2550,6 +2552,7 @@ export const ChatbooksPlaygroundPage: React.FC = () => {
 
           <Space wrap>
             <Select
+              aria-label={t("settings:chatbooksPlayground.conflictResolution", "Conflict resolution")}
               value={conflictResolution}
               onChange={setConflictResolution}
               options={

--- a/apps/tldw-frontend/e2e/smoke/dark-theme-visual-fidelity.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/dark-theme-visual-fidelity.spec.ts
@@ -49,6 +49,26 @@ const fulfillJson = async (route: Route, status: number, body: unknown) =>
     body: JSON.stringify(body),
   })
 
+const emptyChatbookJobsResponse = (url: URL) => {
+  const limit = Number(url.searchParams.get("limit") ?? 100)
+  const offset = Number(url.searchParams.get("offset") ?? 0)
+
+  return {
+    jobs: [],
+    total: 0,
+    has_more: false,
+    next_offset: null,
+    pagination: {
+      mode: "offset",
+      limit,
+      offset,
+      total: 0,
+      has_more: false,
+      next_offset: null,
+    },
+  }
+}
+
 const installApiMocks = async (page: Page) => {
   await page.route("**/*", async (route) => {
     const request = route.request()
@@ -82,6 +102,10 @@ const installApiMocks = async (page: Page) => {
           "/api/v1/characters": {},
           "/api/v1/characters/query": {},
           "/api/v1/characters/world-books": {},
+          "/api/v1/chatbooks/export": {},
+          "/api/v1/chatbooks/export/jobs": {},
+          "/api/v1/chatbooks/health": {},
+          "/api/v1/chatbooks/import/jobs": {},
           "/api/v1/notes/": {},
         },
       })
@@ -91,7 +115,7 @@ const installApiMocks = async (page: Page) => {
     if (path === "/api/v1/config/docs-info") {
       await fulfillJson(route, 200, {
         info: { version: "visual-fidelity" },
-        capabilities: { hasAudio: true, hasStt: true, hasTts: true },
+        capabilities: { hasAudio: true, hasChatbooks: true, hasStt: true, hasTts: true },
       })
       return
     }
@@ -264,6 +288,70 @@ const installApiMocks = async (page: Page) => {
 
     if (path.startsWith("/api/v1/notes/trash")) {
       await fulfillJson(route, 200, { notes: [], total: 0 })
+      return
+    }
+
+    if (path === "/api/v1/media") {
+      await fulfillJson(route, 200, {
+        items: [],
+        pagination: { total_items: 0 },
+      })
+      return
+    }
+
+    if (path === "/api/v1/prompts") {
+      await fulfillJson(route, 200, [])
+      return
+    }
+
+    if (path === "/api/v1/evaluations" || path === "/api/v1/evaluations/") {
+      await fulfillJson(route, 200, { data: [], total: 0 })
+      return
+    }
+
+    if (path === "/api/v1/characters/world-books") {
+      await fulfillJson(route, 200, [])
+      return
+    }
+
+    if (path === "/api/v1/chat/dictionaries") {
+      await fulfillJson(route, 200, [])
+      return
+    }
+
+    if (path === "/api/v1/chat/documents") {
+      await fulfillJson(route, 200, { documents: [], total: 0 })
+      return
+    }
+
+    if (path === "/api/v1/chatbooks/export/jobs") {
+      await fulfillJson(route, 200, emptyChatbookJobsResponse(url))
+      return
+    }
+
+    if (path === "/api/v1/chatbooks/import/jobs") {
+      await fulfillJson(route, 200, emptyChatbookJobsResponse(url))
+      return
+    }
+
+    if (path === "/api/v1/chatbooks/health") {
+      await fulfillJson(route, 200, {
+        service: "chatbooks",
+        status: "healthy",
+        timestamp: "2026-07-05T12:00:00.000Z",
+        components: {
+          storage_base: {
+            path: "/tmp/tldw-chatbooks",
+            exists: true,
+            writable: true,
+          },
+        },
+      })
+      return
+    }
+
+    if (path === "/api/v1/chatbooks/cleanup") {
+      await fulfillJson(route, 200, { deleted_count: 0 })
       return
     }
 
@@ -449,10 +537,10 @@ const preparePage = async (page: Page) => {
   await installApiMocks(page)
 }
 
-test("chat, character chat, extension sidepanel chat, characters, and notes stay visually dark", async ({
+test("chat, character chat, extension sidepanel chat, characters, notes, and chatbooks stay visually dark", async ({
   page,
 }, testInfo) => {
-  test.setTimeout(120_000)
+  test.setTimeout(150_000)
 
   await preparePage(page)
   await page.setViewportSize({ width: 1440, height: 960 })
@@ -535,4 +623,78 @@ test("chat, character chat, extension sidepanel chat, characters, and notes stay
     await overflow.first().click()
     await expectNoDarkVisualLeaks(page, "Notes overflow menu")
   }
+
+  await page.goto("/chatbooks", { waitUntil: "domcontentloaded", timeout: SMOKE_LOAD_TIMEOUT })
+  await waitForAppShell(page, SMOKE_LOAD_TIMEOUT)
+  await expect(page.getByRole("heading", { name: /chatbooks playground/i })).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "chatbooks-export-dark")
+  await expectNoDarkVisualLeaks(page, "Chatbooks export")
+
+  const mediaQualitySelect = page
+    .locator(".ant-select")
+    .filter({ has: page.getByRole("combobox", { name: /media quality/i }) })
+    .first()
+  await mediaQualitySelect.click()
+  const mediaQualityDropdown = page.locator(".ant-select-dropdown:visible").first()
+  await expect(mediaQualityDropdown).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "chatbooks-export-media-menu-dark")
+  await expectNoDarkVisualLeaks(page, "Chatbooks export media menu")
+  await page.keyboard.press("Escape")
+  await expect(mediaQualityDropdown).toBeHidden()
+
+  await page.getByText(/^Evaluations$/).first().scrollIntoViewIfNeeded()
+  await captureDarkScreenshot(page, testInfo, "chatbooks-export-lower-dark")
+  await expectNoDarkVisualLeaks(page, "Chatbooks lower export pickers")
+  await page.getByRole("heading", { name: /chatbooks playground/i }).scrollIntoViewIfNeeded()
+
+  await page.getByRole("tab", { name: /^Import$/ }).click()
+  await expect(page.getByText(/Preview before import|Drop a \.zip/i).first()).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "chatbooks-import-dark")
+  await expectNoDarkVisualLeaks(page, "Chatbooks import")
+
+  const sourceSelect = page
+    .locator(".ant-select")
+    .filter({ has: page.getByRole("combobox", { name: /import source/i }) })
+    .first()
+  await sourceSelect.click()
+  const sourceDropdown = page.locator(".ant-select-dropdown:visible").first()
+  await expect(sourceDropdown).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "chatbooks-import-source-menu-dark")
+  await expectNoDarkVisualLeaks(page, "Chatbooks import source menu")
+  await page.locator(".ant-select-item-option").filter({ hasText: "OpenWebUI JSON" }).first().click()
+  await expect(sourceDropdown).toBeHidden()
+  await expect(page.getByText(/OpenWebUI attachment hydration/i)).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "chatbooks-import-openwebui-dark")
+  await expectNoDarkVisualLeaks(page, "Chatbooks OpenWebUI import")
+
+  const conflictSelect = page
+    .locator(".ant-select")
+    .filter({ has: page.getByRole("combobox", { name: /conflict resolution/i }) })
+    .first()
+  await conflictSelect.click()
+  const conflictDropdown = page.locator(".ant-select-dropdown:visible").first()
+  await expect(conflictDropdown).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "chatbooks-import-conflict-menu-dark")
+  await expectNoDarkVisualLeaks(page, "Chatbooks import conflict menu")
+  await page.keyboard.press("Escape")
+  await expect(conflictDropdown).toBeHidden()
+
+  await page.getByRole("tab", { name: /^Jobs$/ }).click()
+  await expect(page.getByText(/Job status/i)).toBeVisible({
+    timeout: SMOKE_LOAD_TIMEOUT,
+  })
+  await captureDarkScreenshot(page, testInfo, "chatbooks-jobs-dark")
+  await expectNoDarkVisualLeaks(page, "Chatbooks jobs")
 })

--- a/backlog/tasks/task-12897 - Verify-Chatbooks-page-dark-theme-visual-fidelity.md
+++ b/backlog/tasks/task-12897 - Verify-Chatbooks-page-dark-theme-visual-fidelity.md
@@ -1,0 +1,54 @@
+---
+id: TASK-12897
+title: Verify Chatbooks page dark-theme visual fidelity
+status: Done
+assignee: []
+created_date: '2026-07-05 20:43'
+updated_date: '2026-07-05 22:31'
+labels:
+  - frontend
+  - theme
+  - webui
+  - chatbooks
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Walk through the WebUI Chatbooks page in dark mode against a real backend, check menus/options for light-theme or low-contrast visual drift, apply the smallest shared-token/component fix if needed, and record focused verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Chatbooks page dark-mode walkthrough has no large light-surface leaks.
+- [x] #2 Chatbooks menus/options and primary controls are covered by rendered visual QA.
+- [x] #3 Real backend requests used by the walkthrough are recorded with status results.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Real-backend walkthrough completed against frontend http://127.0.0.1:8081 and backend http://127.0.0.1:18001. Covered Chatbooks export, media quality select, import, source select, OpenWebUI JSON hydration controls, conflict select, and jobs. Captured screenshots under /private/tmp/tldw-real-chatbooks-dark. Report: /private/tmp/tldw-real-chatbooks-dark/report.json. Result: 0 light-surface leaks, 0 low-contrast text leaks, no request failures, Chatbooks export/import job endpoints returned 200.
+
+Added Chatbooks coverage to apps/tldw-frontend/e2e/smoke/dark-theme-visual-fidelity.spec.ts for export, lower export pickers, export media select, import, import source select, OpenWebUI JSON hydration controls, conflict select, and jobs. Verification: npx playwright test e2e/smoke/dark-theme-visual-fidelity.spec.ts --reporter=line passed; git diff --check passed. Bandit skipped because touched repository files are frontend Playwright TypeScript and Backlog Markdown only; no Python code changed.
+
+PR review follow-up: rebased on latest dev, aligned Chatbooks job and health mocks with backend response shapes, waited for Ant dropdowns to close before continuing, replaced hardcoded wheel scrolling with locator-based scrolling, and added aria labels to the Chatbooks media quality, import source, and conflict resolution selects so the smoke test can use semantic locators.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Reviewed the Chatbooks page in dark mode against a real backend and found no light-theme visual drift in covered states. Added mocked Playwright dark-theme regression coverage for Chatbooks alongside the existing Chat/Notes/Characters smoke so the export/import/jobs surfaces and key dropdown menus remain guarded.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Extend the existing dark-theme visual smoke test to cover Chatbooks export, import, dropdown menus, lower picker sections, OpenWebUI options, and jobs.
- Add Chatbooks/content API mocks needed by the smoke path.
- Record the real-backend Chatbooks walkthrough in Backlog task TASK-12897.

## Test plan
- [x] `TLDW_WEB_URL=http://localhost:18080 TLDW_WEB_CMD='bun run dev -- --webpack -p 18080' npx playwright test e2e/smoke/dark-theme-visual-fidelity.spec.ts --reporter=line`
- [x] `git diff --check`
- [x] Bandit skipped: no Python files changed.

## Merge note
- Human-authored `Change summary` is still required before merge by repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dark-theme visual coverage for Chatbooks export, import (including OpenWebUI), dropdowns, lower pickers, and jobs to catch light-surface leaks on the Chatbooks page. Includes API mocks, capability flag, and small UI a11y tweaks to keep the flow reliable (Backlog TASK-12897).

- **New Features**
  - Extended `e2e/smoke/dark-theme-visual-fidelity.spec.ts` to cover Chatbooks: export, import (OpenWebUI JSON), jobs; validates dropdowns (media quality, import source, conflict resolution) and lower export pickers.
  - Added API mocks for `/api/v1/chatbooks/*` (export/import jobs, `health`, `cleanup`), plus `/media`, `/prompts`, `/evaluations`, `/chat/dictionaries`, and `/chat/documents`; set `hasChatbooks` in `/api/v1/config/docs-info`.
  - Increased test timeout to 150s and recorded the real-backend walkthrough in Backlog (TASK-12897).
  - Added `aria-label`s to Chatbooks Selects (media quality, import source, conflict resolution) for stable, semantic test locators.

<sup>Written for commit 2dad3dfa0ef4c745a139458e3372473948ed78f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

