### PR TITLE
Fix Research Workspace WP2 media readiness blockers

### DIFF
--- a/backlog/tasks/task-12897 - Fix-Research-Workspace-WP2-media-output-readiness-blockers.md
+++ b/backlog/tasks/task-12897 - Fix-Research-Workspace-WP2-media-output-readiness-blockers.md
@@ -42,6 +42,8 @@ Implementation:
 - Changed image readiness to return `image_backend_not_configured` when backends exist but no configured model exists.
 - Changed output job status to prefer the failed artifact error when the job error is absent or generic `worker_exception`.
 - Added focused regression coverage for image readiness, TTS failed-provider readiness, and artifact error precedence.
+PR review pass after rebasing onto latest `origin/dev`: addressing Qodo marker/type-hint/TTS probe comments and Gemini nullable producer metadata comment on PR #2671.
+PR #2671 review fixes implemented: added `get_existing_tts_factory()` to avoid creating the TTS factory during readiness probes, skipped runtime TTS inspection when no providers are enabled, logged runtime-probe exceptions with exception details, removed the extra `pytest.mark.asyncio` marker by using `asyncio.run`, and added type annotations to the new test helpers. Gemini's nullable `producer_metadata` guard was already present after syncing the remote PR branch.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -54,6 +56,12 @@ Verification:
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Research_Workspace/capabilities.py tldw_Server_API/app/core/Research_Workspace/output_jobs.py -f json -o /tmp/bandit_research_workspace_wp2_readiness.json` -> 0 findings, 0 errors.
 
 Remaining environment requirement: actual WP2 media generation still requires configured local image/TTS providers; this change makes the readiness/status failures precise and fail-closed when providers are missing or failed.
+
+Review-pass verification after rebasing onto latest `origin/dev`:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py tldw_Server_API/tests/Research_Workspace/test_output_jobs_api.py -q` -> 41 passed, 4 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Research_Workspace/test_capability_endpoint.py tldw_Server_API/tests/Research_Workspace/test_output_jobs_worker.py -q` -> 34 passed, 2 warnings.
+- `git diff --check` -> exit 0.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Research_Workspace/capabilities.py tldw_Server_API/app/core/Research_Workspace/output_jobs.py tldw_Server_API/app/core/TTS/adapter_registry.py -f json -o /tmp/bandit_research_workspace_wp2_pr2671_review.json` -> 0 findings, 0 errors.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12897 - Fix-Research-Workspace-WP2-media-output-readiness-blockers.md
+++ b/backlog/tasks/task-12897 - Fix-Research-Workspace-WP2-media-output-readiness-blockers.md
@@ -1,0 +1,65 @@
+---
+id: TASK-12897
+title: Fix Research Workspace WP2 media-output readiness blockers
+status: Done
+labels:
+- research-workspace
+- notebooklm
+- wp2
+- backend-jobs
+- bug
+references:
+- TASK-12173
+- https://github.com/rmusser01/tldw_server/pull/2669
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Root-cause and fix the two blockers recorded by TASK-12173: image generation capability reports an unhelpful `image_backend_unknown` when the backend is enabled but not configured, and Video Overview jobs can surface a generic `worker_exception` even when the linked artifact records `tts_generation_failed`. Keep scope to backend job readiness/capability behavior and precise public failure codes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Infographic capability readiness fails closed with a precise reason when enabled image backends are not configured.
+- [x] #2 Video Overview capability readiness accounts for failed enabled TTS providers without synthesizing audio in the capabilities endpoint.
+- [x] #3 Research Workspace output job status prefers the linked artifact's precise error when the Jobs row only has `worker_exception`.
+- [x] #4 Focused tests cover the fixed readiness/failure behavior for the touched backend paths.
+- [x] #5 No WP3 discovery-loop or WP4 agent-task UI work is included.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Root cause:
+- Image readiness already detected enabled image backends, but when no configured image model was cataloged it returned the generic `image_backend_unknown`; this made the WP2 Infographic blocker harder to diagnose.
+- TTS readiness only counted configured/enabled providers and did not account for providers already marked failed by the TTS factory status, so Video Overview could appear allowed even when all enabled TTS providers were unusable.
+- Output job status trusted the Jobs row error first; when the worker row held generic `worker_exception`, the API hid the linked failed artifact's precise `producer_metadata.error` such as `tts_generation_failed`.
+
+Implementation:
+- Preserved precise TTS health reason codes through Research Workspace capability derivation.
+- Added lightweight TTS factory status inspection that subtracts failed enabled providers without synthesizing audio.
+- Changed image readiness to return `image_backend_not_configured` when backends exist but no configured model exists.
+- Changed output job status to prefer the failed artifact error when the job error is absent or generic `worker_exception`.
+- Added focused regression coverage for image readiness, TTS failed-provider readiness, and artifact error precedence.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py tldw_Server_API/tests/Research_Workspace/test_output_jobs_api.py -q` -> 40 passed, 4 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Research_Workspace/test_capability_endpoint.py tldw_Server_API/tests/Research_Workspace/test_output_jobs_worker.py -q` -> 34 passed, 2 warnings.
+- `git diff --check` -> exit 0.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Research_Workspace/capabilities.py tldw_Server_API/app/core/Research_Workspace/output_jobs.py -f json -o /tmp/bandit_research_workspace_wp2_readiness.json` -> 0 findings, 0 errors.
+
+Remaining environment requirement: actual WP2 media generation still requires configured local image/TTS providers; this change makes the readiness/status failures precise and fail-closed when providers are missing or failed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Root cause investigation notes are recorded in the task.
+- [x] #2 Focused tests pass.
+- [x] #3 Bandit runs on touched backend Python scope.
+- [x] #4 Final summary records verification and any remaining local environment requirements.
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Research_Workspace/capabilities.py
+++ b/tldw_Server_API/app/core/Research_Workspace/capabilities.py
@@ -562,24 +562,35 @@ async def _collect_tts_health() -> Mapping[str, Any]:
         available = len(enabled)
         status = "healthy" if available > 0 else "unhealthy"
         reason_code: str | None = None
+        if available == 0:
+            return {
+                "status": status,
+                "providers": {
+                    "total": total,
+                    "available": available,
+                },
+            }
 
         try:
-            from tldw_Server_API.app.core.TTS.adapter_registry import get_tts_factory
+            from tldw_Server_API.app.core.TTS.adapter_registry import get_existing_tts_factory
 
-            factory = await get_tts_factory()
-            status_summary = factory.get_status()
-            provider_statuses = _mapping_value(status_summary, "providers")
-            failed_enabled = []
-            for provider in enabled:
-                provider_status = _mapping_value(provider_statuses, provider)
-                if isinstance(provider_status, Mapping) and provider_status.get("failed") is True:
-                    failed_enabled.append(provider)
-            if failed_enabled:
-                available = max(0, available - len(failed_enabled))
-                reason_code = "tts_provider_failed" if available == 0 else "tts_provider_degraded"
-                status = "unhealthy" if available == 0 else "degraded"
-        except Exception:
-            logger.debug("Unable to collect Research Workspace TTS runtime status")
+            factory = get_existing_tts_factory()
+            if factory is not None:
+                status_summary = factory.get_status()
+                provider_statuses = _mapping_value(status_summary, "providers")
+                failed_enabled = []
+                for provider in enabled:
+                    provider_status = _mapping_value(provider_statuses, provider)
+                    if isinstance(provider_status, Mapping) and provider_status.get("failed") is True:
+                        failed_enabled.append(provider)
+                if failed_enabled:
+                    available = max(0, available - len(failed_enabled))
+                    reason_code = "tts_provider_failed" if available == 0 else "tts_provider_degraded"
+                    status = "unhealthy" if available == 0 else "degraded"
+        except Exception as exc:
+            logger.bind(error_type=type(exc).__name__).opt(exception=exc).debug(
+                "Unable to collect Research Workspace TTS runtime status"
+            )
 
         payload: dict[str, Any] = {
             "status": status,

--- a/tldw_Server_API/app/core/Research_Workspace/capabilities.py
+++ b/tldw_Server_API/app/core/Research_Workspace/capabilities.py
@@ -228,14 +228,15 @@ def _tts_capability(tts_health: Mapping[str, Any] | None) -> ResearchWorkspaceCa
     providers = _mapping_value(tts_health, "providers")
     available = providers.get("available") if isinstance(providers, Mapping) else None
     status = _status(tts_health)
+    reason = _reason_code(tts_health)
 
     if available == 0 or status == "unavailable":
-        return _cap("unavailable", "block", ["tts"], "tts_unavailable")
+        return _cap("unavailable", "block", ["tts"], reason or "tts_unavailable")
     if status == "degraded":
-        return _cap("degraded", "warn", ["tts"], "tts_degraded")
+        return _cap("degraded", "warn", ["tts"], reason or "tts_degraded")
     if status == "ready":
         return _cap("ready", "allow", ["tts"])
-    return _cap("unknown", "warn", ["tts"], "tts_unknown")
+    return _cap("unknown", "warn", ["tts"], reason or "tts_unknown")
 
 
 def _presentation_render_capability(render_health: Mapping[str, Any] | None) -> ResearchWorkspaceCapability:
@@ -549,7 +550,7 @@ def _collect_slides_health(*, user_id: int | str | None = None) -> Mapping[str, 
 
 
 async def _collect_tts_health() -> Mapping[str, Any]:
-    """Collect config-level TTS availability without initializing providers."""
+    """Collect config/runtime TTS availability without synthesizing audio."""
     try:
         from tldw_Server_API.app.core.TTS.tts_config import get_tts_config_manager
 
@@ -559,14 +560,37 @@ async def _collect_tts_health() -> Mapping[str, Any]:
         total = len(providers) if isinstance(providers, Mapping) else 0
         enabled = manager.get_enabled_providers()
         available = len(enabled)
+        status = "healthy" if available > 0 else "unhealthy"
+        reason_code: str | None = None
 
-        return {
-            "status": "healthy" if available > 0 else "unhealthy",
+        try:
+            from tldw_Server_API.app.core.TTS.adapter_registry import get_tts_factory
+
+            factory = await get_tts_factory()
+            status_summary = factory.get_status()
+            provider_statuses = _mapping_value(status_summary, "providers")
+            failed_enabled = []
+            for provider in enabled:
+                provider_status = _mapping_value(provider_statuses, provider)
+                if isinstance(provider_status, Mapping) and provider_status.get("failed") is True:
+                    failed_enabled.append(provider)
+            if failed_enabled:
+                available = max(0, available - len(failed_enabled))
+                reason_code = "tts_provider_failed" if available == 0 else "tts_provider_degraded"
+                status = "unhealthy" if available == 0 else "degraded"
+        except Exception:
+            logger.debug("Unable to collect Research Workspace TTS runtime status")
+
+        payload: dict[str, Any] = {
+            "status": status,
             "providers": {
                 "total": total,
                 "available": available,
             },
         }
+        if reason_code:
+            payload["reason_code"] = reason_code
+        return payload
     except Exception:
         logger.exception("Failed to collect Research Workspace TTS health")
         return {"status": "unknown", "reason_code": "tts_health_unknown"}
@@ -598,7 +622,7 @@ def _collect_image_health() -> Mapping[str, Any]:
         return {
             "status": "unknown",
             "providers": {"available": 0, "total": total},
-            "reason_code": "image_backend_unknown",
+            "reason_code": "image_backend_not_configured",
         }
     except Exception:
         logger.exception("Failed to collect Research Workspace image health")

--- a/tldw_Server_API/app/core/Research_Workspace/output_jobs.py
+++ b/tldw_Server_API/app/core/Research_Workspace/output_jobs.py
@@ -1079,6 +1079,8 @@ def get_research_workspace_output_job_status(
 
     artifact_row = workspace_db.get_workspace_artifact(workspace_id, artifact_id)
     artifact = WorkspaceArtifactResponse.model_validate(artifact_row) if artifact_row else None
+    job_error = _job_error(job)
+    artifact_error = _artifact_error(artifact)
     return ResearchWorkspaceOutputStatusResponse(
         job_id=int(job["id"]),
         status=_public_job_status(job.get("status")),
@@ -1088,7 +1090,7 @@ def get_research_workspace_output_job_status(
         artifact_id=artifact_id,
         artifact_type=cast(ResearchWorkspaceOutputArtifactType, artifact_type),
         artifact=artifact,
-        error=_job_error(job),
+        error=artifact_error if artifact_error and job_error in {None, "worker_exception"} else job_error,
         result=result,
     )
 
@@ -1480,6 +1482,16 @@ def _job_error(job: dict[str, Any]) -> str | None:
     if _public_job_status(job.get("status")) != "failed":
         return None
     return _safe_public_error_code(str(job.get("error_code") or job.get("last_error") or job.get("error_message") or ""))
+
+
+def _artifact_error(artifact: WorkspaceArtifactResponse | None) -> str | None:
+    """Return a public artifact failure code when the linked artifact has one."""
+    if artifact is None or artifact.status != "failed":
+        return None
+    raw = artifact.producer_metadata.get("error")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return _safe_public_error_code(raw)
 
 
 def _normalize_job_mapping(value: Any) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/Research_Workspace/output_jobs.py
+++ b/tldw_Server_API/app/core/Research_Workspace/output_jobs.py
@@ -1486,7 +1486,7 @@ def _job_error(job: dict[str, Any]) -> str | None:
 
 def _artifact_error(artifact: WorkspaceArtifactResponse | None) -> str | None:
     """Return a public artifact failure code when the linked artifact has one."""
-    if artifact is None or artifact.status != "failed":
+    if artifact is None or artifact.status != "failed" or not artifact.producer_metadata:
         return None
     raw = artifact.producer_metadata.get("error")
     if not isinstance(raw, str) or not raw.strip():

--- a/tldw_Server_API/app/core/TTS/adapter_registry.py
+++ b/tldw_Server_API/app/core/TTS/adapter_registry.py
@@ -1338,6 +1338,11 @@ _factory_instance: Optional[TTSAdapterFactory] = None
 _factory_lock = asyncio.Lock()
 
 
+def get_existing_tts_factory() -> Optional[TTSAdapterFactory]:
+    """Return the current TTS factory singleton without creating it."""
+    return _factory_instance
+
+
 async def get_tts_factory(config: Optional[dict[str, Any]] = None) -> TTSAdapterFactory:
     """
     Get or create the TTS adapter factory singleton.

--- a/tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py
+++ b/tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py
@@ -92,6 +92,29 @@ def test_image_unavailable_blocks_infographic_only():
     assert response.capabilities["slides_generation"].mode == "allow"
 
 
+def test_image_enabled_without_model_reports_not_configured(monkeypatch):
+    from tldw_Server_API.app.core.Image_Generation import adapter_registry, listing
+
+    class _Registry:
+        def list_backend_names(self, *, include_disabled: bool = False) -> list[str]:
+            assert include_disabled is False
+            return ["stable_diffusion_cpp"]
+
+    monkeypatch.setattr(adapter_registry, "get_registry", lambda: _Registry())
+    monkeypatch.setattr(
+        listing,
+        "list_image_models_for_catalog",
+        lambda: [{"name": "stable_diffusion_cpp", "is_configured": False}],
+    )
+
+    image_health = capabilities._collect_image_health()
+    response = build_research_workspace_capabilities(**_health_inputs(image_health=image_health))
+
+    assert image_health["reason_code"] == "image_backend_not_configured"
+    assert response.capabilities["infographic_generation"].mode == "block"
+    assert response.capabilities["infographic_generation"].reason_code == "image_backend_not_configured"
+
+
 def test_ffmpeg_unavailable_blocks_video_overview_only():
     response = build_research_workspace_capabilities(
         **_health_inputs(
@@ -114,6 +137,46 @@ def test_tts_unavailable_blocks_audio_and_video_only():
     assert response.capabilities["video_overview_generation"].reason_code == "tts_unavailable"
     assert response.capabilities["slides_generation"].mode == "allow"
     assert response.capabilities["infographic_generation"].mode == "allow"
+
+
+@pytest.mark.asyncio
+async def test_tts_failed_enabled_provider_blocks_media_generation(monkeypatch):
+    fake_tts_config = ModuleType("tldw_Server_API.app.core.TTS.tts_config")
+    fake_adapter_registry = ModuleType("tldw_Server_API.app.core.TTS.adapter_registry")
+
+    class _Manager:
+        def get_config(self):
+            return SimpleNamespace(providers={"kitten_tts": SimpleNamespace(enabled=True)})
+
+        def get_enabled_providers(self) -> list[str]:
+            return ["kitten_tts"]
+
+    class _Factory:
+        def get_status(self):
+            return {
+                "providers": {
+                    "kitten_tts": {
+                        "failed": True,
+                        "status": "error",
+                    }
+                }
+            }
+
+    async def _get_tts_factory():
+        return _Factory()
+
+    fake_tts_config.get_tts_config_manager = lambda: _Manager()
+    fake_adapter_registry.get_tts_factory = _get_tts_factory
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.core.TTS.tts_config", fake_tts_config)
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.core.TTS.adapter_registry", fake_adapter_registry)
+
+    tts_health = await capabilities._collect_tts_health()
+    response = build_research_workspace_capabilities(**_health_inputs(tts_health=tts_health))
+
+    assert tts_health["reason_code"] == "tts_provider_failed"
+    assert response.capabilities["audio_summary"].mode == "block"
+    assert response.capabilities["video_overview_generation"].mode == "block"
+    assert response.capabilities["video_overview_generation"].reason_code == "tts_provider_failed"
 
 
 def test_unknown_source_health_warns_instead_of_overclaiming_or_blocking():

--- a/tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py
+++ b/tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py
@@ -4,7 +4,7 @@ import asyncio
 import sys
 import time
 from types import ModuleType, SimpleNamespace
-from typing import get_args
+from typing import Any, get_args
 
 import pytest
 
@@ -92,7 +92,7 @@ def test_image_unavailable_blocks_infographic_only():
     assert response.capabilities["slides_generation"].mode == "allow"
 
 
-def test_image_enabled_without_model_reports_not_configured(monkeypatch):
+def test_image_enabled_without_model_reports_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Image_Generation import adapter_registry, listing
 
     class _Registry:
@@ -100,11 +100,17 @@ def test_image_enabled_without_model_reports_not_configured(monkeypatch):
             assert include_disabled is False
             return ["stable_diffusion_cpp"]
 
-    monkeypatch.setattr(adapter_registry, "get_registry", lambda: _Registry())
+    def _get_registry() -> _Registry:
+        return _Registry()
+
+    def _list_image_models_for_catalog() -> list[dict[str, Any]]:
+        return [{"name": "stable_diffusion_cpp", "is_configured": False}]
+
+    monkeypatch.setattr(adapter_registry, "get_registry", _get_registry)
     monkeypatch.setattr(
         listing,
         "list_image_models_for_catalog",
-        lambda: [{"name": "stable_diffusion_cpp", "is_configured": False}],
+        _list_image_models_for_catalog,
     )
 
     image_health = capabilities._collect_image_health()
@@ -139,20 +145,46 @@ def test_tts_unavailable_blocks_audio_and_video_only():
     assert response.capabilities["infographic_generation"].mode == "allow"
 
 
-@pytest.mark.asyncio
-async def test_tts_failed_enabled_provider_blocks_media_generation(monkeypatch):
+def test_tts_without_enabled_providers_skips_runtime_probe(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_tts_config = ModuleType("tldw_Server_API.app.core.TTS.tts_config")
     fake_adapter_registry = ModuleType("tldw_Server_API.app.core.TTS.adapter_registry")
 
     class _Manager:
-        def get_config(self):
+        def get_config(self) -> SimpleNamespace:
+            return SimpleNamespace(providers={"kitten_tts": SimpleNamespace(enabled=False)})
+
+        def get_enabled_providers(self) -> list[str]:
+            return []
+
+    def _get_existing_tts_factory() -> None:
+        raise AssertionError("runtime TTS probe should be skipped")
+
+    def _get_tts_config_manager() -> _Manager:
+        return _Manager()
+
+    fake_tts_config.get_tts_config_manager = _get_tts_config_manager
+    fake_adapter_registry.get_existing_tts_factory = _get_existing_tts_factory
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.core.TTS.tts_config", fake_tts_config)
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.core.TTS.adapter_registry", fake_adapter_registry)
+
+    tts_health = asyncio.run(capabilities._collect_tts_health())
+
+    assert tts_health == {"status": "unhealthy", "providers": {"total": 1, "available": 0}}
+
+
+def test_tts_failed_enabled_provider_blocks_media_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_tts_config = ModuleType("tldw_Server_API.app.core.TTS.tts_config")
+    fake_adapter_registry = ModuleType("tldw_Server_API.app.core.TTS.adapter_registry")
+
+    class _Manager:
+        def get_config(self) -> SimpleNamespace:
             return SimpleNamespace(providers={"kitten_tts": SimpleNamespace(enabled=True)})
 
         def get_enabled_providers(self) -> list[str]:
             return ["kitten_tts"]
 
     class _Factory:
-        def get_status(self):
+        def get_status(self) -> dict[str, Any]:
             return {
                 "providers": {
                     "kitten_tts": {
@@ -162,15 +194,18 @@ async def test_tts_failed_enabled_provider_blocks_media_generation(monkeypatch):
                 }
             }
 
-    async def _get_tts_factory():
+    def _get_existing_tts_factory() -> _Factory:
         return _Factory()
 
-    fake_tts_config.get_tts_config_manager = lambda: _Manager()
-    fake_adapter_registry.get_tts_factory = _get_tts_factory
+    def _get_tts_config_manager() -> _Manager:
+        return _Manager()
+
+    fake_tts_config.get_tts_config_manager = _get_tts_config_manager
+    fake_adapter_registry.get_existing_tts_factory = _get_existing_tts_factory
     monkeypatch.setitem(sys.modules, "tldw_Server_API.app.core.TTS.tts_config", fake_tts_config)
     monkeypatch.setitem(sys.modules, "tldw_Server_API.app.core.TTS.adapter_registry", fake_adapter_registry)
 
-    tts_health = await capabilities._collect_tts_health()
+    tts_health = asyncio.run(capabilities._collect_tts_health())
     response = build_research_workspace_capabilities(**_health_inputs(tts_health=tts_health))
 
     assert tts_health["reason_code"] == "tts_provider_failed"

--- a/tldw_Server_API/tests/Research_Workspace/test_output_jobs_api.py
+++ b/tldw_Server_API/tests/Research_Workspace/test_output_jobs_api.py
@@ -254,6 +254,48 @@ def test_status_returns_job_progress_plus_artifact() -> None:
     assert result.result == {"step": "render"}
 
 
+def test_status_prefers_artifact_error_when_worker_error_is_generic() -> None:
+    workspace_db = FakeWorkspaceDB()
+    artifact = workspace_db.add_workspace_artifact(
+        "ws-1",
+        {
+            "id": "video_overview-abc",
+            "artifact_type": "video_overview",
+            "title": "Video Overview",
+            "status": "failed",
+            "content": None,
+            "content_type": "video/mp4",
+            "producer_metadata": {"error": "tts_generation_failed"},
+        },
+    )
+    job_manager = FakeJobManager()
+    job_manager.jobs[101] = {
+        "id": 101,
+        "status": "failed",
+        "owner_user_id": "42",
+        "domain": RESEARCH_WORKSPACE_OUTPUT_JOB_DOMAIN,
+        "job_type": RESEARCH_WORKSPACE_OUTPUT_JOB_TYPE,
+        "payload": {
+            "workspace_id": "ws-1",
+            "artifact_id": artifact["id"],
+            "artifact_type": "video_overview",
+        },
+        "error_code": "worker_exception",
+        "error_message": "worker_exception",
+    }
+
+    result = get_research_workspace_output_job_status(
+        workspace_id="ws-1",
+        job_id=101,
+        workspace_db=workspace_db,
+        job_manager=job_manager,
+        user_id="42",
+    )
+
+    assert result.status == "failed"
+    assert result.error == "tts_generation_failed"
+
+
 def test_status_rejects_missing_job_domain_before_artifact_lookup() -> None:
     workspace_db = FakeWorkspaceDB()
     job_manager = FakeJobManager()


### PR DESCRIPTION
## Change summary

This PR hardens the backend readiness/status behavior for the WP2 media-output blockers found in the Research Workspace smoke pass.

- Returns `image_backend_not_configured` when image generation backends exist but no configured model is available.
- Accounts for enabled TTS providers already marked failed by the TTS factory status, without synthesizing audio from the capabilities endpoint.
- Preserves precise TTS readiness reason codes in derived Research Workspace capabilities.
- Prefers the failed artifact producer error when output job status would otherwise expose generic `worker_exception`.
- Adds focused regression tests for these backend job/readiness paths.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py tldw_Server_API/tests/Research_Workspace/test_output_jobs_api.py -q` -> 40 passed, 4 warnings.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Research_Workspace/test_capability_endpoint.py tldw_Server_API/tests/Research_Workspace/test_output_jobs_worker.py -q` -> 34 passed, 2 warnings.
- `git diff --check` -> exit 0.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Research_Workspace/capabilities.py tldw_Server_API/app/core/Research_Workspace/output_jobs.py -f json -o /tmp/bandit_research_workspace_wp2_readiness.json` -> 0 findings, 0 errors.

## Notes

Actual WP2 media generation still requires configured local image/TTS providers; this PR makes the readiness and job-status failure modes precise and fail-closed when providers are missing or failed.

AI-generated PR merge gate: this draft still needs a human-authored Change summary explaining what changed and why before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves WP2 media readiness and job error reporting so capabilities fail closed with clear reason codes and jobs surface specific artifact errors. Addresses TASK-12897 by fixing misleading image/TTS readiness and generic job statuses.

- **Bug Fixes**
  - Image: return `image_backend_not_configured` when backends exist but no models are configured.
  - TTS: inspect existing factory status without creating/synthesizing audio; skip runtime probe when no providers; subtract failed enabled providers and emit `tts_provider_failed`/`tts_provider_degraded`; propagate reason codes into capability results.
  - Jobs: prefer the linked artifact error (e.g., `tts_generation_failed`) when the job error is `worker_exception` or missing; otherwise keep the job error.
  - Tests: add coverage for image not-configured, TTS failed-provider/skip-probe, and artifact-error precedence.

<sup>Written for commit f17e7bcdc0fc95acaf28a91286106f2a96060386. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

