### PR TITLE
Fix Postgres AuthNZ password history bootstrap

### DIFF
--- a/tldw_Server_API/app/core/AuthNZ/password_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/password_service.py
@@ -333,7 +333,7 @@ class PasswordService:
                     """
                     SELECT password_hash FROM password_history
                     WHERE user_id = $1
-                    ORDER BY created_at DESC
+                    ORDER BY created_at DESC, id DESC
                     LIMIT $2
                     """,
                     user_id, history_count
@@ -345,7 +345,7 @@ class PasswordService:
                     """
                     SELECT password_hash FROM password_history
                     WHERE user_id = ?
-                    ORDER BY created_at DESC
+                    ORDER BY created_at DESC, id DESC
                     LIMIT ?
                     """,
                     (user_id, history_count)
@@ -422,7 +422,7 @@ class PasswordService:
                     WHERE user_id = $1 AND id NOT IN (
                         SELECT id FROM password_history
                         WHERE user_id = $1
-                        ORDER BY created_at DESC
+                        ORDER BY created_at DESC, id DESC
                         LIMIT $2
                     )
                     """,
@@ -445,7 +445,7 @@ class PasswordService:
                     WHERE user_id = ? AND id NOT IN (
                         SELECT id FROM password_history
                         WHERE user_id = ?
-                        ORDER BY created_at DESC
+                        ORDER BY created_at DESC, id DESC
                         LIMIT ?
                     )
                     """,

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -1156,6 +1156,23 @@ _CREATE_AUTHNZ_CORE_TABLES = [
     ("CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id)", ()),
     ("CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at)", ()),
     ("CREATE INDEX IF NOT EXISTS idx_sessions_access_jti ON sessions(access_jti)", ()),
+    # password_history
+    (
+        """
+        CREATE TABLE IF NOT EXISTS password_history (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            password_hash TEXT NOT NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_password_history_user_created_at "
+        "ON password_history(user_id, created_at DESC, id DESC)",
+        (),
+    ),
     # registration_codes
     (
         """

--- a/tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_authnz_core.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_authnz_core.py
@@ -1,0 +1,38 @@
+"""Unit tests for AuthNZ PostgreSQL core bootstrap migrations."""
+
+import asyncio
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+class _StubPostgresPool:
+    """Capture SQL statements executed by the PostgreSQL migration helper."""
+
+    def __init__(self) -> None:
+        self.pool = object()
+        self.executed_sql: list[str] = []
+
+    async def execute(self, query: str, *args: object) -> None:
+        """Record a migration SQL statement without touching a real database."""
+        self.executed_sql.append(query)
+
+
+def test_ensure_authnz_core_tables_pg_emits_password_history_ddl() -> None:
+    """Verify the core Postgres bootstrap emits password history DDL."""
+    from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import ensure_authnz_core_tables_pg
+
+    async def _run() -> None:
+        """Run the async migration helper inside this synchronous unit test."""
+        pool = _StubPostgresPool()
+        ok = await ensure_authnz_core_tables_pg(pool)
+
+        assert ok is True
+        assert any("CREATE TABLE IF NOT EXISTS password_history" in sql for sql in pool.executed_sql)
+        assert any("created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP" in sql for sql in pool.executed_sql)
+        assert any("idx_password_history_user_created_at" in sql for sql in pool.executed_sql)
+        assert any("ON password_history(user_id, created_at DESC, id DESC)" in sql for sql in pool.executed_sql)
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add Postgres AuthNZ bootstrap DDL for password_history
- add a regression test that the core Postgres AuthNZ migration emits password_history table/index DDL

## Why
Production private-beta signup returned success while rolling back the registration transaction because password_history did not exist. Creating this table in the Postgres bootstrap keeps registration/password-history writes in the same successful transaction.

## Verification
- RED check before fix: source assertion reported missing password_history DDL and indexes
- PASS: python3 source DDL assertion
- PASS: /Users/macbook-dev/.local/bin/python3.12 -m py_compile tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_authnz_core.py

Note: full pytest was not runnable in this local workspace because the repo Python env is not installed; uv project resolution is currently blocked by unrelated optional dependency resolution for russian-text-stresser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create the Postgres AuthNZ `password_history` table and composite index during bootstrap so registration and history writes commit together. Prevents signups appearing successful while rolling back, and makes history queries deterministic by ordering by `created_at` and `id`.

- **Bug Fixes**
  - Add `password_history` table with `created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP` and composite index `(user_id, created_at DESC, id DESC)` to Postgres bootstrap DDL.
  - Update read/trim queries to `ORDER BY created_at DESC, id DESC` across drivers; add regression test covering the table, index, and `created_at` default.

<sup>Written for commit 354662f46d032ae31a63793cfd797cd74c995824. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

