### PR TITLE
Fix frontend startup bursts and settings exit navigation

### DIFF
--- a/apps/packages/ui/src/components/Layouts/SettingsOptionLayout.tsx
+++ b/apps/packages/ui/src/components/Layouts/SettingsOptionLayout.tsx
@@ -28,6 +28,48 @@ const shouldHideForBrowser = (item: SettingsNavItem) =>
   !isChromeTarget && item.to === "/settings/chrome";
 
 const SETTINGS_HIDE_BETA_BADGES_STORAGE_KEY = "tldw:settings:hide-beta-badges";
+const SETTINGS_EXIT_URL_ORIGIN = "https://tldw.local";
+
+const isNextWebAppRuntime = () =>
+  typeof window !== "undefined" && "__NEXT_DATA__" in window;
+
+type SettingsExitNavigationEnvironment = {
+  isNextWebApp?: boolean;
+  assignLocation?: (target: string) => void;
+};
+
+const normalizeSettingsExitTarget = (target: string) => {
+  const trimmedTarget = target.trim();
+  if (!trimmedTarget) return "/";
+
+  try {
+    const url = new URL(trimmedTarget, SETTINGS_EXIT_URL_ORIGIN);
+    if (url.origin !== SETTINGS_EXIT_URL_ORIGIN) return "/";
+    if (url.pathname.startsWith("/settings")) return "/";
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return "/";
+  }
+};
+
+export const navigateFromSettingsExit = (
+  navigate: ReturnType<typeof useNavigate>,
+  target: string,
+  environment?: SettingsExitNavigationEnvironment,
+) => {
+  const isNextWebApp = environment?.isNextWebApp ?? isNextWebAppRuntime();
+  const normalizedTarget = normalizeSettingsExitTarget(target);
+
+  if (isNextWebApp) {
+    const assignLocation =
+      environment?.assignLocation ??
+      window.location.assign.bind(window.location);
+    assignLocation(normalizedTarget);
+    return;
+  }
+
+  navigate(normalizedTarget, { flushSync: true });
+};
 
 const readHideBetaBadgesPreference = (): boolean => {
   try {
@@ -333,12 +375,10 @@ export const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
                   title={t("common:close", "Close")}
                   onClick={(e) => {
                     e.preventDefault();
-                    const returnTo = getSettingsReturnTo();
-                    if (returnTo) {
-                      navigate(returnTo);
-                      return;
-                    }
-                    navigate("/");
+                    navigateFromSettingsExit(
+                      navigate,
+                      getSettingsReturnTo() ?? "/",
+                    );
                   }}
                 >
                   <XIcon className="h-4 w-4" />

--- a/apps/packages/ui/src/components/Layouts/__tests__/settings-layout-exit-navigation.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/settings-layout-exit-navigation.test.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  navigateFromSettingsExit,
+  SettingsLayout,
+} from "../SettingsOptionLayout";
+
+const routerMocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  pathname: "/settings/tldw",
+}));
+
+const settingsReturnMocks = vi.hoisted(() => ({
+  returnTo: "/chat" as string | null,
+}));
+
+const IconStub = () => null;
+
+vi.mock("react-router-dom", async () => {
+  const React = await import("react");
+  return {
+    Link: ({
+      children,
+      to,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      to: string;
+    }) =>
+      React.createElement(
+        "a",
+        {
+          ...props,
+          href: to,
+        },
+        children,
+      ),
+    useLocation: () => ({
+      pathname: routerMocks.pathname,
+      search: "",
+      hash: "",
+      state: null,
+      key: "settings-test",
+    }),
+    useNavigate: () => routerMocks.navigate,
+  };
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (token: string, fallback?: string) => fallback ?? token,
+  }),
+}));
+
+vi.mock("@/config/platform", () => ({
+  isChromeTarget: false,
+}));
+
+vi.mock("../settings-nav", () => ({
+  getSettingsNavGroups: () => [
+    {
+      key: "server",
+      titleToken: "settings:navigation.serverAndAuth",
+      items: [
+        {
+          to: "/settings/tldw",
+          labelToken: "settings:tldw.serverNav",
+          icon: IconStub,
+        },
+      ],
+    },
+  ],
+}));
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: null,
+    loading: false,
+  }),
+}));
+
+vi.mock("@/utils/sidepanel", () => ({
+  isSidepanelSupported: () => false,
+  openSidepanel: vi.fn(),
+}));
+
+vi.mock("@/services/settings/registry", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/services/settings/registry")>();
+  return {
+    ...actual,
+    setSetting: vi.fn(),
+  };
+});
+
+vi.mock("@/utils/settings-return", () => ({
+  getSettingsReturnTo: () => settingsReturnMocks.returnTo,
+}));
+
+const renderSettingsLayout = () =>
+  render(
+    <SettingsLayout>
+      <div>settings content</div>
+    </SettingsLayout>,
+  );
+
+describe("settings layout exit navigation", () => {
+  beforeEach(() => {
+    routerMocks.navigate.mockReset();
+    routerMocks.pathname = "/settings/tldw";
+    settingsReturnMocks.returnTo = "/chat";
+    delete (window as typeof window & { __NEXT_DATA__?: unknown })
+      .__NEXT_DATA__;
+  });
+
+  it("uses flushSync when exiting to the saved return route", async () => {
+    const user = userEvent.setup();
+    renderSettingsLayout();
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(routerMocks.navigate).toHaveBeenCalledWith("/chat", {
+      flushSync: true,
+    });
+  });
+
+  it("uses document navigation in the Next web app", () => {
+    const assignLocation = vi.fn();
+
+    navigateFromSettingsExit(routerMocks.navigate, "/chat", {
+      isNextWebApp: true,
+      assignLocation,
+    });
+
+    expect(assignLocation).toHaveBeenCalledWith("/chat");
+    expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("normalizes external settings exit targets to the app root", () => {
+    const assignLocation = vi.fn();
+
+    navigateFromSettingsExit(
+      routerMocks.navigate,
+      "https://example.test/chat",
+      {
+        isNextWebApp: true,
+        assignLocation,
+      },
+    );
+
+    expect(assignLocation).toHaveBeenCalledWith("/");
+    expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/ui/src/services/__tests__/api-send.test.ts
+++ b/apps/packages/ui/src/services/__tests__/api-send.test.ts
@@ -54,6 +54,48 @@ describe("apiSend timeout fallback policy", () => {
     expect(mocks.tldwRequest).toHaveBeenCalledTimes(1)
   })
 
+  it("coalesces concurrent identical GET requests through direct fallback", async () => {
+    vi.useFakeTimers()
+    mocks.sendMessage.mockImplementation(() => new Promise(() => undefined))
+    mocks.tldwRequest.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: [{ id: "research_assistant" }]
+    })
+
+    const { apiSend } = await importApiSend()
+    const first = apiSend({ path: "/api/v1/persona/profiles", method: "GET" })
+    const second = apiSend({ path: "/api/v1/persona/profiles", method: "GET" })
+
+    await vi.advanceTimersByTimeAsync(10001)
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { ok: true, status: 200, data: [{ id: "research_assistant" }] },
+      { ok: true, status: 200, data: [{ id: "research_assistant" }] }
+    ])
+    expect(mocks.tldwRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not coalesce unsafe POST requests", async () => {
+    mocks.sendMessage.mockResolvedValue({ ok: true, status: 200, data: { ok: true } })
+
+    const { apiSend } = await importApiSend()
+    await Promise.all([
+      apiSend({
+        path: "/api/v1/notes/search/",
+        method: "POST",
+        body: { q: "hello" }
+      }),
+      apiSend({
+        path: "/api/v1/notes/search/",
+        method: "POST",
+        body: { q: "hello" }
+      })
+    ])
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(2)
+  })
+
   it("does not fall back to direct request for POST timeout", async () => {
     vi.useFakeTimers()
     mocks.sendMessage.mockImplementation(() => new Promise(() => undefined))

--- a/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
+++ b/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
@@ -1996,6 +1996,69 @@ describe("background proxy GET coalescing", () => {
     expect(ra1).toBe(ra2)
   })
 
+  it("coalesces serialized returnResponse GETs", async () => {
+    mocks.sendMessage.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: [{ id: "persona-1" }]
+    })
+    const { bgRequest } = await importProxy()
+
+    const [first, second] = await Promise.all([
+      bgRequest({
+        path: "/api/v1/persona/profiles",
+        method: "GET",
+        returnResponse: true
+      }),
+      bgRequest({
+        path: "/api/v1/persona/profiles",
+        method: "GET",
+        returnResponse: true
+      })
+    ])
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
+    expect(first).toBe(second)
+  })
+
+  it("does not coalesce returnResponse GETs with data-only GETs", async () => {
+    mocks.sendMessage.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: { ok: true }
+    })
+    const { bgRequest } = await importProxy()
+
+    await Promise.all([
+      bgRequest({
+        path: "/api/v1/persona/profiles",
+        method: "GET",
+        returnResponse: true
+      }),
+      bgRequest({ path: "/api/v1/persona/profiles", method: "GET" })
+    ])
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it("reuses a recent rate-limited GET failure instead of bursting", async () => {
+    mocks.sendMessage.mockResolvedValue({
+      ok: false,
+      status: 429,
+      error: "rate_limited"
+    })
+    const { bgRequest } = await importProxy()
+
+    await expect(
+      bgRequest({ path: "/api/v1/persona/profiles", method: "GET" })
+    ).rejects.toMatchObject({ status: 429 })
+    await expect(
+      bgRequest({ path: "/api/v1/persona/profiles", method: "GET" })
+    ).rejects.toMatchObject({ status: 429 })
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
+  })
+
   it("does not coalesce POST requests", async () => {
     mocks.sendMessage.mockResolvedValue({ ok: true, status: 200, data: { ok: true } })
     const { bgRequest } = await importProxy()

--- a/apps/packages/ui/src/services/api-send.ts
+++ b/apps/packages/ui/src/services/api-send.ts
@@ -27,7 +27,65 @@ const isSafeFallbackMethod = (method?: string): boolean => {
   return methodUpper === "GET" || methodUpper === "HEAD" || methodUpper === "OPTIONS"
 }
 
+const inFlightGetRequests = new Map<string, Promise<ApiSendResponse<unknown>>>()
+
+const normalizeHeaders = (
+  headers?: Record<string, string>
+): Record<string, string> | null => {
+  if (!headers) return null
+  return Object.keys(headers)
+    .sort()
+    .reduce<Record<string, string>>((acc, headerKey) => {
+      acc[headerKey.toLowerCase()] = headers[headerKey]
+      return acc
+    }, {})
+}
+
+const getCoalescingKey = (payload: ApiSendPayload): string | null => {
+  const method = String(payload.method || "GET").toUpperCase()
+  if (
+    method !== "GET" ||
+    payload.body ||
+    payload.responseType
+  ) {
+    return null
+  }
+
+  return JSON.stringify({
+    method,
+    path: payload.path,
+    headers: normalizeHeaders(payload.headers),
+    noAuth: Object.prototype.hasOwnProperty.call(payload, "noAuth")
+      ? payload.noAuth
+      : "__omitted__",
+    timeoutMs: payload.timeoutMs ?? null
+  })
+}
+
 export async function apiSend<T = any, P extends PathOrUrl = PathOrUrl, M extends AllowedMethodFor<P> = AllowedMethodFor<P>>(
+  payload: ApiSendPayload<P, M>
+): Promise<ApiSendResponse<T>> {
+  const coalescingKey = getCoalescingKey(payload)
+  if (coalescingKey) {
+    const existing = inFlightGetRequests.get(coalescingKey)
+    if (existing) return existing as Promise<ApiSendResponse<T>>
+
+    const pending = apiSendImpl<T, P, M>(payload).finally(() => {
+      if (inFlightGetRequests.get(coalescingKey) === pending) {
+        inFlightGetRequests.delete(coalescingKey)
+      }
+    })
+    inFlightGetRequests.set(
+      coalescingKey,
+      pending as Promise<ApiSendResponse<unknown>>
+    )
+    return pending
+  }
+
+  return apiSendImpl(payload)
+}
+
+async function apiSendImpl<T = any, P extends PathOrUrl = PathOrUrl, M extends AllowedMethodFor<P> = AllowedMethodFor<P>>(
   payload: ApiSendPayload<P, M>
 ): Promise<ApiSendResponse<T>> {
   const methodIsSafeFallback = isSafeFallbackMethod(

--- a/apps/packages/ui/src/services/background-proxy.ts
+++ b/apps/packages/ui/src/services/background-proxy.ts
@@ -3,6 +3,7 @@ import { Storage } from "@plasmohq/storage"
 import { createSafeStorage } from "@/utils/safe-storage"
 import { formatErrorMessage } from "@/utils/format-error-message"
 import {
+  parseRetryAfter,
   resolveBrowserRequestTransport,
   tldwRequest
 } from "@/services/tldw/request-core"
@@ -394,9 +395,61 @@ export interface BgRequestInit<
 // In-flight coalescing for idempotent GET requests: when several callers issue
 // the same GET concurrently (a common pattern when many components mount on a
 // page load and each fetches the same resource), share a single network request
-// instead of firing N identical ones. Only concurrent requests are shared — once
-// the promise settles it is removed, so caching/staleness semantics are unchanged.
+// instead of firing N identical ones. Successful requests are not cached; 429s
+// get a brief per-key cooldown so remount/retry loops do not hammer the server.
 const inFlightGetRequests = new Map<string, Promise<unknown>>()
+const rateLimitedGetResults = new Map<
+  string,
+  { expiresAt: number; rejected: boolean; value: unknown }
+>()
+const DEFAULT_RATE_LIMIT_GET_COOLDOWN_MS = 2_000
+const MAX_RATE_LIMIT_GET_COOLDOWN_MS = 60_000
+
+const isRateLimitedResult = (value: unknown): boolean => {
+  const status = extractHttpStatus(value)
+  if (status === 429) return true
+  if (!(value instanceof Error)) return false
+  const message = value.message
+  return /(?:\b429\b|rate limit|too many requests)/i.test(message)
+}
+
+const readRateLimitCooldownMs = (value: unknown): number => {
+  const candidate = value as
+    | {
+        retryAfterMs?: unknown
+        headers?: Record<string, string | undefined>
+      }
+    | null
+    | undefined
+  const retryAfterMs = Number(candidate?.retryAfterMs)
+  if (Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+    return Math.min(MAX_RATE_LIMIT_GET_COOLDOWN_MS, Math.max(500, retryAfterMs))
+  }
+  const retryAfterHeader =
+    candidate?.headers?.["retry-after"] ?? candidate?.headers?.["Retry-After"]
+  const parsedRetryAfter = parseRetryAfter(retryAfterHeader)
+  if (typeof parsedRetryAfter === "number" && parsedRetryAfter > 0) {
+    return Math.min(
+      MAX_RATE_LIMIT_GET_COOLDOWN_MS,
+      Math.max(500, parsedRetryAfter)
+    )
+  }
+  return DEFAULT_RATE_LIMIT_GET_COOLDOWN_MS
+}
+
+const pruneRateLimitedGetResults = () => {
+  const now = Date.now()
+  for (const [key, entry] of rateLimitedGetResults) {
+    if (entry.expiresAt <= now) {
+      rateLimitedGetResults.delete(key)
+    }
+  }
+  while (rateLimitedGetResults.size > ERROR_LOG_MAX_ENTRIES) {
+    const oldestKey = rateLimitedGetResults.keys().next().value
+    if (!oldestKey) break
+    rateLimitedGetResults.delete(oldestKey)
+  }
+}
 
 type DirectRuntimeStorage = Pick<
   ReturnType<typeof createSafeStorage>,
@@ -484,7 +537,6 @@ export async function bgRequest<
     method === "GET" &&
     !init.body &&
     !init.abortSignal &&
-    !init.returnResponse &&
     !init.responseType &&
     !init.preferDirect &&
     !init.suppressBackendUnavailableEvent &&
@@ -512,6 +564,7 @@ export async function bgRequest<
     noAuth: Object.prototype.hasOwnProperty.call(init, "noAuth")
       ? Boolean(init.noAuth)
       : "__unset__",
+    returnResponse: Boolean(init.returnResponse),
     suppressBackendUnavailableEvent: Boolean(
       init.suppressBackendUnavailableEvent
     ),
@@ -521,13 +574,42 @@ export async function bgRequest<
   if (existing) {
     return existing as Promise<T>
   }
-  const promise = bgRequestImpl<T, P, M>(init).finally(() => {
-    // Only clear the entry if it is still the promise we created — defensive in
-    // case the map handling changes to allow overwrites in the future.
-    if (inFlightGetRequests.get(key) === promise) {
-      inFlightGetRequests.delete(key)
+  const rateLimited = rateLimitedGetResults.get(key)
+  if (rateLimited) {
+    if (rateLimited.expiresAt > Date.now()) {
+      return rateLimited.rejected
+        ? Promise.reject(rateLimited.value)
+        : Promise.resolve(rateLimited.value as T)
     }
-  })
+    rateLimitedGetResults.delete(key)
+  }
+  const rememberRateLimit = (value: unknown, rejected: boolean) => {
+    if (!isRateLimitedResult(value)) return
+    pruneRateLimitedGetResults()
+    rateLimitedGetResults.set(key, {
+      expiresAt: Date.now() + readRateLimitCooldownMs(value),
+      rejected,
+      value
+    })
+  }
+  const promise = bgRequestImpl<T, P, M>(init)
+    .then(
+      (value) => {
+        rememberRateLimit(value, false)
+        return value
+      },
+      (error) => {
+        rememberRateLimit(error, true)
+        throw error
+      }
+    )
+    .finally(() => {
+      // Only clear the entry if it is still the promise we created — defensive in
+      // case the map handling changes to allow overwrites in the future.
+      if (inFlightGetRequests.get(key) === promise) {
+        inFlightGetRequests.delete(key)
+      }
+    })
   inFlightGetRequests.set(key, promise)
   return promise as Promise<T>
 }

--- a/apps/tldw-frontend/__tests__/app/app-layout.test.tsx
+++ b/apps/tldw-frontend/__tests__/app/app-layout.test.tsx
@@ -84,7 +84,20 @@ vi.mock("next/dynamic", () => ({
 }))
 
 vi.mock("@web/components/AppProviders", () => ({
-  AppProviders: ({ children }: { children: React.ReactNode }) => <>{children}</>
+  AppProviders: ({
+    children,
+    enableNotifications
+  }: {
+    children: React.ReactNode
+    enableNotifications?: boolean
+  }) => (
+    <div
+      data-testid="app-providers"
+      data-enable-notifications={String(Boolean(enableNotifications))}
+    >
+      {children}
+    </div>
+  )
 }))
 
 vi.mock("@web/components/networking/ServerReadinessGate", () => ({
@@ -357,7 +370,7 @@ describe("App layout routing", () => {
       serverUrl: "http://127.0.0.1:8000",
       authMode: "single-user"
     }
-    setRuntimeApiKey("runtime-api-key")
+    mockRuntimeApiKey = "runtime-api-key"
 
     renderApp("/media")
 
@@ -379,6 +392,23 @@ describe("App layout routing", () => {
       expect(layout).toHaveAttribute("data-hide-header", "true")
     })
     expect(layout).toHaveAttribute("data-hide-sidebar", "true")
+    expect(screen.getByTestId("app-providers")).toHaveAttribute(
+      "data-enable-notifications",
+      "false"
+    )
+  })
+
+  it("enables notification startup after auth resolves on app routes", async () => {
+    process.env.NEXT_PUBLIC_X_API_KEY = "env-api-key"
+
+    renderApp("/media")
+
+    await waitFor(() => {
+      expect(screen.getByTestId("app-providers")).toHaveAttribute(
+        "data-enable-notifications",
+        "true"
+      )
+    })
   })
 
   it("refreshes nav visibility when auth config updates", async () => {

--- a/apps/tldw-frontend/__tests__/components/app-providers-import.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/app-providers-import.test.tsx
@@ -91,4 +91,17 @@ describe("AppProviders", () => {
     expect(screen.getByText("child content")).toBeInTheDocument()
     expect(screen.getByTestId("notification-toast-bridge")).toBeInTheDocument()
   })
+
+  it("keeps the notification bridge unmounted when notifications are disabled", async () => {
+    const { AppProviders } = await import("@web/components/AppProviders")
+
+    render(
+      <AppProviders enableNotifications={false}>
+        <div>child content</div>
+      </AppProviders>
+    )
+
+    expect(screen.getByText("child content")).toBeInTheDocument()
+    expect(screen.queryByTestId("notification-toast-bridge")).not.toBeInTheDocument()
+  })
 })

--- a/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
@@ -76,6 +76,7 @@ const connectionState = vi.hoisted(() => ({
 }));
 
 const confirmDangerMock = vi.hoisted(() => vi.fn(async () => false));
+const getUnreadCountMock = vi.hoisted(() => vi.fn(async () => ({ unread_count: 0 })));
 const storageState = vi.hoisted(() => ({
   stickyChatInput: true,
 }));
@@ -321,7 +322,7 @@ vi.mock('@web/components/layout/BackendUnavailableModalGate', () => ({
 }));
 
 vi.mock('@web/lib/api/notifications', () => ({
-  getUnreadCount: vi.fn(async () => ({ unread_count: 0 })),
+  getUnreadCount: (...args: unknown[]) => getUnreadCountMock(...args),
 }));
 
 vi.mock('@/components/Common/CommandPalette', () => ({
@@ -526,6 +527,18 @@ describe('WebLayout /chat scroll contract', () => {
       expect(html).toContain(className);
     }
     expect(html).not.toContain('px-4 py-10');
+  });
+
+  it('does not poll the notification count while the header is hidden', async () => {
+    render(
+      <OptionLayout hideHeader hideSidebar>
+        <div data-testid="chat-route-content">Chat route</div>
+      </OptionLayout>
+    );
+
+    await act(async () => undefined);
+
+    expect(getUnreadCountMock).not.toHaveBeenCalled();
   });
 
   it('passes openResetKey when the shared ChatSidebar feature is enabled', () => {

--- a/apps/tldw-frontend/__tests__/navigation/react-router-shim-transition.test.tsx
+++ b/apps/tldw-frontend/__tests__/navigation/react-router-shim-transition.test.tsx
@@ -30,16 +30,25 @@ vi.mock("next/router", () => ({
 
 const NavigateButton = ({
   to,
-  replace = false
+  replace = false,
+  flushSync = false
 }: {
   to: string | number
   replace?: boolean
+  flushSync?: boolean
 }) => {
   const navigate = useNavigate()
   return (
     <button
       type="button"
-      onClick={() => navigate(to, replace ? { replace: true } : undefined)}
+      onClick={() =>
+        navigate(
+          to,
+          replace || flushSync
+            ? { replace: replace || undefined, flushSync: flushSync || undefined }
+            : undefined
+        )
+      }
     >
       navigate
     </button>
@@ -74,6 +83,8 @@ describe("react-router-dom Next.js shim transitions", () => {
     mockPush.mockReset()
     mockReplace.mockReset()
     mockBack.mockReset()
+    mockPush.mockResolvedValue(true)
+    mockReplace.mockResolvedValue(true)
     mockRouter.asPath = "/current?tab=one"
     mockRouter.pathname = "/current"
     mockRouter.query = {}
@@ -91,6 +102,16 @@ describe("react-router-dom Next.js shim transitions", () => {
     await user.click(screen.getByRole("button", { name: "navigate" }))
 
     expect(startTransitionSpy).toHaveBeenCalled()
+    expect(mockPush).toHaveBeenCalledWith("/destination")
+  })
+
+  it("runs flushSync useNavigate pushes without startTransition", async () => {
+    const user = userEvent.setup()
+    render(<NavigateButton to="/destination" flushSync />)
+
+    await user.click(screen.getByRole("button", { name: "navigate" }))
+
+    expect(startTransitionSpy).not.toHaveBeenCalled()
     expect(mockPush).toHaveBeenCalledWith("/destination")
   })
 

--- a/apps/tldw-frontend/components/AppProviders.tsx
+++ b/apps/tldw-frontend/components/AppProviders.tsx
@@ -17,13 +17,17 @@ import { ToastProvider } from "@web/components/ui/ToastProvider"
 
 type AppProvidersProps = {
   children: React.ReactNode
+  enableNotifications?: boolean
 }
 
 const queryClient = getQueryClient()
 const EMPTY_STYLES = { image: { height: 60 } }
 patchStaticAntdNotificationCompat()
 
-export const AppProviders: React.FC<AppProvidersProps> = ({ children }) => {
+export const AppProviders: React.FC<AppProvidersProps> = ({
+  children,
+  enableNotifications = true
+}) => {
   const { antdTheme } = useTheme()
   const { i18n, t } = useTranslation("common")
   const splash = useSplashScreen()
@@ -84,7 +88,7 @@ export const AppProviders: React.FC<AppProvidersProps> = ({ children }) => {
                 direction={direction}
               >
                 <ToastProvider>
-                  <NotificationToastBridge />
+                  {enableNotifications ? <NotificationToastBridge /> : null}
                   <AntdApp>{children}</AntdApp>
                   {splash.visible && splash.card && (
                     <SplashOverlay

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -119,7 +119,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   // Notification unread count for header bell
   const [notificationCount, setNotificationCount] = useState(0);
   useEffect(() => {
-    if (demoEnabled) return;
+    if (demoEnabled || hideHeader) return;
     let cancelled = false;
     const poll = () => {
       getUnreadCount()
@@ -134,7 +134,7 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
       cancelled = true;
       clearInterval(id);
     };
-  }, [demoEnabled]);
+  }, [demoEnabled, hideHeader]);
   const handleOpenNotifications = useCallback(() => navigate('/notifications'), [navigate]);
   const location = useLocation();
   const historyId = useStoreMessageOption((state) => state.historyId);

--- a/apps/tldw-frontend/e2e/chat-request-dedupe.spec.ts
+++ b/apps/tldw-frontend/e2e/chat-request-dedupe.spec.ts
@@ -3,9 +3,8 @@ import { test, expect, seedAuth } from "./smoke/smoke.setup"
 /**
  * UAT Finding #6: identical GET requests fire many times concurrently on /chat load.
  * In-flight coalescing in the bgRequest layer collapses concurrent identical GETs to
- * a single network call. (Endpoints fetched via fetchWithAuth — e.g. /persona/profiles
- * — return a single-read Response and are intentionally out of scope: a Response body
- * cannot be safely shared across callers.)
+ * a single network call. Serialized returnResponse GETs used by fetchWithAuth
+ * are also coalesced; binary/streaming response bodies remain out of scope.
  *
  * Baseline before fix: /users/me/profile x5, /config/providers x3, /characters x2,
  * /persona/catalog x2.

--- a/apps/tldw-frontend/extension/shims/react-router-dom.tsx
+++ b/apps/tldw-frontend/extension/shims/react-router-dom.tsx
@@ -20,6 +20,7 @@ type NavLinkProps = Omit<LinkProps, "className"> & {
 type NavigateOptions = {
   replace?: boolean
   state?: unknown
+  flushSync?: boolean
 }
 
 type NavigateTo =
@@ -43,7 +44,14 @@ type ShimBlocker = {
   reset: () => void
 }
 
-const runNavigationTransition = (update: () => void) => {
+const runNavigationTransition = (
+  update: () => void,
+  options?: { flushSync?: boolean }
+) => {
+  if (options?.flushSync) {
+    update()
+    return
+  }
   if (typeof React.startTransition === "function") {
     React.startTransition(update)
     return
@@ -113,9 +121,12 @@ export const useNavigate = () => {
   return (to: NavigateTo, options?: NavigateOptions) => {
     if (typeof to === "number") {
       if (to < 0) {
-        runNavigationTransition(() => {
-          router.back()
-        })
+        runNavigationTransition(
+          () => {
+            router.back()
+          },
+          { flushSync: options?.flushSync }
+        )
       }
       return
     }
@@ -131,15 +142,18 @@ export const useNavigate = () => {
     }
 
     try {
-      runNavigationTransition(() => {
-        const navigation = options?.replace
-          ? router.replace(href)
-          : router.push(href)
-        void navigation.catch((err) => {
-          console.error("[useNavigate shim] Navigation failed:", err)
-          doFallback()
-        })
-      })
+      runNavigationTransition(
+        () => {
+          const navigation = options?.replace
+            ? router.replace(href)
+            : router.push(href)
+          void navigation.catch((err) => {
+            console.error("[useNavigate shim] Navigation failed:", err)
+            doFallback()
+          })
+        },
+        { flushSync: options?.flushSync }
+      )
     } catch (err) {
       console.error("[useNavigate shim] Navigation failed:", err)
       doFallback()
@@ -204,14 +218,17 @@ export const useSearchParams = (): [
       const nextPath = queryString
         ? `${currentPath}?${queryString}`
         : currentPath
-      runNavigationTransition(() => {
-        const navigation = options?.replace
-          ? router.replace(nextPath)
-          : router.push(nextPath)
-        void navigation.catch((error) => {
-          console.error("[useSearchParams shim] Navigation failed:", error)
-        })
-      })
+      runNavigationTransition(
+        () => {
+          const navigation = options?.replace
+            ? router.replace(nextPath)
+            : router.push(nextPath)
+          void navigation.catch((error) => {
+            console.error("[useSearchParams shim] Navigation failed:", error)
+          })
+        },
+        { flushSync: options?.flushSync }
+      )
     },
     [router]
   )

--- a/apps/tldw-frontend/pages/_app.tsx
+++ b/apps/tldw-frontend/pages/_app.tsx
@@ -342,6 +342,8 @@ export default function App({ Component, pageProps }: AppProps) {
     }),
     [hideShellNav, isSettingsRoute, isSetupRoute]
   )
+  const enableNotifications =
+    authResolved && isAuthenticated && !isPublicAuthRoute && !isSetupRoute
 
   const layoutContent = (
     <OptionLayout {...layoutProps}>
@@ -362,7 +364,7 @@ export default function App({ Component, pageProps }: AppProps) {
   )
 
   return (
-    <AppProviders>
+    <AppProviders enableNotifications={enableNotifications}>
       <ConfigurationGuard>
         <BackendRecoveryUiProvider routeRecoveryEnabled>
           <ErrorBoundary>

--- a/backlog/tasks/task-12918 - Fix-WebUI-chat-startup-request-burst-and-missing-visual-identity-replay.md
+++ b/backlog/tasks/task-12918 - Fix-WebUI-chat-startup-request-burst-and-missing-visual-identity-replay.md
@@ -1,0 +1,37 @@
+---
+id: TASK-12918
+title: Fix WebUI chat startup request burst and missing visual identity replay
+status: Done
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix the WebUI /chat startup request burst that can replay persona, character, and visual identity requests until Resource Governance returns 429. Evidence: stored/default character state on /chat triggers /persona/profiles, /persona/catalog, /characters?limit=1000&offset=0, /characters/3 404, and /visual-identities/bindings/resolve?actor_id=3 404. Scope: remove speculative background route prefetch, gate/dedupe first-run checks, and prevent missing visual identity bindings from being retried on remount churn.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Final summary: Fixed the WebUI /chat startup request burst by removing speculative route warm-prefetch from _app, gating the app-level first-run check until auth is resolved, single-flighting/caching successful first-run profile checks without caching failed responses, re-reading the local dismissal flag when consuming the cache, and caching missing visual identity 404s as no binding for the current JS session. Verification completed: focused Vitest suite passed (39 tests), frontend typecheck passed, Playwright e2e/chat-request-dedupe passed against live frontend/backend with RG enabled, seeded /chat probe against RG-enabled backend reported rateLimited=false and /persona/profiles=1, and backend log scan found no 429/rate_limited entries. Bandit: skipped because the touched implementation scope is frontend TypeScript/TSX only; no Python files were modified.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12919 - Fix-residual-apiSend-GET-burst-on-chat-first-run-checks.md
+++ b/backlog/tasks/task-12919 - Fix-residual-apiSend-GET-burst-on-chat-first-run-checks.md
@@ -1,0 +1,45 @@
+---
+id: TASK-12919
+title: Fix residual apiSend GET burst on chat first-run checks
+status: Done
+labels:
+- frontend
+- bug
+- uat
+priority: High
+modified_files:
+- apps/packages/ui/src/services/api-send.ts
+- apps/packages/ui/src/services/__tests__/api-send.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Real-backend UAT after the background-proxy fix still shows four GET /api/v1/persona/profiles requests during /chat load. Trace shows the caller is useFirstRunCheck via apiSend, which bypasses bgRequest GET coalescing. Add the smallest shared fix so safe apiSend GETs single-flight concurrent identical requests, then rerun focused tests and real-backend UAT.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added shared apiSend GET single-flight coalescing and regression coverage. Focused unit suites passed: bunx vitest run src/services/__tests__/api-send.test.ts src/services/__tests__/background-proxy.test.ts (57 tests). Real-backend UAT passed against frontend 127.0.0.1:8080 and backend 127.0.0.1:8000 with zero 429s, zero bad HTTP responses, and no burst targets. Bandit skipped as not applicable to TS-only frontend files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12920 - Fix-setup-notification-CORS-probes-in-advanced-WebUI-mode.md
+++ b/backlog/tasks/task-12920 - Fix-setup-notification-CORS-probes-in-advanced-WebUI-mode.md
@@ -1,0 +1,47 @@
+---
+id: TASK-12920
+title: Fix setup notification CORS probes in advanced WebUI mode
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-08 14:22'
+labels: []
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Real-backend UAT on the clean dev-based worktree exposed console CORS errors from NotificationToastBridge probing notification endpoints on /setup before API auth is configured. Gate global notification startup on authenticated app state so setup/login do not issue credentialed cross-origin notification requests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Setup and login routes do not start notification bootstrap before auth is configured.
+- [x] #2 Hidden-header layouts do not poll notification unread count.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: after rebasing onto dev, setup mounted global notification clients before auth was configured. The toast bridge and header unread-count poll made credentialed cross-origin notification requests, which the backend CORS policy rejected in advanced local mode.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added an auth-controlled AppProviders notification gate, passed it from _app only after auth resolves on non-setup routes, and skipped WebLayout unread-count polling while the header is hidden. Verified focused Vitest coverage and real-backend UAT: zero 429s, zero burst targets, no bad responses, and setup notification CORS errors removed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12921 - Fix-settings-exit-route-transition-shell-regression.md
+++ b/backlog/tasks/task-12921 - Fix-settings-exit-route-transition-shell-regression.md
@@ -1,0 +1,42 @@
+---
+id: TASK-12921
+title: Fix settings exit route transition shell regression
+status: Done
+labels:
+- frontend
+- bug
+- settings
+- navigation
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix the settings page Exit flow where navigating back to the previous page can leave the settings content visible without the WebUI header/sidebar during the route transition.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Root cause: settings pages intentionally render as shell-less routes. On Exit, Next can update the browser URL back to the previous page before the new page component/hydration has replaced the old settings component, leaving the stale settings layout visible under the prior URL without the WebUI shell. Fix: settings Exit now uses document navigation in the Next web app so stale shell-less settings content is unloaded instead of kept through the SPA transition. Non-Next/shared UI contexts still use SPA navigate with React Router's flushSync option. The Next react-router shim now honors flushSync for callers that need immediate navigation semantics. Settings exit targets are normalized to app-relative paths before navigation so a corrupted sessionStorage return target cannot send document navigation off-origin. Verification: focused settings exit tests pass; existing settings layout tests pass; react-router shim transition tests pass; live Playwright repro against localhost no longer shows the stale settings page under /chat. Typecheck note: UI package tsc requires increased heap and still fails on unrelated existing baseline errors in tests/background code; no new typecheck evidence points at the touched settings files.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed settings Exit route-transition regression by using document navigation for settings Exit under the Next web app, keeping flushSync SPA navigation for non-Next contexts, and normalizing exit targets. Added focused regression coverage and verified with the live localhost repro.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- coalesce duplicate frontend startup GET requests across shared resources
- gate notification startup until authentication resolves
- prevent settings Exit from leaving stale shell-less settings UI under the prior route

## Verification
- bunx vitest run src/components/Layouts/__tests__/settings-layout-exit-navigation.test.tsx --reporter=dot
- bunx vitest run __tests__/navigation/react-router-shim-transition.test.tsx --reporter=dot
- live localhost Playwright repro for settings Exit verified before commit

## Change summary
Human maintainer must replace this with a human-written summary before marking ready for merge, per AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces frontend startup request bursts, gates notifications until auth resolves, and fixes settings Exit leaving stale shell-less UI. Addresses TASK-12918, TASK-12919, TASK-12920, and TASK-12921.

- **Bug Fixes**
  - Coalesced concurrent identical GETs in `bgRequest` and `apiSend`; supports `returnResponse` GETs; POSTs unchanged; recent 429s briefly reused to avoid bursts.
  - Deferred notification bootstrap until after auth; `_app` passes `enableNotifications` to `AppProviders`; header unread polling skipped when `hideHeader` is true.
  - Fixed settings Exit transitions: added `navigateFromSettingsExit` to use document navigation in Next and `flushSync` SPA navigate otherwise; updated Next `react-router` shim to honor `flushSync`; normalized exit targets to app-relative paths.

<sup>Written for commit 5ad8f945b8a8f10dd4c1e3bbb8e487f6b6642496. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

