### PR TITLE
Fix WebUI MCP discovery response parsing

### DIFF
--- a/apps/packages/ui/src/services/tldw/__tests__/mcp.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/mcp.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  bgRequestClient: vi.fn()
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequestClient: (...args: unknown[]) => mocks.bgRequestClient(...args)
+}))
+
+import {
+  fetchMcpModulesViaDiscovery,
+  fetchMcpToolCatalogsViaDiscovery,
+  fetchMcpToolsViaDiscovery
+} from "../mcp"
+
+describe("mcp service client", () => {
+  beforeEach(() => {
+    mocks.bgRequestClient.mockReset()
+  })
+
+  it("normalizes discovery tool results returned as MCP content JSON", async () => {
+    mocks.bgRequestClient
+      .mockResolvedValueOnce({
+        result: {
+          content: [
+            {
+              type: "json",
+              json: {
+                tools: [{ name: "media.search" }]
+              }
+            }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        result: {
+          content: [
+            {
+              type: "json",
+              json: {
+                catalogs: {
+                  global: [{ id: 1, name: "Research" }],
+                  user: [{ id: 2, name: "Personal" }]
+                }
+              }
+            }
+          ]
+        }
+      })
+      .mockResolvedValueOnce({
+        result: {
+          content: [
+            {
+              type: "json",
+              json: {
+                modules: [{ module_id: "media" }]
+              }
+            }
+          ]
+        }
+      })
+
+    await expect(fetchMcpToolsViaDiscovery()).resolves.toEqual([
+      { name: "media.search" }
+    ])
+    await expect(fetchMcpToolCatalogsViaDiscovery()).resolves.toEqual([
+      { id: 1, name: "Research" },
+      { id: 2, name: "Personal" }
+    ])
+    await expect(fetchMcpModulesViaDiscovery()).resolves.toEqual(["media"])
+  })
+})

--- a/apps/packages/ui/src/services/tldw/__tests__/mcp.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/mcp.test.ts
@@ -14,60 +14,95 @@ import {
   fetchMcpToolsViaDiscovery
 } from "../mcp"
 
+const contentJsonResult = (json: Record<string, unknown>) => ({
+  result: {
+    content: [
+      {
+        type: "json",
+        json
+      }
+    ]
+  }
+})
+
 describe("mcp service client", () => {
   beforeEach(() => {
     mocks.bgRequestClient.mockReset()
   })
 
-  it("normalizes discovery tool results returned as MCP content JSON", async () => {
-    mocks.bgRequestClient
-      .mockResolvedValueOnce({
-        result: {
-          content: [
-            {
-              type: "json",
-              json: {
-                tools: [{ name: "media.search" }]
-              }
-            }
-          ]
-        }
+  it("normalizes discovery tools returned as MCP content JSON", async () => {
+    mocks.bgRequestClient.mockResolvedValueOnce(
+      contentJsonResult({
+        tools: [{ name: "media.search" }]
       })
-      .mockResolvedValueOnce({
-        result: {
-          content: [
-            {
-              type: "json",
-              json: {
-                catalogs: {
-                  global: [{ id: 1, name: "Research" }],
-                  user: [{ id: 2, name: "Personal" }]
-                }
-              }
-            }
-          ]
-        }
-      })
-      .mockResolvedValueOnce({
-        result: {
-          content: [
-            {
-              type: "json",
-              json: {
-                modules: [{ module_id: "media" }]
-              }
-            }
-          ]
-        }
-      })
+    )
 
     await expect(fetchMcpToolsViaDiscovery()).resolves.toEqual([
       { name: "media.search" }
     ])
+  })
+
+  it("normalizes discovery catalogs returned as MCP content JSON", async () => {
+    mocks.bgRequestClient.mockResolvedValueOnce(
+      contentJsonResult({
+        catalogs: {
+          global: [{ id: 1, name: "Research" }],
+          user: [{ id: 2, name: "Personal" }]
+        }
+      })
+    )
+
     await expect(fetchMcpToolCatalogsViaDiscovery()).resolves.toEqual([
       { id: 1, name: "Research" },
       { id: 2, name: "Personal" }
     ])
+  })
+
+  it("normalizes discovery modules returned as MCP content JSON", async () => {
+    mocks.bgRequestClient.mockResolvedValueOnce(
+      contentJsonResult({
+        modules: [{ module_id: "media" }]
+      })
+    )
+
+    await expect(fetchMcpModulesViaDiscovery()).resolves.toEqual(["media"])
+  })
+
+  it("normalizes discovery tools returned as plain result payloads", async () => {
+    mocks.bgRequestClient.mockResolvedValueOnce({
+      result: {
+        tools: [{ name: "media.search" }]
+      }
+    })
+
+    await expect(fetchMcpToolsViaDiscovery()).resolves.toEqual([
+      { name: "media.search" }
+    ])
+  })
+
+  it("normalizes discovery catalogs returned as plain result payloads", async () => {
+    mocks.bgRequestClient.mockResolvedValueOnce({
+      result: {
+        catalogs: {
+          global: [{ id: 1, name: "Research" }],
+          user: [{ id: 2, name: "Personal" }]
+        }
+      }
+    })
+
+    await expect(fetchMcpToolCatalogsViaDiscovery()).resolves.toEqual([
+      { id: 1, name: "Research" },
+      { id: 2, name: "Personal" }
+    ])
+  })
+
+  it("normalizes discovery modules returned as plain result payloads", async () => {
+    mocks.bgRequestClient.mockResolvedValueOnce({
+      result: {
+        modules: [{ module_id: "media" }]
+      }
+    })
+
     await expect(fetchMcpModulesViaDiscovery()).resolves.toEqual(["media"])
   })
 })

--- a/apps/packages/ui/src/services/tldw/mcp.ts
+++ b/apps/packages/ui/src/services/tldw/mcp.ts
@@ -101,13 +101,23 @@ export const executeMcpTool = async (
   })
 }
 
-const unwrapToolResult = (payload: Record<string, unknown> | null | undefined) => {
+const unwrapToolResult = (payload: Record<string, unknown> | null | undefined): unknown => {
   if (!payload || typeof payload !== "object") return null
-  if ("result" in payload) {
-    const value = (payload as Record<string, unknown>).result
-    return value && typeof value === "object" ? (value as Record<string, unknown>) : value
+  const value = "result" in payload ? payload.result : payload
+  if (!value || typeof value !== "object") return value
+  const result = value as Record<string, unknown>
+  const content = result.content
+  if (Array.isArray(content)) {
+    const jsonContent = content.find(
+      (entry) =>
+        entry &&
+        typeof entry === "object" &&
+        "json" in entry &&
+        (entry as Record<string, unknown>).json != null
+    ) as Record<string, unknown> | undefined
+    if (jsonContent) return jsonContent.json
   }
-  return payload
+  return result
 }
 
 const normalizeCatalogList = (payload: unknown): McpToolCatalog[] => {

--- a/backlog/tasks/task-12898 - Fix-WebUI-MCP-discovery-response-parsing-for-chat-composer.md
+++ b/backlog/tasks/task-12898 - Fix-WebUI-MCP-discovery-response-parsing-for-chat-composer.md
@@ -1,0 +1,46 @@
+---
+id: TASK-12898
+title: Fix WebUI MCP discovery response parsing for chat composer
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-06 02:50'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the verified first-run MCP issue where setup saves and validates MCP packs, but the chat composer MCP configuration modal shows 0 tools because the WebUI parser does not unwrap tools returned under result.content[0].json from /api/v1/mcp/tools/execute.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Chat MCP discovery normalizes tools returned under result.content[0].json.tools.
+- [x] #2 Catalog/module discovery continues to normalize existing supported shapes.
+- [x] #3 A focused frontend test fails before the parser fix and passes after it.
+- [x] #4 Relevant frontend test command passes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: red test failed with [] before fix; focused vitest passed after fix; useMcpTools gating test passed; real browser post-fix check against live backend/frontend showed 146 tools and no "No MCP tools discovered" message. Bandit not applicable: touched TypeScript/frontend and Backlog task only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Chat composer MCP discovery now handles the MCP execute response envelope returned by the backend, so the tool settings modal renders discovered tools after first-run MCP setup instead of showing 0 tools.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12900 - Fix-WebUI-MCP-discovery-response-parsing-for-chat-composer.md
+++ b/backlog/tasks/task-12900 - Fix-WebUI-MCP-discovery-response-parsing-for-chat-composer.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-12898
+id: TASK-12900
 title: Fix WebUI MCP discovery response parsing for chat composer
 status: Done
 assignee: []


### PR DESCRIPTION
## Summary
- Fix WebUI MCP discovery unwrapping for `/api/v1/mcp/tools/execute` responses shaped as `result.content[0].json`.
- Add a focused regression covering tools, catalogs, and modules returned through the MCP content JSON envelope.
- Track the work in `TASK-12898`.

## Verification
- `bunx vitest run src/services/tldw/__tests__/mcp.test.ts src/hooks/__tests__/useMcpTools.gating.test.tsx`
- `git diff --check origin/dev...HEAD`
- Live browser verification before PR creation showed the chat MCP settings modal rendering `146 tools` instead of `0 tools`.

## Change summary
Human-authored merge-gate summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WebUI MCP discovery parsing to unwrap `result.content[*].json` from `/api/v1/mcp/tools/execute`, so the chat MCP settings modal lists discovered tools instead of 0.

- **Bug Fixes**
  - Unwraps MCP execute responses returned as content JSON and feeds them into existing normalizers.
  - Normalizes tools, catalogs, and modules from both content JSON and plain result payloads.
  - Adds focused tests for both shapes and satisfies TASK-12900.

<sup>Written for commit c266c48c8837e41e0dc98d6fb467848a4c86a88b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

