### PR TITLE
Fix WebUI UAT issues for notes and study pages

### DIFF
--- a/Docs/superpowers/plans/2026-07-06-chatbooks-flashcards-quizzes-uat-plan.md
+++ b/Docs/superpowers/plans/2026-07-06-chatbooks-flashcards-quizzes-uat-plan.md
@@ -1,0 +1,61 @@
+# Chatbooks Flashcards Quizzes UAT Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run live WebUI UAT for Chatbooks, Flashcards, and Quizzes, patch confirmed user-facing root causes, and open a PR against `dev`.
+
+**Architecture:** Reuse existing route components, page objects, and tier-2 e2e specs first. Add only focused tests for confirmed fixes.
+
+**Tech Stack:** Next.js WebUI, React, existing Playwright/Vitest tests, FastAPI backend, live llama.cpp-compatible server at `127.0.0.1:9099`.
+
+---
+
+### Task 1: Live UAT Baseline
+
+**Files:**
+- Inspect: `apps/tldw-frontend/e2e/workflows/tier-2-features/chatbooks.spec.ts`
+- Inspect: `apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts`
+- Inspect: `apps/tldw-frontend/e2e/workflows/tier-2-features/quiz.spec.ts`
+
+- [x] Run the existing tier-2 specs against the live backend.
+- [x] Exercise desktop and mobile rendered states for `/chatbooks-playground`, `/flashcards`, and `/quiz`.
+- [x] Record only reproducible visual or functional issues.
+
+### Task 2: Root-Cause Patches
+
+**Files:**
+- Modify only the route/component files that own confirmed issues.
+- Test with the smallest existing or new focused test.
+
+- [x] Trace each issue to the shared owner.
+- [x] Add focused regression coverage where practical.
+- [x] Apply the shortest root-cause fix.
+- [x] Re-run focused tests.
+
+### Task 3: Final PR
+
+**Files:**
+- Update: `backlog/tasks/task-12904 - Full-UAT-for-Chatbooks-Flashcards-and-Quizzes-WebUI-pages.md`
+
+- [x] Re-run live e2e/UAT.
+- [x] Save screenshot evidence outside the repo.
+- [x] Run Bandit only if Python files are touched.
+- [x] Commit, push, and open a PR against `dev`.
+
+### UAT Findings And Fixes
+
+- Chatbooks import UAT was blocked by a stale page-object locator after the dropzone copy changed from `.zip chatbook` to `.zip or .chatbook archive`.
+- Flashcards search/cleanup returned 500s for plain-text search terms containing punctuation such as hyphens and `front:` because SQLite FTS interpreted user text as operators/columns instead of literal tokens.
+- Flashcards review and Quiz live flows hit shared `core.default` ResourceGovernor throttles too quickly for normal page use.
+- Flashcards Manage first-entry states hid the primary search/deck controls, making deck-scoped creation and filtering harder to discover.
+- Flashcards deck-scoped card creation did not preselect the active Manage deck.
+- Flashcards `Test with Quiz` stayed disabled after selecting a review deck when there was no existing quiz handoff.
+- Flashcards E2E edit flow targeted the stale `Edit Flashcard` dialog label instead of the current `Edit Card` drawer.
+
+### Verification
+
+- Live tier-2 UAT: `TLDW_WEB_AUTOSTART=false TLDW_WEB_URL=http://localhost:8080 TLDW_E2E_SERVER_URL=127.0.0.1:8000 TLDW_E2E_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY npx playwright test e2e/workflows/tier-2-features/chatbooks.spec.ts e2e/workflows/tier-2-features/flashcards.spec.ts e2e/workflows/tier-2-features/quiz.spec.ts --reporter=line --workers=1` passed 32/32.
+- Screenshot smoke check: desktop/mobile screenshots for Chatbooks, Flashcards, and Quiz saved outside the repo at `/private/tmp/tldw-study-pages-uat-shots-20260706`; the check failed on page errors, visible crash text, and backend 4xx/5xx responses.
+- Focused UI tests: `bunx vitest run src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.empty-state.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.first-time.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx src/components/Notes/__tests__/NotesManagerPage.stage20.accessibility-shortcuts.test.tsx src/components/Notes/__tests__/NotesManagerPage.stage33.link-aware-delete-warning.test.tsx` passed 61/61.
+- Focused backend tests: `.venv/bin/python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_db_assets.py::test_list_flashcards_search_accepts_hyphenated_plain_text tldw_Server_API/tests/RAG_NEW/unit/test_fts_query_translation_edge_cases.py::test_sqlite_normalization_quotes_plain_tokens_with_punctuation tldw_Server_API/tests/Resource_Governance/test_policy_loader_route_map_db_store.py::test_db_policy_loader_includes_route_map_from_file tldw_Server_API/tests/Resource_Governance/test_slowapi_decorated_routes_mapped.py::test_rg_route_map_covers_rate_limited_paths -q` passed 4/4.
+- Bandit: touched Python implementation file had no findings; test-file assert warnings were isolated to pytest code and the non-assert scan passed with `-s B101`.

--- a/Docs/superpowers/plans/2026-07-06-notes-page-uat-fixes-plan.md
+++ b/Docs/superpowers/plans/2026-07-06-notes-page-uat-fixes-plan.md
@@ -1,0 +1,44 @@
+# Notes Page UAT Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run full WebUI notes-page UAT against a live backend and patch root causes of blocking or user-visible issues found.
+
+**Architecture:** Keep fixes in the existing notes route/components and current test stack. Add the smallest regression coverage that fails on the confirmed bug and passes after the patch.
+
+**Tech Stack:** Next.js WebUI, React, existing frontend tests, FastAPI backend, live llama.cpp-compatible provider when chat-adjacent notes actions need generation.
+
+---
+
+### Task 1: Map And Exercise Notes Functionality
+
+**Files:**
+- Inspect: `apps/packages/ui/src/routes/option-notes.tsx`
+- Inspect: existing notes tests under `apps/tldw-frontend` and `apps/packages/ui`
+
+- [x] List visible notes-page workflows and controls.
+- [x] Start isolated backend/frontend configured for llama.cpp on `127.0.0.1:9099`.
+- [x] Exercise create, save, reload, select, search, filter, view toggles, trash, restore/delete, collections/tags, editor modes, split/preview, keyboard shortcuts, mobile layout.
+- [x] Record reproducible issues with exact steps and evidence.
+
+### Task 2: Patch Confirmed Root Causes
+
+**Files:**
+- Modify only the notes route/component files required by confirmed bugs.
+- Test with the smallest existing frontend test command that covers the touched behavior.
+
+- [x] For each confirmed bug, trace the event/data flow to the shared root cause.
+- [x] Write a failing regression check first.
+- [x] Implement the shortest fix at the root cause.
+- [x] Verify the regression check passes.
+
+### Task 3: Final Verification
+
+**Files:**
+- Update: `backlog/tasks/task-12903 - Full-notes-page-UAT-and-root-cause-fixes.md`
+
+- [x] Re-run live notes UAT for fixed flows.
+- [x] Run focused frontend tests.
+- [x] Run Bandit only if Python code is touched; otherwise document skip.
+- [x] Save screenshot evidence outside the repo.
+- [x] Summarize findings, fixes, verification, and remaining risk.

--- a/apps/packages/ui/src/components/Common/confirm-danger.tsx
+++ b/apps/packages/ui/src/components/Common/confirm-danger.tsx
@@ -42,7 +42,7 @@ export function useConfirmDanger() {
         okButtonProps: { danger },
         maskClosable: false,
         keyboard: true,
-        autoFocusButton,
+        focusable: { autoFocusButton },
         onOk: () => {
           if (!settled) {
             settled = true

--- a/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
+++ b/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
@@ -288,7 +288,10 @@ export const FlashcardsManager: React.FC = () => {
       forceShowWorkspaceItems: currentStudyIntent?.forceShowWorkspaceItems ?? false
     })
   }, [currentStudyIntent?.attemptId, currentStudyIntent?.deckId, currentStudyIntent?.forceShowWorkspaceItems, currentStudyIntent?.quizId, reviewDeckId])
-  const canOpenQuizCta = currentStudyIntent?.quizId !== undefined
+  const canOpenQuizCta =
+    currentStudyIntent?.quizId !== undefined ||
+    reviewDeckId != null ||
+    currentStudyIntent?.deckId != null
   const effectiveActiveTab = activeTab
   const effectiveSchedulerDeckId = schedulerDeckHandoff?.deckId ?? schedulerHandoffDeckId
   const effectiveSchedulerHandoffKey =
@@ -368,7 +371,7 @@ export const FlashcardsManager: React.FC = () => {
                 canOpenQuizCta
                   ? undefined
                   : t("option:flashcards.quizCtaNeedsContext", {
-                      defaultValue: "Open a Quiz-linked flashcard session before testing with Quiz."
+                      defaultValue: "Select a review deck before testing with Quiz."
                     })
               }
             >

--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
@@ -663,7 +663,22 @@ describe("FlashcardsManager consistency standards", () => {
     expect(mocks.navigate).not.toHaveBeenCalled()
   })
 
-  it("disables quiz CTA without a valid quiz handoff context", () => {
+  it("enables quiz CTA after selecting a review deck", () => {
+    window.history.replaceState({}, "", "/flashcards")
+    render(<FlashcardsManager />)
+
+    fireEvent.click(screen.getByText("Select Deck 12"))
+
+    const quizButton = screen.getByTestId("flashcards-to-quiz-cta")
+    expect(quizButton).not.toBeDisabled()
+    fireEvent.click(quizButton)
+
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      expect.stringContaining("/quiz?tab=take&source=flashcards&deck_id=12")
+    )
+  })
+
+  it("disables quiz CTA without a valid quiz or deck context", () => {
     window.history.replaceState({}, "", "/flashcards")
     render(<FlashcardsManager />)
 

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardActionsMenu.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardActionsMenu.tsx
@@ -48,6 +48,24 @@ export const FlashcardActionsMenu: React.FC<FlashcardActionsMenuProps> = ({
     }
   ]
 
+  const handleEditPointerDown = React.useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0 || disabled) return
+      event.preventDefault()
+      event.stopPropagation()
+      onEdit()
+    },
+    [disabled, onEdit]
+  )
+
+  const handleEditClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      onEdit()
+    },
+    [onEdit]
+  )
+
   return (
     <div className="flex items-center gap-1">
       <Tooltip title={t("common:edit", { defaultValue: "Edit" })}>
@@ -55,10 +73,8 @@ export const FlashcardActionsMenu: React.FC<FlashcardActionsMenuProps> = ({
           type="text"
           size="small"
           icon={<Pen className="size-4" />}
-          onClick={(e) => {
-            e.stopPropagation()
-            onEdit()
-          }}
+          onPointerDown={handleEditPointerDown}
+          onClick={handleEditClick}
           disabled={disabled}
           aria-label={t("common:edit", { defaultValue: "Edit" })}
           data-testid={`flashcard-edit-${card.uuid}`}

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardActionsMenu.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardActionsMenu.tsx
@@ -51,11 +51,9 @@ export const FlashcardActionsMenu: React.FC<FlashcardActionsMenuProps> = ({
   const handleEditPointerDown = React.useCallback(
     (event: React.PointerEvent<HTMLButtonElement>) => {
       if (event.button !== 0 || disabled) return
-      event.preventDefault()
       event.stopPropagation()
-      onEdit()
     },
-    [disabled, onEdit]
+    [disabled]
   )
 
   const handleEditClick = React.useCallback(

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardActionsMenu.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardActionsMenu.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import type { Flashcard } from "@/services/flashcards"
+import { FlashcardActionsMenu } from "../FlashcardActionsMenu"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key
+  })
+}))
+
+const card: Flashcard = {
+  uuid: "card-1",
+  front: "Front",
+  back: "Back",
+  is_cloze: false,
+  ef: 2.5,
+  interval_days: 0,
+  repetitions: 0,
+  lapses: 0,
+  queue_state: "new",
+  deleted: false,
+  client_id: "test",
+  version: 1,
+  model_type: "basic",
+  reverse: false
+}
+
+describe("FlashcardActionsMenu", () => {
+  it("does not fire edit twice for one pointer click", () => {
+    const onEdit = vi.fn()
+    render(
+      <FlashcardActionsMenu
+        card={card}
+        onEdit={onEdit}
+        onReview={vi.fn()}
+        onDuplicate={vi.fn()}
+        onMove={vi.fn()}
+      />
+    )
+
+    const editButton = screen.getByRole("button", { name: "Edit" })
+    fireEvent.pointerDown(editButton, { button: 0 })
+    fireEvent.click(editButton)
+
+    expect(onEdit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -80,6 +80,7 @@ import {
   getFlashcard,
   listFlashcards,
   updateFlashcard,
+  type Deck,
   type Flashcard,
   type FlashcardUpdate
 } from "@/services/flashcards"
@@ -124,6 +125,197 @@ export const buildFlashcardsWorkspaceVisibilityOptions = (
   includeWorkspaceItems: selectedWorkspaceId == null ? showWorkspaceDecks : false,
   include_workspace_items: selectedWorkspaceId == null ? showWorkspaceDecks : false
 })
+
+type ManageExpertFiltersProps = {
+  selectedDeck: Deck | null
+  showWorkspaceDecks: boolean
+  setShowWorkspaceDecks: React.Dispatch<React.SetStateAction<boolean>>
+  selectedWorkspaceId: string | null
+  setSelectedWorkspaceId: React.Dispatch<React.SetStateAction<string | null>>
+  workspaceFilterOptions: Array<{ label: string; value: string }>
+  mTags: string[]
+  mTagInput: string
+  setMTagInput: React.Dispatch<React.SetStateAction<string>>
+  filteredTagSuggestions: string[]
+  hasActiveFilters: boolean
+  openDeckScopeEditor: () => void
+  addTagFilter: (rawValue: string) => void
+  removeTagFilter: (targetTag: string) => void
+  clearAllFilters: () => void
+  setPage: React.Dispatch<React.SetStateAction<number>>
+}
+
+const ManageExpertFilters: React.FC<ManageExpertFiltersProps> = ({
+  selectedDeck,
+  showWorkspaceDecks,
+  setShowWorkspaceDecks,
+  selectedWorkspaceId,
+  setSelectedWorkspaceId,
+  workspaceFilterOptions,
+  mTags,
+  mTagInput,
+  setMTagInput,
+  filteredTagSuggestions,
+  hasActiveFilters,
+  openDeckScopeEditor,
+  addTagFilter,
+  removeTagFilter,
+  clearAllFilters,
+  setPage
+}) => {
+  const { t } = useTranslation(["option", "common"])
+
+  return (
+    <>
+      <Button
+        onClick={openDeckScopeEditor}
+        disabled={!selectedDeck}
+        data-testid="flashcards-manage-move-scope"
+      >
+        {t("option:flashcards.moveScope", { defaultValue: "Move scope" })}
+      </Button>
+      <Checkbox
+        checked={showWorkspaceDecks}
+        onChange={(event) => {
+          setShowWorkspaceDecks(event.target.checked)
+          if (!event.target.checked) {
+            setSelectedWorkspaceId(null)
+          }
+          setPage(1)
+        }}
+        aria-label={t("option:flashcards.showWorkspaceDecks", {
+          defaultValue: "Show workspace decks"
+        })}
+        data-testid="flashcards-manage-show-workspace-decks"
+      >
+        {t("option:flashcards.showWorkspaceDecks", {
+          defaultValue: "Show workspace decks"
+        })}
+      </Checkbox>
+      <Select<string>
+        allowClear
+        showSearch
+        placeholder={t("option:flashcards.filterWorkspace", {
+          defaultValue: "Filter workspace"
+        })}
+        value={selectedWorkspaceId ?? undefined}
+        onChange={(value) => {
+          setSelectedWorkspaceId(value ?? null)
+          setPage(1)
+        }}
+        disabled={!showWorkspaceDecks && selectedWorkspaceId == null}
+        options={workspaceFilterOptions}
+        className="min-w-44"
+        data-testid="flashcards-manage-workspace-filter"
+      />
+      <Popover
+        trigger="click"
+        placement="bottomLeft"
+        content={
+          <div className="w-72 space-y-2">
+            <div className="text-sm font-medium text-text-muted">
+              {t("option:flashcards.filterByTag", {
+                defaultValue: "Filter by tag"
+              })}
+            </div>
+            <Input
+              placeholder={t("option:flashcards.tagPlaceholder", {
+                defaultValue: "Type a tag and press Enter"
+              })}
+              value={mTagInput}
+              onChange={(e) => {
+                setMTagInput(e.target.value)
+              }}
+              onPressEnter={() => addTagFilter(mTagInput)}
+              onKeyDown={(event) => {
+                if (event.key === ",") {
+                  event.preventDefault()
+                  addTagFilter(mTagInput)
+                }
+              }}
+              allowClear
+              data-testid="flashcards-manage-tag-input"
+            />
+            <div className="flex flex-wrap gap-1" data-testid="flashcards-manage-tag-selected">
+              {mTags.length > 0 ? (
+                mTags.map((tag) => (
+                  <Tag
+                    key={tag.toLowerCase()}
+                    closable
+                    onClose={(event) => {
+                      event.preventDefault()
+                      removeTagFilter(tag)
+                    }}
+                    className="!m-0"
+                  >
+                    {tag}
+                  </Tag>
+                ))
+              ) : (
+                <Text type="secondary" className="text-xs">
+                  {t("option:flashcards.tagFilterMatchAllHint", {
+                    defaultValue: "Add one or more tags. Cards must match all selected tags."
+                  })}
+                </Text>
+              )}
+            </div>
+            {filteredTagSuggestions.length > 0 && (
+              <div className="flex flex-wrap gap-1" data-testid="flashcards-manage-tag-suggestions">
+                {filteredTagSuggestions.map((tag) => (
+                  <Button
+                    key={tag.toLowerCase()}
+                    size="small"
+                    type="default"
+                    onClick={() => addTagFilter(tag)}
+                    className="!h-6 !px-2 !text-xs"
+                  >
+                    {tag}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
+        }
+      >
+        <Badge dot={mTags.length > 0} offset={[-4, 4]}>
+          <Button icon={<Filter className="size-4" />}>
+            {t("option:flashcards.moreFilters", { defaultValue: "More" })}
+          </Button>
+        </Badge>
+      </Popover>
+      {hasActiveFilters && (
+        <Button size="small" type="link" onClick={clearAllFilters}>
+          {t("option:flashcards.clearFilters", { defaultValue: "Clear all" })}
+        </Button>
+      )}
+      {mTags.length > 0 && (
+        <div
+          className="flex basis-full flex-wrap items-center gap-1.5"
+          data-testid="flashcards-manage-active-tag-filters"
+        >
+          <Text type="secondary" className="text-xs">
+            {t("option:flashcards.activeTagFilters", {
+              defaultValue: "Tag filters:"
+            })}
+          </Text>
+          {mTags.map((tag) => (
+            <Tag
+              key={`active-${tag.toLowerCase()}`}
+              closable
+              onClose={(event) => {
+                event.preventDefault()
+                removeTagFilter(tag)
+              }}
+              className="!m-0"
+            >
+              {tag}
+            </Tag>
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
 
 /**
  * Cards tab for browsing, filtering, creating, editing, and bulk operations on flashcards.
@@ -1881,158 +2073,26 @@ export const ManageTab: React.FC<ManageTabProps> = ({
               }))}
             />
             {showManageExpertChrome && (
-              <>
-                <Button
-                  onClick={openDeckScopeEditor}
-                  disabled={!selectedDeck}
-                  data-testid="flashcards-manage-move-scope"
-                >
-                  {t("option:flashcards.moveScope", { defaultValue: "Move scope" })}
-                </Button>
-                <Checkbox
-                  checked={showWorkspaceDecks}
-                  onChange={(event) => {
-                    setShowWorkspaceDecks(event.target.checked)
-                    if (!event.target.checked) {
-                      setSelectedWorkspaceId(null)
-                    }
-                    setPage(1)
-                  }}
-                  aria-label={t("option:flashcards.showWorkspaceDecks", {
-                    defaultValue: "Show workspace decks"
-                  })}
-                  data-testid="flashcards-manage-show-workspace-decks"
-                >
-                  {t("option:flashcards.showWorkspaceDecks", {
-                    defaultValue: "Show workspace decks"
-                  })}
-                </Checkbox>
-                <Select<string>
-                  allowClear
-                  showSearch
-                  placeholder={t("option:flashcards.filterWorkspace", {
-                    defaultValue: "Filter workspace"
-                  })}
-                  value={selectedWorkspaceId ?? undefined}
-                  onChange={(value) => {
-                    setSelectedWorkspaceId(value ?? null)
-                    setPage(1)
-                  }}
-                  disabled={!showWorkspaceDecks && selectedWorkspaceId == null}
-                  options={workspaceFilterOptions}
-                  className="min-w-44"
-                  data-testid="flashcards-manage-workspace-filter"
-                />
-                {/* Tag filter in popover */}
-                <Popover
-                  trigger="click"
-                  placement="bottomLeft"
-                  content={
-                    <div className="w-72 space-y-2">
-                      <div className="text-sm font-medium text-text-muted">
-                        {t("option:flashcards.filterByTag", {
-                          defaultValue: "Filter by tag"
-                        })}
-                      </div>
-                      <Input
-                        placeholder={t("option:flashcards.tagPlaceholder", {
-                          defaultValue: "Type a tag and press Enter"
-                        })}
-                        value={mTagInput}
-                        onChange={(e) => {
-                          setMTagInput(e.target.value)
-                        }}
-                        onPressEnter={() => addTagFilter(mTagInput)}
-                        onKeyDown={(event) => {
-                          if (event.key === ",") {
-                            event.preventDefault()
-                            addTagFilter(mTagInput)
-                          }
-                        }}
-                        allowClear
-                        data-testid="flashcards-manage-tag-input"
-                      />
-                      <div className="flex flex-wrap gap-1" data-testid="flashcards-manage-tag-selected">
-                        {mTags.length > 0 ? (
-                          mTags.map((tag) => (
-                            <Tag
-                              key={tag.toLowerCase()}
-                              closable
-                              onClose={(event) => {
-                                event.preventDefault()
-                                removeTagFilter(tag)
-                              }}
-                              className="!m-0"
-                            >
-                              {tag}
-                            </Tag>
-                          ))
-                        ) : (
-                          <Text type="secondary" className="text-xs">
-                            {t("option:flashcards.tagFilterMatchAllHint", {
-                              defaultValue: "Add one or more tags. Cards must match all selected tags."
-                            })}
-                          </Text>
-                        )}
-                      </div>
-                      {filteredTagSuggestions.length > 0 && (
-                        <div className="flex flex-wrap gap-1" data-testid="flashcards-manage-tag-suggestions">
-                          {filteredTagSuggestions.map((tag) => (
-                            <Button
-                              key={tag.toLowerCase()}
-                              size="small"
-                              type="default"
-                              onClick={() => addTagFilter(tag)}
-                              className="!h-6 !px-2 !text-xs"
-                            >
-                              {tag}
-                            </Button>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  }
-                >
-                  <Badge dot={mTags.length > 0} offset={[-4, 4]}>
-                    <Button icon={<Filter className="size-4" />}>
-                      {t("option:flashcards.moreFilters", { defaultValue: "More" })}
-                    </Button>
-                  </Badge>
-                </Popover>
-                {hasActiveFilters && (
-                  <Button size="small" type="link" onClick={clearAllFilters}>
-                    {t("option:flashcards.clearFilters", { defaultValue: "Clear all" })}
-                  </Button>
-                )}
-              </>
+              <ManageExpertFilters
+                selectedDeck={selectedDeck}
+                showWorkspaceDecks={showWorkspaceDecks}
+                setShowWorkspaceDecks={setShowWorkspaceDecks}
+                selectedWorkspaceId={selectedWorkspaceId}
+                setSelectedWorkspaceId={setSelectedWorkspaceId}
+                workspaceFilterOptions={workspaceFilterOptions}
+                mTags={mTags}
+                mTagInput={mTagInput}
+                setMTagInput={setMTagInput}
+                filteredTagSuggestions={filteredTagSuggestions}
+                hasActiveFilters={hasActiveFilters}
+                openDeckScopeEditor={openDeckScopeEditor}
+                addTagFilter={addTagFilter}
+                removeTagFilter={removeTagFilter}
+                clearAllFilters={clearAllFilters}
+                setPage={setPage}
+              />
             )}
           </div>
-
-          {showManageExpertChrome && mTags.length > 0 && (
-            <div
-              className="flex flex-wrap items-center gap-1.5"
-              data-testid="flashcards-manage-active-tag-filters"
-            >
-              <Text type="secondary" className="text-xs">
-                {t("option:flashcards.activeTagFilters", {
-                  defaultValue: "Tag filters:"
-                })}
-              </Text>
-              {mTags.map((tag) => (
-                <Tag
-                  key={`active-${tag.toLowerCase()}`}
-                  closable
-                  onClose={(event) => {
-                    event.preventDefault()
-                    removeTagFilter(tag)
-                  }}
-                  className="!m-0"
-                >
-                  {tag}
-                </Tag>
-              ))}
-            </div>
-          )}
 
           {/* Due status as segmented control + density toggle */}
           {showManageExpertChrome && (

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -672,6 +672,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
     !hasActiveFilters &&
     totalCount === 0 &&
     pageItems.length === 0
+  const showManageFilterChrome = viewMode === "cards"
   const showManageExpertChrome = viewMode === "cards" && !isNoCardFirstRun
 
   React.useEffect(() => {
@@ -1320,10 +1321,10 @@ export const ManageTab: React.FC<ManageTabProps> = ({
   ])
 
   const openManualCreateDrawer = React.useCallback(() => {
-    setCreateDrawerInitialDeckId(null)
+    setCreateDrawerInitialDeckId(mDeckId ?? null)
     onCreateHandoffConsumed?.()
     setCreateOpen(true)
-  }, [onCreateHandoffConsumed])
+  }, [mDeckId, onCreateHandoffConsumed])
 
   const closeCreateDrawer = React.useCallback(() => {
     setCreateOpen(false)
@@ -1847,7 +1848,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
         )}
 
         {/* Simplified Filter UI */}
-        {showManageExpertChrome && (
+        {showManageFilterChrome && (
         <div className="mb-3 space-y-3">
           {/* Primary filters: Search + Deck (always visible) */}
           <div className="flex items-center gap-2 flex-wrap">
@@ -1879,131 +1880,135 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                 value: d.id
               }))}
             />
-            <Button
-              onClick={openDeckScopeEditor}
-              disabled={!selectedDeck}
-              data-testid="flashcards-manage-move-scope"
-            >
-              {t("option:flashcards.moveScope", { defaultValue: "Move scope" })}
-            </Button>
-            <Checkbox
-              checked={showWorkspaceDecks}
-              onChange={(event) => {
-                setShowWorkspaceDecks(event.target.checked)
-                if (!event.target.checked) {
-                  setSelectedWorkspaceId(null)
-                }
-                setPage(1)
-              }}
-              aria-label={t("option:flashcards.showWorkspaceDecks", {
-                defaultValue: "Show workspace decks"
-              })}
-              data-testid="flashcards-manage-show-workspace-decks"
-            >
-              {t("option:flashcards.showWorkspaceDecks", {
-                defaultValue: "Show workspace decks"
-              })}
-            </Checkbox>
-            <Select<string>
-              allowClear
-              showSearch
-              placeholder={t("option:flashcards.filterWorkspace", {
-                defaultValue: "Filter workspace"
-              })}
-              value={selectedWorkspaceId ?? undefined}
-              onChange={(value) => {
-                setSelectedWorkspaceId(value ?? null)
-                setPage(1)
-              }}
-              disabled={!showWorkspaceDecks && selectedWorkspaceId == null}
-              options={workspaceFilterOptions}
-              className="min-w-44"
-              data-testid="flashcards-manage-workspace-filter"
-            />
-            {/* Tag filter in popover */}
-            <Popover
-              trigger="click"
-              placement="bottomLeft"
-              content={
-                <div className="w-72 space-y-2">
-                  <div className="text-sm font-medium text-text-muted">
-                    {t("option:flashcards.filterByTag", {
-                      defaultValue: "Filter by tag"
-                    })}
-                  </div>
-                  <Input
-                    placeholder={t("option:flashcards.tagPlaceholder", {
-                      defaultValue: "Type a tag and press Enter"
-                    })}
-                    value={mTagInput}
-                    onChange={(e) => {
-                      setMTagInput(e.target.value)
-                    }}
-                    onPressEnter={() => addTagFilter(mTagInput)}
-                    onKeyDown={(event) => {
-                      if (event.key === ",") {
-                        event.preventDefault()
-                        addTagFilter(mTagInput)
-                      }
-                    }}
-                    allowClear
-                    data-testid="flashcards-manage-tag-input"
-                  />
-                  <div className="flex flex-wrap gap-1" data-testid="flashcards-manage-tag-selected">
-                    {mTags.length > 0 ? (
-                      mTags.map((tag) => (
-                        <Tag
-                          key={tag.toLowerCase()}
-                          closable
-                          onClose={(event) => {
-                            event.preventDefault()
-                            removeTagFilter(tag)
-                          }}
-                          className="!m-0"
-                        >
-                          {tag}
-                        </Tag>
-                      ))
-                    ) : (
-                      <Text type="secondary" className="text-xs">
-                        {t("option:flashcards.tagFilterMatchAllHint", {
-                          defaultValue: "Add one or more tags. Cards must match all selected tags."
-                        })}
-                      </Text>
-                    )}
-                  </div>
-                  {filteredTagSuggestions.length > 0 && (
-                    <div className="flex flex-wrap gap-1" data-testid="flashcards-manage-tag-suggestions">
-                      {filteredTagSuggestions.map((tag) => (
-                        <Button
-                          key={tag.toLowerCase()}
-                          size="small"
-                          type="default"
-                          onClick={() => addTagFilter(tag)}
-                          className="!h-6 !px-2 !text-xs"
-                        >
-                          {tag}
-                        </Button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              }
-            >
-              <Badge dot={mTags.length > 0} offset={[-4, 4]}>
-                <Button icon={<Filter className="size-4" />}>
-                  {t("option:flashcards.moreFilters", { defaultValue: "More" })}
+            {showManageExpertChrome && (
+              <>
+                <Button
+                  onClick={openDeckScopeEditor}
+                  disabled={!selectedDeck}
+                  data-testid="flashcards-manage-move-scope"
+                >
+                  {t("option:flashcards.moveScope", { defaultValue: "Move scope" })}
                 </Button>
-              </Badge>
-            </Popover>
-            {hasActiveFilters && (
-              <Button size="small" type="link" onClick={clearAllFilters}>
-                {t("option:flashcards.clearFilters", { defaultValue: "Clear all" })}
-              </Button>
+                <Checkbox
+                  checked={showWorkspaceDecks}
+                  onChange={(event) => {
+                    setShowWorkspaceDecks(event.target.checked)
+                    if (!event.target.checked) {
+                      setSelectedWorkspaceId(null)
+                    }
+                    setPage(1)
+                  }}
+                  aria-label={t("option:flashcards.showWorkspaceDecks", {
+                    defaultValue: "Show workspace decks"
+                  })}
+                  data-testid="flashcards-manage-show-workspace-decks"
+                >
+                  {t("option:flashcards.showWorkspaceDecks", {
+                    defaultValue: "Show workspace decks"
+                  })}
+                </Checkbox>
+                <Select<string>
+                  allowClear
+                  showSearch
+                  placeholder={t("option:flashcards.filterWorkspace", {
+                    defaultValue: "Filter workspace"
+                  })}
+                  value={selectedWorkspaceId ?? undefined}
+                  onChange={(value) => {
+                    setSelectedWorkspaceId(value ?? null)
+                    setPage(1)
+                  }}
+                  disabled={!showWorkspaceDecks && selectedWorkspaceId == null}
+                  options={workspaceFilterOptions}
+                  className="min-w-44"
+                  data-testid="flashcards-manage-workspace-filter"
+                />
+                {/* Tag filter in popover */}
+                <Popover
+                  trigger="click"
+                  placement="bottomLeft"
+                  content={
+                    <div className="w-72 space-y-2">
+                      <div className="text-sm font-medium text-text-muted">
+                        {t("option:flashcards.filterByTag", {
+                          defaultValue: "Filter by tag"
+                        })}
+                      </div>
+                      <Input
+                        placeholder={t("option:flashcards.tagPlaceholder", {
+                          defaultValue: "Type a tag and press Enter"
+                        })}
+                        value={mTagInput}
+                        onChange={(e) => {
+                          setMTagInput(e.target.value)
+                        }}
+                        onPressEnter={() => addTagFilter(mTagInput)}
+                        onKeyDown={(event) => {
+                          if (event.key === ",") {
+                            event.preventDefault()
+                            addTagFilter(mTagInput)
+                          }
+                        }}
+                        allowClear
+                        data-testid="flashcards-manage-tag-input"
+                      />
+                      <div className="flex flex-wrap gap-1" data-testid="flashcards-manage-tag-selected">
+                        {mTags.length > 0 ? (
+                          mTags.map((tag) => (
+                            <Tag
+                              key={tag.toLowerCase()}
+                              closable
+                              onClose={(event) => {
+                                event.preventDefault()
+                                removeTagFilter(tag)
+                              }}
+                              className="!m-0"
+                            >
+                              {tag}
+                            </Tag>
+                          ))
+                        ) : (
+                          <Text type="secondary" className="text-xs">
+                            {t("option:flashcards.tagFilterMatchAllHint", {
+                              defaultValue: "Add one or more tags. Cards must match all selected tags."
+                            })}
+                          </Text>
+                        )}
+                      </div>
+                      {filteredTagSuggestions.length > 0 && (
+                        <div className="flex flex-wrap gap-1" data-testid="flashcards-manage-tag-suggestions">
+                          {filteredTagSuggestions.map((tag) => (
+                            <Button
+                              key={tag.toLowerCase()}
+                              size="small"
+                              type="default"
+                              onClick={() => addTagFilter(tag)}
+                              className="!h-6 !px-2 !text-xs"
+                            >
+                              {tag}
+                            </Button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  }
+                >
+                  <Badge dot={mTags.length > 0} offset={[-4, 4]}>
+                    <Button icon={<Filter className="size-4" />}>
+                      {t("option:flashcards.moreFilters", { defaultValue: "More" })}
+                    </Button>
+                  </Badge>
+                </Popover>
+                {hasActiveFilters && (
+                  <Button size="small" type="link" onClick={clearAllFilters}>
+                    {t("option:flashcards.clearFilters", { defaultValue: "Clear all" })}
+                  </Button>
+                )}
+              </>
             )}
           </div>
 
-          {mTags.length > 0 && (
+          {showManageExpertChrome && mTags.length > 0 && (
             <div
               className="flex flex-wrap items-center gap-1.5"
               data-testid="flashcards-manage-active-tag-filters"
@@ -2030,6 +2035,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
           )}
 
           {/* Due status as segmented control + density toggle */}
+          {showManageExpertChrome && (
           <div className="flex items-center justify-between gap-2">
             <Segmented
               value={mDue}
@@ -2109,6 +2115,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
               </div>
             </div>
           </div>
+          )}
         </div>
         )}
 

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.empty-state.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.empty-state.test.tsx
@@ -242,14 +242,15 @@ describe("ManageTab no-card empty state", () => {
     vi.mocked(useCardsKeyboardNav).mockImplementation(() => undefined)
   })
 
-  it("shows create, import, and generate actions before filter chrome for a true first run", () => {
+  it("shows create, import, generate, and primary filters before expert chrome for a true first run", () => {
     renderManageTab()
 
     expect(screen.getByText("No flashcards yet")).toBeInTheDocument()
     expect(screen.getByTestId("flashcards-manage-empty-create-cta")).toBeInTheDocument()
     expect(screen.getByTestId("flashcards-manage-empty-import-cta")).toBeInTheDocument()
     expect(screen.getByTestId("flashcards-manage-empty-generate-cta")).toBeInTheDocument()
-    expect(screen.queryByTestId("flashcards-manage-search")).not.toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-search")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-deck-select")).toBeInTheDocument()
     expect(screen.queryByTestId("flashcards-density-toggle")).not.toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.first-time.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.first-time.test.tsx
@@ -222,7 +222,7 @@ describe("ManageTab first-time state", () => {
     vi.mocked(useCardsKeyboardNav).mockImplementation(() => undefined)
   })
 
-  it("suppresses expert manage chrome when there are no cards and no active filters", () => {
+  it("suppresses expert manage chrome while keeping primary filters when there are no cards and no active filters", () => {
     render(
       <ManageTab
         onNavigateToImport={() => {}}
@@ -233,7 +233,8 @@ describe("ManageTab first-time state", () => {
 
     expect(screen.getByText("No flashcards yet")).toBeInTheDocument()
     expect(screen.queryByTestId("flashcards-manage-shortcut-chips")).not.toBeInTheDocument()
-    expect(screen.queryByTestId("flashcards-manage-search")).not.toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-search")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-deck-select")).toBeInTheDocument()
     expect(screen.queryByTestId("flashcards-manage-sort-select")).not.toBeInTheDocument()
     expect(screen.queryByTestId("flashcards-density-toggle")).not.toBeInTheDocument()
     expect(screen.queryByTestId("flashcards-manage-selection-summary")).not.toBeInTheDocument()

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
@@ -330,8 +330,8 @@ describe("ManageTab scheduling metadata visibility", () => {
 
     expect(screen.getByText("No flashcards yet")).toBeInTheDocument()
     expect(screen.queryByTestId("flashcards-manage-shortcut-chips")).not.toBeInTheDocument()
-    expect(screen.queryByTestId("flashcards-manage-search")).not.toBeInTheDocument()
-    expect(screen.queryByTestId("flashcards-manage-deck-select")).not.toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-search")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-deck-select")).toBeInTheDocument()
     expect(screen.queryByTestId("flashcards-manage-selection-summary")).not.toBeInTheDocument()
     expect(screen.getByTestId("flashcards-manage-empty-create-cta")).toBeInTheDocument()
     expect(screen.getByTestId("flashcards-manage-empty-import-cta")).toBeInTheDocument()
@@ -717,6 +717,24 @@ describe("ManageTab scheduling metadata visibility", () => {
     expect(screen.getByTestId("mock-create-drawer-include-workspace")).toHaveTextContent("false")
     expect(screen.getByTestId("mock-create-drawer-workspace-id")).toBeEmptyDOMElement()
     expect(onCreateHandoffConsumed).toHaveBeenCalledTimes(1)
+  })
+
+  it("preselects the active Manage deck when opening the create drawer", async () => {
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive
+        initialDeckId={1}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId("flashcards-fab-create"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-create-drawer")).toBeInTheDocument()
+    })
+    expect(screen.getByTestId("mock-create-drawer-initial-deck-id")).toHaveTextContent("1")
   })
 
   it("moves deck scope by patching workspace_id in the update payload", async () => {

--- a/apps/packages/ui/src/components/Notes/NotesEditorHeader.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesEditorHeader.tsx
@@ -3,6 +3,7 @@ import { Button, Dropdown, Tooltip, Typography } from 'antd'
 import type { MenuProps } from 'antd'
 import { useTranslation } from 'react-i18next'
 import { useMobile } from '@/hooks/useMediaQuery'
+import { useTutorialStore } from '@/store/tutorials'
 import type { SaveIndicatorState } from './notes-manager-types'
 import NotesSaveStatus from './NotesSaveStatus'
 import {
@@ -481,7 +482,7 @@ const NotesEditorHeader: React.FC<NotesEditorHeaderProps> = ({
         className={
           isMobileViewport
             ? 'flex w-full flex-wrap items-center justify-start gap-2'
-            : 'flex items-center gap-2'
+            : 'flex items-center justify-end gap-2'
         }
         data-testid="notes-header-actions"
       >
@@ -617,6 +618,33 @@ const NotesEditorHeader: React.FC<NotesEditorHeaderProps> = ({
           </div>
         )}
 
+        {!isMobileViewport && onCreateStudyPack ? (
+          <Tooltip
+            title={
+              canCreateStudyPack
+                ? t('option:notesSearch.createStudyPack', {
+                    defaultValue: 'Create study pack'
+                  })
+                : t('option:notesSearch.createStudyPackDisabledTooltip', {
+                    defaultValue: 'Save and title this note before creating a study pack'
+                  })
+            }
+          >
+            <Button
+              type="primary"
+              size={toolbarButtonSize}
+              onClick={onCreateStudyPack}
+              disabled={!canCreateStudyPack}
+              className="whitespace-nowrap"
+              data-testid="notes-create-study-pack-button"
+            >
+              {t('option:notesSearch.createStudyPack', {
+                defaultValue: 'Create study pack'
+              })}
+            </Button>
+          </Tooltip>
+        ) : null}
+
         {/* Overflow "More actions" menu */}
         <Dropdown
           trigger={['click']}
@@ -638,6 +666,9 @@ const NotesEditorHeader: React.FC<NotesEditorHeaderProps> = ({
                 defaultValue: 'More actions'
               })}
               data-testid="notes-overflow-menu-button"
+              onClick={() => {
+                useTutorialStore.getState().endTutorial()
+              }}
             />
           </Tooltip>
         </Dropdown>

--- a/apps/packages/ui/src/components/Notes/NotesManagerPage.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesManagerPage.tsx
@@ -8,7 +8,7 @@ import {
 import { bgRequest } from '@/services/background-proxy'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useServerOnline } from '@/hooks/useServerOnline'
-import { useConfirmDanger } from '@/components/Common/confirm-danger'
+import { useConfirmDanger, type ConfirmDangerOptions } from '@/components/Common/confirm-danger'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { useDemoMode } from '@/context/demo-mode'
@@ -117,7 +117,11 @@ const NotesManagerPage: React.FC = () => {
   const navigate = useNavigate()
   const { capabilities, loading: capsLoading } = useServerCapabilities()
   const message = useAntdMessage()
-  const confirmDanger = useConfirmDanger()
+  const rawConfirmDanger = useConfirmDanger()
+  const confirmDanger = React.useCallback((options: ConfirmDangerOptions) => {
+    useTutorialStore.getState().endTutorial()
+    return rawConfirmDanger(options)
+  }, [rawConfirmDanger])
   const {
     setHistory,
     setMessages,
@@ -2129,13 +2133,37 @@ const NotesManagerPage: React.FC = () => {
     if (typeof window === 'undefined') return
     let cancelled = false
     let timer: number | null = null
+    let userInteracted = false
+
+    function removeInteractionListeners() {
+      window.removeEventListener('pointerdown', handleUserInteraction, true)
+      window.removeEventListener('keydown', handleUserInteraction, true)
+    }
+
+    function handleUserInteraction() {
+      if (cancelled || userInteracted) return
+      userInteracted = true
+      if (timer != null) {
+        window.clearTimeout(timer)
+        timer = null
+      }
+      removeInteractionListeners()
+      void notesUiStorage
+        .set(NOTES_TUTORIAL_SHOWN_STORAGE_KEY, '1')
+        .catch(() => undefined)
+    }
+
+    window.addEventListener('pointerdown', handleUserInteraction, { capture: true, once: true })
+    window.addEventListener('keydown', handleUserInteraction, { capture: true, once: true })
 
     void (async () => {
       const alreadyShown = await notesUiStorage
         .get<string | null>(NOTES_TUTORIAL_SHOWN_STORAGE_KEY)
         .catch(() => null)
-      if (cancelled || alreadyShown) return
+      if (cancelled || alreadyShown || userInteracted) return
       timer = window.setTimeout(() => {
+        if (cancelled || userInteracted) return
+        removeInteractionListeners()
         void notesUiStorage
           .set(NOTES_TUTORIAL_SHOWN_STORAGE_KEY, '1')
           .catch(() => undefined)
@@ -2146,6 +2174,7 @@ const NotesManagerPage: React.FC = () => {
     return () => {
       cancelled = true
       if (timer != null) window.clearTimeout(timer)
+      removeInteractionListeners()
     }
   }, [])
 
@@ -2191,19 +2220,6 @@ const NotesManagerPage: React.FC = () => {
       <p id={NOTES_SHORTCUTS_SUMMARY_ID} className="sr-only">
         {t('option:notesSearch.shortcutSummaryText', { defaultValue: 'Keyboard shortcuts: Ctrl or Command plus S to save, question mark to open keyboard shortcuts help, Escape to close dialogs.' })}
       </p>
-      {!isMobileViewport && (
-        <div className="absolute right-4 top-4 z-20">
-          <Button
-            type="primary"
-            size="small"
-            onClick={handleCreateStudyPackFromNote}
-            disabled={ed.selectedId == null || ed.isDirty || !ed.title.trim()}
-            data-testid="notes-create-study-pack-button"
-          >
-            {t('option:notesSearch.createStudyPack', { defaultValue: 'Create study pack' })}
-          </Button>
-        </div>
-      )}
       {isMobileViewport && mobileSidebarOpen && (
         <button type="button" aria-label={t('option:notesSearch.closeMobileSidebar', { defaultValue: 'Close notes list' })} data-testid="notes-mobile-sidebar-backdrop" className="absolute inset-0 z-30 bg-black/35" onClick={() => setMobileSidebarOpen(false)} />
       )}

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage20.accessibility-shortcuts.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage20.accessibility-shortcuts.test.tsx
@@ -263,6 +263,26 @@ describe("NotesManagerPage stage 20 accessibility shortcut discovery", () => {
     expect(mockStartTutorial).toHaveBeenCalledWith("notes-basics")
   })
 
+  it("suppresses the first-visit tutorial when the user starts interacting before the timer fires", async () => {
+    vi.useFakeTimers()
+    renderPage()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    fireEvent.pointerDown(window)
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockStorageSet).toHaveBeenCalledWith("notes-tutorial-shown", "1")
+    expect(mockStartTutorial).not.toHaveBeenCalled()
+  })
+
   it("removes tutorial state from shared storage when restarting the tutorial", async () => {
     renderPage()
 

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage33.link-aware-delete-warning.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage33.link-aware-delete-warning.test.tsx
@@ -12,6 +12,8 @@ const {
   mockMessageInfo,
   mockNavigate,
   mockConfirmDanger,
+  mockEndTutorial,
+  mockStartTutorial,
   mockGetSetting,
   mockSetSetting,
   mockClearSetting
@@ -23,6 +25,8 @@ const {
   mockMessageInfo: vi.fn(),
   mockNavigate: vi.fn(),
   mockConfirmDanger: vi.fn(),
+  mockEndTutorial: vi.fn(),
+  mockStartTutorial: vi.fn(),
   mockGetSetting: vi.fn(),
   mockSetSetting: vi.fn(),
   mockClearSetting: vi.fn()
@@ -72,6 +76,16 @@ vi.mock("@/hooks/useServerCapabilities", () => ({
 vi.mock("@/components/Common/confirm-danger", () => ({
   useConfirmDanger: () => mockConfirmDanger
 }))
+
+vi.mock("@/store/tutorials", () => {
+  const store = Object.assign(() => ({}), {
+    getState: () => ({
+      endTutorial: mockEndTutorial,
+      startTutorial: mockStartTutorial
+    })
+  })
+  return { useTutorialStore: store }
+})
 
 vi.mock("@/hooks/useAntdMessage", () => ({
   useAntdMessage: () => ({
@@ -243,6 +257,10 @@ describe("NotesManagerPage stage 33 link-aware delete warnings", () => {
     await waitFor(() => {
       expect(mockConfirmDanger).toHaveBeenCalled()
     })
+    expect(mockEndTutorial).toHaveBeenCalled()
+    expect(mockEndTutorial.mock.invocationCallOrder[0]).toBeLessThan(
+      mockConfirmDanger.mock.invocationCallOrder[0]
+    )
     const deleteDialogArgs = mockConfirmDanger.mock.calls[0][0]
     expect(String(deleteDialogArgs.content)).toBe("Delete this note?")
   })

--- a/apps/tldw-frontend/e2e/utils/page-objects/ChatbooksPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/ChatbooksPage.ts
@@ -65,7 +65,7 @@ export class ChatbooksPage extends BasePage {
 
   /** File upload dragger area */
   get uploadDropzone(): Locator {
-    return this.page.getByText(/drop a \.zip chatbook/i)
+    return this.page.getByText(/drop a \.zip or \.chatbook archive/i)
   }
 
   /** Job tracker card */

--- a/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
@@ -670,9 +670,9 @@ export class FlashcardsPage extends BasePage {
   }
 
   async selectManageDeckByName(deckName: string): Promise<void> {
-    await this.manageDeckSelect.click({ force: true });
     const selectedDeck = this.manageDeckSelect.getByText(deckName, { exact: true });
     if (await selectedDeck.isVisible().catch(() => false)) return;
+    await this.manageDeckSelect.click({ force: true });
     const deckOption = this.getActiveSelectOption(deckName);
     await expect(deckOption).toBeVisible({ timeout: 10_000 });
     await deckOption.click();

--- a/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
@@ -56,6 +56,10 @@ export function buildFlashcardsSeedRecord(
   };
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 type FlashcardsCleanupDeck = {
   id?: number;
   name?: string;
@@ -302,6 +306,10 @@ export class FlashcardsPage extends BasePage {
     return this.page.getByRole('tab', { name: /scheduler/i });
   }
 
+  get schedulerEmptyPreview(): Locator {
+    return this.page.locator('[data-testid="flashcards-scheduler-empty-preview"]');
+  }
+
   get templatesCreateButton(): Locator {
     return this.page.getByRole('button', { name: /create template/i });
   }
@@ -541,7 +549,7 @@ export class FlashcardsPage extends BasePage {
   }
 
   get editDrawer(): Locator {
-    return this.page.getByRole('dialog', { name: 'Edit Flashcard' }).last();
+    return this.page.getByRole('dialog', { name: 'Edit Card' }).last();
   }
 
   get editDrawerAdditionalFieldsToggle(): Locator {
@@ -651,16 +659,20 @@ export class FlashcardsPage extends BasePage {
   }
 
   getActiveSelectOption(optionName: string, exact = false): Locator {
+    const optionText = exact
+      ? new RegExp(`^\\s*${escapeRegExp(optionName)}\\s*$`)
+      : optionName;
+
     return this.page
-      .locator('.ant-select-dropdown')
-      .filter({ has: this.page.getByRole('option', { name: optionName, exact }) })
-      .locator('[role="option"]')
-      .filter({ hasText: optionName })
-      .first();
+      .locator('.ant-select-item-option-content')
+      .filter({ hasText: optionText })
+      .last();
   }
 
   async selectManageDeckByName(deckName: string): Promise<void> {
     await this.manageDeckSelect.click({ force: true });
+    const selectedDeck = this.manageDeckSelect.getByText(deckName, { exact: true });
+    if (await selectedDeck.isVisible().catch(() => false)) return;
     const deckOption = this.getActiveSelectOption(deckName);
     await expect(deckOption).toBeVisible({ timeout: 10_000 });
     await deckOption.click();
@@ -687,10 +699,19 @@ export class FlashcardsPage extends BasePage {
   }
 
   async selectCreateDrawerDeckByName(deckName: string): Promise<void> {
+    const selectedDeck = this.createDrawerDeckSelect.getByText(deckName, { exact: true });
+    if (await selectedDeck.isVisible().catch(() => false)) return;
+    await this.createDrawerDeckSelect.scrollIntoViewIfNeeded();
     await this.createDrawerDeckSelect.click({ force: true });
     const deckOption = this.getActiveSelectOption(deckName);
     await expect(deckOption).toBeVisible({ timeout: 10_000 });
     await deckOption.click();
+  }
+
+  async selectVisibleDropdownOption(optionName: string): Promise<void> {
+    const option = this.getActiveSelectOption(optionName, true);
+    await expect(option).toBeVisible({ timeout: 10_000 });
+    await option.click();
   }
 
   async selectImportFormat(formatLabel: string): Promise<void> {
@@ -724,7 +745,12 @@ export class FlashcardsPage extends BasePage {
   }
 
   async openManageFlashcardEdit(cardUuid: string): Promise<void> {
-    await this.getManageFlashcardEditButton(cardUuid).click({ force: true });
+    const editButton = this.getManageFlashcardEditButton(cardUuid);
+    await editButton.scrollIntoViewIfNeeded();
+    await editButton.click();
+    if (await this.editDrawer.isVisible({ timeout: 1_000 }).catch(() => false)) return;
+    await this.getManageFlashcardRow(cardUuid).click();
+    await this.page.keyboard.press('Enter');
   }
 
   // -- Tab Navigation --------------------------------------------------------

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
@@ -163,8 +163,9 @@ async function skipIfFlashcardsBackendUnavailable(
 test.describe('Flashcards', () => {
   let flashcards: FlashcardsPage;
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, request }, testInfo) => {
     await seedAuth(page);
+    await cleanupFlashcardsRunRecords(request, flashcardsRunIdForTest(testInfo));
     flashcards = new FlashcardsPage(page);
   });
 
@@ -236,7 +237,21 @@ test.describe('Flashcards', () => {
         } else if (tab === 'templates') {
           await expect(flashcards.templatesTab).toHaveAttribute('aria-selected', 'true');
         } else if (tab === 'scheduler') {
-          await expect(authedPage.getByPlaceholder('Search decks')).toBeVisible({ timeout: 10_000 });
+          await expect
+            .poll(
+              async () => {
+                const searchVisible = await authedPage
+                  .getByPlaceholder('Search decks')
+                  .isVisible()
+                  .catch(() => false);
+                const emptyPreviewVisible = await flashcards.schedulerEmptyPreview
+                  .isVisible()
+                  .catch(() => false);
+                return searchVisible || emptyPreviewVisible;
+              },
+              { timeout: 10_000 }
+            )
+            .toBe(true);
         } else if (tab === 'transfer') {
           await expect(flashcards.transferTaskSwitcher).toBeVisible({ timeout: 10_000 });
         } else {
@@ -304,7 +319,8 @@ test.describe('Flashcards', () => {
       expect(await flashcards.isOnline()).toBe(true);
       await expect(flashcards.studyTab).toHaveAttribute('aria-selected', 'true');
       await expect(flashcards.transferTab).toBeVisible();
-      await expect(flashcards.schedulerTab).toHaveCount(0);
+      await expect(flashcards.schedulerTab).toBeVisible();
+      await expect(flashcards.schedulerTab).not.toHaveAttribute('aria-selected', 'true');
       await expect(flashcards.tabsContainer.getByText('LLM', { exact: true })).toHaveCount(0);
       await expect(authedPage.locator('[data-testid="flashcards-review-onboarding-guide"]')).toBeVisible({
         timeout: 10_000,
@@ -776,12 +792,7 @@ test.describe('Flashcards', () => {
       await expect(flashcards.createTagPickerSearchInput).toBeVisible({ timeout: 10_000 });
       await flashcards.createTagPickerSearchInput.fill(createSuggestionTag);
 
-      const createTagOption = authedPage.getByRole('option', {
-        name: createSuggestionTag,
-        exact: true,
-      });
-      await expect(createTagOption).toBeVisible({ timeout: 10_000 });
-      await createTagOption.click();
+      await flashcards.selectVisibleDropdownOption(createSuggestionTag);
       await expect(flashcards.createTagPicker).toContainText(createSuggestionTag);
 
       await authedPage.getByPlaceholder('Question or prompt...').fill(`${seed.runId} created via UI`);
@@ -805,7 +816,7 @@ test.describe('Flashcards', () => {
       });
       await flashcards.openManageFlashcardEdit(knownCard.uuid);
 
-      await expect(authedPage.getByText('Edit Flashcard')).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.editDrawer).toBeVisible({ timeout: 10_000 });
       await flashcards.editDrawerAdditionalFieldsToggle.click();
       await expect(flashcards.editTagPicker).toBeVisible({ timeout: 10_000 });
 
@@ -813,12 +824,7 @@ test.describe('Flashcards', () => {
       await expect(flashcards.editTagPickerSearchInput).toBeVisible({ timeout: 10_000 });
       await flashcards.editTagPickerSearchInput.fill(editSuggestionTag);
 
-      const editTagOption = authedPage.getByRole('option', {
-        name: editSuggestionTag,
-        exact: true,
-      });
-      await expect(editTagOption).toBeVisible({ timeout: 10_000 });
-      await editTagOption.click();
+      await flashcards.selectVisibleDropdownOption(editSuggestionTag);
       await expect(flashcards.editTagPicker).toContainText(editSuggestionTag);
 
       const updateResponsePromise = authedPage.waitForResponse((response) => {
@@ -840,7 +846,7 @@ test.describe('Flashcards', () => {
       });
 
       await flashcards.openManageFlashcardEdit(knownCard.uuid);
-      await expect(authedPage.getByText('Edit Flashcard')).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.editDrawer).toBeVisible({ timeout: 10_000 });
       await flashcards.editDrawerAdditionalFieldsToggle.click();
       await expect(flashcards.editTagPicker).toBeVisible({ timeout: 10_000 });
       await expect(flashcards.editTagPicker).toContainText(editSuggestionTag);

--- a/backlog/tasks/task-12903 - Full-notes-page-UAT-and-root-cause-fixes.md
+++ b/backlog/tasks/task-12903 - Full-notes-page-UAT-and-root-cause-fixes.md
@@ -1,0 +1,71 @@
+---
+id: TASK-12903
+title: Full notes page UAT and root-cause fixes
+status: Done
+labels:
+- uat
+- webui
+- notes
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run full UAT on the WebUI notes page against the live backend, identify user-facing functional/visual issues, and patch root causes with focused regression coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-07-06-notes-page-uat-fixes-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created isolated worktree .worktrees/codex-notes-page-uat-fixes from origin/main for UAT and patches.
+
+Live UAT setup:
+- Backend: FastAPI on `127.0.0.1:8000` using temporary UAT profile and live llama.cpp-compatible server at `127.0.0.1:9099`.
+- WebUI: Next dev server on `http://localhost:8080`, advanced mode with live API URL/key.
+- No mock backend used.
+
+Confirmed root cause:
+- Notes first-visit Joyride tour auto-started while users/tests were already in the delete flow. The Joyride overlay sat above Ant Design dropdown/menu/modal surfaces and intercepted clicks on More Actions -> Delete and the delete confirmation.
+- The desktop `Create study pack` action was absolutely positioned at the notes page level, so it could float over the editor header instead of participating in the toolbar layout.
+
+Patch:
+- The first-visit notes tutorial no longer auto-starts after the user has already interacted with the page; the page marks the prompt as seen and cancels the pending timer.
+- Notes confirmation calls now close any active tutorial before showing blocking dialogs.
+- Notes editor overflow trigger closes any active tutorial before opening the menu.
+- Shared confirm-danger wrapper now uses AntD 6 `focusable.autoFocusButton`, removing the console warning from notes confirm dialogs.
+- The `Create study pack` action now lives inside the editor header action row using the existing header props, eliminating the desktop overlap while preserving mobile behavior.
+
+Verification:
+- `bunx vitest run src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability-followup.test.tsx src/components/Notes/__tests__/NotesManagerPage.stage20.accessibility-shortcuts.test.tsx src/components/Notes/__tests__/NotesManagerPage.stage23.responsive-layout.test.tsx src/components/Notes/__tests__/NotesManagerPage.stage33.link-aware-delete-warning.test.tsx src/components/Notes/__tests__/NotesEditorHeader.stage2.touch-layout.test.tsx` passed 22/22.
+- Live `npx playwright test e2e/workflows/tier-1-critical/notes.spec.ts --reporter=line` passed 4/4 against `127.0.0.1:8000` and `http://localhost:8080`.
+- Live `/private/tmp/notes-uat-sweep.mjs` passed 16/16 against `http://localhost:8080` with no failing API events or console events.
+- Screenshot evidence saved outside the repo at `/private/tmp/notes-uat-sweep-shots-final-4`.
+- Bandit skipped because only TypeScript/TSX frontend files were touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the notes-page guided-tour overlay so automatic first-visit tutorial startup cannot interrupt active work, active tours are closed before overflow/destructive confirmation flows, and the desktop study-pack action no longer overlaps the editor header. Verified the notes page against the live backend with create/save/search/select, editor modes, formatting, keyboard shortcut save, shortcut help, pinning, view switches, tag filter, trash delete/restore, export menu, AI title suggestion endpoint, enabled assist controls, and mobile browse drawer.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12904 - Full-UAT-for-Chatbooks-Flashcards-and-Quizzes-WebUI-pages.md
+++ b/backlog/tasks/task-12904 - Full-UAT-for-Chatbooks-Flashcards-and-Quizzes-WebUI-pages.md
@@ -49,6 +49,8 @@ Confirmed root causes and fixes:
 - Flashcards create drawer ignored the active Manage deck filter; it now preselects that deck.
 - Flashcards `Test with Quiz` only honored quiz handoff context; it now enables when a review deck is selected.
 - Flashcards edit E2E targeted stale dialog text; updated the page object to the current `Edit Card` drawer and hardened the edit trigger.
+- PR review follow-up: SQLite FTS normalization now keeps explicit quoted column phrases intact, treats unquoted `field:value` text as a literal to avoid invalid-table-column 500s in Flashcards, and converts mixed negative terms to valid FTS5 `NOT` operands.
+- PR review follow-up: Flashcards edit pointerdown now only stops row propagation; click remains the only edit action trigger, preventing double `onEdit()` calls.
 
 Verification:
 - Live tier-2 UAT passed 32/32 for Chatbooks, Flashcards, and Quizzes against the live backend.
@@ -57,6 +59,7 @@ Verification:
 - Focused backend regression suite passed 4/4.
 - `git diff --check` passed.
 - Bandit found no issues in the touched implementation file. A full touched Python scan only reported `B101` pytest asserts in test files; the non-assert scan passed with `-s B101`.
+- PR review follow-up focused checks passed: backend FTS/Flashcards/ResourceGovernor regressions 6/6, Flashcards UI Vitest 54/54, `git diff --check`, and Bandit with pytest asserts excluded.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12904 - Full-UAT-for-Chatbooks-Flashcards-and-Quizzes-WebUI-pages.md
+++ b/backlog/tasks/task-12904 - Full-UAT-for-Chatbooks-Flashcards-and-Quizzes-WebUI-pages.md
@@ -51,6 +51,8 @@ Confirmed root causes and fixes:
 - Flashcards edit E2E targeted stale dialog text; updated the page object to the current `Edit Card` drawer and hardened the edit trigger.
 - PR review follow-up: SQLite FTS normalization now keeps explicit quoted column phrases intact, treats unquoted `field:value` text as a literal to avoid invalid-table-column 500s in Flashcards, and converts mixed negative terms to valid FTS5 `NOT` operands.
 - PR review follow-up: Flashcards edit pointerdown now only stops row propagation; click remains the only edit action trigger, preventing double `onEdit()` calls.
+- PR review follow-up: CodeRabbit items addressed by extracting Flashcards Manage expert filters into `ManageExpertFilters`, preventing an already-selected Manage deck dropdown from staying open in E2E helpers, and making Flashcards/Quizzes ResourceGovernor policies use `fallback_memory`.
+- PR review follow-up: CodeRabbit's FTS hyphen comment was verified against `9368cde2` and was already addressed by the prior negative-token fix and regression coverage.
 
 Verification:
 - Live tier-2 UAT passed 32/32 for Chatbooks, Flashcards, and Quizzes against the live backend.
@@ -60,6 +62,7 @@ Verification:
 - `git diff --check` passed.
 - Bandit found no issues in the touched implementation file. A full touched Python scan only reported `B101` pytest asserts in test files; the non-assert scan passed with `-s B101`.
 - PR review follow-up focused checks passed: backend FTS/Flashcards/ResourceGovernor regressions 6/6, Flashcards UI Vitest 54/54, `git diff --check`, and Bandit with pytest asserts excluded.
+- CodeRabbit follow-up focused checks passed: Flashcards UI Vitest 54/54, backend FTS/Flashcards/ResourceGovernor regressions 6/6, and frontend `bun run typecheck`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12904 - Full-UAT-for-Chatbooks-Flashcards-and-Quizzes-WebUI-pages.md
+++ b/backlog/tasks/task-12904 - Full-UAT-for-Chatbooks-Flashcards-and-Quizzes-WebUI-pages.md
@@ -1,0 +1,76 @@
+---
+id: TASK-12904
+title: Full UAT for Chatbooks Flashcards and Quizzes WebUI pages
+status: Done
+labels:
+- uat
+- webui
+- chatbooks
+- flashcards
+- quizzes
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run live-backend UAT for the Chatbooks, Flashcards, and Quizzes WebUI pages, patch root causes of user-facing issues found, and prepare a PR against dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Live backend UAT completed for Chatbooks, Flashcards, and Quizzes without mock backends.
+- [x] llama.cpp-compatible server at `127.0.0.1:9099` was verified and used in the UAT environment.
+- [x] Reproducible user-facing issues were patched at the root cause.
+- [x] Focused regression coverage was added or updated for each patchable issue.
+- [x] PR prepared against `dev`.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-07-06-chatbooks-flashcards-quizzes-uat-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Live UAT setup:
+- Backend: FastAPI on `127.0.0.1:8000` using the UAT environment configured with the live llama.cpp-compatible server at `127.0.0.1:9099`.
+- Egress: `WORKFLOWS_EGRESS_ALLOWED_PORTS=80,443,9099`.
+- WebUI: Next dev server on `http://localhost:8080`, advanced mode with live API URL/key.
+- No mock backend used.
+
+Confirmed root causes and fixes:
+- Chatbooks import page object used stale dropzone copy; updated it to the rendered `.zip or .chatbook archive` text.
+- SQLite FTS search treated punctuation-heavy user text as operators/columns; added SQLite token normalization/quoting for literal user terms while preserving valid operators.
+- ResourceGovernor mapped Flashcards and Quizzes traffic into `core.default`; added scoped `health.default`, `flashcards.default`, and `quizzes.default` policies plus route-map coverage.
+- Flashcards Manage first-entry state hid primary search/deck controls; kept those controls visible while still hiding advanced filter chrome until useful.
+- Flashcards create drawer ignored the active Manage deck filter; it now preselects that deck.
+- Flashcards `Test with Quiz` only honored quiz handoff context; it now enables when a review deck is selected.
+- Flashcards edit E2E targeted stale dialog text; updated the page object to the current `Edit Card` drawer and hardened the edit trigger.
+
+Verification:
+- Live tier-2 UAT passed 32/32 for Chatbooks, Flashcards, and Quizzes against the live backend.
+- Screenshot smoke evidence saved outside the repo at `/private/tmp/tldw-study-pages-uat-shots-20260706` for desktop and mobile Chatbooks, Flashcards, and Quiz pages.
+- Focused UI regression suite passed 61/61.
+- Focused backend regression suite passed 4/4.
+- `git diff --check` passed.
+- Bandit found no issues in the touched implementation file. A full touched Python scan only reported `B101` pytest asserts in test files; the non-assert scan passed with `-s B101`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed live WebUI UAT for Chatbooks, Flashcards, and Quizzes using the real backend and llama.cpp server, then patched the confirmed user-facing issues in import locators, SQLite FTS search, ResourceGovernor route policy, Flashcards first-entry controls, deck-scoped creation, quiz handoff enablement, and edit-flow test targeting.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/resource_governor_policies.yaml
+++ b/tldw_Server_API/Config_Files/resource_governor_policies.yaml
@@ -252,10 +252,12 @@ policies:
   flashcards.default:
     requests: { rpm: 600, burst: 1.2 }
     scopes: [user, api_key, ip]
+    fail_mode: fallback_memory
 
   quizzes.default:
     requests: { rpm: 600, burst: 1.2 }
     scopes: [user, api_key, ip]
+    fail_mode: fallback_memory
 
   # Chatbooks import/export endpoints (legacy ingress compat → RG).
   # Covers `/api/v1/chatbooks/*` used for conversation backup/restore and bulk

--- a/tldw_Server_API/Config_Files/resource_governor_policies.yaml
+++ b/tldw_Server_API/Config_Files/resource_governor_policies.yaml
@@ -37,6 +37,13 @@ policies:
   # Core defaults for endpoints without explicit module-level policies.
   core.default: *core_policy
 
+  # Cheap health/readiness probes should not spend the same bucket as
+  # interactive app routes. The WebUI polls these while users work.
+  health.default:
+    requests: { rpm: 6000, burst: 1.0 }
+    scopes: [global, ip]
+    fail_mode: fallback_memory
+
   # Chat API: per-user and per-conversation controls
   chat.default:
     requests: { rpm: 120, burst: 2.0 }
@@ -239,6 +246,17 @@ policies:
     requests: { rpm: 6000, burst: 1.2 }
     scopes: [user, api_key]
 
+  # Interactive study tools make several lightweight reads while the user
+  # navigates decks, reviews cards, and searches content. Keep these separate
+  # from core.default so page boot traffic cannot block a review or quiz action.
+  flashcards.default:
+    requests: { rpm: 600, burst: 1.2 }
+    scopes: [user, api_key, ip]
+
+  quizzes.default:
+    requests: { rpm: 600, burst: 1.2 }
+    scopes: [user, api_key, ip]
+
   # Chatbooks import/export endpoints (legacy ingress compat → RG).
   # Covers `/api/v1/chatbooks/*` used for conversation backup/restore and bulk
   # user-data transfer (export/import). Limits are intentionally conservative
@@ -275,7 +293,7 @@ policies:
 # Route/tag mapping helpers. Middleware may use these to resolve policy_id.
 route_map:
   by_tag:
-    health: core.default
+    health: health.default
     authentication: authnz.default
     auth: authnz.default
     users: core.default
@@ -293,8 +311,8 @@ route_map:
     reading-highlights: core.default
     items: core.default
     kanban: core.default
-    flashcards: core.default
-    quizzes: core.default
+    flashcards: flashcards.default
+    quizzes: quizzes.default
     moderation: core.default
     authnz-debug: core.default
     sandbox: core.default
@@ -355,15 +373,15 @@ route_map:
     watchlists: watchlists.default
     resource-governor: core.default
   by_path:
-    "/health": core.default
-    "/healthz": core.default
-    "/readyz": core.default
+    "/health": health.default
+    "/healthz": health.default
+    "/readyz": health.default
     "/metrics": core.default
     "/setup*": core.default
     "/v1/rerank": core.default
     "/v1/reranking": core.default
-    "/api/v1/health*": core.default
-    "/api/v1/readyz": core.default
+    "/api/v1/health*": health.default
+    "/api/v1/readyz": health.default
     "/api/v1/metrics*": core.default
     "/api/v1/monitoring*": core.default
     "/api/v1/setup*": core.default
@@ -447,8 +465,8 @@ route_map:
     "/api/v1/vlm*": core.default
     "/api/v1/llm*": core.default
     "/api/v1/llamacpp*": core.default
-    "/api/v1/flashcards*": core.default
-    "/api/v1/quizzes*": core.default
+    "/api/v1/flashcards*": flashcards.default
+    "/api/v1/quizzes*": quizzes.default
     "/api/v1/chunking*": core.default
     "/api/v1/resource-governor*": core.default
 

--- a/tldw_Server_API/app/core/DB_Management/backends/fts_translator.py
+++ b/tldw_Server_API/app/core/DB_Management/backends/fts_translator.py
@@ -12,6 +12,9 @@ from typing import Optional
 from loguru import logger
 
 MAX_FTS_QUERY_LENGTH = 8192
+SQLITE_FTS_OPERATOR_TOKENS = {'AND', 'OR', 'NEAR', 'NOT'}
+SQLITE_FTS_SAFE_TOKEN_RE = re.compile(r'^[A-Za-z0-9_]+\*?$')
+SQLITE_FTS_COLUMN_TOKEN_RE = re.compile(r'^([A-Za-z_][A-Za-z0-9_]*):(.*)$')
 
 
 class FTSQueryTranslator:
@@ -177,6 +180,43 @@ class FTSQueryTranslator:
         return query
 
     @staticmethod
+    def _quote_sqlite_fts_token(token: str) -> str:
+        """Quote FTS5 tokens that contain punctuation with query semantics."""
+        if not token or SQLITE_FTS_SAFE_TOKEN_RE.fullmatch(token):
+            return token
+
+        suffix = '*' if token.endswith('*') and len(token) > 1 else ''
+        token_body = token[:-1] if suffix else token
+        escaped = token_body.replace('"', '""')
+        return f'"{escaped}"{suffix}'
+
+    @staticmethod
+    def _normalize_sqlite_query(query: str) -> str:
+        """Protect plain text SQLite FTS5 searches from punctuation parsing."""
+        parts = re.findall(r'"[^"]*"|\S+', query)
+        normalized_parts = []
+
+        for part in parts:
+            upper = part.upper()
+            if upper in SQLITE_FTS_OPERATOR_TOKENS or part.startswith('"') and part.endswith('"'):
+                normalized_parts.append(part)
+                continue
+
+            if part.startswith('-'):
+                normalized_parts.append(part)
+                continue
+
+            column_match = SQLITE_FTS_COLUMN_TOKEN_RE.fullmatch(part)
+            if column_match and column_match.group(2):
+                column, value = column_match.groups()
+                normalized_parts.append(f'{column}:{FTSQueryTranslator._quote_sqlite_fts_token(value)}')
+                continue
+
+            normalized_parts.append(FTSQueryTranslator._quote_sqlite_fts_token(part))
+
+        return ' '.join(normalized_parts)
+
+    @staticmethod
     def normalize_query(query: str, backend: str) -> str:
         """
         Normalize a query for a specific backend.
@@ -210,8 +250,8 @@ class FTSQueryTranslator:
 
         elif backend == 'sqlite':
             if is_postgres and not is_sqlite:
-                return FTSQueryTranslator.postgres_to_sqlite(query)
-            return query
+                query = FTSQueryTranslator.postgres_to_sqlite(query)
+            return FTSQueryTranslator._normalize_sqlite_query(query)
 
         return query
 

--- a/tldw_Server_API/app/core/DB_Management/backends/fts_translator.py
+++ b/tldw_Server_API/app/core/DB_Management/backends/fts_translator.py
@@ -15,6 +15,9 @@ MAX_FTS_QUERY_LENGTH = 8192
 SQLITE_FTS_OPERATOR_TOKENS = {'AND', 'OR', 'NEAR', 'NOT'}
 SQLITE_FTS_SAFE_TOKEN_RE = re.compile(r'^[A-Za-z0-9_]+\*?$')
 SQLITE_FTS_COLUMN_TOKEN_RE = re.compile(r'^([A-Za-z_][A-Za-z0-9_]*):(.*)$')
+SQLITE_FTS_TOKEN_RE = re.compile(
+    r'-?[A-Za-z_][A-Za-z0-9_]*:"[^"]*"|-?"[^"]*"|\S+'
+)
 
 
 class FTSQueryTranslator:
@@ -193,26 +196,53 @@ class FTSQueryTranslator:
     @staticmethod
     def _normalize_sqlite_query(query: str) -> str:
         """Protect plain text SQLite FTS5 searches from punctuation parsing."""
-        parts = re.findall(r'"[^"]*"|\S+', query)
+        parts = SQLITE_FTS_TOKEN_RE.findall(query)
         normalized_parts = []
+        last_allows_not = False
 
         for part in parts:
             upper = part.upper()
             if upper in SQLITE_FTS_OPERATOR_TOKENS or part.startswith('"') and part.endswith('"'):
                 normalized_parts.append(part)
+                last_allows_not = upper not in SQLITE_FTS_OPERATOR_TOKENS
                 continue
 
-            if part.startswith('-'):
-                normalized_parts.append(part)
+            if part.startswith('-') and len(part) > 1:
+                body = part[1:]
+                column_match = SQLITE_FTS_COLUMN_TOKEN_RE.fullmatch(body)
+                if (
+                    column_match
+                    and column_match.group(2).startswith('"')
+                    and column_match.group(2).endswith('"')
+                ):
+                    column, value = column_match.groups()
+                    operand = f'{column}:{value}'
+                elif body.startswith('"') and body.endswith('"'):
+                    operand = body
+                elif last_allows_not:
+                    operand = FTSQueryTranslator._quote_sqlite_fts_token(body)
+                else:
+                    operand = FTSQueryTranslator._quote_sqlite_fts_token(part)
+                if last_allows_not:
+                    normalized_parts.extend(['NOT', operand])
+                else:
+                    normalized_parts.append(operand)
+                last_allows_not = True
                 continue
 
             column_match = SQLITE_FTS_COLUMN_TOKEN_RE.fullmatch(part)
-            if column_match and column_match.group(2):
+            if (
+                column_match
+                and column_match.group(2).startswith('"')
+                and column_match.group(2).endswith('"')
+            ):
                 column, value = column_match.groups()
-                normalized_parts.append(f'{column}:{FTSQueryTranslator._quote_sqlite_fts_token(value)}')
+                normalized_parts.append(f'{column}:{value}')
+                last_allows_not = True
                 continue
 
             normalized_parts.append(FTSQueryTranslator._quote_sqlite_fts_token(part))
+            last_allows_not = True
 
         return ' '.join(normalized_parts)
 

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_db_assets.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_db_assets.py
@@ -137,3 +137,20 @@ def test_list_flashcards_search_matches_sanitized_alt_text(chacha_db):
 
     assert total == 1
     assert [row["uuid"] for row in results] == [card_uuid]
+
+
+def test_list_flashcards_search_accepts_hyphenated_plain_text(chacha_db):
+    card_uuid = chacha_db.add_flashcard(
+        {
+            "front": "codex-flashcards-ux front",
+            "back": "Regression coverage for FTS5 punctuation handling",
+            "notes": "",
+            "extra": "",
+        }
+    )
+
+    results = chacha_db.list_flashcards(q="codex-flashcards-ux")
+    total = chacha_db.count_flashcards(q="codex-flashcards-ux")
+
+    assert total == 1
+    assert [row["uuid"] for row in results] == [card_uuid]

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_db_assets.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_db_assets.py
@@ -154,3 +154,28 @@ def test_list_flashcards_search_accepts_hyphenated_plain_text(chacha_db):
 
     assert total == 1
     assert [row["uuid"] for row in results] == [card_uuid]
+
+
+def test_list_flashcards_search_accepts_negative_hyphenated_terms(chacha_db):
+    keep_uuid = chacha_db.add_flashcard(
+        {
+            "front": "codex-flashcards-ux clean",
+            "back": "",
+            "notes": "",
+            "extra": "",
+        }
+    )
+    chacha_db.add_flashcard(
+        {
+            "front": "codex-flashcards-ux state-of-the-art",
+            "back": "",
+            "notes": "",
+            "extra": "",
+        }
+    )
+
+    results = chacha_db.list_flashcards(q="codex-flashcards-ux -state-of-the-art")
+
+    assert [row["uuid"] for row in results] == [keep_uuid]
+
+    assert isinstance(chacha_db.list_flashcards(q="codex-flashcards-ux -front:state-of-the-art"), list)

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_fts_query_translation_edge_cases.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_fts_query_translation_edge_cases.py
@@ -82,4 +82,22 @@ def test_sqlite_normalization_quotes_plain_tokens_with_punctuation():
         "sqlite",
     )
 
-    assert out == '"codex-flashcards-ux" front:"state-of-the-art"'
+    assert out == '"codex-flashcards-ux" "front:state-of-the-art"'
+
+
+def test_sqlite_normalization_preserves_quoted_column_phrases_and_quotes_negative_terms():
+    from tldw_Server_API.app.core.DB_Management.backends.fts_translator import FTSQueryTranslator
+
+    out = FTSQueryTranslator.normalize_query(
+        'front:"two words" front:"already-quoted" front:"state of the art" '
+        '-state-of-the-art -back:old-style -"two words" -front:"old style"',
+        "sqlite",
+    )
+
+    assert (
+        out
+        == 'front:"two words" front:"already-quoted" front:"state of the art" '
+        'NOT "state-of-the-art" NOT "back:old-style" NOT "two words" NOT front:"old style"'
+    )
+
+    assert FTSQueryTranslator.normalize_query("-state-of-the-art", "sqlite") == '"-state-of-the-art"'

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_fts_query_translation_edge_cases.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_fts_query_translation_edge_cases.py
@@ -72,3 +72,14 @@ def test_postgres_to_sqlite_truncates_long_input():
     long_query = "a" * (MAX_FTS_QUERY_LENGTH + 50)
     out = FTSQueryTranslator.postgres_to_sqlite(long_query)
     assert len(out) == MAX_FTS_QUERY_LENGTH
+
+
+def test_sqlite_normalization_quotes_plain_tokens_with_punctuation():
+    from tldw_Server_API.app.core.DB_Management.backends.fts_translator import FTSQueryTranslator
+
+    out = FTSQueryTranslator.normalize_query(
+        "codex-flashcards-ux front:state-of-the-art",
+        "sqlite",
+    )
+
+    assert out == '"codex-flashcards-ux" front:"state-of-the-art"'

--- a/tldw_Server_API/tests/Resource_Governance/test_policy_loader_route_map_db_store.py
+++ b/tldw_Server_API/tests/Resource_Governance/test_policy_loader_route_map_db_store.py
@@ -26,5 +26,11 @@ async def test_db_policy_loader_includes_route_map_from_file(monkeypatch):
     assert isinstance(snap.route_map, dict) and snap.route_map
     assert "by_tag" in snap.route_map
     assert snap.route_map["by_tag"].get("chat") == "chat.default"
+    assert snap.route_map["by_tag"].get("health") == "health.default"
+    assert snap.route_map["by_tag"].get("flashcards") == "flashcards.default"
+    assert snap.route_map["by_tag"].get("quizzes") == "quizzes.default"
     assert snap.route_map.get("by_path", {}).get("/api/v1/chatbooks/export") == "chatbooks.export"
+    assert snap.route_map.get("by_path", {}).get("/api/v1/health*") == "health.default"
+    assert snap.route_map.get("by_path", {}).get("/api/v1/flashcards*") == "flashcards.default"
+    assert snap.route_map.get("by_path", {}).get("/api/v1/quizzes*") == "quizzes.default"
     assert snap.route_map.get("by_path", {}).get("/api/v1/watchlists/*") == "watchlists.default"

--- a/tldw_Server_API/tests/Resource_Governance/test_slowapi_decorated_routes_mapped.py
+++ b/tldw_Server_API/tests/Resource_Governance/test_slowapi_decorated_routes_mapped.py
@@ -36,6 +36,8 @@ async def test_rg_route_map_covers_rate_limited_paths():
     await loader.load_once()
     snap = loader.get_snapshot()
     by_path = dict((snap.route_map or {}).get("by_path") or {})
+    assert loader.get_policy("flashcards.default")["fail_mode"] == "fallback_memory"
+    assert loader.get_policy("quizzes.default")["fail_mode"] == "fallback_memory"
 
     # Minimal representative set of ingress-limited routes:
     # - audio.py (multiple endpoints) -> /api/v1/audio/*

--- a/tldw_Server_API/tests/Resource_Governance/test_slowapi_decorated_routes_mapped.py
+++ b/tldw_Server_API/tests/Resource_Governance/test_slowapi_decorated_routes_mapped.py
@@ -44,6 +44,9 @@ async def test_rg_route_map_covers_rate_limited_paths():
     decorated_paths = [
         "/api/v1/audio/speech",
         "/api/v1/audio/transcriptions",
+        "/api/v1/health",
+        "/api/v1/flashcards/review",
+        "/api/v1/quizzes",
         "/api/v1/chatbooks/export",
         "/api/v1/chatbooks/import",
         "/api/v1/chatbooks/preview",


### PR DESCRIPTION
## Summary
- Fixed notes-page guided-tour/confirmation overlap and moved the desktop study-pack action into the editor header action row.
- Fixed Chatbooks/Flashcards/Quiz UAT issues: stale Chatbooks import locator, SQLite FTS punctuation searches, ResourceGovernor route policies, Flashcards first-entry/deck-create/quiz-handoff/edit-flow behavior.
- Addressed review feedback by hardening SQLite FTS negative/quoted-token handling, preventing duplicate edit invocation, extracting Flashcards Manage expert filters, stabilizing deck dropdown page-object behavior, and setting Flashcards/Quizzes ResourceGovernor policies to `fallback_memory`.
- Added Backlog.md task records and implementation plans for the UAT work.

## Change Summary
- AI-authored draft: the human requester must replace or confirm this section in their own words before merge to satisfy the repository AI-generated PR merge gate.
- The implementation keeps changes scoped to observed UAT failures and review feedback: UI fixes are localized to affected page flows and backend fixes are limited to SQLite FTS normalization plus ResourceGovernor policy routing.

## Live UAT
- No mock backend used.
- Backend ran at `127.0.0.1:8000` with llama.cpp-compatible server verified at `127.0.0.1:9099`.
- Egress configured with `WORKFLOWS_EGRESS_ALLOWED_PORTS=80,443,9099`.
- Screenshot smoke evidence saved outside the repo at `/private/tmp/tldw-study-pages-uat-shots-20260706`.

## Verification
- `TLDW_WEB_AUTOSTART=false TLDW_WEB_URL=http://localhost:8080 TLDW_E2E_SERVER_URL=127.0.0.1:8000 TLDW_E2E_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY npx playwright test e2e/workflows/tier-2-features/chatbooks.spec.ts e2e/workflows/tier-2-features/flashcards.spec.ts e2e/workflows/tier-2-features/quiz.spec.ts --reporter=line --workers=1`: 32 passed.
- Focused Flashcards/Notes Vitest suites: 61 passed.
- Focused Flashcards/FTS/ResourceGovernor pytest suites: 4 passed.
- Review follow-up Flashcards Vitest suite: 54 passed.
- Review follow-up backend FTS/Flashcards/ResourceGovernor pytest suite: 6 passed.
- `bun run typecheck` in `apps/tldw-frontend`: passed.
- `git diff --check`: passed.
- Bandit touched Python scope with `-s B101`: passed.

## Risk & Rollback
- Risk is limited to Notes tutorial timing, Flashcards Manage filtering/edit controls, Chatbooks/Flashcards E2E page objects, SQLite FTS query normalization, and ResourceGovernor policy selection for health/flashcards/quizzes.
- No database migrations or irreversible data changes are included.
- Rollback is a normal revert of this PR. If only the backend search behavior regresses, revert the `fts_translator.py` and related test changes; if only throttling behavior regresses, revert the ResourceGovernor policy/route-map changes.

## Stage 5 / Watchlists Checklist
- Stage 5 release-gate impact: no new global navigation, auth, build, or deployment behavior is introduced.
- Watchlists impact: N/A; this PR does not modify Watchlists UI, API behavior, schedulers, or templates.
- Responsive/user-facing smoke impact: covered by live UAT screenshots and focused UI tests for the affected Notes/Flashcards/Chatbooks/Quizzes flows.

## Notes
- Browser plugin navigation to localhost was blocked by the in-app Browser policy, so standalone Playwright was used for browser UAT.
