### PR TITLE
fix(llm): route public custom adapters through checked egress

### DIFF
--- a/Docs/ADR/030-configured-local-llm-egress-policy.md
+++ b/Docs/ADR/030-configured-local-llm-egress-policy.md
@@ -44,9 +44,8 @@ Local LLM endpoints on LAN, Docker networks, and approved overlay addresses can 
 
 Adding a configured-local adapter requires registering its server configuration aliases with the trusted resolver and routing its request modes through the checked transport. UI consumers should continue to use the shared `TldwModelsService`/`fetchChatModels` path instead of creating another discovery or cache layer.
 
-Novita, Poe, Together, and other public custom-adapter subclasses do not receive configured-local scope. Migrating those public providers from the legacy client-factory seam to checked central egress is tracked by TASK-12972.1.
+Novita, Poe, and Together now use checked central egress under ordinary policy and do not receive configured-local scope. TASK-12972.1 completed the migration from their legacy client-factory seam.
 
 ## Follow-up
 
-- TASK-12972.1: route Novita, Poe, and Together through checked central egress without granting configured-local scope.
 - Keep the WebUI and browser-extension test configurations on the same shared model/cache contract.

--- a/Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
@@ -29,7 +29,7 @@
 
 **Tests:** Focused public-provider tests fail because current production code still calls `http_client_factory`.
 
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 1.1: Write failing sync and streaming transport tests
 
@@ -150,7 +150,9 @@ Do not commit the failing tests; repository commits must stay green.
 
 **Tests:** Stage 1 tests turn green and configured-custom regressions remain green.
 
-**Status:** Not Started
+**Status:** Complete
+
+Execution evidence: the public contract RED run produced 9 expected failures and 1 pass; the security-boundary RED run produced 6 expected failures and 1 pass. Pre-commit review added a configured-custom injection-compatibility regression that failed 1/1 before the redirect keyword was restricted to public providers. Final focused GREEN passed 40/40 with 2 warnings, and adjacent payload/timeout/role/error-mapping GREEN passed 34/34 with 4 warnings. Scoped Ruff correctness and `git diff --check` passed before commit `5532d7f097`.
 
 ### Task 2.1: Implement the minimal shared path
 
@@ -249,7 +251,9 @@ git commit -m "fix(llm): check public custom adapter egress (TASK-12972.1)"
 
 **Tests:** Complete prior Stage 3 adapter union plus static/security checks.
 
-**Status:** Not Started
+**Status:** In Progress
+
+Pre-rebase verification evidence: the complete affected adapter union passed 143/143 with 5 warnings. Scoped Ruff correctness, Python compilation, the production seam search, and `git diff --check` passed. Bandit scanned 373 production lines with 0 findings and 0 errors. Whole-branch self-review against base `28a305eefc` found no critical, important, or minor code issues; independent delegated review was unavailable under the current no-delegation policy. Final verification remains pending after rebasing onto current `origin/dev`.
 
 ### Task 3.1: Update the ADR and plan status
 

--- a/Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
@@ -363,6 +363,8 @@ git commit -m "docs: finalize public adapter egress migration (TASK-12972.1)"
 
 **Status:** Complete
 
+Post-publication refresh: at requester direction, PR #2744 was rebased without conflicts onto `origin/dev` commit `571bbce834` after PR #2741 merged. The full affected adapter union passed again (143/143, 5 baseline warnings); scoped Ruff, Python compilation, the production seam search, `git diff --check`, and Bandit (373 lines, 0 findings/errors/skips) also passed before the force-with-lease update.
+
 ### Task 4.1: Push and create the pull request
 
 - [x] **Step 1: Verify branch state**

--- a/Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
@@ -361,27 +361,27 @@ git commit -m "docs: finalize public adapter egress migration (TASK-12972.1)"
 
 **Tests:** Re-check clean worktree and PR head after push; do not wait on CI if the requester says to ignore it.
 
-**Status:** In Progress
+**Status:** Complete
 
 ### Task 4.1: Push and create the pull request
 
-- [ ] **Step 1: Verify branch state**
+- [x] **Step 1: Verify branch state**
 
 ```bash
 git status --short --branch
 git log --oneline origin/dev..HEAD
 ```
 
-- [ ] **Step 2: Push the branch**
+- [x] **Step 2: Push the branch**
 
 ```bash
 git push -u origin codex/public-custom-egress
 ```
 
-- [ ] **Step 3: Open a ready PR against `dev`**
+- [x] **Step 3: Open a ready PR against `dev`**
 
 Summarize the checked transport migration and local verification. Leave the human-authored `Change summary` section for the requester; the PR is not merge-ready until that policy gate is satisfied.
 
-- [ ] **Step 4: Address review feedback**
+- [x] **Step 4: Address review feedback**
 
 Verify each comment against current code, fix actionable findings test-first, reply with evidence, resolve addressed threads, and keep the PR ready unless the requester says otherwise.

--- a/Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
@@ -37,7 +37,7 @@
 - Modify: `tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py:1-196`
 - Test: `tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py`
 
-- [ ] **Step 1: Replace the fake-client seam with checked-hook capture**
+- [x] **Step 1: Replace the fake-client seam with checked-hook capture**
 
 Keep `_FakeResp` as the response and stream context. Remove `_FakeClient` after no test needs it. Add one deliberate legacy guard that can be installed with `raising=False` during RED/GREEN:
 
@@ -46,7 +46,7 @@ def _forbid_legacy_factory(*_args, **_kwargs):
     pytest.fail("public provider used the legacy client factory")
 ```
 
-- [ ] **Step 2: Rewrite the non-streaming provider table**
+- [x] **Step 2: Rewrite the non-streaming provider table**
 
 Parameterize Novita, Poe, and Together with their existing environment variables and URL suffixes. Inject `adapter.http_fetcher`, install `_forbid_legacy_factory`, call `chat`, and assert:
 
@@ -60,7 +60,7 @@ assert captured["json"]["model"] == "test-model"
 assert captured["response_closed"] is True
 ```
 
-- [ ] **Step 3: Rewrite the streaming provider table**
+- [x] **Step 3: Rewrite the streaming provider table**
 
 Inject `adapter.http_streamer`, install `_forbid_legacy_factory`, consume `stream`, and assert the existing URL, payload, timeout, SSE, single-`[DONE]`, and context-cleanup contracts plus:
 
@@ -71,7 +71,7 @@ assert captured["response_entered"] is True
 assert captured["response_exited"] is True
 ```
 
-- [ ] **Step 4: Add async coverage for all three subclasses**
+- [x] **Step 4: Add async coverage for all three subclasses**
 
 Use `@pytest.mark.asyncio` and the same injected checked hooks:
 
@@ -85,7 +85,7 @@ assert [call[0] for call in calls] == ["chat", "stream"]
 assert all(call[1]["configured_endpoint"] is None for call in calls)
 ```
 
-- [ ] **Step 5: Run RED and verify the failure reason**
+- [x] **Step 5: Run RED and verify the failure reason**
 
 Run:
 
@@ -104,7 +104,7 @@ Expected: FAIL because Novita, Poe, and Together reach `_forbid_legacy_factory` 
 - Modify: `tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py:307-387`
 - Test: `tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py`
 
-- [ ] **Step 1: Replace the old public transport-boundary assertion**
+- [x] **Step 1: Replace the old public transport-boundary assertion**
 
 Rename `test_public_custom_subclasses_never_use_configured_local_transport` to describe checked ordinary egress. Inject a capturing `http_fetcher`, install a failing legacy factory with `raising=False`, and pass forged request fields:
 
@@ -123,11 +123,11 @@ request = {
 
 Capture the sanitized request by monkeypatching `validate_payload`. Assert every reserved field is absent from validation and JSON, and `captured["configured_endpoint"] is None`.
 
-- [ ] **Step 2: Add typed policy-error coverage for the public path**
+- [x] **Step 2: Add typed policy-error coverage for the public path**
 
 Use one representative public subclass (`NovitaAdapter`) because all three inherit the same methods. Inject fetch and stream hooks that raise an `EgressPolicyError` and exercise `chat`, `stream`, `achat`, and `astream`, following the existing configured-custom test shape. Assert the same error object or `reason_code` survives every mode.
 
-- [ ] **Step 3: Run RED and verify the failure reason**
+- [x] **Step 3: Run RED and verify the failure reason**
 
 Run:
 
@@ -162,11 +162,11 @@ Execution evidence: the public contract RED run produced 9 expected failures and
 - Test: `tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py`
 - Test: `tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py`
 
-- [ ] **Step 1: Delete obsolete transport plumbing**
+- [x] **Step 1: Delete obsolete transport plumbing**
 
 Remove `ExitStack`, the `create_client` import, and the module-level `http_client_factory = create_client`. Keep the string `"http_client_factory"` in `_RESERVED_CONTEXT_KEYS` so caller data cannot leak into validation or provider payloads.
 
-- [ ] **Step 2: Route every non-streaming call through `http_fetcher`**
+- [x] **Step 2: Route every non-streaming call through `http_fetcher`**
 
 Delete the public-only factory branch and retain the existing response `finally`:
 
@@ -189,7 +189,7 @@ finally:
 
 The boolean preserves configured-custom fetch defaults and the public path's previous no-redirect behavior.
 
-- [ ] **Step 3: Route every streaming call through `http_streamer`**
+- [x] **Step 3: Route every streaming call through `http_streamer`**
 
 Replace the `ExitStack` and conditional client construction with the existing checked context:
 
@@ -206,7 +206,7 @@ with self.http_streamer(
     # Keep the existing SSE iteration and finalize_stream body unchanged.
 ```
 
-- [ ] **Step 4: Run focused GREEN**
+- [x] **Step 4: Run focused GREEN**
 
 Run:
 
@@ -219,7 +219,7 @@ python -m pytest -q --tb=short \
 
 Expected: PASS with all Stage 1 and existing configured-custom cases green.
 
-- [ ] **Step 5: Run adjacent compatibility tests**
+- [x] **Step 5: Run adjacent compatibility tests**
 
 Run:
 
@@ -233,7 +233,7 @@ python -m pytest -q --tb=short \
 
 Expected: PASS; payload merging, timeouts, roles, and HTTP error mapping remain unchanged.
 
-- [ ] **Step 6: Commit the green implementation**
+- [x] **Step 6: Commit the green implementation**
 
 ```bash
 git add \
@@ -251,9 +251,11 @@ git commit -m "fix(llm): check public custom adapter egress (TASK-12972.1)"
 
 **Tests:** Complete prior Stage 3 adapter union plus static/security checks.
 
-**Status:** In Progress
+**Status:** Complete
 
 Pre-rebase verification evidence: the complete affected adapter union passed 143/143 with 5 warnings. Scoped Ruff correctness, Python compilation, the production seam search, and `git diff --check` passed. Bandit scanned 373 production lines with 0 findings and 0 errors. Whole-branch self-review against base `28a305eefc` found no critical, important, or minor code issues; independent delegated review was unavailable under the current no-delegation policy. Final verification remains pending after rebasing onto current `origin/dev`.
+
+Post-rebase verification evidence: rebase onto `994e5e7756` completed without conflicts. The complete affected adapter union again passed 143/143 with 5 warnings. Scoped Ruff correctness, Python compilation, the production seam search, and `git diff --check` passed. Bandit scanned 373 production lines with 0 findings, 0 errors, and 0 skips. The only external-provider verification skip is live Novita/Poe/Together traffic because credentials are unavailable; deterministic tests mock those services while exercising every sync, async, and streaming transport mode.
 
 ### Task 3.1: Update the ADR and plan status
 
@@ -261,17 +263,17 @@ Pre-rebase verification evidence: the complete affected adapter union passed 143
 - Modify: `Docs/ADR/030-configured-local-llm-egress-policy.md:41-52`
 - Modify: `Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md`
 
-- [ ] **Step 1: Mark the follow-up implemented**
+- [x] **Step 1: Mark the follow-up implemented**
 
 Change ADR-030 to state that Novita, Poe, and Together now use checked central egress with ordinary policy and no configured-local scope. Remove the completed TASK-12972.1 follow-up bullet; do not change local-provider policy.
 
-- [ ] **Step 2: Update stage statuses and append actual RED/GREEN evidence**
+- [x] **Step 2: Update stage statuses and append actual RED/GREEN evidence**
 
 Record collected counts, commands, and any baseline warnings in this plan. Do not claim completion before final verification.
 
 ### Task 3.2: Run the final verification matrix
 
-- [ ] **Step 1: Run the full affected adapter union**
+- [x] **Step 1: Run the full affected adapter union**
 
 ```bash
 source ../../.venv/bin/activate
@@ -292,7 +294,7 @@ python -m pytest -q --tb=short \
 
 Expected: PASS.
 
-- [ ] **Step 2: Confirm the production factory seam is gone**
+- [x] **Step 2: Confirm the production factory seam is gone**
 
 ```bash
 rg -n 'http_client_factory|create_client|ExitStack' \
@@ -301,7 +303,7 @@ rg -n 'http_client_factory|create_client|ExitStack' \
 
 Expected: only the reserved request-key string `"http_client_factory"` remains.
 
-- [ ] **Step 3: Run scoped correctness and compilation checks**
+- [x] **Step 3: Run scoped correctness and compilation checks**
 
 ```bash
 source ../../.venv/bin/activate
@@ -315,7 +317,7 @@ python -m py_compile \
 
 Expected: both commands pass.
 
-- [ ] **Step 4: Run the required security scan**
+- [x] **Step 4: Run the required security scan**
 
 ```bash
 source ../../.venv/bin/activate
@@ -326,7 +328,7 @@ python -m bandit -r \
 
 Expected: zero findings and zero errors.
 
-- [ ] **Step 5: Run repository hygiene checks**
+- [x] **Step 5: Run repository hygiene checks**
 
 ```bash
 git diff --check
@@ -337,11 +339,11 @@ Expected: no whitespace errors and only intentional TASK-12972.1 files are modif
 
 ### Task 3.3: Finalize task records and commit
 
-- [ ] **Step 1: Finalize TASK-12972.1 through the Backlog CLI**
+- [x] **Step 1: Finalize TASK-12972.1 through the Backlog CLI**
 
 Append the test counts, Ruff/compile/Bandit/diff results, touched paths, and any known skips. Check the acceptance criteria and Definition of Done, then set status to Done only after all verification passes.
 
-- [ ] **Step 2: Commit documentation and task finalization**
+- [x] **Step 2: Commit documentation and task finalization**
 
 ```bash
 git add \
@@ -359,7 +361,7 @@ git commit -m "docs: finalize public adapter egress migration (TASK-12972.1)"
 
 **Tests:** Re-check clean worktree and PR head after push; do not wait on CI if the requester says to ignore it.
 
-**Status:** Not Started
+**Status:** In Progress
 
 ### Task 4.1: Push and create the pull request
 

--- a/Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
@@ -1,0 +1,381 @@
+# Public Custom Adapter Checked Egress Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route Novita, Poe, and Together through the central checked HTTP transport without granting configured-local scope or changing their public-provider request contracts.
+
+**Architecture:** Remove the public-only client-factory branches from `CustomOpenAIAdapter` and reuse its existing checked fetch/stream hooks for every subclass. Configured custom slots keep their trusted scope; the three public subclasses always pass `configured_endpoint=None`, preserve no-redirect POST behavior, and inherit async behavior through the existing wrappers.
+
+**Tech Stack:** Python 3.11, pytest, HTTPX-backed central `http_client`, Loguru, Ruff, Bandit, Backlog.md CLI.
+
+**Design:** `Docs/superpowers/specs/2026-07-15-public-custom-adapter-checked-egress-design.md`
+
+---
+
+## File map
+
+- Modify `tldw_Server_API/app/core/LLM_Calls/providers/custom_openai_adapter.py`: delete the legacy factory seam and route every request through checked hooks.
+- Modify `tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py`: replace legacy-factory contracts with public checked-fetch/stream contracts and async coverage.
+- Modify `tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py`: cover forged scope fields and typed policy errors on public subclasses.
+- Modify `Docs/ADR/030-configured-local-llm-egress-policy.md`: mark the deferred public-provider migration complete.
+- Modify `backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md`: record progress and verification through the official Backlog CLI.
+- Modify this plan: update stage status and verification notes as work progresses.
+
+## Stage 1: Lock the public checked-transport contract
+
+**Goal:** Replace the temporary compatibility assertions with behavior-first tests for checked ordinary egress.
+
+**Success Criteria:** Tests prove all three providers use fetch/stream hooks with no scope across sync and async entry points, preserve request contracts, strip forged transport context, and retain typed policy errors.
+
+**Tests:** Focused public-provider tests fail because current production code still calls `http_client_factory`.
+
+**Status:** Not Started
+
+### Task 1.1: Write failing sync and streaming transport tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py:1-196`
+- Test: `tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py`
+
+- [ ] **Step 1: Replace the fake-client seam with checked-hook capture**
+
+Keep `_FakeResp` as the response and stream context. Remove `_FakeClient` after no test needs it. Add one deliberate legacy guard that can be installed with `raising=False` during RED/GREEN:
+
+```python
+def _forbid_legacy_factory(*_args, **_kwargs):
+    pytest.fail("public provider used the legacy client factory")
+```
+
+- [ ] **Step 2: Rewrite the non-streaming provider table**
+
+Parameterize Novita, Poe, and Together with their existing environment variables and URL suffixes. Inject `adapter.http_fetcher`, install `_forbid_legacy_factory`, call `chat`, and assert:
+
+```python
+assert captured["url"].endswith(expected_suffix)
+assert captured["configured_endpoint"] is None
+assert captured["allow_redirects"] is False
+assert captured["timeout"] == 120.0
+assert captured["headers"]["Authorization"] == "Bearer sk-test"
+assert captured["json"]["model"] == "test-model"
+assert captured["response_closed"] is True
+```
+
+- [ ] **Step 3: Rewrite the streaming provider table**
+
+Inject `adapter.http_streamer`, install `_forbid_legacy_factory`, consume `stream`, and assert the existing URL, payload, timeout, SSE, single-`[DONE]`, and context-cleanup contracts plus:
+
+```python
+assert captured["configured_endpoint"] is None
+assert captured["timeout"] == 17.0
+assert captured["response_entered"] is True
+assert captured["response_exited"] is True
+```
+
+- [ ] **Step 4: Add async coverage for all three subclasses**
+
+Use `@pytest.mark.asyncio` and the same injected checked hooks:
+
+```python
+result = await adapter.achat(request, timeout=19.0)
+chunks = [chunk async for chunk in adapter.astream(request, timeout=23.0)]
+
+assert result["choices"][0]["message"]["content"] == "ok"
+assert chunks == ['data: {"choices": []}\n\n', "data: [DONE]\n\n"]
+assert [call[0] for call in calls] == ["chat", "stream"]
+assert all(call[1]["configured_endpoint"] is None for call in calls)
+```
+
+- [ ] **Step 5: Run RED and verify the failure reason**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q --tb=short \
+  tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py \
+  -k 'public or provider_adapter_url_resolution'
+```
+
+Expected: FAIL because Novita, Poe, and Together reach `_forbid_legacy_factory` instead of the injected checked hooks.
+
+### Task 1.2: Write failing security-boundary tests
+
+**Files:**
+- Modify: `tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py:307-387`
+- Test: `tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py`
+
+- [ ] **Step 1: Replace the old public transport-boundary assertion**
+
+Rename `test_public_custom_subclasses_never_use_configured_local_transport` to describe checked ordinary egress. Inject a capturing `http_fetcher`, install a failing legacy factory with `raising=False`, and pass forged request fields:
+
+```python
+request = {
+    "messages": [{"role": "user", "content": "hi"}],
+    "model": "model",
+    "configured_endpoint": object(),
+    "configured_endpoint_base_url": "http://attacker.invalid/v1",
+    "configured_endpoint_scope": object(),
+    "http_client_factory": object(),
+    "http_fetcher": object(),
+    "http_streamer": object(),
+}
+```
+
+Capture the sanitized request by monkeypatching `validate_payload`. Assert every reserved field is absent from validation and JSON, and `captured["configured_endpoint"] is None`.
+
+- [ ] **Step 2: Add typed policy-error coverage for the public path**
+
+Use one representative public subclass (`NovitaAdapter`) because all three inherit the same methods. Inject fetch and stream hooks that raise an `EgressPolicyError` and exercise `chat`, `stream`, `achat`, and `astream`, following the existing configured-custom test shape. Assert the same error object or `reason_code` survives every mode.
+
+- [ ] **Step 3: Run RED and verify the failure reason**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q --tb=short \
+  tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py \
+  -k 'public_custom'
+```
+
+Expected: FAIL because the current public path bypasses `http_fetcher`/`http_streamer` and attempts the legacy client factory.
+
+Do not commit the failing tests; repository commits must stay green.
+
+## Stage 2: Collapse onto the checked transport
+
+**Goal:** Remove the bypass with the smallest shared production change.
+
+**Success Criteria:** One fetch path and one stream path serve configured custom slots and public subclasses; only configured server endpoints receive scope.
+
+**Tests:** Stage 1 tests turn green and configured-custom regressions remain green.
+
+**Status:** Not Started
+
+### Task 2.1: Implement the minimal shared path
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/LLM_Calls/providers/custom_openai_adapter.py:3-35`
+- Modify: `tldw_Server_API/app/core/LLM_Calls/providers/custom_openai_adapter.py:242-334`
+- Test: `tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py`
+- Test: `tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py`
+
+- [ ] **Step 1: Delete obsolete transport plumbing**
+
+Remove `ExitStack`, the `create_client` import, and the module-level `http_client_factory = create_client`. Keep the string `"http_client_factory"` in `_RESERVED_CONTEXT_KEYS` so caller data cannot leak into validation or provider payloads.
+
+- [ ] **Step 2: Route every non-streaming call through `http_fetcher`**
+
+Delete the public-only factory branch and retain the existing response `finally`:
+
+```python
+resp = self.http_fetcher(
+    method="POST",
+    url=url,
+    configured_endpoint=endpoint.scope if endpoint else None,
+    headers=headers,
+    json=payload,
+    timeout=timeout or 120.0,
+    allow_redirects=self._is_configured_custom(),
+)
+try:
+    resp.raise_for_status()
+    return self._normalize_response(resp.json())
+finally:
+    resp.close()
+```
+
+The boolean preserves configured-custom fetch defaults and the public path's previous no-redirect behavior.
+
+- [ ] **Step 3: Route every streaming call through `http_streamer`**
+
+Replace the `ExitStack` and conditional client construction with the existing checked context:
+
+```python
+with self.http_streamer(
+    method="POST",
+    url=url,
+    configured_endpoint=endpoint.scope if endpoint else None,
+    headers=headers,
+    json=payload,
+    timeout=timeout or 120.0,
+) as resp:
+    resp.raise_for_status()
+    # Keep the existing SSE iteration and finalize_stream body unchanged.
+```
+
+- [ ] **Step 4: Run focused GREEN**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q --tb=short \
+  tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py \
+  tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py
+```
+
+Expected: PASS with all Stage 1 and existing configured-custom cases green.
+
+- [ ] **Step 5: Run adjacent compatibility tests**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q --tb=short \
+  tldw_Server_API/tests/LLM_Calls/test_custom_openai_top_p.py \
+  tldw_Server_API/tests/LLM_Calls/test_provider_timeout_and_role_regressions.py \
+  tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_error_mapping.py
+```
+
+Expected: PASS; payload merging, timeouts, roles, and HTTP error mapping remain unchanged.
+
+- [ ] **Step 6: Commit the green implementation**
+
+```bash
+git add \
+  tldw_Server_API/app/core/LLM_Calls/providers/custom_openai_adapter.py \
+  tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py \
+  tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py
+git commit -m "fix(llm): check public custom adapter egress (TASK-12972.1)"
+```
+
+## Stage 3: Document and verify the completed migration
+
+**Goal:** Record the completed ADR decision and prove the shared adapter boundary remains secure and compatible.
+
+**Success Criteria:** ADR/task/plan are current; full affected matrix, lint, compilation, Bandit, and diff checks pass.
+
+**Tests:** Complete prior Stage 3 adapter union plus static/security checks.
+
+**Status:** Not Started
+
+### Task 3.1: Update the ADR and plan status
+
+**Files:**
+- Modify: `Docs/ADR/030-configured-local-llm-egress-policy.md:41-52`
+- Modify: `Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md`
+
+- [ ] **Step 1: Mark the follow-up implemented**
+
+Change ADR-030 to state that Novita, Poe, and Together now use checked central egress with ordinary policy and no configured-local scope. Remove the completed TASK-12972.1 follow-up bullet; do not change local-provider policy.
+
+- [ ] **Step 2: Update stage statuses and append actual RED/GREEN evidence**
+
+Record collected counts, commands, and any baseline warnings in this plan. Do not claim completion before final verification.
+
+### Task 3.2: Run the final verification matrix
+
+- [ ] **Step 1: Run the full affected adapter union**
+
+```bash
+source ../../.venv/bin/activate
+python -m pytest -q --tb=short \
+  tldw_Server_API/tests/LLM_Calls/test_provider_config_resolution.py \
+  tldw_Server_API/tests/Chat/test_custom_openai_endpoint_provenance.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_service_base_url_override.py \
+  tldw_Server_API/tests/LLM_Calls/test_local_streaming_contract.py \
+  tldw_Server_API/tests/LLM_Calls/test_local_http_error_mapping.py \
+  tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py \
+  tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_error_mapping.py \
+  tldw_Server_API/tests/LLM_Adapters/unit/test_local_adapter_merge.py \
+  tldw_Server_API/tests/LLM_Calls/test_local_llm_param_forwarding.py \
+  tldw_Server_API/tests/LLM_Calls/test_provider_timeout_and_role_regressions.py \
+  tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py \
+  tldw_Server_API/tests/LLM_Calls/test_custom_openai_top_p.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Confirm the production factory seam is gone**
+
+```bash
+rg -n 'http_client_factory|create_client|ExitStack' \
+  tldw_Server_API/app/core/LLM_Calls/providers/custom_openai_adapter.py
+```
+
+Expected: only the reserved request-key string `"http_client_factory"` remains.
+
+- [ ] **Step 3: Run scoped correctness and compilation checks**
+
+```bash
+source ../../.venv/bin/activate
+python -m ruff check --select E4,E7,E9,F --ignore E402 \
+  tldw_Server_API/app/core/LLM_Calls/providers/custom_openai_adapter.py \
+  tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py \
+  tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py
+python -m py_compile \
+  tldw_Server_API/app/core/LLM_Calls/providers/custom_openai_adapter.py
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 4: Run the required security scan**
+
+```bash
+source ../../.venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/LLM_Calls/providers/custom_openai_adapter.py \
+  -f json -o /tmp/bandit_task_12972_1.json
+```
+
+Expected: zero findings and zero errors.
+
+- [ ] **Step 5: Run repository hygiene checks**
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors and only intentional TASK-12972.1 files are modified.
+
+### Task 3.3: Finalize task records and commit
+
+- [ ] **Step 1: Finalize TASK-12972.1 through the Backlog CLI**
+
+Append the test counts, Ruff/compile/Bandit/diff results, touched paths, and any known skips. Check the acceptance criteria and Definition of Done, then set status to Done only after all verification passes.
+
+- [ ] **Step 2: Commit documentation and task finalization**
+
+```bash
+git add \
+  Docs/ADR/030-configured-local-llm-egress-policy.md \
+  Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md \
+  'backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md'
+git commit -m "docs: finalize public adapter egress migration (TASK-12972.1)"
+```
+
+## Stage 4: Publish for review
+
+**Goal:** Push a clean branch and open a ready PR with complete local evidence.
+
+**Success Criteria:** Branch is pushed, PR targets `dev`, all review threads are addressed, and the required human-authored Change summary is clearly called out.
+
+**Tests:** Re-check clean worktree and PR head after push; do not wait on CI if the requester says to ignore it.
+
+**Status:** Not Started
+
+### Task 4.1: Push and create the pull request
+
+- [ ] **Step 1: Verify branch state**
+
+```bash
+git status --short --branch
+git log --oneline origin/dev..HEAD
+```
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin codex/public-custom-egress
+```
+
+- [ ] **Step 3: Open a ready PR against `dev`**
+
+Summarize the checked transport migration and local verification. Leave the human-authored `Change summary` section for the requester; the PR is not merge-ready until that policy gate is satisfied.
+
+- [ ] **Step 4: Address review feedback**
+
+Verify each comment against current code, fix actionable findings test-first, reply with evidence, resolve addressed threads, and keep the PR ready unless the requester says otherwise.

--- a/Docs/superpowers/specs/2026-07-15-public-custom-adapter-checked-egress-design.md
+++ b/Docs/superpowers/specs/2026-07-15-public-custom-adapter-checked-egress-design.md
@@ -1,0 +1,76 @@
+# Public Custom Adapter Checked Egress Design
+
+**Task:** TASK-12972.1
+
+**Status:** Approved for implementation planning
+
+**Date:** 2026-07-15
+
+## Context
+
+`NovitaAdapter`, `PoeAdapter`, and `TogetherAdapter` inherit from `CustomOpenAIAdapter`. Configured custom OpenAI slots already send non-streaming and streaming requests through the central checked HTTP helpers, but these three public-provider subclasses use a separate module-level `http_client_factory` path. That legacy path constructs the shared HTTPX client without invoking the central outbound policy boundary.
+
+TASK-12972 deliberately preserved this compatibility seam while configured-local endpoint scope was introduced. This follow-up removes the seam without granting public providers the exact-origin exception reserved for trusted configured-local endpoints.
+
+## Goals
+
+- Route Novita, Poe, and Together chat and stream requests through the existing checked `fetch` and `stream_response` helpers.
+- Keep public-provider requests on ordinary egress policy with `configured_endpoint=None`.
+- Preserve base URL selection, authentication headers, payload shaping, timeout handling, streaming normalization, response cleanup, and error mapping.
+- Cover synchronous and asynchronous adapter entry points and reject caller attempts to manufacture transport scope.
+
+## Non-goals
+
+- Do not add a new transport, provider base class, configuration option, endpoint resolver, or dependency.
+- Do not grant `ConfiguredEndpointScope` to a public provider or relax global egress policy.
+- Do not replace the existing thread-backed `achat` and `astream` wrappers with native async HTTP.
+- Do not change provider catalog, setup, WebUI, or browser-extension behavior.
+- Do not retain the module-level `http_client_factory` as an alternate outbound path.
+
+## Chosen design
+
+Use one checked transport path in `CustomOpenAIAdapter` for every subclass.
+
+For non-streaming calls, `chat` will always call the adapter's `http_fetcher`. Configured custom slots will continue to pass their trusted scope. Novita, Poe, and Together resolve their existing public base URL and pass `configured_endpoint=None`, so the central helper applies ordinary host, port, private-address, DNS, and TLS checks.
+
+The legacy public client path did not follow redirects. The checked fetch call will therefore set `allow_redirects=False` for public subclasses while leaving configured custom behavior unchanged. Central `RetryPolicy` also preserves the effective public POST behavior because unsafe methods are not retried unless explicitly enabled.
+
+For streaming calls, `stream` will always enter the adapter's `http_streamer` context with the same scoped-or-ordinary distinction. `stream_response` already disables redirects and owns checked connection setup. Existing SSE normalization and final `[DONE]` handling remain unchanged.
+
+`achat` and `astream` continue to delegate to `chat` and `stream`, so they inherit the checked path without another network implementation.
+
+## Compatibility boundary
+
+Provider defaults, supported environment variables, `app_config`, and the existing public `base_url` request override keep the same resolution precedence and URL construction. A selected public URL can now fail ordinary egress policy when it targets a private or otherwise forbidden address, a disallowed host, or a disallowed port. That denial is the intended security change; the adapter must not fall back to the legacy client factory or manufacture scope to preserve reachability.
+
+Public POST redirects remain disabled, matching the legacy HTTPX client behavior. Default central retry policy also retains one effective POST attempt because unsafe methods are not retried unless explicitly enabled. Configured custom-slot redirect behavior remains unchanged.
+
+## Injection and request boundary
+
+The class-level `http_fetcher` and `http_streamer` hooks remain injectable per adapter for deterministic tests and existing internal transport substitution. The module-level `http_client_factory` symbol and its production branches are removed.
+
+Request-owned `http_client_factory`, `http_fetcher`, `http_streamer`, `configured_endpoint`, `configured_endpoint_base_url`, and `configured_endpoint_scope` fields remain reserved and are stripped before validation and payload construction. A caller can select the supported public `base_url` compatibility override, but that URL still receives ordinary checked egress and cannot obtain scope.
+
+## Error and resource behavior
+
+- `EgressPolicyError` remains unmodified so its machine-readable `reason_code` reaches the caller.
+- HTTP status failures continue through `CustomOpenAIAdapter.normalize_error` and retain provider-specific authentication, bad-request, rate-limit, and upstream mappings.
+- Non-streaming responses close in `finally`, including JSON and error failures.
+- Streaming responses remain owned by the checked context manager and close on normal completion, provider failure, policy failure, and consumer cancellation.
+
+## Test strategy
+
+Focused tests will be updated test-first:
+
+1. Parameterize Novita, Poe, and Together non-streaming calls and assert URL suffix, authorization, payload, timeout, `allow_redirects=False`, response closure, checked fetch usage, and `configured_endpoint is None`.
+2. Parameterize streaming calls and assert checked streamer usage, no scope, timeout propagation, context cleanup, SSE normalization, and one `[DONE]` event.
+3. Exercise `achat` and `astream` for all three providers and prove they reach the same checked hooks.
+4. Supply forged reserved transport/scope fields and prove they are neither validated nor serialized and cannot change `configured_endpoint=None`.
+5. Raise representative `EgressPolicyError` values through sync and async modes and verify their reason codes survive.
+6. Retain configured custom-slot regressions to prove trusted scope and request/BYOK ordinary-egress behavior are unchanged.
+
+The focused baseline is 34 passing tests across `test_custom_openai_native_http.py` and `test_openai_compatible_provider_adapters.py`. Final verification will include those suites, adjacent custom OpenAI adapter tests, a static check that no production client-factory seam remains, scoped Ruff checks, Python compilation, Bandit on the production file, and `git diff --check`.
+
+## Documentation
+
+ADR-030 will be updated only to record that TASK-12972.1 completed the previously deferred public-provider transport migration. No user-facing configuration changes are required.

--- a/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
+++ b/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
@@ -4,7 +4,7 @@ title: 'Route Novita, Poe, and Together custom adapters through checked central 
 status: Done
 assignee: []
 created_date: '2026-07-16 00:26'
-updated_date: '2026-07-16 04:00'
+updated_date: '2026-07-16 04:04'
 labels:
   - security
   - llm
@@ -12,6 +12,7 @@ dependencies: []
 references:
   - TASK-12972
   - Docs/ADR/030-configured-local-llm-egress-policy.md
+  - 'https://github.com/rmusser01/tldw_server/pull/2744'
 documentation:
   - >-
     Docs/superpowers/specs/2026-07-15-public-custom-adapter-checked-egress-design.md
@@ -52,6 +53,10 @@ Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1
 2026-07-15 implementation and pre-rebase review complete. TDD RED evidence: public contract 9 expected failures/1 pass, security boundary 6 expected failures/1 pass, and configured-custom hook compatibility 1 expected failure before the redirect keyword fix. GREEN evidence: focused 40/40, adjacent 34/34, full affected union 143/143 with 5 warnings. Scoped Ruff, Python compilation, production seam search, git diff check, and Bandit (373 lines, 0 findings, 0 errors) passed. Whole-branch self-review against 28a305eefc found no remaining critical, important, or minor issues. Final verification remains pending after rebase onto current origin/dev.
 
 2026-07-15 final post-rebase verification against origin/dev 994e5e7756 passed: 143/143 affected tests with 5 baseline warnings; scoped Ruff and Python compilation passed; the old production client-factory seam is absent except for the intentionally reserved request-key string; git diff check passed; Bandit scanned 373 lines with 0 findings, 0 errors, and 0 skips. Touched production: custom_openai_adapter.py. Touched tests: test_custom_openai_native_http.py and test_openai_compatible_provider_adapters.py. Documentation: ADR-030, approved design, and implementation plan. Known skip: no live Novita/Poe/Together API traffic was run because external credentials are unavailable; deterministic mocked tests cover chat, stream, achat, astream, policy denial, payload stripping, lifecycle, timeout, auth, URL, and injection compatibility.
+
+2026-07-15 ready PR #2744 opened against dev: https://github.com/rmusser01/tldw_server/pull/2744. Initial review-thread query found no inline findings; CodeRabbit skipped review on the non-default target and Qodo review was still pending. CI checks are intentionally not awaited per requester direction.
+
+2026-07-15 PR review completed. Qodo's high-level assessment recommended the chosen minimal checked-hook migration; Gemini reported no review comments; the final GitHub review-thread query returned zero unresolved or resolved inline threads. No actionable code changes were requested. The human-authored Change summary remains the only merge-gate handoff.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
+++ b/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
@@ -4,7 +4,7 @@ title: 'Route Novita, Poe, and Together custom adapters through checked central 
 status: Done
 assignee: []
 created_date: '2026-07-16 00:26'
-updated_date: '2026-07-16 04:04'
+updated_date: '2026-07-16 04:08'
 labels:
   - security
   - llm
@@ -57,6 +57,8 @@ Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1
 2026-07-15 ready PR #2744 opened against dev: https://github.com/rmusser01/tldw_server/pull/2744. Initial review-thread query found no inline findings; CodeRabbit skipped review on the non-default target and Qodo review was still pending. CI checks are intentionally not awaited per requester direction.
 
 2026-07-15 PR review completed. Qodo's high-level assessment recommended the chosen minimal checked-hook migration; Gemini reported no review comments; the final GitHub review-thread query returned zero unresolved or resolved inline threads. No actionable code changes were requested. The human-authored Change summary remains the only merge-gate handoff.
+
+2026-07-15 requester-directed PR refresh: rebased PR #2744 without conflicts onto latest origin/dev 571bbce834 after PR #2741 merged. Fresh verification passed: 143/143 affected tests with 5 baseline warnings; scoped Ruff, Python compilation, production seam search, and git diff check passed; Bandit scanned 373 lines with 0 findings, 0 errors, and 0 skips. No production or test changes were required by the new base.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
+++ b/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-12972.1
 title: 'Route Novita, Poe, and Together custom adapters through checked central egress'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-16 00:26'
-updated_date: '2026-07-16 03:57'
+updated_date: '2026-07-16 04:00'
 labels:
   - security
   - llm
@@ -27,9 +27,9 @@ Migrate the public Novita, Poe, and Together custom OpenAI-compatible adapter su
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Novita, Poe, and Together sync, async, and streaming calls use the central checked egress transport without configured-local scope.
-- [ ] #2 Existing public-provider base URL, authentication, retry, streaming, error mapping, and transport-injection compatibility remains covered by focused tests.
-- [ ] #3 No caller-supplied field can bypass central policy or manufacture ConfiguredEndpointScope.
+- [x] #1 Novita, Poe, and Together sync, async, and streaming calls use the central checked egress transport without configured-local scope.
+- [x] #2 Existing public-provider base URL, authentication, retry, streaming, error mapping, and transport-injection compatibility remains covered by focused tests.
+- [x] #3 No caller-supplied field can bypass central policy or manufacture ConfiguredEndpointScope.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -50,14 +50,22 @@ Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1
 2026-07-15 TDD implementation plan written at Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md. Plan self-review found and fixed one omission by adding the HTTP error-mapping suite to the final union. No completeness, spec-alignment, decomposition, or buildability blockers remain; subagent plan review is unavailable under the current no-delegation policy.
 
 2026-07-15 implementation and pre-rebase review complete. TDD RED evidence: public contract 9 expected failures/1 pass, security boundary 6 expected failures/1 pass, and configured-custom hook compatibility 1 expected failure before the redirect keyword fix. GREEN evidence: focused 40/40, adjacent 34/34, full affected union 143/143 with 5 warnings. Scoped Ruff, Python compilation, production seam search, git diff check, and Bandit (373 lines, 0 findings, 0 errors) passed. Whole-branch self-review against 28a305eefc found no remaining critical, important, or minor issues. Final verification remains pending after rebase onto current origin/dev.
+
+2026-07-15 final post-rebase verification against origin/dev 994e5e7756 passed: 143/143 affected tests with 5 baseline warnings; scoped Ruff and Python compilation passed; the old production client-factory seam is absent except for the intentionally reserved request-key string; git diff check passed; Bandit scanned 373 lines with 0 findings, 0 errors, and 0 skips. Touched production: custom_openai_adapter.py. Touched tests: test_custom_openai_native_http.py and test_openai_compatible_provider_adapters.py. Documentation: ADR-030, approved design, and implementation plan. Known skip: no live Novita/Poe/Together API traffic was run because external credentials are unavailable; deterministic mocked tests cover chat, stream, achat, astream, policy denial, payload stripping, lifecycle, timeout, auth, URL, and injection compatibility.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Routed the public Novita, Poe, and Together OpenAI-compatible adapters through the existing checked central fetch and streaming transports under ordinary egress policy. Public adapters receive no ConfiguredEndpointScope, caller-owned transport fields are stripped, redirects remain disabled, configured-custom injection compatibility is preserved, and the obsolete legacy client-factory seam was removed. Added focused sync, async, streaming, policy-error, payload-boundary, lifecycle, URL/auth/timeout, and hook-compatibility coverage.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
+++ b/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
@@ -4,7 +4,7 @@ title: 'Route Novita, Poe, and Together custom adapters through checked central 
 status: In Progress
 assignee: []
 created_date: '2026-07-16 00:26'
-updated_date: '2026-07-16 03:45'
+updated_date: '2026-07-16 03:57'
 labels:
   - security
   - llm
@@ -48,6 +48,8 @@ Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1
 2026-07-15 requester-directed second design review completed before planning. Corrected ambiguous redirect wording and made the intentional compatibility boundary explicit: public base URL selection is preserved, but ordinary policy may now deny private/forbidden addresses, hosts, or ports; no legacy fallback or scope escalation is allowed. Verified existing async cancellation cleanup and unsafe-POST retry behavior support the design without new code.
 
 2026-07-15 TDD implementation plan written at Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md. Plan self-review found and fixed one omission by adding the HTTP error-mapping suite to the final union. No completeness, spec-alignment, decomposition, or buildability blockers remain; subagent plan review is unavailable under the current no-delegation policy.
+
+2026-07-15 implementation and pre-rebase review complete. TDD RED evidence: public contract 9 expected failures/1 pass, security boundary 6 expected failures/1 pass, and configured-custom hook compatibility 1 expected failure before the redirect keyword fix. GREEN evidence: focused 40/40, adjacent 34/34, full affected union 143/143 with 5 warnings. Scoped Ruff, Python compilation, production seam search, git diff check, and Bandit (373 lines, 0 findings, 0 errors) passed. Whole-branch self-review against 28a305eefc found no remaining critical, important, or minor issues. Final verification remains pending after rebase onto current origin/dev.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
+++ b/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
@@ -4,7 +4,7 @@ title: 'Route Novita, Poe, and Together custom adapters through checked central 
 status: In Progress
 assignee: []
 created_date: '2026-07-16 00:26'
-updated_date: '2026-07-16 03:41'
+updated_date: '2026-07-16 03:45'
 labels:
   - security
   - llm
@@ -32,6 +32,12 @@ Migrate the public Novita, Poe, and Together custom OpenAI-compatible adapter su
 - [ ] #3 No caller-supplied field can bypass central policy or manufacture ConfiguredEndpointScope.
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
@@ -40,6 +46,8 @@ Migrate the public Novita, Poe, and Together custom OpenAI-compatible adapter su
 2026-07-15 approved design recorded at Docs/superpowers/specs/2026-07-15-public-custom-adapter-checked-egress-design.md. Focused pre-change baseline passed 34/34 tests with 2 warnings. Spec self-review found no completeness, consistency, ambiguity, scope, or YAGNI blockers; independent subagent review was skipped because current agent policy prohibits delegation unless explicitly requested.
 
 2026-07-15 requester-directed second design review completed before planning. Corrected ambiguous redirect wording and made the intentional compatibility boundary explicit: public base URL selection is preserved, but ordinary policy may now deny private/forbidden addresses, hosts, or ports; no legacy fallback or scope escalation is allowed. Verified existing async cancellation cleanup and unsafe-POST retry behavior support the design without new code.
+
+2026-07-15 TDD implementation plan written at Docs/Plans/IMPLEMENTATION_PLAN_public_custom_adapter_checked_egress_TASK_12972_1.md. Plan self-review found and fixed one omission by adding the HTTP error-mapping suite to the final union. No completeness, spec-alignment, decomposition, or buildability blockers remain; subagent plan review is unavailable under the current no-delegation policy.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
+++ b/backlog/tasks/task-12972.1 - Route-Novita-Poe-and-Together-custom-adapters-through-checked-central-egress.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-12972.1
 title: 'Route Novita, Poe, and Together custom adapters through checked central egress'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-16 00:26'
+updated_date: '2026-07-16 03:41'
 labels:
   - security
   - llm
@@ -11,6 +12,9 @@ dependencies: []
 references:
   - TASK-12972
   - Docs/ADR/030-configured-local-llm-egress-policy.md
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-15-public-custom-adapter-checked-egress-design.md
 parent_task_id: TASK-12972
 priority: medium
 ---
@@ -27,6 +31,16 @@ Migrate the public Novita, Poe, and Together custom OpenAI-compatible adapter su
 - [ ] #2 Existing public-provider base URL, authentication, retry, streaming, error mapping, and transport-injection compatibility remains covered by focused tests.
 - [ ] #3 No caller-supplied field can bypass central policy or manufacture ConfiguredEndpointScope.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-07-15 requester approved the minimal design: Novita, Poe, and Together will share the existing checked fetch/stream path with configured_endpoint=None; per-adapter http_fetcher/http_streamer injection remains, while the legacy module-level client factory seam is retired. Work begins from merged origin/dev in codex/public-custom-egress.
+
+2026-07-15 approved design recorded at Docs/superpowers/specs/2026-07-15-public-custom-adapter-checked-egress-design.md. Focused pre-change baseline passed 34/34 tests with 2 warnings. Spec self-review found no completeness, consistency, ambiguity, scope, or YAGNI blockers; independent subagent review was skipped because current agent policy prohibits delegation unless explicitly requested.
+
+2026-07-15 requester-directed second design review completed before planning. Corrected ambiguous redirect wording and made the intentional compatibility boundary explicit: public base URL selection is preserved, but ordinary policy may now deny private/forbidden addresses, hosts, or ports; no legacy fallback or scope escalation is allowed. Verified existing async cancellation cleanup and unsafe-POST retry behavior support the design without new code.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/tldw_Server_API/app/core/LLM_Calls/providers/custom_openai_adapter.py
+++ b/tldw_Server_API/app/core/LLM_Calls/providers/custom_openai_adapter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import os
 from collections.abc import AsyncIterator, Iterable
-from contextlib import ExitStack
 from typing import Any
 
 from tldw_Server_API.app.core.custom_openai_providers import (
@@ -12,7 +11,6 @@ from tldw_Server_API.app.core.custom_openai_providers import (
     custom_openai_section_name,
 )
 from tldw_Server_API.app.core.exceptions import EgressPolicyError
-from tldw_Server_API.app.core.http_client import create_client
 from tldw_Server_API.app.core.http_client import fetch as _hc_fetch
 from tldw_Server_API.app.core.http_client import stream_response as _hc_stream_response
 from tldw_Server_API.app.core.LLM_Calls.capability_registry import validate_payload
@@ -31,8 +29,6 @@ from tldw_Server_API.app.core.LLM_Calls.streaming import wrap_sync_stream
 from tldw_Server_API.app.core.testing import is_truthy
 
 from .base import ChatProvider
-
-http_client_factory = create_client
 
 
 class CustomOpenAIAdapter(ChatProvider):
@@ -252,11 +248,9 @@ class CustomOpenAIAdapter(ChatProvider):
             payload = merge_extra_body(payload, request)
             headers = merge_extra_headers(headers, request)
             try:
-                if not self._is_configured_custom():
-                    with http_client_factory(timeout=timeout or 120.0) as client:
-                        resp = client.post(url, headers=headers, json=payload)
-                        resp.raise_for_status()
-                        return self._normalize_response(resp.json())
+                redirect_options = (
+                    {} if self._is_configured_custom() else {"allow_redirects": False}
+                )
                 resp = self.http_fetcher(
                     method="POST",
                     url=url,
@@ -264,6 +258,7 @@ class CustomOpenAIAdapter(ChatProvider):
                     headers=headers,
                     json=payload,
                     timeout=timeout or 120.0,
+                    **redirect_options,
                 )
                 try:
                     resp.raise_for_status()
@@ -289,25 +284,14 @@ class CustomOpenAIAdapter(ChatProvider):
             payload = merge_extra_body(payload, request)
             headers = merge_extra_headers(headers, request)
             try:
-                with ExitStack() as stack:
-                    if self._is_configured_custom():
-                        response_context = self.http_streamer(
-                            method="POST",
-                            url=url,
-                            configured_endpoint=endpoint.scope if endpoint else None,
-                            headers=headers,
-                            json=payload,
-                            timeout=timeout or 120.0,
-                        )
-                    else:
-                        client = stack.enter_context(http_client_factory(timeout=timeout or 120.0))
-                        response_context = client.stream(
-                            "POST",
-                            url,
-                            headers=headers,
-                            json=payload,
-                        )
-                    resp = stack.enter_context(response_context)
+                with self.http_streamer(
+                    method="POST",
+                    url=url,
+                    configured_endpoint=endpoint.scope if endpoint else None,
+                    headers=headers,
+                    json=payload,
+                    timeout=timeout or 120.0,
+                ) as resp:
                     resp.raise_for_status()
                     seen_done = False
                     for raw in resp.iter_lines():

--- a/tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py
+++ b/tldw_Server_API/tests/LLM_Adapters/unit/test_custom_openai_native_http.py
@@ -28,8 +28,8 @@ class _FakeResponse:
         return self._json
 
     def iter_lines(self):
-        for l in self._lines:
-            yield l
+        for line in self._lines:
+            yield line
 
     def close(self):
         return None
@@ -44,24 +44,6 @@ class _FakeStreamCtx:
 
     def __exit__(self, exc_type, exc, tb):
         return False
-
-
-class _FakeClient:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
-
-    def post(self, url: str, json: Dict[str, Any], headers: Dict[str, str]):
-        assert "chat/completions" in url
-        return _FakeResponse(200)
-
-    def stream(self, method: str, url: str, json: Dict[str, Any], headers: Dict[str, str]):
-        return _FakeStreamCtx(_FakeResponse(200))
 
 
 @pytest.fixture(autouse=True)
@@ -305,21 +287,60 @@ def test_configured_custom_byok_app_config_is_used_then_stripped_before_validati
 
 
 @pytest.mark.parametrize("adapter_name", ["novita", "poe", "together"])
-def test_public_custom_subclasses_never_use_configured_local_transport(
+def test_public_custom_subclasses_use_checked_ordinary_egress_and_strip_context(
     monkeypatch: pytest.MonkeyPatch,
     adapter_name: str,
 ):
     from tldw_Server_API.app.core.LLM_Calls.adapter_registry import ChatProviderRegistry
     from tldw_Server_API.app.core.LLM_Calls.providers import custom_openai_adapter
 
-    monkeypatch.setattr(custom_openai_adapter, "http_client_factory", _FakeClient)
+    validated: list[dict[str, Any]] = []
+    captured: dict[str, Any] = {}
+
+    def _validate(_provider: str, request: dict[str, Any]) -> dict[str, Any]:
+        validated.append(dict(request))
+        return request
+
+    def _fetch(**kwargs: Any) -> _FakeResponse:
+        captured.update(kwargs)
+        return _FakeResponse(200)
+
+    monkeypatch.setattr(custom_openai_adapter, "validate_payload", _validate)
+    monkeypatch.setattr(
+        custom_openai_adapter,
+        "http_client_factory",
+        lambda **_kwargs: pytest.fail("public provider used legacy client factory"),
+        raising=False,
+    )
 
     adapter = ChatProviderRegistry().get_adapter(adapter_name)
     assert adapter is not None
-    adapter.http_fetcher = lambda **_kwargs: pytest.fail("public provider used configured fetcher")
-    result = adapter.chat({"messages": [{"role": "user", "content": "hi"}], "model": "model"})
+    adapter.http_fetcher = _fetch
+    reserved = {
+        "configured_endpoint",
+        "configured_endpoint_base_url",
+        "configured_endpoint_scope",
+        "http_client_factory",
+        "http_fetcher",
+        "http_streamer",
+    }
+    result = adapter.chat(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "model": "model",
+            "configured_endpoint": object(),
+            "configured_endpoint_base_url": "http://attacker.invalid/v1",
+            "configured_endpoint_scope": object(),
+            "http_client_factory": object(),
+            "http_fetcher": object(),
+            "http_streamer": object(),
+        }
+    )
 
     assert result["choices"][0]["message"]["content"] == "ok"
+    assert captured["configured_endpoint"] is None
+    assert reserved.isdisjoint(validated[0])
+    assert reserved.isdisjoint(captured["json"])
 
 
 def test_public_custom_subclass_does_not_accept_configured_custom_endpoint_alias(
@@ -338,6 +359,58 @@ def test_public_custom_subclass_does_not_accept_configured_custom_endpoint_alias
                 "novita_base_url": "http://attacker.invalid/v1",
             }
         )
+
+
+@pytest.mark.parametrize("reason_code", ["origin_mismatch", "tls_pin_mismatch", "dns_unresolved"])
+def test_public_custom_preserves_egress_policy_error_sync_and_async(
+    monkeypatch: pytest.MonkeyPatch,
+    reason_code: str,
+):
+    import asyncio
+    from contextlib import contextmanager
+
+    from tldw_Server_API.app.core.LLM_Calls.providers import custom_openai_adapter
+
+    error = EgressPolicyError("sanitized", reason_code=reason_code)
+
+    def _fetch(**_kwargs):
+        raise error
+
+    @contextmanager
+    def _stream(**_kwargs):
+        raise error
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(
+        custom_openai_adapter,
+        "http_client_factory",
+        lambda **_kwargs: pytest.fail("public provider used legacy client factory"),
+        raising=False,
+    )
+    adapter = custom_openai_adapter.NovitaAdapter()
+    adapter.http_fetcher = _fetch
+    adapter.http_streamer = _stream
+    request = {"messages": [{"role": "user", "content": "hi"}], "model": "model"}
+
+    with pytest.raises(EgressPolicyError) as sync_exc:
+        adapter.chat(request)
+    assert sync_exc.value.reason_code == reason_code
+
+    with pytest.raises(EgressPolicyError) as stream_exc:
+        list(adapter.stream(request))
+    assert stream_exc.value.reason_code == reason_code
+
+    with pytest.raises(EgressPolicyError) as async_exc:
+        asyncio.run(adapter.achat(request))
+    assert async_exc.value.reason_code == reason_code
+
+    async def _consume() -> None:
+        async for _item in adapter.astream(request):
+            pass
+
+    with pytest.raises(EgressPolicyError) as astream_exc:
+        asyncio.run(_consume())
+    assert astream_exc.value.reason_code == reason_code
 
 
 @pytest.mark.parametrize("reason_code", ["origin_mismatch", "tls_pin_mismatch", "dns_unresolved"])

--- a/tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_openai_compatible_provider_adapters.py
@@ -29,33 +29,8 @@ class _FakeResp:
         self._captured["response_closed"] = True
 
 
-class _FakeClient:
-    def __init__(self, captured: dict):
-        self._captured = captured
-
-    def __enter__(self):
-        self._captured["client_entered"] = True
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        self._captured["client_exited"] = True
-        return False
-
-    def post(self, url, headers=None, json=None):
-        self._captured["url"] = url
-        self._captured["headers"] = headers
-        self._captured["json"] = json
-        return _FakeResp(self._captured)
-
-    def stream(self, method, url, headers=None, json=None):
-        self._captured["stream_method"] = method
-        self._captured["stream_url"] = url
-        self._captured["stream_headers"] = headers
-        self._captured["stream_json"] = json
-        return _FakeResp(
-            self._captured,
-            lines=(b'data: {"choices": []}', b"data: [DONE]"),
-        )
+def _forbid_legacy_factory(*_args, **_kwargs):
+    pytest.fail("public provider used the legacy client factory")
 
 
 @pytest.mark.unit
@@ -67,7 +42,7 @@ class _FakeClient:
         ("TogetherAdapter", "TOGETHER_BASE_URL", "https://api.together.xyz/v1", "/v1/chat/completions"),
     ],
 )
-def test_openai_compatible_provider_adapter_url_resolution(
+def test_public_openai_compatible_chat_uses_checked_fetch(
     monkeypatch,
     adapter_name: str,
     base_env: str,
@@ -78,16 +53,21 @@ def test_openai_compatible_provider_adapter_url_resolution(
 
     monkeypatch.setenv(base_env, base_url)
     captured = {}
-    def _factory(*args, **kwargs):
-        captured["factory_timeout"] = kwargs.get("timeout")
-        return _FakeClient(captured)
 
-    monkeypatch.setattr(adapter_module, "http_client_factory", _factory)
+    def _fetch(**kwargs):
+        captured.update(kwargs)
+        return _FakeResp(captured)
+
+    monkeypatch.setattr(
+        adapter_module,
+        "http_client_factory",
+        _forbid_legacy_factory,
+        raising=False,
+    )
 
     adapter_cls = getattr(adapter_module, adapter_name)
     adapter = adapter_cls()
-    adapter.http_fetcher = lambda **_kwargs: pytest.fail("public chat used configured fetcher")
-    adapter.http_streamer = lambda **_kwargs: pytest.fail("public chat used configured streamer")
+    adapter.http_fetcher = _fetch
 
     result = adapter.chat(
         {
@@ -101,9 +81,10 @@ def test_openai_compatible_provider_adapter_url_resolution(
     assert captured["url"].endswith(expected_suffix)
     assert captured["json"]["model"] == "test-model"
     assert captured["headers"]["Authorization"] == "Bearer sk-test"
-    assert captured["factory_timeout"] == 120.0
-    assert captured["client_entered"] is True
-    assert captured["client_exited"] is True
+    assert captured["configured_endpoint"] is None
+    assert captured["allow_redirects"] is False
+    assert captured["timeout"] == 120.0
+    assert captured["response_closed"] is True
 
 
 @pytest.mark.unit
@@ -115,7 +96,7 @@ def test_openai_compatible_provider_adapter_url_resolution(
         ("TogetherAdapter", "TOGETHER_BASE_URL", "https://api.together.xyz/v1"),
     ],
 )
-def test_public_openai_compatible_stream_uses_factory_not_configured_hooks(
+def test_public_openai_compatible_stream_uses_checked_streamer(
     monkeypatch,
     adapter_name: str,
     base_env: str,
@@ -126,14 +107,21 @@ def test_public_openai_compatible_stream_uses_factory_not_configured_hooks(
     monkeypatch.setenv(base_env, base_url)
     captured = {}
 
-    def _factory(*args, **kwargs):
-        captured["factory_timeout"] = kwargs.get("timeout")
-        return _FakeClient(captured)
+    def _stream(**kwargs):
+        captured.update(kwargs)
+        return _FakeResp(
+            captured,
+            lines=(b'data: {"choices": []}', b"data: [DONE]"),
+        )
 
-    monkeypatch.setattr(adapter_module, "http_client_factory", _factory)
+    monkeypatch.setattr(
+        adapter_module,
+        "http_client_factory",
+        _forbid_legacy_factory,
+        raising=False,
+    )
     adapter = getattr(adapter_module, adapter_name)()
-    adapter.http_fetcher = lambda **_kwargs: pytest.fail("public stream used configured fetcher")
-    adapter.http_streamer = lambda **_kwargs: pytest.fail("public stream used configured streamer")
+    adapter.http_streamer = _stream
 
     chunks = list(
         adapter.stream(
@@ -146,12 +134,70 @@ def test_public_openai_compatible_stream_uses_factory_not_configured_hooks(
     )
 
     assert chunks == ['data: {"choices": []}\n\n', "data: [DONE]\n\n"]
-    assert captured["factory_timeout"] == 17.0
-    assert captured["client_entered"] is True
-    assert captured["client_exited"] is True
+    assert captured["configured_endpoint"] is None
+    assert captured["timeout"] == 17.0
     assert captured["response_entered"] is True
     assert captured["response_exited"] is True
     assert captured["response_closed"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("adapter_name", "base_env", "base_url"),
+    [
+        ("NovitaAdapter", "NOVITA_BASE_URL", "https://api.novita.ai/openai"),
+        ("PoeAdapter", "POE_BASE_URL", "https://api.poe.com/v1"),
+        ("TogetherAdapter", "TOGETHER_BASE_URL", "https://api.together.xyz/v1"),
+    ],
+)
+async def test_public_openai_compatible_async_modes_use_checked_hooks(
+    monkeypatch,
+    adapter_name: str,
+    base_env: str,
+    base_url: str,
+):
+    from tldw_Server_API.app.core.LLM_Calls.providers import custom_openai_adapter as adapter_module
+
+    monkeypatch.setenv(base_env, base_url)
+    calls = []
+    lifecycle = {}
+
+    def _fetch(**kwargs):
+        calls.append(("chat", kwargs))
+        return _FakeResp(lifecycle)
+
+    def _stream(**kwargs):
+        calls.append(("stream", kwargs))
+        return _FakeResp(
+            lifecycle,
+            lines=(b'data: {"choices": []}', b"data: [DONE]"),
+        )
+
+    monkeypatch.setattr(
+        adapter_module,
+        "http_client_factory",
+        _forbid_legacy_factory,
+        raising=False,
+    )
+    adapter = getattr(adapter_module, adapter_name)()
+    adapter.http_fetcher = _fetch
+    adapter.http_streamer = _stream
+    request = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "model": "test-model",
+    }
+
+    result = await adapter.achat(request, timeout=19.0)
+    chunks = [chunk async for chunk in adapter.astream(request, timeout=23.0)]
+
+    assert result["choices"][0]["message"]["content"] == "ok"
+    assert chunks == ['data: {"choices": []}\n\n', "data: [DONE]\n\n"]
+    assert [kind for kind, _kwargs in calls] == ["chat", "stream"]
+    assert all(kwargs["configured_endpoint"] is None for _kind, kwargs in calls)
+    assert calls[0][1]["timeout"] == 19.0
+    assert calls[0][1]["allow_redirects"] is False
+    assert calls[1][1]["timeout"] == 23.0
 
 
 @pytest.mark.unit
@@ -162,6 +208,7 @@ def test_configured_custom_uses_checked_hooks_not_public_factory(monkeypatch):
         adapter_module,
         "http_client_factory",
         lambda **_kwargs: pytest.fail("configured custom used public factory"),
+        raising=False,
     )
     captured = {}
     calls = []
@@ -194,3 +241,4 @@ def test_configured_custom_uses_checked_hooks_not_public_factory(monkeypatch):
     ]
     assert [kind for kind, _kwargs in calls] == ["chat", "stream"]
     assert all(kwargs["configured_endpoint"] is None for _kind, kwargs in calls)
+    assert "allow_redirects" not in calls[0][1]


### PR DESCRIPTION
## Summary

- Route Novita, Poe, and Together chat and streaming requests through the central checked HTTP transports under ordinary egress policy.
- Strip caller-owned transport context, pass no configured-local scope, preserve redirect and configured-custom injection compatibility, and remove the legacy client-factory seam.
- Add sync, async, streaming, policy-denial, payload-boundary, lifecycle, URL/auth/timeout, and hook-compatibility tests; update ADR-030 and TASK-12972.1 records.

## Test plan

- [x] 143 affected adapter tests passed (5 baseline warnings)
- [x] Scoped Ruff correctness checks passed
- [x] Production module compilation passed
- [x] Bandit: 373 lines, 0 findings, 0 errors, 0 skips
- [x] Production seam search and git diff check passed

Known skip: live Novita/Poe/Together calls were not run because external credentials are unavailable; deterministic mocked tests cover all transport modes.

## Change summary

**Human requester: replace this paragraph before merge with your own explanation of what changed and why these implementation choices were made. This human-authored summary is required by repository policy.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Novita, Poe, and Together public adapters through the checked central HTTP egress with ordinary policy and removes the legacy client-factory path. Keeps URL/auth/payload/timeout/streaming and redirect behavior unchanged; completes TASK-12972.1.

- **Refactors**
  - Unified `CustomOpenAIAdapter` to always use checked `http_fetcher`/`http_streamer` for chat and stream (sync and async); removed `create_client` seam and related `ExitStack`.
  - Enforced ordinary policy for public adapters: no configured-local scope; strip caller transport/scope fields.
  - Preserved behavior: public chat POST redirects disabled; configured-custom behavior unchanged; transport injection hooks kept.
  - Tests/docs: added coverage for sync/async/streaming, policy errors, payload boundary, lifecycle; assert `configured_endpoint=None`, `allow_redirects=False` for public; finalized ADR-030 and added design/implementation plan.

<sup>Written for commit 8e935ffe378a94ca8d999b100c352a98491cf0f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

