### PR TITLE
feat(mcp): expose Skills catalog and safe render

### DIFF
--- a/Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md
+++ b/Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md
@@ -178,6 +178,7 @@ Input:
 - `skill_name` is required and uses existing Skill name validation.
 - `arguments` is optional, defaults to an empty string, and is limited to 10,000 characters.
 - The caller cannot provide `dry_run`, model, provider, tools, user identity, paths, or execution settings.
+- `arguments` is preserved verbatim. The module uses exact shape, type, and length validation rather than `BaseModule.sanitize_input()`, whose SQL-oriented token checks would reject valid prompt text such as `--help` or `/* example */`.
 
 Output:
 
@@ -245,6 +246,8 @@ Using `context=None` is intentional: dry render reports declarations and cannot 
 Add one Skills service operation that returns an integrity-filtered page and total from the same row set. It must synchronize the registry once, fetch matching rows once, apply model-visible and integrity filtering once, and then slice the filtered rows. Add a metadata-only exact lookup that uses the same visibility predicate.
 
 Filesystem walks, integrity digest reads, synchronous registry queries, existence checks, and verified Skill parsing must not run on the MCP event loop. The new catalog operations must offload their synchronous work with `asyncio.to_thread`. The verified full-load path used by render should update the existing asynchronous `get_skill()` implementation to offload its filesystem checks and parsing rather than introducing a duplicate loader.
+
+Request cancellation must not close a request-scoped database while an offloaded constructor, registry operation, integrity check, or verified load is still using it. The module must retain and await the in-flight worker task before closing the database and propagating cancellation. If database construction succeeds but service construction fails, the same worker must close the partially initialized database before raising.
 
 These changes preserve existing REST behavior. They change scheduling only and require regression coverage for existing Skills service callers.
 
@@ -320,7 +323,7 @@ Do not add Skills to gateway presets or persona archetypes in this slice unless 
 
 ### Skills service
 
-- Metadata-only lookup may read file bytes for integrity calculation but does not call the verified full-directory parser, parse supporting files into a response, or return path/content fields.
+- Metadata-only lookup may read file bytes for integrity calculation but does not call the verified full-directory parser or return content/supporting-file payloads. Internal `SkillMetadata` may retain registry path and hash fields needed by existing service callers; the MCP formatter must never expose them.
 - Exact lookup excludes hidden, model-disabled, deleted, and integrity-blocked Skills.
 - One page operation returns correct count and pagination after a single integrity-filtering pass.
 - Catalog registry and filesystem work is offloaded from the event loop.
@@ -337,6 +340,7 @@ Do not add Skills to gateway presets or persona archetypes in this slice unless 
 ### MCP module
 
 - Tool definitions, annotations, defaults, bounds, and unknown-property rejection.
+- Search and render text containing punctuation such as `--` and `/* */` is preserved and accepted within the documented bounds.
 - Missing user context and missing ChaChaNotes path fail closed.
 - List/get response shapes expose metadata only.
 - Hidden and model-disabled Skills cannot be listed, fetched, or rendered.
@@ -397,3 +401,5 @@ Those tasks must build on this catalog/render contract rather than expanding `sk
 13. Produce page items and total from one integrity-filtered row set to avoid duplicate full-tree walks.
 14. Offload synchronous database, filesystem, integrity, and verified parsing work from the MCP event loop.
 15. Report omitted supporting material with a boolean rather than silently implying the rendered body is self-contained.
+16. Preserve bounded prompt arguments verbatim instead of applying the generic module SQL-token sanitizer to non-executing text.
+17. Await in-flight offloaded work before request-scoped database cleanup so cancellation cannot race active registry or filesystem access.

--- a/Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md
+++ b/Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md
@@ -226,6 +226,8 @@ Outcomes use existing behavior:
 
 The module does not create grants, prompt for approval, or weaken a decision.
 
+The shared policy-grant validator must admit `skill` as an approval subject type. Grant values continue through `normalize_permission_subject_value()`, so mixed-case Skill grants use the same lowercase canonical form as runtime subjects and rules. This changes no grant storage schema and adds no Skill-specific lease implementation.
+
 ## Render Sequence
 
 1. MCP coordinator validates module and tool access.

--- a/Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md
+++ b/Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md
@@ -1,0 +1,378 @@
+# Skills MCP Catalog and Safe Render Design
+
+**Backlog task:** TASK-2294.1
+
+**Parent task:** TASK-2294
+
+**Status:** Approved for implementation planning
+
+**Date:** 2026-07-13
+
+## Summary
+
+Add a read-only-from-the-caller's-perspective Skills module to MCP Unified with three tools:
+
+- `skills.list` discovers model-visible skills using bounded search and pagination.
+- `skills.get` retrieves the same metadata shape for one skill.
+- `skills.render` substitutes bounded arguments into one authorized skill and returns the rendered prompt without calling a model or tool.
+
+This is the first stability-focused slice of the broader skill and workflow runner work. It reuses the existing Skills registry, integrity resolver, dry-run executor, MCP authorization gateway, approval leases, hooks, reporting, timeout, and circuit-breaker paths. It does not introduce another execution engine or policy evaluator.
+
+## Problem
+
+Skills are available through the REST API and chat integration, but MCP clients do not have a supported way to discover Skills metadata or safely render a Skill for later use. A direct implementation has several failure risks:
+
+- exposing raw `SKILL.md`, supporting files, or filesystem paths during discovery;
+- advertising hidden or model-disabled skills to model-facing clients;
+- authorizing the MCP tool while failing to authorize the selected `Skill(name)` subject;
+- presenting declared tool patterns as effective tool permissions;
+- accidentally invoking fork-mode models or tools during a render request;
+- bypassing MCP hooks, reporting, caller identity, timeouts, or approval leases;
+- duplicating workflows or Jobs behavior in a new runner.
+
+## Goals
+
+1. Provide bounded, user-scoped Skills discovery through MCP Unified.
+2. Return metadata without reading or returning full Skill content for list/get operations.
+3. Render one visible, integrity-approved, policy-approved Skill with forced dry-run behavior.
+4. Preserve existing MCP `deny`, `ask`, approval-lease, and `allow` semantics.
+5. Make declarations and effective authorization clearly distinct.
+6. Register and test the module through the same production paths as existing MCP modules.
+
+## Non-Goals
+
+- Calling an LLM, including for a Skill whose context is `fork`.
+- Executing any declared tool.
+- Running scripts, subagents, hooks owned by Skills, workflows, or Jobs.
+- Creating or mutating authored Skills, workflows, jobs, profiles, or approval grants. Existing Skills registry synchronization may update derived index rows to match files on disk.
+- Returning raw frontmatter, raw `SKILL.md`, supporting-file content, directory paths, or content hashes.
+- Adding frontend or browser-extension UI.
+- Adding a second permission parser, confirmation flow, telemetry system, database table, or execution abstraction.
+- Solving output consolidation, workflow orchestration, evaluations, or durable execution from the parent TASK-2294.
+
+## Existing Components Reused
+
+- `SkillsService` for registry synchronization, metadata, integrity filtering, and full Skill loading.
+- `SkillExecutor.execute(..., dry_run=True)` for argument substitution and side-effect-free rendering.
+- `build_skill_runtime_metadata` for runtime declaration fields.
+- MCP `BaseModule` and `create_tool_definition` for module behavior and schemas.
+- MCP tool authorization and gateway profile permission rules.
+- Existing policy grant store and TTL approval leases for `ask` outcomes.
+- MCP coordinator hooks, tool-use reporting, identity propagation, rate limiting, timeouts, and module circuit breakers.
+- `CharactersRAGDB` and the authenticated request context's `db_paths["chacha"]` for the user-scoped Skill registry.
+
+## Architecture
+
+`SkillsModule` is a thin MCP adapter. It validates inputs, opens a request-scoped user database, constructs `SkillsService`, delegates discovery or rendering, formats a bounded response, and closes the database connection. Existing `SkillsService` initialization and reads may create the user's Skills directory, ensure the registry table, or synchronize derived registry rows. These are internal index-maintenance effects, not caller-authored Skill mutations.
+
+The module must fail closed when any of these are absent or invalid:
+
+- authenticated `context.user_id` convertible to a positive integer;
+- `context.db_paths["chacha"]`;
+- a user-scoped ChaChaNotes database that can initialize the Skill registry.
+
+The Skills base directory is the parent directory of the authenticated context's ChaChaNotes database path. The module must not accept `user_id`, `db_path`, `db_paths`, or a Skill base path from tool arguments.
+
+All three tools run through normal MCP tool execution. The module must not call another module directly or bypass coordinator policy, hooks, reporting, timeout, or circuit-breaker behavior.
+
+## Visibility Model
+
+A Skill is model-visible only when all conditions are true:
+
+- it belongs to the authenticated user's registry;
+- it is not deleted;
+- `user_invocable` is true;
+- `disable_model_invocation` is false;
+- the existing integrity resolver allows it for Skill discovery or execution.
+
+`skills.list`, `skills.get`, and `skills.render` use this same model-visible definition. An exact lookup of an unknown, deleted, hidden, or model-disabled Skill returns the same `skill_not_found` error. The response must not reveal which condition failed.
+
+Catalog visibility is not an execution grant. `skills.list` may show metadata for a model-visible Skill that the active profile cannot render. `skills.render` performs the subject-specific permission check. This avoids per-row policy evaluation, policy-derived pagination errors, and a misleading `can_render` field.
+
+## Tool Contracts
+
+### `skills.list`
+
+Purpose: search and page through model-visible Skill metadata.
+
+Input:
+
+```json
+{
+  "q": "optional case-insensitive name/description query, 0..200 characters",
+  "limit": "integer, 1..100, default 50",
+  "offset": "integer, >= 0, default 0"
+}
+```
+
+Whitespace-only `q` is normalized to no query. Unknown input properties are rejected by module validation even if the generic MCP schema layer permits them.
+
+Output:
+
+```json
+{
+  "skills": [
+    {
+      "name": "summarize-paper",
+      "description": "Summarize a paper for a chosen audience.",
+      "argument_hint": "[audience]",
+      "user_invocable": true,
+      "disable_model_invocation": false,
+      "declared_tools": ["rag.search"],
+      "model": null,
+      "context": "inline",
+      "runtime": {
+        "execution_mode": "inline",
+        "test_run_may_call_model": false,
+        "declares_tools": true,
+        "declared_tool_count": 1,
+        "model_override": null,
+        "auto_invocation_enabled": true
+      },
+      "version": 3
+    }
+  ],
+  "count": 1,
+  "total": 1,
+  "limit": 50,
+  "offset": 0,
+  "next_offset": null
+}
+```
+
+`total` is the integrity-filtered count for the same query. `next_offset` is `offset + count` only when that value is less than `total`; otherwise it is null. Sorting is fixed to name ascending in this first slice so pagination is deterministic.
+
+### `skills.get`
+
+Purpose: retrieve metadata for one exact model-visible Skill without returning its instructions.
+
+Input:
+
+```json
+{
+  "name": "summarize-paper"
+}
+```
+
+`name` uses the existing Skill name normalization and validation rules. The output is one metadata object with the same fields as a `skills.list` item. It does not include content, raw content, supporting files, directory path, content hash, IDs, or timestamps.
+
+`skills.get` is a discovery operation and does not emit a `Skill(name)` permission subject. Its output is no more sensitive than the same row returned by `skills.list`.
+
+### `skills.render`
+
+Purpose: substitute arguments into one authorized Skill without executing it.
+
+Input:
+
+```json
+{
+  "skill_name": "summarize-paper",
+  "arguments": "expert"
+}
+```
+
+- `skill_name` is required and uses existing Skill name validation.
+- `arguments` is optional, defaults to an empty string, and is limited to 10,000 characters.
+- The caller cannot provide `dry_run`, model, provider, tools, user identity, paths, or execution settings.
+
+Output:
+
+```json
+{
+  "skill_name": "summarize-paper",
+  "rendered_prompt": "Summarize this paper for an expert audience...",
+  "declared_tools": ["rag.search"],
+  "model_override": null,
+  "execution_mode": "inline",
+  "dry_run": true,
+  "version": 3
+}
+```
+
+`declared_tools` contains Skill declarations only. It does not assert tool availability or permission. Every later tool call remains subject to MCP catalog, profile, RBAC, hook, and argument-sensitive permission checks.
+
+## Authorization
+
+### Tool-level authorization
+
+The existing gateway must first allow the caller to execute `skills.render`. Normal MCP module and tool RBAC checks remain authoritative.
+
+### Skill subject authorization
+
+The shared MCP permission-subject extractor currently parses `Skill(pattern)` rules but does not emit Skill subjects from tool arguments. Add a bounded `skill_name` argument convention:
+
+- a non-empty string under the exact key `skill_name` emits one normalized `skill` subject;
+- Skill subjects and `Skill(...)` rule patterns are normalized to lowercase, matching canonical Skill name normalization and approval-grant lookup;
+- the existing maximum subject count and value-length limits apply;
+- generic keys such as `name` do not emit Skill subjects;
+- no module evaluates profile documents directly.
+
+Only `skills.render` uses the `skill_name` field in this slice. Therefore its gateway evaluation combines the tool subject and `Skill(skill_name)` subject before the module can load full content.
+
+Outcomes use existing behavior:
+
+- `deny`: return the existing gateway policy-denied response;
+- `ask` with no active lease: return the existing `approval_required` response;
+- `ask` with a valid scoped lease: continue and attach the existing redacted approval marker;
+- `allow` or no matching Skill rule: continue according to existing gateway defaults.
+
+The module does not create grants, prompt for approval, or weaken a decision.
+
+## Render Sequence
+
+1. MCP coordinator validates module and tool access.
+2. Gateway extracts `tool=skills.render` and `skill=<skill_name>` subjects.
+3. Gateway evaluates profile rules and any existing approval lease.
+4. Module validates the exact argument shape and hard limits.
+5. Module resolves authenticated user context and opens the user-scoped registry database.
+6. Module loads metadata only and applies model-visible and integrity checks.
+7. Module loads the full Skill through the existing verified service path.
+8. Module calls `SkillExecutor.execute` with `context=None` and `dry_run=True` forced by code.
+9. Module rejects rendered output above the configured character limit.
+10. Module returns the sanitized result and closes the request-scoped database.
+
+Using `context=None` is intentional: dry render reports declarations and cannot accidentally interpret the current MCP catalog as effective authorization. The executor must never enter inline execution or fork execution in this tool.
+
+## Bounds and Configuration
+
+The module configuration is:
+
+```yaml
+settings:
+  list_page_size: 50
+  max_rendered_skill_chars: 100000
+```
+
+- Tool callers may request `limit` from 1 through 100.
+- `list_page_size` supplies the default and is clamped to 1 through 100.
+- `q` is at most 200 characters.
+- `arguments` is at most 10,000 characters.
+- `max_rendered_skill_chars` defaults to 100,000 and is clamped to 1 through 100,000. Configuration cannot raise the hard ceiling.
+- An oversized rendered prompt fails atomically. It is never truncated or partially returned.
+- Full Skill loading retains all existing Skills parser and storage bounds.
+
+## Error Contract
+
+Module-owned failures use the existing MCP JSON-RPC error classes and bounded reason tokens. Gateway-owned authorization failures retain the existing gateway response format. This slice does not add a new exception transport or error-data schema.
+
+| Condition | JSON-RPC mapping and message | Disclosure rule |
+| --- | --- | --- |
+| Missing or invalid authenticated user context | Authorization error: `skills_user_context_required` | No fallback user or path |
+| Unknown, deleted, hidden, or model-disabled Skill | Invalid params: `skill_not_found` | Same response for every case |
+| Invalid name, query, pagination, or arguments | Invalid params with field and bound | No submitted content |
+| Integrity resolver blocks the Skill | Authorization error: `context_integrity_blocked` | No path, digest, or content |
+| Render exceeds output limit | Invalid params: `rendered_skill_too_large`; include limit | No partial rendered prompt |
+| Registry/storage unavailable | Existing sanitized internal error | Detailed exception type only in bounded logs |
+| Profile rule denies | Existing gateway denial | Existing sanitized provenance rules |
+| Profile rule asks without a lease | Existing `approval_required` | Existing grant availability metadata |
+
+Logs may include a bounded Skill name, user ID, operation, and exception type. Logs and tool responses must not include rendered content, raw Skill content, supporting-file content, API keys, approval tokens, database paths, or filesystem paths.
+
+## Metadata Semantics
+
+The MCP response renames the registry field `allowed_tools` to `declared_tools`. Existing REST schemas remain unchanged.
+
+`runtime` remains declaration metadata:
+
+- `execution_mode` is the Skill's declared `inline` or `fork` mode;
+- `test_run_may_call_model` describes a separate non-dry REST test run, not this MCP render;
+- `declares_tools` and `declared_tool_count` describe declarations only;
+- `model_override` is declarative and is not used by render;
+- `auto_invocation_enabled` is true for every returned row because model-disabled Skills are excluded.
+
+## Registration and Surface
+
+Add an enabled `skills` module to `tldw_Server_API/Config_Files/mcp_modules.yaml` immediately after `prompts`:
+
+```yaml
+- id: skills
+  class: tldw_Server_API.app.core.MCP_unified.modules.implementations.skills_module:SkillsModule
+  enabled: true
+  name: Skills
+  version: "0.1.0"
+  department: knowledge
+  max_concurrent: 10
+  settings:
+    list_page_size: 50
+    max_rendered_skill_chars: 100000
+```
+
+Classify `skills` as read-only in `module_surface.py`. Each tool definition uses `readOnlyHint: true` because no tool intentionally changes caller-authored state. Existing Skills registry synchronization remains permitted as derived index maintenance.
+
+Do not add Skills to gateway presets or persona archetypes in this slice unless an existing test proves enabled modules require an explicit preset entry. Module/tool authorization remains the rollout control.
+
+## Testing Strategy
+
+### Skills service
+
+- After registry synchronization, metadata-only lookup does not call the verified full-directory parser, load supporting files, or return path/content fields.
+- Exact lookup excludes hidden, model-disabled, deleted, and integrity-blocked Skills.
+- List count and pagination remain correct after integrity filtering.
+
+### Permission subject extraction
+
+- `skill_name` emits one normalized Skill subject.
+- Skill subjects, rule patterns, and approval-grant values use the same lowercase canonical form.
+- `name`, blank values, non-string values, and nested values do not emit Skill subjects.
+- Subject length and count limits still fail closed.
+- `deny`, `ask`, active approval lease, and `allow` behavior is exercised through gateway runtime tests.
+
+### MCP module
+
+- Tool definitions, annotations, defaults, bounds, and unknown-property rejection.
+- Missing user context and missing ChaChaNotes path fail closed.
+- List/get response shapes expose metadata only.
+- Hidden and model-disabled Skills cannot be listed, fetched, or rendered.
+- Render substitutes full and indexed arguments using existing executor behavior.
+- Fork-mode render remains dry and does not call a model or tool.
+- Response uses `declared_tools` and never claims effective authorization.
+- Oversized output is rejected without a partial prompt.
+- Database connections close on success and failure.
+- Errors and logs do not expose content or paths.
+
+### Registration and integration
+
+- Default module configuration declares and enables the Skills module with bounded settings.
+- Dynamic module loading imports and registers `SkillsModule`.
+- Module surface reports Skills as read-only.
+- Package-boundary tests allow the intended dependency direction without importing FastAPI endpoint dependencies.
+- An authenticated MCP integration test lists, gets, and renders a user-owned Skill and cannot access another user's Skill.
+
+## Rollout and Compatibility
+
+- No database migration is required.
+- No REST API response is changed.
+- Existing Skills execution behavior is unchanged.
+- Existing profile documents remain valid. `Skill(...)` rules begin applying to tools that use the explicit `skill_name` argument convention; currently this slice introduces the first such tool.
+- The module is enabled by default because it does not intentionally mutate caller-authored state, is user-scoped and integrity-checked, and remains subject to MCP module/tool/profile authorization.
+- If production validation finds unacceptable discovery overhead, disable the module through existing MCP module configuration rather than adding a feature flag.
+
+## Deferred Parent-Task Work
+
+Later TASK-2294 child tasks may add execution, but only after separate designs define ownership and failure semantics for:
+
+- model invocation and fork-mode execution;
+- tool catalog resolution and effective allowed-tool binding;
+- subagent orchestration;
+- multi-step scripts and output consolidation;
+- durable Jobs or Workflows handoff;
+- execution cancellation, retries, quotas, and progress;
+- execution telemetry and evaluations;
+- frontend controls and approval UX.
+
+Those tasks must build on this catalog/render contract rather than expanding `skills.render` into an execution endpoint.
+
+## Decision Record
+
+1. Use three tools rather than one overloaded tool for clear schemas and policy surfaces.
+2. Keep get metadata-only; raw Skill instructions are available only after render authorization.
+3. Exclude both hidden and model-disabled Skills from every model-facing operation.
+4. Keep catalog discovery independent from per-Skill render permission to preserve deterministic pagination.
+5. Extend shared permission-subject extraction instead of parsing profile rules in the module.
+6. Reuse existing approval leases for `ask`; add no second confirmation system.
+7. Force dry-run rendering and omit executor context to prevent execution and avoid permission claims.
+8. Use `declared_tools` in MCP responses to distinguish declarations from effective authorization.
+9. Reject oversized output rather than truncating executable instructions.
+10. Defer all execution and workflow behavior to separately reviewable TASK-2294 child tasks.
+11. Treat existing registry synchronization as derived index maintenance rather than claiming every read is physically mutation-free.
+12. Canonicalize Skill permission subjects, patterns, and grants to lowercase before matching.

--- a/Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md
+++ b/Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md
@@ -33,7 +33,7 @@ Skills are available through the REST API and chat integration, but MCP clients 
 ## Goals
 
 1. Provide bounded, user-scoped Skills discovery through MCP Unified.
-2. Return metadata without reading or returning full Skill content for list/get operations.
+2. Return metadata without parsing or exposing full Skill content for list/get operations.
 3. Render one visible, integrity-approved, policy-approved Skill with forced dry-run behavior.
 4. Preserve existing MCP `deny`, `ask`, approval-lease, and `allow` semantics.
 5. Make declarations and effective authorization clearly distinct.
@@ -64,6 +64,8 @@ Skills are available through the REST API and chat integration, but MCP clients 
 ## Architecture
 
 `SkillsModule` is a thin MCP adapter. It validates inputs, opens a request-scoped user database, constructs `SkillsService`, delegates discovery or rendering, formats a bounded response, and closes the database connection. Existing `SkillsService` initialization and reads may create the user's Skills directory, ensure the registry table, or synchronize derived registry rows. These are internal index-maintenance effects, not caller-authored Skill mutations.
+
+Integrity verification may read the complete Skill file map, including supporting files, to calculate the canonical digest. Metadata operations must not parse those supporting files into the response or expose their content, names, paths, or hashes.
 
 The module must fail closed when any of these are absent or invalid:
 
@@ -142,6 +144,8 @@ Output:
 
 `total` is the integrity-filtered count for the same query. `next_offset` is `offset + count` only when that value is less than `total`; otherwise it is null. Sorting is fixed to name ascending in this first slice so pagination is deterministic.
 
+The page and total must come from one registry query and one integrity-filtering pass. The module must not compose the response by calling existing `list_skills()` and `get_total_count()` separately.
+
 ### `skills.get`
 
 Purpose: retrieve metadata for one exact model-visible Skill without returning its instructions.
@@ -184,12 +188,15 @@ Output:
   "declared_tools": ["rag.search"],
   "model_override": null,
   "execution_mode": "inline",
+  "supporting_files_omitted": false,
   "dry_run": true,
   "version": 3
 }
 ```
 
 `declared_tools` contains Skill declarations only. It does not assert tool availability or permission. Every later tool call remains subject to MCP catalog, profile, RBAC, hook, and argument-sensitive permission checks.
+
+`supporting_files_omitted` is true when the authorized Skill includes supporting files that this first-slice renderer does not return or resolve. It exposes only the existence of omitted material after render authorization, never file names, paths, hashes, or content. Clients must not assume a rendered prompt is self-contained when this field is true.
 
 ## Authorization
 
@@ -225,13 +232,21 @@ The module does not create grants, prompt for approval, or weaken a decision.
 3. Gateway evaluates profile rules and any existing approval lease.
 4. Module validates the exact argument shape and hard limits.
 5. Module resolves authenticated user context and opens the user-scoped registry database.
-6. Module loads metadata only and applies model-visible and integrity checks.
-7. Module loads the full Skill through the existing verified service path.
+6. Module loads metadata through an offloaded model-visible lookup and applies integrity checks.
+7. Module loads the full Skill through an offloaded verified service path.
 8. Module calls `SkillExecutor.execute` with `context=None` and `dry_run=True` forced by code.
 9. Module rejects rendered output above the configured character limit.
 10. Module returns the sanitized result and closes the request-scoped database.
 
 Using `context=None` is intentional: dry render reports declarations and cannot accidentally interpret the current MCP catalog as effective authorization. The executor must never enter inline execution or fork execution in this tool.
+
+## Service and I/O Contract
+
+Add one Skills service operation that returns an integrity-filtered page and total from the same row set. It must synchronize the registry once, fetch matching rows once, apply model-visible and integrity filtering once, and then slice the filtered rows. Add a metadata-only exact lookup that uses the same visibility predicate.
+
+Filesystem walks, integrity digest reads, synchronous registry queries, existence checks, and verified Skill parsing must not run on the MCP event loop. The new catalog operations must offload their synchronous work with `asyncio.to_thread`. The verified full-load path used by render should update the existing asynchronous `get_skill()` implementation to offload its filesystem checks and parsing rather than introducing a duplicate loader.
+
+These changes preserve existing REST behavior. They change scheduling only and require regression coverage for existing Skills service callers.
 
 ## Bounds and Configuration
 
@@ -258,15 +273,15 @@ Module-owned failures use the existing MCP JSON-RPC error classes and bounded re
 | Condition | JSON-RPC mapping and message | Disclosure rule |
 | --- | --- | --- |
 | Missing or invalid authenticated user context | Authorization error: `skills_user_context_required` | No fallback user or path |
-| Unknown, deleted, hidden, or model-disabled Skill | Invalid params: `skill_not_found` | Same response for every case |
+| Unknown, deleted, hidden, model-disabled, or discovery-time integrity-blocked Skill | Invalid params: `skill_not_found` | Same response for every case |
 | Invalid name, query, pagination, or arguments | Invalid params with field and bound | No submitted content |
-| Integrity resolver blocks the Skill | Authorization error: `context_integrity_blocked` | No path, digest, or content |
+| Integrity changes or becomes blocked during verified render after the visibility gate | Authorization error: `context_integrity_blocked` | No path, digest, or content |
 | Render exceeds output limit | Invalid params: `rendered_skill_too_large`; include limit | No partial rendered prompt |
 | Registry/storage unavailable | Existing sanitized internal error | Detailed exception type only in bounded logs |
 | Profile rule denies | Existing gateway denial | Existing sanitized provenance rules |
 | Profile rule asks without a lease | Existing `approval_required` | Existing grant availability metadata |
 
-Logs may include a bounded Skill name, user ID, operation, and exception type. Logs and tool responses must not include rendered content, raw Skill content, supporting-file content, API keys, approval tokens, database paths, or filesystem paths.
+MCP responses and logs newly emitted by `SkillsModule` may include a bounded Skill name, user ID, operation, and exception type. They must not include rendered content, raw Skill content, supporting-file content, API keys, approval tokens, database paths, or filesystem paths. Existing host-local `SkillsService` diagnostic logs are outside this slice and remain unchanged; they must never be copied into an MCP response.
 
 ## Metadata Semantics
 
@@ -305,9 +320,11 @@ Do not add Skills to gateway presets or persona archetypes in this slice unless 
 
 ### Skills service
 
-- After registry synchronization, metadata-only lookup does not call the verified full-directory parser, load supporting files, or return path/content fields.
+- Metadata-only lookup may read file bytes for integrity calculation but does not call the verified full-directory parser, parse supporting files into a response, or return path/content fields.
 - Exact lookup excludes hidden, model-disabled, deleted, and integrity-blocked Skills.
-- List count and pagination remain correct after integrity filtering.
+- One page operation returns correct count and pagination after a single integrity-filtering pass.
+- Catalog registry and filesystem work is offloaded from the event loop.
+- Existing `get_skill()` behavior remains unchanged after its filesystem checks and parsing are offloaded.
 
 ### Permission subject extraction
 
@@ -326,9 +343,10 @@ Do not add Skills to gateway presets or persona archetypes in this slice unless 
 - Render substitutes full and indexed arguments using existing executor behavior.
 - Fork-mode render remains dry and does not call a model or tool.
 - Response uses `declared_tools` and never claims effective authorization.
+- Render reports `supporting_files_omitted=true` without exposing supporting-file details.
 - Oversized output is rejected without a partial prompt.
 - Database connections close on success and failure.
-- Errors and logs do not expose content or paths.
+- MCP responses and logs newly emitted by the module do not expose content or paths.
 
 ### Registration and integration
 
@@ -376,3 +394,6 @@ Those tasks must build on this catalog/render contract rather than expanding `sk
 10. Defer all execution and workflow behavior to separately reviewable TASK-2294 child tasks.
 11. Treat existing registry synchronization as derived index maintenance rather than claiming every read is physically mutation-free.
 12. Canonicalize Skill permission subjects, patterns, and grants to lowercase before matching.
+13. Produce page items and total from one integrity-filtered row set to avoid duplicate full-tree walks.
+14. Offload synchronous database, filesystem, integrity, and verified parsing work from the MCP event loop.
+15. Report omitted supporting material with a boolean rather than silently implying the rendered body is self-contained.

--- a/Docs/MCP/Unified/Modules.md
+++ b/Docs/MCP/Unified/Modules.md
@@ -14,7 +14,7 @@ Use these tiers to explain what an enabled module can do before connecting an MC
 
 | Tier | Meaning | Common modules |
 |---|---|---|
-| `read_only` | Reads or searches existing TLDW data without writing by default. | `media`, `knowledge`, `chats`, `prompts`, `prompts_catalog`, `mcp_discovery` |
+| `read_only` | Reads or searches existing TLDW data without writing by default. | `media`, `knowledge`, `chats`, `prompts`, `prompts_catalog`, `skills`, `mcp_discovery` |
 | `write` | Creates, updates, exports, or manages TLDW data or generated artifacts. | `notes`, `template`, `quizzes`, `flashcards`, `kanban`, `slides`, `characters`, `persona_visuals`, `governance` |
 | `local_files` | Reads, writes, indexes, or scopes local files/workspaces. | `filesystem`, `codegraph` |
 | `external_network` | Connects to external MCP servers or networked tool providers. | `external_federation` |
@@ -98,6 +98,34 @@ relevant entries from
 selected `mcp_modules.yaml`, review the risk comments, set `enabled: true`,
 restart TLDW Server, then verify the module moved from
 `surface.disabled_available` to `surface.tiers`.
+
+## Skills Module
+
+- Module id: `skills`; the default configuration enables it in the `knowledge`
+  department with a concurrency limit of 10.
+- `skills.list` discovers metadata for model-visible Skills, and `skills.get`
+  returns the same metadata for one model-visible Skill. Both operations omit
+  instructions, supporting files, paths, hashes, and other raw Skill content.
+- `skills.render` renders one authorized model-visible Skill with bounded
+  arguments but does not call a model, execute a tool, or run a workflow.
+- Rendering evaluates the existing `Skill(name)` policy subject after normal
+  tool authorization: `deny` is rejected, `ask` requires an active approval
+  lease, and `allow` continues through the normal MCP gateway path.
+- Render arguments are limited to 10,000 characters. Rendered output has a
+  100,000-character hard ceiling and is rejected rather than truncated when it
+  exceeds that limit.
+- `declared_tools` is declaration metadata only; it does not grant effective
+  authorization or assert that a declared tool is available. Every later tool
+  call remains subject to MCP catalog, RBAC, policy, hook, and argument checks.
+- `supporting_files_omitted: true` means the rendered body may not be
+  self-contained. It exposes no supporting-file names, paths, hashes, or
+  content.
+- Discovery and render may synchronize the existing Skills registry, updating
+  derived index rows to match files on disk. This is registry maintenance, not
+  caller-authored Skill mutation.
+- Render uses exact shape, type, and size validation instead of the generic
+  SQL-token sanitizer so bounded, non-executing prompt text such as `--help`
+  and `/* example */` is preserved verbatim.
 
 ## External Federation Module
 

--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
@@ -1,0 +1,557 @@
+# Skills MCP Catalog and Safe Render Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose user-scoped `skills.list`, `skills.get`, and policy-gated `skills.render` through MCP Unified without model calls, tool execution, supporting-file content exposure, or authored Skill mutation.
+
+**Architecture:** Add two catalog-focused service operations to `SkillsService`, extend the standalone MCP profile runtime with a canonical `skill_name` permission subject, and add a thin host-side `SkillsModule`. Reuse existing integrity verification, approval leases, MCP execution/reporting, and `SkillExecutor` dry-run behavior. Keep all blocking registry and filesystem work off the event loop.
+
+**Tech Stack:** Python 3.10+, asyncio, FastAPI MCP runtime, SQLite-backed `CharactersRAGDB`, Pydantic policy models, pytest, Bandit.
+
+**Design:** `Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md`
+
+**Backlog:** `TASK-2294.1`
+
+## Global Constraints
+
+- Work only in `.worktrees/skills-mcp-catalog-render` on `codex/skills-mcp-catalog-render`.
+- Use TDD: add a focused failing test, run it red, implement the minimum behavior, and run it green.
+- Do not add model invocation, tool execution, workflow/job orchestration, frontend changes, new persistence, or a second policy evaluator.
+- Never return raw `SKILL.md`, supporting-file names/content, filesystem paths, database paths, hashes, or raw exceptions from MCP tools.
+- `skills.render` always forces `dry_run=True`, always passes `context=None` to `SkillExecutor`, and never accepts execution controls from callers.
+- Catalog operations include only `user_invocable=true`, `disable_model_invocation=false`, non-deleted, integrity-approved rows for the authenticated user.
+- Page items and total come from one matching row set and one integrity-filtering pass.
+- `arguments` and `q` are preserved verbatim after exact type/length validation; do not call `BaseModule.sanitize_input()` for these non-executing text fields.
+- Render input is limited to 10,000 characters; rendered output defaults to and cannot exceed 100,000 characters.
+- Use the existing MCP gateway, `Skill(...)` permission rules, and approval leases. Do not evaluate profile documents inside `SkillsModule`.
+- Run Bandit on every touched Python path before completion.
+
+## File Map
+
+- Modify `tldw_Server_API/app/core/Skills/skills_service.py`: one-pass model-visible page, metadata lookup, and offloaded verified load.
+- Modify `tldw_Server_API/tests/Skills/unit/test_skills_service.py`: service visibility, pagination, integrity, and thread-offload coverage.
+- Modify `apps/mcp-unified/src/mcp_unified/profiles/subjects.py`: extract bounded `skill_name` subjects.
+- Modify `apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py`: lowercase Skill patterns and subjects consistently.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py`: canonical Skill matching.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py`: extraction and simulated deny/ask/lease behavior.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`: real profile-runtime deny/ask/lease behavior.
+- Create `tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py`: tool schemas, context binding, service delegation, rendering, and safe errors.
+- Create `tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py`: module contracts and user-isolation integration tests.
+- Modify `tldw_Server_API/Config_Files/mcp_modules.yaml`: enable the read-only Skills module.
+- Modify `tldw_Server_API/app/core/MCP_unified/module_surface.py`: classify Skills as read-only.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py`: configuration and dynamic registration tests.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py`: read-only module-surface classification test.
+- Modify `Docs/MCP/Unified/Modules.md`: operator-facing tool, bounds, and permission documentation.
+- Update `backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md` only through Backlog MCP.
+
+---
+
+## Stage 1: Model-Visible Skills Service Primitives
+
+**Goal**: Provide one-pass catalog pagination, exact metadata lookup, and event-loop-safe verified loading.
+
+**Success Criteria**: The service returns only model-visible, integrity-approved Skills; page and total use one matching row query; supporting content is never returned by metadata methods; blocking work runs in worker threads; existing `get_skill()` responses are unchanged.
+
+**Tests**: `tldw_Server_API/tests/Skills/unit/test_skills_service.py`
+
+**Status**: Not Started
+
+### Task 1.1: Write failing catalog service tests
+
+- [ ] Import `AsyncMock` from `unittest.mock`, then add tests using the existing `service` fixture for these behaviors:
+
+```python
+@pytest.mark.asyncio
+async def test_list_model_visible_skills_page_filters_and_counts_once(service, monkeypatch):
+    await service.create_skill("visible", "---\nuser-invocable: true\n---\nVisible")
+    await service.create_skill("hidden", "---\nuser-invocable: false\n---\nHidden")
+    await service.create_skill(
+        "manual-only",
+        "---\ndisable-model-invocation: true\n---\nManual",
+    )
+    await service._sync_registry_async(force=True)
+    monkeypatch.setattr(service, "_sync_registry_async", AsyncMock())
+    calls = 0
+    original = service._get_db().list_skill_registry
+
+    def counted_list(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(service._get_db(), "list_skill_registry", counted_list)
+    items, total = await service.list_model_visible_skills_page(limit=10, offset=0)
+
+    assert [item.name for item in items] == ["visible"]
+    assert total == 1
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_get_model_visible_skill_metadata_hides_non_model_skills(service):
+    await service.create_skill(
+        "manual-only",
+        "---\ndisable-model-invocation: true\n---\nManual",
+    )
+
+    with pytest.raises(SkillNotFoundError):
+        await service.get_model_visible_skill_metadata("manual-only")
+```
+
+- [ ] Add an integrity-resolver fixture or monkeypatch `_is_skill_allowed` so an integrity-blocked row is omitted and the exact lookup raises `SkillNotFoundError`.
+- [ ] Add a supporting-file Skill and assert the metadata-only helpers do not parse or return `content`, `raw_content`, or `supporting_files`. Keep `directory_path` and `content_hash` available only as internal `SkillMetadata` fields; Stage 3 verifies that the MCP formatter never exposes them.
+- [ ] Add an offload test that records `threading.get_ident()` inside the new synchronous page helper and confirms it differs from the test event-loop thread.
+- [ ] Add a regression test that `get_skill()` still returns the same content/supporting-file payload after its filesystem work is moved to a worker thread.
+- [ ] Run the focused tests and confirm they fail because the new methods do not exist:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/Skills/unit/test_skills_service.py \
+  -k 'model_visible or verified_load_offload'
+```
+
+Expected: failures naming `list_model_visible_skills_page` or `get_model_visible_skill_metadata`.
+
+### Task 1.2: Implement one-pass service operations
+
+- [ ] Add these public signatures to `SkillsService`:
+
+```python
+async def list_model_visible_skills_page(
+    self,
+    *,
+    q: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[SkillMetadata], int]:
+    await self._sync_registry_async()
+    return await asyncio.to_thread(
+        self._list_model_visible_skills_page_sync,
+        q,
+        limit,
+        offset,
+    )
+
+
+async def get_model_visible_skill_metadata(self, name: str) -> SkillMetadata:
+    normalized = self._normalize_and_validate_skill_name(name)
+    await self._sync_registry_async()
+    return await asyncio.to_thread(
+        self._get_model_visible_skill_metadata_sync,
+        normalized,
+    )
+```
+
+- [ ] Implement private synchronous helpers that:
+  - after registry synchronization, query non-deleted rows once with fixed `sort="name"`, `order="asc"`, and no DB pagination;
+  - require `user_invocable` and reject `disable_model_invocation`;
+  - call `_is_skill_allowed(name, purpose="skill_discovery")` once per otherwise-visible row;
+  - calculate `total = len(visible_rows)` before slicing;
+  - return `SkillMetadata` objects without full-directory parsing.
+- [ ] Extract the current post-sync body of `get_skill()` into a synchronous private helper and call it through `asyncio.to_thread`. Preserve its exception types, return keys, integrity purpose, registry tombstoning, and optimistic version behavior exactly.
+- [ ] Run the focused service tests:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/Skills/unit/test_skills_service.py
+```
+
+Expected: all tests pass.
+
+- [ ] Commit Stage 1:
+
+```bash
+git add tldw_Server_API/app/core/Skills/skills_service.py \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py
+git commit -m "feat(skills): add model-visible catalog service"
+```
+
+---
+
+## Stage 2: Canonical Skill Permission Subjects
+
+**Goal**: Make `Skill(pattern)` rules enforceable for `skills.render` through the existing gateway and approval-lease system.
+
+**Success Criteria**: `skill_name` emits one lowercase Skill subject; Skill rule patterns, runtime subjects, and approval grants share the same canonical form; deny, ask, valid lease, expired lease, and allow behavior remain gateway-owned.
+
+**Tests**: Profile permission, policy simulation, and FastAPI gateway runtime tests.
+
+**Status**: Not Started
+
+### Task 2.1: Write failing subject and policy tests
+
+- [ ] Extend `test_subjects_module_extracts_permission_rule_subjects` with:
+
+```python
+subjects = extract_permission_rule_subjects(
+    "skills.render",
+    {"skill_name": "Review-Paper", "arguments": "--formal /* example */"},
+)
+pairs = {(subject_type, value) for subject_type, value, _argv in subjects}
+assert ("skill", "review-paper") in pairs
+assert all(subject_type != "skill" for subject_type, _, _ in extract_permission_rule_subjects(
+    "skills.get", {"name": "Review-Paper"}
+))
+```
+
+- [ ] Add profile rule tests proving `Skill(REVIEW-*)` matches `review-paper` and approval grants created with mixed case normalize to the same value.
+- [ ] Add policy simulation tests for:
+  - explicit `Skill(secret-*)` deny;
+  - `Skill(review-*)` ask without a lease;
+  - the same ask with a valid Skill approval lease;
+  - the same ask with an expired Skill approval lease;
+  - explicit `Skill(review-*)` allow;
+  - unrelated Skill rules not blocking an otherwise allowed tool call.
+- [ ] Assert blank, non-string, nested, and generic `name` values emit no Skill subject, while oversized `skill_name` values retain the existing `max_subject_value_length` failure.
+- [ ] Add FastAPI profile-runtime tests using a backend descriptor for `skills.render` and assert denied/approval-required calls never reach the backend, while a valid lease delegates once with a redacted grant marker.
+- [ ] Run the tests and confirm they fail because no Skill subject is extracted:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  -k 'skill and (permission or subject or approval or lease)'
+```
+
+### Task 2.2: Implement shared Skill subject normalization
+
+- [ ] In `subjects.py`, add only the explicit convention:
+
+```python
+SKILL_ARGUMENT_KEYS = frozenset({"skill_name"})
+
+# Inside extract_permission_rule_subjects(...)
+elif normalized_key in SKILL_ARGUMENT_KEYS:
+    for item in _string_values(value):
+        _append_permission_subject(subjects, "skill", item.lower(), None)
+```
+
+- [ ] Export `SKILL_ARGUMENT_KEYS` in `subjects.py.__all__` for test and policy tooling parity.
+- [ ] In `permission_rules.py`, lowercase both sides of Skill matching:
+
+```python
+if tool_name == "Skill":
+    return PolicyDecisionRule(
+        rule_type="skill",
+        outcome=outcome,
+        source=source,
+        pattern=normalized_specifier.lower(),
+        reason_code=reason_code,
+    )
+
+# In _normalize_subject_value(...)
+if subject_type in {"mcp", "skill"}:
+    return normalized.lower()
+```
+
+- [ ] Run all three focused permission suites and confirm they pass.
+- [ ] Run the standalone package boundary smoke that covers the edited package source:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -k 'source or import or package'
+```
+
+- [ ] Commit Stage 2:
+
+```bash
+git add apps/mcp-unified/src/mcp_unified/profiles/subjects.py \
+  apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+git commit -m "feat(mcp): enforce canonical Skill permission subjects"
+```
+
+---
+
+## Stage 3: Read-Only Skills MCP Module
+
+**Goal**: Implement bounded list/get/render tools using authenticated user context and the service primitives.
+
+**Success Criteria**: Tool schemas and validation match the design; user isolation is fail-closed; punctuation is preserved; all database handles close; rendering is always dry; safe errors map through existing MCP exception classes; omitted supporting material is disclosed only as a boolean.
+
+**Tests**: New `test_skills_module.py` unit and integration coverage.
+
+**Status**: Not Started
+
+### Task 3.1: Write failing module contract tests
+
+- [ ] Create `test_skills_module.py` with fixtures that build separate user directories, ChaChaNotes databases, `SkillsService` instances, and `RequestContext` values whose numeric-string `user_id` values and `db_paths["chacha"]` point at each user database.
+- [ ] Assert numeric-string user IDs such as `"1"` are converted to positive integers, while empty, non-numeric, zero, negative, and boolean user IDs fail with `skills_user_context_required`.
+- [ ] Assert `get_tools()` exposes exactly `skills.list`, `skills.get`, and `skills.render`, all with `tool["metadata"]["readOnlyHint"] is True`.
+- [ ] Assert validator behavior for unknown keys, booleans passed as integers, negative offsets, limit 0/101, query length 201, missing/invalid names, and arguments length 10,001.
+- [ ] Assert `q="flags --all /* literal */"` and `arguments="--formal /* literal */\nnext"` reach service/executor unchanged.
+- [ ] Assert list search is fixed to name ascending and returns `skills`, `count`, integrity-filtered `total`, effective `limit`, `offset`, and `next_offset`; verify the final page returns `next_offset=None`.
+- [ ] Assert `skills.get` returns the same metadata formatter shape as one list item, without a wrapper or content fields.
+- [ ] Assert list/get never return IDs, timestamps, content, supporting-file details, paths, or hashes.
+- [ ] Assert hidden, model-disabled, deleted, integrity-blocked, and other-user Skills are absent or return `skill_not_found`.
+- [ ] Assert render output includes:
+
+```python
+assert result == {
+    "skill_name": "review-paper",
+    "rendered_prompt": "Review issue 42",
+    "declared_tools": ["rag.search"],
+    "model_override": None,
+    "execution_mode": "inline",
+    "supporting_files_omitted": False,
+    "dry_run": True,
+    "version": 1,
+}
+```
+
+- [ ] Add a Skill with one supporting file and assert only `supporting_files_omitted=True` is disclosed.
+- [ ] Monkeypatch `SkillExecutor._execute_forked` and `_execute_inline` to raise if called; render an inline Skill and a fork Skill and assert neither method runs.
+- [ ] Configure `max_rendered_skill_chars=10`, render 11 characters, and assert `ValueError("rendered_skill_too_large: limit=10")` without prompt text.
+- [ ] Parameterize missing, boolean, non-integer, below-minimum, valid, and above-maximum module settings; assert invalid types use defaults and integers clamp to the documented bounds.
+- [ ] Assert missing user context raises `PermissionError("skills_user_context_required")`, integrity races raise `PermissionError("context_integrity_blocked")`, and unexpected storage failures expose only `skills_unavailable` inside module-level tests.
+- [ ] Capture logs for a storage exception containing sentinel content and a sentinel path; assert the log includes only operation, numeric user ID, and exception type, with neither sentinel disclosed.
+- [ ] Assert request-scoped databases close after successful list/get/render, not-found, integrity rejection, oversized output, and unexpected storage failure.
+- [ ] Force `SkillsService` construction to fail after `CharactersRAGDB` opens and assert that database is closed before the bounded failure propagates.
+- [ ] Block a worker-side catalog operation, cancel the module call, release the operation, and assert cancellation propagates only after the operation finishes and the database closes.
+- [ ] Run the new test file and confirm import failure because `skills_module.py` does not exist.
+
+### Task 3.2: Implement `SkillsModule`
+
+- [ ] Create constants and clamping helpers:
+
+```python
+DEFAULT_LIST_PAGE_SIZE = 50
+MAX_LIST_PAGE_SIZE = 100
+MAX_QUERY_CHARS = 200
+MAX_ARGUMENT_CHARS = 10_000
+HARD_MAX_RENDERED_SKILL_CHARS = 100_000
+```
+
+- [ ] Implement `on_initialize()` so integer settings are clamped to their documented ranges; missing, boolean, and non-integer values use the defaults. The effective `list_page_size` is the `skills.list` schema and runtime default.
+- [ ] Instantiate one stateless `SkillExecutor()` in `on_initialize()` and retain it as `self._executor`; it receives no request context, model client, or tool registry.
+- [ ] Implement all three `create_tool_definition()` schemas with `category` set to `search` or `retrieval` and `readOnlyHint=True`.
+- [ ] Implement `validate_tool_arguments()` with per-tool exact key allowlists. Reject `bool` for integer fields. Validate but do not rewrite `q` or `arguments`; normalize whitespace-only `q` only when passing it to the service.
+- [ ] Do not call `sanitize_input()`. Start dispatch with a shallow dictionary copy after confirming `arguments` is a dictionary.
+- [ ] Implement a request-scoped context manager/helper that:
+  - converts `context.user_id` with `int(str(value))`, rejects booleans, and requires the result to be greater than zero;
+  - requires trusted `context.db_paths["chacha"]`;
+  - constructs `CharactersRAGDB` from that path and `SkillsService(user_id, Path(chacha_path).parent, db)` together through `asyncio.to_thread`;
+  - closes the database inside the worker if `SkillsService` construction fails after `CharactersRAGDB` opens;
+  - retains each offloaded task and, on cancellation, awaits the in-flight task before propagating cancellation so cleanup cannot race active database work;
+  - closes `db.close_all_connections()` through `asyncio.to_thread` in `finally` on every path after a database has opened, including lookup, render, and response-size failures.
+- [ ] Format catalog metadata with only:
+
+```python
+{
+    "name": metadata.name,
+    "description": metadata.description,
+    "argument_hint": metadata.argument_hint,
+    "user_invocable": metadata.user_invocable,
+    "disable_model_invocation": metadata.disable_model_invocation,
+    "declared_tools": list(metadata.allowed_tools),
+    "model": metadata.model,
+    "context": metadata.context,
+    "runtime": build_skill_runtime_metadata(
+        context=metadata.context,
+        allowed_tools=metadata.allowed_tools,
+        model=metadata.model,
+        disable_model_invocation=metadata.disable_model_invocation,
+    ),
+    "version": metadata.version,
+}
+```
+
+- [ ] Implement `skills.list` by calling `list_model_visible_skills_page(q=effective_q, limit=effective_limit, offset=effective_offset)` exactly once and returning:
+
+```python
+count = len(items)
+next_value = offset + count
+return {
+    "skills": [self._format_metadata(item) for item in items],
+    "count": count,
+    "total": total,
+    "limit": limit,
+    "offset": offset,
+    "next_offset": next_value if next_value < total else None,
+}
+```
+
+- [ ] Implement `skills.get` with one `get_model_visible_skill_metadata(name)` call and return `self._format_metadata(metadata)` directly.
+
+- [ ] For render, call metadata lookup first, then verified `get_skill()`, recheck the parsed `user_invocable` and `disable_model_invocation` flags for races, and call:
+
+```python
+result = await self._executor.execute(
+    skill_data,
+    arguments,
+    context=None,
+    dry_run=True,
+)
+```
+
+- [ ] Check `len(result.rendered_prompt)` before constructing the response. Return `declared_tools=list(result.allowed_tools)` and `supporting_files_omitted=bool(skill_data.get("supporting_files"))`.
+- [ ] Translate exceptions narrowly:
+  - validation and not-found to bounded `ValueError` messages handled as invalid params;
+  - missing user context and render-time `ContextIntegrityBlocked` to bounded `PermissionError` messages;
+  - storage/parser failures to `RuntimeError("skills_unavailable")`, which the MCP runtime sanitizes in production.
+- [ ] For module-owned storage/parser failures, log only operation, numeric user ID, and exception class name. Do not interpolate exception messages, arguments, rendered content, database paths, or filesystem paths.
+- [ ] Run `test_skills_module.py`, then rerun the complete Skills service suite.
+- [ ] Commit Stage 3:
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py
+git commit -m "feat(mcp): add Skills catalog and dry render tools"
+```
+
+---
+
+## Stage 4: Registration, Surface, and Operator Documentation
+
+**Goal**: Make the module available through production configuration and document its safe operating contract.
+
+**Success Criteria**: Default loading registers all three tools; status classifies Skills as read-only; operator docs explain bounds, permission rules, dry-run guarantees, registry maintenance, and supporting-file omission.
+
+**Tests**: Dynamic module catalog, module surface, and authenticated user-isolation tests.
+
+**Status**: Not Started
+
+### Task 4.1: Write failing registration tests
+
+- [ ] Add a dynamic config test asserting the `skills` entry follows `prompts`, is enabled, points to `SkillsModule`, uses version `0.1.0`, has `department=knowledge`, `max_concurrent=10`, and has the two exact settings.
+- [ ] Add a registration test using a temporary MCP module config and assert `find_module_for_tool()` resolves all three tool names.
+- [ ] Extend the module-surface test to assert `skills` appears under `read_only` with no explicit opt-in requirement.
+- [ ] Run the tests and confirm they fail because configuration and surface classification are absent.
+
+### Task 4.2: Register and document the module
+
+- [ ] Add the YAML entry from the approved design immediately after `prompts`.
+- [ ] Add this risk-tier entry:
+
+```python
+"skills": ("read_only", "Discover and safely render user-owned Skills without execution."),
+```
+
+- [ ] Add a `Skills Module` section to `Docs/MCP/Unified/Modules.md` documenting:
+  - `skills.list`, `skills.get`, and `skills.render`;
+  - metadata-only discovery and model-visible filtering;
+  - `Skill(name)` deny/ask/approval/allow evaluation for render;
+  - 10,000-character arguments and 100,000-character hard output ceiling;
+  - `declared_tools` is not effective authorization;
+  - `supporting_files_omitted` means the rendered body may not be self-contained;
+  - registry synchronization may update derived index rows;
+  - the module intentionally bypasses generic SQL-token sanitization for bounded non-executing prompt text.
+- [ ] Update the read-only tier table to include `skills`.
+- [ ] Run dynamic registration, module surface, and Skills module tests.
+- [ ] Commit Stage 4:
+
+```bash
+git add tldw_Server_API/Config_Files/mcp_modules.yaml \
+  tldw_Server_API/app/core/MCP_unified/module_surface.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  Docs/MCP/Unified/Modules.md
+git commit -m "docs(mcp): register and document Skills tools"
+```
+
+---
+
+## Stage 5: Verification and Closeout
+
+**Goal**: Prove the scoped feature is stable, secure, documented, and ready for review against `dev`.
+
+**Success Criteria**: Focused and regression suites pass, Bandit reports no new findings, diff checks pass, only task-related files changed, Backlog records evidence, and the branch is ready for code review.
+
+**Tests**: Full focused matrix below.
+
+**Status**: Not Started
+
+### Task 5.1: Run focused verification
+
+- [ ] Run service and module tests:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py \
+  tldw_Server_API/tests/Skills/unit/test_skill_executor.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+```
+
+- [ ] Run permission and gateway tests:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  -k 'skill or permission_rule or approval_lease'
+```
+
+- [ ] Run the standalone package boundary tests affected by `apps/mcp-unified` changes:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+```
+
+- [ ] Run Bandit on every touched Python path:
+
+```bash
+source ../../.venv/bin/activate
+python -m bandit -r \
+  apps/mcp-unified/src/mcp_unified/profiles/subjects.py \
+  apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py \
+  tldw_Server_API/app/core/Skills/skills_service.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py \
+  tldw_Server_API/app/core/MCP_unified/module_surface.py \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  -s B101 \
+  -f json -o /tmp/bandit_TASK_2294_1.json
+```
+
+- [ ] Run repository hygiene checks:
+
+```bash
+git diff --check
+git status --short
+git diff --stat origin/dev...HEAD
+```
+
+- [ ] Inspect `/tmp/bandit_TASK_2294_1.json`; fix any new finding in touched code before proceeding.
+
+### Task 5.2: Review and finalize tracking
+
+- [ ] Review the final diff against every design decision and Backlog acceptance criterion. Confirm no model/tool execution, frontend changes, workflow code, new persistence, or unrelated formatting entered the branch.
+- [ ] Update every stage status in this plan from `Not Started` to `Complete` only after its commands pass.
+- [ ] Use Backlog MCP to record modified files, implementation plan, verification commands/results, Bandit result, known skips, and final summary for `TASK-2294.1`.
+- [ ] Check all acceptance criteria and Definition of Done items only when evidence exists.
+- [ ] Commit tracking-only closeout changes:
+
+```bash
+git add Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md \
+  'backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md'
+git commit -m "chore: close TASK-2294.1 verification"
+```
+
+- [ ] Use `superpowers:requesting-code-review` for a final correctness and scope review before pushing or opening a PR against `dev`.
+
+## Plan Self-Review Checklist
+
+- [x] Every design requirement maps to a stage and test.
+- [x] Exact interfaces and field names are consistent across service, permission, module, config, docs, and tests.
+- [x] The placeholder scan returns no plan-failure language.
+- [x] All synchronous database/filesystem/integrity work added by this task is explicitly offloaded.
+- [x] Discovery-time and render-race integrity errors have distinct, non-enumerating behavior.
+- [x] Supporting files are never returned and omission is never silent.
+- [x] Permission evaluation remains in the shared gateway and uses existing approval leases.
+- [x] Verification includes focused tests, regression tests, package boundaries, Bandit, and diff hygiene.

--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
@@ -29,6 +29,7 @@
 ## File Map
 
 - Modify `tldw_Server_API/app/core/Skills/skills_service.py`: one-pass model-visible page, metadata lookup, and offloaded verified load.
+- Modify `tldw_Server_API/app/core/exceptions.py`: centralize bounded Skills MCP boundary exceptions.
 - Modify `tldw_Server_API/tests/Skills/unit/test_skills_service.py`: service visibility, pagination, integrity, and thread-offload coverage.
 - Modify `apps/mcp-unified/src/mcp_unified/profiles/subjects.py`: extract bounded `skill_name` subjects.
 - Modify `apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py`: lowercase Skill patterns and subjects consistently.
@@ -577,6 +578,16 @@ git commit -m "chore: close TASK-2294.1 verification"
 ```
 
 - [x] Use `superpowers:requesting-code-review` for a final correctness and scope review before pushing or opening a PR against `dev`.
+
+## Stage 6: Pull Request Review Follow-up
+
+**Goal**: Resolve verified review findings after rebasing onto the latest `dev`.
+
+**Success Criteria**: Nullable registry flags use schema defaults, page collection avoids a second full-list allocation, Skills MCP exceptions are centralized, the module test suite is marked as unit, and all review threads are resolved.
+
+**Tests**: Focused nullable-flag regressions, complete Skills service/module suites, lint, Bandit, and PR check review.
+
+**Status**: In Progress
 
 ## Plan Self-Review Checklist
 

--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
@@ -33,11 +33,13 @@
 - Modify `apps/mcp-unified/src/mcp_unified/profiles/subjects.py`: extract bounded `skill_name` subjects.
 - Modify `apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py`: lowercase Skill patterns and subjects consistently.
 - Modify `apps/mcp-unified/src/mcp_unified/policy_grants/models.py`: admit canonical Skill subjects to existing approval leases.
+- Modify `apps/mcp-unified/src/mcp_unified/gateway/cli.py`: expose authoritative Skill approval subjects through the operator CLI.
 - Modify `tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py`: canonical Skill matching.
 - Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py`: extraction and simulated deny/ask/lease behavior.
 - Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`: real profile-runtime deny/ask/lease behavior.
 - Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py`: Skill approval-grant validation coverage.
 - Modify `tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py`: in-memory and SQLite Skill grant persistence coverage.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`: persistent Skill approval-grant CLI lifecycle coverage.
 - Create `tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py`: tool schemas, context binding, service delegation, rendering, and safe errors.
 - Create `tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py`: module contracts and user-isolation integration tests.
 - Modify `tldw_Server_API/Config_Files/mcp_modules.yaml`: enable the read-only Skills module.
@@ -475,11 +477,11 @@ git commit -m "docs(mcp): register and document Skills tools"
 
 **Tests**: Full focused matrix below.
 
-**Status**: In Progress
+**Status**: Complete
 
 ### Task 5.1: Run focused verification
 
-- [ ] Run service and module tests:
+- [x] Run service and module tests:
 
 ```bash
 source ../../.venv/bin/activate
@@ -491,7 +493,7 @@ python -m pytest -q \
   tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
 ```
 
-- [ ] Run permission and gateway tests:
+- [x] Run permission and gateway tests:
 
 ```bash
 source ../../.venv/bin/activate
@@ -504,14 +506,26 @@ python -m pytest -q \
   -k 'skill or permission_rule or approval_lease'
 ```
 
-- [ ] Run the standalone package boundary tests affected by `apps/mcp-unified` changes:
+- [x] Run the standalone package boundary tests affected by `apps/mcp-unified` changes:
 
 ```bash
 source ../../.venv/bin/activate
 python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
 ```
 
-- [ ] Run Bandit on every touched Python path:
+- [x] Run the Skill approval-grant CLI lifecycle and policy-grant regression tests:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  -k 'approval_grant_lifecycle'
+python -m pytest -q \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
+```
+
+- [x] Run Bandit on every touched Python path:
 
 ```bash
 source ../../.venv/bin/activate
@@ -519,6 +533,7 @@ python -m bandit -r \
   apps/mcp-unified/src/mcp_unified/profiles/subjects.py \
   apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py \
   apps/mcp-unified/src/mcp_unified/policy_grants/models.py \
+  apps/mcp-unified/src/mcp_unified/gateway/cli.py \
   tldw_Server_API/app/core/Skills/skills_service.py \
   tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py \
   tldw_Server_API/app/core/MCP_unified/module_surface.py \
@@ -528,6 +543,7 @@ python -m bandit -r \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
@@ -535,7 +551,7 @@ python -m bandit -r \
   -f json -o /tmp/bandit_TASK_2294_1.json
 ```
 
-- [ ] Run repository hygiene checks:
+- [x] Run repository hygiene checks:
 
 ```bash
 git diff --check
@@ -543,15 +559,16 @@ git status --short
 git diff --stat origin/dev...HEAD
 ```
 
-- [ ] Inspect `/tmp/bandit_TASK_2294_1.json`; fix any new finding in touched code before proceeding.
+- [x] Inspect `/tmp/bandit_TASK_2294_1.json`; fix any new finding in touched code before proceeding.
 
 ### Task 5.2: Review and finalize tracking
 
-- [ ] Review the final diff against every design decision and Backlog acceptance criterion. Confirm no model/tool execution, frontend changes, workflow code, new persistence, or unrelated formatting entered the branch.
-- [ ] Update every stage status in this plan from `Not Started` to `Complete` only after its commands pass.
-- [ ] Use Backlog MCP to record modified files, implementation plan, verification commands/results, Bandit result, known skips, and final summary for `TASK-2294.1`.
-- [ ] Check all acceptance criteria and Definition of Done items only when evidence exists.
-- [ ] Commit tracking-only closeout changes:
+- [x] Review the final diff against every design decision and Backlog acceptance criterion. Confirm no model/tool execution, frontend changes, workflow code, new persistence, or unrelated formatting entered the branch.
+- [x] Address the final-review CLI approval-subject finding and complete a focused clean re-review.
+- [x] Update every stage status in this plan from `Not Started` to `Complete` only after its commands pass.
+- [x] Use Backlog MCP to record modified files, implementation plan, verification commands/results, Bandit result, known skips, and final summary for `TASK-2294.1`.
+- [x] Check all acceptance criteria and Definition of Done items only when evidence exists.
+- [x] Commit tracking-only closeout changes:
 
 ```bash
 git add Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md \
@@ -559,7 +576,7 @@ git add Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md 
 git commit -m "chore: close TASK-2294.1 verification"
 ```
 
-- [ ] Use `superpowers:requesting-code-review` for a final correctness and scope review before pushing or opening a PR against `dev`.
+- [x] Use `superpowers:requesting-code-review` for a final correctness and scope review before pushing or opening a PR against `dev`.
 
 ## Plan Self-Review Checklist
 

--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
@@ -587,7 +587,7 @@ git commit -m "chore: close TASK-2294.1 verification"
 
 **Tests**: Focused nullable-flag regressions, complete Skills service/module suites, lint, Bandit, and PR check review.
 
-**Status**: In Progress
+**Status**: Complete
 
 ## Plan Self-Review Checklist
 

--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
@@ -32,9 +32,12 @@
 - Modify `tldw_Server_API/tests/Skills/unit/test_skills_service.py`: service visibility, pagination, integrity, and thread-offload coverage.
 - Modify `apps/mcp-unified/src/mcp_unified/profiles/subjects.py`: extract bounded `skill_name` subjects.
 - Modify `apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py`: lowercase Skill patterns and subjects consistently.
+- Modify `apps/mcp-unified/src/mcp_unified/policy_grants/models.py`: admit canonical Skill subjects to existing approval leases.
 - Modify `tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py`: canonical Skill matching.
 - Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py`: extraction and simulated deny/ask/lease behavior.
 - Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`: real profile-runtime deny/ask/lease behavior.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py`: Skill approval-grant validation coverage.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py`: in-memory and SQLite Skill grant persistence coverage.
 - Create `tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py`: tool schemas, context binding, service delegation, rendering, and safe errors.
 - Create `tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py`: module contracts and user-isolation integration tests.
 - Modify `tldw_Server_API/Config_Files/mcp_modules.yaml`: enable the read-only Skills module.
@@ -54,11 +57,11 @@
 
 **Tests**: `tldw_Server_API/tests/Skills/unit/test_skills_service.py`
 
-**Status**: Not Started
+**Status**: Complete
 
 ### Task 1.1: Write failing catalog service tests
 
-- [ ] Import `AsyncMock` from `unittest.mock`, then add tests using the existing `service` fixture for these behaviors:
+- [x] Import `AsyncMock` from `unittest.mock`, then add tests using the existing `service` fixture for these behaviors:
 
 ```python
 @pytest.mark.asyncio
@@ -98,11 +101,11 @@ async def test_get_model_visible_skill_metadata_hides_non_model_skills(service):
         await service.get_model_visible_skill_metadata("manual-only")
 ```
 
-- [ ] Add an integrity-resolver fixture or monkeypatch `_is_skill_allowed` so an integrity-blocked row is omitted and the exact lookup raises `SkillNotFoundError`.
-- [ ] Add a supporting-file Skill and assert the metadata-only helpers do not parse or return `content`, `raw_content`, or `supporting_files`. Keep `directory_path` and `content_hash` available only as internal `SkillMetadata` fields; Stage 3 verifies that the MCP formatter never exposes them.
-- [ ] Add an offload test that records `threading.get_ident()` inside the new synchronous page helper and confirms it differs from the test event-loop thread.
-- [ ] Add a regression test that `get_skill()` still returns the same content/supporting-file payload after its filesystem work is moved to a worker thread.
-- [ ] Run the focused tests and confirm they fail because the new methods do not exist:
+- [x] Add an integrity-resolver fixture or monkeypatch `_is_skill_allowed` so an integrity-blocked row is omitted and the exact lookup raises `SkillNotFoundError`.
+- [x] Add a supporting-file Skill and assert the metadata-only helpers do not parse or return `content`, `raw_content`, or `supporting_files`. Keep `directory_path` and `content_hash` available only as internal `SkillMetadata` fields; Stage 3 verifies that the MCP formatter never exposes them.
+- [x] Add an offload test that records `threading.get_ident()` inside the new synchronous page helper and confirms it differs from the test event-loop thread.
+- [x] Add a regression test that `get_skill()` still returns the same content/supporting-file payload after its filesystem work is moved to a worker thread.
+- [x] Run the focused tests and confirm they fail because the new methods do not exist:
 
 ```bash
 source ../../.venv/bin/activate
@@ -114,7 +117,7 @@ Expected: failures naming `list_model_visible_skills_page` or `get_model_visible
 
 ### Task 1.2: Implement one-pass service operations
 
-- [ ] Add these public signatures to `SkillsService`:
+- [x] Add these public signatures to `SkillsService`:
 
 ```python
 async def list_model_visible_skills_page(
@@ -142,14 +145,14 @@ async def get_model_visible_skill_metadata(self, name: str) -> SkillMetadata:
     )
 ```
 
-- [ ] Implement private synchronous helpers that:
+- [x] Implement private synchronous helpers that:
   - after registry synchronization, query non-deleted rows once with fixed `sort="name"`, `order="asc"`, and no DB pagination;
   - require `user_invocable` and reject `disable_model_invocation`;
   - call `_is_skill_allowed(name, purpose="skill_discovery")` once per otherwise-visible row;
   - calculate `total = len(visible_rows)` before slicing;
   - return `SkillMetadata` objects without full-directory parsing.
-- [ ] Extract the current post-sync body of `get_skill()` into a synchronous private helper and call it through `asyncio.to_thread`. Preserve its exception types, return keys, integrity purpose, registry tombstoning, and optimistic version behavior exactly.
-- [ ] Run the focused service tests:
+- [x] Extract the current post-sync body of `get_skill()` into a synchronous private helper and call it through `asyncio.to_thread`. Preserve its exception types, return keys, integrity purpose, registry tombstoning, and optimistic version behavior exactly.
+- [x] Run the focused service tests:
 
 ```bash
 source ../../.venv/bin/activate
@@ -158,7 +161,7 @@ python -m pytest -q tldw_Server_API/tests/Skills/unit/test_skills_service.py
 
 Expected: all tests pass.
 
-- [ ] Commit Stage 1:
+- [x] Commit Stage 1:
 
 ```bash
 git add tldw_Server_API/app/core/Skills/skills_service.py \
@@ -176,11 +179,11 @@ git commit -m "feat(skills): add model-visible catalog service"
 
 **Tests**: Profile permission, policy simulation, and FastAPI gateway runtime tests.
 
-**Status**: Not Started
+**Status**: Complete
 
 ### Task 2.1: Write failing subject and policy tests
 
-- [ ] Extend `test_subjects_module_extracts_permission_rule_subjects` with:
+- [x] Extend `test_subjects_module_extracts_permission_rule_subjects` with:
 
 ```python
 subjects = extract_permission_rule_subjects(
@@ -194,17 +197,18 @@ assert all(subject_type != "skill" for subject_type, _, _ in extract_permission_
 ))
 ```
 
-- [ ] Add profile rule tests proving `Skill(REVIEW-*)` matches `review-paper` and approval grants created with mixed case normalize to the same value.
-- [ ] Add policy simulation tests for:
+- [x] Add profile rule tests proving `Skill(REVIEW-*)` matches `review-paper` and approval grants created with mixed case normalize to the same value.
+- [x] Replace the existing unsupported-Skill grant expectations with tests proving approval grants accept `subject_type="skill"`, normalize mixed-case values to lowercase, and retain existing expiry semantics in both in-memory and SQLite stores.
+- [x] Add policy simulation tests for:
   - explicit `Skill(secret-*)` deny;
   - `Skill(review-*)` ask without a lease;
   - the same ask with a valid Skill approval lease;
   - the same ask with an expired Skill approval lease;
   - explicit `Skill(review-*)` allow;
   - unrelated Skill rules not blocking an otherwise allowed tool call.
-- [ ] Assert blank, non-string, nested, and generic `name` values emit no Skill subject, while oversized `skill_name` values retain the existing `max_subject_value_length` failure.
-- [ ] Add FastAPI profile-runtime tests using a backend descriptor for `skills.render` and assert denied/approval-required calls never reach the backend, while a valid lease delegates once with a redacted grant marker.
-- [ ] Run the tests and confirm they fail because no Skill subject is extracted:
+- [x] Assert blank, non-string, nested, and generic `name` values emit no Skill subject, while oversized `skill_name` values retain the existing `max_subject_value_length` failure.
+- [x] Add FastAPI profile-runtime tests using a backend descriptor for `skills.render` and assert denied/approval-required calls never reach the backend, while a valid lease delegates once with a redacted grant marker.
+- [x] Run the tests and confirm they fail because no Skill subject is extracted:
 
 ```bash
 source ../../.venv/bin/activate
@@ -212,24 +216,26 @@ python -m pytest -q \
   tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py \
   -k 'skill and (permission or subject or approval or lease)'
 ```
 
 ### Task 2.2: Implement shared Skill subject normalization
 
-- [ ] In `subjects.py`, add only the explicit convention:
+- [x] In `subjects.py`, add only the explicit convention:
 
 ```python
 SKILL_ARGUMENT_KEYS = frozenset({"skill_name"})
 
 # Inside extract_permission_rule_subjects(...)
-elif normalized_key in SKILL_ARGUMENT_KEYS:
+elif key in SKILL_ARGUMENT_KEYS:
     for item in _string_values(value):
         _append_permission_subject(subjects, "skill", item.lower(), None)
 ```
 
-- [ ] Export `SKILL_ARGUMENT_KEYS` in `subjects.py.__all__` for test and policy tooling parity.
-- [ ] In `permission_rules.py`, lowercase both sides of Skill matching:
+- [x] Export `SKILL_ARGUMENT_KEYS` in `subjects.py.__all__` for test and policy tooling parity.
+- [x] In `permission_rules.py`, lowercase both sides of Skill matching:
 
 ```python
 if tool_name == "Skill":
@@ -246,8 +252,10 @@ if subject_type in {"mcp", "skill"}:
     return normalized.lower()
 ```
 
-- [ ] Run all three focused permission suites and confirm they pass.
-- [ ] Run the standalone package boundary smoke that covers the edited package source:
+- [x] Add `"skill"` to `APPROVAL_SUBJECT_TYPES` in `policy_grants/models.py`. Do not add a new grant type, table, storage path, or Skill-specific lease branch; existing `normalize_permission_subject_value()` and stores remain authoritative.
+
+- [x] Run all five focused permission/grant suites and confirm they pass.
+- [x] Run the standalone package boundary smoke that covers the edited package source:
 
 ```bash
 source ../../.venv/bin/activate
@@ -255,14 +263,17 @@ python -m pytest -q tldw_Server_API/app/core/MCP_unified/tests/test_runtime_pack
   -k 'source or import or package'
 ```
 
-- [ ] Commit Stage 2:
+- [x] Commit Stage 2:
 
 ```bash
 git add apps/mcp-unified/src/mcp_unified/profiles/subjects.py \
   apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py \
+  apps/mcp-unified/src/mcp_unified/policy_grants/models.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py \
-  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
 git commit -m "feat(mcp): enforce canonical Skill permission subjects"
 ```
 
@@ -276,20 +287,20 @@ git commit -m "feat(mcp): enforce canonical Skill permission subjects"
 
 **Tests**: New `test_skills_module.py` unit and integration coverage.
 
-**Status**: Not Started
+**Status**: Complete
 
 ### Task 3.1: Write failing module contract tests
 
-- [ ] Create `test_skills_module.py` with fixtures that build separate user directories, ChaChaNotes databases, `SkillsService` instances, and `RequestContext` values whose numeric-string `user_id` values and `db_paths["chacha"]` point at each user database.
-- [ ] Assert numeric-string user IDs such as `"1"` are converted to positive integers, while empty, non-numeric, zero, negative, and boolean user IDs fail with `skills_user_context_required`.
-- [ ] Assert `get_tools()` exposes exactly `skills.list`, `skills.get`, and `skills.render`, all with `tool["metadata"]["readOnlyHint"] is True`.
-- [ ] Assert validator behavior for unknown keys, booleans passed as integers, negative offsets, limit 0/101, query length 201, missing/invalid names, and arguments length 10,001.
-- [ ] Assert `q="flags --all /* literal */"` and `arguments="--formal /* literal */\nnext"` reach service/executor unchanged.
-- [ ] Assert list search is fixed to name ascending and returns `skills`, `count`, integrity-filtered `total`, effective `limit`, `offset`, and `next_offset`; verify the final page returns `next_offset=None`.
-- [ ] Assert `skills.get` returns the same metadata formatter shape as one list item, without a wrapper or content fields.
-- [ ] Assert list/get never return IDs, timestamps, content, supporting-file details, paths, or hashes.
-- [ ] Assert hidden, model-disabled, deleted, integrity-blocked, and other-user Skills are absent or return `skill_not_found`.
-- [ ] Assert render output includes:
+- [x] Create `test_skills_module.py` with fixtures that build separate user directories, ChaChaNotes databases, `SkillsService` instances, and `RequestContext` values whose numeric-string `user_id` values and `db_paths["chacha"]` point at each user database.
+- [x] Assert numeric-string user IDs such as `"1"` are converted to positive integers, while empty, non-numeric, zero, negative, and boolean user IDs fail with `skills_user_context_required`.
+- [x] Assert `get_tools()` exposes exactly `skills.list`, `skills.get`, and `skills.render`, all with `tool["metadata"]["readOnlyHint"] is True`.
+- [x] Assert validator behavior for unknown keys, booleans passed as integers, negative offsets, limit 0/101, query length 201, missing/invalid names, and arguments length 10,001.
+- [x] Assert `q="flags --all /* literal */"` and `arguments="--formal /* literal */\nnext"` reach service/executor unchanged.
+- [x] Assert list search is fixed to name ascending and returns `skills`, `count`, integrity-filtered `total`, effective `limit`, `offset`, and `next_offset`; verify the final page returns `next_offset=None`.
+- [x] Assert `skills.get` returns the same metadata formatter shape as one list item, without a wrapper or content fields.
+- [x] Assert list/get never return IDs, timestamps, content, supporting-file details, paths, or hashes.
+- [x] Assert hidden, model-disabled, deleted, integrity-blocked, and other-user Skills are absent or return `skill_not_found`.
+- [x] Assert render output includes:
 
 ```python
 assert result == {
@@ -304,20 +315,20 @@ assert result == {
 }
 ```
 
-- [ ] Add a Skill with one supporting file and assert only `supporting_files_omitted=True` is disclosed.
-- [ ] Monkeypatch `SkillExecutor._execute_forked` and `_execute_inline` to raise if called; render an inline Skill and a fork Skill and assert neither method runs.
-- [ ] Configure `max_rendered_skill_chars=10`, render 11 characters, and assert `ValueError("rendered_skill_too_large: limit=10")` without prompt text.
-- [ ] Parameterize missing, boolean, non-integer, below-minimum, valid, and above-maximum module settings; assert invalid types use defaults and integers clamp to the documented bounds.
-- [ ] Assert missing user context raises `PermissionError("skills_user_context_required")`, integrity races raise `PermissionError("context_integrity_blocked")`, and unexpected storage failures expose only `skills_unavailable` inside module-level tests.
-- [ ] Capture logs for a storage exception containing sentinel content and a sentinel path; assert the log includes only operation, numeric user ID, and exception type, with neither sentinel disclosed.
-- [ ] Assert request-scoped databases close after successful list/get/render, not-found, integrity rejection, oversized output, and unexpected storage failure.
-- [ ] Force `SkillsService` construction to fail after `CharactersRAGDB` opens and assert that database is closed before the bounded failure propagates.
-- [ ] Block a worker-side catalog operation, cancel the module call, release the operation, and assert cancellation propagates only after the operation finishes and the database closes.
-- [ ] Run the new test file and confirm import failure because `skills_module.py` does not exist.
+- [x] Add a Skill with one supporting file and assert only `supporting_files_omitted=True` is disclosed.
+- [x] Monkeypatch `SkillExecutor._execute_forked` and `_execute_inline` to raise if called; render an inline Skill and a fork Skill and assert neither method runs.
+- [x] Configure `max_rendered_skill_chars=10`, render 11 characters, and assert `ValueError("rendered_skill_too_large: limit=10")` without prompt text.
+- [x] Parameterize missing, boolean, non-integer, below-minimum, valid, and above-maximum module settings; assert invalid types use defaults and integers clamp to the documented bounds.
+- [x] Assert missing user context raises `PermissionError("skills_user_context_required")`, integrity races raise `PermissionError("context_integrity_blocked")`, and unexpected storage failures expose only `skills_unavailable` inside module-level tests.
+- [x] Capture logs for a storage exception containing sentinel content and a sentinel path; assert the log includes only operation, numeric user ID, and exception type, with neither sentinel disclosed.
+- [x] Assert request-scoped databases close after successful list/get/render, not-found, integrity rejection, oversized output, and unexpected storage failure.
+- [x] Force `SkillsService` construction to fail after `CharactersRAGDB` opens and assert that database is closed before the bounded failure propagates.
+- [x] Block a worker-side catalog operation, cancel the module call, release the operation, and assert cancellation propagates only after the operation finishes and the database closes.
+- [x] Run the new test file and confirm import failure because `skills_module.py` does not exist.
 
 ### Task 3.2: Implement `SkillsModule`
 
-- [ ] Create constants and clamping helpers:
+- [x] Create constants and clamping helpers:
 
 ```python
 DEFAULT_LIST_PAGE_SIZE = 50
@@ -327,19 +338,19 @@ MAX_ARGUMENT_CHARS = 10_000
 HARD_MAX_RENDERED_SKILL_CHARS = 100_000
 ```
 
-- [ ] Implement `on_initialize()` so integer settings are clamped to their documented ranges; missing, boolean, and non-integer values use the defaults. The effective `list_page_size` is the `skills.list` schema and runtime default.
-- [ ] Instantiate one stateless `SkillExecutor()` in `on_initialize()` and retain it as `self._executor`; it receives no request context, model client, or tool registry.
-- [ ] Implement all three `create_tool_definition()` schemas with `category` set to `search` or `retrieval` and `readOnlyHint=True`.
-- [ ] Implement `validate_tool_arguments()` with per-tool exact key allowlists. Reject `bool` for integer fields. Validate but do not rewrite `q` or `arguments`; normalize whitespace-only `q` only when passing it to the service.
-- [ ] Do not call `sanitize_input()`. Start dispatch with a shallow dictionary copy after confirming `arguments` is a dictionary.
-- [ ] Implement a request-scoped context manager/helper that:
+- [x] Implement `on_initialize()` so integer settings are clamped to their documented ranges; missing, boolean, and non-integer values use the defaults. The effective `list_page_size` is the `skills.list` schema and runtime default.
+- [x] Instantiate one stateless `SkillExecutor()` in `on_initialize()` and retain it as `self._executor`; it receives no request context, model client, or tool registry.
+- [x] Implement all three `create_tool_definition()` schemas with `category` set to `search` or `retrieval` and `readOnlyHint=True`.
+- [x] Implement `validate_tool_arguments()` with per-tool exact key allowlists. Reject `bool` for integer fields. Validate but do not rewrite `q` or `arguments`; normalize whitespace-only `q` only when passing it to the service.
+- [x] Do not call `sanitize_input()`. Start dispatch with a shallow dictionary copy after confirming `arguments` is a dictionary.
+- [x] Implement a request-scoped context manager/helper that:
   - converts `context.user_id` with `int(str(value))`, rejects booleans, and requires the result to be greater than zero;
   - requires trusted `context.db_paths["chacha"]`;
   - constructs `CharactersRAGDB` from that path and `SkillsService(user_id, Path(chacha_path).parent, db)` together through `asyncio.to_thread`;
   - closes the database inside the worker if `SkillsService` construction fails after `CharactersRAGDB` opens;
   - retains each offloaded task and, on cancellation, awaits the in-flight task before propagating cancellation so cleanup cannot race active database work;
   - closes `db.close_all_connections()` through `asyncio.to_thread` in `finally` on every path after a database has opened, including lookup, render, and response-size failures.
-- [ ] Format catalog metadata with only:
+- [x] Format catalog metadata with only:
 
 ```python
 {
@@ -361,7 +372,7 @@ HARD_MAX_RENDERED_SKILL_CHARS = 100_000
 }
 ```
 
-- [ ] Implement `skills.list` by calling `list_model_visible_skills_page(q=effective_q, limit=effective_limit, offset=effective_offset)` exactly once and returning:
+- [x] Implement `skills.list` by calling `list_model_visible_skills_page(q=effective_q, limit=effective_limit, offset=effective_offset)` exactly once and returning:
 
 ```python
 count = len(items)
@@ -376,9 +387,9 @@ return {
 }
 ```
 
-- [ ] Implement `skills.get` with one `get_model_visible_skill_metadata(name)` call and return `self._format_metadata(metadata)` directly.
+- [x] Implement `skills.get` with one `get_model_visible_skill_metadata(name)` call and return `self._format_metadata(metadata)` directly.
 
-- [ ] For render, call metadata lookup first, then verified `get_skill()`, recheck the parsed `user_invocable` and `disable_model_invocation` flags for races, and call:
+- [x] For render, call metadata lookup first, then verified `get_skill()`, recheck the parsed `user_invocable` and `disable_model_invocation` flags for races, and call:
 
 ```python
 result = await self._executor.execute(
@@ -389,14 +400,14 @@ result = await self._executor.execute(
 )
 ```
 
-- [ ] Check `len(result.rendered_prompt)` before constructing the response. Return `declared_tools=list(result.allowed_tools)` and `supporting_files_omitted=bool(skill_data.get("supporting_files"))`.
-- [ ] Translate exceptions narrowly:
+- [x] Check `len(result.rendered_prompt)` before constructing the response. Return `declared_tools=list(result.allowed_tools)` and `supporting_files_omitted=bool(skill_data.get("supporting_files"))`.
+- [x] Translate exceptions narrowly:
   - validation and not-found to bounded `ValueError` messages handled as invalid params;
   - missing user context and render-time `ContextIntegrityBlocked` to bounded `PermissionError` messages;
   - storage/parser failures to `RuntimeError("skills_unavailable")`, which the MCP runtime sanitizes in production.
-- [ ] For module-owned storage/parser failures, log only operation, numeric user ID, and exception class name. Do not interpolate exception messages, arguments, rendered content, database paths, or filesystem paths.
-- [ ] Run `test_skills_module.py`, then rerun the complete Skills service suite.
-- [ ] Commit Stage 3:
+- [x] For module-owned storage/parser failures, log only operation, numeric user ID, and exception class name. Do not interpolate exception messages, arguments, rendered content, database paths, or filesystem paths.
+- [x] Run `test_skills_module.py`, then rerun the complete Skills service suite.
+- [x] Commit Stage 3:
 
 ```bash
 git add tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py \
@@ -414,25 +425,25 @@ git commit -m "feat(mcp): add Skills catalog and dry render tools"
 
 **Tests**: Dynamic module catalog, module surface, and authenticated user-isolation tests.
 
-**Status**: Not Started
+**Status**: Complete
 
 ### Task 4.1: Write failing registration tests
 
-- [ ] Add a dynamic config test asserting the `skills` entry follows `prompts`, is enabled, points to `SkillsModule`, uses version `0.1.0`, has `department=knowledge`, `max_concurrent=10`, and has the two exact settings.
-- [ ] Add a registration test using a temporary MCP module config and assert `find_module_for_tool()` resolves all three tool names.
-- [ ] Extend the module-surface test to assert `skills` appears under `read_only` with no explicit opt-in requirement.
-- [ ] Run the tests and confirm they fail because configuration and surface classification are absent.
+- [x] Add a dynamic config test asserting the `skills` entry follows `prompts`, is enabled, points to `SkillsModule`, uses version `0.1.0`, has `department=knowledge`, `max_concurrent=10`, and has the two exact settings.
+- [x] Add a registration test using a temporary MCP module config and assert `find_module_for_tool()` resolves all three tool names.
+- [x] Extend the module-surface test to assert `skills` appears under `read_only` with no explicit opt-in requirement.
+- [x] Run the tests and confirm they fail because configuration and surface classification are absent.
 
 ### Task 4.2: Register and document the module
 
-- [ ] Add the YAML entry from the approved design immediately after `prompts`.
-- [ ] Add this risk-tier entry:
+- [x] Add the YAML entry from the approved design immediately after `prompts`.
+- [x] Add this risk-tier entry:
 
 ```python
 "skills": ("read_only", "Discover and safely render user-owned Skills without execution."),
 ```
 
-- [ ] Add a `Skills Module` section to `Docs/MCP/Unified/Modules.md` documenting:
+- [x] Add a `Skills Module` section to `Docs/MCP/Unified/Modules.md` documenting:
   - `skills.list`, `skills.get`, and `skills.render`;
   - metadata-only discovery and model-visible filtering;
   - `Skill(name)` deny/ask/approval/allow evaluation for render;
@@ -441,9 +452,9 @@ git commit -m "feat(mcp): add Skills catalog and dry render tools"
   - `supporting_files_omitted` means the rendered body may not be self-contained;
   - registry synchronization may update derived index rows;
   - the module intentionally bypasses generic SQL-token sanitization for bounded non-executing prompt text.
-- [ ] Update the read-only tier table to include `skills`.
-- [ ] Run dynamic registration, module surface, and Skills module tests.
-- [ ] Commit Stage 4:
+- [x] Update the read-only tier table to include `skills`.
+- [x] Run dynamic registration, module surface, and Skills module tests.
+- [x] Commit Stage 4:
 
 ```bash
 git add tldw_Server_API/Config_Files/mcp_modules.yaml \
@@ -464,7 +475,7 @@ git commit -m "docs(mcp): register and document Skills tools"
 
 **Tests**: Full focused matrix below.
 
-**Status**: Not Started
+**Status**: In Progress
 
 ### Task 5.1: Run focused verification
 
@@ -488,6 +499,8 @@ python -m pytest -q \
   tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py \
   -k 'skill or permission_rule or approval_lease'
 ```
 
@@ -505,6 +518,7 @@ source ../../.venv/bin/activate
 python -m bandit -r \
   apps/mcp-unified/src/mcp_unified/profiles/subjects.py \
   apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py \
+  apps/mcp-unified/src/mcp_unified/policy_grants/models.py \
   tldw_Server_API/app/core/Skills/skills_service.py \
   tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py \
   tldw_Server_API/app/core/MCP_unified/module_surface.py \
@@ -512,6 +526,8 @@ python -m bandit -r \
   tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py \
   tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \

--- a/apps/mcp-unified/src/mcp_unified/gateway/cli.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, NoReturn, TextIO
 
 from mcp_unified.package_metadata import package_metadata_summary
+from mcp_unified.policy_grants import APPROVAL_SUBJECT_TYPES
 from mcp_unified.profiles.presets import (
     ProfilePreset,
     duplicate_builtin_preset,
@@ -50,16 +51,16 @@ from .external_registry import (
     GatewayExternalRegistryManagementError,
     GatewayExternalRegistryManager,
 )
-from .policy_grants import (
-    APPROVAL_GRANT_DEFAULT_TTL_SECONDS,
-    GatewayPolicyGrantManagementError,
-    GatewayPolicyGrantManager,
-)
 from .policy_explain import (
     GatewayPolicyExplainError,
     GatewayPolicyExplainService,
     PolicyExplainRequest,
     ProfileToolPreviewRequest,
+)
+from .policy_grants import (
+    APPROVAL_GRANT_DEFAULT_TTL_SECONDS,
+    GatewayPolicyGrantManagementError,
+    GatewayPolicyGrantManager,
 )
 from .policy_simulation import simulate_tool_call_policy
 from .profiles import GatewayProfileManagementError, GatewayProfileManager
@@ -424,7 +425,7 @@ def _build_parser() -> _JsonArgumentParser:
     create_approval_grant.add_argument(
         "--subject-type",
         required=True,
-        choices=("tool", "path", "domain", "command", "mcp"),
+        choices=tuple(sorted(APPROVAL_SUBJECT_TYPES)),
         help="Permission subject family the lease approves.",
     )
     create_approval_grant.add_argument(

--- a/apps/mcp-unified/src/mcp_unified/policy_grants/models.py
+++ b/apps/mcp-unified/src/mcp_unified/policy_grants/models.py
@@ -10,7 +10,7 @@ from mcp_unified.profiles.path_grants import PATH_GRANT_ACTIONS, normalize_path_
 from mcp_unified.profiles.permission_rules import normalize_permission_subject_value
 
 POLICY_GRANT_TYPES = frozenset({"approval", "path"})
-APPROVAL_SUBJECT_TYPES = frozenset({"tool", "path", "domain", "command", "mcp"})
+APPROVAL_SUBJECT_TYPES = frozenset({"tool", "path", "domain", "command", "mcp", "skill"})
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py
+++ b/apps/mcp-unified/src/mcp_unified/profiles/permission_rules.py
@@ -148,7 +148,7 @@ def parse_permission_rule(
             rule_type="skill",
             outcome=outcome,
             source=source,
-            pattern=normalized_specifier,
+            pattern=normalized_specifier.lower(),
             reason_code=reason_code,
         )
     if tool_name == "Agent":
@@ -378,7 +378,7 @@ def _normalize_subject_value(subject_type: PermissionRuleSubject, value: str) ->
         return _normalize_path_pattern(normalized)
     if subject_type == "domain":
         return _normalize_domain_pattern(normalized)
-    if subject_type == "mcp":
+    if subject_type in {"mcp", "skill"}:
         return normalized.lower()
     return normalized
 

--- a/apps/mcp-unified/src/mcp_unified/profiles/subjects.py
+++ b/apps/mcp-unified/src/mcp_unified/profiles/subjects.py
@@ -31,6 +31,7 @@ DOMAIN_ARGUMENT_KEYS = frozenset({"url", "uri", "domain", "host", "base_url"})
 DOMAIN_ARGUMENT_LIST_KEYS = frozenset({"urls", "uris", "domains", "hosts"})
 COMMAND_ARGUMENT_KEYS = frozenset({"command", "cmd", "shell_command"})
 COMMAND_ARGV_KEYS = frozenset({"argv"})
+SKILL_ARGUMENT_KEYS = frozenset({"skill_name"})
 
 
 class PermissionSubjectLimitError(Exception):
@@ -79,6 +80,9 @@ def extract_permission_rule_subjects(
                 if len(argv) > MAX_COMMAND_ARGV_TOKENS:
                     raise PermissionSubjectLimitError("max_command_argv_tokens")
                 _append_permission_subject(subjects, "command", " ".join(argv), argv)
+        elif normalized_key in SKILL_ARGUMENT_KEYS:
+            for item in _string_values(value):
+                _append_permission_subject(subjects, "skill", item.lower(), None)
     return subjects
 
 
@@ -137,5 +141,6 @@ __all__ = [
     "PATH_ARGUMENT_KEYS",
     "PATH_ARGUMENT_LIST_KEYS",
     "PermissionSubjectLimitError",
+    "SKILL_ARGUMENT_KEYS",
     "extract_permission_rule_subjects",
 ]

--- a/apps/mcp-unified/src/mcp_unified/profiles/subjects.py
+++ b/apps/mcp-unified/src/mcp_unified/profiles/subjects.py
@@ -80,7 +80,7 @@ def extract_permission_rule_subjects(
                 if len(argv) > MAX_COMMAND_ARGV_TOKENS:
                     raise PermissionSubjectLimitError("max_command_argv_tokens")
                 _append_permission_subject(subjects, "command", " ".join(argv), argv)
-        elif normalized_key in SKILL_ARGUMENT_KEYS:
+        elif key in SKILL_ARGUMENT_KEYS:
             for item in _string_values(value):
                 _append_permission_subject(subjects, "skill", item.lower(), None)
     return subjects

--- a/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
+++ b/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
@@ -1,0 +1,53 @@
+---
+id: TASK-2294.1
+title: Expose Skills catalog and safe render through MCP
+status: In Progress
+labels:
+- mcp
+- skills
+- security
+- catalog
+parent_task_id: TASK-2294
+documentation:
+- Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first stability-focused slice of TASK-2294: expose user-scoped Skills discovery and side-effect-free rendering through MCP Unified without model calls, tool execution, workflow execution, supporting-file exposure, or mutation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 MCP Unified exposes skills.list, skills.get, and skills.render as read-only tools through the configured Skills module.
+- [ ] #2 skills.list and skills.get return metadata only and exclude user_invocable=false, disable_model_invocation=true, integrity-blocked, deleted, and cross-user skills.
+- [ ] #3 skills.render evaluates both the gateway tool policy and Skill(skill_name) permission rules, including existing deny, ask, approval-lease, and allow behavior.
+- [ ] #4 skills.render forces dry-run rendering, accepts at most 10000 argument characters, returns declared_tools rather than implying effective authorization, and never invokes a model or tool.
+- [ ] #5 Rendered output is rejected atomically above the configured limit, which defaults to and cannot exceed 100000 characters.
+- [ ] #6 Unknown, hidden, model-disabled, integrity-blocked, oversized, denied, and approval-required cases return stable sanitized errors without paths, content, or raw exception details.
+- [ ] #7 The Skills module is registered in default MCP configuration and covered by focused service, module, permission-subject, registration, package-boundary, and integration tests.
+- [ ] #8 Design documentation and a staged implementation plan record scope boundaries, contracts, verification commands, and deferred TASK-2294 work.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
+++ b/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
@@ -10,6 +10,8 @@ labels:
 parent_task_id: TASK-2294
 documentation:
 - Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2725
 ---
 
 ## Description
@@ -62,6 +64,7 @@ Final review follow-up:
 - Fixed in a389236ace: CLI choices now derive deterministically from APPROVAL_SUBJECT_TYPES; added SQLite-backed CLI create/list/revoke coverage proving Review-Paper canonicalizes to review-paper.
 - Fresh fix verification: 2 CLI approval lifecycle tests passed; 30 policy-grant manager/store tests passed; Ruff clean; Bandit medium/high clean; focused re-review approved with no findings.
 Final touched scope additionally includes apps/mcp-unified/src/mcp_unified/gateway/cli.py and tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py for the reviewed approval-lease operator-path fix.
+Draft pull request opened against dev: https://github.com/rmusser01/tldw_server/pull/2725. It remains draft until the human requester supplies the repository-required human-written Change summary.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
+++ b/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
@@ -30,6 +30,12 @@ Implement the first stability-focused slice of TASK-2294: expose user-scoped Ski
 - [ ] #8 Design documentation and a staged implementation plan record scope boundaries, contracts, verification commands, and deferred TASK-2294 work.
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->

--- a/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
+++ b/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2294.1
 title: Expose Skills catalog and safe render through MCP
-status: Done
+status: In Progress
 labels:
 - mcp
 - skills
@@ -65,6 +65,7 @@ Final review follow-up:
 - Fresh fix verification: 2 CLI approval lifecycle tests passed; 30 policy-grant manager/store tests passed; Ruff clean; Bandit medium/high clean; focused re-review approved with no findings.
 Final touched scope additionally includes apps/mcp-unified/src/mcp_unified/gateway/cli.py and tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py for the reviewed approval-lease operator-path fix.
 Draft pull request opened against dev: https://github.com/rmusser01/tldw_server/pull/2725. It remains draft until the human requester supplies the repository-required human-written Change summary.
+PR #2725 review follow-up opened after rebasing onto latest dev eaa06dd855. Five open threads are being addressed: nullable boolean defaults in service/render race checks, centralized MCP Skills exceptions, suite classification for new module tests, and single-pass visible-row pagination collection. Final review/thread resolution and post-rebase verification pending.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
+++ b/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
@@ -15,7 +15,7 @@ documentation:
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Implement the first stability-focused slice of TASK-2294: expose user-scoped Skills discovery and side-effect-free rendering through MCP Unified without model calls, tool execution, workflow execution, supporting-file exposure, or mutation.
+Implement the first stability-focused slice of TASK-2294: expose user-scoped Skills discovery and side-effect-free rendering through MCP Unified without model calls, tool execution, workflow execution, supporting-file content exposure, or authored Skill mutation. Existing registry synchronization remains derived index maintenance.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
+++ b/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2294.1
 title: Expose Skills catalog and safe render through MCP
-status: In Progress
+status: Done
 labels:
 - mcp
 - skills
@@ -66,12 +66,13 @@ Final review follow-up:
 Final touched scope additionally includes apps/mcp-unified/src/mcp_unified/gateway/cli.py and tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py for the reviewed approval-lease operator-path fix.
 Draft pull request opened against dev: https://github.com/rmusser01/tldw_server/pull/2725. It remains draft until the human requester supplies the repository-required human-written Change summary.
 PR #2725 review follow-up opened after rebasing onto latest dev eaa06dd855. Five open threads are being addressed: nullable boolean defaults in service/render race checks, centralized MCP Skills exceptions, suite classification for new module tests, and single-pass visible-row pagination collection. Final review/thread resolution and post-rebase verification pending.
+PR #2725 review follow-up completed on rebased head 0819433c69 (base origin/dev eaa06dd855). Addressed and resolved all five review threads: explicit NULL visibility flags now use schema defaults in service metadata/discovery and the render race check; model-visible pagination counts in one pass while retaining only page items; four Skills MCP exceptions moved to app/core/exceptions.py; and the module suite has the accepted unit marker. Added two focused regressions. Fresh verification: 2 focused regressions passed; 67 Skills MCP module tests passed; all 80 Skills service tests passed in four fresh-process batches to avoid local cumulative runner termination; 71 executor/registration/basic tests passed; 45 permission/gateway tests passed; 2 CLI lifecycle tests passed; 30 grant/store tests passed; compileall and diff hygiene passed; Ruff passed on clean touched files and on legacy touched files with only their documented pre-existing I001/F811 baselines excluded; Bandit reported zero findings across the five touched Python paths. Runtime package boundary remains at 45 passed and the same 2 unrelated publish-workflow assertion failures in untouched files. All five inline threads were replied to and re-queried as resolved; no open review thread remained. GitHub Actions restarted after the force-push and were queued at closeout.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Exposed user-scoped Skills through MCP Unified with metadata-only list/get and policy-gated, side-effect-free render. The implementation reuses the existing gateway, Skill permission rules, and approval leases; forces dry-run rendering with no model/tool/workflow execution; bounds inputs and output; preserves user isolation and integrity checks; and safely handles database cleanup and cancellation. Added default read-only module registration, operator documentation, and focused service/module/gateway/grant/CLI/registration coverage. Final review identified one missing operator path for Skill approval leases; the CLI now derives its subject choices from the authoritative approval-subject set and has a persistent create/list/revoke regression test. Branch is rebased on origin/dev 5e5acac6d5. Known unrelated baselines remain documented: two publish-workflow package-boundary assertions, legacy Ruff findings in three touched files, and low-severity test-only Bandit findings; no medium/high Bandit findings or task-related verification failures remain.
+Exposed user-scoped Skills through MCP Unified with metadata-only list/get and policy-gated, side-effect-free render. The implementation reuses the existing gateway, Skill permission rules, and approval leases; forces dry-run rendering with no model/tool/workflow execution; bounds inputs and output; preserves user isolation and integrity checks; and safely handles database cleanup and cancellation. Added default read-only module registration, operator documentation, and focused service/module/gateway/grant/CLI/registration coverage. Review follow-up fixed nullable visibility defaults, eliminated the second full visible-row allocation while preserving exact integrity-filtered totals, centralized Skills MCP exceptions, and classified the module suite as unit. PR #2725 is rebased on origin/dev eaa06dd855 at head 0819433c69; all five review threads are resolved. Fresh focused, regression, lint, compile, and Bandit verification is recorded above. The only local failures remain two unrelated publish-workflow package-boundary assertions in untouched files; GitHub Actions restarted and were queued after the force-push.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
+++ b/backlog/tasks/task-2294.1 - Expose-Skills-catalog-and-safe-render-through-MCP.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2294.1
 title: Expose Skills catalog and safe render through MCP
-status: In Progress
+status: Done
 labels:
 - mcp
 - skills
@@ -20,14 +20,14 @@ Implement the first stability-focused slice of TASK-2294: expose user-scoped Ski
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 MCP Unified exposes skills.list, skills.get, and skills.render as read-only tools through the configured Skills module.
-- [ ] #2 skills.list and skills.get return metadata only and exclude user_invocable=false, disable_model_invocation=true, integrity-blocked, deleted, and cross-user skills.
-- [ ] #3 skills.render evaluates both the gateway tool policy and Skill(skill_name) permission rules, including existing deny, ask, approval-lease, and allow behavior.
-- [ ] #4 skills.render forces dry-run rendering, accepts at most 10000 argument characters, returns declared_tools rather than implying effective authorization, and never invokes a model or tool.
-- [ ] #5 Rendered output is rejected atomically above the configured limit, which defaults to and cannot exceed 100000 characters.
-- [ ] #6 Unknown, hidden, model-disabled, integrity-blocked, oversized, denied, and approval-required cases return stable sanitized errors without paths, content, or raw exception details.
-- [ ] #7 The Skills module is registered in default MCP configuration and covered by focused service, module, permission-subject, registration, package-boundary, and integration tests.
-- [ ] #8 Design documentation and a staged implementation plan record scope boundaries, contracts, verification commands, and deferred TASK-2294 work.
+- [x] #1 MCP Unified exposes skills.list, skills.get, and skills.render as read-only tools through the configured Skills module.
+- [x] #2 skills.list and skills.get return metadata only and exclude user_invocable=false, disable_model_invocation=true, integrity-blocked, deleted, and cross-user skills.
+- [x] #3 skills.render evaluates both the gateway tool policy and Skill(skill_name) permission rules, including existing deny, ask, approval-lease, and allow behavior.
+- [x] #4 skills.render forces dry-run rendering, accepts at most 10000 argument characters, returns declared_tools rather than implying effective authorization, and never invokes a model or tool.
+- [x] #5 Rendered output is rejected atomically above the configured limit, which defaults to and cannot exceed 100000 characters.
+- [x] #6 Unknown, hidden, model-disabled, integrity-blocked, oversized, denied, and approval-required cases return stable sanitized errors without paths, content, or raw exception details.
+- [x] #7 The Skills module is registered in default MCP configuration and covered by focused service, module, permission-subject, registration, package-boundary, and integration tests.
+- [x] #8 Design documentation and a staged implementation plan record scope boundaries, contracts, verification commands, and deferred TASK-2294 work.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -39,21 +39,43 @@ Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implementation complete through Stage 4 on branch codex/skills-mcp-catalog-render, rebased onto origin/dev 5e5acac6d5.
 
+Implemented:
+- Model-visible Skills service pagination/metadata helpers and worker-thread verified loading.
+- Canonical lowercase skill_name permission subjects plus existing approval-lease validation/storage support.
+- Read-only MCP SkillsModule exposing skills.list, skills.get, and forced-dry-run skills.render with user isolation, bounded schemas/output, safe errors/logs, database cleanup, and cancellation-safe lifecycle handling.
+- Default module registration, read-only surface classification, focused registration tests, and operator documentation.
+
+Touched scope:
+Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md; Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md; Docs/MCP/Unified/Modules.md; apps/mcp-unified/src/mcp_unified/{policy_grants/models.py,profiles/permission_rules.py,profiles/subjects.py}; tldw_Server_API/Config_Files/mcp_modules.yaml; MCP module/surface, focused gateway/grant/module/registration tests; Skills service and service tests.
+
+Fresh post-rebase verification:
+- Skills service/executor/module/registration/basic matrix: 216 passed.
+- Permission/gateway/grant matrix: 45 passed, 234 deselected.
+- Runtime package boundary: 45 passed, 2 unrelated baseline failures in publish-workflow assertions (push trigger and duplicate-version guard), unchanged by this task.
+- Ruff: all clean-scope touched files pass; three legacy touched files pass after excluding only their pre-existing baseline rules (skills_service.py I001; test_skills_service.py I001/F811; test_basic_functionality.py I001/UP035/F401/UP006).
+- Bandit: no medium/high findings and no new findings. Six low test-only baseline findings remain outside changed hunks (B105/B404/B603).
+- git diff --check clean; worktree clean; 20 changed paths all map to TASK-2294.1.
+Final review follow-up:
+- Final whole-branch review found one Important issue: gateway CLI could not create skill approval leases because --subject-type choices were hard-coded.
+- Fixed in a389236ace: CLI choices now derive deterministically from APPROVAL_SUBJECT_TYPES; added SQLite-backed CLI create/list/revoke coverage proving Review-Paper canonicalizes to review-paper.
+- Fresh fix verification: 2 CLI approval lifecycle tests passed; 30 policy-grant manager/store tests passed; Ruff clean; Bandit medium/high clean; focused re-review approved with no findings.
+Final touched scope additionally includes apps/mcp-unified/src/mcp_unified/gateway/cli.py and tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py for the reviewed approval-lease operator-path fix.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Exposed user-scoped Skills through MCP Unified with metadata-only list/get and policy-gated, side-effect-free render. The implementation reuses the existing gateway, Skill permission rules, and approval leases; forces dry-run rendering with no model/tool/workflow execution; bounds inputs and output; preserves user isolation and integrity checks; and safely handles database cleanup and cancellation. Added default read-only module registration, operator documentation, and focused service/module/gateway/grant/CLI/registration coverage. Final review identified one missing operator path for Skill approval leases; the CLI now derives its subject choices from the authoritative approval-subject set and has a persistent create/list/revoke regression test. Branch is rebased on origin/dev 5e5acac6d5. Known unrelated baselines remain documented: two publish-workflow package-boundary assertions, legacy Ruff findings in three touched files, and low-severity test-only Bandit findings; no medium/high Bandit findings or task-related verification failures remain.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/mcp_modules.yaml
+++ b/tldw_Server_API/Config_Files/mcp_modules.yaml
@@ -98,6 +98,17 @@ modules:
         #     key: search_knowledge
         #     title: Search Knowledge
 
+  - id: skills
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.skills_module:SkillsModule
+    enabled: true
+    name: Skills
+    version: "0.1.0"
+    department: knowledge
+    max_concurrent: 10
+    settings:
+      list_page_size: 50
+      max_rendered_skill_chars: 100000
+
   - id: cooking
     class: tldw_Server_API.app.core.MCP_unified.modules.implementations.cooking_module:CookingModule
     enabled: true

--- a/tldw_Server_API/app/core/MCP_unified/module_surface.py
+++ b/tldw_Server_API/app/core/MCP_unified/module_surface.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-
 MODULE_RISK_TIERS: dict[str, tuple[str, str]] = {
     "media": ("read_only", "Search and retrieve existing media records."),
     "knowledge": ("read_only", "Search and retrieve knowledge records."),
@@ -13,6 +12,7 @@ MODULE_RISK_TIERS: dict[str, tuple[str, str]] = {
     "chats": ("read_only", "Read chat/session context."),
     "prompts": ("read_only", "Read prompt library entries."),
     "prompts_catalog": ("read_only", "Expose configured prompt catalogs."),
+    "skills": ("read_only", "Discover and safely render user-owned Skills without execution."),
     "mcp_discovery": ("read_only", "Inspect MCP capabilities."),
     "governance": ("write", "Manage or inspect policy/governance state."),
     "notes": ("write", "Create or modify note data."),

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py
@@ -1,0 +1,450 @@
+"""Read-only MCP catalog and dry-render tools for user-scoped Skills."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+from loguru import logger
+
+from ....Context_Integrity.resolver import ContextIntegrityBlocked
+from ....DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from ....Skills.exceptions import SkillNotFoundError
+from ....Skills.runtime_metadata import build_skill_runtime_metadata
+from ....Skills.skill_executor import SkillExecutor
+from ....Skills.skills_service import SKILL_NAME_PATTERN, SkillMetadata, SkillsService
+from ..base import BaseModule, create_tool_definition
+
+DEFAULT_LIST_PAGE_SIZE = 50
+MAX_LIST_PAGE_SIZE = 100
+MAX_QUERY_CHARS = 200
+MAX_ARGUMENT_CHARS = 10_000
+HARD_MAX_RENDERED_SKILL_CHARS = 100_000
+
+T = TypeVar("T")
+ServiceOperation = Callable[[SkillsService], Awaitable[T]]
+
+
+class _SkillNotFound(ValueError):
+    """Bounded public not-found response."""
+
+
+class _RenderedSkillTooLarge(ValueError):
+    """Bounded public rendered-output rejection."""
+
+
+class _ContextIntegrityBlocked(PermissionError):
+    """Bounded public render-time integrity rejection."""
+
+
+def _clamped_integer(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    """Return a clamped integer setting, excluding booleans and coercion."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    return max(minimum, min(value, maximum))
+
+
+class SkillsModule(BaseModule):
+    """Expose model-visible Skill metadata and side-effect-free rendering."""
+
+    async def on_initialize(self) -> None:
+        """Initialize bounded settings and one stateless dry-run executor."""
+        settings = self.config.settings or {}
+        self._list_page_size = _clamped_integer(
+            settings.get("list_page_size"),
+            default=DEFAULT_LIST_PAGE_SIZE,
+            minimum=1,
+            maximum=MAX_LIST_PAGE_SIZE,
+        )
+        self._max_rendered_skill_chars = _clamped_integer(
+            settings.get("max_rendered_skill_chars"),
+            default=HARD_MAX_RENDERED_SKILL_CHARS,
+            minimum=1,
+            maximum=HARD_MAX_RENDERED_SKILL_CHARS,
+        )
+        self._executor = SkillExecutor()
+
+    async def on_shutdown(self) -> None:
+        """Release no resources; all databases are request scoped."""
+
+    async def check_health(self) -> dict[str, bool]:
+        """Report availability of the request-scoped Skills dependencies."""
+        return {
+            "initialized": hasattr(self, "_executor"),
+            "database_driver_available": CharactersRAGDB is not None,
+            "skills_service_available": SkillsService is not None,
+        }
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        """Return the exact read-only Skills tool catalog."""
+        return [
+            create_tool_definition(
+                name="skills.list",
+                description="List model-visible Skills metadata.",
+                parameters={
+                    "properties": {
+                        "q": {
+                            "type": "string",
+                            "maxLength": MAX_QUERY_CHARS,
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": MAX_LIST_PAGE_SIZE,
+                            "default": self._list_page_size,
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0,
+                        },
+                    },
+                    "required": [],
+                },
+                metadata={"category": "search", "readOnlyHint": True},
+            ),
+            create_tool_definition(
+                name="skills.get",
+                description="Get metadata for one model-visible Skill.",
+                parameters={
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                },
+                metadata={"category": "retrieval", "readOnlyHint": True},
+            ),
+            create_tool_definition(
+                name="skills.render",
+                description="Render one model-visible Skill without model or tool execution.",
+                parameters={
+                    "properties": {
+                        "skill_name": {"type": "string"},
+                        "arguments": {
+                            "type": "string",
+                            "maxLength": MAX_ARGUMENT_CHARS,
+                            "default": "",
+                        },
+                    },
+                    "required": ["skill_name"],
+                },
+                metadata={"category": "retrieval", "readOnlyHint": True},
+            ),
+        ]
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> Any:
+        """Validate and dispatch one Skills operation without rewriting prompt text."""
+        if not isinstance(arguments, dict):
+            raise TypeError("arguments must be an object")
+        args = dict(arguments)
+        self.validate_tool_arguments(tool_name, args)
+
+        if tool_name == "skills.list":
+            return await self._run_with_service(
+                context,
+                tool_name,
+                lambda service: self._list_skills(service, args),
+            )
+        if tool_name == "skills.get":
+            return await self._run_with_service(
+                context,
+                tool_name,
+                lambda service: self._get_skill(service, args),
+            )
+        if tool_name == "skills.render":
+            return await self._run_with_service(
+                context,
+                tool_name,
+                lambda service: self._render_skill(service, args),
+            )
+        raise ValueError(f"Unknown tool: {tool_name}")
+
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
+        """Apply exact per-tool key, type, and size allowlists."""
+        if not isinstance(arguments, dict):
+            raise TypeError("arguments must be an object")
+
+        allowed_keys = {
+            "skills.list": frozenset({"q", "limit", "offset"}),
+            "skills.get": frozenset({"name"}),
+            "skills.render": frozenset({"skill_name", "arguments"}),
+        }
+        allowed = allowed_keys.get(tool_name)
+        if allowed is None:
+            raise ValueError(f"Unknown tool: {tool_name}")
+        if set(arguments) - allowed:
+            raise ValueError(f"unexpected arguments for {tool_name}")
+
+        if tool_name == "skills.list":
+            query = arguments.get("q")
+            if query is not None:
+                if not isinstance(query, str):
+                    raise ValueError("q must be a string")
+                if len(query) > MAX_QUERY_CHARS:
+                    raise ValueError(f"q must be at most {MAX_QUERY_CHARS} characters")
+            self._validate_integer(
+                "limit",
+                arguments.get("limit", self._list_page_size),
+                minimum=1,
+                maximum=MAX_LIST_PAGE_SIZE,
+            )
+            self._validate_integer("offset", arguments.get("offset", 0), minimum=0)
+            return
+
+        if tool_name == "skills.get":
+            self._validate_skill_name("name", arguments.get("name"))
+            return
+
+        self._validate_skill_name("skill_name", arguments.get("skill_name"))
+        prompt_arguments = arguments.get("arguments", "")
+        if not isinstance(prompt_arguments, str):
+            raise ValueError("arguments must be a string")
+        if len(prompt_arguments) > MAX_ARGUMENT_CHARS:
+            raise ValueError(f"arguments must be at most {MAX_ARGUMENT_CHARS} characters")
+
+    @staticmethod
+    def _validate_integer(
+        field: str,
+        value: Any,
+        *,
+        minimum: int,
+        maximum: int | None = None,
+    ) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"{field} must be an integer")
+        if maximum is None and value < minimum:
+            raise ValueError(f"{field} must be >= {minimum}")
+        if maximum is not None and not minimum <= value <= maximum:
+            raise ValueError(f"{field} must be {minimum}..{maximum}")
+
+    @staticmethod
+    def _validate_skill_name(field: str, value: Any) -> None:
+        if not isinstance(value, str) or not SKILL_NAME_PATTERN.fullmatch(value.strip().lower()):
+            raise ValueError(f"{field} must be a valid skill name")
+
+    async def _list_skills(
+        self,
+        service: SkillsService,
+        args: dict[str, Any],
+    ) -> dict[str, Any]:
+        query = args.get("q")
+        effective_query = query if query is None or query.strip() else None
+        limit = args.get("limit", self._list_page_size)
+        offset = args.get("offset", 0)
+        items, total = await service.list_model_visible_skills_page(
+            q=effective_query,
+            limit=limit,
+            offset=offset,
+        )
+        count = len(items)
+        next_value = offset + count
+        return {
+            "skills": [self._format_metadata(item) for item in items],
+            "count": count,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "next_offset": next_value if next_value < total else None,
+        }
+
+    async def _get_skill(
+        self,
+        service: SkillsService,
+        args: dict[str, Any],
+    ) -> dict[str, Any]:
+        try:
+            metadata = await service.get_model_visible_skill_metadata(args["name"])
+        except ContextIntegrityBlocked:
+            raise _SkillNotFound("skill_not_found") from None
+        return self._format_metadata(metadata)
+
+    async def _render_skill(
+        self,
+        service: SkillsService,
+        args: dict[str, Any],
+    ) -> dict[str, Any]:
+        skill_name = args["skill_name"]
+        try:
+            await service.get_model_visible_skill_metadata(skill_name)
+        except ContextIntegrityBlocked:
+            raise _SkillNotFound("skill_not_found") from None
+        skill_data = await service.get_skill(skill_name)
+        if not bool(skill_data.get("user_invocable", True)) or bool(
+            skill_data.get("disable_model_invocation", False)
+        ):
+            raise _SkillNotFound("skill_not_found")
+
+        result = await self._executor.execute(
+            skill_data,
+            args.get("arguments", ""),
+            context=None,
+            dry_run=True,
+        )
+        if len(result.rendered_prompt) > self._max_rendered_skill_chars:
+            raise _RenderedSkillTooLarge(
+                f"rendered_skill_too_large: limit={self._max_rendered_skill_chars}"
+            )
+
+        return {
+            "skill_name": result.skill_name,
+            "rendered_prompt": result.rendered_prompt,
+            "declared_tools": list(result.allowed_tools),
+            "model_override": result.model_override,
+            "execution_mode": result.execution_mode,
+            "supporting_files_omitted": bool(skill_data.get("supporting_files")),
+            "dry_run": True,
+            "version": skill_data.get("version"),
+        }
+
+    @staticmethod
+    def _format_metadata(metadata: SkillMetadata) -> dict[str, Any]:
+        """Return only the approved model-facing metadata fields."""
+        return {
+            "name": metadata.name,
+            "description": metadata.description,
+            "argument_hint": metadata.argument_hint,
+            "user_invocable": metadata.user_invocable,
+            "disable_model_invocation": metadata.disable_model_invocation,
+            "declared_tools": list(metadata.allowed_tools),
+            "model": metadata.model,
+            "context": metadata.context,
+            "runtime": build_skill_runtime_metadata(
+                context=metadata.context,
+                allowed_tools=metadata.allowed_tools,
+                model=metadata.model,
+                disable_model_invocation=metadata.disable_model_invocation,
+            ),
+            "version": metadata.version,
+        }
+
+    async def _run_with_service(
+        self,
+        context: Any,
+        operation_name: str,
+        operation: ServiceOperation[T],
+    ) -> T:
+        user_id, chacha_path = self._trusted_user_context(context)
+        db: CharactersRAGDB | None = None
+        try:
+            db, service = await self._construct_service(user_id, chacha_path)
+            return await self._await_retained(operation(service))
+        except asyncio.CancelledError:
+            raise
+        except _SkillNotFound:
+            raise
+        except _RenderedSkillTooLarge:
+            raise
+        except _ContextIntegrityBlocked:
+            raise
+        except SkillNotFoundError:
+            raise _SkillNotFound("skill_not_found") from None
+        except ContextIntegrityBlocked:
+            raise _ContextIntegrityBlocked("context_integrity_blocked") from None
+        except Exception as exc:  # noqa: BLE001 - public boundary sanitizes every unexpected failure
+            self._log_failure(operation_name, user_id, exc)
+            raise RuntimeError("skills_unavailable") from None
+        finally:
+            if db is not None:
+                try:
+                    await self._close_database(db)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # noqa: BLE001 - cleanup failures must remain bounded
+                    self._log_failure(operation_name, user_id, exc)
+
+    @staticmethod
+    def _trusted_user_context(context: Any) -> tuple[int, Path]:
+        if context is None:
+            raise PermissionError("skills_user_context_required")
+        raw_user_id = getattr(context, "user_id", None)
+        if isinstance(raw_user_id, bool):
+            raise PermissionError("skills_user_context_required")
+        try:
+            user_id = int(str(raw_user_id))
+        except (TypeError, ValueError):
+            raise PermissionError("skills_user_context_required") from None
+        if user_id <= 0:
+            raise PermissionError("skills_user_context_required")
+
+        db_paths = getattr(context, "db_paths", None)
+        if not isinstance(db_paths, dict):
+            raise PermissionError("skills_user_context_required")
+        raw_path = db_paths.get("chacha")
+        if isinstance(raw_path, bool) or not isinstance(raw_path, (str, Path)):
+            raise PermissionError("skills_user_context_required")
+        if isinstance(raw_path, str) and not raw_path.strip():
+            raise PermissionError("skills_user_context_required")
+        return user_id, Path(raw_path)
+
+    async def _construct_service(
+        self,
+        user_id: int,
+        chacha_path: Path,
+    ) -> tuple[CharactersRAGDB, SkillsService]:
+        task = asyncio.create_task(
+            asyncio.to_thread(self._construct_service_sync, user_id, chacha_path)
+        )
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            constructed: tuple[CharactersRAGDB, SkillsService] | None = None
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                constructed = await task
+            if constructed is not None:
+                with contextlib.suppress(Exception):
+                    await self._close_database(constructed[0])
+            raise
+
+    def _construct_service_sync(
+        self,
+        user_id: int,
+        chacha_path: Path,
+    ) -> tuple[CharactersRAGDB, SkillsService]:
+        db: CharactersRAGDB | None = None
+        try:
+            db = CharactersRAGDB(
+                db_path=chacha_path,
+                client_id=f"mcp_skills_{user_id}",
+            )
+            service = SkillsService(user_id, Path(chacha_path).parent, db)
+            return db, service
+        except Exception:
+            if db is not None:
+                db.close_all_connections()
+            raise
+
+    @staticmethod
+    async def _await_retained(awaitable: Awaitable[T]) -> T:
+        """Await an operation without letting request cancellation orphan its worker."""
+        task = asyncio.create_task(awaitable)
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+            raise
+
+    @staticmethod
+    async def _close_database(db: CharactersRAGDB) -> None:
+        task = asyncio.create_task(asyncio.to_thread(db.close_all_connections))
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            with contextlib.suppress(Exception):
+                await task
+            raise
+
+    @staticmethod
+    def _log_failure(operation: str, user_id: int, exc: Exception) -> None:
+        logger.error(
+            "skills operation={} user_id={} exception={}",
+            operation,
+            user_id,
+            type(exc).__name__,
+        )

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py
@@ -347,6 +347,7 @@ class SkillsModule(BaseModule):
         operation: ServiceOperation[T],
     ) -> T:
         user_id, chacha_path = self._trusted_user_context(context)
+        cancellation_requested = asyncio.Event()
         try:
             return await self._await_retained(
                 self._service_lifecycle(
@@ -354,7 +355,9 @@ class SkillsModule(BaseModule):
                     chacha_path,
                     operation_name,
                     operation,
-                )
+                    cancellation_requested,
+                ),
+                cancellation_requested,
             )
         except asyncio.CancelledError:
             raise
@@ -380,6 +383,7 @@ class SkillsModule(BaseModule):
         chacha_path: Path,
         operation_name: str,
         operation: ServiceOperation[T],
+        cancellation_requested: asyncio.Event,
     ) -> T:
         """Own construction, operation, and cleanup inside one retained task."""
         db: CharactersRAGDB | None = None
@@ -390,6 +394,8 @@ class SkillsModule(BaseModule):
                 user_id,
                 chacha_path,
             )
+            if cancellation_requested.is_set():
+                raise asyncio.CancelledError
             result = await operation(service)
             operation_succeeded = True
             return result
@@ -445,7 +451,9 @@ class SkillsModule(BaseModule):
             raise
 
     @staticmethod
-    async def _await_retained(awaitable: Awaitable[T]) -> T:
+    async def _await_retained(
+        awaitable: Awaitable[T], cancellation_requested: asyncio.Event
+    ) -> T:
         """Wait through every cancellation delivery before propagating cancellation."""
         task = asyncio.create_task(awaitable)
         cancellation: asyncio.CancelledError | None = None
@@ -455,6 +463,7 @@ class SkillsModule(BaseModule):
             except asyncio.CancelledError as exc:
                 if cancellation is None:
                     cancellation = exc
+                    cancellation_requested.set()
             except Exception:
                 if cancellation is None:
                     raise

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py
@@ -22,6 +22,7 @@ DEFAULT_LIST_PAGE_SIZE = 50
 MAX_LIST_PAGE_SIZE = 100
 MAX_QUERY_CHARS = 200
 MAX_ARGUMENT_CHARS = 10_000
+MAX_SKILL_NAME_CHARS = 64
 HARD_MAX_RENDERED_SKILL_CHARS = 100_000
 
 T = TypeVar("T")
@@ -38,6 +39,10 @@ class _RenderedSkillTooLarge(ValueError):
 
 class _ContextIntegrityBlocked(PermissionError):
     """Bounded public render-time integrity rejection."""
+
+
+class _DatabaseCloseFailed(Exception):
+    """Internal marker for a logged request-scoped database close failure."""
 
 
 def _clamped_integer(value: Any, *, default: int, minimum: int, maximum: int) -> int:
@@ -80,7 +85,12 @@ class SkillsModule(BaseModule):
 
     async def get_tools(self) -> list[dict[str, Any]]:
         """Return the exact read-only Skills tool catalog."""
-        return [
+        skill_name_schema = {
+            "type": "string",
+            "maxLength": MAX_SKILL_NAME_CHARS,
+            "pattern": SKILL_NAME_PATTERN.pattern,
+        }
+        tools = [
             create_tool_definition(
                 name="skills.list",
                 description="List model-visible Skills metadata.",
@@ -110,7 +120,7 @@ class SkillsModule(BaseModule):
                 name="skills.get",
                 description="Get metadata for one model-visible Skill.",
                 parameters={
-                    "properties": {"name": {"type": "string"}},
+                    "properties": {"name": dict(skill_name_schema)},
                     "required": ["name"],
                 },
                 metadata={"category": "retrieval", "readOnlyHint": True},
@@ -120,7 +130,7 @@ class SkillsModule(BaseModule):
                 description="Render one model-visible Skill without model or tool execution.",
                 parameters={
                     "properties": {
-                        "skill_name": {"type": "string"},
+                        "skill_name": dict(skill_name_schema),
                         "arguments": {
                             "type": "string",
                             "maxLength": MAX_ARGUMENT_CHARS,
@@ -132,6 +142,9 @@ class SkillsModule(BaseModule):
                 metadata={"category": "retrieval", "readOnlyHint": True},
             ),
         ]
+        for tool in tools:
+            tool["inputSchema"]["additionalProperties"] = False
+        return tools
 
     async def execute_tool(
         self,
@@ -182,8 +195,8 @@ class SkillsModule(BaseModule):
             raise ValueError(f"unexpected arguments for {tool_name}")
 
         if tool_name == "skills.list":
-            query = arguments.get("q")
-            if query is not None:
+            if "q" in arguments:
+                query = arguments["q"]
                 if not isinstance(query, str):
                     raise ValueError("q must be a string")
                 if len(query) > MAX_QUERY_CHARS:
@@ -225,7 +238,11 @@ class SkillsModule(BaseModule):
 
     @staticmethod
     def _validate_skill_name(field: str, value: Any) -> None:
-        if not isinstance(value, str) or not SKILL_NAME_PATTERN.fullmatch(value.strip().lower()):
+        if (
+            not isinstance(value, str)
+            or len(value) > MAX_SKILL_NAME_CHARS
+            or not SKILL_NAME_PATTERN.fullmatch(value.strip().lower())
+        ):
             raise ValueError(f"{field} must be a valid skill name")
 
     async def _list_skills(
@@ -330,10 +347,15 @@ class SkillsModule(BaseModule):
         operation: ServiceOperation[T],
     ) -> T:
         user_id, chacha_path = self._trusted_user_context(context)
-        db: CharactersRAGDB | None = None
         try:
-            db, service = await self._construct_service(user_id, chacha_path)
-            return await self._await_retained(operation(service))
+            return await self._await_retained(
+                self._service_lifecycle(
+                    user_id,
+                    chacha_path,
+                    operation_name,
+                    operation,
+                )
+            )
         except asyncio.CancelledError:
             raise
         except _SkillNotFound:
@@ -346,17 +368,39 @@ class SkillsModule(BaseModule):
             raise _SkillNotFound("skill_not_found") from None
         except ContextIntegrityBlocked:
             raise _ContextIntegrityBlocked("context_integrity_blocked") from None
+        except _DatabaseCloseFailed:
+            raise RuntimeError("skills_unavailable") from None
         except Exception as exc:  # noqa: BLE001 - public boundary sanitizes every unexpected failure
             self._log_failure(operation_name, user_id, exc)
             raise RuntimeError("skills_unavailable") from None
+
+    async def _service_lifecycle(
+        self,
+        user_id: int,
+        chacha_path: Path,
+        operation_name: str,
+        operation: ServiceOperation[T],
+    ) -> T:
+        """Own construction, operation, and cleanup inside one retained task."""
+        db: CharactersRAGDB | None = None
+        operation_succeeded = False
+        try:
+            db, service = await asyncio.to_thread(
+                self._construct_service_sync,
+                user_id,
+                chacha_path,
+            )
+            result = await operation(service)
+            operation_succeeded = True
+            return result
         finally:
             if db is not None:
                 try:
-                    await self._close_database(db)
-                except asyncio.CancelledError:
-                    raise
-                except Exception as exc:  # noqa: BLE001 - cleanup failures must remain bounded
+                    await asyncio.to_thread(db.close_all_connections)
+                except Exception as exc:  # noqa: BLE001 - cleanup failures stay bounded
                     self._log_failure(operation_name, user_id, exc)
+                    if operation_succeeded:
+                        raise _DatabaseCloseFailed from None
 
     @staticmethod
     def _trusted_user_context(context: Any) -> tuple[int, Path]:
@@ -382,25 +426,6 @@ class SkillsModule(BaseModule):
             raise PermissionError("skills_user_context_required")
         return user_id, Path(raw_path)
 
-    async def _construct_service(
-        self,
-        user_id: int,
-        chacha_path: Path,
-    ) -> tuple[CharactersRAGDB, SkillsService]:
-        task = asyncio.create_task(
-            asyncio.to_thread(self._construct_service_sync, user_id, chacha_path)
-        )
-        try:
-            return await asyncio.shield(task)
-        except asyncio.CancelledError:
-            constructed: tuple[CharactersRAGDB, SkillsService] | None = None
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                constructed = await task
-            if constructed is not None:
-                with contextlib.suppress(Exception):
-                    await self._close_database(constructed[0])
-            raise
-
     def _construct_service_sync(
         self,
         user_id: int,
@@ -421,24 +446,25 @@ class SkillsModule(BaseModule):
 
     @staticmethod
     async def _await_retained(awaitable: Awaitable[T]) -> T:
-        """Await an operation without letting request cancellation orphan its worker."""
+        """Wait through every cancellation delivery before propagating cancellation."""
         task = asyncio.create_task(awaitable)
-        try:
-            return await asyncio.shield(task)
-        except asyncio.CancelledError:
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await task
-            raise
+        cancellation: asyncio.CancelledError | None = None
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError as exc:
+                if cancellation is None:
+                    cancellation = exc
+            except Exception:
+                if cancellation is None:
+                    raise
 
-    @staticmethod
-    async def _close_database(db: CharactersRAGDB) -> None:
-        task = asyncio.create_task(asyncio.to_thread(db.close_all_connections))
-        try:
-            await asyncio.shield(task)
-        except asyncio.CancelledError:
-            with contextlib.suppress(Exception):
-                await task
-            raise
+        if cancellation is not None:
+            if not task.cancelled():
+                with contextlib.suppress(Exception):
+                    task.result()
+            raise cancellation
+        return task.result()
 
     @staticmethod
     def _log_failure(operation: str, user_id: int, exc: Exception) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/skills_module.py
@@ -12,6 +12,12 @@ from loguru import logger
 
 from ....Context_Integrity.resolver import ContextIntegrityBlocked
 from ....DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from ....exceptions import (
+    SkillsMCPContextIntegrityError,
+    SkillsMCPDatabaseCloseError,
+    SkillsMCPNotFoundError,
+    SkillsMCPRenderedTooLargeError,
+)
 from ....Skills.exceptions import SkillNotFoundError
 from ....Skills.runtime_metadata import build_skill_runtime_metadata
 from ....Skills.skill_executor import SkillExecutor
@@ -27,22 +33,6 @@ HARD_MAX_RENDERED_SKILL_CHARS = 100_000
 
 T = TypeVar("T")
 ServiceOperation = Callable[[SkillsService], Awaitable[T]]
-
-
-class _SkillNotFound(ValueError):
-    """Bounded public not-found response."""
-
-
-class _RenderedSkillTooLarge(ValueError):
-    """Bounded public rendered-output rejection."""
-
-
-class _ContextIntegrityBlocked(PermissionError):
-    """Bounded public render-time integrity rejection."""
-
-
-class _DatabaseCloseFailed(Exception):
-    """Internal marker for a logged request-scoped database close failure."""
 
 
 def _clamped_integer(value: Any, *, default: int, minimum: int, maximum: int) -> int:
@@ -278,7 +268,7 @@ class SkillsModule(BaseModule):
         try:
             metadata = await service.get_model_visible_skill_metadata(args["name"])
         except ContextIntegrityBlocked:
-            raise _SkillNotFound("skill_not_found") from None
+            raise SkillsMCPNotFoundError("skill_not_found") from None
         return self._format_metadata(metadata)
 
     async def _render_skill(
@@ -290,12 +280,14 @@ class SkillsModule(BaseModule):
         try:
             await service.get_model_visible_skill_metadata(skill_name)
         except ContextIntegrityBlocked:
-            raise _SkillNotFound("skill_not_found") from None
+            raise SkillsMCPNotFoundError("skill_not_found") from None
         skill_data = await service.get_skill(skill_name)
-        if not bool(skill_data.get("user_invocable", True)) or bool(
-            skill_data.get("disable_model_invocation", False)
+        user_invocable = skill_data.get("user_invocable")
+        disable_model_invocation = skill_data.get("disable_model_invocation")
+        if (user_invocable is not None and not bool(user_invocable)) or (
+            disable_model_invocation is not None and bool(disable_model_invocation)
         ):
-            raise _SkillNotFound("skill_not_found")
+            raise SkillsMCPNotFoundError("skill_not_found")
 
         result = await self._executor.execute(
             skill_data,
@@ -304,7 +296,7 @@ class SkillsModule(BaseModule):
             dry_run=True,
         )
         if len(result.rendered_prompt) > self._max_rendered_skill_chars:
-            raise _RenderedSkillTooLarge(
+            raise SkillsMCPRenderedTooLargeError(
                 f"rendered_skill_too_large: limit={self._max_rendered_skill_chars}"
             )
 
@@ -361,17 +353,17 @@ class SkillsModule(BaseModule):
             )
         except asyncio.CancelledError:
             raise
-        except _SkillNotFound:
+        except SkillsMCPNotFoundError:
             raise
-        except _RenderedSkillTooLarge:
+        except SkillsMCPRenderedTooLargeError:
             raise
-        except _ContextIntegrityBlocked:
+        except SkillsMCPContextIntegrityError:
             raise
         except SkillNotFoundError:
-            raise _SkillNotFound("skill_not_found") from None
+            raise SkillsMCPNotFoundError("skill_not_found") from None
         except ContextIntegrityBlocked:
-            raise _ContextIntegrityBlocked("context_integrity_blocked") from None
-        except _DatabaseCloseFailed:
+            raise SkillsMCPContextIntegrityError("context_integrity_blocked") from None
+        except SkillsMCPDatabaseCloseError:
             raise RuntimeError("skills_unavailable") from None
         except Exception as exc:  # noqa: BLE001 - public boundary sanitizes every unexpected failure
             self._log_failure(operation_name, user_id, exc)
@@ -406,7 +398,7 @@ class SkillsModule(BaseModule):
                 except Exception as exc:  # noqa: BLE001 - cleanup failures stay bounded
                     self._log_failure(operation_name, user_id, exc)
                     if operation_succeeded:
-                        raise _DatabaseCloseFailed from None
+                        raise SkillsMCPDatabaseCloseError from None
 
     @staticmethod
     def _trusted_user_context(context: Any) -> tuple[int, Path]:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py
@@ -121,6 +121,7 @@ def test_describe_module_surface_groups_enabled_modules_by_risk():
     modules = {
         "cooking": {"enabled": True, "status": "healthy"},
         "media": {"enabled": True, "status": "healthy"},
+        "skills": {"enabled": True, "status": "healthy"},
         "filesystem": {"enabled": True, "status": "healthy"},
         "git": {"enabled": True, "status": "healthy"},
         "web_fetch": {"enabled": True, "status": "healthy"},
@@ -141,7 +142,13 @@ def test_describe_module_surface_groups_enabled_modules_by_risk():
     assert [module["id"] for module in surface["tiers"]["read_only"]["modules"]] == [
         "cooking",
         "media",
+        "skills",
     ]
+    skills_entry = next(
+        module for module in surface["tiers"]["read_only"]["modules"] if module["id"] == "skills"
+    )
+    assert skills_entry["description"] == "Discover and safely render user-owned Skills without execution."
+    assert "requires_explicit_opt_in" not in skills_entry
     assert [module["id"] for module in surface["tiers"]["local_files"]["modules"]] == ["filesystem"]
     assert [module["id"] for module in surface["tiers"]["local_process"]["modules"]] == [
         "browser_cdp",
@@ -153,7 +160,7 @@ def test_describe_module_surface_groups_enabled_modules_by_risk():
         "web_research",
         "web_search",
     ]
-    assert surface["enabled_count"] == 9
+    assert surface["enabled_count"] == 10
 
 
 def test_describe_module_surface_reports_disabled_available_high_risk_modules():

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py
@@ -154,6 +154,71 @@ def test_default_mcp_modules_config_declares_prompts_module_with_empty_config_al
     assert prompts_module["settings"]["config_prompts"] == {"enabled": True, "entries": []}  # nosec B101
 
 
+def test_default_mcp_modules_config_declares_skills_module_after_prompts() -> None:
+    config_path = Path("tldw_Server_API/Config_Files/mcp_modules.yaml")
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    module_ids = [module["id"] for module in data["modules"]]
+    modules = {module["id"]: module for module in data["modules"]}
+
+    skills_module = modules["skills"]
+
+    assert module_ids[module_ids.index("prompts") + 1] == "skills"  # nosec B101
+    assert skills_module == {  # nosec B101
+        "id": "skills",
+        "class": "tldw_Server_API.app.core.MCP_unified.modules.implementations.skills_module:SkillsModule",
+        "enabled": True,
+        "name": "Skills",
+        "version": "0.1.0",
+        "department": "knowledge",
+        "max_concurrent": 10,
+        "settings": {
+            "list_page_size": 50,
+            "max_rendered_skill_chars": 100000,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_server_registers_skills_module_tools_from_temporary_config(monkeypatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.registry import reset_module_registry
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    await reset_module_registry()
+    config_path = tmp_path / "mcp_modules.yaml"
+    config_path.write_text(
+        """
+modules:
+  - id: skills
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.skills_module:SkillsModule
+    enabled: true
+    name: Skills
+    version: "0.1.0"
+    department: knowledge
+    max_concurrent: 10
+    settings:
+      list_page_size: 50
+      max_rendered_skill_chars: 100000
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(config_path))
+    monkeypatch.setenv("MCP_MODULES", "")
+    server = MCPServer()
+
+    try:
+        await server._register_default_modules()
+        registered_modules = [
+            await server.module_registry.find_module_for_tool(tool_name)
+            for tool_name in ("skills.list", "skills.get", "skills.render")
+        ]
+
+        assert all(registered_modules)  # nosec B101
+        assert len({id(module) for module in registered_modules}) == 1  # nosec B101
+    finally:
+        await server.module_registry.shutdown_all()
+        await reset_module_registry()
+
+
 def test_default_mcp_modules_config_declares_docs_module_without_web_acquisition() -> None:
     config_path = Path("tldw_Server_API/Config_Files/mcp_modules.yaml")
     data = yaml.safe_load(config_path.read_text(encoding="utf-8"))

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -2816,6 +2816,64 @@ def test_gateway_cli_approval_grant_lifecycle(
     assert json.loads(capsys.readouterr().out)["grants"] == []
 
 
+def test_gateway_cli_skill_approval_grant_lifecycle_canonicalizes_value(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Create, list, and revoke a canonicalized Skill approval grant through the CLI."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "policy_grants": {
+                    "kind": "sqlite",
+                    "sqlite_path": str(tmp_path / "grants.db"),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "create-approval-grant",
+            "--config",
+            str(config_path),
+            "--profile",
+            "researcher",
+            "--subject-type",
+            "skill",
+            "--value",
+            "Review-Paper",
+            "--ttl-seconds",
+            "900",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    created = json.loads(captured.out)
+    grant = created["grant"]
+    assert grant["subject_type"] == "skill"
+    assert grant["value"] == "review-paper"
+
+    exit_code = gateway_cli.main(
+        ["list-approval-grants", "--config", str(config_path)]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    listed = json.loads(captured.out)
+    assert listed["grants"] == [grant]
+
+    exit_code = gateway_cli.main(
+        ["revoke-approval-grant", grant["grant_id"], "--config", str(config_path)]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert json.loads(captured.out)["grant"] == grant
+
+
 def test_gateway_cli_approval_grant_requires_configured_store(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -207,6 +207,19 @@ class _CustomToolListGatewayRuntime(_FakeGatewayRuntime):
         return self._tools
 
 
+class _SkillsRenderGatewayRuntime(_CustomToolListGatewayRuntime):
+    """Fake backend that accepts the real skills.render argument shape."""
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Any,
+    ) -> dict[str, Any]:
+        self.call_requests.append((name, arguments, context))
+        return {"content": [{"type": "text", "text": f"{name}:{arguments['skill_name']}"}]}
+
+
 class _FakeLogger:
     def __init__(self) -> None:
         self.opt_calls: list[dict[str, Any]] = []
@@ -3254,6 +3267,40 @@ def _web_fetch_tool_descriptor() -> dict[str, Any]:
     }
 
 
+def _skills_render_tool_descriptor() -> dict[str, Any]:
+    return {
+        "name": "skills.render",
+        "description": "Render a Skill without executing it.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"skill_name": {"type": "string"}},
+            "required": ["skill_name"],
+        },
+        "metadata": {"category": "knowledge", "capability": "skills.render"},
+    }
+
+
+def _skill_rule_runtime_with_grant_store(permission_rules: list[Any]) -> tuple[Any, Any, Any]:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _SkillsRenderGatewayRuntime([_skills_render_tool_descriptor()])
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "reviewer",
+        allowed_tools=["skills.render"],
+        permission_rules=permission_rules,
+    )
+    grant_store = InMemoryPolicyGrantStore()
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+        policy_grant_store=grant_store,
+    )
+    return runtime, backend, grant_store
+
+
 def _ask_rule_runtime_with_grant_store() -> tuple[Any, Any, Any]:
     from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
     from mcp_unified.policy_grants import InMemoryPolicyGrantStore
@@ -3273,6 +3320,76 @@ def _ask_rule_runtime_with_grant_store() -> tuple[Any, Any, Any]:
         policy_grant_store=grant_store,
     )
     return runtime, backend, grant_store
+
+
+def test_gateway_profile_runtime_blocks_skill_permission_denial() -> None:
+    runtime, backend, _grant_store = _skill_rule_runtime_with_grant_store(
+        [{"pattern": "Skill(secret-*)", "outcome": "deny"}]
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = _post_tool_call(
+            client,
+            "skills.render",
+            {"skill_name": "secret-plan"},
+            "skill-denied",
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="skill-denied")
+    assert body["error"]["data"]["status"] == "denied"
+    assert body["error"]["data"]["provenance"]["subject_type"] == "skill"
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_skill_permission_ask_requires_approval() -> None:
+    runtime, backend, _grant_store = _skill_rule_runtime_with_grant_store(
+        [{"pattern": "Skill(review-*)", "outcome": "ask"}]
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = _post_tool_call(
+            client,
+            "skills.render",
+            {"skill_name": "Review-Paper"},
+            "skill-ask",
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="skill-ask")
+    assert body["error"]["data"]["status"] == "approval_required"
+    assert body["error"]["data"]["provenance"]["approval"]["subject_type"] == "skill"
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_skill_approval_lease_delegates_with_redacted_marker() -> None:
+    runtime, backend, grant_store = _skill_rule_runtime_with_grant_store(
+        [{"pattern": "Skill(review-*)", "outcome": "ask"}]
+    )
+    grant = grant_store.create_grant(
+        profile_id="reviewer",
+        grant_type="approval",
+        subject_type="skill",
+        value="REVIEW-PAPER",
+        ttl_seconds=900,
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        allowed = _post_tool_call(
+            client,
+            "skills.render",
+            {"skill_name": "Review-Paper"},
+            "skill-lease",
+        )
+
+    assert allowed.json().get("error") is None
+    assert len(backend.call_requests) == 1
+    markers = backend.call_requests[-1][2].metadata.get("mcp_policy_approval_grants")
+    assert markers
+    assert grant.grant_id not in json.dumps(markers)
 
 
 def test_gateway_profile_runtime_ask_denial_reports_approval_availability() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py
@@ -86,25 +86,24 @@ def test_policy_grant_manager_clamps_ttl_to_bounds() -> None:
     assert undersized["grant"]["ttl_seconds"] == APPROVAL_GRANT_MIN_TTL_SECONDS
 
 
-def test_policy_grant_manager_rejects_invalid_requests() -> None:
+def test_policy_grant_manager_accepts_canonical_skill_approval() -> None:
     from mcp_unified.gateway.policy_grants import (
-        GatewayPolicyGrantManagementError,
         GatewayPolicyGrantManager,
     )
     from mcp_unified.policy_grants import InMemoryPolicyGrantStore
 
     manager = GatewayPolicyGrantManager(policy_grant_store=InMemoryPolicyGrantStore())
 
-    with pytest.raises(GatewayPolicyGrantManagementError) as excinfo:
-        asyncio.run(
-            manager.grant_approval(
-                profile_id="researcher",
-                subject_type="skill",
-                value="anything",
-            )
+    created = asyncio.run(
+        manager.grant_approval(
+            profile_id="researcher",
+            subject_type="skill",
+            value="Review-Paper",
         )
-    assert excinfo.value.reason_code == "invalid_policy_grant"
-    assert excinfo.value.to_payload()["ok"] is False
+    )
+
+    assert created["grant"]["subject_type"] == "skill"
+    assert created["grant"]["value"] == "review-paper"
 
 
 def test_policy_grant_manager_revoke_missing_grant_raises_not_found() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py
@@ -45,6 +45,35 @@ def test_subjects_module_extracts_permission_rule_subjects() -> None:
     assert ("domain", "https://example.com/x") in pairs
     assert ("command", "git status") in pairs
 
+    skill_subjects = extract_permission_rule_subjects(
+        "skills.render",
+        {"skill_name": "Review-Paper", "arguments": "--formal /* example */"},
+    )
+    skill_pairs = {(subject_type, value) for subject_type, value, _argv in skill_subjects}
+    assert ("skill", "review-paper") in skill_pairs
+    assert all(
+        subject_type != "skill"
+        for subject_type, _, _ in extract_permission_rule_subjects(
+            "skills.get", {"name": "Review-Paper"}
+        )
+    )
+
+
+def test_skill_permission_subject_extraction_ignores_invalid_values() -> None:
+    from mcp_unified.profiles.subjects import extract_permission_rule_subjects
+
+    for arguments in (
+        {"skill_name": "   "},
+        {"skill_name": 42},
+        {"skill_name": {"name": "Review-Paper"}},
+        {"skill_name": ["Review-Paper"]},
+        {"name": "Review-Paper"},
+    ):
+        assert all(
+            subject_type != "skill"
+            for subject_type, _, _ in extract_permission_rule_subjects("skills.render", arguments)
+        )
+
 
 def test_subjects_module_enforces_extraction_limits() -> None:
     from mcp_unified.profiles.subjects import (
@@ -57,6 +86,20 @@ def test_subjects_module_enforces_extraction_limits() -> None:
         extract_permission_rule_subjects(
             "fs.read_text",
             {"paths": [f"docs/file-{index}.txt" for index in range(MAX_PERMISSION_SUBJECTS + 1)]},
+        )
+
+
+def test_skill_permission_subject_extraction_enforces_value_limit() -> None:
+    from mcp_unified.profiles.subjects import (
+        MAX_SUBJECT_VALUE_LENGTH,
+        PermissionSubjectLimitError,
+        extract_permission_rule_subjects,
+    )
+
+    with pytest.raises(PermissionSubjectLimitError, match="max_subject_value_length"):
+        extract_permission_rule_subjects(
+            "skills.render",
+            {"skill_name": "a" * (MAX_SUBJECT_VALUE_LENGTH + 1)},
         )
 
 
@@ -152,6 +195,96 @@ def test_simulation_ask_rule_blocks_then_lease_allows() -> None:
     )
     assert allowed["overall"]["status"] == "allowed"
     assert allowed["approval_grant_markers"]
+
+
+def test_simulation_skill_permission_applies_deny_allow_and_unrelated_rules() -> None:
+    from mcp_unified.gateway.policy_simulation import simulate_tool_call_policy
+
+    denied_profile = _profile(
+        "reviewer",
+        allowed_tools=["skills.render"],
+        permission_rules=[{"pattern": "Skill(secret-*)", "outcome": "deny"}],
+    )
+    allowed_profile = _profile(
+        "reviewer",
+        allowed_tools=["skills.render"],
+        permission_rules=[{"pattern": "Skill(review-*)", "outcome": "allow"}],
+    )
+    unrelated_profile = _profile(
+        "reviewer",
+        allowed_tools=["skills.render"],
+        permission_rules=[{"pattern": "Skill(secret-*)", "outcome": "deny"}],
+    )
+
+    denied = simulate_tool_call_policy(
+        denied_profile,
+        "skills.render",
+        {"skill_name": "secret-plan"},
+    )
+    allowed = simulate_tool_call_policy(
+        allowed_profile,
+        "skills.render",
+        {"skill_name": "Review-Paper"},
+    )
+    unrelated = simulate_tool_call_policy(
+        unrelated_profile,
+        "skills.render",
+        {"skill_name": "review-paper"},
+    )
+
+    assert denied["overall"]["status"] == "denied"
+    assert allowed["overall"]["status"] == "allowed"
+    assert unrelated["overall"]["status"] == "allowed"
+
+
+def test_simulation_skill_permission_approval_lease_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import mcp_unified.policy_grants.memory as memory_grants
+    from mcp_unified.gateway.policy_simulation import simulate_tool_call_policy
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    profile = _profile(
+        "reviewer",
+        allowed_tools=["skills.render"],
+        permission_rules=[{"pattern": "Skill(review-*)", "outcome": "ask"}],
+    )
+    grant_store = InMemoryPolicyGrantStore()
+    arguments = {"skill_name": "Review-Paper"}
+
+    blocked = simulate_tool_call_policy(
+        profile,
+        "skills.render",
+        arguments,
+        policy_grant_store=grant_store,
+    )
+    assert blocked["overall"]["status"] == "approval_required"
+
+    monkeypatch.setattr(memory_grants.time, "time", lambda: 1_000.0)
+    grant_store.create_grant(
+        profile_id="reviewer",
+        grant_type="approval",
+        subject_type="skill",
+        value="REVIEW-PAPER",
+        ttl_seconds=10,
+    )
+    allowed = simulate_tool_call_policy(
+        profile,
+        "skills.render",
+        arguments,
+        policy_grant_store=grant_store,
+    )
+    assert allowed["overall"]["status"] == "allowed"
+    assert allowed["approval_grant_markers"]
+
+    monkeypatch.setattr(memory_grants.time, "time", lambda: 1_011.0)
+    expired = simulate_tool_call_policy(
+        profile,
+        "skills.render",
+        arguments,
+        policy_grant_store=grant_store,
+    )
+    assert expired["overall"]["status"] == "approval_required"
 
 
 def test_simulation_includes_merged_ttl_path_grants() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py
@@ -75,6 +75,23 @@ def test_skill_permission_subject_extraction_ignores_invalid_values() -> None:
         )
 
 
+def test_skill_permission_subject_extraction_requires_exact_argument_key() -> None:
+    from mcp_unified.profiles.subjects import extract_permission_rule_subjects
+
+    for key in ("SKILL_NAME", " skill_name "):
+        assert all(
+            subject_type != "skill"
+            for subject_type, _, _ in extract_permission_rule_subjects(
+                "skills.render", {key: "Review-Paper"}
+            )
+        )
+
+    subjects = extract_permission_rule_subjects(
+        "skills.render", {"skill_name": "Review-Paper"}
+    )
+    assert ("skill", "review-paper", None) in subjects
+
+
 def test_subjects_module_enforces_extraction_limits() -> None:
     from mcp_unified.profiles.subjects import (
         MAX_PERMISSION_SUBJECTS,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
@@ -50,6 +50,30 @@ def test_memory_store_creates_and_finds_normalized_approval_grant() -> None:
     assert found.grant_id == grant.grant_id
 
 
+def test_memory_store_normalizes_skill_approval_grants() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    grant = store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="skill",
+        value="Review-Paper",
+        ttl_seconds=900,
+    )
+
+    assert grant.value == "review-paper"
+    assert (
+        store.find_active_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="skill",
+            value="REVIEW-PAPER",
+        )
+        == grant
+    )
+
+
 def test_memory_store_find_misses_on_mismatched_dimensions() -> None:
     from mcp_unified.policy_grants import InMemoryPolicyGrantStore
 
@@ -100,8 +124,8 @@ def test_memory_store_expired_grant_is_not_found(monkeypatch: pytest.MonkeyPatch
     store.create_grant(
         profile_id="researcher",
         grant_type="approval",
-        subject_type="domain",
-        value="example.com",
+        subject_type="skill",
+        value="Review-Paper",
         ttl_seconds=10,
     )
 
@@ -110,8 +134,8 @@ def test_memory_store_expired_grant_is_not_found(monkeypatch: pytest.MonkeyPatch
         store.find_active_grant(
             profile_id="researcher",
             grant_type="approval",
-            subject_type="domain",
-            value="example.com",
+            subject_type="skill",
+            value="review-paper",
         )
         is None
     )
@@ -262,7 +286,7 @@ def test_memory_store_rejects_invalid_grants() -> None:
         store.create_grant(
             profile_id="researcher",
             grant_type="approval",
-            subject_type="skill",
+            subject_type="unknown",
             value="anything",
             ttl_seconds=900,
         )
@@ -318,14 +342,14 @@ def test_sqlite_store_persists_grants_across_instances(tmp_path: Path) -> None:
         grant = first.create_grant(
             profile_id="researcher",
             grant_type="approval",
-            subject_type="domain",
-            value="https://Example.com/private",
+            subject_type="skill",
+            value="Review-Paper",
             ttl_seconds=900,
             session_id="session-1",
             granted_by="operator",
             reason="one-off research fetch",
         )
-        assert grant.value == "example.com"
+        assert grant.value == "review-paper"
     finally:
         first.close()
 
@@ -334,8 +358,8 @@ def test_sqlite_store_persists_grants_across_instances(tmp_path: Path) -> None:
         found = second.find_active_grant(
             profile_id="researcher",
             grant_type="approval",
-            subject_type="domain",
-            value="example.com",
+            subject_type="skill",
+            value="REVIEW-PAPER",
             session_id="session-1",
         )
         assert found is not None
@@ -348,8 +372,8 @@ def test_sqlite_store_persists_grants_across_instances(tmp_path: Path) -> None:
             second.find_active_grant(
                 profile_id="researcher",
                 grant_type="approval",
-                subject_type="domain",
-                value="example.com",
+                subject_type="skill",
+                value="review-paper",
                 session_id="session-1",
             )
             is None
@@ -371,8 +395,8 @@ def test_sqlite_store_expired_grant_is_not_found(
         store.create_grant(
             profile_id="researcher",
             grant_type="approval",
-            subject_type="domain",
-            value="example.com",
+            subject_type="skill",
+            value="Review-Paper",
             ttl_seconds=10,
         )
 
@@ -381,8 +405,8 @@ def test_sqlite_store_expired_grant_is_not_found(
             store.find_active_grant(
                 profile_id="researcher",
                 grant_type="approval",
-                subject_type="domain",
-                value="example.com",
+                subject_type="skill",
+                value="review-paper",
             )
             is None
         )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py
@@ -66,6 +66,20 @@ def test_parse_permission_rule_classifies_mixed_case_mcp_rules() -> None:
     assert decision.outcome == "ask"
 
 
+def test_skill_permission_rules_canonicalize_mixed_case_patterns_and_subjects() -> None:
+    rule = parse_permission_rule("Skill(REVIEW-*)", outcome="allow")
+
+    decision = evaluate_permission_rule_decision(
+        [rule],
+        subject_type="skill",
+        value="Review-Paper",
+    )
+
+    assert rule.pattern == "review-*"
+    assert decision.outcome == "allow"
+    assert decision.subject.normalized == "review-paper"
+
+
 @pytest.mark.parametrize(
     "pattern,match",
     [

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py
@@ -1,0 +1,940 @@
+"""Contract tests for the read-only MCP Skills catalog and renderer."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from loguru import logger
+
+from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityBlocked
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations import skills_module
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.skills_module import (
+    DEFAULT_LIST_PAGE_SIZE,
+    HARD_MAX_RENDERED_SKILL_CHARS,
+    SkillsModule,
+)
+from tldw_Server_API.app.core.MCP_unified.protocol_types import RequestContext
+from tldw_Server_API.app.core.Skills.exceptions import SkillNotFoundError
+from tldw_Server_API.app.core.Skills.skill_executor import SkillExecutionResult, SkillExecutor
+from tldw_Server_API.app.core.Skills.skills_service import SkillMetadata, SkillsService
+
+
+@dataclass
+class UserCatalog:
+    user_id: int
+    base_path: Path
+    db_path: Path
+    db: CharactersRAGDB
+    service: SkillsService
+    context: RequestContext
+
+
+@pytest.fixture
+def user_catalogs(tmp_path: Path) -> dict[int, UserCatalog]:
+    """Create isolated real Skills catalogs for two authenticated users."""
+    catalogs: dict[int, UserCatalog] = {}
+    for user_id in (1, 2):
+        base_path = tmp_path / f"user-{user_id}"
+        base_path.mkdir()
+        db_path = base_path / "ChaChaNotes.db"
+        db = CharactersRAGDB(db_path=db_path, client_id=f"seed-skills-{user_id}")
+        service = SkillsService(user_id=user_id, base_path=base_path, db=db)
+        catalogs[user_id] = UserCatalog(
+            user_id=user_id,
+            base_path=base_path,
+            db_path=db_path,
+            db=db,
+            service=service,
+            context=RequestContext(
+                request_id=f"skills-{user_id}",
+                user_id=str(user_id),
+                db_paths={"chacha": str(db_path)},
+            ),
+        )
+    yield catalogs
+    for catalog in catalogs.values():
+        catalog.db.close_all_connections()
+
+
+async def _module(settings: dict[str, Any] | None = None) -> SkillsModule:
+    module = SkillsModule(ModuleConfig(name="skills", settings=settings or {}))
+    await module.on_initialize()
+    return module
+
+
+def _metadata(name: str = "review-paper", *, context: str = "inline") -> SkillMetadata:
+    return SkillMetadata(
+        id="internal-id",
+        name=name,
+        description="Review a paper",
+        argument_hint="[issue]",
+        user_invocable=True,
+        disable_model_invocation=False,
+        allowed_tools=["rag.search"],
+        model=None,
+        context=context,
+        directory_path="/private/catalog/path",
+        content_hash="private-hash",
+        version=1,
+    )
+
+
+def _skill_data(
+    name: str = "review-paper",
+    *,
+    content: str = "Review $ARGUMENTS",
+    context: str = "inline",
+    supporting_files: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "description": "Review a paper",
+        "argument_hint": "[issue]",
+        "user_invocable": True,
+        "disable_model_invocation": False,
+        "allowed_tools": ["rag.search"],
+        "model": None,
+        "context": context,
+        "content": content,
+        "raw_content": content,
+        "supporting_files": supporting_files or {},
+        "directory_path": "/private/catalog/path",
+        "version": 1,
+    }
+
+
+async def _seed_review_skill(
+    service: SkillsService,
+    *,
+    name: str = "review-paper",
+    context: str = "inline",
+    content: str = "Review $ARGUMENTS",
+    supporting_files: dict[str, str] | None = None,
+) -> None:
+    await service.create_skill(
+        name,
+        (
+            "---\n"
+            "description: Review a paper\n"
+            'argument-hint: "[issue]"\n'
+            "allowed-tools:\n"
+            "  - rag.search\n"
+            f"context: {context}\n"
+            "---\n"
+            f"{content}"
+        ),
+        supporting_files=supporting_files,
+    )
+
+
+def _all_keys(value: Any) -> set[str]:
+    if isinstance(value, dict):
+        return set(value) | set().union(*(_all_keys(item) for item in value.values()), set())
+    if isinstance(value, list):
+        return set().union(*(_all_keys(item) for item in value), set())
+    return set()
+
+
+@pytest.mark.asyncio
+async def test_tool_catalog_is_exact_and_read_only() -> None:
+    module = await _module({"list_page_size": 17})
+
+    tools = await module.get_tools()
+
+    assert [tool["name"] for tool in tools] == ["skills.list", "skills.get", "skills.render"]
+    assert all(tool["metadata"]["readOnlyHint"] is True for tool in tools)
+    assert [tool["metadata"]["category"] for tool in tools] == ["search", "retrieval", "retrieval"]
+    list_tool = tools[0]
+    assert list_tool["inputSchema"]["properties"]["limit"]["default"] == 17
+    assert list_tool["inputSchema"]["properties"]["q"]["maxLength"] == 200
+    assert tools[2]["inputSchema"]["properties"]["arguments"]["maxLength"] == 10_000
+
+
+@pytest.mark.parametrize(
+    ("settings", "expected_page_size", "expected_render_limit"),
+    [
+        ({}, DEFAULT_LIST_PAGE_SIZE, HARD_MAX_RENDERED_SKILL_CHARS),
+        (
+            {"list_page_size": True, "max_rendered_skill_chars": False},
+            DEFAULT_LIST_PAGE_SIZE,
+            HARD_MAX_RENDERED_SKILL_CHARS,
+        ),
+        (
+            {"list_page_size": "25", "max_rendered_skill_chars": "900"},
+            DEFAULT_LIST_PAGE_SIZE,
+            HARD_MAX_RENDERED_SKILL_CHARS,
+        ),
+        ({"list_page_size": 0, "max_rendered_skill_chars": 0}, 1, 1),
+        ({"list_page_size": 25, "max_rendered_skill_chars": 900}, 25, 900),
+        (
+            {"list_page_size": 101, "max_rendered_skill_chars": 100_001},
+            100,
+            HARD_MAX_RENDERED_SKILL_CHARS,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_settings_use_defaults_for_invalid_types_and_clamp_integers(
+    settings: dict[str, Any],
+    expected_page_size: int,
+    expected_render_limit: int,
+) -> None:
+    module = await _module(settings)
+
+    assert module._list_page_size == expected_page_size
+    assert module._max_rendered_skill_chars == expected_render_limit
+    assert isinstance(module._executor, SkillExecutor)
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "message"),
+    [
+        ("skills.list", {"unexpected": 1}, "unexpected arguments"),
+        ("skills.get", {"name": "valid", "unexpected": 1}, "unexpected arguments"),
+        ("skills.render", {"skill_name": "valid", "extra": 1}, "unexpected arguments"),
+        ("skills.list", {"limit": True}, "limit must be an integer"),
+        ("skills.list", {"offset": False}, "offset must be an integer"),
+        ("skills.list", {"offset": -1}, "offset must be >= 0"),
+        ("skills.list", {"limit": 0}, "limit must be 1..100"),
+        ("skills.list", {"limit": 101}, "limit must be 1..100"),
+        ("skills.list", {"q": "q" * 201}, "q must be at most 200 characters"),
+        ("skills.list", {"q": 1}, "q must be a string"),
+        ("skills.get", {}, "name must be a valid skill name"),
+        ("skills.get", {"name": "Invalid_Name"}, "name must be a valid skill name"),
+        ("skills.render", {}, "skill_name must be a valid skill name"),
+        ("skills.render", {"skill_name": True}, "skill_name must be a valid skill name"),
+        (
+            "skills.render",
+            {"skill_name": "valid", "arguments": "x" * 10_001},
+            "arguments must be at most 10000 characters",
+        ),
+        ("skills.render", {"skill_name": "valid", "arguments": 1}, "arguments must be a string"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_exact_argument_validation(
+    tool_name: str,
+    arguments: dict[str, Any],
+    message: str,
+) -> None:
+    module = await _module()
+
+    with pytest.raises(ValueError, match=message):
+        module.validate_tool_arguments(tool_name, arguments)
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_non_dictionary_arguments() -> None:
+    module = await _module()
+
+    with pytest.raises(TypeError, match="arguments must be an object"):
+        await module.execute_tool("skills.list", [])  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("user_id", [None, "", "abc", "0", "-1", False, True])
+@pytest.mark.asyncio
+async def test_invalid_authenticated_user_ids_fail_closed(tmp_path: Path, user_id: Any) -> None:
+    module = await _module()
+    context = SimpleNamespace(
+        user_id=user_id,
+        db_paths={"chacha": str(tmp_path / "ChaChaNotes.db")},
+    )
+
+    with pytest.raises(PermissionError, match="^skills_user_context_required$"):
+        await module.execute_tool("skills.list", {}, context=context)
+
+
+@pytest.mark.parametrize(
+    "context",
+    [
+        None,
+        SimpleNamespace(user_id="1", db_paths={}),
+        SimpleNamespace(user_id="1", db_paths={"chacha": ""}),
+        SimpleNamespace(user_id="1", db_paths={"chacha": False}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_missing_database_context_fails_closed(context: Any) -> None:
+    module = await _module()
+
+    with pytest.raises(PermissionError, match="^skills_user_context_required$"):
+        await module.execute_tool("skills.list", {}, context=context)
+
+
+@pytest.mark.asyncio
+async def test_list_uses_one_filtered_page_call_and_exact_pagination(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_one = user_catalogs[1]
+    await user_one.service.create_skill("alpha", "---\ndescription: Alpha\n---\nAlpha")
+    await user_one.service.create_skill("beta", "---\ndescription: Beta\n---\nBeta")
+    await user_one.service.create_skill("blocked", "---\ndescription: Blocked\n---\nBlocked")
+    await user_one.service.create_skill("hidden", "---\nuser-invocable: false\n---\nHidden")
+    await user_one.service.create_skill(
+        "manual-only",
+        "---\ndisable-model-invocation: true\n---\nManual",
+    )
+    await user_one.service.create_skill("deleted", "Deleted")
+    await user_one.service.delete_skill("deleted")
+    await user_catalogs[2].service.create_skill("other-user", "Other user")
+
+    original_allowed = SkillsService._is_skill_allowed
+
+    def allow_except_blocked(self: SkillsService, name: str, *, purpose: str) -> bool:
+        return name != "blocked" and original_allowed(self, name, purpose=purpose)
+
+    original_page = SkillsService.list_model_visible_skills_page
+    page_calls: list[tuple[str | None, int, int]] = []
+
+    async def counted_page(
+        self: SkillsService,
+        *,
+        q: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[SkillMetadata], int]:
+        page_calls.append((q, limit, offset))
+        return await original_page(self, q=q, limit=limit, offset=offset)
+
+    monkeypatch.setattr(SkillsService, "_is_skill_allowed", allow_except_blocked)
+    monkeypatch.setattr(SkillsService, "list_model_visible_skills_page", counted_page)
+    module = await _module()
+
+    first = await module.execute_tool(
+        "skills.list",
+        {"limit": 1, "offset": 0},
+        context=user_one.context,
+    )
+    final = await module.execute_tool(
+        "skills.list",
+        {"limit": 1, "offset": 1},
+        context=user_one.context,
+    )
+
+    assert first["count"] == 1
+    assert first["total"] == 2
+    assert first["limit"] == 1
+    assert first["offset"] == 0
+    assert first["next_offset"] == 1
+    assert [item["name"] for item in first["skills"]] == ["alpha"]
+    assert final["count"] == 1
+    assert final["total"] == 2
+    assert final["next_offset"] is None
+    assert [item["name"] for item in final["skills"]] == ["beta"]
+    assert page_calls == [(None, 1, 0), (None, 1, 1)]
+
+
+@pytest.mark.asyncio
+async def test_list_preserves_query_and_normalizes_only_whitespace_at_delegation(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delegated_queries: list[str | None] = []
+
+    async def capture_page(
+        _self: SkillsService,
+        *,
+        q: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[SkillMetadata], int]:
+        delegated_queries.append(q)
+        assert limit == 50
+        assert offset == 0
+        return [], 0
+
+    monkeypatch.setattr(SkillsService, "list_model_visible_skills_page", capture_page)
+    module = await _module()
+
+    await module.execute_tool(
+        "skills.list",
+        {"q": "flags --all /* literal */"},
+        context=user_catalogs[1].context,
+    )
+    await module.execute_tool("skills.list", {"q": " \n\t "}, context=user_catalogs[1].context)
+
+    assert delegated_queries == ["flags --all /* literal */", None]
+
+
+@pytest.mark.asyncio
+async def test_get_matches_list_metadata_and_excludes_private_fields(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _seed_review_skill(user_catalogs[1].service)
+    original_get = SkillsService.get_model_visible_skill_metadata
+    calls = 0
+
+    async def counted_get(self: SkillsService, name: str) -> SkillMetadata:
+        nonlocal calls
+        calls += 1
+        return await original_get(self, name)
+
+    monkeypatch.setattr(SkillsService, "get_model_visible_skill_metadata", counted_get)
+    module = await _module()
+
+    listed = await module.execute_tool("skills.list", {}, context=user_catalogs[1].context)
+    fetched = await module.execute_tool(
+        "skills.get",
+        {"name": "review-paper"},
+        context=user_catalogs[1].context,
+    )
+
+    assert fetched == listed["skills"][0]
+    assert set(fetched) == {
+        "name",
+        "description",
+        "argument_hint",
+        "user_invocable",
+        "disable_model_invocation",
+        "declared_tools",
+        "model",
+        "context",
+        "runtime",
+        "version",
+    }
+    assert calls == 1
+    assert not (
+        _all_keys(fetched)
+        & {
+            "id",
+            "created_at",
+            "last_modified",
+            "content",
+            "raw_content",
+            "supporting_files",
+            "directory_path",
+            "path",
+            "content_hash",
+            "hash",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_hidden_model_disabled_deleted_blocked_and_other_user_skills_are_not_found(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_one = user_catalogs[1]
+    await user_one.service.create_skill("hidden", "---\nuser-invocable: false\n---\nHidden")
+    await user_one.service.create_skill(
+        "manual-only",
+        "---\ndisable-model-invocation: true\n---\nManual",
+    )
+    await user_one.service.create_skill("deleted", "Deleted")
+    await user_one.service.delete_skill("deleted")
+    await user_one.service.create_skill("blocked", "Blocked")
+    await user_catalogs[2].service.create_skill("other-user", "Other")
+    original_allowed = SkillsService._is_skill_allowed
+
+    def allow_except_blocked(self: SkillsService, name: str, *, purpose: str) -> bool:
+        return name != "blocked" and original_allowed(self, name, purpose=purpose)
+
+    monkeypatch.setattr(SkillsService, "_is_skill_allowed", allow_except_blocked)
+    module = await _module()
+
+    listed = await module.execute_tool("skills.list", {}, context=user_one.context)
+    assert listed["skills"] == []
+
+    for name in ("hidden", "manual-only", "deleted", "blocked", "other-user", "unknown"):
+        with pytest.raises(ValueError, match="^skill_not_found$"):
+            await module.execute_tool("skills.get", {"name": name}, context=user_one.context)
+        with pytest.raises(ValueError, match="^skill_not_found$"):
+            await module.execute_tool(
+                "skills.render",
+                {"skill_name": name},
+                context=user_one.context,
+            )
+
+
+@pytest.mark.asyncio
+async def test_render_is_forced_dry_and_preserves_arguments(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _seed_review_skill(user_catalogs[1].service)
+    module = await _module()
+    execute = AsyncMock(
+        return_value=SkillExecutionResult(
+            skill_name="review-paper",
+            rendered_prompt="Review --formal /* literal */\nnext",
+            allowed_tools=["rag.search"],
+            model_override=None,
+            execution_mode="inline",
+            dry_run=True,
+        )
+    )
+    monkeypatch.setattr(module._executor, "execute", execute)
+
+    result = await module.execute_tool(
+        "skills.render",
+        {"skill_name": "review-paper", "arguments": "--formal /* literal */\nnext"},
+        context=user_catalogs[1].context,
+    )
+
+    assert result == {
+        "skill_name": "review-paper",
+        "rendered_prompt": "Review --formal /* literal */\nnext",
+        "declared_tools": ["rag.search"],
+        "model_override": None,
+        "execution_mode": "inline",
+        "supporting_files_omitted": False,
+        "dry_run": True,
+        "version": 1,
+    }
+    execute.assert_awaited_once()
+    call = execute.await_args
+    assert call.args[1] == "--formal /* literal */\nnext"
+    assert call.kwargs == {"context": None, "dry_run": True}
+
+
+@pytest.mark.asyncio
+async def test_render_calls_visibility_gate_and_verified_load_once(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _seed_review_skill(user_catalogs[1].service)
+    original_metadata = SkillsService.get_model_visible_skill_metadata
+    original_skill = SkillsService.get_skill
+    metadata_calls = 0
+    skill_calls = 0
+
+    async def counted_metadata(self: SkillsService, name: str) -> SkillMetadata:
+        nonlocal metadata_calls
+        metadata_calls += 1
+        return await original_metadata(self, name)
+
+    async def counted_skill(
+        self: SkillsService,
+        name: str,
+        *,
+        enforce_integrity: bool = True,
+    ) -> dict[str, Any]:
+        nonlocal skill_calls
+        skill_calls += 1
+        return await original_skill(self, name, enforce_integrity=enforce_integrity)
+
+    monkeypatch.setattr(SkillsService, "get_model_visible_skill_metadata", counted_metadata)
+    monkeypatch.setattr(SkillsService, "get_skill", counted_skill)
+    module = await _module()
+
+    await module.execute_tool(
+        "skills.render",
+        {"skill_name": "review-paper", "arguments": "issue 42"},
+        context=user_catalogs[1].context,
+    )
+
+    assert metadata_calls == 1
+    assert skill_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_supporting_files_are_disclosed_only_as_boolean(
+    user_catalogs: dict[int, UserCatalog],
+) -> None:
+    await _seed_review_skill(
+        user_catalogs[1].service,
+        supporting_files={"private-reference.md": "private supporting content"},
+    )
+    module = await _module()
+
+    result = await module.execute_tool(
+        "skills.render",
+        {"skill_name": "review-paper", "arguments": "issue 42"},
+        context=user_catalogs[1].context,
+    )
+
+    assert result["supporting_files_omitted"] is True
+    assert isinstance(result["supporting_files_omitted"], bool)
+    assert "private-reference.md" not in str(result)
+    assert "private supporting content" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_inline_and_fork_render_never_enter_execution_paths(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _seed_review_skill(user_catalogs[1].service, name="inline-skill")
+    await _seed_review_skill(user_catalogs[1].service, name="fork-skill", context="fork")
+
+    def forbidden(*_args: Any, **_kwargs: Any) -> Any:
+        pytest.fail("dry render must not execute inline or fork paths")
+
+    monkeypatch.setattr(SkillExecutor, "_execute_inline", forbidden)
+    monkeypatch.setattr(SkillExecutor, "_execute_forked", forbidden)
+    module = await _module()
+
+    inline = await module.execute_tool(
+        "skills.render",
+        {"skill_name": "inline-skill"},
+        context=user_catalogs[1].context,
+    )
+    fork = await module.execute_tool(
+        "skills.render",
+        {"skill_name": "fork-skill"},
+        context=user_catalogs[1].context,
+    )
+
+    assert inline["execution_mode"] == "inline"
+    assert fork["execution_mode"] == "fork"
+    assert inline["dry_run"] is True
+    assert fork["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_oversized_render_is_rejected_atomically(user_catalogs: dict[int, UserCatalog]) -> None:
+    await _seed_review_skill(user_catalogs[1].service, content="12345678901")
+    module = await _module({"max_rendered_skill_chars": 10})
+
+    with pytest.raises(ValueError) as exc_info:
+        await module.execute_tool(
+            "skills.render",
+            {"skill_name": "review-paper"},
+            context=user_catalogs[1].context,
+        )
+
+    assert str(exc_info.value) == "rendered_skill_too_large: limit=10"
+    assert "12345678901" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("user_invocable", False), ("disable_model_invocation", True)],
+)
+@pytest.mark.asyncio
+async def test_render_rechecks_visibility_after_verified_load(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: bool,
+) -> None:
+    await _seed_review_skill(user_catalogs[1].service)
+    original_get_skill = SkillsService.get_skill
+
+    async def raced_get_skill(
+        self: SkillsService,
+        name: str,
+        *,
+        enforce_integrity: bool = True,
+    ) -> dict[str, Any]:
+        skill = await original_get_skill(self, name, enforce_integrity=enforce_integrity)
+        skill[field] = value
+        return skill
+
+    monkeypatch.setattr(SkillsService, "get_skill", raced_get_skill)
+    module = await _module()
+    monkeypatch.setattr(module._executor, "execute", AsyncMock())
+
+    with pytest.raises(ValueError, match="^skill_not_found$"):
+        await module.execute_tool(
+            "skills.render",
+            {"skill_name": "review-paper"},
+            context=user_catalogs[1].context,
+        )
+    module._executor.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_render_integrity_race_is_bounded(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _seed_review_skill(user_catalogs[1].service)
+
+    async def blocked_load(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise ContextIntegrityBlocked("skill:user:1/review-paper", "quarantined")
+
+    monkeypatch.setattr(SkillsService, "get_skill", blocked_load)
+    module = await _module()
+
+    with pytest.raises(PermissionError, match="^context_integrity_blocked$"):
+        await module.execute_tool(
+            "skills.render",
+            {"skill_name": "review-paper"},
+            context=user_catalogs[1].context,
+        )
+
+
+@pytest.mark.asyncio
+async def test_discovery_integrity_exception_is_hidden_as_not_found(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def blocked_metadata(*_args: Any, **_kwargs: Any) -> SkillMetadata:
+        raise ContextIntegrityBlocked("skill:user:1/review-paper", "quarantined")
+
+    monkeypatch.setattr(SkillsService, "get_model_visible_skill_metadata", blocked_metadata)
+    module = await _module()
+
+    with pytest.raises(ValueError, match="^skill_not_found$"):
+        await module.execute_tool(
+            "skills.get",
+            {"name": "review-paper"},
+            context=user_catalogs[1].context,
+        )
+    with pytest.raises(ValueError, match="^skill_not_found$"):
+        await module.execute_tool(
+            "skills.render",
+            {"skill_name": "review-paper"},
+            context=user_catalogs[1].context,
+        )
+
+
+class TrackingDB:
+    instances: list[TrackingDB] = []
+
+    def __init__(self, db_path: str | Path, client_id: str) -> None:
+        self.db_path = db_path
+        self.client_id = client_id
+        self.closed = False
+        self.closed_after_worker = False
+        type(self).instances.append(self)
+
+    def close_all_connections(self) -> None:
+        self.closed = True
+
+
+class ScenarioService:
+    scenario = "list"
+
+    def __init__(self, user_id: int, base_path: Path, db: TrackingDB) -> None:
+        self.user_id = user_id
+        self.base_path = base_path
+        self.db = db
+
+    async def list_model_visible_skills_page(
+        self,
+        *,
+        q: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[SkillMetadata], int]:
+        del q, limit, offset
+        if self.scenario == "storage":
+            raise OSError("SENTINEL_CONTENT /sentinel/private/path")
+        return [_metadata()], 1
+
+    async def get_model_visible_skill_metadata(self, name: str) -> SkillMetadata:
+        if self.scenario == "not_found":
+            raise SkillNotFoundError(name)
+        return _metadata(name)
+
+    async def get_skill(self, name: str, *, enforce_integrity: bool = True) -> dict[str, Any]:
+        assert enforce_integrity is True
+        if self.scenario == "integrity":
+            raise ContextIntegrityBlocked(f"skill:user:1/{name}", "quarantined")
+        if self.scenario == "oversized":
+            return _skill_data(name, content="x" * 11)
+        return _skill_data(name)
+
+
+@pytest.mark.parametrize(
+    ("scenario", "tool_name", "arguments", "settings", "error_type", "message"),
+    [
+        ("list", "skills.list", {}, {}, None, None),
+        ("get", "skills.get", {"name": "review-paper"}, {}, None, None),
+        ("render", "skills.render", {"skill_name": "review-paper"}, {}, None, None),
+        (
+            "not_found",
+            "skills.get",
+            {"name": "missing"},
+            {},
+            ValueError,
+            "skill_not_found",
+        ),
+        (
+            "integrity",
+            "skills.render",
+            {"skill_name": "review-paper"},
+            {},
+            PermissionError,
+            "context_integrity_blocked",
+        ),
+        (
+            "oversized",
+            "skills.render",
+            {"skill_name": "review-paper"},
+            {"max_rendered_skill_chars": 10},
+            ValueError,
+            "rendered_skill_too_large: limit=10",
+        ),
+        ("storage", "skills.list", {}, {}, RuntimeError, "skills_unavailable"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_database_closes_on_every_opened_result_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    scenario: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    settings: dict[str, Any],
+    error_type: type[Exception] | None,
+    message: str | None,
+) -> None:
+    TrackingDB.instances = []
+    ScenarioService.scenario = scenario
+    monkeypatch.setattr(skills_module, "CharactersRAGDB", TrackingDB)
+    monkeypatch.setattr(skills_module, "SkillsService", ScenarioService)
+    module = await _module(settings)
+    context = RequestContext(
+        request_id="tracking",
+        user_id="1",
+        db_paths={"chacha": str(tmp_path / "ChaChaNotes.db")},
+    )
+
+    if error_type is None:
+        await module.execute_tool(tool_name, arguments, context=context)
+    else:
+        with pytest.raises(error_type, match=f"^{message}$"):
+            await module.execute_tool(tool_name, arguments, context=context)
+
+    assert len(TrackingDB.instances) == 1
+    assert TrackingDB.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_service_construction_failure_closes_partial_database_in_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    TrackingDB.instances = []
+    constructor_thread: list[int] = []
+    close_thread: list[int] = []
+
+    class FailingService:
+        def __init__(self, user_id: int, base_path: Path, db: TrackingDB) -> None:
+            del user_id, base_path, db
+            constructor_thread.append(threading.get_ident())
+            raise RuntimeError("private constructor failure")
+
+    original_close = TrackingDB.close_all_connections
+
+    def record_close(self: TrackingDB) -> None:
+        close_thread.append(threading.get_ident())
+        original_close(self)
+
+    monkeypatch.setattr(TrackingDB, "close_all_connections", record_close)
+    monkeypatch.setattr(skills_module, "CharactersRAGDB", TrackingDB)
+    monkeypatch.setattr(skills_module, "SkillsService", FailingService)
+    module = await _module()
+    event_loop_thread = threading.get_ident()
+    context = RequestContext(
+        request_id="constructor-failure",
+        user_id="1",
+        db_paths={"chacha": str(tmp_path / "ChaChaNotes.db")},
+    )
+
+    with pytest.raises(RuntimeError, match="^skills_unavailable$"):
+        await module.execute_tool("skills.list", {}, context=context)
+
+    assert TrackingDB.instances[0].closed is True
+    assert constructor_thread == close_thread
+    assert constructor_thread != [event_loop_thread]
+
+
+@pytest.mark.asyncio
+async def test_storage_failure_log_excludes_exception_message_content_and_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    TrackingDB.instances = []
+    ScenarioService.scenario = "storage"
+    monkeypatch.setattr(skills_module, "CharactersRAGDB", TrackingDB)
+    monkeypatch.setattr(skills_module, "SkillsService", ScenarioService)
+    module = await _module()
+    context = RequestContext(
+        request_id="storage-log",
+        user_id="7",
+        db_paths={"chacha": str(tmp_path / "ChaChaNotes.db")},
+    )
+    messages: list[str] = []
+    sink_id = logger.add(
+        messages.append,
+        format="{message}",
+        filter=lambda record: record["message"].startswith("skills operation="),
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="^skills_unavailable$"):
+            await module.execute_tool("skills.list", {}, context=context)
+    finally:
+        logger.remove(sink_id)
+
+    log_text = "".join(messages)
+    assert "skills operation=skills.list user_id=7 exception=OSError" in log_text
+    assert "SENTINEL_CONTENT" not in log_text
+    assert "/sentinel/private/path" not in log_text
+    assert str(tmp_path) not in log_text
+
+
+@pytest.mark.asyncio
+async def test_cancellation_waits_for_worker_before_database_close(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    TrackingDB.instances = []
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    worker_finished = threading.Event()
+
+    class BlockingService(ScenarioService):
+        async def list_model_visible_skills_page(
+            self,
+            *,
+            q: str | None = None,
+            limit: int = 50,
+            offset: int = 0,
+        ) -> tuple[list[SkillMetadata], int]:
+            del q, limit, offset
+
+            def block() -> tuple[list[SkillMetadata], int]:
+                worker_started.set()
+                release_worker.wait(timeout=5)
+                worker_finished.set()
+                return [], 0
+
+            return await asyncio.to_thread(block)
+
+    original_close = TrackingDB.close_all_connections
+
+    def ordered_close(self: TrackingDB) -> None:
+        self.closed_after_worker = worker_finished.is_set()
+        original_close(self)
+
+    monkeypatch.setattr(TrackingDB, "close_all_connections", ordered_close)
+    monkeypatch.setattr(skills_module, "CharactersRAGDB", TrackingDB)
+    monkeypatch.setattr(skills_module, "SkillsService", BlockingService)
+    module = await _module()
+    context = RequestContext(
+        request_id="cancel",
+        user_id="1",
+        db_paths={"chacha": str(tmp_path / "ChaChaNotes.db")},
+    )
+    task = asyncio.create_task(module.execute_tool("skills.list", {}, context=context))
+    assert await asyncio.to_thread(worker_started.wait, 2)
+
+    task.cancel()
+    await asyncio.sleep(0.05)
+    assert task.done() is False
+    assert TrackingDB.instances[0].closed is False
+
+    release_worker.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert worker_finished.is_set()
+    assert TrackingDB.instances[0].closed is True
+    assert TrackingDB.instances[0].closed_after_worker is True

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py
@@ -25,7 +25,11 @@ from tldw_Server_API.app.core.MCP_unified.modules.implementations.skills_module 
 from tldw_Server_API.app.core.MCP_unified.protocol_types import RequestContext
 from tldw_Server_API.app.core.Skills.exceptions import SkillNotFoundError
 from tldw_Server_API.app.core.Skills.skill_executor import SkillExecutionResult, SkillExecutor
-from tldw_Server_API.app.core.Skills.skills_service import SkillMetadata, SkillsService
+from tldw_Server_API.app.core.Skills.skills_service import (
+    SKILL_NAME_PATTERN,
+    SkillMetadata,
+    SkillsService,
+)
 
 
 @dataclass
@@ -157,6 +161,11 @@ async def test_tool_catalog_is_exact_and_read_only() -> None:
     assert list_tool["inputSchema"]["properties"]["limit"]["default"] == 17
     assert list_tool["inputSchema"]["properties"]["q"]["maxLength"] == 200
     assert tools[2]["inputSchema"]["properties"]["arguments"]["maxLength"] == 10_000
+    assert all(tool["inputSchema"]["additionalProperties"] is False for tool in tools)
+    for tool, field in ((tools[1], "name"), (tools[2], "skill_name")):
+        name_schema = tool["inputSchema"]["properties"][field]
+        assert name_schema["maxLength"] == 64
+        assert name_schema["pattern"] == SKILL_NAME_PATTERN.pattern
 
 
 @pytest.mark.parametrize(
@@ -207,11 +216,22 @@ async def test_settings_use_defaults_for_invalid_types_and_clamp_integers(
         ("skills.list", {"limit": 0}, "limit must be 1..100"),
         ("skills.list", {"limit": 101}, "limit must be 1..100"),
         ("skills.list", {"q": "q" * 201}, "q must be at most 200 characters"),
+        ("skills.list", {"q": None}, "q must be a string"),
         ("skills.list", {"q": 1}, "q must be a string"),
         ("skills.get", {}, "name must be a valid skill name"),
         ("skills.get", {"name": "Invalid_Name"}, "name must be a valid skill name"),
+        (
+            "skills.get",
+            {"name": f" {'a' * 63} "},
+            "name must be a valid skill name",
+        ),
         ("skills.render", {}, "skill_name must be a valid skill name"),
         ("skills.render", {"skill_name": True}, "skill_name must be a valid skill name"),
+        (
+            "skills.render",
+            {"skill_name": f" {'a' * 63} "},
+            "skill_name must be a valid skill name",
+        ),
         (
             "skills.render",
             {"skill_name": "valid", "arguments": "x" * 10_001},
@@ -880,15 +900,33 @@ async def test_storage_failure_log_excludes_exception_message_content_and_path(
     assert str(tmp_path) not in log_text
 
 
+@pytest.mark.parametrize("blocked_phase", ["construction", "service", "closure"])
 @pytest.mark.asyncio
-async def test_cancellation_waits_for_worker_before_database_close(
+async def test_repeated_cancellation_waits_for_lifecycle_and_database_close(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    blocked_phase: str,
 ) -> None:
     TrackingDB.instances = []
-    worker_started = threading.Event()
-    release_worker = threading.Event()
-    worker_finished = threading.Event()
+    phase_started = threading.Event()
+    release_phase = threading.Event()
+    phase_finished = threading.Event()
+
+    def block_phase() -> None:
+        phase_started.set()
+        release_phase.wait(timeout=5)
+        phase_finished.set()
+
+    class BlockingDB(TrackingDB):
+        def __init__(self, db_path: str | Path, client_id: str) -> None:
+            super().__init__(db_path, client_id)
+            if blocked_phase == "construction":
+                block_phase()
+
+        def close_all_connections(self) -> None:
+            if blocked_phase == "closure":
+                block_phase()
+            super().close_all_connections()
 
     class BlockingService(ScenarioService):
         async def list_model_visible_skills_page(
@@ -899,23 +937,11 @@ async def test_cancellation_waits_for_worker_before_database_close(
             offset: int = 0,
         ) -> tuple[list[SkillMetadata], int]:
             del q, limit, offset
+            if blocked_phase == "service":
+                await asyncio.to_thread(block_phase)
+            return [], 0
 
-            def block() -> tuple[list[SkillMetadata], int]:
-                worker_started.set()
-                release_worker.wait(timeout=5)
-                worker_finished.set()
-                return [], 0
-
-            return await asyncio.to_thread(block)
-
-    original_close = TrackingDB.close_all_connections
-
-    def ordered_close(self: TrackingDB) -> None:
-        self.closed_after_worker = worker_finished.is_set()
-        original_close(self)
-
-    monkeypatch.setattr(TrackingDB, "close_all_connections", ordered_close)
-    monkeypatch.setattr(skills_module, "CharactersRAGDB", TrackingDB)
+    monkeypatch.setattr(skills_module, "CharactersRAGDB", BlockingDB)
     monkeypatch.setattr(skills_module, "SkillsService", BlockingService)
     module = await _module()
     context = RequestContext(
@@ -924,17 +950,135 @@ async def test_cancellation_waits_for_worker_before_database_close(
         db_paths={"chacha": str(tmp_path / "ChaChaNotes.db")},
     )
     task = asyncio.create_task(module.execute_tool("skills.list", {}, context=context))
-    assert await asyncio.to_thread(worker_started.wait, 2)
+    assert await asyncio.to_thread(phase_started.wait, 2)
 
     task.cancel()
-    await asyncio.sleep(0.05)
-    assert task.done() is False
-    assert TrackingDB.instances[0].closed is False
+    await asyncio.sleep(0.02)
+    task.cancel()
+    await asyncio.sleep(0.02)
+    completed_before_release = task.done()
+    closed_before_release = TrackingDB.instances[0].closed
 
-    release_worker.set()
+    release_phase.set()
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert worker_finished.is_set()
+    assert completed_before_release is False
+    assert closed_before_release is False
+    assert phase_finished.is_set()
     assert TrackingDB.instances[0].closed is True
-    assert TrackingDB.instances[0].closed_after_worker is True
+
+
+@pytest.mark.asyncio
+async def test_successful_operation_close_failure_is_logged_and_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class CloseFailingDB(TrackingDB):
+        def close_all_connections(self) -> None:
+            super().close_all_connections()
+            raise OSError("SENTINEL_CLOSE /sentinel/close/path")
+
+    TrackingDB.instances = []
+    ScenarioService.scenario = "list"
+    monkeypatch.setattr(skills_module, "CharactersRAGDB", CloseFailingDB)
+    monkeypatch.setattr(skills_module, "SkillsService", ScenarioService)
+    module = await _module()
+    context = RequestContext(
+        request_id="close-failure",
+        user_id="7",
+        db_paths={"chacha": str(tmp_path / "ChaChaNotes.db")},
+    )
+    messages: list[str] = []
+    sink_id = logger.add(
+        messages.append,
+        format="{message}",
+        filter=lambda record: record["message"].startswith("skills operation="),
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="^skills_unavailable$"):
+            await module.execute_tool("skills.list", {}, context=context)
+    finally:
+        logger.remove(sink_id)
+
+    log_text = "".join(messages)
+    assert "skills operation=skills.list user_id=7 exception=OSError" in log_text
+    assert "SENTINEL_CLOSE" not in log_text
+    assert "/sentinel/close/path" not in log_text
+    assert str(tmp_path) not in log_text
+
+
+@pytest.mark.asyncio
+async def test_bounded_operation_error_takes_precedence_over_close_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class CloseFailingDB(TrackingDB):
+        def close_all_connections(self) -> None:
+            super().close_all_connections()
+            raise OSError("private close failure")
+
+    TrackingDB.instances = []
+    ScenarioService.scenario = "not_found"
+    monkeypatch.setattr(skills_module, "CharactersRAGDB", CloseFailingDB)
+    monkeypatch.setattr(skills_module, "SkillsService", ScenarioService)
+    module = await _module()
+    context = RequestContext(
+        request_id="bounded-precedence",
+        user_id="1",
+        db_paths={"chacha": str(tmp_path / "ChaChaNotes.db")},
+    )
+
+    with pytest.raises(ValueError, match="^skill_not_found$"):
+        await module.execute_tool("skills.get", {"name": "missing"}, context=context)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_preserves_cancelled_error_when_close_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    close_started = threading.Event()
+    release_close = threading.Event()
+
+    class BlockingCloseFailingDB(TrackingDB):
+        def close_all_connections(self) -> None:
+            close_started.set()
+            release_close.wait(timeout=5)
+            super().close_all_connections()
+            raise OSError("SENTINEL_CLOSE /sentinel/close/path")
+
+    TrackingDB.instances = []
+    ScenarioService.scenario = "list"
+    monkeypatch.setattr(skills_module, "CharactersRAGDB", BlockingCloseFailingDB)
+    monkeypatch.setattr(skills_module, "SkillsService", ScenarioService)
+    module = await _module()
+    context = RequestContext(
+        request_id="cancel-close-failure",
+        user_id="9",
+        db_paths={"chacha": str(tmp_path / "ChaChaNotes.db")},
+    )
+    messages: list[str] = []
+    sink_id = logger.add(
+        messages.append,
+        format="{message}",
+        filter=lambda record: record["message"].startswith("skills operation="),
+    )
+    task = asyncio.create_task(module.execute_tool("skills.list", {}, context=context))
+    assert await asyncio.to_thread(close_started.wait, 2)
+
+    try:
+        task.cancel()
+        await asyncio.sleep(0.02)
+        release_close.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        release_close.set()
+        logger.remove(sink_id)
+
+    log_text = "".join(messages)
+    assert "skills operation=skills.list user_id=9 exception=OSError" in log_text
+    assert "SENTINEL_CLOSE" not in log_text
+    assert "/sentinel/close/path" not in log_text

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py
@@ -911,6 +911,7 @@ async def test_repeated_cancellation_waits_for_lifecycle_and_database_close(
     phase_started = threading.Event()
     release_phase = threading.Event()
     phase_finished = threading.Event()
+    operation_calls = 0
 
     def block_phase() -> None:
         phase_started.set()
@@ -936,7 +937,9 @@ async def test_repeated_cancellation_waits_for_lifecycle_and_database_close(
             limit: int = 50,
             offset: int = 0,
         ) -> tuple[list[SkillMetadata], int]:
+            nonlocal operation_calls
             del q, limit, offset
+            operation_calls += 1
             if blocked_phase == "service":
                 await asyncio.to_thread(block_phase)
             return [], 0
@@ -967,6 +970,8 @@ async def test_repeated_cancellation_waits_for_lifecycle_and_database_close(
     assert closed_before_release is False
     assert phase_finished.is_set()
     assert TrackingDB.instances[0].closed is True
+    if blocked_phase == "construction":
+        assert operation_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_skills_module.py
@@ -31,6 +31,8 @@ from tldw_Server_API.app.core.Skills.skills_service import (
     SkillsService,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @dataclass
 class UserCatalog:
@@ -557,6 +559,37 @@ async def test_render_calls_visibility_gate_and_verified_load_once(
 
     assert metadata_calls == 1
     assert skill_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_render_applies_schema_defaults_to_null_visibility_flags(
+    user_catalogs: dict[int, UserCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _seed_review_skill(user_catalogs[1].service)
+    original_get_skill = SkillsService.get_skill
+
+    async def legacy_get_skill(
+        self: SkillsService,
+        name: str,
+        *,
+        enforce_integrity: bool = True,
+    ) -> dict[str, Any]:
+        skill = await original_get_skill(self, name, enforce_integrity=enforce_integrity)
+        skill["user_invocable"] = None
+        skill["disable_model_invocation"] = None
+        return skill
+
+    monkeypatch.setattr(SkillsService, "get_skill", legacy_get_skill)
+    module = await _module()
+
+    result = await module.execute_tool(
+        "skills.render",
+        {"skill_name": "review-paper", "arguments": "issue 42"},
+        context=user_catalogs[1].context,
+    )
+
+    assert result["rendered_prompt"] == "Review issue 42"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -891,21 +891,70 @@ class SkillsService:
         )
         return [self._metadata_from_row(row) for row in rows]
 
-    async def get_skill(self, name: str, *, enforce_integrity: bool = True) -> dict[str, Any]:
-        """
-        Get full skill content.
+    def _is_model_visible_registry_row(self, row: dict[str, Any]) -> bool:
+        """Return whether a registry row is eligible for model-facing discovery."""
+        name = str(row.get("name") or "")
+        return (
+            bool(row.get("user_invocable", True))
+            and not bool(row.get("disable_model_invocation", False))
+            and bool(name)
+            and self._is_skill_allowed(name, purpose="skill_discovery")
+        )
 
-        Args:
-            name: The skill name
+    def _list_model_visible_skills_page_sync(
+        self,
+        q: str | None,
+        limit: int,
+        offset: int,
+    ) -> tuple[list[SkillMetadata], int]:
+        """Return a filtered model-visible page and total from one registry query."""
+        rows = self._get_db().list_skill_registry(
+            include_hidden=True,
+            include_deleted=False,
+            q=q,
+            sort="name",
+            order="asc",
+            limit=None,
+            offset=0,
+        )
+        visible_rows = [row for row in rows if self._is_model_visible_registry_row(row)]
+        total = len(visible_rows)
+        return [self._metadata_from_row(row) for row in visible_rows[offset : offset + limit]], total
 
-        Returns:
-            Full skill data including content
-
-        Raises:
-            SkillNotFoundError: If skill doesn't exist
-        """
-        name = name.strip().lower()
+    async def list_model_visible_skills_page(
+        self,
+        *,
+        q: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[SkillMetadata], int]:
+        """Return a model-visible Skill metadata page with its filtered total."""
         await self._sync_registry_async()
+        return await asyncio.to_thread(
+            self._list_model_visible_skills_page_sync,
+            q,
+            limit,
+            offset,
+        )
+
+    def _get_model_visible_skill_metadata_sync(self, name: str) -> SkillMetadata:
+        """Return metadata for one model-visible Skill or hide it as not found."""
+        row = self._get_db().get_skill_registry(name, include_deleted=False)
+        if not row or not self._is_model_visible_registry_row(row):
+            raise SkillNotFoundError(name)
+        return self._metadata_from_row(row)
+
+    async def get_model_visible_skill_metadata(self, name: str) -> SkillMetadata:
+        """Return metadata for an exact model-visible Skill lookup."""
+        normalized = self._normalize_and_validate_skill_name(name)
+        await self._sync_registry_async()
+        return await asyncio.to_thread(
+            self._get_model_visible_skill_metadata_sync,
+            normalized,
+        )
+
+    def _get_skill_sync(self, name: str, *, enforce_integrity: bool) -> dict[str, Any]:
+        """Load and verify a Skill after its asynchronous registry synchronization."""
         db = self._get_db()
 
         row = db.get_skill_registry(name, include_deleted=False)
@@ -947,6 +996,27 @@ class SkillsService:
             "last_modified": metadata.last_modified,
             "version": metadata.version,
         }
+
+    async def get_skill(self, name: str, *, enforce_integrity: bool = True) -> dict[str, Any]:
+        """
+        Get full skill content.
+
+        Args:
+            name: The skill name
+
+        Returns:
+            Full skill data including content
+
+        Raises:
+            SkillNotFoundError: If skill doesn't exist
+        """
+        name = name.strip().lower()
+        await self._sync_registry_async()
+        return await asyncio.to_thread(
+            self._get_skill_sync,
+            name,
+            enforce_integrity=enforce_integrity,
+        )
 
     async def create_skill(
         self,

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -667,13 +667,17 @@ class SkillsService:
     def _metadata_from_row(self, row: dict[str, Any]) -> SkillMetadata:
         created_at = row.get("created_at")
         last_modified = row.get("last_modified")
+        disable_model_invocation = row.get("disable_model_invocation")
+        user_invocable = row.get("user_invocable")
         return SkillMetadata(
             id=row.get("uuid") or row.get("id"),
             name=row.get("name") or "",
             description=row.get("description"),
             argument_hint=row.get("argument_hint"),
-            disable_model_invocation=bool(row.get("disable_model_invocation", False)),
-            user_invocable=bool(row.get("user_invocable", True)),
+            disable_model_invocation=(
+                False if disable_model_invocation is None else bool(disable_model_invocation)
+            ),
+            user_invocable=True if user_invocable is None else bool(user_invocable),
             allowed_tools=row.get("allowed_tools"),
             model=row.get("model"),
             context=row.get("context", "inline"),
@@ -894,9 +898,11 @@ class SkillsService:
     def _is_model_visible_registry_row(self, row: dict[str, Any]) -> bool:
         """Return whether a registry row is eligible for model-facing discovery."""
         name = str(row.get("name") or "")
+        user_invocable = row.get("user_invocable")
+        disable_model_invocation = row.get("disable_model_invocation")
         return (
-            bool(row.get("user_invocable", True))
-            and not bool(row.get("disable_model_invocation", False))
+            (True if user_invocable is None else bool(user_invocable))
+            and not (False if disable_model_invocation is None else bool(disable_model_invocation))
             and bool(name)
             and self._is_skill_allowed(name, purpose="skill_discovery")
         )
@@ -917,9 +923,16 @@ class SkillsService:
             limit=None,
             offset=0,
         )
-        visible_rows = [row for row in rows if self._is_model_visible_registry_row(row)]
-        total = len(visible_rows)
-        return [self._metadata_from_row(row) for row in visible_rows[offset : offset + limit]], total
+        page: list[SkillMetadata] = []
+        total = 0
+        page_end = offset + limit
+        for row in rows:
+            if not self._is_model_visible_registry_row(row):
+                continue
+            if offset <= total < page_end:
+                page.append(self._metadata_from_row(row))
+            total += 1
+        return page, total
 
     async def list_model_visible_skills_page(
         self,

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -890,6 +890,22 @@ class WritingAnnotationReviewJobError(RuntimeError):
         self.failure_code = failure_code
 
 
+class SkillsMCPNotFoundError(ValueError):
+    """Bounded public not-found response from the Skills MCP module."""
+
+
+class SkillsMCPRenderedTooLargeError(ValueError):
+    """Bounded public rendered-output rejection from the Skills MCP module."""
+
+
+class SkillsMCPContextIntegrityError(PermissionError):
+    """Bounded public render-time integrity rejection from the Skills MCP module."""
+
+
+class SkillsMCPDatabaseCloseError(Exception):
+    """Internal marker for a logged Skills MCP database close failure."""
+
+
 class WorkflowAdapterError(Exception):
     """Base exception for workflow adapter errors."""
 

--- a/tldw_Server_API/tests/Skills/unit/test_skills_service.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skills_service.py
@@ -3,8 +3,10 @@
 # Unit tests for the SkillsService class
 #
 import tempfile
+import threading
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -176,6 +178,127 @@ Skill content here.
         """Test that getting a non-existent skill raises NotFoundError."""
         with pytest.raises(SkillNotFoundError):
             await service.get_skill("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_list_model_visible_skills_page_filters_and_counts_once(self, service, monkeypatch):
+        """Catalog pages use one matching registry query and visibility pass."""
+        await service.create_skill("visible", "---\nuser-invocable: true\n---\nVisible")
+        await service.create_skill("hidden", "---\nuser-invocable: false\n---\nHidden")
+        await service.create_skill(
+            "manual-only",
+            "---\ndisable-model-invocation: true\n---\nManual",
+        )
+        await service._sync_registry_async(force=True)
+        monkeypatch.setattr(service, "_sync_registry_async", AsyncMock())
+        calls = 0
+        integrity_calls: list[str] = []
+        original = service._get_db().list_skill_registry
+
+        def counted_list(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)
+
+        def allowed(name, *, purpose):
+            integrity_calls.append(name)
+            assert purpose == "skill_discovery"
+            return True
+
+        monkeypatch.setattr(service._get_db(), "list_skill_registry", counted_list)
+        monkeypatch.setattr(service, "_is_skill_allowed", allowed)
+
+        items, total = await service.list_model_visible_skills_page(limit=10, offset=0)
+
+        assert [item.name for item in items] == ["visible"]
+        assert total == 1
+        assert calls == 1
+        assert integrity_calls == ["visible"]
+
+    @pytest.mark.asyncio
+    async def test_get_model_visible_skill_metadata_hides_non_model_skills(self, service):
+        """Model-disabled skills are indistinguishable from missing catalog entries."""
+        await service.create_skill(
+            "manual-only",
+            "---\ndisable-model-invocation: true\n---\nManual",
+        )
+
+        with pytest.raises(SkillNotFoundError):
+            await service.get_model_visible_skill_metadata("manual-only")
+
+    @pytest.mark.asyncio
+    async def test_model_visible_metadata_hides_integrity_blocked_skills(self, service, monkeypatch):
+        """Integrity-blocked skills are excluded from page and exact discovery."""
+        await service.create_skill("blocked", "---\n---\nBlocked")
+        monkeypatch.setattr(service, "_is_skill_allowed", lambda *_args, **_kwargs: False)
+
+        items, total = await service.list_model_visible_skills_page()
+
+        assert items == []
+        assert total == 0
+        with pytest.raises(SkillNotFoundError):
+            await service.get_model_visible_skill_metadata("blocked")
+
+    @pytest.mark.asyncio
+    async def test_model_visible_metadata_omits_skill_content_and_supporting_files(self, service, monkeypatch):
+        """Catalog helpers return registry metadata without parsing a full skill."""
+        await service.create_skill(
+            "metadata-only",
+            "---\ndescription: Metadata only\n---\nSecret instructions",
+            supporting_files={"reference.md": "Private supporting text"},
+        )
+        monkeypatch.setattr(service, "_is_skill_allowed", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(
+            service,
+            "_parse_verified_skill_directory",
+            lambda *_args, **_kwargs: pytest.fail("metadata helpers must not parse full Skill directories"),
+        )
+        monkeypatch.setattr(
+            service,
+            "_parse_unchecked_skill_directory",
+            lambda *_args, **_kwargs: pytest.fail("metadata helpers must not parse full Skill directories"),
+        )
+
+        metadata = await service.get_model_visible_skill_metadata("metadata-only")
+        items, _ = await service.list_model_visible_skills_page()
+
+        assert [item.name for item in items] == ["metadata-only"]
+        assert metadata.description == "Metadata only"
+        assert metadata.directory_path
+        assert metadata.content_hash
+        for item in [metadata, *items]:
+            assert not hasattr(item, "content")
+            assert not hasattr(item, "raw_content")
+            assert not hasattr(item, "supporting_files")
+
+    @pytest.mark.asyncio
+    async def test_list_model_visible_skills_page_offloads_verified_load(self, service, monkeypatch):
+        """The catalog page's synchronous registry and integrity work leaves the event loop."""
+        event_loop_thread = threading.get_ident()
+        worker_threads: list[int] = []
+
+        def record_thread(*_args, **_kwargs):
+            worker_threads.append(threading.get_ident())
+            return [], 0
+
+        monkeypatch.setattr(service, "_list_model_visible_skills_page_sync", record_thread)
+
+        assert await service.list_model_visible_skills_page() == ([], 0)
+        assert worker_threads != [event_loop_thread]
+
+    @pytest.mark.asyncio
+    async def test_get_skill_verified_load_offload_preserves_content_and_supporting_files(self, service):
+        """Verified loads retain the established full-content response after offloading."""
+        await service.create_skill(
+            "verified-load",
+            "---\ndescription: Full payload\n---\nSkill instructions",
+            supporting_files={"reference.md": "Reference text"},
+        )
+
+        result = await service.get_skill("verified-load")
+
+        assert result["content"] == "Skill instructions"
+        assert result["raw_content"] == "---\ndescription: Full payload\n---\nSkill instructions"
+        assert result["supporting_files"] == {"reference.md": "Reference text"}
 
     @pytest.mark.asyncio
     async def test_list_skills(self, service):

--- a/tldw_Server_API/tests/Skills/unit/test_skills_service.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skills_service.py
@@ -215,6 +215,36 @@ Skill content here.
         assert integrity_calls == ["visible"]
 
     @pytest.mark.asyncio
+    async def test_model_visible_page_applies_schema_defaults_to_null_flags(
+        self,
+        service,
+        monkeypatch,
+    ):
+        """Legacy nullable registry flags retain their documented visibility defaults."""
+        monkeypatch.setattr(service, "_sync_registry_async", AsyncMock())
+        monkeypatch.setattr(
+            service._get_db(),
+            "list_skill_registry",
+            lambda **_kwargs: [
+                {
+                    "uuid": "legacy-null-flags",
+                    "name": "legacy-visible",
+                    "user_invocable": None,
+                    "disable_model_invocation": None,
+                    "version": 1,
+                }
+            ],
+        )
+        monkeypatch.setattr(service, "_is_skill_allowed", lambda *_args, **_kwargs: True)
+
+        items, total = await service.list_model_visible_skills_page()
+
+        assert total == 1
+        assert [item.name for item in items] == ["legacy-visible"]
+        assert items[0].user_invocable is True
+        assert items[0].disable_model_invocation is False
+
+    @pytest.mark.asyncio
     async def test_get_model_visible_skill_metadata_hides_non_model_skills(self, service):
         """Model-disabled skills are indistinguishable from missing catalog entries."""
         await service.create_skill(


### PR DESCRIPTION
## Overview

- Add user-scoped, metadata-only `skills.list` and `skills.get` MCP tools.
- Add policy-gated `skills.render` with forced dry-run behavior, bounded input/output, integrity checks, user isolation, safe errors, and cancellation-safe database cleanup.
- Add canonical Skill permission subjects and approval-lease support, including the gateway CLI operator path.
- Register the module as read-only and document its operating contract.

## Change summary

**Required before this PR can be marked ready:** the human requester must replace this paragraph with their own explanation of what changed and why these implementation choices were made. AI-generated text does not satisfy the repository merge gate.

## Verification

- 216 Skills service/executor/module/registration tests passed.
- 45 permission/gateway/grant tests passed.
- 2 gateway CLI approval-grant lifecycle tests passed.
- 30 policy-grant manager/store tests passed.
- Focused Ruff checks passed.
- Bandit found no medium/high findings and no new task-related findings.
- Final whole-branch review found one Important CLI integration gap; fixed and focused re-review approved with no findings.

## Known baseline failures

`test_runtime_package_boundary.py`: 45 passed, 2 unrelated existing publish-workflow assertions failed because the workflow now includes a push trigger and duplicate-version guard. These files are outside this PR's changed hunks.

## Tracking

- Backlog: `TASK-2294.1`
- Design: `Docs/Design/2026-07-13-skills-mcp-catalog-render-design.md`
- Plan: `Docs/Plans/IMPLEMENTATION_PLAN_skills_mcp_catalog_render_TASK_2294_1.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only `skills` MCP module so models can discover user-owned Skills and safely dry‑render them without execution, gated by policy and approvals. Completes TASK-2294.1.

- **New Features**
  - Exposed `skills.list` (paginated, bounded) and `skills.get` (metadata only).
  - Added `skills.render` with forced dry‑run, policy gate, approval‑lease support, strict size limits, integrity checks, cancellation short‑circuit, and cleanup.
  - Canonical `skill` permission subject derived only from `skill_name`; patterns and values normalized to lowercase; CLI and stores now support canonicalized `skill` approval grants.
  - Updated `SkillsService` with model‑visible catalog filtering (hides disabled/non‑invocable entries, no content exposure) and sane defaults for invocability flags.
  - Registered `skills` as `read_only` in docs and module surface; default module added to `tldw_Server_API/Config_Files/mcp_modules.yaml`; tests cover module, gateway (CLI/FastAPI/simulation), policy, and service paths.

- **Migration**
  - No breaking changes. Ensure the `skills` module is enabled in `tldw_Server_API/Config_Files/mcp_modules.yaml` (default true).
  - Optional settings: `list_page_size` and `max_rendered_skill_chars`.

<sup>Written for commit 4addd2627b0901875ba4e56ed9de02ffbfef30a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

