### PR TITLE
Harden current main CodeQL alert paths

### DIFF
--- a/apps/tldw-frontend/__tests__/extension/runtime-bootstrap.test.ts
+++ b/apps/tldw-frontend/__tests__/extension/runtime-bootstrap.test.ts
@@ -14,8 +14,6 @@ const originalApiUrl = process.env.NEXT_PUBLIC_API_URL
 const originalDeploymentMode = process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
 const originalXApiKey = process.env.NEXT_PUBLIC_X_API_KEY
 const originalWindowLocation = window.location
-const RUNTIME_SESSION_SINGLE_USER_API_KEY =
-  "tldwRuntimeSessionSingleUserApiKey"
 
 const setWindowLocation = (href: string) => {
   Object.defineProperty(window, "location", {
@@ -318,7 +316,7 @@ describe("runtime-bootstrap chrome shim", () => {
     })
   })
 
-  it("keeps a manual single-user key available after a second hard reload in the same browser session", async () => {
+  it("does not persist a scrubbed manual single-user key across module reloads", async () => {
     process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = "advanced"
     process.env.NEXT_PUBLIC_API_URL = "http://127.0.0.1:8000"
     delete process.env.NEXT_PUBLIC_X_API_KEY
@@ -343,13 +341,11 @@ describe("runtime-bootstrap chrome shim", () => {
     await importAndAwaitBootstrap()
     runtimeAuth = await import("@/services/tldw/runtime-auth-override")
 
-    expect(runtimeAuth.getRuntimeSingleUserApiKeyOverride()).toBe(
-      "manual-user-key"
-    )
+    expect(runtimeAuth.getRuntimeSingleUserApiKeyOverride()).toBeNull()
     expect(localStorage.getItem("tldwConfig")).not.toContain("manual-user-key")
   })
 
-  it("rehydrates the session key when stored single-user config has a blank apiKey", async () => {
+  it("does not rehydrate a scrubbed key when stored single-user config has a blank apiKey", async () => {
     process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = "advanced"
     process.env.NEXT_PUBLIC_API_URL = "http://127.0.0.1:8000"
     delete process.env.NEXT_PUBLIC_X_API_KEY
@@ -378,9 +374,7 @@ describe("runtime-bootstrap chrome shim", () => {
     await importAndAwaitBootstrap()
     const runtimeAuth = await import("@/services/tldw/runtime-auth-override")
 
-    expect(runtimeAuth.getRuntimeSingleUserApiKeyOverride()).toBe(
-      "manual-user-key"
-    )
+    expect(runtimeAuth.getRuntimeSingleUserApiKeyOverride()).toBeNull()
     expect(localStorage.getItem("tldwConfig")).not.toContain("manual-user-key")
   })
 
@@ -398,7 +392,8 @@ describe("runtime-bootstrap chrome shim", () => {
     )
 
     await importAndAwaitBootstrap()
-    expect(sessionStorage.getItem(RUNTIME_SESSION_SINGLE_USER_API_KEY)).toBe(
+    let runtimeAuth = await import("@/services/tldw/runtime-auth-override")
+    expect(runtimeAuth.getRuntimeSingleUserApiKeyOverride()).toBe(
       "manual-user-key"
     )
 
@@ -413,9 +408,8 @@ describe("runtime-bootstrap chrome shim", () => {
 
     vi.resetModules()
     await importAndAwaitBootstrap()
-    const runtimeAuth = await import("@/services/tldw/runtime-auth-override")
+    runtimeAuth = await import("@/services/tldw/runtime-auth-override")
 
-    expect(sessionStorage.getItem(RUNTIME_SESSION_SINGLE_USER_API_KEY)).toBeNull()
     expect(runtimeAuth.getRuntimeSingleUserApiKeyOverride()).toBeNull()
   })
 

--- a/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
+++ b/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
@@ -407,9 +407,9 @@ export async function seedAuth(
       const authConfig = {
         serverUrl: cfg.serverUrl,
         authMode: cfg.authMode,
-        apiKey: cfg.apiKey,
         accessToken: cfg.accessToken
       }
+      ;(window as Window & { __tldwRuntimeApiKey?: string }).__tldwRuntimeApiKey = cfg.apiKey
 
       // lgtm[js/clear-text-storage-of-sensitive-data]: synthetic E2E auth seed only.
       localStorage.setItem("tldwConfig", JSON.stringify(authConfig))
@@ -418,8 +418,6 @@ export async function seedAuth(
       localStorage.setItem("serverUrl", cfg.serverUrl)
       localStorage.setItem("tldwServerUrl", cfg.serverUrl)
       localStorage.setItem("authMode", cfg.authMode)
-      // lgtm[js/clear-text-storage-of-sensitive-data]: test-only legacy auth compatibility key.
-      localStorage.setItem("apiKey", cfg.apiKey)
       // lgtm[js/clear-text-storage-of-sensitive-data]: synthetic E2E auth seed only.
       localStorage.setItem("accessToken", cfg.accessToken)
       localStorage.setItem("__tldw_first_run_complete", "true")

--- a/apps/tldw-frontend/extension/shims/runtime-bootstrap.ts
+++ b/apps/tldw-frontend/extension/shims/runtime-bootstrap.ts
@@ -209,7 +209,6 @@ const RUNTIME_CONFIG_ENDPOINT = "/api/_tldw-webui/runtime-config"
 const RUNTIME_AUTH_METADATA_KEY = "tldwRuntimeAuthMetadata"
 const RUNTIME_AUTH_METADATA_VERSION = 1
 const RUNTIME_ENV_AUTH_OPT_OUT_KEY = "tldwRuntimeEnvAuthOptOut"
-const RUNTIME_SESSION_SINGLE_USER_API_KEY = "tldwRuntimeSessionSingleUserApiKey"
 const PLACEHOLDER_API_KEYS = new Set([
   "change-me",
   "changeme",
@@ -335,35 +334,6 @@ const isPlaceholderApiKey = (value: string): boolean => {
   return PLACEHOLDER_API_KEYS.has(normalized)
 }
 
-const readRuntimeSessionApiKey = (): string | null => {
-  if (typeof window === "undefined") return null
-  try {
-    const key = normalizeApiKey(
-      window.sessionStorage.getItem(RUNTIME_SESSION_SINGLE_USER_API_KEY)
-    )
-    return key && !isPlaceholderApiKey(key) ? key : null
-  } catch (error) {
-    console.warn("[runtime-bootstrap] Failed to read session auth key", error)
-    return null
-  }
-}
-
-const writeRuntimeSessionApiKey = (value?: string | null): void => {
-  if (typeof window === "undefined") return
-  const key = normalizeApiKey(value)
-  try {
-    if (key && !isPlaceholderApiKey(key)) {
-      // codeql[js/clear-text-storage-of-sensitive-data]: sessionStorage keeps a user-entered single-user key only for the current browser session after localStorage tldwConfig is scrubbed.
-      window.sessionStorage.setItem(RUNTIME_SESSION_SINGLE_USER_API_KEY, key)
-    } else {
-      window.sessionStorage.removeItem(RUNTIME_SESSION_SINGLE_USER_API_KEY)
-    }
-  } catch (error) {
-    // Best-effort only; runtime auth still works for the current load.
-    console.warn("[runtime-bootstrap] Failed to write session auth key", error)
-  }
-}
-
 const deriveStoredSingleUserAuth = (
   existing: TldwConfig | null
 ): { authMode: string; manualKey: string | null } => {
@@ -376,14 +346,10 @@ const deriveStoredSingleUserAuth = (
     rawSingleUserKey && !isPlaceholderApiKey(rawSingleUserKey)
       ? rawSingleUserKey
       : null
-  const sessionKey =
-    existing && authMode === "single-user" && !configKey
-      ? readRuntimeSessionApiKey()
-      : null
 
   return {
     authMode,
-    manualKey: configKey || sessionKey
+    manualKey: configKey
   }
 }
 
@@ -547,7 +513,6 @@ const seedTldwConfigFromEnv = async (): Promise<void> => {
   if (envAuthOptedOut) {
     setRuntimeApiKey(null)
     setRuntimeSingleUserApiKeyOverride(null)
-    writeRuntimeSessionApiKey(null)
   } else if (apiKey && !getRuntimeSingleUserApiKeyOverride()) {
     setRuntimeApiKey(apiKey)
     setRuntimeSingleUserApiKeyOverride(apiKey)
@@ -578,9 +543,6 @@ const seedTldwConfigFromEnv = async (): Promise<void> => {
     ) {
       setRuntimeApiKey(manualSingleUserKey)
       setRuntimeSingleUserApiKeyOverride(manualSingleUserKey)
-      writeRuntimeSessionApiKey(manualSingleUserKey)
-    } else if (existing && existingAuthMode !== "single-user") {
-      writeRuntimeSessionApiKey(null)
     }
     const quickstartWebUiServerUrl = getQuickstartWebUiServerUrl()
     const effectiveExplicitWebHost =

--- a/apps/tldw-frontend/lib/authStorage.ts
+++ b/apps/tldw-frontend/lib/authStorage.ts
@@ -77,9 +77,18 @@ const readStoredLocalValue = (key: string): string | null => {
   }
 };
 
+const readRuntimeWindowApiKey = (): string | null => {
+  if (typeof window === "undefined") return null;
+  const runtimeValue = (window as Window & { __tldwRuntimeApiKey?: unknown })
+    .__tldwRuntimeApiKey;
+  return typeof runtimeValue === "string" ? normalizeApiKeyValue(runtimeValue) : null;
+};
+
 export const getApiKey = (): string | null => {
   const configuredValue = normalizeApiKeyValue(process.env.NEXT_PUBLIC_X_API_KEY || null);
   if (runtimeApiKey) return runtimeApiKey;
+  const runtimeWindowKey = readRuntimeWindowApiKey();
+  if (runtimeWindowKey) return runtimeWindowKey;
   if (configuredValue && !suppressEnvApiKeyForSession) return configuredValue;
 
   const storedConfig = readStoredTldwConfig();

--- a/backlog/tasks/task-12936 - Address-post-merge-CodeQL-alerts-on-main.md
+++ b/backlog/tasks/task-12936 - Address-post-merge-CodeQL-alerts-on-main.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12936
+title: Address post-merge CodeQL alerts on main
+status: Done
+assignee: []
+created_date: '2026-07-09 06:59'
+updated_date: '2026-07-09 07:00'
+labels:
+  - security
+  - codeql
+  - main
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate current CodeQL alerts on main after PR 2692 merge and implement minimal fixes for the alert classes before opening a main-targeted follow-up PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Current CodeQL alert classes on main are investigated and addressed in code where practical.
+- [x] #2 Regression tests cover changed parser/path/storage behavior.
+- [x] #3 Verification and Bandit status are recorded before PR handoff.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-07-09: Implemented CodeQL hardening for current main alert classes. Replaced vulnerable parser regexes in flashcard structured import, Skills frontmatter parsing, and moderation policy regex scanning with deterministic scanners. Replaced workflow list dynamic ORDER BY construction with a literal validated ordering map. Switched CSRF user binding to hmac.digest and suppressed public header/cookie-name Bandit false positives. Removed exception-detail leaks from setup, prompts, OCR, embeddings, and ACP endpoint responses. Removed frontend/runtime persistence of single-user API keys in local/session storage by using runtime-only key injection for smoke tests and extension bootstrap. Hardened path construction/validation across email mock output, chatbook export work dirs, file-artifact temp exports, RAG checkpoint/regression/personalization stores, research artifact storage, sandbox workspace/snapshot handling, filesystem storage, unified audit fallback queue, audio provider input conversion, visual identity asset storage, and skills service file operations. Added/updated regression tests for parser behavior, policy literal scanning, sandbox snapshot traversal rejection, and research artifact logical-name vs hashed-storage behavior.
+
+Verification: py_compile passed for touched Python; git diff --check passed; focused parser/security tests passed: 54 passed; visual identity storage tests passed: 31 passed; broader focused backend batch passed: 130 passed; frontend vitest runtime/auth storage tests passed: 37 passed; frontend typecheck passed. Bandit app-scope report /tmp/bandit_codeql_main_alerts_app.json has no high/medium findings; remaining 6 LOW findings are pre-existing subprocess warnings in Audio_Transcription_Lib.py outside the changed path-validation logic.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the post-merge main CodeQL alert classes with targeted parser, SQL ordering, path-safety, stack-trace redaction, CSRF binding, and frontend runtime-key-storage hardening. Added regression coverage for parser and storage behaviors. Local verification passed for focused backend/frontend checks; app-scope Bandit has only pre-existing low-severity audio subprocess warnings outside the changed logic. No user-facing documentation changes were needed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -2076,8 +2076,8 @@ async def acp_health(
                     runner_probe["agent_capabilities"] = caps
             else:
                 runner_probe = {"status": "not_running", "detail": "Runner process is not started"}
-        except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS as exc:
-            runner_probe = {"status": "error", "detail": str(exc)}
+        except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS:
+            runner_probe = {"status": "error", "detail": "ACP runner probe failed"}
     result["runner_probe"] = runner_probe
 
     # 4. Route-gating status

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -2194,7 +2194,7 @@ async def create_embeddings_batch_async(
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail="Invalid embedding provider configuration",
         ) from exc
 
     backend_identity = _normalize_cache_backend_identity(config, provider)
@@ -5038,7 +5038,7 @@ async def requeue_dlq_bulk(
                         with suppress(_EMBEDDINGS_NONCRITICAL_EXCEPTIONS):
                             await client.xdel(dlq_stream, eid)
             except _EMBEDDINGS_NONCRITICAL_EXCEPTIONS as e:
-                status = f"error:{type(e).__name__}"
+                status = "error"
                 dlq_requeue_errors_total.labels(queue_name=dlq_stream, error_type=type(e).__name__).inc()
             else:
                 dlq_requeued_total.labels(queue_name=dlq_stream, status=status).inc()

--- a/tldw_Server_API/app/api/v1/endpoints/ocr.py
+++ b/tldw_Server_API/app/api/v1/endpoints/ocr.py
@@ -33,7 +33,7 @@ def _describe_mineru_backend() -> dict[str, Any]:
     return describe_mineru_backend()
 
 
-def _describe_mineru_backend_error(exc: Exception) -> dict[str, Any]:
+def _describe_mineru_backend_error(_exc: Exception) -> dict[str, Any]:
     """Return a conservative MinerU capability stub when adapter discovery fails."""
     return {
         "available": False,
@@ -42,18 +42,18 @@ def _describe_mineru_backend_error(exc: Exception) -> dict[str, Any]:
         "opt_in_only": True,
         "supports_per_page_metrics": False,
         "mode": "cli",
-        "error": str(exc),
+        "error": "MinerU backend discovery failed",
     }
 
 
 def _record_backend_discovery_error(
     out: dict[str, Any],
     backend_name: str,
-    exc: Exception,
+    _exc: Exception,
 ) -> None:
     logging.error("OCR backend discovery failed for {}", backend_name)
     out.setdefault(backend_name, {})
-    out[backend_name]["error"] = str(exc)
+    out[backend_name]["error"] = f"{backend_name} backend discovery failed"
 
 
 @router.get("/backends", response_model=OCRBackendsResponse)

--- a/tldw_Server_API/app/api/v1/endpoints/prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompts.py
@@ -452,9 +452,9 @@ async def prompts_health():
         try:
             importlib.import_module("tldw_Server_API.app.core.DB_Management.Prompts_DB")
             lib_ok = True
-        except ImportError as e:
+        except ImportError:
             lib_ok = False
-            health["components"]["library_error"] = str(e)
+            health["components"]["library_error"] = "Prompts DB import failed"
 
         health["components"]["library"] = {"import_ok": lib_ok}
 

--- a/tldw_Server_API/app/api/v1/endpoints/setup.py
+++ b/tldw_Server_API/app/api/v1/endpoints/setup.py
@@ -1719,7 +1719,7 @@ def _get_audio_install_status(*, allow_completed_when_disabled: bool = False) ->
     if not install_status:
         return JSONResponse({"status": "idle"})
 
-    return JSONResponse(install_status)
+    return JSONResponse(_sanitize_setup_payload(install_status))
 
 
 def _ensure_setup_readiness_available(

--- a/tldw_Server_API/app/core/Audit/unified_audit_service.py
+++ b/tldw_Server_API/app/core/Audit/unified_audit_service.py
@@ -160,8 +160,12 @@ async def _fallback_queue_lock(path: Path) -> AsyncGenerator[None, None]:
 
     Uses a file lock when available; otherwise falls back to a process-wide lock.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = _fallback_lock_path(path)
+    path = path.resolve(strict=False)
+    fallback_dir = path.parent.resolve(strict=False)
+    path.relative_to(fallback_dir)
+    fallback_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = _fallback_lock_path(path).resolve(strict=False)
+    lock_path.relative_to(fallback_dir)
 
     if _HAS_FCNTL:
         def _open_and_lock() -> Any:
@@ -1015,7 +1019,7 @@ class UnifiedAuditService:
                 db_dir.mkdir(parents=True, exist_ok=True)
                 db_path = db_dir / "unified_audit.db"
 
-        self.db_path = Path(db_path)
+        self.db_path = Path(db_path).resolve(strict=False)
         try:
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
         except _AUDIT_NONCRITICAL_EXCEPTIONS as e:
@@ -2592,7 +2596,7 @@ class UnifiedAuditService:
                 if dropped > 0:
                     # Persist dropped events to a fallback JSONL queue for durability
                     try:
-                        fb_path = self.db_path.parent / "audit_fallback_queue.jsonl"
+                        fb_path = self._fallback_queue_path()
                         async with _fallback_queue_lock(fb_path):
                             await asyncio.to_thread(
                                 self._append_events_to_fallback, fb_path, combined[max_buffer:]
@@ -2619,10 +2623,20 @@ class UnifiedAuditService:
             os.fsync(fb.fileno())
 
     async def _spill_events_to_fallback(self, events: list[AuditEvent]) -> Path:
-        fb_path = self.db_path.parent / "audit_fallback_queue.jsonl"
+        fb_path = self._fallback_queue_path()
         async with _fallback_queue_lock(fb_path):
             await asyncio.to_thread(self._append_events_to_fallback, fb_path, events)
         return fb_path
+
+    def _fallback_queue_path(self) -> Path:
+        """Return the fallback JSONL path under the resolved audit DB directory."""
+        fallback_dir = self.db_path.parent.resolve(strict=False)
+        path = (fallback_dir / "audit_fallback_queue.jsonl").resolve(strict=False)
+        try:
+            path.relative_to(fallback_dir)
+        except ValueError as exc:
+            raise ValueError("audit fallback queue path escapes database directory") from exc
+        return path
 
     async def _update_daily_stats(self, db: aiosqlite.Connection, events: list[AuditEvent]):
         """Update daily statistics"""
@@ -2806,7 +2820,7 @@ class UnifiedAuditService:
 
     async def replay_fallback_queue(self, max_batch: int = 5000) -> int:
         """Replay events from the fallback queue back into the main audit table."""
-        fb_path = self.db_path.parent / "audit_fallback_queue.jsonl"
+        fb_path = self._fallback_queue_path()
         async with _fallback_queue_lock(fb_path):
             if not fb_path.exists():
                 return 0

--- a/tldw_Server_API/app/core/AuthNZ/csrf_protection.py
+++ b/tldw_Server_API/app/core/AuthNZ/csrf_protection.py
@@ -59,8 +59,9 @@ class CSRFTokenManager:
     def __init__(self):
         """Initialize CSRF token manager"""
         self.settings = get_settings()
-        self.token_header_name = "X-CSRF-Token"
-        self.token_cookie_name = "csrf_token"
+        # Header and cookie names are public identifiers, not secrets.
+        self.token_header_name = "X-CSRF-Token"  # nosec B105
+        self.token_cookie_name = "csrf_token"  # nosec B105
         self.token_length = 32
 
         # Methods that require CSRF protection
@@ -93,7 +94,7 @@ class CSRFTokenManager:
         s = get_settings()
         if not s.CSRF_BIND_TO_USER or user_id is None:
             return None
-        digest = hmac.new(self._hmac_key(), str(user_id).encode(), hashlib.sha256).digest()
+        digest = hmac.digest(self._hmac_key(), str(user_id).encode(), "sha256")
         return base64.urlsafe_b64encode(digest)[:16].decode()
 
     def generate_token(self, request: Request) -> str:

--- a/tldw_Server_API/app/core/AuthNZ/email_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/email_service.py
@@ -7,6 +7,7 @@ import json
 import os
 import smtplib
 import re
+import secrets
 from datetime import datetime, timezone
 from email import encoders
 from email.mime.base import MIMEBase
@@ -655,13 +656,13 @@ class EmailService:
 
         # Save to file
         if self.mock_output in ["file", "both"]:
-            file_path = self.mock_file_path / f"{email_id}.json"
+            file_path = self._mock_email_path(email_id, ".json")
             with open(file_path, "w") as f:
                 json.dump(email_data, f, indent=2)
 
             # Persist a stub HTML artifact instead of the rendered body so local
             # mock mailboxes do not store sensitive message content at rest.
-            html_path = self.mock_file_path / f"{email_id}.html"
+            html_path = self._mock_email_path(email_id, ".html")
             with open(html_path, "w") as f:
                 f.write(
                     "<!DOCTYPE html><html><body>"
@@ -679,10 +680,24 @@ class EmailService:
     @staticmethod
     def _safe_mock_email_file_id(timestamp: str, to_email: str) -> str:
         """Return a mock-email file stem that is valid across supported platforms."""
-        raw_id = f"{timestamp}_{to_email.replace('@', '_at_')}"
+        del to_email
+        raw_id = f"{timestamp}_{secrets.token_hex(8)}"
         safe_id = re.sub(r'[<>:"/\\|?*\x00-\x1f]+', "_", raw_id)
         safe_id = re.sub(r"_+", "_", safe_id).strip(" ._")
         return safe_id or "mock_email"
+
+    def _mock_email_path(self, email_id: str, suffix: str) -> Path:
+        """Resolve a mock-email artifact path under the configured mock directory."""
+        file_name = f"{email_id}{suffix}"
+        if Path(file_name).name != file_name:
+            raise ValueError("invalid mock email file name")
+        base = self.mock_file_path.resolve(strict=False)
+        path = (base / file_name).resolve(strict=False)
+        try:
+            path.relative_to(base)
+        except ValueError as exc:
+            raise ValueError("invalid mock email path") from exc
+        return path
 
     @staticmethod
     def _redact_mock_email_body(body: str) -> str:

--- a/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
+++ b/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
@@ -25,6 +25,7 @@ import hashlib
 import json
 import os
 import shutil
+import tempfile
 import zipfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
@@ -563,6 +564,47 @@ class ChatbookService:
             if not safe_name:
                 safe_name = "chatbook"
         return f"{safe_name}{suffix}"
+
+    @staticmethod
+    def _safe_path_component(value: object, *, fallback: str) -> str:
+        """Return a filesystem-safe component for generated chatbook files."""
+        safe = "".join(c if c.isalnum() or c in "_-" else "_" for c in str(value))
+        safe = safe.strip("._-")
+        return safe or fallback
+
+    def _resolve_export_path(self, name: str, timestamp: str) -> Path:
+        """Resolve an export archive path within the user export directory."""
+        base = self.export_dir.resolve(strict=False)
+        filename = self._build_export_filename(name, timestamp)
+        path = (base / filename).resolve(strict=False)
+        try:
+            path.relative_to(base)
+        except ValueError as exc:
+            raise SecurityError("Chatbook export path escaped export directory") from exc
+        return path
+
+    def _new_work_dir(self, prefix: str, timestamp: str) -> Path:
+        """Create a temporary work directory inside the user chatbook temp directory."""
+        base = self.temp_dir.resolve(strict=False)
+        base.mkdir(parents=True, exist_ok=True, mode=0o700)
+        safe_prefix = self._safe_path_component(prefix, fallback="chatbook")
+        path = Path(tempfile.mkdtemp(prefix=f"{safe_prefix}_{timestamp}_", dir=base))
+        resolved = path.resolve(strict=False)
+        try:
+            resolved.relative_to(base)
+        except ValueError as exc:
+            raise SecurityError("Chatbook work directory escaped temp directory") from exc
+        return resolved
+
+    async def _remove_work_dir(self, work_dir: Path) -> None:
+        """Remove a chatbook work directory after proving it is under temp_dir."""
+        base = self.temp_dir.resolve(strict=False)
+        resolved = work_dir.resolve(strict=False)
+        try:
+            resolved.relative_to(base)
+        except ValueError as exc:
+            raise SecurityError("Refusing to remove work directory outside chatbook temp directory") from exc
+        await asyncio.to_thread(shutil.rmtree, resolved)
 
     def __init__(
         self,
@@ -1542,8 +1584,7 @@ class ChatbookService:
         output_path: Path | None = None
         try:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            work_dir = self.temp_dir / f"continue_{timestamp}_{uuid4().hex[:8]}"
-            work_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            work_dir = self._new_work_dir("continue", timestamp)
 
             # Determine sequence number from export_id, keeping the base stable
             base_id = export_id.split("_cont_")[0]
@@ -1618,7 +1659,8 @@ class ChatbookService:
                                     "continuation_token": str(last_run_id)
                                 })
 
-                    eval_file = eval_dir / f"evaluation_{eval_id}_cont.json"
+                    safe_eval_id = self._safe_path_component(eval_id, fallback="evaluation")
+                    eval_file = eval_dir / f"evaluation_{safe_eval_id}_cont.json"
                     with open(eval_file, "w", encoding="utf-8") as ef:
                         json.dump(eval_data, ef, indent=2, ensure_ascii=False)
                     content.evaluations[str(eval_id)] = eval_data
@@ -1639,8 +1681,7 @@ class ChatbookService:
                 await f.write(json.dumps(manifest.to_dict(), indent=2, ensure_ascii=False))
 
             # Create archive
-            output_filename = self._build_export_filename(cont_name, timestamp)
-            output_path = self.export_dir / output_filename
+            output_path = self._resolve_export_path(cont_name, timestamp)
             await self._create_zip_archive_async(work_dir, output_path)
 
             manifest.total_size_bytes = output_path.stat().st_size
@@ -1661,7 +1702,7 @@ class ChatbookService:
         finally:
             if work_dir and work_dir.exists():
                 try:
-                    await asyncio.to_thread(shutil.rmtree, work_dir)
+                    await self._remove_work_dir(work_dir)
                 except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
                     pass
 
@@ -1690,8 +1731,7 @@ class ChatbookService:
         try:
             # Create working directory in secure temp location
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            work_dir = self.temp_dir / f"export_{timestamp}_{uuid4().hex[:8]}"
-            work_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            work_dir = self._new_work_dir("export", timestamp)
 
             # Initialize manifest
             manifest = ChatbookManifest(
@@ -1833,8 +1873,7 @@ class ChatbookService:
                 await _write_manifest()
 
             # Create archive in secure export directory
-            output_filename = self._build_export_filename(name, timestamp)
-            output_path = self.export_dir / output_filename
+            output_path = self._resolve_export_path(name, timestamp)
             await self._create_zip_archive_async(work_dir, output_path)
 
             # Update manifest with final archive size; re-zip if manifest changes size.
@@ -1862,7 +1901,7 @@ class ChatbookService:
         finally:
             if work_dir and work_dir.exists():
                 try:
-                    await asyncio.to_thread(shutil.rmtree, work_dir)
+                    await self._remove_work_dir(work_dir)
                 except _CHATBOOK_NONCRITICAL_EXCEPTIONS as cleanup_err:
                     logger.warning(f"Failed to remove work directory {work_dir}: {cleanup_err}")
 

--- a/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
@@ -1950,22 +1950,47 @@ class WorkflowsDatabase:
         if created_before:
             sql += " AND created_at <= ?"
             params.append(created_before)
-        # Whitelist order_by to known columns
-        allowed_order = {"created_at", "started_at", "ended_at"}
-        ob = order_by if order_by in allowed_order else "created_at"
+        order_clauses = {
+            ("created_at", True): (
+                " AND ((created_at < ?) OR (created_at = ? AND run_id < ?))",
+                " ORDER BY created_at DESC, run_id DESC LIMIT ?",
+            ),
+            ("created_at", False): (
+                " AND ((created_at > ?) OR (created_at = ? AND run_id > ?))",
+                " ORDER BY created_at ASC, run_id ASC LIMIT ?",
+            ),
+            ("started_at", True): (
+                " AND ((started_at < ?) OR (started_at = ? AND run_id < ?))",
+                " ORDER BY started_at DESC, run_id DESC LIMIT ?",
+            ),
+            ("started_at", False): (
+                " AND ((started_at > ?) OR (started_at = ? AND run_id > ?))",
+                " ORDER BY started_at ASC, run_id ASC LIMIT ?",
+            ),
+            ("ended_at", True): (
+                " AND ((ended_at < ?) OR (ended_at = ? AND run_id < ?))",
+                " ORDER BY ended_at DESC, run_id DESC LIMIT ?",
+            ),
+            ("ended_at", False): (
+                " AND ((ended_at > ?) OR (ended_at = ? AND run_id > ?))",
+                " ORDER BY ended_at ASC, run_id ASC LIMIT ?",
+            ),
+        }
+        seek_clause, cursor_order_clause = order_clauses.get(
+            (order_by, order_desc),
+            order_clauses[("created_at", order_desc)],
+        )
+        offset_order_clause = cursor_order_clause.replace(" LIMIT ?", " LIMIT ? OFFSET ?")
         # Apply cursor seek if provided (seek pagination)
         if cursor_ts and cursor_id:
-            cmp = "<" if order_desc else ">"
-            # Add tie-breaker on run_id; for DESC use run_id < last_id if same ts, for ASC use run_id > last_id
-            tcmp = "<" if order_desc else ">"
-            sql += f" AND (({ob} {cmp} ?) OR ({ob} = ? AND run_id {tcmp} ?))"
+            sql += seek_clause
             params.extend([cursor_ts, cursor_ts, cursor_id])
             # When using cursor, ignore numeric offset to avoid skipping
-            sql += f" ORDER BY {ob} {'DESC' if order_desc else 'ASC'}, run_id {'DESC' if order_desc else 'ASC'} LIMIT ?"
+            sql += cursor_order_clause
             params.extend([int(limit)])
         else:
             # Stable ordering with tie-breaker by run_id
-            sql += f" ORDER BY {ob} {'DESC' if order_desc else 'ASC'}, run_id {'DESC' if order_desc else 'ASC'} LIMIT ? OFFSET ?"
+            sql += offset_order_clause
             params.extend([int(limit), int(offset)])
 
         if self._using_backend():

--- a/tldw_Server_API/app/core/File_Artifacts/file_artifacts_service.py
+++ b/tldw_Server_API/app/core/File_Artifacts/file_artifacts_service.py
@@ -491,8 +491,13 @@ class FileArtifactsService:
     async def _write_export_file(self, file_id: int, export_format: str, content: bytes) -> tuple[str, int]:
         filename = f"file_{file_id}.{export_format}"
         storage_path = self._cdb.resolve_temp_output_storage_path(filename)
-        outputs_dir = DatabasePaths.get_user_temp_outputs_dir(self._user_id_int)
-        file_path = outputs_dir / storage_path
+        outputs_dir = DatabasePaths.get_user_temp_outputs_dir(self._user_id_int).resolve(strict=False)
+        outputs_dir.mkdir(parents=True, exist_ok=True)
+        file_path = (outputs_dir / storage_path).resolve(strict=False)
+        try:
+            file_path.relative_to(outputs_dir)
+        except ValueError as exc:
+            raise FileArtifactsError("storage_persist_failed", detail="invalid_export_storage_path") from exc
         async with aiofiles.open(file_path, "wb") as handle:
             await handle.write(content)
         return storage_path, len(content)
@@ -500,8 +505,9 @@ class FileArtifactsService:
     def _delete_temp_export_file(self, storage_path: str) -> None:
         try:
             safe_name = self._cdb.resolve_temp_output_storage_path(storage_path)
-            outputs_dir = DatabasePaths.get_user_temp_outputs_dir(self._user_id_int)
-            file_path = outputs_dir / safe_name
+            outputs_dir = DatabasePaths.get_user_temp_outputs_dir(self._user_id_int).resolve(strict=False)
+            file_path = (outputs_dir / safe_name).resolve(strict=False)
+            file_path.relative_to(outputs_dir)
             if file_path.exists():
                 file_path.unlink()
         except Exception as exc:

--- a/tldw_Server_API/app/core/Flashcards/structured_qa_import.py
+++ b/tldw_Server_API/app/core/Flashcards/structured_qa_import.py
@@ -1,11 +1,10 @@
 """Deterministic parser for structured Q&A flashcard preview imports."""
-
-import re
 from dataclasses import dataclass, field
 
 
-QUESTION_RE = re.compile(r"^\s*(?:Q|Question)\s*[:.-]\s*(.*)\s*$", re.IGNORECASE)
-ANSWER_RE = re.compile(r"^\s*(?:A|Answer)\s*[:.-]\s*(.*)\s*$", re.IGNORECASE)
+QUESTION_LABELS = frozenset({"q", "question"})
+ANSWER_LABELS = frozenset({"a", "answer"})
+LABEL_SEPARATORS = frozenset({":", ".", "-"})
 
 
 @dataclass
@@ -35,6 +34,18 @@ class StructuredQaPreviewResult:
 
 def _utf8_length(value: str) -> int:
     return len(value.encode("utf-8"))
+
+
+def _match_labeled_line(raw_line: str, labels: frozenset[str]) -> str | None:
+    stripped = raw_line.lstrip()
+    for index, char in enumerate(stripped):
+        if char not in LABEL_SEPARATORS:
+            continue
+        label = stripped[:index].strip().lower()
+        if label in labels:
+            return stripped[index + 1 :].strip()
+        return None
+    return None
 
 
 def parse_structured_qa_preview(
@@ -122,23 +133,23 @@ def parse_structured_qa_preview(
             push_error(index, f"Line too long (> {max_line_length} bytes)")
             continue
 
-        question_match = QUESTION_RE.match(raw_line)
-        if question_match:
+        question_value = _match_labeled_line(raw_line, QUESTION_LABELS)
+        if question_value is not None:
             finalize_block()
-            question_lines = [question_match.group(1).strip()]
+            question_lines = [question_value]
             answer_lines = []
             line_start = index
             line_end = index
             in_answer = False
             continue
 
-        answer_match = ANSWER_RE.match(raw_line)
-        if answer_match:
+        answer_value = _match_labeled_line(raw_line, ANSWER_LABELS)
+        if answer_value is not None:
             if line_start is None:
                 result.skipped_blocks += 1
                 push_error(index, "Answer block found before any question label")
                 continue
-            answer_lines.append(answer_match.group(1).strip())
+            answer_lines.append(answer_value)
             line_end = index
             in_answer = True
             continue

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -344,12 +344,24 @@ def _resample_audio_without_librosa(audio: np.ndarray, sample_rate: int, target_
     return np.interp(x_new, x_old, audio).astype(np.float32, copy=False)
 
 
-def _load_audio_for_parakeet_nemo(audio_file_path: str, target_sr: int = 16000) -> tuple[np.ndarray, int, float]:
+def _load_audio_for_parakeet_nemo(
+    audio_file_path: str,
+    target_sr: int = 16000,
+    *,
+    base_dir: Optional[Path] = None,
+) -> tuple[np.ndarray, int, float]:
     """Load file audio for Nemo-backed Parakeet variants without importing librosa."""
     try:
         import soundfile as sf
     except ImportError as exc:
         raise STTTranscriptionError("Parakeet audio loading requires the soundfile package.") from exc
+
+    safe_audio_path = _resolve_audio_input_path_for_provider(
+        audio_file_path,
+        base_dir=base_dir,
+        label="Parakeet audio input path",
+    )
+    audio_file_path = str(safe_audio_path)
 
     try:
         audio_data, sample_rate = sf.read(audio_file_path, dtype="float32", always_2d=False)
@@ -361,20 +373,29 @@ def _load_audio_for_parakeet_nemo(audio_file_path: str, target_sr: int = 16000) 
             ) from exc
 
         try:
-            wav_file_path = convert_to_wav(audio_file_path, overwrite=True)
+            wav_file_path = convert_to_wav(audio_file_path, overwrite=True, base_dir=base_dir)
         except Exception as conversion_exc:
             logging.debug(f"Parakeet WAV conversion failed: {type(conversion_exc).__name__}")
             raise STTTranscriptionError(
                 "Parakeet audio loading failed: WAV conversion failed for compressed input."
             ) from conversion_exc
 
-        if not wav_file_path or Path(wav_file_path).suffix.lower() != ".wav" or not Path(wav_file_path).exists():
+        if not wav_file_path:
+            raise STTTranscriptionError(
+                "Parakeet audio loading failed: WAV conversion did not produce a usable WAV file."
+            ) from exc
+        wav_path = _resolve_audio_input_path_for_provider(
+            wav_file_path,
+            base_dir=base_dir,
+            label="Converted Parakeet WAV path",
+        )
+        if wav_path.suffix.lower() != ".wav" or not wav_path.exists():
             raise STTTranscriptionError(
                 "Parakeet audio loading failed: WAV conversion did not produce a usable WAV file."
             ) from exc
 
         try:
-            audio_data, sample_rate = sf.read(wav_file_path, dtype="float32", always_2d=False)
+            audio_data, sample_rate = sf.read(str(wav_path), dtype="float32", always_2d=False)
         except Exception as retry_exc:
             logging.debug(f"Soundfile could not load converted Parakeet WAV: {type(retry_exc).__name__}")
             raise STTTranscriptionError(
@@ -3181,7 +3202,11 @@ def speech_to_text_parakeet(
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo import (
             transcribe_with_parakeet,
         )
-        audio_data, sample_rate, audio_duration = _load_audio_for_parakeet_nemo(audio_file_path, target_sr=16000)
+        audio_data, sample_rate, audio_duration = _load_audio_for_parakeet_nemo(
+            audio_file_path,
+            target_sr=16000,
+            base_dir=base_dir,
+        )
 
         transcribe_kwargs: dict[str, Any] = {}
         if variant == "onnx":

--- a/tldw_Server_API/app/core/Moderation/policy_compiler.py
+++ b/tldw_Server_API/app/core/Moderation/policy_compiler.py
@@ -327,10 +327,38 @@ class PolicyCompiler:
     def has_nested_quantifiers(expr: str) -> bool:
         """Detect nested quantifiers that can trigger catastrophic backtracking."""
 
-        try:
-            return bool(re.search(r"\((?:[^)(]|\([^)(]*\))*[+*][^)]*\)\s*[+*]", expr))
-        except (TypeError, ValueError, re.error):
+        if not isinstance(expr, str):
             return False
+        stack: list[bool] = []
+        escaped = False
+        for index, char in enumerate(expr):
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if char == "(":
+                stack.append(False)
+                continue
+            if char == ")":
+                if not stack:
+                    continue
+                group_has_quantifier = stack.pop()
+                next_index = index + 1
+                while next_index < len(expr) and expr[next_index].isspace():
+                    next_index += 1
+                group_is_quantified = next_index < len(expr) and expr[next_index] in {"+", "*"}
+                if group_has_quantifier and group_is_quantified:
+                    return True
+                if stack and (group_has_quantifier or group_is_quantified):
+                    stack[-1] = True
+                continue
+            if char in {"+", "*"} and stack:
+                if index > 0 and expr[index - 1] == "\\":
+                    continue
+                stack[-1] = True
+        return False
 
     @staticmethod
     def too_many_groups(expr: str, limit: int = 100) -> bool:

--- a/tldw_Server_API/app/core/RAG/rag_service/checkpoint.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/checkpoint.py
@@ -100,7 +100,7 @@ class CheckpointManager:
             checkpoint_dir: Directory for storing checkpoints.
                            Defaults to .tldw/checkpoints/
         """
-        self.checkpoint_dir = Path(checkpoint_dir or self.DEFAULT_CHECKPOINT_DIR)
+        self.checkpoint_dir = Path(checkpoint_dir or self.DEFAULT_CHECKPOINT_DIR).resolve(strict=False)
         self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
     def create(
@@ -122,7 +122,8 @@ class CheckpointManager:
             New CheckpointData instance.
         """
         now = datetime.now(timezone.utc).isoformat()
-        checkpoint_id = f"{task_type}_{uuid.uuid4().hex[:8]}"
+        safe_task_type = self._safe_checkpoint_component(task_type, fallback="task")
+        checkpoint_id = f"{safe_task_type}_{uuid.uuid4().hex[:8]}"
 
         checkpoint = CheckpointData(
             checkpoint_id=checkpoint_id,
@@ -234,7 +235,7 @@ class CheckpointManager:
             FileNotFoundError: If checkpoint file doesn't exist.
             ValueError: If checkpoint file is invalid.
         """
-        path = Path(checkpoint_path)
+        path = self._resolve_checkpoint_path(checkpoint_path)
         if not path.exists():
             msg = f"Checkpoint file not found: {path}"
             raise FileNotFoundError(msg)
@@ -404,11 +405,31 @@ class CheckpointManager:
 
     def _get_checkpoint_path(self, checkpoint_id: str) -> Path:
         """Get the file path for a checkpoint ID."""
-        return self.checkpoint_dir / f"{checkpoint_id}.json"
+        return self._resolve_checkpoint_path(f"{checkpoint_id}.json")
 
     def _get_results_path(self, checkpoint_id: str) -> Path:
         """Get the JSONL sidecar path for checkpoint results."""
-        return self.checkpoint_dir / f"{checkpoint_id}.results.jsonl"
+        return self._resolve_checkpoint_path(f"{checkpoint_id}.results.jsonl")
+
+    @staticmethod
+    def _safe_checkpoint_component(value: str, *, fallback: str) -> str:
+        """Return a checkpoint file component containing only safe filename characters."""
+        safe = "".join(c if c.isalnum() or c in "_.-" else "_" for c in str(value))
+        safe = safe.strip("._")
+        return safe or fallback
+
+    def _resolve_checkpoint_path(self, path_value: Path | str) -> Path:
+        """Resolve a checkpoint file path under the configured checkpoint directory."""
+        raw_path = Path(path_value)
+        if raw_path.is_absolute():
+            path = raw_path.resolve(strict=False)
+        else:
+            path = (self.checkpoint_dir / raw_path).resolve(strict=False)
+        try:
+            path.relative_to(self.checkpoint_dir)
+        except ValueError as exc:
+            raise ValueError("checkpoint path escapes checkpoint directory") from exc
+        return path
 
     def _append_results(
         self, checkpoint_id: str, results: list[dict[str, Any]]

--- a/tldw_Server_API/app/core/RAG/rag_service/regression.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/regression.py
@@ -177,7 +177,7 @@ class RegressionDetector:
                 than this fraction of the baseline value.
             lower_is_better: Set of metric names where lower values are better.
         """
-        self.baseline_dir = Path(baseline_dir or self.DEFAULT_BASELINE_DIR)
+        self.baseline_dir = Path(baseline_dir or self.DEFAULT_BASELINE_DIR).resolve(strict=False)
         self._dir_ensured = False
         self.default_threshold = default_threshold
         self.lower_is_better = lower_is_better or {"hallucination", "latency_p99_ms"}
@@ -394,7 +394,12 @@ class RegressionDetector:
         """
         if not _SAFE_ID_RE.match(baseline_id):
             raise ValueError(f"Invalid baseline ID: {baseline_id!r}")
-        return self.baseline_dir / f"{baseline_id}.json"
+        path = (self.baseline_dir / f"{baseline_id}.json").resolve(strict=False)
+        try:
+            path.relative_to(self.baseline_dir)
+        except ValueError as exc:
+            raise ValueError("baseline path escapes baseline directory") from exc
+        return path
 
     def _save_atomic(self, baseline: MetricBaseline) -> None:
         """Save baseline atomically using temp file + rename."""

--- a/tldw_Server_API/app/core/RAG/rag_service/user_personalization_store.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/user_personalization_store.py
@@ -39,7 +39,13 @@ def _empty_store() -> dict[str, Any]:
 
 class UserPersonalizationStore:
     def __init__(self, user_id: str | None) -> None:
-        self.path = DatabasePaths.get_user_rag_personalization_path(user_id)
+        base = DatabasePaths.get_user_base_directory(user_id).resolve(strict=False)
+        self.path = (base / "rag_personalization.json").resolve(strict=False)
+        try:
+            self.path.relative_to(base)
+        except ValueError as exc:
+            raise ValueError("personalization path escapes user directory") from exc
+        base.mkdir(parents=True, exist_ok=True)
         # Use the sanitized directory name as the canonical user id for storage/logging.
         self.user_id = self.path.parent.name
         self._data: dict[str, Any] = {}

--- a/tldw_Server_API/app/core/Research/artifact_store.py
+++ b/tldw_Server_API/app/core/Research/artifact_store.py
@@ -19,19 +19,50 @@ class ResearchArtifactStore:
     """Write internal artifacts to disk and register them in the research manifest."""
 
     def __init__(self, *, base_dir: str | Path, db: ResearchSessionsDB):
-        self.base_dir = Path(base_dir)
+        self.base_dir = Path(base_dir).resolve(strict=False)
         self.db = db
 
-    def _artifact_path(self, session_id: str, artifact_name: str) -> Path:
-        safe_name = normalize_output_storage_filename(
+    @staticmethod
+    def _safe_session_component(session_id: str) -> str:
+        raw = str(session_id or "").strip()
+        if not raw:
+            raise ValueError("session_id must contain at least one safe character")
+        return f"session_{hashlib.sha256(raw.encode('utf-8')).hexdigest()[:32]}"
+
+    def _resolve_artifact_path(self, session_id: str, safe_name: str) -> Path:
+        base = (self.base_dir / "research").resolve(strict=False)
+        session_dir = (base / self._safe_session_component(session_id)).resolve(strict=False)
+        try:
+            session_dir.relative_to(base)
+        except ValueError as exc:
+            raise ValueError("artifact session path escapes research directory") from exc
+        session_dir.mkdir(parents=True, exist_ok=True)
+        path = (session_dir / safe_name).resolve(strict=False)
+        try:
+            path.relative_to(session_dir)
+        except ValueError as exc:
+            raise ValueError("artifact path escapes session directory") from exc
+        return path
+
+    @staticmethod
+    def _safe_artifact_name(artifact_name: str) -> str:
+        return normalize_output_storage_filename(
             artifact_name,
             allow_absolute=False,
             reject_relative_with_separators=True,
             expand_user=False,
         )
-        artifact_dir = self.base_dir / "research" / session_id
-        artifact_dir.mkdir(parents=True, exist_ok=True)
-        return artifact_dir / safe_name
+
+    @staticmethod
+    def _storage_file_name(safe_name: str) -> str:
+        suffix = "".join(Path(safe_name).suffixes)
+        digest = hashlib.sha256(safe_name.encode("utf-8")).hexdigest()
+        return f"artifact_{digest}{suffix}"
+
+    def _artifact_path(self, session_id: str, artifact_name: str) -> Path:
+        safe_name = self._safe_artifact_name(artifact_name)
+        storage_name = self._storage_file_name(safe_name)
+        return self._resolve_artifact_path(session_id, storage_name)
 
     def _versioned_artifact_path(self, session_id: str, artifact_name: str, artifact_version: int) -> Path:
         path = self._artifact_path(session_id, artifact_name)
@@ -58,10 +89,11 @@ class ResearchArtifactStore:
         return (max(existing) + 1) if existing else 1
 
     def _latest_artifact(self, session_id: str, artifact_name: str) -> ResearchArtifactRow | None:
+        safe_name = self._safe_artifact_name(artifact_name)
         matches = [
             artifact
             for artifact in self.db.list_artifacts(session_id)
-            if artifact.artifact_name == artifact_name
+            if artifact.artifact_name == safe_name
         ]
         if not matches:
             return None
@@ -95,7 +127,7 @@ class ResearchArtifactStore:
         job_id: str | None,
     ) -> ResearchArtifactRow:
         owner_user_id = str(owner_user_id)
-        safe_name = self._artifact_path(session_id, artifact_name).name
+        safe_name = self._safe_artifact_name(artifact_name)
         next_version = self._next_version(session_id, safe_name)
         path = self._versioned_artifact_path(session_id, safe_name, next_version)
         encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
@@ -134,7 +166,7 @@ class ResearchArtifactStore:
         job_id: str | None,
     ) -> ResearchArtifactRow:
         owner_user_id = str(owner_user_id)
-        safe_name = self._artifact_path(session_id, artifact_name).name
+        safe_name = self._safe_artifact_name(artifact_name)
         next_version = self._next_version(session_id, safe_name)
         path = self._versioned_artifact_path(session_id, safe_name, next_version)
         encoded = "".join(
@@ -177,7 +209,7 @@ class ResearchArtifactStore:
         content_type: str = "text/plain",
     ) -> ResearchArtifactRow:
         owner_user_id = str(owner_user_id)
-        safe_name = self._artifact_path(session_id, artifact_name).name
+        safe_name = self._safe_artifact_name(artifact_name)
         next_version = self._next_version(session_id, safe_name)
         path = self._versioned_artifact_path(session_id, safe_name, next_version)
         encoded = content.encode("utf-8")

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 import shutil
@@ -1473,7 +1474,18 @@ class SandboxOrchestrator:
     # -----------------
     # Workspaces
     # -----------------
-    def _workspace_path(self, user_id: Any, session_id: str) -> Path:
+    @staticmethod
+    def _safe_workspace_component(value: Any, *, label: str) -> str:
+        raw = str(value or "").strip()
+        if not raw:
+            raise ValueError(f"{label} is required")
+        safe = "".join(c if c.isalnum() or c in "_.-" else "_" for c in raw).strip("._")
+        if safe and safe == raw:
+            return safe
+        digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+        return f"{label}_{digest}"
+
+    def _workspace_root(self) -> Path:
         try:
             root = getattr(app_settings, "SANDBOX_ROOT_DIR", None)
         except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
@@ -1484,7 +1496,34 @@ class SandboxOrchestrator:
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
                 proj = "."
             root = Path(str(proj)) / "tmp_dir" / "sandbox"
-        return Path(str(root)) / str(user_id) / "sessions" / str(session_id) / "workspace"
+        return Path(str(root)).resolve(strict=False)
+
+    def _workspace_path(self, user_id: Any, session_id: str) -> Path:
+        root = self._workspace_root()
+        user_component = self._safe_workspace_component(user_id, label="user")
+        session_component = self._safe_workspace_component(session_id, label="session")
+        path = (root / user_component / "sessions" / session_component / "workspace").resolve(strict=False)
+        try:
+            path.relative_to(root)
+        except ValueError as exc:
+            raise ValueError("workspace path escapes sandbox root") from exc
+        return path
+
+    def _resolve_workspace_path_from_store(self, workspace_path: Any) -> Path | None:
+        raw = str(workspace_path or "").strip()
+        if not raw:
+            return None
+        root = self._workspace_root()
+        path = Path(raw).resolve(strict=False)
+        try:
+            path.relative_to(root)
+        except ValueError:
+            logger.warning("Ignoring sandbox workspace path outside sandbox root: {}", raw)
+            return None
+        if path.name != "workspace":
+            logger.warning("Ignoring sandbox workspace path without workspace leaf: {}", raw)
+            return None
+        return path
 
     def _ensure_workspace(self, user_id: Any, session_id: str) -> str:
         ws = self._workspace_path(user_id, session_id)
@@ -1530,9 +1569,13 @@ class SandboxOrchestrator:
         if not ws_path:
             self._drop_cached_session(sid)
             return None
-        ws_str = str(ws_path)
+        resolved_ws = self._resolve_workspace_path_from_store(ws_path)
+        if resolved_ws is None:
+            self._drop_cached_session(sid)
+            return None
+        ws_str = str(resolved_ws)
         with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
-            Path(ws_str).mkdir(parents=True, exist_ok=True)
+            resolved_ws.mkdir(parents=True, exist_ok=True)
         with self._lock:
             self._session_roots[sid] = ws_str
         return ws_str
@@ -1555,10 +1598,16 @@ class SandboxOrchestrator:
         with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
             self._prune_expired_sessions()
         try:
-            return self._store.list_workspace_paths_for_user_workspace(
+            paths = self._store.list_workspace_paths_for_user_workspace(
                 user_id=owner_key,
                 workspace_id=workspace_key,
             )
+            resolved_paths = []
+            for path in paths:
+                resolved = self._resolve_workspace_path_from_store(path)
+                if resolved is not None:
+                    resolved_paths.append(str(resolved))
+            return resolved_paths
         except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug(
                 "store.list_workspace_paths_for_user_workspace failed: {}",

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -12,6 +12,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from loguru import logger
@@ -2606,9 +2607,18 @@ class SandboxService:
         ws = str(workspace_root or "").strip()
         if not ws:
             return
-        ws_path = os.path.abspath(ws)
-        session_root = os.path.dirname(ws_path) if os.path.basename(ws_path) == "workspace" else ws_path
-        shutil.rmtree(session_root, ignore_errors=True)
+        resolved_ws = self._orch._resolve_workspace_path_from_store(ws)
+        if resolved_ws is None:
+            logger.warning("Refusing to remove sandbox workspace outside sandbox root: {}", ws)
+            return
+        session_root = resolved_ws.parent if resolved_ws.name == "workspace" else resolved_ws
+        sandbox_root = self._orch._workspace_root()
+        try:
+            session_root.relative_to(sandbox_root)
+        except ValueError:
+            logger.warning("Refusing to remove sandbox session outside sandbox root: {}", session_root)
+            return
+        shutil.rmtree(Path(session_root), ignore_errors=True)
 
     def _cleanup_vz_session_control(self, session_id: str) -> None:
         control = self._orch.get_vz_session_control(session_id)

--- a/tldw_Server_API/app/core/Sandbox/snapshots.py
+++ b/tldw_Server_API/app/core/Sandbox/snapshots.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import os
+import re
 import shutil
 import tarfile
 import time
@@ -32,6 +34,8 @@ _SNAPSHOTS_NONCRITICAL_EXCEPTIONS = (
     tarfile.TarError,
 )
 
+_SAFE_SNAPSHOT_COMPONENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+
 
 class SnapshotManager:
     """Manages session snapshots for checkpoint/restore workflows.
@@ -48,25 +52,43 @@ class SnapshotManager:
                          SANDBOX_SNAPSHOT_PATH env var or /tmp/sandbox_snapshots.
         """
         if storage_path:
-            self.storage_path = storage_path
+            self.storage_path = Path(storage_path).resolve(strict=False)
         else:
-            self.storage_path = os.getenv(
-                "SANDBOX_SNAPSHOT_PATH",
-                os.path.join(os.path.dirname(__file__), "..", "..", "..", "tmp_dir", "sandbox_snapshots")
-            )
+            self.storage_path = Path(
+                os.getenv(
+                    "SANDBOX_SNAPSHOT_PATH",
+                    os.path.join(os.path.dirname(__file__), "..", "..", "..", "tmp_dir", "sandbox_snapshots")
+                )
+            ).resolve(strict=False)
         # Ensure storage directory exists
         try:
             os.makedirs(self.storage_path, exist_ok=True)
         except _SNAPSHOTS_NONCRITICAL_EXCEPTIONS as e:
             logger.warning(f"Failed to create snapshot storage path: {e}")
 
+    @staticmethod
+    def _safe_storage_component(value: str, *, label: str) -> str:
+        """Return a filesystem-safe snapshot storage path component."""
+        component = str(value or "").strip()
+        if not component or "/" in component or "\\" in component:
+            raise ValueError(f"Invalid {label}")
+        if not _SAFE_SNAPSHOT_COMPONENT_RE.fullmatch(component):
+            raise ValueError(f"Invalid {label}")
+        return f"{label}_{hashlib.sha256(component.encode('utf-8')).hexdigest()[:32]}"
+
     def _snapshot_dir(self, session_id: str) -> Path:
         """Get the directory for a session's snapshots."""
-        return Path(self.storage_path) / session_id
+        safe_session_id = self._safe_storage_component(session_id, label="session_id")
+        base = Path(self.storage_path).resolve(strict=False)
+        path = (base / safe_session_id).resolve(strict=False)
+        if path != base and base not in path.parents:
+            raise ValueError("Invalid session_id")
+        return path
 
     def _snapshot_path(self, session_id: str, snapshot_id: str) -> Path:
         """Get the full path for a specific snapshot archive."""
-        return self._snapshot_dir(session_id) / f"{snapshot_id}.tar.gz"
+        safe_snapshot_id = self._safe_storage_component(snapshot_id, label="snapshot_id")
+        return self._snapshot_dir(session_id) / f"{safe_snapshot_id}.tar.gz"
 
     @staticmethod
     def _has_symlink_ancestor(path: Path) -> bool:
@@ -74,9 +96,28 @@ class SnapshotManager:
         absolute = Path(os.path.abspath(path))
         return any(parent.is_symlink() for parent in reversed(absolute.parents))
 
+    @classmethod
+    def _resolve_workspace_root(cls, workspace_path: str, *, require_existing_dir: bool) -> Path:
+        """Resolve and validate a sandbox workspace root path."""
+        raw_path = str(workspace_path or "").strip()
+        if not raw_path:
+            raise ValueError("Invalid workspace path")
+        raw_root = Path(raw_path)
+        if raw_root.is_symlink():
+            raise ValueError("Refusing symlink workspace root")
+        if cls._has_symlink_ancestor(raw_root):
+            raise ValueError("Refusing symlink workspace ancestor")
+        root = raw_root.resolve(strict=False)
+        if require_existing_dir and not root.is_dir():
+            raise ValueError(f"Invalid workspace path: {workspace_path}")
+        if root.exists() and not root.is_dir():
+            raise ValueError(f"Invalid workspace path: {workspace_path}")
+        return root
+
     def _metadata_path(self, session_id: str, snapshot_id: str) -> Path:
         """Get the path for a snapshot's metadata file."""
-        return self._snapshot_dir(session_id) / f"{snapshot_id}.meta.json"
+        safe_snapshot_id = self._safe_storage_component(snapshot_id, label="snapshot_id")
+        return self._snapshot_dir(session_id) / f"{safe_snapshot_id}.meta.json"
 
     @staticmethod
     def _validate_tar_member(member: tarfile.TarInfo, extract_root: Path) -> None:
@@ -154,9 +195,7 @@ class SnapshotManager:
             ValueError: If the workspace path doesn't exist or isn't a directory.
             IOError: If there's an error creating the snapshot archive.
         """
-        if not workspace_path or not os.path.isdir(workspace_path):
-            raise ValueError(f"Invalid workspace path: {workspace_path}")
-        workspace_root = Path(workspace_path)
+        workspace_root = self._resolve_workspace_root(workspace_path, require_existing_dir=True)
         self._validate_workspace_tree_for_copy(workspace_root)
 
         snapshot_id = f"snap-{uuid.uuid4().hex[:12]}"
@@ -173,9 +212,8 @@ class SnapshotManager:
         try:
             with tarfile.open(snapshot_path, "w:gz") as tar:
                 # Add workspace contents with relative paths
-                for item in os.listdir(workspace_path):
-                    item_path = Path(workspace_path) / item
-                    self._add_workspace_item_to_tar(tar, item_path, item)
+                for item_path in workspace_root.iterdir():
+                    self._add_workspace_item_to_tar(tar, item_path, item_path.name)
         except _SNAPSHOTS_NONCRITICAL_EXCEPTIONS as e:
             # Clean up on failure
             with contextlib.suppress(_SNAPSHOTS_NONCRITICAL_EXCEPTIONS):
@@ -195,7 +233,7 @@ class SnapshotManager:
             "session_id": session_id,
             "created_at": created_at,
             "size_bytes": size_bytes,
-            "workspace_path": workspace_path,
+            "workspace_path": str(workspace_root),
         }
 
         # Store metadata
@@ -236,14 +274,7 @@ class SnapshotManager:
         if not snapshot_path.exists():
             raise ValueError(f"Snapshot not found: {snapshot_id}")
 
-        if not workspace_path:
-            raise ValueError("Invalid workspace path")
-
-        workspace_root = Path(workspace_path)
-        if workspace_root.is_symlink():
-            raise ValueError("Refusing symlink workspace root")
-        if self._has_symlink_ancestor(workspace_root):
-            raise ValueError("Refusing symlink workspace ancestor")
+        workspace_root = self._resolve_workspace_root(workspace_path, require_existing_dir=False)
         if workspace_root.exists():
             if not workspace_root.is_dir():
                 raise ValueError(f"Invalid workspace path: {workspace_path}")
@@ -253,31 +284,30 @@ class SnapshotManager:
         # Take a backup first so failed restore can roll back atomically.
         try:
             if workspace_root.exists() and workspace_root.is_dir():
-                shutil.copytree(workspace_path, str(backup_path), dirs_exist_ok=False)
+                shutil.copytree(str(workspace_root), str(backup_path), dirs_exist_ok=False)
             else:
-                os.makedirs(workspace_path, exist_ok=True)
+                workspace_root.mkdir(parents=True, exist_ok=True)
         except _SNAPSHOTS_NONCRITICAL_EXCEPTIONS as e:
             raise OSError(f"Failed to backup workspace before restore: {e}") from e
 
         # Clear current workspace (but keep the directory)
         try:
-            if os.path.isdir(workspace_path):
-                for item in os.listdir(workspace_path):
-                    item_path = os.path.join(workspace_path, item)
-                    if os.path.isdir(item_path):
+            if workspace_root.is_dir():
+                for item_path in workspace_root.iterdir():
+                    if item_path.is_dir():
                         shutil.rmtree(item_path, ignore_errors=True)
                     else:
                         with contextlib.suppress(_SNAPSHOTS_NONCRITICAL_EXCEPTIONS):
-                            os.remove(item_path)
+                            item_path.unlink()
             else:
-                os.makedirs(workspace_path, exist_ok=True)
+                workspace_root.mkdir(parents=True, exist_ok=True)
         except _SNAPSHOTS_NONCRITICAL_EXCEPTIONS as e:
             with contextlib.suppress(_SNAPSHOTS_NONCRITICAL_EXCEPTIONS):
                 if backup_path.exists():
-                    if os.path.isdir(workspace_path):
-                        shutil.rmtree(workspace_path, ignore_errors=True)
-                    os.makedirs(workspace_path, exist_ok=True)
-                    shutil.copytree(str(backup_path), workspace_path, dirs_exist_ok=True)
+                    if workspace_root.is_dir():
+                        shutil.rmtree(workspace_root, ignore_errors=True)
+                    workspace_root.mkdir(parents=True, exist_ok=True)
+                    shutil.copytree(str(backup_path), str(workspace_root), dirs_exist_ok=True)
                     shutil.rmtree(backup_path, ignore_errors=True)
             raise OSError(f"Failed to clear workspace: {e}") from e
 
@@ -286,23 +316,23 @@ class SnapshotManager:
             with tarfile.open(snapshot_path, "r:gz") as tar:
                 for member in tar.getmembers():
                     self._validate_tar_member(member, workspace_root)
-                    tar.extract(member, workspace_path)
+                    tar.extract(member, str(workspace_root))
         except ValueError:
             with contextlib.suppress(_SNAPSHOTS_NONCRITICAL_EXCEPTIONS):
                 if backup_path.exists():
-                    if os.path.isdir(workspace_path):
-                        shutil.rmtree(workspace_path, ignore_errors=True)
-                    os.makedirs(workspace_path, exist_ok=True)
-                    shutil.copytree(str(backup_path), workspace_path, dirs_exist_ok=True)
+                    if workspace_root.is_dir():
+                        shutil.rmtree(workspace_root, ignore_errors=True)
+                    workspace_root.mkdir(parents=True, exist_ok=True)
+                    shutil.copytree(str(backup_path), str(workspace_root), dirs_exist_ok=True)
                     shutil.rmtree(backup_path, ignore_errors=True)
             raise
         except _SNAPSHOTS_NONCRITICAL_EXCEPTIONS as e:
             with contextlib.suppress(_SNAPSHOTS_NONCRITICAL_EXCEPTIONS):
                 if backup_path.exists():
-                    if os.path.isdir(workspace_path):
-                        shutil.rmtree(workspace_path, ignore_errors=True)
-                    os.makedirs(workspace_path, exist_ok=True)
-                    shutil.copytree(str(backup_path), workspace_path, dirs_exist_ok=True)
+                    if workspace_root.is_dir():
+                        shutil.rmtree(workspace_root, ignore_errors=True)
+                    workspace_root.mkdir(parents=True, exist_ok=True)
+                    shutil.copytree(str(backup_path), str(workspace_root), dirs_exist_ok=True)
                     shutil.rmtree(backup_path, ignore_errors=True)
             raise OSError(f"Failed to extract snapshot: {e}") from e
         finally:
@@ -335,23 +365,20 @@ class SnapshotManager:
             ValueError: If paths are invalid.
             IOError: If there's an error copying the workspace.
         """
-        if not source_workspace or not os.path.isdir(source_workspace):
-            raise ValueError(f"Invalid source workspace: {source_workspace}")
+        source_root = self._resolve_workspace_root(source_workspace, require_existing_dir=True)
+        new_root = self._resolve_workspace_root(new_workspace, require_existing_dir=False)
 
-        if not new_workspace:
-            raise ValueError("Invalid new workspace path")
-
-        self._validate_workspace_tree_for_copy(Path(source_workspace))
+        self._validate_workspace_tree_for_copy(source_root)
 
         try:
             # Ensure parent directory exists
-            os.makedirs(os.path.dirname(new_workspace), exist_ok=True)
+            new_root.parent.mkdir(parents=True, exist_ok=True)
 
             # Copy the workspace
-            if os.path.exists(new_workspace):
-                shutil.rmtree(new_workspace, ignore_errors=True)
+            if new_root.exists():
+                shutil.rmtree(new_root, ignore_errors=True)
 
-            shutil.copytree(source_workspace, new_workspace, dirs_exist_ok=True)
+            shutil.copytree(str(source_root), str(new_root), dirs_exist_ok=True)
         except _SNAPSHOTS_NONCRITICAL_EXCEPTIONS as e:
             raise OSError(f"Failed to clone workspace: {e}") from e
 

--- a/tldw_Server_API/app/core/Skills/skill_parser.py
+++ b/tldw_Server_API/app/core/Skills/skill_parser.py
@@ -27,7 +27,6 @@ ${0}, ${1}, etc. for specific arguments.
 """
 
 import hashlib
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
@@ -36,19 +35,6 @@ import yaml
 from loguru import logger
 
 from tldw_Server_API.app.core.Skills.exceptions import SkillParseError
-
-# Regex to match YAML frontmatter at the start of content
-FRONTMATTER_PATTERN = re.compile(
-    r'^---\s*\n(.*?)\n---\s*\n(.*)$',
-    re.DOTALL
-)
-
-# Alternative pattern for Windows line endings
-FRONTMATTER_PATTERN_CRLF = re.compile(
-    r'^---\s*\r?\n(.*?)\r?\n---\s*\r?\n(.*)$',
-    re.DOTALL
-)
-
 
 @dataclass
 class SkillFrontmatter:
@@ -91,6 +77,22 @@ class SkillFrontmatter:
         )
 
 
+def _split_frontmatter(content: str) -> tuple[str, str] | None:
+    first_line_end = content.find("\n")
+    if first_line_end < 0 or content[:first_line_end].strip() != "---":
+        return None
+
+    yaml_start = first_line_end + 1
+    line_start = yaml_start
+    while True:
+        line_end = content.find("\n", line_start)
+        if line_end < 0:
+            return None
+        if content[line_start:line_end].strip() == "---":
+            return content[yaml_start:line_start].rstrip("\r\n"), content[line_end + 1 :]
+        line_start = line_end + 1
+
+
 @dataclass
 class ParsedSkill:
     """Fully parsed skill from SKILL.md and supporting files."""
@@ -130,12 +132,9 @@ class SkillParser:
         markdown_content = content
 
         # Try to extract frontmatter
-        match = FRONTMATTER_PATTERN.match(content)
-        if not match:
-            match = FRONTMATTER_PATTERN_CRLF.match(content)
-
-        if match:
-            frontmatter_yaml, markdown_content = match.groups()
+        frontmatter_parts = _split_frontmatter(content)
+        if frontmatter_parts:
+            frontmatter_yaml, markdown_content = frontmatter_parts
             try:
                 parsed_yaml = yaml.safe_load(frontmatter_yaml)
                 if parsed_yaml and isinstance(parsed_yaml, dict):

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -282,7 +282,34 @@ class SkillsService:
 
     def _get_skill_dir(self, name: str) -> Path:
         """Get the directory path for a skill."""
-        return self.skills_dir / name
+        safe_name = self._normalize_and_validate_skill_name(name)
+        base = self.skills_dir.resolve(strict=False)
+        path = (base / safe_name).resolve(strict=False)
+        try:
+            path.relative_to(base)
+        except ValueError as e:
+            raise SkillValidationError(f"Invalid skill name: {name}", field="name") from e
+        return path
+
+    def _remove_skill_dir(self, skill_dir: Path) -> None:
+        """Remove a skill directory after confirming it is under the user skills root."""
+        base = self.skills_dir.resolve(strict=False)
+        path = skill_dir.resolve(strict=False)
+        try:
+            path.relative_to(base)
+        except ValueError as e:
+            raise SkillStorageError("Refusing to remove skill directory outside skills root", path=str(skill_dir)) from e
+        shutil.rmtree(path, ignore_errors=True)
+
+    def _skill_main_file(self, skill_dir: Path) -> Path:
+        """Return the validated SKILL.md path for a skill directory."""
+        base = skill_dir.resolve(strict=False)
+        path = (base / "SKILL.md").resolve(strict=False)
+        try:
+            path.relative_to(base)
+        except ValueError as e:
+            raise SkillStorageError("SKILL.md path escapes skill directory", path=str(path)) from e
+        return path
 
     def _skill_asset_id(self, name: str) -> str:
         """Return the Context Integrity asset id for a user skill."""
@@ -623,7 +650,7 @@ class SkillsService:
 
     def _parse_skill_file(self, skill_dir: Path) -> Optional[Any]:
         """Parse SKILL.md content without loading supporting files."""
-        skill_file = skill_dir / "SKILL.md"
+        skill_file = self._skill_main_file(skill_dir)
         try:
             content = _read_regular_file_bytes_no_follow(skill_file).decode("utf-8")
         except FileNotFoundError:
@@ -970,11 +997,11 @@ class SkillsService:
             raise SkillStorageError(f"Failed to create skill directory: {e}", path=str(skill_dir)) from e
 
         # Write SKILL.md
-        skill_file = skill_dir / "SKILL.md"
+        skill_file = self._skill_main_file(skill_dir)
         try:
             skill_file.write_text(content, encoding="utf-8")
         except OSError as e:
-            shutil.rmtree(skill_dir, ignore_errors=True)
+            self._remove_skill_dir(skill_dir)
             raise SkillStorageError(f"Failed to write SKILL.md: {e}", path=str(skill_file)) from e
 
         # Write supporting files
@@ -984,7 +1011,7 @@ class SkillsService:
                 try:
                     file_path.write_text(file_content or "", encoding="utf-8")
                 except OSError as e:
-                    shutil.rmtree(skill_dir, ignore_errors=True)
+                    self._remove_skill_dir(skill_dir)
                     raise SkillStorageError(
                         f"Failed to write supporting file {filename}: {e}",
                         path=str(file_path),
@@ -1017,10 +1044,10 @@ class SkillsService:
             else:
                 db.insert_skill_registry(registry_payload)
         except ConflictError as e:
-            shutil.rmtree(skill_dir, ignore_errors=True)
+            self._remove_skill_dir(skill_dir)
             raise SkillConflictError(str(e), skill_name=name) from e
         except (CharactersRAGDBError, InputError) as e:
-            shutil.rmtree(skill_dir, ignore_errors=True)
+            self._remove_skill_dir(skill_dir)
             raise SkillsError(f"Failed to record skill '{name}' in registry: {e}") from e
 
         logger.info(f"Created skill '{name}' for user {self.user_id}")
@@ -1106,7 +1133,7 @@ class SkillsService:
             except Exception as e:
                 raise SkillValidationError(f"Invalid skill content: {e}") from e
 
-            skill_file = skill_dir / "SKILL.md"
+            skill_file = self._skill_main_file(skill_dir)
             try:
                 await snapshot_file(skill_file)
                 await asyncio.to_thread(skill_file.write_text, content, encoding="utf-8")
@@ -1851,7 +1878,7 @@ class SkillsService:
                     )
 
                 if overwrite and destination_dir.exists():
-                    shutil.rmtree(destination_dir, ignore_errors=True)
+                    self._remove_skill_dir(destination_dir)
 
                 if destination_dir.exists():
                     logger.warning(

--- a/tldw_Server_API/app/core/Storage/filesystem_storage.py
+++ b/tldw_Server_API/app/core/Storage/filesystem_storage.py
@@ -80,7 +80,7 @@ class FileSystemStorage(StorageBackend):
             sanitized = "unnamed"
         return sanitized
 
-    def _validate_path(self, path: Path) -> bool:
+    def _validate_path(self, path: Path) -> Path:
         """
         Validate that a path is within the base directory.
 
@@ -88,7 +88,7 @@ class FileSystemStorage(StorageBackend):
             path: Path to validate
 
         Returns:
-            True if valid, raises StorageError otherwise
+            Resolved path if valid, raises StorageError otherwise
         """
         try:
             resolved = path.resolve()
@@ -99,7 +99,7 @@ class FileSystemStorage(StorageBackend):
                     f"Path escapes base directory: {path}",
                     path=str(path),
                 )
-            return True
+            return resolved
         except Exception as e:
             if isinstance(e, StorageError):
                 raise
@@ -126,10 +126,8 @@ class FileSystemStorage(StorageBackend):
         Returns:
             The storage path relative to base_path
         """
-        file_path = self._build_path(user_id, media_id, filename)
-        self._validate_path(file_path)
-        temp_path = file_path.with_name(f".{file_path.name}.{uuid.uuid4().hex}.tmp")
-        self._validate_path(temp_path)
+        file_path = self._validate_path(self._build_path(user_id, media_id, filename))
+        temp_path = self._validate_path(file_path.with_name(f".{file_path.name}.{uuid.uuid4().hex}.tmp"))
 
         try:
             # Ensure parent directory exists
@@ -179,8 +177,7 @@ class FileSystemStorage(StorageBackend):
         Returns:
             A BytesIO object containing the file data
         """
-        full_path = self.base_path / path
-        self._validate_path(full_path)
+        full_path = self._validate_path(self.base_path / path)
 
         if not full_path.exists():
             raise FileNotFoundError(f"File not found: {path}")
@@ -211,8 +208,7 @@ class FileSystemStorage(StorageBackend):
         Yields:
             Chunks of file content as bytes
         """
-        full_path = self.base_path / path
-        self._validate_path(full_path)
+        full_path = self._validate_path(self.base_path / path)
 
         if not full_path.exists():
             raise FileNotFoundError(f"File not found: {path}")

--- a/tldw_Server_API/app/core/Visual_Identities/storage.py
+++ b/tldw_Server_API/app/core/Visual_Identities/storage.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import io
 import os
-import re
 import stat
 import tempfile
 from collections.abc import Mapping
@@ -34,7 +33,6 @@ VISUAL_IDENTITY_STORED_ASSET_HASH_MISMATCH = "stored_asset_hash_mismatch"
 VISUAL_IDENTITY_STORED_ASSET_PUBLISH_UNAVAILABLE = "stored_asset_publish_unavailable"
 
 _IMAGE_VALIDATION_ERRORS = (OSError, ValueError, UnidentifiedImageError)
-_SAFE_COMPONENT_RE = re.compile(r"[^A-Za-z0-9_.-]+")
 _MIME_EXTENSION_CHOICES = {
     "image/png": (".png",),
     "image/jpeg": (".jpg", ".jpeg"),
@@ -260,17 +258,8 @@ def _preview_relpath(
 
 def _safe_storage_component(value: str, *, prefix: str) -> str:
     raw = str(value or "").strip()
-    if not raw or raw in {".", ".."}:
-        digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
-        return f"{prefix}_{digest}"
-    cleaned = _SAFE_COMPONENT_RE.sub("_", raw).strip("._-")
-    if not cleaned:
-        digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
-        return f"{prefix}_{digest}"
-    if cleaned in {".", ".."}:
-        digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
-        return f"{prefix}_{digest}"
-    return cleaned[:120]
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}_{digest}"
 
 
 def _validate_visual_identity_source(

--- a/tldw_Server_API/tests/Flashcards/test_structured_qa_import.py
+++ b/tldw_Server_API/tests/Flashcards/test_structured_qa_import.py
@@ -65,3 +65,12 @@ Answer: Carefully.
         "\n"
         "  2. Return output."
     )
+
+
+def test_parse_structured_qa_preview_accepts_short_labels_with_alt_separators():
+    result = parse_structured_qa_preview("  q. One?\n  a- Two.\n")
+
+    assert len(result.drafts) == 1
+    assert result.drafts[0].front == "One?"
+    assert result.drafts[0].back == "Two."
+    assert result.errors == []

--- a/tldw_Server_API/tests/Research/test_research_artifact_store.py
+++ b/tldw_Server_API/tests/Research/test_research_artifact_store.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 
@@ -18,16 +20,48 @@ def test_write_json_artifact_records_manifest(tmp_path):
     )
     store = ResearchArtifactStore(base_dir=tmp_path / "outputs", db=db)
 
+    payload = {"focus_areas": ["history", "market structure"]}
     artifact = store.write_json(
         owner_user_id=1,
         session_id=session.id,
         artifact_name="plan.json",
-        payload={"focus_areas": ["history", "market structure"]},
+        payload=payload,
         phase="drafting_plan",
         job_id="123",
     )
 
     assert artifact.byte_size > 0
+    artifact_path = Path(artifact.storage_path)
+    assert artifact_path.exists()
+    assert artifact_path.name.startswith("artifact_")
+    assert artifact_path.suffix == ".json"
+
     manifest = db.list_artifacts(session.id)
     assert manifest[0].artifact_name == "plan.json"
-    assert (tmp_path / "outputs" / "research" / session.id / "plan.json").exists()
+    assert not (tmp_path / "outputs" / "research" / session.id / "plan.json").exists()
+    assert store.read_json(session_id=session.id, artifact_name="plan.json") == payload
+
+    records = [{"url": "https://example.test", "rank": 1}]
+    jsonl_artifact = store.write_jsonl(
+        owner_user_id=1,
+        session_id=session.id,
+        artifact_name="sources.jsonl",
+        records=records,
+        phase="drafting_plan",
+        job_id="123",
+    )
+    text_artifact = store.write_text(
+        owner_user_id=1,
+        session_id=session.id,
+        artifact_name="summary.txt",
+        content="summary",
+        phase="drafting_plan",
+        job_id="123",
+    )
+
+    manifest_names = {artifact.artifact_name for artifact in db.list_artifacts(session.id)}
+    assert {"plan.json", "sources.jsonl", "summary.txt"}.issubset(manifest_names)
+    assert Path(jsonl_artifact.storage_path).name.startswith("artifact_")
+    assert Path(text_artifact.storage_path).name.startswith("artifact_")
+    assert store.read_jsonl(session_id=session.id, artifact_name="sources.jsonl") == records
+    assert store.read_text(session_id=session.id, artifact_name="summary.txt") == "summary"

--- a/tldw_Server_API/tests/Skills/unit/test_skill_parser.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skill_parser.py
@@ -99,6 +99,15 @@ Execute the task with $ARGUMENTS detail level.
         assert "Execute the task" in parsed.content
         assert "$ARGUMENTS" in parsed.content
 
+    def test_parse_content_with_crlf_frontmatter(self, parser):
+        """Test parsing YAML frontmatter with Windows line endings."""
+        content = "---\r\nname: crlf-skill\r\n---\r\nBody\r\n"
+
+        parsed = parser.parse_content(content)
+
+        assert parsed.frontmatter.name == "crlf-skill"
+        assert parsed.content == "Body"
+
     def test_parse_content_frontmatter_overrides_default_name(self, parser):
         """Test that frontmatter name overrides default name."""
         content = """---

--- a/tldw_Server_API/tests/sandbox/test_snapshot_manager_restore_security.py
+++ b/tldw_Server_API/tests/sandbox/test_snapshot_manager_restore_security.py
@@ -51,6 +51,15 @@ def test_restore_snapshot_rejects_path_traversal_member(tmp_path: Path) -> None:
     assert not (workspace.parent / "outside.txt").exists()
 
 
+def test_snapshot_paths_reject_traversal_ids(tmp_path: Path) -> None:
+    manager = SnapshotManager(storage_path=str(tmp_path / "snapshots"))
+
+    with pytest.raises(ValueError, match="Invalid session_id"):
+        manager.list_snapshots("../outside")
+    with pytest.raises(ValueError, match="Invalid snapshot_id"):
+        manager.get_snapshot_info("sess-safe", "../outside")
+
+
 def test_restore_snapshot_rejects_symlink_member(tmp_path: Path) -> None:
     manager = SnapshotManager(storage_path=str(tmp_path / "snapshots"))
     workspace = tmp_path / "workspace"

--- a/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+++ b/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
@@ -116,6 +116,14 @@ def test_compile_global_policy_reports_invalid_lines_without_raw_regex():
     assert "(unclosed" not in rendered
 
 
+def test_nested_quantifier_scanner_flags_nested_repetition_only():
+    compiler = PolicyCompiler()
+
+    assert compiler.has_nested_quantifiers("(a+)+")
+    assert compiler.has_nested_quantifiers(r"(foo\\*)*") is False
+    assert compiler.has_nested_quantifiers("(foo)+") is False
+
+
 def test_compile_global_policy_reports_empty_pattern_after_parsing():
     result = PolicyCompiler().compile_global(
         PolicyCompilationInput(


### PR DESCRIPTION
Change summary
- Addressed current main CodeQL alert classes across path injection, polynomial ReDoS, SQL ordering, weak sensitive-data hashing, stack-trace detail exposure, and clear-text frontend API-key storage.
- Hardened path handling by resolving and constraining file operations to known roots, hashing untrusted storage components where user-facing names do not need to be filesystem names, and preserving logical manifest names separately from storage filenames.
- Replaced vulnerable parser regexes with deterministic scanners, changed workflow pagination ordering to a literal validated map, and removed exception detail from user-facing error payloads.
- Stopped persisting single-user API keys in WebUI smoke/runtime extension storage; runtime tests now use ephemeral window injection instead.

Why
- The fixes are intentionally local to the CodeQL alert sinks rather than broad rewrites, so the release branch can unblock while reducing the risky filesystem, parser, and error-detail surfaces that CodeQL identified.

Verification
- python -m py_compile on touched Python files: passed
- git diff --check and git diff --cached --check: passed
- pytest parser/security focused batch: 54 passed
- pytest Visual_Identities storage: 31 passed
- pytest broader focused backend batch: 130 passed
- bunx vitest runtime/auth storage tests: 37 passed
- bun run typecheck: passed
- Bandit app-scope report /tmp/bandit_codeql_main_alerts_app.json: no high/medium findings; remaining six LOW findings are pre-existing Audio_Transcription_Lib subprocess warnings outside the changed path-validation logic.

Backlog
- TASK-12936

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened multiple code paths to resolve current CodeQL alerts on main by constraining filesystem access, replacing risky regex with deterministic scanners, locking SQL ordering to a validated map, redacting error details, strengthening CSRF binding, and removing clear‑text API key storage in the WebUI. Reduces path traversal, ReDoS, injection, and info‑leak risks; addresses TASK-12936.

- **Bug Fixes**
  - Path safety: resolve and contain paths under known roots across audit fallback, sandbox workspaces/snapshots, chatbook exports, research artifacts (hashed storage names), RAG checkpoints/baselines, file artifact exports, user personalization, filesystem storage, email mock outputs, audio input conversion, and skills operations.
  - Parser/regex hardening: replaced vulnerable patterns in flashcards structured Q&A, skills frontmatter splitting, and moderation policy scanning; added focused tests.
  - SQL ordering: workflows run listing now uses a literal, validated ordering map with stable cursor seek.
  - Error and auth: redacted exception details in OCR/embeddings/prompts/setup/ACP; CSRF binds via hmac.digest; removed single-user API key persistence (local/session); runtime bootstrap and tests use runtime-only window injection. All updated tests and type checks pass.

- **Migration**
  - For e2e/local runs, inject the single-user API key at runtime via window.__tldwRuntimeApiKey; stop relying on localStorage apiKey fields.
  - No database or config changes required.

<sup>Written for commit dc1794f4e47108bd42f1a253e155d1a6301c5d39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

