### PR TITLE
Add explicit character emote directives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1185,6 +1185,7 @@ jobs:
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_cards_fts_bootstrap.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_default_provider.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_manager.py
+              tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_generation_presets.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_prompt_presets.py
@@ -2592,6 +2593,7 @@ jobs:
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_cards_fts_bootstrap.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_default_provider.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_manager.py
+              tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_generation_presets.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_prompt_presets.py
@@ -3870,6 +3872,7 @@ jobs:
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_cards_fts_bootstrap.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_default_provider.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_manager.py
+              tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_generation_presets.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_prompt_presets.py
@@ -5072,6 +5075,7 @@ jobs:
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_cards_fts_bootstrap.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_default_provider.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_manager.py
+              tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_generation_presets.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_prompt_presets.py
@@ -6275,6 +6279,7 @@ jobs:
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_cards_fts_bootstrap.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_default_provider.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_manager.py
+              tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_generation_presets.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py
               tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_prompt_presets.py

--- a/Docs/superpowers/plans/2026-07-06-character-chat-streaming-emote-directives-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-06-character-chat-streaming-emote-directives-implementation-plan.md
@@ -1,0 +1,954 @@
+# Character Chat Streaming Emote Directives Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement explicit `Emote: <state>` directives for character chat so portraits can change during streaming while visible and persisted chat text stays clean.
+
+**Architecture:** Add a small shared directive parser contract, then wire it into the existing character chat stream and persist paths. Frontend owns live streaming portrait changes; backend owns API validation and server-side non-streaming sanitization. Keep classifier mood detection as fallback only.
+
+**Tech Stack:** TypeScript, React, Vitest, FastAPI, Pydantic, pytest, existing `metadata_extra` message storage.
+
+---
+
+## Scope And Sequencing
+
+Implement `TASK-12163` only. `TASK-12164` is a follow-up and must not be pulled into this work.
+
+Use TDD. Each task should leave the repo in a working state and commit before moving on.
+
+## File Structure
+
+Create:
+
+- `apps/packages/ui/src/utils/character-emotes.ts`
+  - Frontend directive grammar, final parser, streaming parser, event cap, state normalization, metadata guards.
+- `apps/packages/ui/src/utils/__tests__/character-emotes.test.ts`
+  - TypeScript parser and shared-fixture coverage.
+- `apps/packages/ui/src/utils/__fixtures__/character-emote-directives.json`
+  - Shared parser vectors read by both TypeScript and Python tests.
+- `tldw_Server_API/app/core/Character_Chat/emote_directives.py`
+  - Backend final parser and event validation helpers.
+- `tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py`
+  - Python parser and shared-fixture coverage.
+
+Modify:
+
+- `apps/packages/ui/src/utils/character-mood.ts`
+  - Broaden mood image parsing/resolution to safe custom emote slugs while keeping `detectCharacterMood()` on built-in labels.
+- `apps/packages/ui/src/utils/__tests__/character-mood.test.ts`
+  - Add custom emote image cases.
+- `apps/packages/ui/src/store/option/types.ts`
+  - Add typed `emote_events` metadata shape.
+- `tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py`
+  - Add `CharacterEmoteEvent` model and optional `emote_events` to stream persist request/response path as needed.
+- `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
+  - Add prompt instruction, backend non-streaming sanitization, stream persist metadata storage, and idempotent side-effect handling.
+- `tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py`
+  - Add persist validation and metadata integration cases.
+- `apps/packages/ui/src/hooks/chat/useChatActions.ts`
+  - Apply streaming parser and explicit emote metadata in the primary WebUI character-chat path.
+- `apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts`
+  - Apply the same helper logic to the older/parallel character-chat hook.
+- `apps/packages/ui/src/hooks/useMessage.tsx`
+  - Apply the same helper logic to the legacy character-chat stream/persist path so sibling callers do not leak directives.
+- `apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx`
+  - Add streaming/persist tests for stripped directives and explicit mood override.
+- `apps/packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts`
+  - Add parity coverage for the older hook.
+- `apps/packages/ui/src/components/Common/Playground/Message.tsx`
+  - Stop narrowing explicit `moodLabel` to built-in classifier labels before portrait lookup; preserve custom explicit emote slugs.
+- `apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx`
+  - Add a minimal portrait resolution test for custom explicit emote slugs.
+
+Do not modify character editor mood-image management in this PR.
+
+## Task 1: Shared Directive Parser Contract
+
+**Files:**
+- Create: `apps/packages/ui/src/utils/__fixtures__/character-emote-directives.json`
+- Create: `apps/packages/ui/src/utils/character-emotes.ts`
+- Create: `apps/packages/ui/src/utils/__tests__/character-emotes.test.ts`
+- Create: `tldw_Server_API/app/core/Character_Chat/emote_directives.py`
+- Create: `tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py`
+
+- [ ] **Step 1: Write the shared fixture**
+
+Create `apps/packages/ui/src/utils/__fixtures__/character-emote-directives.json`:
+
+```json
+[
+  {
+    "name": "strips directives and records offsets",
+    "input": "Emote: annoyed\nWhat now?\n\nEmote: smug\nFine.",
+    "clean_text": "What now?\n\nFine.",
+    "events": [
+      { "state": "annoyed", "at_char": 0 },
+      { "state": "smug", "at_char": 11 }
+    ]
+  },
+  {
+    "name": "keeps inline prose visible",
+    "input": "She says Emote: smug and smiles.",
+    "clean_text": "She says Emote: smug and smiles.",
+    "events": []
+  },
+  {
+    "name": "keeps directives inside code fences visible",
+    "input": "```text\nEmote: smug\n```\nDone.",
+    "clean_text": "```text\nEmote: smug\n```\nDone.",
+    "events": []
+  },
+  {
+    "name": "strips invalid standalone directive",
+    "input": "Emote: ../../bad\nVisible.",
+    "clean_text": "Visible.",
+    "events": []
+  },
+  {
+    "name": "normalizes whitespace state",
+    "input": "  Emote: Thinking Hard  \nVisible.",
+    "clean_text": "Visible.",
+    "events": [{ "state": "thinking-hard", "at_char": 0 }]
+  },
+  {
+    "name": "drops duplicate consecutive state",
+    "input": "Emote: smug\nEmote: smug\nVisible.",
+    "clean_text": "Visible.",
+    "events": [{ "state": "smug", "at_char": 0 }]
+  }
+]
+```
+
+- [ ] **Step 2: Write failing TypeScript parser tests**
+
+Create `apps/packages/ui/src/utils/__tests__/character-emotes.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import fixtures from "../__fixtures__/character-emote-directives.json"
+import {
+  EMOTE_EVENT_LIMIT,
+  createCharacterEmoteStreamParser,
+  isValidCharacterEmoteEvent,
+  parseCharacterEmoteDirectives,
+  normalizeCharacterEmoteState
+} from "../character-emotes"
+
+describe("character emote directives", () => {
+  it.each(fixtures)("$name", (fixture) => {
+    expect(parseCharacterEmoteDirectives(fixture.input)).toEqual({
+      cleanText: fixture.clean_text,
+      events: fixture.events
+    })
+  })
+
+  it("uses exact slug normalization rules", () => {
+    expect(normalizeCharacterEmoteState(" Thinking Hard ")).toBe("thinking-hard")
+    expect(normalizeCharacterEmoteState("../../bad")).toBeNull()
+    expect(normalizeCharacterEmoteState("a".repeat(40))).toBe("a".repeat(40))
+    expect(normalizeCharacterEmoteState("a".repeat(41))).toBeNull()
+  })
+
+  it("caps accepted events but strips later directives", () => {
+    const input = Array.from({ length: EMOTE_EVENT_LIMIT + 2 }, (_, index) => `Emote: mood-${index}\n`).join("") + "Done."
+    const result = parseCharacterEmoteDirectives(input)
+    expect(result.cleanText).toBe("Done.")
+    expect(result.events).toHaveLength(EMOTE_EVENT_LIMIT)
+  })
+
+  it("does not leak split directives during streaming", () => {
+    const parser = createCharacterEmoteStreamParser()
+    expect(parser.push("Em")).toEqual({ visibleText: "", events: [] })
+    expect(parser.push("ote: smug\nHello")).toEqual({
+      visibleText: "Hello",
+      events: [{ state: "smug", at_char: 0 }]
+    })
+    expect(parser.flush()).toEqual({ visibleText: "", events: [] })
+  })
+
+  it("streams long non-directive text before newline", () => {
+    const parser = createCharacterEmoteStreamParser()
+    const result = parser.push("This is just normal text without a newline")
+    expect(result.visibleText).toContain("This is just normal text")
+  })
+
+  it("validates metadata event shape", () => {
+    expect(isValidCharacterEmoteEvent({ state: "smug", at_char: 0 })).toBe(true)
+    expect(isValidCharacterEmoteEvent({ state: "../../bad", at_char: 0 })).toBe(false)
+    expect(isValidCharacterEmoteEvent({ state: "smug", at_char: -1 })).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 3: Run TypeScript parser tests to verify failure**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/utils/__tests__/character-emotes.test.ts
+```
+
+Expected: FAIL because `character-emotes.ts` does not exist.
+
+- [ ] **Step 4: Implement frontend parser**
+
+Create `apps/packages/ui/src/utils/character-emotes.ts` with these public exports:
+
+```ts
+export const EMOTE_EVENT_LIMIT = 5
+export const CHARACTER_EMOTE_STATE_PATTERN = /^[a-z0-9][a-z0-9_-]{0,39}$/
+
+export type CharacterEmoteEvent = {
+  state: string
+  at_char: number
+}
+
+export type CharacterEmoteParseResult = {
+  cleanText: string
+  events: CharacterEmoteEvent[]
+}
+
+export const normalizeCharacterEmoteState = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const normalized = value.trim().toLowerCase().replace(/\s+/g, "-")
+  return CHARACTER_EMOTE_STATE_PATTERN.test(normalized) ? normalized : null
+}
+```
+
+Implementation rules:
+
+- Parse only standalone directive lines after trimming leading/trailing whitespace.
+- Strip invalid standalone directive lines.
+- Ignore directives inside fenced code blocks and keep them visible.
+- Track `at_char` as clean-text length before the directive.
+- Drop duplicate consecutive accepted states.
+- Cap accepted events at `EMOTE_EVENT_LIMIT`, but keep stripping later directives.
+- `createCharacterEmoteStreamParser()` should withhold only possible directive/fence prefixes and flush final unterminated text.
+
+- [ ] **Step 5: Run TypeScript parser tests to verify pass**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/utils/__tests__/character-emotes.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Write failing Python parser tests**
+
+Create `tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py`:
+
+```python
+import json
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Character_Chat.emote_directives import (
+    EMOTE_EVENT_LIMIT,
+    parse_character_emote_directives,
+    resolve_character_emote_completion,
+    validate_emote_events,
+)
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "apps/packages/ui/src/utils/__fixtures__/character-emote-directives.json"
+)
+
+
+@pytest.mark.unit
+def test_shared_character_emote_fixtures() -> None:
+    fixtures = json.loads(FIXTURE_PATH.read_text())
+    for fixture in fixtures:
+        result = parse_character_emote_directives(fixture["input"])
+        assert result.clean_text == fixture["clean_text"], fixture["name"]
+        assert [event.model_dump() for event in result.events] == fixture["events"], fixture["name"]
+
+
+@pytest.mark.unit
+def test_validate_emote_events_rejects_malformed_values() -> None:
+    assert validate_emote_events([{"state": "smug", "at_char": 0}])[0].state == "smug"
+    with pytest.raises(ValueError):
+        validate_emote_events([{"state": "../../bad", "at_char": 0}])
+    with pytest.raises(ValueError):
+        validate_emote_events([{"state": "smug", "at_char": -1}])
+    with pytest.raises(ValueError):
+        validate_emote_events(
+            [{"state": f"mood-{index}", "at_char": index} for index in range(EMOTE_EVENT_LIMIT + 1)]
+        )
+```
+
+- [ ] **Step 7: Run Python parser tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py -q
+```
+
+Expected: FAIL because `emote_directives.py` does not exist.
+
+- [ ] **Step 8: Implement backend parser**
+
+Create `tldw_Server_API/app/core/Character_Chat/emote_directives.py`:
+
+```python
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, Field
+
+EMOTE_EVENT_LIMIT = 5
+CHARACTER_EMOTE_STATE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,39}$")
+
+
+class CharacterEmoteEvent(BaseModel):
+    state: str = Field(..., min_length=1, max_length=40)
+    at_char: int = Field(..., ge=0)
+
+
+class CharacterEmoteParseResult(BaseModel):
+    clean_text: str
+    events: list[CharacterEmoteEvent]
+
+
+class CharacterEmoteCompletionResult(BaseModel):
+    clean_text: str
+    mood_label: str | None
+    mood_confidence: float | None
+    mood_topic: str | None
+    emote_events: list[CharacterEmoteEvent]
+```
+
+Implementation rules mirror TypeScript exactly. Keep this parser final-text only; streaming remains frontend-only.
+
+- [ ] **Step 9: Run parser tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/utils/__tests__/character-emotes.test.ts
+cd ../../..
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/packages/ui/src/utils/__fixtures__/character-emote-directives.json \
+  apps/packages/ui/src/utils/character-emotes.ts \
+  apps/packages/ui/src/utils/__tests__/character-emotes.test.ts \
+  tldw_Server_API/app/core/Character_Chat/emote_directives.py \
+  tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
+git commit -m "feat: add character emote directive parser"
+```
+
+## Task 2: Custom Emote Image Resolution
+
+**Files:**
+- Modify: `apps/packages/ui/src/utils/character-mood.ts`
+- Modify: `apps/packages/ui/src/utils/__tests__/character-mood.test.ts`
+
+- [ ] **Step 1: Add failing image map tests**
+
+Extend `apps/packages/ui/src/utils/__tests__/character-mood.test.ts`:
+
+```ts
+it("resolves custom emote image states without expanding classifier labels", () => {
+  const extensions = {
+    tldw: {
+      mood_images: {
+        smug: TINY_PNG_BASE64,
+        "thinking-hard": TINY_PNG_BASE64,
+        "../../bad": TINY_PNG_BASE64
+      }
+    }
+  }
+
+  expect(resolveCharacterMoodImageUrl({ extensions }, "smug")).toMatch(/^data:image\/png;base64,/)
+  expect(resolveCharacterMoodImageUrl({ extensions }, "thinking hard")).toMatch(/^data:image\/png;base64,/)
+  expect(resolveCharacterMoodImageUrl({ extensions }, "../../bad")).toBe("")
+  expect(normalizeCharacterMoodLabel("smug")).toBeNull()
+})
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/utils/__tests__/character-mood.test.ts
+```
+
+Expected: FAIL because custom `smug` images are ignored.
+
+- [ ] **Step 3: Broaden image resolver only**
+
+Modify `apps/packages/ui/src/utils/character-mood.ts`:
+
+- Import or duplicate only the safe slug normalizer from `character-emotes.ts`.
+- Change the mood image map type to `Record<string, string>` for image storage.
+- In `getCharacterMoodImagesFromExtensions()`, normalize keys with `normalizeCharacterEmoteState(rawMood)` instead of `normalizeCharacterMoodLabel(rawMood)`.
+- In `mergeCharacterMoodImagesIntoExtensions()`, normalize keys the same way.
+- In `resolveCharacterMoodImageUrl()`, normalize `moodLabel` with `normalizeCharacterEmoteState(moodLabel)`.
+- Keep `normalizeCharacterMoodLabel()` and `detectCharacterMood()` unchanged for built-in classifier labels.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/utils/__tests__/character-mood.test.ts src/utils/__tests__/character-emotes.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/utils/character-mood.ts apps/packages/ui/src/utils/__tests__/character-mood.test.ts
+git commit -m "feat: resolve custom character emote images"
+```
+
+## Task 3: Backend Persist And Non-Streaming Sanitization
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
+- Modify: `tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py`
+
+- [ ] **Step 1: Add failing stream persist validation test**
+
+Extend `test_character_chat_stream_and_persist.py`:
+
+```python
+def test_persist_streamed_message_stores_emote_events(test_client: TestClient, auth_headers) -> None:
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+
+    response = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={
+            "assistant_content": "What now?\nFine.",
+            "mood_label": "smug",
+            "emote_events": [
+                {"state": "annoyed", "at_char": 0},
+                {"state": "smug", "at_char": 10},
+            ],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assistant_message_id = response.json()["assistant_message_id"]
+    message_resp = test_client.get(
+        f"/api/v1/messages/{assistant_message_id}",
+        params={"include_metadata": "true"},
+        headers=auth_headers,
+    )
+    assert message_resp.status_code == 200
+    metadata_extra = message_resp.json()["metadata_extra"]
+    assert metadata_extra["mood_label"] == "smug"
+    assert metadata_extra["emote_events"] == [
+        {"state": "annoyed", "at_char": 0},
+        {"state": "smug", "at_char": 10},
+    ]
+```
+
+Add a rejection case:
+
+```python
+def test_persist_streamed_message_rejects_invalid_emote_events(test_client: TestClient, auth_headers) -> None:
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+
+    response = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={
+            "assistant_content": "bad metadata",
+            "emote_events": [{"state": "../../bad", "at_char": 0}],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+```
+
+- [ ] **Step 2: Add failing non-streaming sanitization helper test**
+
+Extend `tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py`:
+
+```python
+@pytest.mark.unit
+def test_resolve_completion_emotes_prefers_last_explicit_event() -> None:
+    result = resolve_character_emote_completion(
+        "Emote: annoyed\nWhat now?\nEmote: smug\nFine.",
+        fallback_mood_label="happy",
+        fallback_mood_confidence=0.9,
+        fallback_mood_topic="fallback",
+    )
+
+    assert result.clean_text == "What now?\nFine."
+    assert result.mood_label == "smug"
+    assert result.mood_confidence is None
+    assert result.mood_topic is None
+    assert [event.model_dump() for event in result.emote_events] == [
+        {"state": "annoyed", "at_char": 0},
+        {"state": "smug", "at_char": 10},
+    ]
+```
+
+This helper is the non-streaming endpoint contract: `/complete-v2` must call it
+before returning `assistant_content` or storing assistant metadata.
+
+- [ ] **Step 3: Run backend tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py \
+  tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py \
+  -q
+```
+
+Expected: FAIL because schema/endpoint do not support `emote_events`.
+
+- [ ] **Step 4: Add schema model**
+
+Modify `tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py`:
+
+```python
+from tldw_Server_API.app.core.Character_Chat.emote_directives import CharacterEmoteEvent
+```
+
+Add to `CharacterChatStreamPersistRequest`:
+
+```python
+emote_events: Optional[list[CharacterEmoteEvent]] = Field(
+    None,
+    max_length=5,
+    description="Optional sanitized character emote events for this assistant message.",
+)
+```
+
+If Pydantic does not enforce list `max_length` as expected in this project version, add a validator that calls `validate_emote_events()`.
+
+- [ ] **Step 5: Store emote metadata in stream persist endpoint**
+
+Modify `_build_stream_persist_metadata_extra()` in `character_chat_sessions.py`:
+
+- Add parameter `emote_events: list[CharacterEmoteEvent] | None`.
+- When present, store `[event.model_dump() for event in emote_events]` under `metadata_extra["emote_events"]`.
+- Pass `body.emote_events` in both new persist and existing idempotent side-effect paths.
+
+- [ ] **Step 6: Sanitize backend non-streaming completion**
+
+In `complete_character_chat_v2()` near the existing `assistant_text` and `resolved_mood_label` block:
+
+```python
+resolved_emotes = resolve_character_emote_completion(
+    assistant_text,
+    fallback_mood_label=resolved_mood_label,
+    fallback_mood_confidence=resolved_mood_confidence,
+    fallback_mood_topic=resolved_mood_topic,
+)
+assistant_text = resolved_emotes.clean_text
+resolved_mood_label = resolved_emotes.mood_label
+resolved_mood_confidence = resolved_emotes.mood_confidence
+resolved_mood_topic = resolved_emotes.mood_topic
+```
+
+When building `metadata_extra`, include `resolved_emotes.emote_events` if any exist.
+
+When returning `CharacterChatCompletionV2Response`, return sanitized `assistant_content` and `mood_label` equal to the last accepted event.
+
+- [ ] **Step 7: Add prompt instruction**
+
+In the same endpoint, after `_build_system_prompt_for_preset()` returns `sys_text`, append a short instruction only for character context prompts:
+
+```text
+When the character expression should change, emit a standalone line exactly like `Emote: <state>`. Prefer these available states: <states>. Do not emit an emote after every sentence.
+```
+
+Derive `<states>` from the active character's mood image extension keys using the backend parser/normalizer. If none exist, omit the "Prefer..." sentence.
+
+- [ ] **Step 8: Run backend tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py \
+  tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Character_Chat/emote_directives.py \
+  tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py \
+  tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py \
+  tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py \
+  tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
+git commit -m "feat: persist character emote metadata"
+```
+
+## Task 4: Frontend Character Stream Integration
+
+**Files:**
+- Modify: `apps/packages/ui/src/store/option/types.ts`
+- Modify: `apps/packages/ui/src/hooks/chat/useChatActions.ts`
+- Modify: `apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts`
+- Modify: `apps/packages/ui/src/hooks/useMessage.tsx`
+- Modify: `apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx`
+- Modify: `apps/packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts`
+
+- [ ] **Step 1: Add metadata type**
+
+Modify `MessageMetadataExtra` in `apps/packages/ui/src/store/option/types.ts`:
+
+```ts
+import type { CharacterEmoteEvent } from "@/utils/character-emotes"
+
+export type MessageMetadataExtra = Record<string, unknown> & {
+  dynamic_ui?: DynamicUIEnvelope
+  dynamic_ui_action?: DynamicUIActionUserMetadata
+  emote_events?: CharacterEmoteEvent[]
+}
+```
+
+- [ ] **Step 2: Add failing primary hook integration test**
+
+In `useChatActions.character.integration.test.tsx`, configure `streamCharacterChatCompletionMock` to emit split directive chunks:
+
+```ts
+streamCharacterChatCompletionMock.mockImplementationOnce(async function* () {
+  yield "Em"
+  yield "ote: smug\n"
+  yield "Hello "
+  yield "there.\n"
+  yield "Emote: annoyed\n"
+  yield "Fine."
+})
+```
+
+Assert:
+
+```ts
+expect(persistCharacterCompletionMock).toHaveBeenCalledWith(
+  expect.anything(),
+  expect.objectContaining({
+    assistant_content: "Hello there.\nFine.",
+    mood_label: "annoyed",
+    emote_events: [
+      { state: "smug", at_char: 0 },
+      { state: "annoyed", at_char: 13 }
+    ]
+  }),
+  expect.anything()
+)
+expect(JSON.stringify(options.setMessages.mock.calls)).not.toContain("Emote:")
+
+const initialAssistantMessage = {
+  id: "generated-assistant-id",
+  isBot: true,
+  name: "Ashley",
+  message: "",
+  sources: []
+}
+const messagesAfterUpdates = options.setMessages.mock.calls.reduce(
+  (messages, [updater]) =>
+    typeof updater === "function" ? updater(messages) : updater,
+  [initialAssistantMessage]
+)
+const moodLabelUpdates = messagesAfterUpdates.map((message) => message?.moodLabel)
+expect(moodLabelUpdates).toContain("smug")
+expect(moodLabelUpdates).toContain("annoyed")
+```
+
+Use the generated assistant message id from the existing test harness instead of
+the sample id above. The assertion must prove `moodLabel` changes during
+chunk processing, before final persistence.
+
+- [ ] **Step 3: Run primary hook test to verify failure**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
+```
+
+Expected: FAIL because raw directives are persisted.
+
+- [ ] **Step 4: Implement stream parser wiring in `useChatActions.ts`**
+
+In the character stream branch:
+
+- Create `const emoteParser = createCharacterEmoteStreamParser()`.
+- Keep `fullText` and `contentToSave` sanitized.
+- Feed only text token deltas through the parser.
+- For each accepted event:
+  - append to local `emoteEvents`
+  - update the assistant message `moodLabel` to `event.state`
+  - add/merge `metadataExtra.emote_events`
+- Schedule streaming updates with sanitized text only.
+- On stream completion, call `emoteParser.flush()` before final persistence.
+- If `emoteEvents.length > 0`, set `resolvedMoodLabel = emoteEvents.at(-1)?.state` and skip `detectCharacterMood()`.
+- Include `emote_events` in `persistPayload` and `metadataExtra`.
+
+Do not log full assistant content on parser errors.
+
+- [ ] **Step 5: Add failing parity test for `useCharacterChatMode.ts`**
+
+Extend `apps/packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts` with the same split directive stream and persistence assertions.
+
+- [ ] **Step 6: Implement parity in `useCharacterChatMode.ts`**
+
+Apply the same parser flow as `useChatActions.ts`. If duplication becomes too large, extract a tiny helper into:
+
+- `apps/packages/ui/src/hooks/chat/character-emote-stream.ts`
+
+Keep helper scope limited to:
+
+```ts
+export const applyCharacterEmoteEventsToMessage = (...)
+export const resolveExplicitOrDetectedMood = (...)
+```
+
+Do not create a general event bus or runtime.
+
+- [ ] **Step 7: Update `useMessage.tsx` legacy path**
+
+Run:
+
+```bash
+rg -n "streamCharacterChatCompletion|persistCharacterCompletion|detectCharacterMood" apps/packages/ui/src/hooks/useMessage.tsx
+```
+
+Apply the same parser/persist helper in each character-stream branch that persists character completions. If no existing test harness can drive `useMessage.tsx`, rely on the shared helper tests plus the two hook integration tests, and record the legacy-path coverage decision in `TASK-12163` implementation notes.
+
+- [ ] **Step 8: Run frontend hook tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run \
+  src/utils/__tests__/character-emotes.test.ts \
+  src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx \
+  src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/packages/ui/src/store/option/types.ts \
+  apps/packages/ui/src/hooks/chat/useChatActions.ts \
+  apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts \
+  apps/packages/ui/src/hooks/useMessage.tsx \
+  apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx \
+  apps/packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts
+git commit -m "feat: stream character emote directives in webui"
+```
+
+If `useMessage.tsx` is not touched, omit it from `git add`.
+
+## Task 5: UI Portrait Behavior And History Reload
+
+**Files:**
+- Modify: `apps/packages/ui/src/hooks/chat/useServerChatLoader.ts`
+- Modify: `apps/packages/ui/src/db/dexie/helpers.ts`
+- Modify: `apps/packages/ui/src/components/Common/Playground/Message.tsx`
+- Modify: `apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts`
+- Modify: `apps/packages/ui/src/utils/__tests__/character-mood.test.ts`
+- Modify: `apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx`
+
+- [ ] **Step 1: Add failing history reload test**
+
+Extend `apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts` with a message containing:
+
+```ts
+metadata_extra: {
+  mood_label: "smug",
+  emote_events: [{ state: "smug", at_char: 0 }]
+}
+```
+
+Assert loaded message has:
+
+```ts
+expect(message.moodLabel).toBe("smug")
+expect(message.metadataExtra?.emote_events).toEqual([{ state: "smug", at_char: 0 }])
+```
+
+- [ ] **Step 2: Add Dexie local replay test if local helper drops mood fields**
+
+If `formatToMessage()` in `apps/packages/ui/src/db/dexie/helpers.ts` still does not promote `metadataExtra.mood_label`, add a small test near existing Dexie helper tests or create:
+
+- `apps/packages/ui/src/db/dexie/__tests__/helpers.character-emotes.test.ts`
+
+Assert local messages with `metadataExtra.mood_label` reload with `moodLabel`.
+
+- [ ] **Step 3: Implement history/local metadata normalization**
+
+Modify:
+
+- `useServerChatLoader.ts`: preserve `emote_events` in `metadataExtra` and set `moodLabel` from string `metadataExtra.mood_label`, including custom slugs.
+- `db/dexie/helpers.ts`: when converting local message variants, set `moodLabel` from `metadataExtra.mood_label` if the top-level field is absent.
+
+- [ ] **Step 4: Fix portrait resolver behavior**
+
+Modify `Message.tsx` so explicit `props.moodLabel` uses the custom emote slug normalizer for `resolvedMoodLabel`, while `detectCharacterMood()` remains the fallback and still returns built-in labels. A custom explicit `smug` label must be able to reach `resolveCharacterMoodImageUrl()`.
+
+- [ ] **Step 5: Add UI behavior test**
+
+Extend `Message.routing-fallback.integration.test.tsx` to render a bot message with:
+
+- `moodLabel="smug"`
+- `characterIdentity.extensions.tldw.mood_images.smug`
+
+Assert the rendered portrait image uses the `smug` data URL.
+
+- [ ] **Step 6: Run UI/history tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run \
+  src/hooks/__tests__/useServerChatLoader.test.ts \
+  src/utils/__tests__/character-mood.test.ts \
+  src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx
+```
+
+The Message test is required for this task.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/packages/ui/src/hooks/chat/useServerChatLoader.ts \
+  apps/packages/ui/src/db/dexie/helpers.ts \
+  apps/packages/ui/src/components/Common/Playground/Message.tsx \
+  apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts \
+  apps/packages/ui/src/utils/__tests__/character-mood.test.ts \
+  apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx
+git commit -m "feat: restore explicit character emotes from history"
+```
+
+Omit unchanged optional files from `git add`.
+
+## Task 6: Final Verification And Backlog Update
+
+**Files:**
+- Modify: `backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md`
+
+- [ ] **Step 1: Run targeted frontend tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run \
+  src/utils/__tests__/character-emotes.test.ts \
+  src/utils/__tests__/character-mood.test.ts \
+  src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx \
+  src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts \
+  src/hooks/__tests__/useServerChatLoader.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run targeted backend tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py \
+  tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run typecheck for touched frontend package if time allows**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bun run typecheck
+```
+
+Expected: PASS. If repo-wide baseline fails outside touched files, record the failure and evidence in `TASK-12163`.
+
+- [ ] **Step 4: Run Bandit on touched backend scope**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/Character_Chat/emote_directives.py \
+  tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py \
+  tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py \
+  -f json -o /tmp/bandit_character_emotes.json
+```
+
+Expected: no new findings in touched code. If Bandit reports unrelated existing findings in the huge endpoint file, record the exact finding IDs and why they are unrelated.
+
+- [ ] **Step 5: Update Backlog task**
+
+Use Backlog MCP or CLI:
+
+```bash
+backlog task edit TASK-12163 \
+  --notes "Implemented streaming character emote directives. Verification: <commands/results>. Bandit: /tmp/bandit_character_emotes.json." \
+  --plain
+```
+
+Check acceptance criteria as completed only after the matching tests pass.
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add "backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md"
+git commit -m "chore: record character emote verification"
+```
+
+## Out Of Scope
+
+- No Persona Visual runtime unification.
+- No `set_emote` tool.
+- No character editor mood-image manager.
+- No historic beat replay.
+- No fuzzy asset matching.
+
+## Notes For Implementers
+
+- Do not let raw `Emote:` lines reach rendered or persisted assistant content.
+- Do not let explicit directives be overwritten by `detectCharacterMood()`.
+- Do not expand the classifier taxonomy; custom slugs are for explicit emotes and image lookup only.
+- Keep `emote_events` compact and metadata-only.
+- The current worktree may have unrelated dirty files. Stage only files touched by this plan.

--- a/Docs/superpowers/specs/2026-07-06-character-chat-streaming-emote-directives-design.md
+++ b/Docs/superpowers/specs/2026-07-06-character-chat-streaming-emote-directives-design.md
@@ -141,6 +141,8 @@ Emote: <state>
 Rules:
 
 - Prefix matching is case-insensitive.
+- Directive classification trims leading and trailing whitespace, but stripping
+  removes the whole source line.
 - Inline prose is not parsed. `She says Emote: smug` remains visible text.
 - Directives inside fenced code blocks are ignored and remain visible code.
 - State labels are trimmed, lowercased, and internal whitespace is converted to
@@ -171,6 +173,11 @@ Character-chat prompting should tell the model to emit `Emote: <state>` only
 when the character expression should change. It should not emit an emote after
 every sentence.
 
+When the character has known mood/emote image states, the prompt should include
+those exact normalized state slugs and tell the model to prefer them. Arbitrary
+safe states are still valid metadata, but known states are the only ones that can
+reliably change the portrait image in V1.
+
 Example:
 
 ```text
@@ -191,16 +198,19 @@ misformat instructions.
 ## Streaming Data Flow
 
 1. Character-chat stream starts.
-2. Response chunks are appended to a parser buffer that holds only the current
-   incomplete line.
-3. Complete lines are classified as visible text, directives, or fenced code.
-4. Visible text is emitted to the assistant message.
-5. Accepted directives update the active portrait state immediately and append
+2. Response chunks pass through a streaming parser that withholds only short
+   candidate prefixes that could still become a directive or fenced-code marker.
+3. Once the current line can no longer become `Emote:` or a fence marker, the
+   buffered visible text is emitted and later text on that same line can stream
+   normally instead of waiting for a newline.
+4. Complete lines are classified as visible text, directives, or fenced code.
+5. Visible text is emitted to the assistant message.
+6. Accepted directives update the active portrait state immediately and append
    an event with an offset in sanitized visible text.
-6. Invalid, duplicate, and over-cap directives are stripped without firing an
+7. Invalid, duplicate, and over-cap directives are stripped without firing an
    event.
-7. On stream end, the parser flushes the final unterminated line.
-8. The frontend persists the sanitized assistant text, the last accepted emote
+8. On stream end, the parser flushes the final unterminated line.
+9. The frontend persists the sanitized assistant text, the last accepted emote
    as `mood_label`, and optional `emote_events` metadata.
 
 The parser must normalize `\n`, `\r\n`, and final text without a trailing
@@ -251,6 +261,11 @@ Persistence path:
 
 - Add optional `emote_events` support to the character stream persist request
   and include it in `_build_stream_persist_metadata_extra()`.
+- Validate incoming `emote_events` at the API boundary. The value is optional;
+  when present it must contain at most 5 events. Each event must contain a
+  normalized `state` matching `^[a-z0-9][a-z0-9_-]{0,39}$` and an `at_char`
+  nonnegative integer. Invalid request payloads should fail with request
+  validation rather than being stored.
 - For backend-persisted non-streaming character completions, store parser output
   directly in `metadata_extra`.
 - Do not add a database migration. The existing message metadata storage remains
@@ -274,8 +289,9 @@ current built-in labels. Only the image map and explicit emote resolver need to
 accept arbitrary safe slugs.
 
 If an exact matching asset exists for the normalized state slug, show it. If
-not, keep the current portrait or base character image. Do not add fuzzy
-matching in V1.
+not, do not change the currently displayed portrait. If no emote portrait has
+been displayed for the assistant message yet, remain on the base character
+avatar. Do not add fuzzy matching in V1.
 
 Explicit emote directives override `detectCharacterMood()`. The heuristic
 classifier runs only when no valid explicit directive exists for the assistant
@@ -287,7 +303,8 @@ message.
 - Unsafe state labels are stripped and ignored.
 - Duplicate consecutive states are stripped and ignored.
 - Over-cap directives are stripped and ignored.
-- Asset misses keep the current/base portrait.
+- Asset misses do not change the displayed portrait; if no emote portrait has
+  been displayed yet, the base avatar remains visible.
 - Malformed metadata on load is ignored.
 - Parser errors should fall back to visible sanitized text rather than breaking
   chat rendering.
@@ -312,17 +329,23 @@ The UI should not log full assistant content while reporting parser errors.
 - Records `at_char` against sanitized visible text.
 - Uses the exact 40-character slug limit and 5-event cap.
 
+Use shared parser test vectors for the TypeScript streaming/final parser and
+the Python backend final parser. Prefer one checked-in JSON fixture file that
+both test suites read, so behavior does not drift across runtimes.
+
 ### Streaming Buffer Tests
 
 - A directive split across chunks never appears in visible output.
 - Normal text split across chunks is preserved.
-- The buffer holds only the current incomplete line.
+- Long non-directive lines stream before a newline once they are no longer
+  directive or fence-marker candidates.
 - The final unterminated line flushes correctly on stream completion.
 
 ### Character Chat Integration Tests
 
 - Explicit final emote persists as `mood_label`.
 - `emote_events` persists under metadata.
+- Backend persist request validation rejects malformed `emote_events`.
 - The last accepted emote event becomes `mood_label`.
 - `detectCharacterMood()` is bypassed when at least one valid directive exists.
 - Non-streaming character responses are parsed and stripped before

--- a/Docs/superpowers/specs/2026-07-06-character-chat-streaming-emote-directives-design.md
+++ b/Docs/superpowers/specs/2026-07-06-character-chat-streaming-emote-directives-design.md
@@ -1,0 +1,372 @@
+# Character Chat Streaming Emote Directives PRD
+
+Date: 2026-07-06
+Status: Ready for spec review
+Backlog: TASK-12163
+Follow-up: TASK-12164
+
+## Summary
+
+Add explicit streaming emote control to character chat portraits.
+
+Today, character mood is primarily inferred from assistant text after a response
+finishes. That cannot reproduce the reference behavior: a character portrait
+acts through a single streaming response, changing expression at dialogue beats.
+
+V1 lets the assistant emit standalone control directives such as:
+
+```text
+Emote: annoyed
+```
+
+The character-chat frontend consumes those directives, updates the portrait as
+the response streams, removes the directives from visible and persisted chat
+text, and stores compact metadata for the final emote and future replay.
+
+This is a character-chat portrait feature first. A shared Persona Visual runtime
+integration is intentionally tracked as follow-up work in `TASK-12164`.
+
+## Goals
+
+- Let a character portrait change expression multiple times during one
+  streaming assistant response.
+- Keep raw `Emote:` directives out of rendered chat and persisted assistant
+  content.
+- Preserve clean assistant text for history, search, export, and replay.
+- Reuse existing character mood image resolution and `mood_label` persistence
+  where possible.
+- Make explicit emotes win over heuristic mood detection.
+- Parse non-streaming character responses too, so directives are still stripped
+  when streaming is disabled.
+- Store optional `emote_events` metadata for future replay or shared visual
+  runtime integration.
+- Fail gracefully when an emote state has no matching image asset.
+
+## Non-Goals
+
+- Do not build the shared Persona Visual runtime integration in this PR.
+- Do not expose an agentic `set_emote` or `set_visual_state` tool in this PR.
+- Do not add a database migration for emote events.
+- Do not add fuzzy matching between arbitrary emote labels and available
+  assets.
+- Do not replay historic emote beats on message reload in V1.
+- Do not replace the existing character mood image map format.
+- Do not build a full animation or lip-sync system.
+
+## Existing Context
+
+Relevant current code paths:
+
+- `apps/packages/ui/src/utils/character-mood.ts`
+  - defines current mood labels
+  - infers mood through `detectCharacterMood()`
+  - resolves character mood images from card extensions, currently limited to
+    built-in mood aliases
+- `apps/packages/ui/src/components/Common/Playground/Message.tsx`
+  - chooses explicit mood, inferred mood, and mood-specific portrait image
+- `apps/packages/ui/src/hooks/chat/useChatActions.ts`
+  - streams character chat responses
+  - persists final assistant messages
+  - currently runs final-text mood inference in character chat mode
+- `apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts`
+  - duplicate/older character chat mode flow with similar mood handling
+- `apps/packages/ui/src/hooks/chat/useServerChatLoader.ts`
+  - reloads `mood_label`, `mood_confidence`, and `mood_topic`
+- `tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py`
+  - already accepts `mood_label`, `mood_confidence`, and `mood_topic`
+- `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
+  - stores mood metadata for non-streaming and persisted streaming messages
+- Persona Visual runtime files already support safe named visual states, but
+  that broader integration is deferred to `TASK-12164`.
+
+The character editor currently does not expose full mood-image management,
+while the parser already understands mood image extensions. This PR may rely on
+existing character-card mood image data, but should not expand the character
+asset editor unless required for the core flow.
+
+## Recommended Approach
+
+Use streaming text directives in character chat:
+
+1. Add a small parser for standalone `Emote: <state>` lines.
+2. Add a streaming line buffer that keeps only the current incomplete line.
+3. Strip directives before text reaches rendered chat or persistence.
+4. Fire portrait updates immediately for accepted directives.
+5. Persist clean assistant content, final `mood_label`, and optional
+   `emote_events` in existing metadata.
+
+This approach is recommended because it matches the reference video and works
+with ordinary chat streaming. It does not require provider-specific tool calling,
+a database migration, or a new animation runtime. It does require small request
+schema additions so the existing message metadata can carry `emote_events`.
+
+## Alternatives Considered
+
+### Final Emote Line Only
+
+The model ends with one line such as `Emote: irritated`, the frontend strips it,
+and the final `mood_label` is stored.
+
+This is simpler, but it misses the core behavior from the reference video:
+expression changes during one assistant message.
+
+### Agentic Tool First
+
+Expose a tool such as:
+
+```json
+{ "name": "set_emote", "arguments": { "state": "smug" } }
+```
+
+This is cleaner for future agentic UIs, but it pushes V1 into provider/tool
+orchestration and still does not help plain chat models unless text directives
+also exist.
+
+### Shared Persona Visual Runtime First
+
+Unify character portraits, Persona Buddy, and future agent surfaces around a
+common visual-state contract before shipping character emotes.
+
+This is the right long-term direction, but too broad for the first PR. It is
+tracked as `TASK-12164`.
+
+## Directive Contract
+
+The only V1 directive grammar is a standalone line:
+
+```text
+Emote: <state>
+```
+
+Rules:
+
+- Prefix matching is case-insensitive.
+- Inline prose is not parsed. `She says Emote: smug` remains visible text.
+- Directives inside fenced code blocks are ignored and remain visible code.
+- State labels are trimmed, lowercased, and internal whitespace is converted to
+  `-`.
+- A normalized state is valid only when it matches
+  `^[a-z0-9][a-z0-9_-]{0,39}$`.
+- Empty, unsafe, or longer-than-40-character normalized state labels are
+  invalid.
+- Invalid standalone directives are still stripped, but do not fire or store an
+  event.
+- After the per-response event cap is reached, later standalone directives are
+  still stripped, but do not fire or store new events.
+- Consecutive duplicate states are stripped but ignored as events.
+
+V1 cap: 5 accepted emote events per assistant response.
+
+V1 accepts arbitrary safe state slugs. It does not restrict directives to the
+current built-in classifier labels. Built-in mood labels remain the fallback
+classifier taxonomy, not the full emote taxonomy.
+
+These directives are app-level presentation controls. They are not a security
+boundary. A user can prompt a model to emit them, and that should only affect
+the character portrait state.
+
+## Prompt Contract
+
+Character-chat prompting should tell the model to emit `Emote: <state>` only
+when the character expression should change. It should not emit an emote after
+every sentence.
+
+Example:
+
+```text
+Emote: annoyed
+What the hell is that supposed to mean?
+
+Emote: smug
+I'm feeling great because I just saved us.
+
+Emote: irritated
+You should be thanking me.
+```
+
+The exact prompt wording can live near the existing character-chat prompt
+assembly. The parser remains defensive because models will sometimes ignore or
+misformat instructions.
+
+## Streaming Data Flow
+
+1. Character-chat stream starts.
+2. Response chunks are appended to a parser buffer that holds only the current
+   incomplete line.
+3. Complete lines are classified as visible text, directives, or fenced code.
+4. Visible text is emitted to the assistant message.
+5. Accepted directives update the active portrait state immediately and append
+   an event with an offset in sanitized visible text.
+6. Invalid, duplicate, and over-cap directives are stripped without firing an
+   event.
+7. On stream end, the parser flushes the final unterminated line.
+8. The frontend persists the sanitized assistant text, the last accepted emote
+   as `mood_label`, and optional `emote_events` metadata.
+
+The parser must normalize `\n`, `\r\n`, and final text without a trailing
+newline. It must also track fenced-code state across chunks.
+
+## Non-Streaming Data Flow
+
+Non-streaming character responses use the same directive contract in
+final-content mode.
+
+The UI should never show raw directive lines. Persistence should receive only
+sanitized content and emote metadata.
+
+If the WebUI owns the non-streaming response before persistence, it should parse
+and strip in the frontend before saving. If a backend endpoint persists a
+non-streaming character response server-side, that backend path must run an
+equivalent parser before saving and before returning `assistant_content`. V1 does
+not need to simulate intermediate beat timing for a non-streaming response; the
+portrait can update to the last accepted emote after parsing.
+
+## Metadata Contract
+
+Reuse `mood_label` as the final emote so existing message rendering and history
+loading keep working.
+
+The final emote is the last accepted emote event in sanitized response order. If
+there are no accepted emote events, no explicit final emote exists and the
+existing heuristic mood fallback may run.
+
+Store optional event metadata under existing message metadata, for example:
+
+```json
+{
+  "mood_label": "irritated",
+  "emote_events": [
+    { "at_char": 0, "state": "annoyed" },
+    { "at_char": 94, "state": "smug" },
+    { "at_char": 212, "state": "irritated" }
+  ]
+}
+```
+
+`at_char` is the JavaScript string offset in sanitized assistant text after
+visible text emitted so far. It is for ordering and future best-effort replay,
+not exact grapheme or animation timing.
+
+Persistence path:
+
+- Add optional `emote_events` support to the character stream persist request
+  and include it in `_build_stream_persist_metadata_extra()`.
+- For backend-persisted non-streaming character completions, store parser output
+  directly in `metadata_extra`.
+- Do not add a database migration. The existing message metadata storage remains
+  the durable location.
+- Frontend message objects keep carrying this through `metadataExtra`.
+
+Metadata loading should be best-effort. Missing or malformed `emote_events`
+must not block chat history rendering.
+
+On history reload, V1 restores only the final emote through the existing
+`mood_label` path. It does not replay beat events.
+
+## Portrait Resolution
+
+Use the existing character mood image extension locations, but broaden the
+frontend mood image parser/resolver to support safe custom state slugs instead
+of only built-in `CharacterMoodLabel` values.
+
+The implementation should keep `detectCharacterMood()` constrained to the
+current built-in labels. Only the image map and explicit emote resolver need to
+accept arbitrary safe slugs.
+
+If an exact matching asset exists for the normalized state slug, show it. If
+not, keep the current portrait or base character image. Do not add fuzzy
+matching in V1.
+
+Explicit emote directives override `detectCharacterMood()`. The heuristic
+classifier runs only when no valid explicit directive exists for the assistant
+message.
+
+## Error Handling
+
+- Malformed directives are stripped and ignored.
+- Unsafe state labels are stripped and ignored.
+- Duplicate consecutive states are stripped and ignored.
+- Over-cap directives are stripped and ignored.
+- Asset misses keep the current/base portrait.
+- Malformed metadata on load is ignored.
+- Parser errors should fall back to visible sanitized text rather than breaking
+  chat rendering.
+
+The UI should not log full assistant content while reporting parser errors.
+
+## Testing Requirements
+
+### Parser Unit Tests
+
+- Strips standalone directives and returns clean text.
+- Ignores inline `Emote:` prose.
+- Ignores directives inside fenced code blocks.
+- Tracks fenced code state across split streaming chunks.
+- Normalizes safe state labels.
+- Rejects labels that are empty, unsafe, or longer than 40 characters after
+  normalization.
+- Strips invalid standalone directives without returning events.
+- Drops duplicate consecutive states.
+- Strips but ignores events after the cap.
+- Handles `\n`, `\r\n`, and final text without trailing newline.
+- Records `at_char` against sanitized visible text.
+- Uses the exact 40-character slug limit and 5-event cap.
+
+### Streaming Buffer Tests
+
+- A directive split across chunks never appears in visible output.
+- Normal text split across chunks is preserved.
+- The buffer holds only the current incomplete line.
+- The final unterminated line flushes correctly on stream completion.
+
+### Character Chat Integration Tests
+
+- Explicit final emote persists as `mood_label`.
+- `emote_events` persists under metadata.
+- The last accepted emote event becomes `mood_label`.
+- `detectCharacterMood()` is bypassed when at least one valid directive exists.
+- Non-streaming character responses are parsed and stripped before
+  display/persist.
+- History reload restores the final emote without replaying events.
+
+### UI Behavior Test
+
+One minimal browser or component test should stream chunks containing an emote
+directive, then assert:
+
+- the portrait changes when a matching mood image exists
+- raw `Emote:` text never appears in rendered chat
+
+## Acceptance Criteria
+
+- Streaming character chat can change the character portrait multiple times
+  within one assistant response when valid `Emote:` directives arrive.
+- Raw `Emote:` directive lines never appear in rendered chat or persisted
+  assistant content, including partial/chunked streaming cases.
+- Explicit emote directives override heuristic mood detection.
+- `detectCharacterMood()` only runs when no valid directive exists.
+- Non-streaming character responses are also parsed and stripped.
+- Invalid, unsafe, duplicate consecutive, and over-cap directives are stripped
+  but do not fire or store emote events.
+- Missing emote image assets do not break rendering.
+- Final emote, defined as the last accepted event, persists as `mood_label`.
+- Optional `emote_events` persist in metadata.
+- History reload restores the final emote and does not replay beats.
+- Parser, streaming-buffer, integration, and minimal UI behavior tests cover the
+  directive flow.
+
+## Follow-Up: Shared Persona Visual Runtime
+
+`TASK-12164` should evaluate the broader design after this V1 lands.
+
+Follow-up scope:
+
+- Review existing Persona Visual runtime state handling and character mood image
+  resolution for a shared boundary.
+- Define how character emote states map to Persona Visual runtime/custom states.
+- Decide whether a future agentic control should be `set_emote` or
+  `set_visual_state`.
+- Define how agentic tool control coexists with text directives.
+
+This follow-up should be planned separately. It should not block the V1
+character-chat portrait behavior.

--- a/apps/packages/ui/src/components/Common/Playground/Message.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/Message.tsx
@@ -56,10 +56,10 @@ import {
 } from "@/utils/disco-skill-check"
 import {
   detectCharacterMood,
-  normalizeCharacterMoodLabel,
   resolveCharacterBaseAvatarUrl,
   resolveCharacterMoodImageUrl
 } from "@/utils/character-mood"
+import { normalizeCharacterEmoteState } from "@/utils/character-emotes"
 import { useStoreMessage } from "@/store"
 import { updateMessageDiscoSkillComment } from "@/db/dexie/helpers"
 import type { MessageSteeringMode } from "@/types/message-steering"
@@ -820,7 +820,7 @@ export const PlaygroundMessage = (props: Props) => {
     Boolean(props.characterIdentityEnabled) &&
     Boolean(props.characterIdentity?.id) &&
     speakerMatchesCharacterIdentity
-  const explicitMoodLabel = normalizeCharacterMoodLabel(props.moodLabel)
+  const explicitMoodLabel = normalizeCharacterEmoteState(props.moodLabel)
   const inferredMoodLabel = React.useMemo(() => {
     if (!props.isBot || isSystemMessage) return null
     return detectCharacterMood({ assistantText: props.message }).label

--- a/apps/packages/ui/src/components/Common/Playground/Message.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/Message.tsx
@@ -822,9 +822,9 @@ export const PlaygroundMessage = (props: Props) => {
     speakerMatchesCharacterIdentity
   const explicitMoodLabel = normalizeCharacterEmoteState(props.moodLabel)
   const inferredMoodLabel = React.useMemo(() => {
-    if (!props.isBot || isSystemMessage) return null
+    if (explicitMoodLabel || !props.isBot || isSystemMessage) return null
     return detectCharacterMood({ assistantText: props.message }).label
-  }, [isSystemMessage, props.isBot, props.message])
+  }, [explicitMoodLabel, isSystemMessage, props.isBot, props.message])
   const resolvedMoodLabel = explicitMoodLabel || inferredMoodLabel
   const moodBadgeLabel = React.useMemo(() => {
     if (!resolvedMoodLabel) return null

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx
@@ -9,6 +9,7 @@ const storageOverrides = vi.hoisted(() => new Map<string, unknown>())
 const detectCharacterMoodMock = vi.hoisted(() =>
   vi.fn(() => ({ label: "neutral", confidence: 0.5, topic: null }))
 )
+const resolveCharacterMoodImageUrlMock = vi.hoisted(() => vi.fn(() => ""))
 const initializeMock = vi.hoisted(() => vi.fn(async () => undefined))
 const saveChatKnowledgeMock = vi.hoisted(() => vi.fn(async () => undefined))
 
@@ -262,9 +263,10 @@ vi.mock("@/utils/disco-skill-check", () => ({
 
 vi.mock("@/utils/character-mood", () => ({
   detectCharacterMood: detectCharacterMoodMock,
-  normalizeCharacterMoodLabel: (value: unknown) => value,
+  normalizeCharacterMoodLabel: (value: unknown) =>
+    value === "neutral" ? "neutral" : null,
   resolveCharacterBaseAvatarUrl: () => "",
-  resolveCharacterMoodImageUrl: () => ""
+  resolveCharacterMoodImageUrl: resolveCharacterMoodImageUrlMock
 }))
 
 vi.mock("@/db/dexie/helpers", () => ({
@@ -303,6 +305,8 @@ describe("PlaygroundMessage routing fallback integration", () => {
     storageOverrides.clear()
     initializeMock.mockClear()
     saveChatKnowledgeMock.mockClear()
+    resolveCharacterMoodImageUrlMock.mockReset()
+    resolveCharacterMoodImageUrlMock.mockReturnValue("")
     detectCharacterMoodMock.mockReset()
     detectCharacterMoodMock.mockReturnValue({
       label: "neutral",
@@ -328,10 +332,8 @@ describe("PlaygroundMessage routing fallback integration", () => {
     )
 
     const audit = screen.getByTestId("message-fallback-audit")
-    expect(audit).toHaveTextContent("Auto fallback")
-    expect(audit).toHaveTextContent(
-      "openai/gpt-4o-mini → anthropic/claude-3-5-sonnet"
-    )
+    expect(audit).toHaveTextContent("Using: anthropic/claude-3-5-sonnet")
+    expect(audit).toHaveTextContent("(fallback)")
     expect(audit).toHaveTextContent("2 attempts")
     expect(audit).toHaveTextContent("Rate limited upstream")
   })
@@ -453,6 +455,41 @@ describe("PlaygroundMessage routing fallback integration", () => {
       "final response"
     )
     expect(screen.queryByTestId("playground-streaming-plain-text")).toBeNull()
+  })
+
+  it("renders a custom explicit emote portrait for character messages", () => {
+    const smugPortrait = "data:image/png;base64,c211Zw=="
+    resolveCharacterMoodImageUrlMock.mockImplementation((_character, mood) =>
+      mood === "smug" ? smugPortrait : ""
+    )
+
+    render(
+      <PlaygroundMessage
+        {...baseProps}
+        moodLabel="smug"
+        characterIdentityEnabled
+        characterIdentity={
+          {
+            id: 42,
+            name: "Ashley",
+            extensions: {
+              tldw: {
+                mood_images: {
+                  smug: smugPortrait
+                }
+              }
+            }
+          } as any
+        }
+        speakerCharacterId={42}
+      />
+    )
+
+    expect(resolveCharacterMoodImageUrlMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "smug"
+    )
+    expect(screen.getByAltText("Ashley")).toHaveAttribute("src", smugPortrait)
   })
 
   it("passes workspace scope when saving chat knowledge", async () => {

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx
@@ -489,6 +489,7 @@ describe("PlaygroundMessage routing fallback integration", () => {
       expect.anything(),
       "smug"
     )
+    expect(detectCharacterMoodMock).not.toHaveBeenCalled()
     expect(screen.getByAltText("Ashley")).toHaveAttribute("src", smugPortrait)
   })
 

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
@@ -206,6 +206,10 @@ vi.mock("@/hooks/useSmartScroll", () => ({
 
 vi.mock("@/services/settings/ui-settings", () => ({
   CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
+  THEME_SETTING: {
+    key: "theme",
+    defaultValue: "dark"
+  },
   HEADER_SHORTCUT_IDS: [],
   SIDEBAR_SHORTCUT_IDS: []
 }))

--- a/apps/packages/ui/src/db/dexie/__tests__/helpers.character-emotes.test.ts
+++ b/apps/packages/ui/src/db/dexie/__tests__/helpers.character-emotes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/db/dexie/chat", () => ({
+  PageAssistDatabase: class {}
+}))
+
+import { formatToMessage } from "../helpers"
+
+describe("formatToMessage character emotes", () => {
+  it("promotes explicit mood metadata from local history", () => {
+    const [message] = formatToMessage([
+      {
+        id: "assistant-1",
+        history_id: "history-1",
+        name: "Ashley",
+        role: "assistant",
+        content: "What now?",
+        createdAt: 1000,
+        metadataExtra: {
+          mood_label: "smug",
+          emote_events: [{ state: "smug", at_char: 0 }]
+        }
+      }
+    ])
+
+    expect(message.moodLabel).toBe("smug")
+    expect(message.metadataExtra?.emote_events).toEqual([
+      { state: "smug", at_char: 0 }
+    ])
+  })
+})

--- a/apps/packages/ui/src/db/dexie/helpers.ts
+++ b/apps/packages/ui/src/db/dexie/helpers.ts
@@ -277,6 +277,12 @@ export const formatToMessage = (messages: MessageHistory): MessageType[] => {
   const { collapsed, variantsByParent } = collapseVariantMessages(messages)
   return collapsed.map((message) => {
     const normalizedRole = normalizeChatRole(message.role)
+    const metadataExtra =
+      message?.metadataExtra as MessageType["metadataExtra"] | undefined
+    const moodLabel =
+      typeof metadataExtra?.mood_label === "string"
+        ? metadataExtra.mood_label
+        : undefined
     const mapped: MessageType = {
       isBot: normalizedRole === "assistant",
       message: message.content,
@@ -289,7 +295,8 @@ export const formatToMessage = (messages: MessageHistory): MessageType[] => {
       modelId: message?.modelId,
       parentMessageId: message?.parent_message_id ?? null,
       generationInfo: message?.generationInfo,
-      metadataExtra: message?.metadataExtra as MessageType["metadataExtra"],
+      metadataExtra,
+      moodLabel,
       reasoning_time_taken: message?.reasoning_time_taken,
       modelName: message?.modelName,
       modelImage: message?.modelImage,

--- a/apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts
@@ -449,6 +449,31 @@ describe("mapServerChatMessagesToPlaygroundMessages", () => {
     })
   })
 
+  it("restores explicit character emote metadata from server messages", () => {
+    const [message] = mapServerChatMessagesToPlaygroundMessages({
+      assistantName: "Ashley",
+      characterId: 42,
+      serverMessages: [
+        {
+          id: "server-1",
+          role: "assistant",
+          content: "What now?",
+          created_at: "2026-06-01T00:00:00.000Z",
+          metadata_extra: {
+            speaker_character_id: 42,
+            mood_label: "smug",
+            emote_events: [{ state: "smug", at_char: 0 }]
+          }
+        }
+      ]
+    })
+
+    expect(message.moodLabel).toBe("smug")
+    expect(message.metadataExtra?.emote_events).toEqual([
+      { state: "smug", at_char: 0 }
+    ])
+  })
+
   it("maps mirrored image event messages into assistant image event cards", () => {
     const mirroredContent = buildImageGenerationEventMirrorContent({
       kind: "image_generation_event",

--- a/apps/packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts
@@ -360,6 +360,112 @@ describe("createCharacterChatMode contract", () => {
     expect(moodLabels).toContain("annoyed")
   })
 
+  it("preserves explicit emote metadata when recovering a failed stream", async () => {
+    const setters = createSetterBundle()
+    let messagesState: any[] = []
+    const messageSnapshots: any[][] = []
+    setters.setMessages.mockImplementation((next) => {
+      messagesState = typeof next === "function" ? next(messagesState) : next
+      messageSnapshots.push(messagesState)
+    })
+    mocks.streamCharacterChatCompletionMock.mockImplementationOnce(
+      async function* () {
+        yield "Em"
+        yield "ote: smug\n"
+        yield "Em"
+        throw new Error("stream failed")
+      }
+    )
+    const controller = new AbortController()
+    const mode = createCharacterChatMode({
+      ...setters,
+      t: translate as any,
+      notification: { error: vi.fn() },
+      selectedCharacter: {
+        id: 42,
+        name: "Mira",
+        avatar_url: "https://example.test/mira.png"
+      } as any,
+      temporaryChat: false,
+      historyId: "history-1",
+      serverChatId: null,
+      serverChatCharacterId: null,
+      serverChatState: "in-progress",
+      serverChatTopic: null,
+      serverChatClusterId: null,
+      serverChatSource: null,
+      serverChatExternalRef: null,
+      currentChatModelSettings: {
+        apiProvider: "openai",
+        setSystemPrompt: vi.fn()
+      },
+      invalidateServerChatHistory: vi.fn(),
+      greetingEnabled: false,
+      greetingSelectionId: null,
+      greetingsChecksum: null,
+      useCharacterDefault: false,
+      directedCharacterId: 88,
+      resolvedMessageSteeringPrompts: null,
+      getEffectiveSelectedModel: vi.fn(() => "tldw:test-model"),
+      saveMessageOnSuccess: vi.fn(async () => "history-1"),
+      saveMessageOnError: vi.fn(async () => "history-1"),
+      discardCurrentTurnOnAbortRef: { current: false }
+    } as any)
+
+    await mode({
+      message: "Recover explicit emote",
+      image: "",
+      isRegenerate: false,
+      messages: [],
+      history: [],
+      signal: controller.signal,
+      model: "tldw:test-model",
+      controller,
+      messageSteering: {
+        continueAsUser: false,
+        impersonateUser: false,
+        forceNarrate: false
+      }
+    })
+
+    const persistCall = mocks.persistCharacterCompletionMock.mock.calls.at(-1) as
+      | unknown[]
+      | undefined
+    const persistPayload = persistCall?.[1] as
+      | Record<string, unknown>
+      | undefined
+    expect(persistPayload).toMatchObject({
+      assistant_content: "Em",
+      mood_label: "smug",
+      emote_events: [{ state: "smug", at_char: 0 }]
+    })
+    expect(persistPayload).not.toHaveProperty("mood_confidence")
+    expect(persistPayload).not.toHaveProperty("mood_topic")
+    expect(mocks.detectCharacterMoodMock).not.toHaveBeenCalled()
+
+    const assistantMessages = messageSnapshots
+      .flatMap((snapshot) => snapshot.filter((message) => message?.isBot))
+      .map((message) => ({
+        message: String(message?.message ?? ""),
+        moodLabel: message?.moodLabel,
+        metadataExtra: message?.metadataExtra
+      }))
+    expect(assistantMessages.some((entry) => entry.message.includes("Emote:"))).toBe(
+      false
+    )
+    expect(assistantMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "Em",
+          moodLabel: "smug",
+          metadataExtra: expect.objectContaining({
+            emote_events: [{ state: "smug", at_char: 0 }]
+          })
+        })
+      ])
+    )
+  })
+
   it("classifies structured provider setup failures without treating every 503 as configuration", () => {
     const providerSetupError = Object.assign(
       new Error("provider_not_configured: OpenAI API key is missing"),

--- a/apps/packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts
@@ -124,7 +124,15 @@ describe("createCharacterChatMode contract", () => {
       yield { delta: "Pong" }
     })
     mocks.consumeStreamingChunkMock.mockImplementation((state, chunk) => {
-      const token = String((chunk as { delta?: string })?.delta || "")
+      const token =
+        typeof chunk === "string"
+          ? chunk
+          : String(
+              (chunk as any)?.choices?.[0]?.delta?.content ??
+                (chunk as { delta?: string; content?: string })?.delta ??
+                (chunk as { content?: string })?.content ??
+                ""
+            )
       return {
         fullText: `${state.fullText}${token}`,
         contentToSave: `${state.contentToSave}${token}`,
@@ -243,6 +251,113 @@ describe("createCharacterChatMode contract", () => {
     )
     expect(setters.setServerChatId).toHaveBeenCalledWith("chat-77")
     expect(setters.setServerChatCharacterId).toHaveBeenCalledWith(42)
+  })
+
+  it("strips explicit streaming emote directives and persists emote events", async () => {
+    const setters = createSetterBundle()
+    let messagesState: any[] = []
+    const messageSnapshots: any[][] = []
+    const moodLabels: unknown[] = []
+    setters.setMessages.mockImplementation((next) => {
+      messagesState = typeof next === "function" ? next(messagesState) : next
+      messageSnapshots.push(messagesState)
+      const assistant = messagesState.find((message) => message?.isBot)
+      moodLabels.push(assistant?.moodLabel)
+    })
+    mocks.streamCharacterChatCompletionMock.mockImplementationOnce(
+      async function* () {
+        yield "Em"
+        yield "ote: smug\n"
+        yield "Hello "
+        yield "there.\n"
+        yield "Emote: annoyed\n"
+        yield "Fine."
+      }
+    )
+    mocks.detectCharacterMoodMock.mockReturnValueOnce({
+      label: "happy",
+      confidence: 0.9,
+      topic: "classifier"
+    })
+    const controller = new AbortController()
+    const mode = createCharacterChatMode({
+      ...setters,
+      t: translate as any,
+      notification: { error: vi.fn() },
+      selectedCharacter: {
+        id: 42,
+        name: "Mira",
+        avatar_url: "https://example.test/mira.png"
+      } as any,
+      temporaryChat: false,
+      historyId: "history-1",
+      serverChatId: null,
+      serverChatCharacterId: null,
+      serverChatState: "in-progress",
+      serverChatTopic: null,
+      serverChatClusterId: null,
+      serverChatSource: null,
+      serverChatExternalRef: null,
+      currentChatModelSettings: {
+        apiProvider: "openai",
+        setSystemPrompt: vi.fn()
+      },
+      invalidateServerChatHistory: vi.fn(),
+      greetingEnabled: false,
+      greetingSelectionId: null,
+      greetingsChecksum: null,
+      useCharacterDefault: false,
+      directedCharacterId: 88,
+      resolvedMessageSteeringPrompts: null,
+      getEffectiveSelectedModel: vi.fn(() => "tldw:test-model"),
+      saveMessageOnSuccess: vi.fn(async () => "history-1"),
+      saveMessageOnError: vi.fn(async () => "history-1"),
+      discardCurrentTurnOnAbortRef: { current: false }
+    } as any)
+
+    await mode({
+      message: "Test explicit emotes",
+      image: "",
+      isRegenerate: false,
+      messages: [],
+      history: [],
+      signal: controller.signal,
+      model: "tldw:test-model",
+      controller,
+      messageSteering: {
+        continueAsUser: false,
+        impersonateUser: false,
+        forceNarrate: false
+      }
+    })
+
+    const persistCall = mocks.persistCharacterCompletionMock.mock.calls.at(-1) as
+      | unknown[]
+      | undefined
+    const persistPayload = persistCall?.[1] as
+      | Record<string, unknown>
+      | undefined
+    expect(persistPayload).toMatchObject({
+      assistant_content: "Hello there.\nFine.",
+      mood_label: "annoyed",
+      emote_events: [
+        { state: "smug", at_char: 0 },
+        { state: "annoyed", at_char: 13 }
+      ]
+    })
+    expect(persistPayload).not.toHaveProperty("mood_confidence")
+    expect(persistPayload).not.toHaveProperty("mood_topic")
+    expect(mocks.detectCharacterMoodMock).not.toHaveBeenCalled()
+
+    const renderedAssistantMessages = messageSnapshots
+      .flatMap((snapshot) => snapshot.filter((message) => message?.isBot))
+      .map((message) => String(message?.message ?? ""))
+    expect(
+      renderedAssistantMessages.some((message) => message.includes("Emote:"))
+    ).toBe(false)
+    expect(renderedAssistantMessages.at(-1)).toBe("Hello there.\nFine.")
+    expect(moodLabels).toContain("smug")
+    expect(moodLabels).toContain("annoyed")
   })
 
   it("classifies structured provider setup failures without treating every 503 as configuration", () => {

--- a/apps/packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts
@@ -466,6 +466,196 @@ describe("createCharacterChatMode contract", () => {
     )
   })
 
+  it(
+    "does not duplicate recovery persistence when saved-degraded includes emote metadata",
+    async () => {
+      const setters = createSetterBundle()
+      let messagesState: any[] = []
+      setters.setMessages.mockImplementation((next) => {
+        messagesState =
+          typeof next === "function" ? next(messagesState) : next
+      })
+      mocks.streamCharacterChatCompletionMock.mockImplementationOnce(
+        async function* () {
+          yield "Em"
+          yield "ote: smug\n"
+          yield "Em"
+          throw new Error("stream failed")
+        }
+      )
+      mocks.persistCharacterCompletionMock.mockRejectedValueOnce(
+        Object.assign(new Error("saved degraded"), {
+          status: 503,
+          detail: {
+            code: "persist_validation_degraded",
+            saved: true,
+            assistant_message_id: "assistant-degraded-1",
+            version: 7
+          }
+        })
+      )
+      const controller = new AbortController()
+      const mode = createCharacterChatMode({
+        ...setters,
+        t: translate as any,
+        notification: { error: vi.fn() },
+        selectedCharacter: {
+          id: 42,
+          name: "Mira",
+          avatar_url: "https://example.test/mira.png"
+        } as any,
+        temporaryChat: false,
+        historyId: "history-1",
+        serverChatId: null,
+        serverChatCharacterId: null,
+        serverChatState: "in-progress",
+        serverChatTopic: null,
+        serverChatClusterId: null,
+        serverChatSource: null,
+        serverChatExternalRef: null,
+        currentChatModelSettings: {
+          apiProvider: "openai",
+          setSystemPrompt: vi.fn()
+        },
+        invalidateServerChatHistory: vi.fn(),
+        greetingEnabled: false,
+        greetingSelectionId: null,
+        greetingsChecksum: null,
+        useCharacterDefault: false,
+        directedCharacterId: 88,
+        resolvedMessageSteeringPrompts: null,
+        getEffectiveSelectedModel: vi.fn(() => "tldw:test-model"),
+        saveMessageOnSuccess: vi.fn(async () => "history-1"),
+        saveMessageOnError: vi.fn(async () => "history-1"),
+        discardCurrentTurnOnAbortRef: { current: false }
+      } as any)
+
+      await mode({
+        message: "Recover saved degraded emote",
+        image: "",
+        isRegenerate: false,
+        messages: [],
+        history: [],
+        signal: controller.signal,
+        model: "tldw:test-model",
+        controller,
+        messageSteering: {
+          continueAsUser: false,
+          impersonateUser: false,
+          forceNarrate: false
+        }
+      })
+
+      const assistantAddCalls = mocks.addChatMessageMock.mock.calls.filter(
+        ([, payload]: [unknown, any]) => payload?.role === "assistant"
+      )
+      expect(assistantAddCalls).toHaveLength(0)
+      expect(messagesState).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            isBot: true,
+            serverMessageId: "assistant-degraded-1",
+            serverMessageVersion: 7,
+            moodLabel: "smug",
+            metadataExtra: expect.objectContaining({
+              emote_events: [{ state: "smug", at_char: 0 }]
+            })
+          })
+        ])
+      )
+    }
+  )
+
+  it("sends emote metadata when normal persist falls back to addChatMessage", async () => {
+    const setters = createSetterBundle()
+    let messagesState: any[] = []
+    setters.setMessages.mockImplementation((next) => {
+      messagesState = typeof next === "function" ? next(messagesState) : next
+    })
+    mocks.streamCharacterChatCompletionMock.mockImplementationOnce(
+      async function* () {
+        yield "Em"
+        yield "ote: smug\n"
+        yield "Hello."
+      }
+    )
+    mocks.persistCharacterCompletionMock.mockRejectedValueOnce(
+      Object.assign(new Error("persist failed"), { status: 500 })
+    )
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+    const controller = new AbortController()
+    const mode = createCharacterChatMode({
+      ...setters,
+      t: translate as any,
+      notification: { error: vi.fn() },
+      selectedCharacter: {
+        id: 42,
+        name: "Mira",
+        avatar_url: "https://example.test/mira.png"
+      } as any,
+      temporaryChat: false,
+      historyId: "history-1",
+      serverChatId: null,
+      serverChatCharacterId: null,
+      serverChatState: "in-progress",
+      serverChatTopic: null,
+      serverChatClusterId: null,
+      serverChatSource: null,
+      serverChatExternalRef: null,
+      currentChatModelSettings: {
+        apiProvider: "openai",
+        setSystemPrompt: vi.fn()
+      },
+      invalidateServerChatHistory: vi.fn(),
+      greetingEnabled: false,
+      greetingSelectionId: null,
+      greetingsChecksum: null,
+      useCharacterDefault: false,
+      directedCharacterId: 88,
+      resolvedMessageSteeringPrompts: null,
+      getEffectiveSelectedModel: vi.fn(() => "tldw:test-model"),
+      saveMessageOnSuccess: vi.fn(async () => "history-1"),
+      saveMessageOnError: vi.fn(async () => "history-1"),
+      discardCurrentTurnOnAbortRef: { current: false }
+    } as any)
+
+    try {
+      await mode({
+        message: "Fallback explicit emote",
+        image: "",
+        isRegenerate: false,
+        messages: [],
+        history: [],
+        signal: controller.signal,
+        model: "tldw:test-model",
+        controller,
+        messageSteering: {
+          continueAsUser: false,
+          impersonateUser: false,
+          forceNarrate: false
+        }
+      })
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+
+    const assistantAddCall = mocks.addChatMessageMock.mock.calls.find(
+      ([, payload]: [unknown, any]) => payload?.role === "assistant"
+    )
+    expect(assistantAddCall?.[1]).toMatchObject({
+      role: "assistant",
+      content: "Hello.",
+      metadata_extra: expect.objectContaining({
+        mood_label: "smug",
+        mood_confidence: null,
+        mood_topic: null,
+        emote_events: [{ state: "smug", at_char: 0 }]
+      })
+    })
+  })
+
   it("classifies structured provider setup failures without treating every 503 as configuration", () => {
     const providerSetupError = Object.assign(
       new Error("provider_not_configured: OpenAI API key is missing"),

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
@@ -7,6 +7,7 @@ import { useChatActions } from "../useChatActions"
 
 const {
   createChatMock,
+  detectCharacterMoodMock,
   streamCharacterChatCompletionMock,
   persistCharacterCompletionMock,
   addChatMessageMock,
@@ -14,6 +15,7 @@ const {
   resolveVisualIdentityBindingMock
 } = vi.hoisted(() => ({
   createChatMock: vi.fn(),
+  detectCharacterMoodMock: vi.fn(),
   streamCharacterChatCompletionMock: vi.fn(),
   persistCharacterCompletionMock: vi.fn(async () => ({
     assistant_message_id: "assistant-server-1",
@@ -112,6 +114,10 @@ vi.mock("@/db/dexie/branch", () => ({
 
 vi.mock("@/services/actor-settings", () => ({
   getActorSettingsForChat: vi.fn(async () => null)
+}))
+
+vi.mock("@/utils/character-mood", () => ({
+  detectCharacterMood: detectCharacterMoodMock
 }))
 
 vi.mock("@/utils/selected-character-storage", () => ({
@@ -272,6 +278,11 @@ describe("useChatActions character integration", () => {
           }
         ]
       }
+    })
+    detectCharacterMoodMock.mockReturnValue({
+      label: "neutral",
+      confidence: 0.2,
+      topic: "reply"
     })
     messageStoreState.value = {
       selectedModel: "deepseek-chat",
@@ -661,5 +672,70 @@ describe("useChatActions character integration", () => {
       { scope }
     )
     expect(normalChatModeMock).not.toHaveBeenCalled()
+  })
+
+  it("strips explicit streaming emote directives and persists emote events", async () => {
+    streamCharacterChatCompletionMock.mockImplementationOnce(async function* () {
+      yield "Em"
+      yield "ote: smug\n"
+      yield "Hello "
+      yield "there.\n"
+      yield "Emote: annoyed\n"
+      yield "Fine."
+    })
+    detectCharacterMoodMock.mockReturnValueOnce({
+      label: "happy",
+      confidence: 0.9,
+      topic: "classifier"
+    })
+
+    let messagesState: any[] = []
+    const messageSnapshots: any[][] = []
+    const moodLabels: unknown[] = []
+    const options = {
+      ...createHookOptions(),
+      setMessages: vi.fn((next) => {
+        messagesState = typeof next === "function" ? next(messagesState) : next
+        messageSnapshots.push(messagesState)
+        const assistant = messagesState.find((message) => message?.isBot)
+        moodLabels.push(assistant?.moodLabel)
+      })
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Test explicit emotes",
+        image: ""
+      })
+    })
+
+    const persistCall = persistCharacterCompletionMock.mock.calls.at(-1) as
+      | unknown[]
+      | undefined
+    const persistPayload = persistCall?.[1] as
+      | Record<string, unknown>
+      | undefined
+    expect(persistPayload).toMatchObject({
+      assistant_content: "Hello there.\nFine.",
+      mood_label: "annoyed",
+      emote_events: [
+        { state: "smug", at_char: 0 },
+        { state: "annoyed", at_char: 13 }
+      ]
+    })
+    expect(persistPayload).not.toHaveProperty("mood_confidence")
+    expect(persistPayload).not.toHaveProperty("mood_topic")
+    expect(detectCharacterMoodMock).not.toHaveBeenCalled()
+
+    const renderedAssistantMessages = messageSnapshots
+      .flatMap((snapshot) => snapshot.filter((message) => message?.isBot))
+      .map((message) => String(message?.message ?? ""))
+    expect(
+      renderedAssistantMessages.some((message) => message.includes("Emote:"))
+    ).toBe(false)
+    expect(renderedAssistantMessages.at(-1)).toBe("Hello there.\nFine.")
+    expect(moodLabels).toContain("smug")
+    expect(moodLabels).toContain("annoyed")
   })
 })

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
@@ -738,4 +738,68 @@ describe("useChatActions character integration", () => {
     expect(moodLabels).toContain("smug")
     expect(moodLabels).toContain("annoyed")
   })
+
+  it("preserves explicit emote metadata when recovering a failed stream", async () => {
+    streamCharacterChatCompletionMock.mockImplementationOnce(async function* () {
+      yield "Em"
+      yield "ote: smug\n"
+      yield "Em"
+      throw new Error("stream failed")
+    })
+
+    let messagesState: any[] = []
+    const messageSnapshots: any[][] = []
+    const options = {
+      ...createHookOptions(),
+      setMessages: vi.fn((next) => {
+        messagesState = typeof next === "function" ? next(messagesState) : next
+        messageSnapshots.push(messagesState)
+      })
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Recover explicit emote",
+        image: ""
+      })
+    })
+
+    const persistCall = persistCharacterCompletionMock.mock.calls.at(-1) as
+      | unknown[]
+      | undefined
+    const persistPayload = persistCall?.[1] as
+      | Record<string, unknown>
+      | undefined
+    expect(persistPayload).toMatchObject({
+      assistant_content: "Em",
+      mood_label: "smug",
+      emote_events: [{ state: "smug", at_char: 0 }]
+    })
+    expect(persistPayload).not.toHaveProperty("mood_confidence")
+    expect(persistPayload).not.toHaveProperty("mood_topic")
+    expect(detectCharacterMoodMock).not.toHaveBeenCalled()
+
+    const assistantMessages = messageSnapshots
+      .flatMap((snapshot) => snapshot.filter((message) => message?.isBot))
+      .map((message) => ({
+        message: String(message?.message ?? ""),
+        moodLabel: message?.moodLabel,
+        metadataExtra: message?.metadataExtra
+      }))
+    expect(assistantMessages.some((entry) => entry.message.includes("Emote:"))).toBe(
+      false
+    )
+    expect(assistantMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "Em",
+          moodLabel: "smug",
+          metadataExtra: expect.objectContaining({
+            emote_events: [{ state: "smug", at_char: 0 }]
+          })
+        })
+      ])
+    )
+  })
 })

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { useChatActions } from "../useChatActions"
 
 const {
+  addChatMessageMock,
   createChatMock,
   detectCharacterMoodMock,
   streamCharacterChatCompletionMock,
@@ -14,6 +15,7 @@ const {
   normalChatModeMock,
   resolveVisualIdentityBindingMock
 } = vi.hoisted(() => ({
+  addChatMessageMock: vi.fn(async () => ({ id: "user-server-1", version: 1 })),
   createChatMock: vi.fn(),
   detectCharacterMoodMock: vi.fn(),
   streamCharacterChatCompletionMock: vi.fn(),
@@ -801,5 +803,108 @@ describe("useChatActions character integration", () => {
         })
       ])
     )
+  })
+
+  it(
+    "does not duplicate recovery persistence when saved-degraded includes emote metadata",
+    async () => {
+      streamCharacterChatCompletionMock.mockImplementationOnce(
+        async function* () {
+          yield "Em"
+          yield "ote: smug\n"
+          yield "Em"
+          throw new Error("stream failed")
+        }
+      )
+      persistCharacterCompletionMock.mockRejectedValueOnce(
+        Object.assign(new Error("saved degraded"), {
+          status: 503,
+          detail: {
+            code: "persist_validation_degraded",
+            saved: true,
+            assistant_message_id: "assistant-degraded-1",
+            version: 7
+          }
+        })
+      )
+
+      let messagesState: any[] = []
+      const options = {
+        ...createHookOptions(),
+        setMessages: vi.fn((next) => {
+          messagesState =
+            typeof next === "function" ? next(messagesState) : next
+        })
+      }
+      const { result } = renderHook(() => useChatActions(options as any))
+
+      await act(async () => {
+        await result.current.onSubmit({
+          message: "Recover saved degraded emote",
+          image: ""
+        })
+      })
+
+      const tldwAddCalls = addChatMessageMock.mock.calls.filter(
+        ([, payload]: [unknown, any]) => payload?.role === "assistant"
+      )
+      expect(tldwAddCalls).toHaveLength(0)
+      expect(messagesState).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            isBot: true,
+            serverMessageId: "assistant-degraded-1",
+            serverMessageVersion: 7,
+            moodLabel: "smug",
+            metadataExtra: expect.objectContaining({
+              emote_events: [{ state: "smug", at_char: 0 }]
+            })
+          })
+        ])
+      )
+    }
+  )
+
+  it("sends emote metadata when normal persist falls back to addChatMessage", async () => {
+    streamCharacterChatCompletionMock.mockImplementationOnce(async function* () {
+      yield "Em"
+      yield "ote: smug\n"
+      yield "Hello."
+    })
+    persistCharacterCompletionMock.mockRejectedValueOnce(
+      Object.assign(new Error("persist failed"), { status: 500 })
+    )
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+
+    const options = createHookOptions()
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    try {
+      await act(async () => {
+        await result.current.onSubmit({
+          message: "Fallback explicit emote",
+          image: ""
+        })
+      })
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+
+    const tldwAddCalls = addChatMessageMock.mock.calls
+    const assistantAddCall = tldwAddCalls.find(
+      ([, payload]: [unknown, any]) => payload?.role === "assistant"
+    )
+    expect(assistantAddCall?.[1]).toMatchObject({
+      role: "assistant",
+      content: "Hello.",
+      metadata_extra: expect.objectContaining({
+        mood_label: "smug",
+        mood_confidence: null,
+        mood_topic: null,
+        emote_events: [{ state: "smug", at_char: 0 }]
+      })
+    })
   })
 })

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx
@@ -11,7 +11,6 @@ const {
   detectCharacterMoodMock,
   streamCharacterChatCompletionMock,
   persistCharacterCompletionMock,
-  addChatMessageMock,
   normalChatModeMock,
   resolveVisualIdentityBindingMock
 } = vi.hoisted(() => ({
@@ -23,7 +22,6 @@ const {
     assistant_message_id: "assistant-server-1",
     version: 1
   })),
-  addChatMessageMock: vi.fn(async () => ({ id: "user-server-1", version: 1 })),
   normalChatModeMock: vi.fn(),
   resolveVisualIdentityBindingMock: vi.fn(async () => ({
     actor_kind: "character",

--- a/apps/packages/ui/src/hooks/chat/character-emote-stream.ts
+++ b/apps/packages/ui/src/hooks/chat/character-emote-stream.ts
@@ -1,0 +1,71 @@
+import {
+  createCharacterEmoteStreamParser,
+  type CharacterEmoteEvent
+} from "@/utils/character-emotes"
+
+type StreamChunkState = {
+  fullText: string
+  contentToSave: string
+  token: string
+}
+
+type StreamTextState = {
+  fullText: string
+  contentToSave: string
+}
+
+const replaceTrailingToken = (
+  text: string,
+  token: string,
+  visibleText: string
+): string => {
+  if (!token) return text
+  return `${text.slice(0, Math.max(0, text.length - token.length))}${visibleText}`
+}
+
+export const createCharacterEmoteStream = () => {
+  const parser = createCharacterEmoteStreamParser()
+  const events: CharacterEmoteEvent[] = []
+
+  const remember = (newEvents: CharacterEmoteEvent[]) => {
+    if (newEvents.length > 0) events.push(...newEvents)
+    return newEvents
+  }
+
+  return {
+    events,
+    sanitizeChunk<T extends StreamChunkState>(chunkState: T) {
+      if (!chunkState.token) {
+        return { ...chunkState, visibleText: "", emoteEvents: [] }
+      }
+      const parsed = parser.push(chunkState.token)
+      return {
+        ...chunkState,
+        fullText: replaceTrailingToken(
+          chunkState.fullText,
+          chunkState.token,
+          parsed.visibleText
+        ),
+        contentToSave: replaceTrailingToken(
+          chunkState.contentToSave,
+          chunkState.token,
+          parsed.visibleText
+        ),
+        visibleText: parsed.visibleText,
+        emoteEvents: remember(parsed.events)
+      }
+    },
+    flush(state: StreamTextState) {
+      const parsed = parser.flush()
+      if (!parsed.visibleText) {
+        return { ...state, visibleText: "", emoteEvents: remember(parsed.events) }
+      }
+      return {
+        fullText: `${state.fullText}${parsed.visibleText}`,
+        contentToSave: `${state.contentToSave}${parsed.visibleText}`,
+        visibleText: parsed.visibleText,
+        emoteEvents: remember(parsed.events)
+      }
+    }
+  }
+}

--- a/apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts
+++ b/apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts
@@ -43,9 +43,11 @@ import {
   discardAbortedTurnIfRequested,
 } from "@/hooks/chat/abort-turn-cleanup";
 import { resolveSavedDegradedCharacterPersist } from "@/hooks/chat/characterPersistOutcome";
+import { createCharacterEmoteStream } from "@/hooks/chat/character-emote-stream";
 import type { Character } from "@/types/character";
+import type { CharacterEmoteEvent } from "@/utils/character-emotes";
 import type { ChatScope } from "@/types/chat-scope";
-import type { ChatHistory, Message } from "@/store/option";
+import type { ChatHistory, Message, MessageMetadataExtra } from "@/store/option";
 import {
   attemptCharacterStreamRecoveryPersist,
   type TldwChatMeta,
@@ -884,6 +886,27 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
       let apiReasoning = false;
       let streamTransportInterrupted = false;
       let streamTransportInterruptionReason: string | null = null;
+      const emoteStream = createCharacterEmoteStream();
+      const applyEmoteEventsToMessage = (
+        newEvents: CharacterEmoteEvent[],
+      ) => {
+        if (newEvents.length === 0) return;
+        const moodLabel =
+          emoteStream.events[emoteStream.events.length - 1]?.state;
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === generateMessageId
+              ? updateActiveVariant(m, {
+                  moodLabel,
+                  metadataExtra: {
+                    ...(m.metadataExtra ?? {}),
+                    emote_events: [...emoteStream.events],
+                  },
+                })
+              : m,
+          ),
+        );
+      };
 
       const explicitProvider = resolveExplicitProviderForSelectedModel({
         currentSelectedModel: getEffectiveSelectedModel(),
@@ -945,15 +968,18 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
             detail.length > 0 ? detail : streamTransportInterruptionReason;
           continue;
         }
+        const previousFullText = fullText;
         const chunkState = consumeStreamingChunk(
           { fullText, contentToSave, apiReasoning },
           chunk,
         );
-        fullText = chunkState.fullText;
-        contentToSave = chunkState.contentToSave;
-        apiReasoning = chunkState.apiReasoning;
+        const sanitizedChunkState = emoteStream.sanitizeChunk(chunkState);
+        fullText = sanitizedChunkState.fullText;
+        contentToSave = sanitizedChunkState.contentToSave;
+        apiReasoning = sanitizedChunkState.apiReasoning;
+        applyEmoteEventsToMessage(sanitizedChunkState.emoteEvents);
 
-        if (chunkState.token) {
+        if (chunkState.token && fullText !== previousFullText) {
           scheduleStreamingUpdate(`${fullText}▋`, timetaken);
         }
         if (count === 0) {
@@ -981,6 +1007,10 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
       cancelStreamingUpdate();
       flushStreamingUpdate();
       if (inactivityTimer) clearTimeout(inactivityTimer);
+      const flushedEmotes = emoteStream.flush({ fullText, contentToSave });
+      fullText = flushedEmotes.fullText;
+      contentToSave = flushedEmotes.contentToSave;
+      applyEmoteEventsToMessage(flushedEmotes.emoteEvents);
 
       if (inactivityAborted) {
         const timeoutError = new Error(
@@ -1036,7 +1066,7 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
         let resolvedMoodLabel: string | undefined;
         let resolvedMoodConfidence: number | undefined;
         let resolvedMoodTopic: string | undefined;
-        let metadataExtra: Record<string, unknown> | undefined;
+        let metadataExtra: MessageMetadataExtra | undefined;
         try {
           fallbackSpeakerId = Number.parseInt(
             String(activeCharacter.id),
@@ -1049,20 +1079,26 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
               : Number.isFinite(fallbackSpeakerId) && fallbackSpeakerId > 0
                 ? fallbackSpeakerId
                 : undefined;
-          detectedMood = detectCharacterMood({
-            assistantText: finalPersistedContent,
-            userText: message,
-          });
-          resolvedMoodLabel = detectedMood.label;
-          resolvedMoodConfidence =
-            typeof detectedMood.confidence === "number" &&
-            Number.isFinite(detectedMood.confidence)
-              ? detectedMood.confidence
-              : undefined;
-          resolvedMoodTopic =
-            typeof detectedMood.topic === "string" && detectedMood.topic.trim()
-              ? detectedMood.topic.trim()
-              : undefined;
+          if (emoteStream.events.length > 0) {
+            resolvedMoodLabel =
+              emoteStream.events[emoteStream.events.length - 1]?.state;
+          } else {
+            detectedMood = detectCharacterMood({
+              assistantText: finalPersistedContent,
+              userText: message,
+            });
+            resolvedMoodLabel = detectedMood.label;
+            resolvedMoodConfidence =
+              typeof detectedMood.confidence === "number" &&
+              Number.isFinite(detectedMood.confidence)
+                ? detectedMood.confidence
+                : undefined;
+            resolvedMoodTopic =
+              typeof detectedMood.topic === "string" &&
+              detectedMood.topic.trim()
+                ? detectedMood.topic.trim()
+                : undefined;
+          }
 
           const persistPayload: Record<string, unknown> = {
             assistant_content: finalPersistedContent,
@@ -1079,6 +1115,9 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
           if (resolvedMoodTopic) {
             persistPayload.mood_topic = resolvedMoodTopic;
           }
+          if (emoteStream.events.length > 0) {
+            persistPayload.emote_events = [...emoteStream.events];
+          }
           if (persistedUserServerMessageId) {
             persistPayload.user_message_id = persistedUserServerMessageId;
           }
@@ -1088,6 +1127,9 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
             mood_label: resolvedMoodLabel,
             mood_confidence: resolvedMoodConfidence ?? null,
             mood_topic: resolvedMoodTopic ?? null,
+            ...(emoteStream.events.length > 0
+              ? { emote_events: [...emoteStream.events] }
+              : {}),
           };
 
           const persisted = (await tldwClient.persistCharacterCompletion(

--- a/apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts
+++ b/apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts
@@ -1220,6 +1220,7 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
                 {
                   role: "assistant",
                   content: finalPersistedContent,
+                  ...(metadataExtra ? { metadata_extra: metadataExtra } : {}),
                 },
                 scope ? { scope } : undefined,
               )) as { id?: string | number; version?: number } | null;
@@ -1388,8 +1389,34 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
                 );
                 return true;
               }
-            } catch {
-              // Fall back to the generic chat-message endpoint below.
+            } catch (persistError) {
+              const savedOutcome =
+                resolveSavedDegradedCharacterPersist(persistError);
+              if (savedOutcome?.saved) {
+                assistantPersistedToServer = true;
+                setMessages(
+                  (prev) =>
+                    (prev as any[]).map((m) => {
+                      if (m.id !== generateMessageId) return m;
+                      const serverMessageId =
+                        savedOutcome.assistantMessageId != null
+                          ? String(savedOutcome.assistantMessageId)
+                          : undefined;
+                      return updateActiveVariant(m, {
+                        serverMessageId,
+                        serverMessageVersion: savedOutcome.version,
+                        metadataExtra: {
+                          ...(m.metadataExtra ?? {}),
+                          ...(recoveryMetadataExtra ?? {}),
+                        },
+                        moodLabel: recoveryMoodLabel,
+                        moodConfidence: null,
+                        moodTopic: null,
+                      });
+                    }) as Message[],
+                );
+                return true;
+              }
             }
           }
           const payload: Record<string, unknown> = {

--- a/apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts
+++ b/apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts
@@ -565,6 +565,47 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
       clearTimeout(streamingTimer);
       streamingTimer = null;
     };
+    const emoteStream = createCharacterEmoteStream();
+    const getExplicitEmoteMoodLabel = () =>
+      emoteStream.events.length > 0
+        ? emoteStream.events[emoteStream.events.length - 1]?.state
+        : undefined;
+    const getExplicitEmoteMetadataExtra = (): MessageMetadataExtra | undefined => {
+      const moodLabel = getExplicitEmoteMoodLabel();
+      return moodLabel
+        ? {
+            mood_label: moodLabel,
+            mood_confidence: null,
+            mood_topic: null,
+            emote_events: [...emoteStream.events],
+          }
+        : undefined;
+    };
+    const applyEmoteEventsToMessage = (
+      newEvents: CharacterEmoteEvent[],
+    ) => {
+      if (newEvents.length === 0) return;
+      const moodLabel = getExplicitEmoteMoodLabel();
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === generateMessageId
+            ? updateActiveVariant(m, {
+                moodLabel,
+                metadataExtra: {
+                  ...(m.metadataExtra ?? {}),
+                  emote_events: [...emoteStream.events],
+                },
+              })
+            : m,
+        ),
+      );
+    };
+    const flushCharacterEmoteStream = () => {
+      const flushedEmotes = emoteStream.flush({ fullText, contentToSave });
+      fullText = flushedEmotes.fullText;
+      contentToSave = flushedEmotes.contentToSave;
+      applyEmoteEventsToMessage(flushedEmotes.emoteEvents);
+    };
 
     const abortCancelStreamingUpdate = () => cancelStreamingUpdate();
     signal.addEventListener("abort", abortCancelStreamingUpdate);
@@ -886,27 +927,6 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
       let apiReasoning = false;
       let streamTransportInterrupted = false;
       let streamTransportInterruptionReason: string | null = null;
-      const emoteStream = createCharacterEmoteStream();
-      const applyEmoteEventsToMessage = (
-        newEvents: CharacterEmoteEvent[],
-      ) => {
-        if (newEvents.length === 0) return;
-        const moodLabel =
-          emoteStream.events[emoteStream.events.length - 1]?.state;
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === generateMessageId
-              ? updateActiveVariant(m, {
-                  moodLabel,
-                  metadataExtra: {
-                    ...(m.metadataExtra ?? {}),
-                    emote_events: [...emoteStream.events],
-                  },
-                })
-              : m,
-          ),
-        );
-      };
 
       const explicitProvider = resolveExplicitProviderForSelectedModel({
         currentSelectedModel: getEffectiveSelectedModel(),
@@ -1007,10 +1027,7 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
       cancelStreamingUpdate();
       flushStreamingUpdate();
       if (inactivityTimer) clearTimeout(inactivityTimer);
-      const flushedEmotes = emoteStream.flush({ fullText, contentToSave });
-      fullText = flushedEmotes.fullText;
-      contentToSave = flushedEmotes.contentToSave;
-      applyEmoteEventsToMessage(flushedEmotes.emoteEvents);
+      flushCharacterEmoteStream();
 
       if (inactivityAborted) {
         const timeoutError = new Error(
@@ -1314,6 +1331,9 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
       }
 
       cancelStreamingUpdate();
+      flushCharacterEmoteStream();
+      const recoveryMoodLabel = getExplicitEmoteMoodLabel();
+      const recoveryMetadataExtra = getExplicitEmoteMetadataExtra();
       await attemptCharacterStreamRecoveryPersist({
         chatId: activeChatId,
         temporaryChat,
@@ -1322,12 +1342,66 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
         error: e,
         persist: async (assistantContent) => {
           if (!activeChatId) return false;
+          if (recoveryMoodLabel) {
+            try {
+              const persistPayload: Record<string, unknown> = {
+                assistant_content: assistantContent,
+                assistant_message_id: generateMessageId,
+                mood_label: recoveryMoodLabel,
+                emote_events: [...emoteStream.events],
+              };
+              if (persistedUserServerMessageId) {
+                persistPayload.user_message_id = persistedUserServerMessageId;
+              }
+              const persisted = (await tldwClient.persistCharacterCompletion(
+                activeChatId,
+                persistPayload,
+                scope ? { scope } : undefined,
+              )) as {
+                assistant_message_id?: string | number;
+                message_id?: string | number;
+                id?: string | number;
+                version?: number;
+              } | null;
+              const createdAsstServerId =
+                persisted?.assistant_message_id ??
+                persisted?.message_id ??
+                persisted?.id;
+              if (createdAsstServerId != null) {
+                assistantPersistedToServer = true;
+                setMessages(
+                  (prev) =>
+                    (prev as any[]).map((m) => {
+                      if (m.id !== generateMessageId) return m;
+                      return updateActiveVariant(m, {
+                        serverMessageId: String(createdAsstServerId),
+                        serverMessageVersion: persisted?.version,
+                        metadataExtra: {
+                          ...(m.metadataExtra ?? {}),
+                          ...(recoveryMetadataExtra ?? {}),
+                        },
+                        moodLabel: recoveryMoodLabel,
+                        moodConfidence: null,
+                        moodTopic: null,
+                      });
+                    }) as Message[],
+                );
+                return true;
+              }
+            } catch {
+              // Fall back to the generic chat-message endpoint below.
+            }
+          }
+          const payload: Record<string, unknown> = {
+            role: "assistant",
+            content: assistantContent,
+          };
+          if (recoveryMetadataExtra) {
+            payload.metadata_extra = recoveryMetadataExtra;
+          }
           const createdAsst = (await tldwClient.addChatMessage(
             activeChatId,
-            {
-              role: "assistant",
-              content: assistantContent,
-            },
+            payload,
             scope ? { scope } : undefined,
           )) as { id?: string | number; version?: number } | null;
           if (createdAsst?.id == null) return false;
@@ -1339,6 +1413,17 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
                 return updateActiveVariant(m, {
                   serverMessageId: String(createdAsst.id),
                   serverMessageVersion: createdAsst?.version,
+                  ...(recoveryMetadataExtra
+                    ? {
+                        metadataExtra: {
+                          ...(m.metadataExtra ?? {}),
+                          ...recoveryMetadataExtra,
+                        },
+                        moodLabel: recoveryMoodLabel,
+                        moodConfidence: null,
+                        moodTopic: null,
+                      }
+                    : {}),
                 });
               }) as Message[],
           );
@@ -1358,6 +1443,17 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
             msg.id === generateMessageId
               ? updateActiveVariant(msg, {
                   message: assistantContent,
+                  ...(recoveryMetadataExtra
+                    ? {
+                        metadataExtra: {
+                          ...(msg.metadataExtra ?? {}),
+                          ...recoveryMetadataExtra,
+                        },
+                        moodLabel: recoveryMoodLabel,
+                        moodConfidence: null,
+                        moodTopic: null,
+                      }
+                    : {}),
                   generationInfo: {
                     ...(msg.generationInfo || {}),
                     interrupted: true,

--- a/apps/packages/ui/src/hooks/chat/useChatActions.ts
+++ b/apps/packages/ui/src/hooks/chat/useChatActions.ts
@@ -2441,10 +2441,15 @@ export const useChatActions = ({
             )
           } else {
             try {
-              const createdAsst = (await tldwClient.addChatMessage(chatId, {
-                role: "assistant",
-                content: finalPersistedContent
-              }, scope ? { scope } : undefined)) as {
+              const createdAsst = (await tldwClient.addChatMessage(
+                chatId,
+                {
+                  role: "assistant",
+                  content: finalPersistedContent,
+                  ...(metadataExtra ? { metadata_extra: metadataExtra } : {})
+                },
+                scope ? { scope } : undefined
+              )) as {
                 id?: string | number
                 version?: number
               } | null
@@ -2614,8 +2619,33 @@ export const useChatActions = ({
                 )
                 return true
               }
-            } catch {
-              // Fall back to the generic chat-message endpoint below.
+            } catch (persistError) {
+              const savedOutcome =
+                resolveSavedDegradedCharacterPersist(persistError)
+              if (savedOutcome?.saved) {
+                assistantPersistedToServer = true
+                setMessages((prev) =>
+                  ((prev as any[]).map((m) => {
+                    if (m.id !== generateMessageId) return m
+                    const serverMessageId =
+                      savedOutcome.assistantMessageId != null
+                        ? String(savedOutcome.assistantMessageId)
+                        : undefined
+                    return updateActiveVariant(m, {
+                      serverMessageId,
+                      serverMessageVersion: savedOutcome.version,
+                      metadataExtra: {
+                        ...(m.metadataExtra ?? {}),
+                        ...(recoveryMetadataExtra ?? {})
+                      },
+                      moodLabel: recoveryMoodLabel,
+                      moodConfidence: null,
+                      moodTopic: null
+                    })
+                  }) as Message[])
+                )
+                return true
+              }
             }
           }
           const payload: Record<string, unknown> = {

--- a/apps/packages/ui/src/hooks/chat/useChatActions.ts
+++ b/apps/packages/ui/src/hooks/chat/useChatActions.ts
@@ -94,6 +94,7 @@ import { validateCachedServerChatId } from "@/store/workspace-sync-contract"
 import { trackCompareMetric } from "@/utils/compare-metrics"
 import { MAX_COMPARE_MODELS } from "@/hooks/chat/compare-constants"
 import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord"
+import { createCharacterEmoteStream } from "@/hooks/chat/character-emote-stream"
 import {
   discardAbortedTurnIfRequested,
   isAbortLikeError
@@ -120,6 +121,7 @@ import {
   type AssistantSelection
 } from "@/types/assistant-selection"
 import type { Character } from "@/types/character"
+import type { CharacterEmoteEvent } from "@/utils/character-emotes"
 import type {
   MessageSteeringMode,
   MessageSteeringPromptTemplates,
@@ -2046,6 +2048,27 @@ export const useChatActions = ({
       let apiReasoning = false
       let streamTransportInterrupted = false
       let streamTransportInterruptionReason: string | null = null
+      const emoteStream = createCharacterEmoteStream()
+      const applyEmoteEventsToMessage = (
+        newEvents: CharacterEmoteEvent[]
+      ) => {
+        if (newEvents.length === 0) return
+        const moodLabel =
+          emoteStream.events[emoteStream.events.length - 1]?.state
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === generateMessageId
+              ? updateActiveVariant(m, {
+                  moodLabel,
+                  metadataExtra: {
+                    ...(m.metadataExtra ?? {}),
+                    emote_events: [...emoteStream.events]
+                  }
+                })
+              : m
+          )
+        )
+      }
 
       const explicitProvider = resolveExplicitProviderForSelectedModel({
         currentSelectedModel: getEffectiveSelectedModel(),
@@ -2114,15 +2137,18 @@ export const useChatActions = ({
             detail.length > 0 ? detail : streamTransportInterruptionReason
           continue
         }
+        const previousFullText = fullText
         const chunkState = consumeStreamingChunk(
           { fullText, contentToSave, apiReasoning },
           chunk
         )
-        fullText = chunkState.fullText
-        contentToSave = chunkState.contentToSave
-        apiReasoning = chunkState.apiReasoning
+        const sanitizedChunkState = emoteStream.sanitizeChunk(chunkState)
+        fullText = sanitizedChunkState.fullText
+        contentToSave = sanitizedChunkState.contentToSave
+        apiReasoning = sanitizedChunkState.apiReasoning
+        applyEmoteEventsToMessage(sanitizedChunkState.emoteEvents)
 
-        if (chunkState.token) {
+        if (chunkState.token && fullText !== previousFullText) {
           scheduleStreamingUpdate(`${fullText}▋`, timetaken)
         }
         if (count === 0) {
@@ -2150,6 +2176,10 @@ export const useChatActions = ({
       cancelStreamingUpdate()
       flushStreamingUpdate()
       if (inactivityTimer) clearTimeout(inactivityTimer)
+      const flushedEmotes = emoteStream.flush({ fullText, contentToSave })
+      fullText = flushedEmotes.fullText
+      contentToSave = flushedEmotes.contentToSave
+      applyEmoteEventsToMessage(flushedEmotes.emoteEvents)
 
       if (inactivityAborted) {
         const timeoutError = new Error(
@@ -2205,7 +2235,7 @@ export const useChatActions = ({
         let resolvedMoodLabel: string | undefined
         let resolvedMoodConfidence: number | undefined
         let resolvedMoodTopic: string | undefined
-        let metadataExtra: Record<string, unknown> | undefined
+        let metadataExtra: MessageMetadataExtra | undefined
         let speakerCharacterName: string | undefined
         let visualIdentityFields: VisualIdentityMessageFields = {}
         try {
@@ -2243,20 +2273,26 @@ export const useChatActions = ({
             directedSpeakerId ?? (activeCharacterMatchesChat
               ? fallbackSpeakerId
               : chatSpeakerId ?? fallbackSpeakerId)
-          detectedMood = detectCharacterMood({
-            assistantText: finalPersistedContent,
-            userText: message
-          })
-          resolvedMoodLabel = detectedMood.label
-          resolvedMoodConfidence =
-            typeof detectedMood.confidence === "number" &&
-            Number.isFinite(detectedMood.confidence)
-              ? detectedMood.confidence
-              : undefined
-          resolvedMoodTopic =
-            typeof detectedMood.topic === "string" && detectedMood.topic.trim()
-              ? detectedMood.topic.trim()
-              : undefined
+          if (emoteStream.events.length > 0) {
+            resolvedMoodLabel =
+              emoteStream.events[emoteStream.events.length - 1]?.state
+          } else {
+            detectedMood = detectCharacterMood({
+              assistantText: finalPersistedContent,
+              userText: message
+            })
+            resolvedMoodLabel = detectedMood.label
+            resolvedMoodConfidence =
+              typeof detectedMood.confidence === "number" &&
+              Number.isFinite(detectedMood.confidence)
+                ? detectedMood.confidence
+                : undefined
+            resolvedMoodTopic =
+              typeof detectedMood.topic === "string" &&
+              detectedMood.topic.trim()
+                ? detectedMood.topic.trim()
+                : undefined
+          }
 
           if (
             speakerCharacterId &&
@@ -2304,6 +2340,9 @@ export const useChatActions = ({
           if (resolvedMoodTopic) {
             persistPayload.mood_topic = resolvedMoodTopic
           }
+          if (emoteStream.events.length > 0) {
+            persistPayload.emote_events = [...emoteStream.events]
+          }
           if (persistedUserServerMessageId) {
             persistPayload.user_message_id = persistedUserServerMessageId
           }
@@ -2313,7 +2352,10 @@ export const useChatActions = ({
             mood_label: resolvedMoodLabel,
             mood_confidence: resolvedMoodConfidence ?? null,
             mood_topic: resolvedMoodTopic ?? null,
-            ...buildVisualIdentityMetadataExtra(visualIdentityFields)
+            ...buildVisualIdentityMetadataExtra(visualIdentityFields),
+            ...(emoteStream.events.length > 0
+              ? { emote_events: [...emoteStream.events] }
+              : {})
           }
 
           const persisted = (await tldwClient.persistCharacterCompletion(

--- a/apps/packages/ui/src/hooks/chat/useChatActions.ts
+++ b/apps/packages/ui/src/hooks/chat/useChatActions.ts
@@ -1697,6 +1697,45 @@ export const useChatActions = ({
       clearTimeout(streamingTimer)
       streamingTimer = null
     }
+    const emoteStream = createCharacterEmoteStream()
+    const getExplicitEmoteMoodLabel = () =>
+      emoteStream.events.length > 0
+        ? emoteStream.events[emoteStream.events.length - 1]?.state
+        : undefined
+    const getExplicitEmoteMetadataExtra = (): MessageMetadataExtra | undefined => {
+      const moodLabel = getExplicitEmoteMoodLabel()
+      return moodLabel
+        ? {
+            mood_label: moodLabel,
+            mood_confidence: null,
+            mood_topic: null,
+            emote_events: [...emoteStream.events]
+          }
+        : undefined
+    }
+    const applyEmoteEventsToMessage = (newEvents: CharacterEmoteEvent[]) => {
+      if (newEvents.length === 0) return
+      const moodLabel = getExplicitEmoteMoodLabel()
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === generateMessageId
+            ? updateActiveVariant(m, {
+                moodLabel,
+                metadataExtra: {
+                  ...(m.metadataExtra ?? {}),
+                  emote_events: [...emoteStream.events]
+                }
+              })
+            : m
+        )
+      )
+    }
+    const flushCharacterEmoteStream = () => {
+      const flushedEmotes = emoteStream.flush({ fullText, contentToSave })
+      fullText = flushedEmotes.fullText
+      contentToSave = flushedEmotes.contentToSave
+      applyEmoteEventsToMessage(flushedEmotes.emoteEvents)
+    }
 
     try {
       if (!resolvedModel) {
@@ -2048,27 +2087,6 @@ export const useChatActions = ({
       let apiReasoning = false
       let streamTransportInterrupted = false
       let streamTransportInterruptionReason: string | null = null
-      const emoteStream = createCharacterEmoteStream()
-      const applyEmoteEventsToMessage = (
-        newEvents: CharacterEmoteEvent[]
-      ) => {
-        if (newEvents.length === 0) return
-        const moodLabel =
-          emoteStream.events[emoteStream.events.length - 1]?.state
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === generateMessageId
-              ? updateActiveVariant(m, {
-                  moodLabel,
-                  metadataExtra: {
-                    ...(m.metadataExtra ?? {}),
-                    emote_events: [...emoteStream.events]
-                  }
-                })
-              : m
-          )
-        )
-      }
 
       const explicitProvider = resolveExplicitProviderForSelectedModel({
         currentSelectedModel: getEffectiveSelectedModel(),
@@ -2176,10 +2194,7 @@ export const useChatActions = ({
       cancelStreamingUpdate()
       flushStreamingUpdate()
       if (inactivityTimer) clearTimeout(inactivityTimer)
-      const flushedEmotes = emoteStream.flush({ fullText, contentToSave })
-      fullText = flushedEmotes.fullText
-      contentToSave = flushedEmotes.contentToSave
-      applyEmoteEventsToMessage(flushedEmotes.emoteEvents)
+      flushCharacterEmoteStream()
 
       if (inactivityAborted) {
         const timeoutError = new Error(
@@ -2544,6 +2559,9 @@ export const useChatActions = ({
       }
 
       cancelStreamingUpdate()
+      flushCharacterEmoteStream()
+      const recoveryMoodLabel = getExplicitEmoteMoodLabel()
+      const recoveryMetadataExtra = getExplicitEmoteMetadataExtra()
       await attemptCharacterStreamRecoveryPersist({
         chatId: activeChatId,
         temporaryChat,
@@ -2552,10 +2570,66 @@ export const useChatActions = ({
         error: e,
         persist: async (assistantContent) => {
           if (!activeChatId) return false
-          const createdAsst = (await tldwClient.addChatMessage(activeChatId, {
+          if (recoveryMoodLabel) {
+            try {
+              const persistPayload: Record<string, unknown> = {
+                assistant_content: assistantContent,
+                assistant_message_id: generateMessageId,
+                mood_label: recoveryMoodLabel,
+                emote_events: [...emoteStream.events]
+              }
+              if (persistedUserServerMessageId) {
+                persistPayload.user_message_id = persistedUserServerMessageId
+              }
+              const persisted = (await tldwClient.persistCharacterCompletion(
+                activeChatId,
+                persistPayload
+              )) as {
+                assistant_message_id?: string | number
+                message_id?: string | number
+                id?: string | number
+                version?: number
+              } | null
+              const createdAsstServerId =
+                persisted?.assistant_message_id ??
+                persisted?.message_id ??
+                persisted?.id
+              if (createdAsstServerId != null) {
+                assistantPersistedToServer = true
+                setMessages((prev) =>
+                  ((prev as any[]).map((m) => {
+                    if (m.id !== generateMessageId) return m
+                    return updateActiveVariant(m, {
+                      serverMessageId: String(createdAsstServerId),
+                      serverMessageVersion: persisted?.version,
+                      metadataExtra: {
+                        ...(m.metadataExtra ?? {}),
+                        ...(recoveryMetadataExtra ?? {})
+                      },
+                      moodLabel: recoveryMoodLabel,
+                      moodConfidence: null,
+                      moodTopic: null
+                    })
+                  }) as Message[])
+                )
+                return true
+              }
+            } catch {
+              // Fall back to the generic chat-message endpoint below.
+            }
+          }
+          const payload: Record<string, unknown> = {
             role: "assistant",
             content: assistantContent
-          }, scope ? { scope } : undefined)) as {
+          }
+          if (recoveryMetadataExtra) {
+            payload.metadata_extra = recoveryMetadataExtra
+          }
+          const createdAsst = (await tldwClient.addChatMessage(
+            activeChatId,
+            payload,
+            scope ? { scope } : undefined
+          )) as {
             id?: string | number
             version?: number
           } | null
@@ -2566,7 +2640,18 @@ export const useChatActions = ({
               if (m.id !== generateMessageId) return m
               return updateActiveVariant(m, {
                 serverMessageId: String(createdAsst.id),
-                serverMessageVersion: createdAsst?.version
+                serverMessageVersion: createdAsst?.version,
+                ...(recoveryMetadataExtra
+                  ? {
+                      metadataExtra: {
+                        ...(m.metadataExtra ?? {}),
+                        ...recoveryMetadataExtra
+                      },
+                      moodLabel: recoveryMoodLabel,
+                      moodConfidence: null,
+                      moodTopic: null
+                    }
+                  : {})
               })
             }) as Message[])
           )
@@ -2586,6 +2671,17 @@ export const useChatActions = ({
             msg.id === generateMessageId
               ? updateActiveVariant(msg, {
                   message: assistantContent,
+                  ...(recoveryMetadataExtra
+                    ? {
+                        metadataExtra: {
+                          ...(msg.metadataExtra ?? {}),
+                          ...recoveryMetadataExtra
+                        },
+                        moodLabel: recoveryMoodLabel,
+                        moodConfidence: null,
+                        moodTopic: null
+                      }
+                    : {}),
                   generationInfo: {
                     ...(msg.generationInfo || {}),
                     interrupted: true,

--- a/apps/packages/ui/src/hooks/useMessage.tsx
+++ b/apps/packages/ui/src/hooks/useMessage.tsx
@@ -1309,6 +1309,47 @@ export const useMessage = () => {
     if (!activeCharacter?.id) {
       throw new Error("No character selected");
     }
+    const emoteStream = createCharacterEmoteStream();
+    const getExplicitEmoteMoodLabel = () =>
+      emoteStream.events.length > 0
+        ? emoteStream.events[emoteStream.events.length - 1]?.state
+        : undefined;
+    const getExplicitEmoteMetadataExtra = (): MessageMetadataExtra | undefined => {
+      const moodLabel = getExplicitEmoteMoodLabel();
+      return moodLabel
+        ? {
+            mood_label: moodLabel,
+            mood_confidence: null,
+            mood_topic: null,
+            emote_events: [...emoteStream.events],
+          }
+        : undefined;
+    };
+    const applyEmoteEventsToMessage = (
+      newEvents: CharacterEmoteEvent[],
+    ) => {
+      if (newEvents.length === 0) return;
+      const moodLabel = getExplicitEmoteMoodLabel();
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === generateMessageId
+            ? updateActiveVariant(m, {
+                moodLabel,
+                metadataExtra: {
+                  ...(m.metadataExtra ?? {}),
+                  emote_events: [...emoteStream.events],
+                },
+              })
+            : m,
+        ),
+      );
+    };
+    const flushCharacterEmoteStream = () => {
+      const flushedEmotes = emoteStream.flush({ fullText, contentToSave });
+      fullText = flushedEmotes.fullText;
+      contentToSave = flushedEmotes.contentToSave;
+      applyEmoteEventsToMessage(flushedEmotes.emoteEvents);
+    };
 
     try {
       const hasImageInput =
@@ -1591,27 +1632,6 @@ export const useMessage = () => {
       let reasoningEndTime: Date | null = null;
       let timetaken = 0;
       let apiReasoning = false;
-      const emoteStream = createCharacterEmoteStream();
-      const applyEmoteEventsToMessage = (
-        newEvents: CharacterEmoteEvent[],
-      ) => {
-        if (newEvents.length === 0) return;
-        const moodLabel =
-          emoteStream.events[emoteStream.events.length - 1]?.state;
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === generateMessageId
-              ? updateActiveVariant(m, {
-                  moodLabel,
-                  metadataExtra: {
-                    ...(m.metadataExtra ?? {}),
-                    emote_events: [...emoteStream.events],
-                  },
-                })
-              : m,
-          ),
-        );
-      };
 
       const explicitProvider = resolveExplicitProviderForSelectedModel({
         currentSelectedModel: selectedModel,
@@ -1699,10 +1719,7 @@ export const useMessage = () => {
         if (signal?.aborted) break;
       }
       if (inactivityTimer) clearTimeout(inactivityTimer);
-      const flushedEmotes = emoteStream.flush({ fullText, contentToSave });
-      fullText = flushedEmotes.fullText;
-      contentToSave = flushedEmotes.contentToSave;
-      applyEmoteEventsToMessage(flushedEmotes.emoteEvents);
+      flushCharacterEmoteStream();
 
       if (inactivityAborted) {
         const timeoutError = new Error(
@@ -1973,6 +1990,9 @@ export const useMessage = () => {
         return;
       }
 
+      flushCharacterEmoteStream();
+      const recoveryMoodLabel = getExplicitEmoteMoodLabel();
+      const recoveryMetadataExtra = getExplicitEmoteMetadataExtra();
       const assistantContent = buildCharacterChatAssistantErrorContent(
         fullText,
         e,
@@ -1982,7 +2002,20 @@ export const useMessage = () => {
         setMessages((prev) =>
           prev.map((msg) =>
             msg.id === generateMessageId
-              ? updateActiveVariant(msg, { message: assistantContent })
+              ? updateActiveVariant(msg, {
+                  message: assistantContent,
+                  ...(recoveryMetadataExtra
+                    ? {
+                        metadataExtra: {
+                          ...(msg.metadataExtra ?? {}),
+                          ...recoveryMetadataExtra,
+                        },
+                        moodLabel: recoveryMoodLabel,
+                        moodConfidence: null,
+                        moodTopic: null,
+                      }
+                    : {}),
+                })
               : msg,
           ),
         );

--- a/apps/packages/ui/src/hooks/useMessage.tsx
+++ b/apps/packages/ui/src/hooks/useMessage.tsx
@@ -1882,6 +1882,7 @@ export const useMessage = () => {
               const createdAsst = (await tldwClient.addChatMessage(chatId, {
                 role: "assistant",
                 content: finalPersistedContent,
+                ...(metadataExtra ? { metadata_extra: metadataExtra } : {}),
               })) as { id?: string | number; version?: number } | null;
               setMessages(
                 (prev) =>

--- a/apps/packages/ui/src/hooks/useMessage.tsx
+++ b/apps/packages/ui/src/hooks/useMessage.tsx
@@ -5,7 +5,7 @@ import { useStoreMessageOption, type Message } from "~/store/option";
 import { useStoreMessage } from "~/store";
 import { getContentFromCurrentTab } from "~/libs/get-html";
 // RAG now uses tldw_server endpoints instead of local embeddings
-import { ChatHistory } from "@/store/option";
+import { ChatHistory, type MessageMetadataExtra } from "@/store/option";
 import {
   deleteChatForEdit,
   deleteChatAfterMessageId,
@@ -21,6 +21,7 @@ import { usePageAssist } from "@/context";
 import { formatDocs } from "@/utils/format-docs";
 import { buildAssistantErrorContent } from "@/utils/chat-error-message";
 import { buildCharacterChatAssistantErrorContent } from "@/hooks/chat/useCharacterChatMode";
+import { createCharacterEmoteStream } from "@/hooks/chat/character-emote-stream";
 import { detectCharacterMood } from "@/utils/character-mood";
 import { useStorage } from "@plasmohq/storage/hook";
 import { useStoreChatModelSettings } from "@/store/model";
@@ -50,6 +51,7 @@ import {
   createRegenerateLastMessage,
 } from "./handlers/messageHandlers";
 import { consumeStreamingChunk } from "@/utils/streaming-chunks";
+import type { CharacterEmoteEvent } from "@/utils/character-emotes";
 import type { ToolCall } from "@/types/tool-calls";
 import {
   createSaveMessageOnError,
@@ -1589,6 +1591,27 @@ export const useMessage = () => {
       let reasoningEndTime: Date | null = null;
       let timetaken = 0;
       let apiReasoning = false;
+      const emoteStream = createCharacterEmoteStream();
+      const applyEmoteEventsToMessage = (
+        newEvents: CharacterEmoteEvent[],
+      ) => {
+        if (newEvents.length === 0) return;
+        const moodLabel =
+          emoteStream.events[emoteStream.events.length - 1]?.state;
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === generateMessageId
+              ? updateActiveVariant(m, {
+                  moodLabel,
+                  metadataExtra: {
+                    ...(m.metadataExtra ?? {}),
+                    emote_events: [...emoteStream.events],
+                  },
+                })
+              : m,
+          ),
+        );
+      };
 
       const explicitProvider = resolveExplicitProviderForSelectedModel({
         currentSelectedModel: selectedModel,
@@ -1632,15 +1655,18 @@ export const useMessage = () => {
         if (loopEvent) {
           dispatchChatLoopEvent(loopEvent);
         }
+        const previousFullText = fullText;
         const chunkState = consumeStreamingChunk(
           { fullText, contentToSave, apiReasoning },
           chunk,
         );
-        fullText = chunkState.fullText;
-        contentToSave = chunkState.contentToSave;
-        apiReasoning = chunkState.apiReasoning;
+        const sanitizedChunkState = emoteStream.sanitizeChunk(chunkState);
+        fullText = sanitizedChunkState.fullText;
+        contentToSave = sanitizedChunkState.contentToSave;
+        apiReasoning = sanitizedChunkState.apiReasoning;
+        applyEmoteEventsToMessage(sanitizedChunkState.emoteEvents);
 
-        if (chunkState.token) {
+        if (chunkState.token && fullText !== previousFullText) {
           setMessages((prev) =>
             prev.map((m) =>
               m.id === generateMessageId
@@ -1673,6 +1699,10 @@ export const useMessage = () => {
         if (signal?.aborted) break;
       }
       if (inactivityTimer) clearTimeout(inactivityTimer);
+      const flushedEmotes = emoteStream.flush({ fullText, contentToSave });
+      fullText = flushedEmotes.fullText;
+      contentToSave = flushedEmotes.contentToSave;
+      applyEmoteEventsToMessage(flushedEmotes.emoteEvents);
 
       if (inactivityAborted) {
         const timeoutError = new Error(
@@ -1699,7 +1729,8 @@ export const useMessage = () => {
       );
 
       // Persist assistant reply on server
-      const finalPersistedContent = fullText.trim();
+      const finalContent = contentToSave || fullText;
+      const finalPersistedContent = finalContent.trim();
       if (finalPersistedContent.length > 0) {
         let fallbackSpeakerId: number | undefined;
         let speakerCharacterId: number | undefined;
@@ -1707,7 +1738,7 @@ export const useMessage = () => {
         let resolvedMoodLabel: string | undefined;
         let resolvedMoodConfidence: number | undefined;
         let resolvedMoodTopic: string | undefined;
-        let metadataExtra: Record<string, unknown> | undefined;
+        let metadataExtra: MessageMetadataExtra | undefined;
         try {
           fallbackSpeakerId = Number.parseInt(
             String(activeCharacter.id),
@@ -1717,20 +1748,26 @@ export const useMessage = () => {
             Number.isFinite(fallbackSpeakerId) && fallbackSpeakerId > 0
               ? fallbackSpeakerId
               : undefined;
-          detectedMood = detectCharacterMood({
-            assistantText: finalPersistedContent,
-            userText: message,
-          });
-          resolvedMoodLabel = detectedMood.label;
-          resolvedMoodConfidence =
-            typeof detectedMood.confidence === "number" &&
-            Number.isFinite(detectedMood.confidence)
-              ? detectedMood.confidence
-              : undefined;
-          resolvedMoodTopic =
-            typeof detectedMood.topic === "string" && detectedMood.topic.trim()
-              ? detectedMood.topic.trim()
-              : undefined;
+          if (emoteStream.events.length > 0) {
+            resolvedMoodLabel =
+              emoteStream.events[emoteStream.events.length - 1]?.state;
+          } else {
+            detectedMood = detectCharacterMood({
+              assistantText: finalPersistedContent,
+              userText: message,
+            });
+            resolvedMoodLabel = detectedMood.label;
+            resolvedMoodConfidence =
+              typeof detectedMood.confidence === "number" &&
+              Number.isFinite(detectedMood.confidence)
+                ? detectedMood.confidence
+                : undefined;
+            resolvedMoodTopic =
+              typeof detectedMood.topic === "string" &&
+              detectedMood.topic.trim()
+                ? detectedMood.topic.trim()
+                : undefined;
+          }
           const persistPayload: Record<string, unknown> = {
             assistant_content: finalPersistedContent,
             assistant_message_id: generateMessageId,
@@ -1746,6 +1783,9 @@ export const useMessage = () => {
           if (resolvedMoodTopic) {
             persistPayload.mood_topic = resolvedMoodTopic;
           }
+          if (emoteStream.events.length > 0) {
+            persistPayload.emote_events = [...emoteStream.events];
+          }
           if (persistedUserServerMessageId) {
             persistPayload.user_message_id = persistedUserServerMessageId;
           }
@@ -1755,6 +1795,9 @@ export const useMessage = () => {
             mood_label: resolvedMoodLabel,
             mood_confidence: resolvedMoodConfidence ?? null,
             mood_topic: resolvedMoodTopic ?? null,
+            ...(emoteStream.events.length > 0
+              ? { emote_events: [...emoteStream.events] }
+              : {}),
           };
           const persisted = (await tldwClient.persistCharacterCompletion(
             chatId,
@@ -1870,13 +1913,13 @@ export const useMessage = () => {
         if (endsWithUser) {
           setHistory([
             ...historyBase,
-            { role: "assistant", content: fullText },
+            { role: "assistant", content: finalContent },
           ]);
         } else if (endsWithUserAssistant) {
           setHistory(
             historyBase.map((entry, index) =>
               index === historyBase.length - 1 && entry.role === "assistant"
-                ? { ...entry, content: fullText }
+                ? { ...entry, content: finalContent }
                 : entry,
             ),
           );
@@ -1884,14 +1927,14 @@ export const useMessage = () => {
           setHistory([
             ...historyBase,
             { role: "user", content: message, image },
-            { role: "assistant", content: fullText },
+            { role: "assistant", content: finalContent },
           ]);
         }
       } else {
         setHistory([
           ...historyBase,
           { role: "user", content: message, image },
-          { role: "assistant", content: fullText },
+          { role: "assistant", content: finalContent },
         ]);
       }
 

--- a/apps/packages/ui/src/store/option/types.ts
+++ b/apps/packages/ui/src/store/option/types.ts
@@ -13,6 +13,7 @@ import type {
   QueuedRequest,
   QueuedRequestInput
 } from "@/utils/chat-request-queue"
+import type { CharacterEmoteEvent } from "@/utils/character-emotes"
 
 // Knowledge type is now server-side only; this is a placeholder for legacy compatibility
 export type Knowledge = {
@@ -37,6 +38,7 @@ export type CompareContinuationMode = "winner" | "compare"
 export type MessageMetadataExtra = Record<string, unknown> & {
   dynamic_ui?: DynamicUIEnvelope
   dynamic_ui_action?: DynamicUIActionUserMetadata
+  emote_events?: CharacterEmoteEvent[]
 }
 
 export type ReplyTarget = {

--- a/apps/packages/ui/src/utils/__fixtures__/character-emote-directives.json
+++ b/apps/packages/ui/src/utils/__fixtures__/character-emote-directives.json
@@ -1,0 +1,41 @@
+[
+  {
+    "name": "strips directives and records offsets",
+    "input": "Emote: annoyed\nWhat now?\n\nEmote: smug\nFine.",
+    "clean_text": "What now?\n\nFine.",
+    "events": [
+      { "state": "annoyed", "at_char": 0 },
+      { "state": "smug", "at_char": 11 }
+    ]
+  },
+  {
+    "name": "keeps inline prose visible",
+    "input": "She says Emote: smug and smiles.",
+    "clean_text": "She says Emote: smug and smiles.",
+    "events": []
+  },
+  {
+    "name": "keeps directives inside code fences visible",
+    "input": "```text\nEmote: smug\n```\nDone.",
+    "clean_text": "```text\nEmote: smug\n```\nDone.",
+    "events": []
+  },
+  {
+    "name": "strips invalid standalone directive",
+    "input": "Emote: ../../bad\nVisible.",
+    "clean_text": "Visible.",
+    "events": []
+  },
+  {
+    "name": "normalizes whitespace state",
+    "input": "  Emote: Thinking Hard  \nVisible.",
+    "clean_text": "Visible.",
+    "events": [{ "state": "thinking-hard", "at_char": 0 }]
+  },
+  {
+    "name": "drops duplicate consecutive state",
+    "input": "Emote: smug\nEmote: smug\nVisible.",
+    "clean_text": "Visible.",
+    "events": [{ "state": "smug", "at_char": 0 }]
+  }
+]

--- a/apps/packages/ui/src/utils/__tests__/character-emotes.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/character-emotes.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+import fixtures from "../__fixtures__/character-emote-directives.json"
+import {
+  EMOTE_EVENT_LIMIT,
+  createCharacterEmoteStreamParser,
+  isValidCharacterEmoteEvent,
+  normalizeCharacterEmoteState,
+  parseCharacterEmoteDirectives
+} from "../character-emotes"
+
+describe("character emote directives", () => {
+  it.each(fixtures)("$name", (fixture) => {
+    expect(parseCharacterEmoteDirectives(fixture.input)).toEqual({
+      cleanText: fixture.clean_text,
+      events: fixture.events
+    })
+  })
+
+  it("normalizes emote states exactly", () => {
+    expect(normalizeCharacterEmoteState(" Thinking Hard ")).toBe("thinking-hard")
+    expect(normalizeCharacterEmoteState("../../bad")).toBeNull()
+    expect(normalizeCharacterEmoteState("a".repeat(40))).toBe("a".repeat(40))
+    expect(normalizeCharacterEmoteState("a".repeat(41))).toBeNull()
+  })
+
+  it("caps accepted events while stripping later directives", () => {
+    const directives = Array.from(
+      { length: EMOTE_EVENT_LIMIT + 2 },
+      (_, index) => `Emote: state-${index}`
+    )
+    const parsed = parseCharacterEmoteDirectives(`${directives.join("\n")}\nDone.`)
+
+    expect(parsed.cleanText).toBe("Done.")
+    expect(parsed.events).toEqual(
+      Array.from({ length: EMOTE_EVENT_LIMIT }, (_, index) => ({
+        state: `state-${index}`,
+        at_char: 0
+      }))
+    )
+  })
+
+  it("does not leak a directive split across streaming chunks", () => {
+    const parser = createCharacterEmoteStreamParser()
+
+    expect(parser.push("Em")).toEqual({ visibleText: "", events: [] })
+    expect(parser.push("ote: smug\nHello")).toEqual({
+      visibleText: "Hello",
+      events: [{ state: "smug", at_char: 0 }]
+    })
+    expect(parser.flush()).toEqual({ visibleText: "", events: [] })
+  })
+
+  it("streams long non-directive text before newline", () => {
+    const parser = createCharacterEmoteStreamParser()
+    const text = "This ordinary prose has no newline yet."
+
+    expect(parser.push(text)).toEqual({ visibleText: text, events: [] })
+  })
+
+  it("validates compact emote event metadata", () => {
+    expect(isValidCharacterEmoteEvent({ state: "smug", at_char: 0 })).toBe(true)
+    expect(isValidCharacterEmoteEvent({ state: "../../bad", at_char: 0 })).toBe(false)
+    expect(isValidCharacterEmoteEvent({ state: "smug", at_char: -1 })).toBe(false)
+  })
+})

--- a/apps/packages/ui/src/utils/__tests__/character-emotes.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/character-emotes.test.ts
@@ -16,6 +16,32 @@ describe("character emote directives", () => {
     })
   })
 
+  it.each(fixtures)("streams fixture parity: $name", (fixture) => {
+    const parser = createCharacterEmoteStreamParser()
+    const sizes = [1, 2, 5, 3]
+    const events = []
+    let cleanText = ""
+    let offset = 0
+
+    for (let index = 0; offset < fixture.input.length; index += 1) {
+      const size = sizes[index % sizes.length]
+      const pushed = parser.push(fixture.input.slice(offset, offset + size))
+      cleanText += pushed.visibleText
+      events.push(...pushed.events)
+      offset += size
+    }
+
+    const flushed = parser.flush()
+    cleanText += flushed.visibleText
+    events.push(...flushed.events)
+
+    expect({ cleanText, events }).toEqual({
+      cleanText: fixture.clean_text,
+      events: fixture.events
+    })
+    expect(parser.flush()).toEqual({ visibleText: "", events: [] })
+  })
+
   it("normalizes emote states exactly", () => {
     expect(normalizeCharacterEmoteState(" Thinking Hard ")).toBe("thinking-hard")
     expect(normalizeCharacterEmoteState("../../bad")).toBeNull()

--- a/apps/packages/ui/src/utils/__tests__/character-mood.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/character-mood.test.ts
@@ -60,6 +60,23 @@ describe("character mood utilities", () => {
     expect((merged as any).tldw.prompt_preset).toBe("default")
   })
 
+  it("resolves custom emote image states without expanding classifier labels", () => {
+    const extensions = {
+      tldw: {
+        mood_images: {
+          smug: TINY_PNG_BASE64,
+          "thinking-hard": TINY_PNG_BASE64,
+          "../../bad": TINY_PNG_BASE64
+        }
+      }
+    }
+
+    expect(resolveCharacterMoodImageUrl({ extensions }, "smug")).toMatch(/^data:image\/png;base64,/)
+    expect(resolveCharacterMoodImageUrl({ extensions }, "thinking hard")).toMatch(/^data:image\/png;base64,/)
+    expect(resolveCharacterMoodImageUrl({ extensions }, "../../bad")).toBe("")
+    expect(normalizeCharacterMoodLabel("smug")).toBeNull()
+  })
+
   it("upserts and removes mood images", () => {
     const withImage = upsertCharacterMoodImage({}, "happy", TINY_PNG_BASE64)
     const imageAfterUpsert = resolveCharacterMoodImageUrl(

--- a/apps/packages/ui/src/utils/character-emotes.ts
+++ b/apps/packages/ui/src/utils/character-emotes.ts
@@ -1,0 +1,175 @@
+export const EMOTE_EVENT_LIMIT = 5
+export const CHARACTER_EMOTE_STATE_PATTERN = /^[a-z0-9][a-z0-9_-]{0,39}$/
+
+export type CharacterEmoteEvent = {
+  state: string
+  at_char: number
+}
+
+export type CharacterEmoteParseResult = {
+  cleanText: string
+  events: CharacterEmoteEvent[]
+}
+
+type StreamParseResult = {
+  visibleText: string
+  events: CharacterEmoteEvent[]
+}
+
+const DIRECTIVE_PATTERN = /^emote:(.*)$/i
+
+export const normalizeCharacterEmoteState = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const normalized = value.trim().toLowerCase().replace(/\s+/g, "-")
+  return CHARACTER_EMOTE_STATE_PATTERN.test(normalized) ? normalized : null
+}
+
+const parseDirectiveState = (line: string): string | null | undefined => {
+  const match = line.trim().match(DIRECTIVE_PATTERN)
+  return match ? normalizeCharacterEmoteState(match[1]) : undefined
+}
+
+const isFenceLine = (line: string): boolean => line.trim().startsWith("```")
+
+export const parseCharacterEmoteDirectives = (
+  input: string
+): CharacterEmoteParseResult => {
+  let cleanText = ""
+  const events: CharacterEmoteEvent[] = []
+  let inFence = false
+  let lastState: string | null = null
+  let index = 0
+
+  while (index < input.length) {
+    const newlineIndex = input.indexOf("\n", index)
+    const hasNewline = newlineIndex !== -1
+    const line = hasNewline ? input.slice(index, newlineIndex) : input.slice(index)
+    const separator = hasNewline ? "\n" : ""
+    index = hasNewline ? newlineIndex + 1 : input.length
+
+    if (isFenceLine(line)) {
+      cleanText += line + separator
+      inFence = !inFence
+      continue
+    }
+
+    if (!inFence) {
+      const state = parseDirectiveState(line)
+      if (state !== undefined) {
+        if (state && state !== lastState && events.length < EMOTE_EVENT_LIMIT) {
+          events.push({ state, at_char: cleanText.length })
+          lastState = state
+        }
+        continue
+      }
+    }
+
+    cleanText += line + separator
+  }
+
+  return { cleanText, events }
+}
+
+export const isValidCharacterEmoteEvent = (value: unknown): boolean => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  const event = value as Partial<CharacterEmoteEvent>
+  return (
+    typeof event.state === "string" &&
+    CHARACTER_EMOTE_STATE_PATTERN.test(event.state) &&
+    Number.isInteger(event.at_char) &&
+    Number(event.at_char) >= 0
+  )
+}
+
+export const createCharacterEmoteStreamParser = () => {
+  let buffer = ""
+  let cleanLength = 0
+  let inFence = false
+  let lineMode: "maybe" | "ordinary" = "maybe"
+  let lastState: string | null = null
+  let eventCount = 0
+
+  const couldBeControlLine = (line: string): boolean => {
+    const trimmed = line.trimStart()
+    if (!trimmed) return true
+    if ("```".startsWith(trimmed) || trimmed.startsWith("```")) return true
+    if (inFence) return false
+    const lower = trimmed.toLowerCase()
+    return "emote:".startsWith(lower) || lower.startsWith("emote:")
+  }
+
+  const acceptEvent = (state: string, events: CharacterEmoteEvent[]) => {
+    if (state === lastState || eventCount >= EMOTE_EVENT_LIMIT) return
+    events.push({ state, at_char: cleanLength })
+    lastState = state
+    eventCount += 1
+  }
+
+  const parseBufferedLine = (rawLine: string): StreamParseResult => {
+    const hasNewline = rawLine.endsWith("\n")
+    const line = hasNewline ? rawLine.slice(0, -1) : rawLine
+    const separator = hasNewline ? "\n" : ""
+    const events: CharacterEmoteEvent[] = []
+
+    if (isFenceLine(line)) {
+      const visibleText = line + separator
+      cleanLength += visibleText.length
+      inFence = !inFence
+      return { visibleText, events }
+    }
+
+    if (!inFence) {
+      const state = parseDirectiveState(line)
+      if (state !== undefined) {
+        if (state) acceptEvent(state, events)
+        return { visibleText: "", events }
+      }
+    }
+
+    const visibleText = line + separator
+    cleanLength += visibleText.length
+    return { visibleText, events }
+  }
+
+  const push = (chunk: string): StreamParseResult => {
+    let visibleText = ""
+    const events: CharacterEmoteEvent[] = []
+
+    for (const char of chunk) {
+      if (lineMode === "ordinary") {
+        visibleText += char
+        cleanLength += char.length
+        if (char === "\n") lineMode = "maybe"
+        continue
+      }
+
+      buffer += char
+      if (char === "\n") {
+        const parsed = parseBufferedLine(buffer)
+        visibleText += parsed.visibleText
+        events.push(...parsed.events)
+        buffer = ""
+        continue
+      }
+
+      if (!couldBeControlLine(buffer)) {
+        visibleText += buffer
+        cleanLength += buffer.length
+        buffer = ""
+        lineMode = "ordinary"
+      }
+    }
+
+    return { visibleText, events }
+  }
+
+  const flush = (): StreamParseResult => {
+    if (!buffer) return { visibleText: "", events: [] }
+    const parsed = parseBufferedLine(buffer)
+    buffer = ""
+    lineMode = "maybe"
+    return parsed
+  }
+
+  return { push, flush }
+}

--- a/apps/packages/ui/src/utils/character-mood.ts
+++ b/apps/packages/ui/src/utils/character-mood.ts
@@ -1,4 +1,5 @@
 import { createImageDataUrl } from "@/utils/image-utils"
+import { normalizeCharacterEmoteState } from "./character-emotes"
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value)
@@ -25,7 +26,7 @@ export type CharacterMoodDetection = {
   topic: string | null
 }
 
-type CharacterMoodImages = Partial<Record<CharacterMoodLabel, string>>
+type CharacterMoodImages = Record<string, string>
 
 type CharacterWithPortraitData = {
   avatar_url?: string | null
@@ -239,7 +240,7 @@ export const getCharacterMoodImagesFromExtensions = (
 
   const result: CharacterMoodImages = {}
   Object.entries(source).forEach(([rawMood, rawImage]) => {
-    const moodLabel = normalizeCharacterMoodLabel(rawMood)
+    const moodLabel = normalizeCharacterEmoteState(rawMood)
     if (!moodLabel) return
     const normalizedImage = normalizeMoodImageSource(rawImage)
     if (!normalizedImage) return
@@ -258,7 +259,7 @@ export const mergeCharacterMoodImagesIntoExtensions = (
 
   const normalizedMap: CharacterMoodImages = {}
   Object.entries(moodImages || {}).forEach(([rawMood, rawImage]) => {
-    const moodLabel = normalizeCharacterMoodLabel(rawMood)
+    const moodLabel = normalizeCharacterEmoteState(rawMood)
     if (!moodLabel) return
     const normalizedImage = normalizeMoodImageSource(rawImage)
     if (!normalizedImage) return
@@ -340,7 +341,7 @@ export const resolveCharacterMoodImageUrl = (
 ): string => {
   if (!character) return ""
 
-  const normalizedMood = normalizeCharacterMoodLabel(moodLabel)
+  const normalizedMood = normalizeCharacterEmoteState(moodLabel)
   if (!normalizedMood) return ""
 
   const moodImages = getCharacterMoodImagesFromExtensions(character.extensions)

--- a/apps/tldw-frontend/e2e/workflows/chat-cockpit.real-server.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/chat-cockpit.real-server.spec.ts
@@ -675,6 +675,26 @@ const assertCoreComposerControls = async (
   await expect(page.getByRole('button', { name: /Advanced controls/i })).toBeVisible();
 };
 
+const fillEditableComposer = async (page: Page, value: string) => {
+  const input = page.getByTestId('chat-input');
+  await expect(input).toBeEditable({ timeout: 15_000 });
+  await input.fill(value);
+  await expect(input).toHaveValue(value);
+};
+
+const ensureDesktopCockpitRailsVisible = async (page: Page) => {
+  const leftRestore = page.getByTestId('playground-cockpit-left-rail-restore');
+  if (await leftRestore.isVisible().catch(() => false)) {
+    await leftRestore.click();
+  }
+  const rightRestore = page.getByTestId('playground-cockpit-right-rail-restore');
+  if (await rightRestore.isVisible().catch(() => false)) {
+    await rightRestore.click();
+  }
+  await expect(page.getByTestId('playground-cockpit-left-rail')).toBeVisible();
+  await expect(page.getByTestId('playground-cockpit-right-rail')).toBeVisible();
+};
+
 const assertRuntimeProviderSummary = async (runtimeInspector: Locator) => {
   const runtimeState = runtimeInspector.getByRole('region', { name: 'Runtime state' });
   await expect(runtimeState.getByRole('heading', { name: 'Runtime' })).toBeVisible();
@@ -1647,8 +1667,7 @@ test.describe('/chat cockpit real-server parity', () => {
     });
 
     await switchChatLayoutMode(page, 'cockpit');
-    await expect(page.getByTestId('playground-cockpit-left-rail')).toBeVisible();
-    await expect(page.getByTestId('playground-cockpit-right-rail')).toBeVisible();
+    await ensureDesktopCockpitRailsVisible(page);
     await assertNoHorizontalOverflow(page);
     await expect(
       getDesktopContextRail(page).getByRole('button', { name: 'Web search', exact: true })
@@ -1929,7 +1948,7 @@ test.describe('/chat cockpit real-server parity', () => {
       await expect(panel).toHaveAttribute('aria-labelledby', tabId as string);
       return panel;
     };
-    await page.getByTestId('chat-input').fill(mobileDraft);
+    await fillEditableComposer(page, mobileDraft);
     await expectMobileDraftReachable();
     await expectNoMobileBottomControls();
 

--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -2,6 +2,6 @@
   "note": "Regenerate with `make openapi-fingerprint`. A change here means the backend API contract drifted; regenerate the frontend types (`bun run generate:api-types` in apps/tldw-frontend) and review.",
   "openapi_version": "3.1.0",
   "path_count": 1963,
-  "schema_count": 2827,
-  "sha256": "ccf658a22089cc43e9d691d1ac000e3a4f473c7159135a72217d32df0b1652dd"
+  "schema_count": 2830,
+  "sha256": "0a8d215b32bccb8180583be28c90e9b63ac0d344bea49244f083164b0fda6cdc"
 }

--- a/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
+++ b/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
@@ -1,18 +1,20 @@
 ---
 id: TASK-12163
 title: Add explicit streaming emote directives for character chat portraits
-status: To Do
+status: Done
 assignee: []
 created_date: ''
-updated_date: 2026-07-06 16:36
+updated_date: '2026-07-06 18:58'
 labels:
-- frontend
-- character-chat
-- emotes
+  - frontend
+  - character-chat
+  - emotes
 dependencies: []
 documentation:
-- Docs/superpowers/specs/2026-07-06-character-chat-streaming-emote-directives-design.md
-- Docs/superpowers/plans/2026-07-06-character-chat-streaming-emote-directives-implementation-plan.md
+  - >-
+    Docs/superpowers/specs/2026-07-06-character-chat-streaming-emote-directives-design.md
+  - >-
+    Docs/superpowers/plans/2026-07-06-character-chat-streaming-emote-directives-implementation-plan.md
 priority: high
 ---
 
@@ -24,15 +26,15 @@ Implement v1 character chat emote control: parse standalone Emote: <state> direc
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Streaming character chat can change the character portrait multiple times within one assistant response when valid Emote directives arrive.
-- [ ] #2 Raw Emote directive lines never appear in rendered chat or persisted assistant content, including partial/chunked streaming cases.
-- [ ] #3 Explicit emote directives override heuristic mood detection; detectCharacterMood only runs when no valid directive is present.
-- [ ] #4 Non-streaming character responses are also parsed and stripped before display/persist.
-- [ ] #5 Invalid, unsafe, duplicate consecutive, or over-cap directives are stripped but do not fire/store emote events.
-- [ ] #6 Missing emote image assets do not break rendering; the UI keeps the current/base portrait.
-- [ ] #7 Final emote, defined as the last accepted event, persists as mood_label and optional emote_events are stored in metadata_extra.
-- [ ] #8 History reload restores the final emote and does not replay beat events in v1.
-- [ ] #9 Parser, streaming-buffer, integration, and minimal UI behavior tests cover the directive flow.
+- [x] #1 Streaming character chat can change the character portrait multiple times within one assistant response when valid Emote directives arrive.
+- [x] #2 Raw Emote directive lines never appear in rendered chat or persisted assistant content, including partial/chunked streaming cases.
+- [x] #3 Explicit emote directives override heuristic mood detection; detectCharacterMood only runs when no valid directive is present.
+- [x] #4 Non-streaming character responses are also parsed and stripped before display/persist.
+- [x] #5 Invalid, unsafe, duplicate consecutive, or over-cap directives are stripped but do not fire/store emote events.
+- [x] #6 Missing emote image assets do not break rendering; the UI keeps the current/base portrait.
+- [x] #7 Final emote, defined as the last accepted event, persists as mood_label and optional emote_events are stored in metadata_extra.
+- [x] #8 History reload restores the final emote and does not replay beat events in v1.
+- [x] #9 Parser, streaming-buffer, integration, and minimal UI behavior tests cover the directive flow.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,21 +46,23 @@ Docs/superpowers/plans/2026-07-06-character-chat-streaming-emote-directives-impl
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+Task 2 complete in commit 48df2747c7: custom safe emote image slugs resolve via character mood image maps while classifier labels remain unchanged. Red: bunx vitest run src/utils/__tests__/character-mood.test.ts --maxWorkers=1 failed on smug returning empty string. Green: bunx vitest run src/utils/__tests__/character-mood.test.ts src/utils/__tests__/character-emotes.test.ts --maxWorkers=1 passed 23 tests. Bandit not run: touched files are frontend TypeScript only.
 
+Task 6 final verification complete. Targeted frontend suite: bunx vitest run src/utils/__tests__/character-emotes.test.ts src/utils/__tests__/character-mood.test.ts src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts src/hooks/__tests__/useServerChatLoader.test.ts src/db/dexie/__tests__/helpers.character-emotes.test.ts src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx --maxWorkers=1 passed 7 files / 82 tests. Targeted backend suite: python -m pytest tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py -q passed 39 tests with 4 warnings. Bandit touched backend scope: no errors and no findings in /tmp/bandit_character_emotes.json. App-wide frontend typecheck was attempted with bun run typecheck and failed on existing baseline errors outside the character-emote touched files: TimelineEditor referrerPolicy, ScheduledTasks definitions, Skills Manager checkbox aria-label, scheduled task service param types, MCP hub path type, voice cloning ArrayBuffer, and e2e fixture/spec typing.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented explicit character chat Emote directives across backend and WebUI. The parser strips standalone directives from visible and persisted assistant text, streams accepted events live to portrait mood state, stores strict emote_events metadata plus final mood_label, resolves safe custom emote image slugs, keeps heuristic mood detection as fallback only when no explicit directive exists, sanitizes non-streaming responses, and restores final explicit emotes from history without replaying beat events in v1. Follow-up B remains tracked separately as TASK-12164.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
+++ b/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
@@ -4,15 +4,15 @@ title: Add explicit streaming emote directives for character chat portraits
 status: To Do
 assignee: []
 created_date: ''
-updated_date: '2026-07-06 16:36'
+updated_date: 2026-07-06 16:36
 labels:
-  - frontend
-  - character-chat
-  - emotes
+- frontend
+- character-chat
+- emotes
 dependencies: []
 documentation:
-  - >-
-    Docs/superpowers/specs/2026-07-06-character-chat-streaming-emote-directives-design.md
+- Docs/superpowers/specs/2026-07-06-character-chat-streaming-emote-directives-design.md
+- Docs/superpowers/plans/2026-07-06-character-chat-streaming-emote-directives-implementation-plan.md
 priority: high
 ---
 
@@ -35,21 +35,21 @@ Implement v1 character chat emote control: parse standalone Emote: <state> direc
 - [ ] #9 Parser, streaming-buffer, integration, and minimal UI behavior tests cover the directive flow.
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-07-06-character-chat-streaming-emote-directives-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:END -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
+++ b/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
@@ -1,0 +1,64 @@
+---
+id: TASK-12163
+title: Add explicit streaming emote directives for character chat portraits
+status: To Do
+assignee: []
+created_date: ''
+updated_date: '2026-07-06 16:36'
+labels:
+  - frontend
+  - character-chat
+  - emotes
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-06-character-chat-streaming-emote-directives-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement v1 character chat emote control: parse standalone Emote: <state> directives from assistant responses, strip them from visible/stored text, update character portraits live during streaming, persist final mood_label plus emote_events metadata, and demote heuristic mood detection to fallback when explicit directives exist.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Streaming character chat can change the character portrait multiple times within one assistant response when valid Emote directives arrive.
+- [ ] #2 Raw Emote directive lines never appear in rendered chat or persisted assistant content, including partial/chunked streaming cases.
+- [ ] #3 Explicit emote directives override heuristic mood detection; detectCharacterMood only runs when no valid directive is present.
+- [ ] #4 Non-streaming character responses are also parsed and stripped before display/persist.
+- [ ] #5 Invalid, unsafe, duplicate consecutive, or over-cap directives are stripped but do not fire/store emote events.
+- [ ] #6 Missing emote image assets do not break rendering; the UI keeps the current/base portrait.
+- [ ] #7 Final emote, defined as the last accepted event, persists as mood_label and optional emote_events are stored in metadata_extra.
+- [ ] #8 History reload restores the final emote and does not replay beat events in v1.
+- [ ] #9 Parser, streaming-buffer, integration, and minimal UI behavior tests cover the directive flow.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
+++ b/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
@@ -4,7 +4,7 @@ title: Add explicit streaming emote directives for character chat portraits
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-06 19:12'
+updated_date: '2026-07-06 20:04'
 labels:
   - frontend
   - character-chat
@@ -53,6 +53,10 @@ Task 6 final verification complete. Targeted frontend suite: bunx vitest run src
 Code review follow-up reopened: fixing explicit-mood classifier short-circuit and stream persist assistant_content sanitization before merge.
 
 Code review follow-up fixed in this branch: Message now skips detectCharacterMood when an explicit moodLabel is present, and the stream persist endpoint sanitizes raw Emote directives before fingerprint/idempotency/storage while deriving emote_events when the client did not send them. Red checks: Message routing test failed on detectCharacterMood being called once; backend persist sanitization test failed before endpoint sanitization. Green checks: Message routing suite passed 12 tests; targeted frontend emote suite passed 7 files / 82 tests; targeted backend emote suite passed 40 tests with 3 warnings; Bandit review-fix report had no errors and no findings. bun run typecheck was rerun and still fails on the known unrelated baseline files outside this feature.
+
+PR review follow-up after rebase on latest dev: addressing Qodo comments for docstrings/types, moving emote prompt business logic to core, capping prompt state lists, pytest markers, and validating persisted emote event offsets.
+
+PR review follow-up complete after focused rebase onto origin/dev. Addressed Qodo comments by adding emote core docstrings/type annotations, moving prompt instruction/state extraction into core Character_Chat logic, capping prompt state lists at 25 with (+N more), adding module-level pytest markers, validating persisted client emote offsets against sanitized UTF-16 content length with non-decreasing offsets, and removing a rebase duplicate mock declaration in the frontend integration test. Verification: backend targeted suite passed 44 tests with 3 warnings; frontend targeted emote suite passed 7 files / 85 tests; apps/tldw-frontend bun run typecheck passed; Bandit touched backend report /tmp/bandit_character_emotes_pr_review.json had no errors and no findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
+++ b/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
@@ -4,7 +4,7 @@ title: Add explicit streaming emote directives for character chat portraits
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-06 18:58'
+updated_date: '2026-07-06 19:12'
 labels:
   - frontend
   - character-chat
@@ -49,6 +49,10 @@ Docs/superpowers/plans/2026-07-06-character-chat-streaming-emote-directives-impl
 Task 2 complete in commit 48df2747c7: custom safe emote image slugs resolve via character mood image maps while classifier labels remain unchanged. Red: bunx vitest run src/utils/__tests__/character-mood.test.ts --maxWorkers=1 failed on smug returning empty string. Green: bunx vitest run src/utils/__tests__/character-mood.test.ts src/utils/__tests__/character-emotes.test.ts --maxWorkers=1 passed 23 tests. Bandit not run: touched files are frontend TypeScript only.
 
 Task 6 final verification complete. Targeted frontend suite: bunx vitest run src/utils/__tests__/character-emotes.test.ts src/utils/__tests__/character-mood.test.ts src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts src/hooks/__tests__/useServerChatLoader.test.ts src/db/dexie/__tests__/helpers.character-emotes.test.ts src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx --maxWorkers=1 passed 7 files / 82 tests. Targeted backend suite: python -m pytest tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py -q passed 39 tests with 4 warnings. Bandit touched backend scope: no errors and no findings in /tmp/bandit_character_emotes.json. App-wide frontend typecheck was attempted with bun run typecheck and failed on existing baseline errors outside the character-emote touched files: TimelineEditor referrerPolicy, ScheduledTasks definitions, Skills Manager checkbox aria-label, scheduled task service param types, MCP hub path type, voice cloning ArrayBuffer, and e2e fixture/spec typing.
+
+Code review follow-up reopened: fixing explicit-mood classifier short-circuit and stream persist assistant_content sanitization before merge.
+
+Code review follow-up fixed in this branch: Message now skips detectCharacterMood when an explicit moodLabel is present, and the stream persist endpoint sanitizes raw Emote directives before fingerprint/idempotency/storage while deriving emote_events when the client did not send them. Red checks: Message routing test failed on detectCharacterMood being called once; backend persist sanitization test failed before endpoint sanitization. Green checks: Message routing suite passed 12 tests; targeted frontend emote suite passed 7 files / 82 tests; targeted backend emote suite passed 40 tests with 3 warnings; Bandit review-fix report had no errors and no findings. bun run typecheck was rerun and still fails on the known unrelated baseline files outside this feature.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
+++ b/backlog/tasks/task-12163 - Add-explicit-streaming-emote-directives-for-character-chat-portraits.md
@@ -4,7 +4,7 @@ title: Add explicit streaming emote directives for character chat portraits
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-06 20:04'
+updated_date: '2026-07-07 07:00'
 labels:
   - frontend
   - character-chat
@@ -57,6 +57,10 @@ Code review follow-up fixed in this branch: Message now skips detectCharacterMoo
 PR review follow-up after rebase on latest dev: addressing Qodo comments for docstrings/types, moving emote prompt business logic to core, capping prompt state lists, pytest markers, and validating persisted emote event offsets.
 
 PR review follow-up complete after focused rebase onto origin/dev. Addressed Qodo comments by adding emote core docstrings/type annotations, moving prompt instruction/state extraction into core Character_Chat logic, capping prompt state lists at 25 with (+N more), adding module-level pytest markers, validating persisted client emote offsets against sanitized UTF-16 content length with non-decreasing offsets, and removing a rebase duplicate mock declaration in the frontend integration test. Verification: backend targeted suite passed 44 tests with 3 warnings; frontend targeted emote suite passed 7 files / 85 tests; apps/tldw-frontend bun run typecheck passed; Bandit touched backend report /tmp/bandit_character_emotes_pr_review.json had no errors and no findings.
+
+CI follow-up reopened after rebasing onto dev eeec7431f3. Current failing checks include PR-owned failures: visual identity metadata helper missing emote_events default, shard coverage missing test_character_emote_directives.py, and OpenAPI fingerprint drift. Other observed failures appear unrelated/baseline: OIDC password policy, Guardian timestamp, Windows zip path handling, Playground THEME_SETTING mock, and UX smoke cockpit layout/draft failures. Investigating and fixing branch-owned failures first.
+
+CI follow-up fixes complete. Addressed current PR-owned failures by adding the emote directive unit test to every chat-character shard list, regenerating apps/tldw-frontend/lib/api/openapi.fingerprint.json from the rebased backend contract, making _build_stream_persist_metadata_extra backward-compatible for visual identity metadata tests, adding THEME_SETTING to the Playground a11y test mock, and hardening the chat cockpit real-server spec to wait for an editable composer and restore cockpit rails after focus mode. Verification: backend visual identity plus emote directive tests passed 22 tests; shard coverage guard passed with 0 new uncovered tests; make openapi-drift-check passed; apps/packages/ui bun run test:playground:a11y passed 10 files / 27 tests; apps/tldw-frontend bun run typecheck passed; Playwright listed the two affected chat cockpit real-server tests successfully. The full UX smoke live-server command was not run locally because it depends on the CI-launched backend/frontend environment. Bandit touched backend report /tmp/bandit_character_emotes_ci_followup.json had no errors and no findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12164 - Follow-up-unify-character-emotes-with-Persona-Visual-runtime-states.md
+++ b/backlog/tasks/task-12164 - Follow-up-unify-character-emotes-with-Persona-Visual-runtime-states.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12164
+title: 'Follow up: unify character emotes with Persona Visual runtime states'
+status: To Do
+labels:
+- frontend
+- persona-visuals
+- follow-up
+- emotes
+priority: Medium
+references:
+- TASK-12163
+documentation:
+- Docs/superpowers/specs/2026-07-06-character-chat-streaming-emote-directives-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up after v1 character emote directives: evaluate and design a shared visual-state integration so character portraits, PersonaBuddy, and future agentic UIs can use a common set_emote/set_visual_state style runtime path instead of character-chat-only directive handling.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Review existing persona visual runtime state handling and character mood image resolution for a shared boundary.
+- [ ] #2 Define how character emote states map to Persona Visual runtime/custom states without breaking existing character chat behavior.
+- [ ] #3 Define whether a future agentic UI tool should be set_emote or set_visual_state and how it coexists with text directives.
+- [ ] #4 Produce a focused design/plan before implementation.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -933,7 +933,7 @@ def _build_stream_persist_metadata_extra(
     mood_label: str | None,
     mood_confidence: float | None,
     mood_topic: str | None,
-    emote_events: list[CharacterEmoteEvent] | None,
+    emote_events: list[CharacterEmoteEvent] | None = None,
     usage: dict[str, Any] | None,
     visual_identity: Any | None = None,
 ) -> dict[str, Any]:

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -944,18 +944,20 @@ def _build_stream_persist_metadata_extra(
     }
     if persist_fingerprint:
         metadata_extra["stream_persist_fingerprint"] = persist_fingerprint
-    if isinstance(mood_label, str):
-        trimmed_label = mood_label.strip()
-        if trimmed_label:
-            metadata_extra["mood_label"] = trimmed_label
-    if mood_confidence is not None:
-        metadata_extra["mood_confidence"] = float(mood_confidence)
-    if isinstance(mood_topic, str):
-        trimmed_topic = mood_topic.strip()
-        if trimmed_topic:
-            metadata_extra["mood_topic"] = trimmed_topic
     if emote_events:
+        metadata_extra["mood_label"] = emote_events[-1].state
         metadata_extra["emote_events"] = [event.model_dump() for event in emote_events]
+    else:
+        if isinstance(mood_label, str):
+            trimmed_label = mood_label.strip()
+            if trimmed_label:
+                metadata_extra["mood_label"] = trimmed_label
+        if mood_confidence is not None:
+            metadata_extra["mood_confidence"] = float(mood_confidence)
+        if isinstance(mood_topic, str):
+            trimmed_topic = mood_topic.strip()
+            if trimmed_topic:
+                metadata_extra["mood_topic"] = trimmed_topic
     if usage is not None:
         metadata_extra["usage"] = usage
     metadata_extra.update(_visual_identity_metadata_extra(visual_identity))
@@ -4700,6 +4702,7 @@ async def prepare_chat_completion(
                 user_name=user_name,
                 preset_id=effective_preset,
             )
+            sys_text = _append_character_emote_prompt_instruction(sys_text, character)
             if sys_text.strip():
                 formatted.append({"role": "system", "content": sys_text.strip()})
         if summary_content:
@@ -5100,6 +5103,7 @@ async def prompt_assembly_preview(
                 user_name=user_name,
                 preset_id=preview_preset,
             )
+            sys_text = _append_character_emote_prompt_instruction(sys_text, character)
             if sys_text.strip():
                 formatted.append({"role": "system", "content": sys_text.strip()})
         if summary_content:

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -7335,17 +7335,28 @@ async def persist_streamed_assistant_message(
             if isinstance(body.assistant_message_id, str)
             else ""
         ) or None
+        resolved_emotes = resolve_character_emote_completion(
+            body.assistant_content,
+            fallback_mood_label=body.mood_label,
+            fallback_mood_confidence=body.mood_confidence,
+            fallback_mood_topic=body.mood_topic,
+        )
+        assistant_content = resolved_emotes.clean_text
+        emote_events = body.emote_events or resolved_emotes.emote_events
+        resolved_visual_mood = (
+            emote_events[-1].state if emote_events else resolved_emotes.mood_label
+        )
         visual_identity_metadata = _safe_resolve_character_visual_identity(
             db=db,
             current_user=current_user,
             actor_id=resolved_speaker_id,
-            mood_label=_optional_text_metadata(body.mood_label),
+            mood_label=_optional_text_metadata(resolved_visual_mood),
         )
         persist_fingerprint = None
         if not requested_assistant_message_id and getattr(body, "user_message_id", None):
             persist_fingerprint = _build_stream_persist_fingerprint(
                 chat_id,
-                body.assistant_content,
+                assistant_content,
                 body.user_message_id,
                 resolved_speaker_id,
                 body.ranking if getattr(body, "ranking", None) is not None else None,
@@ -7371,7 +7382,7 @@ async def persist_streamed_assistant_message(
                 db,
                 chat_id,
                 requested_assistant_message_id,
-                assistant_content=body.assistant_content,
+                assistant_content=assistant_content,
                 parent_message_id=body.user_message_id,
                 speaker_name=resolved_speaker_name,
             )
@@ -7390,10 +7401,10 @@ async def persist_streamed_assistant_message(
                     turn_taking_mode=resolved_turn_mode,
                     validation_degraded=existing_extra.get("persist_validation_degraded") is True,
                     persist_fingerprint=persist_fingerprint,
-                    mood_label=body.mood_label,
-                    mood_confidence=body.mood_confidence,
-                    mood_topic=body.mood_topic,
-                    emote_events=body.emote_events,
+                    mood_label=resolved_emotes.mood_label,
+                    mood_confidence=resolved_emotes.mood_confidence,
+                    mood_topic=resolved_emotes.mood_topic,
+                    emote_events=emote_events,
                     usage=_validate_stream_persist_usage(getattr(body, "usage", None)),
                     visual_identity=visual_identity_metadata,
                 ),
@@ -7428,10 +7439,10 @@ async def persist_streamed_assistant_message(
             turn_taking_mode=resolved_turn_mode,
             validation_degraded=validation_degraded is not None,
             persist_fingerprint=persist_fingerprint,
-            mood_label=body.mood_label,
-            mood_confidence=body.mood_confidence,
-            mood_topic=body.mood_topic,
-            emote_events=body.emote_events,
+            mood_label=resolved_emotes.mood_label,
+            mood_confidence=resolved_emotes.mood_confidence,
+            mood_topic=resolved_emotes.mood_topic,
+            emote_events=emote_events,
             usage=_validate_stream_persist_usage(getattr(body, "usage", None)),
             visual_identity=visual_identity_metadata,
         )
@@ -7442,7 +7453,7 @@ async def persist_streamed_assistant_message(
                 db=db,
                 conversation_id=chat_id,
                 character_name=resolved_speaker_name,
-                message_content=body.assistant_content,
+                message_content=assistant_content,
                 is_user_message=False,
                 message_id=requested_assistant_message_id,
                 parent_message_id=body.user_message_id,
@@ -7455,7 +7466,7 @@ async def persist_streamed_assistant_message(
                 db,
                 chat_id,
                 requested_assistant_message_id,
-                assistant_content=body.assistant_content,
+                assistant_content=assistant_content,
                 parent_message_id=body.user_message_id,
                 speaker_name=resolved_speaker_name,
             )

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -124,6 +124,11 @@ from tldw_Server_API.app.core.testing import is_truthy
 from tldw_Server_API.app.core.Character_Chat.modules.character_generation_presets import (
     resolve_character_generation_settings,
 )
+from tldw_Server_API.app.core.Character_Chat.emote_directives import (
+    CharacterEmoteEvent,
+    normalize_character_emote_state,
+    resolve_character_emote_completion,
+)
 from tldw_Server_API.app.core.Character_Chat.modules.character_prompt_presets import (
     DEFAULT_PROMPT_PRESET,
     build_character_system_prompt,
@@ -927,6 +932,7 @@ def _build_stream_persist_metadata_extra(
     mood_label: str | None,
     mood_confidence: float | None,
     mood_topic: str | None,
+    emote_events: list[CharacterEmoteEvent] | None,
     usage: dict[str, Any] | None,
     visual_identity: Any | None = None,
 ) -> dict[str, Any]:
@@ -948,6 +954,8 @@ def _build_stream_persist_metadata_extra(
         trimmed_topic = mood_topic.strip()
         if trimmed_topic:
             metadata_extra["mood_topic"] = trimmed_topic
+    if emote_events:
+        metadata_extra["emote_events"] = [event.model_dump() for event in emote_events]
     if usage is not None:
         metadata_extra["usage"] = usage
     metadata_extra.update(_visual_identity_metadata_extra(visual_identity))
@@ -2404,6 +2412,48 @@ def _extract_character_default_author_note(character: dict[str, Any]) -> str:
         if ext_value:
             return ext_value
     return ""
+
+
+def _extract_character_mood_image_states(character: dict[str, Any]) -> list[str]:
+    extensions = character.get("extensions") if isinstance(character, dict) else None
+    if isinstance(extensions, str):
+        try:
+            extensions = json.loads(extensions)
+        except _CHAR_CHAT_SESSIONS_NONCRITICAL_EXCEPTIONS:
+            extensions = {}
+    if not isinstance(extensions, dict):
+        return []
+
+    tldw = extensions.get("tldw") if isinstance(extensions.get("tldw"), dict) else {}
+    for source in (
+        tldw.get("mood_images"),
+        tldw.get("moodImages"),
+        extensions.get("mood_images"),
+        extensions.get("moodImages"),
+    ):
+        if not isinstance(source, dict):
+            continue
+        states: list[str] = []
+        seen: set[str] = set()
+        for raw_state in source:
+            state = normalize_character_emote_state(raw_state)
+            if state and state not in seen:
+                states.append(state)
+                seen.add(state)
+        return states
+    return []
+
+
+def _append_character_emote_prompt_instruction(sys_text: str, character: dict[str, Any]) -> str:
+    states = _extract_character_mood_image_states(character)
+    prefer = f" Prefer these available states: {', '.join(states)}." if states else ""
+    instruction = (
+        "When the character expression should change, emit a standalone line exactly like "
+        "`Emote: <state>`."
+        f"{prefer} Do not emit an emote after every sentence."
+    )
+    base = sys_text.strip()
+    return f"{base}\n\n{instruction}" if base else instruction
 
 
 def _extract_character_memory_note(settings: dict[str, Any], character_id: Any) -> str:
@@ -5428,6 +5478,7 @@ async def character_chat_completion(
                 user_name=user_name,
                 preset_id=completion_preset,
             )
+            sys_text = _append_character_emote_prompt_instruction(sys_text, character)
             if sys_text.strip():
                 formatted.append({"role": "system", "content": sys_text.strip()})
         if summary_content:
@@ -6111,6 +6162,16 @@ async def character_chat_completion(
             if isinstance(body.mood_topic, str) and body.mood_topic.strip()
             else None
         )
+        resolved_emotes = resolve_character_emote_completion(
+            assistant_text,
+            fallback_mood_label=resolved_mood_label,
+            fallback_mood_confidence=resolved_mood_confidence,
+            fallback_mood_topic=resolved_mood_topic,
+        )
+        assistant_text = resolved_emotes.clean_text
+        resolved_mood_label = resolved_emotes.mood_label
+        resolved_mood_confidence = resolved_emotes.mood_confidence
+        resolved_mood_topic = resolved_emotes.mood_topic
 
         saved = False
         assistant_msg_id: Optional[str] = None
@@ -6163,6 +6224,10 @@ async def character_chat_completion(
                 metadata_extra["mood_confidence"] = resolved_mood_confidence
             if resolved_mood_topic:
                 metadata_extra["mood_topic"] = resolved_mood_topic
+            if resolved_emotes.emote_events:
+                metadata_extra["emote_events"] = [
+                    event.model_dump() for event in resolved_emotes.emote_events
+                ]
             if turn_lorebook_diagnostics:
                 metadata_extra["lorebook_diagnostics"] = turn_lorebook_diagnostics
             if turn_lorebook_cost_diagnostics:
@@ -7324,6 +7389,7 @@ async def persist_streamed_assistant_message(
                     mood_label=body.mood_label,
                     mood_confidence=body.mood_confidence,
                     mood_topic=body.mood_topic,
+                    emote_events=body.emote_events,
                     usage=_validate_stream_persist_usage(getattr(body, "usage", None)),
                     visual_identity=visual_identity_metadata,
                 ),
@@ -7361,6 +7427,7 @@ async def persist_streamed_assistant_message(
             mood_label=body.mood_label,
             mood_confidence=body.mood_confidence,
             mood_topic=body.mood_topic,
+            emote_events=body.emote_events,
             usage=_validate_stream_persist_usage(getattr(body, "usage", None)),
             visual_identity=visual_identity_metadata,
         )

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -126,8 +126,9 @@ from tldw_Server_API.app.core.Character_Chat.modules.character_generation_preset
 )
 from tldw_Server_API.app.core.Character_Chat.emote_directives import (
     CharacterEmoteEvent,
-    normalize_character_emote_state,
+    append_character_emote_prompt_instruction,
     resolve_character_emote_completion,
+    validate_emote_events_for_text,
 )
 from tldw_Server_API.app.core.Character_Chat.modules.character_prompt_presets import (
     DEFAULT_PROMPT_PRESET,
@@ -2416,48 +2417,6 @@ def _extract_character_default_author_note(character: dict[str, Any]) -> str:
     return ""
 
 
-def _extract_character_mood_image_states(character: dict[str, Any]) -> list[str]:
-    extensions = character.get("extensions") if isinstance(character, dict) else None
-    if isinstance(extensions, str):
-        try:
-            extensions = json.loads(extensions)
-        except _CHAR_CHAT_SESSIONS_NONCRITICAL_EXCEPTIONS:
-            extensions = {}
-    if not isinstance(extensions, dict):
-        return []
-
-    tldw = extensions.get("tldw") if isinstance(extensions.get("tldw"), dict) else {}
-    for source in (
-        tldw.get("mood_images"),
-        tldw.get("moodImages"),
-        extensions.get("mood_images"),
-        extensions.get("moodImages"),
-    ):
-        if not isinstance(source, dict):
-            continue
-        states: list[str] = []
-        seen: set[str] = set()
-        for raw_state in source:
-            state = normalize_character_emote_state(raw_state)
-            if state and state not in seen:
-                states.append(state)
-                seen.add(state)
-        return states
-    return []
-
-
-def _append_character_emote_prompt_instruction(sys_text: str, character: dict[str, Any]) -> str:
-    states = _extract_character_mood_image_states(character)
-    prefer = f" Prefer these available states: {', '.join(states)}." if states else ""
-    instruction = (
-        "When the character expression should change, emit a standalone line exactly like "
-        "`Emote: <state>`."
-        f"{prefer} Do not emit an emote after every sentence."
-    )
-    base = sys_text.strip()
-    return f"{base}\n\n{instruction}" if base else instruction
-
-
 def _extract_character_memory_note(settings: dict[str, Any], character_id: Any) -> str:
     memory_by_id = settings.get("characterMemoryById")
     if not isinstance(memory_by_id, dict):
@@ -4702,7 +4661,7 @@ async def prepare_chat_completion(
                 user_name=user_name,
                 preset_id=effective_preset,
             )
-            sys_text = _append_character_emote_prompt_instruction(sys_text, character)
+            sys_text = append_character_emote_prompt_instruction(sys_text, character)
             if sys_text.strip():
                 formatted.append({"role": "system", "content": sys_text.strip()})
         if summary_content:
@@ -5103,7 +5062,7 @@ async def prompt_assembly_preview(
                 user_name=user_name,
                 preset_id=preview_preset,
             )
-            sys_text = _append_character_emote_prompt_instruction(sys_text, character)
+            sys_text = append_character_emote_prompt_instruction(sys_text, character)
             if sys_text.strip():
                 formatted.append({"role": "system", "content": sys_text.strip()})
         if summary_content:
@@ -5482,7 +5441,7 @@ async def character_chat_completion(
                 user_name=user_name,
                 preset_id=completion_preset,
             )
-            sys_text = _append_character_emote_prompt_instruction(sys_text, character)
+            sys_text = append_character_emote_prompt_instruction(sys_text, character)
             if sys_text.strip():
                 formatted.append({"role": "system", "content": sys_text.strip()})
         if summary_content:
@@ -7342,7 +7301,17 @@ async def persist_streamed_assistant_message(
             fallback_mood_topic=body.mood_topic,
         )
         assistant_content = resolved_emotes.clean_text
-        emote_events = body.emote_events or resolved_emotes.emote_events
+        try:
+            emote_events = (
+                validate_emote_events_for_text(body.emote_events, assistant_content)
+                if body.emote_events
+                else resolved_emotes.emote_events
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(exc),
+            ) from exc
         resolved_visual_mood = (
             emote_events[-1].state if emote_events else resolved_emotes.mood_label
         )

--- a/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta, PagePaginationMeta
+from tldw_Server_API.app.core.Character_Chat.emote_directives import CharacterEmoteEvent
 from tldw_Server_API.app.core.LLM_Calls.routing.models import RoutingOverride
 
 ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
@@ -802,6 +803,11 @@ class CharacterChatStreamPersistRequest(BaseModel):
         None,
         max_length=200,
         description="Optional short topic cue associated with the detected mood.",
+    )
+    emote_events: Optional[list[CharacterEmoteEvent]] = Field(
+        None,
+        max_length=5,
+        description="Optional sanitized character emote events for this assistant message.",
     )
     tool_calls: Optional[list[dict[str, Any]]] = Field(None, description="Optional tool_calls metadata to store")
     usage: Optional[dict[str, int]] = Field(None, description="Optional token usage stats: prompt_tokens, completion_tokens, total_tokens")

--- a/tldw_Server_API/app/core/Character_Chat/emote_directives.py
+++ b/tldw_Server_API/app/core/Character_Chat/emote_directives.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, Field, ValidationError
+
+EMOTE_EVENT_LIMIT = 5
+CHARACTER_EMOTE_STATE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,39}$")
+
+_DIRECTIVE_PATTERN = re.compile(r"^emote:(.*)$", re.IGNORECASE)
+
+
+class CharacterEmoteEvent(BaseModel):
+    state: str = Field(..., min_length=1, max_length=40)
+    at_char: int = Field(..., ge=0)
+
+
+class CharacterEmoteParseResult(BaseModel):
+    clean_text: str
+    events: list[CharacterEmoteEvent]
+
+
+class CharacterEmoteCompletionResult(BaseModel):
+    clean_text: str
+    mood_label: str | None
+    mood_confidence: float | None
+    mood_topic: str | None
+    emote_events: list[CharacterEmoteEvent]
+
+
+def normalize_character_emote_state(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = re.sub(r"\s+", "-", value.strip().lower())
+    return normalized if CHARACTER_EMOTE_STATE_PATTERN.fullmatch(normalized) else None
+
+
+def _iter_lines(text: str):
+    index = 0
+    while index < len(text):
+        newline_index = text.find("\n", index)
+        if newline_index == -1:
+            yield text[index:], ""
+            break
+        yield text[index:newline_index], "\n"
+        index = newline_index + 1
+
+
+def _is_fence_line(line: str) -> bool:
+    return line.strip().startswith("```")
+
+
+def _parse_directive_state(line: str) -> str | None | object:
+    match = _DIRECTIVE_PATTERN.fullmatch(line.strip())
+    return normalize_character_emote_state(match.group(1)) if match else _NO_DIRECTIVE
+
+
+_NO_DIRECTIVE = object()
+
+
+def parse_character_emote_directives(text: str) -> CharacterEmoteParseResult:
+    clean_parts: list[str] = []
+    events: list[CharacterEmoteEvent] = []
+    in_fence = False
+    last_state: str | None = None
+    clean_length = 0
+
+    for line, separator in _iter_lines(text):
+        if _is_fence_line(line):
+            visible = line + separator
+            clean_parts.append(visible)
+            clean_length += len(visible)
+            in_fence = not in_fence
+            continue
+
+        if not in_fence:
+            state = _parse_directive_state(line)
+            if state is not _NO_DIRECTIVE:
+                if (
+                    isinstance(state, str)
+                    and state != last_state
+                    and len(events) < EMOTE_EVENT_LIMIT
+                ):
+                    events.append(CharacterEmoteEvent(state=state, at_char=clean_length))
+                    last_state = state
+                continue
+
+        visible = line + separator
+        clean_parts.append(visible)
+        clean_length += len(visible)
+
+    return CharacterEmoteParseResult(clean_text="".join(clean_parts), events=events)
+
+
+def validate_emote_events(events: object) -> list[CharacterEmoteEvent]:
+    if not isinstance(events, list):
+        raise ValueError("emote events must be a list")
+    if len(events) > EMOTE_EVENT_LIMIT:
+        raise ValueError("too many emote events")
+
+    validated: list[CharacterEmoteEvent] = []
+    for event in events:
+        try:
+            parsed = (
+                event
+                if isinstance(event, CharacterEmoteEvent)
+                else CharacterEmoteEvent.model_validate(event)
+            )
+        except ValidationError as exc:
+            raise ValueError("invalid emote event") from exc
+
+        if not CHARACTER_EMOTE_STATE_PATTERN.fullmatch(parsed.state):
+            raise ValueError("invalid emote state")
+        validated.append(parsed)
+
+    return validated
+
+
+def resolve_character_emote_completion(
+    text: str,
+    *,
+    fallback_mood_label: str | None = None,
+    fallback_mood_confidence: float | None = None,
+    fallback_mood_topic: str | None = None,
+) -> CharacterEmoteCompletionResult:
+    parsed = parse_character_emote_directives(text)
+    if parsed.events:
+        return CharacterEmoteCompletionResult(
+            clean_text=parsed.clean_text,
+            mood_label=parsed.events[-1].state,
+            mood_confidence=None,
+            mood_topic=None,
+            emote_events=parsed.events,
+        )
+
+    return CharacterEmoteCompletionResult(
+        clean_text=parsed.clean_text,
+        mood_label=fallback_mood_label,
+        mood_confidence=fallback_mood_confidence,
+        mood_topic=fallback_mood_topic,
+        emote_events=[],
+    )

--- a/tldw_Server_API/app/core/Character_Chat/emote_directives.py
+++ b/tldw_Server_API/app/core/Character_Chat/emote_directives.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 EMOTE_EVENT_LIMIT = 5
 CHARACTER_EMOTE_STATE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,39}$")
@@ -11,8 +11,16 @@ _DIRECTIVE_PATTERN = re.compile(r"^emote:(.*)$", re.IGNORECASE)
 
 
 class CharacterEmoteEvent(BaseModel):
-    state: str = Field(..., min_length=1, max_length=40)
-    at_char: int = Field(..., ge=0)
+    model_config = ConfigDict(extra="forbid")
+
+    state: str = Field(
+        ...,
+        min_length=1,
+        max_length=40,
+        pattern=CHARACTER_EMOTE_STATE_PATTERN.pattern,
+        strict=True,
+    )
+    at_char: int = Field(..., ge=0, strict=True)
 
 
 class CharacterEmoteParseResult(BaseModel):

--- a/tldw_Server_API/app/core/Character_Chat/emote_directives.py
+++ b/tldw_Server_API/app/core/Character_Chat/emote_directives.py
@@ -50,6 +50,10 @@ def _is_fence_line(line: str) -> bool:
     return line.strip().startswith("```")
 
 
+def _js_string_length(value: str) -> int:
+    return len(value.encode("utf-16-le", errors="surrogatepass")) // 2
+
+
 def _parse_directive_state(line: str) -> str | None | object:
     match = _DIRECTIVE_PATTERN.fullmatch(line.strip())
     return normalize_character_emote_state(match.group(1)) if match else _NO_DIRECTIVE
@@ -69,7 +73,7 @@ def parse_character_emote_directives(text: str) -> CharacterEmoteParseResult:
         if _is_fence_line(line):
             visible = line + separator
             clean_parts.append(visible)
-            clean_length += len(visible)
+            clean_length += _js_string_length(visible)
             in_fence = not in_fence
             continue
 
@@ -87,7 +91,7 @@ def parse_character_emote_directives(text: str) -> CharacterEmoteParseResult:
 
         visible = line + separator
         clean_parts.append(visible)
-        clean_length += len(visible)
+        clean_length += _js_string_length(visible)
 
     return CharacterEmoteParseResult(clean_text="".join(clean_parts), events=events)
 

--- a/tldw_Server_API/app/core/Character_Chat/emote_directives.py
+++ b/tldw_Server_API/app/core/Character_Chat/emote_directives.py
@@ -1,16 +1,23 @@
+"""Utilities for explicit character emote directives in assistant text."""
+
 from __future__ import annotations
 
+import json
 import re
+from collections.abc import Iterator, Mapping
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 EMOTE_EVENT_LIMIT = 5
+EMOTE_PROMPT_STATE_LIMIT = 25
 CHARACTER_EMOTE_STATE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,39}$")
 
 _DIRECTIVE_PATTERN = re.compile(r"^emote:(.*)$", re.IGNORECASE)
 
 
 class CharacterEmoteEvent(BaseModel):
+    """Accepted emote state transition at a UTF-16 character offset."""
+
     model_config = ConfigDict(extra="forbid")
 
     state: str = Field(
@@ -24,11 +31,15 @@ class CharacterEmoteEvent(BaseModel):
 
 
 class CharacterEmoteParseResult(BaseModel):
+    """Visible assistant text and emote events parsed from it."""
+
     clean_text: str
     events: list[CharacterEmoteEvent]
 
 
 class CharacterEmoteCompletionResult(BaseModel):
+    """Resolved assistant text plus explicit-or-fallback mood metadata."""
+
     clean_text: str
     mood_label: str | None
     mood_confidence: float | None
@@ -37,13 +48,17 @@ class CharacterEmoteCompletionResult(BaseModel):
 
 
 def normalize_character_emote_state(value: object) -> str | None:
+    """Return a safe emote slug, or None when the value is not usable."""
+
     if not isinstance(value, str):
         return None
     normalized = re.sub(r"\s+", "-", value.strip().lower())
     return normalized if CHARACTER_EMOTE_STATE_PATTERN.fullmatch(normalized) else None
 
 
-def _iter_lines(text: str):
+def _iter_lines(text: str) -> Iterator[tuple[str, str]]:
+    """Yield text lines with their original newline separator."""
+
     index = 0
     while index < len(text):
         newline_index = text.find("\n", index)
@@ -55,14 +70,20 @@ def _iter_lines(text: str):
 
 
 def _is_fence_line(line: str) -> bool:
+    """Return whether the line toggles a Markdown code fence."""
+
     return line.strip().startswith("```")
 
 
 def _js_string_length(value: str) -> int:
+    """Return JavaScript string length measured in UTF-16 code units."""
+
     return len(value.encode("utf-16-le", errors="surrogatepass")) // 2
 
 
 def _parse_directive_state(line: str) -> str | None | object:
+    """Parse one standalone Emote directive line."""
+
     match = _DIRECTIVE_PATTERN.fullmatch(line.strip())
     return normalize_character_emote_state(match.group(1)) if match else _NO_DIRECTIVE
 
@@ -71,6 +92,8 @@ _NO_DIRECTIVE = object()
 
 
 def parse_character_emote_directives(text: str) -> CharacterEmoteParseResult:
+    """Strip standalone Emote directives and return accepted state events."""
+
     clean_parts: list[str] = []
     events: list[CharacterEmoteEvent] = []
     in_fence = False
@@ -105,6 +128,8 @@ def parse_character_emote_directives(text: str) -> CharacterEmoteParseResult:
 
 
 def validate_emote_events(events: object) -> list[CharacterEmoteEvent]:
+    """Validate client-provided emote event shape and count."""
+
     if not isinstance(events, list):
         raise ValueError("emote events must be a list")
     if len(events) > EMOTE_EVENT_LIMIT:
@@ -128,6 +153,24 @@ def validate_emote_events(events: object) -> list[CharacterEmoteEvent]:
     return validated
 
 
+def validate_emote_events_for_text(
+    events: object,
+    text: str,
+) -> list[CharacterEmoteEvent]:
+    """Validate emote events against sanitized assistant text length."""
+
+    validated = validate_emote_events(events)
+    max_offset = _js_string_length(text)
+    previous_offset = -1
+    for event in validated:
+        if event.at_char > max_offset:
+            raise ValueError("emote event offset exceeds assistant content length")
+        if event.at_char < previous_offset:
+            raise ValueError("emote event offsets must be non-decreasing")
+        previous_offset = event.at_char
+    return validated
+
+
 def resolve_character_emote_completion(
     text: str,
     *,
@@ -135,6 +178,8 @@ def resolve_character_emote_completion(
     fallback_mood_confidence: float | None = None,
     fallback_mood_topic: str | None = None,
 ) -> CharacterEmoteCompletionResult:
+    """Resolve visible text and mood metadata from an assistant completion."""
+
     parsed = parse_character_emote_directives(text)
     if parsed.events:
         return CharacterEmoteCompletionResult(
@@ -152,3 +197,66 @@ def resolve_character_emote_completion(
         mood_topic=fallback_mood_topic,
         emote_events=[],
     )
+
+
+def extract_character_mood_image_states(character: Mapping[str, object]) -> list[str]:
+    """Return safe custom emote states from character extension mood images."""
+
+    extensions: object = character.get("extensions") if isinstance(character, Mapping) else None
+    if isinstance(extensions, str):
+        try:
+            extensions = json.loads(extensions)
+        except (TypeError, ValueError):
+            extensions = {}
+    if not isinstance(extensions, Mapping):
+        return []
+
+    tldw_source = extensions.get("tldw")
+    tldw = tldw_source if isinstance(tldw_source, Mapping) else {}
+    for source in (
+        tldw.get("mood_images"),
+        tldw.get("moodImages"),
+        extensions.get("mood_images"),
+        extensions.get("moodImages"),
+    ):
+        if not isinstance(source, Mapping):
+            continue
+        states: list[str] = []
+        seen: set[str] = set()
+        for raw_state in source:
+            state = normalize_character_emote_state(raw_state)
+            if state and state not in seen:
+                states.append(state)
+                seen.add(state)
+        return states
+    return []
+
+
+def _format_prompt_state_list(states: list[str]) -> str:
+    """Format a capped emote state list for the system prompt."""
+
+    visible_states = states[:EMOTE_PROMPT_STATE_LIMIT]
+    hidden_count = max(0, len(states) - len(visible_states))
+    suffix = f" (+{hidden_count} more)" if hidden_count else ""
+    return f"{', '.join(visible_states)}{suffix}"
+
+
+def append_character_emote_prompt_instruction(
+    sys_text: str,
+    character: Mapping[str, object],
+) -> str:
+    """Append the Emote directive instruction to a character system prompt."""
+
+    states = extract_character_mood_image_states(character)
+    prefer = (
+        f" Prefer these available states: {_format_prompt_state_list(states)}."
+        if states
+        else ""
+    )
+    instruction = (
+        "When the character expression should change, emit a standalone line exactly like "
+        "`Emote: <state>`."
+        f"{prefer} Do not emit an emote after every sentence."
+    )
+    base = sys_text.strip()
+    return f"{base}\n\n{instruction}" if base else instruction

--- a/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
@@ -8,6 +8,8 @@ import pytest
 pytestmark = pytest.mark.integration
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.core.Character_Chat.emote_directives import EMOTE_EVENT_LIMIT
+
 
 def _create_character_and_chat(client: TestClient, headers) -> tuple[int, str]:
     char_resp = client.post(
@@ -226,7 +228,9 @@ def test_persist_streamed_message_stores_emote_events(test_client: TestClient, a
         f"/api/v1/chats/{chat_id}/completions/persist",
         json={
             "assistant_content": "What now?\nFine.",
-            "mood_label": "smug",
+            "mood_label": "happy",
+            "mood_confidence": 0.91,
+            "mood_topic": "fallback",
             "emote_events": [
                 {"state": "annoyed", "at_char": 0},
                 {"state": "smug", "at_char": 10},
@@ -245,6 +249,8 @@ def test_persist_streamed_message_stores_emote_events(test_client: TestClient, a
     assert message_resp.status_code == 200
     metadata_extra = message_resp.json()["metadata_extra"]
     assert metadata_extra["mood_label"] == "smug"
+    assert "mood_confidence" not in metadata_extra
+    assert "mood_topic" not in metadata_extra
     assert metadata_extra["emote_events"] == [
         {"state": "annoyed", "at_char": 0},
         {"state": "smug", "at_char": 10},
@@ -259,6 +265,24 @@ def test_persist_streamed_message_rejects_invalid_emote_events(test_client: Test
         json={
             "assistant_content": "bad metadata",
             "emote_events": [{"state": "../../bad", "at_char": 0}],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_persist_streamed_message_rejects_too_many_emote_events(test_client: TestClient, auth_headers) -> None:
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+
+    response = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={
+            "assistant_content": "too many",
+            "emote_events": [
+                {"state": f"state-{index}", "at_char": 0}
+                for index in range(EMOTE_EVENT_LIMIT + 1)
+            ],
         },
         headers=auth_headers,
     )
@@ -281,6 +305,9 @@ def test_persist_streamed_message_retry_preserves_emote_events(
     payload = {
         "assistant_content": "idempotent emote reply",
         "user_message_id": user_resp.json()["id"],
+        "mood_label": "happy",
+        "mood_confidence": 0.8,
+        "mood_topic": "fallback",
         "emote_events": [{"state": "smug", "at_char": 0}],
     }
 
@@ -305,7 +332,11 @@ def test_persist_streamed_message_retry_preserves_emote_events(
         headers=auth_headers,
     )
     assert message_resp.status_code == 200
-    assert message_resp.json()["metadata_extra"]["emote_events"] == [
+    metadata_extra = message_resp.json()["metadata_extra"]
+    assert metadata_extra["mood_label"] == "smug"
+    assert "mood_confidence" not in metadata_extra
+    assert "mood_topic" not in metadata_extra
+    assert metadata_extra["emote_events"] == [
         {"state": "smug", "at_char": 0}
     ]
 
@@ -433,6 +464,42 @@ def test_complete_v2_prompt_contract_mentions_available_emote_states(
     assert "Emote: <state>" in system_text
     assert "Prefer these available states: smug, thinking-hard." in system_text
     assert "../../bad" not in system_text
+
+    prep_response = test_client.post(
+        f"/api/v1/chats/{chat_resp.json()['id']}/completions",
+        json={
+            "append_user_message": "go",
+            "include_character_context": True,
+        },
+        headers=auth_headers,
+    )
+    assert prep_response.status_code == 200
+    prep_system_text = "\n".join(
+        message.get("content", "")
+        for message in prep_response.json()["messages"]
+        if message.get("role") == "system"
+    )
+    assert "Emote: <state>" in prep_system_text
+    assert "Prefer these available states: smug, thinking-hard." in prep_system_text
+    assert "../../bad" not in prep_system_text
+
+    preview_response = test_client.post(
+        f"/api/v1/chats/{chat_resp.json()['id']}/prompt-preview",
+        json={
+            "append_user_message": "go",
+            "include_character_context": True,
+        },
+        headers=auth_headers,
+    )
+    assert preview_response.status_code == 200
+    preset_section = next(
+        section
+        for section in preview_response.json()["sections"]
+        if section["name"] == "preset"
+    )
+    assert "Emote: <state>" in preset_section["content"]
+    assert "Prefer these available states: smug, thinking-hard." in preset_section["content"]
+    assert "../../bad" not in preset_section["content"]
 
 
 def test_persist_streamed_message_saves_then_returns_503_when_counting_degrades(

--- a/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
@@ -219,6 +219,222 @@ def test_persist_streamed_message_preserves_active_speaker_identity(test_client:
     }
 
 
+def test_persist_streamed_message_stores_emote_events(test_client: TestClient, auth_headers) -> None:
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+
+    response = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={
+            "assistant_content": "What now?\nFine.",
+            "mood_label": "smug",
+            "emote_events": [
+                {"state": "annoyed", "at_char": 0},
+                {"state": "smug", "at_char": 10},
+            ],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assistant_message_id = response.json()["assistant_message_id"]
+    message_resp = test_client.get(
+        f"/api/v1/messages/{assistant_message_id}",
+        params={"include_metadata": "true"},
+        headers=auth_headers,
+    )
+    assert message_resp.status_code == 200
+    metadata_extra = message_resp.json()["metadata_extra"]
+    assert metadata_extra["mood_label"] == "smug"
+    assert metadata_extra["emote_events"] == [
+        {"state": "annoyed", "at_char": 0},
+        {"state": "smug", "at_char": 10},
+    ]
+
+
+def test_persist_streamed_message_rejects_invalid_emote_events(test_client: TestClient, auth_headers) -> None:
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+
+    response = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={
+            "assistant_content": "bad metadata",
+            "emote_events": [{"state": "../../bad", "at_char": 0}],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
+def test_persist_streamed_message_retry_preserves_emote_events(
+    test_client: TestClient,
+    auth_headers,
+) -> None:
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+    user_resp = test_client.post(
+        f"/api/v1/chats/{chat_id}/messages",
+        json={"role": "user", "content": "trigger duplicate guard"},
+        headers=auth_headers,
+    )
+    assert user_resp.status_code == 201
+
+    payload = {
+        "assistant_content": "idempotent emote reply",
+        "user_message_id": user_resp.json()["id"],
+        "emote_events": [{"state": "smug", "at_char": 0}],
+    }
+
+    first = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json=payload,
+        headers=auth_headers,
+    )
+    second = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json=payload,
+        headers=auth_headers,
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["assistant_message_id"] == second.json()["assistant_message_id"]
+
+    message_resp = test_client.get(
+        f"/api/v1/messages/{second.json()['assistant_message_id']}",
+        params={"include_metadata": "true"},
+        headers=auth_headers,
+    )
+    assert message_resp.status_code == 200
+    assert message_resp.json()["metadata_extra"]["emote_events"] == [
+        {"state": "smug", "at_char": 0}
+    ]
+
+
+def test_complete_v2_sanitizes_emote_directives_for_non_streaming_response_and_storage(
+    test_client: TestClient,
+    auth_headers,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+    monkeypatch.setenv("ENABLE_LOCAL_LLM_PROVIDER", "1")
+
+    import tldw_Server_API.app.api.v1.endpoints.character_chat_sessions as mod
+
+    def _stub_chat_api_call(api_endpoint, messages_payload, **kwargs):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": "Emote: annoyed\nWhat now?\nEmote: smug\nFine."
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(mod, "perform_chat_api_call", _stub_chat_api_call)
+
+    response = test_client.post(
+        f"/api/v1/chats/{chat_id}/complete-v2",
+        json={
+            "provider": "local-llm",
+            "model": "local-test",
+            "append_user_message": "continue",
+            "include_character_context": False,
+            "save_to_db": True,
+            "mood_label": "happy",
+            "mood_confidence": 0.9,
+            "mood_topic": "fallback",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["assistant_content"] == "What now?\nFine."
+    assert payload["mood_label"] == "smug"
+    assert payload["mood_confidence"] is None
+    assert payload["mood_topic"] is None
+
+    message_resp = test_client.get(
+        f"/api/v1/messages/{payload['assistant_message_id']}",
+        params={"include_metadata": "true"},
+        headers=auth_headers,
+    )
+    assert message_resp.status_code == 200
+    stored = message_resp.json()
+    assert stored["content"] == "What now?\nFine."
+    assert stored["metadata_extra"]["mood_label"] == "smug"
+    assert stored["metadata_extra"]["emote_events"] == [
+        {"state": "annoyed", "at_char": 0},
+        {"state": "smug", "at_char": 10},
+    ]
+
+
+def test_complete_v2_prompt_contract_mentions_available_emote_states(
+    test_client: TestClient,
+    auth_headers,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    char_resp = test_client.post(
+        "/api/v1/characters/",
+        json={
+            "name": "EmotePromptChar",
+            "description": "Streaming test",
+            "personality": "Calm",
+            "first_message": "Hello!",
+            "extensions": {
+                "tldw": {
+                    "mood_images": {
+                        "smug": "data:image/png;base64,AA==",
+                        "thinking hard": "data:image/png;base64,AA==",
+                        "../../bad": "data:image/png;base64,AA==",
+                    }
+                }
+            },
+        },
+        headers=auth_headers,
+    )
+    assert char_resp.status_code == 201
+    chat_resp = test_client.post(
+        "/api/v1/chats/",
+        json={"character_id": char_resp.json()["id"], "title": "Prompt Contract"},
+        headers=auth_headers,
+    )
+    assert chat_resp.status_code == 201
+    captured = {}
+    monkeypatch.setenv("ENABLE_LOCAL_LLM_PROVIDER", "1")
+
+    import tldw_Server_API.app.api.v1.endpoints.character_chat_sessions as mod
+
+    def _stub_chat_api_call(api_endpoint, messages_payload, **kwargs):
+        captured["messages"] = messages_payload
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr(mod, "perform_chat_api_call", _stub_chat_api_call)
+
+    response = test_client.post(
+        f"/api/v1/chats/{chat_resp.json()['id']}/complete-v2",
+        json={
+            "provider": "local-llm",
+            "model": "local-test",
+            "append_user_message": "go",
+            "include_character_context": True,
+            "save_to_db": False,
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    system_text = "\n".join(
+        message.get("content", "")
+        for message in captured["messages"]
+        if message.get("role") == "system"
+    )
+    assert "Emote: <state>" in system_text
+    assert "Prefer these available states: smug, thinking-hard." in system_text
+    assert "../../bad" not in system_text
+
+
 def test_persist_streamed_message_saves_then_returns_503_when_counting_degrades(
     test_client: TestClient,
     auth_headers,

--- a/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
@@ -319,6 +319,24 @@ def test_persist_streamed_message_rejects_too_many_emote_events(test_client: Tes
     assert response.status_code == 422
 
 
+def test_persist_streamed_message_rejects_emote_event_offset_beyond_clean_content(
+    test_client: TestClient,
+    auth_headers,
+) -> None:
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+
+    response = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={
+            "assistant_content": "Emote: smug\nVisible",
+            "emote_events": [{"state": "smug", "at_char": 99}],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422
+
+
 def test_persist_streamed_message_retry_preserves_emote_events(
     test_client: TestClient,
     auth_headers,

--- a/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
@@ -257,6 +257,35 @@ def test_persist_streamed_message_stores_emote_events(test_client: TestClient, a
     ]
 
 
+def test_persist_streamed_message_sanitizes_raw_emote_directives(
+    test_client: TestClient,
+    auth_headers,
+) -> None:
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+
+    response = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={
+            "assistant_content": "Emote: smug\nVisible reply",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assistant_message_id = response.json()["assistant_message_id"]
+    message_resp = test_client.get(
+        f"/api/v1/messages/{assistant_message_id}",
+        params={"include_metadata": "true"},
+        headers=auth_headers,
+    )
+    assert message_resp.status_code == 200
+    stored = message_resp.json()
+    assert stored["content"] == "Visible reply"
+    metadata_extra = stored["metadata_extra"]
+    assert metadata_extra["mood_label"] == "smug"
+    assert metadata_extra["emote_events"] == [{"state": "smug", "at_char": 0}]
+
+
 def test_persist_streamed_message_rejects_invalid_emote_events(test_client: TestClient, auth_headers) -> None:
     _, chat_id = _create_character_and_chat(test_client, auth_headers)
 

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from unittest import TestCase
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Character_Chat.emote_directives import (
+    EMOTE_EVENT_LIMIT,
+    parse_character_emote_directives,
+    validate_emote_events,
+)
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "apps/packages/ui/src/utils/__fixtures__/character-emote-directives.json"
+)
+CASE = TestCase()
+
+
+def _event_dicts(result):
+    return [event.model_dump() for event in result.events]
+
+
+@pytest.mark.parametrize("fixture", json.loads(FIXTURE_PATH.read_text()))
+def test_parse_character_emote_directives_matches_shared_fixture(fixture):
+    result = parse_character_emote_directives(fixture["input"])
+
+    CASE.assertEqual(result.clean_text, fixture["clean_text"])
+    CASE.assertEqual(_event_dicts(result), fixture["events"])
+
+
+def test_validate_emote_events_accepts_valid_event():
+    events = validate_emote_events([{"state": "smug", "at_char": 0}])
+
+    CASE.assertEqual(
+        [event.model_dump() for event in events],
+        [{"state": "smug", "at_char": 0}],
+    )
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        [{"state": "../../bad", "at_char": 0}],
+        [{"state": "smug", "at_char": -1}],
+        [{"state": f"state-{index}", "at_char": 0} for index in range(EMOTE_EVENT_LIMIT + 1)],
+    ],
+)
+def test_validate_emote_events_rejects_invalid_metadata(events):
+    with pytest.raises(ValueError):
+        validate_emote_events(events)

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
@@ -67,21 +67,25 @@ def test_validate_emote_events_rejects_invalid_metadata(events):
         validate_emote_events(events)
 
 
-def test_resolve_character_emote_completion_prefers_explicit_directives():
+@pytest.mark.unit
+def test_resolve_completion_emotes_prefers_last_explicit_event() -> None:
     result = resolve_character_emote_completion(
-        "Emote: smug\nFine.",
+        "Emote: annoyed\nWhat now?\nEmote: smug\nFine.",
         fallback_mood_label="happy",
         fallback_mood_confidence=0.9,
         fallback_mood_topic="fallback",
     )
 
-    CASE.assertEqual(result.clean_text, "Fine.")
+    CASE.assertEqual(result.clean_text, "What now?\nFine.")
     CASE.assertEqual(result.mood_label, "smug")
     CASE.assertIsNone(result.mood_confidence)
     CASE.assertIsNone(result.mood_topic)
     CASE.assertEqual(
         [event.model_dump() for event in result.emote_events],
-        [{"state": "smug", "at_char": 0}],
+        [
+            {"state": "annoyed", "at_char": 0},
+            {"state": "smug", "at_char": 10},
+        ],
     )
 
 

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
@@ -8,10 +8,15 @@ import pytest
 
 from tldw_Server_API.app.core.Character_Chat.emote_directives import (
     EMOTE_EVENT_LIMIT,
+    CharacterEmoteParseResult,
+    append_character_emote_prompt_instruction,
     parse_character_emote_directives,
     resolve_character_emote_completion,
     validate_emote_events,
+    validate_emote_events_for_text,
 )
+
+pytestmark = pytest.mark.unit
 
 
 FIXTURE_PATH = (
@@ -21,26 +26,28 @@ FIXTURE_PATH = (
 CASE = TestCase()
 
 
-def _event_dicts(result):
+def _event_dicts(result: CharacterEmoteParseResult) -> list[dict[str, object]]:
     return [event.model_dump() for event in result.events]
 
 
 @pytest.mark.parametrize("fixture", json.loads(FIXTURE_PATH.read_text()))
-def test_parse_character_emote_directives_matches_shared_fixture(fixture):
+def test_parse_character_emote_directives_matches_shared_fixture(
+    fixture: dict[str, object],
+) -> None:
     result = parse_character_emote_directives(fixture["input"])
 
     CASE.assertEqual(result.clean_text, fixture["clean_text"])
     CASE.assertEqual(_event_dicts(result), fixture["events"])
 
 
-def test_parse_character_emote_directives_counts_offsets_like_js_strings():
+def test_parse_character_emote_directives_counts_offsets_like_js_strings() -> None:
     result = parse_character_emote_directives("😀\nEmote: smug\nDone.")
 
     CASE.assertEqual(result.clean_text, "😀\nDone.")
     CASE.assertEqual(_event_dicts(result), [{"state": "smug", "at_char": 3}])
 
 
-def test_validate_emote_events_accepts_valid_event():
+def test_validate_emote_events_accepts_valid_event() -> None:
     events = validate_emote_events([{"state": "smug", "at_char": 0}])
 
     CASE.assertEqual(
@@ -62,12 +69,29 @@ def test_validate_emote_events_accepts_valid_event():
         [{"state": "smug", "at_char": 0, "extra": "ignored"}],
     ],
 )
-def test_validate_emote_events_rejects_invalid_metadata(events):
+def test_validate_emote_events_rejects_invalid_metadata(
+    events: list[dict[str, object]],
+) -> None:
     with pytest.raises(ValueError):
         validate_emote_events(events)
 
 
-@pytest.mark.unit
+def test_validate_emote_events_for_text_rejects_out_of_bounds_offset() -> None:
+    with pytest.raises(ValueError, match="offset exceeds"):
+        validate_emote_events_for_text([{"state": "smug", "at_char": 8}], "short")
+
+
+def test_validate_emote_events_for_text_rejects_decreasing_offsets() -> None:
+    with pytest.raises(ValueError, match="non-decreasing"):
+        validate_emote_events_for_text(
+            [
+                {"state": "smug", "at_char": 3},
+                {"state": "annoyed", "at_char": 1},
+            ],
+            "visible reply",
+        )
+
+
 def test_resolve_completion_emotes_prefers_last_explicit_event() -> None:
     result = resolve_character_emote_completion(
         "Emote: annoyed\nWhat now?\nEmote: smug\nFine.",
@@ -89,7 +113,7 @@ def test_resolve_completion_emotes_prefers_last_explicit_event() -> None:
     )
 
 
-def test_resolve_character_emote_completion_preserves_fallback_without_directives():
+def test_resolve_character_emote_completion_preserves_fallback_without_directives() -> None:
     result = resolve_character_emote_completion(
         "Fine.",
         fallback_mood_label="happy",
@@ -102,3 +126,24 @@ def test_resolve_character_emote_completion_preserves_fallback_without_directive
     CASE.assertEqual(result.mood_confidence, 0.9)
     CASE.assertEqual(result.mood_topic, "fallback")
     CASE.assertEqual(result.emote_events, [])
+
+
+def test_append_character_emote_prompt_instruction_caps_state_list() -> None:
+    character = {
+        "extensions": {
+            "tldw": {
+                "mood_images": {
+                    f"state-{index}": f"/state-{index}.png"
+                    for index in range(35)
+                }
+            }
+        }
+    }
+
+    prompt = append_character_emote_prompt_instruction("Base prompt", character)
+
+    CASE.assertIn("Base prompt", prompt)
+    CASE.assertIn("Prefer these available states:", prompt)
+    CASE.assertIn("state-24", prompt)
+    CASE.assertNotIn("state-25", prompt)
+    CASE.assertIn("(+10 more)", prompt)

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
@@ -9,6 +9,7 @@ import pytest
 from tldw_Server_API.app.core.Character_Chat.emote_directives import (
     EMOTE_EVENT_LIMIT,
     parse_character_emote_directives,
+    resolve_character_emote_completion,
     validate_emote_events,
 )
 
@@ -54,8 +55,46 @@ def test_validate_emote_events_accepts_valid_event():
         [{"state": "../../bad", "at_char": 0}],
         [{"state": "smug", "at_char": -1}],
         [{"state": f"state-{index}", "at_char": 0} for index in range(EMOTE_EVENT_LIMIT + 1)],
+        [{"state": "smug", "at_char": "1"}],
+        [{"state": "smug", "at_char": 1.0}],
+        [{"state": "smug", "at_char": True}],
+        [{"state": b"smug", "at_char": 0}],
+        [{"state": "smug", "at_char": 0, "extra": "ignored"}],
     ],
 )
 def test_validate_emote_events_rejects_invalid_metadata(events):
     with pytest.raises(ValueError):
         validate_emote_events(events)
+
+
+def test_resolve_character_emote_completion_prefers_explicit_directives():
+    result = resolve_character_emote_completion(
+        "Emote: smug\nFine.",
+        fallback_mood_label="happy",
+        fallback_mood_confidence=0.9,
+        fallback_mood_topic="fallback",
+    )
+
+    CASE.assertEqual(result.clean_text, "Fine.")
+    CASE.assertEqual(result.mood_label, "smug")
+    CASE.assertIsNone(result.mood_confidence)
+    CASE.assertIsNone(result.mood_topic)
+    CASE.assertEqual(
+        [event.model_dump() for event in result.emote_events],
+        [{"state": "smug", "at_char": 0}],
+    )
+
+
+def test_resolve_character_emote_completion_preserves_fallback_without_directives():
+    result = resolve_character_emote_completion(
+        "Fine.",
+        fallback_mood_label="happy",
+        fallback_mood_confidence=0.9,
+        fallback_mood_topic="fallback",
+    )
+
+    CASE.assertEqual(result.clean_text, "Fine.")
+    CASE.assertEqual(result.mood_label, "happy")
+    CASE.assertEqual(result.mood_confidence, 0.9)
+    CASE.assertEqual(result.mood_topic, "fallback")
+    CASE.assertEqual(result.emote_events, [])

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py
@@ -32,6 +32,13 @@ def test_parse_character_emote_directives_matches_shared_fixture(fixture):
     CASE.assertEqual(_event_dicts(result), fixture["events"])
 
 
+def test_parse_character_emote_directives_counts_offsets_like_js_strings():
+    result = parse_character_emote_directives("😀\nEmote: smug\nDone.")
+
+    CASE.assertEqual(result.clean_text, "😀\nDone.")
+    CASE.assertEqual(_event_dicts(result), [{"state": "smug", "at_char": 3}])
+
+
 def test_validate_emote_events_accepts_valid_event():
     events = validate_emote_events([{"state": "smug", "at_char": 0}])
 


### PR DESCRIPTION
## Summary
- Add explicit `Emote: <state>` parsing/sanitization for character chat responses across streaming and non-streaming paths.
- Stream/persist final `mood_label` plus strict `emote_events`, resolve safe custom emote portrait slugs, and restore explicit moods from history.
- Address review fixes: explicit moods skip heuristic classification, and direct stream-persist API calls sanitize raw emote directives before storage.

## Test Plan
- `bunx vitest run src/utils/__tests__/character-emotes.test.ts src/utils/__tests__/character-mood.test.ts src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx src/hooks/chat/__tests__/useCharacterChatMode.contract.test.ts src/hooks/__tests__/useServerChatLoader.test.ts src/db/dexie/__tests__/helpers.character-emotes.test.ts src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx --maxWorkers=1`
- `python -m pytest tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_emote_directives.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py -q`
- `python -m bandit -r tldw_Server_API/app/core/Character_Chat/emote_directives.py tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py -f json -o /tmp/bandit_character_emotes_review_fix.json`
- `bun run typecheck` was attempted and still fails on unrelated baseline files outside this feature.

## Change summary
Human-authored change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit “Emote: <state>” directives to character chat so portraits change during streaming while chat text stays clean. Parses, validates, persists, and restores emote events (UTF‑16 offsets) and final mood across frontend and backend (TASK-12163).

- **New Features**
  - Frontend: `createCharacterEmoteStream` strips standalone directives during streaming, updates the portrait live, records events, persists `mood_label` and `metadataExtra.emote_events`; explicit moods skip heuristic detection; history/server loaders restore these fields and resolve custom emote image states.
  - Backend: Adds a strict parser/validator for emote directives, accepts `emote_events` in `CharacterChatStreamPersistRequest`, sanitizes and limits to 5, enforces UTF‑16 offsets, computes a clean assistant completion, and provides a prompt instruction helper.

- **Bug Fixes**
  - Canonicalizes streamed emote metadata, counts offsets as UTF‑16 units, sanitizes persisted directives, preserves emote events during stream recovery and fallback persistence, and fixes CI failures by adding emote unit tests to the workflow and stabilizing mocks/test defaults.

<sup>Written for commit 3910405f403fed3f78e51d954a093dd351eb25d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

