### PR TITLE
Fix missing analysis provider error

### DIFF
--- a/apps/packages/ui/src/components/Common/QuickIngest/ResultsListItem.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ResultsListItem.tsx
@@ -124,6 +124,9 @@ export const ResultsListItem: React.FC<ResultsListItemProps> = React.memo(
           {item.error ? (
             <div className="text-xs text-danger">{item.error}</div>
           ) : null}
+          {item.warning ? (
+            <div className="text-xs text-warn">{item.warning}</div>
+          ) : null}
         </div>
       </List.Item>
     )

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/ResultsListItem.status.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/ResultsListItem.status.test.tsx
@@ -52,4 +52,31 @@ describe("ResultsListItem status labels", () => {
     expect(screen.getByText("Not submitted")).toBeTruthy()
     expect(screen.queryByText("Failed")).toBeNull()
   })
+
+  it("shows analysis warnings on successful ingest rows", () => {
+    const item: ResultItemWithMediaId = {
+      id: "ingested-1",
+      status: "ok",
+      outcome: "ingested",
+      type: "html",
+      url: "https://example.com/article",
+      mediaId: "42",
+      warning: "Analysis skipped: choose an analysis provider, then retry analysis."
+    } as ResultItemWithMediaId
+
+    render(
+      <ResultsListItem
+        item={item}
+        processOnly={false}
+        onDownloadJson={vi.fn()}
+        onOpenMedia={vi.fn()}
+        onDiscussInChat={vi.fn()}
+        t={t as any}
+      />
+    )
+
+    expect(
+      screen.getByText("Analysis skipped: choose an analysis provider, then retry analysis.")
+    ).toBeTruthy()
+  })
 })

--- a/apps/packages/ui/src/components/Common/QuickIngest/types.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/types.ts
@@ -26,6 +26,7 @@ export type ResultItem = {
   type: string
   data?: unknown
   error?: string
+  warning?: string
   /** Whether the original file was persisted during this ingest run. */
   persisted?: boolean
 }

--- a/apps/packages/ui/src/components/Common/QuickIngestModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestModal.tsx
@@ -6,6 +6,7 @@ import { browser } from "wxt/browser"
 import { tldwClient } from '@/services/tldw/TldwApiClient'
 import {
   cancelQuickIngestSession,
+  getQuickIngestAnalysisProviderWarning,
   startQuickIngestSession,
   submitQuickIngestBatch
 } from "@/services/tldw/quick-ingest-batch"
@@ -643,6 +644,15 @@ export const QuickIngestModal: React.FC<Props> = ({
         : `One or more files are too large. Each file must be smaller than ${maxLabel}.`
       messageApi.error(msg)
       setLastRunError(msg)
+      return
+    }
+    const analysisProviderWarning = getQuickIngestAnalysisProviderWarning({
+      common,
+      advancedValues
+    })
+    if (analysisProviderWarning) {
+      messageApi.warning(analysisProviderWarning)
+      setLastRunError(analysisProviderWarning)
       return
     }
     const total = valid.length + attachedFiles.length

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -18,6 +18,7 @@ import { WizardResultsStep } from "./QuickIngest/WizardResultsStep"
 import { FloatingProgressWidget } from "./QuickIngest/FloatingProgressWidget"
 import {
   cancelQuickIngestSession,
+  getQuickIngestAnalysisProviderWarning,
   startQuickIngestSession,
   submitQuickIngestBatch,
 } from "@/services/tldw/quick-ingest-batch"
@@ -1404,6 +1405,14 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
           typeDefaults: presetConfig.typeDefaults,
         }
       )
+      const analysisProviderWarning = getQuickIngestAnalysisProviderWarning({
+        common: requestPayload.common,
+        advancedValues: requestPayload.advancedValues,
+      })
+      if (analysisProviderWarning) {
+        finalizeFailure(analysisProviderWarning, "failed")
+        return
+      }
 
       const startAck = await startQuickIngestSession(requestPayload)
       if (!startAck?.ok || !startAck?.sessionId) {

--- a/apps/packages/ui/src/components/Common/hooks/useIngestResults.tsx
+++ b/apps/packages/ui/src/components/Common/hooks/useIngestResults.tsx
@@ -43,8 +43,11 @@ export type ProcessingItem = {
   transcript?: string
   transcription?: string
   summary?: string
-  analysis_content?: string
-  analysis?: string
+  analysis_content?: string | null
+  analysis?: string | null
+  analysis_status?: string
+  analysis_error?: string
+  warnings?: string[]
   prompt?: string
   custom_prompt?: string
   title?: string
@@ -73,6 +76,7 @@ export type ResultItem = {
   type: string
   data?: ProcessingResultPayload
   error?: string
+  warning?: string
 }
 
 type ProcessingOptions = {
@@ -186,8 +190,8 @@ const resolveTitle = (item: ProcessingItem, fallback: string): string => {
 }
 
 const resolveAnalysis = (item: ProcessingItem): string | undefined => {
-  if (typeof item?.analysis === "string") return item.analysis
-  if (typeof item?.analysis_content === "string") return item.analysis_content
+  if (typeof item?.analysis === "string" && !analysisWarningFromText(item.analysis)) return item.analysis
+  if (typeof item?.analysis_content === "string" && !analysisWarningFromText(item.analysis_content)) return item.analysis_content
   return undefined
 }
 
@@ -244,6 +248,42 @@ const extractProcessingItems = (data: ProcessingResultPayload): ProcessingItem[]
 const getProcessingStatusLabels = (data: ProcessingResultPayload): string[] =>
   extractProcessingItems(data).map((item) => normalizeStatusLabel(item.status)).filter(Boolean)
 
+const analysisWarningFromText = (value: unknown): string | null => {
+  const text = String(value || "").trim()
+  if (!text) return null
+  const normalized = text.toLowerCase()
+  const reason = text.replace(/^error:\s*/i, "").replace(/^\[|\]$/g, "").trim()
+  if (
+    normalized.includes("analysis api provider is required") ||
+    normalized.includes("no api specified") ||
+    normalized.includes("choose an analysis provider")
+  ) {
+    return "Analysis skipped: choose an analysis provider, then retry analysis."
+  }
+  if (normalized.startsWith("error:")) return `Analysis failed: ${reason || "API error"}`
+  if (normalized.startsWith("[analysis failed")) return `Analysis failed: ${reason || "API error"}`
+  if (normalized.startsWith("[analysis skipped")) return `Analysis skipped: ${reason || "not available"}`
+  return null
+}
+
+export const analysisWarningFromPayload = (data: ProcessingResultPayload): string | undefined => {
+  for (const item of extractProcessingItems(data)) {
+    const status = normalizeStatusLabel(item.analysis_status)
+    const detail = item.analysis_error || item.warnings?.find((warning) => analysisWarningFromText(warning))
+    if (status === "skipped") {
+      return analysisWarningFromText(detail) || `Analysis skipped: ${String(detail || "not available").trim()}`
+    }
+    if (status === "failed") {
+      return analysisWarningFromText(detail) || `Analysis failed: ${String(detail || "API error").trim()}`
+    }
+    const analysisWarning =
+      analysisWarningFromText(item.analysis) ||
+      analysisWarningFromText(item.analysis_content)
+    if (analysisWarning) return analysisWarning
+  }
+  return undefined
+}
+
 export const normalizeResultItem = (
   item: Partial<ResultItem> | null | undefined
 ): ResultItem | null => {
@@ -258,7 +298,8 @@ export const normalizeResultItem = (
     fileName: item.fileName,
     type: String(item.type || "item"),
     data: item.data as ProcessingResultPayload,
-    error: item.error
+    error: item.error,
+    warning: item.warning || analysisWarningFromPayload(item.data as ProcessingResultPayload)
   }
 }
 

--- a/apps/packages/ui/src/components/Media/AnalysisModal.tsx
+++ b/apps/packages/ui/src/components/Media/AnalysisModal.tsx
@@ -474,7 +474,15 @@ export function AnalysisModal({
       if (isTimeoutError(err)) {
         messageApi.error(buildTimeoutMessage())
       } else {
-        messageApi.error(t('mediaPage.analysisGenerateFailed', 'Failed to generate analysis'))
+        const errorText = String((err as Error)?.message || err || '').toLowerCase()
+        messageApi.error(
+          errorText.includes('analysis api provider is required')
+            ? t(
+                'mediaPage.analysisProviderRequired',
+                'Choose an analysis provider, then retry analysis.'
+              )
+            : t('mediaPage.analysisGenerateFailed', 'Failed to generate analysis')
+        )
       }
       console.error('Generation error:', err)
     } finally {

--- a/apps/packages/ui/src/components/Media/__tests__/AnalysisModal.stage3.regression.test.tsx
+++ b/apps/packages/ui/src/components/Media/__tests__/AnalysisModal.stage3.regression.test.tsx
@@ -231,4 +231,37 @@ describe('AnalysisModal stage 3 regression coverage', () => {
     expect(mocks.messageSuccess).toHaveBeenCalledWith('Analysis generated and saved')
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  it('shows provider recovery copy when generation fails without a provider', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mocks.bgStream.mockImplementation(() =>
+      (async function* () {
+        throw new Error('Error: Analysis API provider is required.')
+      })()
+    )
+    mocks.bgRequest.mockRejectedValueOnce(new Error('Error: Analysis API provider is required.'))
+
+    render(
+      <AnalysisModal
+        open
+        onClose={vi.fn()}
+        mediaId={42}
+        mediaContent="media body"
+        onAnalysisGenerated={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Generate Analysis' })).not.toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate Analysis' }))
+
+    await waitFor(() => {
+      expect(mocks.messageError).toHaveBeenCalledWith(
+        'Choose an analysis provider, then retry analysis.'
+      )
+    })
+    consoleError.mockRestore()
+  })
 })

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/services/background-proxy", () => ({
 import {
   __resetQuickIngestRuntimeHealthForTests,
   cancelQuickIngestSession,
+  getQuickIngestAnalysisProviderWarning,
   startQuickIngestSession,
   submitQuickIngestBatch
 } from "@/services/tldw/quick-ingest-batch"
@@ -44,6 +45,27 @@ describe("submitQuickIngestBatch", () => {
     mocks.sendMessage.mockReset()
     mocks.bgRequest.mockReset()
     mocks.bgUpload.mockReset()
+  })
+
+  it("warns when analysis is enabled without an analysis provider", () => {
+    expect(
+      getQuickIngestAnalysisProviderWarning({
+        common: { perform_analysis: true },
+        advancedValues: {}
+      } as any)
+    ).toBe("Choose an analysis provider before running ingest analysis.")
+    expect(
+      getQuickIngestAnalysisProviderWarning({
+        common: { perform_analysis: true },
+        advancedValues: { api_name: "openai" }
+      } as any)
+    ).toBeNull()
+    expect(
+      getQuickIngestAnalysisProviderWarning({
+        common: { perform_analysis: true },
+        advancedValues: { api_provider: "openai" }
+      } as any)
+    ).toBe("Choose an analysis provider before running ingest analysis.")
   })
 
   it("uses direct upload path when extension runtime id is unavailable", async () => {

--- a/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
@@ -119,6 +119,25 @@ type QuickIngestBatchResponse = {
   results?: QuickIngestBatchResult[];
 };
 
+export const QUICK_INGEST_ANALYSIS_PROVIDER_WARNING =
+  "Choose an analysis provider before running ingest analysis.";
+
+const hasAnalysisProviderValue = (value: unknown): boolean => {
+  const normalized = String(value || "").trim();
+  return Boolean(normalized) && normalized.toLowerCase() !== "none";
+};
+
+export const getQuickIngestAnalysisProviderWarning = (
+  input: Pick<QuickIngestBatchInput, "common" | "advancedValues">,
+): string | null => {
+  if (!input?.common?.perform_analysis) return null;
+  const advancedValues = input.advancedValues || {};
+  if (hasAnalysisProviderValue(advancedValues.api_name)) {
+    return null;
+  }
+  return QUICK_INGEST_ANALYSIS_PROVIDER_WARNING;
+};
+
 export type QuickIngestStartAck = {
   ok: boolean;
   sessionId?: string;

--- a/backlog/tasks/task-12915 - Fix-missing-analysis-provider-error-in-legacy-analyzer.md
+++ b/backlog/tasks/task-12915 - Fix-missing-analysis-provider-error-in-legacy-analyzer.md
@@ -1,0 +1,46 @@
+---
+id: TASK-12915
+title: Fix missing analysis provider error in legacy analyzer
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-08 02:35'
+labels:
+  - bug
+  - media
+  - analysis
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prevent analysis/summarization requests with a missing api_name from surfacing `Error calling API None: 'NoneType' object has no attribute 'lower'`. Add focused regression coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Shared analyzer guard normalizes api_name and rejects None, blank, and 'none' before dispatch. Regression covers all missing-provider aliases.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the missing analysis provider path so it returns `Error: Analysis API provider is required.` instead of leaking `Error calling API None: 'NoneType' object has no attribute 'lower'`. Verification: regression failed before the fix, then `python -m pytest tldw_Server_API/tests/LLM_Calls/test_summarization_adapter.py tldw_Server_API/tests/LLM_Calls/test_local_summarization_config.py -q` passed with 8 tests. Bandit on the touched backend file reported 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12916 - Harden-ingest-analysis-UX-for-missing-providers.md
+++ b/backlog/tasks/task-12916 - Harden-ingest-analysis-UX-for-missing-providers.md
@@ -1,0 +1,61 @@
+---
+id: TASK-12916
+title: Harden ingest analysis UX for missing providers
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-07-08 03:14
+labels: []
+dependencies: []
+priority: high
+modified_files:
+- apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+- apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+- apps/packages/ui/src/components/Common/QuickIngestModal.tsx
+- apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+- apps/packages/ui/src/components/Common/hooks/useIngestResults.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/types.ts
+- apps/packages/ui/src/components/Common/QuickIngest/ResultsListItem.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/ResultsListItem.status.test.tsx
+- apps/packages/ui/src/components/Media/AnalysisModal.tsx
+- apps/packages/ui/src/components/Media/__tests__/AnalysisModal.stage3.regression.test.tsx
+- tldw_Server_API/app/services/web_scraping_service.py
+- tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address UX/HCI findings from the analysis-provider error investigation: prevent Quick Ingest from silently requesting analysis without a configured provider, avoid treating analyzer error strings as generated analysis content, and surface analysis skipped/failed states as recoverable warnings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Quick Ingest warns users when analysis is enabled without an analysis provider before work starts.
+- [x] #2 Web ingest does not store analyzer Error: strings as analysis content.
+- [x] #3 Ingest result normalization separates analysis warnings/errors from successful analysis text.
+- [x] #4 Existing media Analysis modal keeps actionable error handling for missing provider failures.
+- [x] #5 Focused frontend/backend tests cover the new behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the UX/HCI recommendations by adding an early Quick Ingest provider preflight for analysis, aligning the check with the backend api_name contract, and surfacing the warning in both the classic modal and wizard before work starts. Web ingest now records missing-provider and analyzer error-string outcomes as structured analysis_status/analysis_error warnings instead of returning Error: text as analysis content. Quick Ingest result normalization now suppresses analysis error markers from the analysis text slot and shows recoverable warnings in result rows. The media Analysis modal now maps the missing-provider failure to actionable retry copy.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Quick Ingest now blocks analysis runs without an `api_name`, backend web-ingest analysis failures are represented as skipped/failed metadata instead of generated content, and result rows/modals show actionable recovery copy. Verification: Vitest focused suite passed 37/37 tests; pytest focused backend/provider suite passed 10/10 tests; `git diff --check` passed; Bandit reported 0 findings for `web_scraping_service.py`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/LLM_Calls/Summarization_General_Lib.py
+++ b/tldw_Server_API/app/core/LLM_Calls/Summarization_General_Lib.py
@@ -404,7 +404,7 @@ def _dispatch_to_api(
 
 # --- Main Summarization Function ---
 def analyze(
-    api_name: str,
+    api_name: Optional[str],
     input_data: Any,
     custom_prompt_arg: Optional[str],
     api_key: Optional[str] = None,
@@ -443,6 +443,18 @@ def analyze(
     """
     # Load config here if needed for top-level decisions, otherwise let specific funcs handle it
     # loaded_config_data = load_and_log_configs() # Load once if needed globally
+    raw_api_name = api_name
+    api_name = str(raw_api_name).strip() if raw_api_name is not None else ""
+    if not api_name or api_name.lower() == "none":
+        error_msg = "Error: Analysis API provider is required."
+        logging.bind(
+            component="llm_summarization",
+            operation="analyze",
+            api_name_state="missing" if raw_api_name is None else "blank_or_none",
+            input_type=type(input_data).__name__,
+        ).warning(error_msg)
+        return error_msg
+
     logging.info(f"Starting summarization process. API: {api_name}, Recursive: {recursive_summarization}, Chunked: {chunked_summarization}, Streaming: {streaming}")
 
     if recursive_summarization and chunked_summarization:

--- a/tldw_Server_API/app/services/web_scraping_service.py
+++ b/tldw_Server_API/app/services/web_scraping_service.py
@@ -60,6 +60,54 @@ _FALLBACK_UNSUPPORTED_CONTROLS = (
     "include_external",
     "score_threshold",
 )
+_ANALYSIS_PROVIDER_REQUIRED_MESSAGE = "Choose an analysis provider before running ingest analysis."
+
+
+def _has_analysis_provider(api_name: Optional[str]) -> bool:
+    provider = str(api_name or "").strip()
+    return bool(provider) and provider.lower() != "none"
+
+
+def _analysis_error_detail(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text.lower().startswith("error:"):
+        return None
+    return text.split(":", 1)[1].strip() or "Analysis failed."
+
+
+def _mark_analysis_state(
+    article: dict[str, Any],
+    field_name: str,
+    status: str,
+    message: str,
+) -> dict[str, Any]:
+    article[field_name] = None
+    article["analysis_status"] = status
+    article["analysis_error"] = message
+    warnings = article.setdefault("warnings", [])
+    if isinstance(warnings, list) and message not in warnings:
+        warnings.append(message)
+    return article
+
+
+def _sanitize_analysis_result(
+    article: dict[str, Any],
+    field_name: str,
+    value: Any,
+) -> bool:
+    detail = _analysis_error_detail(value)
+    if not detail:
+        return False
+    normalized = detail.lower()
+    status = (
+        "skipped"
+        if "provider is required" in normalized or "no api specified" in normalized
+        else "failed"
+    )
+    _mark_analysis_state(article, field_name, status, detail)
+    return True
 
 
 def _normalize_strategy_value(crawl_strategy: Optional[str]) -> Optional[str]:
@@ -424,17 +472,31 @@ async def process_web_scraping_task(
                 for article in result_list:
                     content = article.get("content", "")
                     if content:
-                        summary = analyze(
-                            input_data=content,
-                            custom_prompt_arg=custom_prompt or "",
-                            api_name=api_name,
-                            api_key=api_key,
-                            temp=temperature,
-                            system_message=system_prompt or "",
-                        )
-                        article["summary"] = summary
+                        if not _has_analysis_provider(api_name):
+                            _mark_analysis_state(
+                                article,
+                                "summary",
+                                "skipped",
+                                _ANALYSIS_PROVIDER_REQUIRED_MESSAGE,
+                            )
+                        else:
+                            summary = analyze(
+                                input_data=content,
+                                custom_prompt_arg=custom_prompt or "",
+                                api_name=api_name,
+                                api_key=api_key,
+                                temp=temperature,
+                                system_message=system_prompt or "",
+                            )
+                            if not _sanitize_analysis_result(article, "summary", summary):
+                                article["summary"] = summary
                     else:
-                        article["summary"] = "No content to summarize."
+                        _mark_analysis_state(article, "summary", "skipped", "No content to summarize.")
+
+            for article in result_list:
+                if isinstance(article, dict):
+                    _sanitize_analysis_result(article, "summary", article.get("summary"))
+                    _sanitize_analysis_result(article, "analysis", article.get("analysis"))
 
             # 3) If "persist" mode, insert into DB; if ephemeral, store ephemeral
             #    (We can store all articles in the DB or ephemeral. Typically you'd store each as a new "media" row.)
@@ -666,17 +728,26 @@ async def ingest_web_content_orchestrate(
 
         content = article.get("content", "")
         if not content:
-            article["analysis"] = "No content to analyze."
-            return article
+            return _mark_analysis_state(article, "analysis", "skipped", "No content to analyze.")
+
+        api_name = getattr(request, "api_name", None)
+        if not _has_analysis_provider(api_name):
+            return _mark_analysis_state(
+                article,
+                "analysis",
+                "skipped",
+                _ANALYSIS_PROVIDER_REQUIRED_MESSAGE,
+            )
 
         analysis_results = analyze(
             input_data=content,
             custom_prompt_arg=getattr(request, "custom_prompt", None) or "Summarize this article.",
-            api_name=getattr(request, "api_name", None),
+            api_name=api_name,
             temp=0.7,
             system_message=getattr(request, "system_prompt", None) or "Act as a professional summarizer.",
         )
-        article["analysis"] = analysis_results
+        if not _sanitize_analysis_result(article, "analysis", analysis_results):
+            article["analysis"] = analysis_results
 
         if getattr(request, "perform_rolling_summarization", False):
             logging.info("Performing rolling summarization (placeholder).")

--- a/tldw_Server_API/tests/LLM_Calls/test_summarization_adapter.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_summarization_adapter.py
@@ -6,6 +6,21 @@ from tldw_Server_API.app.core.LLM_Calls import Summarization_General_Lib as sgl
 import tldw_Server_API.app.core.LLM_Calls.providers.openai_adapter as openai_mod
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize("api_name", [None, "", "   ", "none", "None"])
+def test_analyze_returns_clear_error_when_api_name_missing(api_name: str | None) -> None:
+    """Missing analysis providers return a clear error instead of leaking dispatch internals."""
+    result = sgl.analyze(
+        api_name=api_name,
+        input_data="hello",
+        custom_prompt_arg="summarize",
+    )
+
+    assert result == "Error: Analysis API provider is required."
+    assert "NoneType" not in result
+    assert "Error calling API" not in result
+
+
 class _FakeResp:
     def __init__(self, *, json_data=None, lines=None):
         self._json = json_data or {}

--- a/tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import pytest
 from fastapi import HTTPException
 
+from tldw_Server_API.app.api.v1.schemas.media_request_models import IngestWebContentRequest
 from tldw_Server_API.app.services import web_scraping_service as ws_service
 from tldw_Server_API.app.services.ephemeral_store import EphemeralStorage
 
@@ -42,6 +43,11 @@ def _force_fallback(monkeypatch):
         raise RuntimeError("enhanced service unavailable in test")
 
     monkeypatch.setattr(ws_service, "get_web_scraping_service", _raise, raising=True)
+
+
+class _UsageLog:
+    def log_event(self, *args, **kwargs):
+        pass
 
 
 @pytest.fixture(autouse=True)
@@ -131,6 +137,84 @@ async def test_fallback_url_level_ephemeral_smoke_applies_max_pages_cap(monkeypa
     assert fallback_context["enabled"] is True
     assert fallback_context["trigger_error_type"] == "RuntimeError"
     assert "max_pages" in fallback_context["degraded_controls_applied"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_web_content_skips_analysis_without_provider(monkeypatch):
+    async def fake_scrape_article(url, custom_cookies=None):
+        return {
+            "url": url,
+            "title": "Example",
+            "content": "article body",
+            "extraction_successful": True,
+        }
+
+    def fail_analyze(**kwargs):
+        raise AssertionError("analysis should not run without a provider")
+
+    monkeypatch.setattr(ws_service, "scrape_article", fake_scrape_article, raising=True)
+    monkeypatch.setattr(ws_service, "analyze", fail_analyze, raising=True)
+
+    result = await ws_service.ingest_web_content_orchestrate(
+        request=IngestWebContentRequest(
+            urls=["https://example.com/a"],
+            perform_analysis=True,
+            api_name=None,
+        ),
+        db=object(),
+        usage_log=_UsageLog(),
+    )
+
+    assert result is not None
+    assert result[0]["analysis"] is None
+    assert result[0]["analysis_status"] == "skipped"
+    assert result[0]["analysis_error"] == "Choose an analysis provider before running ingest analysis."
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_summarization_error_is_not_returned_as_summary(monkeypatch):
+    _force_fallback(monkeypatch)
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return [
+            {
+                "url": "https://example.com/a",
+                "title": "A",
+                "content": "content",
+                "extraction_successful": True,
+            }
+        ]
+
+    monkeypatch.setattr(ws_service.asyncio, "to_thread", fake_to_thread, raising=True)
+    monkeypatch.setattr(
+        ws_service,
+        "analyze",
+        lambda **_kwargs: "Error: Analysis API provider is required.",
+        raising=True,
+    )
+    monkeypatch.setattr(
+        ws_service.ephemeral_storage,
+        "store_data",
+        lambda data: "ephemeral-analysis-error-id",
+        raising=True,
+    )
+
+    result = await ws_service.process_web_scraping_task(
+        **_base_kwargs(
+            scrape_method="URL Level",
+            url_level=2,
+            summarize_checkbox=True,
+            api_name="openai",
+            mode="ephemeral",
+        )
+    )
+
+    article = result["results"][0]
+    assert article["summary"] is None
+    assert article["analysis_status"] == "skipped"
+    assert article["analysis_error"] == "Analysis API provider is required."
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Guard legacy summarization analysis against missing API provider values before dispatch
- Return a clear `Error: Analysis API provider is required.` message instead of leaking `NoneType.lower`
- Add regression coverage for `None`, blank, whitespace, and `none` provider values

## Verification
- `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Calls/test_summarization_adapter.py tldw_Server_API/tests/LLM_Calls/test_local_summarization_config.py -q`
- `source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/LLM_Calls/Summarization_General_Lib.py -f json -o /tmp/bandit_task_12915_clean_worktree.json`
- `git diff --cached --check`

## Backlog
- TASK-12915

## Change summary
This change fixes the root cause at the shared analyzer entrypoint so every caller gets the same missing-provider behavior. The test covers the reported `None` case plus the common empty and `none` aliases while leaving valid provider dispatch unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing analysis provider handling end-to-end: returns a clear backend error, blocks Quick Ingest runs without a provider, and surfaces recoverable warnings in the UI. Addresses TASK-12915 and TASK-12916 with backend guards, UI preflight checks, and regression tests.

- **Bug Fixes**
  - Backend: `analyze` accepts optional provider and returns "Error: Analysis API provider is required."; web ingest marks missing-provider runs as `skipped` with `analysis_error`, and sanitizes analyzer "Error:" strings instead of storing them as content.
  - UI: Quick Ingest preflights analysis and warns/block when no `api_name`; result rows show analysis warnings; analysis error text is not shown as generated analysis.
  - Media Analysis: maps provider-missing failures to a clear "Choose an analysis provider, then retry analysis." message.
  - Tests: added focused frontend and backend coverage for missing-provider paths and warning propagation.

<sup>Written for commit e204d26cce466ddb3ca730087f83d88f3399c7e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

