### PR TITLE
Fix Research Workspace header sanity tests

### DIFF
--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
@@ -1569,7 +1569,10 @@ describe("WorkspaceHeader workspace browser modal", () => {
     expect(await screen.findByText("Import Workspace")).toBeInTheDocument()
 
     await waitFor(() => {
-      expect(screen.queryByText("View all workspaces")).not.toBeInTheDocument()
+      const viewAllWorkspaces = screen.queryByText("View all workspaces")
+      if (viewAllWorkspaces) {
+        expect(viewAllWorkspaces).not.toBeVisible()
+      }
     })
   })
 
@@ -3942,15 +3945,25 @@ describe("WorkspaceHeader workspace browser modal", () => {
 
     fireEvent.click(within(handoffModal).getByRole("button", { name: "Cancel" }))
     await waitFor(() => {
-      expect(screen.queryByRole("dialog", { name: "Create agent task" }))
-        .not.toBeInTheDocument()
+      const dialog = screen.queryByRole("dialog", { name: "Create agent task" })
+      if (!dialog) {
+        expect(dialog).not.toBeInTheDocument()
+        return
+      }
+      expect(dialog).toHaveClass("ant-zoom-leave")
     })
 
     fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
-    fireEvent.click(await screen.findByText("Create agent task"))
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Create agent task" })
+    )
 
-    const manualModal = await screen.findByRole("dialog", {
-      name: "Create agent task"
+    const manualModal = await waitFor(() => {
+      const activeDialog = screen
+        .getAllByRole("dialog", { name: "Create agent task" })
+        .find((dialog) => !dialog.classList.contains("ant-zoom-leave"))
+      expect(activeDialog).toBeDefined()
+      return activeDialog as HTMLElement
     })
     expect(within(manualModal).getByLabelText("Task title")).not.toHaveValue(
       "Review captured page: Example Story"

--- a/backlog/tasks/task-12899 - Fix-Research-Workspace-latest-dev-parity-sanity-failures.md
+++ b/backlog/tasks/task-12899 - Fix-Research-Workspace-latest-dev-parity-sanity-failures.md
@@ -1,0 +1,59 @@
+---
+id: TASK-12899
+title: Fix Research Workspace latest-dev parity sanity failures
+status: Done
+labels:
+- research-workspace
+- notebooklm
+- uat
+- frontend
+- bug
+priority: high
+modified_files:
+- apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+references:
+- https://github.com/rmusser01/tldw_server/pull/2674
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Latest-dev Research Workspace / NotebookLM parity sanity pass found two isolated WorkspaceHeader test failures: the Workspaces dropdown can remain visible when opening Workspace settings, and the agent-task modal close assertion does not account for Ant modal teardown timing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WorkspaceHeader focused tests pass on latest dev.
+- [x] #2 Focused Research Workspace/WebClipper frontend sanity suite passes.
+- [x] #3 Changes stay limited to the WorkspaceHeader sanity failures unless another directly related regression is found.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm root cause from WorkspaceHeader and WorkspaceAgentTaskHandoffModal behavior.
+2. Apply minimal frontend fix/test hardening for the two latest-dev sanity failures.
+3. Re-run targeted failing tests, full WorkspaceHeader test file, focused frontend sanity suite, and lightweight diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Review follow-up: rebased on origin/dev at 5605c36949, renumbered this task from TASK-12898 to TASK-12899 after dev introduced a different TASK-12898, checked AC/DOD items to match Done status, simplified the redundant null assertion, and made the manual agent-task modal lookup select the non-leaving dialog when Ant leaves the prior portal mounted.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Latest-dev Research Workspace sanity failures are fixed in the focused test coverage. PR: https://github.com/rmusser01/tldw_server/pull/2674. Verification: targeted failing WorkspaceHeader cases passed; full WorkspaceHeader suite passed (69 tests); focused Research Workspace/WebClipper sanity suite passed (12 files, 296 tests); git diff --check and git diff --cached --check passed. Frontend package typecheck was rerun with NODE_OPTIONS=--max-old-space-size=8192 and failed on unrelated existing test type errors outside the touched file: ChatGreetingPicker, MCPHub first-run, background-session-store, useSetupOnboarding, TldwChat abort, and character-export SSRF tests. Bandit skipped because the change only touches a TypeScript test and Backlog task metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Align WorkspaceHeader dropdown/modal assertions with Ant portal teardown behavior used elsewhere in Research Workspace tests.
- Scope the manual agent-task menu click by role so it does not match the closing modal title.
- Add Backlog task TASK-12898 for the latest-dev sanity failure fix.

## Verification
- bunx vitest run src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx -t "dismisses the workspaces menu" --maxWorkers=1 --no-file-parallelism
- bunx vitest run src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx -t "does not reuse web-clip agent-task prefill" --maxWorkers=1 --no-file-parallelism
- bunx vitest run src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism
- bunx vitest run src/components/Option/ResearchWorkspace/__tests__/research-workspace-capabilities.test.ts src/components/Option/ResearchWorkspace/__tests__/research-workspace-route-state.test.ts src/components/Option/ResearchWorkspace/__tests__/workspace-server-reconcile.test.ts src/components/Option/ResearchWorkspace/__tests__/AddSourceModal.stage2.intake.test.tsx src/components/Option/ResearchWorkspace/__tests__/deep-research-bundle-import.test.ts src/components/Option/ResearchWorkspace/__tests__/ResearchWorkspace.stage2.responsive.test.tsx src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx src/components/Option/ResearchWorkspace/__tests__/ChatPane.stage1.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage3.test.tsx src/components/Sidepanel/Clipper/__tests__/WebClipperPanel.save-flow.test.tsx src/services/web-clipper/__tests__/agent-task-handoff.test.ts --maxWorkers=1 --no-file-parallelism
- git diff --check

## Known baseline failures
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false currently fails on unrelated existing test type errors outside this change: ChatGreetingPicker, MCPHub first-run, background-session-store, useSetupOnboarding, TldwChat abort, and character-export SSRF tests.

## Change summary
AI-generated draft. Human requester must replace this with a human-written summary before merge per repository policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Research Workspace header sanity tests by aligning modal assertions with Ant Design portal teardown and selecting the correct, active dialog/menu item. Resolves latest-dev parity failures (TASK-12899).

- **Bug Fixes**
  - Treat closing dropdowns/modals as invisible or with `ant-zoom-leave` instead of requiring removal, including "View all workspaces" and "Create agent task".
  - Click "Create agent task" via `role=menuitem` and assert against the non-leaving dialog to avoid matching the closing portal.

<sup>Written for commit de1671ce10fbc7555ffd66b799b105c3980c5a91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

