### PR TITLE
Fix PDF/EPUB ingest error handling

### DIFF
--- a/apps/packages/ui/src/entries/background.ts
+++ b/apps/packages/ui/src/entries/background.ts
@@ -55,6 +55,7 @@ import {
 import {
   createIngestJobsTracker,
   pollTrackedIngestJobs,
+  requireSubmittedIngestJobs,
 } from "@/services/tldw/ingest-jobs-orchestrator";
 import {
   completedIngestJobIndicatesFailure,
@@ -1148,13 +1149,6 @@ export default defineBackground({
       return null;
     };
 
-    type UploadResult = {
-      ok: boolean;
-      status?: number;
-      data?: any;
-      error?: string;
-    };
-
     const handleUpload = async (payload: {
       path?: string;
       method?: string;
@@ -1185,7 +1179,7 @@ export default defineBackground({
       timeoutMs?: number;
       responseType?: "json" | "text" | "arrayBuffer";
       quickIngestSessionId?: string;
-    }): Promise<UploadResult> => {
+    }) => {
       const {
         path,
         method = "POST",
@@ -1250,7 +1244,7 @@ export default defineBackground({
           },
           fieldName: string,
           { appendLegacyFileAlias = false }: { appendLegacyFileAlias?: boolean } = {},
-        ): UploadResult => {
+        ): { ok: true } | { ok: false; status: number; error: string } => {
           if (item?.data === undefined || item?.data === null) return { ok: true };
           const bytes = normalizeFileData(item.data);
           if (!bytes || bytes.byteLength === 0) {
@@ -1753,18 +1747,6 @@ export default defineBackground({
       }
     };
 
-    const extractIngestJobIds = (data: any): number[] => {
-      const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
-      const ids: number[] = [];
-      for (const item of jobs) {
-        const id = Number(item?.id);
-        if (Number.isFinite(id) && id > 0) {
-          ids.push(Math.trunc(id));
-        }
-      }
-      return ids;
-    };
-
     const extractMediaIdFromJobStatus = (data: any): number | null => {
       const direct = Number(data?.media_id);
       if (Number.isFinite(direct) && direct > 0) {
@@ -2226,13 +2208,15 @@ export default defineBackground({
         return;
       }
 
-      session.jobIds = extractIngestJobIds(jobsResp.data);
-      session.batchId =
-        typeof jobsResp.data?.batch_id === "string"
-          ? jobsResp.data.batch_id
-          : undefined;
-      if (session.jobIds.length === 0) {
-        const msg = "Ingest job submission returned no job IDs.";
+      try {
+        const submittedJobs = requireSubmittedIngestJobs(jobsResp.data);
+        session.jobIds = submittedJobs.jobIds;
+        session.batchId = submittedJobs.batchId;
+      } catch (error) {
+        const msg =
+          error instanceof Error
+            ? error.message
+            : String(error || "Ingest job submission returned no job IDs.");
         session.lastError = msg;
         await emitIngestStatus(session, {
           status: "failed",

--- a/apps/packages/ui/src/services/__tests__/ingest-jobs-orchestrator.test.ts
+++ b/apps/packages/ui/src/services/__tests__/ingest-jobs-orchestrator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import {
   createIngestJobsTracker,
+  extractIngestJobSubmitError,
   pollSingleIngestJob,
   pollTrackedIngestJobs
 } from "@/services/tldw/ingest-jobs-orchestrator"
@@ -41,6 +42,32 @@ describe("ingest-jobs-orchestrator", () => {
 
     expect(tracker.getJobIds().sort((a, b) => a - b)).toEqual([11, 12, 13, 21])
     expect(cancelled.sort()).toEqual(["batch-a", "batch-b"])
+  })
+
+  it("surfaces submit payload errors when no valid jobs are returned", () => {
+    const tracker = createIngestJobsTracker<{ label: string }>()
+
+    expect(() =>
+      tracker.trackSubmit(
+        {
+          batch_id: "batch-error",
+          jobs: [],
+          errors: ["Validation failed: Claimed filename 'upload' has no extension."]
+        },
+        { label: "failed-submit" }
+      )
+    ).toThrow("Validation failed: Claimed filename 'upload' has no extension.")
+  })
+
+  it("formats array detail submit errors", () => {
+    expect(
+      extractIngestJobSubmitError({
+        detail: [
+          { loc: ["body", "file"], msg: "Field required", type: "missing" },
+          "Upload failed"
+        ]
+      })
+    ).toBe("body.file: Field required; Upload failed")
   })
 
   it("polls tracked jobs to terminal statuses and maps results", async () => {

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
@@ -148,6 +148,42 @@ describe("submitQuickIngestBatch", () => {
     })
   })
 
+  it("surfaces backend ingest job submit errors when no jobs are created", async () => {
+    mocks.bgUpload.mockResolvedValue({
+      batch_id: "batch-upload-error",
+      jobs: [],
+      errors: ["Validation failed: Claimed filename 'upload' has no extension."]
+    })
+
+    const result = await submitQuickIngestBatch({
+      entries: [],
+      files: [
+        {
+          id: "file-invalid-pdf",
+          name: "upload",
+          type: "application/pdf",
+          data: [37, 80, 68, 70]
+        }
+      ],
+      storeRemote: true,
+      processOnly: false,
+      common: {
+        perform_analysis: true,
+        perform_chunking: false,
+        overwrite_existing: false
+      },
+      advancedValues: {}
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.results?.[0]).toMatchObject({
+      id: "file-invalid-pdf",
+      status: "error",
+      fileName: "upload",
+      error: "Validation failed: Claimed filename 'upload' has no extension."
+    })
+  })
+
   it("surfaces completed ingest jobs with backend error payloads as failed results", async () => {
     mocks.bgUpload.mockResolvedValue({
       batch_id: "batch-completed-error",

--- a/apps/packages/ui/src/services/tldw/ingest-jobs-orchestrator.ts
+++ b/apps/packages/ui/src/services/tldw/ingest-jobs-orchestrator.ts
@@ -40,6 +40,42 @@ export type PollSingleIngestJobResult = {
 
 const normalizeBatchId = (value: unknown): string => String(value || "").trim()
 
+const formatIngestSubmitDetail = (item: unknown): string => {
+  if (typeof item === "string") return item.trim()
+  if (!item || typeof item !== "object") return ""
+
+  const detail = item as { loc?: unknown; msg?: unknown }
+  const msg = typeof detail.msg === "string" ? detail.msg.trim() : ""
+  const loc = Array.isArray(detail.loc)
+    ? detail.loc
+        .map((part: unknown) => String(part).trim())
+        .filter(Boolean)
+        .join(".")
+    : ""
+
+  return loc && msg ? `${loc}: ${msg}` : msg
+}
+
+export const extractIngestJobSubmitError = (data: any): string | null => {
+  const errors = Array.isArray(data?.errors)
+    ? data.errors
+        .map((item: unknown) => String(item || "").trim())
+        .filter(Boolean)
+    : []
+  if (errors.length > 0) return errors.join("; ")
+
+  const detail = data?.detail
+  if (typeof detail === "string" && detail.trim()) {
+    return detail.trim()
+  }
+  if (Array.isArray(detail)) {
+    const detailMessages = detail.map(formatIngestSubmitDetail).filter(Boolean)
+    if (detailMessages.length > 0) return detailMessages.join("; ")
+  }
+
+  return null
+}
+
 export const extractIngestJobIds = (data: any): number[] => {
   const jobs = Array.isArray(data?.jobs) ? data.jobs : []
   const ids: number[] = []
@@ -50,6 +86,20 @@ export const extractIngestJobIds = (data: any): number[] => {
     }
   }
   return ids
+}
+
+export const requireSubmittedIngestJobs = (
+  submitData: any
+): { batchId: string; jobIds: number[] } => {
+  const batchId = normalizeBatchId(submitData?.batch_id)
+  const jobIds = extractIngestJobIds(submitData)
+  if (!batchId || jobIds.length === 0) {
+    throw new Error(
+      extractIngestJobSubmitError(submitData) ||
+        "Ingest job submission returned no job IDs."
+    )
+  }
+  return { batchId, jobIds }
 }
 
 export const createIngestJobsTracker = <TMeta>() => {
@@ -82,8 +132,7 @@ export const createIngestJobsTracker = <TMeta>() => {
   }
 
   const trackSubmit = (submitData: any, meta: TMeta): number[] => {
-    const batchId = normalizeBatchId(submitData?.batch_id)
-    const jobIds = extractIngestJobIds(submitData)
+    const { batchId, jobIds } = requireSubmittedIngestJobs(submitData)
     return trackJobs(batchId, jobIds, meta)
   }
 

--- a/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
@@ -15,8 +15,8 @@ import {
 } from "@/services/tldw/quick-ingest-chunking";
 import {
   createIngestJobsTracker,
-  extractIngestJobIds,
   pollSingleIngestJob,
+  requireSubmittedIngestJobs,
 } from "@/services/tldw/ingest-jobs-orchestrator";
 import {
   completedIngestJobIndicatesSkipped,
@@ -874,11 +874,7 @@ const runDirectQuickIngestBatch = async (
               timeoutMs: DIRECT_INGEST_TIMEOUT_MS,
               ...DIRECT_QUICK_INGEST_TRANSPORT,
             });
-            const batchId = String(submitData?.batch_id || "").trim();
-            const jobIds = extractIngestJobIds(submitData);
-            if (!batchId || jobIds.length === 0) {
-              throw new Error("Ingest job submission returned no job IDs.");
-            }
+            const { batchId, jobIds } = requireSubmittedIngestJobs(submitData);
             const firstJobId = jobIds[0];
             jobSubmitted = true;
             latestJobId = firstJobId;
@@ -1067,11 +1063,7 @@ const runDirectQuickIngestBatch = async (
               timeoutMs: DIRECT_INGEST_TIMEOUT_MS,
               ...DIRECT_QUICK_INGEST_TRANSPORT,
             });
-            const batchId = String(submitData?.batch_id || "").trim();
-            const jobIds = extractIngestJobIds(submitData);
-            if (!batchId || jobIds.length === 0) {
-              throw new Error("Ingest job submission returned no job IDs.");
-            }
+            const { batchId, jobIds } = requireSubmittedIngestJobs(submitData);
             const directTracker = ensureDirectSessionTracker(directSessionId);
             directTracker?.trackJobs(batchId, jobIds, { sourceId: id });
             input.onTrackingMetadata?.({

--- a/backlog/tasks/task-12909 - Resolve-PDF-EPUB-ingest-verification-migration-blocker.md
+++ b/backlog/tasks/task-12909 - Resolve-PDF-EPUB-ingest-verification-migration-blocker.md
@@ -1,0 +1,47 @@
+---
+id: TASK-12909
+title: Resolve PDF EPUB ingest verification migration blocker
+status: Done
+labels:
+- bug
+- ingestion
+- media
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Clean up the local duplicate migration artifact blocker and verify PDF/EPUB ingest endpoints and job submission paths against the default test setup. If investigation shows a tracked packaging or migration bug, make the smallest repo fix and add verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Ignored duplicate JSON migration artifacts no longer block default PDF/EPUB endpoint verification.
+- [x] PDF and EPUB process endpoint tests pass.
+- [x] PDF and EPUB `/api/v1/media/ingest/jobs` submission path queues jobs with no errors.
+- [x] Package-data contract covers DB migration SQL.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Moved ignored local JSON migration artifacts from `tldw_Server_API/app/core/DB_Management/migrations` to `/tmp/tldw-db-migration-json-backup-20260707163619`.
+- Added `app/core/DB_Management/migrations/*.sql` to `pyproject.toml` package data so installed packages include runtime DB migration SQL.
+- Added a pyproject contract assertion for the migration SQL package-data entry.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PDF and EPUB ingestion were validated after removing the local duplicate migration artifact blocker. Endpoint upload processing tests pass, PDF/EPUB job submission queues jobs successfully, and package metadata now includes DB migration SQL for installed-package migrations.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12910 - Fix-Collections-content-items-bootstrap-duplicate-column-logs.md
+++ b/backlog/tasks/task-12910 - Fix-Collections-content-items-bootstrap-duplicate-column-logs.md
@@ -1,0 +1,46 @@
+---
+id: TASK-12910
+title: Fix Collections content_items bootstrap duplicate column logs
+status: Done
+labels:
+- bug
+- collections
+- ingestion
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix the duplicate column error logs emitted by CollectionsDatabase.ensure_schema during media ingest job submission, without changing PDF/EPUB ingest behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Fresh Collections SQLite bootstrap does not issue `content_items` ADD COLUMN backfills for columns already declared by `CREATE TABLE`.
+- [x] PDF/EPUB media ingest job submission no longer emits duplicate-column ERROR logs.
+- [x] Existing targeted Collections tests pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Root cause: `CollectionsDatabase.ensure_schema()` captured `content_items` columns before running the `CREATE TABLE IF NOT EXISTS content_items` DDL.
+- On a fresh SQLite DB, that snapshot stayed empty after table creation, so the later backfill loop attempted `ALTER TABLE content_items ADD COLUMN` for columns already declared in the fresh schema.
+- Fix: refresh `content_columns` after `content_items` DDL runs for SQLite, before the backfill loop.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the Collections bootstrap duplicate-column log root cause by refreshing the content_items column snapshot after creating the table. Added a regression test proving fresh bootstrap does not issue content_items ADD COLUMN backfills for columns already declared in the fresh schema.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12911 - Surface-media-ingest-job-submission-errors-in-quick-ingest.md
+++ b/backlog/tasks/task-12911 - Surface-media-ingest-job-submission-errors-in-quick-ingest.md
@@ -1,0 +1,63 @@
+---
+id: TASK-12911
+title: Surface media ingest job submission errors in quick ingest
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-07 23:17'
+labels:
+  - bug
+  - frontend
+  - media-ingest
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate reported PDF ingest failure where quick ingest reports a generic invalid/no-job message when async media ingest job submission returns no usable jobs. Preserve backend submit errors in the UI/client error path.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused frontend and backend ingest-job tests pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the reported no-jobs submit path with a focused quick-ingest regression test.
+2. Preserve backend submit errors when ingest job creation returns no usable jobs.
+3. Reuse the same validation in the direct quick-ingest and extension background submit paths.
+4. Verify focused frontend and backend ingest-job tests.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red test confirmed prior behavior: backend errors were present in the mocked submit response but the quick-ingest result showed only "Ingest job submission returned no job IDs."
+- Verification: bunx vitest run src/services/__tests__/quick-ingest-batch.test.ts -t "surfaces backend ingest job submit errors when no jobs are created" passed after the fix.
+- Verification: bunx vitest run src/services/__tests__/ingest-jobs-orchestrator.test.ts passed.
+- Verification: bunx vitest run src/services/__tests__/quick-ingest-batch.test.ts passed.
+- Verification: source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py -q passed.
+- Attempted package typecheck with NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit; it failed on pre-existing unrelated baseline errors across tests/background typing. Initial no-heap run hit Node OOM.
+- git diff --check scoped to touched frontend files passed. Full git diff --check is blocked by an unrelated existing whitespace issue in Docs/Design/Tool-Calling.md.
+- Bandit not run because no Python source was changed; frontend TypeScript and tests only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Investigation found no evidence that PDF validation was broadly rejecting PDFs. The broken user-visible behavior was that /api/v1/media/ingest/jobs can return HTTP 207 with jobs: [] and errors: [...] when upload staging/validation fails, but the frontend treated the 2xx response as success and replaced the useful backend error with the generic "Ingest job submission returned no job IDs." Added a shared submit-response validator that extracts backend errors, wired it into quick ingest URL/file submissions and the extension background ingest path, and added regression coverage.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -513,6 +513,7 @@ tldw_Server_API = [
   "app/Setup_UI/*.html",
   "app/core/Evaluations/data/*.json",
   "app/core/Evaluations/data/**/*.json",
+  "app/core/DB_Management/migrations/*.sql",
   "app/core/Persona/assets/**/*.png",
   "app/core/Slides/revealjs/**/*",
   "Databases/**/*.sql",

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -2382,6 +2382,8 @@ class CollectionsDatabase:
         except _COLLECTIONS_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Collections content_items schema init failed: {e}")
             raise
+        if self.backend.backend_type == BackendType.SQLITE:
+            content_columns = self._sqlite_columns("content_items")
         if fts_available:
             try:
                 self.backend.create_tables(

--- a/tldw_Server_API/tests/Collections/test_collections_schema_bootstrap.py
+++ b/tldw_Server_API/tests/Collections/test_collections_schema_bootstrap.py
@@ -1,0 +1,54 @@
+"""Regression tests for Collections schema bootstrap SQL."""
+
+import sqlite3
+import types
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+from tldw_Server_API.app.core.DB_Management.backends.base import (
+    BackendType,
+    DatabaseConfig,
+    QueryResult,
+)
+from tldw_Server_API.app.core.DB_Management.backends.sqlite_backend import SQLiteBackend
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_fresh_content_items_bootstrap_does_not_readd_declared_columns(
+    tmp_path: Path,
+) -> None:
+    """Fresh SQLite bootstrap must not re-add columns already in CREATE TABLE."""
+    backend = SQLiteBackend(
+        DatabaseConfig(
+            backend_type=BackendType.SQLITE,
+            sqlite_path=str(tmp_path / "collections.db"),
+        )
+    )
+    original_execute = backend.execute
+    executed_sql: list[str] = []
+
+    def spy_execute(
+        self: SQLiteBackend,
+        query: str,
+        params: tuple[object, ...] | dict[str, object] | None = None,
+        connection: sqlite3.Connection | None = None,
+    ) -> QueryResult:
+        """Record SQL before delegating to the real backend executor."""
+        executed_sql.append(query)
+        return original_execute(query, params, connection)
+
+    backend.execute = types.MethodType(spy_execute, backend)
+    try:
+        CollectionsDatabase.from_backend(user_id="1", backend=backend)
+    finally:
+        backend.get_pool().close_all()
+
+    assert not [  # nosec B101
+        sql
+        for sql in executed_sql
+        if "ALTER TABLE CONTENT_ITEMS ADD COLUMN" in " ".join(sql.upper().split())
+    ]

--- a/tldw_Server_API/tests/Config/test_pyproject_tooling_extra.py
+++ b/tldw_Server_API/tests/Config/test_pyproject_tooling_extra.py
@@ -1,4 +1,8 @@
+"""Pyproject contract tests for packaging and tooling metadata."""
+
 from pathlib import Path
+
+import pytest
 
 try:
     import tomllib  # type: ignore[attr-defined]
@@ -6,8 +10,19 @@ except ImportError:  # pragma: no cover
     import tomli as tomllib  # type: ignore[no-redef]
 
 
-def test_pyproject_has_tooling_optional_dependency_group():
+pytestmark = pytest.mark.unit
+
+
+def test_pyproject_has_tooling_optional_dependency_group() -> None:
+    """The tooling extra must remain available for helper scripts."""
     data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     optional = data["project"]["optional-dependencies"]
-    assert "tooling" in optional
-    assert any(dep.startswith("requests") for dep in optional["tooling"])
+    assert "tooling" in optional  # nosec B101
+    assert any(dep.startswith("requests") for dep in optional["tooling"])  # nosec B101
+
+
+def test_pyproject_packages_db_migration_sql() -> None:
+    """Installed packages must include DB migration SQL files."""
+    data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    package_data = data["tool"]["setuptools"]["package-data"]["tldw_Server_API"]
+    assert "app/core/DB_Management/migrations/*.sql" in package_data  # nosec B101


### PR DESCRIPTION
## Change summary

AI draft for review; a human owner should replace or confirm this section before merge per the repo's AI-generated PR policy.

- Surface backend `/api/v1/media/ingest/jobs` submission errors in quick ingest instead of replacing them with the generic no-job-ID message.
- Package DB migration SQL with `tldw_Server_API` so installed-package migrations can find the runtime SQL files.
- Fix fresh Collections SQLite bootstrap so it does not re-add `content_items` columns already declared by the fresh schema, removing duplicate-column ERROR logs seen during ingest.
- Add Backlog task records for the investigated root causes.

## Verification

- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Config/test_pyproject_tooling_extra.py tldw_Server_API/tests/Collections/test_collections_schema_bootstrap.py tldw_Server_API/tests/Collections/test_content_items_fts_contentless.py tldw_Server_API/tests/Collections/test_reminders_notifications_db.py 'tldw_Server_API/tests/Media_Ingestion_Modification/test_media_processing.py::TestProcessPdfs::test_process_pdf_upload_success[pymupdf4llm]' tldw_Server_API/tests/Media_Ingestion_Modification/test_media_processing.py::TestProcessEbooks::test_process_ebook_upload_success_defaults -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/node_modules/.bin/vitest run /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/codex-fix-pdf-epub-ingest-errors/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/codex-fix-pdf-epub-ingest-errors/apps/packages/ui/src/services/__tests__/ingest-jobs-orchestrator.test.ts --config /private/tmp/vitest-clean-ingest.config.ts --reporter=dot`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/DB_Management/Collections_DB.py tldw_Server_API/tests/Collections/test_collections_schema_bootstrap.py tldw_Server_API/tests/Config/test_pyproject_tooling_extra.py -f json -o /tmp/bandit_pr_pdf_epub_ingest.json`
- `git diff --check`

Notes:
- The first root `bunx vitest ...` attempt in the clean worktree failed because the worktree has no local UI `node_modules`; the successful run used the main checkout's already-installed UI Vitest binary plus a temporary minimal config pointing at the clean worktree sources.
- Bandit JSON reported `results=0 errors=0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces backend PDF/EPUB ingest submission errors from `errors`/`detail` instead of the generic “no job IDs” message, fixes SQLite Collections bootstrap duplicate-column logs, and ships DB migration SQL with `tldw_Server_API`.

- **Bug Fixes**
  - Add `extractIngestJobSubmitError` (formats array `detail` like “body.file: Field required”) and `requireSubmittedIngestJobs`; used in background, direct quick-ingest, and tracker to surface submit errors when no jobs are created.
  - Refresh `content_items` column snapshot after SQLite table creation to stop duplicate “ADD COLUMN” logs; add a regression test to ensure no re-adds.
  - Include `app/core/DB_Management/migrations/*.sql` in `pyproject.toml` so installed `tldw_Server_API` packages contain runtime DB migrations; add a packaging contract test.

<sup>Written for commit eff842d08f41f9a4d705ffa60fee57bccbb7c0f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

