### PR TITLE
Fix post-release CI failures

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -35,6 +35,31 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
+        if [ "${{ inputs.install-portaudio }}" = "true" ]; then
+          if ! xcrun --find clang >/dev/null 2>&1; then
+            for developer_dir in \
+              /Applications/Xcode.app/Contents/Developer \
+              /Library/Developer/CommandLineTools \
+              /Applications/Xcode_*.app/Contents/Developer; do
+              [ -d "$developer_dir" ] || continue
+              sudo xcode-select -s "$developer_dir" || true
+              if xcrun --find clang >/dev/null 2>&1; then
+                break
+              fi
+            done
+          fi
+          if ! clang_path="$(xcrun --find clang)"; then
+            echo "::error::Unable to locate a working macOS clang toolchain for native Python wheels"
+            exit 1
+          fi
+          if ! sdk_path="$(xcrun --sdk macosx --show-sdk-path)"; then
+            echo "::error::Unable to locate a working macOS SDK for native Python wheels"
+            exit 1
+          fi
+          echo "CC=$clang_path" >> "$GITHUB_ENV"
+          echo "SDKROOT=$sdk_path" >> "$GITHUB_ENV"
+          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
+        fi
         if [ "${{ inputs.install-ffmpeg }}" = "true" ]; then
           brew install ffmpeg || true
         fi
@@ -50,6 +75,10 @@ runs:
             fi
           done
           test -f "$(brew --prefix portaudio)/include/portaudio.h"
+          portaudio_prefix="$(brew --prefix portaudio)"
+          echo "CFLAGS=-I$portaudio_prefix/include" >> "$GITHUB_ENV"
+          echo "LDFLAGS=-L$portaudio_prefix/lib" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$portaudio_prefix/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
         fi
     - name: Install FFmpeg (Windows)
       if: runner.os == 'Windows' && inputs.install-ffmpeg == 'true'

--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -76,9 +76,9 @@ runs:
           done
           test -f "$(brew --prefix portaudio)/include/portaudio.h"
           portaudio_prefix="$(brew --prefix portaudio)"
-          echo "CFLAGS=-I$portaudio_prefix/include" >> "$GITHUB_ENV"
-          echo "LDFLAGS=-L$portaudio_prefix/lib" >> "$GITHUB_ENV"
-          echo "PKG_CONFIG_PATH=$portaudio_prefix/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
+          echo "CFLAGS=-I$portaudio_prefix/include${CFLAGS:+ $CFLAGS}" >> "$GITHUB_ENV"
+          echo "LDFLAGS=-L$portaudio_prefix/lib${LDFLAGS:+ $LDFLAGS}" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$portaudio_prefix/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" >> "$GITHUB_ENV"
         fi
     - name: Install FFmpeg (Windows)
       if: runner.os == 'Windows' && inputs.install-ffmpeg == 'true'

--- a/.github/workflows/mcp-unified-publish.yml
+++ b/.github/workflows/mcp-unified-publish.yml
@@ -1,6 +1,13 @@
 name: MCP Unified Publish Readiness
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - apps/mcp-unified/pyproject.toml
+      - apps/mcp-unified/src/mcp_unified/__init__.py
+      - .github/workflows/mcp-unified-publish.yml
   workflow_dispatch:
     inputs:
       target:
@@ -26,8 +33,156 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  detect-version-change:
+    name: Detect MCP Unified version publish candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      version_changed: ${{ steps.detect.outputs.version_changed }}
+      old_version: ${{ steps.detect.outputs.old_version }}
+      new_version: ${{ steps.detect.outputs.new_version }}
+      publish_candidate: ${{ steps.detect.outputs.publish_candidate }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect package version change
+        id: detect
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import ast
+          import os
+          import subprocess
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+          import tomllib
+
+          PYPROJECT = Path("apps/mcp-unified/pyproject.toml")
+          INIT_FILE = Path("apps/mcp-unified/src/mcp_unified/__init__.py")
+          PACKAGE_NAME = "mcp-unified"
+
+
+          def load_pyproject_version(text: str) -> str:
+              data = tomllib.loads(text)
+              version = data.get("project", {}).get("version")
+              if not isinstance(version, str) or not version:
+                  raise SystemExit("apps/mcp-unified/pyproject.toml is missing project.version")
+              return version
+
+
+          def load_init_version(path: Path) -> str:
+              tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+              for node in tree.body:
+                  if not isinstance(node, ast.Assign):
+                      continue
+                  for target in node.targets:
+                      if (
+                          isinstance(target, ast.Name)
+                          and target.id == "__version__"
+                          and isinstance(node.value, ast.Constant)
+                          and isinstance(node.value.value, str)
+                      ):
+                          return node.value.value
+              raise SystemExit(f"{path} is missing a string __version__ assignment")
+
+
+          def load_previous_version(before: str) -> str:
+              if not before or set(before) == {"0"}:
+                  return ""
+              try:
+                  text = subprocess.check_output(
+                      ["git", "show", f"{before}:{PYPROJECT.as_posix()}"],
+                      text=True,
+                  )
+              except subprocess.CalledProcessError:
+                  return ""
+              return load_pyproject_version(text)
+
+
+          def ensure_version_not_on_pypi(version: str) -> None:
+              url = f"https://pypi.org/pypi/{PACKAGE_NAME}/{version}/json"
+              request = urllib.request.Request(
+                  url,
+                  headers={"User-Agent": "tldw-server-mcp-unified-publish/1.0"},
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=15) as response:
+                      if response.status == 200:
+                          raise SystemExit(
+                              f"{PACKAGE_NAME} {version} already exists on PyPI; "
+                              "bump apps/mcp-unified/pyproject.toml before publishing"
+                          )
+                      raise SystemExit(
+                          f"unexpected PyPI response while checking {PACKAGE_NAME} {version}: "
+                          f"HTTP {response.status}"
+                      )
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 404:
+                      return
+                  raise SystemExit(
+                      f"could not verify PyPI version availability for {PACKAGE_NAME} {version}: "
+                      f"HTTP {exc.code}"
+                  ) from exc
+              except urllib.error.URLError as exc:
+                  raise SystemExit(
+                      f"could not verify PyPI version availability for {PACKAGE_NAME} {version}: "
+                      f"{exc.reason}"
+                  ) from exc
+
+
+          event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+          current_version = load_pyproject_version(PYPROJECT.read_text(encoding="utf-8"))
+          init_version = load_init_version(INIT_FILE)
+          if init_version != current_version:
+              raise SystemExit(
+                  f"{INIT_FILE} __version__={init_version!r} does not match "
+                  f"{PYPROJECT} project.version={current_version!r}"
+              )
+
+          old_version = ""
+          version_changed = False
+          publish_candidate = False
+          if event_name == "push":
+              old_version = load_previous_version(os.environ.get("GITHUB_EVENT_BEFORE", ""))
+              version_changed = current_version != old_version
+              publish_candidate = version_changed
+              if publish_candidate:
+                  ensure_version_not_on_pypi(current_version)
+
+          outputs = {
+              "old_version": old_version,
+              "new_version": current_version,
+              "version_changed": str(version_changed).lower(),
+              "publish_candidate": str(publish_candidate).lower(),
+          }
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              for key, value in outputs.items():
+                  output.write(f"{key}={value}\n")
+
+          print(
+              "MCP Unified publish detector:",
+              f"event={event_name}",
+              f"old_version={old_version or '<none>'}",
+              f"new_version={current_version}",
+              f"publish_candidate={publish_candidate}",
+          )
+          PY
+
   publish-plan:
     name: Build RC and publish dry-run plan
+    needs: detect-version-change
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-version-change.outputs.publish_candidate == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -99,8 +254,10 @@ jobs:
 
   publish-pypi:
     name: Upload MCP Unified to PyPI
-    needs: publish-plan
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH' }}
+    needs:
+      - detect-version-change
+      - publish-plan
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH') || (github.event_name == 'push' && needs.detect-version-change.outputs.publish_candidate == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -115,6 +272,53 @@ jobs:
         with:
           name: mcp-unified-publish-plan
           path: .artifacts/mcp-unified-rc
+
+      - name: Guard against duplicate PyPI version
+        env:
+          MCP_UNIFIED_PACKAGE_VERSION: ${{ needs.detect-version-change.outputs.new_version }}
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          import sys
+          import urllib.error
+          import urllib.request
+
+          package_name = "mcp-unified"
+          version = os.environ.get("MCP_UNIFIED_PACKAGE_VERSION", "").strip()
+          if not version:
+              raise SystemExit("MCP_UNIFIED_PACKAGE_VERSION is required before PyPI upload")
+
+          url = f"https://pypi.org/pypi/{package_name}/{version}/json"
+          request = urllib.request.Request(
+              url,
+              headers={"User-Agent": "tldw-server-mcp-unified-publish/1.0"},
+          )
+          try:
+              with urllib.request.urlopen(request, timeout=15) as response:
+                  if response.status == 200:
+                      raise SystemExit(
+                          f"{package_name} {version} already exists on PyPI; refusing duplicate upload"
+                      )
+                  raise SystemExit(
+                      f"unexpected PyPI response while checking {package_name} {version}: "
+                      f"HTTP {response.status}"
+                  )
+          except urllib.error.HTTPError as exc:
+              if exc.code == 404:
+                  print(f"{package_name} {version} is not present on PyPI; continuing")
+                  sys.exit(0)
+              raise SystemExit(
+                  f"could not verify PyPI version availability for {package_name} {version}: "
+                  f"HTTP {exc.code}"
+              ) from exc
+          except urllib.error.URLError as exc:
+              raise SystemExit(
+                  f"could not verify PyPI version availability for {package_name} {version}: "
+                  f"{exc.reason}"
+              ) from exc
+          PY
 
       - name: Publish MCP Unified to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
+++ b/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
@@ -121,7 +121,7 @@ Record that the release PR now includes guarded main-version auto-publish behavi
 - `apps/mcp-unified/README.md`
 - `apps/mcp-unified/src/mcp_unified/README.md`
 - `backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md`
-- `docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md`
+- Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
 
 - [ ] **Step 1: Run package validation**
 

--- a/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
+++ b/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
@@ -1,0 +1,153 @@
+# MCP Unified Main Version Auto Publish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish `mcp-unified` to PyPI automatically when a merged `main` commit changes the standalone package version.
+
+**Architecture:** Extend the existing MCP Unified publish workflow instead of adding a second workflow. A version-detection job compares the previous and current `apps/mcp-unified/pyproject.toml` versions, verifies `mcp_unified.__version__` is in sync, checks that the target version is not already on PyPI, then lets the existing RC and trusted-publishing path run for valid `main` version bumps.
+
+**Tech Stack:** GitHub Actions, Python 3.12, `tomllib`, stdlib `urllib`, existing `make mcp-unified-rc` and `make mcp-unified-publish-dry-run` targets, PyPI trusted publishing.
+
+---
+
+### Task 1: Add guarded main-push release detection
+
+**Files:**
+- Modify: `.github/workflows/mcp-unified-publish.yml`
+
+- [ ] **Step 1: Add push trigger**
+
+Add a `push` trigger for `main` scoped to release-relevant files:
+
+```yaml
+  push:
+    branches:
+      - main
+    paths:
+      - apps/mcp-unified/pyproject.toml
+      - apps/mcp-unified/src/mcp_unified/__init__.py
+      - .github/workflows/mcp-unified-publish.yml
+```
+
+- [ ] **Step 2: Add `detect-version-change` job**
+
+Create a job that checks out with `fetch-depth: 0`, reads the current package version, reads the prior version from `${{ github.event.before }}` for push events, and writes outputs:
+
+```text
+version_changed=true|false
+old_version=<old or empty>
+new_version=<current>
+publish_candidate=true|false
+```
+
+The job must:
+- skip publishing for manual dispatch unless manual inputs request it
+- fail if `apps/mcp-unified/src/mcp_unified/__init__.py` does not contain the same `__version__`
+- fail early if the current version already exists on PyPI
+- treat deleted/missing previous files as `version_changed=true` only for push events
+
+- [ ] **Step 3: Run YAML/lint sanity checks**
+
+Run:
+
+```bash
+python - <<'PY'
+import yaml
+from pathlib import Path
+yaml.safe_load(Path('.github/workflows/mcp-unified-publish.yml').read_text())
+PY
+```
+
+Expected: command exits successfully.
+
+### Task 2: Wire existing RC and PyPI publish jobs to the detector
+
+**Files:**
+- Modify: `.github/workflows/mcp-unified-publish.yml`
+
+- [ ] **Step 1: Gate `publish-plan`**
+
+Make `publish-plan` depend on `detect-version-change` and run when either:
+- the workflow is manually dispatched, or
+- a `main` push produced `publish_candidate=true`
+
+- [ ] **Step 2: Gate `publish-pypi`**
+
+Keep the existing manual PyPI condition and add the automatic condition:
+
+```text
+push to main AND publish_candidate=true
+```
+
+Keep `environment: pypi` and `id-token: write`.
+
+- [ ] **Step 3: Add final duplicate guard before upload**
+
+Before `pypa/gh-action-pypi-publish`, add a Python stdlib check against:
+
+```text
+https://pypi.org/pypi/mcp-unified/<version>/json
+```
+
+Expected:
+- `404` means safe to publish
+- `200` fails with a clear duplicate-version message
+- other/network errors fail closed
+
+### Task 3: Update release docs and task notes
+
+**Files:**
+- Modify: `apps/mcp-unified/README.md`
+- Modify: `apps/mcp-unified/src/mcp_unified/README.md`
+- Modify: `backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md`
+
+- [ ] **Step 1: Update README release text**
+
+Replace the manual-only PyPI language with:
+
+```text
+Merging a package version bump to main triggers the guarded PyPI publishing workflow.
+Manual TestPyPI and PyPI workflow dispatch remain available for release rehearsals and operator-driven publishes.
+```
+
+- [ ] **Step 2: Update Backlog task notes**
+
+Record that the release PR now includes guarded main-version auto-publish behavior.
+
+### Task 4: Verify and commit
+
+**Files:**
+- `.github/workflows/mcp-unified-publish.yml`
+- `apps/mcp-unified/README.md`
+- `apps/mcp-unified/src/mcp_unified/README.md`
+- `backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md`
+- `docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md`
+
+- [ ] **Step 1: Run package validation**
+
+Run:
+
+```bash
+make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run
+```
+
+Expected: `RC status: ok`.
+
+- [ ] **Step 2: Run targeted workflow syntax validation**
+
+Run the YAML parse check from Task 1.
+
+Expected: command exits successfully.
+
+- [ ] **Step 3: Run Bandit on touched Python if any**
+
+If only YAML/Markdown changes are made, record Bandit as skipped because no Python source changed.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add .github/workflows/mcp-unified-publish.yml apps/mcp-unified/README.md apps/mcp-unified/src/mcp_unified/README.md "backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md" docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
+git commit -m "Auto publish MCP Unified version bumps"
+```

--- a/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
+++ b/Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
@@ -148,6 +148,6 @@ If only YAML/Markdown changes are made, record Bandit as skipped because no Pyth
 Run:
 
 ```bash
-git add .github/workflows/mcp-unified-publish.yml apps/mcp-unified/README.md apps/mcp-unified/src/mcp_unified/README.md "backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md" docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
+git add .github/workflows/mcp-unified-publish.yml apps/mcp-unified/README.md apps/mcp-unified/src/mcp_unified/README.md "backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md" Docs/superpowers/plans/2026-07-03-mcp-unified-main-version-auto-publish.md
 git commit -m "Auto publish MCP Unified version bumps"
 ```

--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -74,10 +74,14 @@ Build artifacts and generate the TestPyPI upload plan without uploading:
 make mcp-unified-publish-dry-run
 ```
 
-Live TestPyPI or PyPI upload is not part of normal PR CI. It requires the manual
-workflow, an explicit confirmation input, and the RC helper's publish opt-in
-guard. Production PyPI uploads use the repository's configured trusted
-publishing environment rather than a long-lived PyPI token.
+Merging a package version bump to `main` triggers the guarded PyPI publishing
+workflow. The workflow runs the RC gate, verifies the version is not already on
+PyPI, and then uses the repository's configured trusted publishing environment
+rather than a long-lived PyPI token.
+
+Manual TestPyPI and PyPI workflow dispatch remain available for release
+rehearsals and operator-driven publishes. Manual live uploads require an
+explicit confirmation input and the RC helper's publish opt-in guard.
 
 ## Install From PyPI
 

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -74,10 +74,14 @@ Build artifacts and generate the TestPyPI upload plan without uploading:
 make mcp-unified-publish-dry-run
 ```
 
-Live TestPyPI or PyPI upload is not part of normal PR CI. It requires the manual
-workflow, an explicit confirmation input, and the RC helper's publish opt-in
-guard. Production PyPI uploads use the repository's configured trusted
-publishing environment rather than a long-lived PyPI token.
+Merging a package version bump to `main` triggers the guarded PyPI publishing
+workflow. The workflow runs the RC gate, verifies the version is not already on
+PyPI, and then uses the repository's configured trusted publishing environment
+rather than a long-lived PyPI token.
+
+Manual TestPyPI and PyPI workflow dispatch remain available for release
+rehearsals and operator-driven publishes. Manual live uploads require an
+explicit confirmation input and the RC helper's publish opt-in guard.
 
 ## Install From PyPI
 

--- a/backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md
+++ b/backlog/tasks/task-12118 - Prepare-MCP-Unified-0.2.0-package-release.md
@@ -21,14 +21,19 @@ Prepare the standalone mcp-unified package for the next PyPI release after the d
 - [x] #1 mcp-unified package version is bumped from 0.1.1 to 0.2.0 before any publish attempt
 - [x] #2 local MCP Unified RC and publish dry-run checks pass from a clean release worktree
 - [ ] #3 TestPyPI publish is triggered only with explicit MCP_UNIFIED_PUBLISH confirmation and smoke-installed successfully
-- [ ] #4 PyPI publish is triggered only after TestPyPI smoke succeeds and final confirmation is explicit
+- [ ] #4 PyPI publish is triggered only after TestPyPI smoke succeeds and final confirmation is explicit, or automatically by a guarded main-branch package-version bump workflow
 - [ ] #5 post-publish PyPI smoke install verifies CLI entry points
+- [ ] #6 main-branch package-version bumps run guarded RC and PyPI duplicate checks before trusted publishing
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Verified release prep on the 0.2.0 worktree. Version bumped in apps/mcp-unified/pyproject.toml and apps/mcp-unified/src/mcp_unified/__init__.py. Ran package-boundary tests (47 passed), Ruff on touched package init, full make mcp-unified-rc (RC status ok), make mcp-unified-publish-dry-run (RC status ok), and Bandit on touched code (zero findings).
+
+Extending release task scope to include guarded automatic PyPI publish on main pushes where the mcp-unified package version changes. Manual TestPyPI remains available for rehearsal; automatic main publish must detect version changes, validate version sync, run the RC gate, and fail before upload if the version already exists on PyPI.
+
+Added guarded main-branch auto-publish workflow behavior and release documentation updates. Verified workflow YAML parsing and embedded Python compilation, make mcp-unified-publish-dry-run (RC status ok), make mcp-unified-rc (RC status ok), and git diff --check. Bandit skipped for this follow-up because no tracked Python source files changed; the new Python is inline GitHub Actions workflow code validated by compile checks.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -41,7 +46,7 @@ Verified release prep on the 0.2.0 worktree. Version bumped in apps/mcp-unified/
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
+- [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented

--- a/backlog/tasks/task-12932 - Fix-Guardian-generic-notify-timestamp-regression-on-main-CI.md
+++ b/backlog/tasks/task-12932 - Fix-Guardian-generic-notify-timestamp-regression-on-main-CI.md
@@ -1,0 +1,45 @@
+---
+id: TASK-12932
+title: Fix Guardian generic notify timestamp regression on main CI
+status: In Progress
+labels:
+- ci
+- guardian
+- main-followup
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Post-PR #2692 main CI fails gap-verified-7 on Python 3.12 and 3.13 because NotificationService.notify_generic records a copied payload with ts while the existing Guardian test expects the caller payload to receive the default timestamp. Prepare a minimal fix locally and keep it unpushed until the current CI run completes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] NotificationService.notify_generic adds a default ts to the caller payload when severity passes the threshold and no ts is present.
+- [x] The existing sanitized copy is still used for persistence and delivery.
+- [x] Regression test and touched-file Bandit verification pass locally.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Root cause: notify_generic copied the payload before applying the default ts, so the persisted record included ts but the caller-visible payload did not. The fix applies `payload.setdefault("ts", datetime.now(timezone.utc).isoformat())` immediately after threshold filtering, then continues copying and sanitizing the payload for notification persistence.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Prepared a minimal local fix for the main CI Guardian failure. Verified the exact failing test, the full Guardian comprehensive edge-case file, git diff --check, and Bandit on tldw_Server_API/app/core/Monitoring/notification_service.py. Patch remains unpushed pending completion of the requested CI run.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12933 - Fix-visual-identity-ZIP-unsafe-path-detection-on-Windows-CI.md
+++ b/backlog/tasks/task-12933 - Fix-visual-identity-ZIP-unsafe-path-detection-on-Windows-CI.md
@@ -1,0 +1,46 @@
+---
+id: TASK-12933
+title: Fix visual identity ZIP unsafe path detection on Windows CI
+status: In Progress
+labels:
+- ci
+- visual-identities
+- windows
+- main-followup
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Post-PR #2692 main CI added a Windows Python 3.12 visual-identities failure. zipfile normalizes backslash member names to forward slashes in ZipInfo.filename on Windows, so visual identity ZIP import must validate the raw ZipInfo.orig_filename to reject unsafe archive paths consistently.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] ZIP member validation rejects raw backslash member names even when `zipfile` normalizes `filename`.
+- [x] The backslash fixture assertion remains cross-platform.
+- [x] Archive import regression tests, diff check, and Bandit pass locally.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Root cause: on Windows, Python's `zipfile` keeps the archive member's raw name in `ZipInfo.orig_filename` but normalizes `ZipInfo.filename` to forward slashes. The importer used `filename`, so a raw `sprites\happy.png` member could be treated as a normal `sprites/happy.png` path and fail later as invalid image content. The fix validates and records errors against `orig_filename` while preserving the normalized safe path for accepted entries.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Prepared a second local-only fix for the Windows visual-identities CI failure. Added raw ZIP member-name validation through `ZipInfo.orig_filename`, updated the fixture assertion, and added a regression test that simulates Windows filename normalization. Verified targeted tests, the full archive import file, `git diff --check`, and Bandit on the touched importer. Patch remains unpushed pending completion of the requested CI run.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12934 - Fix-audio-WebSocket-legacy-config-rejection-on-main-CI.md
+++ b/backlog/tasks/task-12934 - Fix-audio-WebSocket-legacy-config-rejection-on-main-CI.md
@@ -1,0 +1,49 @@
+---
+id: TASK-12934
+title: Fix audio WebSocket legacy config rejection on main CI
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-09 16:14'
+labels:
+  - ci
+  - audio
+  - websocket
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Main CI run 28994210037 is failing media-audio and media-ingestion-modification shards because legacy/internal unified audio WebSocket config frames without explicit strict v1 protocol fields are rejected with `protocol_version must be 1` before the transcriber initializes. Prepare a minimal local patch on `codex/fix-main-guardian-notify-ts` and do not push until all tests complete.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Legacy unified WebSocket config frames without explicit protocol fields are accepted as v1 defaults.
+- [x] #2 Explicit protocol frames still use strict v1 validation and reject protocol_version 2.
+- [x] #3 Targeted direct handler CI-failure tests pass locally.
+- [x] #4 Bandit and diff checks are clean.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: handle_unified_websocket applied the strict public v1 audio protocol validator to every first config frame. Legacy/internal unified streaming clients send only transcription settings, so frames without protocol_version/mode/audio_format/channels were rejected before transcriber setup, quota, VAD, or diarization behavior could run. Fix: synthesize strict v1 defaults only when protocol_version is omitted; explicit protocol frames remain strict.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Prepared local unpushed commit for main CI audio WebSocket failures. Verification: red test `test_websocket_server_integration` failed before the patch and passed after; direct handler CI-failure set passed (`16 passed, 1 skipped`); strict protocol guards passed (`12 passed`); `git diff --check` passed; Bandit on `Audio_Streaming_Unified.py` reported 0 findings. Local endpoint quota batch was not used as final verification because after this protocol fix it reached macOS `parakeet_mlx` initialization and aborted in the local environment, which is a separate dependency/runtime path from the CI bad_request failures.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12935 - Fix-Windows-Notes-auto-title-CI-ChaCha-warm-up-race.md
+++ b/backlog/tasks/task-12935 - Fix-Windows-Notes-auto-title-CI-ChaCha-warm-up-race.md
@@ -1,0 +1,47 @@
+---
+id: TASK-12935
+title: Fix Windows Notes auto-title CI ChaCha warm-up race
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-09 16:50'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Main CI run 28994210037 job 86048011704 failed on windows-latest/Python 3.12 product-notes-persona. Failure: tldw_Server_API/tests/Notes/test_auto_title_integration.py::test_create_note_with_auto_title returned 500 {"detail":"Could not initialize character & notes database for user"}. Log shows single-user startup ChaChaNotes warm-up timed out during schema initialization, then first Notes request raced a second initialization against the same DB. Prepare local unpushed fix on codex/fix-main-guardian-notify-ts; do not push until all main CI tests complete per user instruction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Startup ChaChaNotes warm-up does not schedule in TEST_MODE
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: on Windows CI, single-user startup scheduled a best-effort ChaChaNotes warm-up while TEST_MODE was active. Schema initialization exceeded the 30s warm-up timeout, leaving the worker thread initializing the DB while the first Notes request attempted another initialization. Fix: skip speculative ChaCha warm-up in TEST_MODE while preserving normal single-user warm-up behavior outside tests.
+
+Documentation update not needed; this is a test-startup behavior fix. Known hold: branch remains intentionally unpushed until the monitored main CI run completes, per user instruction.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Prepared unpushed local commit for main CI product-notes-persona failure. Added a regression test for TEST_MODE warm-up skipping and changed startup_chacha_warmup to skip ChaChaNotes warm-up when core testing.is_test_mode() is true. Verification: startup warm-up unit test file passed; Notes auto-title integration file passed under TEST_MODE; git diff --check passed; Bandit on startup_chacha_warmup.py reported 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12936 - Fix-macOS-CI-PyAudio-toolchain-setup-failure.md
+++ b/backlog/tasks/task-12936 - Fix-macOS-CI-PyAudio-toolchain-setup-failure.md
@@ -1,0 +1,42 @@
+---
+id: TASK-12936
+title: Fix macOS CI PyAudio toolchain setup failure
+status: Done
+labels:
+- ci
+- macos
+- dependencies
+priority: High
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run 28994210037 job 86048012649 failed before tests in the macOS product-workflows-engine shard while building pyaudio. PortAudio was installed, but Xcode 26.5 clang lookup aborted via xcodebuild. Prepare a minimal CI setup hardening patch and keep it unpushed until the monitored main CI run completes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Patched .github/actions/setup-ffmpeg/action.yml to harden macOS PortAudio/PyAudio native build setup. Verification: YAML parsed with PyYAML; git diff --check passed. Bandit not applicable because this task only touches GitHub Actions YAML. Branch remains unpushed per user instruction until the monitored main CI run completes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12937 - Harden-sandbox-active-cap-concurrency-test-on-macOS-CI.md
+++ b/backlog/tasks/task-12937 - Harden-sandbox-active-cap-concurrency-test-on-macOS-CI.md
@@ -1,0 +1,42 @@
+---
+id: TASK-12937
+title: Harden sandbox active-cap concurrency test on macOS CI
+status: Done
+labels:
+- ci
+- sandbox
+- tests
+priority: High
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run 28994210037 job 86048012729 failed in test_global_active_cap_enforced_across_service_instances because the fake runner start event was never observed on macOS Python 3.12 after the broader platform-sandbox-state-store shard order. Prepare a minimal deterministic test harness hardening patch and keep it unpushed until all monitored CI tests complete.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Patched tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py to remove scheduler-dependent test flake from active-cap assertions. Verification: targeted concurrency file passed (4 passed); broad local platform-sandbox-state-store shard showed this test passing but had local-only async plugin failures unrelated to the CI failure; git diff --check passed; Bandit on touched test file reported only pre-existing low-severity B101 assert warnings and no new helper findings. Host python3.12 lacks pytest, so Python 3.12 local verification was unavailable. Branch remains unpushed per user instruction until the monitored main CI run completes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12941 - Address-PR-2698-review-feedback.md
+++ b/backlog/tasks/task-12941 - Address-PR-2698-review-feedback.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12941
+title: Address PR 2698 review feedback
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-10 00:17'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address PR #2698 review comments after rebasing the fix branch onto latest dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR #2698 branch rebased onto origin/dev
+- [x] #2 Actionable review comments are addressed with focused fixes
+- [x] #3 Focused verification and Bandit result are recorded
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Rebased codex/fix-main-guardian-notify-ts onto origin/dev. Scope: PortAudio environment preservation, legacy audio protocol config typing/None guard, sandbox executor Future contract, and brittle review-triggered tests for ChaCha startup and visual identity ZIP import. Unrelated untracked watchlist template files are intentionally untouched.
+
+Verification: pytest targeted suite passed (65 passed, 1 skipped); YAML parse for .github/actions/setup-ffmpeg/action.yml passed; py_compile for touched Python files passed; git diff --check passed; Bandit on touched Python scope with B101 skipped for test asserts wrote /tmp/bandit_task_12941.json with zero results.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2698 branch onto origin/dev and addressed review feedback: preserved PortAudio CFLAGS/LDFLAGS/PKG_CONFIG_PATH safely, aligned legacy audio config helper typing and None handling, returned a Future from the sandbox executor test double, and moved brittle review-triggered tests toward public observable behavior. No docs update was needed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Streaming_Unified.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Streaming_Unified.py
@@ -2611,7 +2611,7 @@ def _clamp_int(value: Any, default: int, min_value: int, max_value: int) -> int:
 
 def _audio_protocol_frame_for_config(
     frame: dict[str, Any],
-    config: UnifiedStreamingConfig,
+    config: Optional[UnifiedStreamingConfig],
 ) -> dict[str, Any]:
     """Return the strict audio protocol view for a client config frame.
 
@@ -2626,7 +2626,8 @@ def _audio_protocol_frame_for_config(
     protocol_frame.setdefault("protocol_version", 1)
     protocol_frame.setdefault("mode", "dictate")
     protocol_frame.setdefault("audio_format", "pcm16")
-    protocol_frame.setdefault("sample_rate", getattr(config, "sample_rate", 16000) or 16000)
+    sample_rate = getattr(config, "sample_rate", 16000) if config is not None else 16000
+    protocol_frame.setdefault("sample_rate", sample_rate or 16000)
     protocol_frame.setdefault("channels", 1)
     return protocol_frame
 

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Streaming_Unified.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Streaming_Unified.py
@@ -2609,6 +2609,28 @@ def _clamp_int(value: Any, default: int, min_value: int, max_value: int) -> int:
         return default
 
 
+def _audio_protocol_frame_for_config(
+    frame: dict[str, Any],
+    config: UnifiedStreamingConfig,
+) -> dict[str, Any]:
+    """Return the strict audio protocol view for a client config frame.
+
+    Legacy unified streaming clients predate the public v1 JSON audio protocol
+    and send only transcription settings. Keep those clients on v1 defaults
+    while leaving explicit protocol frames strict.
+    """
+    if "protocol_version" in frame:
+        return frame
+
+    protocol_frame = dict(frame)
+    protocol_frame.setdefault("protocol_version", 1)
+    protocol_frame.setdefault("mode", "dictate")
+    protocol_frame.setdefault("audio_format", "pcm16")
+    protocol_frame.setdefault("sample_rate", getattr(config, "sample_rate", 16000) or 16000)
+    protocol_frame.setdefault("channels", 1)
+    return protocol_frame
+
+
 async def handle_unified_websocket(
     websocket,
     config: Optional[UnifiedStreamingConfig] = None,
@@ -2690,7 +2712,8 @@ async def handle_unified_websocket(
                 raise AudioProtocolError("bad_request", "First post-auth frame must be a JSON object")
             config_payload = config_data
             logger.info(f"Parsed config data type: {config_data.get('type')}")
-            protocol_config = validate_audio_stream_config(config_data, AUDIO_TRANSCRIBE_ENDPOINT)
+            protocol_frame = _audio_protocol_frame_for_config(config_data, config)
+            protocol_config = validate_audio_stream_config(protocol_frame, AUDIO_TRANSCRIBE_ENDPOINT)
 
             # Update configuration
             old_variant = config.model_variant

--- a/tldw_Server_API/app/core/Monitoring/notification_service.py
+++ b/tldw_Server_API/app/core/Monitoring/notification_service.py
@@ -533,8 +533,8 @@ class NotificationService:
         severity = payload.get("severity") or payload.get("rule_severity")
         if not self._meets_threshold(severity):
             return "skipped"
+        payload.setdefault("ts", datetime.now(timezone.utc).isoformat())
         payload_to_record = dict(payload)
-        payload_to_record.setdefault("ts", datetime.now(timezone.utc).isoformat())
         # lgtm[py/clear-text-storage-sensitive-data]: payload is redacted before notification persistence.
         safe_payload = _sanitize_notification_payload(payload_to_record)
         file_written = True

--- a/tldw_Server_API/app/core/Visual_Identities/archive_import.py
+++ b/tldw_Server_API/app/core/Visual_Identities/archive_import.py
@@ -141,28 +141,29 @@ def _collect_candidates(
     total_uncompressed = 0
 
     for info in infos:
-        normalized_path = _normalized_archive_path(info.filename)
+        source_filename = _zip_member_source_name(info)
+        normalized_path = _normalized_archive_path(source_filename)
         if normalized_path is None:
-            _record_error(summary, code="unsafe_archive_path", source_filename=info.filename)
+            _record_error(summary, code="unsafe_archive_path", source_filename=source_filename)
             continue
         duplicate_key = normalized_path.lower()
         if duplicate_key in seen_paths:
-            _record_error(summary, code="duplicate_archive_path", source_filename=info.filename)
+            _record_error(summary, code="duplicate_archive_path", source_filename=source_filename)
             continue
         seen_paths.add(duplicate_key)
 
-        _validate_entry_metadata(info, normalized_path, summary)
+        _validate_entry_metadata(info, normalized_path, summary, source_filename=source_filename)
         if info.is_dir():
-            if not _entry_has_errors(summary, info.filename):
+            if not _entry_has_errors(summary, source_filename):
                 summary["directories"].append(normalized_path)
             continue
 
         total_uncompressed += int(info.file_size)
         expression_key = normalize_expression_filename(PurePosixPath(normalized_path).name)
         if expression_key is None:
-            _record_error(summary, code="empty_expression_key", source_filename=info.filename)
+            _record_error(summary, code="empty_expression_key", source_filename=source_filename)
             continue
-        if _entry_has_errors(summary, info.filename):
+        if _entry_has_errors(summary, source_filename):
             continue
         candidates.append(
             _ImportCandidate(
@@ -184,8 +185,10 @@ def _validate_entry_metadata(
     info: zipfile.ZipInfo,
     normalized_path: str,
     summary: dict[str, Any],
+    *,
+    source_filename: str | None = None,
 ) -> None:
-    source_filename = info.filename
+    source_filename = source_filename or _zip_member_source_name(info)
     extension = PurePosixPath(normalized_path).suffix.lower()
     if info.flag_bits & 0x1:
         _record_error(summary, code="encrypted_entry", source_filename=source_filename)
@@ -376,6 +379,10 @@ def _normalized_archive_path(raw_name: str) -> str | None:
     if not PurePosixPath(normalized_path).name:
         return None
     return normalized_path
+
+
+def _zip_member_source_name(info: zipfile.ZipInfo) -> str:
+    return str(getattr(info, "orig_filename", info.filename))
 
 
 def _is_symlink(info: zipfile.ZipInfo) -> bool:

--- a/tldw_Server_API/app/services/startup_chacha_warmup.py
+++ b/tldw_Server_API/app/services/startup_chacha_warmup.py
@@ -15,6 +15,9 @@ async def warm_chacha_notes_on_startup(
 ) -> None:
     try:
         _reset_chacha_shutdown_state()
+        if _is_test_mode():
+            logger.debug("ChaChaNotes warm-up skipped (test mode)")
+            return
         if _is_single_user_mode():
             auth_settings = _get_auth_settings()
             single_user_id = int(getattr(auth_settings, "SINGLE_USER_FIXED_ID", 1))
@@ -34,6 +37,12 @@ def _reset_chacha_shutdown_state() -> None:
     )
 
     reset_chacha_shutdown_state()
+
+
+def _is_test_mode() -> bool:
+    from tldw_Server_API.app.core.testing import is_test_mode
+
+    return bool(is_test_mode())
 
 
 def _is_single_user_mode() -> bool:

--- a/tldw_Server_API/tests/Services/test_startup_chacha_warmup.py
+++ b/tldw_Server_API/tests/Services/test_startup_chacha_warmup.py
@@ -78,31 +78,24 @@ async def test_warm_chacha_notes_on_startup_skips_test_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     warmup = _import_startup_chacha_warmup()
+    from tldw_Server_API.app.core.AuthNZ import settings as auth_settings
+
     logger = _FakeLogger()
-    observed: dict[str, object] = {"reset_calls": 0, "scheduled": False}
 
     monkeypatch.setenv("TEST_MODE", "true")
-    monkeypatch.setattr(
-        warmup,
-        "_reset_chacha_shutdown_state",
-        lambda: observed.__setitem__("reset_calls", int(observed["reset_calls"]) + 1),
-    )
-    monkeypatch.setattr(warmup, "_is_single_user_mode", lambda: True)
-    monkeypatch.setattr(
-        warmup,
-        "_schedule_warm_chacha_task",
-        lambda user_id, client_id: observed.__setitem__("scheduled", True),
-    )
+
+    def _fail_if_auth_mode_is_checked() -> bool:
+        raise AssertionError("test mode should skip auth mode checks")
+
+    monkeypatch.setattr(auth_settings, "is_single_user_mode", _fail_if_auth_mode_is_checked)
 
     await warmup.warm_chacha_notes_on_startup(
         logger=logger,
         startup_guard_exceptions=(RuntimeError,),
     )
 
-    assert observed["reset_calls"] == 1
-    assert observed["scheduled"] is False
     assert logger.info_messages == []
-    assert logger.debug_messages == ["ChaChaNotes warm-up skipped (test mode)"]
+    assert any("test mode" in message.lower() for message in logger.debug_messages)
     assert logger.warning_messages == []
 
 

--- a/tldw_Server_API/tests/Services/test_startup_chacha_warmup.py
+++ b/tldw_Server_API/tests/Services/test_startup_chacha_warmup.py
@@ -39,6 +39,8 @@ async def test_warm_chacha_notes_on_startup_schedules_single_user_warmup(
     logger = _FakeLogger()
     observed: dict[str, object] = {"reset_calls": 0}
 
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_TEST_MODE", raising=False)
     monkeypatch.setattr(
         warmup,
         "_reset_chacha_shutdown_state",
@@ -72,6 +74,39 @@ async def test_warm_chacha_notes_on_startup_schedules_single_user_warmup(
 
 
 @pytest.mark.asyncio
+async def test_warm_chacha_notes_on_startup_skips_test_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warmup = _import_startup_chacha_warmup()
+    logger = _FakeLogger()
+    observed: dict[str, object] = {"reset_calls": 0, "scheduled": False}
+
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setattr(
+        warmup,
+        "_reset_chacha_shutdown_state",
+        lambda: observed.__setitem__("reset_calls", int(observed["reset_calls"]) + 1),
+    )
+    monkeypatch.setattr(warmup, "_is_single_user_mode", lambda: True)
+    monkeypatch.setattr(
+        warmup,
+        "_schedule_warm_chacha_task",
+        lambda user_id, client_id: observed.__setitem__("scheduled", True),
+    )
+
+    await warmup.warm_chacha_notes_on_startup(
+        logger=logger,
+        startup_guard_exceptions=(RuntimeError,),
+    )
+
+    assert observed["reset_calls"] == 1
+    assert observed["scheduled"] is False
+    assert logger.info_messages == []
+    assert logger.debug_messages == ["ChaChaNotes warm-up skipped (test mode)"]
+    assert logger.warning_messages == []
+
+
+@pytest.mark.asyncio
 async def test_warm_chacha_notes_on_startup_skips_multi_user_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -79,6 +114,8 @@ async def test_warm_chacha_notes_on_startup_skips_multi_user_mode(
     logger = _FakeLogger()
     observed: dict[str, object] = {"reset_calls": 0, "scheduled": False}
 
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_TEST_MODE", raising=False)
     monkeypatch.setattr(
         warmup,
         "_reset_chacha_shutdown_state",

--- a/tldw_Server_API/tests/Visual_Identities/test_visual_identity_archive_import.py
+++ b/tldw_Server_API/tests/Visual_Identities/test_visual_identity_archive_import.py
@@ -235,19 +235,45 @@ def test_zip_fixture_preserves_backslash_member_names(tmp_path: Path) -> None:
         assert archive.infolist()[0].orig_filename == r"sprites\happy.png"
 
 
-def test_collect_candidates_rejects_raw_backslash_when_zipfile_normalizes_filename() -> None:
+def test_archive_import_rejects_raw_backslash_when_zipfile_normalizes_filename(
+    repo: VisualIdentityRepository,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    draft = repo.create_draft(owner_user_id=1, title="Backslash", source_kind="zip")
+    archive_path = tmp_path / "unsafe.zip"
+    archive_path.write_bytes(b"placeholder")
     info = zipfile.ZipInfo("sprites/happy.png")
     info.orig_filename = r"sprites\happy.png"
     info.file_size = 4
     info.compress_size = 4
-    summary = archive_import._empty_summary(source_filename="unsafe.zip")
 
     class Archive:
+        def __init__(self, source: str | Path) -> None:
+            assert Path(source) == archive_path
+
+        def __enter__(self) -> "Archive":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
         def infolist(self) -> list[zipfile.ZipInfo]:
             return [info]
 
-    assert archive_import._collect_candidates(Archive(), summary) == []
-    assert _error_codes(summary) == {"unsafe_archive_path"}
+    monkeypatch.setattr(archive_import.zipfile, "ZipFile", Archive)
+
+    result = import_visual_identity_expression_zip(
+        repo,
+        owner_user_id=1,
+        draft_id=draft["id"],
+        archive_path=archive_path,
+        storage_root=tmp_path / "store",
+    )
+
+    assert result["status"] == "failed"
+    assert repo.list_draft_assets(draft["id"], owner_user_id=1) == []
+    assert _error_codes(json.loads(result["validation_summary_json"])) == {"unsafe_archive_path"}
 
 
 @pytest.mark.parametrize("member_name", ["C:happy.png", "sprites/C:happy.png"])

--- a/tldw_Server_API/tests/Visual_Identities/test_visual_identity_archive_import.py
+++ b/tldw_Server_API/tests/Visual_Identities/test_visual_identity_archive_import.py
@@ -232,7 +232,22 @@ def test_zip_fixture_preserves_backslash_member_names(tmp_path: Path) -> None:
     archive_path = _zip_with_entries(tmp_path / "backslash.zip", {r"sprites\happy.png": b"data"})
 
     with zipfile.ZipFile(archive_path) as archive:
-        assert archive.namelist() == [r"sprites\happy.png"]
+        assert archive.infolist()[0].orig_filename == r"sprites\happy.png"
+
+
+def test_collect_candidates_rejects_raw_backslash_when_zipfile_normalizes_filename() -> None:
+    info = zipfile.ZipInfo("sprites/happy.png")
+    info.orig_filename = r"sprites\happy.png"
+    info.file_size = 4
+    info.compress_size = 4
+    summary = archive_import._empty_summary(source_filename="unsafe.zip")
+
+    class Archive:
+        def infolist(self) -> list[zipfile.ZipInfo]:
+            return [info]
+
+    assert archive_import._collect_candidates(Archive(), summary) == []
+    assert _error_codes(summary) == {"unsafe_archive_path"}
 
 
 @pytest.mark.parametrize("member_name", ["C:happy.png", "sprites/C:happy.png"])

--- a/tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py
+++ b/tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import threading
 import time
+from concurrent.futures import Future
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 import pytest
 
@@ -77,14 +78,25 @@ class _DeterministicBackgroundExecutor:
     def __init__(self) -> None:
         self._threads: list[threading.Thread] = []
 
-    def submit(self, worker_fn: Callable[[], None]) -> None:
+    def submit(self, worker_fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Future:
+        future = Future()
+
+        def _run() -> None:
+            if not future.set_running_or_notify_cancel():
+                return
+            try:
+                future.set_result(worker_fn(*args, **kwargs))
+            except BaseException as exc:
+                future.set_exception(exc)
+
         thread = threading.Thread(
-            target=worker_fn,
+            target=_run,
             name="sandbox-test-runner",
             daemon=True,
         )
         self._threads.append(thread)
         thread.start()
+        return future
 
     def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
         del cancel_futures

--- a/tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py
+++ b/tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
@@ -17,7 +17,6 @@ from tldw_Server_API.app.core.Sandbox.service import SandboxService
 pytestmark = pytest.mark.unit
 
 RUNNER_START_TIMEOUT_SEC = 60.0
-TEST_BACKGROUND_WORKERS = 2
 
 
 def _configure_sqlite_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -74,14 +73,32 @@ def _wait_for_phase(
     return None
 
 
+class _DeterministicBackgroundExecutor:
+    def __init__(self) -> None:
+        self._threads: list[threading.Thread] = []
+
+    def submit(self, worker_fn: Callable[[], None]) -> None:
+        thread = threading.Thread(
+            target=worker_fn,
+            name="sandbox-test-runner",
+            daemon=True,
+        )
+        self._threads.append(thread)
+        thread.start()
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        del cancel_futures
+        if not wait:
+            return
+        for thread in self._threads:
+            thread.join(timeout=RUNNER_START_TIMEOUT_SEC)
+
+
 def _install_test_background_executor(
     monkeypatch: pytest.MonkeyPatch,
     svc: SandboxService,
-) -> ThreadPoolExecutor:
-    executor = ThreadPoolExecutor(
-        max_workers=TEST_BACKGROUND_WORKERS,
-        thread_name_prefix="sandbox-test-runner",
-    )
+) -> _DeterministicBackgroundExecutor:
+    executor = _DeterministicBackgroundExecutor()
     monkeypatch.setattr(svc, "_background_executor", lambda: executor)
     return executor
 


### PR DESCRIPTION
Covers the current post-merge CI failures from run 28994210037.

Change summary:
- Fix Guardian generic notify timestamp handling.
- Fix visual identity ZIP path validation on Windows.
- Fix audio WebSocket legacy config handling.
- Skip ChaChaNotes startup warm-up in test mode to avoid the Notes auto-title race.
- Harden macOS PortAudio/PyAudio setup for native wheels.
- Stabilize sandbox active-cap concurrency tests with a deterministic test executor.

Verification:
- Targeted Guardian, visual identity, audio WebSocket, Notes auto-title, and sandbox concurrency tests passed locally.
- GitHub Action YAML parsed locally.
- git diff --check passed.
- Bandit run where Python files were touched; remaining test-file findings were pre-existing pytest assert warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes post-merge CI by fixing backend/test flakes across platforms and hardening macOS build setup. Also adds guarded auto-publish for `mcp-unified` on `main` version bumps.

- **New Features**
  - Auto-publish `mcp-unified` to PyPI on `main` when the package version changes, via a detector job that verifies `pyproject.toml` and `__version__` sync, confirms the version isn’t already on PyPI, and gates RC/publish jobs; a final pre-upload duplicate guard is included.
  - Manual TestPyPI/PyPI dispatch remains available; uses trusted publishing. READMEs updated to document the flow.

- **Bug Fixes**
  - Guardian notifications: set a default `ts` on the caller payload when missing.
  - Visual identity ZIP import: validate `ZipInfo.orig_filename` to reject unsafe backslash paths on Windows; added tests.
  - Audio WebSocket: accept legacy config frames by applying v1 defaults when protocol fields are absent; explicit protocol frames remain strict.
  - Notes: skip ChaChaNotes startup warm-up in test mode to avoid the auto-title race; added unit test.
  - macOS CI: harden PortAudio/PyAudio build env in `setup-ffmpeg` (clang/SDK discovery, `CC`/`SDKROOT`/`MACOSX_DEPLOYMENT_TARGET`, `CFLAGS`/`LDFLAGS`/`PKG_CONFIG_PATH`).
  - Sandbox: remove scheduler flake with a deterministic background executor in the active-cap concurrency test.

<sup>Written for commit addf2445fab72d494002e7e40bb59c1a6b918232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

