### PR TITLE
Fix advanced WebUI Quick Ingest transport

### DIFF
--- a/Docs/superpowers/specs/2026-07-09-quick-ingest-advanced-transport-design.md
+++ b/Docs/superpowers/specs/2026-07-09-quick-ingest-advanced-transport-design.md
@@ -1,0 +1,43 @@
+# Quick Ingest Advanced Transport Fix
+
+## Problem
+
+In an advanced WebUI deployment, `resolveBrowserRequestTransport` can build a
+valid absolute API URL from `NEXT_PUBLIC_API_URL`. `tldwRequest` nevertheless
+rejects the request when persisted `tldwConfig.serverUrl` is empty. Quick
+Ingest uses this direct request path for multipart submission, so the job never
+reaches `/api/v1/media/ingest/jobs`.
+
+The resulting HTTP 400 text is also classified as an unsupported input format,
+which hides the actual server-configuration problem.
+
+## Design
+
+Keep transport resolution as the single source of truth. For non-absolute,
+advanced requests, reject only when the resolved transport URL has no valid
+HTTP origin. This matches the existing direct streaming behavior and preserves
+the current precedence order: persisted `serverUrl`, then
+`NEXT_PUBLIC_API_URL`, with hosted and quickstart modes unchanged.
+
+Add a dedicated configuration error category using the existing `auth`
+classification value. It will present a server-configuration message before
+the generic HTTP 400 format rule is considered.
+
+No new transport type or abstraction is needed.
+
+## Tests
+
+1. A direct multipart upload with no persisted `serverUrl` uses the advanced
+   origin from `NEXT_PUBLIC_API_URL`.
+2. An advanced request with neither a persisted nor runtime API origin remains
+   rejected before `fetch`.
+3. `tldw server not configured` maps to a configuration message rather than a
+   file-format message.
+4. Existing focused service tests and frontend typecheck remain green.
+
+## Scope
+
+The patch changes only shared frontend request validation, Quick Ingest error
+classification, and their focused tests. Backend ingestion and dependency
+versions are outside this patch because UAT proved ingestion succeeds with a
+current `yt-dlp` installation.

--- a/apps/packages/ui/src/components/Common/QuickIngest/ErrorClassification.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ErrorClassification.ts
@@ -45,6 +45,15 @@ const AUTH_CATEGORY: ErrorCategory = {
   suggestion: "Check your API key or server configuration.",
 }
 
+const CONFIG_CATEGORY: ErrorCategory = {
+  classification: "auth",
+  retryable: false,
+  badgeLabel: "Config \u00b7 Check Server",
+  badgeColor: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  userMessage: "The tldw server is not configured.",
+  suggestion: "Set the server URL and API key in Settings, then try again.",
+}
+
 const VALIDATION_CATEGORY: ErrorCategory = {
   classification: "validation",
   retryable: false,
@@ -102,6 +111,10 @@ const PATTERN_TABLE: PatternEntry[] = [
   {
     patterns: /\b429\b|too many requests|concurrent job limit|max(?:imum)? concurrent/i,
     category: JOB_LIMIT_CATEGORY,
+  },
+  {
+    patterns: /server (?:is )?not configured|server configuration/i,
+    category: CONFIG_CATEGORY,
   },
   {
     patterns: /\b40[13]\b|unauthorized|forbidden|auth/i,

--- a/apps/packages/ui/src/components/Common/QuickIngest/ErrorClassification.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ErrorClassification.ts
@@ -113,7 +113,7 @@ const PATTERN_TABLE: PatternEntry[] = [
     category: JOB_LIMIT_CATEGORY,
   },
   {
-    patterns: /server (?:is )?not configured|server configuration/i,
+    patterns: /^(?:HTTP 400:\s*)?tldw server not configured\.?$/i,
     category: CONFIG_CATEGORY,
   },
   {

--- a/apps/packages/ui/src/components/Common/QuickIngest/ErrorClassification.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/ErrorClassification.ts
@@ -141,8 +141,9 @@ const PATTERN_TABLE: PatternEntry[] = [
 /**
  * Classify an error message string into a structured `ErrorCategory`.
  *
- * Pattern matching is applied in priority order (timeout > auth > validation >
- * server > network) so that overlapping keywords resolve deterministically.
+ * Pattern matching follows `PATTERN_TABLE` order so timeout, job-limit, and
+ * client-configuration errors win before broader auth, validation, server, and
+ * network patterns.
  * If nothing matches, the error is classified as `"unknown"` (retryable).
  */
 export function classifyError(error: string | undefined): ErrorCategory {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/ErrorClassification.test.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/ErrorClassification.test.ts
@@ -57,6 +57,15 @@ describe("classifyError", () => {
       expect(result.badgeLabel).toContain("Config")
       expect(result.userMessage).toContain("server is not configured")
     })
+
+    it("does not relabel unrelated server configuration errors", () => {
+      const result = classifyError(
+        "Third-party server configuration is invalid"
+      )
+
+      expect(result.badgeLabel).not.toContain("Config")
+      expect(result.userMessage).not.toContain("server is not configured")
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/ErrorClassification.test.ts
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/ErrorClassification.test.ts
@@ -48,6 +48,15 @@ describe("classifyError", () => {
       expect(result.retryable).toBe(false)
       expect(result.badgeLabel).toContain("Auth")
     })
+
+    it("returns configuration guidance before generic HTTP 400 handling", () => {
+      const result = classifyError("HTTP 400: tldw server not configured")
+
+      expect(result.classification).toBe("auth")
+      expect(result.retryable).toBe(false)
+      expect(result.badgeLabel).toContain("Config")
+      expect(result.userMessage).toContain("server is not configured")
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/apps/packages/ui/src/services/__tests__/request-core.path-normalization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/request-core.path-normalization.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { deriveRequestTimeout, tldwRequest } from "@/services/tldw/request-core"
 
@@ -62,10 +62,46 @@ describe("request-core media path normalization", () => {
 })
 
 describe("request-core advanced WebUI transport", () => {
+  let originalDeploymentMode: string | undefined
+  let originalApiUrl: string | undefined
+  let originalWindow: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    originalDeploymentMode = process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
+    originalApiUrl = process.env.NEXT_PUBLIC_API_URL
+    originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window")
+
+    process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = "advanced"
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        location: {
+          origin: "https://webui.example.test",
+          protocol: "https:"
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    if (originalDeploymentMode === undefined) {
+      delete process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
+    } else {
+      process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = originalDeploymentMode
+    }
+    if (originalApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalApiUrl
+    }
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow)
+    } else {
+      Reflect.deleteProperty(globalThis, "window")
+    }
+  })
+
   it("uses the runtime API origin without a persisted server URL", async () => {
-    const originalDeploymentMode = process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
-    const originalApiUrl = process.env.NEXT_PUBLIC_API_URL
-    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window")
     const fetchFn = vi.fn(async () =>
       new Response(JSON.stringify({ batch_id: "batch-1", jobs: [] }), {
         status: 200,
@@ -73,109 +109,50 @@ describe("request-core advanced WebUI transport", () => {
       })
     )
 
-    process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = "advanced"
     process.env.NEXT_PUBLIC_API_URL = "https://api.example.test"
-    Object.defineProperty(globalThis, "window", {
-      configurable: true,
-      value: {
-        location: {
-          origin: "https://webui.example.test",
-          protocol: "https:"
-        }
-      }
-    })
 
-    try {
-      const response = await tldwRequest(
-        {
-          path: "/api/v1/media/ingest/jobs",
-          method: "POST",
-          body: new FormData(),
-          noAuth: true
-        },
-        {
-          getConfig: async () => null,
-          fetchFn
-        }
-      )
+    const response = await tldwRequest(
+      {
+        path: "/api/v1/media/ingest/jobs",
+        method: "POST",
+        body: new FormData(),
+        noAuth: true
+      },
+      {
+        getConfig: async () => null,
+        fetchFn
+      }
+    )
 
-      expect(response.ok).toBe(true)
-      expect(fetchFn).toHaveBeenCalledTimes(1)
-      expect(getFetchCall(fetchFn)?.[0]).toBe(
-        "https://api.example.test/api/v1/media/ingest/jobs"
-      )
-    } finally {
-      if (originalDeploymentMode === undefined) {
-        delete process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
-      } else {
-        process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = originalDeploymentMode
-      }
-      if (originalApiUrl === undefined) {
-        delete process.env.NEXT_PUBLIC_API_URL
-      } else {
-        process.env.NEXT_PUBLIC_API_URL = originalApiUrl
-      }
-      if (originalWindow) {
-        Object.defineProperty(globalThis, "window", originalWindow)
-      } else {
-        Reflect.deleteProperty(globalThis, "window")
-      }
-    }
+    expect(response.ok).toBe(true)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(getFetchCall(fetchFn)?.[0]).toBe(
+      "https://api.example.test/api/v1/media/ingest/jobs"
+    )
   })
 
   it("fails closed when no persisted or runtime API origin exists", async () => {
-    const originalDeploymentMode = process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
-    const originalApiUrl = process.env.NEXT_PUBLIC_API_URL
-    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window")
     const fetchFn = vi.fn()
 
-    process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = "advanced"
     delete process.env.NEXT_PUBLIC_API_URL
-    Object.defineProperty(globalThis, "window", {
-      configurable: true,
-      value: {
-        location: {
-          origin: "https://webui.example.test",
-          protocol: "https:"
-        }
-      }
-    })
 
-    try {
-      const response = await tldwRequest(
-        {
-          path: "/api/v1/media/ingest/jobs",
-          method: "POST",
-          body: new FormData(),
-          noAuth: true
-        },
-        {
-          getConfig: async () => null,
-          fetchFn
-        }
-      )
+    const response = await tldwRequest(
+      {
+        path: "/api/v1/media/ingest/jobs",
+        method: "POST",
+        body: new FormData(),
+        noAuth: true
+      },
+      {
+        getConfig: async () => null,
+        fetchFn
+      }
+    )
 
-      expect(response.ok).toBe(false)
-      expect(response.status).toBe(400)
-      expect(String(response.error || "")).toContain("server not configured")
-      expect(fetchFn).not.toHaveBeenCalled()
-    } finally {
-      if (originalDeploymentMode === undefined) {
-        delete process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
-      } else {
-        process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = originalDeploymentMode
-      }
-      if (originalApiUrl === undefined) {
-        delete process.env.NEXT_PUBLIC_API_URL
-      } else {
-        process.env.NEXT_PUBLIC_API_URL = originalApiUrl
-      }
-      if (originalWindow) {
-        Object.defineProperty(globalThis, "window", originalWindow)
-      } else {
-        Reflect.deleteProperty(globalThis, "window")
-      }
-    }
+    expect(response.ok).toBe(false)
+    expect(response.status).toBe(400)
+    expect(String(response.error || "")).toContain("server not configured")
+    expect(fetchFn).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/packages/ui/src/services/__tests__/request-core.path-normalization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/request-core.path-normalization.test.ts
@@ -61,6 +61,124 @@ describe("request-core media path normalization", () => {
   })
 })
 
+describe("request-core advanced WebUI transport", () => {
+  it("uses the runtime API origin without a persisted server URL", async () => {
+    const originalDeploymentMode = process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
+    const originalApiUrl = process.env.NEXT_PUBLIC_API_URL
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window")
+    const fetchFn = vi.fn(async () =>
+      new Response(JSON.stringify({ batch_id: "batch-1", jobs: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      })
+    )
+
+    process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = "advanced"
+    process.env.NEXT_PUBLIC_API_URL = "https://api.example.test"
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        location: {
+          origin: "https://webui.example.test",
+          protocol: "https:"
+        }
+      }
+    })
+
+    try {
+      const response = await tldwRequest(
+        {
+          path: "/api/v1/media/ingest/jobs",
+          method: "POST",
+          body: new FormData(),
+          noAuth: true
+        },
+        {
+          getConfig: async () => null,
+          fetchFn
+        }
+      )
+
+      expect(response.ok).toBe(true)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+      expect(getFetchCall(fetchFn)?.[0]).toBe(
+        "https://api.example.test/api/v1/media/ingest/jobs"
+      )
+    } finally {
+      if (originalDeploymentMode === undefined) {
+        delete process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
+      } else {
+        process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = originalDeploymentMode
+      }
+      if (originalApiUrl === undefined) {
+        delete process.env.NEXT_PUBLIC_API_URL
+      } else {
+        process.env.NEXT_PUBLIC_API_URL = originalApiUrl
+      }
+      if (originalWindow) {
+        Object.defineProperty(globalThis, "window", originalWindow)
+      } else {
+        Reflect.deleteProperty(globalThis, "window")
+      }
+    }
+  })
+
+  it("fails closed when no persisted or runtime API origin exists", async () => {
+    const originalDeploymentMode = process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
+    const originalApiUrl = process.env.NEXT_PUBLIC_API_URL
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window")
+    const fetchFn = vi.fn()
+
+    process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = "advanced"
+    delete process.env.NEXT_PUBLIC_API_URL
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        location: {
+          origin: "https://webui.example.test",
+          protocol: "https:"
+        }
+      }
+    })
+
+    try {
+      const response = await tldwRequest(
+        {
+          path: "/api/v1/media/ingest/jobs",
+          method: "POST",
+          body: new FormData(),
+          noAuth: true
+        },
+        {
+          getConfig: async () => null,
+          fetchFn
+        }
+      )
+
+      expect(response.ok).toBe(false)
+      expect(response.status).toBe(400)
+      expect(String(response.error || "")).toContain("server not configured")
+      expect(fetchFn).not.toHaveBeenCalled()
+    } finally {
+      if (originalDeploymentMode === undefined) {
+        delete process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
+      } else {
+        process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = originalDeploymentMode
+      }
+      if (originalApiUrl === undefined) {
+        delete process.env.NEXT_PUBLIC_API_URL
+      } else {
+        process.env.NEXT_PUBLIC_API_URL = originalApiUrl
+      }
+      if (originalWindow) {
+        Object.defineProperty(globalThis, "window", originalWindow)
+      } else {
+        Reflect.deleteProperty(globalThis, "window")
+      }
+    }
+  })
+})
+
 describe("request-core absolute URL policy", () => {
   it("rejects absolute URLs by default when no allowlist is configured", async () => {
     const fetchFn = vi.fn(async () =>

--- a/apps/packages/ui/src/services/background-proxy.ts
+++ b/apps/packages/ui/src/services/background-proxy.ts
@@ -7,6 +7,7 @@ import {
   resolveBrowserRequestTransport,
   tldwRequest
 } from "@/services/tldw/request-core"
+import { resolveAdvancedRequestTransportGuard } from "@/services/tldw/browser-networking"
 import { getRuntimeSingleUserApiKeyOverride } from "@/services/tldw/runtime-auth-override"
 import {
   BACKEND_UNREACHABLE_EVENT,
@@ -22,8 +23,7 @@ import type {
 } from "@/services/tldw/openapi-guard"
 import {
   isAbsoluteUrlAllowlisted,
-  isSameOriginAbsoluteUrlForConfiguredServer,
-  parseHttpOrigin
+  isSameOriginAbsoluteUrlForConfiguredServer
 } from "@/utils/absolute-url-guard"
 
 const ERROR_LOG_THROTTLE_MS = 15_000
@@ -1092,21 +1092,19 @@ async function* bgStreamDirect<
         })
       : null
   const hostedMode = transport?.mode === "hosted"
-  const advancedTransportOrigin =
-    transport?.mode === "advanced" ? parseHttpOrigin(transport?.url) : null
+  const advancedTransportGuard = resolveAdvancedRequestTransportGuard({
+    transport,
+    hasConfiguredServerUrl: Boolean(cfg?.serverUrl),
+    isAbsolute
+  })
   if (isAbsolute && !isAbsoluteUrlAllowlisted(absolutePath, cfg)) {
     throw new Error(ABSOLUTE_URL_BLOCK_ERROR)
   }
-  if (
-    !cfg?.serverUrl &&
-    !isAbsolute &&
-    transport?.mode === "advanced" &&
-    !advancedTransportOrigin
-  ) {
+  if (advancedTransportGuard.isUnconfigured) {
     throw new Error("tldw server not configured")
   }
   const baseUrl =
-    advancedTransportOrigin ||
+    advancedTransportGuard.origin ||
     (cfg?.serverUrl ? String(cfg.serverUrl).replace(/\/$/, "") : "")
   const url = isAbsolute
     ? absolutePath

--- a/apps/packages/ui/src/services/tldw/browser-networking.ts
+++ b/apps/packages/ui/src/services/tldw/browser-networking.ts
@@ -22,6 +22,22 @@ type ResolveBrowserTransportInput = {
   apiOrigin?: string | null
 }
 
+type AdvancedRequestTransportLike = {
+  mode: string
+  url: string
+}
+
+type ResolveAdvancedRequestTransportGuardInput = {
+  transport?: AdvancedRequestTransportLike | null
+  hasConfiguredServerUrl: boolean
+  isAbsolute: boolean
+}
+
+export type AdvancedRequestTransportGuard = {
+  origin: string | null
+  isUnconfigured: boolean
+}
+
 const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, "")
 
 const normalizeString = (value?: string | null): string =>
@@ -51,6 +67,25 @@ const normalizeOrigin = (value?: string | null): string => {
   }
 
   return trimTrailingSlash(normalizeString(value))
+}
+
+export const resolveAdvancedRequestTransportGuard = ({
+  transport,
+  hasConfiguredServerUrl,
+  isAbsolute
+}: ResolveAdvancedRequestTransportGuardInput): AdvancedRequestTransportGuard => {
+  const parsedOrigin =
+    transport?.mode === "advanced" ? parseHttpOrigin(transport.url) : null
+  const origin = parsedOrigin?.origin.toLowerCase() ?? null
+
+  return {
+    origin,
+    isUnconfigured:
+      !hasConfiguredServerUrl &&
+      !isAbsolute &&
+      transport?.mode === "advanced" &&
+      !origin
+  }
 }
 
 export const resolveBrowserTransportMode = (

--- a/apps/packages/ui/src/services/tldw/request-core.ts
+++ b/apps/packages/ui/src/services/tldw/request-core.ts
@@ -5,6 +5,7 @@ import type { ApiSendResponse } from "@/services/api-send"
 import { isHostedTldwDeployment } from "@/services/tldw/deployment-mode"
 import {
   buildBrowserHttpBase,
+  resolveAdvancedRequestTransportGuard,
   resolveBrowserTransport,
   type BrowserSurface
 } from "@/services/tldw/browser-networking"
@@ -13,7 +14,6 @@ import {
   ABSOLUTE_URL_BLOCK_ERROR,
   isAbsoluteUrlAllowlisted as guardIsAbsoluteUrlAllowlisted,
   isSameOriginAbsoluteUrlForConfiguredServer as guardIsSameOriginAbsoluteUrlForConfiguredServer,
-  parseHttpOrigin,
   type AllowlistWarnHooks
 } from "@/utils/absolute-url-guard"
 
@@ -284,8 +284,11 @@ export const tldwRequest = async (
         })
       : null
   const hostedMode = transport?.mode === "hosted"
-  const advancedTransportOrigin =
-    transport?.mode === "advanced" ? parseHttpOrigin(transport.url) : null
+  const advancedTransportGuard = resolveAdvancedRequestTransportGuard({
+    transport,
+    hasConfiguredServerUrl: Boolean(cfg?.serverUrl),
+    isAbsolute
+  })
   const sameOriginAbsoluteUrl =
     isAbsolute && isSameOriginAbsoluteUrlForConfiguredServer(absolutePath, cfg)
   if (
@@ -299,12 +302,7 @@ export const tldwRequest = async (
       error: ABSOLUTE_URL_BLOCK_ERROR
     }
   }
-  if (
-    !cfg?.serverUrl &&
-    !isAbsolute &&
-    transport?.mode === "advanced" &&
-    !advancedTransportOrigin
-  ) {
+  if (advancedTransportGuard.isUnconfigured) {
     return { ok: false, status: 400, error: "tldw server not configured" }
   }
   if (!normalizedPath) {

--- a/apps/packages/ui/src/services/tldw/request-core.ts
+++ b/apps/packages/ui/src/services/tldw/request-core.ts
@@ -13,6 +13,7 @@ import {
   ABSOLUTE_URL_BLOCK_ERROR,
   isAbsoluteUrlAllowlisted as guardIsAbsoluteUrlAllowlisted,
   isSameOriginAbsoluteUrlForConfiguredServer as guardIsSameOriginAbsoluteUrlForConfiguredServer,
+  parseHttpOrigin,
   type AllowlistWarnHooks
 } from "@/utils/absolute-url-guard"
 
@@ -283,6 +284,8 @@ export const tldwRequest = async (
         })
       : null
   const hostedMode = transport?.mode === "hosted"
+  const advancedTransportOrigin =
+    transport?.mode === "advanced" ? parseHttpOrigin(transport.url) : null
   const sameOriginAbsoluteUrl =
     isAbsolute && isSameOriginAbsoluteUrlForConfiguredServer(absolutePath, cfg)
   if (
@@ -296,7 +299,12 @@ export const tldwRequest = async (
       error: ABSOLUTE_URL_BLOCK_ERROR
     }
   }
-  if (!cfg?.serverUrl && !isAbsolute && transport?.mode === "advanced") {
+  if (
+    !cfg?.serverUrl &&
+    !isAbsolute &&
+    transport?.mode === "advanced" &&
+    !advancedTransportOrigin
+  ) {
     return { ok: false, status: 400, error: "tldw server not configured" }
   }
   if (!normalizedPath) {

--- a/backlog/tasks/task-12945 - Fix-advanced-WebUI-Quick-Ingest-transport-without-persisted-server-URL.md
+++ b/backlog/tasks/task-12945 - Fix-advanced-WebUI-Quick-Ingest-transport-without-persisted-server-URL.md
@@ -4,7 +4,7 @@ title: Fix advanced WebUI Quick Ingest transport without persisted server URL
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-10 05:20'
+updated_date: '2026-07-10 05:27'
 labels:
   - frontend
   - quick-ingest
@@ -36,6 +36,8 @@ UAT on release 0.1.40 found that Quick Ingest direct uploads fail before reachin
 
 <!-- SECTION:NOTES:BEGIN -->
 Full-stack CDP UAT remains valid: with localStorage.tldwConfig removed immediately before submission, Quick preset sent an authenticated POST to the runtime API origin; batch 05dd45df-9788-4618-91e3-63328861aade / job 1 completed with 1 succeeded and 0 failed, and SQLite stored media ID 1 (Me at the zoo) with 210 content characters. PR #2703 review follow-up addressed all three inline findings: narrowly matched client configuration errors, deduplicated test fixtures, and centralized foreground/background advanced transport validation. Verification: 35 request/classification tests and 63 networking/background-proxy tests passed; frontend typecheck passed; touched-file ESLint had 0 errors with existing warnings only; git diff --check passed. Bandit remains not applicable because only TypeScript, tests, and Backlog metadata changed.
+
+Post-push Qodo feedback was also addressed: classifyError documentation now describes table-order precedence including job-limit and client-configuration categories. The 26 classifier tests and touched-file ESLint passed after this documentation update.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12945 - Fix-advanced-WebUI-Quick-Ingest-transport-without-persisted-server-URL.md
+++ b/backlog/tasks/task-12945 - Fix-advanced-WebUI-Quick-Ingest-transport-without-persisted-server-URL.md
@@ -4,7 +4,7 @@ title: Fix advanced WebUI Quick Ingest transport without persisted server URL
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-10 04:59'
+updated_date: '2026-07-10 05:20'
 labels:
   - frontend
   - quick-ingest
@@ -35,15 +35,13 @@ UAT on release 0.1.40 found that Quick Ingest direct uploads fail before reachin
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Full-stack CDP UAT completed after the patched WebUI and isolated backend were launched on ports 18180 and 18000. With localStorage.tldwConfig removed immediately before submission, Quick preset sent an authenticated POST to http://127.0.0.1:18000/api/v1/media/ingest/jobs and received batch 05dd45df-9788-4618-91e3-63328861aade / job 1. The WebUI's own polling completed with 1 succeeded, 0 failed in 15 seconds. SQLite verification found media ID 1, title 'Me at the zoo', exact YouTube URL, type video, and 210 content characters. Screenshot: /tmp/quick-ingest-advanced-transport-uat.png. The initial attempt to remove every connection-related storage key was intentionally discarded because it destabilized unrelated connection state; the authoritative regression check removes only tldwConfig, which is the config source evaluated by the request guard, while retaining runtime/bootstrap mirrors.
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+Full-stack CDP UAT remains valid: with localStorage.tldwConfig removed immediately before submission, Quick preset sent an authenticated POST to the runtime API origin; batch 05dd45df-9788-4618-91e3-63328861aade / job 1 completed with 1 succeeded and 0 failed, and SQLite stored media ID 1 (Me at the zoo) with 210 content characters. PR #2703 review follow-up addressed all three inline findings: narrowly matched client configuration errors, deduplicated test fixtures, and centralized foreground/background advanced transport validation. Verification: 35 request/classification tests and 63 networking/background-proxy tests passed; frontend typecheck passed; touched-file ESLint had 0 errors with existing warnings only; git diff --check passed. Bandit remains not applicable because only TypeScript, tests, and Backlog metadata changed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed advanced WebUI requests so a valid resolved NEXT_PUBLIC_API_URL transport is accepted when tldwConfig.serverUrl is absent, while retaining fail-closed behavior for invalid or missing origins. Added focused request-core and Quick Ingest error-classification regression tests, and classified missing server configuration as an auth/configuration issue instead of an unsupported file format. Verified with focused Vitest, frontend typecheck, touched-file ESLint, git diff checks, and full-stack CDP UAT of a real YouTube Quick Ingest that stored 'Me at the zoo' with transcript content.
+Fixed advanced WebUI requests so a valid resolved NEXT_PUBLIC_API_URL transport is accepted when tldwConfig.serverUrl is absent while invalid or missing origins remain fail-closed. Configuration errors are narrowly classified without capturing unrelated backend messages. Review follow-up centralized advanced transport origin/validation for request-core and background-proxy and reduced test fixture duplication. Focused tests, background-proxy suites, typecheck, lint, diff checks, and full-stack YouTube ingestion UAT passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12945 - Fix-advanced-WebUI-Quick-Ingest-transport-without-persisted-server-URL.md
+++ b/backlog/tasks/task-12945 - Fix-advanced-WebUI-Quick-Ingest-transport-without-persisted-server-URL.md
@@ -1,17 +1,21 @@
 ---
 id: TASK-12945
 title: Fix advanced WebUI Quick Ingest transport without persisted server URL
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-10 04:59'
 labels:
-- frontend
-- quick-ingest
-- bug
-- uat
+  - frontend
+  - quick-ingest
+  - bug
+  - uat
+dependencies: []
+references:
+  - 'PR #2702 release UAT'
+  - 'https://github.com/rmusser01/tldw_server/pull/2702'
 priority: high
 ordinal: 12105
-references:
-- 'PR #2702 release UAT'
-- https://github.com/rmusser01/tldw_server/pull/2702
 ---
 
 ## Description
@@ -22,30 +26,32 @@ UAT on release 0.1.40 found that Quick Ingest direct uploads fail before reachin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Direct browser upload requests use the resolved advanced NEXT_PUBLIC_API_URL origin when persisted serverUrl is unset.
-- [ ] #2 Advanced requests still fail closed when neither persisted nor runtime API origin resolves to a valid HTTP origin.
-- [ ] #3 A missing server configuration is not presented as an unsupported file format.
-- [ ] #4 Focused frontend tests and typecheck pass.
+- [x] #1 Direct browser upload requests use the resolved advanced NEXT_PUBLIC_API_URL origin when persisted serverUrl is unset.
+- [x] #2 Advanced requests still fail closed when neither persisted nor runtime API origin resolves to a valid HTTP origin.
+- [x] #3 A missing server configuration is not presented as an unsupported file format.
+- [x] #4 Focused frontend tests and typecheck pass.
 <!-- AC:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Full-stack CDP UAT completed after the patched WebUI and isolated backend were launched on ports 18180 and 18000. With localStorage.tldwConfig removed immediately before submission, Quick preset sent an authenticated POST to http://127.0.0.1:18000/api/v1/media/ingest/jobs and received batch 05dd45df-9788-4618-91e3-63328861aade / job 1. The WebUI's own polling completed with 1 succeeded, 0 failed in 15 seconds. SQLite verification found media ID 1, title 'Me at the zoo', exact YouTube URL, type video, and 210 content characters. Screenshot: /tmp/quick-ingest-advanced-transport-uat.png. The initial attempt to remove every connection-related storage key was intentionally discarded because it destabilized unrelated connection state; the authoritative regression check removes only tldwConfig, which is the config source evaluated by the request guard, while retaining runtime/bootstrap mirrors.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Fixed advanced WebUI requests so a valid resolved NEXT_PUBLIC_API_URL transport is accepted when tldwConfig.serverUrl is absent, while retaining fail-closed behavior for invalid or missing origins. Added focused request-core and Quick Ingest error-classification regression tests, and classified missing server configuration as an auth/configuration issue instead of an unsupported file format. Verified with focused Vitest, frontend typecheck, touched-file ESLint, git diff checks, and full-stack CDP UAT of a real YouTube Quick Ingest that stored 'Me at the zoo' with transcript content.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12945 - Fix-advanced-WebUI-Quick-Ingest-transport-without-persisted-server-URL.md
+++ b/backlog/tasks/task-12945 - Fix-advanced-WebUI-Quick-Ingest-transport-without-persisted-server-URL.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12945
+title: Fix advanced WebUI Quick Ingest transport without persisted server URL
+status: In Progress
+labels:
+- frontend
+- quick-ingest
+- bug
+- uat
+priority: high
+ordinal: 12105
+references:
+- 'PR #2702 release UAT'
+- https://github.com/rmusser01/tldw_server/pull/2702
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+UAT on release 0.1.40 found that Quick Ingest direct uploads fail before reaching the backend when advanced WebUI mode is configured via NEXT_PUBLIC_API_URL but tldwConfig.serverUrl is unset. Fix the shared request guard, correct the misleading configuration error classification, and add focused regression coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Direct browser upload requests use the resolved advanced NEXT_PUBLIC_API_URL origin when persisted serverUrl is unset.
+- [ ] #2 Advanced requests still fail closed when neither persisted nor runtime API origin resolves to a valid HTTP origin.
+- [ ] #3 A missing server configuration is not presented as an unsupported file format.
+- [ ] #4 Focused frontend tests and typecheck pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary (human-authored; required before merge)

<!-- Requester: explain in your own words what changed and why these implementation choices were made. -->

## Implementation

- Accept a resolved, valid advanced WebUI transport origin when `tldwConfig.serverUrl` is absent, while preserving fail-closed behavior when no valid persisted or runtime origin exists.
- Classify missing-server configuration failures as configuration/auth guidance instead of unsupported-file validation errors.
- Add focused request-core and Quick Ingest classification regressions.

## Verification

- `bunx vitest run src/services/__tests__/request-core.path-normalization.test.ts src/components/Common/QuickIngest/__tests__/ErrorClassification.test.ts --maxWorkers=1 --no-file-parallelism` (34 passed)
- `bun run typecheck` in `apps/tldw-frontend`
- touched-file ESLint: 0 errors; 6 existing `no-explicit-any` warnings in `request-core.ts`
- `git diff --check`
- Bandit not applicable: TypeScript, tests, documentation, and Backlog metadata only

## UAT

- Launched an isolated backend on `127.0.0.1:18000` and patched advanced WebUI on `127.0.0.1:18180`.
- Used Chrome CDP to remove `localStorage.tldwConfig` immediately before submission.
- Quick preset sent authenticated `POST http://127.0.0.1:18000/api/v1/media/ingest/jobs` and received batch `05dd45df-9788-4618-91e3-63328861aade`, job `1`.
- WebUI polling completed with `1 succeeded, 0 failed` in 15 seconds.
- SQLite stored media ID `1`, title `Me at the zoo`, exact YouTube URL, type `video`, and 210 content characters.

Backlog: `TASK-12945`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes advanced WebUI Quick Ingest so direct uploads work without a persisted server URL by using the resolved `NEXT_PUBLIC_API_URL` origin. Clarifies error classification priority and messaging; completes TASK-12945.

- **Bug Fixes**
  - `tldwRequest` and background proxy accept advanced transport when `tldwConfig.serverUrl` is empty if the resolved origin is valid; still fail-closed when no valid origin exists.
  - Quick Ingest UI: map “HTTP 400: tldw server not configured” to a configuration/auth category before broader 400 handling.
  - Centralized advanced transport validation in `resolveAdvancedRequestTransportGuard` and applied it in both request-core and background proxy; added focused service/classifier tests and documented table-order priority.

<sup>Written for commit b2114c18255e340df515dda9cd19c387c07833d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

