### PR TITLE
Fix Docker image missing standalone MCP package

### DIFF
--- a/Dockerfiles/Dockerfile.prod
+++ b/Dockerfiles/Dockerfile.prod
@@ -20,6 +20,7 @@ WORKDIR /app
 # Copy packaging metadata and source to build/install python deps.
 COPY pyproject.toml README.md /app/
 COPY tldw_Server_API /app/tldw_Server_API
+COPY apps/mcp-unified/src /app/apps/mcp-unified/src
 
 RUN pip install --upgrade pip && \
     pip install --prefix=/install .

--- a/backlog/tasks/task-12175 - Fix-Docker-image-missing-standalone-MCP-Unified-package.md
+++ b/backlog/tasks/task-12175 - Fix-Docker-image-missing-standalone-MCP-Unified-package.md
@@ -1,0 +1,40 @@
+---
+id: TASK-12175
+title: Fix Docker image missing standalone MCP Unified package
+status: Done
+modified_files:
+- Dockerfiles/Dockerfile.prod
+- tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Users following the single-user Docker guide can hit ModuleNotFoundError for the standalone mcp_unified package because Dockerfile.prod installs the root project before copying apps/mcp-unified/src into the builder context.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the single-user Docker image path so the standalone MCP Unified source is present when pip installs the root package. Verified with the targeted MCP Docker packaging contract test and Bandit on the touched test file.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 DOCKER_README = Path("tldw_Server_API/app/core/MCP_unified/docker/README.md")
 DOCKERFILE = Path("tldw_Server_API/app/core/MCP_unified/docker/Dockerfile")
+ROOT_DOCKERFILE = Path("Dockerfiles/Dockerfile.prod")
 ENTRYPOINT = Path("tldw_Server_API/app/core/MCP_unified/docker/entrypoint.sh")
 CORE_README = Path("tldw_Server_API/app/core/MCP_unified/README.md")
 
@@ -68,3 +69,14 @@ def test_mcp_entrypoint_script_exists_and_execs_command() -> None:
     entrypoint = ENTRYPOINT.read_text(encoding="utf-8")
     _ensure('exec "$@"' in entrypoint, "Entrypoint does not exec the runtime command")
     _ensure("mkdir -p /data" not in entrypoint, "Entrypoint should not rely on runtime directory creation under /data")
+
+
+def test_root_dockerfile_installs_standalone_mcp_package_source() -> None:
+    _ensure(ROOT_DOCKERFILE.exists(), "Root production Dockerfile is missing")
+    dockerfile = ROOT_DOCKERFILE.read_text(encoding="utf-8")
+    copy_index = dockerfile.find("COPY apps/mcp-unified/src /app/apps/mcp-unified/src")
+    install_index = dockerfile.find("pip install --prefix=/install .")
+
+    _ensure(copy_index >= 0, "Root Docker image must copy standalone MCP Unified source")
+    _ensure(install_index >= 0, "Root Docker image must install the root package")
+    _ensure(copy_index < install_index, "Standalone MCP Unified source must be copied before pip install")


### PR DESCRIPTION
## Change summary

AI-generated draft; requester/maintainer should replace or confirm this section in their own words before merge per the repository AI-generated PR policy.

- Copy `apps/mcp-unified/src` into the production Docker builder before `pip install .`, so root package discovery can install the top-level `mcp_unified` package.
- Add a Docker packaging contract test that keeps the copy before the root package install.

Why: the embedded MCP Unified server imports package-owned `mcp_unified` modules, but the single-user Docker image only copied `tldw_Server_API` into the builder. Source checkouts worked via a local sys.path bootstrap; built images did not have the standalone source available.

## Verification

- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py -q`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -q tldw_Server_API/app/core/MCP_unified/tests/test_docker_packaging_contract.py`
- `git diff --check`

Full Docker image build was not run locally; the added contract test covers the packaging omission that caused `ModuleNotFoundError: mcp_unified`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `mcp_unified` in the single-user Docker image by copying `apps/mcp-unified/src` into the build context before `pip install .`, preventing runtime import errors. Adds a packaging contract test to lock this order. Addresses TASK-12175.

- **Bug Fixes**
  - Update `Dockerfiles/Dockerfile.prod` to `COPY apps/mcp-unified/src` before installing the root package.
  - Add `test_root_dockerfile_installs_standalone_mcp_package_source` to ensure the copy exists and happens before `pip install .`.

<sup>Written for commit 5e54c1a2be127bf54009fd4994c8a2ac98d5776e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

