### PR TITLE
Allow 8080 in default egress ports

### DIFF
--- a/Docs/ADR/026-security-outbound-egress-and-ssrf-policy.md
+++ b/Docs/ADR/026-security-outbound-egress-and-ssrf-policy.md
@@ -18,7 +18,7 @@ The Security module owns outbound network policy helpers in `egress.py` and endp
 TASK-2247 confirmed the current implementation that bounds this ADR:
 
 - `evaluate_url_policy()` accepts only HTTP and HTTPS schemes.
-- URLs must include a hostname and a valid port. Allowed ports default to 80 and 443 unless `WORKFLOWS_EGRESS_ALLOWED_PORTS` changes that policy.
+- URLs must include a hostname and a valid port. Allowed ports default to 80, 443, and 8080 unless `WORKFLOWS_EGRESS_ALLOWED_PORTS` changes that policy.
 - Global and workflow allow/deny lists are merged from `EGRESS_ALLOWLIST`, `EGRESS_DENYLIST`, `WORKFLOWS_EGRESS_ALLOWLIST`, and `WORKFLOWS_EGRESS_DENYLIST`.
 - Denylist entries win over allowlist entries.
 - Production-like environments default to a strict profile that requires an allowlist; non-production defaults to permissive public-host behavior unless allowlists are configured.

--- a/Docs/Design/Workflows.md
+++ b/Docs/Design/Workflows.md
@@ -236,7 +236,7 @@ In single-user mode, the fixed user is exposed with admin-like claims for compat
 - Egress policy (centralized):
   - Profile: `WORKFLOWS_EGRESS_PROFILE=strict|permissive|custom` (default `strict` in `prod`, `permissive` otherwise based on `ENVIRONMENT`/`APP_ENV`).
   - Allowed schemes: `http, https` (fixed).
-  - Allowed ports: `WORKFLOWS_EGRESS_ALLOWED_PORTS` (comma-separated; default `80,443`).
+  - Allowed ports: `WORKFLOWS_EGRESS_ALLOWED_PORTS` (comma-separated; default `80,443,8080`).
   - Allowlist (host/domain): `WORKFLOWS_EGRESS_ALLOWLIST` (comma-separated; supports subdomains via `example.com`).
   - Block private/reserved IPs: `WORKFLOWS_EGRESS_BLOCK_PRIVATE=true|false` (default true). DNS is resolved and all target IPs must be public.
   - Webhook-specific allow/deny (global and per-tenant) remain available as documented above; they use the centralized evaluator.
@@ -404,7 +404,7 @@ Ordering is stable with a tie-breaker (`run_id` for runs; `event_id` for events)
 
 - Egress policy
   - Profile: `WORKFLOWS_EGRESS_PROFILE=strict|permissive|custom` (defaults to `strict` in prod, `permissive` elsewhere).
-  - Allowed ports: `WORKFLOWS_EGRESS_ALLOWED_PORTS` (default `80,443`).
+  - Allowed ports: `WORKFLOWS_EGRESS_ALLOWED_PORTS` (default `80,443,8080`).
   - Host allowlist: `WORKFLOWS_EGRESS_ALLOWLIST` (comma-separated, supports subdomains).
   - Private IP blocking: `WORKFLOWS_EGRESS_BLOCK_PRIVATE=true|false` (default true).
   - Webhook allow/deny: `WORKFLOWS_WEBHOOK_ALLOWLIST(_<TENANT>)`, `WORKFLOWS_WEBHOOK_DENYLIST(_<TENANT>)`.

--- a/Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md
+++ b/Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md
@@ -104,6 +104,7 @@ After this profile is running, continue with one of:
 - If startup fails, check the bundled `postgres` service logs and only inspect `TLDW_DATABASE_URL_OVERRIDE` / `TLDW_JOBS_DB_URL_OVERRIDE` if you intentionally configured external databases.
 - If login fails, check app logs with `docker compose -f Dockerfiles/docker-compose.multi-user-postgres.yml logs --tail=200 app`.
 - If port `8000` is already in use, stop the conflicting process or change the host port mapping in the compose file.
+- If provider validation or first chat cannot reach your inference server, remember the API server makes that outbound request, not the browser. Egress allows ports `80`, `443`, and `8080` by default; inference servers on ports such as `9099` or private/LAN/loopback addresses need `WORKFLOWS_EGRESS_ALLOWED_PORTS` and possibly `WORKFLOWS_EGRESS_BLOCK_PRIVATE=false`, then a restart. In Docker, use an address reachable from the app container.
 - If you need a full reset, stop the stack and remove volumes with `docker compose -f Dockerfiles/docker-compose.multi-user-postgres.yml down -v`.
 
 ## Optional Add-ons

--- a/Docs/Getting_Started/Profile_Docker_Single_User.md
+++ b/Docs/Getting_Started/Profile_Docker_Single_User.md
@@ -114,6 +114,7 @@ After this profile is running, continue with one of:
 - If the WebUI is unavailable, verify no other process is using port `8080`.
 - If direct API calls return `401`, confirm `SINGLE_USER_API_KEY` in `tldw_Server_API/Config_Files/.env` and use it as `X-API-KEY`.
 - If WebUI setup cannot save provider settings, use `/setup` as the backend/operator recovery surface and inspect `tldw_Server_API/Config_Files/.env` only as a troubleshooting step.
+- If provider validation or first chat cannot reach your inference server, remember the API server makes that outbound request, not the browser. Egress allows ports `80`, `443`, and `8080` by default; inference servers on ports such as `9099` or private/LAN/loopback addresses need `WORKFLOWS_EGRESS_ALLOWED_PORTS` and possibly `WORKFLOWS_EGRESS_BLOCK_PRIVATE=false`, then a restart. In Docker, use an address reachable from the app container.
 - If you need a full reset, stop the stack and remove volumes with `docker compose -f Dockerfiles/docker-compose.single-user.yml -f Dockerfiles/docker-compose.webui.yml down -v`.
 
 ## Optional Add-ons

--- a/Docs/Published/Getting_Started/Profile_Docker_Multi_User_Postgres.md
+++ b/Docs/Published/Getting_Started/Profile_Docker_Multi_User_Postgres.md
@@ -104,6 +104,7 @@ After this profile is running, continue with one of:
 - If startup fails, check the bundled `postgres` service logs and only inspect `TLDW_DATABASE_URL_OVERRIDE` / `TLDW_JOBS_DB_URL_OVERRIDE` if you intentionally configured external databases.
 - If login fails, check app logs with `docker compose -f Dockerfiles/docker-compose.multi-user-postgres.yml logs --tail=200 app`.
 - If port `8000` is already in use, stop the conflicting process or change the host port mapping in the compose file.
+- If provider validation or first chat cannot reach your inference server, remember the API server makes that outbound request, not the browser. Egress allows ports `80`, `443`, and `8080` by default; inference servers on ports such as `9099` or private/LAN/loopback addresses need `WORKFLOWS_EGRESS_ALLOWED_PORTS` and possibly `WORKFLOWS_EGRESS_BLOCK_PRIVATE=false`, then a restart. In Docker, use an address reachable from the app container.
 - If you need a full reset, stop the stack and remove volumes with `docker compose -f Dockerfiles/docker-compose.multi-user-postgres.yml down -v`.
 
 ## Optional Add-ons

--- a/Docs/Published/Getting_Started/Profile_Docker_Single_User.md
+++ b/Docs/Published/Getting_Started/Profile_Docker_Single_User.md
@@ -114,6 +114,7 @@ After this profile is running, continue with one of:
 - If the WebUI is unavailable, verify no other process is using port `8080`.
 - If direct API calls return `401`, confirm `SINGLE_USER_API_KEY` in `tldw_Server_API/Config_Files/.env` and use it as `X-API-KEY`.
 - If WebUI setup cannot save provider settings, use `/setup` as the backend/operator recovery surface and inspect `tldw_Server_API/Config_Files/.env` only as a troubleshooting step.
+- If provider validation or first chat cannot reach your inference server, remember the API server makes that outbound request, not the browser. Egress allows ports `80`, `443`, and `8080` by default; inference servers on ports such as `9099` or private/LAN/loopback addresses need `WORKFLOWS_EGRESS_ALLOWED_PORTS` and possibly `WORKFLOWS_EGRESS_BLOCK_PRIVATE=false`, then a restart. In Docker, use an address reachable from the app container.
 - If you need a full reset, stop the stack and remove volumes with `docker compose -f Dockerfiles/docker-compose.single-user.yml -f Dockerfiles/docker-compose.webui.yml down -v`.
 
 ## Optional Add-ons

--- a/backlog/tasks/task-12898 - Allow-8080-in-default-egress-ports.md
+++ b/backlog/tasks/task-12898 - Allow-8080-in-default-egress-ports.md
@@ -1,0 +1,49 @@
+---
+id: TASK-12898
+title: Allow 8080 in default egress ports
+status: Done
+assignee: []
+created_date: '2026-07-06 00:12'
+updated_date: '2026-07-06 00:13'
+labels:
+  - security
+  - docs
+  - setup
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fresh installs should allow outbound inference/provider calls on port 8080 without custom port configuration, while documenting why other hosted inference ports or private addresses may still need egress settings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Default egress ports include 8080 in code and shipped config.
+- [x] #2 Single-user and multi-user setup docs explain provider connectivity failures caused by server-side egress policy.
+- [x] #3 Config and design docs stay consistent with the new default.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Changed default egress port set from 80,443 to 80,443,8080 in the evaluator fallback and shipped config. Updated config, ADR, workflow, Docker single-user, and Docker multi-user setup docs including published copies. Verification: stale-default rg returned no hits; evaluator check printed egress-default-ok; Bandit on tldw_Server_API/app/core/Security/egress.py reported 0 results and 0 errors.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Default egress ports now include 8080 permanently, and setup docs explain why hosted inference servers on other ports or private/LAN/loopback addresses may need WORKFLOWS_EGRESS_ALLOWED_PORTS and WORKFLOWS_EGRESS_BLOCK_PRIVATE configuration.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12898 - Allow-8080-in-default-egress-ports.md
+++ b/backlog/tasks/task-12898 - Allow-8080-in-default-egress-ports.md
@@ -4,7 +4,7 @@ title: Allow 8080 in default egress ports
 status: Done
 assignee: []
 created_date: '2026-07-06 00:12'
-updated_date: '2026-07-06 00:13'
+updated_date: '2026-07-06 00:57'
 labels:
   - security
   - docs
@@ -30,6 +30,8 @@ Fresh installs should allow outbound inference/provider calls on port 8080 witho
 
 <!-- SECTION:NOTES:BEGIN -->
 Changed default egress port set from 80,443 to 80,443,8080 in the evaluator fallback and shipped config. Updated config, ADR, workflow, Docker single-user, and Docker multi-user setup docs including published copies. Verification: stale-default rg returned no hits; evaluator check printed egress-default-ok; Bandit on tldw_Server_API/app/core/Security/egress.py reported 0 results and 0 errors.
+
+Review follow-up: centralized DEFAULT_ALLOWED_PORTS in the egress module, reused it from the Workflows config endpoint, and added regressions for 8080 default allowance, empty/invalid port env fallback, and /workflows/config reported defaults. Verification: focused pytest for security/workflows config defaults passed; stale-default rg returned no hits; Bandit on touched Python files reported 0 results.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/Config_Files/README.md
+++ b/tldw_Server_API/Config_Files/README.md
@@ -587,14 +587,14 @@ async for evt in astream_sse(method="GET", url="https://host/stream"):
   - `workflows_denylist` → `WORKFLOWS_EGRESS_DENYLIST`
 
 - Ports, profile, private IPs
-  - `allowed_ports` → `WORKFLOWS_EGRESS_ALLOWED_PORTS` (csv of ints; default `80,443`)
+  - `allowed_ports` → `WORKFLOWS_EGRESS_ALLOWED_PORTS` (csv of ints; default `80,443,8080`)
   - `block_private` → `WORKFLOWS_EGRESS_BLOCK_PRIVATE` (bool; default `true`)
   - `profile` → `WORKFLOWS_EGRESS_PROFILE` (`strict|permissive|custom`)
 
 Notes
 - The egress policy denies unsupported schemes, disallowed ports, denylisted hosts, and private/reserved IP ranges by default (when `block_private=true`).
 - HTTP helpers in `http_client.py` and workflows/webhook components consult this policy before network I/O and on each redirect hop.
-- Local LLM model discovery (e.g., Aphrodite/Oobabooga/VLLM/Ollama endpoints) also uses the same egress policy. If a local endpoint runs on non-default ports like `8080` or on `127.0.0.1`, discovery calls can be blocked unless the port is listed in `WORKFLOWS_EGRESS_ALLOWED_PORTS` and private IP blocking is disabled via `WORKFLOWS_EGRESS_BLOCK_PRIVATE=false`. To avoid discovery entirely, set the provider’s model explicitly in config (e.g., `aphrodite_model=...`).
+- Local LLM model discovery (e.g., Aphrodite/Oobabooga/VLLM/Ollama endpoints) also uses the same egress policy. If a local endpoint runs on non-default ports like `9099` or on `127.0.0.1`, discovery calls can be blocked unless the port is listed in `WORKFLOWS_EGRESS_ALLOWED_PORTS` and private IP blocking is disabled via `WORKFLOWS_EGRESS_BLOCK_PRIVATE=false`. To avoid discovery entirely, set the provider’s model explicitly in config (e.g., `aphrodite_model=...`).
 
 ## [Moderation]
 - `enabled` (bool)

--- a/tldw_Server_API/Config_Files/config.txt
+++ b/tldw_Server_API/Config_Files/config.txt
@@ -589,8 +589,8 @@ egress_denylist =
 workflows_allowlist =
 workflows_denylist =
 
-# Allowed outbound ports (comma-separated integers; default: 80,443)
-allowed_ports = 80,443
+# Allowed outbound ports (comma-separated integers; default: 80,443,8080)
+allowed_ports = 80,443,8080
 
 # Block private/reserved IP ranges by default (true/false)
 block_private = true

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -82,6 +82,10 @@ from tldw_Server_API.app.core.http_client import afetch as _http_afetch
 from tldw_Server_API.app.core.MCP_unified.auth.jwt_manager import get_jwt_manager
 from tldw_Server_API.app.core.Resource_Governance.deps import derive_entity_key
 from tldw_Server_API.app.core.Resource_Governance.governor import RGRequest
+from tldw_Server_API.app.core.Security.egress import (
+    ALLOWED_PORTS_ENV,
+    DEFAULT_ALLOWED_PORTS,
+)
 from tldw_Server_API.app.core.Streaming.streams import WebSocketStream
 from tldw_Server_API.app.core.testing import (
     env_flag_enabled,
@@ -4329,7 +4333,7 @@ async def get_workflows_config(
         },
         "egress": {
             "profile": (os.getenv("WORKFLOWS_EGRESS_PROFILE", "") or "(auto)").strip(),
-            "allowed_ports": _csv("WORKFLOWS_EGRESS_ALLOWED_PORTS") or ["80","443"],
+            "allowed_ports": _csv(ALLOWED_PORTS_ENV) or [str(port) for port in DEFAULT_ALLOWED_PORTS],
             "allowlist": _csv("WORKFLOWS_EGRESS_ALLOWLIST"),
             "block_private": _env_bool("WORKFLOWS_EGRESS_BLOCK_PRIVATE", True),
         },

--- a/tldw_Server_API/app/core/Security/egress.py
+++ b/tldw_Server_API/app/core/Security/egress.py
@@ -15,6 +15,8 @@ from loguru import logger
 from tldw_Server_API.app.core.testing import is_truthy
 
 DEFAULT_ALLOWED_SCHEMES = {"http", "https"}
+DEFAULT_ALLOWED_PORTS = (80, 443, 8080)
+DEFAULT_ALLOWED_PORTS_ENV_VALUE = ",".join(str(port) for port in DEFAULT_ALLOWED_PORTS)
 ALLOWLIST_ENV = "WORKFLOWS_EGRESS_ALLOWLIST"
 DENYLIST_ENV = "WORKFLOWS_EGRESS_DENYLIST"
 # Global variants (applied across all usages)
@@ -394,7 +396,7 @@ def evaluate_url_policy(
 
     # Ports policy (defaults 80/443/8080; override via env)
     def _default_ports() -> list[int]:
-        raw = os.getenv(ALLOWED_PORTS_ENV, "80,443,8080")
+        raw = os.getenv(ALLOWED_PORTS_ENV, DEFAULT_ALLOWED_PORTS_ENV_VALUE)
         tokens = [part.strip().lower() for part in (raw or "").split(",") if part.strip()]
         if any(token in {"*", "any", "all"} for token in tokens):
             return []
@@ -404,7 +406,7 @@ def evaluate_url_policy(
                 out.append(int(p))
             except ValueError:
                 continue
-        return out or [80, 443]
+        return out or list(DEFAULT_ALLOWED_PORTS)
 
     allowed_ports = _default_ports()
     if (os.getenv("PYTEST_CURRENT_TEST") or os.getenv("TESTING")) and host in {"localhost", "127.0.0.1", "::1"}:

--- a/tldw_Server_API/app/core/Security/egress.py
+++ b/tldw_Server_API/app/core/Security/egress.py
@@ -392,9 +392,9 @@ def evaluate_url_policy(
     if not host:
         return URLPolicyResult(False, "URL must include a hostname")
 
-    # Ports policy (defaults 80/443; override via env)
+    # Ports policy (defaults 80/443/8080; override via env)
     def _default_ports() -> list[int]:
-        raw = os.getenv(ALLOWED_PORTS_ENV, "80,443")
+        raw = os.getenv(ALLOWED_PORTS_ENV, "80,443,8080")
         tokens = [part.strip().lower() for part in (raw or "").split(",") if part.strip()]
         if any(token in {"*", "any", "all"} for token in tokens):
             return []

--- a/tldw_Server_API/tests/Security/test_egress_env_absent_defaults.py
+++ b/tldw_Server_API/tests/Security/test_egress_env_absent_defaults.py
@@ -7,7 +7,7 @@ no-override defaults. The existing private-IP tests explicitly SET
 pass that flips the ``os.getenv(..., "true")`` fallback would not be caught.
 
 These tests scrub every egress env var and assert the real-deployment defaults:
-private IPs blocked, only ports 80/443 allowed, non-http(s) schemes rejected.
+private IPs blocked, ports 80/443/8080 allowed, non-http(s) schemes rejected.
 ``resolved_ips_override`` avoids real DNS.
 """
 from __future__ import annotations
@@ -76,15 +76,36 @@ def test_public_ip_allowed_by_default_in_non_prod(monkeypatch: pytest.MonkeyPatc
     assert result.allowed is True, f"public URL wrongly denied by default: {result.reason}"
 
 
-def test_non_standard_port_rejected_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no WORKFLOWS_EGRESS_ALLOWED_PORTS, only 80/443 are allowed."""
+def test_default_ports_allow_8080_and_reject_other_non_standard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no WORKFLOWS_EGRESS_ALLOWED_PORTS, 80/443/8080 are allowed."""
     _scrub_egress_env(monkeypatch)
+    allowed = egress.evaluate_url_policy(
+        "https://example.com:8080/ok",
+        resolved_ips_override=["93.184.216.34"],
+    )
+    assert allowed.allowed is True, f"8080 wrongly denied by default: {allowed.reason}"
+
+    rejected = egress.evaluate_url_policy(
+        "https://example.com:9099/ok",
+        resolved_ips_override=["93.184.216.34"],
+    )
+    assert rejected.allowed is False
+    assert "port" in (rejected.reason or "").lower()
+
+
+@pytest.mark.parametrize("raw_ports", ["", "not-a-port"])
+def test_invalid_allowed_ports_env_falls_back_to_default_ports(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_ports: str,
+) -> None:
+    """An empty or invalid port override should not silently drop default port 8080."""
+    _scrub_egress_env(monkeypatch)
+    monkeypatch.setenv(egress.ALLOWED_PORTS_ENV, raw_ports)
     result = egress.evaluate_url_policy(
         "https://example.com:8080/ok",
         resolved_ips_override=["93.184.216.34"],
     )
-    assert result.allowed is False
-    assert "port" in (result.reason or "").lower()
+    assert result.allowed is True, f"8080 wrongly denied with invalid port env: {result.reason}"
 
 
 def test_non_http_scheme_rejected_by_default(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tldw_Server_API/tests/Workflows/test_workflows_config_defaults.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_config_defaults.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints import workflows as workflows_api
+from tldw_Server_API.app.core.Security import egress
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_workflows_config_reports_default_egress_ports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(egress.ALLOWED_PORTS_ENV, raising=False)
+    monkeypatch.setattr(workflows_api, "get_content_backend_instance", lambda: None)
+
+    cfg = await workflows_api.get_workflows_config(_current_user=object())
+
+    assert cfg["egress"]["allowed_ports"] == ["80", "443", "8080"]


### PR DESCRIPTION
Change summary (human-owned, required before merge):
TODO: Please replace this with the requester-owned summary explaining what changed and why 8080 should be part of the default egress port set.

Implementation summary:
- Added 8080 to the default egress allowed-port fallback and shipped config default.
- Updated config, ADR, Workflow, Docker single-user, and Docker multi-user setup docs, including published copies.
- Added TASK-12898 to track the work and verification.

Verification:
- `rg` stale-default check for old `80,443` default text: no hits.
- `python -c ... evaluate_url_policy(...)`: `egress-default-ok`; public `:8080` allowed, public `:9099` still blocked by default.
- `python -m bandit -r tldw_Server_API/app/core/Security/egress.py -f json -o /tmp/bandit_default_egress_8080.json`: 0 results, 0 errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 8080 to the default egress allowed ports so common inference/provider endpoints work out of the box. Other ports stay blocked unless configured. Fulfills Linear TASK-12898.

- **New Features**
  - Default allowed ports are now 80, 443, 8080 in `egress.py` and shipped `config.txt` (override via `WORKFLOWS_EGRESS_ALLOWED_PORTS`).
  - `DEFAULT_ALLOWED_PORTS` is centralized in `egress.py` and used by `@/workflows/config`, which now reports ["80","443","8080"] when unset; tests cover the 8080 default and invalid/empty env fallbacks.
  - Updated ADR, Workflows design, and Docker single-user/multi-user setup docs to reflect the new default and clarify `WORKFLOWS_EGRESS_BLOCK_PRIVATE` behavior.

<sup>Written for commit 71f4129253abc971cf9ef9a4ece321463629ac1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

