### PR TITLE
Fix Quick Ingest defaults render loop

### DIFF
--- a/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/AddContentStep.tsx
@@ -231,6 +231,7 @@ type AddContentStepProps = {
   connectionRecoveryMessage?: string
   onRetryConnection?: () => void
   onQuickProcess?: () => void
+  quickProcessWarning?: string | null
 }
 
 export const AddContentStep: React.FC<AddContentStepProps> = ({
@@ -239,6 +240,7 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
   connectionRecoveryMessage,
   onRetryConnection,
   onQuickProcess,
+  quickProcessWarning = null,
 }) => {
   const { t } = useTranslation(["option"])
   const {
@@ -865,6 +867,16 @@ export const AddContentStep: React.FC<AddContentStepProps> = ({
       )}
 
       {hasItems && <BatchMetadataPanel />}
+
+      {hasItems && quickProcessWarning && (
+        <DesignSystemAlert
+          variant="warning"
+          role="alert"
+          icon={<AlertTriangle className="h-4 w-4" aria-hidden="true" />}
+          className="mt-3"
+          title={quickProcessWarning}
+        />
+      )}
 
       {/* Action buttons */}
       <div className="mt-4 flex items-center justify-end gap-2">

--- a/apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
 import { AlertTriangle, Loader2, Check, ExternalLink, XCircle } from "lucide-react"
+import { shallow } from "zustand/shallow"
 import { useIngestWizard } from "./IngestWizardContext"
 import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
 import type { WizardResultItem } from "./types"
@@ -88,11 +89,14 @@ export const FloatingProgressWidget: React.FC = () => {
   const { t } = useTranslation(["option"])
   const { state, restore } = useIngestWizard()
   const { processingState, isMinimized, results, conferenceBatchMetadata } = state
-  const { sessionVisibility, sessionLifecycle, showSession } = useQuickIngestSessionStore((store) => ({
-    sessionLifecycle: store.session?.lifecycle,
-    sessionVisibility: store.session?.visibility,
-    showSession: store.showSession,
-  }))
+  const { sessionVisibility, sessionLifecycle, showSession } = useQuickIngestSessionStore(
+    (store) => ({
+      sessionLifecycle: store.session?.lifecycle,
+      sessionVisibility: store.session?.visibility,
+      showSession: store.showSession,
+    }),
+    shallow
+  )
   const [dismissed, setDismissed] = useState(false)
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 

--- a/apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/FloatingProgressWidget.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
 import { AlertTriangle, Loader2, Check, ExternalLink, XCircle } from "lucide-react"
-import { shallow } from "zustand/shallow"
+import { useShallow } from "zustand/react/shallow"
 import { useIngestWizard } from "./IngestWizardContext"
 import { useQuickIngestSessionStore } from "@/store/quick-ingest-session"
 import type { WizardResultItem } from "./types"
@@ -90,12 +90,11 @@ export const FloatingProgressWidget: React.FC = () => {
   const { state, restore } = useIngestWizard()
   const { processingState, isMinimized, results, conferenceBatchMetadata } = state
   const { sessionVisibility, sessionLifecycle, showSession } = useQuickIngestSessionStore(
-    (store) => ({
+    useShallow((store) => ({
       sessionLifecycle: store.session?.lifecycle,
       sessionVisibility: store.session?.visibility,
       showSession: store.showSession,
-    }),
-    shallow
+    }))
   )
   const [dismissed, setDismissed] = useState(false)
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -222,6 +221,7 @@ export const FloatingProgressWidget: React.FC = () => {
 
   // Only render when minimized and not dismissed
   if (!isMinimized || sessionVisibility !== "hidden" || dismissed) return null
+  if (totalCount === 0 && !terminalState) return null
 
   const estimatedText =
     processingState.estimatedRemaining > 0

--- a/apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
@@ -343,16 +343,16 @@ const reducer = (state: IngestWizardState, action: Action): IngestWizardState =>
       }
 
     case "UPDATE_ITEM_PROGRESS":
+      const existingProgressItem = state.processingState.perItemProgress.find(
+        (p) => p.id === action.progress.id
+      )
+      if (!existingProgressItem) return state
       if (
-        state.processingState.perItemProgress.some(
-          (p) =>
-            p.id === action.progress.id &&
-            p.status === action.progress.status &&
-            p.progressPercent === action.progress.progressPercent &&
-            p.currentStage === action.progress.currentStage &&
-            p.estimatedRemaining === action.progress.estimatedRemaining &&
-            p.error === action.progress.error
-        )
+        existingProgressItem.status === action.progress.status &&
+        existingProgressItem.progressPercent === action.progress.progressPercent &&
+        existingProgressItem.currentStage === action.progress.currentStage &&
+        existingProgressItem.estimatedRemaining === action.progress.estimatedRemaining &&
+        existingProgressItem.error === action.progress.error
       ) {
         return state
       }

--- a/apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/IngestWizardContext.tsx
@@ -343,6 +343,19 @@ const reducer = (state: IngestWizardState, action: Action): IngestWizardState =>
       }
 
     case "UPDATE_ITEM_PROGRESS":
+      if (
+        state.processingState.perItemProgress.some(
+          (p) =>
+            p.id === action.progress.id &&
+            p.status === action.progress.status &&
+            p.progressPercent === action.progress.progressPercent &&
+            p.currentStage === action.progress.currentStage &&
+            p.estimatedRemaining === action.progress.estimatedRemaining &&
+            p.error === action.progress.error
+        )
+      ) {
+        return state
+      }
       return {
         ...state,
         processingState: {
@@ -354,12 +367,21 @@ const reducer = (state: IngestWizardState, action: Action): IngestWizardState =>
       }
 
     case "UPDATE_PROCESSING_STATE":
+      if (
+        Object.entries(action.state).every(
+          ([key, value]) =>
+            state.processingState[key as keyof WizardProcessingState] === value
+        )
+      ) {
+        return state
+      }
       return {
         ...state,
         processingState: { ...state.processingState, ...action.state },
       }
 
     case "SET_RESULTS":
+      if (state.results === action.results) return state
       return { ...state, results: action.results }
 
     case "SKIP_TO_PROCESSING": {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -330,6 +330,18 @@ const emitRuntimeMessage = (message: any) => {
   }
 }
 
+const SessionBackedQuickIngestModal = () => {
+  const open = useQuickIngestSessionStore(
+    (store) => store.session?.visibility === "visible"
+  )
+  return (
+    <QuickIngestWizardModal
+      open={open}
+      onClose={() => useQuickIngestSessionStore.getState().hideSession()}
+    />
+  )
+}
+
 describe("QuickIngestWizardModal session runtime", () => {
   beforeEach(() => {
     mocks.runtimeListeners.splice(0, mocks.runtimeListeners.length)
@@ -425,6 +437,56 @@ describe("QuickIngestWizardModal session runtime", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Choose an analysis provider before running ingest analysis."
     )
+    expect(screen.queryByTestId("wizard-processing")).not.toBeInTheDocument()
+    expect(mocks.startQuickIngestSession).not.toHaveBeenCalled()
+    expect(mocks.submitQuickIngestBatch).not.toHaveBeenCalled()
+  })
+
+  it("restores a hidden processing session when the late analysis provider guard blocks startRun", async () => {
+    mocks.getQuickIngestAnalysisProviderWarning.mockReturnValue(
+      "Choose an analysis provider before running ingest analysis."
+    )
+    useQuickIngestSessionStore.getState().createDraftSession({
+      visibility: "hidden",
+      lifecycle: "processing",
+      currentStep: 4,
+      queueItems: [
+        {
+          id: "late-guard-url-1",
+          url: "https://example.com/article",
+          detectedType: "web",
+          icon: "Globe",
+          fileSize: 0,
+          validation: { valid: true },
+        },
+      ],
+      processingState: {
+        status: "running",
+        perItemProgress: [
+          {
+            id: "late-guard-url-1",
+            status: "processing",
+            progressPercent: 10,
+            currentStage: "Processing",
+            estimatedRemaining: 0,
+          },
+        ],
+        elapsed: 0,
+        estimatedRemaining: 0,
+      },
+    })
+
+    render(<SessionBackedQuickIngestModal />)
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Choose an analysis provider before running ingest analysis."
+      )
+    })
+
+    const session = useQuickIngestSessionStore.getState().session
+    expect(session?.visibility).toBe("visible")
+    expect(session?.currentStep).toBe(1)
     expect(screen.queryByTestId("wizard-processing")).not.toBeInTheDocument()
     expect(mocks.startQuickIngestSession).not.toHaveBeenCalled()
     expect(mocks.submitQuickIngestBatch).not.toHaveBeenCalled()

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   submitQuickIngestBatch: vi.fn(),
   cancelQuickIngestSession: vi.fn(),
   reattachQuickIngestSession: vi.fn(),
+  getQuickIngestAnalysisProviderWarning: vi.fn(),
   checkConnection: vi.fn(),
   navigate: vi.fn(),
   runtimeListeners: [] as Array<(message: any) => void>,
@@ -152,6 +153,8 @@ vi.mock("@/services/tldw/quick-ingest-batch", () => ({
   startQuickIngestSession: (...args: unknown[]) => mocks.startQuickIngestSession(...args),
   submitQuickIngestBatch: (...args: unknown[]) => mocks.submitQuickIngestBatch(...args),
   cancelQuickIngestSession: (...args: unknown[]) => mocks.cancelQuickIngestSession(...args),
+  getQuickIngestAnalysisProviderWarning: (...args: unknown[]) =>
+    mocks.getQuickIngestAnalysisProviderWarning(...args),
 }))
 
 vi.mock("@/services/tldw/quick-ingest-session-reattach", () => ({
@@ -174,11 +177,18 @@ vi.mock("@/components/Common/QuickIngest/AddContentStep", async () => {
     typeof import("@/components/Common/QuickIngest/IngestWizardContext")
   >("@/components/Common/QuickIngest/IngestWizardContext")
   return {
-    AddContentStep: ({ onQuickProcess }: { onQuickProcess?: () => void }) => {
+    AddContentStep: ({
+      onQuickProcess,
+      quickProcessWarning,
+    }: {
+      onQuickProcess?: () => void
+      quickProcessWarning?: string | null
+    }) => {
       const context = actual.useIngestWizard() as any
       const { state, setQueueItems } = context
       return (
         <div>
+          {quickProcessWarning ? <div role="alert">{quickProcessWarning}</div> : null}
           <button
             onClick={() => {
               setQueueItems([
@@ -327,6 +337,8 @@ describe("QuickIngestWizardModal session runtime", () => {
     mocks.submitQuickIngestBatch.mockReset()
     mocks.cancelQuickIngestSession.mockReset()
     mocks.reattachQuickIngestSession.mockReset()
+    mocks.getQuickIngestAnalysisProviderWarning.mockReset()
+    mocks.getQuickIngestAnalysisProviderWarning.mockReturnValue(null)
     mocks.checkConnection.mockReset()
     mocks.navigate.mockReset()
     mocks.cancelQuickIngestSession.mockResolvedValue({ ok: true })
@@ -397,6 +409,25 @@ describe("QuickIngestWizardModal session runtime", () => {
     await waitFor(() => {
       expect(screen.getByTestId("wizard-results")).toHaveTextContent("complete:1")
     })
+  })
+
+  it("keeps quick defaults on the add step when analysis needs a provider", async () => {
+    const user = userEvent.setup()
+    useQuickIngestSessionStore.getState().createDraftSession()
+    mocks.getQuickIngestAnalysisProviderWarning.mockReturnValue(
+      "Choose an analysis provider before running ingest analysis."
+    )
+
+    render(<QuickIngestWizardModal open onClose={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: "Queue And Process" }))
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Choose an analysis provider before running ingest analysis."
+    )
+    expect(screen.queryByTestId("wizard-processing")).not.toBeInTheDocument()
+    expect(mocks.startQuickIngestSession).not.toHaveBeenCalled()
+    expect(mocks.submitQuickIngestBatch).not.toHaveBeenCalled()
   })
 
   it("preserves first-source open detail while syncing wizard state", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useRef } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Modal, Button } from "antd"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { XCircle } from "lucide-react"
+import { shallow } from "zustand/shallow"
 import { browser } from "wxt/browser"
 import {
   IngestWizardProvider,
@@ -854,9 +855,11 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
     updateItemProgress,
     updateProcessingState,
     setResults,
+    goToStep,
     goNext,
   } = useIngestWizard()
   const { currentStep, queueItems, processingState, presetConfig, results } = state
+  const [quickProcessWarning, setQuickProcessWarning] = useState<string | null>(null)
   const connectionState = useConnectionStore((store) => store.state)
   const checkConnection = useConnectionStore((store) => store.checkOnce)
   const activeSessionIdRef = useRef<string | null>(null)
@@ -937,6 +940,17 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
   const handleRetryConnection = useCallback(() => {
     void checkConnection()
   }, [checkConnection])
+
+  useEffect(() => {
+    if (!quickProcessWarning) return
+    const analysisProviderWarning = getQuickIngestAnalysisProviderWarning({
+      common: presetConfig.common,
+      advancedValues: presetConfig.advancedValues,
+    })
+    if (!analysisProviderWarning) {
+      setQuickProcessWarning(null)
+    }
+  }, [presetConfig.advancedValues, presetConfig.common, quickProcessWarning])
 
   useEffect(() => {
     resultsRef.current = results
@@ -1410,7 +1424,16 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
         advancedValues: requestPayload.advancedValues,
       })
       if (analysisProviderWarning) {
-        finalizeFailure(analysisProviderWarning, "failed")
+        setQuickProcessWarning(analysisProviderWarning)
+        updateProcessingState({
+          status: "idle",
+          perItemProgress: [],
+          elapsed: 0,
+          estimatedRemaining: 0,
+        })
+        hasStartedRunRef.current = false
+        activeSessionIdRef.current = null
+        goToStep(1)
         return
       }
 
@@ -1492,6 +1515,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
     presetConfig.storeRemote,
     presetConfig.typeDefaults,
     state.conferenceBatchMetadata,
+    goToStep,
     markProcessingTracking,
     validQueueItems,
   ])
@@ -1583,8 +1607,23 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
   // Quick-process callback for AddContentStep (skip to processing with defaults)
   const handleQuickProcess = useCallback(() => {
     if (!isOnlineForIngest || isCheckingConnection) return
+    const analysisProviderWarning = getQuickIngestAnalysisProviderWarning({
+      common: presetConfig.common,
+      advancedValues: presetConfig.advancedValues,
+    })
+    if (analysisProviderWarning) {
+      setQuickProcessWarning(analysisProviderWarning)
+      return
+    }
+    setQuickProcessWarning(null)
     skipToProcessing()
-  }, [isCheckingConnection, isOnlineForIngest, skipToProcessing])
+  }, [
+    isCheckingConnection,
+    isOnlineForIngest,
+    presetConfig.advancedValues,
+    presetConfig.common,
+    skipToProcessing,
+  ])
 
   // Navigation callbacks for WizardResultsStep CTAs
   const navigate = useNavigate()
@@ -1639,6 +1678,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
             connectionRecoveryMessage={connectionRecoveryMessage}
             onRetryConnection={handleRetryConnection}
             onQuickProcess={handleQuickProcess}
+            quickProcessWarning={quickProcessWarning}
           />
         )
       case 2:
@@ -1684,6 +1724,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
     isOnlineForIngest,
     onClose,
     open,
+    quickProcessWarning,
     state.isMinimized,
   ])
 
@@ -1733,13 +1774,16 @@ export const QuickIngestWizardModal: React.FC<QuickIngestWizardModalProps> = ({
     markInterrupted,
     createDraftSession,
   } =
-    useQuickIngestSessionStore((store) => ({
-      session: store.session,
-      upsertSession: store.upsertSession,
-      markProcessingTracking: store.markProcessingTracking,
-      markInterrupted: store.markInterrupted,
-      createDraftSession: store.createDraftSession,
-    }))
+    useQuickIngestSessionStore(
+      (store) => ({
+        session: store.session,
+        upsertSession: store.upsertSession,
+        markProcessingTracking: store.markProcessingTracking,
+        markInterrupted: store.markInterrupted,
+        createDraftSession: store.createDraftSession,
+      }),
+      shallow
+    )
 
   const initialState = useMemo(
     () => (session ? buildInitialWizardState(session) : undefined),

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -3,7 +3,7 @@ import { Modal, Button } from "antd"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { XCircle } from "lucide-react"
-import { shallow } from "zustand/shallow"
+import { useShallow } from "zustand/react/shallow"
 import { browser } from "wxt/browser"
 import {
   IngestWizardProvider,
@@ -833,6 +833,7 @@ type WizardModalContentProps = {
   session: QuickIngestSessionRecord
   markProcessingTracking: (tracking: PersistedQuickIngestTracking) => void
   markInterrupted: (reason?: string) => void
+  showSession: () => void
   shouldAttemptPersistedReattach: boolean
 }
 
@@ -843,6 +844,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
   session,
   markProcessingTracking,
   markInterrupted,
+  showSession,
   shouldAttemptPersistedReattach,
 }) => {
   const { t } = useTranslation(["option"])
@@ -1399,7 +1401,6 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
   const startRun = useCallback(async () => {
     if (hasStartedRunRef.current || validQueueItems.length === 0) return
     hasStartedRunRef.current = true
-    markRunActive()
 
     try {
       try {
@@ -1433,9 +1434,13 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
         })
         hasStartedRunRef.current = false
         activeSessionIdRef.current = null
+        restore()
+        showSession()
         goToStep(1)
         return
       }
+
+      markRunActive()
 
       const startAck = await startQuickIngestSession(requestPayload)
       if (!startAck?.ok || !startAck?.sessionId) {
@@ -1516,6 +1521,8 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
     presetConfig.typeDefaults,
     state.conferenceBatchMetadata,
     goToStep,
+    restore,
+    showSession,
     markProcessingTracking,
     validQueueItems,
   ])
@@ -1773,16 +1780,17 @@ export const QuickIngestWizardModal: React.FC<QuickIngestWizardModalProps> = ({
     markProcessingTracking,
     markInterrupted,
     createDraftSession,
+    showSession,
   } =
     useQuickIngestSessionStore(
-      (store) => ({
+      useShallow((store) => ({
         session: store.session,
         upsertSession: store.upsertSession,
         markProcessingTracking: store.markProcessingTracking,
         markInterrupted: store.markInterrupted,
         createDraftSession: store.createDraftSession,
-      }),
-      shallow
+        showSession: store.showSession,
+      }))
     )
 
   const initialState = useMemo(
@@ -1824,6 +1832,7 @@ export const QuickIngestWizardModal: React.FC<QuickIngestWizardModalProps> = ({
         session={session}
         markProcessingTracking={markProcessingTracking}
         markInterrupted={markInterrupted}
+        showSession={showSession}
         shouldAttemptPersistedReattach={
           session.lifecycle === "processing" &&
           session.tracking?.mode === "webui-direct" &&

--- a/apps/tldw-frontend/e2e/quick-ingest-render-loop.spec.ts
+++ b/apps/tldw-frontend/e2e/quick-ingest-render-loop.spec.ts
@@ -43,7 +43,7 @@ test("Quick Ingest defaults flow does not trigger a Maximum update depth render 
   await expect(dialog).toContainText("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
 
   await dialog.getByRole("button", { name: /Use defaults/i }).click()
-  await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {})
+  await expect(dialog.getByRole("alert")).toContainText(/analysis provider/i)
 
   await expect(page.locator("body")).not.toContainText("Runtime Error")
   expect(renderLoopErrors, "no Maximum update depth render loop").toEqual([])

--- a/apps/tldw-frontend/e2e/quick-ingest-render-loop.spec.ts
+++ b/apps/tldw-frontend/e2e/quick-ingest-render-loop.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect, seedAuth } from "./smoke/smoke.setup"
+
+test("Quick Ingest defaults flow does not trigger a Maximum update depth render loop", async ({
+  page,
+}) => {
+  test.setTimeout(90_000)
+  const renderLoopErrors: string[] = []
+
+  page.on("console", (message) => {
+    if (
+      message.type() === "error" &&
+      /Maximum update depth exceeded/i.test(message.text())
+    ) {
+      renderLoopErrors.push(message.text().slice(0, 240))
+    }
+  })
+  page.on("pageerror", (error) => {
+    if (/Maximum update depth exceeded/i.test(error.message)) {
+      renderLoopErrors.push(error.message)
+    }
+  })
+
+  await page.route("**/api/v1/llm/models/metadata**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ models: [], total: 0 }),
+    })
+  })
+
+  await seedAuth(page)
+  await page.goto("/", { waitUntil: "domcontentloaded" })
+
+  const quickIngestTrigger = page.getByRole("button", { name: /^Quick Ingest$/i }).first()
+  await expect(quickIngestTrigger).toBeVisible({ timeout: 30_000 })
+  await quickIngestTrigger.click()
+
+  const dialog = page.getByRole("dialog", { name: /Quick Ingest/i }).first()
+  await expect(dialog).toBeVisible({ timeout: 30_000 })
+  const urlInput = dialog.locator("textarea").first()
+  await urlInput.fill("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+  await dialog.getByRole("button", { name: /Add URLs/i }).click()
+  await expect(dialog).toContainText("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+
+  await dialog.getByRole("button", { name: /Use defaults/i }).click()
+  await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {})
+
+  await expect(page.locator("body")).not.toContainText("Runtime Error")
+  expect(renderLoopErrors, "no Maximum update depth render loop").toEqual([])
+})

--- a/backlog/tasks/task-12105 - Fix-Quick-Ingest-YouTube-defaults-maximum-update-depth-regression.md
+++ b/backlog/tasks/task-12105 - Fix-Quick-Ingest-YouTube-defaults-maximum-update-depth-regression.md
@@ -1,0 +1,56 @@
+---
+id: TASK-12105
+title: Fix Quick Ingest YouTube defaults maximum update depth regression
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-10 17:00'
+labels:
+  - bug
+  - frontend
+  - quick-ingest
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix the latest-dev Quick Ingest regression where adding a YouTube URL and clicking Use defaults & process triggers React's maximum update depth error. Include focused frontend regression coverage and browser verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Reproduce and identify the latest-dev Quick Ingest YouTube defaults render-loop path
+- [x] Prevent `Use defaults & process` from entering processing when analysis requires a missing provider
+- [x] Add focused unit and browser coverage for the regression path
+- [x] Run targeted tests, typecheck, and browser verification
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Latest-dev investigation used a clean worktree at `.worktrees/investigate-quick-ingest-loop`. PR #2700 is present on `origin/dev` and `origin/main`; the original `/media` render-loop fixes remain.
+
+Root cause: a later commit, `e204d26cce` (`Harden ingest analysis provider UX`), added an analysis-provider guard inside `QuickIngestWizardModal.startRun`. The default Quick Ingest preset has `perform_analysis=true` and no `api_name`, so clicking `Use defaults & process` moves the wizard into processing and then immediately creates a synthetic failed run. In a real browser that reproduced React `Maximum update depth exceeded` through the AntD/rc-portal modal path.
+
+Fix in the clean worktree: detect the missing provider before `skipToProcessing` and keep the user on the add-content step with an inline warning; make the late guard reset back to the add step instead of synthesizing a failed run; shallow-stabilize the Quick Ingest session-store selectors used by the modal/widget; make repeated wizard progress/result reducer updates idempotent. Added a focused Vitest regression and a Playwright E2E spec for the YouTube defaults flow.
+
+Verification: RED session test failed on latest behavior, then passed after fix (22/22); quick-ingest-batch service tests passed (33/33); frontend typecheck passed; Playwright browser regression passed after walking through the Quick Ingest YouTube defaults flow. Bandit was skipped because only frontend TypeScript and Backlog Markdown were touched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the Quick Ingest YouTube defaults render-loop regression by validating the analysis provider before entering processing, keeping the user on the add-content step with an inline warning when defaults require analysis but no provider is selected. Added browser and unit regression coverage for the path and hardened the related modal/session update edges.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12105 - Fix-Quick-Ingest-YouTube-defaults-maximum-update-depth-regression.md
+++ b/backlog/tasks/task-12105 - Fix-Quick-Ingest-YouTube-defaults-maximum-update-depth-regression.md
@@ -4,7 +4,7 @@ title: Fix Quick Ingest YouTube defaults maximum update depth regression
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-10 17:00'
+updated_date: '2026-07-10 19:36'
 labels:
   - bug
   - frontend
@@ -36,12 +36,16 @@ Root cause: a later commit, `e204d26cce` (`Harden ingest analysis provider UX`),
 Fix in the clean worktree: detect the missing provider before `skipToProcessing` and keep the user on the add-content step with an inline warning; make the late guard reset back to the add step instead of synthesizing a failed run; shallow-stabilize the Quick Ingest session-store selectors used by the modal/widget; make repeated wizard progress/result reducer updates idempotent. Added a focused Vitest regression and a Playwright E2E spec for the YouTube defaults flow.
 
 Verification: RED session test failed on latest behavior, then passed after fix (22/22); quick-ingest-batch service tests passed (33/33); frontend typecheck passed; Playwright browser regression passed after walking through the Quick Ingest YouTube defaults flow. Bandit was skipped because only frontend TypeScript and Backlog Markdown were touched.
+
+PR review follow-up: rebased PR #2707 on latest `origin/dev` (already up to date), addressed Gemini/CodeRabbit/Qodo comments by moving `markRunActive()` after the late provider guard, restoring and re-showing hidden/minimized sessions when that guard blocks user action, suppressing the floating widget's non-terminal 0/0 state, switching touched Zustand selectors to `useShallow`, avoiding unknown progress-id reducer array rebuilds, removing the swallowed Playwright `networkidle` catch, and adding late-guard regression coverage. Verification after review fixes: QuickIngestWizardModal session suite passed (23/23), Playwright Quick Ingest browser regression passed, quick-ingest-batch service suite passed (33/33), frontend typecheck passed, and `git diff --check` passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Fixed the Quick Ingest YouTube defaults render-loop regression by validating the analysis provider before entering processing, keeping the user on the add-content step with an inline warning when defaults require analysis but no provider is selected. Added browser and unit regression coverage for the path and hardened the related modal/session update edges.
+
+PR review comments were addressed with an additional late-guard fix for hidden/minimized sessions, a reducer no-op improvement, `useShallow` selector updates, and a stricter Playwright assertion that no longer swallows `networkidle` timeouts.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 


### PR DESCRIPTION
## Summary

- Fixes the Quick Ingest YouTube `Use defaults & process` regression by validating the missing analysis provider before entering processing.
- Keeps the wizard on the add-content step with an inline warning instead of synthesizing an immediate failed processing run.
- Adds browser regression coverage for the reported YouTube defaults flow and focused unit coverage for the missing-provider path.

## Change Summary

Human maintainer required before merge: add a human-written summary explaining what changed and why these implementation choices are correct for this PR.

## Root Cause

`e204d26cce` added an analysis-provider guard inside `QuickIngestWizardModal.startRun`. The default Quick Ingest preset enables analysis but has no provider selected, so the quick-defaults path entered processing and then immediately finalized as failed. In a real browser this reproduced React's `Maximum update depth exceeded` through the AntD/rc-portal modal path.

## Risk & Rollback

Risk is limited to the Quick Ingest modal, its floating progress widget, and the targeted Quick Ingest session reducer paths. The main behavior change is that invalid analysis-provider defaults now stay on Add Content with a warning instead of entering processing.

Rollback: revert the two commits in this PR, or temporarily disable analysis in the default preset if an urgent mitigation is needed while preserving ingestion.

## UX Checklist

- [x] User-visible warning is shown inline when defaults require an analysis provider.
- [x] Hidden/minimized sessions are restored when user action is required.
- [x] Floating widget does not show a misleading non-terminal `0/0` progress state.
- [x] Browser regression test covers the reported YouTube defaults flow.

## Test Plan

- [x] `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000 npx playwright test e2e/quick-ingest-render-loop.spec.ts --project=chromium --reporter=line --workers=1`
- [x] `bun run test -- src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx --reporter=verbose --maxWorkers=1 --no-file-parallelism`
- [x] `bun run test -- src/services/__tests__/quick-ingest-batch.test.ts --reporter=verbose --maxWorkers=1 --no-file-parallelism`
- [x] `bun run typecheck`

## Merge Note

This PR is AI-authored. Per repo policy, the `Change Summary` section above must be replaced by a human-written summary before merge.
