### PR TITLE
Harden settings UX after IA split

### DIFF
--- a/apps/packages/ui/src/components/Layouts/SettingsOptionLayout.tsx
+++ b/apps/packages/ui/src/components/Layouts/SettingsOptionLayout.tsx
@@ -134,7 +134,7 @@ export const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <div className="flex min-h-screen w-full min-w-0 flex-col">
-      <main className="relative w-full min-w-0 flex-1">
+      <div className="relative w-full min-w-0 flex-1">
         <div className="mx-auto w-full h-full custom-scrollbar overflow-y-auto">
           <div className="flex min-w-0 flex-col lg:flex-row lg:gap-x-16 lg:px-24">
             <aside className="lg:sticky lg:mt-0 mt-14 lg:top-0 z-20 min-w-0 bg-surface border-b border-border lg:w-64 lg:shrink-0 lg:border-0 lg:bg-transparent">
@@ -322,7 +322,10 @@ export const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
                 ) : null}
               </nav>
             </aside>
-            <main className="relative min-w-0 flex-1 px-4 py-8 sm:px-6 lg:px-0 lg:py-20">
+            <section
+              className="relative min-w-0 flex-1 px-4 py-8 sm:px-6 lg:px-0 lg:py-20"
+              aria-labelledby="settings-route-heading"
+            >
               {/* Close button over right of content area */}
               <div className="absolute right-4 top-4 lg:right-0 lg:top-6 lg:translate-x-[-1rem]">
                 <button
@@ -343,7 +346,10 @@ export const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
                 </button>
               </div>
               <div className="mx-auto w-full min-w-0 max-w-4xl space-y-8 sm:space-y-10">
-                <h1 className="text-2xl font-semibold text-text">
+                <h1
+                  id="settings-route-heading"
+                  className="text-2xl font-semibold text-text"
+                >
                   {routeHeadingLabel}
                 </h1>
                 {currentBreadcrumbLabel ? (
@@ -368,10 +374,10 @@ export const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
                 ) : null}
                 {children}
               </div>
-            </main>
+            </section>
           </div>
         </div>
-      </main>
+      </div>
     </div>
   );
 };

--- a/apps/packages/ui/src/components/Layouts/__tests__/settings-layout-focus-order.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/settings-layout-focus-order.test.tsx
@@ -203,4 +203,16 @@ describe("settings navigation wayfinding", () => {
       "min-w-max",
     );
   });
+
+  it("does not add main landmarks inside the app shell", () => {
+    const { container } = renderSettingsLayout("/settings/tldw");
+
+    expect(container.querySelector("main")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "settings:tldw.serverNav",
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx
@@ -93,6 +93,9 @@ describe("DataManagementSettings", () => {
     expect(screen.getByRole("button", { name: /export data/i })).toBeInTheDocument()
     expect(screen.getByText(/import data/i)).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /reset all/i })).toBeInTheDocument()
+    expect(screen.getByText(/exports a json backup/i)).toBeInTheDocument()
+    expect(screen.getByText(/import adds or updates local webui and extension data/i)).toBeInTheDocument()
+    expect(screen.getByText(/permanently deletes local chat history/i)).toBeInTheDocument()
   })
 
   it("opens the hidden import file input from a keyboard-focusable button", () => {

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/PreferencesSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/PreferencesSettings.test.tsx
@@ -57,7 +57,7 @@ describe("PreferencesSettings", () => {
   })
 
   it("owns personal defaults and web search without setup, theme, OCR, extension promo, or destructive reset", () => {
-    render(
+    const { container } = render(
       <MemoryRouter>
         <PreferencesSettings />
       </MemoryRouter>
@@ -82,5 +82,6 @@ describe("PreferencesSettings", () => {
     expect(
       screen.queryByRole("button", { name: /reset all/i })
     ).not.toBeInTheDocument()
+    expect(container.querySelector("dl")).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/UiCustomizationSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/UiCustomizationSettings.test.tsx
@@ -30,4 +30,13 @@ describe("UiCustomizationSettings", () => {
     expect(screen.getByText("Theme picker")).toBeInTheDocument()
     expect(screen.getByText("System basics")).toBeInTheDocument()
   })
+
+  it("keeps dense shortcut and display controls collapsed by default", () => {
+    render(<UiCustomizationSettings />)
+
+    expect(screen.getByTestId("sidebar-shortcuts-disclosure")).not.toHaveAttribute("open")
+    expect(screen.getByTestId("playground-shortcuts-disclosure")).not.toHaveAttribute("open")
+    expect(screen.getByTestId("theme-display-disclosure")).not.toHaveAttribute("open")
+    expect(screen.getByTestId("system-display-disclosure")).not.toHaveAttribute("open")
+  })
 })

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/UiCustomizationSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/UiCustomizationSettings.test.tsx
@@ -39,4 +39,12 @@ describe("UiCustomizationSettings", () => {
     expect(screen.getByTestId("theme-display-disclosure")).not.toHaveAttribute("open")
     expect(screen.getByTestId("system-display-disclosure")).not.toHaveAttribute("open")
   })
+
+  it("keeps native disclosure summaries free of invalid block markup", () => {
+    const { container } = render(<UiCustomizationSettings />)
+
+    for (const summary of container.querySelectorAll("summary")) {
+      expect(summary.querySelector("div, p")).toBeNull()
+    }
+  })
 })

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/UiCustomizationSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/UiCustomizationSettings.test.tsx
@@ -45,6 +45,7 @@ describe("UiCustomizationSettings", () => {
 
     for (const summary of container.querySelectorAll("summary")) {
       expect(summary.querySelector("div, p")).toBeNull()
+      expect(summary.className).toContain("[&::-webkit-details-marker]:hidden")
     }
   })
 })

--- a/apps/packages/ui/src/components/Option/Settings/preferences-settings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/preferences-settings.tsx
@@ -47,7 +47,7 @@ export const PreferencesSettings = () => {
   }
 
   return (
-    <dl className="flex flex-col space-y-6 text-sm">
+    <div className="flex flex-col space-y-6 text-sm">
       <div>
         <h2 className="text-base font-semibold leading-7 text-text">
           {t("preferencesSettings.title", "General preferences")}
@@ -239,7 +239,7 @@ export const PreferencesSettings = () => {
       </div>
 
       <SearchModeSettings />
-    </dl>
+    </div>
   )
 }
 

--- a/apps/packages/ui/src/components/Option/Settings/search-mode.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/search-mode.tsx
@@ -78,7 +78,7 @@ export const SearchModeSettings = () => {
           </span>
           <div>
             <Select
-              aria-label={t("generalSettings.webSearch.provider.label")}
+              aria-label={t("generalSettings.webSearch.provider.label", "Web Search Provider")}
               placeholder={t("generalSettings.webSearch.provider.placeholder")}
               showSearch
               className="w-full mt-4 sm:mt-0 sm:w-[200px]"
@@ -99,7 +99,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Input
-                  aria-label={t("generalSettings.webSearch.searxng.url.label")}
+                  aria-label={t("generalSettings.webSearch.searxng.url.label", "SearXNG URL")}
                   placeholder="https://searxng.example.com"
                   className="w-full mt-4 sm:mt-0 sm:w-[200px]"
                   required
@@ -117,7 +117,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Select
-                  aria-label={t("generalSettings.webSearch.googleDomain.label")}
+                  aria-label={t("generalSettings.webSearch.googleDomain.label", "Google Domain")}
                   showSearch
                   className="w-full mt-4 sm:mt-0 sm:w-[200px]"
                   options={ALL_GOOGLE_DOMAINS.map((e) => ({
@@ -144,7 +144,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Input.Password
-                  aria-label={t("generalSettings.webSearch.braveApi.label")}
+                  aria-label={t("generalSettings.webSearch.braveApi.label", "Brave API Key")}
                   placeholder={t(
                     "generalSettings.webSearch.braveApi.placeholder"
                   )}
@@ -164,7 +164,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Input.Password
-                  aria-label={t("generalSettings.webSearch.tavilyApi.label")}
+                  aria-label={t("generalSettings.webSearch.tavilyApi.label", "Tavily API Key")}
                   placeholder={t(
                     "generalSettings.webSearch.tavilyApi.placeholder"
                   )}
@@ -185,7 +185,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Input.Password
-                  aria-label={t("generalSettings.webSearch.exa.label")}
+                  aria-label={t("generalSettings.webSearch.exa.label", "Exa API Key")}
                   placeholder={t("generalSettings.webSearch.exa.placeholder")}
                   required
                   className="w-full mt-4 sm:mt-0 sm:w-[200px]"
@@ -204,7 +204,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Input.Password
-                  aria-label={t("generalSettings.webSearch.firecrawlAPIKey.label")}
+                  aria-label={t("generalSettings.webSearch.firecrawlAPIKey.label", "Firecrawl API Key")}
                   placeholder={t(
                     "generalSettings.webSearch.firecrawlAPIKey.placeholder"
                   )}
@@ -224,7 +224,7 @@ export const SearchModeSettings = () => {
           <div>
             <Switch
               className="mt-4 sm:mt-0"
-              aria-label={t("generalSettings.webSearch.searchMode.label")}
+              aria-label={t("generalSettings.webSearch.searchMode.label", "Search Mode")}
               {...form.getInputProps("isSimpleInternetSearch", {
                 type: "checkbox"
               })}
@@ -237,7 +237,7 @@ export const SearchModeSettings = () => {
           </span>
           <div>
             <InputNumber
-              aria-label={t("generalSettings.webSearch.totalSearchResults.label")}
+              aria-label={t("generalSettings.webSearch.totalSearchResults.label", "Total Search Results")}
               placeholder={t(
                 "generalSettings.webSearch.totalSearchResults.placeholder"
               )}
@@ -254,7 +254,7 @@ export const SearchModeSettings = () => {
           <div>
             <Switch
               className="mt-4 sm:mt-0"
-              aria-label={t("generalSettings.webSearch.visitSpecificWebsite.label")}
+              aria-label={t("generalSettings.webSearch.visitSpecificWebsite.label", "Visit Specific Website")}
               {...form.getInputProps("visitSpecificWebsite", {
                 type: "checkbox"
               })}
@@ -269,7 +269,7 @@ export const SearchModeSettings = () => {
           <div>
             <Switch
               className="mt-4 sm:mt-0"
-              aria-label={t("generalSettings.webSearch.searchOnByDefault.label")}
+              aria-label={t("generalSettings.webSearch.searchOnByDefault.label", "Search On By Default")}
               {...form.getInputProps("defaultInternetSearchOn", {
                 type: "checkbox"
               })}

--- a/apps/packages/ui/src/components/Option/Settings/search-mode.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/search-mode.tsx
@@ -78,6 +78,7 @@ export const SearchModeSettings = () => {
           </span>
           <div>
             <Select
+              aria-label={t("generalSettings.webSearch.provider.label")}
               placeholder={t("generalSettings.webSearch.provider.placeholder")}
               showSearch
               className="w-full mt-4 sm:mt-0 sm:w-[200px]"
@@ -98,6 +99,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Input
+                  aria-label={t("generalSettings.webSearch.searxng.url.label")}
                   placeholder="https://searxng.example.com"
                   className="w-full mt-4 sm:mt-0 sm:w-[200px]"
                   required
@@ -115,6 +117,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Select
+                  aria-label={t("generalSettings.webSearch.googleDomain.label")}
                   showSearch
                   className="w-full mt-4 sm:mt-0 sm:w-[200px]"
                   options={ALL_GOOGLE_DOMAINS.map((e) => ({
@@ -141,6 +144,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Input.Password
+                  aria-label={t("generalSettings.webSearch.braveApi.label")}
                   placeholder={t(
                     "generalSettings.webSearch.braveApi.placeholder"
                   )}
@@ -160,6 +164,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Input.Password
+                  aria-label={t("generalSettings.webSearch.tavilyApi.label")}
                   placeholder={t(
                     "generalSettings.webSearch.tavilyApi.placeholder"
                   )}
@@ -180,6 +185,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Input.Password
+                  aria-label={t("generalSettings.webSearch.exa.label")}
                   placeholder={t("generalSettings.webSearch.exa.placeholder")}
                   required
                   className="w-full mt-4 sm:mt-0 sm:w-[200px]"
@@ -198,6 +204,7 @@ export const SearchModeSettings = () => {
               </span>
               <div>
                 <Input.Password
+                  aria-label={t("generalSettings.webSearch.firecrawlAPIKey.label")}
                   placeholder={t(
                     "generalSettings.webSearch.firecrawlAPIKey.placeholder"
                   )}
@@ -230,6 +237,7 @@ export const SearchModeSettings = () => {
           </span>
           <div>
             <InputNumber
+              aria-label={t("generalSettings.webSearch.totalSearchResults.label")}
               placeholder={t(
                 "generalSettings.webSearch.totalSearchResults.placeholder"
               )}

--- a/apps/packages/ui/src/components/Option/Settings/system-settings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/system-settings.tsx
@@ -172,11 +172,17 @@ export const DataManagementSettings = () => {
         )
       })
     },
-    onError: () => {
+    onError: (error) => {
+      console.error("Firefox data sync error:", error)
+      const errorMsg = error instanceof Error ? error.message : String(error)
       notification.error({
         message: t(
           "settings:systemNotifications.syncError",
           "Firefox data sync failed"
+        ),
+        description: errorMsg || t(
+          "settings:systemNotifications.syncErrorDetail",
+          "Firefox data could not be synced for private mode."
         )
       })
     }
@@ -310,7 +316,7 @@ export const DataManagementSettings = () => {
 
         <button
           onClick={() => setResetModalOpen(true)}
-          className="w-full rounded-md bg-red-700 px-4 py-2 text-white transition hover:bg-red-800 sm:w-auto">
+          className="w-full rounded-md bg-danger px-4 py-2 text-white transition hover:brightness-90 sm:w-auto">
           {t("generalSettings.systemData.deleteChatHistory.button", { defaultValue: t("generalSettings.system.deleteChatHistory.button", { defaultValue: "Reset All" }) as string })}
         </button>
       </div>

--- a/apps/packages/ui/src/components/Option/Settings/system-settings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/system-settings.tsx
@@ -172,7 +172,7 @@ export const DataManagementSettings = () => {
         )
       })
     },
-    onError: (error) => {
+    onError: () => {
       notification.error({
         message: t(
           "settings:systemNotifications.syncError",
@@ -223,7 +223,7 @@ export const DataManagementSettings = () => {
               })
             }}
             disabled={syncFirefoxData.isPending}
-            className="cursor-pointer rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong w-full sm:w-auto">
+            className="cursor-pointer rounded-md bg-primaryStrong px-4 py-2 text-white transition hover:brightness-95 w-full sm:w-auto">
             {syncFirefoxData.isPending ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             ) : (
@@ -235,27 +235,43 @@ export const DataManagementSettings = () => {
         </div>
       )}
 
-      <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
-        <span className="text-text">
-          {t("generalSettings.systemData.export.label", { defaultValue: t("generalSettings.system.export.label", { defaultValue: "Export Chat History, Knowledge Base, and Prompts" }) as string })}
-        </span>
+      <div className="flex flex-col sm:flex-row mb-4 gap-3 sm:gap-0 sm:justify-between sm:items-center">
+        <div className="space-y-1">
+          <span className="text-text">
+            {t("generalSettings.systemData.export.label", { defaultValue: t("generalSettings.system.export.label", { defaultValue: "Export Chat History, Knowledge Base, and Prompts" }) as string })}
+          </span>
+          <p className="max-w-xl text-xs text-text-muted">
+            {t(
+              "generalSettings.systemData.export.description",
+              "Exports a JSON backup of local chat history, prompts, model nicknames, and custom models."
+            )}
+          </p>
+        </div>
         <button
           onClick={exportPageAssistData}
-          className="cursor-pointer rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong w-full sm:w-auto">
+          className="cursor-pointer rounded-md bg-primaryStrong px-4 py-2 text-white transition hover:brightness-95 w-full sm:w-auto">
           {t("generalSettings.systemData.export.button", { defaultValue: t("generalSettings.system.export.button", { defaultValue: "Export Data" }) as string })}
         </button>
       </div>
 
-      <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
-        <span className="text-text">
-          {t("generalSettings.systemData.import.label", { defaultValue: t("generalSettings.system.import.label", { defaultValue: "Import Chat History, Knowledge Base, and Prompts" }) as string })}
-        </span>
+      <div className="flex flex-col sm:flex-row mb-4 gap-3 sm:gap-0 sm:justify-between sm:items-center">
+        <div className="space-y-1">
+          <span className="text-text">
+            {t("generalSettings.systemData.import.label", { defaultValue: t("generalSettings.system.import.label", { defaultValue: "Import Chat History, Knowledge Base, and Prompts" }) as string })}
+          </span>
+          <p className="max-w-xl text-xs text-text-muted">
+            {t(
+              "generalSettings.systemData.import.description",
+              "Import adds or updates local WebUI and extension data from the selected JSON backup, then reloads the page."
+            )}
+          </p>
+        </div>
         <button
           type="button"
           disabled={importDataMutation.isPending}
           aria-disabled={importDataMutation.isPending}
           onClick={() => importInputRef.current?.click()}
-          className="flex w-full cursor-pointer items-center justify-center rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto">
+          className="flex w-full cursor-pointer items-center justify-center rounded-md bg-primaryStrong px-4 py-2 text-white transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto">
           {importDataMutation.isPending ? (
             <>
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -279,14 +295,22 @@ export const DataManagementSettings = () => {
         />
       </div>
 
-      <div className="flex flex-col sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
-        <span className="text-text">
-          {t("generalSettings.systemData.deleteChatHistory.label", { defaultValue: t("generalSettings.system.deleteChatHistory.label", { defaultValue: "System Reset" }) as string })}
-        </span>
+      <div className="flex flex-col rounded-md border border-danger/40 bg-danger/5 p-4 sm:flex-row mb-3 gap-3 sm:gap-0 sm:justify-between sm:items-center">
+        <div className="space-y-1">
+          <span className="font-medium text-danger">
+            {t("generalSettings.systemData.deleteChatHistory.label", { defaultValue: t("generalSettings.system.deleteChatHistory.label", { defaultValue: "System Reset" }) as string })}
+          </span>
+          <p className="max-w-xl text-xs text-text-muted">
+            {t(
+              "generalSettings.systemData.deleteChatHistory.description",
+              "Permanently deletes local chat history, knowledge base items, prompts, custom models, settings, and session storage."
+            )}
+          </p>
+        </div>
 
         <button
           onClick={() => setResetModalOpen(true)}
-          className="w-full rounded-md bg-danger px-4 py-2 text-white transition-colors hover:bg-danger sm:w-auto">
+          className="w-full rounded-md bg-red-700 px-4 py-2 text-white transition hover:bg-red-800 sm:w-auto">
           {t("generalSettings.systemData.deleteChatHistory.button", { defaultValue: t("generalSettings.system.deleteChatHistory.button", { defaultValue: "Reset All" }) as string })}
         </button>
       </div>
@@ -489,6 +513,7 @@ export const SystemSettings = () => {
           {t("generalSettings.systemBasics.uiMode.label", { defaultValue: "Default UI Mode" })}
         </span>
         <Select
+          aria-label={t("generalSettings.systemBasics.uiMode.label", { defaultValue: "Default UI Mode" })}
           options={[
             { label: t("generalSettings.systemBasics.uiMode.options.sidePanel", { defaultValue: "Sidebar" }), value: "sidePanel" },
             { label: t("generalSettings.systemBasics.uiMode.options.webui", { defaultValue: "Full Screen (Web UI)" }), value: "webui" }
@@ -511,7 +536,10 @@ export const SystemSettings = () => {
         <div className="flex flex-row items-center gap-3 justify-center sm:justify-end">
           <button
             onClick={decrease}
-            className="rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-white transition-colors duration-200 hover:bg-primaryStrong"
+            aria-label={t("generalSettings.systemBasics.fontSize.decrease", {
+              defaultValue: "Decrease font size"
+            })}
+            className="rounded-lg bg-primaryStrong px-3 py-1.5 text-sm font-medium text-white transition duration-200 hover:brightness-95"
           >
             A-
           </button>
@@ -520,7 +548,10 @@ export const SystemSettings = () => {
           </span>
           <button
             onClick={increase}
-            className="rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-white transition-colors duration-200 hover:bg-primaryStrong"
+            aria-label={t("generalSettings.systemBasics.fontSize.increase", {
+              defaultValue: "Increase font size"
+            })}
+            className="rounded-lg bg-primaryStrong px-3 py-1.5 text-sm font-medium text-white transition duration-200 hover:brightness-95"
           >
             A+
           </button>{" "}
@@ -535,6 +566,9 @@ export const SystemSettings = () => {
         </span>
         <div className="w-full sm:w-[320px] flex flex-col gap-2">
           <Select
+            aria-label={t("generalSettings.systemBasics.codeTheme.label", {
+              defaultValue: "Code block theme"
+            })}
             className="w-full"
             value={codeTheme}
             onChange={setCodeTheme}
@@ -565,7 +599,7 @@ export const SystemSettings = () => {
                 </div>
                 <Highlight
                   code={sampleCode}
-                  language={"tsx" as any}
+                  language="tsx"
                   theme={resolvePreviewTheme(opt.value)}>
                   {({ className, style, tokens, getLineProps, getTokenProps }) => (
                     <pre
@@ -601,6 +635,7 @@ export const SystemSettings = () => {
           {t("generalSettings.systemBasics.actionIcon.label", { defaultValue: t("generalSettings.system.actionIcon.label", { defaultValue: "Browser Action Button" }) as string })}
         </span>
         <Select
+          aria-label={t("generalSettings.systemBasics.actionIcon.label", { defaultValue: t("generalSettings.system.actionIcon.label", { defaultValue: "Browser Action Button" }) as string })}
           options={[
             {
               label: "Open Web UI",
@@ -624,6 +659,7 @@ export const SystemSettings = () => {
           {t("generalSettings.systemBasics.contextMenu.label", { defaultValue: t("generalSettings.system.contextMenu.label", { defaultValue: "Context Menu Action" }) as string })}
         </span>
         <Select
+          aria-label={t("generalSettings.systemBasics.contextMenu.label", { defaultValue: t("generalSettings.system.contextMenu.label", { defaultValue: "Context Menu Action" }) as string })}
           options={[
             {
               label: "Open Web UI",
@@ -647,6 +683,7 @@ export const SystemSettings = () => {
         </span>
          <div>
           <Switch
+          aria-label={t("generalSettings.systemBasics.webuiBtnSidePanel.label", { defaultValue: t("generalSettings.system.webuiBtnSidePanel.label", { defaultValue: "Show Web UI button in Sidebar" }) as string })}
           checked={webuiBtnSidePanel}
           onChange={(checked) => {
             setWebuiBtnSidePanel(checked)
@@ -666,13 +703,16 @@ export const SystemSettings = () => {
               onClick={() => {
                 void setChatBackgroundImage(undefined)
               }}
+              aria-label={t("generalSettings.systemBasics.chatBackgroundImage.clear", {
+                defaultValue: "Remove chat background image"
+              })}
               className="text-text">
               <RotateCcw className="size-4" />
             </button>
           ) : null}
           <label
             htmlFor="background-image-upload"
-            className="inline-flex cursor-pointer gap-2 rounded-md bg-primary px-4 py-2 text-white transition-colors hover:bg-primaryStrong">
+            className="inline-flex cursor-pointer gap-2 rounded-md bg-primaryStrong px-4 py-2 text-white transition hover:brightness-95">
             <Upload className="size-4" />
             {t("knowledge:form.uploadFile.label")}
           </label>

--- a/apps/packages/ui/src/components/Option/Settings/ui-customization.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ui-customization.tsx
@@ -38,9 +38,58 @@ const orderHeaderShortcutSelection = (selection: HeaderShortcutId[]) => {
   )
 }
 
+type SettingsDisclosureProps = {
+  title: string
+  description: string
+  testId: string
+  summaryMeta?: React.ReactNode
+  children: React.ReactNode
+}
+
+const SettingsDisclosure = ({
+  title,
+  description,
+  testId,
+  summaryMeta,
+  children
+}: SettingsDisclosureProps) => {
+  const { t } = useTranslation(["settings", "common"])
+
+  return (
+    <details
+      className="panel-card group p-4"
+      data-testid={testId}
+    >
+      <summary className="flex cursor-pointer list-none flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <span className="block text-sm font-semibold text-text">{title}</span>
+          <p className="text-xs text-text-muted">{description}</p>
+          {summaryMeta ? (
+            <div className="text-xs text-text-muted">{summaryMeta}</div>
+          ) : null}
+        </div>
+        <span className="shrink-0 text-xs font-medium text-primary group-open:hidden">
+          {t("uiCustomization.sections.configure", {
+            defaultValue: "Configure"
+          })}
+        </span>
+        <span className="hidden shrink-0 text-xs font-medium text-text-muted group-open:inline">
+          {t("uiCustomization.sections.expanded", {
+            defaultValue: "Expanded"
+          })}
+        </span>
+      </summary>
+      <div className="mt-4 space-y-3 border-t border-border pt-4">
+        {children}
+      </div>
+    </details>
+  )
+}
+
 type SidebarShortcutSelectorProps = {
   title: string
   description: string
+  testId: string
   selection: SidebarShortcutId[]
   defaultSelection: SidebarShortcutId[]
   onChange: (next: SidebarShortcutId[]) => void
@@ -50,6 +99,7 @@ type SidebarShortcutSelectorProps = {
 const SidebarShortcutSelector = ({
   title,
   description,
+  testId,
   selection,
   defaultSelection,
   onChange,
@@ -88,13 +138,21 @@ const SidebarShortcutSelector = ({
     onChange(next)
   }
 
+  const countLabel = t("uiCustomization.shortcuts.countLabel", {
+    defaultValue: "{{count}} / {{max}} selected",
+    count: selectionCount,
+    max: maxCount
+  })
+
   return (
-    <div className="panel-card p-4 space-y-3">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-text">{title}</h3>
-          <p className="text-xs text-text-muted">{description}</p>
-        </div>
+    <SettingsDisclosure
+      title={title}
+      description={description}
+      testId={testId}
+      summaryMeta={<span>{countLabel}</span>}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-text-muted">
+        <span>{countLabel}</span>
         {isModified && (
           <button
             type="button"
@@ -107,23 +165,14 @@ const SidebarShortcutSelector = ({
           </button>
         )}
       </div>
-      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-text-muted">
-        <span>
-          {t("uiCustomization.shortcuts.countLabel", {
-            defaultValue: "{{count}} / {{max}} selected",
-            count: selectionCount,
+      {selectionCount >= maxCount && (
+        <p className="text-xs text-text-muted">
+          {t("uiCustomization.shortcuts.maxReached", {
+            defaultValue: "You can select up to {{max}} shortcuts.",
             max: maxCount
           })}
-        </span>
-        {selectionCount >= maxCount && (
-          <span>
-            {t("uiCustomization.shortcuts.maxReached", {
-              defaultValue: "You can select up to {{max}} shortcuts.",
-              max: maxCount
-            })}
-          </span>
-        )}
-      </div>
+        </p>
+      )}
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         {SIDEBAR_SHORTCUT_ACTIONS.map((item) => {
           const selected = selectionSet.has(item.id)
@@ -154,13 +203,14 @@ const SidebarShortcutSelector = ({
           )
         })}
       </div>
-    </div>
+    </SettingsDisclosure>
   )
 }
 
 type HeaderShortcutSelectorProps = {
   title: string
   description: string
+  testId: string
   selection: HeaderShortcutId[]
   defaultSelection: HeaderShortcutId[]
   onChange: (next: HeaderShortcutId[]) => void
@@ -169,6 +219,7 @@ type HeaderShortcutSelectorProps = {
 const HeaderShortcutSelector = ({
   title,
   description,
+  testId,
   selection,
   defaultSelection,
   onChange
@@ -198,13 +249,21 @@ const HeaderShortcutSelector = ({
     onChange(next)
   }
 
+  const countLabel = t("uiCustomization.headerShortcuts.countLabel", {
+    defaultValue: "{{count}} of {{total}} selected",
+    count: selectionCount,
+    total: totalCount
+  })
+
   return (
-    <div className="panel-card p-4 space-y-3">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <div className="space-y-1">
-          <h3 className="text-sm font-semibold text-text">{title}</h3>
-          <p className="text-xs text-text-muted">{description}</p>
-        </div>
+    <SettingsDisclosure
+      title={title}
+      description={description}
+      testId={testId}
+      summaryMeta={<span>{countLabel}</span>}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-text-muted">
+        <span>{countLabel}</span>
         {isModified && (
           <button
             type="button"
@@ -216,15 +275,6 @@ const HeaderShortcutSelector = ({
             })}
           </button>
         )}
-      </div>
-      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-text-muted">
-        <span>
-          {t("uiCustomization.headerShortcuts.countLabel", {
-            defaultValue: "{{count}} of {{total}} selected",
-            count: selectionCount,
-            total: totalCount
-          })}
-        </span>
       </div>
       <div className="space-y-3">
         {getHeaderShortcutGroups().map((group) => (
@@ -265,7 +315,7 @@ const HeaderShortcutSelector = ({
           </div>
         ))}
       </div>
-    </div>
+    </SettingsDisclosure>
   )
 }
 
@@ -335,8 +385,10 @@ export const UiCustomizationSettings = () => {
           })}
           description={t("uiCustomization.shortcuts.description", {
             defaultValue:
-              "Choose up to 10 items for the sidebar icons and shortcuts list."
+              "Choose up to {{max}} items for the sidebar icons and shortcuts list.",
+            max: SIDEBAR_SHORTCUT_MAX_COUNT
           })}
+          testId="sidebar-shortcuts-disclosure"
           selection={shortcutSelectionNormalized}
           defaultSelection={DEFAULT_SIDEBAR_SHORTCUT_SELECTION}
           onChange={(next) => void setShortcutSelection(next)}
@@ -350,12 +402,35 @@ export const UiCustomizationSettings = () => {
             defaultValue:
               "Choose which shortcuts appear in the header shortcuts panel."
           })}
+          testId="playground-shortcuts-disclosure"
           selection={headerShortcutSelectionNormalized}
           defaultSelection={DEFAULT_HEADER_SHORTCUT_SELECTION}
           onChange={(next) => void setHeaderShortcutSelection(next)}
         />
-        <ThemePicker />
-        <SystemSettings />
+        <SettingsDisclosure
+          title={t("uiCustomization.theme.title", {
+            defaultValue: "Theme and appearance"
+          })}
+          description={t("uiCustomization.theme.description", {
+            defaultValue:
+              "Choose the app theme, presets, custom palettes, and import or export theme files."
+          })}
+          testId="theme-display-disclosure"
+        >
+          <ThemePicker />
+        </SettingsDisclosure>
+        <SettingsDisclosure
+          title={t("uiCustomization.system.title", {
+            defaultValue: "Display and browser behavior"
+          })}
+          description={t("uiCustomization.system.description", {
+            defaultValue:
+              "Set default layout behavior, text size, code theme, and chat background."
+          })}
+          testId="system-display-disclosure"
+        >
+          <SystemSettings />
+        </SettingsDisclosure>
       </div>
     </div>
   )

--- a/apps/packages/ui/src/components/Option/Settings/ui-customization.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ui-customization.tsx
@@ -60,7 +60,7 @@ const SettingsDisclosure = ({
       className="panel-card group p-4"
       data-testid={testId}
     >
-      <summary className="cursor-pointer list-none">
+      <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden">
         <span className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <span className="block space-y-1">
             <span className="block text-sm font-semibold text-text">

--- a/apps/packages/ui/src/components/Option/Settings/ui-customization.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ui-customization.tsx
@@ -60,23 +60,31 @@ const SettingsDisclosure = ({
       className="panel-card group p-4"
       data-testid={testId}
     >
-      <summary className="flex cursor-pointer list-none flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="space-y-1">
-          <span className="block text-sm font-semibold text-text">{title}</span>
-          <p className="text-xs text-text-muted">{description}</p>
-          {summaryMeta ? (
-            <div className="text-xs text-text-muted">{summaryMeta}</div>
-          ) : null}
-        </div>
-        <span className="shrink-0 text-xs font-medium text-primary group-open:hidden">
-          {t("uiCustomization.sections.configure", {
-            defaultValue: "Configure"
-          })}
-        </span>
-        <span className="hidden shrink-0 text-xs font-medium text-text-muted group-open:inline">
-          {t("uiCustomization.sections.expanded", {
-            defaultValue: "Expanded"
-          })}
+      <summary className="cursor-pointer list-none">
+        <span className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <span className="block space-y-1">
+            <span className="block text-sm font-semibold text-text">
+              {title}
+            </span>
+            <span className="block text-xs text-text-muted">
+              {description}
+            </span>
+            {summaryMeta ? (
+              <span className="block text-xs text-text-muted">
+                {summaryMeta}
+              </span>
+            ) : null}
+          </span>
+          <span className="shrink-0 text-xs font-medium text-primary group-open:hidden">
+            {t("uiCustomization.sections.configure", {
+              defaultValue: "Configure"
+            })}
+          </span>
+          <span className="hidden shrink-0 text-xs font-medium text-text-muted group-open:inline">
+            {t("uiCustomization.sections.expanded", {
+              defaultValue: "Expanded"
+            })}
+          </span>
         </span>
       </summary>
       <div className="mt-4 space-y-3 border-t border-border pt-4">

--- a/apps/packages/ui/src/routes/__tests__/option-settings-route-split.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-settings-route-split.test.tsx
@@ -46,6 +46,21 @@ describe("settings route split", () => {
     expect(dataPageSource).toContain("SettingsRoute")
   })
 
+  it("sets document titles on the hosted settings pages", async () => {
+    const pagePaths = [
+      "../../../../../tldw-frontend/pages/settings/index.tsx",
+      "../../../../../tldw-frontend/pages/settings/preferences.tsx",
+      "../../../../../tldw-frontend/pages/settings/ui.tsx",
+      "../../../../../tldw-frontend/pages/settings/data.tsx"
+    ]
+
+    for (const pagePath of pagePaths) {
+      const source = await readFile(resolve(__dirname, pagePath), "utf8")
+      expect(source).toContain("next/head")
+      expect(source).toContain("<title>")
+    }
+  })
+
   it("lists setup, preferences, and data settings in hosted smoke inventories", async () => {
     const pageMapping = await readFile(
       resolve(__dirname, "../../../../../tldw-frontend/e2e/page-mapping.ts"),

--- a/apps/packages/ui/src/routes/__tests__/option-settings-route-split.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-settings-route-split.test.tsx
@@ -47,17 +47,29 @@ describe("settings route split", () => {
   })
 
   it("sets document titles on the hosted settings pages", async () => {
-    const pagePaths = [
-      "../../../../../tldw-frontend/pages/settings/index.tsx",
-      "../../../../../tldw-frontend/pages/settings/preferences.tsx",
-      "../../../../../tldw-frontend/pages/settings/ui.tsx",
-      "../../../../../tldw-frontend/pages/settings/data.tsx"
+    const pageTitles = [
+      [
+        "../../../../../tldw-frontend/pages/settings/index.tsx",
+        "Setup &amp; Recovery | Settings | tldw"
+      ],
+      [
+        "../../../../../tldw-frontend/pages/settings/preferences.tsx",
+        "Preferences | Settings | tldw"
+      ],
+      [
+        "../../../../../tldw-frontend/pages/settings/ui.tsx",
+        "UI Customization | Settings | tldw"
+      ],
+      [
+        "../../../../../tldw-frontend/pages/settings/data.tsx",
+        "Data Management | Settings | tldw"
+      ]
     ]
 
-    for (const pagePath of pagePaths) {
+    for (const [pagePath, title] of pageTitles) {
       const source = await readFile(resolve(__dirname, pagePath), "utf8")
       expect(source).toContain("next/head")
-      expect(source).toContain("<title>")
+      expect(source).toContain(`<title>${title}</title>`)
     }
   })
 

--- a/apps/tldw-frontend/__tests__/components/layout/WebLayout.backend-unreachable.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/layout/WebLayout.backend-unreachable.test.tsx
@@ -31,6 +31,34 @@ describe("BackendUnavailableModalGate", () => {
     ).toBeInTheDocument()
   })
 
+  it("can render backend-unreachable detail as a non-blocking inline alert", () => {
+    render(
+      <BackendUnavailableModalGate
+        backendUnavailableDetail={{
+          method: "GET",
+          path: "/api/v1/llm/models/metadata",
+          message: "Failed to fetch",
+          source: "direct",
+          timestamp: Date.now()
+        }}
+        fatalBackendRecoveryActive={false}
+        isChecking={false}
+        onClose={vi.fn()}
+        onOpenHealth={vi.fn()}
+        onRetry={vi.fn()}
+        presentation="inline"
+        t={(key: string, fallback?: string) => fallback ?? key}
+      />
+    )
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("status", { name: "Can't reach your tldw server" })
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument()
+  })
+
   it("suppresses the modal while a fatal backend recovery takeover is active", () => {
     render(
       <BackendUnavailableModalGate

--- a/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
@@ -467,6 +467,37 @@ describe('WebLayout /chat scroll contract', () => {
     );
   });
 
+  it('does not treat settings-prefixed non-settings routes as settings routes', async () => {
+    routerState.location.pathname = '/settings-wizard';
+
+    render(
+      <OptionLayout>
+        <div data-testid="route-content">Settings wizard route</div>
+      </OptionLayout>
+    );
+
+    await act(async () => undefined);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('tldw:backend-unreachable', {
+          detail: {
+            method: 'GET',
+            path: '/api/v1/llm/models/metadata',
+            message: 'Failed to fetch',
+            source: 'direct',
+            timestamp: Date.now(),
+          },
+        })
+      );
+    });
+
+    expect(screen.getByTestId('backend-unavailable-modal')).toHaveAttribute(
+      'data-presentation',
+      'modal'
+    );
+  });
+
   it('marks the /chat route shell as transcript-owned when sticky chat input is active', () => {
     const html = renderToStaticMarkup(
       <OptionLayout hideSidebar>

--- a/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
@@ -311,7 +311,12 @@ vi.mock('@/components/Common/BackendRecoveryUiContext', () => ({
 vi.mock('@web/components/layout/BackendUnavailableModalGate', () => ({
   BackendUnavailableModalGate: (props: Record<string, unknown>) => {
     backendUnavailableGateState.props.push(props);
-    return props.backendUnavailableDetail ? <div data-testid="backend-unavailable-modal" /> : null;
+    return props.backendUnavailableDetail ? (
+      <div
+        data-presentation={String(props.presentation)}
+        data-testid="backend-unavailable-modal"
+      />
+    ) : null;
   },
 }));
 
@@ -401,7 +406,10 @@ describe('WebLayout /chat scroll contract', () => {
     });
 
     expect(connectionState.value.checkOnce).toHaveBeenCalledWith({ force: true });
-    expect(screen.getByTestId('backend-unavailable-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('backend-unavailable-modal')).toHaveAttribute(
+      'data-presentation',
+      'modal'
+    );
 
     connectionState.value.isChecking = true;
     rerender(
@@ -421,6 +429,42 @@ describe('WebLayout /chat scroll contract', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('backend-unavailable-modal')).toBeNull();
     });
+  });
+
+  it('uses the non-blocking backend-unreachable presentation on settings routes', async () => {
+    routerState.location.pathname = '/settings/ui';
+
+    render(
+      <OptionLayout>
+        <div data-testid="route-content">Settings UI route</div>
+      </OptionLayout>
+    );
+
+    await act(async () => undefined);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('tldw:backend-unreachable', {
+          detail: {
+            method: 'GET',
+            path: '/api/v1/llm/models/metadata',
+            message: 'Failed to fetch',
+            source: 'direct',
+            timestamp: Date.now(),
+          },
+        })
+      );
+    });
+
+    expect(screen.getByTestId('backend-unavailable-modal')).toHaveAttribute(
+      'data-presentation',
+      'inline'
+    );
+    const latestGateProps =
+      backendUnavailableGateState.props[backendUnavailableGateState.props.length - 1];
+    expect(latestGateProps).toEqual(
+      expect.objectContaining({ presentation: 'inline' })
+    );
   });
 
   it('marks the /chat route shell as transcript-owned when sticky chat input is active', () => {

--- a/apps/tldw-frontend/__tests__/extension/settings-route-landmark.test.tsx
+++ b/apps/tldw-frontend/__tests__/extension/settings-route-landmark.test.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("~/components/Layouts/SettingsOptionLayout", () => ({
+  SettingsLayout: ({ children }: { children: React.ReactNode }) => (
+    <section data-testid="settings-layout">{children}</section>
+  )
+}))
+
+vi.mock("@/components/Common/RouteErrorBoundary", () => ({
+  RouteErrorBoundary: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  )
+}))
+
+import { SettingsRoute } from "@web/extension/routes/settings-route"
+
+describe("extension settings route", () => {
+  it("provides one main landmark around settings content", () => {
+    render(
+      <SettingsRoute>
+        <div>Extension settings</div>
+      </SettingsRoute>
+    )
+
+    const main = screen.getByRole("main")
+
+    expect(main).toContainElement(screen.getByTestId("settings-layout"))
+    expect(main).toHaveTextContent("Extension settings")
+  })
+})

--- a/apps/tldw-frontend/components/layout/BackendUnavailableModalGate.tsx
+++ b/apps/tldw-frontend/components/layout/BackendUnavailableModalGate.tsx
@@ -12,6 +12,7 @@ export type BackendUnavailableModalGateProps = {
   onConsumeHiddenDetail?: () => void
   onOpenHealth: () => void
   onRetry: () => void
+  presentation?: "modal" | "inline"
   t: TFunction
 }
 
@@ -25,20 +26,74 @@ export const BackendUnavailableModalGate: React.FC<
   onConsumeHiddenDetail,
   onOpenHealth,
   onRetry,
+  presentation = "modal",
   t
 }) => {
+  const inlineTitleId = React.useId()
+
   React.useEffect(() => {
     if (fatalBackendRecoveryActive && backendUnavailableDetail) {
       onConsumeHiddenDetail?.()
     }
   }, [backendUnavailableDetail, fatalBackendRecoveryActive, onConsumeHiddenDetail])
 
+  const title = t(
+    "sidepanel:connectionBanner.unreachableTitle",
+    "Can't reach your tldw server"
+  )
+  const body = t(
+    "sidepanel:connectionBanner.unreachableBody",
+    "Check that your server is running and accessible."
+  )
+
+  if (presentation === "inline") {
+    if (!backendUnavailableDetail || fatalBackendRecoveryActive) return null
+
+    return (
+      <div
+        role="status"
+        aria-labelledby={inlineTitleId}
+        aria-live="polite"
+        className="fixed bottom-4 right-4 z-[1000] w-[min(24rem,calc(100vw-2rem))] rounded-md border border-border bg-surface p-4 text-text shadow-lg sm:bottom-auto sm:top-24"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p id={inlineTitleId} className="text-sm font-semibold">
+              {title}
+            </p>
+            <p className="mt-1 text-sm text-text-muted">{body}</p>
+            <p className="mt-2 break-all text-xs text-text-subtle">
+              {`${backendUnavailableDetail.message} (${backendUnavailableDetail.method} ${backendUnavailableDetail.path})`}
+            </p>
+          </div>
+          <Button type="text" size="small" onClick={onClose}>
+            {t("common:dismiss", "Dismiss")}
+          </Button>
+        </div>
+        <div className="mt-3 flex justify-end gap-2">
+          <Button size="small" onClick={onOpenHealth}>
+            {t(
+              "settings:healthSummary.diagnostics",
+              "Health & diagnostics"
+            )}
+          </Button>
+          <Button
+            size="small"
+            type="primary"
+            loading={isChecking}
+            onClick={onRetry}
+            className="!bg-primaryStrong !text-white hover:!bg-primaryStrong hover:brightness-95"
+          >
+            {t("common:retry", "Retry")}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <Modal
-      title={t(
-        "sidepanel:connectionBanner.unreachableTitle",
-        "Can't reach your tldw server"
-      )}
+      title={title}
       open={Boolean(backendUnavailableDetail) && !fatalBackendRecoveryActive}
       onCancel={onClose}
       maskClosable={false}
@@ -64,10 +119,7 @@ export const BackendUnavailableModalGate: React.FC<
       ]}
     >
       <p className="text-sm text-text">
-        {t(
-          "sidepanel:connectionBanner.unreachableBody",
-          "Check that your server is running and accessible."
-        )}
+        {body}
       </p>
       {backendUnavailableDetail && (
         <p className="mt-2 break-all text-xs text-text-subtle">

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -163,6 +163,8 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
     !hideSidebar &&
     !isMobileViewport;
   const stickyChatLayoutActive = isChatScreen && stickyChatInput;
+  const useInlineBackendUnavailableAlert =
+    location.pathname.startsWith('/settings');
   const isViewportConstrainedRoute =
     stickyChatLayoutActive ||
     (VIEWPORT_CONSTRAINED_PATHS as readonly string[]).includes(location.pathname);
@@ -634,6 +636,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
             onConsumeHiddenDetail={closeBackendUnavailableModal}
             onOpenHealth={openHealthDiagnostics}
             onRetry={retryConnectionCheck}
+            presentation={useInlineBackendUnavailableAlert ? 'inline' : 'modal'}
             t={t}
           />
         </main>

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -164,7 +164,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
     !isMobileViewport;
   const stickyChatLayoutActive = isChatScreen && stickyChatInput;
   const useInlineBackendUnavailableAlert =
-    location.pathname.startsWith('/settings');
+    /^\/settings(\/|$)/.test(location.pathname);
   const isViewportConstrainedRoute =
     stickyChatLayoutActive ||
     (VIEWPORT_CONSTRAINED_PATHS as readonly string[]).includes(location.pathname);

--- a/apps/tldw-frontend/extension/routes/settings-route.tsx
+++ b/apps/tldw-frontend/extension/routes/settings-route.tsx
@@ -8,7 +8,9 @@ type SettingsRouteProps = {
 
 export const SettingsRoute = ({ children }: SettingsRouteProps) => (
   <RouteErrorBoundary routeId="settings" routeLabel="Settings">
-    <SettingsLayout>{children}</SettingsLayout>
+    <main>
+      <SettingsLayout>{children}</SettingsLayout>
+    </main>
   </RouteErrorBoundary>
 )
 

--- a/apps/tldw-frontend/pages/settings/data.tsx
+++ b/apps/tldw-frontend/pages/settings/data.tsx
@@ -1,13 +1,19 @@
 import dynamic from "next/dynamic"
+import Head from "next/head"
 
 export default dynamic(async () => {
   const { SettingsRoute } = await import("@/routes/settings-route")
   const mod = await import("@/components/Option/Settings/data-management")
   const Component = mod.DataManagementSettings
   const Page = () => (
-    <SettingsRoute>
-      <Component />
-    </SettingsRoute>
+    <>
+      <Head>
+        <title>Data Management | Settings | tldw</title>
+      </Head>
+      <SettingsRoute>
+        <Component />
+      </SettingsRoute>
+    </>
   )
   return { default: Page }
 }, { ssr: false })

--- a/apps/tldw-frontend/pages/settings/index.tsx
+++ b/apps/tldw-frontend/pages/settings/index.tsx
@@ -1,13 +1,19 @@
 import dynamic from "next/dynamic"
+import Head from "next/head"
 
 export default dynamic(async () => {
   const { SettingsRoute } = await import("@/routes/settings-route")
   const mod = await import("@/components/Option/Settings/setup-recovery-settings")
   const Component = mod.SetupRecoverySettings
   const Page = () => (
-    <SettingsRoute>
-      <Component />
-    </SettingsRoute>
+    <>
+      <Head>
+        <title>Setup &amp; Recovery | Settings | tldw</title>
+      </Head>
+      <SettingsRoute>
+        <Component />
+      </SettingsRoute>
+    </>
   )
   return { default: Page }
 }, { ssr: false })

--- a/apps/tldw-frontend/pages/settings/preferences.tsx
+++ b/apps/tldw-frontend/pages/settings/preferences.tsx
@@ -1,13 +1,19 @@
 import dynamic from "next/dynamic"
+import Head from "next/head"
 
 export default dynamic(async () => {
   const { SettingsRoute } = await import("@/routes/settings-route")
   const mod = await import("@/components/Option/Settings/preferences-settings")
   const Component = mod.PreferencesSettings
   const Page = () => (
-    <SettingsRoute>
-      <Component />
-    </SettingsRoute>
+    <>
+      <Head>
+        <title>Preferences | Settings | tldw</title>
+      </Head>
+      <SettingsRoute>
+        <Component />
+      </SettingsRoute>
+    </>
   )
   return { default: Page }
 }, { ssr: false })

--- a/apps/tldw-frontend/pages/settings/ui.tsx
+++ b/apps/tldw-frontend/pages/settings/ui.tsx
@@ -1,13 +1,19 @@
 import dynamic from "next/dynamic"
+import Head from "next/head"
 
 export default dynamic(async () => {
   const { SettingsRoute } = await import("@/routes/settings-route")
   const mod = await import("@/components/Option/Settings/ui-customization")
   const Component = mod.UiCustomizationSettings
   const Page = () => (
-    <SettingsRoute>
-      <Component />
-    </SettingsRoute>
+    <>
+      <Head>
+        <title>UI Customization | Settings | tldw</title>
+      </Head>
+      <SettingsRoute>
+        <Component />
+      </SettingsRoute>
+    </>
   )
   return { default: Page }
 }, { ssr: false })

--- a/backlog/tasks/task-12912 - Harden-settings-UX-after-IA-split-review.md
+++ b/backlog/tasks/task-12912 - Harden-settings-UX-after-IA-split-review.md
@@ -4,12 +4,15 @@ title: Harden settings UX after IA split review
 status: Done
 priority: High
 modified_files:
+- apps/tldw-frontend/extension/routes/settings-route.tsx
+- apps/tldw-frontend/__tests__/extension/settings-route-landmark.test.tsx
+- apps/packages/ui/src/components/Option/Settings/search-mode.tsx
+- apps/packages/ui/src/components/Option/Settings/system-settings.tsx
 - apps/packages/ui/src/components/Option/Settings/ui-customization.tsx
+- apps/tldw-frontend/components/layout/WebLayout.tsx
+- apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
 - apps/packages/ui/src/components/Option/Settings/__tests__/UiCustomizationSettings.test.tsx
 - apps/packages/ui/src/routes/__tests__/option-settings-route-split.test.tsx
-- apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
-- apps/tldw-frontend/components/layout/WebLayout.tsx
-- apps/tldw-frontend/components/layout/BackendUnavailableModalGate.tsx
 - backlog/tasks/task-12912 - Harden-settings-UX-after-IA-split-review.md
 ---
 
@@ -58,7 +61,7 @@ Address the senior UX/HCI review findings on the merged settings IA split: reduc
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Hardened the settings UX after the IA split review by removing modal interruption on settings routes, reducing /settings/ui density with collapsed native sections, improving route/page semantics, clarifying data action consequences, and fixing reviewed settings contrast/a11y issues. Follow-up review fixes validated native summary markup, added WebLayout route-level backend-unreachable regression coverage, and asserted exact hosted settings page titles.
+Rebased PR #2689 on latest dev and addressed all open PR review comments: restored a main landmark for extension settings routes, preserved Firefox sync error diagnostics, added web-search aria-label fallbacks, switched reset styling to semantic danger color, hid Safari disclosure markers, and narrowed settings-route matching to /settings and /settings/* only. Verification: focused Vitest passed 23 tests, typecheck passed, eslint on touched files passed with the known Next pages-directory notice, and git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12912 - Harden-settings-UX-after-IA-split-review.md
+++ b/backlog/tasks/task-12912 - Harden-settings-UX-after-IA-split-review.md
@@ -1,0 +1,64 @@
+---
+id: TASK-12912
+title: Harden settings UX after IA split review
+status: In Progress
+priority: High
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the senior UX/HCI review findings on the merged settings IA split: reduce interruption from backend-down state, improve accessibility semantics, add progressive disclosure for dense UI customization settings, and clarify data management consequences.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Settings server-unreachable state no longer blocks unrelated settings tasks with a modal.
+- [x] #2 Settings pages have valid title/main landmark/form semantics for the reviewed routes.
+- [x] #3 UI customization reduces first-screen cognitive load with collapsed or task-oriented sections for shortcut matrices and display settings.
+- [x] #4 Data management explains export/import/reset consequences inline before action.
+- [x] #5 Focused tests and visual/a11y verification cover the changed behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect current merged settings implementation and existing tests.
+2. Add failing tests for accessibility semantics, non-blocking error behavior, progressive disclosure, and data danger copy.
+3. Implement minimal UI changes using existing components and patterns.
+4. Run focused Vitest, Playwright/axe checks, and diff verification.
+5. Update task, commit, and push branch.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Replaced settings-owned `main` landmarks with shell-safe `div`/`section` semantics so the hosted app keeps one page `main`.
+- Added explicit document titles to the reviewed hosted settings pages.
+- Converted `/settings/ui` shortcut, theme, and system display sections to collapsed native disclosures.
+- Changed settings backend-unreachable handling from a modal to a non-blocking status toast on settings routes.
+- Added inline export/import/reset consequence copy and tightened visible settings action button contrast.
+- Added focused tests for landmark/title semantics, invalid `dl` prevention, collapsed disclosure defaults, inline unreachable status, and data consequence copy.
+- Verification:
+  - `bun run test:run ../packages/ui/src/components/Layouts/__tests__/settings-layout-focus-order.test.tsx ../packages/ui/src/components/Option/Settings/__tests__/PreferencesSettings.test.tsx ../packages/ui/src/components/Option/Settings/__tests__/UiCustomizationSettings.test.tsx ../packages/ui/src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx __tests__/components/layout/WebLayout.backend-unreachable.test.tsx ../packages/ui/src/routes/__tests__/option-settings-route-split.test.tsx`
+  - `bun run typecheck`
+  - `apps/tldw-frontend/node_modules/.bin/eslint -c apps/tldw-frontend/eslint.config.mjs <touched files>` exits 0; Next plugin emits a cwd notice because the config is invoked from repo root for cross-package files.
+  - Playwright + axe on `/settings/preferences`, `/settings/ui`, and `/settings/data` at desktop and mobile: 0 axe violations, one `main`, no nested `main`, no invalid `dl`, reviewed titles present, UI disclosures closed by default, and no backend-unreachable dialog.
+- Bandit: not applicable; touched code is frontend TypeScript/TSX plus Backlog metadata, with no Python files changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the settings UX after the IA split review by removing modal interruption on settings routes, reducing `/settings/ui` density with collapsed native sections, improving route/page semantics, clarifying data action consequences, and fixing reviewed settings contrast/a11y issues.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12912 - Harden-settings-UX-after-IA-split-review.md
+++ b/backlog/tasks/task-12912 - Harden-settings-UX-after-IA-split-review.md
@@ -1,8 +1,16 @@
 ---
 id: TASK-12912
 title: Harden settings UX after IA split review
-status: In Progress
+status: Done
 priority: High
+modified_files:
+- apps/packages/ui/src/components/Option/Settings/ui-customization.tsx
+- apps/packages/ui/src/components/Option/Settings/__tests__/UiCustomizationSettings.test.tsx
+- apps/packages/ui/src/routes/__tests__/option-settings-route-split.test.tsx
+- apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+- apps/tldw-frontend/components/layout/WebLayout.tsx
+- apps/tldw-frontend/components/layout/BackendUnavailableModalGate.tsx
+- backlog/tasks/task-12912 - Harden-settings-UX-after-IA-split-review.md
 ---
 
 ## Description
@@ -50,7 +58,7 @@ Address the senior UX/HCI review findings on the merged settings IA split: reduc
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Hardened the settings UX after the IA split review by removing modal interruption on settings routes, reducing `/settings/ui` density with collapsed native sections, improving route/page semantics, clarifying data action consequences, and fixing reviewed settings contrast/a11y issues.
+Hardened the settings UX after the IA split review by removing modal interruption on settings routes, reducing /settings/ui density with collapsed native sections, improving route/page semantics, clarifying data action consequences, and fixing reviewed settings contrast/a11y issues. Follow-up review fixes validated native summary markup, added WebLayout route-level backend-unreachable regression coverage, and asserted exact hosted settings page titles.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Change summary

Agent draft: hardens the post-IA-split settings experience by reducing interruption, improving accessibility semantics, collapsing dense UI customization controls, and clarifying data management consequences. Per repo policy, this section still needs human-owned wording before merge.

## What changed

- Replaced the settings-route modal backend-unreachable interruption with a non-blocking status toast.
- Removed settings-owned main landmarks so hosted settings pages keep a single app main landmark.
- Added explicit document titles for reviewed settings pages.
- Collapsed dense /settings/ui shortcut, theme, and display sections behind native details disclosures.
- Added inline export/import/reset consequence copy on Data Management.
- Added aria labels for reviewed settings controls and fixed settings action button contrast.

## Verification

- bun run test:run ../packages/ui/src/components/Layouts/__tests__/settings-layout-focus-order.test.tsx ../packages/ui/src/components/Option/Settings/__tests__/PreferencesSettings.test.tsx ../packages/ui/src/components/Option/Settings/__tests__/UiCustomizationSettings.test.tsx ../packages/ui/src/components/Option/Settings/__tests__/DataManagementSettings.test.tsx __tests__/components/layout/WebLayout.backend-unreachable.test.tsx ../packages/ui/src/routes/__tests__/option-settings-route-split.test.tsx
- bun run typecheck
- apps/tldw-frontend/node_modules/.bin/eslint -c apps/tldw-frontend/eslint.config.mjs <touched files>
- Playwright + axe on /settings/preferences, /settings/ui, /settings/data at desktop and mobile: 0 axe violations, one main, no nested main, no invalid dl, no backend-unreachable dialog.
- Bandit not applicable: frontend TypeScript/TSX and Backlog metadata only.

Backlog: TASK-12912

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the settings UX after the IA split by making backend-unreachable non-blocking on settings pages, tightening landmarks and labels, and collapsing dense UI customization. Addresses TASK-12912 by clarifying data actions and adding document titles to hosted settings.

- **New Features**
  - Non-blocking inline backend-unreachable alert on `/settings` and `/settings/*` (no modal; dismiss, retry, and health diagnostics).
  - Collapsed sidebar/playground shortcuts, theme, and display sections on `/settings/ui` using native disclosures (closed by default).
  - Added document titles to `pages/settings/*` via `next/head`.

- **Bug Fixes**
  - Single main landmark on hosted pages: settings content uses `div`/`section` with `aria-labelledby`; extension settings route now wraps layout in `main`.
  - Clearer export/import/reset consequences; danger styling and higher-contrast actions; preserved sync error details in notifications.
  - A11y fixes: added aria-labels across web search and system controls; removed invalid `dl`; no block elements inside `summary`.

<sup>Written for commit 2fe2c9858ead7ddb0c28a72e7c8939beac5b851d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

