### PR TITLE
Fix YouTube quick ingest worker startup and render loop

### DIFF
--- a/Docs/API-related/Media_Ingest_Jobs_API.md
+++ b/Docs/API-related/Media_Ingest_Jobs_API.md
@@ -63,7 +63,7 @@ Google Drive and Microsoft OneDrive source sync runs are queued through the conn
 
 - Service: `tldw_Server_API/app/services/media_ingest_jobs_worker.py`
 - Env flags:
-  - `MEDIA_INGEST_JOBS_WORKER_ENABLED`: `true|false` (default false)
+  - `MEDIA_INGEST_JOBS_WORKER_ENABLED`: `true|false` (default follows the `media` route policy; set `false` to disable the in-process worker)
   - `MEDIA_INGEST_JOBS_QUEUE`: queue name (default `default`)
   - `JOBS_DB_URL` or `JOBS_DB_PATH`: Jobs backend (Postgres DSN or SQLite path)
 

--- a/Docs/Deployment/Long_Term_Admin_Guide.md
+++ b/Docs/Deployment/Long_Term_Admin_Guide.md
@@ -118,7 +118,7 @@ Circuit breaker observability and tuning
 Application
 - CPU workers: set `UVICORN_WORKERS` (default 4 in Dockerfile.prod). Monitor latency and CPU to tune.
 - Caching: ensure embeddings/model caches reside on fast disk; configure per module where available.
- - Background jobs: Chatbooks worker enabled by default (core backend). Control via `CHATBOOKS_CORE_WORKER_ENABLED`. Media ingest jobs worker is opt-in via `MEDIA_INGEST_JOBS_WORKER_ENABLED`.
+- Background jobs: Chatbooks worker enabled by default (core backend). Control via `CHATBOOKS_CORE_WORKER_ENABLED`. Media ingest jobs worker follows the `media` route policy by default; control via `MEDIA_INGEST_JOBS_WORKER_ENABLED`, or use sidecar workers for multi-worker deployments.
 - SQLite deployments: avoid multiple Uvicorn workers with in-process jobs. Use sidecar workers or Postgres for higher concurrency.
 
 Database

--- a/Docs/Published/API-related/Media_Ingest_Jobs_API.md
+++ b/Docs/Published/API-related/Media_Ingest_Jobs_API.md
@@ -63,7 +63,7 @@ Google Drive and Microsoft OneDrive source sync runs are queued through the conn
 
 - Service: `tldw_Server_API/app/services/media_ingest_jobs_worker.py`
 - Env flags:
-  - `MEDIA_INGEST_JOBS_WORKER_ENABLED`: `true|false` (default false)
+  - `MEDIA_INGEST_JOBS_WORKER_ENABLED`: `true|false` (default follows the `media` route policy; set `false` to disable the in-process worker)
   - `MEDIA_INGEST_JOBS_QUEUE`: queue name (default `default`)
   - `JOBS_DB_URL` or `JOBS_DB_PATH`: Jobs backend (Postgres DSN or SQLite path)
 

--- a/Docs/Published/Deployment/Long_Term_Admin_Guide.md
+++ b/Docs/Published/Deployment/Long_Term_Admin_Guide.md
@@ -118,7 +118,7 @@ Circuit breaker observability and tuning
 Application
 - CPU workers: set `UVICORN_WORKERS` (default 4 in Dockerfile.prod). Monitor latency and CPU to tune.
 - Caching: ensure embeddings/model caches reside on fast disk; configure per module where available.
- - Background jobs: Chatbooks worker enabled by default (core backend). Control via `CHATBOOKS_CORE_WORKER_ENABLED`. Media ingest jobs worker is opt-in via `MEDIA_INGEST_JOBS_WORKER_ENABLED`.
+- Background jobs: Chatbooks worker enabled by default (core backend). Control via `CHATBOOKS_CORE_WORKER_ENABLED`. Media ingest jobs worker follows the `media` route policy by default; control via `MEDIA_INGEST_JOBS_WORKER_ENABLED`, or use sidecar workers for multi-worker deployments.
 - SQLite deployments: avoid multiple Uvicorn workers with in-process jobs. Use sidecar workers or Postgres for higher concurrency.
 
 Database

--- a/Docs/superpowers/plans/2026-07-09-media-ingest-worker-startup-capability-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-09-media-ingest-worker-startup-capability-implementation-plan.md
@@ -1,0 +1,640 @@
+# Media Ingest Worker Startup Capability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix media ingest jobs so the normal in-process worker starts by default when the `media` route is enabled, and make docs-info report that normal worker capability accurately.
+
+**Architecture:** Reuse the existing `should_start_inprocess_worker()` startup policy instead of introducing another flag parser. Extend that helper with an optional injected route checker so declarative lifecycle specs can use their `WorkerLifecycleContext`, while existing global-config callers keep current behavior. Add one local lifecycle-spec predicate in the content jobs poller provider and wire it only to the normal and heavy media ingest worker specs. Update docs-info to compute `hasMediaIngestWorker` from the same normal-worker policy with sidecar awareness.
+
+**Tech Stack:** FastAPI service code, pytest unit tests, Loguru-backed startup services, Backlog.md task `TASK-12100`.
+
+---
+
+## Source Spec
+
+- `Docs/superpowers/specs/2026-07-09-media-ingest-worker-startup-capability-design.md`
+
+## Files
+
+- Modify: `tldw_Server_API/app/services/worker_startup_policy.py`
+  - Add optional injected `route_enabled` support while preserving current global-config behavior.
+  - Make injected route callback failures fail closed; keep legacy default fallback only for global config lookup failures.
+- Modify: `tldw_Server_API/app/services/startup_content_jobs_pollers.py`
+  - Add a focused media ingest lifecycle predicate that delegates to `should_start_inprocess_worker()`.
+  - Replace only the media ingest worker spec predicates.
+- Modify: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py`
+  - Add failing tests for the startup policy helper and the actual lifecycle spec boundary.
+- Modify: `tldw_Server_API/app/api/v1/endpoints/config_info.py`
+  - Compute `hasMediaIngestWorker` from normal worker policy plus `TLDW_WORKERS_SIDECAR_MODE`.
+- Modify: `tldw_Server_API/tests/Config/test_docs_info_capabilities.py`
+  - Update existing media ingest capability expectation and add sidecar/opt-out coverage.
+- Modify: `Docs/API-related/Media_Ingest_Jobs_API.md`
+- Modify: `Docs/Published/API-related/Media_Ingest_Jobs_API.md`
+- Modify: `Docs/Deployment/Long_Term_Admin_Guide.md`
+- Modify: `Docs/Published/Deployment/Long_Term_Admin_Guide.md`
+  - Reconcile normal worker default wording.
+- Update: `backlog/tasks/task-12100 - Fix-media-ingest-worker-startup-default-and-capability-reporting.md`
+  - Keep status, notes, changed files, and verification results current.
+
+---
+
+### Task 1: Add Startup Policy And Lifecycle Spec Regression Tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py`
+
+- [x] **Step 1: Add imports for the real spec provider and context**
+
+Add:
+
+```python
+from tldw_Server_API.app.services.lifecycle_worker_specs import WorkerLifecycleContext
+from tldw_Server_API.app.services.startup_content_jobs_pollers import provide_content_jobs_worker_specs
+```
+
+- [x] **Step 2: Add a tiny context helper**
+
+```python
+def _worker_context(*, sidecar_mode: bool = False, route_allowed: bool = True) -> WorkerLifecycleContext:
+    return WorkerLifecycleContext(
+        app=object(),
+        settings={},
+        test_mode=False,
+        route_enabled=lambda *_args, **_kwargs: route_allowed,
+        logger=None,
+        startup_guard_exceptions=(),
+        import_exceptions=(),
+        sidecar_mode=sidecar_mode,
+    )
+```
+
+- [x] **Step 3: Add a spec lookup helper**
+
+```python
+def _content_spec(name: str):
+    specs = {spec.name: spec for spec in provide_content_jobs_worker_specs()}
+    return specs[name]
+```
+
+- [x] **Step 4: Add failing startup policy tests for injected route checks**
+
+```python
+def test_should_start_inprocess_worker_uses_injected_route_policy_when_flag_unset(
+    monkeypatch,
+):
+    from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    assert should_start_inprocess_worker(
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "media",
+        sidecar_mode=False,
+        default_stable=True,
+        test_mode=False,
+        route_enabled=lambda route_key, **_kwargs: route_key == "media",
+    )
+
+
+def test_should_start_inprocess_worker_honors_injected_route_disabled_when_flag_unset(
+    monkeypatch,
+):
+    from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    assert not should_start_inprocess_worker(
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "media",
+        sidecar_mode=False,
+        default_stable=True,
+        test_mode=False,
+        route_enabled=lambda *_args, **_kwargs: False,
+    )
+
+
+def test_should_start_inprocess_worker_supports_single_arg_injected_route_policy(
+    monkeypatch,
+):
+    from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    assert not should_start_inprocess_worker(
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "media",
+        sidecar_mode=False,
+        default_stable=True,
+        test_mode=False,
+        route_enabled=lambda _route_key: False,
+    )
+
+
+def test_should_start_inprocess_worker_does_not_mask_route_policy_type_errors(
+    monkeypatch,
+):
+    from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+
+    def broken_route_enabled(_route_key, **_kwargs):
+        raise TypeError("broken route policy")
+
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    assert not should_start_inprocess_worker(
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "media",
+        sidecar_mode=False,
+        default_stable=True,
+        test_mode=False,
+        route_enabled=broken_route_enabled,
+    )
+```
+
+Expected before implementation: `TypeError` because `route_enabled` is not accepted yet.
+
+- [x] **Step 5: Add the failing normal-worker route-default lifecycle tests**
+
+```python
+def test_media_ingest_lifecycle_spec_uses_route_policy_when_flag_unset(monkeypatch):
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    spec = _content_spec("media_ingest_jobs_task")
+
+    assert spec.enabled(_worker_context(route_allowed=True)) is True
+
+
+def test_media_ingest_lifecycle_spec_disables_when_route_policy_disabled(monkeypatch):
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    spec = _content_spec("media_ingest_jobs_task")
+
+    assert spec.enabled(_worker_context(route_allowed=False)) is False
+```
+
+Expected before implementation: `False`.
+
+- [x] **Step 6: Add explicit opt-out, sidecar, and heavy default tests**
+
+```python
+def test_media_ingest_lifecycle_spec_respects_explicit_false(monkeypatch):
+    monkeypatch.setenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", "false")
+
+    spec = _content_spec("media_ingest_jobs_task")
+
+    assert spec.enabled(_worker_context(route_allowed=True)) is False
+
+
+def test_media_ingest_lifecycle_spec_skips_in_sidecar_mode(monkeypatch):
+    monkeypatch.setenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", "true")
+
+    spec = _content_spec("media_ingest_jobs_task")
+
+    assert spec.enabled(_worker_context(sidecar_mode=True, route_allowed=True)) is False
+
+
+def test_media_ingest_heavy_lifecycle_spec_remains_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED", raising=False)
+
+    spec = _content_spec("media_ingest_heavy_jobs_task")
+
+    assert spec.enabled(_worker_context(route_allowed=False)) is False
+```
+
+- [x] **Step 7: Run tests and confirm the intended failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py -v
+```
+
+Expected: the injected-route startup policy tests fail before implementation, and the normal-worker route-default lifecycle spec test still fails until the media ingest spec is rewired.
+
+---
+
+### Task 2: Wire Media Ingest Specs To In-Process Worker Policy
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/worker_startup_policy.py`
+- Modify: `tldw_Server_API/app/services/startup_content_jobs_pollers.py`
+
+- [x] **Step 1: Extend worker startup policy with optional injected route checks**
+
+In `worker_startup_policy.py`, import `Callable`, `Parameter`, and `signature`:
+
+```python
+from collections.abc import Callable
+from inspect import Parameter, signature
+```
+
+Then extend the helper signatures:
+
+```python
+def worker_route_default(
+    route_key: str,
+    *,
+    default_stable: bool = True,
+    test_mode: bool = False,
+    route_enabled: Callable[..., bool] | None = None,
+) -> bool:
+```
+
+```python
+def worker_path_enabled(
+    flag_key: str,
+    route_key: str,
+    *,
+    default_stable: bool = True,
+    test_mode: bool = False,
+    route_enabled: Callable[..., bool] | None = None,
+) -> bool:
+```
+
+```python
+def should_start_inprocess_worker(
+    flag_key: str,
+    route_key: str,
+    *,
+    sidecar_mode: bool,
+    default_stable: bool = True,
+    test_mode: bool = False,
+    route_enabled: Callable[..., bool] | None = None,
+) -> bool:
+```
+
+In `worker_route_default()`, keep the existing `test_mode` early return. After that, use the injected route checker when provided. Use stdlib signature inspection to call one-argument callbacks without `default_stable`; do not use broad `TypeError` fallback as signature detection because it can mask real route callback failures.
+
+```python
+    if route_enabled is not None:
+        try:
+            if _route_enabled_accepts_default_stable(route_enabled):
+                return bool(route_enabled(route_key, default_stable=default_stable))
+            return bool(route_enabled(route_key))
+        except _WORKER_POLICY_EXCEPTIONS as exc:
+            logger.debug("Worker startup policy route check failed for {}: {}", route_key, exc)
+            return False
+```
+
+Thread `route_enabled=route_enabled` through `worker_path_enabled()` and `should_start_inprocess_worker()`.
+
+- [x] **Step 2: Import the existing policy helper**
+
+Change imports near the lifecycle spec imports:
+
+```python
+from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+```
+
+- [x] **Step 3: Add the focused predicate helper**
+
+Add near `provide_content_jobs_worker_specs()`:
+
+```python
+def media_ingest_worker_predicate(
+    flag_key: str,
+    route_key: str,
+    *,
+    default_stable: bool,
+):
+    """Return an in-process media ingest worker predicate."""
+
+    def _enabled(context: WorkerLifecycleContext) -> bool:
+        return should_start_inprocess_worker(
+            flag_key,
+            route_key,
+            sidecar_mode=context.sidecar_mode,
+            default_stable=default_stable,
+            test_mode=context.test_mode,
+            route_enabled=context.route_enabled,
+        )
+
+    return _enabled
+```
+
+Keep this helper local to the content jobs poller module unless another worker family needs the same semantics later.
+
+- [x] **Step 4: Replace only the media ingest predicates**
+
+Change normal worker spec:
+
+```python
+enabled=media_ingest_worker_predicate(
+    "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+    "media",
+    default_stable=True,
+),
+```
+
+Change heavy worker spec:
+
+```python
+enabled=media_ingest_worker_predicate(
+    "MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED",
+    "media-ingest-heavy-jobs",
+    default_stable=False,
+),
+```
+
+Leave all other `route_enabled_predicate(...)` usages alone.
+
+- [x] **Step 5: Run the focused startup tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py -v
+```
+
+Expected: all tests in that file pass.
+
+- [x] **Step 6: Run lifecycle catalog guard tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Services/test_lifecycle_worker_catalog.py tldw_Server_API/tests/Services/test_startup_worker_groups.py -v
+```
+
+Expected: pass, proving the provider graph still validates.
+
+---
+
+### Task 3: Fix Docs-Info Worker Capability Reporting
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Config/test_docs_info_capabilities.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/config_info.py`
+
+- [x] **Step 1: Update the existing capability expectation to fail first**
+
+In `test_docs_info_exposes_bulk_conference_ingest_capabilities`, clear the normal flag and sidecar mode:
+
+```python
+monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+monkeypatch.delenv("TLDW_WORKERS_SIDECAR_MODE", raising=False)
+```
+
+Change:
+
+```python
+assert caps["hasMediaIngestWorker"] is True
+```
+
+Expected before implementation: this fails because the code still checks the heavy worker.
+
+- [x] **Step 2: Add explicit false and sidecar capability tests**
+
+```python
+def test_docs_info_media_ingest_worker_capability_respects_explicit_false(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.txt"
+    _write_minimal_config(config_path)
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", "false")
+    monkeypatch.delenv("TLDW_WORKERS_SIDECAR_MODE", raising=False)
+    config_mod._route_toggle_policy.cache_clear()
+
+    safe_config = config_info.load_safe_config()
+
+    assert safe_config["capabilities"]["hasMediaIngestWorker"] is False
+
+
+def test_docs_info_media_ingest_worker_capability_is_false_in_sidecar_mode(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.txt"
+    _write_minimal_config(config_path)
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", "true")
+    monkeypatch.setenv("TLDW_WORKERS_SIDECAR_MODE", "true")
+    config_mod._route_toggle_policy.cache_clear()
+
+    safe_config = config_info.load_safe_config()
+
+    assert safe_config["capabilities"]["hasMediaIngestWorker"] is False
+```
+
+- [x] **Step 3: Run docs-info tests and confirm failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Config/test_docs_info_capabilities.py -v
+```
+
+Expected before implementation: `hasMediaIngestWorker` route-default expectation fails.
+
+- [x] **Step 4: Import the correct helpers in config_info**
+
+Change the worker startup policy import to include `should_start_inprocess_worker`; keep `worker_path_enabled` only if other code still uses it.
+
+Also import `env_flag_enabled` if not already available:
+
+```python
+from tldw_Server_API.app.core.testing import env_flag_enabled
+from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+```
+
+- [x] **Step 5: Compute capability from the normal worker policy**
+
+Replace the current heavy-worker block with:
+
+```python
+caps["hasMediaIngestWorker"] = bool(
+    should_start_inprocess_worker(
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "media",
+        sidecar_mode=env_flag_enabled("TLDW_WORKERS_SIDECAR_MODE"),
+        default_stable=True,
+        test_mode=False,
+    )
+)
+```
+
+- [x] **Step 6: Run docs-info tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Config/test_docs_info_capabilities.py -v
+```
+
+Expected: pass.
+
+---
+
+### Task 4: Reconcile Documentation Defaults
+
+**Files:**
+- Modify: `Docs/API-related/Media_Ingest_Jobs_API.md`
+- Modify: `Docs/Published/API-related/Media_Ingest_Jobs_API.md`
+- Modify: `Docs/Deployment/Long_Term_Admin_Guide.md`
+- Modify: `Docs/Published/Deployment/Long_Term_Admin_Guide.md`
+
+- [x] **Step 1: Update API docs worker flag wording**
+
+In both API docs files, replace:
+
+```markdown
+- `MEDIA_INGEST_JOBS_WORKER_ENABLED`: `true|false` (default false)
+```
+
+with:
+
+```markdown
+- `MEDIA_INGEST_JOBS_WORKER_ENABLED`: `true|false` (default follows the `media` route policy; set `false` to disable the in-process worker)
+```
+
+- [x] **Step 2: Update deployment guide wording**
+
+In both deployment guide files, replace the media ingest sentence with:
+
+```markdown
+- Background jobs: Chatbooks worker enabled by default (core backend). Control via `CHATBOOKS_CORE_WORKER_ENABLED`. Media ingest jobs worker follows the `media` route policy by default; control via `MEDIA_INGEST_JOBS_WORKER_ENABLED`, or use sidecar workers for multi-worker deployments.
+```
+
+- [x] **Step 3: Check for stale contradictory docs**
+
+Run:
+
+```bash
+rg -n "MEDIA_INGEST_JOBS_WORKER_ENABLED.*default false|Media ingest jobs worker is opt-in" Docs \
+  -g '!**/superpowers/plans/**'
+```
+
+Expected: no results.
+
+---
+
+### Task 5: Verification And Handoff
+
+**Files:**
+- Update: `backlog/tasks/task-12100 - Fix-media-ingest-worker-startup-default-and-capability-reporting.md`
+
+- [x] **Step 1: Run focused regression tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py \
+  tldw_Server_API/tests/Config/test_docs_info_capabilities.py \
+  tldw_Server_API/tests/Services/test_lifecycle_worker_catalog.py \
+  tldw_Server_API/tests/Services/test_startup_worker_groups.py \
+  -v
+```
+
+Expected: pass.
+
+- [x] **Step 2: Run Bandit on touched backend scopes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/services/worker_startup_policy.py \
+  tldw_Server_API/app/services/startup_content_jobs_pollers.py \
+  tldw_Server_API/app/api/v1/endpoints/config_info.py \
+  -f json -o /tmp/bandit_media_ingest_worker_startup.json
+```
+
+Expected: no new high or medium findings in touched code.
+
+- [x] **Step 3: Smoke-check startup policy with the real spec**
+
+Run a small Python check:
+
+```bash
+source .venv/bin/activate
+python - <<'PY'
+from fastapi import FastAPI
+from tldw_Server_API.app.services.lifecycle_worker_specs import WorkerLifecycleContext
+from tldw_Server_API.app.services.startup_content_jobs_pollers import provide_content_jobs_worker_specs
+
+ctx = WorkerLifecycleContext(
+    app=FastAPI(),
+    settings={},
+    test_mode=False,
+    route_enabled=lambda route_key, **kwargs: route_key == "media",
+    logger=None,
+    startup_guard_exceptions=(),
+    import_exceptions=(),
+    sidecar_mode=False,
+)
+specs = {spec.name: spec for spec in provide_content_jobs_worker_specs()}
+print(specs["media_ingest_jobs_task"].enabled(ctx))
+PY
+```
+
+Expected output: `True`.
+
+- [x] **Step 4: Run the end-to-end YouTube quick-ingest walkthrough**
+
+Use the already established local WebUI/browser-extension walkthrough rather than stopping at unit tests:
+
+- Start the backend and WebUI if they are not already running.
+- Submit a YouTube quick-ingest job from the browser path that previously reproduced the 0% queue stall.
+- Confirm the job status leaves `queued` and reaches `running`, `completed`, or a real ingestion failure with a specific error.
+- Capture the relevant backend log line or API status payload in the final handoff.
+
+- [x] **Step 5: Update Backlog task with results**
+
+Record:
+
+- Files changed.
+- Focused pytest command result.
+- Bandit result.
+- Startup smoke result.
+- Browser walkthrough result.
+
+- [x] **Step 6: Self-review changed files**
+
+Run:
+
+```bash
+git diff --check
+git diff -- tldw_Server_API/app/services/startup_content_jobs_pollers.py \
+  tldw_Server_API/app/services/worker_startup_policy.py \
+  tldw_Server_API/app/api/v1/endpoints/config_info.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py \
+  tldw_Server_API/tests/Config/test_docs_info_capabilities.py \
+  Docs/API-related/Media_Ingest_Jobs_API.md \
+  Docs/Published/API-related/Media_Ingest_Jobs_API.md \
+  Docs/Deployment/Long_Term_Admin_Guide.md \
+  Docs/Published/Deployment/Long_Term_Admin_Guide.md
+```
+
+Expected: no whitespace errors; diff is limited to the planned files.
+
+- [x] **Step 7: Commit only this task's files**
+
+Run:
+
+```bash
+git add \
+  Docs/superpowers/specs/2026-07-09-media-ingest-worker-startup-capability-design.md \
+  Docs/superpowers/plans/2026-07-09-media-ingest-worker-startup-capability-implementation-plan.md \
+  tldw_Server_API/app/services/worker_startup_policy.py \
+  tldw_Server_API/app/services/startup_content_jobs_pollers.py \
+  tldw_Server_API/app/api/v1/endpoints/config_info.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py \
+  tldw_Server_API/tests/Config/test_docs_info_capabilities.py \
+  Docs/API-related/Media_Ingest_Jobs_API.md \
+  Docs/Published/API-related/Media_Ingest_Jobs_API.md \
+  Docs/Deployment/Long_Term_Admin_Guide.md \
+  Docs/Published/Deployment/Long_Term_Admin_Guide.md \
+  "backlog/tasks/task-12100 - Fix-media-ingest-worker-startup-default-and-capability-reporting.md"
+git commit -m "fix: start media ingest worker by route default"
+```
+
+Expected: commit succeeds without including unrelated dirty files.

--- a/Docs/superpowers/specs/2026-07-09-media-ingest-worker-startup-capability-design.md
+++ b/Docs/superpowers/specs/2026-07-09-media-ingest-worker-startup-capability-design.md
@@ -1,0 +1,93 @@
+# Media Ingest Worker Startup And Capability Design
+
+Date: 2026-07-09
+Task: TASK-12100
+
+## Problem
+
+YouTube quick ingest can submit a media ingest job that remains `queued` at 0% because the normal in-process media ingest worker is not started by default in the declarative lifecycle path.
+
+The enqueue path creates jobs with `domain="media_ingest"`, the selected queue, and `job_type="media_ingest_item"`. The worker can process those jobs, but `media_ingest_jobs_task` currently uses a lifecycle predicate that requires `MEDIA_INGEST_JOBS_WORKER_ENABLED` to be explicitly truthy. That contradicts the operations docs, which say the default follows the `media` route policy.
+
+A second issue is capability reporting: `hasMediaIngestWorker` is derived from the heavy-worker flag and route instead of the normal media ingest worker policy.
+
+## Goals
+
+- Start the normal in-process media ingest worker by default whenever the `media` route is enabled.
+- Preserve explicit opt-out with `MEDIA_INGEST_JOBS_WORKER_ENABLED=false`.
+- Preserve sidecar mode: `TLDW_WORKERS_SIDECAR_MODE=true` must prevent in-process worker startup.
+- Keep the heavy worker opt-in unless its route or flag enables it.
+- Report `hasMediaIngestWorker` from the normal in-process worker policy.
+- Reconcile docs so route-default behavior is clear.
+
+## Non-Goals
+
+- Do not change job enqueue shape, queue names, or worker handler behavior.
+- Do not change `route_enabled_predicate` globally.
+- Do not prove whether an external sidecar worker is running from the API process.
+- Do not add new UI states in this slice.
+
+## Design
+
+Extend the existing worker startup policy helper with an optional injected route checker, then add a lifecycle worker predicate that delegates to it:
+
+`should_start_inprocess_worker(flag_key, route_key, sidecar_mode=context.sidecar_mode, default_stable=..., test_mode=context.test_mode, route_enabled=context.route_enabled)`
+
+When no route checker is passed, the helper keeps its current behavior of consulting the global config route policy. This preserves existing callers while letting declarative lifecycle specs respect the `WorkerLifecycleContext` they are already given.
+
+Injected route checker failures fail closed for in-process worker startup. The existing default-stable fallback remains only for the global config route lookup path.
+
+Use this predicate only for the media ingest lifecycle specs:
+
+- `media_ingest_jobs_task`: `MEDIA_INGEST_JOBS_WORKER_ENABLED`, route `media`, `default_stable=True`.
+- `media_ingest_heavy_jobs_task`: `MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED`, route `media-ingest-heavy-jobs`, `default_stable=False`.
+
+This keeps current global route-backed workers unchanged while restoring the documented media ingest behavior.
+
+Update `config_info.py` so `hasMediaIngestWorker` uses the same normal in-process worker policy with sidecar awareness. In sidecar mode this should report `false` for the API process, because the API cannot verify an external worker is actually running.
+
+Update docs that currently describe media ingest jobs as opt-in or default-false, including both source and published copies:
+
+- `Docs/API-related/Media_Ingest_Jobs_API.md`
+- `Docs/Published/API-related/Media_Ingest_Jobs_API.md`
+- `Docs/Deployment/Long_Term_Admin_Guide.md`
+- `Docs/Published/Deployment/Long_Term_Admin_Guide.md`
+
+The corrected wording should say the normal worker follows the `media` route policy by default and can be disabled explicitly or skipped in sidecar mode.
+
+## Behavior Matrix
+
+| Case | Expected normal worker result |
+| --- | --- |
+| `media` route enabled, flag unset, sidecar off | enabled |
+| `media` route enabled, `MEDIA_INGEST_JOBS_WORKER_ENABLED=false` | disabled |
+| `media` route disabled, flag unset | disabled |
+| `MEDIA_INGEST_JOBS_WORKER_ENABLED=true` | enabled, unless sidecar mode is on |
+| `TLDW_WORKERS_SIDECAR_MODE=true` | disabled in this API process |
+
+The heavy worker remains disabled by default because its route uses `default_stable=False`.
+
+## Tests
+
+- Unit test the actual `media_ingest_jobs_task` spec predicate for route-default enablement.
+- Unit test the actual `media_ingest_jobs_task` spec predicate for route-disabled behavior through the lifecycle context.
+- Unit test explicit false disables the normal worker.
+- Unit test sidecar mode disables the normal worker.
+- Unit test the heavy worker remains off by default.
+- Unit test the startup policy helper still works without an injected route checker.
+- Unit test one-argument route callbacks and broken injected route callbacks.
+- Unit test `hasMediaIngestWorker` uses the normal worker flag and honors sidecar mode.
+
+## Verification
+
+After implementation:
+
+- Run the focused backend tests covering startup policy and config capabilities.
+- Run a backend startup smoke check with `MEDIA_INGEST_JOBS_WORKER_ENABLED` unset and confirm `media_ingest_jobs_task` starts when the `media` route is enabled.
+- Re-run the YouTube quick-ingest walkthrough far enough to confirm the job leaves `queued` and reaches worker processing or a real ingestion failure.
+
+## Risks
+
+- Local installs may now start the normal ingest worker automatically where they previously did not. This is intended for option 1 and matches the operations docs.
+- Multi-worker SQLite deployments remain risky. Existing deployment guidance should continue recommending sidecar workers or Postgres for higher concurrency.
+- `hasMediaIngestWorker=false` in sidecar mode does not prove no sidecar exists; it only means this API process did not start one.

--- a/apps/packages/ui/src/components/Review/__tests__/useMediaSelection.reading-progress.test.tsx
+++ b/apps/packages/ui/src/components/Review/__tests__/useMediaSelection.reading-progress.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMediaSelection } from '../hooks/useMediaSelection'
+import { tldwClient } from '@/services/tldw/TldwApiClient'
+import type { MediaResultItem } from '@/components/Media/types'
+
+vi.mock('@plasmohq/storage/hook', () => ({
+  useStorage: (_key: string, initialValue: unknown) => [
+    initialValue,
+    vi.fn(),
+    { isLoading: false }
+  ]
+}))
+
+vi.mock('@/hooks/useUndoNotification', () => ({
+  useUndoNotification: () => ({ showUndoNotification: vi.fn() })
+}))
+
+vi.mock('@/services/settings/registry', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/settings/registry')>()),
+  setSetting: vi.fn()
+}))
+
+vi.mock('@/services/background-proxy', () => ({
+  bgRequest: vi.fn()
+}))
+
+vi.mock('@/services/tldw/TldwApiClient', () => ({
+  tldwClient: {
+    getReadingProgress: vi.fn()
+  }
+}))
+
+const createMediaItem = (id: string): MediaResultItem => ({
+  id,
+  kind: 'media',
+  title: `Document ${id}`,
+  content: '',
+  meta: { type: 'pdf' },
+  raw: { id, type: 'pdf' }
+} as MediaResultItem)
+
+const createDeps = (displayResults: MediaResultItem[]) => ({
+  t: (key: string) => key,
+  message: {
+    error: vi.fn(),
+    warning: vi.fn(),
+    success: vi.fn()
+  },
+  displayResults,
+  selected: null,
+  setSelected: vi.fn(),
+  setSelectedContent: vi.fn(),
+  setSelectedDetail: vi.fn(),
+  setLastFetchedId: vi.fn(),
+  refetch: vi.fn()
+})
+
+describe('useMediaSelection reading progress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked((tldwClient as any).getReadingProgress).mockResolvedValue({
+      has_progress: true,
+      percent_complete: 25
+    })
+  })
+
+  it('does not refetch progress when visible reading-progress ids are unchanged', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <MemoryRouter>{children}</MemoryRouter>
+    )
+    const initialItems = [createMediaItem('101')]
+
+    const { rerender } = renderHook(
+      ({ displayResults }) => useMediaSelection(createDeps(displayResults)),
+      {
+        wrapper,
+        initialProps: { displayResults: initialItems }
+      }
+    )
+
+    await waitFor(() => {
+      expect((tldwClient as any).getReadingProgress).toHaveBeenCalledTimes(1)
+    })
+
+    rerender({ displayResults: [createMediaItem('101')] })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect((tldwClient as any).getReadingProgress).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/packages/ui/src/components/Review/__tests__/useMediaSelection.reading-progress.test.tsx
+++ b/apps/packages/ui/src/components/Review/__tests__/useMediaSelection.reading-progress.test.tsx
@@ -87,8 +87,9 @@ describe('useMediaSelection reading progress', () => {
     })
 
     rerender({ displayResults: [createMediaItem('101')] })
-    await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect((tldwClient as any).getReadingProgress).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect((tldwClient as any).getReadingProgress).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/apps/packages/ui/src/components/Review/hooks/useMediaSearch.ts
+++ b/apps/packages/ui/src/components/Review/hooks/useMediaSearch.ts
@@ -37,6 +37,7 @@ import {
 } from '@/components/Review/mediaTypeCache'
 
 const MEDIA_KEYWORD_ENDPOINT_RETRY_COOLDOWN_MS = 30_000
+const EMPTY_MEDIA_RESULTS: MediaResultItem[] = []
 
 export const deriveMediaMeta = (m: any): {
   type: string
@@ -646,7 +647,7 @@ export function useMediaSearch(deps: UseMediaSearchDeps) {
     t
   ])
 
-  const { data: results = [], refetch, isLoading, isFetching } = useQuery({
+  const { data: queryResults, refetch, isLoading, isFetching } = useQuery({
     queryKey: [
       'media-search',
       query,
@@ -671,6 +672,7 @@ export function useMediaSearch(deps: UseMediaSearchDeps) {
     queryFn: runSearch,
     enabled: false
   })
+  const results = queryResults ?? EMPTY_MEDIA_RESULTS
 
   const normalizedMetadataFilters = useMemo(
     () => normalizeMetadataSearchFilters(metadataFilters),

--- a/apps/packages/ui/src/components/Review/hooks/useMediaSelection.ts
+++ b/apps/packages/ui/src/components/Review/hooks/useMediaSelection.ts
@@ -63,6 +63,17 @@ const supportsReadingProgressForResult = (item: MediaResultItem): boolean => {
   return READING_PROGRESS_SUPPORTED_MEDIA_TYPES.has(rawType.trim().toLowerCase())
 }
 
+const areReadingProgressMapsEqual = (
+  left: Map<string, number>,
+  right: Map<string, number>
+): boolean => {
+  if (left.size !== right.size) return false
+  for (const [key, value] of right) {
+    if (left.get(key) !== value) return false
+  }
+  return true
+}
+
 type MediaCollectionRecord = {
   id: string
   name: string
@@ -125,6 +136,18 @@ export function useMediaSelection(deps: UseMediaSelectionDeps) {
   // Reading progress
   const [readingProgressMap, setReadingProgressMap] = useState<Map<string, number>>(new Map())
   const readingProgressUnavailableRef = useRef(false)
+  const readingProgressMediaIdsKey = useMemo(() => {
+    const mediaIds = displayResults
+      .filter((r) => supportsReadingProgressForResult(r))
+      .map((r) => String(r.id))
+    return JSON.stringify(mediaIds)
+  }, [displayResults])
+  const updateReadingProgressMap = useCallback((entries: Array<[string, number]>) => {
+    const next = new Map(entries)
+    setReadingProgressMap((prev) =>
+      areReadingProgressMapsEqual(prev, next) ? prev : next
+    )
+  }, [])
 
   const toggleFavorite = useCallback((id: string) => {
     const idStr = String(id)
@@ -189,19 +212,22 @@ export function useMediaSelection(deps: UseMediaSelectionDeps) {
   // Reading progress
   useEffect(() => {
     if (readingProgressUnavailableRef.current) {
-      setReadingProgressMap(new Map())
+      updateReadingProgressMap([])
       return
     }
-    const mediaIds = displayResults
-      .filter((r) => supportsReadingProgressForResult(r))
-      .map((r) => String(r.id))
+    let mediaIds: string[] = []
+    try {
+      mediaIds = JSON.parse(readingProgressMediaIdsKey)
+    } catch {
+      mediaIds = []
+    }
     if (mediaIds.length === 0) {
-      setReadingProgressMap(new Map())
+      updateReadingProgressMap([])
       return
     }
     const getReadingProgress = (tldwClient as any).getReadingProgress
     if (typeof getReadingProgress !== 'function') {
-      setReadingProgressMap(new Map())
+      updateReadingProgressMap([])
       return
     }
     let cancelled = false
@@ -221,18 +247,18 @@ export function useMediaSelection(deps: UseMediaSelectionDeps) {
           if (cancelled) return
           if (isReadingProgressEndpointUnavailableError(error)) {
             readingProgressUnavailableRef.current = true
-            setReadingProgressMap(new Map(entries))
+            updateReadingProgressMap(entries)
             return
           }
         }
       }
       if (!cancelled) {
-        setReadingProgressMap(new Map(entries))
+        updateReadingProgressMap(entries)
       }
     }
     void fetchProgress()
     return () => { cancelled = true }
-  }, [displayResults])
+  }, [readingProgressMediaIdsKey, updateReadingProgressMap])
 
   // Storage usage
   const refreshLibraryStorageUsage = useCallback(async () => {

--- a/apps/packages/ui/src/components/Review/hooks/useMediaSelection.ts
+++ b/apps/packages/ui/src/components/Review/hooks/useMediaSelection.ts
@@ -15,6 +15,7 @@ import type { MediaLibraryStorageUsage } from '@/components/Media/MediaLibrarySt
 import { getErrorStatusCode } from './useMediaSearch'
 
 const MEDIA_COLLECTIONS_STORAGE_KEY = 'media:collections:v1'
+const READING_PROGRESS_MEDIA_ID_SEPARATOR = '\u001f'
 
 const toNonNegativeFiniteNumber = (value: unknown): number | null => {
   if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value
@@ -140,7 +141,7 @@ export function useMediaSelection(deps: UseMediaSelectionDeps) {
     const mediaIds = displayResults
       .filter((r) => supportsReadingProgressForResult(r))
       .map((r) => String(r.id))
-    return JSON.stringify(mediaIds)
+    return mediaIds.join(READING_PROGRESS_MEDIA_ID_SEPARATOR)
   }, [displayResults])
   const updateReadingProgressMap = useCallback((entries: Array<[string, number]>) => {
     const next = new Map(entries)
@@ -215,12 +216,9 @@ export function useMediaSelection(deps: UseMediaSelectionDeps) {
       updateReadingProgressMap([])
       return
     }
-    let mediaIds: string[] = []
-    try {
-      mediaIds = JSON.parse(readingProgressMediaIdsKey)
-    } catch {
-      mediaIds = []
-    }
+    const mediaIds = readingProgressMediaIdsKey === ''
+      ? []
+      : readingProgressMediaIdsKey.split(READING_PROGRESS_MEDIA_ID_SEPARATOR)
     if (mediaIds.length === 0) {
       updateReadingProgressMap([])
       return

--- a/backlog/tasks/task-12099 - Fix-media-render-loop-after-YouTube-quick-ingest-walkthrough.md
+++ b/backlog/tasks/task-12099 - Fix-media-render-loop-after-YouTube-quick-ingest-walkthrough.md
@@ -1,0 +1,53 @@
+---
+id: TASK-12099
+title: Fix media render loop after YouTube quick ingest walkthrough
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-09 20:28'
+labels:
+  - bug
+  - webui
+  - media
+  - quick-ingest
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix the WebUI /media maximum update depth warning reproduced during an authenticated browser walkthrough of Quick Ingest / YouTube ingestion paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Authenticated /media browser walkthrough does not emit Maximum update depth exceeded.
+- [x] #2 Quick Ingest modal can be opened on /media without triggering the media render loop.
+- [x] #3 Existing media render-loop regression coverage passes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the /media render loop encountered during YouTube Quick Ingest walkthrough. Added a hook regression for equivalent media IDs, stabilized empty media search results before query data exists, and made reading-progress state updates idempotent. Verification: focused Vitest hook/read-progress tests pass; Playwright media-render-loop spec passes against live 18001/8080; final full YouTube Quick Ingest browser walkthrough reached job submission/polling with zero maximum-depth warnings, page errors, HTTP errors, or request failures.
+
+Additional verification on 2026-07-09: focused Vitest regression passed, and the live WebUI Quick Ingest walkthrough on backend 18001/frontend 3000 reached Results without any Maximum update depth exceeded console error. The only console warnings observed were setup readiness fetch warnings from the first-run setup modal before entering Quick Ingest.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12100 - Fix-media-ingest-worker-startup-default-and-capability-reporting.md
+++ b/backlog/tasks/task-12100 - Fix-media-ingest-worker-startup-default-and-capability-reporting.md
@@ -4,12 +4,30 @@ title: Fix media ingest worker startup default and capability reporting
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-09 20:27'
+updated_date: 2026-07-09 20:27
 labels:
-  - backend
-  - jobs
-  - media-ingest
+- backend
+- jobs
+- media-ingest
 dependencies: []
+references:
+- Code review 019f4893-defb-7dd3-8c2b-c97fda9af220
+documentation:
+- 'Review follow-up: generated Docs/Docs/site HTML was stale but ignored by .gitignore'
+- so not a merge artifact; adding route-disabled docs-info regression coverage.
+modified_files:
+- tldw_Server_API/app/services/worker_startup_policy.py
+- tldw_Server_API/app/services/startup_content_jobs_pollers.py
+- tldw_Server_API/app/api/v1/endpoints/config_info.py
+- tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py
+- tldw_Server_API/tests/Config/test_docs_info_capabilities.py
+- tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
+- Docs/API-related/Media_Ingest_Jobs_API.md
+- Docs/Published/API-related/Media_Ingest_Jobs_API.md
+- Docs/Deployment/Long_Term_Admin_Guide.md
+- Docs/Published/Deployment/Long_Term_Admin_Guide.md
+- Docs/superpowers/specs/2026-07-09-media-ingest-worker-startup-capability-design.md
+- Docs/superpowers/plans/2026-07-09-media-ingest-worker-startup-capability-implementation-plan.md
 ---
 
 ## Description
@@ -36,7 +54,7 @@ Plan review: Approved locally after correcting the route-policy design to inject
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed media ingest jobs staying queued indefinitely by wiring the normal media ingest lifecycle spec through the shared in-process worker startup policy with the `media` route default enabled. Kept the heavy media ingest worker opt-in, made docs-info report the normal worker capability with sidecar awareness, and updated API/deployment docs to match. Verification: focused backend pytest passed (38 passed); Bandit on touched backend code completed with no findings; startup smoke returned `True`; full WebUI Quick Ingest walkthrough submitted a YouTube URL, observed the job leave queued 0%, and verified API job 277 transitioned to `quarantined` with the concrete yt-dlp error `ERROR: [youtube] E2ETLDW26AB: Video unavailable` instead of remaining queued.
+Fixed media ingest jobs staying queued indefinitely by wiring the normal media ingest lifecycle spec through the shared in-process worker startup policy with the `media` route default enabled. Kept the heavy media ingest worker opt-in, made docs-info report the normal worker capability with sidecar awareness, and updated API/deployment docs to match. Verification: focused backend pytest passed (39 passed after review follow-up); Bandit on touched backend app code completed with no findings; startup smoke returned `True`; full WebUI Quick Ingest walkthrough submitted a YouTube URL, observed the job leave queued 0%, and verified API job 277 transitioned to `quarantined` with the concrete yt-dlp error `ERROR: [youtube] E2ETLDW26AB: Video unavailable` instead of remaining queued. Code review follow-up: generated Docs/Docs/site HTML was stale but ignored by .gitignore and not part of the merge artifact; added docs-info coverage for `ROUTES_DISABLE=media` with the worker flag unset.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12100 - Fix-media-ingest-worker-startup-default-and-capability-reporting.md
+++ b/backlog/tasks/task-12100 - Fix-media-ingest-worker-startup-default-and-capability-reporting.md
@@ -1,0 +1,50 @@
+---
+id: TASK-12100
+title: Fix media ingest worker startup default and capability reporting
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-09 20:27'
+labels:
+  - backend
+  - jobs
+  - media-ingest
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and implement fixes for media ingest jobs staying queued when the normal media ingest worker is not started by default, plus incorrect hasMediaIngestWorker capability reporting.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Design spec written: Docs/superpowers/specs/2026-07-09-media-ingest-worker-startup-capability-design.md
+Implementation plan written: Docs/superpowers/plans/2026-07-09-media-ingest-worker-startup-capability-implementation-plan.md
+Spec review: Approved locally. No TODO/TBD/placeholders; scope limited to media ingest worker startup, config capability reporting, and matching docs. Subagent reviewer not dispatched because this session's tool rules require explicit user authorization for delegation.
+Plan review: Approved locally after correcting the route-policy design to inject WorkerLifecycleContext.route_enabled into should_start_inprocess_worker(). No implementation code changed yet.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed media ingest jobs staying queued indefinitely by wiring the normal media ingest lifecycle spec through the shared in-process worker startup policy with the `media` route default enabled. Kept the heavy media ingest worker opt-in, made docs-info report the normal worker capability with sidecar awareness, and updated API/deployment docs to match. Verification: focused backend pytest passed (38 passed); Bandit on touched backend code completed with no findings; startup smoke returned `True`; full WebUI Quick Ingest walkthrough submitted a YouTube URL, observed the job leave queued 0%, and verified API job 277 transitioned to `quarantined` with the concrete yt-dlp error `ERROR: [youtube] E2ETLDW26AB: Video unavailable` instead of remaining queued.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12100 - Fix-media-ingest-worker-startup-default-and-capability-reporting.md
+++ b/backlog/tasks/task-12100 - Fix-media-ingest-worker-startup-default-and-capability-reporting.md
@@ -15,6 +15,11 @@ references:
 documentation:
 - 'Review follow-up: generated Docs/Docs/site HTML was stale but ignored by .gitignore'
 - so not a merge artifact; adding route-disabled docs-info regression coverage.
+- 'PR #2700 dev rebase follow-up: addressed Qodo review comments for deterministic
+  UI test wait'
+- JSON parse fallback removal
+- non-introspectable route callbacks
+- and route-disabled capability consistency.
 modified_files:
 - tldw_Server_API/app/services/worker_startup_policy.py
 - tldw_Server_API/app/services/startup_content_jobs_pollers.py
@@ -54,7 +59,7 @@ Plan review: Approved locally after correcting the route-policy design to inject
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed media ingest jobs staying queued indefinitely by wiring the normal media ingest lifecycle spec through the shared in-process worker startup policy with the `media` route default enabled. Kept the heavy media ingest worker opt-in, made docs-info report the normal worker capability with sidecar awareness, and updated API/deployment docs to match. Verification: focused backend pytest passed (39 passed after review follow-up); Bandit on touched backend app code completed with no findings; startup smoke returned `True`; full WebUI Quick Ingest walkthrough submitted a YouTube URL, observed the job leave queued 0%, and verified API job 277 transitioned to `quarantined` with the concrete yt-dlp error `ERROR: [youtube] E2ETLDW26AB: Video unavailable` instead of remaining queued. Code review follow-up: generated Docs/Docs/site HTML was stale but ignored by .gitignore and not part of the merge artifact; added docs-info coverage for `ROUTES_DISABLE=media` with the worker flag unset.
+Fixed media ingest jobs staying queued indefinitely by wiring the normal media ingest lifecycle spec through the shared in-process worker startup policy with the `media` route default enabled. Kept the heavy media ingest worker opt-in, made docs-info report the normal worker capability with sidecar and route-disable awareness, and updated API/deployment docs to match. Verification after dev rebase and PR review follow-up: focused backend pytest passed (41 passed); UI hook Vitest regression passed (1 passed); Bandit on touched backend app code completed with no findings; startup smoke returned `True`; full WebUI Quick Ingest walkthrough submitted a YouTube URL, observed the job leave queued 0%, and verified API job 277 transitioned to `quarantined` with the concrete yt-dlp error `ERROR: [youtube] E2ETLDW26AB: Video unavailable` instead of remaining queued. Code review follow-up: removed nondeterministic test sleep, removed JSON.parse fallback, made non-introspectable injected route callbacks prefer the one-arg route policy form, and kept media worker capability false when the media route is disabled even if the worker flag is explicitly true.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/config_info.py
+++ b/tldw_Server_API/app/api/v1/endpoints/config_info.py
@@ -146,7 +146,8 @@ def load_safe_config() -> dict:
         caps["hasMediaIngestJobs"] = has_media_routes
         caps["hasMediaIngestJobEvents"] = has_media_routes
         caps["hasMediaIngestWorker"] = bool(
-            should_start_inprocess_worker(
+            has_media_routes
+            and should_start_inprocess_worker(
                 "MEDIA_INGEST_JOBS_WORKER_ENABLED",
                 "media",
                 sidecar_mode=env_flag_enabled("TLDW_WORKERS_SIDECAR_MODE"),

--- a/tldw_Server_API/app/api/v1/endpoints/config_info.py
+++ b/tldw_Server_API/app/api/v1/endpoints/config_info.py
@@ -25,8 +25,8 @@ from tldw_Server_API.app.core.custom_openai_providers import (
     custom_openai_provider_number,
     iter_custom_openai_provider_names,
 )
-from tldw_Server_API.app.core.testing import is_truthy
-from tldw_Server_API.app.services.worker_startup_policy import worker_path_enabled
+from tldw_Server_API.app.core.testing import env_flag_enabled, is_truthy
+from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
 
 router = APIRouter()
 _DOCS_API_KEY_PLACEHOLDER = "YOUR_API_KEY"
@@ -146,10 +146,11 @@ def load_safe_config() -> dict:
         caps["hasMediaIngestJobs"] = has_media_routes
         caps["hasMediaIngestJobEvents"] = has_media_routes
         caps["hasMediaIngestWorker"] = bool(
-            worker_path_enabled(
-                "MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED",
-                "media-ingest-heavy-jobs",
-                default_stable=False,
+            should_start_inprocess_worker(
+                "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+                "media",
+                sidecar_mode=env_flag_enabled("TLDW_WORKERS_SIDECAR_MODE"),
+                default_stable=True,
                 test_mode=False,
             )
         )

--- a/tldw_Server_API/app/services/startup_content_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_content_jobs_pollers.py
@@ -18,6 +18,7 @@ from tldw_Server_API.app.services.lifecycle_worker_specs import (
     stop_event_worker_spec,
 )
 from tldw_Server_API.app.services.lifecycle_workers import WorkerRegistry
+from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
 
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
@@ -58,6 +59,27 @@ class ContentJobsPollerHandles:
     vn_asset_generation_jobs_task: Any | None = None
     companion_reflection_jobs_stop_event: Any | None = None
     companion_reflection_jobs_task: Any | None = None
+
+
+def media_ingest_worker_predicate(
+    flag_key: str,
+    route_key: str,
+    *,
+    default_stable: bool,
+) -> Callable[[WorkerLifecycleContext], bool]:
+    """Return an in-process media ingest worker predicate."""
+
+    def _enabled(context: WorkerLifecycleContext) -> bool:
+        return should_start_inprocess_worker(
+            flag_key,
+            route_key,
+            sidecar_mode=context.sidecar_mode,
+            default_stable=default_stable,
+            test_mode=context.test_mode,
+            route_enabled=context.route_enabled,
+        )
+
+    return _enabled
 
 
 def provide_content_jobs_worker_specs(
@@ -109,9 +131,10 @@ def provide_content_jobs_worker_specs(
             worker_service=_run_media_ingest_jobs_worker_service,
             category="jobs",
             phase=ShutdownPhase.JOB_POLLER_QUIESCE,
-            enabled=route_enabled_predicate(
+            enabled=media_ingest_worker_predicate(
                 "MEDIA_INGEST_JOBS_WORKER_ENABLED",
                 "media",
+                default_stable=True,
             ),
         ),
         stop_event_worker_spec(
@@ -119,7 +142,7 @@ def provide_content_jobs_worker_specs(
             worker_service=_run_media_ingest_heavy_jobs_worker_service,
             category="jobs",
             phase=ShutdownPhase.JOB_POLLER_QUIESCE,
-            enabled=route_enabled_predicate(
+            enabled=media_ingest_worker_predicate(
                 "MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED",
                 "media-ingest-heavy-jobs",
                 default_stable=False,

--- a/tldw_Server_API/app/services/worker_startup_policy.py
+++ b/tldw_Server_API/app/services/worker_startup_policy.py
@@ -24,11 +24,13 @@ def env_flag(name: str, default: bool) -> bool:
     return is_truthy(raw)
 
 
-def _route_enabled_accepts_default_stable(route_enabled: Callable[..., bool]) -> bool:
+def _route_enabled_accepts_default_stable(route_enabled: Callable[..., bool]) -> bool | None:
+    """Return whether a route callback advertises default_stable support."""
+
     try:
         parameters = signature(route_enabled).parameters.values()
     except (TypeError, ValueError):
-        return True
+        return None
 
     return any(
         parameter.kind is Parameter.VAR_KEYWORD
@@ -49,7 +51,8 @@ def worker_route_default(
 
     if route_enabled is not None:
         try:
-            if _route_enabled_accepts_default_stable(route_enabled):
+            accepts_default_stable = _route_enabled_accepts_default_stable(route_enabled)
+            if accepts_default_stable is True:
                 return bool(route_enabled(route_key, default_stable=default_stable))
             else:
                 return bool(route_enabled(route_key))

--- a/tldw_Server_API/app/services/worker_startup_policy.py
+++ b/tldw_Server_API/app/services/worker_startup_policy.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
+from inspect import Parameter, signature
 
 from loguru import logger
 
@@ -22,22 +24,46 @@ def env_flag(name: str, default: bool) -> bool:
     return is_truthy(raw)
 
 
+def _route_enabled_accepts_default_stable(route_enabled: Callable[..., bool]) -> bool:
+    try:
+        parameters = signature(route_enabled).parameters.values()
+    except (TypeError, ValueError):
+        return True
+
+    return any(
+        parameter.kind is Parameter.VAR_KEYWORD
+        or parameter.name == "default_stable"
+        for parameter in parameters
+    )
+
+
 def worker_route_default(
     route_key: str,
     *,
     default_stable: bool = True,
     test_mode: bool = False,
+    route_enabled: Callable[..., bool] | None = None,
 ) -> bool:
     if test_mode:
         return False
 
+    if route_enabled is not None:
+        try:
+            if _route_enabled_accepts_default_stable(route_enabled):
+                return bool(route_enabled(route_key, default_stable=default_stable))
+            else:
+                return bool(route_enabled(route_key))
+        except _WORKER_POLICY_EXCEPTIONS as exc:
+            logger.debug("Worker startup policy route check failed for {}: {}", route_key, exc)
+            return False
+
     try:
-        from tldw_Server_API.app.core.config import refresh_config_cache, route_enabled
+        from tldw_Server_API.app.core.config import refresh_config_cache, route_enabled as config_route_enabled
 
         if is_explicit_pytest_runtime():
             refresh_config_cache()
 
-        return bool(route_enabled(route_key, default_stable=default_stable))
+        return bool(config_route_enabled(route_key, default_stable=default_stable))
     except _WORKER_POLICY_EXCEPTIONS as exc:
         logger.debug("Worker startup policy route check failed for {}: {}", route_key, exc)
         return bool(default_stable)
@@ -49,11 +75,13 @@ def worker_path_enabled(
     *,
     default_stable: bool = True,
     test_mode: bool = False,
+    route_enabled: Callable[..., bool] | None = None,
 ) -> bool:
     route_default = worker_route_default(
         route_key,
         default_stable=default_stable,
         test_mode=test_mode,
+        route_enabled=route_enabled,
     )
     return env_flag(flag_key, route_default)
 
@@ -65,6 +93,7 @@ def should_start_inprocess_worker(
     sidecar_mode: bool,
     default_stable: bool = True,
     test_mode: bool = False,
+    route_enabled: Callable[..., bool] | None = None,
 ) -> bool:
     if sidecar_mode:
         return False
@@ -74,4 +103,5 @@ def should_start_inprocess_worker(
         route_key,
         default_stable=default_stable,
         test_mode=test_mode,
+        route_enabled=route_enabled,
     )

--- a/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
+++ b/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
@@ -219,6 +219,27 @@ def test_docs_info_media_ingest_worker_capability_follows_disabled_media_route(
     assert safe_config["capabilities"]["hasMediaIngestWorker"] is False
 
 
+def test_docs_info_media_ingest_worker_capability_stays_false_when_route_disabled_and_flag_true(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.txt"
+    _write_minimal_config(config_path)
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("ROUTES_DISABLE", "media")
+    monkeypatch.delenv("ROUTES_ENABLE", raising=False)
+    monkeypatch.setenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", "true")
+    monkeypatch.delenv("TLDW_WORKERS_SIDECAR_MODE", raising=False)
+    config_mod._route_toggle_policy.cache_clear()
+
+    safe_config = config_info.load_safe_config()
+    caps = safe_config["capabilities"]
+
+    assert caps["hasMediaIngestJobs"] is False
+    assert caps["hasMediaIngestJobEvents"] is False
+    assert caps["hasMediaIngestWorker"] is False
+
+
 def test_docs_info_media_ingest_worker_capability_is_false_in_sidecar_mode(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
+++ b/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
@@ -168,7 +168,9 @@ def test_docs_info_exposes_bulk_conference_ingest_capabilities(
     monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
     monkeypatch.delenv("ROUTES_DISABLE", raising=False)
     monkeypatch.delenv("ROUTES_ENABLE", raising=False)
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
     monkeypatch.delenv("MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED", raising=False)
+    monkeypatch.delenv("TLDW_WORKERS_SIDECAR_MODE", raising=False)
     config_mod._route_toggle_policy.cache_clear()
 
     safe_config = config_info.load_safe_config()
@@ -177,10 +179,42 @@ def test_docs_info_exposes_bulk_conference_ingest_capabilities(
     assert caps["hasMediaPlaylistPreflight"] is True
     assert caps["hasMediaIngestJobs"] is True
     assert caps["hasMediaIngestJobEvents"] is True
-    assert caps["hasMediaIngestWorker"] is False
+    assert caps["hasMediaIngestWorker"] is True
     assert caps["hasDurableMediaCollections"] is True
     assert caps["hasKnowledgeQaMediaScope"] is True
     assert safe_config["supported_features"] == caps
+
+
+def test_docs_info_media_ingest_worker_capability_respects_explicit_false(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.txt"
+    _write_minimal_config(config_path)
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", "false")
+    monkeypatch.delenv("TLDW_WORKERS_SIDECAR_MODE", raising=False)
+    config_mod._route_toggle_policy.cache_clear()
+
+    safe_config = config_info.load_safe_config()
+
+    assert safe_config["capabilities"]["hasMediaIngestWorker"] is False
+
+
+def test_docs_info_media_ingest_worker_capability_is_false_in_sidecar_mode(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.txt"
+    _write_minimal_config(config_path)
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", "true")
+    monkeypatch.setenv("TLDW_WORKERS_SIDECAR_MODE", "true")
+    config_mod._route_toggle_policy.cache_clear()
+
+    safe_config = config_info.load_safe_config()
+
+    assert safe_config["capabilities"]["hasMediaIngestWorker"] is False
 
 
 def test_docs_info_disables_voice_transport_when_audio_websocket_route_disabled(

--- a/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
+++ b/tldw_Server_API/tests/Config/test_docs_info_capabilities.py
@@ -201,6 +201,24 @@ def test_docs_info_media_ingest_worker_capability_respects_explicit_false(
     assert safe_config["capabilities"]["hasMediaIngestWorker"] is False
 
 
+def test_docs_info_media_ingest_worker_capability_follows_disabled_media_route(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.txt"
+    _write_minimal_config(config_path)
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("ROUTES_DISABLE", "media")
+    monkeypatch.delenv("ROUTES_ENABLE", raising=False)
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+    monkeypatch.delenv("TLDW_WORKERS_SIDECAR_MODE", raising=False)
+    config_mod._route_toggle_policy.cache_clear()
+
+    safe_config = config_info.load_safe_config()
+
+    assert safe_config["capabilities"]["hasMediaIngestWorker"] is False
+
+
 def test_docs_info_media_ingest_worker_capability_is_false_in_sidecar_mode(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py
@@ -95,6 +95,31 @@ def test_should_start_inprocess_worker_supports_single_arg_injected_route_policy
     )
 
 
+def test_should_start_inprocess_worker_supports_non_introspectable_single_arg_route_policy(
+    monkeypatch,
+):
+    from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+
+    class NonIntrospectableRoutePolicy:
+        @property
+        def __signature__(self):
+            raise ValueError("signature unavailable")
+
+        def __call__(self, route_key):
+            return route_key == "media"
+
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    assert should_start_inprocess_worker(
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "media",
+        sidecar_mode=False,
+        default_stable=True,
+        test_mode=False,
+        route_enabled=NonIntrospectableRoutePolicy(),
+    )
+
+
 def test_should_start_inprocess_worker_does_not_mask_route_policy_type_errors(
     monkeypatch,
 ):

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_startup.py
@@ -1,7 +1,32 @@
 import pytest
 
+from tldw_Server_API.app.services.lifecycle_worker_specs import WorkerLifecycleContext
+from tldw_Server_API.app.services.startup_content_jobs_pollers import (
+    provide_content_jobs_worker_specs,
+)
+
 
 pytestmark = pytest.mark.unit
+
+
+def _worker_context(
+    *, sidecar_mode: bool = False, route_allowed: bool = True
+) -> WorkerLifecycleContext:
+    return WorkerLifecycleContext(
+        app=object(),
+        settings={},
+        test_mode=False,
+        route_enabled=lambda *_args, **_kwargs: route_allowed,
+        logger=None,
+        startup_guard_exceptions=(),
+        import_exceptions=(),
+        sidecar_mode=sidecar_mode,
+    )
+
+
+def _content_spec(name: str):
+    specs = {spec.name: spec for spec in provide_content_jobs_worker_specs()}
+    return specs[name]
 
 
 def test_should_start_inprocess_worker_uses_route_policy_when_flag_unset(monkeypatch):
@@ -16,6 +41,77 @@ def test_should_start_inprocess_worker_uses_route_policy_when_flag_unset(monkeyp
         sidecar_mode=False,
         default_stable=False,
         test_mode=False,
+    )
+
+
+def test_should_start_inprocess_worker_uses_injected_route_policy_when_flag_unset(
+    monkeypatch,
+):
+    from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    assert should_start_inprocess_worker(
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "media",
+        sidecar_mode=False,
+        default_stable=True,
+        test_mode=False,
+        route_enabled=lambda route_key, **_kwargs: route_key == "media",
+    )
+
+
+def test_should_start_inprocess_worker_honors_injected_route_disabled_when_flag_unset(
+    monkeypatch,
+):
+    from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    assert not should_start_inprocess_worker(
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "media",
+        sidecar_mode=False,
+        default_stable=True,
+        test_mode=False,
+        route_enabled=lambda *_args, **_kwargs: False,
+    )
+
+
+def test_should_start_inprocess_worker_supports_single_arg_injected_route_policy(
+    monkeypatch,
+):
+    from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    assert not should_start_inprocess_worker(
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "media",
+        sidecar_mode=False,
+        default_stable=True,
+        test_mode=False,
+        route_enabled=lambda _route_key: False,
+    )
+
+
+def test_should_start_inprocess_worker_does_not_mask_route_policy_type_errors(
+    monkeypatch,
+):
+    from tldw_Server_API.app.services.worker_startup_policy import should_start_inprocess_worker
+
+    def broken_route_enabled(_route_key, **_kwargs):
+        raise TypeError("broken route policy")
+
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    assert not should_start_inprocess_worker(
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "media",
+        sidecar_mode=False,
+        default_stable=True,
+        test_mode=False,
+        route_enabled=broken_route_enabled,
     )
 
 
@@ -46,3 +142,61 @@ def test_should_start_inprocess_worker_disables_startup_in_sidecar_mode(monkeypa
         default_stable=False,
         test_mode=False,
     )
+
+
+def test_media_ingest_lifecycle_spec_uses_route_policy_when_flag_unset(monkeypatch):
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    spec = _content_spec("media_ingest_jobs_task")
+
+    assert spec.enabled(_worker_context(route_allowed=True)) is True
+
+
+def test_media_ingest_lifecycle_spec_disables_when_route_policy_disabled(monkeypatch):
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", raising=False)
+
+    spec = _content_spec("media_ingest_jobs_task")
+
+    assert spec.enabled(_worker_context(route_allowed=False)) is False
+
+
+def test_media_ingest_lifecycle_spec_respects_explicit_false(monkeypatch):
+    monkeypatch.setenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", "false")
+
+    spec = _content_spec("media_ingest_jobs_task")
+
+    assert spec.enabled(_worker_context(route_allowed=True)) is False
+
+
+def test_media_ingest_lifecycle_spec_skips_in_sidecar_mode(monkeypatch):
+    monkeypatch.setenv("MEDIA_INGEST_JOBS_WORKER_ENABLED", "true")
+
+    spec = _content_spec("media_ingest_jobs_task")
+
+    assert spec.enabled(_worker_context(sidecar_mode=True, route_allowed=True)) is False
+
+
+def test_media_ingest_heavy_lifecycle_spec_remains_disabled_by_default(monkeypatch):
+    route_calls = []
+
+    def _route_enabled(*args, **kwargs):
+        route_calls.append((args, kwargs))
+        return kwargs.get("default_stable", True)
+
+    monkeypatch.delenv("MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED", raising=False)
+
+    spec = _content_spec("media_ingest_heavy_jobs_task")
+
+    assert spec.enabled(
+        WorkerLifecycleContext(
+            app=object(),
+            settings={},
+            test_mode=False,
+            route_enabled=_route_enabled,
+            logger=None,
+            startup_guard_exceptions=(),
+            import_exceptions=(),
+            sidecar_mode=False,
+        )
+    ) is False
+    assert route_calls == [(("media-ingest-heavy-jobs",), {"default_stable": False})]

--- a/tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
@@ -155,6 +155,10 @@ def test_content_jobs_worker_spec_predicates_use_route_enabled_arguments(
 
     context = _context(route_enabled=_route_enabled)
     specs = _specs_by_name(startup_pollers)
+    media_ingest_explicit_flag_specs = {
+        "media_ingest_jobs_task",
+        "media_ingest_heavy_jobs_task",
+    }
 
     for spec_name in [
         "audio_jobs_task",
@@ -187,18 +191,15 @@ def test_content_jobs_worker_spec_predicates_use_route_enabled_arguments(
             }[spec_name],
             "true",
         )
-        assert specs[spec_name].enabled(context) is False
+        assert specs[spec_name].enabled(context) is (
+            spec_name in media_ingest_explicit_flag_specs
+        )
 
     assert calls == [
         (("audio-jobs",), {}),
         (("audiobooks",), {}),
         (("slides",), {}),
         (("research-workspace-output-jobs",), {"default_stable": True}),
-        (("media",), {}),
-        (
-            ("media-ingest-heavy-jobs",),
-            {"default_stable": False},
-        ),
         (("reading",), {}),
         (("llamacpp-acquisition",), {}),
         (("visual-identities",), {"default_stable": True}),


### PR DESCRIPTION
## Summary
- Fix WebUI media selection reading-progress loop that could trigger maximum update depth during Quick Ingest.
- Start the normal media ingest worker by route default while keeping heavy ingest opt-in.
- Correct docs-info worker capability reporting and docs, with route-disabled regression coverage.

## Validation
- [x] Backend focused pytest: 41 passed
- [x] UI package Vitest hook regression: 1 passed
- [x] Bandit on touched backend app code
- [x] Manual WebUI Quick Ingest walkthrough: invalid YouTube URL left queued 0% and reached quarantined yt-dlp error

## Review Resolution
- [x] Rebased PR onto latest `dev`
- [x] Removed nondeterministic `setTimeout` wait from the UI regression test
- [x] Removed the `JSON.parse(readingProgressMediaIdsKey)` empty fallback path
- [x] Made non-introspectable injected route callbacks fall back to one-arg invocation
- [x] Kept `hasMediaIngestWorker` false when the media route is disabled, even if the worker env flag is true

## Risk & Rollback
- Risk is limited to media ingest worker startup policy, docs-info capability flags, and the Review hook reading-progress polling path.
- Rollback is the PR branch revert; no schema/data migration is involved.
- Heavy media ingest remains opt-in by default, and sidecar mode still disables in-process worker capability reporting.