### PR TITLE
Add chat theming transparency controls

### DIFF
--- a/apps/packages/ui/src/components/Common/Playground/Message.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/Message.tsx
@@ -93,6 +93,11 @@ import {
   DEFAULT_TTS_PROVIDER
 } from "@/services/tts"
 import type { DynamicUISurface } from "@/types/dynamic-ui"
+import { useSetting } from "@/hooks/useSetting"
+import {
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING,
+  CHAT_MESSAGE_OPACITY_SETTING
+} from "@/services/settings/ui-settings"
 import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings"
 import { VisualIdentityImage } from "@/components/Common/VisualIdentity/VisualIdentityImage"
 
@@ -360,6 +365,10 @@ export const PlaygroundMessage = (props: Props) => {
     moodConfidenceDefault
   )
   const [userPersonaImage] = useStorage("chatUserPersonaImage", "")
+  const [chatMessageOpacity] = useSetting(CHAT_MESSAGE_OPACITY_SETTING)
+  const [chatCharacterImageOpacity] = useSetting(
+    CHAT_CHARACTER_IMAGE_OPACITY_SETTING
+  )
   const [renderMermaidDiagrams] = useStorage(
     "renderMermaidDiagrams",
     DEFAULT_CHAT_SETTINGS.renderMermaidDiagrams
@@ -1915,8 +1924,18 @@ export const PlaygroundMessage = (props: Props) => {
   const messageCardClass = isSystemMessage
     ? `flex max-w-[calc(100%-1.75rem)] flex-col rounded-2xl border border-dashed border-warn/30 bg-warn/10 shadow-sm ${messageSpacing}`
     : props.isBot
-      ? `flex max-w-[calc(100%-1.75rem)] flex-col rounded-2xl border border-border/50 bg-surface/60 shadow-sm border-l-2 border-l-primary/20 ${messageSpacing}`
-      : `flex max-w-[calc(100%-1.75rem)] flex-col rounded-2xl border border-border/50 bg-surface2/60 shadow-sm ${messageSpacing}`
+      ? `flex max-w-[calc(100%-1.75rem)] flex-col rounded-2xl border border-border/50 shadow-sm border-l-2 border-l-primary/20 ${messageSpacing}`
+      : `flex max-w-[calc(100%-1.75rem)] flex-col rounded-2xl border border-border/50 shadow-sm ${messageSpacing}`
+  const messageCardStyle = isSystemMessage
+    ? undefined
+    : ({
+        backgroundColor: `rgb(var(${
+          props.isBot ? "--color-surface" : "--color-surface-2"
+        }) / ${chatMessageOpacity / 100})`
+      } as React.CSSProperties)
+  const chatCharacterImageOpacityStyle = {
+    opacity: chatCharacterImageOpacity / 100
+  } as React.CSSProperties
   const portraitPanel = shouldShowPortrait ? (
     <button
       type="button"
@@ -1937,6 +1956,7 @@ export const PlaygroundMessage = (props: Props) => {
         }
         className="h-full w-full object-cover"
         loading="lazy"
+        style={chatCharacterImageOpacityStyle}
       />
       <span className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
     </button>
@@ -1961,6 +1981,7 @@ export const PlaygroundMessage = (props: Props) => {
               src={resolvedModelImage}
               alt={resolvedModelName || props.name}
               className="size-8"
+              style={chatCharacterImageOpacityStyle}
             />
           </button>
         ) : (
@@ -1968,6 +1989,7 @@ export const PlaygroundMessage = (props: Props) => {
             src={resolvedModelImage}
             alt={resolvedModelName || props.name}
             className="size-8"
+            style={chatCharacterImageOpacityStyle}
           />
         )
       ) : isSystemMessage ? (
@@ -2041,7 +2063,7 @@ export const PlaygroundMessage = (props: Props) => {
         {portraitSide === "left" ? portraitPanel : null}
         {portraitSide === "left" ? avatarColumn : null}
         <div className="flex min-w-0 flex-1 flex-col gap-2">
-          <div className={messageCardClass}>
+          <div className={messageCardClass} style={messageCardStyle}>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div className="flex flex-wrap items-center gap-2">
                 {isSystemMessage ? (

--- a/apps/packages/ui/src/components/Common/Playground/Message.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/Message.tsx
@@ -93,15 +93,13 @@ import {
   DEFAULT_TTS_PROVIDER
 } from "@/services/tts"
 import type { DynamicUISurface } from "@/types/dynamic-ui"
-import { useSetting } from "@/hooks/useSetting"
-import {
-  CHAT_CHARACTER_IMAGE_OPACITY_SETTING,
-  CHAT_MESSAGE_OPACITY_SETTING
-} from "@/services/settings/ui-settings"
 import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings"
 import { VisualIdentityImage } from "@/components/Common/VisualIdentity/VisualIdentityImage"
 
 const Markdown = React.lazy(() => import("../../Common/Markdown"))
+const CHAT_MESSAGE_OPACITY_ALPHA = "var(--chat-message-opacity, 0.6)"
+const CHAT_CHARACTER_IMAGE_OPACITY_ALPHA =
+  "var(--chat-character-image-opacity, 1)"
 
 const ErrorBubble: React.FC<{
   payload: ChatErrorPayload
@@ -365,10 +363,6 @@ export const PlaygroundMessage = (props: Props) => {
     moodConfidenceDefault
   )
   const [userPersonaImage] = useStorage("chatUserPersonaImage", "")
-  const [chatMessageOpacity] = useSetting(CHAT_MESSAGE_OPACITY_SETTING)
-  const [chatCharacterImageOpacity] = useSetting(
-    CHAT_CHARACTER_IMAGE_OPACITY_SETTING
-  )
   const [renderMermaidDiagrams] = useStorage(
     "renderMermaidDiagrams",
     DEFAULT_CHAT_SETTINGS.renderMermaidDiagrams
@@ -1930,11 +1924,11 @@ export const PlaygroundMessage = (props: Props) => {
     ? undefined
     : ({
         backgroundColor: `rgb(var(${
-          props.isBot ? "--color-surface" : "--color-surface-2"
-        }) / ${chatMessageOpacity / 100})`
+          props.isBot ? "--color-surface" : "--color-surface2"
+        }) / ${CHAT_MESSAGE_OPACITY_ALPHA})`
       } as React.CSSProperties)
   const chatCharacterImageOpacityStyle = {
-    opacity: chatCharacterImageOpacity / 100
+    opacity: CHAT_CHARACTER_IMAGE_OPACITY_ALPHA
   } as React.CSSProperties
   const portraitPanel = shouldShowPortrait ? (
     <button

--- a/apps/packages/ui/src/components/Common/Playground/PlaygroundUserMessage.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/PlaygroundUserMessage.tsx
@@ -23,11 +23,10 @@ import { useUiModeStore } from "@/store/ui-mode"
 import { useStoreMessageOption } from "@/store/option"
 import { EDIT_MESSAGE_EVENT } from "@/utils/timeline-actions"
 import { Badge, type BadgeVariant } from "@/components/ui/primitives"
-import { useSetting } from "@/hooks/useSetting"
-import { CHAT_MESSAGE_OPACITY_SETTING } from "@/services/settings/ui-settings"
 
 const ACTION_BUTTON_CLASS =
   "flex items-center justify-center rounded-full border border-border bg-surface2 text-text-muted hover:bg-surface hover:text-text transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-focus min-w-[44px] min-h-[44px]"
+const CHAT_MESSAGE_OPACITY_ALPHA = "var(--chat-message-opacity, 0.6)"
 
 const MESSAGE_TYPE_BADGE_VARIANT: Record<string, BadgeVariant> = {
   summary: "info",
@@ -99,7 +98,6 @@ export const PlaygroundUserMessageBubble: React.FC<Props> = (props) => {
   const [userTextFont] = useStorage("chatUserTextFont", "default")
   const [userTextSize] = useStorage("chatUserTextSize", "md")
   const [userDisplayName] = useStorage("chatUserDisplayName", "")
-  const [chatMessageOpacity] = useSetting(CHAT_MESSAGE_OPACITY_SETTING)
   const [isBtnPressed, setIsBtnPressed] = React.useState(false)
   const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const [editMode, setEditMode] = React.useState(false)
@@ -192,9 +190,7 @@ export const PlaygroundUserMessageBubble: React.FC<Props> = (props) => {
   const messageBubbleStyle = isSystemMessage
     ? undefined
     : ({
-        backgroundColor: `rgb(var(--color-surface-2) / ${
-          chatMessageOpacity / 100
-        })`
+        backgroundColor: `rgb(var(--color-surface2) / ${CHAT_MESSAGE_OPACITY_ALPHA})`
       } as React.CSSProperties)
 
   return (

--- a/apps/packages/ui/src/components/Common/Playground/PlaygroundUserMessage.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/PlaygroundUserMessage.tsx
@@ -23,6 +23,8 @@ import { useUiModeStore } from "@/store/ui-mode"
 import { useStoreMessageOption } from "@/store/option"
 import { EDIT_MESSAGE_EVENT } from "@/utils/timeline-actions"
 import { Badge, type BadgeVariant } from "@/components/ui/primitives"
+import { useSetting } from "@/hooks/useSetting"
+import { CHAT_MESSAGE_OPACITY_SETTING } from "@/services/settings/ui-settings"
 
 const ACTION_BUTTON_CLASS =
   "flex items-center justify-center rounded-full border border-border bg-surface2 text-text-muted hover:bg-surface hover:text-text transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-focus min-w-[44px] min-h-[44px]"
@@ -97,6 +99,7 @@ export const PlaygroundUserMessageBubble: React.FC<Props> = (props) => {
   const [userTextFont] = useStorage("chatUserTextFont", "default")
   const [userTextSize] = useStorage("chatUserTextSize", "md")
   const [userDisplayName] = useStorage("chatUserDisplayName", "")
+  const [chatMessageOpacity] = useSetting(CHAT_MESSAGE_OPACITY_SETTING)
   const [isBtnPressed, setIsBtnPressed] = React.useState(false)
   const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const [editMode, setEditMode] = React.useState(false)
@@ -185,7 +188,14 @@ export const PlaygroundUserMessageBubble: React.FC<Props> = (props) => {
   )
   const bubbleToneClass = isSystemMessage
     ? "bg-warn/10 border-warn/30 border-dashed"
-    : "bg-surface2/80 border-border"
+    : "border-border"
+  const messageBubbleStyle = isSystemMessage
+    ? undefined
+    : ({
+        backgroundColor: `rgb(var(--color-surface-2) / ${
+          chatMessageOpacity / 100
+        })`
+      } as React.CSSProperties)
 
   return (
     <div
@@ -275,7 +285,8 @@ export const PlaygroundUserMessageBubble: React.FC<Props> = (props) => {
           data-is-not-editable={!editMode}
           className={`message-bubble ${bubbleToneClass} shadow-sm rounded-3xl prose max-w-none dark:prose-invert break-words min-h-7 prose-p:opacity-95 prose-strong:opacity-100 border max-w-[calc(100%-1.75rem)] px-4 py-3 rounded-br-lg ${userTextClass} ${
             props.message_type && !editMode ? "italic" : ""
-          }`}>
+          }`}
+          style={messageBubbleStyle}>
           <HumanMessage message={props.message} />
         </div>
       )}
@@ -285,7 +296,8 @@ export const PlaygroundUserMessageBubble: React.FC<Props> = (props) => {
           dir="auto"
           className={`message-bubble ${bubbleToneClass} shadow-sm rounded-3xl prose max-w-none dark:prose-invert break-words min-h-7 prose-p:opacity-95 prose-strong:opacity-100 border max-w-[calc(100%-1.75rem)] px-4 py-3 rounded-br-lg ${userTextClass} ${
             props.message_type && !editMode ? "italic" : ""
-          }`}>
+          }`}
+          style={messageBubbleStyle}>
           <div className="w-screen max-w-[100%]">
             <EditMessageForm
               value={props.message}

--- a/apps/packages/ui/src/components/Common/VisualIdentity/VisualIdentityImage.tsx
+++ b/apps/packages/ui/src/components/Common/VisualIdentity/VisualIdentityImage.tsx
@@ -33,6 +33,7 @@ export type VisualIdentityImageProps = {
   isAnimated?: boolean
   alt?: string
   className?: string
+  style?: React.CSSProperties
   loading?: "eager" | "lazy"
   onClick?: () => void
 }
@@ -43,6 +44,7 @@ export const VisualIdentityImage = ({
   isAnimated = false,
   alt = "",
   className = "h-full w-full object-cover",
+  style,
   loading = "lazy",
   onClick
 }: VisualIdentityImageProps) => {
@@ -55,6 +57,7 @@ export const VisualIdentityImage = ({
       src={resolvedSrc}
       alt={alt}
       className={className}
+      style={style}
       loading={loading}
       onClick={onClick}
     />

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -74,7 +74,10 @@ import {
   Sun,
   X,
 } from "lucide-react";
-import { CHAT_BACKGROUND_IMAGE_SETTING } from "@/services/settings/ui-settings";
+import {
+  CHAT_BACKGROUND_IMAGE_SETTING,
+  CHAT_WINDOW_OPACITY_SETTING,
+} from "@/services/settings/ui-settings";
 import { otherUnsupportedTypes } from "../Knowledge/utils/unsupported-types";
 import { useTranslation } from "react-i18next";
 import { useStoreMessageOption, type Message } from "@/store/option";
@@ -374,6 +377,8 @@ export const Playground = () => {
   const { mode: themeMode, toggleDarkMode } = useDarkMode();
   const navigate = useNavigate();
   const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING);
+  const [chatWindowOpacity] = useSetting(CHAT_WINDOW_OPACITY_SETTING);
+  const chatWindowOpacityAlpha = chatWindowOpacity / 100;
   const [stickyChatInput] = useStorage(
     "stickyChatInput",
     DEFAULT_CHAT_SETTINGS.stickyChatInput,
@@ -3494,11 +3499,13 @@ export const Playground = () => {
           : {}
       }
     >
-      {/* Background overlay for opacity effect */}
+      {/* Keep themed background images visible while preserving text contrast. */}
       {chatBackgroundImage && (
         <div
-          className="absolute inset-0 bg-bg"
-          style={{ opacity: 0.9, pointerEvents: "none" }}
+          className="pointer-events-none absolute inset-0 backdrop-blur-[1px]"
+          style={{
+            backgroundColor: `rgb(var(--color-bg) / ${chatWindowOpacityAlpha})`,
+          }}
         />
       )}
 
@@ -3549,6 +3556,8 @@ export const Playground = () => {
       <div className="relative z-10 flex h-full min-h-0 w-full">
         <PlaygroundCockpitShell
           mode={normalizedChatLayoutMode}
+          themedBackdrop={Boolean(chatBackgroundImage)}
+          themedBackdropOpacity={chatWindowOpacityAlpha}
           leftRailVisible={normalizedCockpitContextRailVisible}
           rightRailVisible={normalizedCockpitRuntimeRailVisible}
           onLeftRailVisibleChange={setCockpitContextRailVisible}

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -76,7 +76,10 @@ import {
 } from "lucide-react";
 import {
   CHAT_BACKGROUND_IMAGE_SETTING,
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING,
+  CHAT_MESSAGE_OPACITY_SETTING,
   CHAT_WINDOW_OPACITY_SETTING,
+  resolveOpacityAlpha,
 } from "@/services/settings/ui-settings";
 import { otherUnsupportedTypes } from "../Knowledge/utils/unsupported-types";
 import { useTranslation } from "react-i18next";
@@ -378,7 +381,22 @@ export const Playground = () => {
   const navigate = useNavigate();
   const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING);
   const [chatWindowOpacity] = useSetting(CHAT_WINDOW_OPACITY_SETTING);
-  const chatWindowOpacityAlpha = chatWindowOpacity / 100;
+  const [chatMessageOpacity] = useSetting(CHAT_MESSAGE_OPACITY_SETTING);
+  const [chatCharacterImageOpacity] = useSetting(
+    CHAT_CHARACTER_IMAGE_OPACITY_SETTING,
+  );
+  const chatWindowOpacityAlpha = resolveOpacityAlpha(
+    chatWindowOpacity,
+    CHAT_WINDOW_OPACITY_SETTING.defaultValue,
+  );
+  const chatMessageOpacityAlpha = resolveOpacityAlpha(
+    chatMessageOpacity,
+    CHAT_MESSAGE_OPACITY_SETTING.defaultValue,
+  );
+  const chatCharacterImageOpacityAlpha = resolveOpacityAlpha(
+    chatCharacterImageOpacity,
+    CHAT_CHARACTER_IMAGE_OPACITY_SETTING.defaultValue,
+  );
   const [stickyChatInput] = useStorage(
     "stickyChatInput",
     DEFAULT_CHAT_SETTINGS.stickyChatInput,
@@ -3488,16 +3506,20 @@ export const Playground = () => {
       ref={drop}
       data-is-dragging={dropState === "dragging"}
       className="relative flex h-full min-h-0 w-full flex-col items-center bg-bg text-text data-[is-dragging=true]:bg-surface2"
-      style={
-        chatBackgroundImage
+      style={{
+        "--chat-message-opacity": String(chatMessageOpacityAlpha),
+        "--chat-character-image-opacity": String(
+          chatCharacterImageOpacityAlpha,
+        ),
+        ...(chatBackgroundImage
           ? {
               backgroundImage: `url(${chatBackgroundImage})`,
               backgroundSize: "cover",
               backgroundPosition: "center",
               backgroundRepeat: "no-repeat",
             }
-          : {}
-      }
+          : {}),
+      } as React.CSSProperties}
     >
       {/* Keep themed background images visible while preserving text contrast. */}
       {chatBackgroundImage && (

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -3557,7 +3557,6 @@ export const Playground = () => {
         <PlaygroundCockpitShell
           mode={normalizedChatLayoutMode}
           themedBackdrop={Boolean(chatBackgroundImage)}
-          themedBackdropOpacity={chatWindowOpacityAlpha}
           leftRailVisible={normalizedCockpitContextRailVisible}
           rightRailVisible={normalizedCockpitRuntimeRailVisible}
           onLeftRailVisibleChange={setCockpitContextRailVisible}

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundCockpitShell.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundCockpitShell.tsx
@@ -14,6 +14,8 @@ export type PlaygroundCockpitMobilePanel = "context" | "runtime" | null;
 
 export type PlaygroundCockpitShellProps = {
   mode: PlaygroundCockpitMode;
+  themedBackdrop?: boolean;
+  themedBackdropOpacity?: number;
   leftRailVisible?: boolean;
   rightRailVisible?: boolean;
   onLeftRailVisibleChange?: (visible: boolean) => void;
@@ -115,6 +117,8 @@ const buildModeSummaryKey = (
 
 export const PlaygroundCockpitShell = ({
   mode,
+  themedBackdrop = false,
+  themedBackdropOpacity = 0.35,
   leftRailVisible = true,
   rightRailVisible = true,
   onLeftRailVisibleChange,
@@ -137,6 +141,15 @@ export const PlaygroundCockpitShell = ({
   const mobilePanelSummaryId = `${mobilePanelIdPrefix}-mobile-panel-summary`;
   const showLeftRail = !focusMode && leftRailVisible;
   const showRightRail = !focusMode && rightRailVisible;
+  const clampedThemedBackdropOpacity = Math.min(
+    1,
+    Math.max(0, themedBackdropOpacity),
+  );
+  const shellStyle = themedBackdrop
+    ? ({
+        backgroundColor: `rgb(var(--color-bg) / ${clampedThemedBackdropOpacity})`,
+      } as React.CSSProperties)
+    : undefined;
   const resolvedMobilePanel =
     mobilePanel !== undefined ? mobilePanel : uncontrolledMobilePanel;
   const setMobilePanel = React.useCallback(
@@ -243,7 +256,10 @@ export const PlaygroundCockpitShell = ({
       data-mode={mode}
       data-left-rail={showLeftRail ? "visible" : "hidden"}
       data-right-rail={showRightRail ? "visible" : "hidden"}
-      className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden bg-bg text-text"
+      className={`flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden text-text ${
+        themedBackdrop ? "backdrop-blur-[1px]" : "bg-bg"
+      }`}
+      style={shellStyle}
     >
       <p
         data-testid="playground-cockpit-mode-summary"
@@ -415,7 +431,9 @@ export const PlaygroundCockpitShell = ({
 
         <main
           data-testid="playground-cockpit-main"
-          className={`min-h-0 min-w-0 overflow-hidden bg-bg ${
+          className={`min-h-0 min-w-0 overflow-hidden ${
+            themedBackdrop ? "bg-transparent" : "bg-bg"
+          } ${
             focusMode
               ? "w-full max-w-[72rem]"
               : !showLeftRail && !showRightRail

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundCockpitShell.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundCockpitShell.tsx
@@ -15,7 +15,6 @@ export type PlaygroundCockpitMobilePanel = "context" | "runtime" | null;
 export type PlaygroundCockpitShellProps = {
   mode: PlaygroundCockpitMode;
   themedBackdrop?: boolean;
-  themedBackdropOpacity?: number;
   leftRailVisible?: boolean;
   rightRailVisible?: boolean;
   onLeftRailVisibleChange?: (visible: boolean) => void;
@@ -118,7 +117,6 @@ const buildModeSummaryKey = (
 export const PlaygroundCockpitShell = ({
   mode,
   themedBackdrop = false,
-  themedBackdropOpacity = 0.35,
   leftRailVisible = true,
   rightRailVisible = true,
   onLeftRailVisibleChange,
@@ -141,15 +139,6 @@ export const PlaygroundCockpitShell = ({
   const mobilePanelSummaryId = `${mobilePanelIdPrefix}-mobile-panel-summary`;
   const showLeftRail = !focusMode && leftRailVisible;
   const showRightRail = !focusMode && rightRailVisible;
-  const clampedThemedBackdropOpacity = Math.min(
-    1,
-    Math.max(0, themedBackdropOpacity),
-  );
-  const shellStyle = themedBackdrop
-    ? ({
-        backgroundColor: `rgb(var(--color-bg) / ${clampedThemedBackdropOpacity})`,
-      } as React.CSSProperties)
-    : undefined;
   const resolvedMobilePanel =
     mobilePanel !== undefined ? mobilePanel : uncontrolledMobilePanel;
   const setMobilePanel = React.useCallback(
@@ -259,7 +248,6 @@ export const PlaygroundCockpitShell = ({
       className={`flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden text-text ${
         themedBackdrop ? "backdrop-blur-[1px]" : "bg-bg"
       }`}
-      style={shellStyle}
     >
       <p
         data-testid="playground-cockpit-mode-summary"

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
@@ -270,6 +270,12 @@ vi.mock("@/hooks/useSmartScroll", () => ({
 vi.mock("@/services/settings/ui-settings", () => ({
   CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
   CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
+  CHAT_MESSAGE_OPACITY_SETTING: "chatMessageOpacity",
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING: "chatCharacterImageOpacity",
+  resolveOpacityAlpha: (value: unknown, fallback = 35) =>
+    typeof value === "number" && Number.isFinite(value)
+      ? value / 100
+      : fallback / 100,
   THEME_SETTING: {
     key: "theme",
     defaultValue: "dark"
@@ -319,7 +325,12 @@ vi.mock("@/store/artifacts", () => ({
 }));
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: (setting: string) => [setting === "chatWindowOpacity" ? 35 : ""],
+  useSetting: (setting: string) => {
+    if (setting === "chatWindowOpacity") return [35];
+    if (setting === "chatMessageOpacity") return [60];
+    if (setting === "chatCharacterImageOpacity") return [100];
+    return [""];
+  },
 }));
 
 vi.mock("@plasmohq/storage/hook", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx
@@ -269,6 +269,13 @@ vi.mock("@/hooks/useSmartScroll", () => ({
 
 vi.mock("@/services/settings/ui-settings", () => ({
   CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
+  CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
+  THEME_SETTING: {
+    key: "theme",
+    defaultValue: "dark"
+  },
+  HEADER_SHORTCUT_IDS: [],
+  SIDEBAR_SHORTCUT_IDS: [],
 }));
 
 vi.mock("../Knowledge/utils/unsupported-types", () => ({
@@ -312,7 +319,7 @@ vi.mock("@/store/artifacts", () => ({
 }));
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: () => [""],
+  useSetting: (setting: string) => [setting === "chatWindowOpacity" ? 35 : ""],
 }));
 
 vi.mock("@plasmohq/storage/hook", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -249,6 +249,12 @@ vi.mock("@/services/settings/ui-settings", () => ({
   HEADER_SHORTCUT_IDS: [],
   SIDEBAR_SHORTCUT_IDS: [],
   CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
+  CHAT_MESSAGE_OPACITY_SETTING: "chatMessageOpacity",
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING: "chatCharacterImageOpacity",
+  resolveOpacityAlpha: (value: unknown, fallback = 35) =>
+    typeof value === "number" && Number.isFinite(value)
+      ? value / 100
+      : fallback / 100,
 }));
 
 vi.mock("../Knowledge/utils/unsupported-types", () => ({
@@ -292,7 +298,12 @@ vi.mock("@/store/artifacts", () => ({
 }));
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: (setting: string) => [setting === "chatWindowOpacity" ? 35 : ""],
+  useSetting: (setting: string) => {
+    if (setting === "chatWindowOpacity") return [35];
+    if (setting === "chatMessageOpacity") return [60];
+    if (setting === "chatCharacterImageOpacity") return [100];
+    return [""];
+  },
 }));
 
 vi.mock("@/hooks/useDarkmode", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -11,6 +11,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Playground } from "../Playground";
+import { PlaygroundCockpitShell } from "../PlaygroundCockpitShell";
 
 const messageOptionState = vi.hoisted(() => ({
   value: {
@@ -411,6 +412,23 @@ describe("Playground cockpit shell", () => {
       }),
     );
     characterSessionsPanelState.props = [];
+  });
+
+  it("does not add a second themed wash on the cockpit shell", () => {
+    render(
+      <PlaygroundCockpitShell
+        mode="cockpit"
+        themedBackdrop
+        leftRail={<aside>Context</aside>}
+        rightRail={<aside>Runtime</aside>}
+      >
+        <main>Chat</main>
+      </PlaygroundCockpitShell>,
+    );
+
+    const shell = screen.getByTestId("playground-cockpit-shell");
+    expect(shell).toHaveClass("backdrop-blur-[1px]");
+    expect(shell.style.backgroundColor).toBe("");
   });
 
   it("renders the cockpit rails and main chat surface without a bottom status strip by default", async () => {

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx
@@ -247,6 +247,7 @@ vi.mock("@/services/settings/ui-settings", () => ({
   HEADER_SHORTCUT_SELECTION_SETTING: "headerShortcutSelection",
   HEADER_SHORTCUT_IDS: [],
   SIDEBAR_SHORTCUT_IDS: [],
+  CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
 }));
 
 vi.mock("../Knowledge/utils/unsupported-types", () => ({
@@ -290,7 +291,7 @@ vi.mock("@/store/artifacts", () => ({
 }));
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: () => [""],
+  useSetting: (setting: string) => [setting === "chatWindowOpacity" ? 35 : ""],
 }));
 
 vi.mock("@/hooks/useDarkmode", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
@@ -121,7 +121,14 @@ vi.mock("@/hooks/useSmartScroll", () => ({
 }))
 
 vi.mock("@/services/settings/ui-settings", () => ({
-  CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage"
+  CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
+  CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
+  THEME_SETTING: {
+    key: "theme",
+    defaultValue: "dark"
+  },
+  HEADER_SHORTCUT_IDS: [],
+  SIDEBAR_SHORTCUT_IDS: []
 }))
 
 vi.mock("../Knowledge/utils/unsupported-types", () => ({
@@ -157,7 +164,7 @@ vi.mock("@/store/artifacts", () => ({
 }))
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: () => [""]
+  useSetting: (setting: string) => [setting === "chatWindowOpacity" ? 35 : ""]
 }))
 
 vi.mock("@plasmohq/storage/hook", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx
@@ -123,6 +123,12 @@ vi.mock("@/hooks/useSmartScroll", () => ({
 vi.mock("@/services/settings/ui-settings", () => ({
   CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
   CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
+  CHAT_MESSAGE_OPACITY_SETTING: "chatMessageOpacity",
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING: "chatCharacterImageOpacity",
+  resolveOpacityAlpha: (value: unknown, fallback = 35) =>
+    typeof value === "number" && Number.isFinite(value)
+      ? value / 100
+      : fallback / 100,
   THEME_SETTING: {
     key: "theme",
     defaultValue: "dark"
@@ -164,7 +170,12 @@ vi.mock("@/store/artifacts", () => ({
 }))
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: (setting: string) => [setting === "chatWindowOpacity" ? 35 : ""]
+  useSetting: (setting: string) => {
+    if (setting === "chatWindowOpacity") return [35]
+    if (setting === "chatMessageOpacity") return [60]
+    if (setting === "chatCharacterImageOpacity") return [100]
+    return [""]
+  }
 }))
 
 vi.mock("@plasmohq/storage/hook", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.research-context.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.research-context.integration.test.tsx
@@ -456,6 +456,12 @@ vi.mock("@/hooks/useSmartScroll", () => ({
 vi.mock("@/services/settings/ui-settings", () => ({
   CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
   CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
+  CHAT_MESSAGE_OPACITY_SETTING: "chatMessageOpacity",
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING: "chatCharacterImageOpacity",
+  resolveOpacityAlpha: (value: unknown, fallback = 35) =>
+    typeof value === "number" && Number.isFinite(value)
+      ? value / 100
+      : fallback / 100,
   THEME_SETTING: {
     key: "theme",
     defaultValue: "dark"
@@ -480,11 +486,13 @@ vi.mock("@/store/artifacts", () => ({
 }))
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: (setting: string | { key?: string; defaultValue?: unknown }) => [
-    (typeof setting === "string" ? setting : setting?.key) === "chatWindowOpacity"
-      ? 35
-      : (typeof setting === "string" ? "" : setting?.defaultValue ?? "")
-  ]
+  useSetting: (setting: string | { key?: string; defaultValue?: unknown }) => {
+    const key = typeof setting === "string" ? setting : setting?.key
+    if (key === "chatWindowOpacity") return [35]
+    if (key === "chatMessageOpacity") return [60]
+    if (key === "chatCharacterImageOpacity") return [100]
+    return [typeof setting === "string" ? "" : setting?.defaultValue ?? ""]
+  }
 }))
 
 vi.mock("@plasmohq/storage/hook", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.research-context.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.research-context.integration.test.tsx
@@ -454,7 +454,14 @@ vi.mock("@/hooks/useSmartScroll", () => ({
 }))
 
 vi.mock("@/services/settings/ui-settings", () => ({
-  CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage"
+  CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
+  CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
+  THEME_SETTING: {
+    key: "theme",
+    defaultValue: "dark"
+  },
+  HEADER_SHORTCUT_IDS: [],
+  SIDEBAR_SHORTCUT_IDS: []
 }))
 
 vi.mock("../Knowledge/utils/unsupported-types", () => ({
@@ -473,7 +480,11 @@ vi.mock("@/store/artifacts", () => ({
 }))
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: () => [""]
+  useSetting: (setting: string | { key?: string; defaultValue?: unknown }) => [
+    (typeof setting === "string" ? setting : setting?.key) === "chatWindowOpacity"
+      ? 35
+      : (typeof setting === "string" ? "" : setting?.defaultValue ?? "")
+  ]
 }))
 
 vi.mock("@plasmohq/storage/hook", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
@@ -211,7 +211,8 @@ vi.mock("@/services/settings/ui-settings", () => ({
     defaultValue: "dark"
   },
   HEADER_SHORTCUT_IDS: [],
-  SIDEBAR_SHORTCUT_IDS: []
+  SIDEBAR_SHORTCUT_IDS: [],
+  CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity"
 }))
 
 vi.mock("../Knowledge/utils/unsupported-types", () => ({
@@ -230,7 +231,7 @@ vi.mock("@/store/artifacts", () => ({
 }))
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: () => [""]
+  useSetting: (setting: string) => [setting === "chatWindowOpacity" ? 35 : ""]
 }))
 
 vi.mock("@plasmohq/storage/hook", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx
@@ -212,7 +212,13 @@ vi.mock("@/services/settings/ui-settings", () => ({
   },
   HEADER_SHORTCUT_IDS: [],
   SIDEBAR_SHORTCUT_IDS: [],
-  CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity"
+  CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
+  CHAT_MESSAGE_OPACITY_SETTING: "chatMessageOpacity",
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING: "chatCharacterImageOpacity",
+  resolveOpacityAlpha: (value: unknown, fallback = 35) =>
+    typeof value === "number" && Number.isFinite(value)
+      ? value / 100
+      : fallback / 100
 }))
 
 vi.mock("../Knowledge/utils/unsupported-types", () => ({
@@ -231,7 +237,12 @@ vi.mock("@/store/artifacts", () => ({
 }))
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: (setting: string) => [setting === "chatWindowOpacity" ? 35 : ""]
+  useSetting: (setting: string) => {
+    if (setting === "chatWindowOpacity") return [35]
+    if (setting === "chatMessageOpacity") return [60]
+    if (setting === "chatCharacterImageOpacity") return [100]
+    return [""]
+  }
 }))
 
 vi.mock("@plasmohq/storage/hook", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
@@ -162,6 +162,13 @@ vi.mock("@/hooks/useSmartScroll", () => ({
 
 vi.mock("@/services/settings/ui-settings", () => ({
   CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
+  CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
+  THEME_SETTING: {
+    key: "theme",
+    defaultValue: "dark"
+  },
+  HEADER_SHORTCUT_IDS: [],
+  SIDEBAR_SHORTCUT_IDS: [],
 }));
 
 vi.mock("../Knowledge/utils/unsupported-types", () => ({
@@ -181,7 +188,7 @@ vi.mock("@/store/artifacts", () => ({
 }));
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: () => [""],
+  useSetting: (setting: string) => [setting === "chatWindowOpacity" ? 35 : ""],
 }));
 
 vi.mock("@plasmohq/storage/hook", () => ({

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
@@ -163,6 +163,12 @@ vi.mock("@/hooks/useSmartScroll", () => ({
 vi.mock("@/services/settings/ui-settings", () => ({
   CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
   CHAT_WINDOW_OPACITY_SETTING: "chatWindowOpacity",
+  CHAT_MESSAGE_OPACITY_SETTING: "chatMessageOpacity",
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING: "chatCharacterImageOpacity",
+  resolveOpacityAlpha: (value: unknown, fallback = 35) =>
+    typeof value === "number" && Number.isFinite(value)
+      ? value / 100
+      : fallback / 100,
   THEME_SETTING: {
     key: "theme",
     defaultValue: "dark"
@@ -188,7 +194,12 @@ vi.mock("@/store/artifacts", () => ({
 }));
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: (setting: string) => [setting === "chatWindowOpacity" ? 35 : ""],
+  useSetting: (setting: string) => {
+    if (setting === "chatWindowOpacity") return [35];
+    if (setting === "chatMessageOpacity") return [60];
+    if (setting === "chatCharacterImageOpacity") return [100];
+    return [""];
+  },
 }));
 
 vi.mock("@plasmohq/storage/hook", () => ({

--- a/apps/packages/ui/src/components/Option/Settings/ChatSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ChatSettings.tsx
@@ -18,7 +18,10 @@ import { toBase64 } from "@/libs/to-base64"
 import {
   CHAT_BACKGROUND_IMAGE_MAX_BASE64_LENGTH,
   CHAT_BACKGROUND_IMAGE_MAX_SIZE_MB,
-  CHAT_BACKGROUND_IMAGE_SETTING
+  CHAT_BACKGROUND_IMAGE_SETTING,
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING,
+  CHAT_MESSAGE_OPACITY_SETTING,
+  CHAT_WINDOW_OPACITY_SETTING
 } from "@/services/settings/ui-settings"
 import { RotateCcw, Upload } from "lucide-react"
 import { DiscoSkillsSettings } from "./DiscoSkillsSettings"
@@ -36,11 +39,21 @@ import {
 import { ComposerStyleSettings } from "@/components/Chat/composer/settings/ComposerStyleSettings"
 
 const SELECT_CLASSNAME = "w-[200px]"
+const OPACITY_RANGE_CLASSNAME = "w-40 accent-primary"
 export const ChatSettings = () => {
   const { t } = useTranslation("settings")
   const notification = useAntdNotification()
   const [chatBackgroundImage, setChatBackgroundImage] = useSetting(
     CHAT_BACKGROUND_IMAGE_SETTING
+  )
+  const [chatWindowOpacity, setChatWindowOpacity] = useSetting(
+    CHAT_WINDOW_OPACITY_SETTING
+  )
+  const [chatMessageOpacity, setChatMessageOpacity] = useSetting(
+    CHAT_MESSAGE_OPACITY_SETTING
+  )
+  const [chatCharacterImageOpacity, setChatCharacterImageOpacity] = useSetting(
+    CHAT_CHARACTER_IMAGE_OPACITY_SETTING
   )
   const [quickChatStrictDocsOnly, setQuickChatStrictDocsOnly] = useStorage<boolean>(
     "quickChatStrictDocsOnly",
@@ -461,7 +474,7 @@ export const ChatSettings = () => {
     [notification, setChatBackgroundImage, t]
   )
 
-  const getResetProps = <T extends boolean | string>(
+  const getResetProps = <T extends boolean | number | string>(
     value: T,
     defaultValue: T,
     setter: (next: T | ((prev: T) => T)) => void | Promise<void>
@@ -469,6 +482,28 @@ export const ChatSettings = () => {
     modified: value !== defaultValue,
     onReset: () => void setter(defaultValue)
   })
+
+  const renderOpacityControl = (
+    value: number,
+    setter: (next: number) => void | Promise<void>,
+    label: string
+  ) => (
+    <div className="flex min-w-[220px] items-center gap-3">
+      <input
+        type="range"
+        min={0}
+        max={100}
+        step={5}
+        value={value}
+        onChange={(event) => void setter(Number(event.currentTarget.value))}
+        className={OPACITY_RANGE_CLASSNAME}
+        aria-label={label}
+      />
+      <span className="w-10 text-right tabular-nums text-text-muted">
+        {value}%
+      </span>
+    </div>
+  )
 
   return (
     <div className="flex flex-col space-y-6 text-sm">
@@ -1350,6 +1385,66 @@ export const ChatSettings = () => {
             />
           </div>
         }
+      />
+
+      <SettingRow
+        label={t("chatAppearance.windowOpacity.label", "Chat window opacity")}
+        description={t(
+          "chatAppearance.windowOpacity.description",
+          "Adjusts the chat screen wash over your background image."
+        )}
+        {...getResetProps(
+          chatWindowOpacity,
+          CHAT_WINDOW_OPACITY_SETTING.defaultValue,
+          setChatWindowOpacity
+        )}
+        control={renderOpacityControl(
+          chatWindowOpacity,
+          setChatWindowOpacity,
+          t("chatAppearance.windowOpacity.label", "Chat window opacity")
+        )}
+      />
+
+      <SettingRow
+        label={t("chatAppearance.messageOpacity.label", "Message window opacity")}
+        description={t(
+          "chatAppearance.messageOpacity.description",
+          "Adjusts message bubble backgrounds without fading the message text."
+        )}
+        {...getResetProps(
+          chatMessageOpacity,
+          CHAT_MESSAGE_OPACITY_SETTING.defaultValue,
+          setChatMessageOpacity
+        )}
+        control={renderOpacityControl(
+          chatMessageOpacity,
+          setChatMessageOpacity,
+          t("chatAppearance.messageOpacity.label", "Message window opacity")
+        )}
+      />
+
+      <SettingRow
+        label={t(
+          "chatAppearance.characterImageOpacity.label",
+          "Character image opacity"
+        )}
+        description={t(
+          "chatAppearance.characterImageOpacity.description",
+          "Adjusts character portraits and assistant avatars in chat."
+        )}
+        {...getResetProps(
+          chatCharacterImageOpacity,
+          CHAT_CHARACTER_IMAGE_OPACITY_SETTING.defaultValue,
+          setChatCharacterImageOpacity
+        )}
+        control={renderOpacityControl(
+          chatCharacterImageOpacity,
+          setChatCharacterImageOpacity,
+          t(
+            "chatAppearance.characterImageOpacity.label",
+            "Character image opacity"
+          )
+        )}
       />
 
       <div className="pt-4">

--- a/apps/packages/ui/src/components/Option/Settings/ChatSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ChatSettings.tsx
@@ -487,23 +487,27 @@ export const ChatSettings = () => {
     value: number,
     setter: (next: number) => void | Promise<void>,
     label: string
-  ) => (
-    <div className="flex min-w-[220px] items-center gap-3">
-      <input
-        type="range"
-        min={0}
-        max={100}
-        step={5}
-        value={value}
-        onChange={(event) => void setter(Number(event.currentTarget.value))}
-        className={OPACITY_RANGE_CLASSNAME}
-        aria-label={label}
-      />
-      <span className="w-10 text-right tabular-nums text-text-muted">
-        {value}%
-      </span>
-    </div>
-  )
+  ) => {
+    const safeValue = Number.isFinite(value) ? value : 100
+
+    return (
+      <div className="flex min-w-[220px] items-center gap-3">
+        <input
+          type="range"
+          min={0}
+          max={100}
+          step={5}
+          value={safeValue}
+          onChange={(event) => void setter(Number(event.currentTarget.value))}
+          className={OPACITY_RANGE_CLASSNAME}
+          aria-label={label}
+        />
+        <span className="w-10 text-right tabular-nums text-text-muted">
+          {safeValue}%
+        </span>
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-col space-y-6 text-sm">

--- a/apps/packages/ui/src/routes/__tests__/chat-background-translucency.guard.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/chat-background-translucency.guard.test.ts
@@ -71,11 +71,20 @@ describe("chat background image translucency", () => {
 
   it("lets the playground cockpit shell reveal themed backgrounds", () => {
     expect(playgroundSource).toContain("themedBackdrop={Boolean(chatBackgroundImage)}")
-    expect(playgroundSource).toContain("themedBackdropOpacity={chatWindowOpacityAlpha}")
+    expect(playgroundSource).not.toContain("themedBackdropOpacity")
     expect(cockpitShellSource).toContain("themedBackdrop?: boolean")
-    expect(cockpitShellSource).toContain("themedBackdropOpacity?: number")
-    expect(cockpitShellSource).toContain("backgroundColor: `rgb(var(--color-bg) / ${clampedThemedBackdropOpacity})`")
+    expect(cockpitShellSource).not.toContain("themedBackdropOpacity")
+    expect(cockpitShellSource).not.toContain("backgroundColor: `rgb(var(--color-bg)")
     expect(cockpitShellSource).toContain("themedBackdrop ? \"bg-transparent\" : \"bg-bg\"")
+  })
+
+  it("keeps exactly one playground chat window wash layer", () => {
+    const playgroundWashMatches =
+      playgroundSource.match(
+        /backgroundColor: `rgb\(var\(--color-bg\) \/ \$\{chatWindowOpacityAlpha\}\)`/g
+      ) ?? []
+
+    expect(playgroundWashMatches).toHaveLength(1)
   })
 
   it("wires adjustable transparency settings into chat theming surfaces", () => {
@@ -90,7 +99,6 @@ describe("chat background image translucency", () => {
     expect(playgroundSource).toContain("chatWindowOpacity")
     expect(sidepanelSource).toContain("chatWindowOpacity")
     expect(extensionSidepanelSource).toContain("chatWindowOpacity")
-    expect(cockpitShellSource).toContain("themedBackdropOpacity")
 
     expect(messageSource).toContain("chatMessageOpacity")
     expect(messageSource).toContain("chatCharacterImageOpacity")

--- a/apps/packages/ui/src/routes/__tests__/chat-background-translucency.guard.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/chat-background-translucency.guard.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+import { normalizeSettingValue } from "@/services/settings/registry"
+import {
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING,
+  CHAT_MESSAGE_OPACITY_SETTING,
+  CHAT_WINDOW_OPACITY_SETTING
+} from "@/services/settings/ui-settings"
+
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const sidepanelSource = readFileSync(
+  path.resolve(testDir, "../sidepanel-chat.tsx"),
+  "utf8"
+)
+const extensionSidepanelSource = readFileSync(
+  path.resolve(
+    testDir,
+    "../../../../../tldw-frontend/extension/routes/sidepanel-chat.tsx"
+  ),
+  "utf8"
+)
+const playgroundSource = readFileSync(
+  path.resolve(
+    testDir,
+    "../../components/Option/Playground/Playground.tsx"
+  ),
+  "utf8"
+)
+const cockpitShellSource = readFileSync(
+  path.resolve(
+    testDir,
+    "../../components/Option/Playground/PlaygroundCockpitShell.tsx"
+  ),
+  "utf8"
+)
+const uiSettingsSource = readFileSync(
+  path.resolve(testDir, "../../services/settings/ui-settings.ts"),
+  "utf8"
+)
+const chatSettingsSource = readFileSync(
+  path.resolve(
+    testDir,
+    "../../components/Option/Settings/ChatSettings.tsx"
+  ),
+  "utf8"
+)
+const messageSource = readFileSync(
+  path.resolve(testDir, "../../components/Common/Playground/Message.tsx"),
+  "utf8"
+)
+const playgroundUserMessageSource = readFileSync(
+  path.resolve(
+    testDir,
+    "../../components/Common/Playground/PlaygroundUserMessage.tsx"
+  ),
+  "utf8"
+)
+
+describe("chat background image translucency", () => {
+  it.each([
+    ["sidepanel chat", sidepanelSource],
+    ["extension sidepanel chat", extensionSidepanelSource],
+    ["playground chat", playgroundSource]
+  ])("%s keeps background images visible behind the chat wash", (_name, source) => {
+    expect(source).toContain("chatWindowOpacity")
+    expect(source).toContain("backgroundColor: `rgb(var(--color-bg) / ${")
+    expect(source).not.toContain("style={{ opacity: 0.9, pointerEvents: \"none\" }}")
+  })
+
+  it("lets the playground cockpit shell reveal themed backgrounds", () => {
+    expect(playgroundSource).toContain("themedBackdrop={Boolean(chatBackgroundImage)}")
+    expect(playgroundSource).toContain("themedBackdropOpacity={chatWindowOpacityAlpha}")
+    expect(cockpitShellSource).toContain("themedBackdrop?: boolean")
+    expect(cockpitShellSource).toContain("themedBackdropOpacity?: number")
+    expect(cockpitShellSource).toContain("backgroundColor: `rgb(var(--color-bg) / ${clampedThemedBackdropOpacity})`")
+    expect(cockpitShellSource).toContain("themedBackdrop ? \"bg-transparent\" : \"bg-bg\"")
+  })
+
+  it("wires adjustable transparency settings into chat theming surfaces", () => {
+    expect(uiSettingsSource).toContain("CHAT_WINDOW_OPACITY_SETTING")
+    expect(uiSettingsSource).toContain("CHAT_MESSAGE_OPACITY_SETTING")
+    expect(uiSettingsSource).toContain("CHAT_CHARACTER_IMAGE_OPACITY_SETTING")
+
+    expect(chatSettingsSource).toContain("chatWindowOpacity")
+    expect(chatSettingsSource).toContain("chatMessageOpacity")
+    expect(chatSettingsSource).toContain("chatCharacterImageOpacity")
+
+    expect(playgroundSource).toContain("chatWindowOpacity")
+    expect(sidepanelSource).toContain("chatWindowOpacity")
+    expect(extensionSidepanelSource).toContain("chatWindowOpacity")
+    expect(cockpitShellSource).toContain("themedBackdropOpacity")
+
+    expect(messageSource).toContain("chatMessageOpacity")
+    expect(messageSource).toContain("chatCharacterImageOpacity")
+    expect(playgroundUserMessageSource).toContain("chatMessageOpacity")
+  })
+
+  it("clamps chat transparency settings to usable percentages", () => {
+    expect(normalizeSettingValue(CHAT_WINDOW_OPACITY_SETTING, "115")).toBe(100)
+    expect(normalizeSettingValue(CHAT_MESSAGE_OPACITY_SETTING, -15)).toBe(0)
+    expect(normalizeSettingValue(CHAT_CHARACTER_IMAGE_OPACITY_SETTING, 48.6)).toBe(49)
+  })
+})

--- a/apps/packages/ui/src/routes/__tests__/chat-background-translucency.guard.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/chat-background-translucency.guard.test.ts
@@ -1,7 +1,7 @@
-import { readFileSync } from "node:fs"
+import { readFile } from "node:fs/promises"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import { describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { normalizeSettingValue } from "@/services/settings/registry"
 import {
   CHAT_CHARACTER_IMAGE_OPACITY_SETTING,
@@ -10,66 +10,72 @@ import {
 } from "@/services/settings/ui-settings"
 
 const testDir = path.dirname(fileURLToPath(import.meta.url))
-const sidepanelSource = readFileSync(
-  path.resolve(testDir, "../sidepanel-chat.tsx"),
-  "utf8"
-)
-const extensionSidepanelSource = readFileSync(
-  path.resolve(
+const sourcePaths = {
+  sidepanel: path.resolve(testDir, "../sidepanel-chat.tsx"),
+  extensionSidepanel: path.resolve(
     testDir,
     "../../../../../tldw-frontend/extension/routes/sidepanel-chat.tsx"
   ),
-  "utf8"
-)
-const playgroundSource = readFileSync(
-  path.resolve(
+  playground: path.resolve(
     testDir,
     "../../components/Option/Playground/Playground.tsx"
   ),
-  "utf8"
-)
-const cockpitShellSource = readFileSync(
-  path.resolve(
+  cockpitShell: path.resolve(
     testDir,
     "../../components/Option/Playground/PlaygroundCockpitShell.tsx"
   ),
-  "utf8"
-)
-const uiSettingsSource = readFileSync(
-  path.resolve(testDir, "../../services/settings/ui-settings.ts"),
-  "utf8"
-)
-const chatSettingsSource = readFileSync(
-  path.resolve(
+  uiSettings: path.resolve(testDir, "../../services/settings/ui-settings.ts"),
+  chatSettings: path.resolve(
     testDir,
     "../../components/Option/Settings/ChatSettings.tsx"
   ),
-  "utf8"
-)
-const messageSource = readFileSync(
-  path.resolve(testDir, "../../components/Common/Playground/Message.tsx"),
-  "utf8"
-)
-const playgroundUserMessageSource = readFileSync(
-  path.resolve(
+  message: path.resolve(
+    testDir,
+    "../../components/Common/Playground/Message.tsx"
+  ),
+  playgroundUserMessage: path.resolve(
     testDir,
     "../../components/Common/Playground/PlaygroundUserMessage.tsx"
-  ),
-  "utf8"
-)
+  )
+} as const
+type SourceKey = keyof typeof sourcePaths
+const sources = {} as Record<SourceKey, string>
+
+const readSource = async (key: SourceKey): Promise<string> => {
+  try {
+    return await readFile(sourcePaths[key], "utf8")
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Unable to read ${key} source at ${sourcePaths[key]}. This guard expects a full monorepo checkout. ${message}`
+    )
+  }
+}
 
 describe("chat background image translucency", () => {
+  beforeAll(async () => {
+    await Promise.all(
+      (Object.keys(sourcePaths) as SourceKey[]).map(async (key) => {
+        sources[key] = await readSource(key)
+      })
+    )
+  })
+
   it.each([
-    ["sidepanel chat", sidepanelSource],
-    ["extension sidepanel chat", extensionSidepanelSource],
-    ["playground chat", playgroundSource]
-  ])("%s keeps background images visible behind the chat wash", (_name, source) => {
+    ["sidepanel chat", "sidepanel"],
+    ["extension sidepanel chat", "extensionSidepanel"],
+    ["playground chat", "playground"]
+  ] as const)("%s keeps background images visible behind the chat wash", (_name, key) => {
+    const source = sources[key]
     expect(source).toContain("chatWindowOpacity")
     expect(source).toContain("backgroundColor: `rgb(var(--color-bg) / ${")
     expect(source).not.toContain("style={{ opacity: 0.9, pointerEvents: \"none\" }}")
   })
 
   it("lets the playground cockpit shell reveal themed backgrounds", () => {
+    const playgroundSource = sources.playground
+    const cockpitShellSource = sources.cockpitShell
+
     expect(playgroundSource).toContain("themedBackdrop={Boolean(chatBackgroundImage)}")
     expect(playgroundSource).not.toContain("themedBackdropOpacity")
     expect(cockpitShellSource).toContain("themedBackdrop?: boolean")
@@ -79,6 +85,7 @@ describe("chat background image translucency", () => {
   })
 
   it("keeps exactly one playground chat window wash layer", () => {
+    const playgroundSource = sources.playground
     const playgroundWashMatches =
       playgroundSource.match(
         /backgroundColor: `rgb\(var\(--color-bg\) \/ \$\{chatWindowOpacityAlpha\}\)`/g
@@ -88,9 +95,18 @@ describe("chat background image translucency", () => {
   })
 
   it("wires adjustable transparency settings into chat theming surfaces", () => {
+    const chatSettingsSource = sources.chatSettings
+    const extensionSidepanelSource = sources.extensionSidepanel
+    const messageSource = sources.message
+    const playgroundSource = sources.playground
+    const playgroundUserMessageSource = sources.playgroundUserMessage
+    const sidepanelSource = sources.sidepanel
+    const uiSettingsSource = sources.uiSettings
+
     expect(uiSettingsSource).toContain("CHAT_WINDOW_OPACITY_SETTING")
     expect(uiSettingsSource).toContain("CHAT_MESSAGE_OPACITY_SETTING")
     expect(uiSettingsSource).toContain("CHAT_CHARACTER_IMAGE_OPACITY_SETTING")
+    expect(uiSettingsSource).toContain("resolveOpacityAlpha")
 
     expect(chatSettingsSource).toContain("chatWindowOpacity")
     expect(chatSettingsSource).toContain("chatMessageOpacity")
@@ -99,10 +115,27 @@ describe("chat background image translucency", () => {
     expect(playgroundSource).toContain("chatWindowOpacity")
     expect(sidepanelSource).toContain("chatWindowOpacity")
     expect(extensionSidepanelSource).toContain("chatWindowOpacity")
+    expect(playgroundSource).toContain("CHAT_MESSAGE_OPACITY_SETTING")
+    expect(sidepanelSource).toContain("CHAT_MESSAGE_OPACITY_SETTING")
+    expect(extensionSidepanelSource).toContain("CHAT_MESSAGE_OPACITY_SETTING")
+    expect(playgroundSource).toContain("--chat-message-opacity")
+    expect(sidepanelSource).toContain("--chat-message-opacity")
+    expect(extensionSidepanelSource).toContain("--chat-message-opacity")
+    expect(playgroundSource).toContain("--chat-character-image-opacity")
+    expect(sidepanelSource).toContain("--chat-character-image-opacity")
+    expect(extensionSidepanelSource).toContain("--chat-character-image-opacity")
 
-    expect(messageSource).toContain("chatMessageOpacity")
-    expect(messageSource).toContain("chatCharacterImageOpacity")
-    expect(playgroundUserMessageSource).toContain("chatMessageOpacity")
+    expect(messageSource).toContain("--chat-message-opacity")
+    expect(messageSource).toContain("--chat-character-image-opacity")
+    expect(messageSource).toContain("--color-surface2")
+    expect(messageSource).not.toContain("--color-surface-2")
+    expect(messageSource).not.toContain("CHAT_MESSAGE_OPACITY_SETTING")
+    expect(playgroundUserMessageSource).toContain("--chat-message-opacity")
+    expect(playgroundUserMessageSource).toContain("--color-surface2")
+    expect(playgroundUserMessageSource).not.toContain("--color-surface-2")
+    expect(playgroundUserMessageSource).not.toContain(
+      "CHAT_MESSAGE_OPACITY_SETTING"
+    )
   })
 
   it("clamps chat transparency settings to usable percentages", () => {

--- a/apps/packages/ui/src/routes/sidepanel-chat.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-chat.tsx
@@ -30,7 +30,11 @@ import { tldwClient } from "@/services/tldw/TldwApiClient"
 import type { ServerChatMessage as ApiServerChatMessage } from "@/services/tldw/TldwApiClient"
 import { createSafeStorage } from "@/utils/safe-storage"
 import { requestQuickIngestOpen } from "@/utils/quick-ingest-open"
-import { CHAT_BACKGROUND_IMAGE_SETTING } from "@/services/settings/ui-settings"
+import {
+  CHAT_BACKGROUND_IMAGE_SETTING,
+  CHAT_WINDOW_OPACITY_SETTING
+} from "@/services/settings/ui-settings"
+import { useSetting } from "@/hooks/useSetting"
 import { useStorage } from "@plasmohq/storage/hook"
 import { ChevronDown, ExternalLink } from "lucide-react"
 import React, { lazy, Suspense } from "react"
@@ -903,6 +907,7 @@ const SidepanelChat = () => {
     key: CHAT_BACKGROUND_IMAGE_SETTING.key,
     instance: backgroundImageStorageRef.current
   })
+  const [chatWindowOpacity] = useSetting(CHAT_WINDOW_OPACITY_SETTING)
   const bgMsg = useBackgroundMessage()
   const lastBgMsgRef = React.useRef<typeof bgMsg | null>(null)
   const pendingWebClipAnalyzeRef = React.useRef<string | null>(null)
@@ -2335,11 +2340,13 @@ const SidepanelChat = () => {
                 }
               : {}
           }>
-          {/* Background overlay for opacity effect */}
+          {/* Keep themed background images visible while preserving text contrast. */}
           {chatBackgroundImage && (
             <div
-              className="absolute inset-0 bg-bg"
-              style={{ opacity: 0.9, pointerEvents: "none" }}
+              className="pointer-events-none absolute inset-0 backdrop-blur-[1px]"
+              style={{
+                backgroundColor: `rgb(var(--color-bg) / ${chatWindowOpacity / 100})`
+              }}
             />
           )}
 

--- a/apps/packages/ui/src/routes/sidepanel-chat.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-chat.tsx
@@ -32,7 +32,10 @@ import { createSafeStorage } from "@/utils/safe-storage"
 import { requestQuickIngestOpen } from "@/utils/quick-ingest-open"
 import {
   CHAT_BACKGROUND_IMAGE_SETTING,
-  CHAT_WINDOW_OPACITY_SETTING
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING,
+  CHAT_MESSAGE_OPACITY_SETTING,
+  CHAT_WINDOW_OPACITY_SETTING,
+  resolveOpacityAlpha
 } from "@/services/settings/ui-settings"
 import { useSetting } from "@/hooks/useSetting"
 import { useStorage } from "@plasmohq/storage/hook"
@@ -908,6 +911,22 @@ const SidepanelChat = () => {
     instance: backgroundImageStorageRef.current
   })
   const [chatWindowOpacity] = useSetting(CHAT_WINDOW_OPACITY_SETTING)
+  const [chatMessageOpacity] = useSetting(CHAT_MESSAGE_OPACITY_SETTING)
+  const [chatCharacterImageOpacity] = useSetting(
+    CHAT_CHARACTER_IMAGE_OPACITY_SETTING
+  )
+  const chatWindowOpacityAlpha = resolveOpacityAlpha(
+    chatWindowOpacity,
+    CHAT_WINDOW_OPACITY_SETTING.defaultValue
+  )
+  const chatMessageOpacityAlpha = resolveOpacityAlpha(
+    chatMessageOpacity,
+    CHAT_MESSAGE_OPACITY_SETTING.defaultValue
+  )
+  const chatCharacterImageOpacityAlpha = resolveOpacityAlpha(
+    chatCharacterImageOpacity,
+    CHAT_CHARACTER_IMAGE_OPACITY_SETTING.defaultValue
+  )
   const bgMsg = useBackgroundMessage()
   const lastBgMsgRef = React.useRef<typeof bgMsg | null>(null)
   const pendingWebClipAnalyzeRef = React.useRef<string | null>(null)
@@ -2330,22 +2349,26 @@ const SidepanelChat = () => {
           className={`relative flex min-h-0 min-w-0 flex-1 flex-col items-center overflow-x-hidden bg-bg ${
             dropState === "dragging" ? "bg-surface2" : ""
           }`}
-          style={
-            chatBackgroundImage
+          style={{
+            "--chat-message-opacity": String(chatMessageOpacityAlpha),
+            "--chat-character-image-opacity": String(
+              chatCharacterImageOpacityAlpha
+            ),
+            ...(chatBackgroundImage
               ? {
                   backgroundImage: `url(${chatBackgroundImage})`,
                   backgroundSize: "cover",
                   backgroundPosition: "center",
                   backgroundRepeat: "no-repeat"
                 }
-              : {}
-          }>
+              : {})
+          } as React.CSSProperties}>
           {/* Keep themed background images visible while preserving text contrast. */}
           {chatBackgroundImage && (
             <div
               className="pointer-events-none absolute inset-0 backdrop-blur-[1px]"
               style={{
-                backgroundColor: `rgb(var(--color-bg) / ${chatWindowOpacity / 100})`
+                backgroundColor: `rgb(var(--color-bg) / ${chatWindowOpacityAlpha})`
               }}
             />
           )}

--- a/apps/packages/ui/src/services/settings/ui-settings.ts
+++ b/apps/packages/ui/src/services/settings/ui-settings.ts
@@ -96,6 +96,11 @@ const coerceOpacityPercent = (value: unknown, fallback: number): number => {
   return Math.min(100, Math.max(0, parsed))
 }
 
+export const resolveOpacityAlpha = (
+  value: unknown,
+  fallback: number
+): number => coerceOpacityPercent(value, fallback) / 100
+
 export const CHAT_WINDOW_OPACITY_SETTING = defineSetting(
   "chatWindowOpacity",
   35,

--- a/apps/packages/ui/src/services/settings/ui-settings.ts
+++ b/apps/packages/ui/src/services/settings/ui-settings.ts
@@ -90,6 +90,30 @@ export const CHAT_BACKGROUND_IMAGE_MAX_SIZE_MB = 15
 export const CHAT_BACKGROUND_IMAGE_MAX_BASE64_LENGTH =
   CHAT_BACKGROUND_IMAGE_MAX_SIZE_MB * 1_000_000
 
+const coerceOpacityPercent = (value: unknown, fallback: number): number => {
+  const parsed = Math.round(coerceNumber(value, fallback))
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.min(100, Math.max(0, parsed))
+}
+
+export const CHAT_WINDOW_OPACITY_SETTING = defineSetting(
+  "chatWindowOpacity",
+  35,
+  (value) => coerceOpacityPercent(value, 35)
+)
+
+export const CHAT_MESSAGE_OPACITY_SETTING = defineSetting(
+  "chatMessageOpacity",
+  60,
+  (value) => coerceOpacityPercent(value, 60)
+)
+
+export const CHAT_CHARACTER_IMAGE_OPACITY_SETTING = defineSetting(
+  "chatCharacterImageOpacity",
+  100,
+  (value) => coerceOpacityPercent(value, 100)
+)
+
 const SPLASH_CARD_NAME_SET = new Set(DEFAULT_SPLASH_CARD_NAMES)
 
 const coerceSplashCardNameArray = (value: unknown): string[] => {

--- a/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx
+++ b/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx
@@ -29,7 +29,10 @@ import type { ServerChatMessage as ApiServerChatMessage } from "@/services/tldw/
 import { createSafeStorage } from "@/utils/safe-storage"
 import {
   CHAT_BACKGROUND_IMAGE_SETTING,
-  CHAT_WINDOW_OPACITY_SETTING
+  CHAT_CHARACTER_IMAGE_OPACITY_SETTING,
+  CHAT_MESSAGE_OPACITY_SETTING,
+  CHAT_WINDOW_OPACITY_SETTING,
+  resolveOpacityAlpha
 } from "@/services/settings/ui-settings"
 import { useSetting } from "@/hooks/useSetting"
 import { useStorage } from "@plasmohq/storage/hook"
@@ -677,6 +680,22 @@ const SidepanelChat = () => {
     null
   )
   const [chatWindowOpacity] = useSetting(CHAT_WINDOW_OPACITY_SETTING)
+  const [chatMessageOpacity] = useSetting(CHAT_MESSAGE_OPACITY_SETTING)
+  const [chatCharacterImageOpacity] = useSetting(
+    CHAT_CHARACTER_IMAGE_OPACITY_SETTING
+  )
+  const chatWindowOpacityAlpha = resolveOpacityAlpha(
+    chatWindowOpacity,
+    CHAT_WINDOW_OPACITY_SETTING.defaultValue
+  )
+  const chatMessageOpacityAlpha = resolveOpacityAlpha(
+    chatMessageOpacity,
+    CHAT_MESSAGE_OPACITY_SETTING.defaultValue
+  )
+  const chatCharacterImageOpacityAlpha = resolveOpacityAlpha(
+    chatCharacterImageOpacity,
+    CHAT_CHARACTER_IMAGE_OPACITY_SETTING.defaultValue
+  )
   const resolvedChatBackgroundImage = chatBackgroundImage ?? null
   const bgMsg = useBackgroundMessage()
   const lastBgMsgRef = React.useRef<typeof bgMsg | null>(null)
@@ -1858,22 +1877,26 @@ const SidepanelChat = () => {
           className={`relative flex min-h-0 flex-1 flex-col items-center bg-bg ${
             dropState === "dragging" ? "bg-surface2" : ""
           }`}
-          style={
-            resolvedChatBackgroundImage
+          style={{
+            "--chat-message-opacity": String(chatMessageOpacityAlpha),
+            "--chat-character-image-opacity": String(
+              chatCharacterImageOpacityAlpha
+            ),
+            ...(resolvedChatBackgroundImage
               ? {
                   backgroundImage: `url(${resolvedChatBackgroundImage})`,
                   backgroundSize: "cover",
                   backgroundPosition: "center",
                   backgroundRepeat: "no-repeat"
                 }
-              : {}
-          }>
+              : {})
+          } as React.CSSProperties}>
           {/* Keep themed background images visible while preserving text contrast. */}
           {resolvedChatBackgroundImage && (
             <div
               className="pointer-events-none absolute inset-0 backdrop-blur-[1px]"
               style={{
-                backgroundColor: `rgb(var(--color-bg) / ${chatWindowOpacity / 100})`
+                backgroundColor: `rgb(var(--color-bg) / ${chatWindowOpacityAlpha})`
               }}
             />
           )}

--- a/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx
+++ b/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx
@@ -27,7 +27,11 @@ import { copilotResumeLastChat } from "@/services/app"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import type { ServerChatMessage as ApiServerChatMessage } from "@/services/tldw/TldwApiClient"
 import { createSafeStorage } from "@/utils/safe-storage"
-import { CHAT_BACKGROUND_IMAGE_SETTING } from "@/services/settings/ui-settings"
+import {
+  CHAT_BACKGROUND_IMAGE_SETTING,
+  CHAT_WINDOW_OPACITY_SETTING
+} from "@/services/settings/ui-settings"
+import { useSetting } from "@/hooks/useSetting"
 import { useStorage } from "@plasmohq/storage/hook"
 import { browser } from "wxt/browser"
 import { ChevronDown } from "lucide-react"
@@ -672,6 +676,7 @@ const SidepanelChat = () => {
     },
     null
   )
+  const [chatWindowOpacity] = useSetting(CHAT_WINDOW_OPACITY_SETTING)
   const resolvedChatBackgroundImage = chatBackgroundImage ?? null
   const bgMsg = useBackgroundMessage()
   const lastBgMsgRef = React.useRef<typeof bgMsg | null>(null)
@@ -1863,11 +1868,13 @@ const SidepanelChat = () => {
                 }
               : {}
           }>
-          {/* Background overlay for opacity effect */}
+          {/* Keep themed background images visible while preserving text contrast. */}
           {resolvedChatBackgroundImage && (
             <div
-              className="absolute inset-0 bg-bg"
-              style={{ opacity: 0.9, pointerEvents: "none" }}
+              className="pointer-events-none absolute inset-0 backdrop-blur-[1px]"
+              style={{
+                backgroundColor: `rgb(var(--color-bg) / ${chatWindowOpacity / 100})`
+              }}
             />
           )}
 

--- a/backlog/tasks/task-12908 - Add-adjustable-chat-transparency-theming-controls.md
+++ b/backlog/tasks/task-12908 - Add-adjustable-chat-transparency-theming-controls.md
@@ -4,7 +4,7 @@ title: Add adjustable chat transparency theming controls
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-08 01:28'
+updated_date: '2026-07-08 01:56'
 labels:
   - frontend
   - theming
@@ -56,6 +56,8 @@ Clean PR worktree verification: bunx vitest run src/routes/__tests__/chat-backgr
 TypeScript follow-up: VisualIdentityImage now passes an optional style prop through to its img element so character-image opacity can be applied to animated visual identity portraits without violating the component prop contract.
 
 Final clean-worktree verification after VisualIdentityImage style passthrough: bunx vitest run src/components/Common/VisualIdentity/__tests__/VisualIdentityImage.test.tsx src/routes/__tests__/chat-background-translucency.guard.test.ts src/components/Option/Settings/__tests__/ChatSettings.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-a11y.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx --reporter=dot passed from apps/packages/ui with 10 files and 110 tests. NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc -p tsconfig.json --noEmit still fails on existing baseline test typing errors outside the touched implementation; the prior touched-file VisualIdentityImage/Message.tsx style-prop error is resolved.
+
+Code review follow-up for PR #2685: removed themedBackdropOpacity from PlaygroundCockpitShell so full Playground applies chatWindowOpacityAlpha only once via the root background wash. Added a cockpit-shell render assertion and source guard to prevent reintroducing a second wash. Verification: bunx vitest run src/routes/__tests__/chat-background-translucency.guard.test.ts src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx --reporter=dot passed with 2 files and 49 tests.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12908 - Add-adjustable-chat-transparency-theming-controls.md
+++ b/backlog/tasks/task-12908 - Add-adjustable-chat-transparency-theming-controls.md
@@ -4,7 +4,7 @@ title: Add adjustable chat transparency theming controls
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-08 01:56'
+updated_date: '2026-07-08 02:10'
 labels:
   - frontend
   - theming
@@ -58,6 +58,10 @@ TypeScript follow-up: VisualIdentityImage now passes an optional style prop thro
 Final clean-worktree verification after VisualIdentityImage style passthrough: bunx vitest run src/components/Common/VisualIdentity/__tests__/VisualIdentityImage.test.tsx src/routes/__tests__/chat-background-translucency.guard.test.ts src/components/Option/Settings/__tests__/ChatSettings.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-a11y.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx --reporter=dot passed from apps/packages/ui with 10 files and 110 tests. NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc -p tsconfig.json --noEmit still fails on existing baseline test typing errors outside the touched implementation; the prior touched-file VisualIdentityImage/Message.tsx style-prop error is resolved.
 
 Code review follow-up for PR #2685: removed themedBackdropOpacity from PlaygroundCockpitShell so full Playground applies chatWindowOpacityAlpha only once via the root background wash. Added a cockpit-shell render assertion and source guard to prevent reintroducing a second wash. Verification: bunx vitest run src/routes/__tests__/chat-background-translucency.guard.test.ts src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx --reporter=dot passed with 2 files and 49 tests.
+
+PR #2685 review follow-up completed after rebasing on origin/dev: fixed the invalid --color-surface-2 CSS variable, added opacity alpha fallbacks, moved message/character opacity setting subscriptions to the chat roots via CSS variables, kept message text opaque, and changed the guard test to async source reads with a clear monorepo-checkout error.
+
+Review follow-up verification: bunx vitest run src/components/Common/VisualIdentity/__tests__/VisualIdentityImage.test.tsx src/routes/__tests__/chat-background-translucency.guard.test.ts src/components/Option/Settings/__tests__/ChatSettings.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-a11y.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx --reporter=dot passed from apps/packages/ui with 10 files and 112 tests. git diff --check passed. NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc -p tsconfig.json --noEmit still fails on existing baseline type errors outside the touched transparency files.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12908 - Add-adjustable-chat-transparency-theming-controls.md
+++ b/backlog/tasks/task-12908 - Add-adjustable-chat-transparency-theming-controls.md
@@ -1,0 +1,75 @@
+---
+id: TASK-12908
+title: Add adjustable chat transparency theming controls
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-08 01:28'
+labels:
+  - frontend
+  - theming
+  - chat
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add user-adjustable transparency controls for chat text/windows and character images so chat theming can reveal configured backgrounds while preserving readability.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Chat window/surface transparency can be adjusted from existing chat/background settings.
+- [x] #2 Chat text/message surface transparency can be adjusted without making text itself unreadable by default.
+- [x] #3 Character image transparency can be adjusted where character images are rendered in chat.
+- [x] #4 A targeted regression check covers the new transparency settings wiring.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Implemented adjustable chat transparency controls in the existing Chat Appearance settings. Added clamped percent settings for chatWindowOpacity, chatMessageOpacity, and chatCharacterImageOpacity.
+
+Wired chatWindowOpacity into the full Playground background wash and cockpit shell plus both sidepanel chat routes. Wired chatMessageOpacity into shared assistant/user message cards and compact user bubbles using background-color alpha so text itself remains opaque. Wired chatCharacterImageOpacity into character portrait images and assistant avatars.
+
+Touched files: apps/packages/ui/src/services/settings/ui-settings.ts, apps/packages/ui/src/components/Option/Settings/ChatSettings.tsx, apps/packages/ui/src/components/Option/Playground/Playground.tsx, apps/packages/ui/src/components/Option/Playground/PlaygroundCockpitShell.tsx, apps/packages/ui/src/routes/sidepanel-chat.tsx, apps/tldw-frontend/extension/routes/sidepanel-chat.tsx, apps/packages/ui/src/components/Common/Playground/Message.tsx, apps/packages/ui/src/components/Common/Playground/PlaygroundUserMessage.tsx, apps/packages/ui/src/routes/__tests__/chat-background-translucency.guard.test.ts.
+
+Verification: bunx vitest run src/routes/__tests__/chat-background-translucency.guard.test.ts src/components/Option/Settings/__tests__/ChatSettings.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-a11y.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx passed from apps/packages/ui with 4 files and 26 tests. git diff --check scoped to touched files passed.
+
+Additional verification: ./node_modules/.bin/tsc -p tsconfig.json --noEmit initially hit Node heap limit. Retried with NODE_OPTIONS=--max-old-space-size=8192 and it completed with existing unrelated baseline errors in ChatGreetingPicker, Notes, AudioStudio, ScheduledTasks, background.ts, and other files, with no diagnostics in the touched chat transparency files.
+
+Bandit skipped because the touched implementation is TypeScript/TSX frontend code only.
+
+Code review found an Important risk: broader Playground tests may have stale @/services/settings/ui-settings mocks missing CHAT_WINDOW_OPACITY_SETTING. Reopened task to update mocks and rerun affected tests.
+
+Code review follow-up completed: added CHAT_WINDOW_OPACITY_SETTING and setting-aware useSetting defaults to six Playground test mocks, added an opacity clamping behavior assertion to the transparency guard, and removed duplicate final-summary markers left by the CLI artifact.
+
+Review follow-up verification: bunx vitest run src/routes/__tests__/chat-background-translucency.guard.test.ts src/components/Option/Playground/__tests__/Playground.research-context.integration.test.tsx src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx passed from apps/packages/ui with 7 files and 102 tests. git diff --check scoped to touched files passed after review follow-up.
+
+Clean PR worktree verification: bunx vitest run src/routes/__tests__/chat-background-translucency.guard.test.ts src/components/Option/Settings/__tests__/ChatSettings.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-a11y.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx --reporter=dot passed from apps/packages/ui with 9 files and 108 tests. git diff --check passed. A temporary origin/dev baseline confirmed Playground.research-context.integration.test.tsx is already broken on dev before this PR because its ui-settings mock lacks HEADER_SHORTCUT_IDS; this PR updates related mocks, but that baseline-broken suite was not used as a completion gate.
+
+TypeScript follow-up: VisualIdentityImage now passes an optional style prop through to its img element so character-image opacity can be applied to animated visual identity portraits without violating the component prop contract.
+
+Final clean-worktree verification after VisualIdentityImage style passthrough: bunx vitest run src/components/Common/VisualIdentity/__tests__/VisualIdentityImage.test.tsx src/routes/__tests__/chat-background-translucency.guard.test.ts src/components/Option/Settings/__tests__/ChatSettings.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-a11y.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx --reporter=dot passed from apps/packages/ui with 10 files and 110 tests. NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc -p tsconfig.json --noEmit still fails on existing baseline test typing errors outside the touched implementation; the prior touched-file VisualIdentityImage/Message.tsx style-prop error is resolved.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added three Chat Appearance opacity controls for chat window wash, message window backgrounds, and character images. The settings are clamped percentages, apply across WebUI chat and both sidepanel routes, and preserve message text opacity/readability while allowing themed backgrounds to show through.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

Adds chat theming transparency controls so configured background images remain visible behind the chat experience while message text stays fully opaque and readable.

Implemented three clamped Chat Appearance settings:
- Chat window opacity for the page/cockpit wash over a background image.
- Message window opacity for assistant/user message surfaces.
- Character image opacity for portraits and assistant avatars.

The full Playground, cockpit shell, shared message components, WebUI sidepanel route, and extension sidepanel route now use those settings instead of painting opaque surfaces over the background image. `VisualIdentityImage` also passes through a standard image `style` prop so animated visual identity portraits can receive the opacity setting without changing text opacity.

## Verification

- `bunx vitest run src/components/Common/VisualIdentity/__tests__/VisualIdentityImage.test.tsx src/routes/__tests__/chat-background-translucency.guard.test.ts src/components/Option/Settings/__tests__/ChatSettings.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-a11y.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-rail-restore.test.tsx src/components/Option/Playground/__tests__/Playground.coordinator.integration.test.tsx src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-controls.test.tsx src/components/Option/Playground/__tests__/Playground.cockpit-shell.test.tsx src/components/Option/Playground/__tests__/Playground.search.integration.test.tsx --reporter=dot`
  - Passed on the rebased PR worktree: 10 files, 110 tests.
- `git diff --check origin/dev...HEAD`
  - Passed.
- `NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc -p tsconfig.json --noEmit`
  - Still fails on existing baseline test typing errors outside the touched implementation.
  - The touched-file `VisualIdentityImage` / `Message.tsx` style-prop error found during this PR was fixed and did not recur.

## Notes

- Bandit was skipped because the implementation is frontend TypeScript/TSX only.
- A temporary plain `origin/dev` baseline check confirmed `Playground.research-context.integration.test.tsx` is already broken before this PR due a stale `ui-settings` mock missing `HEADER_SHORTCUT_IDS`. This PR updates related mocks, but that baseline-broken suite was not used as the completion gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds adjustable chat transparency so background images show through while chat text stays fully readable across the Playground and both sidepanels. Uses CSS variables and a single, subtle blurred root wash for consistent theming; addresses TASK-12908.

- **New Features**
  - Three Chat Appearance controls (0–100%, clamped): chat window opacity (35% default), message window opacity (60%), and character image opacity (100%).
  - Applied across the Playground cockpit shell and chat, WebUI sidepanel, and extension sidepanel; settings flow via CSS variables, and message bubbles use alpha backgrounds so text remains opaque.
  - `VisualIdentityImage` now forwards a `style` prop to support opacity on portraits and assistant avatars.

- **Bug Fixes**
  - Prevented double background wash in the Playground by making `PlaygroundCockpitShell` transparent when a themed backdrop is active and applying the wash once at the root; added guard tests to ensure this stays single-layered.

<sup>Written for commit 24497f91c8ef684e833692fde5137d573794bc01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

