### PR TITLE
refactor(jobs): extract single-job lease acquisition

### DIFF
--- a/Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md
+++ b/Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md
@@ -14,7 +14,7 @@
 - Admission implementation task: `TASK-12969.1`.
 - Lease acquisition task: `TASK-12969.2`, dependent on `TASK-12969.1`.
 - Lease renewal/release task: `TASK-12969.3`, dependent on `TASK-12969.2`.
-- Current execution base: `7c7d591c6e3552ca4bdbf30bdd6bf79460221ece` from `origin/dev`.
+- Current execution base: `0f3983788c413e0d17ffe7eabe8cff4a9f6ae723` from `origin/dev`.
 - Findings were reproduced on `132037dd075090c295003d6885ac4276a9640916`; the intervening upstream commits did not change Jobs source or tests, and each task reconfirms its red state before implementation.
 - Preserve every public `JobManager` method signature and return shape.
 - Backend operation modules must not import `JobManager`.
@@ -69,7 +69,7 @@ quota concurrency: 2 created, expected 1
 **Goal:** Define the typed acquisition command and characterize acquisition before moving SQL.
 **Success Criteria:** Facade tests cover contention, expiry, dependencies, quotas, counters, ordering, and post-commit effects on both backends.
 **Tests:** Contract tests, shared acquisition parity scenarios, direct backend operation tests.
-**Status:** Not Started
+**Status:** In Progress
 
 ### Stage 4: Acquisition Extraction
 **Goal:** Move single-job acquisition SQL into backend modules and leave `JobManager.acquire_next_job` as a thin compatibility facade.
@@ -671,11 +671,11 @@ Open a PR against `dev` containing only `TASK-12969.1` implementation and planni
 - Consumes: merged PR 1 and current `origin/dev`.
 - Produces: a new clean acquisition worktree/branch based on the merge commit.
 
-- [ ] **Step 1: Confirm the admission PR is merged and green**
+- [x] **Step 1: Confirm the admission PR is merged and green**
 
 Record the PR URL, merge commit, focused test results, Bandit result, and requester-owned Change summary in `TASK-12969.1`. Mark it Done only after the merge is visible on `origin/dev`.
 
-- [ ] **Step 2: Create a new acquisition worktree**
+- [x] **Step 2: Create a new acquisition worktree**
 
 ```bash
 git fetch origin dev
@@ -685,9 +685,11 @@ git worktree add .worktrees/jobs-lease-acquisition \
 
 Do not continue acquisition work on the admission branch. Set `TASK-12969.2` to In Progress and record the new worktree/branch.
 
-- [ ] **Step 3: Re-run the merged admission gate**
+- [x] **Step 3: Re-run the merged admission gate**
 
 Run the Task 4 admission gate in the new worktree. Expected: all tests pass with real PostgreSQL execution. Stop and repair regression fallout before any acquisition edits.
+
+Execution evidence on the merged base: 63 tests passed with required real PostgreSQL execution and zero skips. The first sandboxed run could not reach the healthy local PostgreSQL container; the unchanged matrix passed when rerun with local service access.
 
 ## Task 6: Add the Typed Single-Job Acquisition Command
 
@@ -1146,7 +1148,7 @@ python -m compileall -q \
 python -m bandit -r \
   tldw_Server_API/app/core/Jobs/manager.py \
   tldw_Server_API/app/core/Jobs/operations \
-  -f json -o /tmp/bandit_task_12968_2.json
+  -f json -o /tmp/bandit_task_12969_2.json
 ```
 
 Expected: compile succeeds and Bandit reports no new findings.
@@ -1166,7 +1168,7 @@ Confirm the PR does not contain:
 
 ```bash
 git add Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md \
-  backlog/tasks/task-12968*
+  backlog/tasks/task-12969*
 git commit -m "docs(jobs): record acquisition extraction verification"
 ```
 

--- a/Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md
+++ b/Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md
@@ -4,7 +4,7 @@
 
 **Goal:** Remove the three validated Jobs admission defects, then incrementally extract the single-job lease acquisition, renewal, and release transaction boundaries without changing the public `JobManager` API.
 
-**Architecture:** Deliver three separate PRs. PR 1 keeps `JobManager.create_job` as the facade while making secret rejection authoritative, quota failures fail closed, optional PostgreSQL counters savepoint-isolated, and enabled quotas atomic. PostgreSQL uses owner/domain-scoped advisory locks; SQLite uses a short `BEGIN IMMEDIATE` transaction because SQLite write locking is database-wide. PR 2 starts only after PR 1 is merged and rebased; it adds a typed acquisition command and moves only single-job acquisition SQL into backend lifecycle modules. PR 3 starts only after PR 2 is merged and rebased; it adds typed renewal/release commands and moves those two transitions. Validation, compatibility mapping, and post-commit effects remain in `JobManager` throughout.
+**Architecture:** Deliver three separate PRs. PR 1 keeps `JobManager.create_job` as the facade while making secret rejection authoritative, quota failures fail closed, optional PostgreSQL counters savepoint-isolated, and enabled quotas atomic. PostgreSQL uses owner/domain-scoped advisory locks; SQLite uses a short `BEGIN IMMEDIATE` transaction because SQLite write locking is database-wide. PR 2 starts only after PR 1 is merged and rebased; it adds a typed acquisition command and moves only single-job acquisition SQL into backend lifecycle modules. PR 3 starts only after PR 2 is merged and rebased; it adds typed renewal/release commands and moves those two transitions. Validation, compatibility mapping, expired-processing recovery, and post-commit effects remain in `JobManager` throughout. Expired recovery can schedule retries or apply terminal failure policy, so it is not part of the single queued-to-processing acquisition transaction extracted in PR 2.
 
 **Tech Stack:** Python 3.14, sqlite3, psycopg 3, PostgreSQL transaction-scoped advisory locks, SQLite `BEGIN IMMEDIATE`, dataclasses, pytest, existing Jobs temporary PostgreSQL fixtures, Loguru, Bandit.
 
@@ -19,7 +19,7 @@
 - Preserve every public `JobManager` method signature and return shape.
 - Backend operation modules must not import `JobManager`.
 - Do not add or change database schema in any PR.
-- Acquire quota locks only when the corresponding quota is enabled and an owner scope exists; do not globally serialize normal admissions or acquisitions.
+- Acquire PostgreSQL quota locks only when the corresponding quota is enabled and an owner scope exists; do not globally serialize normal PostgreSQL admissions or acquisitions. Preserve SQLite's merged unconditional `BEGIN IMMEDIATE` acquisition boundary, which prevents dependency edges from committing between candidate selection and the queued-to-processing update.
 - Durable job row, counter, and existing outbox writes remain in the backend transaction. Metrics, tracing, gauges, SLA reporting, and `emit_job_event` calls run after commit.
 - `complete_job`, `fail_job`, `cancel_job`, terminal transitions, `batch_renew_leases`, batch completion/failure, retry, quarantine, pruning, and admin-owned SQL are out of scope.
 - Real PostgreSQL tests use `pytest.mark.pg_jobs`, `jobs_pg_dsn`, and `RUN_JOBS=1`; a skipped PostgreSQL test is not acceptable evidence for any PR.
@@ -69,13 +69,13 @@ quota concurrency: 2 created, expected 1
 **Goal:** Define the typed acquisition command and characterize acquisition before moving SQL.
 **Success Criteria:** Facade tests cover contention, expiry, dependencies, quotas, counters, ordering, and post-commit effects on both backends.
 **Tests:** Contract tests, shared acquisition parity scenarios, direct backend operation tests.
-**Status:** In Progress
+**Status:** Complete
 
 ### Stage 4: Acquisition Extraction
 **Goal:** Move single-job acquisition SQL into backend modules and leave `JobManager.acquire_next_job` as a thin compatibility facade.
 **Success Criteria:** SQLite and real PostgreSQL acquisition suites pass with no operation-module dependency on `JobManager`; renewal, release, batch, and terminal paths remain unchanged.
 **Tests:** Focused acquisition matrix, acquisition concurrency stress, Jobs parity, Bandit, compile check.
-**Status:** Not Started
+**Status:** Complete
 
 ### Stage 5: Renewal and Release Extraction
 **Goal:** Characterize and move single-job renewal/release SQL only after acquisition is merged.
@@ -701,11 +701,11 @@ Execution evidence on the merged base: 63 tests passed with required real Postgr
 - Consumes: existing `LifecycleResult`, `NoTransitionReason`, and manager arguments.
 - Produces: `AcquireJobCommand` used by both backend modules.
 
-- [ ] **Step 1: Add red command and invariant tests**
+- [x] **Step 1: Add red command and invariant tests**
 
 Test exact field preservation, frozen behavior, invalid ordering values, and invalid lease duration. Add no-transition coverage for `NO_ELIGIBLE_JOB`.
 
-- [ ] **Step 2: Add the acquisition command dataclass**
+- [x] **Step 2: Add the acquisition command dataclass**
 
 Implement these contracts:
 
@@ -743,7 +743,7 @@ NO_ELIGIBLE_JOB = "no_eligible_job"
 
 Preserve `tie_break=None`: PostgreSQL currently resolves it to FIFO, while SQLite keeps the current Chatbooks dynamic default and FIFO for other domains.
 
-- [ ] **Step 3: Export and verify contracts**
+- [x] **Step 3: Export and verify contracts**
 
 Add the command classes to `__all__`, run:
 
@@ -753,7 +753,7 @@ RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_operation_contr
 
 Expected: all contract tests pass, including the recursive no-`JobManager` import guard.
 
-- [ ] **Step 4: Commit Task 6**
+- [x] **Step 4: Commit Task 6**
 
 ```bash
 git add tldw_Server_API/app/core/Jobs/operations/contracts.py \
@@ -772,7 +772,7 @@ git commit -m "refactor(jobs): define single job acquisition command"
 - Consumes: current public `JobManager` methods.
 - Produces: passing backend-neutral acquisition scenarios that remain unchanged while Tasks 8-9 move the implementation.
 
-- [ ] **Step 1: Add shared public parity scenarios**
+- [x] **Step 1: Add shared public parity scenarios**
 
 Add these helpers to `parity/scenarios.py` and wrappers in both backend parity files. Add imports for `ThreadPoolExecutor`, `Barrier`, and `Callable`.
 
@@ -847,7 +847,7 @@ def run_expired_lease_reclaim_scenario(
 
 Construct PostgreSQL managers before entering the executor so concurrent schema initialization cannot interfere with the contention assertion.
 
-- [ ] **Step 2: Add backend expiry adapters in the wrapper files**
+- [x] **Step 2: Add backend expiry adapters in the wrapper files**
 
 The SQLite wrapper passes this callback:
 
@@ -881,7 +881,7 @@ def _expire_postgres_lease(manager: JobManager, job_id: int) -> None:
 
 Add one wrapper test per new scenario in each parity file.
 
-- [ ] **Step 3: Verify the characterization suite is green before extraction**
+- [x] **Step 3: Verify the characterization suite is green before extraction**
 
 ```bash
 RUN_JOBS=1 python -m pytest \
@@ -892,7 +892,7 @@ RUN_JOBS=1 python -m pytest \
 
 Expected: every shared scenario passes on both backends and no PostgreSQL test skips. If a scenario fails, correct the scenario or split a newly discovered behavior defect into a separate task before extraction.
 
-- [ ] **Step 4: Commit the green characterization tests**
+- [x] **Step 4: Commit the green characterization tests**
 
 ```bash
 git add tldw_Server_API/tests/Jobs/parity
@@ -917,9 +917,9 @@ The module exposes one function with this exact signature:
 
 - `acquire_job(conn: sqlite3.Connection, *, command: AcquireJobCommand, counters_enabled: bool, now: datetime) -> LifecycleResult`
 
-- [ ] **Step 1: Write and run the red SQLite direct-operation tests**
+- [x] **Step 1: Write and run the red SQLite direct-operation tests**
 
-Import `acquire_job` from the future SQLite lifecycle module. Cover applied acquisition, no eligible row, FIFO/LIFO/default ordering, dependency blocking, expired reclaim, max-inflight quota, and counter movement. Run:
+Import `acquire_job` from the future SQLite lifecycle module. Cover applied acquisition, no eligible row, FIFO/LIFO/default ordering, dependency blocking, max-inflight quota including expired leases not counting as active inflight work, and counter movement. Expired-processing recovery remains a facade workflow and is covered by the unchanged public parity reclaim scenario from Task 7. Run:
 
 ```bash
 RUN_JOBS=1 python -m pytest \
@@ -929,9 +929,9 @@ RUN_JOBS=1 python -m pytest \
 
 Expected: collection fails because `operations.sqlite.lifecycle` does not exist.
 
-- [ ] **Step 2: Implement SQLite acquire transaction**
+- [x] **Step 2: Implement SQLite acquire transaction**
 
-Move the existing eligibility, dependency, ordering, single-update toggle, expired-lease reclaim, update, row fetch, and counter SQL into `acquire_job`. Preserve dynamic Chatbooks ordering exactly. When `max_inflight_quota > 0` and `owner_user_id` exists, execute `BEGIN IMMEDIATE` before count plus acquisition so both are one serialized decision.
+Move the existing queued-job eligibility, dependency, ordering, single-update toggle, update, row fetch, and counter SQL into `acquire_job`. Preserve dynamic Chatbooks ordering exactly. Keep expired-processing recovery in `JobManager`; it owns retry scheduling and terminal failure behavior outside this extraction. Preserve the merged unconditional `BEGIN IMMEDIATE` before candidate selection: it prevents a dependency edge from committing between the eligibility query and queued-to-processing update, and it also keeps an enabled max-inflight count plus acquisition in one serialized decision. Do not narrow this lock to quota-enabled calls during extraction.
 
 Use `cursor.rowcount` for transition success. Return:
 
@@ -942,11 +942,12 @@ LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
 
 Counter updates remain inside the transaction. Do not decrypt payloads, emit events, update gauges, record SLA breaches, or observe metrics in the operation module.
 
-- [ ] **Step 3: Export acquisition and route the SQLite facade**
+- [x] **Step 3: Export acquisition and route the SQLite facade**
 
 `JobManager` continues to:
 - honor acquire gate and queue pause;
 - clamp/adapt lease seconds;
+- recover expired processing jobs and reconcile terminal dependents before queued selection;
 - resolve priority direction, tie-break, single-update flag, and quota values;
 - generate the lease id;
 - decrypt/parse payload and assert public invariants;
@@ -977,11 +978,11 @@ result = _sqlite_acquire_job(
 )
 ```
 
-- [ ] **Step 4: Add and satisfy facade post-commit side-effect tests**
+- [x] **Step 4: Add and satisfy facade post-commit side-effect tests**
 
 In `test_jobs_lifecycle_side_effects.py`, monkeypatch `emit_job_event`, `observe_queue_latency`, and `_update_gauges`. Stub `_sqlite_acquire_job` with applied and no-transition `LifecycleResult` values. Assert applied acquisition emits one `job.acquired`; no-transition or raised backend errors emit no success event, metric, or gauge. Record `"operation-returned"` in the stub and assert every callback occurs later in the recorded order.
 
-- [ ] **Step 5: Verify SQLite direct and facade behavior**
+- [x] **Step 5: Verify SQLite direct and facade behavior**
 
 ```bash
 RUN_JOBS=1 python -m pytest \
@@ -996,11 +997,11 @@ RUN_JOBS=1 python -m pytest \
 
 Expected: all selected tests pass.
 
-- [ ] **Step 6: Confirm renewal and release are untouched**
+- [x] **Step 6: Confirm renewal and release are untouched**
 
 Use `git diff --function-context origin/dev -- tldw_Server_API/app/core/Jobs/manager.py` and verify `renew_job_lease`, `release_job`, `batch_renew_leases`, and terminal methods contain no behavioral edits. Import-only adjacency changes must be reviewed explicitly.
 
-- [ ] **Step 7: Commit Task 8**
+- [x] **Step 7: Commit Task 8**
 
 ```bash
 git add tldw_Server_API/app/core/Jobs/operations/sqlite \
@@ -1028,9 +1029,9 @@ The module exposes one function with this exact signature:
 
 - `acquire_job(conn: Any, cursor_factory: Callable[[Any], AbstractContextManager[Any]], *, command: AcquireJobCommand, counters_enabled: bool, now: datetime) -> LifecycleResult`
 
-- [ ] **Step 1: Write and run the red PostgreSQL direct-operation tests**
+- [x] **Step 1: Write and run the red PostgreSQL direct-operation tests**
 
-Import `acquire_job` from the future PostgreSQL lifecycle module. Use `pytestmark = pytest.mark.pg_jobs` and `jobs_pg_dsn`. Cover applied acquisition, no eligible row, `SKIP LOCKED` contention, priority/tie ordering, dependency blocking, expired reclaim, atomic max-inflight quota, counter movement, and counter savepoint recovery. Run:
+Import `acquire_job` from the future PostgreSQL lifecycle module. Use `pytestmark = pytest.mark.pg_jobs` and `jobs_pg_dsn`. Cover applied acquisition, no eligible row, `SKIP LOCKED` contention, priority/tie ordering, dependency blocking, atomic max-inflight quota including expired leases not counting as active inflight work, counter movement, and counter savepoint recovery. Expired-processing recovery remains a facade workflow and is covered by the Task 7 public parity reclaim scenario. Run:
 
 ```bash
 RUN_JOBS=1 python -m pytest \
@@ -1040,21 +1041,21 @@ RUN_JOBS=1 python -m pytest \
 
 Expected: collection fails because `operations.postgres.lifecycle` does not exist. The test must execute rather than skip.
 
-- [ ] **Step 2: Implement PostgreSQL acquire transaction**
+- [x] **Step 2: Implement PostgreSQL acquire transaction**
 
-Move both existing `JOBS_PG_SINGLE_UPDATE_ACQUIRE` and two-step `FOR UPDATE SKIP LOCKED` paths into the operation. Preserve current ordering and dependency predicates. If max-inflight quota is enabled for an owner, acquire a transaction-scoped advisory lock in the namespace `jobs:acquire-inflight`, count active unexpired processing rows, and return `NO_ELIGIBLE_JOB` at the limit before selecting another row.
+Move both existing `JOBS_PG_SINGLE_UPDATE_ACQUIRE` and two-step `FOR UPDATE SKIP LOCKED` paths into the operation. Preserve current ordering and dependency predicates. Keep expired-processing recovery in `JobManager`; it owns retry scheduling and terminal failure behavior outside this extraction. If max-inflight quota is enabled for an owner, acquire the current transaction-scoped advisory lock, count active unexpired processing rows, and return `NO_ELIGIBLE_JOB` at the limit before selecting another row.
 
-Generate the advisory key with the same stable BLAKE2b technique as admission but a distinct fixed prefix. Keep counter updates in a savepoint so a noncritical counter failure cannot poison the lease transaction.
+Preserve the exact current `JobManager._pg_advisory_key("max-inflight", domain, owner_user_id)` SHA-1-derived key material and signed-BIGINT mapping in a private operation helper. This keeps mixed old/new workers on the same lock during rolling deployment; changing to a new BLAKE2b namespace inside the extraction would temporarily break quota serialization. Keep counter updates in a savepoint so a noncritical counter failure cannot poison the lease transaction.
 
-- [ ] **Step 3: Route PostgreSQL facade calls and remove migrated acquisition SQL**
+- [x] **Step 3: Route PostgreSQL facade calls and remove migrated acquisition SQL**
 
 Use the same facade responsibilities and result mapping established for SQLite. Delete the old PostgreSQL acquisition SQL only after direct and parity tests pass. Keep renewal, release, batch renewal, and terminal methods byte-for-byte unchanged except import/format adjustments required by tooling.
 
-- [ ] **Step 4: Extend post-commit side-effect tests to PostgreSQL routing**
+- [x] **Step 4: Extend post-commit side-effect tests to PostgreSQL routing**
 
 Add applied, no-transition, and raised-error stubs for `_postgres_acquire_job`. Reuse the Task 8 event-order assertions and verify facade behavior is identical across backend routing.
 
-- [ ] **Step 5: Verify direct PostgreSQL and parity behavior**
+- [x] **Step 5: Verify direct PostgreSQL and parity behavior**
 
 ```bash
 RUN_JOBS=1 python -m pytest \
@@ -1068,7 +1069,7 @@ RUN_JOBS=1 python -m pytest \
 
 Expected: all selected tests pass and none skip.
 
-- [ ] **Step 6: Run focused concurrency stress**
+- [x] **Step 6: Run focused concurrency stress**
 
 ```bash
 RUN_JOBS=1 python -m pytest \
@@ -1079,11 +1080,11 @@ RUN_JOBS=1 python -m pytest \
 
 Expected: both stress files pass. Record runtime and test counts in `TASK-12969.2`.
 
-- [ ] **Step 7: Confirm renewal and release are untouched**
+- [x] **Step 7: Confirm renewal and release are untouched**
 
 Repeat the Task 8 function-context review for `manager.py`. The acquisition PR must not move, rewrite, or opportunistically clean up renewal/release code.
 
-- [ ] **Step 8: Commit Task 9**
+- [x] **Step 8: Commit Task 9**
 
 ```bash
 git add tldw_Server_API/app/core/Jobs/operations/postgres \
@@ -1097,13 +1098,13 @@ git commit -m "refactor(jobs): extract postgres lease acquisition"
 
 **Files:**
 - Modify: `Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md`
-- Update through Backlog MCP: `TASK-12969`, `TASK-12969.2`
+- Update through Backlog MCP: `TASK-12969.2`. The intended Jobs parent cannot be updated safely until the repository's unrelated duplicate `TASK-12969` records are disambiguated.
 
 **Interfaces:**
 - Consumes: completed Tasks 6-9.
 - Produces: a review-ready PR against `dev` containing only the single-job acquisition extraction.
 
-- [ ] **Step 1: Run the focused two-backend matrix**
+- [x] **Step 1: Run the focused two-backend matrix**
 
 ```bash
 RUN_JOBS=1 python -m pytest \
@@ -1122,7 +1123,7 @@ RUN_JOBS=1 python -m pytest \
 
 Expected: all selected tests pass and no PostgreSQL test skips.
 
-- [ ] **Step 2: Verify boundaries mechanically**
+- [x] **Step 2: Verify boundaries mechanically**
 
 ```bash
 rg -n "JobManager" tldw_Server_API/app/core/Jobs/operations
@@ -1138,7 +1139,7 @@ Expected:
 - only migrated acquisition SQL is present in lifecycle modules;
 - renewal, release, `batch_renew_leases`, and terminal SQL remain in manager and are explicitly listed as deferred.
 
-- [ ] **Step 3: Run syntax and security validation**
+- [x] **Step 3: Run syntax and security validation**
 
 ```bash
 python -m compileall -q \
@@ -1153,7 +1154,7 @@ python -m bandit -r \
 
 Expected: compile succeeds and Bandit reports no new findings.
 
-- [ ] **Step 4: Review scope and diff**
+- [x] **Step 4: Review scope and diff**
 
 Confirm the PR does not contain:
 - admission behavior changes beyond merged PR 1;
@@ -1164,11 +1165,11 @@ Confirm the PR does not contain:
 - public API response changes;
 - unrelated formatting or generated metadata.
 
-- [ ] **Step 5: Commit tracking updates and open PR 2**
+- [x] **Step 5: Commit tracking updates and open PR 2**
 
 ```bash
 git add Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md \
-  backlog/tasks/task-12969*
+  'backlog/tasks/task-12969.2 - Extract-Jobs-single-job-lease-acquisition-operation.md'
 git commit -m "docs(jobs): record acquisition extraction verification"
 ```
 

--- a/backlog/tasks/task-12969.1 - Harden-Jobs-admission-transaction-security-and-quota-semantics.md
+++ b/backlog/tasks/task-12969.1 - Harden-Jobs-admission-transaction-security-and-quota-semantics.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12969.1
 title: Harden Jobs admission transaction security and quota semantics
-status: In Progress
+status: Done
 created_date: 2026-07-15 01:19
 labels:
 - Jobs
@@ -28,7 +28,7 @@ modified_files:
 - tldw_Server_API/tests/Jobs/test_jobs_quotas_sqlite.py
 - tldw_Server_API/tests/Jobs/test_jobs_quotas_postgres.py
 - tldw_Server_API/tests/Jobs/test_jobs_manager_pg_fakes_extended.py
-updated_date: 2026-07-26 03:38
+updated_date: 2026-07-26 05:54
 ---
 
 ## Description
@@ -68,12 +68,13 @@ Rebased PR #2750 onto latest origin/dev 1b9518c68c929162b755a35b6863b407962c595e
 Final independent review found a no-quota PostgreSQL idempotent replay/prune ordering race. A deterministic real-PostgreSQL regression reproduced prune committing before the replay event. Commit aeff41d653 adds FOR KEY SHARE to the post-conflict replay fetch, preserving quota-specific advisory locks and isolation behavior. Final focused gate: 71 passed with required real PostgreSQL and zero skips (150 warnings); Ruff and compileall passed; Bandit reported 0 findings and 0 errors; git diff --check passed.
 A second independent review identified an earlier conflict window: PostgreSQL ON CONFLICT DO NOTHING can lose the conflicting row to pruning before the subsequent locking fetch. It also found the no-quota test cleared JOBS_QUOTA_SUBMITS_PER_MINUTE instead of the production JOBS_QUOTA_SUBMITS_PER_MIN key. Both findings were validated. TDD reproduced the current TypeError after prune deleted the row. Commit 1fdc2ed658 replaces the invalid synthetic fallback with bounded insert-or-lock conflict resolution, explicitly zeroes all global/domain/user/domain+user quota scopes, and requires the no-quota test to exercise the SELECT * fallback path. Final gate: 72 passed with required real PostgreSQL and zero skips (152 warnings); Ruff and compileall passed; Bandit reported 0 findings and 0 errors; git diff --check passed.
 Rebased PR #2750 again onto latest origin/dev 2e0d3f1a2cfcad9798008f5bd249d91bbac43f07. The intervening upstream changes were limited to trusted license-first CI workflows, CI tests, and their tracking docs; no Jobs files overlapped. The rebase completed without conflicts, and range-diff preserved all 22 PR commits. Post-rebase verification: 72 focused tests passed with required real PostgreSQL and zero skips (152 warnings); Ruff and compileall passed; Bandit reported 0 findings and 0 errors; git diff --check passed. The requester-authored Change summary remains the only human merge gate.
+PR #2750 merged into dev as 0f3983788c413e0d17ffe7eabe8cff4a9f6ae723 on 2026-07-26. The merge contains reviewed branch head b3315054c27cade716593d4dd1416f7b27239e86. The PR body still contained the pending requester-authored Change summary placeholder at merge time; this project-policy deviation is recorded explicitly and no summary was fabricated.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Hardened Jobs admission without changing the JobManager public facade: secret rejection now fails before persistence, optional PostgreSQL counter failures are savepoint-isolated, quota reads fail closed, and enabled owner/domain quotas are serialized atomically on SQLite and PostgreSQL. PostgreSQL idempotent admission resolves conflicts through a bounded insert-or-lock loop: existing rows stay locked through replay-event commit, while a conflict deleted before the locking fetch is retried as a valid fresh admission. Optional psycopg absence produces an explicit dependency error. Added deterministic SQLite/PostgreSQL coverage for quota races, both replay/prune interleavings, independent owner scopes, transaction recovery, no-quota fast paths, and optional-dependency failure behavior. The implementation is rebased on origin/dev 2e0d3f1a2c and locally verified with 72 focused tests plus security/static gates; final PR checks and the requester-authored Change summary remain merge gates.
+Hardened Jobs admission without changing the JobManager public facade: secret rejection now fails before persistence, optional PostgreSQL counter failures are savepoint-isolated, quota reads fail closed, and enabled owner/domain quotas are serialized atomically on SQLite and PostgreSQL. PostgreSQL idempotent admission uses bounded insert-or-lock conflict resolution to preserve replay semantics across pruning races, and optional psycopg absence produces an explicit dependency error. Deterministic SQLite/PostgreSQL coverage passed with 72 focused tests plus Ruff, compileall, Bandit, and diff checks. PR #2750 merged into dev as 0f3983788c413e0d17ffe7eabe8cff4a9f6ae723. The required requester-authored Change summary was still absent from the PR body at merge time; that process deviation is recorded rather than backfilled with AI-authored text.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12969.2 - Extract-Jobs-single-job-lease-acquisition-operation.md
+++ b/backlog/tasks/task-12969.2 - Extract-Jobs-single-job-lease-acquisition-operation.md
@@ -35,7 +35,7 @@ modified_files:
 - tldw_Server_API/tests/Jobs/parity/scenarios.py
 - tldw_Server_API/tests/Jobs/parity/test_sqlite_parity.py
 - tldw_Server_API/tests/Jobs/parity/test_postgres_parity.py
-updated_date: 2026-07-26 07:34
+updated_date: 2026-07-26 14:57
 ---
 
 ## Description
@@ -71,6 +71,7 @@ Implementation completed in reviewable commits 998c94e103 (typed acquisition com
 Final post-review rerun on commit 38135ac945 supersedes the earlier 75-test matrix: 76 tests passed with required real PostgreSQL and zero skips (163 warnings in 18.64s).
 Final whole-branch review of origin/dev..38135ac945 approved with no actionable correctness, concurrency, security, regression, scope, or test-coverage findings. Residual risks are intentional and documented: PostgreSQL acquisition counters remain best-effort after savepoint-isolated failure; noncritical post-commit observers may be absent after a durable lease commit; targeted stress cannot exhaust process crashes, unusual SQLite lock environments, or every PostgreSQL scheduling interleaving.
 Draft PR #2760 opened against dev: https://github.com/rmusser01/tldw_server/pull/2760. It is intentionally blocked from merge until the requester replaces the PR's Change summary placeholder with their own explanation of what changed and why these implementation choices were made.
+PR #2760 maintenance on 2026-07-26: rebased all seven PR commits without conflicts onto current origin/dev d710e5a5eefb86945309d3975acaa71691d26f26. Qodo review comments 3652719068 and 3652719069 were validated as compliance improvements: ordering and candidate SQL no longer use f-string interpolation, both backends select from four fixed allowlisted ordering clauses, and SQLite's B608 suppressions were removed. Added AST/token regression guards that permit only the bound lease-duration f-string while rejecting f-strings, format/format_map, percent formatting, and any nosec comment in acquisition lifecycle modules. TDD red produced the expected three failures before the fix; focused contracts then passed 19 tests. Fresh rebased two-backend matrix passed 80 tests with required real PostgreSQL and zero skips (171 warnings in 21.03s); PostgreSQL stress passed 4 tests with zero skips. Ruff and compileall passed. Bandit /private/tmp/bandit_TASK-12969.2-review-fixes.json reports 0 findings, 0 errors, 0 nosec, and 0 skipped tests. Independent review challenged three static-guard bypasses; all were fixed and final re-review approved with no actionable findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12969.2 - Extract-Jobs-single-job-lease-acquisition-operation.md
+++ b/backlog/tasks/task-12969.2 - Extract-Jobs-single-job-lease-acquisition-operation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12969.2
 title: Extract Jobs single-job lease acquisition operation
-status: To Do
+status: In Progress
 created_date: 2026-07-15 01:19
 dependencies:
 - TASK-12969.1
@@ -34,6 +34,7 @@ modified_files:
 - tldw_Server_API/tests/Jobs/parity/scenarios.py
 - tldw_Server_API/tests/Jobs/parity/test_sqlite_parity.py
 - tldw_Server_API/tests/Jobs/parity/test_postgres_parity.py
+updated_date: 2026-07-26 05:59
 ---
 
 ## Description
@@ -60,7 +61,8 @@ After TASK-12969.1 is merged, execute Tasks 5-10 in the linked plan from a fresh
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Execution started from merged origin/dev 0f3983788c413e0d17ffe7eabe8cff4a9f6ae723 in isolated worktree .worktrees/jobs-lease-acquisition on branch codex/jobs-lease-acquisition. TASK-12969.1 is merged and finalized; PR #2750's missing requester-authored Change summary is recorded as a process deviation. Preflight also identified two plan typos where 12968 must be corrected to 12969 during final tracking.
+Fresh-base admission boundary completed before acquisition edits: 63 tests passed with required real PostgreSQL execution and zero skips (134 warnings). The initial sandboxed run produced 39 passes and 24 PostgreSQL setup errors because local Docker/socket and database access were denied; the unchanged matrix passed outside the sandbox against the healthy existing test container with TLDW_TEST_NO_DOCKER=1. Parent TASK-12969 cannot be updated safely through Backlog MCP because unrelated active/completed records reuse the same ID.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12969.2 - Extract-Jobs-single-job-lease-acquisition-operation.md
+++ b/backlog/tasks/task-12969.2 - Extract-Jobs-single-job-lease-acquisition-operation.md
@@ -18,6 +18,7 @@ references:
 - Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md
 - TASK-12969.1
 - Docs/superpowers/specs/2026-06-24-jobs-backend-parity-refactor-design.md
+- https://github.com/rmusser01/tldw_server/pull/2760
 documentation:
 - Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md
 modified_files:
@@ -34,7 +35,7 @@ modified_files:
 - tldw_Server_API/tests/Jobs/parity/scenarios.py
 - tldw_Server_API/tests/Jobs/parity/test_sqlite_parity.py
 - tldw_Server_API/tests/Jobs/parity/test_postgres_parity.py
-updated_date: 2026-07-26 05:59
+updated_date: 2026-07-26 07:34
 ---
 
 ## Description
@@ -45,11 +46,11 @@ After admission hardening is merged, extract only single-job lease acquisition f
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Work starts only after TASK-12969.1 is merged and the acquisition branch is based on current dev.
-- [ ] #2 JobManager remains the public facade while backend-specific single-job acquire SQL moves into sqlite/lifecycle.py and postgres/lifecycle.py.
-- [ ] #3 Acquisition preserves ordering, dependency blocking, expired reclaim, worker and lease identity, counters, atomic max-inflight quota, and post-commit event behavior.
-- [ ] #4 SQLite and real PostgreSQL tests cover contention, no eligible jobs, expired reclaim, ordering variants, dependencies, and max-inflight quota.
-- [ ] #5 Renewal, release, batch lease operations, and terminal transitions are not moved in this task.
+- [x] #1 Work starts only after TASK-12969.1 is merged and the acquisition branch is based on current dev.
+- [x] #2 JobManager remains the public facade while backend-specific single-job acquire SQL moves into sqlite/lifecycle.py and postgres/lifecycle.py.
+- [x] #3 Acquisition preserves ordering, dependency blocking, expired reclaim, worker and lease identity, counters, atomic max-inflight quota, and post-commit event behavior.
+- [x] #4 SQLite and real PostgreSQL tests cover contention, no eligible jobs, expired reclaim, ordering variants, dependencies, and max-inflight quota.
+- [x] #5 Renewal, release, batch lease operations, and terminal transitions are not moved in this task.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -63,20 +64,27 @@ After TASK-12969.1 is merged, execute Tasks 5-10 in the linked plan from a fresh
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Execution started from merged origin/dev 0f3983788c413e0d17ffe7eabe8cff4a9f6ae723 in isolated worktree .worktrees/jobs-lease-acquisition on branch codex/jobs-lease-acquisition. TASK-12969.1 is merged and finalized; PR #2750's missing requester-authored Change summary is recorded as a process deviation. Preflight also identified two plan typos where 12968 must be corrected to 12969 during final tracking.
 Fresh-base admission boundary completed before acquisition edits: 63 tests passed with required real PostgreSQL execution and zero skips (134 warnings). The initial sandboxed run produced 39 passes and 24 PostgreSQL setup errors because local Docker/socket and database access were denied; the unchanged matrix passed outside the sandbox against the healthy existing test container with TLDW_TEST_NO_DOCKER=1. Parent TASK-12969 cannot be updated safely through Backlog MCP because unrelated active/completed records reuse the same ID.
+Task 8 preflight found upstream commit f8f10bde54a (merged after the plan was authored) made SQLite acquire use unconditional BEGIN IMMEDIATE to prevent dependency edges from committing between candidate selection and queued-to-processing update. The plan was corrected to preserve that current-dev safety boundary; extraction must not narrow it to quota-enabled calls.
+Task 8 execution clarified a second stale boundary: expired-processing recovery can schedule retries or terminally fail jobs and therefore remains in JobManager, outside the queued-to-processing backend operation. Task 7's public parity reclaim scenario preserves end-to-end behavior; direct SQLite operation tests instead cover expired leases being excluded from active inflight quota counts. The plan was updated accordingly.
+Task 9 preflight corrected the PostgreSQL lock-key plan: extraction must preserve the existing SHA-1-derived jobs:max-inflight:domain:owner advisory key mapping rather than introduce a new BLAKE2b namespace. This preserves quota serialization across mixed old/new workers during rolling deployment. PostgreSQL expired-processing recovery also remains in the facade and is covered end-to-end by Task 7 parity.
+Implementation completed in reviewable commits 998c94e103 (typed acquisition command), 84e0f5f0c9 (public parity characterization), 73b2348c4f (SQLite extraction), dc40e7ec88 (PostgreSQL extraction), and 38135ac945 (review follow-up). Final focused two-backend matrix passed 75 tests with TLDW_TEST_POSTGRES_REQUIRED=1 and zero skips; PostgreSQL contention stress passed 4 tests with RUN_PG_JOBS_STRESS=1 and zero skips. Focused review follow-up passed 22 tests. Ruff passed on touched scope with only unchanged contracts.py UP037 lines explicitly excluded and manager.py's established B023 exclusion; compileall succeeded. Bandit report /private/tmp/bandit_TASK-12969.2-final.json contains 0 findings and 0 errors. Independent Task 9 review found one P2 mechanical boundary issue in a docstring; it was corrected, facade ordering coverage was strengthened for both PostgreSQL acquisition modes, and re-review approved with no remaining actionable findings. Mechanical checks confirm operation modules no longer reference JobManager and renewal, release, batch, terminal, schema, and migration behavior remain outside this task. The task remains In Progress until its PR is merged. Merge readiness is additionally gated on a requester-owned Change summary. The intended Jobs parent cannot be updated through Backlog MCP while unrelated records duplicate TASK-12969.
+Final post-review rerun on commit 38135ac945 supersedes the earlier 75-test matrix: 76 tests passed with required real PostgreSQL and zero skips (163 warnings in 18.64s).
+Final whole-branch review of origin/dev..38135ac945 approved with no actionable correctness, concurrency, security, regression, scope, or test-coverage findings. Residual risks are intentional and documented: PostgreSQL acquisition counters remain best-effort after savepoint-isolated failure; noncritical post-commit observers may be absent after a durable lease commit; targeted stress cannot exhaust process crashes, unusual SQLite lock environments, or every PostgreSQL scheduling interleaving.
+Draft PR #2760 opened against dev: https://github.com/rmusser01/tldw_server/pull/2760. It is intentionally blocked from merge until the requester replaces the PR's Change summary placeholder with their own explanation of what changed and why these implementation choices were made.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Extracted single-job queued-to-processing acquisition behind the existing JobManager facade into backend-specific SQLite and PostgreSQL lifecycle operations. Added a frozen acquisition command/result contract, direct backend tests, shared parity scenarios, concurrency and quota coverage, and post-commit observer tests. Preserved SQLite's unconditional BEGIN IMMEDIATE dependency-safety boundary, PostgreSQL's legacy SHA-1 advisory-lock identity for mixed-worker compatibility, exact facade-generated lease IDs, dynamic ordering, dependency eligibility, RLS cursor setup, counter transaction semantics, expired-processing facade recovery, and all public return behavior. Verification is green on SQLite and required real PostgreSQL; no schema, renewal, release, batch, or terminal transition changes are included. Draft PR #2760 is open against dev and awaits the requester-owned Change summary plus review/merge.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -60,12 +60,14 @@ from .migrations import (
     ensure_jobs_tables,
 )
 from .operations.contracts import (
+    AcquireJobCommand,
     AdmissionRejectionReason,
     AdmissionResult,
     CreateJobCommand,
     OperationOutcome,
 )
 from .operations.postgres import create_job_admission as _postgres_create_job_admission
+from .operations.sqlite import acquire_job as _sqlite_acquire_job
 from .operations.sqlite import create_job_admission as _sqlite_create_job_admission
 from .pg_migrations import (
     POSTGRES_ARCHIVE_CURSOR_TIME_SQL,
@@ -3741,202 +3743,34 @@ class JobManager:
                                 ),
                             )
             else:
-                with conn:
-                    # Serialize candidate selection with dependency insertion.
-                    # A deferred transaction would allow an edge to commit
-                    # between the two-step SELECT and queued->processing UPDATE.
-                    conn.execute("BEGIN IMMEDIATE")
-                    if max_inflight and owner_user_id:
-                        inflight_row = conn.execute(
-                            "SELECT COUNT(*) FROM jobs WHERE domain=? AND owner_user_id=? AND status='processing' AND leased_until IS NOT NULL AND leased_until > DATETIME('now')",
-                            (domain, owner_user_id),
-                        ).fetchone()
-                        if int(inflight_row[0] or 0) >= max_inflight:
-                            return None
-                    # Optional one-shot acquisition path for SQLite to reduce contention
-                    if JobManager._is_truthy(os.getenv("JOBS_SQLITE_SINGLE_UPDATE_ACQUIRE", "")):
-                        lease_id = str(_uuid.uuid4())
-                        sub = (
-                            "SELECT id FROM jobs WHERE domain = ? AND queue = ? "
-                            "AND status = 'queued' AND (available_at IS NULL OR available_at <= DATETIME('now'))"
+                result = _sqlite_acquire_job(
+                    conn,
+                    command=AcquireJobCommand(
+                        domain=domain,
+                        queue=queue,
+                        lease_seconds=lease_seconds,
+                        worker_id=worker_id,
+                        lease_id=str(_uuid.uuid4()),
+                        owner_user_id=owner_user_id,
+                        job_type=job_type,
+                        max_inflight_quota=max_inflight,
+                        priority_direction=self._priority_dir_for(domain, backend="sqlite"),
+                        tie_break=self._tie_break_for(domain, backend="sqlite"),
+                        single_update=JobManager._is_truthy(
+                            os.getenv("JOBS_SQLITE_SINGLE_UPDATE_ACQUIRE", "")
+                        ),
+                    ),
+                    counters_enabled=JobManager._is_truthy(os.getenv("JOBS_COUNTERS_ENABLED", "")),
+                    now=self._clock.now_utc(),
+                )
+                if result.outcome is not OperationOutcome.APPLIED or result.row is None:
+                    return None
+                acquired = result.row
+                if _test_mode:
+                    with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
+                        logger.info(
+                            f"[JM TEST] acquired id={acquired.get('id')} status={acquired.get('status')} leased_until={acquired.get('leased_until')} worker_id={acquired.get('worker_id')} lease_id={acquired.get('lease_id')}"
                         )
-                        sub += dep_cond
-                        params_sub: list[Any] = [domain, queue]
-                        if owner_user_id:
-                            sub += " AND owner_user_id = ?"
-                            params_sub.append(owner_user_id)
-                        if job_type:
-                            sub += " AND job_type = ?"
-                            params_sub.append(job_type)
-                        # Ordering: env-based override; else default FIFO
-                        prio_dir = self._priority_dir_for(domain, backend="sqlite")
-                        tie = self._tie_break_for(domain, backend="sqlite")
-                        if tie == "fifo":
-                            order_sql = (
-                                f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1"
-                            )
-                        elif tie == "lifo":
-                            order_sql = f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) DESC, id DESC LIMIT 1"
-                        else:
-                            order_sql = (
-                                f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1"
-                            )
-                        sub += order_sql
-                        sql = (
-                            "UPDATE jobs SET status='processing', "  # nosec B608
-                            "retry_count = CASE WHEN status='processing' THEN retry_count + 1 ELSE retry_count END, "
-                            "started_at = COALESCE(started_at, DATETIME('now')), "
-                            "acquired_at = COALESCE(acquired_at, DATETIME('now')), "
-                            "leased_until = DATETIME('now', ?), worker_id = ?, lease_id = ?, completion_token = NULL "
-                            f"WHERE id IN ({sub})"
-                        )
-                        params_upd: list[Any] = [f"+{lease_seconds} seconds", worker_id, lease_id] + params_sub
-                        changed = conn.execute(sql, tuple(params_upd))
-                        if changed.rowcount != 1:
-                            return None
-                        row = conn.execute("SELECT * FROM jobs WHERE lease_id = ?", (lease_id,)).fetchone()
-                        if not row:
-                            return None
-                        acquired = dict(row)
-                        if JobManager._is_truthy(os.getenv("JOBS_COUNTERS_ENABLED", "")):
-                            is_scheduled = acquired.get("available_at") is not None
-                            conn.execute(
-                                (
-                                    "INSERT INTO job_counters(domain,queue,job_type,ready_count,scheduled_count,processing_count,quarantined_count) "
-                                    "VALUES(?,?,?,?,?,?,?) ON CONFLICT(domain,queue,job_type) DO UPDATE SET "
-                                    "ready_count = MAX(ready_count + ?, 0), "
-                                    "scheduled_count = MAX(scheduled_count + ?, 0), "
-                                    "processing_count = processing_count + 1, updated_at = DATETIME('now')"
-                                ),
-                                (
-                                    acquired.get("domain"),
-                                    acquired.get("queue"),
-                                    acquired.get("job_type"),
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    -1 if not is_scheduled else 0,
-                                    -1 if is_scheduled else 0,
-                                ),
-                            )
-                    else:
-                        # Expired leases were normalized before queued selection.
-                        base = (
-                            "SELECT id FROM jobs WHERE domain = ? AND queue = ? "
-                            "AND status = 'queued' AND (available_at IS NULL OR available_at <= DATETIME('now'))"
-                        )
-                        base += dep_cond
-                        params: list[Any] = [domain, queue]
-                        if owner_user_id:
-                            base += " AND owner_user_id = ?"
-                            params.append(owner_user_id)
-                        if job_type:
-                            base += " AND job_type = ?"
-                            params.append(job_type)
-                        # Ordering: env-based override; otherwise default FIFO for most domains.
-                        prio_dir = self._priority_dir_for(domain, backend="sqlite")
-                        tie = self._tie_break_for(domain, backend="sqlite")
-                        if tie == "fifo":
-                            order_sql = (
-                                f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1"
-                            )
-                        elif tie == "lifo":
-                            order_sql = f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) DESC, id DESC LIMIT 1"
-                        else:
-                            # Only 'chatbooks' uses the dynamic tie-break by default; others stick to FIFO
-                            if str(domain) == "chatbooks":
-                                try:
-                                    if job_type:
-                                        _r = conn.execute(
-                                            "SELECT 1 FROM jobs WHERE domain=? AND queue=? AND job_type=? AND status='queued' AND (available_at IS NOT NULL AND available_at > DATETIME('now')) LIMIT 1",
-                                            (domain, queue, job_type),
-                                        ).fetchone()
-                                    else:
-                                        _r = conn.execute(
-                                            "SELECT 1 FROM jobs WHERE domain=? AND queue=? AND status='queued' AND (available_at IS NOT NULL AND available_at > DATETIME('now')) LIMIT 1",
-                                            (domain, queue),
-                                        ).fetchone()
-                                    _has_sched = bool(_r)
-                                except _JOB_NONCRITICAL_EXCEPTIONS:
-                                    _has_sched = False
-                                if _has_sched:
-                                    order_sql = f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1"
-                                else:
-                                    order_sql = f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) DESC, id DESC LIMIT 1"
-                            else:
-                                order_sql = f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1"
-                        base += order_sql
-                        if _test_mode:
-                            with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                                logger.info(f"[JM TEST] acquire SELECT sql={base} params={params}")
-                        # Spin a few times if a race causes the UPDATE to affect zero rows
-                        _max_spin = 20 if _test_mode else 3
-                        job_id = None
-                        for _spin in range(_max_spin):
-                            row = conn.execute(base, params).fetchone()
-                            if not row:
-                                if _spin == 0:
-                                    # No eligible rows at the moment
-                                    return None
-                                break
-                            selected_id = int(row[0])
-                            if _test_mode:
-                                with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                                    logger.info(f"[JM TEST] selected job_id={selected_id} spin={_spin}")
-                            # Transition the selected queued job to processing with a lease.
-                            changed = conn.execute(
-                                (
-                                    "UPDATE jobs SET status = 'processing', "
-                                    "retry_count = CASE WHEN status = 'processing' THEN retry_count + 1 ELSE retry_count END, "
-                                    "started_at = COALESCE(started_at, DATETIME('now')), "
-                                    "acquired_at = COALESCE(acquired_at, DATETIME('now')), "
-                                    "leased_until = DATETIME('now', ?), worker_id = ?, lease_id = ?, completion_token = NULL "
-                                    "WHERE id = ? AND status = 'queued'"
-                                ),
-                                (f"+{lease_seconds} seconds", worker_id, str(_uuid.uuid4()), selected_id),
-                            )
-                            if changed.rowcount != 1:
-                                if _test_mode:
-                                    with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                                        logger.info(f"[JM TEST] update changed=0 for job_id={selected_id}; retrying")
-                                continue
-                            # Success
-                            job_id = selected_id
-                            break
-                        if job_id is None:
-                            return None
-                        row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
-                        if not row:
-                            return None
-                        acquired = dict(row)
-                        if _test_mode:
-                            with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                                logger.info(
-                                    f"[JM TEST] acquired id={acquired.get('id')} status={acquired.get('status')} leased_until={acquired.get('leased_until')} worker_id={acquired.get('worker_id')} lease_id={acquired.get('lease_id')}"
-                                )
-                        if JobManager._is_truthy(os.getenv("JOBS_COUNTERS_ENABLED", "")):
-                            is_scheduled = acquired.get("available_at") is not None
-                            conn.execute(
-                                (
-                                    "INSERT INTO job_counters(domain,queue,job_type,ready_count,scheduled_count,processing_count,quarantined_count) "
-                                    "VALUES(?,?,?,?,?,?,?) ON CONFLICT(domain,queue,job_type) DO UPDATE SET "
-                                    "ready_count = MAX(ready_count + ?, 0), "
-                                    "scheduled_count = MAX(scheduled_count + ?, 0), "
-                                    "processing_count = processing_count + 1, updated_at = DATETIME('now')"
-                                ),
-                                (
-                                    acquired.get("domain"),
-                                    acquired.get("queue"),
-                                    acquired.get("job_type"),
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    -1 if not is_scheduled else 0,
-                                    -1 if is_scheduled else 0,
-                                ),
-                            )
 
             if acquired is None:
                 return None

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -66,6 +66,7 @@ from .operations.contracts import (
     CreateJobCommand,
     OperationOutcome,
 )
+from .operations.postgres import acquire_job as _postgres_acquire_job
 from .operations.postgres import create_job_admission as _postgres_create_job_admission
 from .operations.sqlite import acquire_job as _sqlite_acquire_job
 from .operations.sqlite import create_job_admission as _sqlite_create_job_admission
@@ -3615,133 +3616,32 @@ class JobManager:
         self._reconcile_terminal_dependents(**reconciliation_scope)
         conn = self._connect()
         acquired: dict[str, Any] | None = None
-        dep_cond = (
-            " AND (status != 'queued' OR NOT EXISTS ("
-            "SELECT 1 FROM job_dependencies jd "
-            "LEFT JOIN jobs dep ON dep.uuid = jd.depends_on_job_uuid "
-            "WHERE jd.job_uuid = jobs.uuid AND "
-            "COALESCE(dep.status, jd.depends_on_terminal_status, 'missing') <> 'completed'"
-            "))"
-        )
         try:
             if self.backend == "postgres":
-                with conn:  # noqa: SIM117
-                    with self._pg_cursor(conn) as cur:
-                        if max_inflight and owner_user_id:
-                            cur.execute(
-                                "SELECT pg_advisory_xact_lock(%s)",
-                                (self._pg_advisory_key("max-inflight", domain, owner_user_id),),
-                            )
-                            cur.execute(
-                                "SELECT COUNT(*) AS c FROM jobs WHERE domain=%s AND owner_user_id=%s AND status='processing' AND leased_until IS NOT NULL AND leased_until > NOW()",
-                                (domain, owner_user_id),
-                            )
-                            inflight_row = cur.fetchone()
-                            if int(inflight_row.get("c") if isinstance(inflight_row, dict) else 0) >= max_inflight:
-                                return None
-                        if JobManager._is_truthy(os.getenv("JOBS_PG_SINGLE_UPDATE_ACQUIRE", "")):
-                            # Build ordering clause with optional env overrides
-                            prio_dir = self._priority_dir_for(domain, backend="pg")
-                            tie = self._tie_break_for(domain, backend="pg")
-                            if tie == "fifo":
-                                _order = f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1 FOR UPDATE SKIP LOCKED"
-                            elif tie == "lifo":
-                                _order = f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) DESC, id DESC LIMIT 1 FOR UPDATE SKIP LOCKED"
-                            else:
-                                _order = f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1 FOR UPDATE SKIP LOCKED"
-                            _cond_owner = " AND owner_user_id = %s" if owner_user_id else ""
-                            _cond_job_type = " AND job_type = %s" if job_type else ""
-                            _sql = "".join(
-                                [
-                                    "WITH picked AS (",
-                                    "  SELECT id FROM jobs WHERE domain=%s AND queue=%s ",
-                                    "  AND status='queued' AND (available_at IS NULL OR available_at <= NOW())",
-                                    dep_cond,
-                                    _cond_owner,
-                                    _cond_job_type,
-                                    _order,
-                                    ") ",
-                                    "UPDATE jobs SET status='processing', retry_count = CASE WHEN status='processing' THEN retry_count + 1 ELSE retry_count END, started_at = COALESCE(started_at, NOW()), acquired_at = COALESCE(acquired_at, NOW()), leased_until = NOW() + (%s || ' seconds')::interval, worker_id = %s, lease_id = %s, completion_token = NULL ",
-                                    "WHERE id IN (SELECT id FROM picked) RETURNING *",
-                                ]
-                            )
-                            cur.execute(
-                                _sql,
-                                (
-                                    [domain, queue]
-                                    + ([owner_user_id] if owner_user_id else [])
-                                    + ([job_type] if job_type else [])
-                                    + [int(lease_seconds), worker_id, str(_uuid.uuid4())]
-                                ),
-                            )
-                            row2 = cur.fetchone()
-                            if not row2:
-                                return None
-                            acquired = dict(row2)
-                        else:
-                            # Two-step acquire: select next ID then update+return full row
-                            base = (
-                                "SELECT id FROM jobs WHERE domain = %s AND queue = %s "
-                                "AND status = 'queued' AND (available_at IS NULL OR available_at <= NOW())"
-                            )
-                            base += dep_cond
-                            params: list[Any] = [domain, queue]
-                            if owner_user_id:
-                                base += " AND owner_user_id = %s"
-                                params.append(owner_user_id)
-                            if job_type:
-                                base += " AND job_type = %s"
-                                params.append(job_type)
-                            # Stable ordering: allow env-based override
-                            prio_dir = self._priority_dir_for(domain, backend="pg")
-                            tie = self._tie_break_for(domain, backend="pg")
-                            if tie == "fifo":
-                                base += f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1 FOR UPDATE SKIP LOCKED"
-                            elif tie == "lifo":
-                                base += f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) DESC, id DESC LIMIT 1 FOR UPDATE SKIP LOCKED"
-                            else:
-                                base += f" ORDER BY priority {prio_dir}, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1 FOR UPDATE SKIP LOCKED"
-                            cur.execute(base, params)
-                            row = cur.fetchone()
-                            if not row:
-                                return None
-                            job_id = int(row["id"])  # dict_row
-                            # Acquire and start lease
-                            cur.execute(
-                                (
-                                    "UPDATE jobs SET status = 'processing', "
-                                    "retry_count = CASE WHEN status = 'processing' THEN retry_count + 1 ELSE retry_count END, "
-                                    "started_at = COALESCE(started_at, NOW()), "
-                                    "acquired_at = COALESCE(acquired_at, NOW()), "
-                                    "leased_until = NOW() + (%s || ' seconds')::interval, "
-                                    "worker_id = %s, lease_id = %s, completion_token = NULL WHERE id = %s"
-                                ),
-                                (int(lease_seconds), worker_id, str(_uuid.uuid4()), job_id),
-                            )
-                            cur.execute("SELECT * FROM jobs WHERE id = %s", (job_id,))
-                            row2 = cur.fetchone()
-                            if not row2:
-                                return None
-                            acquired = dict(row2)
-
-                        if JobManager._is_truthy(os.getenv("JOBS_COUNTERS_ENABLED", "")):
-                            is_scheduled = acquired.get("available_at") is not None
-                            cur.execute(
-                                (
-                                    "INSERT INTO job_counters(domain,queue,job_type,ready_count,scheduled_count,processing_count,quarantined_count) "
-                                    "VALUES(%s,%s,%s,0,0,1,0) ON CONFLICT (domain,queue,job_type) DO UPDATE SET "
-                                    "ready_count = GREATEST(job_counters.ready_count + %s, 0), "
-                                    "scheduled_count = GREATEST(job_counters.scheduled_count + %s, 0), "
-                                    "processing_count = job_counters.processing_count + 1, updated_at = NOW()"
-                                ),
-                                (
-                                    acquired.get("domain"),
-                                    acquired.get("queue"),
-                                    acquired.get("job_type"),
-                                    -1 if not is_scheduled else 0,
-                                    -1 if is_scheduled else 0,
-                                ),
-                            )
+                result = _postgres_acquire_job(
+                    conn,
+                    self._pg_cursor,
+                    command=AcquireJobCommand(
+                        domain=domain,
+                        queue=queue,
+                        lease_seconds=lease_seconds,
+                        worker_id=worker_id,
+                        lease_id=str(_uuid.uuid4()),
+                        owner_user_id=owner_user_id,
+                        job_type=job_type,
+                        max_inflight_quota=max_inflight,
+                        priority_direction=self._priority_dir_for(domain, backend="pg"),
+                        tie_break=self._tie_break_for(domain, backend="pg"),
+                        single_update=JobManager._is_truthy(
+                            os.getenv("JOBS_PG_SINGLE_UPDATE_ACQUIRE", "")
+                        ),
+                    ),
+                    counters_enabled=JobManager._is_truthy(os.getenv("JOBS_COUNTERS_ENABLED", "")),
+                    now=self._clock.now_utc(),
+                )
+                if result.outcome is not OperationOutcome.APPLIED or result.row is None:
+                    return None
+                acquired = result.row
             else:
                 result = _sqlite_acquire_job(
                     conn,

--- a/tldw_Server_API/app/core/Jobs/operations/contracts.py
+++ b/tldw_Server_API/app/core/Jobs/operations/contracts.py
@@ -30,6 +30,7 @@ class NoTransitionReason(str, Enum):
     ALREADY_TERMINAL = "already_terminal"
     IDEMPOTENT_EXISTING = "idempotent_existing"
     RLS_FILTERED = "rls_filtered"
+    NO_ELIGIBLE_JOB = "no_eligible_job"
 
 
 class AdmissionRejectionReason(str, Enum):
@@ -60,6 +61,31 @@ class CreateJobCommand:
     batch_group: str | None = None
     request_id: str | None = None
     trace_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AcquireJobCommand:
+    """Backend-neutral command payload for acquiring one eligible Jobs row."""
+
+    domain: str
+    queue: str
+    lease_seconds: int
+    worker_id: str
+    lease_id: str
+    owner_user_id: str | None = None
+    job_type: str | None = None
+    max_inflight_quota: int = 0
+    priority_direction: str = "ASC"
+    tie_break: str | None = None
+    single_update: bool = False
+
+    def __post_init__(self) -> None:
+        if self.priority_direction not in {"ASC", "DESC"}:
+            raise ValueError("priority_direction must be ASC or DESC")
+        if self.tie_break not in {None, "fifo", "lifo"}:
+            raise ValueError("tie_break must be fifo, lifo, or None")
+        if self.lease_seconds < 1:
+            raise ValueError("lease_seconds must be positive")
 
 
 @dataclass(frozen=True)
@@ -217,6 +243,7 @@ class LifecycleResult:
 __all__ = [
     "AdmissionRejectionReason",
     "AdmissionResult",
+    "AcquireJobCommand",
     "CreateJobCommand",
     "LifecycleResult",
     "NoTransitionReason",

--- a/tldw_Server_API/app/core/Jobs/operations/postgres/__init__.py
+++ b/tldw_Server_API/app/core/Jobs/operations/postgres/__init__.py
@@ -1,5 +1,6 @@
-"""Postgres Jobs admission operations."""
+"""Postgres Jobs operations."""
 
 from .admission import create_job_admission
+from .lifecycle import acquire_job
 
-__all__ = ["create_job_admission"]
+__all__ = ["acquire_job", "create_job_admission"]

--- a/tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py
+++ b/tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py
@@ -34,7 +34,7 @@ _COUNTER_NONCRITICAL_ERRORS: tuple[type[BaseException], ...] = (
 
 
 def _pg_advisory_key(*parts: str) -> int:
-    """Match the legacy JobManager advisory key used by deployed workers."""
+    """Match the legacy advisory key used by deployed workers."""
 
     material = (":".join(["jobs"] + [part or "" for part in parts])).encode(
         "utf-8",

--- a/tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py
+++ b/tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py
@@ -1,0 +1,219 @@
+"""Postgres-backed Jobs single-job lifecycle operations."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from datetime import datetime
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Jobs.operations.contracts import (
+    AcquireJobCommand,
+    LifecycleResult,
+    NoTransitionReason,
+)
+
+try:
+    import psycopg as _psycopg  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency path
+    _PG_ERRORS = ()
+else:
+    _PG_ERRORS: tuple[type[BaseException], ...] = (_psycopg.Error,)
+
+
+_COUNTER_NONCRITICAL_ERRORS: tuple[type[BaseException], ...] = (
+    AttributeError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+    *_PG_ERRORS,
+)
+
+
+def _pg_advisory_key(*parts: str) -> int:
+    """Match the legacy JobManager advisory key used by deployed workers."""
+
+    material = (":".join(["jobs"] + [part or "" for part in parts])).encode(
+        "utf-8",
+        "ignore",
+    )
+    value = int.from_bytes(
+        hashlib.sha1(material, usedforsecurity=False).digest()[:8],
+        "big",
+        signed=False,
+    )
+    if value >= 2**63:
+        value -= 2**63
+    return int(value)
+
+
+def _count_from_row(row: Any) -> int:
+    if row is None:
+        return 0
+    if isinstance(row, dict):
+        return int(row.get("c") or 0)
+    return int(row[0] or 0)
+
+
+def _dependency_condition() -> str:
+    return (
+        " AND (status != 'queued' OR NOT EXISTS ("
+        "SELECT 1 FROM job_dependencies jd "
+        "LEFT JOIN jobs dep ON dep.uuid = jd.depends_on_job_uuid "
+        "WHERE jd.job_uuid = jobs.uuid AND "
+        "COALESCE(dep.status, jd.depends_on_terminal_status, 'missing') <> 'completed'"
+        "))"
+    )
+
+
+def _order_clause(command: AcquireJobCommand) -> str:
+    tie_direction = "DESC" if command.tie_break == "lifo" else "ASC"
+    return (
+        f" ORDER BY priority {command.priority_direction}, "
+        f"COALESCE(available_at, created_at) {tie_direction}, "
+        f"id {tie_direction} LIMIT 1 FOR UPDATE SKIP LOCKED"
+    )
+
+
+def _candidate_sql(command: AcquireJobCommand) -> tuple[str, list[Any]]:
+    sql = (
+        "SELECT id FROM jobs WHERE domain = %s AND queue = %s "
+        "AND status = 'queued' AND (available_at IS NULL OR available_at <= NOW())"
+    )
+    sql += _dependency_condition()
+    params: list[Any] = [command.domain, command.queue]
+    if command.owner_user_id:
+        sql += " AND owner_user_id = %s"
+        params.append(command.owner_user_id)
+    if command.job_type:
+        sql += " AND job_type = %s"
+        params.append(command.job_type)
+    sql += _order_clause(command)
+    return sql, params
+
+
+def _single_update_acquire(cur: Any, *, command: AcquireJobCommand) -> dict[str, Any] | None:
+    candidate_sql, candidate_params = _candidate_sql(command)
+    sql = "".join(
+        [
+            "WITH picked AS (",
+            f"  {candidate_sql}",
+            ") ",
+            "UPDATE jobs SET status='processing', "
+            "retry_count = CASE WHEN status='processing' THEN retry_count + 1 ELSE retry_count END, "
+            "started_at = COALESCE(started_at, NOW()), acquired_at = COALESCE(acquired_at, NOW()), "
+            "leased_until = NOW() + (%s || ' seconds')::interval, worker_id = %s, lease_id = %s, "
+            "completion_token = NULL WHERE id IN (SELECT id FROM picked) RETURNING *",
+        ]
+    )
+    cur.execute(
+        sql,
+        (*candidate_params, command.lease_seconds, command.worker_id, command.lease_id),
+    )
+    row = cur.fetchone()
+    return dict(row) if row else None
+
+
+def _two_step_acquire(cur: Any, *, command: AcquireJobCommand) -> dict[str, Any] | None:
+    candidate_sql, candidate_params = _candidate_sql(command)
+    cur.execute(candidate_sql, candidate_params)
+    candidate = cur.fetchone()
+    if not candidate:
+        return None
+    job_id = int(candidate["id"] if isinstance(candidate, dict) else candidate[0])
+    cur.execute(
+        (
+            "UPDATE jobs SET status = 'processing', "
+            "retry_count = CASE WHEN status = 'processing' THEN retry_count + 1 ELSE retry_count END, "
+            "started_at = COALESCE(started_at, NOW()), acquired_at = COALESCE(acquired_at, NOW()), "
+            "leased_until = NOW() + (%s || ' seconds')::interval, "
+            "worker_id = %s, lease_id = %s, completion_token = NULL WHERE id = %s"
+        ),
+        (command.lease_seconds, command.worker_id, command.lease_id, job_id),
+    )
+    cur.execute("SELECT * FROM jobs WHERE id = %s", (job_id,))
+    row = cur.fetchone()
+    return dict(row) if row else None
+
+
+def _bump_acquired_counters(cur: Any, *, acquired: dict[str, Any]) -> None:
+    is_scheduled = acquired.get("available_at") is not None
+    cur.execute(
+        (
+            "INSERT INTO job_counters(domain,queue,job_type,ready_count,scheduled_count,processing_count,"
+            "quarantined_count) VALUES(%s,%s,%s,0,0,1,0) "
+            "ON CONFLICT (domain,queue,job_type) DO UPDATE SET "
+            "ready_count = GREATEST(job_counters.ready_count + %s, 0), "
+            "scheduled_count = GREATEST(job_counters.scheduled_count + %s, 0), "
+            "processing_count = job_counters.processing_count + 1, updated_at = NOW()"
+        ),
+        (
+            acquired.get("domain"),
+            acquired.get("queue"),
+            acquired.get("job_type"),
+            -1 if not is_scheduled else 0,
+            -1 if is_scheduled else 0,
+        ),
+    )
+
+
+def _bump_acquired_counters_best_effort(cur: Any, *, acquired: dict[str, Any]) -> None:
+    cur.execute("SAVEPOINT jobs_acquire_counter_update")
+    try:
+        _bump_acquired_counters(cur, acquired=acquired)
+    except _COUNTER_NONCRITICAL_ERRORS as exc:
+        cur.execute("ROLLBACK TO SAVEPOINT jobs_acquire_counter_update")
+        cur.execute("RELEASE SAVEPOINT jobs_acquire_counter_update")
+        logger.warning(
+            "Non-critical Postgres jobs acquisition counter update failed for {}:{}:{}: {}",
+            acquired.get("domain"),
+            acquired.get("queue"),
+            acquired.get("job_type"),
+            exc,
+        )
+    else:
+        cur.execute("RELEASE SAVEPOINT jobs_acquire_counter_update")
+
+
+def acquire_job(
+    conn: Any,
+    cursor_factory: Callable[[Any], AbstractContextManager[Any]],
+    *,
+    command: AcquireJobCommand,
+    counters_enabled: bool,
+    now: datetime,
+) -> LifecycleResult:
+    """Atomically acquire the next eligible Postgres job."""
+
+    del now  # Postgres remains authoritative for lease and eligibility timestamps.
+    with conn:
+        with cursor_factory(conn) as cur:
+            if command.max_inflight_quota and command.owner_user_id:
+                cur.execute(
+                    "SELECT pg_advisory_xact_lock(%s)",
+                    (_pg_advisory_key("max-inflight", command.domain, command.owner_user_id),),
+                )
+                cur.execute(
+                    "SELECT COUNT(*) AS c FROM jobs WHERE domain=%s AND owner_user_id=%s "
+                    "AND status='processing' AND leased_until IS NOT NULL AND leased_until > NOW()",
+                    (command.domain, command.owner_user_id),
+                )
+                if _count_from_row(cur.fetchone()) >= command.max_inflight_quota:
+                    return LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
+
+            acquired = (
+                _single_update_acquire(cur, command=command)
+                if command.single_update
+                else _two_step_acquire(cur, command=command)
+            )
+            if acquired is None:
+                return LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
+            if counters_enabled:
+                _bump_acquired_counters_best_effort(cur, acquired=acquired)
+            return LifecycleResult.applied(row=acquired)
+
+
+__all__ = ["acquire_job"]

--- a/tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py
+++ b/tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py
@@ -32,6 +32,25 @@ _COUNTER_NONCRITICAL_ERRORS: tuple[type[BaseException], ...] = (
     *_PG_ERRORS,
 )
 
+_ORDER_CLAUSES = {
+    ("ASC", "ASC"): (
+        " ORDER BY priority ASC, COALESCE(available_at, created_at) ASC, "
+        "id ASC LIMIT 1 FOR UPDATE SKIP LOCKED"
+    ),
+    ("ASC", "DESC"): (
+        " ORDER BY priority ASC, COALESCE(available_at, created_at) DESC, "
+        "id DESC LIMIT 1 FOR UPDATE SKIP LOCKED"
+    ),
+    ("DESC", "ASC"): (
+        " ORDER BY priority DESC, COALESCE(available_at, created_at) ASC, "
+        "id ASC LIMIT 1 FOR UPDATE SKIP LOCKED"
+    ),
+    ("DESC", "DESC"): (
+        " ORDER BY priority DESC, COALESCE(available_at, created_at) DESC, "
+        "id DESC LIMIT 1 FOR UPDATE SKIP LOCKED"
+    ),
+}
+
 
 def _pg_advisory_key(*parts: str) -> int:
     """Match the legacy advisory key used by deployed workers."""
@@ -71,11 +90,7 @@ def _dependency_condition() -> str:
 
 def _order_clause(command: AcquireJobCommand) -> str:
     tie_direction = "DESC" if command.tie_break == "lifo" else "ASC"
-    return (
-        f" ORDER BY priority {command.priority_direction}, "
-        f"COALESCE(available_at, created_at) {tie_direction}, "
-        f"id {tie_direction} LIMIT 1 FOR UPDATE SKIP LOCKED"
-    )
+    return _ORDER_CLAUSES[(command.priority_direction, tie_direction)]
 
 
 def _candidate_sql(command: AcquireJobCommand) -> tuple[str, list[Any]]:
@@ -100,7 +115,8 @@ def _single_update_acquire(cur: Any, *, command: AcquireJobCommand) -> dict[str,
     sql = "".join(
         [
             "WITH picked AS (",
-            f"  {candidate_sql}",
+            "  ",
+            candidate_sql,
             ") ",
             "UPDATE jobs SET status='processing', "
             "retry_count = CASE WHEN status='processing' THEN retry_count + 1 ELSE retry_count END, "

--- a/tldw_Server_API/app/core/Jobs/operations/sqlite/__init__.py
+++ b/tldw_Server_API/app/core/Jobs/operations/sqlite/__init__.py
@@ -1,5 +1,6 @@
-"""SQLite Jobs admission operations."""
+"""SQLite Jobs backend operations."""
 
 from .admission import create_job_admission
+from .lifecycle import acquire_job
 
-__all__ = ["create_job_admission"]
+__all__ = ["acquire_job", "create_job_admission"]

--- a/tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
+++ b/tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
@@ -1,0 +1,190 @@
+"""SQLite-backed Jobs single-job lifecycle operations."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any
+
+from tldw_Server_API.app.core.Jobs.operations.contracts import (
+    AcquireJobCommand,
+    LifecycleResult,
+    NoTransitionReason,
+)
+
+
+def _sqlite_timestamp(value: datetime) -> str:
+    """Return the UTC timestamp representation used by the Jobs table."""
+
+    normalized = value
+    if value.tzinfo is not None:
+        normalized = value.astimezone(timezone.utc).replace(tzinfo=None)
+    return normalized.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _dependency_condition() -> str:
+    return (
+        " AND (status != 'queued' OR NOT EXISTS ("
+        "SELECT 1 FROM job_dependencies jd "
+        "LEFT JOIN jobs dep ON dep.uuid = jd.depends_on_job_uuid "
+        "WHERE jd.job_uuid = jobs.uuid AND "
+        "COALESCE(dep.status, jd.depends_on_terminal_status, 'missing') <> 'completed'"
+        "))"
+    )
+
+
+def _candidate_sql(
+    conn: sqlite3.Connection,
+    *,
+    command: AcquireJobCommand,
+    now_sql: str,
+) -> tuple[str, list[Any]]:
+    sql = (
+        "SELECT id FROM jobs WHERE domain = ? AND queue = ? "
+        "AND status = 'queued' AND (available_at IS NULL OR available_at <= DATETIME(?))"
+    )
+    sql += _dependency_condition()
+    params: list[Any] = [command.domain, command.queue, now_sql]
+    if command.owner_user_id:
+        sql += " AND owner_user_id = ?"
+        params.append(command.owner_user_id)
+    if command.job_type:
+        sql += " AND job_type = ?"
+        params.append(command.job_type)
+
+    if command.tie_break == "fifo":
+        tie_direction = "ASC"
+    elif command.tie_break == "lifo":
+        tie_direction = "DESC"
+    elif command.single_update or command.domain != "chatbooks":
+        tie_direction = "ASC"
+    else:
+        scheduled_sql = (
+            "SELECT 1 FROM jobs WHERE domain=? AND queue=? "
+            "AND status='queued' AND available_at IS NOT NULL AND available_at > DATETIME(?)"
+        )
+        scheduled_params: list[Any] = [command.domain, command.queue, now_sql]
+        if command.job_type:
+            scheduled_sql += " AND job_type=?"
+            scheduled_params.append(command.job_type)
+        scheduled_sql += " LIMIT 1"
+        tie_direction = "ASC" if conn.execute(scheduled_sql, scheduled_params).fetchone() else "DESC"
+
+    sql += (
+        f" ORDER BY priority {command.priority_direction}, "  # nosec B608
+        f"COALESCE(available_at, created_at) {tie_direction}, id {tie_direction} LIMIT 1"
+    )
+    return sql, params
+
+
+def _bump_acquired_counters(conn: sqlite3.Connection, *, acquired: dict[str, Any]) -> None:
+    is_scheduled = acquired.get("available_at") is not None
+    conn.execute(
+        (
+            "INSERT INTO job_counters(domain,queue,job_type,ready_count,scheduled_count,processing_count,"
+            "quarantined_count) VALUES(?,?,?,?,?,?,?) ON CONFLICT(domain,queue,job_type) DO UPDATE SET "
+            "ready_count = MAX(ready_count + ?, 0), "
+            "scheduled_count = MAX(scheduled_count + ?, 0), "
+            "processing_count = processing_count + 1, updated_at = DATETIME('now')"
+        ),
+        (
+            acquired.get("domain"),
+            acquired.get("queue"),
+            acquired.get("job_type"),
+            0,
+            0,
+            1,
+            0,
+            -1 if not is_scheduled else 0,
+            -1 if is_scheduled else 0,
+        ),
+    )
+
+
+def acquire_job(
+    conn: sqlite3.Connection,
+    *,
+    command: AcquireJobCommand,
+    counters_enabled: bool,
+    now: datetime,
+) -> LifecycleResult:
+    """Atomically acquire the next eligible SQLite job."""
+
+    now_sql = _sqlite_timestamp(now)
+    with conn:
+        # Selection and transition must exclude concurrent dependency writers.
+        conn.execute("BEGIN IMMEDIATE")
+        if command.max_inflight_quota and command.owner_user_id:
+            inflight_row = conn.execute(
+                (
+                    "SELECT COUNT(*) FROM jobs WHERE domain=? AND owner_user_id=? AND status='processing' "
+                    "AND leased_until IS NOT NULL AND leased_until > DATETIME(?)"
+                ),
+                (command.domain, command.owner_user_id, now_sql),
+            ).fetchone()
+            if int(inflight_row[0] or 0) >= command.max_inflight_quota:
+                return LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
+
+        candidate_sql, candidate_params = _candidate_sql(conn, command=command, now_sql=now_sql)
+        job_id: int | None = None
+        if command.single_update:
+            update_sql = (
+                "UPDATE jobs SET status='processing', "  # nosec B608
+                "retry_count = CASE WHEN status='processing' THEN retry_count + 1 ELSE retry_count END, "
+                "started_at = COALESCE(started_at, DATETIME(?)), "
+                "acquired_at = COALESCE(acquired_at, DATETIME(?)), "
+                "leased_until = DATETIME(?, ?), worker_id = ?, lease_id = ?, completion_token = NULL "
+                f"WHERE id IN ({candidate_sql})"
+            )
+            changed = conn.execute(
+                update_sql,
+                (
+                    now_sql,
+                    now_sql,
+                    now_sql,
+                    f"+{command.lease_seconds} seconds",
+                    command.worker_id,
+                    command.lease_id,
+                    *candidate_params,
+                ),
+            )
+            if changed.rowcount != 1:
+                return LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
+            row = conn.execute(
+                "SELECT * FROM jobs WHERE lease_id = ?",
+                (command.lease_id,),
+            ).fetchone()
+        else:
+            candidate = conn.execute(candidate_sql, candidate_params).fetchone()
+            if not candidate:
+                return LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
+            job_id = int(candidate[0])
+            changed = conn.execute(
+                (
+                    "UPDATE jobs SET status = 'processing', "
+                    "retry_count = CASE WHEN status = 'processing' THEN retry_count + 1 ELSE retry_count END, "
+                    "started_at = COALESCE(started_at, DATETIME(?)), "
+                    "acquired_at = COALESCE(acquired_at, DATETIME(?)), "
+                    "leased_until = DATETIME(?, ?), worker_id = ?, lease_id = ?, completion_token = NULL "
+                    "WHERE id = ? AND status = 'queued'"
+                ),
+                (
+                    now_sql,
+                    now_sql,
+                    now_sql,
+                    f"+{command.lease_seconds} seconds",
+                    command.worker_id,
+                    command.lease_id,
+                    job_id,
+                ),
+            )
+            if changed.rowcount != 1:
+                return LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
+            row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+
+        if not row:
+            return LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
+        acquired = dict(row)
+        if counters_enabled:
+            _bump_acquired_counters(conn, acquired=acquired)
+        return LifecycleResult.applied(row=acquired)

--- a/tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
+++ b/tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
@@ -12,6 +12,21 @@ from tldw_Server_API.app.core.Jobs.operations.contracts import (
     NoTransitionReason,
 )
 
+_ORDER_CLAUSES = {
+    ("ASC", "ASC"): (
+        " ORDER BY priority ASC, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1"
+    ),
+    ("ASC", "DESC"): (
+        " ORDER BY priority ASC, COALESCE(available_at, created_at) DESC, id DESC LIMIT 1"
+    ),
+    ("DESC", "ASC"): (
+        " ORDER BY priority DESC, COALESCE(available_at, created_at) ASC, id ASC LIMIT 1"
+    ),
+    ("DESC", "DESC"): (
+        " ORDER BY priority DESC, COALESCE(available_at, created_at) DESC, id DESC LIMIT 1"
+    ),
+}
+
 
 def _sqlite_timestamp(value: datetime) -> str:
     """Return the UTC timestamp representation used by the Jobs table."""
@@ -70,10 +85,7 @@ def _candidate_sql(
         scheduled_sql += " LIMIT 1"
         tie_direction = "ASC" if conn.execute(scheduled_sql, scheduled_params).fetchone() else "DESC"
 
-    sql += (
-        f" ORDER BY priority {command.priority_direction}, "  # nosec B608
-        f"COALESCE(available_at, created_at) {tie_direction}, id {tie_direction} LIMIT 1"
-    )
+    sql += _ORDER_CLAUSES[(command.priority_direction, tie_direction)]
     return sql, params
 
 
@@ -128,13 +140,17 @@ def acquire_job(
         candidate_sql, candidate_params = _candidate_sql(conn, command=command, now_sql=now_sql)
         job_id: int | None = None
         if command.single_update:
-            update_sql = (
-                "UPDATE jobs SET status='processing', "  # nosec B608
-                "retry_count = CASE WHEN status='processing' THEN retry_count + 1 ELSE retry_count END, "
-                "started_at = COALESCE(started_at, DATETIME(?)), "
-                "acquired_at = COALESCE(acquired_at, DATETIME(?)), "
-                "leased_until = DATETIME(?, ?), worker_id = ?, lease_id = ?, completion_token = NULL "
-                f"WHERE id IN ({candidate_sql})"
+            update_sql = "".join(
+                [
+                    "UPDATE jobs SET status='processing', ",
+                    "retry_count = CASE WHEN status='processing' THEN retry_count + 1 ELSE retry_count END, ",
+                    "started_at = COALESCE(started_at, DATETIME(?)), ",
+                    "acquired_at = COALESCE(acquired_at, DATETIME(?)), ",
+                    "leased_until = DATETIME(?, ?), worker_id = ?, lease_id = ?, completion_token = NULL ",
+                    "WHERE id IN (",
+                    candidate_sql,
+                    ")",
+                ]
             )
             changed = conn.execute(
                 update_sql,

--- a/tldw_Server_API/tests/Jobs/parity/scenarios.py
+++ b/tldw_Server_API/tests/Jobs/parity/scenarios.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import json
 from collections import Counter
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 
 ManagerFactory = Callable[[], JobManager]
+LeaseExpiry = Callable[[JobManager, int], None]
 
 
 def run_idempotent_create_scope_scenario(make_manager: ManagerFactory) -> None:
@@ -194,6 +197,73 @@ def run_acquire_complete_lifecycle_scenario(make_manager: ManagerFactory) -> Non
     assert stored is not None
     assert stored["status"] == "completed"
     assert stored.get("leased_until") is None
+
+
+def run_acquire_contention_scenario(make_manager: ManagerFactory) -> None:
+    """Verify concurrent workers acquire a pending job at most once."""
+
+    seed = make_manager()
+    job = seed.create_job(
+        domain="parity-contention",
+        queue="default",
+        job_type="single",
+        payload={},
+        owner_user_id="owner-1",
+    )
+    managers = [make_manager(), make_manager()]
+    barrier = Barrier(2)
+
+    def acquire(item: tuple[JobManager, str]) -> dict[str, object] | None:
+        manager, worker_id = item
+        barrier.wait(timeout=10)
+        return manager.acquire_next_job(
+            domain="parity-contention",
+            queue="default",
+            lease_seconds=30,
+            worker_id=worker_id,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(acquire, zip(managers, ("worker-1", "worker-2"), strict=True)))
+
+    acquired = [result for result in results if result is not None]
+    assert len(acquired) == 1
+    assert int(acquired[0]["id"]) == int(job["id"])
+
+
+def run_expired_lease_reclaim_scenario(
+    make_manager: ManagerFactory,
+    expire_lease: LeaseExpiry,
+) -> None:
+    """Verify a different worker can reclaim an expired lease."""
+
+    manager = make_manager()
+    job = manager.create_job(
+        domain="parity-expiry",
+        queue="default",
+        job_type="reclaim",
+        payload={},
+        owner_user_id="owner-1",
+    )
+    first = manager.acquire_next_job(
+        domain="parity-expiry",
+        queue="default",
+        lease_seconds=30,
+        worker_id="worker-1",
+    )
+    assert first is not None
+    expire_lease(manager, int(job["id"]))
+
+    second = manager.acquire_next_job(
+        domain="parity-expiry",
+        queue="default",
+        lease_seconds=30,
+        worker_id="worker-2",
+    )
+    assert second is not None
+    assert int(second["id"]) == int(job["id"])
+    assert second["worker_id"] == "worker-2"
+    assert second["lease_id"] != first["lease_id"]
 
 
 def run_complete_idempotency_scenario(make_manager: ManagerFactory) -> None:

--- a/tldw_Server_API/tests/Jobs/parity/test_postgres_parity.py
+++ b/tldw_Server_API/tests/Jobs/parity/test_postgres_parity.py
@@ -11,13 +11,13 @@ pytestmark = pytest.mark.pg_jobs
 
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.tests.Jobs.parity.scenarios import (
-    run_acquire_contention_scenario,
     run_acquire_complete_lifecycle_scenario,
+    run_acquire_contention_scenario,
     run_cancel_terminal_noop_scenario,
     run_events_outbox_create_complete_scenario,
     run_expired_lease_reclaim_scenario,
-    run_idempotent_create_replay_event_uses_current_request_ids_scenario,
     run_idempotent_create_preserves_original_request_ids_scenario,
+    run_idempotent_create_replay_event_uses_current_request_ids_scenario,
     run_idempotent_create_scope_scenario,
     run_renew_stale_lease_noop_scenario,
 )

--- a/tldw_Server_API/tests/Jobs/parity/test_postgres_parity.py
+++ b/tldw_Server_API/tests/Jobs/parity/test_postgres_parity.py
@@ -11,9 +11,11 @@ pytestmark = pytest.mark.pg_jobs
 
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.tests.Jobs.parity.scenarios import (
+    run_acquire_contention_scenario,
     run_acquire_complete_lifecycle_scenario,
     run_cancel_terminal_noop_scenario,
     run_events_outbox_create_complete_scenario,
+    run_expired_lease_reclaim_scenario,
     run_idempotent_create_replay_event_uses_current_request_ids_scenario,
     run_idempotent_create_preserves_original_request_ids_scenario,
     run_idempotent_create_scope_scenario,
@@ -29,6 +31,18 @@ def postgres_manager_factory(jobs_pg_dsn: str, monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setenv("JOBS_DISABLE_LEASE_ENFORCEMENT", "true")
     monkeypatch.setenv("JOBS_EVENTS_OUTBOX", "true")
     return lambda: JobManager(None, backend="postgres", db_url=jobs_pg_dsn)
+
+
+def _expire_postgres_lease(manager: JobManager, job_id: int) -> None:
+    conn = manager._connect()
+    try:
+        with conn, manager._pg_cursor(conn) as cur:
+            cur.execute(
+                "UPDATE jobs SET leased_until = NOW() - interval '10 seconds' WHERE id = %s",
+                (job_id,),
+            )
+    finally:
+        conn.close()
 
 
 def test_postgres_idempotent_create_scope(postgres_manager_factory: Callable[[], JobManager]) -> None:
@@ -55,6 +69,18 @@ def test_postgres_acquire_complete_lifecycle(postgres_manager_factory: Callable[
     """Run the acquire-complete lifecycle scenario against Postgres."""
 
     run_acquire_complete_lifecycle_scenario(postgres_manager_factory)
+
+
+def test_postgres_acquire_contention(postgres_manager_factory: Callable[[], JobManager]) -> None:
+    """Run the concurrent acquisition scenario against Postgres."""
+
+    run_acquire_contention_scenario(postgres_manager_factory)
+
+
+def test_postgres_expired_lease_reclaim(postgres_manager_factory: Callable[[], JobManager]) -> None:
+    """Run the expired lease reclaim scenario against Postgres."""
+
+    run_expired_lease_reclaim_scenario(postgres_manager_factory, _expire_postgres_lease)
 
 
 def test_postgres_renew_stale_lease_noop(postgres_manager_factory: Callable[[], JobManager]) -> None:

--- a/tldw_Server_API/tests/Jobs/parity/test_sqlite_parity.py
+++ b/tldw_Server_API/tests/Jobs/parity/test_sqlite_parity.py
@@ -10,9 +10,11 @@ import pytest
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
 from tldw_Server_API.tests.Jobs.parity.scenarios import (
+    run_acquire_contention_scenario,
     run_acquire_complete_lifecycle_scenario,
     run_cancel_terminal_noop_scenario,
     run_events_outbox_create_complete_scenario,
+    run_expired_lease_reclaim_scenario,
     run_idempotent_create_replay_event_uses_current_request_ids_scenario,
     run_idempotent_create_preserves_original_request_ids_scenario,
     run_idempotent_create_scope_scenario,
@@ -33,6 +35,18 @@ def sqlite_manager_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> C
     monkeypatch.setenv("JOBS_DISABLE_LEASE_ENFORCEMENT", "true")
     monkeypatch.setenv("JOBS_EVENTS_OUTBOX", "true")
     return lambda: JobManager(db_path)
+
+
+def _expire_sqlite_lease(manager: JobManager, job_id: int) -> None:
+    conn = manager._connect()
+    try:
+        with conn:
+            conn.execute(
+                "UPDATE jobs SET leased_until = DATETIME('now', '-10 seconds') WHERE id = ?",
+                (job_id,),
+            )
+    finally:
+        conn.close()
 
 
 def test_sqlite_idempotent_create_scope(sqlite_manager_factory: Callable[[], JobManager]) -> None:
@@ -59,6 +73,18 @@ def test_sqlite_acquire_complete_lifecycle(sqlite_manager_factory: Callable[[], 
     """Run the acquire-complete lifecycle scenario against SQLite."""
 
     run_acquire_complete_lifecycle_scenario(sqlite_manager_factory)
+
+
+def test_sqlite_acquire_contention(sqlite_manager_factory: Callable[[], JobManager]) -> None:
+    """Run the concurrent acquisition scenario against SQLite."""
+
+    run_acquire_contention_scenario(sqlite_manager_factory)
+
+
+def test_sqlite_expired_lease_reclaim(sqlite_manager_factory: Callable[[], JobManager]) -> None:
+    """Run the expired lease reclaim scenario against SQLite."""
+
+    run_expired_lease_reclaim_scenario(sqlite_manager_factory, _expire_sqlite_lease)
 
 
 def test_sqlite_renew_stale_lease_noop(sqlite_manager_factory: Callable[[], JobManager]) -> None:

--- a/tldw_Server_API/tests/Jobs/parity/test_sqlite_parity.py
+++ b/tldw_Server_API/tests/Jobs/parity/test_sqlite_parity.py
@@ -10,17 +10,16 @@ import pytest
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
 from tldw_Server_API.tests.Jobs.parity.scenarios import (
-    run_acquire_contention_scenario,
     run_acquire_complete_lifecycle_scenario,
+    run_acquire_contention_scenario,
     run_cancel_terminal_noop_scenario,
     run_events_outbox_create_complete_scenario,
     run_expired_lease_reclaim_scenario,
-    run_idempotent_create_replay_event_uses_current_request_ids_scenario,
     run_idempotent_create_preserves_original_request_ids_scenario,
+    run_idempotent_create_replay_event_uses_current_request_ids_scenario,
     run_idempotent_create_scope_scenario,
     run_renew_stale_lease_noop_scenario,
 )
-
 
 pytestmark = pytest.mark.jobs
 

--- a/tldw_Server_API/tests/Jobs/test_jobs_acquire_operations_postgres.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_acquire_operations_postgres.py
@@ -1,0 +1,446 @@
+"""Direct Postgres single-job acquisition operation tests."""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import AbstractContextManager
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Jobs.operations.contracts import (
+    AcquireJobCommand,
+    NoTransitionReason,
+    OperationOutcome,
+)
+from tldw_Server_API.app.core.Jobs.operations.postgres import lifecycle
+from tldw_Server_API.app.core.Jobs.operations.postgres.lifecycle import acquire_job
+
+psycopg = pytest.importorskip("psycopg")
+pytestmark = pytest.mark.pg_jobs
+
+NOW = datetime(2026, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture()
+def manager(jobs_pg_dsn: str, monkeypatch: pytest.MonkeyPatch) -> JobManager:
+    monkeypatch.setenv("JOBS_DB_URL", jobs_pg_dsn)
+    monkeypatch.setenv("JOBS_COUNTERS_ENABLED", "false")
+    monkeypatch.setenv("JOBS_EVENTS_OUTBOX", "false")
+    return JobManager(None, backend="postgres", db_url=jobs_pg_dsn)
+
+
+@pytest.fixture()
+def conn(manager: JobManager):
+    connection = manager._connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _create_job(
+    manager: JobManager,
+    *,
+    domain: str = "acquire",
+    job_type: str = "work",
+    owner_user_id: str = "owner",
+    priority: int = 5,
+) -> dict[str, Any]:
+    return manager.create_job(
+        domain=domain,
+        queue="default",
+        job_type=job_type,
+        payload={},
+        owner_user_id=owner_user_id,
+        priority=priority,
+    )
+
+
+def _execute(manager: JobManager, sql: str, params: tuple[Any, ...] = ()) -> None:
+    connection = manager._connect()
+    try:
+        with connection, manager._pg_cursor(connection) as cur:
+            cur.execute(sql, params)
+    finally:
+        connection.close()
+
+
+def _command(
+    *,
+    domain: str = "acquire",
+    lease_id: str = "lease-exact",
+    owner_user_id: str | None = None,
+    max_inflight_quota: int = 0,
+    priority_direction: str = "ASC",
+    tie_break: str | None = None,
+    single_update: bool = False,
+) -> AcquireJobCommand:
+    return AcquireJobCommand(
+        domain=domain,
+        queue="default",
+        lease_seconds=30,
+        worker_id="worker-1",
+        lease_id=lease_id,
+        owner_user_id=owner_user_id,
+        job_type="work",
+        max_inflight_quota=max_inflight_quota,
+        priority_direction=priority_direction,
+        tie_break=tie_break,
+        single_update=single_update,
+    )
+
+
+@pytest.mark.parametrize("single_update", [False, True], ids=["two-step", "single-update"])
+def test_postgres_acquire_applies_exact_command_lease_identity(
+    manager: JobManager,
+    conn: Any,
+    single_update: bool,
+) -> None:
+    job = _create_job(manager)
+
+    result = acquire_job(
+        conn,
+        manager._pg_cursor,
+        command=_command(single_update=single_update),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.outcome is OperationOutcome.APPLIED
+    assert result.row is not None
+    assert int(result.row["id"]) == int(job["id"])
+    assert result.row["status"] == "processing"
+    assert result.row["worker_id"] == "worker-1"
+    assert result.row["lease_id"] == "lease-exact"
+
+
+def test_postgres_acquire_returns_no_transition_without_eligible_row(
+    manager: JobManager,
+    conn: Any,
+) -> None:
+    job = _create_job(manager)
+    _execute(
+        manager,
+        "UPDATE jobs SET available_at = NOW() + interval '1 day' WHERE id = %s",
+        (int(job["id"]),),
+    )
+
+    result = acquire_job(
+        conn,
+        manager._pg_cursor,
+        command=_command(),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.outcome is OperationOutcome.NO_TRANSITION
+    assert result.no_transition_reason is NoTransitionReason.NO_ELIGIBLE_JOB
+
+
+@pytest.mark.parametrize("single_update", [False, True], ids=["two-step", "single-update"])
+def test_postgres_acquire_skips_locked_candidate(
+    manager: JobManager,
+    conn: Any,
+    single_update: bool,
+) -> None:
+    locked = _create_job(manager, priority=1)
+    eligible = _create_job(manager, priority=2)
+    locking_conn = manager._connect()
+    try:
+        with manager._pg_cursor(locking_conn) as cur:
+            cur.execute("SELECT id FROM jobs WHERE id = %s FOR UPDATE", (int(locked["id"]),))
+
+        result = acquire_job(
+            conn,
+            manager._pg_cursor,
+            command=_command(single_update=single_update),
+            counters_enabled=False,
+            now=NOW,
+        )
+    finally:
+        locking_conn.rollback()
+        locking_conn.close()
+
+    assert result.row is not None
+    assert int(result.row["id"]) == int(eligible["id"])
+
+
+@pytest.mark.parametrize("single_update", [False, True], ids=["two-step", "single-update"])
+def test_postgres_acquire_honors_resolved_priority_direction(
+    manager: JobManager,
+    conn: Any,
+    single_update: bool,
+) -> None:
+    _create_job(manager, priority=1)
+    lower_priority = _create_job(manager, priority=10)
+
+    result = acquire_job(
+        conn,
+        manager._pg_cursor,
+        command=_command(priority_direction="DESC", single_update=single_update),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.row is not None
+    assert int(result.row["id"]) == int(lower_priority["id"])
+
+
+@pytest.mark.parametrize(
+    ("tie_break", "expected_offset"),
+    [("fifo", "-1 hour"), ("lifo", "-1 minute"), (None, "-1 hour")],
+    ids=["fifo", "lifo", "default-fifo"],
+)
+def test_postgres_acquire_honors_resolved_tie_ordering(
+    manager: JobManager,
+    conn: Any,
+    tie_break: str | None,
+    expected_offset: str,
+) -> None:
+    older = _create_job(manager)
+    newer = _create_job(manager)
+    _execute(
+        manager,
+        "UPDATE jobs SET created_at = NOW() - (%s)::interval WHERE id = %s",
+        ("1 hour", int(older["id"])),
+    )
+    _execute(
+        manager,
+        "UPDATE jobs SET created_at = NOW() - (%s)::interval WHERE id = %s",
+        ("1 minute", int(newer["id"])),
+    )
+
+    result = acquire_job(
+        conn,
+        manager._pg_cursor,
+        command=_command(tie_break=tie_break),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    expected = older if expected_offset == "-1 hour" else newer
+    assert result.row is not None
+    assert int(result.row["id"]) == int(expected["id"])
+
+
+def test_postgres_acquire_skips_dependency_blocked_job(
+    manager: JobManager,
+    conn: Any,
+) -> None:
+    parent = _create_job(manager, job_type="parent", priority=1)
+    blocked = _create_job(manager, priority=1)
+    eligible = _create_job(manager, priority=2)
+    assert manager.add_job_dependency(str(blocked["uuid"]), str(parent["uuid"]))
+
+    result = acquire_job(
+        conn,
+        manager._pg_cursor,
+        command=_command(),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.row is not None
+    assert int(result.row["id"]) == int(eligible["id"])
+
+
+def test_postgres_acquire_serializes_max_inflight_quota(manager: JobManager) -> None:
+    _create_job(manager)
+    _create_job(manager)
+    barrier = threading.Barrier(2)
+
+    def run(index: int):
+        connection = manager._connect()
+        try:
+            barrier.wait(timeout=5)
+            return acquire_job(
+                connection,
+                manager._pg_cursor,
+                command=_command(
+                    lease_id=f"lease-{index}",
+                    owner_user_id="owner",
+                    max_inflight_quota=1,
+                ),
+                counters_enabled=False,
+                now=NOW,
+            )
+        finally:
+            connection.close()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(run, range(2)))
+
+    assert [result.outcome for result in results].count(OperationOutcome.APPLIED) == 1
+    assert [result.outcome for result in results].count(OperationOutcome.NO_TRANSITION) == 1
+    assert {result.no_transition_reason for result in results if not result.transition_applied} == {
+        NoTransitionReason.NO_ELIGIBLE_JOB
+    }
+    connection = manager._connect()
+    try:
+        with manager._pg_cursor(connection) as cur:
+            cur.execute("SELECT status, COUNT(*) AS c FROM jobs GROUP BY status ORDER BY status")
+            counts = {row["status"]: int(row["c"]) for row in cur.fetchall()}
+    finally:
+        connection.close()
+    assert counts == {"processing": 1, "queued": 1}
+
+
+def test_postgres_acquire_ignores_expired_processing_lease_for_quota(
+    manager: JobManager,
+    conn: Any,
+) -> None:
+    expired = _create_job(manager)
+    queued = _create_job(manager)
+    _execute(
+        manager,
+        "UPDATE jobs SET status = 'processing', leased_until = NOW() - interval '1 hour' WHERE id = %s",
+        (int(expired["id"]),),
+    )
+
+    result = acquire_job(
+        conn,
+        manager._pg_cursor,
+        command=_command(owner_user_id="owner", max_inflight_quota=1),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.row is not None
+    assert int(result.row["id"]) == int(queued["id"])
+
+
+@pytest.mark.parametrize(
+    ("scheduled", "initial_counts"),
+    [(False, (1, 0, 0)), (True, (0, 1, 0))],
+    ids=["ready", "scheduled"],
+)
+def test_postgres_acquire_moves_counter_to_processing(
+    manager: JobManager,
+    conn: Any,
+    scheduled: bool,
+    initial_counts: tuple[int, int, int],
+) -> None:
+    job = _create_job(manager)
+    if scheduled:
+        _execute(
+            manager,
+            "UPDATE jobs SET available_at = NOW() - interval '1 second' WHERE id = %s",
+            (int(job["id"]),),
+        )
+    _execute(
+        manager,
+        (
+            "INSERT INTO job_counters(domain, queue, job_type, ready_count, scheduled_count, "
+            "processing_count, quarantined_count) VALUES('acquire', 'default', 'work', %s, %s, %s, 0)"
+        ),
+        initial_counts,
+    )
+
+    result = acquire_job(
+        conn,
+        manager._pg_cursor,
+        command=_command(),
+        counters_enabled=True,
+        now=NOW,
+    )
+
+    assert result.outcome is OperationOutcome.APPLIED
+    connection = manager._connect()
+    try:
+        with manager._pg_cursor(connection) as cur:
+            cur.execute(
+                "SELECT ready_count, scheduled_count, processing_count FROM job_counters "
+                "WHERE domain = 'acquire' AND queue = 'default' AND job_type = 'work'"
+            )
+            counter = cur.fetchone()
+    finally:
+        connection.close()
+    assert tuple(counter.values()) == (0, 0, 1)
+
+
+def test_postgres_counter_failure_rolls_back_to_savepoint_and_commits_lease(
+    manager: JobManager,
+    conn: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = _create_job(manager)
+
+    def fail_counter(cur: Any, *, acquired: dict[str, Any]) -> None:
+        del acquired
+        cur.execute("SELECT definitely_missing_column FROM job_counters")
+
+    monkeypatch.setattr(lifecycle, "_bump_acquired_counters", fail_counter)
+
+    result = acquire_job(
+        conn,
+        manager._pg_cursor,
+        command=_command(),
+        counters_enabled=True,
+        now=NOW,
+    )
+
+    assert result.outcome is OperationOutcome.APPLIED
+    stored = manager.get_job(int(job["id"]))
+    assert stored is not None
+    assert stored["status"] == "processing"
+    assert stored["lease_id"] == "lease-exact"
+
+
+class _SavepointFailureCursor(AbstractContextManager[Any]):
+    def __init__(self, inner: AbstractContextManager[Any]) -> None:
+        self._inner = inner
+        self._cursor: Any = None
+
+    def __enter__(self) -> _SavepointFailureCursor:
+        self._cursor = self._inner.__enter__()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> Any:
+        return self._inner.__exit__(exc_type, exc, traceback)
+
+    def execute(self, sql: Any, params: Any = None) -> Any:
+        if str(sql).startswith("SAVEPOINT"):
+            raise psycopg.OperationalError("savepoint infrastructure failed")
+        return self._cursor.execute(sql, params)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._cursor, name)
+
+
+def test_postgres_savepoint_infrastructure_failure_propagates_and_rolls_back_lease(
+    manager: JobManager,
+    conn: Any,
+) -> None:
+    job = _create_job(manager)
+
+    def cursor_factory(connection: Any) -> _SavepointFailureCursor:
+        return _SavepointFailureCursor(manager._pg_cursor(connection))
+
+    with pytest.raises(psycopg.OperationalError, match="savepoint infrastructure failed"):
+        acquire_job(
+            conn,
+            cursor_factory,
+            command=_command(),
+            counters_enabled=True,
+            now=NOW,
+        )
+
+    stored = manager.get_job(int(job["id"]))
+    assert stored is not None
+    assert stored["status"] == "queued"
+    assert stored["lease_id"] is None
+
+
+def test_postgres_max_inflight_advisory_key_matches_existing_workers() -> None:
+    expected = JobManager._pg_advisory_key(
+        object(),
+        "max-inflight",
+        "chatbooks",
+        "owner-1",
+    )
+
+    assert lifecycle._pg_advisory_key("max-inflight", "chatbooks", "owner-1") == expected

--- a/tldw_Server_API/tests/Jobs/test_jobs_acquire_operations_sqlite.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_acquire_operations_sqlite.py
@@ -1,0 +1,279 @@
+"""Direct SQLite single-job acquisition operation tests."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
+from tldw_Server_API.app.core.Jobs.operations.contracts import (
+    AcquireJobCommand,
+    NoTransitionReason,
+    OperationOutcome,
+)
+from tldw_Server_API.app.core.Jobs.operations.sqlite.lifecycle import acquire_job
+
+NOW = datetime(2026, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    db_path = ensure_jobs_tables(tmp_path / "jobs.db")
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _insert_job(
+    conn: sqlite3.Connection,
+    *,
+    uuid: str,
+    domain: str = "acquire",
+    job_type: str = "work",
+    owner_user_id: str = "owner",
+    status: str = "queued",
+    priority: int = 5,
+    available_at: str | None = None,
+    created_at: str = "2026-01-01 00:00:00",
+    leased_until: str | None = None,
+) -> int:
+    cursor = conn.execute(
+        (
+            "INSERT INTO jobs(uuid, domain, queue, job_type, owner_user_id, payload, status, priority, "
+            "available_at, leased_until, created_at, updated_at) "
+            "VALUES(?, ?, 'default', ?, ?, '{}', ?, ?, ?, ?, ?, ?)"
+        ),
+        (
+            uuid,
+            domain,
+            job_type,
+            owner_user_id,
+            status,
+            priority,
+            available_at,
+            leased_until,
+            created_at,
+            created_at,
+        ),
+    )
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+def _command(
+    *,
+    domain: str = "acquire",
+    lease_id: str = "lease-exact",
+    owner_user_id: str | None = None,
+    max_inflight_quota: int = 0,
+    priority_direction: str = "ASC",
+    tie_break: str | None = None,
+    single_update: bool = False,
+) -> AcquireJobCommand:
+    return AcquireJobCommand(
+        domain=domain,
+        queue="default",
+        lease_seconds=30,
+        worker_id="worker-1",
+        lease_id=lease_id,
+        owner_user_id=owner_user_id,
+        job_type="work",
+        max_inflight_quota=max_inflight_quota,
+        priority_direction=priority_direction,
+        tie_break=tie_break,
+        single_update=single_update,
+    )
+
+
+@pytest.mark.parametrize("single_update", [False, True], ids=["two-step", "single-update"])
+def test_sqlite_acquire_applies_exact_command_lease_identity(
+    conn: sqlite3.Connection,
+    single_update: bool,
+) -> None:
+    job_id = _insert_job(conn, uuid=f"job-{single_update}")
+
+    result = acquire_job(
+        conn,
+        command=_command(single_update=single_update),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.outcome is OperationOutcome.APPLIED
+    assert result.row is not None
+    assert int(result.row["id"]) == job_id
+    assert result.row["status"] == "processing"
+    assert result.row["worker_id"] == "worker-1"
+    assert result.row["lease_id"] == "lease-exact"
+
+
+def test_sqlite_acquire_returns_no_transition_without_eligible_row(conn: sqlite3.Connection) -> None:
+    _insert_job(conn, uuid="future", available_at="2026-01-03 00:00:00")
+
+    result = acquire_job(
+        conn,
+        command=_command(),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.outcome is OperationOutcome.NO_TRANSITION
+    assert result.no_transition_reason is NoTransitionReason.NO_ELIGIBLE_JOB
+
+
+@pytest.mark.parametrize(
+    ("tie_break", "expected_uuid"),
+    [("fifo", "older"), ("lifo", "newer"), (None, "older")],
+    ids=["fifo", "lifo", "default-fifo"],
+)
+def test_sqlite_acquire_honors_resolved_ordering(
+    conn: sqlite3.Connection,
+    tie_break: str | None,
+    expected_uuid: str,
+) -> None:
+    _insert_job(conn, uuid="older", created_at="2026-01-01 00:00:00")
+    _insert_job(conn, uuid="newer", created_at="2026-01-01 01:00:00")
+
+    result = acquire_job(
+        conn,
+        command=_command(tie_break=tie_break),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.row is not None
+    assert result.row["uuid"] == expected_uuid
+
+
+def test_sqlite_two_step_chatbooks_default_uses_lifo_without_scheduled_work(
+    conn: sqlite3.Connection,
+) -> None:
+    _insert_job(conn, uuid="older", domain="chatbooks", created_at="2026-01-01 00:00:00")
+    _insert_job(conn, uuid="newer", domain="chatbooks", created_at="2026-01-01 01:00:00")
+
+    result = acquire_job(
+        conn,
+        command=_command(domain="chatbooks"),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.row is not None
+    assert result.row["uuid"] == "newer"
+
+
+def test_sqlite_two_step_chatbooks_default_uses_fifo_with_scheduled_work(
+    conn: sqlite3.Connection,
+) -> None:
+    _insert_job(conn, uuid="older", domain="chatbooks", created_at="2026-01-01 00:00:00")
+    _insert_job(conn, uuid="newer", domain="chatbooks", created_at="2026-01-01 01:00:00")
+    _insert_job(
+        conn,
+        uuid="scheduled",
+        domain="chatbooks",
+        available_at="2026-01-03 00:00:00",
+        created_at="2026-01-01 02:00:00",
+    )
+
+    result = acquire_job(
+        conn,
+        command=_command(domain="chatbooks"),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.row is not None
+    assert result.row["uuid"] == "older"
+
+
+def test_sqlite_acquire_skips_dependency_blocked_job(conn: sqlite3.Connection) -> None:
+    _insert_job(conn, uuid="parent", job_type="parent", priority=1)
+    _insert_job(conn, uuid="blocked", priority=1)
+    eligible_id = _insert_job(conn, uuid="eligible", priority=2)
+    conn.execute(
+        "INSERT INTO job_dependencies(job_uuid, depends_on_job_uuid) VALUES(?, ?)",
+        ("blocked", "parent"),
+    )
+    conn.commit()
+
+    result = acquire_job(
+        conn,
+        command=_command(),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.row is not None
+    assert int(result.row["id"]) == eligible_id
+
+
+def test_sqlite_acquire_enforces_max_inflight_quota(conn: sqlite3.Connection) -> None:
+    _insert_job(
+        conn,
+        uuid="active",
+        status="processing",
+        leased_until="2026-01-02 13:00:00",
+    )
+    queued_id = _insert_job(conn, uuid="queued")
+
+    result = acquire_job(
+        conn,
+        command=_command(owner_user_id="owner", max_inflight_quota=1),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.no_transition_reason is NoTransitionReason.NO_ELIGIBLE_JOB
+    assert conn.execute("SELECT status FROM jobs WHERE id = ?", (queued_id,)).fetchone()[0] == "queued"
+
+
+def test_sqlite_acquire_ignores_expired_processing_lease_for_quota(conn: sqlite3.Connection) -> None:
+    _insert_job(
+        conn,
+        uuid="expired",
+        status="processing",
+        leased_until="2026-01-02 11:00:00",
+    )
+    queued_id = _insert_job(conn, uuid="queued")
+
+    result = acquire_job(
+        conn,
+        command=_command(owner_user_id="owner", max_inflight_quota=1),
+        counters_enabled=False,
+        now=NOW,
+    )
+
+    assert result.row is not None
+    assert int(result.row["id"]) == queued_id
+
+
+@pytest.mark.parametrize("single_update", [False, True], ids=["two-step", "single-update"])
+def test_sqlite_acquire_moves_ready_counter_to_processing(
+    conn: sqlite3.Connection,
+    single_update: bool,
+) -> None:
+    _insert_job(conn, uuid=f"counter-{single_update}")
+    conn.execute(
+        "INSERT INTO job_counters(domain, queue, job_type, ready_count, scheduled_count, "
+        "processing_count, quarantined_count) VALUES('acquire', 'default', 'work', 1, 0, 0, 0)"
+    )
+    conn.commit()
+
+    acquire_job(
+        conn,
+        command=_command(single_update=single_update),
+        counters_enabled=True,
+        now=NOW,
+    )
+
+    counter = conn.execute(
+        "SELECT ready_count, scheduled_count, processing_count FROM job_counters "
+        "WHERE domain='acquire' AND queue='default' AND job_type='work'"
+    ).fetchone()
+    assert tuple(counter) == (0, 0, 1)

--- a/tldw_Server_API/tests/Jobs/test_jobs_lifecycle_side_effects.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_lifecycle_side_effects.py
@@ -139,3 +139,127 @@ def test_sqlite_acquire_backend_error_runs_no_success_observers(
         )
 
     assert observed == ["operation-returned"]
+
+
+class _FakePostgresConnection:
+    def close(self) -> None:
+        return None
+
+
+def _postgres_manager_without_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    observed: list[str],
+) -> JobManager:
+    manager = _manager_without_preflight(tmp_path, monkeypatch, observed)
+    manager.backend = "postgres"
+    monkeypatch.setattr(manager, "_connect", lambda: _FakePostgresConnection())
+    return manager
+
+
+def test_postgres_acquire_runs_success_observers_after_operation_returns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[str] = []
+    captured: dict[str, Any] = {}
+    manager = _postgres_manager_without_preflight(tmp_path, monkeypatch, observed)
+
+    def acquire_stub(
+        _conn: Any,
+        cursor_factory: Any,
+        *,
+        command: Any,
+        counters_enabled: bool,
+        now: Any,
+    ) -> LifecycleResult:
+        captured.update(
+            command=command,
+            counters_enabled=counters_enabled,
+            cursor_factory=cursor_factory,
+            now=now,
+        )
+        observed.append("operation-returned")
+        return LifecycleResult.applied(
+            row={
+                "id": 1,
+                "uuid": "job-1",
+                "domain": command.domain,
+                "queue": command.queue,
+                "job_type": "work",
+                "owner_user_id": "owner",
+                "status": "processing",
+                "worker_id": command.worker_id,
+                "lease_id": command.lease_id,
+                "leased_until": "2026-01-01 00:00:30",
+                "created_at": "2026-01-01 00:00:00",
+                "acquired_at": "2026-01-01 00:00:00",
+                "retry_count": 0,
+                "payload": '{"value": 1}',
+            }
+        )
+
+    monkeypatch.setattr(manager_module, "_postgres_acquire_job", acquire_stub, raising=False)
+
+    acquired = manager.acquire_next_job(
+        domain="facade",
+        queue="default",
+        job_type="work",
+        lease_seconds=30,
+        worker_id="worker-1",
+        owner_user_id="owner",
+    )
+
+    assert acquired is not None
+    assert acquired["payload"] == {"value": 1}
+    assert acquired["lease_id"] == captured["command"].lease_id
+    assert captured["cursor_factory"] == manager._pg_cursor
+    assert observed == ["operation-returned", "latency", "gauge", "event"]
+
+
+def test_postgres_acquire_no_transition_runs_no_success_observers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[str] = []
+    manager = _postgres_manager_without_preflight(tmp_path, monkeypatch, observed)
+
+    def acquire_stub(*_args: Any, **_kwargs: Any) -> LifecycleResult:
+        observed.append("operation-returned")
+        return LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
+
+    monkeypatch.setattr(manager_module, "_postgres_acquire_job", acquire_stub, raising=False)
+
+    acquired = manager.acquire_next_job(
+        domain="facade",
+        queue="default",
+        lease_seconds=30,
+        worker_id="worker-1",
+    )
+
+    assert acquired is None
+    assert observed == ["operation-returned"]
+
+
+def test_postgres_acquire_backend_error_runs_no_success_observers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[str] = []
+    manager = _postgres_manager_without_preflight(tmp_path, monkeypatch, observed)
+
+    def acquire_stub(*_args: Any, **_kwargs: Any) -> LifecycleResult:
+        observed.append("operation-returned")
+        raise RuntimeError("forced acquisition failure")
+
+    monkeypatch.setattr(manager_module, "_postgres_acquire_job", acquire_stub, raising=False)
+
+    with pytest.raises(RuntimeError, match="forced acquisition failure"):
+        manager.acquire_next_job(
+            domain="facade",
+            queue="default",
+            lease_seconds=30,
+            worker_id="worker-1",
+        )
+
+    assert observed == ["operation-returned"]

--- a/tldw_Server_API/tests/Jobs/test_jobs_lifecycle_side_effects.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_lifecycle_side_effects.py
@@ -1,0 +1,141 @@
+"""Facade side-effect ordering tests for extracted Jobs lifecycle operations."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import tldw_Server_API.app.core.Jobs.manager as manager_module
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Jobs.operations.contracts import (
+    LifecycleResult,
+    NoTransitionReason,
+)
+
+
+def _manager_without_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    observed: list[str],
+) -> JobManager:
+    manager = JobManager(tmp_path / "jobs.db")
+    monkeypatch.setattr(manager, "_get_queue_flags", lambda *_args: {"paused": False, "drain": False})
+    monkeypatch.setattr(manager, "_reconcile_terminal_dependents", lambda **_kwargs: 0)
+    monkeypatch.setattr(manager, "_recover_expired_processing_jobs", lambda **_kwargs: 0)
+    monkeypatch.setattr(manager, "_quota_get", lambda *_args: 0)
+    monkeypatch.setattr(
+        manager_module,
+        "observe_queue_latency",
+        lambda *_args, **_kwargs: observed.append("latency"),
+    )
+    monkeypatch.setattr(
+        manager_module,
+        "emit_job_event",
+        lambda *_args, **_kwargs: observed.append("event"),
+    )
+    monkeypatch.setattr(manager, "_update_gauges", lambda **_kwargs: observed.append("gauge"))
+    return manager
+
+
+def test_sqlite_acquire_runs_success_observers_after_operation_returns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[str] = []
+    captured: dict[str, Any] = {}
+    manager = _manager_without_preflight(tmp_path, monkeypatch, observed)
+
+    def acquire_stub(
+        _conn: sqlite3.Connection,
+        *,
+        command: Any,
+        counters_enabled: bool,
+        now: Any,
+    ) -> LifecycleResult:
+        captured.update(command=command, counters_enabled=counters_enabled, now=now)
+        observed.append("operation-returned")
+        return LifecycleResult.applied(
+            row={
+                "id": 1,
+                "uuid": "job-1",
+                "domain": command.domain,
+                "queue": command.queue,
+                "job_type": "work",
+                "owner_user_id": "owner",
+                "status": "processing",
+                "worker_id": command.worker_id,
+                "lease_id": command.lease_id,
+                "leased_until": "2026-01-01 00:00:30",
+                "created_at": "2026-01-01 00:00:00",
+                "acquired_at": "2026-01-01 00:00:00",
+                "retry_count": 0,
+                "payload": '{"value": 1}',
+            }
+        )
+
+    monkeypatch.setattr(manager_module, "_sqlite_acquire_job", acquire_stub, raising=False)
+
+    acquired = manager.acquire_next_job(
+        domain="facade",
+        queue="default",
+        job_type="work",
+        lease_seconds=30,
+        worker_id="worker-1",
+        owner_user_id="owner",
+    )
+
+    assert acquired is not None
+    assert acquired["payload"] == {"value": 1}
+    assert acquired["lease_id"] == captured["command"].lease_id
+    assert observed == ["operation-returned", "latency", "gauge", "event"]
+
+
+def test_sqlite_acquire_no_transition_runs_no_success_observers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[str] = []
+    manager = _manager_without_preflight(tmp_path, monkeypatch, observed)
+
+    def acquire_stub(*_args: Any, **_kwargs: Any) -> LifecycleResult:
+        observed.append("operation-returned")
+        return LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
+
+    monkeypatch.setattr(manager_module, "_sqlite_acquire_job", acquire_stub, raising=False)
+
+    acquired = manager.acquire_next_job(
+        domain="facade",
+        queue="default",
+        lease_seconds=30,
+        worker_id="worker-1",
+    )
+
+    assert acquired is None
+    assert observed == ["operation-returned"]
+
+
+def test_sqlite_acquire_backend_error_runs_no_success_observers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[str] = []
+    manager = _manager_without_preflight(tmp_path, monkeypatch, observed)
+
+    def acquire_stub(*_args: Any, **_kwargs: Any) -> LifecycleResult:
+        observed.append("operation-returned")
+        raise sqlite3.OperationalError("forced acquisition failure")
+
+    monkeypatch.setattr(manager_module, "_sqlite_acquire_job", acquire_stub, raising=False)
+
+    with pytest.raises(sqlite3.OperationalError, match="forced acquisition failure"):
+        manager.acquire_next_job(
+            domain="facade",
+            queue="default",
+            lease_seconds=30,
+            worker_id="worker-1",
+        )
+
+    assert observed == ["operation-returned"]

--- a/tldw_Server_API/tests/Jobs/test_jobs_lifecycle_side_effects.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_lifecycle_side_effects.py
@@ -157,13 +157,18 @@ def _postgres_manager_without_preflight(
     return manager
 
 
+@pytest.mark.parametrize("single_update", [False, True])
 def test_postgres_acquire_runs_success_observers_after_operation_returns(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    single_update: bool,
 ) -> None:
     observed: list[str] = []
     captured: dict[str, Any] = {}
     manager = _postgres_manager_without_preflight(tmp_path, monkeypatch, observed)
+    monkeypatch.setenv("JOBS_PG_ACQUIRE_PRIORITY_DESC_DOMAINS", "facade")
+    monkeypatch.setenv("JOBS_PG_ACQUIRE_TIE_BREAK_FACADE", "lifo")
+    monkeypatch.setenv("JOBS_PG_SINGLE_UPDATE_ACQUIRE", str(single_update))
 
     def acquire_stub(
         _conn: Any,
@@ -214,6 +219,9 @@ def test_postgres_acquire_runs_success_observers_after_operation_returns(
     assert acquired["payload"] == {"value": 1}
     assert acquired["lease_id"] == captured["command"].lease_id
     assert captured["cursor_factory"] == manager._pg_cursor
+    assert captured["command"].priority_direction == "DESC"
+    assert captured["command"].tie_break == "lifo"
+    assert captured["command"].single_update is single_update
     assert observed == ["operation-returned", "latency", "gauge", "event"]
 
 

--- a/tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ import pytest
 from tldw_Server_API.app.core.Jobs.operations.contracts import (
     AdmissionRejectionReason,
     AdmissionResult,
+    AcquireJobCommand,
     CreateJobCommand,
     LifecycleResult,
     NoTransitionReason,
@@ -131,6 +133,98 @@ def test_lifecycle_result_names_no_transition_reason() -> None:
     assert result.outcome is OperationOutcome.NO_TRANSITION
     assert result.no_transition_reason is NoTransitionReason.STALE_LEASE
     assert result.transition_applied is False
+
+
+def test_acquire_job_command_preserves_all_public_job_facts() -> None:
+    """Verify acquisition commands preserve every caller-provided field."""
+
+    command = AcquireJobCommand(
+        domain="chatbooks",
+        queue="priority",
+        lease_seconds=45,
+        worker_id="worker-1",
+        lease_id="lease-1",
+        owner_user_id="user-1",
+        job_type="export",
+        max_inflight_quota=3,
+        priority_direction="DESC",
+        tie_break="lifo",
+        single_update=True,
+    )
+
+    assert command.domain == "chatbooks"
+    assert command.queue == "priority"
+    assert command.lease_seconds == 45
+    assert command.worker_id == "worker-1"
+    assert command.lease_id == "lease-1"
+    assert command.owner_user_id == "user-1"
+    assert command.job_type == "export"
+    assert command.max_inflight_quota == 3
+    assert command.priority_direction == "DESC"
+    assert command.tie_break == "lifo"
+    assert command.single_update is True
+
+
+def test_acquire_job_command_is_frozen() -> None:
+    """Verify acquisition command fields cannot be reassigned."""
+
+    command = AcquireJobCommand(
+        domain="chatbooks",
+        queue="default",
+        lease_seconds=30,
+        worker_id="worker-1",
+        lease_id="lease-1",
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        command.queue = "other"
+
+
+def test_acquire_job_command_rejects_invalid_ordering_values() -> None:
+    """Verify acquisition ordering controls accept only documented values."""
+
+    with pytest.raises(ValueError, match="priority_direction must be ASC or DESC"):
+        AcquireJobCommand(
+            domain="chatbooks",
+            queue="default",
+            lease_seconds=30,
+            worker_id="worker-1",
+            lease_id="lease-1",
+            priority_direction="invalid",
+        )
+
+    with pytest.raises(ValueError, match="tie_break must be fifo, lifo, or None"):
+        AcquireJobCommand(
+            domain="chatbooks",
+            queue="default",
+            lease_seconds=30,
+            worker_id="worker-1",
+            lease_id="lease-1",
+            tie_break="invalid",
+        )
+
+
+def test_acquire_job_command_rejects_non_positive_lease_duration() -> None:
+    """Verify acquisition leases must have a positive duration."""
+
+    for lease_seconds in (0, -1):
+        with pytest.raises(ValueError, match="lease_seconds must be positive"):
+            AcquireJobCommand(
+                domain="chatbooks",
+                queue="default",
+                lease_seconds=lease_seconds,
+                worker_id="worker-1",
+                lease_id="lease-1",
+            )
+
+
+def test_lifecycle_result_supports_no_eligible_job_reason() -> None:
+    """Verify acquisition can report that no eligible job was available."""
+
+    result = LifecycleResult.no_transition(NoTransitionReason.NO_ELIGIBLE_JOB)
+
+    assert result.outcome is OperationOutcome.NO_TRANSITION
+    assert result.no_transition_reason is NoTransitionReason.NO_ELIGIBLE_JOB
 
 
 def test_lifecycle_result_rejects_inconsistent_states() -> None:

--- a/tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import ast
+import io
+import tokenize
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 
@@ -285,6 +287,64 @@ def test_lifecycle_result_copies_mutable_facts() -> None:
 
     assert result.row == {"id": 1, "status": "processing", "result": {"ok": True}}
     assert result.durable_events == ({"event_type": "job.completed", "attrs": {"attempt": 1}},)
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "postgres"])
+def test_acquire_sql_does_not_interpolate_query_fragments(backend: str) -> None:
+    """Verify acquisition SQL uses fixed fragments for ordering and candidate queries."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "tldw_Server_API/app/core/Jobs/operations"
+        / backend
+        / "lifecycle.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    formatted: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.JoinedStr):
+            expressions = [value.value for value in node.values if isinstance(value, ast.FormattedValue)]
+            lease_parameter_only = expressions and all(
+                isinstance(expression, ast.Attribute)
+                and isinstance(expression.value, ast.Name)
+                and expression.value.id == "command"
+                and expression.attr == "lease_seconds"
+                for expression in expressions
+            )
+            if not lease_parameter_only:
+                formatted.append((node.lineno, "f-string"))
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"format", "format_map"}
+        ):
+            formatted.append((node.lineno, node.func.attr))
+        elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mod):
+            formatted.append((node.lineno, "percent-format"))
+
+    assert formatted == []
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "postgres"])
+def test_acquire_sql_has_no_bandit_query_suppressions(backend: str) -> None:
+    """Verify acquisition SQL does not rely on Bandit query suppressions."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "tldw_Server_API/app/core/Jobs/operations"
+        / backend
+        / "lifecycle.py"
+    )
+
+    source = path.read_text(encoding="utf-8")
+    comments = [
+        token.string
+        for token in tokenize.generate_tokens(io.StringIO(source).readline)
+        if token.type == tokenize.COMMENT and "nosec" in token.string.casefold()
+    ]
+
+    assert comments == []
 
 
 def test_operation_contracts_do_not_import_job_manager() -> None:

--- a/tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py
@@ -9,9 +9,9 @@ from pathlib import Path
 import pytest
 
 from tldw_Server_API.app.core.Jobs.operations.contracts import (
+    AcquireJobCommand,
     AdmissionRejectionReason,
     AdmissionResult,
-    AcquireJobCommand,
     CreateJobCommand,
     LifecycleResult,
     NoTransitionReason,
@@ -178,6 +178,20 @@ def test_acquire_job_command_is_frozen() -> None:
 
     with pytest.raises(FrozenInstanceError):
         command.queue = "other"
+
+
+def test_acquire_job_command_defaults_to_backend_ordering() -> None:
+    """Verify omitted tie-breaking delegates ordering to the backend default."""
+
+    command = AcquireJobCommand(
+        domain="chatbooks",
+        queue="default",
+        lease_seconds=30,
+        worker_id="worker-1",
+        lease_id="lease-1",
+    )
+
+    assert command.tie_break is None
 
 
 def test_acquire_job_command_rejects_invalid_ordering_values() -> None:


### PR DESCRIPTION
## Summary

- What changed: Added a typed single-job acquisition contract and moved SQLite and PostgreSQL queued-to-processing lease acquisition into backend lifecycle operation modules behind the unchanged `JobManager.acquire_next_job` facade.
- Why: Reduce `JobManager` transaction ownership incrementally while preserving public behavior and backend-specific concurrency guarantees.

## Change summary (requester-authored, required before merge)

**BLOCKED:** The requester must replace this paragraph with their own explanation of what changed and why these implementation choices were made. This placeholder is not merge-ready.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Final focused SQLite/required-real-PostgreSQL matrix: 76 passed, zero skips
- [x] PostgreSQL acquisition stress: 4 passed, zero skips
- [x] Ruff and compile checks passed within documented existing exclusions
- [x] Bandit: 0 findings, 0 errors
- [x] Independent backend and whole-branch reviews approved with no actionable findings
- [x] Plan and Backlog task updated

## Scope controls

- No public API signature or return-shape changes
- No schema or migration changes
- No renewal, release, batch lease, or terminal transition extraction
- Expired-processing retry/terminal recovery remains in `JobManager`
- SQLite retains unconditional `BEGIN IMMEDIATE` acquisition serialization
- PostgreSQL retains the deployed SHA-1 advisory-lock identity for mixed-worker compatibility

## Risk & Rollback

- Risk level: Medium
- Residual risk: Counters and post-commit observers remain intentionally best-effort; targeted stress cannot exhaust every crash or database scheduling interleaving.
- Rollback plan: Revert this PR. The public facade and database schema remain unchanged, so no data migration rollback is required.

Backlog: `TASK-12969.2`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted single‑job lease acquisition into backend lifecycle modules for SQLite and Postgres behind the unchanged `JobManager.acquire_next_job` facade. Adds `AcquireJobCommand`, fixes deterministic ORDER BY/tie‑break SQL, and preserves quotas, dependency gating, and acquisition semantics to advance TASK-12969.2.

- **Refactors**
  - Added `AcquireJobCommand` and `NoTransitionReason.NO_ELIGIBLE_JOB`; facade builds a command and delegates to `operations/sqlite/lifecycle.acquire_job` and `operations/postgres/lifecycle.acquire_job`.
  - Preserved behavior: SQLite uses `BEGIN IMMEDIATE`; Postgres keeps SHA‑1 advisory lock for max‑inflight; dependency gating, quotas, and priority/tie‑break rules unchanged; optional single‑update paths via `JOBS_SQLITE_SINGLE_UPDATE_ACQUIRE`/`JOBS_PG_SINGLE_UPDATE_ACQUIRE`.
  - Counters run under a savepoint; failures roll back without losing the acquired lease.
  - Added tests: direct operation coverage, parity for ordering/contention/expired‑lease reclaim, and facade side‑effect ordering; docs/backlog updated; no public API or schema changes.

- **Bug Fixes**
  - Use fixed acquisition ORDER BY clauses in both backends for stable priority/available_at/id selection.

<sup>Written for commit 6dc1534666edff9003db92f14c830442e2acad60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

