### PR TITLE
Fix Quick Ingest repeat ingestion and YouTube extractor floor

### DIFF
--- a/Docs/Code_Documentation/Ingestion_Pipeline_Video.md
+++ b/Docs/Code_Documentation/Ingestion_Pipeline_Video.md
@@ -81,6 +81,7 @@ Endpoint specifics:
 ## Dependencies & Config
 
 - Requires `ffmpeg` and `yt-dlp`.
+- Existing environments are not updated by pulling new code; update the active environment with `pip install -U "yt-dlp>=2026.7.4"`.
 - Summarization provider is chosen via `api_name`; credentials come from server config.
 
 ## Error Handling & Notes

--- a/Docs/Getting_Started/TROUBLESHOOTING.md
+++ b/Docs/Getting_Started/TROUBLESHOOTING.md
@@ -157,10 +157,10 @@ Verify: `ffmpeg -version`
 
 ### 12. YouTube download fails ("yt-dlp error")
 
-**Symptoms:** URL ingestion returns an error mentioning yt-dlp, HTTP 403, or "format not available".
+**Symptoms:** URL ingestion returns an error mentioning yt-dlp, HTTP 403, "format not available", or YouTube reporting that content is "not available on this app".
 
 **Fix:**
-1. Update yt-dlp to the latest version: `pip install -U yt-dlp`
+1. Update yt-dlp to at least the project minimum: `pip install -U "yt-dlp>=2026.7.4"`
 2. Some sites require cookies. If authentication is needed, configure yt-dlp cookies.
 3. Check if the URL is accessible: `yt-dlp --simulate "YOUR_URL"`
 

--- a/Docs/Published/Getting_Started/TROUBLESHOOTING.md
+++ b/Docs/Published/Getting_Started/TROUBLESHOOTING.md
@@ -157,10 +157,10 @@ Verify: `ffmpeg -version`
 
 ### 12. YouTube download fails ("yt-dlp error")
 
-**Symptoms:** URL ingestion returns an error mentioning yt-dlp, HTTP 403, or "format not available".
+**Symptoms:** URL ingestion returns an error mentioning yt-dlp, HTTP 403, "format not available", or YouTube reporting that content is "not available on this app".
 
 **Fix:**
-1. Update yt-dlp to the latest version: `pip install -U yt-dlp`
+1. Update yt-dlp to at least the project minimum: `pip install -U "yt-dlp>=2026.7.4"`
 2. Some sites require cookies. If authentication is needed, configure yt-dlp cookies.
 3. Check if the URL is accessible: `yt-dlp --simulate "YOUR_URL"`
 

--- a/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
@@ -1,0 +1,385 @@
+# Quick Ingest PR 2709 Review Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve every actionable PR #2709 review finding without adding a new public ingestion parameter, then validate repeat Quick Ingest behavior through real PDF, web-link, and YouTube Shorts user workflows.
+
+**Architecture:** Preserve the two existing web API contracts and propagate their existing analysis booleans into the internal extraction pipeline as an LLM permission gate. Keep the remaining fixes local to their owning boundaries: Watchpack configuration, restored-session polling, persistence classification/logging, dependency diagnostics, and Quick Ingest UI regression coverage.
+
+**Tech Stack:** FastAPI/Pydantic, Python asyncio, yt-dlp, SQLite repository layer, Next.js/Webpack, React/Ant Design, TypeScript, Vitest, Playwright, pytest, Bandit.
+
+---
+
+## File Map
+
+- `apps/tldw-frontend/next.config.mjs`: preserve existing Webpack ignore entries and append absolute backend runtime globs.
+- `apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts`: behavioral Watchpack ignore coverage.
+- `apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts`: bounded retries for transient direct-job reads.
+- `apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts`: transient/permanent reattachment contracts.
+- `apps/packages/ui/src/services/tldw/quick-ingest-batch.ts`: one terminal conference-item status helper.
+- `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`: existing analysis declaration and result classification coverage.
+- `apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx`: retain stable AntD modal styles.
+- `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx`: exact modal style assertions.
+- `apps/extension/tests/e2e/live-ux-workflows.spec.ts`: real waiting assertions in changed workflow helpers.
+- `apps/extension/tests/e2e/quick-ingest-workflows.spec.ts`: two submissions in one mounted app session with console/page-error capture.
+- `apps/extension/tests/e2e/utils/quick-ingest-options.ts`: shared option-toggle helper for the changed Quick Ingest browser tests.
+- `tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py`: restore the established default order and apply an internal request LLM permission gate.
+- `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`: carry the analysis intent through queued, sitemap, URL-level, and recursive scraping.
+- `tldw_Server_API/app/services/enhanced_web_scraping_service.py`: pass the existing API declaration, classify exact duplicate repository results, and redact logged URLs.
+- `tldw_Server_API/app/services/web_scraping_service.py`: forward `perform_analysis`/`summarize_checkbox` to extraction without changing either request schema.
+- `tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py`: default/custom strategy permission-gate tests.
+- `tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py`: service propagation coverage for analysis intent.
+- `tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py`: real duplicate repository, negative, mixed, and log-redaction tests.
+- `tldw_Server_API/app/core/Ingestion_Media_Processing/yt_dlp_support.py`: one-shot, non-blocking installed-version diagnostic.
+- `tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py`: invoke the diagnostic at yt-dlp request boundaries.
+- `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_yt_dlp_support.py`: stale/current/invalid version behavior.
+- `Docs/Code_Documentation/Ingestion_Pipeline_Video.md`: existing-environment update guidance.
+- `backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md`: maintained only through Backlog MCP/CLI.
+
+### Task 1: Preserve Webpack Watch Ignores
+
+**Files:**
+- Modify: `apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts`
+- Modify: `apps/tldw-frontend/next.config.mjs`
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Load `next.config.mjs`, pass `ignored: [/node_modules/, "**/.next/**"]`, and assert both entries survive unchanged. Resolve representative runtime files from the repository workspace and assert appended forward-slash globs match:
+
+```ts
+expect(webpackConfig.watchOptions.ignored).toContain(existingRegex)
+expect(webpackConfig.watchOptions.ignored).toContain("**/.next/**")
+expect(backendPatterns).toEqual(expect.arrayContaining([
+  expect.stringMatching(/\/Databases\/\*\*$/),
+  expect.stringMatching(/\/tldw_Server_API\/Logs\/\*\*$/),
+]))
+```
+
+- [ ] **Step 2: Run the focused test outside the sandbox and verify RED**
+
+Run: `bunx vitest run apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts`
+
+Expected: FAIL because the current filter drops the regular expression and the appended patterns are relative.
+
+- [ ] **Step 3: Implement the minimal normalization**
+
+Keep every non-null Webpack-supported ignore entry, discard only blank strings, and construct absolute globs from the repository workspace root with backslashes normalized to `/`.
+
+- [ ] **Step 4: Run the focused test outside the sandbox and verify GREEN**
+
+Run the Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Commit the isolated config fix**
+
+```bash
+git add apps/tldw-frontend/next.config.mjs apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts
+git commit -m "fix: preserve webui dev watch ignores"
+```
+
+### Task 2: Make Direct-Job Reattachment Tolerate Transient Reads
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts`
+- Modify: `apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts`
+
+- [ ] **Step 1: Write failing transient and permanent tests**
+
+Add one test where `bgRequest` rejects once and then returns `processing`, one where it returns HTTP 503 then `completed`, and retain a 404 test that must interrupt immediately. Use fake timers or inject a zero-delay test seam so retries are deterministic.
+
+- [ ] **Step 2: Run the focused test outside the sandbox and verify RED**
+
+Run: `bunx vitest run apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts`
+
+Expected: transient cases return `interrupted` before the fix.
+
+- [ ] **Step 3: Add one bounded status-read helper**
+
+Retry network exceptions, 408, 429, and 5xx responses at most three attempts using the existing fixed-delay style. Return permanent 401/403/404 and malformed successful responses without retry. Keep `preferDirect: true` on every attempt.
+
+- [ ] **Step 4: Run focused reattachment and session tests outside the sandbox**
+
+Run:
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx \
+  apps/packages/ui/src/store/__tests__/quick-ingest-session.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the reattachment fix**
+
+```bash
+git add apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts
+git commit -m "fix: retry transient quick ingest job reads"
+```
+
+### Task 3: Correct Duplicate Persistence, Status, and URL Logging
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py`
+- Modify: `tldw_Server_API/app/services/enhanced_web_scraping_service.py`
+- Modify: `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
+- Modify: `apps/packages/ui/src/services/tldw/quick-ingest-batch.ts`
+
+- [ ] **Step 1: Write failing backend boundary tests**
+
+Add coverage for:
+
+1. Persist the same successful article twice through the temporary real Media DB. The second call must return `status == "duplicate"`, no `media_ids`, `stored_articles == 0`, and one duplicate/skipped article.
+2. An extraction failure such as `"deduplicate worker unavailable"` without `is_duplicate is True` or `error_code == "duplicate_content"` remains an error.
+3. A batch containing one exact duplicate and one unrelated failure returns errors and does not collapse to all-duplicate status.
+4. A URL containing `?token=secret-value` never writes `secret-value` to captured logs.
+
+- [ ] **Step 2: Run the backend test outside the sandbox and verify RED**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py -q`
+
+Expected: FAIL because a repository duplicate ID is counted as stored and broad substring matching classifies unrelated failures as duplicates.
+
+- [ ] **Step 3: Implement exact duplicate classification**
+
+Treat extraction output as duplicate only for `is_duplicate is True` or `error_code == "duplicate_content"`. After `add_media_with_keywords`, inspect its repository-owned message and classify only the two exact overwrite-disabled forms as duplicate; do not append that returned existing ID to `media_ids`. Preserve canonicalization, overwrite, and insert/update success behavior. Use `redact_url_for_log` for every touched article URL log.
+
+- [ ] **Step 4: Write the failing frontend terminal-status helper test**
+
+Extend batch tests to prove duplicate wins over completed, error wins over completed, and success remains completed for conference collection patches.
+
+- [ ] **Step 5: Replace the repeated ternary with one local helper**
+
+```ts
+const terminalConferenceStatus = (skipped: boolean, error?: string) =>
+  skipped ? "skipped_existing" : error ? "failed" : "completed"
+```
+
+- [ ] **Step 6: Run backend and frontend focused tests outside the sandbox**
+
+Run the Step 2 command and:
+
+`bunx vitest run apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit duplicate and logging corrections**
+
+```bash
+git add tldw_Server_API/app/services/enhanced_web_scraping_service.py tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py apps/packages/ui/src/services/tldw/quick-ingest-batch.ts apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+git commit -m "fix: classify persisted web duplicates exactly"
+```
+
+### Task 4: Honor Existing API Analysis Declarations
+
+**Files:**
+- Modify: `tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py`
+- Modify: `tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py`
+- Modify: `tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py`
+- Modify: `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`
+- Modify: `tldw_Server_API/app/services/enhanced_web_scraping_service.py`
+- Modify: `tldw_Server_API/app/services/web_scraping_service.py`
+- Modify: `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
+
+- [ ] **Step 1: Write failing extraction permission tests**
+
+Assert the global `DEFAULT_EXTRACTION_STRATEGY_ORDER` includes `llm`. For both the default order and a custom router order containing `llm`, assert `allow_llm_extraction=False` removes only `llm` while preserving relative order; assert `True` leaves the order intact.
+
+- [ ] **Step 2: Write failing API/service propagation tests**
+
+Patch the scraper boundary and verify:
+
+- `/process-web-scraping` with `summarize_checkbox=False` reaches extraction with `allow_llm_extraction=False`;
+- the same path with `True` reaches it with `True`;
+- `/ingest-web-content` maps `perform_analysis` identically;
+- Quick Ingest still sends only its existing `summarize_checkbox` declaration and no `strategy_order`/`extraction_strategy_order` property.
+
+- [ ] **Step 3: Run the focused backend/frontend tests outside the sandbox and verify RED**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py \
+  tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py -q
+bunx vitest run apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+```
+
+Expected: default-order assertion and propagation assertions fail.
+
+- [ ] **Step 4: Implement the internal permission gate**
+
+Restore `"llm"` in `DEFAULT_EXTRACTION_STRATEGY_ORDER`. Add an internal optional `allow_llm_extraction: bool = True` argument at scraper functions only, never to Pydantic request schemas. Resolve the effective order once per article:
+
+```python
+order, unknown = _normalize_strategy_order(strategy_order)
+if not allow_llm_extraction:
+    order = [strategy for strategy in order if strategy != "llm"]
+```
+
+Carry the existing `summarize_checkbox`/`perform_analysis` boolean through individual, sitemap, URL-level, recursive, and queued-job metadata paths. Keep direct non-API scraper consumers backward compatible with the default `True`.
+
+- [ ] **Step 5: Run focused and adjacent web-scraping tests outside the sandbox**
+
+Run the Step 3 commands plus:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/WebScraping/test_phase1_compatibility_contracts.py \
+  tldw_Server_API/tests/WebScraping/test_llm_extraction.py \
+  tldw_Server_API/tests/WebScraping/integration/test_llm_extraction_pipeline.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the declaration wiring fix**
+
+```bash
+git add tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py tldw_Server_API/app/services/enhanced_web_scraping_service.py tldw_Server_API/app/services/web_scraping_service.py tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+git commit -m "fix: honor web analysis intent during extraction"
+```
+
+### Task 5: Warn Once for Stale yt-dlp
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Ingestion_Media_Processing/yt_dlp_support.py`
+- Create: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_yt_dlp_support.py`
+- Modify: `tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py`
+- Modify: `Docs/Code_Documentation/Ingestion_Pipeline_Video.md`
+
+- [ ] **Step 1: Write failing version diagnostic tests**
+
+Patch installed-version lookup and logging to prove versions below `2026.7.4` emit exactly one warning containing `pip install -U "yt-dlp>=2026.7.4"`; current versions emit none; missing or malformed metadata never raises.
+
+- [ ] **Step 2: Run the focused test outside the sandbox and verify RED**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/MediaIngestion_NEW/unit/test_yt_dlp_support.py -q`
+
+Expected: FAIL because the helper does not exist.
+
+- [ ] **Step 3: Implement a minimal one-shot helper**
+
+Use `importlib.metadata.version("yt-dlp")` and `packaging.version.Version`. Keep module state only for suppressing duplicate warnings. Return normally for every lookup or parse failure. Call it immediately before video yt-dlp request boundaries, after outbound URL validation so unrelated/blocked requests do not create misleading diagnostics.
+
+- [ ] **Step 4: Run focused video tests outside the sandbox**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_yt_dlp_support.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_video_boundary_regressions.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_youtube_audio_downloads.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the diagnostic**
+
+```bash
+git add tldw_Server_API/app/core/Ingestion_Media_Processing/yt_dlp_support.py tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_yt_dlp_support.py Docs/Code_Documentation/Ingestion_Pipeline_Video.md
+git commit -m "fix: warn when yt-dlp is below supported version"
+```
+
+### Task 6: Strengthen Modal and Browser Regression Coverage
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx`
+- Modify: `apps/extension/tests/e2e/live-ux-workflows.spec.ts`
+- Modify: `apps/extension/tests/e2e/quick-ingest-workflows.spec.ts`
+- Create: `apps/extension/tests/e2e/utils/quick-ingest-options.ts`
+
+- [ ] **Step 1: Strengthen the modal unit assertion**
+
+Assert the production AntD modal receives:
+
+```ts
+expect(modalProps.styles.body).toEqual(expect.objectContaining({
+  padding: "0 16px 16px",
+  maxHeight: "calc(100vh - 180px)",
+  overflowY: "auto",
+}))
+```
+
+- [ ] **Step 2: Replace non-waiting Playwright visibility checks**
+
+For changed transition controls, use `await expect(locator).toBeVisible({ timeout: 5_000 })` before interaction. Use count/immediate visibility only for genuinely optional controls, with a short documented branch. Reuse one option-toggle helper for identical selector/state transitions.
+
+- [ ] **Step 3: Add the real repeated-submission browser scenario**
+
+In one mounted WebUI session, open Quick Ingest, submit a persisted URL, wait for terminal success, reset/reopen without reloading the app, submit the same URL again, and assert terminal skipped/existing status. Capture `pageerror` and console errors before the first submission and assert no message contains `Maximum update depth exceeded`.
+
+- [ ] **Step 4: Run focused UI unit tests outside the sandbox**
+
+Run:
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx \
+  apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run focused browser tests outside the sandbox**
+
+From `apps/extension`, with the real backend and WebUI already running, run:
+
+`TLDW_LIVE_E2E=1 npx playwright test tests/e2e/quick-ingest-workflows.spec.ts tests/e2e/live-ux-workflows.spec.ts --reporter=line`
+
+The command must use `apps/extension/playwright.config.ts` and its global setup. Expected: both files execute rather than reporting the live workflow as skipped, and all executed tests PASS.
+
+Expected: PASS against the explicitly configured local WebUI/backend test environment.
+
+- [ ] **Step 6: Commit the UI regression coverage**
+
+```bash
+git add apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx apps/extension/tests/e2e/live-ux-workflows.spec.ts apps/extension/tests/e2e/quick-ingest-workflows.spec.ts apps/extension/tests/e2e/utils/quick-ingest-options.ts
+git commit -m "test: cover repeated quick ingest browser flow"
+```
+
+### Task 7: Full Verification, UAT, and PR Closeout
+
+**Files:**
+- Modify through Backlog CLI/MCP: `backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md`
+- Modify: `Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md` status checkboxes during execution.
+
+- [ ] **Step 1: Run all affected automated suites outside the sandbox**
+
+Run the focused commands from Tasks 1-6, then the affected frontend Quick Ingest suite and backend web/video suites. Record exact pass/fail totals in TASK-12946.
+
+- [ ] **Step 2: Run Bandit outside the sandbox**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py \
+  tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py \
+  tldw_Server_API/app/services/enhanced_web_scraping_service.py \
+  tldw_Server_API/app/services/web_scraping_service.py \
+  tldw_Server_API/app/core/Ingestion_Media_Processing/yt_dlp_support.py \
+  tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py \
+  -f json -o /tmp/bandit_task_12946.json
+```
+
+Expected: no new findings in changed code.
+
+- [ ] **Step 3: Perform full user acceptance testing outside the sandbox**
+
+Start the real backend and WebUI. Through the browser, upload a PDF, ingest a reachable local link, ingest `https://www.youtube.com/shorts/6-rf_YXDpPg`, then repeat the link and YouTube submissions in the same mounted app session. Verify visible progress leaves queued/0%, each first submission reaches terminal success with stored media, repeats are visibly skipped/existing, and no maximum-depth console/page error occurs. Inspect corresponding backend job status/results and Media DB entries rather than relying only on UI toasts.
+
+- [ ] **Step 4: Self-review the complete diff against current `origin/dev`**
+
+Check behavior, compatibility, logging safety, exact duplicate boundaries, test quality, and accidental unrelated changes. Run `git diff --check` and inspect `git status --short` without touching the two unrelated untracked watchlist templates.
+
+- [ ] **Step 5: Update Backlog and resolve PR comments**
+
+Use official Backlog MCP/CLI to check acceptance criteria/DoD, replace stale notes with real line breaks, attach plan and verification evidence, and keep status accurate. Reply to and resolve every actionable PR review thread with the implementing commit/test evidence.
+
+- [ ] **Step 6: Rebase, reverify changed surfaces, and push**
+
+Fetch and rebase onto latest `origin/dev`; rerun any conflict-affected focused tests; push with `--force-with-lease`. Confirm PR checks and unresolved-thread count.
+
+- [ ] **Step 7: Enforce the human change-summary merge gate**
+
+Do not claim merge readiness until the human requester has supplied the required change summary explaining what changed and why. Record this as the only blocker if all technical work is complete.

--- a/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
@@ -189,11 +189,11 @@ git commit -m "fix: classify persisted web duplicates exactly"
 - Modify: `tldw_Server_API/app/services/web_scraping_service.py`
 - Modify: `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
 
-- [ ] **Step 1: Write failing extraction permission tests**
+- [x] **Step 1: Write failing extraction permission tests**
 
 Assert the global `DEFAULT_EXTRACTION_STRATEGY_ORDER` includes `llm`. For both the default order and a custom router order containing `llm`, assert `allow_llm_extraction=False` removes only `llm` while preserving relative order; assert `True` leaves the order intact.
 
-- [ ] **Step 2: Write failing API/service propagation tests**
+- [x] **Step 2: Write failing API/service propagation tests**
 
 Patch the scraper boundary and verify:
 
@@ -202,7 +202,7 @@ Patch the scraper boundary and verify:
 - `/ingest-web-content` maps `perform_analysis` identically;
 - Quick Ingest still sends only its existing `summarize_checkbox` declaration and no `strategy_order`/`extraction_strategy_order` property.
 
-- [ ] **Step 3: Run the focused backend/frontend tests outside the sandbox and verify RED**
+- [x] **Step 3: Run the focused backend/frontend tests outside the sandbox and verify RED**
 
 Run:
 
@@ -215,7 +215,7 @@ bunx vitest run apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.
 
 Expected: default-order assertion and propagation assertions fail.
 
-- [ ] **Step 4: Implement the internal permission gate**
+- [x] **Step 4: Implement the internal permission gate**
 
 Restore `"llm"` in `DEFAULT_EXTRACTION_STRATEGY_ORDER`. Add an internal optional `allow_llm_extraction: bool = True` argument at scraper functions only, never to Pydantic request schemas. Resolve the effective order once per article:
 
@@ -227,7 +227,7 @@ if not allow_llm_extraction:
 
 Carry the existing `summarize_checkbox`/`perform_analysis` boolean through individual, sitemap, URL-level, recursive, and queued-job metadata paths. Keep direct non-API scraper consumers backward compatible with the default `True`.
 
-- [ ] **Step 5: Run focused and adjacent web-scraping tests outside the sandbox**
+- [x] **Step 5: Run focused and adjacent web-scraping tests outside the sandbox**
 
 Run the Step 3 commands plus:
 
@@ -240,7 +240,7 @@ source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && py
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit the declaration wiring fix**
+- [x] **Step 6: Commit the declaration wiring fix**
 
 ```bash
 git add tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py tldw_Server_API/app/services/enhanced_web_scraping_service.py tldw_Server_API/app/services/web_scraping_service.py tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts

--- a/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
@@ -255,21 +255,21 @@ git commit -m "fix: honor web analysis intent during extraction"
 - Modify: `tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py`
 - Modify: `Docs/Code_Documentation/Ingestion_Pipeline_Video.md`
 
-- [ ] **Step 1: Write failing version diagnostic tests**
+- [x] **Step 1: Write failing version diagnostic tests**
 
 Patch installed-version lookup and logging to prove versions below `2026.7.4` emit exactly one warning containing `pip install -U "yt-dlp>=2026.7.4"`; current versions emit none; missing or malformed metadata never raises.
 
-- [ ] **Step 2: Run the focused test outside the sandbox and verify RED**
+- [x] **Step 2: Run the focused test outside the sandbox and verify RED**
 
 Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/MediaIngestion_NEW/unit/test_yt_dlp_support.py -q`
 
 Expected: FAIL because the helper does not exist.
 
-- [ ] **Step 3: Implement a minimal one-shot helper**
+- [x] **Step 3: Implement a minimal one-shot helper**
 
 Use `importlib.metadata.version("yt-dlp")` and `packaging.version.Version`. Keep module state only for suppressing duplicate warnings. Return normally for every lookup or parse failure. Call it immediately before video yt-dlp request boundaries, after outbound URL validation so unrelated/blocked requests do not create misleading diagnostics.
 
-- [ ] **Step 4: Run focused video tests outside the sandbox**
+- [x] **Step 4: Run focused video tests outside the sandbox**
 
 Run:
 
@@ -282,7 +282,7 @@ source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && py
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the diagnostic**
+- [x] **Step 5: Commit the diagnostic**
 
 ```bash
 git add tldw_Server_API/app/core/Ingestion_Media_Processing/yt_dlp_support.py tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py tldw_Server_API/tests/MediaIngestion_NEW/unit/test_yt_dlp_support.py Docs/Code_Documentation/Ingestion_Pipeline_Video.md

--- a/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
@@ -91,21 +91,21 @@ git commit -m "fix: preserve webui dev watch ignores"
 - Modify: `apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts`
 - Modify: `apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts`
 
-- [ ] **Step 1: Write failing transient and permanent tests**
+- [x] **Step 1: Write failing transient and permanent tests**
 
 Add one test where `bgRequest` rejects once and then returns `processing`, one where it returns HTTP 503 then `completed`, and retain a 404 test that must interrupt immediately. Use fake timers or inject a zero-delay test seam so retries are deterministic.
 
-- [ ] **Step 2: Run the focused test outside the sandbox and verify RED**
+- [x] **Step 2: Run the focused test outside the sandbox and verify RED**
 
 Run: `bunx vitest run apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts`
 
 Expected: transient cases return `interrupted` before the fix.
 
-- [ ] **Step 3: Add one bounded status-read helper**
+- [x] **Step 3: Add one bounded status-read helper**
 
 Retry network exceptions, 408, 429, and 5xx responses at most three attempts using the existing fixed-delay style. Return permanent 401/403/404 and malformed successful responses without retry. Keep `preferDirect: true` on every attempt.
 
-- [ ] **Step 4: Run focused reattachment and session tests outside the sandbox**
+- [x] **Step 4: Run focused reattachment and session tests outside the sandbox**
 
 Run:
 
@@ -118,7 +118,7 @@ bunx vitest run \
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the reattachment fix**
+- [x] **Step 5: Commit the reattachment fix**
 
 ```bash
 git add apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts

--- a/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
@@ -133,7 +133,7 @@ git commit -m "fix: retry transient quick ingest job reads"
 - Modify: `apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts`
 - Modify: `apps/packages/ui/src/services/tldw/quick-ingest-batch.ts`
 
-- [ ] **Step 1: Write failing backend boundary tests**
+- [x] **Step 1: Write failing backend boundary tests**
 
 Add coverage for:
 
@@ -142,28 +142,28 @@ Add coverage for:
 3. A batch containing one exact duplicate and one unrelated failure returns errors and does not collapse to all-duplicate status.
 4. A URL containing `?token=secret-value` never writes `secret-value` to captured logs.
 
-- [ ] **Step 2: Run the backend test outside the sandbox and verify RED**
+- [x] **Step 2: Run the backend test outside the sandbox and verify RED**
 
 Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py -q`
 
 Expected: FAIL because a repository duplicate ID is counted as stored and broad substring matching classifies unrelated failures as duplicates.
 
-- [ ] **Step 3: Implement exact duplicate classification**
+- [x] **Step 3: Implement exact duplicate classification**
 
 Treat extraction output as duplicate only for `is_duplicate is True` or `error_code == "duplicate_content"`. After `add_media_with_keywords`, inspect its repository-owned message and classify only the two exact overwrite-disabled forms as duplicate; do not append that returned existing ID to `media_ids`. Preserve canonicalization, overwrite, and insert/update success behavior. Use `redact_url_for_log` for every touched article URL log.
 
-- [ ] **Step 4: Write the failing frontend terminal-status helper test**
+- [x] **Step 4: Write the failing frontend terminal-status helper test**
 
 Extend batch tests to prove duplicate wins over completed, error wins over completed, and success remains completed for conference collection patches.
 
-- [ ] **Step 5: Replace the repeated ternary with one local helper**
+- [x] **Step 5: Replace the repeated ternary with one local helper**
 
 ```ts
 const terminalConferenceStatus = (skipped: boolean, error?: string) =>
   skipped ? "skipped_existing" : error ? "failed" : "completed"
 ```
 
-- [ ] **Step 6: Run backend and frontend focused tests outside the sandbox**
+- [x] **Step 6: Run backend and frontend focused tests outside the sandbox**
 
 Run the Step 2 command and:
 
@@ -171,7 +171,7 @@ Run the Step 2 command and:
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit duplicate and logging corrections**
+- [x] **Step 7: Commit duplicate and logging corrections**
 
 ```bash
 git add tldw_Server_API/app/services/enhanced_web_scraping_service.py tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py apps/packages/ui/src/services/tldw/quick-ingest-batch.ts apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts

--- a/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
@@ -42,9 +42,14 @@
 - Modify: `apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts`
 - Modify: `apps/tldw-frontend/next.config.mjs`
 
-- [ ] **Step 1: Write the failing behavioral test**
+- [x] **Step 1: Write the failing behavioral test**
 
-Load `next.config.mjs`, pass `ignored: [/node_modules/, "**/.next/**"]`, and assert both entries survive unchanged. Resolve representative runtime files from the repository workspace and assert appended forward-slash globs match:
+Load `next.config.mjs` with each Webpack-valid input shape. For a standalone
+`/node_modules/` expression, assert its matching semantics survive in a single
+schema-valid expression that also matches the backend roots. For string and
+string-array inputs, assert the original strings survive unchanged and the
+absolute globs are appended. Resolve representative runtime files from the
+repository workspace and assert the final ignore value matches:
 
 ```ts
 expect(webpackConfig.watchOptions.ignored).toContain(existingRegex)
@@ -55,21 +60,25 @@ expect(backendPatterns).toEqual(expect.arrayContaining([
 ]))
 ```
 
-- [ ] **Step 2: Run the focused test outside the sandbox and verify RED**
+- [x] **Step 2: Run the focused test outside the sandbox and verify RED**
 
 Run: `bunx vitest run apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts`
 
 Expected: FAIL because the current filter drops the regular expression and the appended patterns are relative.
 
-- [ ] **Step 3: Implement the minimal normalization**
+- [x] **Step 3: Implement the minimal normalization**
 
-Keep every non-null Webpack-supported ignore entry, discard only blank strings, and construct absolute globs from the repository workspace root with backslashes normalized to `/`.
+Preserve the semantics of every Webpack-supported ignore shape while keeping the
+final shape schema-valid (`RegExp`, string, or string array). Discard only blank
+strings and construct absolute globs from the repository workspace root with
+backslashes normalized to `/`. Do not produce a mixed RegExp/string array,
+which Watchpack treats as an invalid string array.
 
-- [ ] **Step 4: Run the focused test outside the sandbox and verify GREEN**
+- [x] **Step 4: Run the focused test outside the sandbox and verify GREEN**
 
 Run the Step 2 command. Expected: PASS.
 
-- [ ] **Step 5: Commit the isolated config fix**
+- [x] **Step 5: Commit the isolated config fix**
 
 ```bash
 git add apps/tldw-frontend/next.config.mjs apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts

--- a/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
@@ -297,7 +297,7 @@ git commit -m "fix: warn when yt-dlp is below supported version"
 - Modify: `apps/extension/tests/e2e/quick-ingest-workflows.spec.ts`
 - Create: `apps/extension/tests/e2e/utils/quick-ingest-options.ts`
 
-- [ ] **Step 1: Strengthen the modal unit assertion**
+- [x] **Step 1: Strengthen the modal unit assertion**
 
 Assert the production AntD modal receives:
 
@@ -309,15 +309,15 @@ expect(modalProps.styles.body).toEqual(expect.objectContaining({
 }))
 ```
 
-- [ ] **Step 2: Replace non-waiting Playwright visibility checks**
+- [x] **Step 2: Replace non-waiting Playwright visibility checks**
 
 For changed transition controls, use `await expect(locator).toBeVisible({ timeout: 5_000 })` before interaction. Use count/immediate visibility only for genuinely optional controls, with a short documented branch. Reuse one option-toggle helper for identical selector/state transitions.
 
-- [ ] **Step 3: Add the real repeated-submission browser scenario**
+- [x] **Step 3: Add the real repeated-submission browser scenario**
 
 In one mounted WebUI session, open Quick Ingest, submit a persisted URL, wait for terminal success, reset/reopen without reloading the app, submit the same URL again, and assert terminal skipped/existing status. Capture `pageerror` and console errors before the first submission and assert no message contains `Maximum update depth exceeded`.
 
-- [ ] **Step 4: Run focused UI unit tests outside the sandbox**
+- [x] **Step 4: Run focused UI unit tests outside the sandbox**
 
 Run:
 
@@ -352,11 +352,11 @@ git commit -m "test: cover repeated quick ingest browser flow"
 - Modify through Backlog CLI/MCP: `backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md`
 - Modify: `Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md` status checkboxes during execution.
 
-- [ ] **Step 1: Run all affected automated suites outside the sandbox**
+- [x] **Step 1: Run all affected automated suites outside the sandbox**
 
 Run the focused commands from Tasks 1-6, then the affected frontend Quick Ingest suite and backend web/video suites. Record exact pass/fail totals in TASK-12946.
 
-- [ ] **Step 2: Run Bandit outside the sandbox**
+- [x] **Step 2: Run Bandit outside the sandbox**
 
 Run:
 
@@ -373,7 +373,7 @@ source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && py
 
 Expected: no new findings in changed code.
 
-- [ ] **Step 3: Perform full user acceptance testing outside the sandbox**
+- [x] **Step 3: Perform full user acceptance testing outside the sandbox**
 
 Start the real backend and WebUI. Through the browser, upload a PDF, ingest a reachable local link, ingest `https://www.youtube.com/shorts/6-rf_YXDpPg`, then repeat the link and YouTube submissions in the same mounted app session. Verify visible progress leaves queued/0%, each first submission reaches terminal success with stored media, repeats are visibly skipped/existing, and no maximum-depth console/page error occurs. Inspect corresponding backend job status/results and Media DB entries rather than relying only on UI toasts.
 

--- a/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
@@ -339,7 +339,7 @@ The command must use `apps/extension/playwright.config.ts` and its global setup.
 
 Expected: PASS against the explicitly configured local WebUI/backend test environment.
 
-- [ ] **Step 6: Commit the UI regression coverage**
+- [x] **Step 6: Commit the UI regression coverage**
 
 ```bash
 git add apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx apps/extension/tests/e2e/live-ux-workflows.spec.ts apps/extension/tests/e2e/quick-ingest-workflows.spec.ts apps/extension/tests/e2e/utils/quick-ingest-options.ts
@@ -377,15 +377,15 @@ Expected: no new findings in changed code.
 
 Start the real backend and WebUI. Through the browser, upload a PDF, ingest a reachable local link, ingest `https://www.youtube.com/shorts/6-rf_YXDpPg`, then repeat the link and YouTube submissions in the same mounted app session. Verify visible progress leaves queued/0%, each first submission reaches terminal success with stored media, repeats are visibly skipped/existing, and no maximum-depth console/page error occurs. Inspect corresponding backend job status/results and Media DB entries rather than relying only on UI toasts.
 
-- [ ] **Step 4: Self-review the complete diff against current `origin/dev`**
+- [x] **Step 4: Self-review the complete diff against current `origin/dev`**
 
 Check behavior, compatibility, logging safety, exact duplicate boundaries, test quality, and accidental unrelated changes. Run `git diff --check` and inspect `git status --short` without touching the two unrelated untracked watchlist templates.
 
-- [ ] **Step 5: Update Backlog and resolve PR comments**
+- [x] **Step 5: Update Backlog and resolve PR comments**
 
 Use official Backlog MCP/CLI to check acceptance criteria/DoD, replace stale notes with real line breaks, attach plan and verification evidence, and keep status accurate. Reply to and resolve every actionable PR review thread with the implementing commit/test evidence.
 
-- [ ] **Step 6: Rebase, reverify changed surfaces, and push**
+- [x] **Step 6: Rebase, reverify changed surfaces, and push**
 
 Fetch and rebase onto latest `origin/dev`; rerun any conflict-affected focused tests; push with `--force-with-lease`. Confirm PR checks and unresolved-thread count.
 

--- a/Docs/superpowers/specs/2026-07-10-quick-ingest-pr-2709-review-remediation-design.md
+++ b/Docs/superpowers/specs/2026-07-10-quick-ingest-pr-2709-review-remediation-design.md
@@ -1,0 +1,109 @@
+# Quick Ingest PR 2709 Review Remediation Design
+
+## Context
+
+PR #2709 fixes repeat Quick Ingest result classification, restored-job polling,
+the reported AntD maximum-update-depth error, and stale YouTube extractor
+behavior. Review found several cases where the implementation or regression
+coverage did not match the production path. This follow-up addresses those
+findings without redesigning the ingestion system.
+
+## Scope
+
+The remediation will:
+
+- preserve existing Webpack watch ignores while appending backend runtime paths;
+- make direct-job reattachment tolerate transient status-read failures;
+- classify database-level existing-media results as duplicates;
+- exercise two consecutive duplicate submissions with the real AntD modal in a
+  browser;
+- preserve the established global article extraction strategy order while
+  opting Quick Ingest's default scrape request out of LLM extraction explicitly;
+- surface an actionable warning when the installed yt-dlp is below the supported
+  floor;
+- redact user-controlled URLs in the touched persistence logging path.
+
+The remediation will not introduce a new job framework, automatically mutate a
+user's Python environment, or change the public ingestion API shape beyond the
+already-added duplicate counts/status.
+
+## Design
+
+### Webpack Watch Configuration
+
+The Next.js Webpack callback will normalize `watchOptions.ignored` to an array
+without converting or dropping valid entries. Empty strings and nullish values
+will be removed; strings, regular expressions, and other Webpack-supported
+entries will be retained. Backend runtime patterns will then be appended.
+
+### Reattachment Semantics
+
+`reattachQuickIngestSession` will distinguish permanent lookup failures from
+transient transport failures. Missing or forbidden jobs remain terminal
+interruptions. Network failures, timeouts, rate limits, and server errors will
+be retried with a small bounded budget and existing fixed-delay behavior. A
+transient failure followed by a valid active or terminal response must preserve
+the session.
+
+### Duplicate Persistence
+
+The persistence service will inspect the database repository's returned message
+in addition to the media ID. An existing-media message with overwrite disabled
+will increment duplicate/skipped counts and will not increment stored counts.
+Canonicalization and actual insert/update results remain successful storage.
+Regression coverage will persist the same successful article twice through the
+real repository contract rather than injecting `is_duplicate` into extractor
+output.
+
+### Modal Regression Coverage
+
+The unit test will continue checking stable modal props, but it will not be
+treated as proof of the AntD behavior. A browser test using the production AntD
+component will submit the same URL twice in one mounted application session,
+observe a terminal duplicate/skipped result on the second run, and fail on any
+`Maximum update depth exceeded` console or page error.
+
+### Extraction Strategy Scope
+
+The global default extraction order will retain `llm` to avoid changing
+watchlists and other scraper consumers. Quick Ingest's web-scraping request path
+will explicitly select the non-LLM strategy order unless the user explicitly
+requests LLM-backed extraction. This keeps the incident fix at the client/service
+boundary that owns Quick Ingest defaults.
+
+### yt-dlp Upgrade Diagnostics
+
+The dependency floor remains `yt-dlp>=2026.7.4`. Existing environments will not
+be upgraded automatically. The media ingestion startup or request boundary will
+compare the installed version with the supported floor and emit one redacted,
+actionable warning that includes the supported update command. The check must
+not block non-YouTube ingestion.
+
+### Logging Safety
+
+User-controlled article URLs logged in the touched persistence path will use the
+existing `redact_url_for_log` helper. Query values and credentials must not be
+written to logs; enough origin/path context may remain for diagnosis.
+
+## Testing
+
+Each behavior change will follow red-green verification outside the sandbox:
+
+1. Webpack config test preserving an existing regular-expression ignore.
+2. Reattach tests for transient failure then success and permanent 404 failure.
+3. Backend test that stores the same URL twice and verifies duplicate counts.
+4. Extraction tests proving the global default still includes `llm` and Quick
+   Ingest sends the explicit non-LLM strategy order.
+5. Version-warning unit test for stale and current yt-dlp versions.
+6. Logging test proving secrets in URL query values are absent.
+7. Real-browser repeated duplicate Quick Ingest flow with console/page-error
+   capture.
+
+After focused tests, run the affected frontend/backend suites, Bandit on touched
+Python files, and the full PDF, local-link, and YouTube Shorts UAT walkthrough.
+
+## Merge Conditions
+
+The branch must be rebased on current `dev`, all actionable PR review threads
+must be resolved, required checks must pass, and the human requester must provide
+the repository-required human-written change summary before merge.

--- a/Docs/superpowers/specs/2026-07-10-quick-ingest-pr-2709-review-remediation-design.md
+++ b/Docs/superpowers/specs/2026-07-10-quick-ingest-pr-2709-review-remediation-design.md
@@ -18,7 +18,8 @@ The remediation will:
 - exercise two consecutive duplicate submissions with the real AntD modal in a
   browser;
 - preserve the established global article extraction strategy order while
-  opting Quick Ingest's default scrape request out of LLM extraction explicitly;
+  honoring the web ingestion APIs' existing analysis declarations when deciding
+  whether a request may use LLM extraction;
 - surface an actionable warning when the installed yt-dlp is below the supported
   floor;
 - redact user-controlled URLs in the touched persistence logging path.
@@ -34,7 +35,18 @@ already-added duplicate counts/status.
 The Next.js Webpack callback will normalize `watchOptions.ignored` to an array
 without converting or dropping valid entries. Empty strings and nullish values
 will be removed; strings, regular expressions, and other Webpack-supported
-entries will be retained. Backend runtime patterns will then be appended.
+entries will be retained. The following backend runtime patterns will then be
+appended as absolute, forward-slash-normalized globs rooted at the repository
+workspace so Watchpack can match the absolute paths it observes:
+
+- `<repoWorkspaceRoot>/Databases/**`
+- `<repoWorkspaceRoot>/tldw_Server_API/Databases/**`
+- `<repoWorkspaceRoot>/tldw_Server_API/Logs/**`
+- `<repoWorkspaceRoot>/logs/**`
+
+Tests will exercise representative absolute paths under
+`Databases/user_databases/1/Media_DB_v2.db` and
+`tldw_Server_API/Logs/server.log`.
 
 ### Reattachment Semantics
 
@@ -47,29 +59,59 @@ the session.
 
 ### Duplicate Persistence
 
-The persistence service will inspect the database repository's returned message
-in addition to the media ID. An existing-media message with overwrite disabled
-will increment duplicate/skipped counts and will not increment stored counts.
-Canonicalization and actual insert/update results remain successful storage.
-Regression coverage will persist the same successful article twice through the
-real repository contract rather than injecting `is_duplicate` into extractor
-output.
+The persistence service will use structured duplicate signals from extraction
+and inspect the database repository's returned message in addition to the media
+ID. Broad substring matching is not authoritative. Extractor output is a
+duplicate only when `is_duplicate is True` or `error_code ==
+"duplicate_content"`. Database output is a duplicate only when its result
+message matches one of the repository-owned forms:
+
+- `Media '<title>' already exists. Overwrite not enabled.`
+- `Media '<title>' already exists (concurrent insert). Overwrite not enabled.`
+
+The canonicalization and handled-overwrite messages are not duplicates. An
+existing-media result with overwrite disabled will increment duplicate/skipped
+counts and will not increment stored counts. Canonicalization and actual
+insert/update results remain successful storage. Regression coverage will
+persist the same successful article twice through the real repository contract
+rather than injecting `is_duplicate` into extractor output.
 
 ### Modal Regression Coverage
 
-The unit test will continue checking stable modal props, but it will not be
-treated as proof of the AntD behavior. A browser test using the production AntD
-component will submit the same URL twice in one mounted application session,
-observe a terminal duplicate/skipped result on the second run, and fail on any
-`Maximum update depth exceeded` console or page error.
+The unit test will continue checking stable modal props and will assert that
+`styles.body` contains `padding: "0 16px 16px"`, `maxHeight:
+"calc(100vh - 180px)"`, and `overflowY: "auto"`; it will not be treated as
+proof of the AntD behavior. A browser test using the production AntD component
+will submit the same URL twice in one mounted application session, observe a
+terminal duplicate/skipped result on the second run, and fail on any `Maximum
+update depth exceeded` console or page error. Changed Playwright helpers will use
+waiting assertions for controls that appear during transitions; immediate
+`isVisible({ timeout })` checks will not be used as waits. Shared option-toggle
+helpers will be reused where the same selector and state transition otherwise
+remain duplicated across changed tests.
 
 ### Extraction Strategy Scope
 
 The global default extraction order will retain `llm` to avoid changing
-watchlists and other scraper consumers. Quick Ingest's web-scraping request path
-will explicitly select the non-LLM strategy order unless the user explicitly
-requests LLM-backed extraction. This keeps the incident fix at the client/service
-boundary that owns Quick Ingest defaults.
+watchlists and other scraper consumers. No new public request field will be
+introduced. The existing API declarations remain authoritative:
+
+- `/api/v1/media/ingest-web-content` uses `perform_analysis`;
+- `/api/v1/media/process-web-scraping` uses `summarize_checkbox`;
+- `api_name` selects the requested analysis provider when analysis is enabled.
+
+Those declarations already flow into the scraping service as the `summarize`
+intent, but the extraction router currently ignores that intent and selects its
+strategy order independently. The service/core boundary will carry that existing
+boolean intent into extraction. When analysis is false, `llm` will be removed
+from the effective extraction order for that request. When analysis is true, the
+configured or default order will remain intact, including `llm`. Explicit
+per-domain custom scraper ordering remains ordered as configured except for this
+request-level LLM permission gate. `auto_chunking_use_llm` remains independent
+and controls only chunk planning.
+
+Quick Ingest already sends `summarize_checkbox` from its `perform_analysis`
+option, so it needs no new request property or user-facing control.
 
 ### yt-dlp Upgrade Diagnostics
 
@@ -85,15 +127,26 @@ User-controlled article URLs logged in the touched persistence path will use the
 existing `redact_url_for_log` helper. Query values and credentials must not be
 written to logs; enough origin/path context may remain for diagnosis.
 
+### Result Status Consistency
+
+The repeated conference-item terminal status expression will be represented by
+one small local helper returning `skipped_existing`, `failed`, or `completed`.
+This is the only production refactor included beyond the behavior fixes.
+
 ## Testing
 
 Each behavior change will follow red-green verification outside the sandbox:
 
-1. Webpack config test preserving an existing regular-expression ignore.
+1. Webpack config test preserving an existing regular-expression ignore and
+   matching representative absolute backend runtime paths.
 2. Reattach tests for transient failure then success and permanent 404 failure.
-3. Backend test that stores the same URL twice and verifies duplicate counts.
-4. Extraction tests proving the global default still includes `llm` and Quick
-   Ingest sends the explicit non-LLM strategy order.
+3. Backend test that stores the same URL twice and verifies duplicate counts,
+   plus negative and mixed-result cases proving unrelated errors containing the
+   word `duplicate` remain failures.
+4. Extraction tests proving the global default still includes `llm`, requests
+   with `perform_analysis`/`summarize_checkbox` false suppress it, requests with
+   analysis enabled retain it, and Quick Ingest continues sending its existing
+   `summarize_checkbox` declaration without a new strategy property.
 5. Version-warning unit test for stale and current yt-dlp versions.
 6. Logging test proving secrets in URL query values are absent.
 7. Real-browser repeated duplicate Quick Ingest flow with console/page-error
@@ -106,4 +159,6 @@ Python files, and the full PDF, local-link, and YouTube Shorts UAT walkthrough.
 
 The branch must be rebased on current `dev`, all actionable PR review threads
 must be resolved, required checks must pass, and the human requester must provide
-the repository-required human-written change summary before merge.
+the repository-required human-written change summary before merge. TASK-12946
+must contain concrete acceptance criteria, current verification evidence, and
+accurate Definition of Done/status fields before closeout.

--- a/apps/extension/tests/e2e/live-ux-workflows.spec.ts
+++ b/apps/extension/tests/e2e/live-ux-workflows.spec.ts
@@ -7,6 +7,7 @@ import {
   waitForConnectionStore,
   logConnectionSnapshot
 } from './utils/connection'
+import { setQuickIngestSwitch } from './utils/quick-ingest-options'
 
 const SERVER_URL =
   process.env.TLDW_SERVER_URL ?? 'http://127.0.0.1:8000'
@@ -166,8 +167,8 @@ describeLive('Live server UX workflows (no mocks)', () => {
     }
   })
 
-  test('Quick ingest reaches terminal results and reopens them in the installed extension', async () => {
-    test.setTimeout(180_000)
+  test('Quick ingest repeats a persisted URL in one installed extension session', async () => {
+    test.setTimeout(300_000)
 
     const fixtureId = `extension-live-${Date.now()}`
     const ingestUrl = `${SERVER_URL.replace(/\/$/, '')}/docs?quick_ingest_fixture=${fixtureId}`
@@ -180,6 +181,17 @@ describeLive('Live server UX workflows (no mocks)', () => {
           apiKey: API_KEY
         }
       })
+
+    const pageErrors: string[] = []
+    const consoleErrors: string[] = []
+    page.on('pageerror', (error) => {
+      pageErrors.push(error.stack || error.message)
+    })
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text())
+      }
+    })
 
     try {
       await page.goto(optionsUrl + '#/media', {
@@ -197,96 +209,93 @@ describeLive('Live server UX workflows (no mocks)', () => {
       const dialog = page.getByRole('dialog', { name: /quick ingest/i }).first()
       await expect(dialog).toBeVisible({ timeout: 15_000 })
 
-      const urlInput = dialog
-        .getByLabel(/Paste URLs input/i)
-        .or(dialog.getByPlaceholder(/https:\/\/example\.com/i))
-        .first()
-      await expect(urlInput).toBeEnabled({ timeout: 20_000 })
-      await urlInput.fill(ingestUrl)
-      await dialog.getByRole('button', { name: /add url|add urls/i }).first().click()
-      await expect(dialog.getByText(ingestUrl, { exact: false }).first()).toBeVisible({
-        timeout: 20_000
-      })
+      const submitIngest = async () => {
+        const urlInput = dialog
+          .getByLabel(/Paste URLs input/i)
+          .or(dialog.getByPlaceholder(/https:\/\/example\.com/i))
+          .first()
+        await expect(urlInput).toBeEnabled({ timeout: 20_000 })
+        await urlInput.fill(ingestUrl)
+        await dialog.getByRole('button', { name: /add url|add urls/i }).first().click()
+        await expect(dialog.getByText(ingestUrl, { exact: false }).first()).toBeVisible({
+          timeout: 20_000
+        })
 
-      const configureButton = dialog
-        .getByRole('button', { name: /configure \d+ items/i })
-        .first()
-      if (await configureButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        const configureButton = dialog
+          .getByRole('button', { name: /configure \d+ items/i })
+          .first()
+        await expect(configureButton).toBeVisible({ timeout: 20_000 })
         await expect(configureButton).toBeEnabled({ timeout: 20_000 })
         await configureButton.click()
-      }
 
-      const analysisSwitch = dialog
-        .getByRole('switch', { name: /^Ingestion options\s*[–-]\s*analysis$/i })
-        .first()
-      if (await analysisSwitch.isVisible({ timeout: 5_000 }).catch(() => false)) {
-        if ((await analysisSwitch.getAttribute('aria-checked')) === 'true') {
-          await analysisSwitch.click()
-          await expect(analysisSwitch).toHaveAttribute('aria-checked', 'false')
-        }
-      }
-      const chunkingSwitch = dialog
-        .getByRole('switch', { name: /^Ingestion options\s*[–-]\s*chunking$/i })
-        .first()
-      if (await chunkingSwitch.isVisible({ timeout: 5_000 }).catch(() => false)) {
-        if ((await chunkingSwitch.getAttribute('aria-checked')) === 'true') {
-          await chunkingSwitch.click()
-          await expect(chunkingSwitch).toHaveAttribute('aria-checked', 'false')
-        }
-      }
+        await setQuickIngestSwitch(dialog, 'analysis', false)
+        await setQuickIngestSwitch(dialog, 'chunking', false)
 
-      const nextButton = dialog.getByRole('button', { name: /^next$/i }).first()
-      if (await nextButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        const nextButton = dialog.getByRole('button', { name: /^next$/i }).first()
+        await expect(nextButton).toBeVisible({ timeout: 20_000 })
         await expect(nextButton).toBeEnabled({ timeout: 20_000 })
         await nextButton.click()
         await expect(dialog.getByText(/ready to process/i)).toBeVisible({
           timeout: 20_000
         })
-      }
 
-      const runButton = dialog.getByTestId('quick-ingest-run').first()
-      await expect(runButton).toBeEnabled({ timeout: 20_000 })
-      await runButton.click()
+        const runButton = dialog.getByTestId('quick-ingest-run').first()
+        await expect(runButton).toBeEnabled({ timeout: 20_000 })
+        await runButton.click()
+      }
 
       const resultsStep = dialog.getByTestId('wizard-results-step')
       const completedRegion = dialog.getByRole('region', { name: /completed items/i }).first()
       const skippedRegion = dialog.getByRole('region', { name: /skipped items/i }).first()
-      const errorRegion = dialog.getByRole('region', { name: /error items/i }).first()
+      const summary = dialog.getByText(/Total:\s*\d+\s+succeeded.*\d+\s+failed/i).first()
 
+      await submitIngest()
       await expect(resultsStep).toBeVisible({ timeout: 120_000 })
+      await expect(completedRegion).toBeVisible({ timeout: 120_000 })
+      await expect(dialog.getByText(new RegExp(fixtureId, 'i')).first()).toBeVisible({
+        timeout: 30_000
+      })
+      await expect(summary).toBeVisible({ timeout: 30_000 })
+
+      const ingestMoreButton = dialog
+        .getByRole('button', { name: /start a new ingest|ingest more/i })
+        .first()
+      await expect(ingestMoreButton).toBeVisible({ timeout: 15_000 })
+      await ingestMoreButton.click()
+      await expect(resultsStep).toBeHidden({ timeout: 20_000 })
+
+      await submitIngest()
+      await expect(resultsStep).toBeVisible({ timeout: 120_000 })
+      await expect(dialog.getByText(new RegExp(fixtureId, 'i')).first()).toBeVisible({
+        timeout: 30_000
+      })
       await expect
         .poll(
-          async () =>
-            (await completedRegion.isVisible().catch(() => false)) ||
-            (await skippedRegion.isVisible().catch(() => false)) ||
-            (await errorRegion.isVisible().catch(() => false)),
+          async () => {
+            if (await skippedRegion.isVisible().catch(() => false)) return true
+            const summaryText = await summary.textContent().catch(() => '')
+            if (/\b[1-9]\d*\s+skipped\b/i.test(summaryText || '')) return true
+            return dialog
+              .getByText(/skipped existing|already exists|already ingested|existing item/i)
+              .first()
+              .isVisible()
+              .catch(() => false)
+          },
           {
             timeout: 120_000,
-            message: 'Timed out waiting for the extension quick ingest run to reach terminal results'
+            message: 'Second ingest did not report a skipped or existing result'
           }
         )
         .toBe(true)
 
-      await expect(dialog.getByText(new RegExp(fixtureId, 'i')).first()).toBeVisible({
-        timeout: 30_000
-      })
-      await expect(
-        dialog.getByText(/Total:\s*\d+\s+succeeded(?:,\s*\d+\s+skipped)?,\s*\d+\s+failed/i)
-      ).toBeVisible({
-        timeout: 30_000
-      })
-
-      const doneButton = dialog.getByRole('button', { name: /done|close the ingest wizard/i }).first()
-      await expect(doneButton).toBeVisible({ timeout: 15_000 })
-      await doneButton.click()
-      await expect(dialog).toBeHidden({ timeout: 20_000 })
-
-      await openQuickIngestButton.click()
-      await expect(dialog).toBeVisible({ timeout: 15_000 })
-      await expect(resultsStep).toBeVisible({ timeout: 30_000 })
-      await expect(dialog.getByText(new RegExp(fixtureId, 'i')).first()).toBeVisible({
-        timeout: 30_000
-      })
+      const capturedErrors = [
+        ...pageErrors.map((message) => `pageerror: ${message}`),
+        ...consoleErrors.map((message) => `console.error: ${message}`)
+      ]
+      expect(
+        capturedErrors.filter((message) => /maximum update depth exceeded/i.test(message)),
+        `Captured browser errors:\n${capturedErrors.join('\n') || '(none)'}`
+      ).toEqual([])
     } finally {
       await context.close()
     }

--- a/apps/extension/tests/e2e/live-ux-workflows.spec.ts
+++ b/apps/extension/tests/e2e/live-ux-workflows.spec.ts
@@ -208,34 +208,45 @@ describeLive('Live server UX workflows (no mocks)', () => {
         timeout: 20_000
       })
 
-      const useDefaultsButton = dialog
-        .getByRole('button', { name: /use defaults/i })
+      const configureButton = dialog
+        .getByRole('button', { name: /configure \d+ items/i })
         .first()
-      if (await useDefaultsButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
-        await expect(useDefaultsButton).toBeEnabled({ timeout: 20_000 })
-        await useDefaultsButton.click()
-      } else {
-        const configureButton = dialog
-          .getByRole('button', { name: /configure \d+ items/i })
-          .first()
-        if (await configureButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
-          await expect(configureButton).toBeEnabled({ timeout: 20_000 })
-          await configureButton.click()
-        }
-
-        const nextButton = dialog.getByRole('button', { name: /^next$/i }).first()
-        if (await nextButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
-          await expect(nextButton).toBeEnabled({ timeout: 20_000 })
-          await nextButton.click()
-          await expect(dialog.getByText(/ready to process/i)).toBeVisible({
-            timeout: 20_000
-          })
-        }
-
-        const runButton = dialog.getByTestId('quick-ingest-run').first()
-        await expect(runButton).toBeEnabled({ timeout: 20_000 })
-        await runButton.click()
+      if (await configureButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        await expect(configureButton).toBeEnabled({ timeout: 20_000 })
+        await configureButton.click()
       }
+
+      const analysisSwitch = dialog
+        .getByRole('switch', { name: /^Ingestion options\s*[–-]\s*analysis$/i })
+        .first()
+      if (await analysisSwitch.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        if ((await analysisSwitch.getAttribute('aria-checked')) === 'true') {
+          await analysisSwitch.click()
+          await expect(analysisSwitch).toHaveAttribute('aria-checked', 'false')
+        }
+      }
+      const chunkingSwitch = dialog
+        .getByRole('switch', { name: /^Ingestion options\s*[–-]\s*chunking$/i })
+        .first()
+      if (await chunkingSwitch.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        if ((await chunkingSwitch.getAttribute('aria-checked')) === 'true') {
+          await chunkingSwitch.click()
+          await expect(chunkingSwitch).toHaveAttribute('aria-checked', 'false')
+        }
+      }
+
+      const nextButton = dialog.getByRole('button', { name: /^next$/i }).first()
+      if (await nextButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        await expect(nextButton).toBeEnabled({ timeout: 20_000 })
+        await nextButton.click()
+        await expect(dialog.getByText(/ready to process/i)).toBeVisible({
+          timeout: 20_000
+        })
+      }
+
+      const runButton = dialog.getByTestId('quick-ingest-run').first()
+      await expect(runButton).toBeEnabled({ timeout: 20_000 })
+      await runButton.click()
 
       const resultsStep = dialog.getByTestId('wizard-results-step')
       const completedRegion = dialog.getByRole('region', { name: /completed items/i }).first()

--- a/apps/extension/tests/e2e/quick-ingest-cancel.spec.ts
+++ b/apps/extension/tests/e2e/quick-ingest-cancel.spec.ts
@@ -89,7 +89,8 @@ test.describe("Quick ingest cancel flow", () => {
                     ]
                   }
                 })
-              }, 500)
+                ;(window as any).__quickIngestLateCompletionEmitted = true
+              }, 0)
               return { ok: true }
             }
             return originalSendMessage(message)
@@ -161,7 +162,9 @@ test.describe("Quick ingest cancel flow", () => {
       })
       await expect(dialog.getByRole("region", { name: /error items/i })).toBeVisible()
 
-      await page.waitForTimeout(1200)
+      await page.waitForFunction(
+        () => (window as any).__quickIngestLateCompletionEmitted === true
+      )
       await expect(dialog.getByTestId("wizard-results-step")).toBeVisible()
     } finally {
       try {
@@ -172,6 +175,7 @@ test.describe("Quick ingest cancel flow", () => {
               restore()
             }
             delete (window as any).__restoreQuickIngestCancelPatch
+            delete (window as any).__quickIngestLateCompletionEmitted
           } catch {
             // ignore best-effort cleanup failures
           }

--- a/apps/extension/tests/e2e/quick-ingest-cancel.spec.ts
+++ b/apps/extension/tests/e2e/quick-ingest-cancel.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test"
 import { launchWithBuiltExtension } from "./utils/extension-build"
 import { forceConnected, waitForConnectionStore } from "./utils/connection"
+import { setQuickIngestSwitch } from "./utils/quick-ingest-options"
 
 const API_KEY = "THIS-IS-A-SECURE-KEY-123-FAKE-KEY"
 
@@ -139,22 +140,8 @@ test.describe("Quick ingest cancel flow", () => {
       await expect(configureButton).toBeVisible()
       await configureButton.click()
 
-      const analysisSwitch = dialog
-        .getByRole("switch", { name: /^Ingestion options\s*[–-]\s*analysis$/i })
-        .first()
-      await expect(analysisSwitch).toBeVisible()
-      if ((await analysisSwitch.getAttribute("aria-checked")) === "true") {
-        await analysisSwitch.click()
-        await expect(analysisSwitch).toHaveAttribute("aria-checked", "false")
-      }
-      const chunkingSwitch = dialog
-        .getByRole("switch", { name: /^Ingestion options\s*[–-]\s*chunking$/i })
-        .first()
-      await expect(chunkingSwitch).toBeVisible()
-      if ((await chunkingSwitch.getAttribute("aria-checked")) === "true") {
-        await chunkingSwitch.click()
-        await expect(chunkingSwitch).toHaveAttribute("aria-checked", "false")
-      }
+      await setQuickIngestSwitch(dialog, "analysis", false)
+      await setQuickIngestSwitch(dialog, "chunking", false)
 
       const nextButton = dialog.getByRole("button", { name: /^next$/i }).first()
       await expect(nextButton).toBeVisible()

--- a/apps/extension/tests/e2e/quick-ingest-cancel.spec.ts
+++ b/apps/extension/tests/e2e/quick-ingest-cancel.spec.ts
@@ -133,11 +133,36 @@ test.describe("Quick ingest cancel flow", () => {
       await urlInput.fill("https://example.com/cancel-me")
       await dialog.getByRole("button", { name: /add urls/i }).first().click()
 
-      const useDefaultsButton = dialog
-        .getByRole("button", { name: /use defaults & process/i })
+      const configureButton = dialog
+        .getByRole("button", { name: /configure \d+ items/i })
         .first()
-      await expect(useDefaultsButton).toBeVisible()
-      await useDefaultsButton.click()
+      await expect(configureButton).toBeVisible()
+      await configureButton.click()
+
+      const analysisSwitch = dialog
+        .getByRole("switch", { name: /^Ingestion options\s*[–-]\s*analysis$/i })
+        .first()
+      await expect(analysisSwitch).toBeVisible()
+      if ((await analysisSwitch.getAttribute("aria-checked")) === "true") {
+        await analysisSwitch.click()
+        await expect(analysisSwitch).toHaveAttribute("aria-checked", "false")
+      }
+      const chunkingSwitch = dialog
+        .getByRole("switch", { name: /^Ingestion options\s*[–-]\s*chunking$/i })
+        .first()
+      await expect(chunkingSwitch).toBeVisible()
+      if ((await chunkingSwitch.getAttribute("aria-checked")) === "true") {
+        await chunkingSwitch.click()
+        await expect(chunkingSwitch).toHaveAttribute("aria-checked", "false")
+      }
+
+      const nextButton = dialog.getByRole("button", { name: /^next$/i }).first()
+      await expect(nextButton).toBeVisible()
+      await nextButton.click()
+
+      const startButton = dialog.getByRole("button", { name: /start processing/i }).first()
+      await expect(startButton).toBeVisible()
+      await startButton.click()
 
       const cancelButton = dialog.getByRole("button", { name: /cancel all/i }).first()
       await expect(cancelButton).toBeVisible({ timeout: 10000 })

--- a/apps/extension/tests/e2e/quick-ingest-cancel.spec.ts
+++ b/apps/extension/tests/e2e/quick-ingest-cancel.spec.ts
@@ -166,6 +166,10 @@ test.describe("Quick ingest cancel flow", () => {
         () => (window as any).__quickIngestLateCompletionEmitted === true
       )
       await expect(dialog.getByTestId("wizard-results-step")).toBeVisible()
+      await expect(dialog.getByRole("region", { name: /error items/i })).toBeVisible()
+      await expect(
+        dialog.getByRole("region", { name: /completed items/i })
+      ).toHaveCount(0)
     } finally {
       try {
         await page.evaluate(() => {

--- a/apps/extension/tests/e2e/quick-ingest-ux-audit.spec.ts
+++ b/apps/extension/tests/e2e/quick-ingest-ux-audit.spec.ts
@@ -37,19 +37,28 @@ const addUrlToQuickIngest = async (dialog: Locator, url: string) => {
 }
 
 const startQueuedQuickIngest = async (dialog: Locator) => {
-  const useDefaultsButton = dialog
-    .getByRole('button', { name: /use defaults & process/i })
-    .first()
-  if (await useDefaultsButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-    await useDefaultsButton.click()
-    return
-  }
-
   const configureButton = dialog
     .getByRole('button', { name: /configure \d+ items/i })
     .first()
   await expect(configureButton).toBeVisible()
   await configureButton.click()
+
+  const analysisSwitch = dialog
+    .getByRole('switch', { name: /^Ingestion options\s*[–-]\s*analysis$/i })
+    .first()
+  await expect(analysisSwitch).toBeVisible()
+  if ((await analysisSwitch.getAttribute('aria-checked')) === 'true') {
+    await analysisSwitch.click()
+    await expect(analysisSwitch).toHaveAttribute('aria-checked', 'false')
+  }
+  const chunkingSwitch = dialog
+    .getByRole('switch', { name: /^Ingestion options\s*[–-]\s*chunking$/i })
+    .first()
+  await expect(chunkingSwitch).toBeVisible()
+  if ((await chunkingSwitch.getAttribute('aria-checked')) === 'true') {
+    await chunkingSwitch.click()
+    await expect(chunkingSwitch).toHaveAttribute('aria-checked', 'false')
+  }
 
   const nextButton = dialog.getByRole('button', { name: /^next$/i }).first()
   await expect(nextButton).toBeVisible()

--- a/apps/extension/tests/e2e/quick-ingest-ux-audit.spec.ts
+++ b/apps/extension/tests/e2e/quick-ingest-ux-audit.spec.ts
@@ -5,6 +5,7 @@ import {
   forceUnconfigured,
   forceErrorUnreachable
 } from './utils/connection'
+import { setQuickIngestSwitch } from './utils/quick-ingest-options'
 
 const API_KEY = 'THIS-IS-A-SECURE-KEY-123-FAKE-KEY'
 
@@ -43,22 +44,8 @@ const startQueuedQuickIngest = async (dialog: Locator) => {
   await expect(configureButton).toBeVisible()
   await configureButton.click()
 
-  const analysisSwitch = dialog
-    .getByRole('switch', { name: /^Ingestion options\s*[–-]\s*analysis$/i })
-    .first()
-  await expect(analysisSwitch).toBeVisible()
-  if ((await analysisSwitch.getAttribute('aria-checked')) === 'true') {
-    await analysisSwitch.click()
-    await expect(analysisSwitch).toHaveAttribute('aria-checked', 'false')
-  }
-  const chunkingSwitch = dialog
-    .getByRole('switch', { name: /^Ingestion options\s*[–-]\s*chunking$/i })
-    .first()
-  await expect(chunkingSwitch).toBeVisible()
-  if ((await chunkingSwitch.getAttribute('aria-checked')) === 'true') {
-    await chunkingSwitch.click()
-    await expect(chunkingSwitch).toHaveAttribute('aria-checked', 'false')
-  }
+  await setQuickIngestSwitch(dialog, 'analysis', false)
+  await setQuickIngestSwitch(dialog, 'chunking', false)
 
   const nextButton = dialog.getByRole('button', { name: /^next$/i }).first()
   await expect(nextButton).toBeVisible()

--- a/apps/extension/tests/e2e/quick-ingest-workflows.spec.ts
+++ b/apps/extension/tests/e2e/quick-ingest-workflows.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type BrowserContext } from '@playwright/test'
 import path from 'path'
 import { launchWithBuiltExtension } from './utils/extension-build'
+import { setQuickIngestSwitch } from './utils/quick-ingest-options'
 
 const SERVER_URL = process.env.TLDW_URL || 'http://127.0.0.1:8000'
 const API_KEY = process.env.TLDW_API_KEY || 'THIS-IS-A-SECURE-KEY-123-FAKE-KEY'
@@ -89,10 +90,9 @@ test.describe('Quick Ingest workflows and UX', () => {
 
       await expect(page.getByText(/File settings follow/i)).toBeVisible()
 
-      const analysisToggle = page.getByLabel(/Ingestion options .*analysis/i)
-      await analysisToggle.click()
-      const chunkingToggle = page.getByLabel(/Ingestion options .*chunking/i)
-      await chunkingToggle.click()
+      const dialog = page.getByRole('dialog', { name: /quick ingest/i }).first()
+      await setQuickIngestSwitch(dialog, 'analysis', false)
+      await setQuickIngestSwitch(dialog, 'chunking', false)
 
       // Snapshot for UX review
       const screenshotPath = testInfo.outputPath('quick-ingest-workflows.png')

--- a/apps/extension/tests/e2e/utils/quick-ingest-options.ts
+++ b/apps/extension/tests/e2e/utils/quick-ingest-options.ts
@@ -1,0 +1,24 @@
+import { type Locator, expect } from "@playwright/test"
+
+export async function setQuickIngestSwitch(
+  dialog: Locator,
+  optionName: string,
+  checked: boolean,
+  timeout = 20_000
+) {
+  const escapedName = optionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const optionSwitch = dialog
+    .getByRole("switch", {
+      name: new RegExp(`^Ingestion options\\s*[–-]\\s*${escapedName}$`, "i")
+    })
+    .first()
+  const desiredState = String(checked)
+
+  await expect(optionSwitch).toBeVisible({ timeout })
+  if ((await optionSwitch.getAttribute("aria-checked")) !== desiredState) {
+    await optionSwitch.click()
+  }
+  await expect(optionSwitch).toHaveAttribute("aria-checked", desiredState, {
+    timeout
+  })
+}

--- a/apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/WizardResultsStep.tsx
@@ -38,6 +38,7 @@ import {
 
 type WizardResultsStepProps = {
   onClose: () => void
+  onIngestMore?: () => void
   onRetryItems?: (
     itemIds: string[],
     retryItems?: ConferenceRetryRequestItem[]
@@ -316,6 +317,7 @@ ErrorRow.displayName = "ErrorRow"
 
 export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
   onClose,
+  onIngestMore,
   onRetryItems,
   onOpenMedia,
   onDiscussInChat,
@@ -486,8 +488,12 @@ export const WizardResultsStep: React.FC<WizardResultsStepProps> = ({
   )
 
   const handleIngestMore = useCallback(() => {
+    if (onIngestMore) {
+      onIngestMore()
+      return
+    }
     reset()
-  }, [reset])
+  }, [onIngestMore, reset])
 
   // -- Elapsed time ---------------------------------------------------------
 

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   checkConnection: vi.fn(),
   navigate: vi.fn(),
   runtimeListeners: [] as Array<(message: any) => void>,
+  modalProps: [] as any[],
 }))
 
 vi.mock("react-i18next", () => ({
@@ -33,8 +34,10 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("antd", () => ({
   Modal: Object.assign(
-    ({ children, open, onCancel, className, title }: any) =>
-      open ? (
+    (props: any) => {
+      mocks.modalProps.push(props)
+      const { children, open, onCancel, className, title } = props
+      return open ? (
         <div role="dialog" className={className}>
           <div className="ant-modal-content">
             <h2>{title}</h2>
@@ -42,7 +45,8 @@ vi.mock("antd", () => ({
             {children}
           </div>
         </div>
-      ) : null,
+      ) : null
+    },
     {
       confirm: vi.fn(),
       destroyAll: vi.fn(),
@@ -353,6 +357,7 @@ describe("QuickIngestWizardModal session runtime", () => {
     mocks.getQuickIngestAnalysisProviderWarning.mockReturnValue(null)
     mocks.checkConnection.mockReset()
     mocks.navigate.mockReset()
+    mocks.modalProps.splice(0, mocks.modalProps.length)
     mocks.cancelQuickIngestSession.mockResolvedValue({ ok: true })
     useQuickIngestSessionStore.setState({
       session: null,
@@ -421,6 +426,42 @@ describe("QuickIngestWizardModal session runtime", () => {
     await waitFor(() => {
       expect(screen.getByTestId("wizard-results")).toHaveTextContent("complete:1")
     })
+  })
+
+  it("keeps AntD modal portal props stable while results land", async () => {
+    const user = userEvent.setup()
+    useQuickIngestSessionStore.getState().createDraftSession()
+    mocks.startQuickIngestSession.mockResolvedValue({
+      ok: true,
+      sessionId: "qi-direct-stable-modal",
+    })
+    mocks.submitQuickIngestBatch.mockResolvedValue({
+      ok: true,
+      results: [
+        {
+          id: "queued-url-1",
+          status: "ok",
+          outcome: "skipped",
+          url: "https://example.com/article",
+          type: "html",
+        },
+      ],
+    })
+
+    render(<QuickIngestWizardModal open onClose={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: "Queue And Process" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wizard-results")).toHaveTextContent("complete:1")
+    })
+
+    const renderedModalProps = mocks.modalProps.filter((props) => props.open)
+    expect(renderedModalProps.length).toBeGreaterThan(1)
+    expect(renderedModalProps.every((props) => props.getContainer === false)).toBe(
+      true
+    )
+    expect(new Set(renderedModalProps.map((props) => props.styles)).size).toBe(1)
   })
 
   it("keeps quick defaults on the add step when analysis needs a provider", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -289,8 +289,10 @@ vi.mock("@/components/Common/QuickIngest/WizardResultsStep", async () => {
   return {
     WizardResultsStep: ({
       onOpenCollection,
+      onIngestMore,
     }: {
       onOpenCollection?: (collectionId: string) => void
+      onIngestMore?: () => void
     }) => {
       const { state, reset } = actual.useIngestWizard()
       return (
@@ -309,7 +311,7 @@ vi.mock("@/components/Common/QuickIngest/WizardResultsStep", async () => {
               Open collection
             </button>
           ) : null}
-          <button type="button" onClick={reset}>
+          <button type="button" onClick={onIngestMore || reset}>
             Start over
           </button>
         </div>
@@ -466,6 +468,43 @@ describe("QuickIngestWizardModal session runtime", () => {
       padding: "0 16px 16px",
       maxHeight: "calc(100vh - 180px)",
       overflowY: "auto",
+    })
+  })
+
+  it("starts Ingest More in a new persisted session", async () => {
+    const user = userEvent.setup()
+    const firstSession = useQuickIngestSessionStore.getState().createDraftSession()
+    mocks.startQuickIngestSession.mockResolvedValue({
+      ok: true,
+      sessionId: "qi-direct-first-run",
+    })
+    mocks.submitQuickIngestBatch.mockResolvedValue({
+      ok: true,
+      results: [
+        {
+          id: "queued-url-1",
+          status: "ok",
+          url: "https://example.com/article",
+          type: "html",
+        },
+      ],
+    })
+
+    render(<QuickIngestWizardModal open onClose={vi.fn()} />)
+    await user.click(screen.getByRole("button", { name: "Queue And Process" }))
+    await screen.findByTestId("wizard-results")
+
+    await user.click(screen.getByRole("button", { name: "Start over" }))
+
+    await waitFor(() => {
+      expect(useQuickIngestSessionStore.getState().session?.id).not.toBe(
+        firstSession.id
+      )
+    })
+    expect(useQuickIngestSessionStore.getState().session).toMatchObject({
+      lifecycle: "draft",
+      currentStep: 1,
+      tracking: undefined,
     })
   })
 

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -462,13 +462,11 @@ describe("QuickIngestWizardModal session runtime", () => {
       true
     )
     expect(new Set(renderedModalProps.map((props) => props.styles)).size).toBe(1)
-    expect(renderedModalProps[0].styles.body).toEqual(
-      expect.objectContaining({
-        padding: "0 16px 16px",
-        maxHeight: "calc(100vh - 180px)",
-        overflowY: "auto",
-      })
-    )
+    expect(renderedModalProps[0].styles.body).toEqual({
+      padding: "0 16px 16px",
+      maxHeight: "calc(100vh - 180px)",
+      overflowY: "auto",
+    })
   })
 
   it("keeps quick defaults on the add step when analysis needs a provider", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -462,6 +462,13 @@ describe("QuickIngestWizardModal session runtime", () => {
       true
     )
     expect(new Set(renderedModalProps.map((props) => props.styles)).size).toBe(1)
+    expect(renderedModalProps[0].styles.body).toEqual(
+      expect.objectContaining({
+        padding: "0 16px 16px",
+        maxHeight: "calc(100vh - 180px)",
+        overflowY: "auto",
+      })
+    )
   })
 
   it("keeps quick defaults on the add step when analysis needs a provider", async () => {

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -841,6 +841,7 @@ type WizardModalContentProps = {
   markProcessingTracking: (tracking: PersistedQuickIngestTracking) => void
   markInterrupted: (reason?: string) => void
   showSession: () => void
+  replaceWithNewDraft: () => QuickIngestSessionRecord
   shouldAttemptPersistedReattach: boolean
 }
 
@@ -852,6 +853,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
   markProcessingTracking,
   markInterrupted,
   showSession,
+  replaceWithNewDraft,
   shouldAttemptPersistedReattach,
 }) => {
   const { t } = useTranslation(["option"])
@@ -1647,6 +1649,10 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
     onClose()
   }, [navigate, onClose])
 
+  const handleIngestMore = useCallback(() => {
+    replaceWithNewDraft()
+  }, [replaceWithNewDraft])
+
   const handleOpenWorkspace = useCallback(
     (item: WizardResultItem) => {
       const mediaId = item.mediaId
@@ -1716,6 +1722,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
         return (
           <WizardResultsStep
             onClose={onClose}
+            onIngestMore={handleIngestMore}
             onOpenMedia={handleOpenMedia}
             onSearchKnowledge={handleSearchKnowledge}
             onOpenWorkspace={handleOpenWorkspace}
@@ -1731,6 +1738,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
     handleOpenMedia,
     handleOpenCollection,
     handleOpenWorkspace,
+    handleIngestMore,
     handleQuickProcess,
     handleRetryConnection,
     handleSearchKnowledge,
@@ -1783,6 +1791,7 @@ export const QuickIngestWizardModal: React.FC<QuickIngestWizardModalProps> = ({
     markInterrupted,
     createDraftSession,
     showSession,
+    replaceWithNewDraft,
   } =
     useQuickIngestSessionStore(
       useShallow((store) => ({
@@ -1792,6 +1801,7 @@ export const QuickIngestWizardModal: React.FC<QuickIngestWizardModalProps> = ({
         markInterrupted: store.markInterrupted,
         createDraftSession: store.createDraftSession,
         showSession: store.showSession,
+        replaceWithNewDraft: store.replaceWithNewDraft,
       }))
     )
 
@@ -1835,6 +1845,7 @@ export const QuickIngestWizardModal: React.FC<QuickIngestWizardModalProps> = ({
         markProcessingTracking={markProcessingTracking}
         markInterrupted={markInterrupted}
         showSession={showSession}
+        replaceWithNewDraft={replaceWithNewDraft}
         shouldAttemptPersistedReattach={
           session.lifecycle === "processing" &&
           session.tracking?.mode === "webui-direct" &&

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -128,6 +128,13 @@ const RESULT_SUCCESS_STATUS_TOKENS = [
 const RESULT_CANCELLED_STATUS_TOKENS = ["cancelled", "canceled"]
 const FILE_REATTACH_WARNING = "Reattach this file after refresh to process it."
 const PERSISTED_REATTACH_POLL_INTERVAL_MS = 1_500
+const QUICK_INGEST_MODAL_STYLES = {
+  body: {
+    padding: "0 16px 16px",
+    maxHeight: "calc(100vh - 180px)",
+    overflowY: "auto",
+  },
+}
 
 const mapDetectedTypeToEntryType = (
   detectedType: DetectedMediaType
@@ -1744,13 +1751,8 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
         footer={null}
         width={800}
         className="quick-ingest-modal quick-ingest-wizard-modal"
-        styles={{
-          body: {
-            padding: "0 16px 16px",
-            maxHeight: "calc(100vh - 180px)",
-            overflowY: "auto",
-          },
-        }}
+        getContainer={false}
+        styles={QUICK_INGEST_MODAL_STYLES}
       >
         {/* Stepper navigation */}
         <IngestWizardStepper />

--- a/apps/packages/ui/src/services/__tests__/ingest-job-results.test.ts
+++ b/apps/packages/ui/src/services/__tests__/ingest-job-results.test.ts
@@ -45,4 +45,18 @@ describe("ingest job result helpers", () => {
     expect(completedIngestJobIndicatesFailure(payload)).toBe(true)
     expect(extractCompletedIngestJobError(payload)).toBe("Quota exceeded")
   })
+
+  it("surfaces backend errors arrays from persist-style responses", () => {
+    const payload = {
+      status: "persist-ok",
+      total_articles: 1,
+      stored_articles: 0,
+      errors: ["Failed to extract: https://example.com/article"]
+    }
+
+    expect(completedIngestJobIndicatesFailure(payload)).toBe(true)
+    expect(extractCompletedIngestJobError(payload)).toBe(
+      "Failed to extract: https://example.com/article"
+    )
+  })
 })

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
@@ -1131,6 +1131,45 @@ describe("submitQuickIngestBatch", () => {
     })
   })
 
+  it.each([true, false])(
+    "maps perform_analysis=%s to summarize_checkbox without extraction-order fields",
+    async (performAnalysis) => {
+      mocks.bgRequest.mockResolvedValue({
+        status: "persist-ok",
+        media_ids: [123],
+        total_articles: 1
+      })
+
+      await submitQuickIngestBatch({
+        entries: [
+          {
+            id: `entry-analysis-${performAnalysis}`,
+            url: "https://example.com/article",
+            type: "html"
+          }
+        ],
+        files: [],
+        storeRemote: true,
+        processOnly: false,
+        common: {
+          perform_analysis: performAnalysis,
+          perform_chunking: true,
+          overwrite_existing: false
+        },
+        advancedValues: {}
+      })
+
+      const scrapeCall = mocks.bgRequest.mock.calls.find(
+        ([request]) => request?.path === "/api/v1/media/process-web-scraping"
+      )
+      const body = scrapeCall?.[0]?.body
+
+      expect(body).toMatchObject({ summarize_checkbox: performAnalysis })
+      expect(body).not.toHaveProperty("strategy_order")
+      expect(body).not.toHaveProperty("extraction_strategy_order")
+    }
+  )
+
   it("keeps direct Markdown URLs on the document ingest job route", async () => {
     mocks.bgUpload.mockResolvedValue({
       batch_id: "batch-markdown-url",

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
@@ -249,6 +249,89 @@ describe("submitQuickIngestBatch", () => {
     })
   })
 
+  it("marks duplicate direct HTML scrape responses as skipped", async () => {
+    mocks.bgRequest.mockResolvedValue({
+      status: "duplicate",
+      media_ids: [],
+      total_articles: 1,
+      stored_articles: 0,
+      skipped_articles: 1,
+      duplicate_articles: 1,
+      errors: null
+    })
+
+    const result = await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "entry-duplicate-html",
+          url: "http://localhost:8080/e2e/quick-ingest-source.html?repeat=1",
+          type: "html"
+        }
+      ],
+      files: [],
+      storeRemote: true,
+      processOnly: false,
+      common: {
+        perform_analysis: false,
+        perform_chunking: false,
+        overwrite_existing: false
+      },
+      advancedValues: {},
+      __quickIngestSessionId: "qi-direct-duplicate-html"
+    })
+
+    expect(result.ok).toBe(true)
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/process-web-scraping",
+        method: "POST"
+      })
+    )
+    expect(result.results?.[0]).toMatchObject({
+      id: "entry-duplicate-html",
+      status: "ok",
+      outcome: "skipped",
+      message: DUPLICATE_SKIP_MESSAGE
+    })
+  })
+
+  it("surfaces direct HTML scrape responses with zero stored articles as failed", async () => {
+    mocks.bgRequest.mockResolvedValue({
+      status: "persist-ok",
+      media_ids: [],
+      total_articles: 1,
+      stored_articles: 0,
+      errors: ["Failed to extract: http://localhost:8080/e2e/source.html"]
+    })
+
+    const result = await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "entry-failed-html",
+          url: "http://localhost:8080/e2e/source.html",
+          type: "html"
+        }
+      ],
+      files: [],
+      storeRemote: true,
+      processOnly: false,
+      common: {
+        perform_analysis: false,
+        perform_chunking: false,
+        overwrite_existing: false
+      },
+      advancedValues: {},
+      __quickIngestSessionId: "qi-direct-failed-html"
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.results?.[0]).toMatchObject({
+      id: "entry-failed-html",
+      status: "error",
+      error: "Failed to extract: http://localhost:8080/e2e/source.html"
+    })
+  })
+
   it("defaults perform_chunking to true when common options are omitted", async () => {
     mocks.bgUpload.mockResolvedValue({
       batch_id: "batch-default-chunking",

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
@@ -1571,6 +1571,134 @@ describe("submitQuickIngestBatch", () => {
     )
   })
 
+  it.each([
+    {
+      label: "duplicate",
+      terminalData: {
+        status: "duplicate",
+        media_ids: [],
+        stored_articles: 0,
+        duplicate_articles: 1,
+        errors: null
+      },
+      expectedStatus: "skipped_existing"
+    },
+    {
+      label: "result error",
+      terminalData: {
+        status: "persist-ok",
+        media_ids: [],
+        stored_articles: 0,
+        errors: ["Storage failed for article"]
+      },
+      expectedStatus: "failed"
+    },
+    {
+      label: "duplicate with result error",
+      terminalData: {
+        status: "duplicate",
+        media_ids: [],
+        stored_articles: 0,
+        duplicate_articles: 1,
+        errors: ["Storage failed for article"]
+      },
+      expectedStatus: "skipped_existing"
+    },
+    {
+      label: "ordinary success",
+      terminalData: {
+        status: "persist-ok",
+        media_ids: [901],
+        stored_articles: 1,
+        errors: null
+      },
+      expectedStatus: "completed"
+    }
+  ])("patches a conference item to $expectedStatus for $label", async ({
+    terminalData,
+    expectedStatus
+  }) => {
+    mocks.bgRequest.mockImplementation(async (request: { path?: string; body?: any }) => {
+      const path = String(request?.path || "")
+      if (path === "/api/v1/media/collections") {
+        return {
+          id: 13,
+          name: "Conference Batch",
+          kind: "conference",
+          metadata: {},
+          default_tags: [],
+          items: []
+        }
+      }
+      if (path === "/api/v1/media/collections/13/items") {
+        return {
+          id: 131,
+          collection_id: 13,
+          ordinal: 1,
+          source_url: request.body?.source_url,
+          duplicate_status: "new",
+          status: "planned",
+          retry_count: 0,
+          warnings: [],
+          metadata: {},
+          tags: []
+        }
+      }
+      if (path === "/api/v1/media/process-web-scraping") {
+        return terminalData
+      }
+      if (path === "/api/v1/media/collections/13/items/131") {
+        return {
+          id: 131,
+          collection_id: 13,
+          source_url: "https://example.com/talk",
+          status: request.body?.status
+        }
+      }
+      throw new Error(`Unexpected bgRequest path: ${path}`)
+    })
+
+    await submitQuickIngestBatch({
+      entries: [
+        {
+          id: "conference-html",
+          url: "https://example.com/talk",
+          type: "html",
+          conferenceOverride: { selected: true, title: "Conference Talk" }
+        }
+      ],
+      files: [],
+      storeRemote: true,
+      processOnly: false,
+      conferenceBatchMetadata: {
+        collectionName: "Conference Batch",
+        sharedTags: []
+      },
+      common: {
+        perform_analysis: false,
+        perform_chunking: false,
+        overwrite_existing: false
+      },
+      advancedValues: {}
+    } as any)
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/collections/13/items/131",
+        method: "PATCH",
+        body: expect.objectContaining({ status: expectedStatus })
+      })
+    )
+    const terminalPatchStatuses = mocks.bgRequest.mock.calls
+      .filter(
+        ([request]) =>
+          request?.path === "/api/v1/media/collections/13/items/131" &&
+          request?.method === "PATCH"
+      )
+      .map(([request]) => request.body?.status)
+    expect(terminalPatchStatuses).toEqual([expectedStatus])
+  })
+
   it("skips direct ingest submission for existing conference items when policy includes existing", async () => {
     mocks.bgRequest.mockImplementation(async (request: { path?: string; body?: any }) => {
       const path = String(request?.path || "")

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts
@@ -37,6 +37,14 @@ describe("reattachQuickIngestSession", () => {
         status: "processing",
       }),
     ])
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/media/ingest/jobs/77",
+        method: "GET",
+        returnResponse: true,
+        preferDirect: true,
+      })
+    )
   })
 
   it("marks a persisted processing session as interrupted when reattachment cannot prove live progress", async () => {

--- a/apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts
+++ b/apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   bgRequest: vi.fn(),
@@ -13,6 +13,10 @@ import { reattachQuickIngestSession } from "@/services/tldw/quick-ingest-session
 describe("reattachQuickIngestSession", () => {
   beforeEach(() => {
     mocks.bgRequest.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it("reattaches active direct jobs into a processing snapshot", async () => {
@@ -47,6 +51,231 @@ describe("reattachQuickIngestSession", () => {
     )
   })
 
+  it("retries a thrown status read and preserves direct transport", async () => {
+    vi.useFakeTimers()
+    mocks.bgRequest
+      .mockRejectedValueOnce(new Error("network timeout"))
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          status: "processing",
+        },
+      })
+
+    const pendingSnapshot = reattachQuickIngestSession({
+      mode: "webui-direct",
+      batchId: "batch-1",
+      jobIds: [77],
+      startedAt: Date.now(),
+    })
+
+    await vi.runAllTimersAsync()
+    const snapshot = await pendingSnapshot
+
+    expect(snapshot.lifecycle).toBe("processing")
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(2)
+    for (const [request] of mocks.bgRequest.mock.calls) {
+      expect(request).toEqual(expect.objectContaining({ preferDirect: true }))
+    }
+  })
+
+  it("retries a thrown transient numeric status", async () => {
+    vi.useFakeTimers()
+    mocks.bgRequest
+      .mockRejectedValueOnce(
+        Object.assign(new Error("service unavailable"), { status: 503 })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          status: "processing",
+        },
+      })
+
+    const pendingSnapshot = reattachQuickIngestSession({
+      mode: "webui-direct",
+      jobIds: [77],
+      startedAt: Date.now(),
+    })
+
+    await vi.runAllTimersAsync()
+    const snapshot = await pendingSnapshot
+
+    expect(snapshot.lifecycle).toBe("processing")
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it("retries a thrown status-zero transport failure", async () => {
+    vi.useFakeTimers()
+    mocks.bgRequest
+      .mockRejectedValueOnce(
+        Object.assign(new Error("network unavailable"), { status: 0 })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          status: "processing",
+        },
+      })
+
+    const pendingSnapshot = reattachQuickIngestSession({
+      mode: "webui-direct",
+      jobIds: [77],
+      startedAt: Date.now(),
+    })
+
+    await vi.runAllTimersAsync()
+    const snapshot = await pendingSnapshot
+
+    expect(snapshot.lifecycle).toBe("processing")
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not retry a thrown permanent numeric status", async () => {
+    vi.useFakeTimers()
+    mocks.bgRequest
+      .mockRejectedValueOnce(
+        Object.assign(new Error("unauthorized"), { status: 401 })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          status: "processing",
+        },
+      })
+
+    const pendingSnapshot = reattachQuickIngestSession({
+      mode: "webui-direct",
+      jobIds: [77],
+      startedAt: Date.now(),
+    })
+
+    await vi.runAllTimersAsync()
+    const snapshot = await pendingSnapshot
+
+    expect(snapshot.lifecycle).toBe("interrupted")
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it("retries an HTTP 503 status read and returns the completed job", async () => {
+    vi.useFakeTimers()
+    mocks.bgRequest
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        error: "service unavailable",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          status: "completed",
+          result: { media_id: "media-77" },
+        },
+      })
+
+    const pendingSnapshot = reattachQuickIngestSession({
+      mode: "webui-direct",
+      batchId: "batch-1",
+      jobIds: [77],
+      startedAt: Date.now(),
+    })
+
+    await vi.runAllTimersAsync()
+    const snapshot = await pendingSnapshot
+
+    expect(snapshot.lifecycle).toBe("completed")
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(2)
+    for (const [request] of mocks.bgRequest.mock.calls) {
+      expect(request).toEqual(expect.objectContaining({ preferDirect: true }))
+    }
+  })
+
+  it("retries a resolved status-zero transport failure", async () => {
+    vi.useFakeTimers()
+    mocks.bgRequest
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 0,
+        error: "network unavailable",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          status: "processing",
+        },
+      })
+
+    const pendingSnapshot = reattachQuickIngestSession({
+      mode: "webui-direct",
+      jobIds: [77],
+      startedAt: Date.now(),
+    })
+
+    await vi.runAllTimersAsync()
+    const snapshot = await pendingSnapshot
+
+    expect(snapshot.lifecycle).toBe("processing")
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not retry a string HTTP status", async () => {
+    vi.useFakeTimers()
+    mocks.bgRequest
+      .mockResolvedValueOnce({
+        ok: false,
+        status: "503",
+        error: "service unavailable",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          status: "completed",
+        },
+      })
+
+    const pendingSnapshot = reattachQuickIngestSession({
+      mode: "webui-direct",
+      jobIds: [77],
+      startedAt: Date.now(),
+    })
+
+    await vi.runAllTimersAsync()
+    const snapshot = await pendingSnapshot
+
+    expect(snapshot.lifecycle).toBe("interrupted")
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not retry an ok response carrying a transient status code", async () => {
+    vi.useFakeTimers()
+    mocks.bgRequest
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 503,
+        data: {
+          status: "processing",
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          status: "completed",
+        },
+      })
+
+    const pendingSnapshot = reattachQuickIngestSession({
+      mode: "webui-direct",
+      jobIds: [77],
+      startedAt: Date.now(),
+    })
+
+    await vi.runAllTimersAsync()
+    const snapshot = await pendingSnapshot
+
+    expect(snapshot.lifecycle).toBe("processing")
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(1)
+  })
+
   it("marks a persisted processing session as interrupted when reattachment cannot prove live progress", async () => {
     mocks.bgRequest.mockResolvedValue({
       ok: false,
@@ -63,7 +292,68 @@ describe("reattachQuickIngestSession", () => {
 
     expect(result.lifecycle).toBe("interrupted")
     expect(result.errorMessage).toMatch(/could not reconnect/i)
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(1)
   })
+
+  it.each([401, 403])(
+    "does not retry permanent HTTP %i status reads",
+    async (status) => {
+      mocks.bgRequest.mockResolvedValue({
+        ok: false,
+        status,
+        error: "permanent failure",
+      })
+
+      const result = await reattachQuickIngestSession({
+        mode: "webui-direct",
+        jobIds: [77],
+        startedAt: Date.now(),
+      })
+
+      expect(result.lifecycle).toBe("interrupted")
+      expect(mocks.bgRequest).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it("does not retry a successful response with no job status", async () => {
+    mocks.bgRequest.mockResolvedValue({
+      ok: true,
+      data: {},
+    })
+
+    const result = await reattachQuickIngestSession({
+      mode: "webui-direct",
+      jobIds: [77],
+      startedAt: Date.now(),
+    })
+
+    expect(result.lifecycle).toBe("interrupted")
+    expect(mocks.bgRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([408, 429])(
+    "stops after three transient HTTP %i status-read attempts",
+    async (status) => {
+      vi.useFakeTimers()
+      mocks.bgRequest.mockResolvedValue({
+        ok: false,
+        status,
+        error: "transient failure",
+      })
+
+      const pendingSnapshot = reattachQuickIngestSession({
+        mode: "webui-direct",
+        jobIds: [77],
+        startedAt: Date.now(),
+      })
+
+      await vi.runAllTimersAsync()
+      const result = await pendingSnapshot
+
+      expect(result.lifecycle).toBe("interrupted")
+      expect(mocks.bgRequest).toHaveBeenCalledTimes(3)
+    }
+  )
 
   it("maps reattached jobs back to submitted queue item identities", async () => {
     mocks.bgRequest

--- a/apps/packages/ui/src/services/tldw/ingest-job-results.ts
+++ b/apps/packages/ui/src/services/tldw/ingest-job-results.ts
@@ -27,6 +27,16 @@ const firstNonEmptyString = (...values: unknown[]): string | undefined => {
   return undefined
 }
 
+const firstStringFromArray = (value: unknown): string | undefined => {
+  if (!Array.isArray(value)) return undefined
+  for (const item of value) {
+    if (typeof item !== "string") continue
+    const normalized = item.trim()
+    if (normalized) return normalized
+  }
+  return undefined
+}
+
 export const extractCompletedIngestJobPayload = (
   value: unknown
 ): RecordLike | undefined => {
@@ -55,9 +65,11 @@ export const extractCompletedIngestJobError = (
   return firstNonEmptyString(
     payload?.error,
     payload?.detail,
+    firstStringFromArray(payload?.errors),
     record?.error_message,
     record?.cancellation_reason,
-    record?.error
+    record?.error,
+    firstStringFromArray(record?.errors)
   )
 }
 

--- a/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
@@ -46,6 +46,7 @@ import {
   resolveConferenceDuplicatePolicy,
   type ApiMediaCollection,
   type ApiMediaCollectionItem,
+  type MediaCollectionItemStatus,
 } from "@/services/tldw/conference-collections";
 
 type TypeDefaults = {
@@ -714,6 +715,12 @@ const patchConferenceCollectionItem = async (
   });
 };
 
+const getConferenceTerminalStatus = (
+  duplicate: boolean,
+  failed: boolean,
+): MediaCollectionItemStatus =>
+  duplicate ? "skipped_existing" : failed ? "failed" : "completed";
+
 const applyPlannedConferenceFields = (
   fields: Record<string, any>,
   planned: PlannedConferenceCollectionItem | undefined,
@@ -877,11 +884,7 @@ const runDirectQuickIngestBatch = async (
             !resultError &&
             webScrapeResponseIndicatesPersisted(data, resultMediaId);
           await patchConferenceCollectionItem(plannedConferenceItem, {
-            status: htmlDuplicate
-              ? "skipped_existing"
-              : resultError
-                ? "failed"
-                : "completed",
+            status: getConferenceTerminalStatus(htmlDuplicate, Boolean(resultError)),
             media_id: resultMediaId,
             error_summary: resultError,
           });
@@ -963,11 +966,10 @@ const runDirectQuickIngestBatch = async (
                 extractCompletedIngestJobError(pollResult.data) || "Ingest failed";
             }
             await patchConferenceCollectionItem(plannedConferenceItem, {
-              status: completedDuplicate
-                ? "skipped_existing"
-                : resultError
-                  ? "failed"
-                  : "completed",
+              status: getConferenceTerminalStatus(
+                completedDuplicate,
+                Boolean(resultError),
+              ),
               latest_job_id: String(latestJobId),
               media_id: resultMediaId,
               error_summary: resultError,
@@ -998,11 +1000,10 @@ const runDirectQuickIngestBatch = async (
                 extractCompletedIngestJobError(data) || "Ingest failed";
             }
             await patchConferenceCollectionItem(plannedConferenceItem, {
-              status: fallbackDuplicate
-                ? "skipped_existing"
-                : resultError
-                  ? "failed"
-                  : "completed",
+              status: getConferenceTerminalStatus(
+                fallbackDuplicate,
+                Boolean(resultError),
+              ),
               latest_job_id:
                 typeof latestJobId === "number" ? String(latestJobId) : undefined,
               media_id: resultMediaId,

--- a/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
@@ -19,7 +19,9 @@ import {
   requireSubmittedIngestJobs,
 } from "@/services/tldw/ingest-jobs-orchestrator";
 import {
+  completedIngestJobIndicatesFailure,
   completedIngestJobIndicatesSkipped,
+  extractCompletedIngestJobError,
   extractCompletedIngestJobMediaId,
 } from "@/services/tldw/ingest-job-results";
 import {
@@ -846,6 +848,7 @@ const runDirectQuickIngestBatch = async (
         let data: unknown;
         let resultOutcome: QuickIngestBatchResult["outcome"];
         let resultMessage: string | undefined;
+        let resultError: string | undefined;
         let resultMediaId: string | number | null = null;
         let resultPersisted = false;
         if (resolvedType === "html") {
@@ -859,13 +862,28 @@ const runDirectQuickIngestBatch = async (
             autoApplyTemplate: input.autoApplyTemplate,
             persist: shouldStoreRemote,
           });
+          const htmlDuplicate = completedIngestJobIndicatesSkipped(data);
+          const htmlFailure = completedIngestJobIndicatesFailure(data);
+          if (htmlDuplicate) {
+            resultOutcome = "skipped";
+            resultMessage = DUPLICATE_SKIP_MESSAGE;
+          } else if (htmlFailure) {
+            resultError =
+              extractCompletedIngestJobError(data) || "Web scraping failed";
+          }
           resultMediaId = shouldStoreRemote ? extractWebScrapeMediaId(data) : null;
           resultPersisted =
             shouldStoreRemote &&
+            !resultError &&
             webScrapeResponseIndicatesPersisted(data, resultMediaId);
           await patchConferenceCollectionItem(plannedConferenceItem, {
-            status: "completed",
+            status: htmlDuplicate
+              ? "skipped_existing"
+              : resultError
+                ? "failed"
+                : "completed",
             media_id: resultMediaId,
+            error_summary: resultError,
           });
         } else if (shouldStoreRemote) {
           const fields = buildFields({
@@ -940,11 +958,19 @@ const runDirectQuickIngestBatch = async (
             if (completedDuplicate) {
               resultOutcome = "skipped";
               resultMessage = DUPLICATE_SKIP_MESSAGE;
+            } else if (completedIngestJobIndicatesFailure(pollResult.data)) {
+              resultError =
+                extractCompletedIngestJobError(pollResult.data) || "Ingest failed";
             }
             await patchConferenceCollectionItem(plannedConferenceItem, {
-              status: completedDuplicate ? "skipped_existing" : "completed",
+              status: completedDuplicate
+                ? "skipped_existing"
+                : resultError
+                  ? "failed"
+                  : "completed",
               latest_job_id: String(latestJobId),
               media_id: resultMediaId,
+              error_summary: resultError,
             });
           } catch (error) {
             if (!shouldFallbackToPersistentAdd(error)) {
@@ -967,12 +993,20 @@ const runDirectQuickIngestBatch = async (
             if (fallbackDuplicate) {
               resultOutcome = "skipped";
               resultMessage = DUPLICATE_SKIP_MESSAGE;
+            } else if (completedIngestJobIndicatesFailure(data)) {
+              resultError =
+                extractCompletedIngestJobError(data) || "Ingest failed";
             }
             await patchConferenceCollectionItem(plannedConferenceItem, {
-              status: fallbackDuplicate ? "skipped_existing" : "completed",
+              status: fallbackDuplicate
+                ? "skipped_existing"
+                : resultError
+                  ? "failed"
+                  : "completed",
               latest_job_id:
                 typeof latestJobId === "number" ? String(latestJobId) : undefined,
               media_id: resultMediaId,
+              error_summary: resultError,
             });
           }
         } else {
@@ -998,15 +1032,23 @@ const runDirectQuickIngestBatch = async (
             timeoutMs: DIRECT_INGEST_TIMEOUT_MS,
             ...DIRECT_QUICK_INGEST_TRANSPORT,
           });
+          if (completedIngestJobIndicatesFailure(data)) {
+            resultError =
+              extractCompletedIngestJobError(data) || "Ingest failed";
+          } else if (completedIngestJobIndicatesSkipped(data)) {
+            resultOutcome = "skipped";
+            resultMessage = DUPLICATE_SKIP_MESSAGE;
+          }
         }
 
         out.push({
           id: entry.id,
-          status: "ok",
-          outcome: resultOutcome,
+          status: resultError ? "error" : "ok",
+          outcome: resultError ? "failed" : resultOutcome,
           url,
           type: resolvedType,
           data,
+          error: resultError,
           message: resultMessage,
           persisted: resultPersisted,
           mediaId: resultMediaId,

--- a/apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts
@@ -24,6 +24,8 @@ const ACTIVE_JOB_STATUSES = new Set([
 ])
 
 const FAILED_JOB_STATUSES = new Set(["failed", "quarantined", "timeout"])
+const STATUS_READ_ATTEMPTS = 3
+const STATUS_READ_RETRY_DELAY_MS = 100
 
 const normalizeJobIds = (jobIds?: number[]): number[] =>
   Array.isArray(jobIds)
@@ -71,6 +73,52 @@ const interruptedSnapshot = (
 
 const normalizeJobStatus = (value: unknown): string =>
   String(value || "").trim().toLowerCase()
+
+const isTransientHttpStatus = (status: unknown): status is number =>
+  typeof status === "number" &&
+  Number.isFinite(status) &&
+  (status === 0 ||
+    status === 408 ||
+    status === 429 ||
+    (status >= 500 && status < 600))
+
+const isTransientStatusRead = (
+  response: { ok?: unknown; status?: unknown } | null
+): boolean => response?.ok === false && isTransientHttpStatus(response.status)
+
+const isTransientThrownStatusRead = (error: unknown): boolean => {
+  const status = (error as { status?: unknown } | null)?.status
+  return typeof status === "undefined" || isTransientHttpStatus(status)
+}
+
+const readJobStatus = async (jobId: number): Promise<any> => {
+  for (let attempt = 0; attempt < STATUS_READ_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await bgRequest<any>({
+        path: `/api/v1/media/ingest/jobs/${jobId}`,
+        method: "GET",
+        timeoutMs: 10_000,
+        returnResponse: true,
+        preferDirect: true,
+      })
+
+      if (!isTransientStatusRead(response) || attempt === STATUS_READ_ATTEMPTS - 1) {
+        return response
+      }
+    } catch (error) {
+      if (
+        !isTransientThrownStatusRead(error) ||
+        attempt === STATUS_READ_ATTEMPTS - 1
+      ) {
+        return null
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, STATUS_READ_RETRY_DELAY_MS))
+  }
+
+  return null
+}
 
 const isLogicalFailure = (job: ReattachedQuickIngestJob): boolean =>
   FAILED_JOB_STATUSES.has(job.status) ||
@@ -141,13 +189,7 @@ export const reattachQuickIngestSession = async (
 
   try {
     for (const [index, jobId] of jobIds.entries()) {
-      const response = await bgRequest<any>({
-        path: `/api/v1/media/ingest/jobs/${jobId}`,
-        method: "GET",
-        timeoutMs: 10_000,
-        returnResponse: true,
-        preferDirect: true,
-      })
+      const response = await readJobStatus(jobId)
 
       if (!response?.ok || !normalizeJobStatus(response.data?.status)) {
         return interruptedSnapshot()

--- a/apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts
+++ b/apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts
@@ -146,6 +146,7 @@ export const reattachQuickIngestSession = async (
         method: "GET",
         timeoutMs: 10_000,
         returnResponse: true,
+        preferDirect: true,
       })
 
       if (!response?.ok || !normalizeJobStatus(response.data?.status)) {

--- a/apps/packages/ui/src/store/__tests__/quick-ingest-session.test.ts
+++ b/apps/packages/ui/src/store/__tests__/quick-ingest-session.test.ts
@@ -139,4 +139,22 @@ describe("quick ingest session store", () => {
       startedAt: 1700000000000,
     })
   })
+
+  it("clears completed run tracking when the session returns to draft", () => {
+    const store = createQuickIngestSessionStore()
+
+    store.getState().markProcessingTracking({
+      mode: "webui-direct",
+      sessionId: "qi-direct-completed",
+      batchId: "batch-1",
+      jobIds: [77],
+    })
+
+    store.getState().upsertSession({
+      lifecycle: "draft",
+      currentStep: 1,
+    })
+
+    expect(store.getState().session?.tracking).toBeUndefined()
+  })
 })

--- a/apps/packages/ui/src/store/quick-ingest-session.ts
+++ b/apps/packages/ui/src/store/quick-ingest-session.ts
@@ -635,7 +635,9 @@ export const createQuickIngestSessionStore = () =>
                 ...(next.resultSummary || {}),
               },
               tracking:
-                next.tracking === undefined
+                next.lifecycle === "draft"
+                  ? undefined
+                  : next.tracking === undefined
                   ? base.tracking
                   : mergeTracking(base.tracking, next.tracking),
               updatedAt: Date.now(),

--- a/apps/tldw-frontend/__tests__/frontend-dev-config.test.ts
+++ b/apps/tldw-frontend/__tests__/frontend-dev-config.test.ts
@@ -33,10 +33,12 @@ describe("frontend dev config", () => {
     )
   })
 
-  it("provides a webpack dev fallback script", () => {
+  it("uses webpack for local dev and keeps Turbopack as an explicit opt-in", () => {
     const packageJson = loadPackageJson()
 
+    expect(packageJson.scripts?.dev).toBe("next dev --webpack")
     expect(packageJson.scripts?.["dev:webpack"]).toBe("next dev --webpack")
+    expect(packageJson.scripts?.["dev:turbopack"]).toBe("next dev")
   })
 
   it("routes Turbopack build entrypoints through the profile wrapper", () => {

--- a/apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts
+++ b/apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+import { describe, expect, it } from "vitest"
+
+describe("Next dev watch guard", () => {
+  const configSource = readFileSync(
+    path.resolve(__dirname, "../next.config.mjs"),
+    "utf8",
+  )
+  const packageJson = JSON.parse(
+    readFileSync(path.resolve(__dirname, "../package.json"), "utf8"),
+  ) as { scripts?: Record<string, string> }
+  const loadNextConfig = async () => {
+    process.env.NEXT_PUBLIC_API_URL = "http://127.0.0.1:8001"
+    delete process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
+    delete process.env.TLDW_INTERNAL_API_ORIGIN
+    const moduleUrl = `${pathToFileURL(
+      path.resolve(__dirname, "../next.config.mjs"),
+    ).href}?watch-guard`
+    const mod = await import(moduleUrl)
+    return mod.default
+  }
+
+  it("uses webpack for default local dev so watch ignores are honored", () => {
+    expect(packageJson.scripts?.dev).toBe("next dev --webpack")
+    expect(packageJson.scripts?.["dev:turbopack"]).toBe("next dev")
+  })
+
+  it("ignores backend runtime output for webpack dev fallback", () => {
+    expect(configSource).toContain("backendRuntimeWatchIgnorePatterns")
+    expect(configSource).toContain("../../Databases")
+    expect(configSource).toContain("../../tldw_Server_API/Databases")
+    expect(configSource).toContain("config.watchOptions")
+    expect(configSource).toContain("ignored")
+  })
+
+  it("normalizes webpack ignored watch patterns to strings", async () => {
+    const nextConfig = await loadNextConfig()
+    const webpackConfig = nextConfig.webpack({
+      resolve: { alias: {} },
+      watchOptions: {
+        ignored: [/node_modules/],
+      },
+    })
+
+    expect(webpackConfig.watchOptions.ignored.every(
+      (item: unknown) => typeof item === "string" && item.length > 0,
+    )).toBe(true)
+    expect(webpackConfig.watchOptions.ignored).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("../../Databases"),
+        expect.stringContaining("../../tldw_Server_API/Databases"),
+      ]),
+    )
+  })
+})

--- a/apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts
+++ b/apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
 import { describe, expect, it } from "vitest"
@@ -11,6 +12,27 @@ describe("Next dev watch guard", () => {
   const packageJson = JSON.parse(
     readFileSync(path.resolve(__dirname, "../package.json"), "utf8"),
   ) as { scripts?: Record<string, string> }
+  const webpack = (
+    createRequire(path.resolve(__dirname, "../package.json"))(
+      "next/dist/compiled/webpack/webpack",
+    ) as { webpack: { validate(config: unknown): void } }
+  ).webpack
+  const workspaceRoot = path.resolve(__dirname, "../../..")
+  const normalizePath = (value: string) => value.split(path.sep).join("/")
+  const runtimePaths = [
+    "Databases/user_databases/1/Media_DB_v2.db",
+    "tldw_Server_API/Databases/runtime.db",
+    "tldw_Server_API/Logs/server.log",
+    "logs/runtime.log",
+  ].map((runtimePath) =>
+    normalizePath(path.resolve(workspaceRoot, runtimePath)),
+  )
+  const backendPatterns = [
+    "Databases/**",
+    "tldw_Server_API/Databases/**",
+    "tldw_Server_API/Logs/**",
+    "logs/**",
+  ].map((pattern) => normalizePath(path.resolve(workspaceRoot, pattern)))
   const loadNextConfig = async () => {
     process.env.NEXT_PUBLIC_API_URL = "http://127.0.0.1:8001"
     delete process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE
@@ -29,29 +51,95 @@ describe("Next dev watch guard", () => {
 
   it("ignores backend runtime output for webpack dev fallback", () => {
     expect(configSource).toContain("backendRuntimeWatchIgnorePatterns")
-    expect(configSource).toContain("../../Databases")
-    expect(configSource).toContain("../../tldw_Server_API/Databases")
     expect(configSource).toContain("config.watchOptions")
     expect(configSource).toContain("ignored")
   })
 
-  it("normalizes webpack ignored watch patterns to strings", async () => {
+  it("combines a standalone RegExp with backend runtime roots", async () => {
     const nextConfig = await loadNextConfig()
+    const existingRegex = /node_modules/
     const webpackConfig = nextConfig.webpack({
       resolve: { alias: {} },
       watchOptions: {
-        ignored: [/node_modules/],
+        ignored: existingRegex,
       },
     })
+    const ignored = webpackConfig.watchOptions.ignored
 
-    expect(webpackConfig.watchOptions.ignored.every(
-      (item: unknown) => typeof item === "string" && item.length > 0,
-    )).toBe(true)
-    expect(webpackConfig.watchOptions.ignored).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("../../Databases"),
-        expect.stringContaining("../../tldw_Server_API/Databases"),
-      ]),
+    expect(() => webpack.validate({ watchOptions: { ignored } })).not.toThrow()
+    expect(ignored).toBeInstanceOf(RegExp)
+    const nodeModulesPath = normalizePath(
+      path.resolve(workspaceRoot, "node_modules/webpack"),
     )
+    expect(ignored.test(nodeModulesPath)).toBe(true)
+    for (const runtimePath of runtimePaths) {
+      expect(ignored.test(runtimePath)).toBe(true)
+    }
+  })
+
+  it("removes stateful RegExp flags while preserving other flags", async () => {
+    const nextConfig = await loadNextConfig()
+    const webpackConfig = nextConfig.webpack({
+      resolve: { alias: {} },
+      watchOptions: { ignored: /node_modules/gim },
+    })
+    const ignored = webpackConfig.watchOptions.ignored
+    const nodeModulesPath = normalizePath(
+      path.resolve(workspaceRoot, "node_modules/webpack"),
+    )
+
+    expect(() => webpack.validate({ watchOptions: { ignored } })).not.toThrow()
+    expect(ignored.flags).toBe("im")
+    expect(ignored.test(nodeModulesPath)).toBe(true)
+    expect(ignored.test(nodeModulesPath)).toBe(true)
+  })
+
+  it("preserves string-array ignores and appends backend runtime globs", async () => {
+    const nextConfig = await loadNextConfig()
+    const existingIgnored = ["**/node_modules/**", "**/.next/**"]
+    const webpackConfig = nextConfig.webpack({
+      resolve: { alias: {} },
+      watchOptions: { ignored: existingIgnored },
+    })
+    const ignored = webpackConfig.watchOptions.ignored
+
+    expect(ignored).toEqual([...existingIgnored, ...backendPatterns])
+    expect(backendPatterns.every((pattern) => path.isAbsolute(pattern))).toBe(true)
+    expect(backendPatterns.every((pattern) => !pattern.includes("\\"))).toBe(true)
+    expect(() => webpack.validate({ watchOptions: { ignored } })).not.toThrow()
+  })
+
+  it("filters unsupported values from ignored arrays", async () => {
+    const nextConfig = await loadNextConfig()
+    const existingGlob = "**/.next/**"
+    const webpackConfig = nextConfig.webpack({
+      resolve: { alias: {} },
+      watchOptions: {
+        ignored: [
+          existingGlob,
+          /node_modules/,
+          () => true,
+          { test: true },
+          "",
+          "   ",
+        ],
+      },
+    })
+    const ignored = webpackConfig.watchOptions.ignored
+
+    expect(ignored).toEqual([existingGlob, ...backendPatterns])
+    expect(() => webpack.validate({ watchOptions: { ignored } })).not.toThrow()
+  })
+
+  it("normalizes a standalone string ignore to a string array", async () => {
+    const nextConfig = await loadNextConfig()
+    const webpackConfig = nextConfig.webpack({
+      resolve: { alias: {} },
+      watchOptions: { ignored: "**/.next/**" },
+    })
+    const ignored = webpackConfig.watchOptions.ignored
+
+    expect(ignored).toEqual(["**/.next/**", ...backendPatterns])
+    expect(() => webpack.validate({ watchOptions: { ignored } })).not.toThrow()
   })
 })

--- a/apps/tldw-frontend/e2e/onboarding-uat/helpers.ts
+++ b/apps/tldw-frontend/e2e/onboarding-uat/helpers.ts
@@ -305,7 +305,31 @@ export async function completeFirstSourcePasteIngest(
     .getByRole("button", { name: /add pasted text to queue/i })
     .click()
   await expect(page.getByText(/queued/i)).toBeVisible({ timeout: 20_000 })
-  await page.getByRole("button", { name: /use defaults & process/i }).click()
+
+  await page.getByRole("button", { name: /configure \d+ items/i }).click()
+  const analysisSwitch = page
+    .getByRole("switch", { name: /^Ingestion options\s*[–-]\s*analysis$/i })
+    .first()
+  await expect(analysisSwitch).toBeVisible({ timeout: 20_000 })
+  if ((await analysisSwitch.getAttribute("aria-checked")) === "true") {
+    await analysisSwitch.click()
+    await expect(analysisSwitch).toHaveAttribute("aria-checked", "false")
+  }
+  const chunkingSwitch = page
+    .getByRole("switch", { name: /^Ingestion options\s*[–-]\s*chunking$/i })
+    .first()
+  await expect(chunkingSwitch).toBeVisible({ timeout: 20_000 })
+  if ((await chunkingSwitch.getAttribute("aria-checked")) === "true") {
+    await chunkingSwitch.click()
+    await expect(chunkingSwitch).toHaveAttribute("aria-checked", "false")
+  }
+
+  await page.getByRole("button", { name: /^next$/i }).click()
+  await expect(page.getByText(/ready to process/i)).toBeVisible({
+    timeout: 20_000,
+  })
+  await page.getByRole("button", { name: /start processing/i }).click()
+
   await expect(page.getByTestId("wizard-results-step")).toBeVisible({
     timeout: 120_000,
   })

--- a/apps/tldw-frontend/e2e/utils/journey-helpers.ts
+++ b/apps/tldw-frontend/e2e/utils/journey-helpers.ts
@@ -8,18 +8,29 @@ import { TEST_CONFIG, fetchWithApiKey, waitForConnection } from "./helpers"
 import { NotesPage } from "./page-objects"
 
 const QUICK_INGEST_JOB_STATUS_PATH = "/api/v1/media/ingest/jobs/"
+const QUICK_INGEST_JOB_SUBMIT_MATCHER =
+  /\/api\/v1\/media\/ingest\/jobs(?:[/?]|$)/i
 const QUICK_INGEST_SUBMIT_MATCHER =
   /\/api\/v1\/media\/(?:ingest\/jobs|process-web-scraping|add)(?:[/?]|$)/i
 
 const extractMediaId = (payload: unknown): string | undefined => {
   const body = payload as Record<string, any> | null
-  const candidate =
-    body?.result?.media_id ??
-    body?.media_id ??
-    body?.data?.media_id ??
-    body?.job?.result?.media_id
+  const candidates = [
+    body?.result?.media_id,
+    body?.media_id,
+    body?.data?.media_id,
+    body?.job?.result?.media_id,
+    ...(Array.isArray(body?.media_ids) ? body.media_ids : []),
+    ...(Array.isArray(body?.result?.media_ids) ? body.result.media_ids : []),
+    ...(Array.isArray(body?.data?.media_ids) ? body.data.media_ids : []),
+  ]
 
-  return typeof candidate === "string" && candidate.trim() ? candidate.trim() : undefined
+  for (const candidate of candidates) {
+    const value = String(candidate ?? "").trim()
+    if (value) return value
+  }
+
+  return undefined
 }
 
 const extractIngestJobIds = (payload: unknown): number[] => {
@@ -247,6 +258,9 @@ type QuickIngestProcessingTarget = "processing" | "completed"
 
 type QueueUrlAndStartProcessingOptions = {
   waitForState?: QuickIngestProcessingTarget
+  performAnalysis?: boolean
+  performChunking?: boolean
+  requireJobSubmit?: boolean
   timeoutMs?: number
 }
 
@@ -300,14 +314,71 @@ const ensureQuickIngestAddStep = async (
 
 const advanceQuickIngestToReviewStep = async (
   dialog: Locator,
-  timeoutMs: number
+  timeoutMs: number,
+  options: Pick<QueueUrlAndStartProcessingOptions, "performAnalysis" | "performChunking"> = {}
 ): Promise<void> => {
+  await applyQuickIngestProcessOptions(dialog, options, timeoutMs)
+
   const nextBtn = dialog.getByRole("button", { name: /^next$/i }).first()
   await expect(nextBtn).toBeVisible({ timeout: timeoutMs })
   await nextBtn.click()
   await expect(dialog.getByRole("button", { name: /start processing/i }).first()).toBeVisible({
     timeout: timeoutMs,
   })
+  await assertQuickIngestReviewProcessOptions(dialog, options, timeoutMs)
+}
+
+const quickIngestOptionName = (option: "analysis" | "chunking"): RegExp =>
+  new RegExp(`^Ingestion options\\s*[–-]\\s*${option}$`, "i")
+
+const setQuickIngestProcessOptionEnabled = async (
+  dialog: Locator,
+  option: "analysis" | "chunking",
+  enabled: boolean,
+  timeoutMs: number
+): Promise<void> => {
+  const analysisToggle = dialog
+    .getByRole("switch", { name: quickIngestOptionName(option) })
+    .first()
+
+  await expect(analysisToggle).toBeVisible({ timeout: timeoutMs })
+  const current = (await analysisToggle.getAttribute("aria-checked")) === "true"
+  if (current === enabled) return
+
+  await analysisToggle.click()
+  await expect(analysisToggle).toHaveAttribute(
+    "aria-checked",
+    enabled ? "true" : "false",
+    { timeout: timeoutMs }
+  )
+}
+
+const applyQuickIngestProcessOptions = async (
+  dialog: Locator,
+  options: Pick<QueueUrlAndStartProcessingOptions, "performAnalysis" | "performChunking">,
+  timeoutMs: number
+): Promise<void> => {
+  if (options.performAnalysis !== true) {
+    await setQuickIngestProcessOptionEnabled(dialog, "analysis", false, timeoutMs)
+  }
+  if (options.performChunking !== true) {
+    await setQuickIngestProcessOptionEnabled(dialog, "chunking", false, timeoutMs)
+  }
+}
+
+const assertQuickIngestReviewProcessOptions = async (
+  dialog: Locator,
+  options: Pick<QueueUrlAndStartProcessingOptions, "performAnalysis" | "performChunking">,
+  timeoutMs: number
+): Promise<void> => {
+  const itemList = dialog.getByRole("list", { name: /items to process/i }).first()
+  await expect(itemList).toBeVisible({ timeout: timeoutMs })
+  if (options.performAnalysis !== true) {
+    await expect(itemList).not.toContainText(/\bAnalyze\b/i, { timeout: timeoutMs })
+  }
+  if (options.performChunking !== true) {
+    await expect(itemList).not.toContainText(/\bChunk\b/i, { timeout: timeoutMs })
+  }
 }
 
 const startQuickIngestProcessing = async (
@@ -321,28 +392,40 @@ const startQuickIngestProcessing = async (
 
 const startQueuedQuickIngestFromCurrentStep = async (
   dialog: Locator,
-  timeoutMs: number
+  timeoutMs: number,
+  options: Pick<QueueUrlAndStartProcessingOptions, "performAnalysis" | "performChunking"> = {}
 ): Promise<void> => {
-  const useDefaultsBtn = dialog.getByRole("button", { name: /use defaults/i }).first()
-  if (await useDefaultsBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    await useDefaultsBtn.click()
-    return
-  }
-
   const configureBtn = dialog
     .getByRole("button", { name: /configure \d+ items/i })
     .first()
   if (await configureBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
     await configureBtn.click()
     await waitForQuickIngestConfigureUi(dialog, timeoutMs)
-    await advanceQuickIngestToReviewStep(dialog, timeoutMs)
+    await advanceQuickIngestToReviewStep(dialog, timeoutMs, options)
     await startQuickIngestProcessing(dialog, timeoutMs)
     return
   }
 
   const startProcessingBtn = dialog.getByRole("button", { name: /start processing/i }).first()
-  await expect(startProcessingBtn).toBeVisible({ timeout: timeoutMs })
-  await startProcessingBtn.click()
+  if (await startProcessingBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await startProcessingBtn.click()
+    return
+  }
+
+  const useDefaultsBtn = dialog.getByRole("button", { name: /use defaults/i }).first()
+  if (
+    options.performAnalysis === true &&
+    (await useDefaultsBtn.isVisible({ timeout: 3_000 }).catch(() => false))
+  ) {
+    await useDefaultsBtn.click()
+    return
+  }
+
+  await expect(configureBtn).toBeVisible({ timeout: timeoutMs })
+  await configureBtn.click()
+  await waitForQuickIngestConfigureUi(dialog, timeoutMs)
+  await advanceQuickIngestToReviewStep(dialog, timeoutMs, options)
+  await startQuickIngestProcessing(dialog, timeoutMs)
 }
 
 /**
@@ -436,13 +519,15 @@ export async function queueUrlAndStartProcessing(
     page,
     {
       method: "POST",
-      url: QUICK_INGEST_SUBMIT_MATCHER,
+      url: options.requireJobSubmit
+        ? QUICK_INGEST_JOB_SUBMIT_MATCHER
+        : QUICK_INGEST_SUBMIT_MATCHER,
     },
     timeoutMs
   )
 
   await advanceQuickIngestToConfigureStep(dialog, url, { timeoutMs })
-  await advanceQuickIngestToReviewStep(dialog, timeoutMs)
+  await advanceQuickIngestToReviewStep(dialog, timeoutMs, options)
   await startQuickIngestProcessing(dialog, timeoutMs)
 
   await submitRequest
@@ -464,8 +549,19 @@ export async function startQueuedQuickIngestProcessing(
   options: QueueUrlAndStartProcessingOptions = {}
 ): Promise<Locator> {
   const timeoutMs = options.timeoutMs ?? 120_000
+  const submitRequest = expectApiCall(
+    dialog.page(),
+    {
+      method: "POST",
+      url: options.requireJobSubmit
+        ? QUICK_INGEST_JOB_SUBMIT_MATCHER
+        : QUICK_INGEST_SUBMIT_MATCHER,
+    },
+    timeoutMs
+  )
 
-  await startQueuedQuickIngestFromCurrentStep(dialog, timeoutMs)
+  await startQueuedQuickIngestFromCurrentStep(dialog, timeoutMs, options)
+  await submitRequest
 
   if (options.waitForState === "processing") {
     await waitForQuickIngestProcessingUi(dialog, timeoutMs)
@@ -732,55 +828,45 @@ export async function ingestAndWaitForReady(
   if ("url" in input) {
     await advanceQuickIngestToConfigureStep(quickIngestDialog, input.url)
 
-    const useDefaultsBtn = quickIngestDialog
-      .getByRole("button", { name: /use defaults/i })
-      .first()
-    if (await useDefaultsBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
-      await useDefaultsBtn.click()
-    } else {
-      const nextBtn = quickIngestDialog.getByRole("button", { name: /^next$/i }).first()
-      if (await nextBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
-        await nextBtn.click()
-        await expect(quickIngestDialog.getByText(/ready to process/i)).toBeVisible({
-          timeout: 20_000,
-        })
-      }
-
-      const startProcessingBtn = quickIngestDialog
-        .getByRole("button", { name: /start processing/i })
-        .first()
-      await startProcessingBtn.click()
+    await applyQuickIngestProcessOptions(quickIngestDialog, {}, timeoutMs)
+    const nextBtn = quickIngestDialog.getByRole("button", { name: /^next$/i }).first()
+    if (await nextBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await nextBtn.click()
+      await expect(quickIngestDialog.getByText(/ready to process/i)).toBeVisible({
+        timeout: 20_000,
+      })
+      await assertQuickIngestReviewProcessOptions(quickIngestDialog, {}, timeoutMs)
     }
+
+    const startProcessingBtn = quickIngestDialog
+      .getByRole("button", { name: /start processing/i })
+      .first()
+    await startProcessingBtn.click()
   } else {
     await queueFileForQuickIngest(quickIngestDialog, input.file, timeoutMs)
 
-    const useDefaultsBtn = quickIngestDialog
-      .getByRole("button", { name: /use defaults/i })
+    const configureBtn = quickIngestDialog
+      .getByRole("button", { name: /configure \d+ items/i })
       .first()
-    if (await useDefaultsBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
-      await useDefaultsBtn.click()
-    } else {
-      const configureBtn = quickIngestDialog
-        .getByRole("button", { name: /configure \d+ items/i })
-        .first()
-      if (await configureBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
-        await configureBtn.click()
-        await waitForQuickIngestConfigureUi(quickIngestDialog, timeoutMs)
-      }
-
-      const nextBtn = quickIngestDialog.getByRole("button", { name: /^next$/i }).first()
-      if (await nextBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
-        await nextBtn.click()
-        await expect(quickIngestDialog.getByText(/ready to process/i)).toBeVisible({
-          timeout: timeoutMs,
-        })
-      }
-
-      const startProcessingBtn = quickIngestDialog
-        .getByRole("button", { name: /start processing/i })
-        .first()
-      await startProcessingBtn.click()
+    if (await configureBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await configureBtn.click()
+      await waitForQuickIngestConfigureUi(quickIngestDialog, timeoutMs)
     }
+
+    await applyQuickIngestProcessOptions(quickIngestDialog, {}, timeoutMs)
+    const nextBtn = quickIngestDialog.getByRole("button", { name: /^next$/i }).first()
+    if (await nextBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await nextBtn.click()
+      await expect(quickIngestDialog.getByText(/ready to process/i)).toBeVisible({
+        timeout: timeoutMs,
+      })
+      await assertQuickIngestReviewProcessOptions(quickIngestDialog, {}, timeoutMs)
+    }
+
+    const startProcessingBtn = quickIngestDialog
+      .getByRole("button", { name: /start processing/i })
+      .first()
+    await startProcessingBtn.click()
   }
 
   const { response } = await submitRequest

--- a/apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
@@ -14,7 +14,8 @@ import { MediaPage } from "../utils/page-objects"
 import {
   seedAuth,
   generateTestId,
-  waitForConnection
+  waitForConnection,
+  TEST_CONFIG
 } from "../utils/helpers"
 import { expectApiCall } from "../utils/api-assertions"
 import {
@@ -459,11 +460,19 @@ test.describe("Media Ingestion Workflow", () => {
   })
 
   test.describe("Quick Ingest", () => {
+    test.describe.configure({ mode: "serial" })
+
     const quickIngestFixtureFile = path.resolve(
       process.cwd(),
       "e2e/fixtures/media/quick-ingest-sample.mkv"
     )
-    const quickIngestFixtureUrl = "https://example.com/e2e/quick-ingest-source.html"
+    const quickIngestFixtureUrl = new URL(
+      "/e2e/quick-ingest-source.html",
+      TEST_CONFIG.webUrl
+    ).toString()
+    const mockedQuickIngestJobUrl =
+      "https://www.youtube.com/watch?v=tldw-quick-ingest-e2e"
+    let mockedQuickIngestLifecycleSequence = 0
     const bulkConferencePlaylistUrl =
       "https://www.youtube.com/watch?v=PrNmmN6qBiw&list=PL0065D9B288E6804B"
     const bulkConferenceCollectionId = 700
@@ -785,10 +794,13 @@ test.describe("Media Ingestion Workflow", () => {
         }
       } = {}
     ) => {
-      const sourceUrl = options.sourceUrl ?? quickIngestFixtureUrl
-      const mediaId = options.mediaId ?? "qi-media-e2e-101"
-      const jobId = options.jobId ?? 101
-      const batchId = options.batchId ?? "batch-e2e-quick-ingest"
+      mockedQuickIngestLifecycleSequence += 1
+      const mockSequence = mockedQuickIngestLifecycleSequence
+      const sourceUrl =
+        options.sourceUrl ?? `${mockedQuickIngestJobUrl}&mock=${mockSequence}`
+      const mediaId = options.mediaId ?? `qi-media-e2e-${mockSequence}`
+      const jobId = options.jobId ?? 1000 + mockSequence
+      const batchId = options.batchId ?? `batch-e2e-quick-ingest-${mockSequence}`
       const title = "Quick ingest source"
       let remainingProcessingResponses = Math.max(0, options.processingResponses ?? 0)
 
@@ -919,7 +931,26 @@ test.describe("Media Ingestion Workflow", () => {
           .first()
       }
       await expect(emptyStateTrigger).toBeVisible({ timeout: 15_000 })
-      await emptyStateTrigger.click()
+      await expect
+        .poll(
+          async () => {
+            const trigger = authedPage
+              .getByTestId("first-ingest-tutorial")
+              .getByRole("button", { name: /^ingest$/i })
+              .or(authedPage.getByRole("button", { name: /open quick ingest/i }))
+              .first()
+            if (!(await trigger.isVisible().catch(() => false))) {
+              return false
+            }
+            await trigger.click({ timeout: 2_000 }).catch(() => undefined)
+            return await dialog.isVisible().catch(() => false)
+          },
+          {
+            timeout: 15_000,
+            message: "Timed out opening Quick Ingest from the visible media page trigger",
+          }
+        )
+        .toBe(true)
       await expect(dialog).toBeVisible({ timeout: 15_000 })
       await expect(dialog).toContainText(
         /Add URLs or files\. Stored items appear in Media/i
@@ -990,18 +1021,24 @@ test.describe("Media Ingestion Workflow", () => {
       test.setTimeout(180_000)
       skipIfServerUnavailable(serverInfo)
 
-      const {
-        sourceUrl: ingestUrl,
-        mediaId: expectedMediaId,
-        title,
-      } = await mockQuickIngestLifecycle(
-        authedPage,
-        {
-          mediaId: "qi-media-url-complete"
-        }
-      )
-      const mediaId = await ingestAndWaitForReady(authedPage, { url: ingestUrl })
-      expect(mediaId).toBe(expectedMediaId)
+      const ingestUrl = quickIngestFixtureUrl
+      const title = "quick-ingest-source.html"
+      const processRequestPromise = authedPage.waitForRequest((request) => {
+        if (request.method().toUpperCase() !== "POST") return false
+        const url = new URL(request.url())
+        return url.pathname.replace(/\/+$/, "") === "/api/v1/media/process-web-scraping"
+      })
+
+      const mediaIdPromise = ingestAndWaitForReady(authedPage, { url: ingestUrl })
+      const processRequest = await processRequestPromise
+      const processBody = processRequest.postDataJSON() as Record<string, unknown>
+      expect(processBody).toMatchObject({
+        url_input: ingestUrl,
+        summarize_checkbox: false,
+        perform_chunking: false,
+      })
+      const mediaId = await mediaIdPromise
+      expect(mediaId).not.toBe("unknown")
 
       await dismissQuickIngest(authedPage)
       const dialog = await reopenQuickIngest(authedPage)
@@ -1019,7 +1056,7 @@ test.describe("Media Ingestion Workflow", () => {
       await authedPage.waitForURL(
         (url) =>
           url.pathname === "/media" &&
-          url.searchParams.get("id") === expectedMediaId,
+          url.searchParams.get("id") === mediaId,
         { timeout: 15_000 }
       )
       await expect(dialog).toBeHidden({ timeout: 15_000 })
@@ -1081,7 +1118,7 @@ test.describe("Media Ingestion Workflow", () => {
               {
                 status: "Success",
                 media_id: "qi-media-url-fallback",
-                source_url: quickIngestFixtureUrl,
+                source_url: mockedQuickIngestJobUrl,
                 title: "Quick ingest source"
               }
             ]
@@ -1147,7 +1184,7 @@ test.describe("Media Ingestion Workflow", () => {
 
       const { sourceUrl: ingestUrl } = await mockQuickIngestLifecycle(authedPage, {
         mediaId: "qi-media-url-resume",
-        processingResponses: 1
+        processingResponses: 5
       })
       const dialog = await queueUrlAndStartProcessing(authedPage, ingestUrl, {
         waitForState: "processing"
@@ -1171,7 +1208,8 @@ test.describe("Media Ingestion Workflow", () => {
       skipIfServerUnavailable(serverInfo)
 
       const { sourceUrl: ingestUrl, title } = await mockQuickIngestLifecycle(authedPage, {
-        mediaId: "qi-media-url-refresh"
+        mediaId: "qi-media-url-refresh",
+        processingResponses: 1
       })
 
       let dialog = await openQuickIngestDialog(authedPage)
@@ -1181,7 +1219,8 @@ test.describe("Media Ingestion Workflow", () => {
       await expect(dialog).toContainText(ingestUrl)
 
       dialog = await startQueuedQuickIngestProcessing(dialog, {
-        waitForState: "processing"
+        waitForState: "processing",
+        requireJobSubmit: true,
       })
       await authedPage.reload({ waitUntil: "domcontentloaded" })
       dialog = await reopenQuickIngest(authedPage)
@@ -1236,7 +1275,7 @@ test.describe("Media Ingestion Workflow", () => {
 
       const { sourceUrl: ingestUrl } = await mockQuickIngestLifecycle(authedPage, {
         mediaId: "qi-media-url-draft",
-        processingResponses: 1
+        processingResponses: 5
       })
       let dialog = await openQuickIngestDialog(authedPage)
       await advanceQuickIngestToConfigureStep(dialog, ingestUrl, { proceedToConfigure: false })
@@ -1296,6 +1335,18 @@ test.describe("Media Ingestion Workflow", () => {
       await metadataPanel.getByLabel("Shared tags").fill("conference, talks")
 
       await dialog.getByRole("button", { name: /configure 33 items/i }).click()
+      for (const option of ["analysis", "chunking"]) {
+        const toggle = dialog
+          .getByRole("switch", {
+            name: new RegExp(`^Ingestion options\\s*[–-]\\s*${option}$`, "i")
+          })
+          .first()
+        await expect(toggle).toBeVisible()
+        if ((await toggle.getAttribute("aria-checked")) === "true") {
+          await toggle.click()
+          await expect(toggle).toHaveAttribute("aria-checked", "false")
+        }
+      }
       await dialog.getByRole("button", { name: "Next" }).click()
       await expect(dialog).toContainText("Ready to Process")
       await dialog.getByRole("button", { name: /start processing/i }).click()

--- a/apps/tldw-frontend/next.config.mjs
+++ b/apps/tldw-frontend/next.config.mjs
@@ -7,12 +7,19 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const paTesseractPath = path.resolve(__dirname, 'node_modules/pa-tesseract.js');
 const repoWorkspaceRoot = path.resolve(__dirname, '../..');
-const backendRuntimeWatchIgnorePatterns = [
-  '../../Databases/**',
-  '../../tldw_Server_API/Databases/**',
-  '../../tldw_Server_API/Logs/**',
-  '../../logs/**',
-];
+const backendRuntimeWatchIgnoreRoots = [
+  'Databases',
+  'tldw_Server_API/Databases',
+  'tldw_Server_API/Logs',
+  'logs',
+].map((root) => path.resolve(repoWorkspaceRoot, root).split(path.sep).join('/'));
+const backendRuntimeWatchIgnorePatterns = backendRuntimeWatchIgnoreRoots.map(
+  (root) => `${root}/**`
+);
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const backendRuntimeWatchIgnoreSource = backendRuntimeWatchIgnoreRoots
+  .map((root) => `^${escapeRegExp(root)}(?:/|$)`)
+  .join('|');
 const {
   deploymentMode,
   internalApiOrigin: validatedInternalApiOrigin
@@ -194,12 +201,22 @@ const nextConfig = {
       'extension/shims/wxt-browser.ts'
     );
     const existingIgnored = config.watchOptions?.ignored;
+    if (existingIgnored instanceof RegExp) {
+      config.watchOptions = {
+        ...config.watchOptions,
+        ignored: new RegExp(
+          `(?:${existingIgnored.source})|(?:${backendRuntimeWatchIgnoreSource})`,
+          existingIgnored.flags.replace(/[gy]/g, '')
+        ),
+      };
+      return config;
+    }
     const normalizedExistingIgnored = (
       Array.isArray(existingIgnored)
         ? existingIgnored
-        : existingIgnored
-          ? [existingIgnored]
-          : []
+        : existingIgnored == null
+          ? []
+          : [existingIgnored]
     ).filter((item) => typeof item === 'string' && item.trim());
     config.watchOptions = {
       ...config.watchOptions,

--- a/apps/tldw-frontend/next.config.mjs
+++ b/apps/tldw-frontend/next.config.mjs
@@ -6,6 +6,13 @@ import { validateNetworkingConfig } from './scripts/validate-networking-config.m
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const paTesseractPath = path.resolve(__dirname, 'node_modules/pa-tesseract.js');
+const repoWorkspaceRoot = path.resolve(__dirname, '../..');
+const backendRuntimeWatchIgnorePatterns = [
+  '../../Databases/**',
+  '../../tldw_Server_API/Databases/**',
+  '../../tldw_Server_API/Logs/**',
+  '../../logs/**',
+];
 const {
   deploymentMode,
   internalApiOrigin: validatedInternalApiOrigin
@@ -146,6 +153,7 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   turbopack: {
+    root: repoWorkspaceRoot,
     // Keep Turbopack aliases aligned with shared UI + web shims.
     resolveAlias: {
       '@tldw/ui': '../packages/ui/src',
@@ -160,7 +168,7 @@ const nextConfig = {
     },
   },
   // Ensure Next resolves the correct monorepo root when multiple lockfiles exist.
-  outputFileTracingRoot: path.resolve(__dirname, '../..'),
+  outputFileTracingRoot: repoWorkspaceRoot,
   transpilePackages: ['@tldw/ui'],
   webpack: (config) => {
     // Support extension-aligned aliases + shims
@@ -185,6 +193,21 @@ const nextConfig = {
       __dirname,
       'extension/shims/wxt-browser.ts'
     );
+    const existingIgnored = config.watchOptions?.ignored;
+    const normalizedExistingIgnored = (
+      Array.isArray(existingIgnored)
+        ? existingIgnored
+        : existingIgnored
+          ? [existingIgnored]
+          : []
+    ).filter((item) => typeof item === 'string' && item.trim());
+    config.watchOptions = {
+      ...config.watchOptions,
+      ignored: [
+        ...normalizedExistingIgnored,
+        ...backendRuntimeWatchIgnorePatterns,
+      ],
+    };
     return config;
   },
 };

--- a/apps/tldw-frontend/package.json
+++ b/apps/tldw-frontend/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "postinstall": "node scripts/copy-pdf-worker.mjs",
     "generate:api-types": "node scripts/generate-api-types.mjs",
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "dev:webpack": "next dev --webpack",
+    "dev:turbopack": "next dev",
     "build": "node scripts/build-with-profile.mjs --bundler=turbopack && node scripts/verify-shared-token-sync.mjs --dir .next",
     "build:prod": "cross-env TLDW_BUILD_PROFILE=production node scripts/build-with-profile.mjs --bundler=turbopack && node scripts/verify-shared-token-sync.mjs --dir .next",
     "build:dev": "cross-env TLDW_BUILD_PROFILE=development node scripts/build-with-profile.mjs --bundler=turbopack && node scripts/verify-shared-token-sync.mjs --dir .next",

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -4,7 +4,7 @@ title: Fix Quick Ingest repeat ingestion and queued job recovery
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-07-11 07:29'
+updated_date: '2026-07-11 07:53'
 labels: []
 dependencies: []
 documentation:
@@ -51,6 +51,8 @@ Draft PR: https://github.com/rmusser01/tldw_server/pull/2709
 Task 1 complete at 7be983885e: Webpack watch ignores now preserve valid existing semantics in schema-valid shapes and append absolute normalized backend runtime roots. Outside-sandbox focused Vitest passed 7/7; spec and quality reviews approved.
 
 Task 2 complete at 853f6a5a77: restored direct-job reads retry status-less/network/status-0, 408, 429, and 5xx failures up to three attempts while permanent/malformed responses interrupt immediately. Outside-sandbox focused Vitest passed 17/17 and adjacent session/store suites passed 45/45; spec and quality reviews approved.
+
+Task 3 complete at 02da73990a: persistence uses structured extractor signals and exact repository messages, repeated real repository writes classify as skipped duplicates, null-ID/storage failures are accounted, touched URL/exception logs are sanitized, and frontend terminal status uses one typed helper with duplicate precedence. Outside-sandbox backend pytest passed 15/15, frontend Vitest 39/39, Bandit 0 findings; reviews approved.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -1,0 +1,63 @@
+---
+id: TASK-12946
+title: Fix Quick Ingest repeat ingestion and queued job recovery
+status: In Progress
+modified_files:
+- apps/extension/tests/e2e/live-ux-workflows.spec.ts
+- apps/extension/tests/e2e/quick-ingest-cancel.spec.ts
+- apps/extension/tests/e2e/quick-ingest-ux-audit.spec.ts
+- apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+- apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+- apps/packages/ui/src/services/tldw/ingest-job-results.ts
+- apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
+- apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts
+- apps/packages/ui/src/services/__tests__/ingest-job-results.test.ts
+- apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
+- apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts
+- apps/tldw-frontend/package.json
+- apps/tldw-frontend/next.config.mjs
+- apps/tldw-frontend/__tests__/frontend-dev-config.test.ts
+- apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts
+- apps/tldw-frontend/e2e/onboarding-uat/helpers.ts
+- apps/tldw-frontend/e2e/utils/journey-helpers.ts
+- apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
+- Docs/Getting_Started/TROUBLESHOOTING.md
+- Docs/Published/Getting_Started/TROUBLESHOOTING.md
+- pyproject.toml
+- tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py
+- tldw_Server_API/app/services/enhanced_web_scraping_service.py
+- tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py
+- tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate repeated user reports of WebUI/browser-extension Quick Ingest failures: `Maximum update depth exceeded` after repeated YouTube/web ingestion and backend ingest jobs appearing queued at 0%. Require real end-to-end user acceptance walkthroughs before relying on automated E2E coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-07-10 follow-up UAT isolated the repeat YouTube Shorts failure to stale yt-dlp in the project venv. Before updating, yt-dlp 2025.8.11 quarantined `https://www.youtube.com/shorts/6-rf_YXDpPg` at 20% with "content is not available on this app." After updating the venv to yt-dlp 2026.7.4, the same Quick Ingest browser flow completed the YouTube job at 100% and added media id 5. Raised `pyproject.toml` yt-dlp floor to `>=2026.7.4` so fresh installs pick up the extractor fix.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Investigated with real WebUI walkthroughs before relying on E2E. Root causes fixed: repeat/duplicate web scrape responses were returned as HTTP 200 with zero stored articles and not classified as skipped/failure consistently; Quick Ingest direct scrape handling treated some error payloads as success; default web scraping extraction implicitly invoked LLM analysis without an explicit provider; Next dev mode watched backend runtime DB/log writes and could remount the UI; AntD Modal portal styling in QuickIngestWizardModal still triggered the reported Maximum update depth crash on repeat duplicate URL submissions; restored queued-job polling did not force the direct backend path and could leave refresh/reopen flows stuck at 0%; stale yt-dlp 2025.8.11 caused current YouTube/Shorts extractor failures that disappeared after updating to yt-dlp 2026.7.4. Added regression coverage for duplicate persistence, extraction method defaults, batch result classification, restored job polling, modal session stability, dev watcher config, and Quick Ingest E2E helper timing/isolation. Verification was run outside the sandbox: manual UAT covered duplicate URLs, mixed file+URL ingest, backend job status progressing to completed/100%, and PDF + local link + YouTube Shorts ingestion after the yt-dlp update; focused Vitest passed 75 tests across 6 files; focused backend pytest passed 11 tests; Bandit on touched backend code reported 0 findings; targeted Playwright Quick Ingest/media ingest set passed 14 tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -44,6 +44,8 @@ Investigate repeated user reports of WebUI/browser-extension Quick Ingest failur
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 2026-07-10 follow-up UAT isolated the repeat YouTube Shorts failure to stale yt-dlp in the project venv. Before updating, yt-dlp 2025.8.11 quarantined `https://www.youtube.com/shorts/6-rf_YXDpPg` at 20% with "content is not available on this app." After updating the venv to yt-dlp 2026.7.4, the same Quick Ingest browser flow completed the YouTube job at 100% and added media id 5. Raised `pyproject.toml` yt-dlp floor to `>=2026.7.4` so fresh installs pick up the extractor fix.
+
+Draft PR: https://github.com/rmusser01/tldw_server/pull/2709
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -4,7 +4,7 @@ title: Fix Quick Ingest repeat ingestion and queued job recovery
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-07-11 08:36'
+updated_date: '2026-07-11 09:04'
 labels: []
 dependencies: []
 documentation:
@@ -55,6 +55,8 @@ Task 2 complete at 853f6a5a77: restored direct-job reads retry status-less/netwo
 Task 3 complete at 02da73990a: persistence uses structured extractor signals and exact repository messages, repeated real repository writes classify as skipped duplicates, null-ID/storage failures are accounted, touched URL/exception logs are sanitized, and frontend terminal status uses one typed helper with duplicate precedence. Outside-sandbox backend pytest passed 15/15, frontend Vitest 39/39, Bandit 0 findings; reviews approved.
 
 Task 4 complete at a72449d733: restored llm in the global extraction default and explicitly propagated existing perform_analysis/summarize_checkbox intent through enhanced, queued, crawl, legacy, and friendly-ingest paths via internal default-true arguments only. Async enhanced extraction is offloaded from the event loop. No public schema/request field changed. Outside-sandbox 115 tests passed and Bandit reported 0 findings; reviews approved.
+
+Task 5 complete at f4e6e81c33: added a thread-safe, exactly-once, nonblocking yt-dlp floor diagnostic at all seven validated Video_DL boundaries plus existing-environment update docs. Lazy version-helper imports cannot break ingestion. Outside-sandbox focused pytest passed 24/24, adjacent video tests 33/33, Bandit 0 findings; reviews approved.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -4,7 +4,7 @@ title: Fix Quick Ingest repeat ingestion and queued job recovery
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-07-11 06:31'
+updated_date: '2026-07-11 07:06'
 labels: []
 dependencies: []
 documentation:
@@ -47,6 +47,8 @@ Draft PR: https://github.com/rmusser01/tldw_server/pull/2709
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 2026-07-10: Corrected the remediation design after tracing both public web ingestion contracts. No new strategy request field will be added; existing perform_analysis/summarize_checkbox intent will be propagated to the internal extraction pipeline.
+
+Task 1 complete at 7be983885e: Webpack watch ignores now preserve valid existing semantics in schema-valid shapes and append absolute normalized backend runtime roots. Outside-sandbox focused Vitest passed 7/7; spec and quality reviews approved.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -4,7 +4,7 @@ title: Fix Quick Ingest repeat ingestion and queued job recovery
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-07-11 09:04'
+updated_date: '2026-07-11 16:23'
 labels: []
 dependencies: []
 documentation:
@@ -20,14 +20,14 @@ Investigate repeated user reports of WebUI/browser-extension Quick Ingest failur
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Repeat Quick Ingest submissions complete without Maximum update depth errors and classify existing media as skipped.
-- [ ] #2 Restored direct ingest jobs survive transient status-read failures and terminate correctly for permanent missing jobs.
-- [ ] #3 Webpack dev watch ignores preserve existing patterns and match backend runtime directories using absolute normalized paths.
-- [ ] #4 Stale yt-dlp installations produce actionable diagnostics and current installations continue normally.
-- [ ] #5 Touched persistence logs redact user-controlled URL secrets.
-- [ ] #6 Focused automated verification, Bandit, and full PDF, local-link, and YouTube Shorts UAT pass outside the sandbox.
+- [x] #1 Repeat Quick Ingest submissions complete without Maximum update depth errors and classify existing media as skipped.
+- [x] #2 Restored direct ingest jobs survive transient status-read failures and terminate correctly for permanent missing jobs.
+- [x] #3 Webpack dev watch ignores preserve existing patterns and match backend runtime directories using absolute normalized paths.
+- [x] #4 Stale yt-dlp installations produce actionable diagnostics and current installations continue normally.
+- [x] #5 Touched persistence logs redact user-controlled URL secrets.
+- [x] #6 Focused automated verification, Bandit, and full PDF, local-link, and YouTube Shorts UAT pass outside the sandbox.
 - [ ] #7 All actionable PR review threads are resolved and the branch is current with dev.
-- [ ] #8 Existing perform_analysis and summarize_checkbox declarations govern request-level LLM extraction without a new public API field, while non-API scraper consumers retain the established default order.
+- [x] #8 Existing perform_analysis and summarize_checkbox declarations govern request-level LLM extraction without a new public API field, while non-API scraper consumers retain the established default order.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -57,20 +57,18 @@ Task 3 complete at 02da73990a: persistence uses structured extractor signals and
 Task 4 complete at a72449d733: restored llm in the global extraction default and explicitly propagated existing perform_analysis/summarize_checkbox intent through enhanced, queued, crawl, legacy, and friendly-ingest paths via internal default-true arguments only. Async enhanced extraction is offloaded from the event loop. No public schema/request field changed. Outside-sandbox 115 tests passed and Bandit reported 0 findings; reviews approved.
 
 Task 5 complete at f4e6e81c33: added a thread-safe, exactly-once, nonblocking yt-dlp floor diagnostic at all seven validated Video_DL boundaries plus existing-environment update docs. Lazy version-helper imports cannot break ingestion. Outside-sandbox focused pytest passed 24/24, adjacent video tests 33/33, Bandit 0 findings; reviews approved.
+
+2026-07-11 renewed host-side UAT: a clean PDF run completed, but every same-mounted-session second submission reproduced Maximum update depth in @rc-component/portal before the link result rendered. Three isolated attempts disproved getContainer and stale-tracking-only fixes. Proven findings retained: returning a session to draft must clear old direct job tracking; the media worker's generic exponential idle backoff reached a 30-second ceiling (observed queued for 28 seconds before claim), so its user-facing default ceiling is reduced to 2 seconds while preserving the env override. Remaining proposed architecture change requires approval: Ingest More should call the existing replaceWithNewDraft() so the provider key/session/run refs remount instead of reusing the completed provider. Full PDF/link/YouTube repeat UAT is not yet passing; prior final summary cleared as stale.
+
+2026-07-11 approved architecture fix and fresh host-side UAT: Ingest More now calls the existing replaceWithNewDraft path, creating a new session/provider key instead of reusing completed reducer and run refs. Draft upserts also clear stale direct-job tracking. One mounted WebUI walkthrough passed PDF, RFC 9110 link, repeated RFC link, exact YouTube Short https://www.youtube.com/shorts/6-rf_YXDpPg, and repeated YouTube Short. First submissions succeeded; repeats were classified as skipped existing. pageErrors and consoleErrors were empty. PDF and YouTube jobs began within one second of creation, confirming the media worker 2-second default idle-backoff ceiling removes the observed 28-second queued-at-0-percent delay. Jobs DB: three completed 100-percent jobs with Success, Success, Skipped. Media DB: exactly three rows for PDF, RFC link, and YouTube Short. Evidence: /tmp/task12946_quick_ingest_uat_10_evidence.json and /tmp/task12946_quick_ingest_uat_10_final.png. Focused UI Vitest passed 46/46, media worker pytest passed 19/19, extension TypeScript compile passed, and Bandit reported zero findings. The focused extension Playwright test could not be completed locally after three launch attempts: two headless attempts exposed no MV3 targets and the required headful attempt timed out; repository CI uses xvfb with TLDW_E2E_EXTENSION_HEADLESS=0, so this test remains for CI verification after push.
 <!-- SECTION:NOTES:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Investigated with real WebUI walkthroughs before relying on E2E. Root causes fixed: repeat/duplicate web scrape responses were returned as HTTP 200 with zero stored articles and not classified as skipped/failure consistently; Quick Ingest direct scrape handling treated some error payloads as success; default web scraping extraction implicitly invoked LLM analysis without an explicit provider; Next dev mode watched backend runtime DB/log writes and could remount the UI; AntD Modal portal styling in QuickIngestWizardModal still triggered the reported Maximum update depth crash on repeat duplicate URL submissions; restored queued-job polling did not force the direct backend path and could leave refresh/reopen flows stuck at 0%; stale yt-dlp 2025.8.11 caused current YouTube/Shorts extractor failures that disappeared after updating to yt-dlp 2026.7.4. Added regression coverage for duplicate persistence, extraction method defaults, batch result classification, restored job polling, modal session stability, dev watcher config, and Quick Ingest E2E helper timing/isolation. Verification was run outside the sandbox: manual UAT covered duplicate URLs, mixed file+URL ingest, backend job status progressing to completed/100%, and PDF + local link + YouTube Shorts ingestion after the yt-dlp update; focused Vitest passed 75 tests across 6 files; focused backend pytest passed 11 tests; Bandit on touched backend code reported 0 findings; targeted Playwright Quick Ingest/media ingest set passed 14 tests.
-<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -4,7 +4,7 @@ title: Fix Quick Ingest repeat ingestion and queued job recovery
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-07-11 16:23'
+updated_date: '2026-07-11 16:27'
 labels: []
 dependencies: []
 documentation:
@@ -26,7 +26,7 @@ Investigate repeated user reports of WebUI/browser-extension Quick Ingest failur
 - [x] #4 Stale yt-dlp installations produce actionable diagnostics and current installations continue normally.
 - [x] #5 Touched persistence logs redact user-controlled URL secrets.
 - [x] #6 Focused automated verification, Bandit, and full PDF, local-link, and YouTube Shorts UAT pass outside the sandbox.
-- [ ] #7 All actionable PR review threads are resolved and the branch is current with dev.
+- [x] #7 All actionable PR review threads are resolved and the branch is current with dev.
 - [x] #8 Existing perform_analysis and summarize_checkbox declarations govern request-level LLM extraction without a new public API field, while non-API scraper consumers retain the established default order.
 <!-- AC:END -->
 
@@ -61,14 +61,24 @@ Task 5 complete at f4e6e81c33: added a thread-safe, exactly-once, nonblocking yt
 2026-07-11 renewed host-side UAT: a clean PDF run completed, but every same-mounted-session second submission reproduced Maximum update depth in @rc-component/portal before the link result rendered. Three isolated attempts disproved getContainer and stale-tracking-only fixes. Proven findings retained: returning a session to draft must clear old direct job tracking; the media worker's generic exponential idle backoff reached a 30-second ceiling (observed queued for 28 seconds before claim), so its user-facing default ceiling is reduced to 2 seconds while preserving the env override. Remaining proposed architecture change requires approval: Ingest More should call the existing replaceWithNewDraft() so the provider key/session/run refs remount instead of reusing the completed provider. Full PDF/link/YouTube repeat UAT is not yet passing; prior final summary cleared as stale.
 
 2026-07-11 approved architecture fix and fresh host-side UAT: Ingest More now calls the existing replaceWithNewDraft path, creating a new session/provider key instead of reusing completed reducer and run refs. Draft upserts also clear stale direct-job tracking. One mounted WebUI walkthrough passed PDF, RFC 9110 link, repeated RFC link, exact YouTube Short https://www.youtube.com/shorts/6-rf_YXDpPg, and repeated YouTube Short. First submissions succeeded; repeats were classified as skipped existing. pageErrors and consoleErrors were empty. PDF and YouTube jobs began within one second of creation, confirming the media worker 2-second default idle-backoff ceiling removes the observed 28-second queued-at-0-percent delay. Jobs DB: three completed 100-percent jobs with Success, Success, Skipped. Media DB: exactly three rows for PDF, RFC link, and YouTube Short. Evidence: /tmp/task12946_quick_ingest_uat_10_evidence.json and /tmp/task12946_quick_ingest_uat_10_final.png. Focused UI Vitest passed 46/46, media worker pytest passed 19/19, extension TypeScript compile passed, and Bandit reported zero findings. The focused extension Playwright test could not be completed locally after three launch attempts: two headless attempts exposed no MV3 targets and the required headful attempt timed out; repository CI uses xvfb with TLDW_E2E_EXTENSION_HEADLESS=0, so this test remains for CI verification after push.
+
+2026-07-11 closeout: rebased cleanly onto latest origin/dev, reran 46/46 UI tests, 19/19 media worker tests, and extension TypeScript compile successfully, force-pushed head 9ccf66c89a, posted UAT evidence to PR #2709, and resolved all 13 inline review threads. GitHub reports the PR mergeable; 20 checks are queued, 1 succeeded, and 2 skipped. Human Change summary remains the merge gate.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Root causes and fixes are now validated. Repeated Ingest More submissions reused the completed persisted session, provider key, reducer, and run refs; the wizard now uses replaceWithNewDraft so each new run remounts under a fresh session id, and draft transitions clear stale direct-job tracking. Backend jobs appeared queued at 0 percent because the media worker inherited a generic exponential idle backoff with a 30-second ceiling; the media worker default ceiling is now 2 seconds while preserving the environment override. Earlier fixes in this task also made duplicate outcomes exact and visible, restored transient job reattachment, honored the existing web ingestion analysis declarations without a new API field, protected URL logs, preserved Webpack watch ignores, and diagnosed stale yt-dlp versions.
+
+Fresh host-side UAT in one mounted WebUI passed PDF, RFC link and duplicate, and the exact YouTube Short https://www.youtube.com/shorts/6-rf_YXDpPg and duplicate. First submissions succeeded, repeats were skipped existing, no page or console errors occurred, jobs began within one second and reached 100 percent, and the Media DB contained exactly three unique records. Post-rebase verification passed 46 UI tests, 19 media-worker tests, TypeScript compile, Bandit with zero findings, and diff whitespace checks. All 13 PR review threads are resolved and the branch is current with dev. GitHub CI is queued. The PR is not merge-ready until the human requester writes the required Change summary explaining what changed and why; the local MV3 Playwright launcher limitation is documented and CI remains its verifier.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -4,7 +4,7 @@ title: Fix Quick Ingest repeat ingestion and queued job recovery
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-07-11 07:53'
+updated_date: '2026-07-11 08:36'
 labels: []
 dependencies: []
 documentation:
@@ -53,6 +53,8 @@ Task 1 complete at 7be983885e: Webpack watch ignores now preserve valid existing
 Task 2 complete at 853f6a5a77: restored direct-job reads retry status-less/network/status-0, 408, 429, and 5xx failures up to three attempts while permanent/malformed responses interrupt immediately. Outside-sandbox focused Vitest passed 17/17 and adjacent session/store suites passed 45/45; spec and quality reviews approved.
 
 Task 3 complete at 02da73990a: persistence uses structured extractor signals and exact repository messages, repeated real repository writes classify as skipped duplicates, null-ID/storage failures are accounted, touched URL/exception logs are sanitized, and frontend terminal status uses one typed helper with duplicate precedence. Outside-sandbox backend pytest passed 15/15, frontend Vitest 39/39, Bandit 0 findings; reviews approved.
+
+Task 4 complete at a72449d733: restored llm in the global extraction default and explicitly propagated existing perform_analysis/summarize_checkbox intent through enhanced, queued, crawl, legacy, and friendly-ingest paths via internal default-true arguments only. Async enhanced extraction is offloaded from the event loop. No public schema/request field changed. Outside-sandbox 115 tests passed and Bandit reported 0 findings; reviews approved.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -2,35 +2,14 @@
 id: TASK-12946
 title: Fix Quick Ingest repeat ingestion and queued job recovery
 status: In Progress
-modified_files:
-- apps/extension/tests/e2e/live-ux-workflows.spec.ts
-- apps/extension/tests/e2e/quick-ingest-cancel.spec.ts
-- apps/extension/tests/e2e/quick-ingest-ux-audit.spec.ts
-- apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
-- apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
-- apps/packages/ui/src/services/tldw/ingest-job-results.ts
-- apps/packages/ui/src/services/tldw/quick-ingest-batch.ts
-- apps/packages/ui/src/services/tldw/quick-ingest-session-reattach.ts
-- apps/packages/ui/src/services/__tests__/ingest-job-results.test.ts
-- apps/packages/ui/src/services/__tests__/quick-ingest-batch.test.ts
-- apps/packages/ui/src/services/__tests__/quick-ingest-session-reattach.test.ts
-- apps/tldw-frontend/package.json
-- apps/tldw-frontend/next.config.mjs
-- apps/tldw-frontend/__tests__/frontend-dev-config.test.ts
-- apps/tldw-frontend/__tests__/next-config-dev-watch-guard.test.ts
-- apps/tldw-frontend/e2e/onboarding-uat/helpers.ts
-- apps/tldw-frontend/e2e/utils/journey-helpers.ts
-- apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
-- Docs/Getting_Started/TROUBLESHOOTING.md
-- Docs/Published/Getting_Started/TROUBLESHOOTING.md
-- Docs/superpowers/specs/2026-07-10-quick-ingest-pr-2709-review-remediation-design.md
-- pyproject.toml
-- tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py
-- tldw_Server_API/app/services/enhanced_web_scraping_service.py
-- tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py
-- tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py
+assignee: []
+created_date: ''
+updated_date: '2026-07-11 06:31'
+labels: []
+dependencies: []
 documentation:
-- Docs/superpowers/specs/2026-07-10-quick-ingest-pr-2709-review-remediation-design.md
+  - >-
+    Docs/superpowers/specs/2026-07-10-quick-ingest-pr-2709-review-remediation-design.md
 ---
 
 ## Description
@@ -41,15 +20,34 @@ Investigate repeated user reports of WebUI/browser-extension Quick Ingest failur
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [ ] #1 Repeat Quick Ingest submissions complete without Maximum update depth errors and classify existing media as skipped.
+- [ ] #2 Restored direct ingest jobs survive transient status-read failures and terminate correctly for permanent missing jobs.
+- [ ] #3 Webpack dev watch ignores preserve existing patterns and match backend runtime directories using absolute normalized paths.
+- [ ] #4 Stale yt-dlp installations produce actionable diagnostics and current installations continue normally.
+- [ ] #5 Touched persistence logs redact user-controlled URL secrets.
+- [ ] #6 Focused automated verification, Bandit, and full PDF, local-link, and YouTube Shorts UAT pass outside the sandbox.
+- [ ] #7 All actionable PR review threads are resolved and the branch is current with dev.
+- [ ] #8 Existing perform_analysis and summarize_checkbox declarations govern request-level LLM extraction without a new public API field, while non-API scraper consumers retain the established default order.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-07-10-quick-ingest-pr-2709-review-remediation-plan.md
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 2026-07-10 follow-up UAT isolated the repeat YouTube Shorts failure to stale yt-dlp in the project venv. Before updating, yt-dlp 2025.8.11 quarantined `https://www.youtube.com/shorts/6-rf_YXDpPg` at 20% with "content is not available on this app." After updating the venv to yt-dlp 2026.7.4, the same Quick Ingest browser flow completed the YouTube job at 100% and added media id 5. Raised `pyproject.toml` yt-dlp floor to `>=2026.7.4` so fresh installs pick up the extractor fix.
 
 Draft PR: https://github.com/rmusser01/tldw_server/pull/2709
+2026-07-10: Rebasing review follow-up completed cleanly onto current origin/dev. Approved remediation design committed at Docs/superpowers/specs/2026-07-10-quick-ingest-pr-2709-review-remediation-design.md; implementation remains pending spec/plan gates.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+2026-07-10: Corrected the remediation design after tracing both public web ingestion contracts. No new strategy request field will be added; existing perform_analysis/summarize_checkbox intent will be propagated to the internal extraction pipeline.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -23,11 +23,14 @@ modified_files:
 - apps/tldw-frontend/e2e/workflows/media-ingest.spec.ts
 - Docs/Getting_Started/TROUBLESHOOTING.md
 - Docs/Published/Getting_Started/TROUBLESHOOTING.md
+- Docs/superpowers/specs/2026-07-10-quick-ingest-pr-2709-review-remediation-design.md
 - pyproject.toml
 - tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py
 - tldw_Server_API/app/services/enhanced_web_scraping_service.py
 - tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py
 - tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py
+documentation:
+- Docs/superpowers/specs/2026-07-10-quick-ingest-pr-2709-review-remediation-design.md
 ---
 
 ## Description

--- a/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
+++ b/backlog/tasks/task-12946 - Fix-Quick-Ingest-repeat-ingestion-and-queued-job-recovery.md
@@ -4,7 +4,7 @@ title: Fix Quick Ingest repeat ingestion and queued job recovery
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-07-11 07:06'
+updated_date: '2026-07-11 07:29'
 labels: []
 dependencies: []
 documentation:
@@ -49,6 +49,8 @@ Draft PR: https://github.com/rmusser01/tldw_server/pull/2709
 2026-07-10: Corrected the remediation design after tracing both public web ingestion contracts. No new strategy request field will be added; existing perform_analysis/summarize_checkbox intent will be propagated to the internal extraction pipeline.
 
 Task 1 complete at 7be983885e: Webpack watch ignores now preserve valid existing semantics in schema-valid shapes and append absolute normalized backend runtime roots. Outside-sandbox focused Vitest passed 7/7; spec and quality reviews approved.
+
+Task 2 complete at 853f6a5a77: restored direct-job reads retry status-less/network/status-0, 408, 429, and 5xx failures up to three attempts while permanent/malformed responses interrupt immediately. Outside-sandbox focused Vitest passed 17/17 and adjacent session/store suites passed 45/45; spec and quality reviews approved.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ dependencies = [
   "PyAudio>=0.2.0",
   "sounddevice>=0.4.0",
   "soundfile>=0.12.0",
-  "yt-dlp>=2023.12.0",
+  "yt-dlp>=2026.7.4",
 
   # NLP/Text Processing
   "chardet>=5.0.0",

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
@@ -66,6 +66,9 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.logging_safety import (
     redact_urls_for_log,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.path_utils import resolve_safe_local_path
+from tldw_Server_API.app.core.Ingestion_Media_Processing.yt_dlp_support import (
+    warn_if_yt_dlp_is_stale,
+)
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze
 from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_Server_API.app.core.Security.egress import evaluate_url_policy
@@ -460,6 +463,7 @@ def get_video_info(url: str, *, use_cookies: bool = False, cookies: Optional[dic
                 ydl_opts.setdefault('http_headers', {})['Cookie'] = cookie_header
         except _VIDEO_NONCRITICAL_EXCEPTIONS:
             pass
+    warn_if_yt_dlp_is_stale()
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         try:
             info_dict = ydl.extract_info(url, download=False)
@@ -484,6 +488,7 @@ def get_youtube(video_url: str, *, use_cookies: bool = False, cookies: Optional[
                 ydl_opts.setdefault('http_headers', {})['Cookie'] = cookie_header
         except _VIDEO_NONCRITICAL_EXCEPTIONS:
             pass
+    warn_if_yt_dlp_is_stale()
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         logging.debug("About to extract youtube info")
         info_dict = ydl.extract_info(video_url, download=False)
@@ -506,6 +511,7 @@ def get_playlist_videos(playlist_url: str, *, use_cookies: bool = False, cookies
         except _VIDEO_NONCRITICAL_EXCEPTIONS:
             pass
 
+    warn_if_yt_dlp_is_stale()
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         info = ydl.extract_info(playlist_url, download=False)
 
@@ -587,6 +593,7 @@ def download_video(
     downloaded_path: Optional[Path] = None
 
     try:
+        warn_if_yt_dlp_is_stale()
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             result = ydl.extract_info(video_url, download=True)
 
@@ -634,6 +641,7 @@ def download_video(
 def extract_video_info(url):
     _raise_if_url_blocked(url)
     try:
+        warn_if_yt_dlp_is_stale()
         with yt_dlp.YoutubeDL({'quiet': True}) as ydl:
             info = ydl.extract_info(url, download=False)
 
@@ -659,6 +667,7 @@ def get_youtube_playlist_urls(playlist_id):
         'quiet': True,
     }
 
+    warn_if_yt_dlp_is_stale()
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         result = ydl.extract_info(playlist_url, download=False)
         return [entry['url'] for entry in result['entries'] if entry.get('url')]
@@ -827,6 +836,7 @@ def extract_metadata(url, use_cookies=False, cookies=None):
         else:
             logging.warning("Invalid cookie input provided; continuing without cookies header.")
 
+    warn_if_yt_dlp_is_stale()
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         try:
             info = ydl.extract_info(url, download=False)

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/yt_dlp_support.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/yt_dlp_support.py
@@ -1,0 +1,34 @@
+"""Best-effort runtime diagnostics for yt-dlp support."""
+
+from importlib import metadata
+from threading import Lock
+
+from loguru import logger
+
+
+MINIMUM_YT_DLP_VERSION = "2026.7.4"
+_UPDATE_COMMAND = f'pip install -U "yt-dlp>={MINIMUM_YT_DLP_VERSION}"'
+_check_lock = Lock()
+_checked = False
+
+
+def warn_if_yt_dlp_is_stale() -> None:
+    """Warn once when installed yt-dlp is below the supported version floor."""
+    global _checked
+
+    with _check_lock:
+        if _checked:
+            return
+        _checked = True
+
+    try:
+        from packaging.version import Version
+
+        installed_version = metadata.version("yt-dlp")
+        if Version(installed_version) < Version(MINIMUM_YT_DLP_VERSION):
+            logger.warning(
+                f"Installed yt-dlp version {installed_version} is below the supported "
+                f"minimum {MINIMUM_YT_DLP_VERSION}. Update it with: {_UPDATE_COMMAND}"
+            )
+    except Exception:  # noqa: BLE001 - diagnostics must never block ingestion
+        return

--- a/tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py
+++ b/tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py
@@ -390,10 +390,10 @@ DEFAULT_EXTRACTION_STRATEGY_ORDER = [
     "jsonld",
     "schema",
     "regex",
-    "llm",
     "cluster",
     "trafilatura",
 ]
+EXPLICIT_EXTRACTION_STRATEGIES = {"llm"}
 _STRATEGY_ALIASES = {
     "json-ld": "jsonld",
     "json_ld": "jsonld",
@@ -402,7 +402,7 @@ _STRATEGY_ALIASES = {
     "schema_xpath": "schema",
     "clustering": "cluster",
 }
-_KNOWN_STRATEGIES = set(DEFAULT_EXTRACTION_STRATEGY_ORDER)
+_KNOWN_STRATEGIES = set(DEFAULT_EXTRACTION_STRATEGY_ORDER) | EXPLICIT_EXTRACTION_STRATEGIES
 _MAX_REGEX_TOTAL_MATCHES = 200
 _MAX_REGEX_MATCHES_PER_LABEL = {
     "number": 50,

--- a/tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py
+++ b/tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py
@@ -390,10 +390,10 @@ DEFAULT_EXTRACTION_STRATEGY_ORDER = [
     "jsonld",
     "schema",
     "regex",
+    "llm",
     "cluster",
     "trafilatura",
 ]
-EXPLICIT_EXTRACTION_STRATEGIES = {"llm"}
 _STRATEGY_ALIASES = {
     "json-ld": "jsonld",
     "json_ld": "jsonld",
@@ -402,7 +402,7 @@ _STRATEGY_ALIASES = {
     "schema_xpath": "schema",
     "clustering": "cluster",
 }
-_KNOWN_STRATEGIES = set(DEFAULT_EXTRACTION_STRATEGY_ORDER) | EXPLICIT_EXTRACTION_STRATEGIES
+_KNOWN_STRATEGIES = set(DEFAULT_EXTRACTION_STRATEGY_ORDER)
 _MAX_REGEX_TOTAL_MATCHES = 200
 _MAX_REGEX_MATCHES_PER_LABEL = {
     "number": 50,
@@ -2464,9 +2464,12 @@ def extract_article_with_pipeline(
     llm_settings: Optional[dict[str, Any]] = None,
     regex_settings: Optional[dict[str, Any]] = None,
     cluster_settings: Optional[dict[str, Any]] = None,
+    allow_llm_extraction: bool = True,
 ) -> dict[str, Any]:
     trace: list[dict[str, Any]] = []
     order, unknown = _normalize_strategy_order(strategy_order)
+    if not allow_llm_extraction:
+        order = [strategy for strategy in order if strategy != "llm"]
     if _should_clear_caches("start"):
         clear_extraction_caches()
 
@@ -2662,6 +2665,7 @@ def extract_article_data_from_html(
     llm_settings: Optional[dict[str, Any]] = None,
     regex_settings: Optional[dict[str, Any]] = None,
     cluster_settings: Optional[dict[str, Any]] = None,
+    allow_llm_extraction: bool = True,
 ) -> dict[str, Any]:
     """Extract article metadata and body from raw HTML."""
     return extract_article_with_pipeline(
@@ -2673,6 +2677,7 @@ def extract_article_data_from_html(
         llm_settings=llm_settings,
         regex_settings=regex_settings,
         cluster_settings=cluster_settings,
+        allow_llm_extraction=allow_llm_extraction,
     )
 
 
@@ -2791,7 +2796,12 @@ def _fetch_article_lightweight(
     return response, response.backend or "httpx"
 
 
-async def scrape_article(url: str, custom_cookies: Optional[list[dict[str, Any]]] = None) -> dict[str, Any]:
+async def scrape_article(
+    url: str,
+    custom_cookies: Optional[list[dict[str, Any]]] = None,
+    *,
+    allow_llm_extraction: bool = True,
+) -> dict[str, Any]:
     logging.info(f"Scraping article from URL: {url}")
     # Resolve scraper plan via router (configurable via YAML)
     ws_cfg: dict[str, Any] = {}
@@ -2978,6 +2988,7 @@ async def scrape_article(url: str, custom_cookies: Optional[list[dict[str, Any]]
                     llm_settings=llm_settings,
                     regex_settings=regex_settings,
                     cluster_settings=cluster_settings,
+                    allow_llm_extraction=allow_llm_extraction,
                 )
                 if article_data.get("extraction_successful"):
                     if not use_handler and article_data.get("content"):
@@ -3109,6 +3120,7 @@ async def scrape_article(url: str, custom_cookies: Optional[list[dict[str, Any]]
         llm_settings=llm_settings,
         regex_settings=regex_settings,
         cluster_settings=cluster_settings,
+        allow_llm_extraction=allow_llm_extraction,
     )
     if article_data.get("extraction_successful") and not use_handler and article_data.get("content"):
         article_data["content"] = convert_html_to_markdown(article_data["content"])
@@ -3123,7 +3135,12 @@ async def scrape_article(url: str, custom_cookies: Optional[list[dict[str, Any]]
     return _attach_preflight(article_data)
 
 
-def scrape_article_blocking(url: str, custom_cookies: Optional[list[dict[str, Any]]] = None) -> dict[str, Any]:
+def scrape_article_blocking(
+    url: str,
+    custom_cookies: Optional[list[dict[str, Any]]] = None,
+    *,
+    allow_llm_extraction: bool = True,
+) -> dict[str, Any]:
     """Blocking scraper for synchronous code paths.
 
     Fetches HTML with http_client using a desktop-like user agent and optional cookies,
@@ -3178,7 +3195,11 @@ def scrape_article_blocking(url: str, custom_cookies: Optional[list[dict[str, An
             logging.error(f"Failed to fetch {url}, status: {status}")
             return {"url": url, "title": "N/A", "author": "N/A", "date": "N/A", "content": "", "extraction_successful": False}
 
-        article_data = extract_article_data_from_html(text, url)
+        article_data = extract_article_data_from_html(
+            text,
+            url,
+            allow_llm_extraction=allow_llm_extraction,
+        )
         if article_data.get("extraction_successful"):
             article_data["content"] = convert_html_to_markdown(article_data["content"])
         return article_data
@@ -3198,7 +3219,8 @@ async def scrape_and_summarize_multiple(
     system_message: Optional[str] = None,
     summarize_checkbox: bool = False,
     custom_cookies: Optional[list[dict[str, Any]]] = None,
-    temperature: float = 0.7
+    temperature: float = 0.7,
+    allow_llm_extraction: bool = True,
 ) -> list[dict[str, Any]]:
     urls_list = [url.strip() for url in urls.split('\n') if url.strip()]
     custom_titles = custom_article_titles.split('\n') if custom_article_titles else []
@@ -3225,7 +3247,11 @@ async def scrape_and_summarize_multiple(
                 with suppress(_ARTICLE_EXTRACTOR_NONCRITICAL_EXCEPTIONS):
                     await rate_limiter.acquire()
             # Scrape the article
-            article = await scrape_article(url, custom_cookies=custom_cookies)
+            article = await scrape_article(
+                url,
+                custom_cookies=custom_cookies,
+                allow_llm_extraction=allow_llm_extraction,
+            )
             if article and article['extraction_successful']:
                 log_counter("article_scraped", labels={"success": "true", "url": url})
                 if custom_title:
@@ -3467,7 +3493,12 @@ async def scrape_entire_site(base_url: str) -> list[dict]:
     return scraped_articles
 
 
-def scrape_by_url_level(base_url: str, level: int) -> list:
+def scrape_by_url_level(
+    base_url: str,
+    level: int,
+    *,
+    allow_llm_extraction: bool = True,
+) -> list:
     """Scrape articles from URLs up to a certain level under the base URL."""
 
     def get_url_level(url: str) -> int:
@@ -3478,13 +3509,20 @@ def scrape_by_url_level(base_url: str, level: int) -> list:
 
     results = []
     for link in filtered_links:
-        article = scrape_article_blocking(link)
+        article = scrape_article_blocking(
+            link,
+            allow_llm_extraction=allow_llm_extraction,
+        )
         if article:
             results.append(article)
     return results
 
 
-def scrape_from_sitemap(sitemap_url: str) -> list:
+def scrape_from_sitemap(
+    sitemap_url: str,
+    *,
+    allow_llm_extraction: bool = True,
+) -> list:
     """Scrape articles from a sitemap URL."""
     try:
         try:
@@ -3533,7 +3571,10 @@ def scrape_from_sitemap(sitemap_url: str) -> list:
 
         results = []
         for url in root.findall('.//{http://www.sitemaps.org/schemas/sitemap/0.9}loc'):
-            article = scrape_article_blocking(url.text)
+            article = scrape_article_blocking(
+                url.text,
+                allow_llm_extraction=allow_llm_extraction,
+            )
             if article:
                 results.append(article)
         return results
@@ -4120,12 +4161,26 @@ class ContentMetadataHandler:
 def get_url_depth(url: str) -> int:
     return len(urlparse(url).path.strip('/').split('/'))
 
-def sync_recursive_scrape(url_input, max_pages, max_depth, delay=1.0, custom_cookies=None):
+def sync_recursive_scrape(
+    url_input,
+    max_pages,
+    max_depth,
+    delay=1.0,
+    custom_cookies=None,
+    allow_llm_extraction: bool = True,
+):
     def run_async_scrape():
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         return loop.run_until_complete(
-            recursive_scrape(url_input, max_pages, max_depth, delay=delay, custom_cookies=custom_cookies)
+            recursive_scrape(
+                url_input,
+                max_pages,
+                max_depth,
+                delay=delay,
+                custom_cookies=custom_cookies,
+                allow_llm_extraction=allow_llm_extraction,
+            )
         )
 
     with ThreadPoolExecutor(max_workers=_extractor_max_workers()) as executor:
@@ -4140,7 +4195,8 @@ async def recursive_scrape(
         resume_file: str = 'scrape_progress.json',
         user_agent: str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
         custom_cookies: Optional[list[dict[str, Any]]] = None,
-        progress_callback: Optional[callable] = None
+        progress_callback: Optional[callable] = None,
+        allow_llm_extraction: bool = True,
 ) -> list[dict]:
     async def save_progress():
         temp_file = resume_file + ".tmp"
@@ -4195,7 +4251,11 @@ async def recursive_scrape(
                     try:
                         await asyncio.sleep(random.uniform(delay * 0.8, delay * 1.2))  # nosec B311
 
-                        article_data = await scrape_article_async(context, current_url)
+                        article_data = await scrape_article_async(
+                            context,
+                            current_url,
+                            allow_llm_extraction=allow_llm_extraction,
+                        )
 
                         if article_data and article_data['extraction_successful']:
                             scraped_articles.append(article_data)
@@ -4241,7 +4301,12 @@ async def recursive_scrape(
 
     return scraped_articles
 
-async def scrape_article_async(context, url: str) -> dict[str, Any]:
+async def scrape_article_async(
+    context,
+    url: str,
+    *,
+    allow_llm_extraction: bool = True,
+) -> dict[str, Any]:
     page = await context.new_page()
     try:
         await page.goto(url)
@@ -4250,12 +4315,17 @@ async def scrape_article_async(context, url: str) -> dict[str, Any]:
         title = await page.title()
         content = await page.content()
 
-        return {
-            'url': url,
-            'title': title,
-            'content': content,
-            'extraction_successful': True
-        }
+        article_data = extract_article_with_pipeline(
+            content,
+            url,
+            allow_llm_extraction=allow_llm_extraction,
+        )
+        if article_data.get("extraction_successful"):
+            if article_data.get("title") in {None, "", "N/A"}:
+                article_data["title"] = title
+            if article_data.get("content"):
+                article_data["content"] = convert_html_to_markdown(article_data["content"])
+        return article_data
     except _ARTICLE_EXTRACTOR_NONCRITICAL_EXCEPTIONS as e:
         logging.error(f"Error scraping article {url}: {str(e)}")
         return {

--- a/tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
+++ b/tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
@@ -797,13 +797,18 @@ class ScrapingJobQueue:
                 job.method,
                 custom_cookies=job.metadata.get('custom_cookies'),
                 user_agent=job.metadata.get('user_agent'),
-                custom_headers=job.metadata.get('custom_headers')
+                custom_headers=job.metadata.get('custom_headers'),
+                allow_llm_extraction=job.metadata.get('allow_llm_extraction', True),
             )
         else:
             # Fallback to importing the standalone scraping function
             logger.warning(f"No parent scraper available for job {job.job_id}, using fallback scraping")
             from tldw_Server_API.app.core.Web_Scraping.Article_Extractor_Lib import scrape_article
-            return await scrape_article(job.url, custom_cookies=job.metadata.get('custom_cookies'))
+            return await scrape_article(
+                job.url,
+                custom_cookies=job.metadata.get('custom_cookies'),
+                allow_llm_extraction=job.metadata.get('allow_llm_extraction', True),
+            )
 
     def get_status(self) -> dict[str, Any]:
         """Get queue status"""
@@ -1175,6 +1180,7 @@ class EnhancedWebScraper:
         llm_settings: Optional[dict[str, Any]] = None,
         regex_settings: Optional[dict[str, Any]] = None,
         cluster_settings: Optional[dict[str, Any]] = None,
+        allow_llm_extraction: bool = True,
     ) -> dict[str, Any]:
         from tldw_Server_API.app.core.Web_Scraping.Article_Extractor_Lib import (
             convert_html_to_markdown,
@@ -1191,6 +1197,7 @@ class EnhancedWebScraper:
             llm_settings=llm_settings,
             regex_settings=regex_settings,
             cluster_settings=cluster_settings,
+            allow_llm_extraction=allow_llm_extraction,
         )
         if postprocess_markdown and data.get("extraction_successful") and data.get("content"):
             data["content"] = convert_html_to_markdown(data["content"])
@@ -1338,6 +1345,7 @@ class EnhancedWebScraper:
         custom_cookies: Optional[list[dict[str, Any]]] = None,
         user_agent: Optional[str] = None,
         custom_headers: Optional[dict[str, str]] = None,
+        allow_llm_extraction: bool = True,
     ) -> dict[str, Any]:
         """Scrape a single article with specified method"""
         # Apply rate limiting
@@ -1440,6 +1448,7 @@ class EnhancedWebScraper:
                     llm_settings=llm_settings,
                     regex_settings=regex_settings,
                     cluster_settings=cluster_settings,
+                    allow_llm_extraction=allow_llm_extraction,
                 )
                 return _attach_preflight(result)
             elif effective_method == "playwright":
@@ -1456,6 +1465,7 @@ class EnhancedWebScraper:
                     llm_settings=llm_settings,
                     regex_settings=regex_settings,
                     cluster_settings=cluster_settings,
+                    allow_llm_extraction=allow_llm_extraction,
                 )
                 return _attach_preflight(result)
             elif effective_method == "beautifulsoup":
@@ -1474,6 +1484,7 @@ class EnhancedWebScraper:
                     llm_settings=llm_settings,
                     regex_settings=regex_settings,
                     cluster_settings=cluster_settings,
+                    allow_llm_extraction=allow_llm_extraction,
                 )
                 return _attach_preflight(result)
             else:
@@ -1503,6 +1514,7 @@ class EnhancedWebScraper:
         llm_settings: Optional[dict[str, Any]] = None,
         regex_settings: Optional[dict[str, Any]] = None,
         cluster_settings: Optional[dict[str, Any]] = None,
+        allow_llm_extraction: bool = True,
     ) -> dict[str, Any]:
         """Scrape using trafilatura"""
         headers = self._build_request_headers(user_agent, custom_headers)
@@ -1532,7 +1544,8 @@ class EnhancedWebScraper:
             )
             return {"url": url, "error": str(exc), "extraction_successful": False}
 
-        data = self._extract_from_html_with_pipeline(
+        data = await asyncio.to_thread(
+            self._extract_from_html_with_pipeline,
             html,
             url,
             strategy_order=strategy_order,
@@ -1544,6 +1557,7 @@ class EnhancedWebScraper:
             llm_settings=llm_settings,
             regex_settings=regex_settings,
             cluster_settings=cluster_settings,
+            allow_llm_extraction=allow_llm_extraction,
         )
         outcome = "success" if data.get("extraction_successful") else "no_extract"
         self._emit_scrape_metrics(
@@ -1604,6 +1618,7 @@ class EnhancedWebScraper:
         llm_settings: Optional[dict[str, Any]] = None,
         regex_settings: Optional[dict[str, Any]] = None,
         cluster_settings: Optional[dict[str, Any]] = None,
+        allow_llm_extraction: bool = True,
     ) -> dict[str, Any]:
         """Scrape using Playwright for JavaScript-heavy sites"""
         # Fallback gracefully if browser isn't initialized
@@ -1620,6 +1635,7 @@ class EnhancedWebScraper:
                 llm_settings=llm_settings,
                 regex_settings=regex_settings,
                 cluster_settings=cluster_settings,
+                allow_llm_extraction=allow_llm_extraction,
             )
         headers_copy = dict(custom_headers) if custom_headers else {}
         effective_user_agent = user_agent or headers_copy.pop("User-Agent", None) or DEFAULT_USER_AGENT
@@ -1663,7 +1679,8 @@ class EnhancedWebScraper:
             await page.wait_for_load_state("domcontentloaded")
 
             html = await page.content()
-            data = self._extract_from_html_with_pipeline(
+            data = await asyncio.to_thread(
+                self._extract_from_html_with_pipeline,
                 html,
                 url,
                 strategy_order=strategy_order,
@@ -1675,6 +1692,7 @@ class EnhancedWebScraper:
                 llm_settings=llm_settings,
                 regex_settings=regex_settings,
                 cluster_settings=cluster_settings,
+                allow_llm_extraction=allow_llm_extraction,
             )
             if data.get("extraction_successful") or handler is not None:
                 outcome = "success" if data.get("extraction_successful") else "no_extract"
@@ -1769,6 +1787,7 @@ class EnhancedWebScraper:
         llm_settings: Optional[dict[str, Any]] = None,
         regex_settings: Optional[dict[str, Any]] = None,
         cluster_settings: Optional[dict[str, Any]] = None,
+        allow_llm_extraction: bool = True,
     ) -> dict[str, Any]:
         """Scrape using BeautifulSoup for simple HTML parsing"""
         headers = self._build_request_headers(user_agent, custom_headers)
@@ -1798,7 +1817,8 @@ class EnhancedWebScraper:
             )
             return {"url": url, "error": str(exc), "extraction_successful": False}
 
-        data = self._extract_from_html_with_pipeline(
+        data = await asyncio.to_thread(
+            self._extract_from_html_with_pipeline,
             html,
             url,
             strategy_order=strategy_order,
@@ -1810,6 +1830,7 @@ class EnhancedWebScraper:
             llm_settings=llm_settings,
             regex_settings=regex_settings,
             cluster_settings=cluster_settings,
+            allow_llm_extraction=allow_llm_extraction,
         )
         if data.get("extraction_successful") or handler is not None:
             outcome = "success" if data.get("extraction_successful") else "no_extract"
@@ -1885,6 +1906,7 @@ class EnhancedWebScraper:
         priority: JobPriority = JobPriority.NORMAL,
         summarize: bool = False,
         user_id: Optional[str] = None,
+        allow_llm_extraction: bool = True,
         **kwargs,
     ) -> list[dict[str, Any]]:
         """Scrape multiple URLs concurrently"""
@@ -1909,7 +1931,10 @@ class EnhancedWebScraper:
                 method=method,
                 user_id=owner_id,
                 priority=priority,
-                metadata=kwargs
+                metadata={
+                    **kwargs,
+                    "allow_llm_extraction": allow_llm_extraction,
+                },
             )
             future = await self.job_queue.add_job(job)
             jobs.append(job)
@@ -1966,6 +1991,7 @@ class EnhancedWebScraper:
         custom_headers: Optional[dict[str, str]] = None,
         task_id: Optional[str] = None,
         user_id: Optional[str] = None,
+        allow_llm_extraction: bool = True,
     ) -> list[dict[str, Any]]:
         """Scrape all URLs from a sitemap"""
         headers = self._build_request_headers(user_agent, custom_headers)
@@ -2029,6 +2055,7 @@ class EnhancedWebScraper:
             user_agent=user_agent,
             custom_headers=custom_headers,
             user_id=user_id,
+            allow_llm_extraction=allow_llm_extraction,
         )
         self._set_progress(
             task_id,
@@ -2053,6 +2080,7 @@ class EnhancedWebScraper:
         include_external_override: Optional[bool] = None,
         score_threshold_override: Optional[float] = None,
         crawl_strategy: Optional[str] = None,
+        allow_llm_extraction: bool = True,
     ) -> list[dict[str, Any]]:
         """Recursively scrape a website"""
         try:
@@ -2299,6 +2327,7 @@ class EnhancedWebScraper:
                     user_agent=user_agent,
                     custom_headers=custom_headers,
                     user_id=user_id,
+                    allow_llm_extraction=allow_llm_extraction,
                 )
 
                 # Map url -> (neg_score, depth, parent)
@@ -2517,6 +2546,7 @@ class EnhancedWebScraper:
                     user_agent=user_agent,
                     custom_headers=custom_headers,
                     user_id=user_id,
+                    allow_llm_extraction=allow_llm_extraction,
                 )
 
                 meta_map_fifo = {u: (d, p) for (d, u, p) in batch_fifo}

--- a/tldw_Server_API/app/services/enhanced_web_scraping_service.py
+++ b/tldw_Server_API/app/services/enhanced_web_scraping_service.py
@@ -709,6 +709,8 @@ class WebScrapingService:
         """Store results in database"""
         media_ids = []
         errors = []
+        skipped_articles = 0
+        duplicate_articles = 0
 
         logger.info(f"Storing {len(result.get('articles', []))} articles to database")
 
@@ -746,6 +748,12 @@ class WebScrapingService:
                     f"extraction_successful={article.get('extraction_successful')}"
                 )
                 if not article.get("extraction_successful"):
+                    error_text = str(article.get("error") or "").strip().lower()
+                    if article.get("is_duplicate") is True or "duplicate" in error_text:
+                        skipped_articles += 1
+                        duplicate_articles += 1
+                        logger.info(f"Skipping duplicate article: {article.get('url', 'Unknown URL')}")
+                        continue
                     error_msg = f"Failed to extract: {article.get('url', 'Unknown URL')}"
                     logger.warning(error_msg)
                     errors.append(error_msg)
@@ -971,11 +979,23 @@ class WebScrapingService:
             except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as me:
                 logger.debug(f"webscraping.persist: batch metric observe failed: {me}")
 
+        stored_articles = len(media_ids)
+        status = (
+            "duplicate"
+            if stored_articles == 0
+            and duplicate_articles > 0
+            and duplicate_articles == len(result.get("articles", []))
+            and not errors
+            else "persist-ok"
+        )
+
         return {
-            "status": "persist-ok",
+            "status": status,
             "media_ids": media_ids,
             "total_articles": len(result.get("articles", [])),
-            "stored_articles": len(media_ids),
+            "stored_articles": stored_articles,
+            "skipped_articles": skipped_articles,
+            "duplicate_articles": duplicate_articles,
             "method": result.get("method"),
             "errors": errors if errors else None,
         }

--- a/tldw_Server_API/app/services/enhanced_web_scraping_service.py
+++ b/tldw_Server_API/app/services/enhanced_web_scraping_service.py
@@ -24,6 +24,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import
     async_resolve_chunking_options_and_plan,
     attach_chunking_plan_to_result,
 )
+from tldw_Server_API.app.core.Ingestion_Media_Processing.logging_safety import redact_url_for_log
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze
 from tldw_Server_API.app.core.Metrics import get_metrics_registry
 from tldw_Server_API.app.core.testing import is_truthy
@@ -744,18 +745,25 @@ class WebScrapingService:
             _batch_t0 = time.perf_counter()
             for article in result.get("articles", []):
                 logger.debug(
-                    f"Processing article: url={article.get('url')}, "
+                    f"Processing article: url={redact_url_for_log(article.get('url'))}, "
                     f"extraction_successful={article.get('extraction_successful')}"
                 )
                 if not article.get("extraction_successful"):
-                    error_text = str(article.get("error") or "").strip().lower()
-                    if article.get("is_duplicate") is True or "duplicate" in error_text:
+                    if (
+                        article.get("is_duplicate") is True
+                        or article.get("error_code") == "duplicate_content"
+                    ):
                         skipped_articles += 1
                         duplicate_articles += 1
-                        logger.info(f"Skipping duplicate article: {article.get('url', 'Unknown URL')}")
+                        logger.info(
+                            f"Skipping duplicate article: "
+                            f"{redact_url_for_log(article.get('url', 'Unknown URL'))}"
+                        )
                         continue
                     error_msg = f"Failed to extract: {article.get('url', 'Unknown URL')}"
-                    logger.warning(error_msg)
+                    logger.warning(
+                        f"Failed to extract: {redact_url_for_log(article.get('url', 'Unknown URL'))}"
+                    )
                     errors.append(error_msg)
                     continue
 
@@ -933,6 +941,19 @@ class WebScrapingService:
                     except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as me:
                         logger.debug(f"webscraping.persist: metric observe failed: {me}")
 
+                    title = article.get("title", "Untitled")
+                    if media_id and message in {
+                        f"Media '{title}' already exists. Overwrite not enabled.",
+                        f"Media '{title}' already exists (concurrent insert). Overwrite not enabled.",
+                    }:
+                        skipped_articles += 1
+                        duplicate_articles += 1
+                        logger.info(
+                            f"Skipping duplicate article: "
+                            f"{redact_url_for_log(article.get('url', 'Unknown URL'))}"
+                        )
+                        continue
+
                     if media_id:
                         media_ids.append(media_id)
                         logger.info(f"Stored article with media_id: {media_id}, uuid: {media_uuid}")
@@ -946,7 +967,11 @@ class WebScrapingService:
                         except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as me:
                             logger.debug(f"webscraping.persist: metric increment failed: {me}")
                     else:
-                        logger.warning(f"Failed to get media_id for article: {article.get('url')}")
+                        logger.warning(
+                            f"Failed to get media_id for article: "
+                            f"{redact_url_for_log(article.get('url'))}"
+                        )
+                        errors.append("Storage failed for article")
                         try:
                             if reg:
                                 reg.increment(
@@ -957,8 +982,8 @@ class WebScrapingService:
                         except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as me:
                             logger.debug(f"webscraping.persist: metric increment failed: {me}")
 
-                except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS as e:
-                    logger.error(f"Failed to store article: {e}")
+                except _WEB_SCRAPE_NONCRITICAL_EXCEPTIONS:
+                    logger.error("Failed to store article")
                     errors.append("Storage failed for article")
                     try:
                         if reg:

--- a/tldw_Server_API/app/services/enhanced_web_scraping_service.py
+++ b/tldw_Server_API/app/services/enhanced_web_scraping_service.py
@@ -428,6 +428,7 @@ class WebScrapingService:
             user_agent=user_agent,
             custom_headers=custom_headers,
             user_id=str(user_id) if user_id is not None else None,
+            allow_llm_extraction=summarize,
         )
 
         logger.info(f"Scraping completed, got {len(results)} results")
@@ -480,6 +481,7 @@ class WebScrapingService:
             custom_headers=custom_headers,
             user_id=str(user_id) if user_id is not None else None,
             task_id=task_id,
+            allow_llm_extraction=summarize,
         )
 
         # Add summarization if requested
@@ -545,6 +547,7 @@ class WebScrapingService:
             score_threshold_override=score_threshold,
             crawl_strategy=crawl_strategy,
             task_id=task_id,
+            allow_llm_extraction=summarize,
         )
 
         # Add summarization if requested
@@ -607,6 +610,7 @@ class WebScrapingService:
                 score_threshold_override=score_threshold,
                 crawl_strategy=crawl_strategy,
                 task_id=task_id,
+                allow_llm_extraction=summarize,
             )
 
             # Add summarization if requested

--- a/tldw_Server_API/app/services/media_ingest_jobs_worker.py
+++ b/tldw_Server_API/app/services/media_ingest_jobs_worker.py
@@ -118,7 +118,7 @@ def _build_worker_config(*, worker_id: str, queue: str) -> WorkerConfig:
         renew_jitter_seconds=renew_jitter_seconds,
         renew_threshold_seconds=renew_threshold_seconds,
         backoff_base_seconds=_coerce_int(os.getenv("MEDIA_INGEST_JOBS_BACKOFF_BASE_SECONDS"), 2),
-        backoff_max_seconds=_coerce_int(os.getenv("MEDIA_INGEST_JOBS_BACKOFF_MAX_SECONDS"), 30),
+        backoff_max_seconds=_coerce_int(os.getenv("MEDIA_INGEST_JOBS_BACKOFF_MAX_SECONDS"), 2),
         retry_on_exception=True,
         retry_backoff_seconds=_coerce_int(os.getenv("MEDIA_INGEST_JOBS_RETRY_BACKOFF_SECONDS"), 10),
     )

--- a/tldw_Server_API/app/services/web_scraping_service.py
+++ b/tldw_Server_API/app/services/web_scraping_service.py
@@ -409,14 +409,24 @@ async def process_web_scraping_task(
                     summarize_checkbox=summarize_checkbox,
                     custom_cookies=custom_cookies,
                     temperature=temperature,
+                    allow_llm_extraction=summarize_checkbox,
                 )
             elif scrape_method == "Sitemap":
                 # Synchronous approach in your code, might need `asyncio.to_thread`
-                result_list = await asyncio.to_thread(scrape_from_sitemap, url_input)
+                result_list = await asyncio.to_thread(
+                    scrape_from_sitemap,
+                    url_input,
+                    allow_llm_extraction=summarize_checkbox,
+                )
             elif scrape_method == "URL Level":
                 if url_level is None:
                     raise ValueError("`url_level` must be provided when scraping method is 'URL Level'")
-                result_list = await asyncio.to_thread(scrape_by_url_level, url_input, url_level)
+                result_list = await asyncio.to_thread(
+                    scrape_by_url_level,
+                    url_input,
+                    url_level,
+                    allow_llm_extraction=summarize_checkbox,
+                )
             elif scrape_method == "Recursive Scraping":
                 # Call the existing async recursive_scrape implementation.
                 # It returns a list of dicts:
@@ -430,6 +440,7 @@ async def process_web_scraping_task(
                     "progress_callback": (lambda x: None),  # no-op
                     "delay": 1.0,
                     "custom_cookies": custom_cookies,
+                    "allow_llm_extraction": summarize_checkbox,
                 }
                 # Only override user-agent if explicitly provided, otherwise keep
                 # the default behavior inside recursive_scrape.
@@ -819,7 +830,11 @@ async def ingest_web_content_orchestrate(
             author_ = authors[i]
             kw_ = keywords[i]
 
-            article_data = await scrape_article(url, custom_cookies=custom_cookies_list)
+            article_data = await scrape_article(
+                url,
+                custom_cookies=custom_cookies_list,
+                allow_llm_extraction=bool(request.perform_analysis),
+            )
             if not article_data or not article_data.get("extraction_successful"):
                 logging.warning(f"Failed to scrape: {url}")
                 continue
@@ -842,7 +857,10 @@ async def ingest_web_content_orchestrate(
         sitemap_url = urls[0]
 
         def scrape_in_thread() -> list[dict[str, Any]]:
-            return scrape_from_sitemap(sitemap_url)
+            return scrape_from_sitemap(
+                sitemap_url,
+                allow_llm_extraction=bool(request.perform_analysis),
+            )
 
         loop = asyncio.get_running_loop()
         results = await loop.run_in_executor(None, scrape_in_thread)

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
@@ -23,6 +23,18 @@ class _CollectionUpdateRecorder:
         return None
 
 
+def test_media_ingest_worker_defaults_to_responsive_idle_backoff(monkeypatch):
+    import tldw_Server_API.app.services.media_ingest_jobs_worker as worker
+
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_BACKOFF_BASE_SECONDS", raising=False)
+    monkeypatch.delenv("MEDIA_INGEST_JOBS_BACKOFF_MAX_SECONDS", raising=False)
+
+    config = worker._build_worker_config(worker_id="media-worker", queue="default")
+
+    assert config.backoff_base_seconds == 2
+    assert config.backoff_max_seconds == 2
+
+
 def _install_fake_collections_db(monkeypatch, worker, recorder: _CollectionUpdateRecorder):
     class _FakeCollectionsDatabase:
         @classmethod

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_yt_dlp_support.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_yt_dlp_support.py
@@ -1,0 +1,304 @@
+"""Tests for the nonblocking yt-dlp version diagnostic."""
+
+import builtins
+import importlib
+import sys
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from importlib.metadata import PackageNotFoundError
+from threading import Barrier, Lock
+from types import SimpleNamespace
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+
+from tldw_Server_API.app.core.Ingestion_Media_Processing import yt_dlp_support
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_state() -> Iterator[None]:
+    with yt_dlp_support._check_lock:
+        yt_dlp_support._checked = False
+    yield
+    with yt_dlp_support._check_lock:
+        yt_dlp_support._checked = False
+
+
+@pytest.mark.unit
+def test_stale_yt_dlp_warns_once_without_request_data(monkeypatch: MonkeyPatch) -> None:
+    warnings: list[str] = []
+    monkeypatch.setattr(yt_dlp_support.metadata, "version", lambda _name: "2025.8.11")
+    monkeypatch.setattr(
+        yt_dlp_support,
+        "logger",
+        SimpleNamespace(warning=lambda message: warnings.append(message)),
+    )
+
+    yt_dlp_support.warn_if_yt_dlp_is_stale()
+    yt_dlp_support.warn_if_yt_dlp_is_stale()
+
+    assert yt_dlp_support.MINIMUM_YT_DLP_VERSION == "2026.7.4"
+    assert len(warnings) == 1
+    assert "2025.8.11" in warnings[0]
+    assert "minimum 2026.7.4" in warnings[0]
+    assert 'pip install -U "yt-dlp>=2026.7.4"' in warnings[0]
+    assert "http" not in warnings[0]
+    assert "token" not in warnings[0]
+    assert "password" not in warnings[0]
+    assert "secret" not in warnings[0]
+
+
+@pytest.mark.unit
+def test_concurrent_stale_checks_perform_one_lookup_and_warning(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    worker_count = 16
+    start = Barrier(worker_count)
+    lookup_lock = Lock()
+    lookup_count = 0
+    warnings: list[str] = []
+
+    def _version(_name: str) -> str:
+        nonlocal lookup_count
+        with lookup_lock:
+            lookup_count += 1
+        return "2025.8.11"
+
+    def _check_version() -> None:
+        start.wait()
+        yt_dlp_support.warn_if_yt_dlp_is_stale()
+
+    monkeypatch.setattr(yt_dlp_support.metadata, "version", _version)
+    monkeypatch.setattr(
+        yt_dlp_support,
+        "logger",
+        SimpleNamespace(warning=lambda message: warnings.append(message)),
+    )
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = [executor.submit(_check_version) for _ in range(worker_count)]
+        for future in futures:
+            future.result()
+
+    assert lookup_count == 1
+    assert len(warnings) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("installed_version", ["2026.7.4", "2027.1.1"])
+def test_current_or_newer_yt_dlp_does_not_warn(
+    monkeypatch: MonkeyPatch,
+    installed_version: str,
+) -> None:
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        yt_dlp_support.metadata,
+        "version",
+        lambda _name: installed_version,
+    )
+    monkeypatch.setattr(
+        yt_dlp_support,
+        "logger",
+        SimpleNamespace(warning=lambda message: warnings.append(message)),
+    )
+
+    yt_dlp_support.warn_if_yt_dlp_is_stale()
+
+    assert warnings == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("failure", ["malformed", "missing", "lookup", "version"])
+def test_version_lookup_failures_do_not_raise_or_warn(
+    monkeypatch: MonkeyPatch,
+    failure: str,
+) -> None:
+    lookups = 0
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        yt_dlp_support,
+        "logger",
+        SimpleNamespace(warning=lambda message: warnings.append(message)),
+    )
+
+    def _version(_name: str) -> str:
+        nonlocal lookups
+        lookups += 1
+        if failure == "malformed":
+            return "not-a-version"
+        if failure == "missing":
+            raise PackageNotFoundError("yt-dlp")
+        if failure == "lookup":
+            raise RuntimeError("metadata unavailable")
+        return "2025.8.11"
+
+    monkeypatch.setattr(yt_dlp_support.metadata, "version", _version)
+    if failure == "version":
+        def _version_error(_value: str) -> object:
+            raise RuntimeError("version parser unavailable")
+
+        original_import = builtins.__import__
+
+        def _import(
+            name: str,
+            globals: object = None,
+            locals: object = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> object:
+            if name == "packaging.version":
+                return SimpleNamespace(Version=_version_error)
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _import)
+
+    yt_dlp_support.warn_if_yt_dlp_is_stale()
+    yt_dlp_support.warn_if_yt_dlp_is_stale()
+
+    assert lookups == 1
+    assert warnings == []
+
+
+@pytest.mark.unit
+def test_logging_failure_does_not_raise(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(yt_dlp_support.metadata, "version", lambda _name: "2025.8.11")
+    logging_attempts = 0
+
+    def _logging_error(_message: str) -> None:
+        nonlocal logging_attempts
+        logging_attempts += 1
+        raise RuntimeError("logging unavailable")
+
+    monkeypatch.setattr(
+        yt_dlp_support,
+        "logger",
+        SimpleNamespace(warning=_logging_error),
+    )
+
+    yt_dlp_support.warn_if_yt_dlp_is_stale()
+    yt_dlp_support.warn_if_yt_dlp_is_stale()
+
+    assert logging_attempts == 1
+
+
+@pytest.mark.unit
+def test_video_import_and_diagnostic_survive_unavailable_packaging(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    support_module_name = yt_dlp_support.__name__
+    video_module_name = (
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Video."
+        "Video_DL_Ingestion_Lib"
+    )
+    ingestion_package = importlib.import_module(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing"
+    )
+    video_package = importlib.import_module(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Video"
+    )
+    previous_video_module = sys.modules.get(video_module_name)
+    if previous_video_module is not None:
+        monkeypatch.setattr(
+            video_package,
+            "Video_DL_Ingestion_Lib",
+            previous_video_module,
+            raising=False,
+        )
+    monkeypatch.setattr(
+        ingestion_package,
+        "yt_dlp_support",
+        yt_dlp_support,
+        raising=False,
+    )
+    monkeypatch.delitem(sys.modules, support_module_name)
+    monkeypatch.delitem(sys.modules, video_module_name, raising=False)
+
+    original_import = builtins.__import__
+
+    def _import(
+        name: str,
+        globals: object = None,
+        locals: object = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "packaging.version":
+            raise ModuleNotFoundError("packaging is unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+
+    video_lib = importlib.import_module(video_module_name)
+    fresh_support = sys.modules[support_module_name]
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        fresh_support,
+        "logger",
+        SimpleNamespace(warning=lambda message: warnings.append(message)),
+    )
+
+    video_lib.warn_if_yt_dlp_is_stale()
+
+    assert warnings == []
+
+
+class _BoundaryReached(BaseException):
+    """Stop a boundary test immediately after YoutubeDL construction."""
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("allowed", [True, False], ids=["allowed", "blocked"])
+@pytest.mark.parametrize(
+    "helper_name,args",
+    [
+        ("get_video_info", ("https://example.com/video",)),
+        ("get_youtube", ("https://example.com/video",)),
+        ("get_playlist_videos", ("https://example.com/playlist",)),
+        (
+            "download_video",
+            ("https://example.com/video", "/unused", {}, False),
+        ),
+        ("extract_video_info", ("https://example.com/video",)),
+        ("get_youtube_playlist_urls", ("PL123",)),
+        ("extract_metadata", ("https://example.com/video",)),
+    ],
+)
+def test_video_boundaries_check_version_after_url_validation(
+    monkeypatch: MonkeyPatch,
+    allowed: bool,
+    helper_name: str,
+    args: tuple[object, ...],
+) -> None:
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.Video import (
+        Video_DL_Ingestion_Lib as video_lib,
+    )
+
+    events: list[str] = []
+
+    def _evaluate_url(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        events.append("validate")
+        return SimpleNamespace(allowed=allowed, reason=None if allowed else "blocked")
+
+    class _YoutubeDL:
+        def __init__(self, _options: dict[str, object]) -> None:
+            events.append("construct")
+            raise _BoundaryReached
+
+    monkeypatch.setattr(video_lib, "evaluate_url_policy", _evaluate_url)
+    monkeypatch.setattr(
+        video_lib,
+        "warn_if_yt_dlp_is_stale",
+        lambda: events.append("diagnostic"),
+    )
+    monkeypatch.setattr(video_lib.yt_dlp, "YoutubeDL", _YoutubeDL)
+    if helper_name == "download_video":
+        monkeypatch.setattr(video_lib.Path, "mkdir", lambda *_args, **_kwargs: None)
+
+    if allowed:
+        with pytest.raises(_BoundaryReached):
+            getattr(video_lib, helper_name)(*args)
+        assert events == ["validate", "diagnostic", "construct"]
+    else:
+        with pytest.raises(ValueError, match="blocked"):
+            getattr(video_lib, helper_name)(*args)
+        assert events == ["validate"]

--- a/tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py
+++ b/tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py
@@ -1,59 +1,43 @@
-import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 import pytest
+from loguru import logger
 
+import tldw_Server_API.app.services.enhanced_web_scraping_service as svc_mod
 from tldw_Server_API.app.services.enhanced_web_scraping_service import WebScrapingService
 
 
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_enhanced_webscraping_persist_with_mocked_db_path(tmp_path: Path, monkeypatch):
-    # Arrange: route user DB path to a temp file
-    db_file = tmp_path / "media_test.db"
-    db_file.parent.mkdir(parents=True, exist_ok=True)
-
-    # Patch the function used by the service module to resolve DB path
-    import tldw_Server_API.app.services.enhanced_web_scraping_service as svc_mod
-
-    def _fake_get_user_media_db_path(user_id: int):
-        return str(db_file)
-
-    monkeypatch.setattr(svc_mod, "get_user_media_db_path", _fake_get_user_media_db_path)
-
-    # Prepare a small batch of articles (simulate successful scraping)
-    result = {
-        "method": "Individual URLs",
-        "articles": [
-            {
-                "url": "https://example.com/a",
-                "title": "Article A",
-                "author": "Alice",
-                "date": "2024-10-01",
-                "content": "Hello world from article A.",
-                "extraction_successful": True,
-                "summary": "Summary A",
-                "method": "enhanced",
-            },
-            {
-                "url": "https://example.com/b",
-                "title": "Article B",
-                "author": "Bob",
-                "date": "2024-10-02",
-                "content": "Hello world from article B.",
-                "extraction_successful": True,
-                "summary": "Summary B",
-                "method": "enhanced",
-            },
-        ],
+def _article(
+    url: str = "https://example.com/a",
+    title: str = "Article A",
+    **overrides: Any,
+) -> dict[str, Any]:
+    article = {
+        "url": url,
+        "title": title,
+        "author": "Alice",
+        "date": "2024-10-01",
+        "content": "Extracted article content.",
+        "extraction_successful": True,
+        "summary": "Article summary",
+        "method": "enhanced",
     }
+    article.update(overrides)
+    return article
 
-    svc = WebScrapingService()
 
-    # Act: directly exercise the persistence path
-    res = await svc._store_persistent(
-        result=result,
-        keywords="foo,bar",
+async def _persist(
+    articles: list[dict[str, Any]],
+    *,
+    service: WebScrapingService | None = None,
+    keywords: str = "",
+) -> dict[str, Any]:
+    return await (service or WebScrapingService())._store_persistent(
+        result={"method": "Individual URLs", "articles": articles},
+        keywords=keywords,
         user_id=7,
         perform_chunking=False,
         chunking_mode=None,
@@ -61,118 +45,314 @@ async def test_enhanced_webscraping_persist_with_mocked_db_path(tmp_path: Path, 
         auto_chunking_use_llm=False,
     )
 
-    # Assert: verify status and number of stored articles
-    assert res["status"] == "persist-ok"
-    assert res["total_articles"] == 2
-    assert isinstance(res.get("media_ids"), list)
-    assert len(res["media_ids"]) == 2
 
+def _patch_db(monkeypatch: pytest.MonkeyPatch, *responses: Any) -> None:
+    pending = list(responses)
 
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_enhanced_webscraping_persist_sanitizes_storage_failure(
-    tmp_path: Path,
-    monkeypatch,
-):
-    import tldw_Server_API.app.services.enhanced_web_scraping_service as svc_mod
+    class _StaticDB:
+        def add_media_with_keywords(self, **_kwargs: Any) -> tuple[Any, Any, Any]:
+            response = pending.pop(0)
+            if isinstance(response, BaseException):
+                raise response
+            return response
 
-    class _FailingDB:
-        def add_media_with_keywords(self, **_kwargs):
-            raise RuntimeError("storage backend exploded at /private/db/media.sqlite")
+    class _StaticDBContext:
+        def __enter__(self) -> _StaticDB:
+            return _StaticDB()
 
-    class _FailingDBContext:
-        def __enter__(self):
-            return _FailingDB()
-
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
             return False
 
+    monkeypatch.setattr(svc_mod, "get_user_media_db_path", lambda _user_id: "unused.db")
+    monkeypatch.setattr(svc_mod, "managed_media_database", lambda **_kwargs: _StaticDBContext())
+
+
+def _patch_real_db_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
         svc_mod,
         "get_user_media_db_path",
         lambda _user_id: str(tmp_path / "media_test.db"),
     )
-    monkeypatch.setattr(
-        svc_mod,
-        "managed_media_database",
-        lambda **_kwargs: _FailingDBContext(),
-    )
 
-    result = {
-        "method": "Individual URLs",
-        "articles": [
-            {
-                "url": "https://example.com/a",
-                "title": "Article A",
-                "author": "Alice",
-                "date": "2024-10-01",
-                "content": "Hello world from article A.",
-                "extraction_successful": True,
-                "summary": "Summary A",
-                "method": "enhanced",
-            },
-        ],
-    }
 
-    res = await WebScrapingService()._store_persistent(
-        result=result,
-        keywords="foo,bar",
-        user_id=7,
-        perform_chunking=False,
-        chunking_mode=None,
-        auto_chunking_goal="balanced",
-        auto_chunking_use_llm=False,
-    )
-
-    assert res["status"] == "persist-ok"
-    assert res["media_ids"] == []
-    assert res["errors"] == ["Storage failed for article"]
-    assert "storage backend exploded" not in str(res)
-    assert "/private/db/media.sqlite" not in str(res)
+@contextmanager
+def _captured_logs() -> Iterator[list[str]]:
+    records: list[str] = []
+    sink_id = logger.add(records.append, level="DEBUG", format="{message}")
+    try:
+        yield records
+    finally:
+        logger.remove(sink_id)
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_enhanced_webscraping_persist_reports_duplicate_articles_as_skipped(
+async def test_enhanced_webscraping_persist_stores_successful_batch(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ):
-    import tldw_Server_API.app.services.enhanced_web_scraping_service as svc_mod
+    _patch_real_db_path(monkeypatch, tmp_path)
 
-    monkeypatch.setattr(
-        svc_mod,
-        "get_user_media_db_path",
-        lambda _user_id: str(tmp_path / "media_test.db"),
-    )
-
-    result = {
-        "method": "Individual URLs",
-        "articles": [
-            {
-                "url": "https://example.com/a?repeat=1",
-                "title": "Article A",
-                "content": "",
-                "extraction_successful": False,
-                "error": "Duplicate content",
-                "is_duplicate": True,
-            },
+    response = await _persist(
+        [
+            _article(),
+            _article(
+                "https://example.com/b",
+                "Article B",
+                author="Bob",
+                content="Second extracted article.",
+            ),
         ],
-    }
-
-    res = await WebScrapingService()._store_persistent(
-        result=result,
         keywords="foo,bar",
-        user_id=7,
-        perform_chunking=False,
-        chunking_mode=None,
-        auto_chunking_goal="balanced",
-        auto_chunking_use_llm=False,
     )
 
-    assert res["status"] == "duplicate"
-    assert res["media_ids"] == []
-    assert res["total_articles"] == 1
-    assert res["stored_articles"] == 0
-    assert res["skipped_articles"] == 1
-    assert res["duplicate_articles"] == 1
-    assert res["errors"] is None
+    assert response["status"] == "persist-ok"
+    assert response["total_articles"] == 2
+    assert len(response["media_ids"]) == 2
+    assert response["stored_articles"] == 2
+    assert response["errors"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_enhanced_webscraping_persist_repeated_real_repository_write_is_duplicate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_real_db_path(monkeypatch, tmp_path)
+    article = _article(
+        "https://example.com/repeated",
+        "Repeated Article",
+        content="The same persisted article content.",
+    )
+    service = WebScrapingService()
+
+    first = await _persist([article], service=service, keywords="foo,bar")
+    second = await _persist([article], service=service, keywords="foo,bar")
+
+    assert first["stored_articles"] == 1
+    assert second["status"] == "duplicate"
+    assert second["media_ids"] == []
+    assert second["stored_articles"] == 0
+    assert second["skipped_articles"] == 1
+    assert second["duplicate_articles"] == 1
+    assert second["errors"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "duplicate_fields",
+    [{"is_duplicate": True}, {"error_code": "duplicate_content"}],
+    ids=["duplicate-flag", "duplicate-error-code"],
+)
+async def test_enhanced_webscraping_persist_uses_structured_extraction_duplicate_signals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    duplicate_fields: dict[str, Any],
+):
+    _patch_real_db_path(monkeypatch, tmp_path)
+
+    response = await _persist(
+        [
+            _article(
+                "https://example.com/a?repeat=1",
+                extraction_successful=False,
+                content="",
+                error="Extraction skipped",
+                **duplicate_fields,
+            )
+        ]
+    )
+
+    assert response["status"] == "duplicate"
+    assert response["media_ids"] == []
+    assert response["stored_articles"] == 0
+    assert response["skipped_articles"] == 1
+    assert response["duplicate_articles"] == 1
+    assert response["errors"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_enhanced_webscraping_persist_does_not_infer_duplicate_from_error_text(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_real_db_path(monkeypatch, tmp_path)
+
+    response = await _persist(
+        [
+            _article(
+                "https://example.com/unavailable",
+                extraction_successful=False,
+                content="",
+                error="deduplicate worker unavailable",
+            )
+        ]
+    )
+
+    assert response["status"] == "persist-ok"
+    assert response["duplicate_articles"] == 0
+    assert response["errors"] == ["Failed to extract: https://example.com/unavailable"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Media 'Article A' already exists. Overwrite not enabled.",
+        "Media 'Article A' already exists (concurrent insert). Overwrite not enabled.",
+    ],
+)
+async def test_enhanced_webscraping_persist_recognizes_exact_repository_duplicate_messages(
+    monkeypatch: pytest.MonkeyPatch,
+    message: str,
+):
+    _patch_db(monkeypatch, (42, "existing-uuid", message))
+
+    response = await _persist([_article(content="Existing content")])
+
+    assert response["status"] == "duplicate"
+    assert response["media_ids"] == []
+    assert response["stored_articles"] == 0
+    assert response["skipped_articles"] == 1
+    assert response["duplicate_articles"] == 1
+    assert response["errors"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Media 'Article A' URL canonicalized.",
+        "Media 'Article A' already exists (handled concurrent insert).",
+        "Media 'Other Article' already exists. Overwrite not enabled.",
+    ],
+)
+async def test_enhanced_webscraping_persist_does_not_expand_repository_duplicate_messages(
+    monkeypatch: pytest.MonkeyPatch,
+    message: str,
+):
+    _patch_db(monkeypatch, (42, "stored-uuid", message))
+
+    response = await _persist([_article(content="Stored content")])
+
+    assert response["status"] == "persist-ok"
+    assert response["media_ids"] == [42]
+    assert response["stored_articles"] == 1
+    assert response["skipped_articles"] == 0
+    assert response["duplicate_articles"] == 0
+    assert response["errors"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_enhanced_webscraping_persist_mixed_duplicate_and_failure_retains_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_db(
+        monkeypatch,
+        (42, "existing-uuid", "Media 'Article A' already exists. Overwrite not enabled."),
+    )
+
+    response = await _persist(
+        [
+            _article(content="Existing content"),
+            _article(
+                "https://example.com/b",
+                "Article B",
+                extraction_successful=False,
+                content="",
+                error="extractor unavailable",
+            ),
+        ]
+    )
+
+    assert response["status"] == "persist-ok"
+    assert response["media_ids"] == []
+    assert response["stored_articles"] == 0
+    assert response["skipped_articles"] == 1
+    assert response["duplicate_articles"] == 1
+    assert response["errors"] == ["Failed to extract: https://example.com/b"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_enhanced_webscraping_persist_null_media_id_is_storage_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_db(monkeypatch, (None, None, "No media stored"))
+
+    response = await _persist([_article()])
+
+    assert response["media_ids"] == []
+    assert response["stored_articles"] == 0
+    assert response["errors"] == ["Storage failed for article"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_enhanced_webscraping_persist_mixed_stored_and_null_id_accounts_for_both(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_db(
+        monkeypatch,
+        (101, "stored-uuid", "Media stored successfully"),
+        (None, None, "No media stored"),
+    )
+
+    response = await _persist([_article(), _article("https://example.com/b", "Article B")])
+
+    assert response["status"] == "persist-ok"
+    assert response["total_articles"] == 2
+    assert response["media_ids"] == [101]
+    assert response["stored_articles"] == 1
+    assert response["errors"] == ["Storage failed for article"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_enhanced_webscraping_persist_redacts_article_urls_from_logs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_db(monkeypatch, (None, None, "No media stored"))
+    secret = "secret-value"
+    url = f"https://example.com/private?token={secret}"
+
+    with _captured_logs() as records:
+        await _persist(
+            [
+                _article(url, extraction_successful=False, content="", is_duplicate=True),
+                _article(
+                    url,
+                    "Failed Article",
+                    extraction_successful=False,
+                    content="",
+                    error="extractor unavailable",
+                ),
+                _article(url, "Unstored Article"),
+            ]
+        )
+
+    captured = "\n".join(records)
+    assert "https://example.com/private" in captured
+    assert secret not in captured
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_enhanced_webscraping_persist_redacts_storage_exception_from_logs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    secret = "secret-value"
+    url = f"https://example.com/private?token={secret}"
+    _patch_db(monkeypatch, RuntimeError(f"storage failed for {url}"))
+
+    with _captured_logs() as records:
+        response = await _persist([_article(url)])
+
+    assert response["errors"] == ["Storage failed for article"]
+    assert secret not in "\n".join(records)

--- a/tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py
+++ b/tldw_Server_API/tests/Services/test_enhanced_webscraping_persist.py
@@ -129,3 +129,50 @@ async def test_enhanced_webscraping_persist_sanitizes_storage_failure(
     assert res["errors"] == ["Storage failed for article"]
     assert "storage backend exploded" not in str(res)
     assert "/private/db/media.sqlite" not in str(res)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_enhanced_webscraping_persist_reports_duplicate_articles_as_skipped(
+    tmp_path: Path,
+    monkeypatch,
+):
+    import tldw_Server_API.app.services.enhanced_web_scraping_service as svc_mod
+
+    monkeypatch.setattr(
+        svc_mod,
+        "get_user_media_db_path",
+        lambda _user_id: str(tmp_path / "media_test.db"),
+    )
+
+    result = {
+        "method": "Individual URLs",
+        "articles": [
+            {
+                "url": "https://example.com/a?repeat=1",
+                "title": "Article A",
+                "content": "",
+                "extraction_successful": False,
+                "error": "Duplicate content",
+                "is_duplicate": True,
+            },
+        ],
+    }
+
+    res = await WebScrapingService()._store_persistent(
+        result=result,
+        keywords="foo,bar",
+        user_id=7,
+        perform_chunking=False,
+        chunking_mode=None,
+        auto_chunking_goal="balanced",
+        auto_chunking_use_llm=False,
+    )
+
+    assert res["status"] == "duplicate"
+    assert res["media_ids"] == []
+    assert res["total_articles"] == 1
+    assert res["stored_articles"] == 0
+    assert res["skipped_articles"] == 1
+    assert res["duplicate_articles"] == 1
+    assert res["errors"] is None

--- a/tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py
+++ b/tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py
@@ -7,6 +7,17 @@ from tldw_Server_API.app.core.Web_Scraping.Article_Extractor_Lib import (
 from tldw_Server_API.app.core.Web_Scraping.scraper_router import ScraperRouter
 
 
+def test_default_extraction_strategy_order_includes_llm_after_regex():
+    assert DEFAULT_EXTRACTION_STRATEGY_ORDER == [
+        "jsonld",
+        "schema",
+        "regex",
+        "llm",
+        "cluster",
+        "trafilatura",
+    ]
+
+
 def test_pipeline_trace_default_order(monkeypatch):
     from tldw_Server_API.app.core.Chat import chat_service
 
@@ -38,7 +49,7 @@ def test_pipeline_trace_default_order(monkeypatch):
     assert [entry["strategy"] for entry in result["extraction_trace"]] == expected[:stop_at]
 
 
-def test_default_pipeline_does_not_call_llm_provider(monkeypatch):
+def test_default_pipeline_omits_only_llm_when_disallowed(monkeypatch):
     from tldw_Server_API.app.core.Chat import chat_service
 
     llm_calls = []
@@ -59,12 +70,78 @@ def test_default_pipeline_does_not_call_llm_provider(monkeypatch):
         </html>
         """,
         "https://example.com/plain",
+        allow_llm_extraction=False,
     )
 
     assert result["extraction_successful"] is True
     assert llm_calls == []
-    assert "llm" not in result["extraction_strategy_order"]
+    assert result["extraction_strategy_order"] == [
+        strategy for strategy in DEFAULT_EXTRACTION_STRATEGY_ORDER if strategy != "llm"
+    ]
     assert all(entry["strategy"] != "llm" for entry in result["extraction_trace"])
+
+
+def test_default_pipeline_preserves_llm_when_allowed(monkeypatch):
+    from tldw_Server_API.app.core.Chat import chat_service
+
+    monkeypatch.setattr(
+        chat_service,
+        "perform_chat_api_call",
+        lambda **_kwargs: {"choices": [{"message": {"content": ""}}], "usage": {}},
+    )
+
+    result = extract_article_with_pipeline(
+        "<html><body><p>Plain article content.</p></body></html>",
+        "https://example.com/default-allowed",
+        allow_llm_extraction=True,
+    )
+
+    assert result["extraction_strategy_order"] == DEFAULT_EXTRACTION_STRATEGY_ORDER
+
+
+@pytest.mark.parametrize("allow_llm_extraction", [False, True])
+def test_custom_pipeline_filters_only_llm_when_disallowed(
+    monkeypatch,
+    allow_llm_extraction,
+):
+    from tldw_Server_API.app.core.Chat import chat_service
+
+    llm_calls = []
+
+    def fake_llm_call(**kwargs):
+        llm_calls.append(kwargs)
+        return {"choices": [{"message": {"content": ""}}], "usage": {}}
+
+    monkeypatch.setattr(
+        chat_service,
+        "perform_chat_api_call",
+        fake_llm_call,
+    )
+    custom_order = ["llm", "trafilatura"]
+
+    def fake_extractor(_html: str, url: str):
+        return {
+            "url": url,
+            "title": "Test",
+            "author": "N/A",
+            "date": "N/A",
+            "content": "Fallback content",
+            "extraction_successful": True,
+        }
+
+    result = extract_article_with_pipeline(
+        "<html><body><p>Custom ordered article content.</p></body></html>",
+        "https://example.com/custom-order",
+        strategy_order=custom_order,
+        allow_llm_extraction=allow_llm_extraction,
+        fallback_extractor=fake_extractor,
+    )
+
+    expected_order = custom_order if allow_llm_extraction else ["trafilatura"]
+    expected_trace = expected_order
+    assert len(llm_calls) == (1 if allow_llm_extraction else 0)
+    assert [entry["strategy"] for entry in result["extraction_trace"]] == expected_trace
+    assert result["extraction_strategy_order"] == expected_order
 
 
 def test_pipeline_strategy_order_override_from_router():
@@ -72,7 +149,7 @@ def test_pipeline_strategy_order_override_from_router():
         {
             "domains": {
                 "example.com": {
-                    "strategy_order": ["schema", "trafilatura"],
+                    "strategy_order": ["schema", "llm", "trafilatura"],
                 }
             }
         }
@@ -80,7 +157,7 @@ def test_pipeline_strategy_order_override_from_router():
     router = ScraperRouter(rules)
     plan = router.resolve("https://example.com/page")
 
-    assert plan.strategy_order == ["schema", "trafilatura"]
+    assert plan.strategy_order == ["schema", "llm", "trafilatura"]
 
     def fake_extractor(html: str, url: str):  # noqa: ANN001
         return {
@@ -97,8 +174,10 @@ def test_pipeline_strategy_order_override_from_router():
         "https://example.com/page",
         strategy_order=plan.strategy_order,
         fallback_extractor=fake_extractor,
+        allow_llm_extraction=False,
     )
     assert [entry["strategy"] for entry in result["extraction_trace"]] == ["schema", "trafilatura"]
+    assert result["extraction_strategy_order"] == ["schema", "trafilatura"]
 
 
 def test_pipeline_handler_stage_short_circuits():

--- a/tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py
+++ b/tldw_Server_API/tests/WebScraping/test_extraction_pipeline_router.py
@@ -38,6 +38,35 @@ def test_pipeline_trace_default_order(monkeypatch):
     assert [entry["strategy"] for entry in result["extraction_trace"]] == expected[:stop_at]
 
 
+def test_default_pipeline_does_not_call_llm_provider(monkeypatch):
+    from tldw_Server_API.app.core.Chat import chat_service
+
+    llm_calls = []
+
+    def _fake_llm_call(**kwargs):
+        llm_calls.append(kwargs)
+        return {"choices": [{"message": {"content": ""}}], "usage": {}}
+
+    monkeypatch.setattr(chat_service, "perform_chat_api_call", _fake_llm_call)
+
+    result = extract_article_with_pipeline(
+        """
+        <html>
+          <body>
+            <p>Plain article content without structured metadata.</p>
+            <p>Another paragraph for fallback extraction.</p>
+          </body>
+        </html>
+        """,
+        "https://example.com/plain",
+    )
+
+    assert result["extraction_successful"] is True
+    assert llm_calls == []
+    assert "llm" not in result["extraction_strategy_order"]
+    assert all(entry["strategy"] != "llm" for entry in result["extraction_trace"])
+
+
 def test_pipeline_strategy_order_override_from_router():
     rules = ScraperRouter.validate_rules(
         {

--- a/tldw_Server_API/tests/WebScraping/test_legacy_sync_helpers.py
+++ b/tldw_Server_API/tests/WebScraping/test_legacy_sync_helpers.py
@@ -29,8 +29,8 @@ def test_scrape_from_sitemap_uses_blocking(monkeypatch):
     def fake_fetch(*args, **kwargs):
         return FakeResp()
 
-    def fake_blocking(url):
-        calls.append(url)
+    def fake_blocking(url, *, allow_llm_extraction=None):
+        calls.append((url, allow_llm_extraction))
         return {"url": url, "title": "ok", "author": "", "date": "", "content": "", "extraction_successful": True}
 
     monkeypatch.setattr(AEL, "http_fetch", fake_fetch)
@@ -38,7 +38,10 @@ def test_scrape_from_sitemap_uses_blocking(monkeypatch):
 
     results = AEL.scrape_from_sitemap("https://example.com/sitemap.xml")
     assert len(results) == 2
-    assert set(calls) == {"https://example.com/a", "https://example.com/b"}
+    assert set(calls) == {
+        ("https://example.com/a", True),
+        ("https://example.com/b", True),
+    }
 
 
 def test_scrape_by_url_level_uses_blocking(monkeypatch):
@@ -48,8 +51,8 @@ def test_scrape_by_url_level_uses_blocking(monkeypatch):
 
     calls = []
 
-    def fake_blocking(url):
-        calls.append(url)
+    def fake_blocking(url, *, allow_llm_extraction=None):
+        calls.append((url, allow_llm_extraction))
         return {"url": url, "title": "t", "author": "", "date": "", "content": "", "extraction_successful": True}
 
     monkeypatch.setattr(AEL, "scrape_article_blocking", fake_blocking)
@@ -57,7 +60,7 @@ def test_scrape_by_url_level_uses_blocking(monkeypatch):
     # Level 1 should include only the first url
     results = AEL.scrape_by_url_level("https://example.com", level=1)
     assert len(results) == 1
-    assert calls == ["https://example.com/one"]
+    assert calls == [("https://example.com/one", True)]
 
 
 def test_scrape_from_sitemap_blocks_on_shared_sync_policy_denial(monkeypatch):

--- a/tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from fastapi import HTTPException
 
+import tldw_Server_API.app.core.Web_Scraping.Article_Extractor_Lib as extractor_mod
+import tldw_Server_API.app.core.Web_Scraping.enhanced_web_scraping as enhanced_core_mod
+import tldw_Server_API.app.services.web_scraping_service as legacy_svc_mod
 import tldw_Server_API.app.services.enhanced_web_scraping_service as enhanced_svc_mod
+from tldw_Server_API.app.api.v1.schemas.media_request_models import ScrapeMethod
+from tldw_Server_API.app.core.Web_Scraping.enhanced_web_scraping import (
+    EnhancedWebScraper,
+    ScrapingJob,
+    ScrapingJobQueue,
+)
 from tldw_Server_API.app.services.enhanced_web_scraping_service import WebScrapingService
 
 
@@ -206,3 +217,298 @@ def test_process_web_scraping_endpoint_omitted_max_pages_forwards_none(
     response = client_user_only.post("/api/v1/media/process-web-scraping", json=payload)
     assert response.status_code == 200
     assert captured.get("max_pages") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("scrape_method", "analysis_intent", "expected_call"),
+    [
+        ("Individual URLs", False, "multiple"),
+        ("Sitemap", True, "sitemap"),
+    ],
+)
+async def test_enhanced_service_propagates_analysis_intent_to_scraper(
+    monkeypatch,
+    scrape_method,
+    analysis_intent,
+    expected_call,
+):
+    captured: dict[str, dict[str, object]] = {}
+
+    class FakeScraper:
+        async def scrape_multiple(self, _urls, **kwargs):
+            captured["multiple"] = kwargs
+            return []
+
+        async def scrape_sitemap(self, _url, **kwargs):
+            captured["sitemap"] = kwargs
+            return []
+
+    svc = WebScrapingService()
+    svc._initialized = True
+    svc.scraper = FakeScraper()
+
+    async def fake_store_ephemeral(result, _task_id, _user_id):
+        return result
+
+    monkeypatch.setattr(enhanced_svc_mod, "load_and_log_configs", lambda: _cfg())
+    monkeypatch.setattr(svc, "_store_ephemeral", fake_store_ephemeral)
+
+    await svc.process_web_scraping_task(
+        scrape_method=scrape_method,
+        url_input="https://example.com/sitemap.xml" if scrape_method == "Sitemap" else "https://example.com/article",
+        max_pages=5,
+        summarize_checkbox=analysis_intent,
+        mode="ephemeral",
+    )
+
+    assert captured[expected_call]["allow_llm_extraction"] is analysis_intent
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_scraping_job_queue_propagates_analysis_intent_to_article_scrape():
+    captured: dict[str, object] = {}
+
+    class FakeScraper:
+        async def scrape_article(self, _url, _method, **kwargs):
+            captured.update(kwargs)
+            return {"extraction_successful": True}
+
+    queue = ScrapingJobQueue(parent_scraper=FakeScraper())
+    job = ScrapingJob(
+        job_id="job-analysis-disabled",
+        url="https://example.com/article",
+        method="trafilatura",
+        metadata={"allow_llm_extraction": False},
+    )
+
+    await queue._execute_job(job)
+
+    assert captured["allow_llm_extraction"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sitemap_crawl_retains_analysis_intent_for_scrape_multiple(monkeypatch):
+    captured: dict[str, object] = {}
+    scraper = EnhancedWebScraper(config={})
+
+    async def fake_policy(url, **kwargs):
+        return enhanced_core_mod.WebOutboundPolicyDecision(
+            allowed=True,
+            mode="strict",
+            reason="allowed",
+            stage=kwargs["stage"],
+            source=kwargs["source"],
+        )
+
+    class DummyResponse:
+        text = "<urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'><url><loc>https://example.com/a</loc></url></urlset>"
+
+        async def aclose(self):
+            return None
+
+    async def fake_afetch(**_kwargs):
+        return DummyResponse()
+
+    async def fake_scrape_multiple(_urls, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(enhanced_core_mod, "decide_web_outbound_policy", fake_policy)
+    monkeypatch.setattr(enhanced_core_mod, "afetch", fake_afetch)
+    monkeypatch.setattr(scraper, "scrape_multiple", fake_scrape_multiple)
+
+    await scraper.scrape_sitemap(
+        "https://example.com/sitemap.xml",
+        allow_llm_extraction=False,
+    )
+
+    assert captured["allow_llm_extraction"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("analysis_intent", [False, True])
+def test_url_level_scraper_explicitly_forwards_analysis_intent(monkeypatch, analysis_intent):
+    captured: list[object] = []
+
+    def fake_scrape_article_blocking(_url, *, allow_llm_extraction=None):
+        captured.append(allow_llm_extraction)
+        return {"url": _url, "extraction_successful": True}
+
+    monkeypatch.setattr(extractor_mod, "collect_internal_links", lambda _url: {"https://example.com/article"})
+    monkeypatch.setattr(extractor_mod, "scrape_article_blocking", fake_scrape_article_blocking)
+
+    extractor_mod.scrape_by_url_level(
+        "https://example.com",
+        1,
+        allow_llm_extraction=analysis_intent,
+    )
+
+    assert captured == [analysis_intent]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("analysis_intent", [False, True])
+def test_sitemap_scraper_explicitly_forwards_analysis_intent(monkeypatch, analysis_intent):
+    captured: list[object] = []
+    sitemap = """
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://example.com/article</loc></url>
+    </urlset>
+    """
+
+    def fake_scrape_article_blocking(_url, *, allow_llm_extraction=None):
+        captured.append(allow_llm_extraction)
+        return {"url": _url, "extraction_successful": True}
+
+    monkeypatch.setattr(
+        extractor_mod,
+        "decide_web_outbound_policy_sync",
+        lambda *_args, **_kwargs: SimpleNamespace(allowed=True),
+    )
+    monkeypatch.setattr(
+        extractor_mod,
+        "http_fetch",
+        lambda **_kwargs: {"status": 200, "text": sitemap},
+    )
+    monkeypatch.setattr(extractor_mod, "scrape_article_blocking", fake_scrape_article_blocking)
+
+    extractor_mod.scrape_from_sitemap(
+        "https://example.com/sitemap.xml",
+        allow_llm_extraction=analysis_intent,
+    )
+
+    assert captured == [analysis_intent]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["trafilatura", "playwright", "beautifulsoup"])
+async def test_async_scrapers_offload_extraction_pipeline(monkeypatch, method):
+    scraper = EnhancedWebScraper(config={})
+    offload_calls: list[dict[str, object]] = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        offload_calls.append({"func": func, "args": args, "kwargs": kwargs})
+        return func(*args, **kwargs)
+
+    async def fake_fetch_html(*_args, **_kwargs):
+        return "<html><body>article</body></html>", "httpx", 0.01
+
+    def fake_extract(html, url, **kwargs):
+        return {
+            "url": url,
+            "title": "Article",
+            "content": html,
+            "extraction_successful": True,
+            "allow_llm_extraction": kwargs["allow_llm_extraction"],
+        }
+
+    class FakePage:
+        async def goto(self, *_args, **_kwargs):
+            return None
+
+        async def wait_for_load_state(self, *_args, **_kwargs):
+            return None
+
+        async def content(self):
+            return "<html><body>article</body></html>"
+
+        async def close(self):
+            return None
+
+    class FakeContext:
+        async def set_extra_http_headers(self, _headers):
+            return None
+
+        async def add_cookies(self, _cookies):
+            return None
+
+        async def new_page(self):
+            return FakePage()
+
+        async def close(self):
+            return None
+
+    class FakeBrowser:
+        async def new_context(self, **_kwargs):
+            return FakeContext()
+
+    monkeypatch.setattr(enhanced_core_mod.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(scraper, "_fetch_html", fake_fetch_html)
+    monkeypatch.setattr(scraper, "_extract_from_html_with_pipeline", fake_extract)
+    monkeypatch.setattr(scraper, "_apply_dedup", lambda _url, data: data)
+    scraper._browser = FakeBrowser()
+
+    scrape_method = getattr(scraper, f"_scrape_with_{method}")
+    result = await scrape_method(
+        "https://example.com/article",
+        allow_llm_extraction=False,
+    )
+
+    assert result["allow_llm_extraction"] is False
+    assert len(offload_calls) == 1
+    assert offload_calls[0]["func"] is fake_extract
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("scrape_method", "analysis_intent"),
+    [
+        (ScrapeMethod.INDIVIDUAL, False),
+        (ScrapeMethod.INDIVIDUAL, True),
+        (ScrapeMethod.SITEMAP, False),
+        (ScrapeMethod.SITEMAP, True),
+    ],
+)
+async def test_friendly_ingest_propagates_analysis_intent_to_direct_scrapers(
+    monkeypatch,
+    scrape_method,
+    analysis_intent,
+):
+    captured: dict[str, object] = {}
+
+    async def fake_scrape_article(_url, *, custom_cookies=None, allow_llm_extraction=None):
+        captured["allow_llm_extraction"] = allow_llm_extraction
+        return {
+            "url": "https://example.com/article",
+            "content": "article",
+            "extraction_successful": True,
+        }
+
+    def fake_scrape_from_sitemap(_url, *, allow_llm_extraction=None):
+        captured["allow_llm_extraction"] = allow_llm_extraction
+        return [
+            {
+                "url": "https://example.com/article",
+                "content": "article",
+                "extraction_successful": True,
+            }
+        ]
+
+    monkeypatch.setattr(legacy_svc_mod, "scrape_article", fake_scrape_article)
+    monkeypatch.setattr(legacy_svc_mod, "scrape_from_sitemap", fake_scrape_from_sitemap)
+
+    request = SimpleNamespace(
+        scrape_method=scrape_method,
+        urls=["https://example.com/sitemap.xml"],
+        titles=[],
+        authors=[],
+        keywords=[],
+        perform_analysis=analysis_intent,
+        api_name=None,
+        use_cookies=False,
+    )
+    usage_log = SimpleNamespace(log_event=lambda *_args, **_kwargs: None)
+
+    await legacy_svc_mod.ingest_web_content_orchestrate(
+        request,
+        SimpleNamespace(client_id="test-user"),
+        usage_log,
+    )
+
+    assert captured["allow_llm_extraction"] is analysis_intent

--- a/tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py
@@ -100,8 +100,10 @@ async def test_fallback_url_level_rejects_threshold_control(monkeypatch):
 @pytest.mark.asyncio
 async def test_fallback_url_level_ephemeral_smoke_applies_max_pages_cap(monkeypatch):
     _force_fallback(monkeypatch)
+    captured = {}
 
-    async def fake_scrape_by_url_level(base_url, level):
+    async def fake_scrape_by_url_level(base_url, level, *, allow_llm_extraction=None):
+        captured["allow_llm_extraction"] = allow_llm_extraction
         return [
             {"url": "https://example.com/1", "title": "A", "content": "c1", "extraction_successful": True},
             {"url": "https://example.com/2", "title": "B", "content": "c2", "extraction_successful": True},
@@ -133,6 +135,7 @@ async def test_fallback_url_level_ephemeral_smoke_applies_max_pages_cap(monkeypa
     assert result["engine"] == "legacy_fallback"
     assert result["total_articles"] == 2
     assert len(result["results"]) == 2
+    assert captured["allow_llm_extraction"] is False
     fallback_context = result["fallback_context"]
     assert fallback_context["enabled"] is True
     assert fallback_context["trigger_error_type"] == "RuntimeError"
@@ -142,7 +145,10 @@ async def test_fallback_url_level_ephemeral_smoke_applies_max_pages_cap(monkeypa
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_ingest_web_content_skips_analysis_without_provider(monkeypatch):
-    async def fake_scrape_article(url, custom_cookies=None):
+    captured = {}
+
+    async def fake_scrape_article(url, custom_cookies=None, *, allow_llm_extraction=None):
+        captured["allow_llm_extraction"] = allow_llm_extraction
         return {
             "url": url,
             "title": "Example",
@@ -168,6 +174,7 @@ async def test_ingest_web_content_skips_analysis_without_provider(monkeypatch):
 
     assert result is not None
     assert result[0]["analysis"] is None
+    assert captured["allow_llm_extraction"] is True
     assert result[0]["analysis_status"] == "skipped"
     assert result[0]["analysis_error"] == "Choose an analysis provider before running ingest analysis."
 
@@ -244,8 +251,10 @@ async def test_fallback_url_level_sanitizes_unexpected_runtime_error(monkeypatch
 @pytest.mark.asyncio
 async def test_fallback_ephemeral_result_retrievable_within_ttl(monkeypatch):
     _force_fallback(monkeypatch)
+    captured = {}
 
-    async def fake_scrape_by_url_level(base_url, level):
+    async def fake_scrape_by_url_level(base_url, level, *, allow_llm_extraction=None):
+        captured["allow_llm_extraction"] = allow_llm_extraction
         return [
             {"url": "https://example.com/a", "title": "A", "content": "c1", "extraction_successful": True},
             {"url": "https://example.com/b", "title": "B", "content": "c2", "extraction_successful": True},
@@ -279,6 +288,7 @@ async def test_fallback_ephemeral_result_retrievable_within_ttl(monkeypatch):
     stored = local_store.get_data(ephemeral_id)
     assert isinstance(stored, dict)
     assert len(stored.get("articles", [])) == 2
+    assert captured["allow_llm_extraction"] is False
 
     state["now"] = 300.0
     assert local_store.get_data(ephemeral_id) is None


### PR DESCRIPTION
## Summary
- Fix Quick Ingest repeat/direct ingestion paths so duplicate URL submissions resolve to stable skipped or success states instead of leaving jobs queued or retriggering modal updates.
- Reattach polling to existing ingest jobs and surface terminal success, failure, and quarantine results consistently.
- Default Quick Ingest URL extraction away from LLM analysis and raise the yt-dlp floor to 2026.7.4 after UAT reproduced stale extractor failures on YouTube Shorts.

## Validation
- Full browser UAT outside the sandbox for Quick Ingest PDF, local web link, and YouTube Short: https://www.youtube.com/shorts/6-rf_YXDpPg.
- After updating the venv to yt-dlp 2026.07.04, the YouTube job completed at 100% and created media id 5; final UI result was 1 succeeded, 2 skipped, 0 failed with no console/page errors.
- Verified dependency/docs references with rg for yt-dlp>=2026.7.4 and the YouTube "not available on this app" symptom.
- Ran Bandit on touched backend files: zero findings.

## Change summary
Required before merge: the human requester must replace this section with their own explanation of what changed and why these implementation choices were made, per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

## Notes
- Two unrelated untracked watchlist template files were intentionally left out of this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Quick Ingest repeat ingestion and job recovery: duplicates are skipped, transient job status reads are retried, and LLM extraction is only used when analysis is enabled. Raises the `yt-dlp` floor to `>=2026.7.4` with a one‑time stale‑version warning, and hardens dev watch config while keeping Webpack as the default dev bundler.

- **Bug Fixes**
  - Duplicate web/HTML submissions return `status: "duplicate"` and are shown as skipped; persist-style `errors` arrays surface as failures.
  - Reattach polling prefers direct GETs, retries transient 0/408/429/5xx status reads, and resumes queued sessions; terminal success/failure/quarantine states render consistently.
  - “Ingest more” now resets the session and clears completed-run tracking; modal props stay stable to prevent maximum-update-depth crashes.
  - Web extraction honors the analysis toggle end‑to‑end (LLM excluded unless enabled), including sitemap and URL-level paths.
  - Media ingest worker uses a 2s max idle backoff for faster recovery.

- **Dependencies**
  - Bump `yt-dlp` to `>=2026.7.4`; docs updated with the minimum and the “not available on this app” symptom; backend logs a one‑time warning if the installed version is below the floor.
  - Frontend dev defaults to `next dev --webpack` with `dev:turbopack` opt‑in; Next config adds backend runtime watch ignores with tests to keep local hot‑reload stable.

<sup>Written for commit 307d36f2fabfe5d7ced821dd96ad69cb0afd53d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

