### PR TITLE
Fix stale webapp session redirect after relaunch

### DIFF
--- a/apps/tldw-frontend/__tests__/app/app-layout.test.tsx
+++ b/apps/tldw-frontend/__tests__/app/app-layout.test.tsx
@@ -58,6 +58,7 @@ const mockRouter = {
 const mockGetConfig = vi.fn()
 const mockGetCurrentUser = vi.fn()
 const mockLogout = vi.fn()
+let mockLogoutAvailable = true
 let currentConfig: Record<string, unknown> | null = null
 
 vi.mock("next/router", () => ({
@@ -146,7 +147,9 @@ vi.mock("@web/lib/configured-auth-state", () => ({
   }),
   loadTldwAuth: async () => ({
     getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
-    logout: (...args: unknown[]) => mockLogout(...args)
+    ...(mockLogoutAvailable
+      ? { logout: (...args: unknown[]) => mockLogout(...args) }
+      : {})
   })
 }))
 
@@ -174,6 +177,7 @@ beforeEach(() => {
   mockGetConfig.mockReset()
   mockGetCurrentUser.mockReset()
   mockLogout.mockReset()
+  mockLogoutAvailable = true
   mockGetCurrentUser.mockResolvedValue({ username: "test-user" })
   mockLogout.mockResolvedValue(undefined)
   currentConfig = null
@@ -495,6 +499,65 @@ describe("App layout routing", () => {
     expect(mockLogout).toHaveBeenCalled()
   })
 
+  it("redirects stale sessions when the auth provider has no logout method", async () => {
+    mockLogoutAvailable = false
+    currentConfig = {
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "multi-user",
+      accessToken: "stale-token"
+    }
+    mockGetCurrentUser.mockRejectedValueOnce(makeStatusError("Unauthorized", 401))
+
+    renderApp("/media")
+
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith("/login")
+    })
+    expect(mockLogout).not.toHaveBeenCalled()
+  })
+
+  it("logs logout failures while still redirecting stale sessions", async () => {
+    const logoutError = new Error("Storage unavailable")
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    currentConfig = {
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "multi-user",
+      accessToken: "stale-token"
+    }
+    mockGetCurrentUser.mockRejectedValueOnce(makeStatusError("Unauthorized", 401))
+    mockLogout.mockRejectedValueOnce(logoutError)
+
+    try {
+      renderApp("/media")
+
+      await waitFor(() => {
+        expect(mockRouter.push).toHaveBeenCalledWith("/login")
+      })
+      expect(warn).toHaveBeenCalledWith(
+        "Failed to clear stale tldw auth session:",
+        logoutError
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it("redirects when auth validation returns a plain unauthenticated error", async () => {
+    currentConfig = {
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "multi-user",
+      accessToken: "stale-token"
+    }
+    mockGetCurrentUser.mockRejectedValueOnce({ message: "Not authenticated" })
+
+    renderApp("/media")
+
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith("/login")
+    })
+    expect(mockLogout).toHaveBeenCalled()
+  })
+
   it("keeps persisted multi-user auth when validation fails with a non-auth status", async () => {
     currentConfig = {
       serverUrl: "http://127.0.0.1:8000",
@@ -525,6 +588,30 @@ describe("App layout routing", () => {
       serverUrl: "",
       authMode: "multi-user"
     }
+
+    renderApp("/chat")
+    const layout = await screen.findByTestId("option-layout")
+
+    await waitFor(() => {
+      expect(mockGetCurrentUser).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(layout).toHaveAttribute("data-hide-header", "false")
+    })
+    expect(layout).toHaveAttribute("data-hide-sidebar", "false")
+    expect(mockLogout).not.toHaveBeenCalled()
+    expect(mockRouter.push).not.toHaveBeenCalledWith("/login")
+  })
+
+  it("keeps hosted tokenless auth on non-auth validation failures", async () => {
+    process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = "hosted"
+    currentConfig = {
+      serverUrl: "",
+      authMode: "multi-user"
+    }
+    mockGetCurrentUser.mockRejectedValueOnce(
+      makeStatusError("Server unavailable", 500)
+    )
 
     renderApp("/chat")
     const layout = await screen.findByTestId("option-layout")

--- a/apps/tldw-frontend/__tests__/app/app-layout.test.tsx
+++ b/apps/tldw-frontend/__tests__/app/app-layout.test.tsx
@@ -57,6 +57,7 @@ const mockRouter = {
 
 const mockGetConfig = vi.fn()
 const mockGetCurrentUser = vi.fn()
+const mockLogout = vi.fn()
 let currentConfig: Record<string, unknown> | null = null
 
 vi.mock("next/router", () => ({
@@ -144,7 +145,8 @@ vi.mock("@web/lib/configured-auth-state", () => ({
     getConfig: (...args: unknown[]) => mockGetConfig(...args)
   }),
   loadTldwAuth: async () => ({
-    getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args)
+    getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+    logout: (...args: unknown[]) => mockLogout(...args)
   })
 }))
 
@@ -156,6 +158,11 @@ const renderApp = (pathname: string, asPath = pathname) => {
   return render(<App Component={DummyPage} pageProps={{}} />)
 }
 
+const makeStatusError = (
+  message: string,
+  status: number
+): Error & { status: number } => Object.assign(new Error(message), { status })
+
 const originalEnvApiKey = process.env.NEXT_PUBLIC_X_API_KEY
 const originalEnvBearer = process.env.NEXT_PUBLIC_API_BEARER
 const originalDeploymentMode = process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
@@ -166,7 +173,9 @@ beforeEach(() => {
   mockRouter.prefetch.mockClear()
   mockGetConfig.mockReset()
   mockGetCurrentUser.mockReset()
+  mockLogout.mockReset()
   mockGetCurrentUser.mockResolvedValue({ username: "test-user" })
+  mockLogout.mockResolvedValue(undefined)
   currentConfig = null
   mockGetConfig.mockImplementation(async () => currentConfig)
   delete process.env.NEXT_PUBLIC_X_API_KEY
@@ -464,13 +473,13 @@ describe("App layout routing", () => {
     expect(layout).toHaveAttribute("data-hide-sidebar", "false")
   })
 
-  it("keeps header and sidebar hidden when multi-user token validation fails", async () => {
+  it("redirects protected routes to login when multi-user token validation fails", async () => {
     currentConfig = {
       serverUrl: "http://127.0.0.1:8000",
       authMode: "multi-user",
       accessToken: "stale-token"
     }
-    mockGetCurrentUser.mockRejectedValueOnce(new Error("Unauthorized"))
+    mockGetCurrentUser.mockRejectedValueOnce(makeStatusError("Unauthorized", 401))
 
     renderApp("/media")
     const layout = await screen.findByTestId("option-layout")
@@ -478,8 +487,57 @@ describe("App layout routing", () => {
     await waitFor(() => {
       expect(mockGetCurrentUser).toHaveBeenCalled()
     })
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith("/login")
+    })
     expect(layout).toHaveAttribute("data-hide-header", "true")
     expect(layout).toHaveAttribute("data-hide-sidebar", "true")
+    expect(mockLogout).toHaveBeenCalled()
+  })
+
+  it("keeps persisted multi-user auth when validation fails with a non-auth status", async () => {
+    currentConfig = {
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "multi-user",
+      accessToken: "still-valid-token"
+    }
+    mockGetCurrentUser.mockRejectedValueOnce(
+      makeStatusError("Server unavailable", 500)
+    )
+
+    renderApp("/media")
+    const layout = await screen.findByTestId("option-layout")
+
+    await waitFor(() => {
+      expect(mockGetCurrentUser).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(layout).toHaveAttribute("data-hide-header", "false")
+    })
+    expect(layout).toHaveAttribute("data-hide-sidebar", "false")
+    expect(mockLogout).not.toHaveBeenCalled()
+    expect(mockRouter.push).not.toHaveBeenCalledWith("/login")
+  })
+
+  it("validates hosted multi-user sessions without a persisted access token", async () => {
+    process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = "hosted"
+    currentConfig = {
+      serverUrl: "",
+      authMode: "multi-user"
+    }
+
+    renderApp("/chat")
+    const layout = await screen.findByTestId("option-layout")
+
+    await waitFor(() => {
+      expect(mockGetCurrentUser).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(layout).toHaveAttribute("data-hide-header", "false")
+    })
+    expect(layout).toHaveAttribute("data-hide-sidebar", "false")
+    expect(mockLogout).not.toHaveBeenCalled()
+    expect(mockRouter.push).not.toHaveBeenCalledWith("/login")
   })
 
   it("warms primary navigation routes after auth resolves", async () => {

--- a/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
+++ b/apps/tldw-frontend/e2e/smoke/smoke.setup.ts
@@ -220,6 +220,22 @@ export async function seedAuth(
         : AUTH_CONFIG.allowOffline
   }
 
+  if (cfg.authMode === "single-user") {
+    await page.route("**/api/_tldw-webui/runtime-config", async (route) => {
+      await fulfillSmokeJson(route, 200, {
+        runtimeAuth: {
+          available: true,
+          authMode: "single-user",
+          apiKey: cfg.apiKey
+        },
+        networking: {
+          deploymentMode: "advanced",
+          serverUrl: cfg.serverUrl
+        }
+      })
+    })
+  }
+
   await page.addInitScript(
     (cfg) => {
       const readStorageValue = (key: string) => {
@@ -227,7 +243,7 @@ export async function seedAuth(
         if (raw == null) return undefined
         try {
           return JSON.parse(raw)
-        } catch (_error) {
+        } catch {
           return raw
         }
       }
@@ -409,7 +425,6 @@ export async function seedAuth(
         authMode: cfg.authMode,
         accessToken: cfg.accessToken
       }
-      ;(window as Window & { __tldwRuntimeApiKey?: string }).__tldwRuntimeApiKey = cfg.apiKey
 
       // lgtm[js/clear-text-storage-of-sensitive-data]: synthetic E2E auth seed only.
       localStorage.setItem("tldwConfig", JSON.stringify(authConfig))

--- a/apps/tldw-frontend/lib/configured-auth-state.ts
+++ b/apps/tldw-frontend/lib/configured-auth-state.ts
@@ -12,6 +12,7 @@ type TldwClientLike = {
 
 type TldwAuthLike = {
   getCurrentUser: () => Promise<unknown>
+  logout?: () => Promise<void>
 }
 
 export const loadTldwClient = async (): Promise<TldwClientLike> => {

--- a/apps/tldw-frontend/pages/_app.tsx
+++ b/apps/tldw-frontend/pages/_app.tsx
@@ -84,7 +84,14 @@ const getErrorStatus = (error: unknown): number | null => {
 const isAuthValidationFailure = (error: unknown): boolean => {
   const status = getErrorStatus(error)
   if (status === 401 || status === 403) return true
-  return error instanceof Error && error.message.trim() === "Not authenticated"
+  const candidate = error as { message?: unknown } | null
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof candidate?.message === "string"
+        ? candidate.message
+        : ""
+  return message.trim() === "Not authenticated"
 }
 
 const splitRouteAsPath = (asPath: string) => {
@@ -166,7 +173,11 @@ const getConfiguredAuthState = async (): Promise<ConfiguredAuthState> => {
             isAuthenticated: true
           }
         }
-        await tldwAuth.logout?.().catch(() => undefined)
+        try {
+          await tldwAuth.logout?.()
+        } catch (logoutError) {
+          console.warn("Failed to clear stale tldw auth session:", logoutError)
+        }
         return {
           hasConfig: true,
           authMode: "multi-user",

--- a/apps/tldw-frontend/pages/_app.tsx
+++ b/apps/tldw-frontend/pages/_app.tsx
@@ -19,6 +19,7 @@ import {
   hasEnvApiAuth
 } from "@web/lib/authStorage"
 import { loadTldwAuth, loadTldwClient } from "@web/lib/configured-auth-state"
+import { isHostedTldwDeployment } from "@/services/tldw/deployment-mode"
 import {
   buildFirstRunOnboardingRoute,
   CHARACTER_CHAT_ONBOARDING_INTENT,
@@ -63,6 +64,27 @@ type ConfiguredAuthState = {
   hasConfig: boolean
   authMode?: "single-user" | "multi-user"
   isAuthenticated: boolean
+}
+
+const getErrorStatus = (error: unknown): number | null => {
+  const candidate = error as
+    | {
+        status?: unknown
+        statusCode?: unknown
+        response?: { status?: unknown }
+      }
+    | null
+  const rawStatus =
+    candidate?.status ?? candidate?.statusCode ?? candidate?.response?.status
+  return typeof rawStatus === "number" && Number.isFinite(rawStatus)
+    ? rawStatus
+    : null
+}
+
+const isAuthValidationFailure = (error: unknown): boolean => {
+  const status = getErrorStatus(error)
+  if (status === 401 || status === 403) return true
+  return error instanceof Error && error.message.trim() === "Not authenticated"
 }
 
 const splitRouteAsPath = (asPath: string) => {
@@ -116,10 +138,11 @@ const getConfiguredAuthState = async (): Promise<ConfiguredAuthState> => {
     }
 
     if (config.authMode === "multi-user") {
+      const hostedMode = isHostedTldwDeployment()
       const hasAccessToken =
         typeof config.accessToken === "string" &&
         config.accessToken.trim().length > 0
-      if (!hasAccessToken) {
+      if (!hasAccessToken && !hostedMode) {
         return {
           hasConfig: true,
           authMode: "multi-user",
@@ -127,15 +150,23 @@ const getConfiguredAuthState = async (): Promise<ConfiguredAuthState> => {
         }
       }
 
+      const tldwAuth = await loadTldwAuth()
       try {
-        const tldwAuth = await loadTldwAuth()
         await tldwAuth.getCurrentUser()
         return {
           hasConfig: true,
           authMode: "multi-user",
           isAuthenticated: true
         }
-      } catch {
+      } catch (error) {
+        if (!isAuthValidationFailure(error)) {
+          return {
+            hasConfig: true,
+            authMode: "multi-user",
+            isAuthenticated: true
+          }
+        }
+        await tldwAuth.logout?.().catch(() => undefined)
         return {
           hasConfig: true,
           authMode: "multi-user",
@@ -172,6 +203,8 @@ export default function App({ Component, pageProps }: AppProps) {
   const isSidepanelDebugRoute = routePath === "/__debug__/sidepanel-chat"
   const isSettingsRoute =
     routePath === "/settings" || routePath.startsWith("/settings/")
+  const shouldBypassGates =
+    isPublicAuthRoute || isSettingsRoute || isSetupRoute || isDebugRoute
   const [isAuthenticated, setIsAuthenticated] = React.useState(false)
   const [authResolved, setAuthResolved] = React.useState(false)
   const didWarmRoutePrefetch = React.useRef(false)
@@ -198,6 +231,14 @@ export default function App({ Component, pageProps }: AppProps) {
       if (!cancelled) {
         setIsAuthenticated(authed)
         setAuthResolved(true)
+        if (
+          !authed &&
+          configuredAuth.hasConfig &&
+          configuredAuth.authMode === "multi-user" &&
+          !shouldBypassGates
+        ) {
+          void router.push("/login")
+        }
       }
     }
 
@@ -222,7 +263,7 @@ export default function App({ Component, pageProps }: AppProps) {
       window.removeEventListener("focus", onConfigUpdated)
       window.removeEventListener("storage", onStorage)
     }
-  }, [router.asPath])
+  }, [router, router.asPath, shouldBypassGates])
 
   React.useEffect(() => {
     if (typeof window === "undefined") return
@@ -310,8 +351,6 @@ export default function App({ Component, pageProps }: AppProps) {
   }, [authResolved, isAuthenticated, isPublicAuthRoute, routePath, router])
 
   const hideShellNav = !authResolved || !isAuthenticated
-  const shouldBypassGates =
-    isPublicAuthRoute || isSettingsRoute || isSetupRoute || isDebugRoute
   const shouldAllowDegradedReadiness = DEGRADED_READINESS_ROUTES.has(routePath)
   const firstRunRouteParts = React.useMemo(
     () => splitRouteAsPath(router.asPath || routePath || "/"),

--- a/backlog/tasks/task-12943 - Fix-stale-webapp-session-redirect-after-relaunch.md
+++ b/backlog/tasks/task-12943 - Fix-stale-webapp-session-redirect-after-relaunch.md
@@ -4,7 +4,7 @@ title: Fix stale webapp session redirect after relaunch
 status: Done
 assignee: []
 created_date: '2026-07-10 01:41'
-updated_date: '2026-07-10 01:45'
+updated_date: '2026-07-10 03:32'
 labels:
   - frontend
   - auth
@@ -44,12 +44,16 @@ Verification:
 - git diff --check -- touched files
 
 Bandit: skipped because the touched implementation and tests are TypeScript/React frontend files only; no Python code changed.
+
+PR review follow-up: replaced silent logout rejection handling with logged try/catch, classified plain-object Not authenticated errors, and added coverage for optional logout, logout rejection, and hosted tokenless transient failures. Verification: app-layout Vitest 25/25, touched frontend ESLint, TypeScript noEmit, and git diff --check.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Fixed multi-user app-shell auth resolution after relaunch. Explicit auth validation failures now clear stale auth and redirect protected routes to /login, while transient validation failures preserve the persisted authenticated shell. Hosted deployments now validate sessions without requiring a locally stored access token.
+
+PR review feedback is addressed with explicit logout diagnostics and broader auth-error compatibility.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12943 - Fix-stale-webapp-session-redirect-after-relaunch.md
+++ b/backlog/tasks/task-12943 - Fix-stale-webapp-session-redirect-after-relaunch.md
@@ -1,0 +1,63 @@
+---
+id: TASK-12943
+title: Fix stale webapp session redirect after relaunch
+status: Done
+assignee: []
+created_date: '2026-07-10 01:41'
+updated_date: '2026-07-10 01:45'
+labels:
+  - frontend
+  - auth
+  - bug
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix the webapp relaunch path where a stale multi-user session can bypass /login and render the protected homepage without header/sidebar chrome.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Stale multi-user access tokens redirect protected routes to /login after validation fails.
+- [x] #2 Transient non-auth validation failures preserve persisted authenticated shell state.
+- [x] #3 Hosted multi-user sessions validate without requiring a locally persisted access token.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add regression coverage for stale token, transient validation failure, and hosted tokenless session cases.
+2. Update app shell auth resolution to distinguish auth failures from transient validation errors.
+3. Verify focused frontend auth/layout tests and lint touched files.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification:
+- bunx vitest run __tests__/app/app-layout.test.tsx (red before production fix: 3 expected failures; green after fix: 21/21 passed)
+- ./node_modules/.bin/eslint pages/_app.tsx lib/configured-auth-state.ts __tests__/app/app-layout.test.tsx
+- ./node_modules/.bin/tsc --noEmit --pretty false
+- git diff --check -- touched files
+
+Bandit: skipped because the touched implementation and tests are TypeScript/React frontend files only; no Python code changed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed multi-user app-shell auth resolution after relaunch. Explicit auth validation failures now clear stale auth and redirect protected routes to /login, while transient validation failures preserve the persisted authenticated shell. Hosted deployments now validate sessions without requiring a locally stored access token.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12944 - Repair-dev-CI-regressions-exposed-by-PR-2701.md
+++ b/backlog/tasks/task-12944 - Repair-dev-CI-regressions-exposed-by-PR-2701.md
@@ -1,0 +1,58 @@
+---
+id: TASK-12944
+title: Repair dev CI regressions exposed by PR 2701
+status: Done
+assignee: []
+created_date: '2026-07-10 03:25'
+updated_date: '2026-07-10 03:44'
+labels:
+  - ci
+  - frontend
+  - research
+  - tests
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the latest dev baseline regressions surfaced by PR 2701: smoke auth no longer reaches the app-shell runtime auth path, and research tests still assert pre-hardening clear-text artifact paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Shared smoke auth seeds credentials through the runtime-config contract without persisting API keys.
+- [x] #2 Research tests validate hashed artifact storage through ResearchArtifactStore instead of clear-text paths.
+- [x] #3 The focused UX smoke and critical deep-research tests pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce both CI failures. 2. Update the shared smoke fixture and stale research assertions. 3. Run focused frontend/backend verification and Bandit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root causes: fecb7e4b22 moved smoke credentials out of persistent storage without routing them through runtime-config, and hardened research artifact storage while leaving clear-text path assertions behind. Verification: Stage 6 Playwright 6/6; critical deep-research E2E 1/1; research worker tests 21/21; frontend ESLint and TypeScript noEmit; Python Ruff; git diff --check. Bandit: touched Python test files scanned with B101 excluded; 0 findings. The unfiltered scan reported only expected B101 pytest assertions (278 low, 0 medium/high). Docs: no user-facing documentation change required. Blockers: none.
+
+Independent final-diff review found that manifest-backed assertions should also prove storage-path confinement. Updated both research test helpers to require each resolved artifact path to remain under the configured research output root; focused E2E and worker suites were rerun successfully.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Repaired latest-dev CI regressions by seeding smoke auth through the runtime-config endpoint and validating research artifacts through their manifest-backed hashed storage paths.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/Research/test_research_jobs_worker.py
+++ b/tldw_Server_API/tests/Research/test_research_jobs_worker.py
@@ -1,7 +1,26 @@
+from pathlib import Path
+
 import pytest
 
-
 pytestmark = pytest.mark.unit
+
+
+def _assert_artifacts_exist(
+    db,
+    base_dir: Path,
+    session_id: str,
+    artifact_names: set[str],
+) -> None:
+    artifacts = {
+        artifact.artifact_name: artifact
+        for artifact in db.list_artifacts(session_id)
+    }
+    assert artifact_names <= artifacts.keys()
+    research_root = (base_dir / "research").resolve()
+    for name in artifact_names:
+        path = Path(artifacts[name].storage_path).resolve()
+        path.relative_to(research_root)
+        assert path.is_file()
 
 
 class _ProviderStub:
@@ -293,7 +312,7 @@ async def test_planning_job_writes_plan_and_opens_checkpoint(tmp_path):
     assert updated.latest_checkpoint_id is not None
     assert result["phase"] == "awaiting_plan_review"
     assert result["artifacts_written"] >= 1
-    assert (tmp_path / "outputs" / "research" / session.id / "plan.json").exists()
+    _assert_artifacts_exist(db, tmp_path / "outputs", session.id, {"plan.json"})
 
 
 @pytest.mark.asyncio
@@ -435,9 +454,12 @@ async def test_collecting_job_writes_artifacts_and_opens_source_review(tmp_path)
     assert updated.latest_checkpoint_id is not None
     assert result["phase"] == "awaiting_source_review"
     assert result["artifacts_written"] >= 3
-    assert (tmp_path / "outputs" / "research" / session.id / "source_registry.json").exists()
-    assert (tmp_path / "outputs" / "research" / session.id / "evidence_notes.jsonl").exists()
-    assert (tmp_path / "outputs" / "research" / session.id / "collection_summary.json").exists()
+    _assert_artifacts_exist(
+        db,
+        tmp_path / "outputs",
+        session.id,
+        {"source_registry.json", "evidence_notes.jsonl", "collection_summary.json"},
+    )
 
 
 @pytest.mark.asyncio
@@ -1158,14 +1180,21 @@ async def test_synthesizing_job_writes_artifacts_and_opens_outline_review(tmp_pa
     assert updated.latest_checkpoint_id is not None
     assert result["phase"] == "awaiting_outline_review"
     assert result["artifacts_written"] >= 4
-    assert (tmp_path / "outputs" / "research" / session.id / "outline_v1.json").exists()
-    assert (tmp_path / "outputs" / "research" / session.id / "claims.json").exists()
-    assert (tmp_path / "outputs" / "research" / session.id / "report_v1.md").exists()
-    assert (tmp_path / "outputs" / "research" / session.id / "synthesis_summary.json").exists()
-    assert (tmp_path / "outputs" / "research" / session.id / "verification_summary.json").exists()
-    assert (tmp_path / "outputs" / "research" / session.id / "unsupported_claims.json").exists()
-    assert (tmp_path / "outputs" / "research" / session.id / "contradictions.json").exists()
-    assert (tmp_path / "outputs" / "research" / session.id / "source_trust.json").exists()
+    _assert_artifacts_exist(
+        db,
+        tmp_path / "outputs",
+        session.id,
+        {
+            "outline_v1.json",
+            "claims.json",
+            "report_v1.md",
+            "synthesis_summary.json",
+            "verification_summary.json",
+            "unsupported_claims.json",
+            "contradictions.json",
+            "source_trust.json",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -1957,8 +1986,8 @@ async def test_packaging_job_writes_bundle_and_completes_session(tmp_path):
 @pytest.mark.asyncio
 async def test_packaging_job_inserts_completion_message_into_linked_chat(tmp_path, monkeypatch):
     from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
-    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
     from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
     from tldw_Server_API.app.core.Research.artifact_store import ResearchArtifactStore
     from tldw_Server_API.app.core.Research.jobs import handle_research_phase_job
 

--- a/tldw_Server_API/tests/e2e/test_deep_research_runs.py
+++ b/tldw_Server_API/tests/e2e/test_deep_research_runs.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import threading
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Callable
 
@@ -11,8 +12,25 @@ from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
 
-
 pytestmark = pytest.mark.critical
+
+
+def _assert_artifacts_exist(
+    db,
+    base_dir: Path,
+    session_id: str,
+    artifact_names: set[str],
+) -> None:
+    artifacts = {
+        artifact.artifact_name: artifact
+        for artifact in db.list_artifacts(session_id)
+    }
+    assert artifact_names <= artifacts.keys()
+    research_root = (base_dir / "research").resolve()
+    for name in artifact_names:
+        path = Path(artifacts[name].storage_path).resolve()
+        path.relative_to(research_root)
+        assert path.is_file()
 
 
 def _set_user_db_base(monkeypatch: pytest.MonkeyPatch, base_dir) -> str | None:
@@ -251,9 +269,12 @@ def test_deep_research_run_can_be_approved_and_exported(tmp_path):
     assert session is not None
     assert session.phase == "awaiting_source_review"
     assert session.latest_checkpoint_id is not None
-    assert (outputs_dir / "research" / session_id / "source_registry.json").exists()
-    assert (outputs_dir / "research" / session_id / "evidence_notes.jsonl").exists()
-    assert (outputs_dir / "research" / session_id / "collection_summary.json").exists()
+    _assert_artifacts_exist(
+        db,
+        outputs_dir,
+        session_id,
+        {"source_registry.json", "evidence_notes.jsonl", "collection_summary.json"},
+    )
     source_registry = ResearchArtifactStore(base_dir=outputs_dir, db=db).read_json(
         session_id=session_id,
         artifact_name="source_registry.json",
@@ -332,10 +353,12 @@ def test_deep_research_run_can_be_approved_and_exported(tmp_path):
     assert session is not None
     assert session.phase == "awaiting_outline_review"
     assert session.latest_checkpoint_id is not None
-    assert (outputs_dir / "research" / session_id / "outline_v1.json").exists()
-    assert (outputs_dir / "research" / session_id / "claims.json").exists()
-    assert (outputs_dir / "research" / session_id / "report_v1.md").exists()
-    assert (outputs_dir / "research" / session_id / "synthesis_summary.json").exists()
+    _assert_artifacts_exist(
+        db,
+        outputs_dir,
+        session_id,
+        {"outline_v1.json", "claims.json", "report_v1.md", "synthesis_summary.json"},
+    )
     synthesis_summary = store.read_json(session_id=session_id, artifact_name="synthesis_summary.json")
     assert synthesis_summary is not None
     assert synthesis_summary["mode"] == "llm_backed"
@@ -404,13 +427,13 @@ def test_deep_research_run_can_be_approved_and_exported(tmp_path):
     export = adapter.export(package, format="md")
     assert export.status == "ready"
     assert export.content.startswith(b"# Research Report")
-    assert (outputs_dir / "research" / session_id / "bundle.json").exists()
+    _assert_artifacts_exist(db, outputs_dir, session_id, {"bundle.json"})
 
 
 def test_deep_research_run_creation_persists_chat_handoff(tmp_path, monkeypatch):
     from tldw_Server_API.app.api.v1.endpoints import research_runs
-    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
     from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
     from tldw_Server_API.app.core.Research.service import ResearchService
 
     class DummyJobs:


### PR DESCRIPTION
## Summary
- Redirect protected routes to /login when multi-user session validation returns an explicit auth failure.
- Preserve authenticated shell state for transient non-auth validation failures so relaunch does not hide header/sidebar unnecessarily.
- Allow hosted multi-user sessions to validate without requiring a locally persisted access token.

## Test Plan
- bunx vitest run __tests__/app/app-layout.test.tsx
- ./node_modules/.bin/eslint pages/_app.tsx lib/configured-auth-state.ts __tests__/app/app-layout.test.tsx
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check

Bandit skipped: TypeScript/React frontend-only change; no Python touched.

Backlog: TASK-12943

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale session handling after relaunch so protected routes redirect to /login instead of rendering without hidden chrome. Adds clearer auth-error handling and repairs dev CI for smoke auth and research artifact checks. Addresses TASK-12943 and TASK-12944.

- **Bug Fixes**
  - Detect 401/403 or "Not authenticated" (by status or message), call optional `logout`, log failures, then redirect protected routes to /login.
  - Keep header/sidebar visible on non-auth validation failures (e.g., 5xx); hosted multi-user sessions validate without a persisted `accessToken`.
  - Seed single-user smoke auth via the runtime-config endpoint without persisting API keys; update research tests to assert hashed artifact paths remain under the research output root.

<sup>Written for commit 4079060ebc90798302265426fbf1e8e08022ab57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

