### PR TITLE
test(embeddings): characterize Stage 2A workflow contracts

### DIFF
--- a/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
@@ -12,7 +12,7 @@
 
 ## Scope And Existing Coverage
 
-The branch was initially rebased onto `origin/dev` at `1b9518c68c`, rebased onto `0f3983788c` before final review, and rebased again onto the latest `origin/dev` at `d710e5a5ee` before branch handoff. Stage 2A is test-only.
+The branch was initially rebased onto `origin/dev` at `1b9518c68c`, rebased onto `0f3983788c` before final review, rebased onto `d710e5a5ee` before handoff, and finally rebased at user request onto `76481b2939` for PR #2762. Stage 2A is test-only.
 
 **Files modified during implementation:**
 
@@ -1073,7 +1073,7 @@ git commit -m "chore(backlog): close embeddings workflow stage 2a"
 
 ### Task 8: Refresh The Final Dev Base
 
-**Goal**: Rebase the approved Stage 2A branch onto the latest `origin/dev` immediately before handoff.
+**Goal**: Rebase the approved Stage 2A branch onto the latest `origin/dev` immediately before handoff and refresh it when requested on the open PR.
 
 **Success Criteria**: The rebase is conflict-free, focused post-rebase tests and static checks pass, tracking names the final base, and the branch has no commits behind `origin/dev`.
 
@@ -1081,5 +1081,18 @@ git commit -m "chore(backlog): close embeddings workflow stage 2a"
 
 **Status**: Complete
 
-- [x] Rebase the 12 Stage 2A commits onto `origin/dev` at `d710e5a5ee`.
+- [x] Rebase the 12 Stage 2A commits onto `origin/dev` at `d710e5a5ee`, then rebase the 14-commit PR branch onto `76481b2939` at user request.
 - [x] Run post-rebase verification and refresh closeout metadata.
+
+### Task 9: Verify The PR Rebase
+
+**Goal**: Verify PR #2762 after rebasing it onto `origin/dev` at `76481b2939`.
+
+**Success Criteria**: Focused tests and static checks pass, tracking names the new base, and the force-with-lease update preserves the PR branch.
+
+**Tests**: Touched Embeddings modules, Ruff, Bandit, and diff/scope checks.
+
+**Status**: Complete
+
+- [x] Rebase onto `origin/dev` at `76481b2939` without conflicts.
+- [x] Run post-rebase verification, close tracking, and update PR #2762.

--- a/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
@@ -12,7 +12,7 @@
 
 ## Scope And Existing Coverage
 
-The branch was initially rebased onto `origin/dev` at `1b9518c68c` before this plan was written and was rebased again onto `origin/dev` at `0f3983788c` before final review. Stage 2A is test-only.
+The branch was initially rebased onto `origin/dev` at `1b9518c68c`, rebased onto `0f3983788c` before final review, and rebased again onto the latest `origin/dev` at `d710e5a5ee` before branch handoff. Stage 2A is test-only.
 
 **Files modified during implementation:**
 
@@ -1070,3 +1070,16 @@ git commit -m "chore(backlog): close embeddings workflow stage 2a"
 - [x] Add direct production endpoint identity and cache-key failure characterization and reconcile the error-routing text.
 - [x] Cover active-request cleanup on reservation denial and noncritical resource-governor commit failure.
 - [x] Normalize Backlog metadata, rerun all verification gates, and obtain final specification and quality approval.
+
+### Task 8: Refresh The Final Dev Base
+
+**Goal**: Rebase the approved Stage 2A branch onto the latest `origin/dev` immediately before handoff.
+
+**Success Criteria**: The rebase is conflict-free, focused post-rebase tests and static checks pass, tracking names the final base, and the branch has no commits behind `origin/dev`.
+
+**Tests**: Focused remediation tests, Ruff, Bandit, and diff/scope checks.
+
+**Status**: Complete
+
+- [x] Rebase the 12 Stage 2A commits onto `origin/dev` at `d710e5a5ee`.
+- [x] Run post-rebase verification and refresh closeout metadata.

--- a/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
@@ -1,0 +1,1056 @@
+# Embeddings Workflow Stage 2A Characterization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete `TASK-12973.1` by adding behavior-first tests for the remaining Embeddings orchestration boundaries without changing production execution behavior.
+
+**Architecture:** Keep `EmbeddingRequestOrchestrator`, `EmbeddingInlineWorkflowRunner`, and the endpoint implementation unchanged. Extend their existing focused test modules with source-aware failure probes, exact lifecycle assertions, and resource-accounting checks; reuse the credential-isolation and malformed-cache coverage already present on current `dev`.
+
+**Tech Stack:** Python 3.11, FastAPI, asyncio, pytest, pytest-asyncio, unittest.mock, Ruff, Bandit.
+
+---
+
+## Scope And Existing Coverage
+
+The branch was rebased onto `origin/dev` at `1b9518c68c` before this plan was written. Stage 2A is test-only.
+
+**Files modified during implementation:**
+
+- `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+  - Preparation order, primary/fallback readiness, source-shaped failures, adapter counters, malformed cache values, and write-before-validation protection.
+- `tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py`
+  - Exact Stage 1 trace status sequence and cancellation behavior.
+- `tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py`
+  - Endpoint cache-adapter exception identity, reservation cleanup, zero-token accounting, active-request accounting, and final credential-touch identity.
+- `backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md`
+  - Verification notes, acceptance criteria, and final status.
+
+**Production files modified:** none.
+
+Current `dev` already supplies the following required evidence. Do not duplicate these tests:
+
+- Private credentials bypass shared reads/writes:
+  - `test_orchestrator_resolved_credentials_bypass_shared_provider_cache`
+  - `test_orchestrator_adapter_miss_with_resolved_key_bypasses_shared_cache`
+  - `test_resolved_keys_never_share_cached_vectors_sequentially_or_concurrently`
+- Credential usage timing:
+  - `test_executor_uses_adapter_registry_before_provider_execution`
+  - `test_executor_multibatch_marks_first_valid_batch_before_second_error`
+  - `test_public_multibatch_marks_first_valid_batch_before_second_cancel`
+- Public malformed-cache replacement:
+  - `test_public_malformed_cached_vector_is_replaced_from_provider_boundary`
+- Primary execution cardinality:
+  - `test_fallback_execution_maps_model_and_returns_fallback_headers`
+  - `test_endpoint_real_orchestrator_applies_fallback_response_headers`
+- Complete primary result validation before writeback:
+  - `test_execute_rejects_mixed_width_partial_cache_and_provider_result_without_writeback`
+
+### Task 1: Characterize Preparation And Readiness Order
+
+**Files:**
+
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+
+- [ ] **Step 1: Allow the isolated factory to inject runtime identity and cache-key probes**
+
+Extend `_orchestrator` with narrow optional overrides while preserving every existing default:
+
+```python
+def _orchestrator(
+    *,
+    cache: RecordingCache | None = None,
+    executor: RecordingExecutor | None = None,
+    settings_fallback_chain: dict[str, object] | None = None,
+    settings_fallback_model_map: dict[str, object] | None = None,
+    dimension_policy: str = "reduce",
+    provider_preflight=None,
+    execution_path: str = "legacy",
+    cache_key_fn=_cache_key,
+    backend_identity_resolver=None,
+) -> EmbeddingRequestOrchestrator:
+    identity_resolver = backend_identity_resolver or (
+        lambda provider, model: f"{provider}:{model}:backend"
+    )
+    return EmbeddingRequestOrchestrator(
+        count_tokens=_count_tokens,
+        tokens_to_texts=_tokens_to_texts,
+        cache_key_fn=cache_key_fn,
+        cache=cache or RecordingCache(),
+        executor=executor or RecordingExecutor(),
+        settings_config={},
+        max_tokens=100,
+        implemented_providers={"openai", "cohere", "huggingface", "onnx", "local_api"},
+        allowed_providers=None,
+        allowed_models=None,
+        enforce_policy=True,
+        allow_fallback_with_header=True,
+        settings_fallback_chain=settings_fallback_chain,
+        settings_fallback_model_map=settings_fallback_model_map,
+        dimension_policy=dimension_policy,
+        backend_identity_resolver=identity_resolver,
+        provider_preflight=provider_preflight,
+        execution_path=execution_path,  # type: ignore[arg-type]
+    )
+```
+
+- [ ] **Step 2: Add a preparation-order characterization test**
+
+Import the orchestrator module for monkeypatching:
+
+```python
+from tldw_Server_API.app.core.Embeddings import orchestrator as orchestrator_module
+```
+
+Add a test that wraps the real preparation functions and records only their order:
+
+```python
+@pytest.mark.unit
+def test_prepare_orders_intent_normalization_policy_and_plan_identity(monkeypatch):
+    order: list[str] = []
+    original_resolve = orchestrator_module.resolve_provider_model
+    original_normalize = orchestrator_module.normalize_embedding_input
+    original_policy = orchestrator_module.enforce_embedding_policy
+
+    def resolve_probe(*args, **kwargs):
+        order.append("resolve_intent")
+        return original_resolve(*args, **kwargs)
+
+    def normalize_probe(*args, **kwargs):
+        order.append("normalize")
+        return original_normalize(*args, **kwargs)
+
+    def policy_probe(*args, **kwargs):
+        order.append("resolve_policy")
+        return original_policy(*args, **kwargs)
+
+    def identity_probe(provider: str, model: str) -> str:
+        order.append("plan_identity")
+        return f"{provider}:{model}:backend"
+
+    monkeypatch.setattr(orchestrator_module, "resolve_provider_model", resolve_probe)
+    monkeypatch.setattr(orchestrator_module, "normalize_embedding_input", normalize_probe)
+    monkeypatch.setattr(orchestrator_module, "enforce_embedding_policy", policy_probe)
+    orchestrator = _orchestrator(backend_identity_resolver=identity_probe)
+
+    orchestrator.prepare("ordered preparation", _context())
+
+    assert order == [
+        "resolve_intent",
+        "normalize",
+        "resolve_policy",
+        "plan_identity",
+    ]
+```
+
+- [ ] **Step 3: Add a primary-preflight failure test**
+
+The test must prove readiness runs before cache access and that even a retryable primary readiness failure does not enter fallback:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_primary_preflight_failure_propagates_without_cache_or_fallback():
+    original = EmbeddingExecutionError(
+        "provider_unavailable",
+        "primary preflight failed",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+    cache = RecordingCache()
+    executor = RecordingExecutor(
+        provider_vectors={"huggingface": [[0.5, 0.25]]}
+    )
+
+    async def provider_preflight(provider: str, model: str) -> None:
+        assert (provider, model) == ("openai", "text-embedding-3-small")
+        raise original
+
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        provider_preflight=provider_preflight,
+        settings_fallback_chain={"openai": ["huggingface"]},
+    )
+    prepared = orchestrator.prepare(
+        "preflight failure",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    with pytest.raises(EmbeddingExecutionError) as exc_info:
+        await orchestrator.execute(prepared)
+
+    assert exc_info.value is original
+    assert cache.get_keys == []
+    assert cache.set_calls == []
+    assert executor.calls == []
+```
+
+- [ ] **Step 4: Add retryable fallback-preflight traversal coverage**
+
+Keep the existing missing-credential skip test. Add a separate retryable readiness case that proves the failed candidate is skipped and the next candidate is attempted:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_retryable_fallback_preflight_failure_continues_to_next_candidate():
+    primary_error = EmbeddingProviderError(
+        "provider_unavailable",
+        "primary unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+    fallback_preflight_error = EmbeddingExecutionError(
+        "circuit_breaker_open",
+        "cohere circuit open",
+        provider="cohere",
+        model="embed-english-v3.0",
+        retryable=True,
+    )
+    executor = RecordingExecutor(
+        failures={"openai": primary_error},
+        provider_vectors={"huggingface": [[0.5, 0.25]]},
+    )
+    preflight_calls: list[tuple[str, str]] = []
+
+    async def provider_preflight(provider: str, model: str) -> None:
+        preflight_calls.append((provider, model))
+        if provider == "cohere":
+            raise fallback_preflight_error
+
+    orchestrator = _orchestrator(
+        executor=executor,
+        provider_preflight=provider_preflight,
+        settings_fallback_chain={"openai": ["cohere", "huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "cohere": "embed-english-v3.0",
+                "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        "retry fallback readiness",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    result = await orchestrator.execute(prepared)
+
+    assert result.provider == "huggingface"
+    assert preflight_calls == [
+        ("openai", "text-embedding-3-small"),
+        ("cohere", "embed-english-v3.0"),
+        ("huggingface", "sentence-transformers/all-MiniLM-L6-v2"),
+    ]
+    assert [call["provider"] for call in executor.calls] == [
+        "openai",
+        "huggingface",
+    ]
+```
+
+- [ ] **Step 5: Run the new preparation/readiness tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py::test_prepare_orders_intent_normalization_policy_and_plan_identity \
+  tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py::test_primary_preflight_failure_propagates_without_cache_or_fallback \
+  tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py::test_retryable_fallback_preflight_failure_continues_to_next_candidate \
+  -q
+```
+
+Expected: 3 passed. These are characterization tests; a failure means the test assumption must be reconciled with current behavior, not that production code should be changed.
+
+- [ ] **Step 6: Commit the preparation/readiness tests**
+
+```bash
+git add tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+git commit -m "test(embeddings): characterize preparation and readiness order"
+```
+
+### Task 2: Pin Infrastructure Failure Sources
+
+**Files:**
+
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+- Modify: `tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py`
+
+- [ ] **Step 1: Add a primary infrastructure-failure parameterization**
+
+Add a small raising cache inside the test and cover read-time identity, key derivation, and cache access. Each error is a generic infrastructure exception and must propagate unchanged without provider fallback:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "boundary",
+    ["backend_identity", "cache_key", "cache_get"],
+)
+async def test_primary_infrastructure_failure_propagates_without_fallback(boundary):
+    original = RuntimeError(f"{boundary} failed")
+    identity_calls = 0
+
+    def identity_resolver(provider: str, model: str) -> str:
+        nonlocal identity_calls
+        identity_calls += 1
+        if boundary == "backend_identity" and identity_calls > 1:
+            raise original
+        return f"{provider}:{model}:backend"
+
+    def cache_key_fn(text, provider, model, dimensions, backend_identity):
+        if boundary == "cache_key":
+            raise original
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    class FailingGetCache(RecordingCache):
+        async def get(self, key: str) -> list[float] | None:
+            if boundary == "cache_get":
+                raise original
+            return await super().get(key)
+
+    cache = FailingGetCache()
+    executor = RecordingExecutor(
+        provider_vectors={"huggingface": [[0.5, 0.25]]}
+    )
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        cache_key_fn=cache_key_fn,
+        backend_identity_resolver=identity_resolver,
+        settings_fallback_chain={"openai": ["huggingface"]},
+    )
+    prepared = orchestrator.prepare(
+        "primary infrastructure failure",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await orchestrator.execute(prepared)
+
+    assert exc_info.value is original
+    assert executor.calls == []
+    assert cache.set_calls == []
+```
+
+- [ ] **Step 2: Characterize the current broad fallback-domain catch**
+
+This test intentionally records behavior that Stage 2D will correct. A retryable domain-shaped error from fallback identity, key, cache read, or cache write currently advances to the next provider:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "boundary",
+    ["backend_identity", "cache_key", "cache_get", "cache_set"],
+)
+async def test_fallback_domain_shaped_infrastructure_failure_currently_advances_candidate(
+    boundary,
+):
+    original = EmbeddingExecutionError(
+        "internal_execution_failure",
+        f"{boundary} failed",
+        provider="cohere",
+        model="embed-english-v3.0",
+        retryable=True,
+    )
+    primary_error = EmbeddingProviderError(
+        "provider_unavailable",
+        "primary unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+
+    def identity_resolver(provider: str, model: str) -> str:
+        if boundary == "backend_identity" and provider == "cohere":
+            raise original
+        return f"{provider}:{model}:backend"
+
+    def cache_key_fn(text, provider, model, dimensions, backend_identity):
+        if boundary == "cache_key" and provider == "cohere":
+            raise original
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    class BoundaryCache(RecordingCache):
+        async def get(self, key: str) -> list[float] | None:
+            self.get_keys.append(key)
+            if boundary == "cache_get" and "|cohere|" in key:
+                raise original
+            return self.values.get(key)
+
+        async def set(self, key: str, value: list[float]) -> object:
+            if boundary == "cache_set" and "|cohere|" in key:
+                raise original
+            return await super().set(key, value)
+
+    executor = RecordingExecutor(
+        failures={"openai": primary_error},
+        provider_vectors={
+            "cohere": [[0.4, 0.6]],
+            "huggingface": [[0.5, 0.25]],
+        },
+    )
+    orchestrator = _orchestrator(
+        cache=BoundaryCache(),
+        executor=executor,
+        cache_key_fn=cache_key_fn,
+        backend_identity_resolver=identity_resolver,
+        settings_fallback_chain={"openai": ["cohere", "huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "cohere": "embed-english-v3.0",
+                "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        "fallback infrastructure failure",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    result = await orchestrator.execute(prepared)
+
+    assert result.provider == "huggingface"
+    providers = [call["provider"] for call in executor.calls]
+    assert providers[0] == "openai"
+    assert providers[-1] == "huggingface"
+    assert providers.count("openai") == 1
+```
+
+- [ ] **Step 3: Characterize endpoint cache-adapter exception identity**
+
+In `test_embeddings_orchestrator_endpoint_parity.py`, add:
+
+```python
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["get", "set"])
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        pytest.param(
+            lambda: RuntimeError("cache dependency failed"),
+            id="unexpected",
+        ),
+        pytest.param(
+            lambda: EmbeddingExecutionError(
+                "internal_execution_failure",
+                "domain-shaped cache failure",
+                retryable=True,
+            ),
+            id="domain",
+        ),
+    ],
+)
+async def test_endpoint_cache_adapter_propagates_dependency_error_unchanged(
+    monkeypatch,
+    method_name,
+    error_factory,
+):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    original = error_factory()
+    dependency = AsyncMock(side_effect=original)
+    monkeypatch.setattr(mod.embedding_cache, method_name, dependency)
+    cache = mod._EndpointEmbeddingCache()
+
+    with pytest.raises(type(original)) as exc_info:
+        if method_name == "get":
+            await cache.get("cache-key")
+        else:
+            await cache.set("cache-key", [0.1, 0.2])
+
+    assert exc_info.value is original
+    dependency.assert_awaited_once()
+```
+
+- [ ] **Step 4: Run the infrastructure-source tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py \
+  tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py \
+  -k "infrastructure_failure or endpoint_cache_adapter_propagates" \
+  -q
+```
+
+Expected: 11 passed: 3 primary cases, 4 current fallback cases, and 4 endpoint adapter cases.
+
+- [ ] **Step 5: Commit the failure-source tests**
+
+```bash
+git add \
+  tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py \
+  tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
+git commit -m "test(embeddings): pin orchestration failure sources"
+```
+
+### Task 3: Characterize Adapter And Cache-Validation Contracts
+
+**Files:**
+
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+
+- [ ] **Step 1: Add successful adapter accounting and bypass coverage**
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_successful_adapter_reports_compatibility_cache_counts_and_bypasses_provider():
+    cache = RecordingCache()
+    preflight_calls: list[tuple[str, str]] = []
+
+    async def provider_preflight(provider: str, model: str) -> None:
+        preflight_calls.append((provider, model))
+
+    executor = AdapterAwareExecutor(
+        vectors=[[9.0, 9.0]],
+        adapter_output=EmbeddingExecutorOutput(
+            vectors=[[0.1, 0.2], [0.3, 0.4]],
+            embeddings_from_adapter=True,
+        ),
+    )
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        execution_path="adapter",
+        provider_preflight=provider_preflight,
+    )
+    prepared = orchestrator.prepare(
+        ["one", "two"],
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    result = await orchestrator.execute(prepared)
+
+    assert result.vectors == [[0.1, 0.2], [0.3, 0.4]]
+    assert result.embeddings_from_adapter is True
+    assert result.cache_hits == 0
+    assert result.cache_misses == 2
+    assert preflight_calls == []
+    assert cache.get_keys == []
+    assert cache.set_calls == []
+    assert executor.calls == []
+```
+
+- [ ] **Step 2: Add isolated malformed/non-finite cache replacement cases**
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cached",
+    [
+        pytest.param([], id="empty"),
+        pytest.param(["not-a-number"], id="nonnumeric"),
+        pytest.param([float("nan"), 0.0], id="nan"),
+        pytest.param([float("inf"), 0.0], id="infinite"),
+    ],
+)
+async def test_malformed_cached_vector_becomes_miss_and_is_replaced(cached):
+    cache_key = (
+        "replace|huggingface|sentence-transformers/all-MiniLM-L6-v2|"
+        "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend"
+    )
+    cache = RecordingCache({cache_key: cached})  # type: ignore[dict-item]
+    executor = RecordingExecutor(vectors=[[0.25, 0.75]])
+    orchestrator = _orchestrator(cache=cache, executor=executor)
+    prepared = orchestrator.prepare("replace", _context())
+
+    result = await orchestrator.execute(prepared)
+
+    assert result.vectors == [[0.25, 0.75]]
+    assert result.cache_hits == 0
+    assert result.cache_misses == 1
+    assert len(executor.calls) == 1
+    assert cache.set_calls == [(cache_key, [0.25, 0.75])]
+```
+
+- [ ] **Step 3: Add fallback complete-result validation before writeback**
+
+Keep the existing primary mixed-width test unchanged. Add the equivalent full fallback path:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_complete_result_is_validated_before_first_cache_write():
+    primary_error = EmbeddingProviderError(
+        "provider_unavailable",
+        "primary unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+    cache = RecordingCache()
+    executor = RecordingExecutor(
+        failures={"openai": primary_error},
+        provider_vectors={
+            "huggingface": [[0.1, 0.2], [0.3, 0.4, 0.5]],
+        },
+    )
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        settings_fallback_chain={"openai": ["huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        ["one", "two"],
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        await orchestrator.execute(prepared)
+
+    assert exc_info.value.code == "provider_malformed_response"
+    assert cache.set_calls == []
+```
+
+- [ ] **Step 4: Reassert primary execution cardinality**
+
+In `test_fallback_execution_maps_model_and_returns_fallback_headers`, add:
+
+```python
+    assert prepared.execution_plan.fallback_chain == ["openai", "huggingface"]
+    assert [call["provider"] for call in executor.calls].count("openai") == 1
+```
+
+- [ ] **Step 5: Run adapter/cache characterization**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py \
+  -k "successful_adapter or malformed_cached_vector or validated_before_first_cache_write or fallback_execution_maps_model" \
+  -q
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 6: Commit adapter/cache characterization**
+
+```bash
+git add tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+git commit -m "test(embeddings): characterize adapter and cache validation"
+```
+
+### Task 4: Pin Stage 1 Trace And Cancellation Behavior
+
+**Files:**
+
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py`
+
+- [ ] **Step 1: Assert the exact current success statuses**
+
+Extend `test_runner_returns_orchestrator_result_and_records_safe_success_events`:
+
+```python
+    assert [event.status for event in collector.events] == [
+        "running",
+        "running",
+        "running",
+        "running",
+        "running",
+        "running",
+        "completed",
+    ]
+```
+
+This intentionally pins the Stage 1 sequence. Do not add Stage 2 phases in Stage 2A.
+
+- [ ] **Step 2: Add cancellation propagation and trace truncation**
+
+Import `asyncio`, then add:
+
+```python
+@pytest.mark.asyncio
+async def test_execute_cancellation_propagates_without_terminal_trace_event():
+    cancellation = asyncio.CancelledError()
+    collector = EmbeddingInMemoryWorkflowTraceCollector()
+    runner = EmbeddingInlineWorkflowRunner(
+        FakeOrchestrator(execute_error=cancellation),
+        trace_collector=collector,
+    )
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await runner.run(["one"], _request_context())
+
+    assert exc_info.value is cancellation
+    assert [event.event_type for event in collector.events] == [
+        "workflow_started",
+        "phase_changed",
+        "phase_changed",
+        "prepare_completed",
+        "phase_changed",
+    ]
+    assert collector.events[-1].phase == "executing"
+    assert all(
+        event.event_type not in {"workflow_failed", "workflow_completed"}
+        for event in collector.events
+    )
+```
+
+- [ ] **Step 3: Run the runner characterization tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py \
+  -q
+```
+
+Expected: all runner tests pass, including the new cancellation case.
+
+- [ ] **Step 4: Commit runner characterization**
+
+```bash
+git add tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py
+git commit -m "test(embeddings): pin inline runner cancellation"
+```
+
+### Task 5: Characterize Endpoint Lifecycle And Accounting
+
+**Files:**
+
+- Modify: `tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py`
+
+- [ ] **Step 1: Add a recording active-request gauge**
+
+Place this beside the existing metric fakes:
+
+```python
+class _RecordingGauge(_NoopMetric):
+    def __init__(self) -> None:
+        self.inc_count = 0
+        self.dec_count = 0
+
+    def inc(self, *_args, **_kwargs):
+        self.inc_count += 1
+
+    def dec(self, *_args, **_kwargs):
+        self.dec_count += 1
+```
+
+- [ ] **Step 2: Make the endpoint fake support zero-token preparation**
+
+Change only the test fake:
+
+```python
+class FakeOrchestrator:
+    def __init__(
+        self,
+        *,
+        result=None,
+        prepare_error=None,
+        execute_error=None,
+        prepared_total_tokens: int = 3,
+    ) -> None:
+        self.result = result
+        self.prepare_error = prepare_error
+        self.execute_error = execute_error
+        self.prepared_total_tokens = prepared_total_tokens
+        self.prepare_calls = []
+        self.execute_calls = []
+
+    def prepare(self, raw_input, context):
+        self.prepare_calls.append((raw_input, context))
+        if self.prepare_error is not None:
+            raise self.prepare_error
+        return FakePrepared(total_tokens=self.prepared_total_tokens)
+```
+
+- [ ] **Step 3: Strengthen existing success and post-reservation failure tests**
+
+In both `test_orchestrator_path_uses_inline_workflow_runner_and_preserves_rg_reservation` and `test_orchestrator_path_commits_reserved_units_after_execute_failure`, install a fresh `_RecordingGauge`:
+
+```python
+    active_requests = _RecordingGauge()
+    monkeypatch.setattr(mod, "active_embedding_requests", active_requests)
+```
+
+At the end of each test, assert:
+
+```python
+    assert active_requests.inc_count == 1
+    assert active_requests.dec_count == 1
+```
+
+In the success test, replace `_EndpointEmbeddingExecutor` with a test double and assert the endpoint's final touch uses the actual outcome identity:
+
+```python
+    endpoint_executor = SimpleNamespace(touch_resolved_credentials=AsyncMock())
+    monkeypatch.setattr(
+        mod,
+        "_EndpointEmbeddingExecutor",
+        lambda **_kwargs: endpoint_executor,
+    )
+```
+
+After the response:
+
+```python
+    endpoint_executor.touch_resolved_credentials.assert_awaited_once_with(
+        "huggingface",
+        "sentence-transformers/all-MiniLM-L6-v2",
+    )
+```
+
+- [ ] **Step 4: Add successful zero-token reserved-unit fallback**
+
+```python
+def test_orchestrator_zero_token_success_commits_reserved_unit(client, monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    monkeypatch.setenv("EMBEDDINGS_ORCHESTRATOR_ENABLED", "true")
+    fake_orchestrator = FakeOrchestrator(
+        prepared_total_tokens=0,
+        result=EmbeddingExecutionResult(
+            vectors=[[0.25, 0.75]],
+            provider="huggingface",
+            model="sentence-transformers/all-MiniLM-L6-v2",
+            prompt_tokens=0,
+            total_tokens=0,
+            cache_hits=0,
+            cache_misses=1,
+        ),
+    )
+    governor = SimpleNamespace(commit=AsyncMock())
+    monkeypatch.setattr(
+        mod,
+        "_build_embedding_request_orchestrator",
+        lambda *_args, **_kwargs: fake_orchestrator,
+    )
+
+    async def reserve(*, request, current_user, token_total):
+        del request, current_user
+        assert token_total == 1
+        return governor, "zero-handle", "zero-op", 1
+
+    monkeypatch.setattr(mod, "_reserve_embedding_rg_tokens", reserve)
+
+    response = client.post(
+        "/api/v1/embeddings",
+        headers={"x-provider": "huggingface"},
+        json={
+            "model": "sentence-transformers/all-MiniLM-L6-v2",
+            "input": "zero accounting",
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    governor.commit.assert_awaited_once_with(
+        "zero-handle",
+        actuals={"tokens": 1},
+        op_id="zero-op",
+    )
+```
+
+- [ ] **Step 5: Add direct endpoint cancellation cleanup**
+
+Call the endpoint coroutine directly so `CancelledError` is observable rather than translated by `TestClient`:
+
+```python
+@pytest.mark.asyncio
+async def test_orchestrator_cancellation_commits_reserved_units_and_decrements_active(
+    monkeypatch,
+):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    cancellation = asyncio.CancelledError()
+    active_requests = _RecordingGauge()
+    governor = SimpleNamespace(commit=AsyncMock())
+    fake_orchestrator = FakeOrchestrator(prepared_total_tokens=3)
+
+    async def no_backpressure(*_args, **_kwargs):
+        return None
+
+    async def reserve(*, request, current_user, token_total):
+        del request, current_user
+        return governor, "cancel-handle", "cancel-op", token_total
+
+    class CancellingRunner:
+        def __init__(self, orchestrator, *, trace_collector=None, pre_execute=None):
+            del trace_collector
+            self.orchestrator = orchestrator
+            self.pre_execute = pre_execute
+
+        async def run(self, raw_input, context):
+            prepared = self.orchestrator.prepare(raw_input, context)
+            assert self.pre_execute is not None
+            await self.pre_execute(prepared)
+            raise cancellation
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(),
+        headers={},
+        method="POST",
+        url=SimpleNamespace(path="/api/v1/embeddings"),
+    )
+    monkeypatch.setattr(mod, "EMBEDDINGS_AVAILABLE", True)
+    monkeypatch.setattr(mod, "active_embedding_requests", active_requests)
+    monkeypatch.setattr(mod, "_check_backpressure_and_quotas", no_backpressure)
+    monkeypatch.setattr(mod, "_reserve_embedding_rg_tokens", reserve)
+    monkeypatch.setattr(
+        mod,
+        "_build_embedding_request_orchestrator",
+        lambda *_args, **_kwargs: fake_orchestrator,
+    )
+    monkeypatch.setattr(mod, "EmbeddingInlineWorkflowRunner", CancellingRunner)
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await mod._create_embedding_with_orchestrator(
+            request=request,
+            embedding_request=mod.CreateEmbeddingRequest(
+                input="cancel endpoint",
+                model="sentence-transformers/all-MiniLM-L6-v2",
+            ),
+            current_user=_user(),
+            background_tasks=SimpleNamespace(),
+            x_provider="huggingface",
+            response=SimpleNamespace(headers={}),
+        )
+
+    assert exc_info.value is cancellation
+    governor.commit.assert_awaited_once_with(
+        "cancel-handle",
+        actuals={"tokens": 3},
+        op_id="cancel-op",
+    )
+    assert active_requests.inc_count == 1
+    assert active_requests.dec_count == 1
+```
+
+- [ ] **Step 6: Run endpoint lifecycle characterization**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py \
+  -k "preserves_rg_reservation or commits_reserved_units_after_execute_failure or zero_token_success or cancellation_commits_reserved_units" \
+  -q
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 7: Commit endpoint lifecycle characterization**
+
+```bash
+git add tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
+git commit -m "test(embeddings): characterize endpoint workflow accounting"
+```
+
+### Task 6: Verify Existing Credential Contracts And Close Stage 2A
+
+**Files:**
+
+- Modify: `backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md`
+
+- [ ] **Step 1: Run all touched test modules**
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py \
+  tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py \
+  tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py \
+  -q
+```
+
+Expected: all tests pass with no unexpected skips or warnings introduced by Stage 2A.
+
+- [ ] **Step 2: Run the broader isolated Embeddings suite**
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Embeddings_isolated -q
+```
+
+Expected: all isolated Embeddings tests pass.
+
+- [ ] **Step 3: Explicitly rerun the latest-dev credential/cache evidence**
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py \
+  -k "resolved_credentials_bypass_shared_provider_cache or adapter_miss_with_resolved_key_bypasses_shared_cache or resolved_keys_never_share_cached_vectors or executor_uses_adapter_registry_before_provider_execution or executor_multibatch_marks_first_valid_batch_before_second_error or public_multibatch_marks_first_valid_batch_before_second_cancel or public_malformed_cached_vector_is_replaced_from_provider_boundary or endpoint_real_orchestrator_applies_fallback_response_headers" \
+  -q
+```
+
+Expected: all selected credential, cache-isolation, malformed-cache, and primary-cardinality cases pass.
+
+- [ ] **Step 4: Run Ruff on touched Python files**
+
+```bash
+source .venv/bin/activate
+python -m ruff check \
+  tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py \
+  tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py \
+  tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
+```
+
+Expected: no lint findings.
+
+- [ ] **Step 5: Run Bandit on the touched test scope**
+
+Assertions are the purpose of these test files, so exclude Bandit's test-only `B101` rule:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py \
+  tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py \
+  tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py \
+  -s B101 \
+  -f json \
+  -o /tmp/bandit_embeddings_stage2a.json
+```
+
+Expected: zero new security findings.
+
+- [ ] **Step 6: Verify the diff is test/tracking-only**
+
+```bash
+git diff --check
+git diff --name-only origin/dev...HEAD
+```
+
+Expected implementation paths are the three test files plus the approved design, plan, and Backlog task files. No path under `tldw_Server_API/app/` may be changed by Stage 2A.
+
+- [ ] **Step 7: Finalize `TASK-12973.1` through Backlog**
+
+Using the Backlog MCP or CLI:
+
+1. Check all acceptance criteria and definition-of-done items.
+2. Record exact test counts, Ruff output, Bandit output path, and any skips.
+3. Add the final summary stating that Stage 2A changed tests/tracking only.
+4. Mark `TASK-12973.1` Done.
+
+- [ ] **Step 8: Commit Stage 2A closeout metadata**
+
+```bash
+git add \
+  "backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md"
+git commit -m "chore(backlog): close embeddings workflow stage 2a"
+```

--- a/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
@@ -12,7 +12,7 @@
 
 ## Scope And Existing Coverage
 
-The branch was rebased onto `origin/dev` at `1b9518c68c` before this plan was written. Stage 2A is test-only.
+The branch was initially rebased onto `origin/dev` at `1b9518c68c` before this plan was written and was rebased again onto `origin/dev` at `0f3983788c` before final review. Stage 2A is test-only.
 
 **Files modified during implementation:**
 
@@ -1054,3 +1054,19 @@ git add \
   "backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md"
 git commit -m "chore(backlog): close embeddings workflow stage 2a"
 ```
+
+### Task 7: Remediate Final Whole-Branch Review
+
+**Goal**: Remove brittle implementation-detail assertions, complete endpoint boundary and resource-accounting characterization, and correct closeout metadata.
+
+**Success Criteria**: Tests preserve the approved Stage 2C ordering correction, production endpoint identity/key behavior and cleanup paths are characterized accurately, the design distinguishes collapsed identity construction failures from escaping failures, and tracking reflects the final rebase.
+
+**Tests**: Focused isolated-orchestrator and endpoint-parity tests, then the complete Task 6 verification matrix.
+
+**Status**: Complete
+
+- [x] Replace exact fallback event-list equality with semantic order and no-Cohere-work assertions.
+- [x] Remove the extra writeback cache-key derivation requirement from complete-result validation coverage.
+- [x] Add direct production endpoint identity and cache-key failure characterization and reconcile the error-routing text.
+- [x] Cover active-request cleanup on reservation denial and noncritical resource-governor commit failure.
+- [x] Normalize Backlog metadata, rerun all verification gates, and obtain final specification and quality approval.

--- a/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
@@ -966,7 +966,7 @@ git commit -m "test(embeddings): characterize endpoint workflow accounting"
 
 - Modify: `backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md`
 
-- [ ] **Step 1: Run all touched test modules**
+- [x] **Step 1: Run all touched test modules**
 
 ```bash
 source .venv/bin/activate
@@ -979,7 +979,7 @@ python -m pytest \
 
 Expected: all tests pass with no unexpected skips or warnings introduced by Stage 2A.
 
-- [ ] **Step 2: Run the broader isolated Embeddings suite**
+- [x] **Step 2: Run the broader isolated Embeddings suite**
 
 ```bash
 source .venv/bin/activate
@@ -988,7 +988,7 @@ python -m pytest tldw_Server_API/tests/Embeddings_isolated -q
 
 Expected: all isolated Embeddings tests pass.
 
-- [ ] **Step 3: Explicitly rerun the latest-dev credential/cache evidence**
+- [x] **Step 3: Explicitly rerun the latest-dev credential/cache evidence**
 
 ```bash
 source .venv/bin/activate
@@ -1000,7 +1000,7 @@ python -m pytest \
 
 Expected: all selected credential, cache-isolation, malformed-cache, and primary-cardinality cases pass.
 
-- [ ] **Step 4: Run Ruff on touched Python files**
+- [x] **Step 4: Run Ruff on touched Python files**
 
 ```bash
 source .venv/bin/activate
@@ -1012,7 +1012,7 @@ python -m ruff check \
 
 Expected: no lint findings.
 
-- [ ] **Step 5: Run Bandit on the touched test scope**
+- [x] **Step 5: Run Bandit on the touched test scope**
 
 Assertions are the purpose of these test files, so exclude Bandit's test-only `B101` rule:
 
@@ -1029,7 +1029,7 @@ python -m bandit -r \
 
 Expected: zero new security findings.
 
-- [ ] **Step 6: Verify the diff is test/tracking-only**
+- [x] **Step 6: Verify the diff is test/tracking-only**
 
 ```bash
 git diff --check
@@ -1038,7 +1038,7 @@ git diff --name-only origin/dev...HEAD
 
 Expected implementation paths are the three test files plus the approved design, plan, and Backlog task files. No path under `tldw_Server_API/app/` may be changed by Stage 2A.
 
-- [ ] **Step 7: Finalize `TASK-12973.1` through Backlog**
+- [x] **Step 7: Finalize `TASK-12973.1` through Backlog**
 
 Using the Backlog MCP or CLI:
 
@@ -1047,7 +1047,7 @@ Using the Backlog MCP or CLI:
 3. Add the final summary stating that Stage 2A changed tests/tracking only.
 4. Mark `TASK-12973.1` Done.
 
-- [ ] **Step 8: Commit Stage 2A closeout metadata**
+- [x] **Step 8: Commit Stage 2A closeout metadata**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
@@ -1096,3 +1096,69 @@ git commit -m "chore(backlog): close embeddings workflow stage 2a"
 
 - [x] Rebase onto `origin/dev` at `76481b2939` without conflicts.
 - [x] Run post-rebase verification, close tracking, and update PR #2762.
+
+### Task 10: Remediate Pre-Merge Review Findings
+
+**Goal**: Close the validated pre-merge review gaps without changing production execution behavior.
+
+**Success Criteria**: Tests distinguish total, prompt, and reserved token-accounting precedence; active-request accounting is observed during backpressure rejection; complete-result validation is asserted through observable behavior instead of a private validator call trace; parent tracking reflects the completed design review; and the remediation passes all local required checks before PR CI.
+
+**Files:**
+
+- Modify: `tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py`
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+- Modify through Backlog CLI: `backlog/tasks/task-12973 - Extract-concrete-API-workflow-steps-for-Embeddings.md`
+- Modify through Backlog CLI: `backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md`
+
+**Status**: Complete
+
+- [x] **Step 1: Pin resource-governor actual-token precedence**
+
+Change the existing successful endpoint fixture to use distinct values:
+
+```python
+prompt_tokens=2,
+total_tokens=5,
+```
+
+Keep the prepared reservation at three tokens and assert:
+
+```python
+rg_governor.commit.assert_awaited_once_with(
+    "rg-handle",
+    actuals={"tokens": 5},
+    op_id="rg-op",
+)
+```
+
+Temporarily reverse the production `total_tokens`/`prompt_tokens` expression, run this one test, and confirm it fails with committed actuals of two tokens. Restore the production expression immediately and rerun for PASS; no production file may remain modified.
+
+- [x] **Step 2: Characterize active accounting during backpressure rejection**
+
+Add a test whose rejecting backpressure probe observes the live gauge:
+
+```python
+async def reject_for_backpressure(*_args, **_kwargs):
+    assert active_requests.inc_count == 1
+    assert active_requests.dec_count == 0
+    return HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail="Backpressure: queue overload",
+    )
+```
+
+Call `/api/v1/embeddings` with the orchestrator flag enabled, assert status 429, and assert final counts of one increment and one decrement. Verify test sensitivity with a temporary ordering mutation, restore production immediately, and retain no production diff.
+
+- [x] **Step 3: Remove private validator call-trace coupling**
+
+Delete the `validated_embedding_vectors` monkeypatch and `validation_calls` equality assertion from `test_fallback_complete_result_is_validated_before_first_cache_write`. Preserve the exact malformed-response assertions, executor/cache-read evidence, and `cache.set_calls == []` so the test continues to prove complete ordered-result validation occurs before writeback.
+
+- [x] **Step 4: Reconcile parent Stage 2 tracking**
+
+Use Backlog CLI to check parent acceptance criteria 1 and 2 and replace the stale pending-review note with a dated record that the design was approved, the five child tasks exist, and Stage 2A is complete while Stage 2B-2E remain pending.
+
+- [x] **Step 5: Verify and finalize the remediation**
+
+Run the changed tests, all three touched Stage 2A modules, the complete `Embeddings_isolated` suite, Ruff, Bandit with B101 excluded, `git diff --check origin/dev`, and the application-path scope check. Close `TASK-12973.1` with exact evidence and obtain final independent review approval.
+
+**Merge handoff:** Commit and push the scoped remediation, wait for required CI, and merge PR #2762 only after the requester supplies the mandatory human-authored Change summary.

--- a/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
@@ -51,7 +51,7 @@ Current `dev` already supplies the following required evidence. Do not duplicate
 
 - Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
 
-- [ ] **Step 1: Allow the isolated factory to inject runtime identity and cache-key probes**
+- [x] **Step 1: Allow the isolated factory to inject runtime identity and cache-key probes**
 
 Extend `_orchestrator` with narrow optional overrides while preserving every existing default:
 
@@ -93,7 +93,7 @@ def _orchestrator(
     )
 ```
 
-- [ ] **Step 2: Add a preparation-order characterization test**
+- [x] **Step 2: Add a preparation-order characterization test**
 
 Import the orchestrator module for monkeypatching:
 
@@ -142,7 +142,7 @@ def test_prepare_orders_intent_normalization_policy_and_plan_identity(monkeypatc
     ]
 ```
 
-- [ ] **Step 3: Add a primary-preflight failure test**
+- [x] **Step 3: Add a primary-preflight failure test**
 
 The test must prove readiness runs before cache access and that even a retryable primary readiness failure does not enter fallback:
 
@@ -186,7 +186,7 @@ async def test_primary_preflight_failure_propagates_without_cache_or_fallback():
     assert executor.calls == []
 ```
 
-- [ ] **Step 4: Add retryable fallback-preflight traversal coverage**
+- [x] **Step 4: Add retryable fallback-preflight traversal coverage**
 
 Keep the existing missing-credential skip test. Add a separate retryable readiness case that proves the failed candidate is skipped and the next candidate is attempted:
 
@@ -249,7 +249,7 @@ async def test_retryable_fallback_preflight_failure_continues_to_next_candidate(
     ]
 ```
 
-- [ ] **Step 5: Run the new preparation/readiness tests**
+- [x] **Step 5: Run the new preparation/readiness tests**
 
 Run:
 
@@ -264,7 +264,7 @@ python -m pytest \
 
 Expected: 3 passed. These are characterization tests; a failure means the test assumption must be reconciled with current behavior, not that production code should be changed.
 
-- [ ] **Step 6: Commit the preparation/readiness tests**
+- [x] **Step 6: Commit the preparation/readiness tests**
 
 ```bash
 git add tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -278,7 +278,7 @@ git commit -m "test(embeddings): characterize preparation and readiness order"
 - Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
 - Modify: `tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py`
 
-- [ ] **Step 1: Add a primary infrastructure-failure parameterization**
+- [x] **Step 1: Add a primary infrastructure-failure parameterization**
 
 Add a small raising cache inside the test and cover read-time identity, key derivation, and cache access. Each error is a generic infrastructure exception and must propagate unchanged without provider fallback:
 
@@ -335,7 +335,7 @@ async def test_primary_infrastructure_failure_propagates_without_fallback(bounda
     assert cache.set_calls == []
 ```
 
-- [ ] **Step 2: Characterize the current broad fallback-domain catch**
+- [x] **Step 2: Characterize the current broad fallback-domain catch**
 
 This test intentionally records behavior that Stage 2D will correct. A retryable domain-shaped error from fallback identity, key, cache read, or cache write currently advances to the next provider:
 
@@ -420,7 +420,7 @@ async def test_fallback_domain_shaped_infrastructure_failure_currently_advances_
     assert providers.count("openai") == 1
 ```
 
-- [ ] **Step 3: Characterize endpoint cache-adapter exception identity**
+- [x] **Step 3: Characterize endpoint cache-adapter exception identity**
 
 In `test_embeddings_orchestrator_endpoint_parity.py`, add:
 
@@ -468,7 +468,7 @@ async def test_endpoint_cache_adapter_propagates_dependency_error_unchanged(
     dependency.assert_awaited_once()
 ```
 
-- [ ] **Step 4: Run the infrastructure-source tests**
+- [x] **Step 4: Run the infrastructure-source tests**
 
 Run:
 
@@ -483,7 +483,7 @@ python -m pytest \
 
 Expected: 11 passed: 3 primary cases, 4 current fallback cases, and 4 endpoint adapter cases.
 
-- [ ] **Step 5: Commit the failure-source tests**
+- [x] **Step 5: Commit the failure-source tests**
 
 ```bash
 git add \
@@ -498,7 +498,7 @@ git commit -m "test(embeddings): pin orchestration failure sources"
 
 - Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
 
-- [ ] **Step 1: Add successful adapter accounting and bypass coverage**
+- [x] **Step 1: Add successful adapter accounting and bypass coverage**
 
 ```python
 @pytest.mark.unit
@@ -540,7 +540,7 @@ async def test_successful_adapter_reports_compatibility_cache_counts_and_bypasse
     assert executor.calls == []
 ```
 
-- [ ] **Step 2: Add isolated malformed/non-finite cache replacement cases**
+- [x] **Step 2: Add isolated malformed/non-finite cache replacement cases**
 
 ```python
 @pytest.mark.unit
@@ -573,7 +573,7 @@ async def test_malformed_cached_vector_becomes_miss_and_is_replaced(cached):
     assert cache.set_calls == [(cache_key, [0.25, 0.75])]
 ```
 
-- [ ] **Step 3: Add fallback complete-result validation before writeback**
+- [x] **Step 3: Add fallback complete-result validation before writeback**
 
 Keep the existing primary mixed-width test unchanged. Add the equivalent full fallback path:
 
@@ -617,7 +617,7 @@ async def test_fallback_complete_result_is_validated_before_first_cache_write():
     assert cache.set_calls == []
 ```
 
-- [ ] **Step 4: Reassert primary execution cardinality**
+- [x] **Step 4: Reassert primary execution cardinality**
 
 In `test_fallback_execution_maps_model_and_returns_fallback_headers`, add:
 
@@ -626,7 +626,7 @@ In `test_fallback_execution_maps_model_and_returns_fallback_headers`, add:
     assert [call["provider"] for call in executor.calls].count("openai") == 1
 ```
 
-- [ ] **Step 5: Run adapter/cache characterization**
+- [x] **Step 5: Run adapter/cache characterization**
 
 Run:
 
@@ -640,7 +640,7 @@ python -m pytest \
 
 Expected: 7 passed.
 
-- [ ] **Step 6: Commit adapter/cache characterization**
+- [x] **Step 6: Commit adapter/cache characterization**
 
 ```bash
 git add tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -653,7 +653,7 @@ git commit -m "test(embeddings): characterize adapter and cache validation"
 
 - Modify: `tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py`
 
-- [ ] **Step 1: Assert the exact current success statuses**
+- [x] **Step 1: Assert the exact current success statuses**
 
 Extend `test_runner_returns_orchestrator_result_and_records_safe_success_events`:
 
@@ -671,7 +671,7 @@ Extend `test_runner_returns_orchestrator_result_and_records_safe_success_events`
 
 This intentionally pins the Stage 1 sequence. Do not add Stage 2 phases in Stage 2A.
 
-- [ ] **Step 2: Add cancellation propagation and trace truncation**
+- [x] **Step 2: Add cancellation propagation and trace truncation**
 
 Import `asyncio`, then add:
 
@@ -703,7 +703,7 @@ async def test_execute_cancellation_propagates_without_terminal_trace_event():
     )
 ```
 
-- [ ] **Step 3: Run the runner characterization tests**
+- [x] **Step 3: Run the runner characterization tests**
 
 Run:
 
@@ -716,7 +716,7 @@ python -m pytest \
 
 Expected: all runner tests pass, including the new cancellation case.
 
-- [ ] **Step 4: Commit runner characterization**
+- [x] **Step 4: Commit runner characterization**
 
 ```bash
 git add tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py
@@ -729,7 +729,7 @@ git commit -m "test(embeddings): pin inline runner cancellation"
 
 - Modify: `tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py`
 
-- [ ] **Step 1: Add a recording active-request gauge**
+- [x] **Step 1: Add a recording active-request gauge**
 
 Place this beside the existing metric fakes:
 
@@ -746,7 +746,7 @@ class _RecordingGauge(_NoopMetric):
         self.dec_count += 1
 ```
 
-- [ ] **Step 2: Make the endpoint fake support zero-token preparation**
+- [x] **Step 2: Make the endpoint fake support zero-token preparation**
 
 Change only the test fake:
 
@@ -774,7 +774,7 @@ class FakeOrchestrator:
         return FakePrepared(total_tokens=self.prepared_total_tokens)
 ```
 
-- [ ] **Step 3: Strengthen existing success and post-reservation failure tests**
+- [x] **Step 3: Strengthen existing success and post-reservation failure tests**
 
 In both `test_orchestrator_path_uses_inline_workflow_runner_and_preserves_rg_reservation` and `test_orchestrator_path_commits_reserved_units_after_execute_failure`, install a fresh `_RecordingGauge`:
 
@@ -810,7 +810,7 @@ After the response:
     )
 ```
 
-- [ ] **Step 4: Add successful zero-token reserved-unit fallback**
+- [x] **Step 4: Add successful zero-token reserved-unit fallback**
 
 ```python
 def test_orchestrator_zero_token_success_commits_reserved_unit(client, monkeypatch):
@@ -862,7 +862,7 @@ def test_orchestrator_zero_token_success_commits_reserved_unit(client, monkeypat
     )
 ```
 
-- [ ] **Step 5: Add direct endpoint cancellation cleanup**
+- [x] **Step 5: Add direct endpoint cancellation cleanup**
 
 Call the endpoint coroutine directly so `CancelledError` is observable rather than translated by `TestClient`:
 
@@ -939,7 +939,7 @@ async def test_orchestrator_cancellation_commits_reserved_units_and_decrements_a
     assert active_requests.dec_count == 1
 ```
 
-- [ ] **Step 6: Run endpoint lifecycle characterization**
+- [x] **Step 6: Run endpoint lifecycle characterization**
 
 Run:
 
@@ -953,7 +953,7 @@ python -m pytest \
 
 Expected: 4 passed.
 
-- [ ] **Step 7: Commit endpoint lifecycle characterization**
+- [x] **Step 7: Commit endpoint lifecycle characterization**
 
 ```bash
 git add tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py

--- a/Docs/superpowers/specs/2026-07-03-embeddings-workflow-architecture-design.md
+++ b/Docs/superpowers/specs/2026-07-03-embeddings-workflow-architecture-design.md
@@ -89,6 +89,7 @@ Workflow identity is safe metadata. Inline API workflows always generate and val
 Request phase values:
 
 - `created`
+- `resolving_intent`
 - `normalizing`
 - `resolving_policy`
 - `planning`
@@ -119,7 +120,7 @@ Initial item state values:
 
 Slice one does not persist these states. It derives coarse workflow trace events from `PreparedEmbeddingRequest` and `EmbeddingExecutionResult`.
 
-The full phase vocabulary is intentionally larger than slice one. Slice one should emit only phases it can represent truthfully around the current wrapped orchestrator. More granular cache, provider, postprocessing, and persistence phases become mandatory when those behaviors move into workflow-owned steps.
+The full phase vocabulary is intentionally larger than slice one. Slice one should emit only phases it can represent truthfully around the current wrapped orchestrator. Stage 2 adds truthful preparation phases but keeps cache, provider, postprocessing, and writeback as attempt-local stages under the monotonic request-level `executing` phase. The durable attempt model in Stage 3 decides which granular phase and item-state literals become persisted attempt transitions; fallback must not move the request-level phase backward.
 
 Item events carry stable `item_index`, aggregate state, and fixed execution categories. Provider/model/backend identity, fallback source, and other caller-controlled identifiers require explicit trusted canonicalization before a later slice may add them. They do not carry raw text, token arrays, API keys, auth headers, or provider response bodies.
 
@@ -235,7 +236,7 @@ Trace metadata must be safe by construction:
 - Accept string metadata only for fixed enum values; do not trace caller-controlled provider, model, cache, fallback, error, class, request, user, or header identifiers.
 - Validate workflow ids independently at context and event construction so they cannot bypass metadata rules.
 - Treat credential-pattern detection as defense in depth, not proof that an arbitrary string is safe.
-- Use aggregate response-header counts, not names or values.
+- Slice one uses aggregate response-header counts, not names or values; Stage 2 replaces them with bounded aggregate attempt counters.
 - Freeze validated metadata mappings and sequence values before collectors can retain them.
 - Bound collection size to prevent unbounded memory growth in tests or future callers.
 - Fail closed on trace metadata validation errors. Bad trace metadata should fail isolated workflow tests and future debug callers, not become production logs.
@@ -276,6 +277,8 @@ Add `workflow_types.py` and `workflow_runner.py`. Wrap the feature-flagged `/api
 ### Stage 2: Extract Concrete API Steps
 
 Move cache serving, provider execution, fallback, postprocessing, and response metadata out of `EmbeddingRequestOrchestrator` into workflow-compatible components. Keep `EmbeddingRequestOrchestrator` as a compatibility facade until tests migrate.
+
+Stage 2 refines the inline trace contract by adding `resolving_intent`, replacing HTTP-derived response-header counts with bounded aggregate attempt counters, and emitting no per-attempt or per-item events. `completed` remains a request status, not a phase. Granular attempt persistence remains Stage 3 work.
 
 ### Stage 3: Durable Workflow Store And Jobs Runner
 

--- a/Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+++ b/Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
@@ -120,7 +120,7 @@ Re-resolving identity before writeback is the approved Stage 2C correctness corr
 
 The attempt does not promise transactional cache writes. If a later write fails, earlier writes may already exist, matching current behavior. Read-time or write-time backend-identity resolution, cache-key derivation, cache access, validation, postprocessing, and writeback failures are not provider-call failures and must never trigger fallback.
 
-Stage 2A must characterize the exception types passed through by the production endpoint identity resolver, cache-key function, and cache adapter. Generic infrastructure failures already propagate without fallback. Stage 2D explicitly corrects the current fallback-wide `EmbeddingDomainError` catch so a domain-shaped error originating from identity resolution, key derivation, cache access, validation, postprocessing, or writeback also propagates instead of being misclassified as a provider failure.
+Stage 2A must characterize the exception types passed through by the production endpoint identity resolver, cache-key function, and cache adapter. The endpoint compatibility helper `_orchestrator_backend_identity` collapses allowlisted noncritical identity-construction failures to `None`. That narrow compatibility behavior is not a general exception-swallowing policy: exceptions that escape identity resolution, cache-key derivation, or cache access propagate and do not trigger fallback. Generic infrastructure failures already satisfy this rule. Stage 2D explicitly corrects the current fallback-wide `EmbeddingDomainError` catch so a domain-shaped error originating from identity resolution, key derivation, cache access, validation, postprocessing, or writeback also propagates instead of being misclassified as a provider failure.
 
 Provider-call failures are represented by a private frozen `ProviderCallFailure` DTO containing the exact original `EmbeddingDomainError`. `EmbeddingProviderAttempt` returns `ProviderAttemptSuccess | ProviderCallFailure` and catches domain errors only around the executor call. Readiness, backend-identity resolution, cache-key derivation, cache access, validation, postprocessing, writeback, tracing, and resource-governor errors are never converted to this result. If the coordinator ultimately raises the failure, it raises the contained error object unchanged.
 
@@ -240,6 +240,13 @@ Stage 2 preserves current task-cancellation behavior. `asyncio.CancelledError` p
 
 ## Error Routing Matrix
 
+The endpoint compatibility helper `_orchestrator_backend_identity` collapses an
+allowlisted noncritical construction failure to `None`; that behavior is local
+to the helper and does not make identity, cache-key, or cache access broadly
+exception-swallowing. Exceptions that escape those boundaries, including
+infrastructure and domain errors, fail the request without activating
+fallback.
+
 | Operation | Result |
 | --- | --- |
 | Intent resolution, normalization, or policy failure | Fail request; no execution or fallback |
@@ -247,7 +254,8 @@ Stage 2 preserves current task-cancellation behavior. `asyncio.CancelledError` p
 | Preferred adapter exception | Fail request unchanged; no provider fallback |
 | Preferred adapter returns no result | Continue to primary readiness |
 | Primary readiness failure | Fail request unchanged; no fallback |
-| Primary backend-identity or cache-key derivation failure | Fail request; no fallback |
+| Allowlisted noncritical endpoint backend-identity construction failure | `_orchestrator_backend_identity` returns `None` for compatibility; no exception escapes that helper |
+| Escaping primary backend-identity or cache-key infrastructure/domain failure | Fail request unchanged; no fallback |
 | Malformed or non-finite primary cached vector | Treat as a miss and replace through provider execution |
 | Primary cache read, postprocessing, or cache write failure | Fail request; no fallback |
 | Eligible primary provider-call failure with fallback allowed | Start fallback with the complete input |
@@ -256,7 +264,7 @@ Stage 2 preserves current task-cancellation behavior. `asyncio.CancelledError` p
 | Fallback provider call reports missing credentials | Skip candidate, preserving current candidate behavior |
 | Other eligible fallback readiness or `ProviderCallFailure` | Continue to the next candidate |
 | Ineligible fallback failure | Raise immediately |
-| Fallback backend-identity or cache-key derivation failure | Fail request; do not try another provider |
+| Escaping fallback backend-identity or cache-key infrastructure/domain failure | Fail request unchanged; do not try another provider |
 | Malformed or non-finite fallback cached vector | Treat as a miss and replace through that fallback candidate |
 | Fallback cache read, postprocessing, or cache write failure | Fail request; do not try another provider |
 | Fallback exhaustion | Apply existing exhausted-error selection, preserving rate-limit retry metadata |

--- a/Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+++ b/Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
@@ -1,0 +1,292 @@
+# Embeddings Workflow Stage 2: Concrete API Steps Design
+
+**Status:** Approved design; written-spec review pending
+
+**Parent task:** `TASK-12973`
+
+**Depends on:** PR #2733 and `Docs/superpowers/specs/2026-07-03-embeddings-workflow-architecture-design.md`
+
+## Purpose
+
+Stage 1 placed the feature-flagged `/api/v1/embeddings` path behind typed workflow contracts and an inline runner, but the runner still delegates execution to `EmbeddingRequestOrchestrator`. Stage 2 extracts the concrete preparation and execution responsibilities into workflow-compatible components while preserving current API behavior.
+
+Stage 2 is delivered as five sequential child tasks and pull requests. Each pull request must leave the workflow-enabled endpoint usable, tested, and independently reversible.
+
+## Goals
+
+1. Represent the actual preparation and execution order with explicit contracts.
+2. Isolate adapter execution, provider readiness, single-provider attempts, fallback policy, vector processing, and result assembly.
+3. Make the inline runner sequence the concrete application-level workflow.
+4. Reduce `EmbeddingRequestOrchestrator` to delegation and legacy result compatibility.
+5. Move HTTP response-header construction to the endpoint boundary.
+6. Preserve endpoint output, fallback, caching, resource governance, metrics inputs, credential touching, and error behavior.
+
+## Non-Goals
+
+Stage 2 does not add durable workflow storage, Jobs workers, retries across process boundaries, pause/resume, cancellation, leases, persisted item records, media-ingestion migration, vector-store migration, or re-embedding migration. Those remain later stages of the architecture roadmap.
+
+Stage 2 also does not redesign cache keys, make cache writes transactional, optimize full-cache-hit credential checks, alter fallback policy, remove the legacy endpoint path, or promote the workflow feature flag.
+
+## Existing Behavioral Order
+
+The extraction must start from the current order rather than the apparent order implied by existing phase names.
+
+Preparation currently performs:
+
+1. Resolve provider/model intent.
+2. Normalize and decode input using the resolved model.
+3. Enforce provider, model, dimension, and fallback policy.
+4. Build the execution plan and token totals.
+
+Execution currently performs:
+
+1. Run the optional resource-governor reservation hook after planning.
+2. Try the preferred adapter path before provider preflight or cache access.
+3. Preflight the requested primary provider.
+4. Read primary cache entries in request order.
+5. Execute only primary misses.
+6. If an eligible primary provider-call failure occurs, discard primary partial results and resolve the complete request through fallback candidates.
+7. Validate and canonicalize provider output, apply request-specific dimension processing, then write provider-native vectors to cache.
+8. Assemble the result, touch credentials for the actual provider, record metrics and usage, map HTTP headers, and commit the resource reservation at the endpoint boundary.
+
+The extraction may not reorder these operations unless a child task explicitly identifies, tests, and documents a separate behavior correction.
+
+## Architecture
+
+### EmbeddingPreparationPipeline
+
+`EmbeddingPreparationPipeline` owns the existing preparation order. It exposes one preparation operation and accepts an optional phase sink so the inline runner can report truthful phases without duplicating the preparation algorithm.
+
+Its internal steps are:
+
+- Resolve `ProviderModelIntent`.
+- Produce `NormalizedEmbeddingInput`.
+- Produce `EmbeddingPolicyDecision`.
+- Produce `PreparedEmbeddingRequest` and `EmbeddingExecutionPlan`.
+
+The compatibility orchestrator calls the same pipeline without a phase sink.
+
+### EmbeddingAdapterAttempt
+
+`EmbeddingAdapterAttempt` implements the optional preferred adapter fast path. It runs only when the execution plan requests the adapter path and the executor exposes `create_adapter`.
+
+An adapter result must be validated and postprocessed. A successful adapter result bypasses provider preflight and all cache access. A `None` or non-adapter result continues to primary readiness. Adapter exceptions propagate unchanged and never activate provider fallback.
+
+### EmbeddingProviderReadinessCheck
+
+`EmbeddingProviderReadinessCheck` wraps provider preflight independently from cache and execution. Keeping readiness separate is required because primary and fallback readiness failures have different policy:
+
+- A requested primary readiness failure propagates immediately and does not enter fallback.
+- A fallback candidate with missing credentials is skipped.
+- Other fallback readiness failures follow the existing eligibility rules.
+
+Readiness continues to run before cache lookup, including full cache hits.
+
+### EmbeddingVectorProcessor
+
+`EmbeddingVectorProcessor` is a pure component for vector-count validation, numeric canonicalization, and request-specific dimension adjustment. It preserves the current rule that base64 requests with explicit dimensions use the `reduce` policy.
+
+It receives provider/model context for domain errors and adjustment metrics but does not access the cache, executor, endpoint response, or workflow collector.
+
+### EmbeddingProviderAttempt
+
+`EmbeddingProviderAttempt` resolves one provider/model against the complete ordered input. Readiness is performed by the caller before the attempt.
+
+The attempt performs:
+
+1. Resolve backend identity and derive cache keys.
+2. Read cache entries in request order.
+3. Canonicalize and postprocess each cache hit before provider execution.
+4. Execute only missing texts.
+5. Validate the complete miss response before any writeback.
+6. Canonicalize provider-native miss vectors.
+7. Postprocess all miss vectors successfully.
+8. Write provider-native miss vectors to cache in request order unless the executor marked them as adapter-originated.
+9. Assemble final vectors in original request order.
+
+The attempt does not promise transactional cache writes. If a later write fails, earlier writes may already exist, matching current behavior. Cache read, postprocessing, and writeback failures are not provider-call failures and must never trigger fallback.
+
+Stage 2A must verify that the production endpoint cache adapter does not translate cache failures into fallback-eligible provider errors. If characterization finds such a translation, changing that observable behavior is outside this extraction and requires a separately approved correction.
+
+Provider-call failures are represented separately from other exceptions so the coordinator can make a fallback decision without wrapping or replacing the original domain exception.
+
+### EmbeddingFallbackCoordinator
+
+`EmbeddingFallbackCoordinator` owns fallback candidate traversal only. For each candidate it:
+
+1. Maps the requested model to the candidate provider.
+2. Runs candidate readiness.
+3. Skips missing candidate credentials.
+4. Executes a full-request provider attempt.
+5. Applies fallback eligibility and exhausted-error precedence to provider-call or readiness failures.
+
+A successful fallback always returns vectors for the complete original input. Primary cache hits and partial primary state never appear in a fallback result.
+
+### EmbeddingExecutionCoordinator
+
+`EmbeddingExecutionCoordinator` owns the domain execution sequence:
+
+1. Try `EmbeddingAdapterAttempt`.
+2. Run primary `EmbeddingProviderReadinessCheck` outside fallback handling.
+3. Run the primary `EmbeddingProviderAttempt`.
+4. Return primary success, or invoke `EmbeddingFallbackCoordinator` for an eligible primary provider-call failure when policy allows fallback.
+5. Preserve the original error object when fallback is denied or exhausted-error selection chooses it.
+
+The coordinator contains no HTTP response formatting, resource-governor reservation, usage logging, or workflow persistence.
+
+### EmbeddingExecutionOutcome and Result Assembly
+
+`EmbeddingResultAssembler` combines a prepared request and successful execution into a canonical `EmbeddingExecutionOutcome`. The outcome contains:
+
+- Ordered vectors.
+- Actual provider and model.
+- Prompt and total token counts.
+- Cache hit and miss counts.
+- Requested dimensions and effective dimension policy.
+- `fallback_from` when applicable.
+- Whether the returned vectors originated from an adapter.
+
+The canonical outcome contains no HTTP headers.
+
+`EmbeddingExecutionResult` remains temporarily as the compatibility DTO returned by `EmbeddingRequestOrchestrator`. A compatibility mapper derives it from the canonical outcome and preserves the current `response_headers` field for existing internal callers and tests. The endpoint workflow path consumes the canonical outcome directly.
+
+### Endpoint Response Mapping
+
+The endpoint maps canonical outcome metadata to:
+
+- `X-Embeddings-Provider`
+- `X-Embeddings-Fallback-From` when fallback changed the provider
+- `X-Embeddings-Dimensions-Policy` when dimensions were requested
+
+Credential touching, cache-hit metrics, duration metrics, usage logging, OpenAI response formatting, and resource-governor commit remain endpoint responsibilities in Stage 2.
+
+## Inline Runner and State Model
+
+The inline runner sequences:
+
+1. Workflow creation.
+2. Preparation pipeline.
+3. Existing `pre_execute` reservation hook.
+4. Execution coordinator.
+5. Result assembly.
+6. Workflow completion or failure.
+
+The truthful Stage 2 top-level phase order is:
+
+```text
+created
+  -> resolving_intent
+  -> normalizing
+  -> resolving_policy
+  -> planning
+  -> executing
+  -> finalizing
+  -> completed
+```
+
+The `pre_execute` hook runs while the workflow is in `planning`. Its failure is recorded as a planning failure and prevents adapter, readiness, cache, and provider work.
+
+Cache lookup, provider call, postprocessing, and cache writeback are attempt-local stages under `executing`. Fallback repeats attempt-local stages without moving the top-level workflow phase backward. Existing `serving_cache` and `postprocessing` phase literals may remain temporarily for compatibility but are not emitted as Stage 2 top-level transitions.
+
+Stage 2 emits aggregate workflow and attempt metadata only. It does not emit one event per input item. Attempt metadata may include bounded fields such as attempt index, primary/fallback role, cache hit count, cache miss count, adapter use, and retryability. It must not include provider names, model names, raw input, token arrays, cache keys, credentials, provider response bodies, or caller-controlled headers.
+
+The production default collector remains disabled. The bounded in-memory collector remains fail-closed when enabled. Collector failures are never interpreted as provider failures and never trigger fallback. Failure-event recording remains best effort so a collector failure cannot replace the original request exception.
+
+## Error Routing Matrix
+
+| Operation | Result |
+| --- | --- |
+| Intent resolution, normalization, or policy failure | Fail request; no execution or fallback |
+| Resource reservation failure | Fail in planning; no adapter, cache, provider, or fallback work |
+| Preferred adapter exception | Fail request unchanged; no provider fallback |
+| Preferred adapter returns no result | Continue to primary readiness |
+| Primary readiness failure | Fail request unchanged; no fallback |
+| Primary cache read, postprocessing, or cache write failure | Fail request; no fallback |
+| Eligible primary provider-call failure with fallback allowed | Start fallback with the complete input |
+| Ineligible primary provider-call failure | Raise the original error unchanged |
+| Fallback readiness reports missing credentials | Skip candidate |
+| Other eligible fallback readiness or provider-call failure | Continue to the next candidate |
+| Ineligible fallback failure | Raise immediately |
+| Fallback cache read, postprocessing, or cache write failure | Fail request; do not try another provider |
+| Fallback exhaustion | Apply existing exhausted-error selection, preserving rate-limit retry metadata |
+| Trace collector failure during normal tracing | Fail closed, but never enter provider fallback |
+| Failure-event collector failure | Preserve and re-raise the original request error |
+| Resource-governor commit failure | Log as noncritical at the endpoint boundary |
+
+## Security and Privacy
+
+- Raw text and token arrays remain outside execution plans, results, and workflow events.
+- Provider/model identifiers remain excluded from trace metadata because caller-controlled values can resemble credentials.
+- Cache keys and backend identities are never traced.
+- Domain exceptions are traced only as fixed failure kind, phase, and retryability fields.
+- The existing metadata allowlist, credential-pattern checks, immutable event metadata, generated workflow identifiers, and event bounds remain enforced.
+- No provider secrets, BYOK material, request headers, or provider bodies enter component DTO representations.
+
+## Compatibility and Rollback
+
+The existing workflow feature flag remains the operational rollback for all Stage 2 pull requests. Disabling it routes requests through the legacy endpoint implementation.
+
+Within the workflow-enabled path:
+
+- `EmbeddingRequestOrchestrator.prepare` delegates to `EmbeddingPreparationPipeline`.
+- `EmbeddingRequestOrchestrator.execute` delegates to `EmbeddingExecutionCoordinator` and the compatibility result mapper.
+- The final Stage 2 orchestrator contains no cache loops, executor calls, fallback traversal, vector postprocessing, or HTTP policy decisions.
+
+The legacy endpoint implementation is not removed in Stage 2.
+
+## Delivery Plan
+
+### Stage 2A: Characterization and Contracts (`TASK-12973.1`)
+
+Add missing behavior-first tests before production extraction. Coverage includes preparation order, reservation ordering, primary readiness non-fallback behavior, fallback readiness behavior, cache failure routing, adapter writeback bypass, exact error identity, and exhausted-error precedence. This pull request changes no production execution behavior.
+
+### Stage 2B: Preparation and Result Contracts (`TASK-12973.2`)
+
+Extract preparation steps, vector processing, the canonical outcome, a parity-tested endpoint header mapper, and the legacy result adapter. Existing execution and production endpoint wiring remain in place while the pure components gain focused coverage. The endpoint switches to the new mapper in Stage 2E.
+
+### Stage 2C: Single-Provider Attempts (`TASK-12973.3`)
+
+Extract readiness and provider-attempt behavior. Differential tests run the new attempt and existing orchestrator scenarios with independent fakes. The production orchestrator may delegate the isolated responsibility only after those tests pass.
+
+### Stage 2D: Execution and Fallback Coordinators (`TASK-12973.4`)
+
+Extract adapter, primary, fallback, mapping, eligibility, coherence, and exhausted-error behavior. Differential tests remain until the coordinator fully replaces the old execution branches.
+
+### Stage 2E: Runner and Facade Integration (`TASK-12973.5`)
+
+Wire the inline runner to the preparation pipeline, reservation hook, execution coordinator, and result assembler. Move workflow-path HTTP headers to the endpoint mapper, reduce the orchestrator to its compatibility facade, and remove superseded private execution branches.
+
+## Test Strategy
+
+Every child pull request runs the focused Embeddings isolated suites and endpoint parity suite. Stage-specific tests cover:
+
+- Provider/model intent resolution before model-dependent normalization.
+- Existing preparation error precedence.
+- Reservation ordering for adapter success, cache hit, provider success, and failure.
+- Adapter success, adapter decline, adapter exception, and adapter-originated standard executor output.
+- Primary full and partial cache hits, ordered misses, and canonical raw writeback.
+- Provider vector count mismatch and malformed numeric data before writeback.
+- Request-specific dimension processing over cached provider-native vectors.
+- Primary readiness failures with no fallback.
+- Fallback candidate missing credentials and retryable readiness failures.
+- Whole-request fallback after partial primary cache hits.
+- Nonretryable provider errors and exact exception identity.
+- Rate-limit `retry_after` preservation and exhausted-error selection.
+- Cache read and write failures never activating fallback.
+- Aggregate trace ordering, metadata allowlisting, event bounds, and failure preservation.
+- Workflow-enabled versus legacy endpoint status, body, headers, credential touching, resource accounting, and metric inputs.
+
+Tests mock external embedding providers and use deterministic in-memory caches and executors. No external API calls are required.
+
+## Verification Gates
+
+Each pull request must pass:
+
+1. Its new focused unit tests.
+2. `test_embedding_orchestrator.py`.
+3. `test_workflow_types.py` and `test_workflow_runner.py` when workflow contracts change.
+4. `test_embeddings_orchestrator_endpoint_parity.py`.
+5. Formatting and lint checks for touched files.
+6. Bandit over touched Python paths.
+
+Stage 2 is complete only when all five child tasks are merged, the compatibility facade contains delegation only, the feature flag still provides rollback, and no Stage 3 durability behavior has entered the implementation.

--- a/Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+++ b/Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
@@ -8,7 +8,7 @@
 
 ## Purpose
 
-Stage 1 placed the feature-flagged `/api/v1/embeddings` path behind typed workflow contracts and an inline runner, but the runner still delegates execution to `EmbeddingRequestOrchestrator`. Stage 2 extracts the concrete preparation and execution responsibilities into workflow-compatible components while preserving current API behavior.
+Stage 1 placed the feature-flagged `/api/v1/embeddings` path behind typed workflow contracts and an inline runner, but the runner still delegates execution to `EmbeddingRequestOrchestrator`. Stage 2 extracts the concrete preparation and execution responsibilities into workflow-compatible components while preserving the public API contract and current domain execution behavior except for the two explicitly approved correctness corrections in this document. Workflow trace metadata evolves only as specified under Inline Runner and State Model.
 
 Stage 2 is delivered as five sequential child tasks and pull requests. Each pull request must leave the workflow-enabled endpoint usable, tested, and independently reversible.
 
@@ -19,13 +19,13 @@ Stage 2 is delivered as five sequential child tasks and pull requests. Each pull
 3. Make the inline runner sequence the concrete application-level workflow.
 4. Reduce `EmbeddingRequestOrchestrator` to delegation and legacy result compatibility.
 5. Move HTTP response-header construction to the endpoint boundary.
-6. Preserve endpoint output, fallback, caching, resource governance, metrics inputs, credential touching, and error behavior.
+6. Preserve endpoint output, fallback, caching, resource governance, metrics inputs, credential touching, and error behavior except for the two source-routing and stale-write corrections explicitly approved in this document.
 
 ## Non-Goals
 
 Stage 2 does not add durable workflow storage, Jobs workers, retries across process boundaries, pause/resume, cancellation, leases, persisted item records, media-ingestion migration, vector-store migration, or re-embedding migration. Those remain later stages of the architecture roadmap.
 
-Stage 2 also does not redesign cache keys, make cache writes transactional, optimize full-cache-hit credential checks, alter fallback policy, remove the legacy endpoint path, or promote the workflow feature flag.
+Stage 2 also does not redesign cache-key inputs, make cache writes transactional, optimize full-cache-hit credential checks, alter provider eligibility policy, remove the legacy endpoint path, or promote the workflow feature flag.
 
 ## Existing Behavioral Order
 
@@ -53,9 +53,11 @@ The extraction may not reorder these operations unless a child task explicitly i
 
 ## Architecture
 
+The component names below define ownership and contracts, not a requirement to create one class per heading. Stateless transformations and mappers should be functions, external dependencies should use narrow protocols, immutable data should use frozen DTOs, and classes should be reserved for components that own meaningful injected state.
+
 ### EmbeddingPreparationPipeline
 
-`EmbeddingPreparationPipeline` owns the existing preparation order. It exposes one preparation operation and accepts an optional phase sink so the inline runner can report truthful phases without duplicating the preparation algorithm.
+`EmbeddingPreparationPipeline` owns the existing preparation order. It exposes one preparation operation and accepts an optional phase sink so the inline runner can report truthful phases without duplicating the preparation algorithm. The phase sink receives only an `EmbeddingWorkflowPhase`; it never receives raw input, provider/model intent, a prepared request, or execution-plan observability tags.
 
 Its internal steps are:
 
@@ -84,9 +86,9 @@ Readiness continues to run before cache lookup, including full cache hits.
 
 ### EmbeddingVectorProcessor
 
-`EmbeddingVectorProcessor` is a pure component for vector-count validation, numeric canonicalization, and request-specific dimension adjustment. It preserves the current rule that base64 requests with explicit dimensions use the `reduce` policy.
+`EmbeddingVectorProcessor` is a deterministic transformation boundary for vector-count validation, numeric canonicalization, and request-specific dimension adjustment. It preserves the current rule that base64 requests with explicit dimensions use the `reduce` policy.
 
-It receives provider/model context for domain errors and adjustment metrics but does not access the cache, executor, endpoint response, or workflow collector.
+It receives provider/model context for domain errors and an optional dimension-adjustment recorder. Because that recorder is an observable callback that may fail, the processor is not described or tested as side-effect-free. It does not access the cache, executor, endpoint response, or workflow collector.
 
 ### EmbeddingProviderAttempt
 
@@ -94,21 +96,26 @@ It receives provider/model context for domain errors and adjustment metrics but 
 
 The attempt performs:
 
-1. Resolve backend identity and derive cache keys.
+1. Resolve a read-time backend identity after readiness succeeds and derive cache keys.
 2. Read cache entries in request order.
 3. Canonicalize and postprocess each cache hit before provider execution.
 4. Execute only missing texts.
 5. Validate the complete miss response before any writeback.
 6. Canonicalize provider-native miss vectors.
 7. Postprocess all miss vectors successfully.
-8. Write provider-native miss vectors to cache in request order unless the executor marked them as adapter-originated.
-9. Assemble final vectors in original request order.
+8. Re-resolve backend identity after provider execution.
+9. Write provider-native miss vectors under the post-execution identity in request order unless the executor marked them as adapter-originated.
+10. Assemble final vectors in original request order.
+
+Cache-key inputs remain exactly text, provider, model, requested dimensions, and backend identity. `cache_namespace` remains outside the current endpoint cache key. The attempt must not use `EmbeddingExecutionPlan.backend_identity` as an authoritative cache identity because that field may have been created before request credentials were resolved. `cache_namespace`, `batch_size`, `execution_path`, and sanitized `observability_tags` remain preserved on the plan for compatibility and later stages, but the tags are never forwarded to workflow trace metadata.
+
+Re-resolving identity before writeback is the approved Stage 2C correctness correction. Primary execution already does this; fallback execution currently reuses its pre-call identity. Stage 2C makes both paths consistent so a provider-side credential or endpoint refresh cannot write new vectors under a stale backend identity. An identity change does not restart the request or re-read earlier cache hits; it only controls keys used for new writeback.
 
 The attempt does not promise transactional cache writes. If a later write fails, earlier writes may already exist, matching current behavior. Cache read, postprocessing, and writeback failures are not provider-call failures and must never trigger fallback.
 
-Stage 2A must verify that the production endpoint cache adapter does not translate cache failures into fallback-eligible provider errors. If characterization finds such a translation, changing that observable behavior is outside this extraction and requires a separately approved correction.
+Stage 2A must characterize the exception types passed through by the production endpoint cache adapter. Generic cache failures already propagate without fallback. Stage 2D explicitly corrects the current fallback-wide `EmbeddingDomainError` catch so a domain-shaped error originating from cache, postprocessing, or writeback also propagates instead of being misclassified as a provider failure.
 
-Provider-call failures are represented separately from other exceptions so the coordinator can make a fallback decision without wrapping or replacing the original domain exception.
+Provider-call failures are represented by a private frozen `ProviderCallFailure` DTO containing the exact original `EmbeddingDomainError`. `EmbeddingProviderAttempt` returns `ProviderAttemptSuccess | ProviderCallFailure` and catches domain errors only around the executor call. Readiness, cache, validation, postprocessing, writeback, tracing, and resource-governor errors are never converted to this result. If the coordinator ultimately raises the failure, it raises the contained error object unchanged.
 
 ### EmbeddingFallbackCoordinator
 
@@ -116,7 +123,7 @@ Provider-call failures are represented separately from other exceptions so the c
 
 1. Maps the requested model to the candidate provider.
 2. Runs candidate readiness.
-3. Skips missing candidate credentials.
+3. Skips missing candidate credentials reported by readiness or the provider call.
 4. Executes a full-request provider attempt.
 5. Applies fallback eligibility and exhausted-error precedence to provider-call or readiness failures.
 
@@ -148,7 +155,9 @@ The coordinator contains no HTTP response formatting, resource-governor reservat
 
 The canonical outcome contains no HTTP headers.
 
-`EmbeddingExecutionResult` remains temporarily as the compatibility DTO returned by `EmbeddingRequestOrchestrator`. A compatibility mapper derives it from the canonical outcome and preserves the current `response_headers` field for existing internal callers and tests. The endpoint workflow path consumes the canonical outcome directly.
+The outcome also carries aggregate execution counters for tracing: `attempt_count` is the number of concrete execution paths entered, counting an invoked preferred adapter and every provider candidate whose readiness check began; `fallback_attempt_count` is the number of fallback candidates whose readiness check began. Missing-credential candidates count as attempted. These counters do not affect API response formatting.
+
+`EmbeddingExecutionResult` remains temporarily as the compatibility DTO returned by `EmbeddingRequestOrchestrator`. A compatibility mapper derives it from the canonical outcome and preserves the current `response_headers` field for existing internal callers and tests. This mapper is the only approved temporary exception to endpoint-owned header construction. It lives outside the canonical runner path, is invoked by the compatibility facade without embedding header decisions in the orchestrator, and is scheduled for removal in Stage 6. The endpoint workflow path consumes the canonical outcome directly.
 
 ### Endpoint Response Mapping
 
@@ -159,6 +168,19 @@ The endpoint maps canonical outcome metadata to:
 - `X-Embeddings-Dimensions-Policy` when dimensions were requested
 
 Credential touching, cache-hit metrics, duration metrics, usage logging, OpenAI response formatting, and resource-governor commit remain endpoint responsibilities in Stage 2.
+
+### Endpoint Lifecycle and Resource Accounting
+
+Stage 2 preserves the endpoint lifecycle around the runner:
+
+1. `active_embedding_requests` is incremented after the service-availability guard and before backpressure and quota admission, then decremented from the endpoint `finally` block.
+2. Resource-governor reservation runs after preparation and before adapter, readiness, cache, or provider work.
+3. On success, committed token actuals use `result.total_tokens`, then `result.prompt_tokens`, then the reserved token count when the earlier values are zero or absent.
+4. After a reservation succeeds, any later failure or cancellation commits the reserved token count because no successful result supplied actuals.
+5. Resource-governor commit remains in the endpoint `finally` block and commit failures remain noncritical.
+6. Credential touching, metrics, usage logging, response headers, and response formatting run only after a successful outcome, in their existing order.
+
+The inline runner does not own reservation commit or active-request accounting.
 
 ## Inline Runner and State Model
 
@@ -186,9 +208,9 @@ created
 
 The `pre_execute` hook runs while the workflow is in `planning`. Its failure is recorded as a planning failure and prevents adapter, readiness, cache, and provider work.
 
-Cache lookup, provider call, postprocessing, and cache writeback are attempt-local stages under `executing`. Fallback repeats attempt-local stages without moving the top-level workflow phase backward. Existing `serving_cache` and `postprocessing` phase literals may remain temporarily for compatibility but are not emitted as Stage 2 top-level transitions.
+Cache lookup, provider call, postprocessing, and cache writeback are attempt-local stages under `executing`. Fallback repeats attempt-local stages without moving the top-level workflow phase backward. Existing `serving_cache`, `postprocessing`, and `persisting_outputs` phase literals, plus `item_state_changed` and item-state literals, remain accepted through Stage 2 for compatibility but are not emitted by the inline runner. The Stage 3 durable design will decide which become persisted states.
 
-Stage 2 emits aggregate workflow and attempt metadata only. It does not emit one event per input item. Attempt metadata may include bounded fields such as attempt index, primary/fallback role, cache hit count, cache miss count, adapter use, and retryability. It must not include provider names, model names, raw input, token arrays, cache keys, credentials, provider response bodies, or caller-controlled headers.
+Stage 2 adds no per-attempt or per-item events. A successful workflow emits exactly one `execute_completed` event containing aggregate `attempt_count`, `fallback_attempt_count`, vector count, cache hit count, cache miss count, and adapter use. It removes the HTTP-derived `response_header_count` field. Event count therefore remains constant regardless of input size or fallback-chain length. Trace metadata must not include provider names, model names, raw input, token arrays, cache keys, credentials, provider response bodies, caller-controlled headers, or execution-plan observability tags.
 
 The production default collector remains disabled. The bounded in-memory collector remains fail-closed when enabled. Collector failures are never interpreted as provider failures and never trigger fallback. Failure-event recording remains best effort so a collector failure cannot replace the original request exception.
 
@@ -205,7 +227,8 @@ The production default collector remains disabled. The bounded in-memory collect
 | Eligible primary provider-call failure with fallback allowed | Start fallback with the complete input |
 | Ineligible primary provider-call failure | Raise the original error unchanged |
 | Fallback readiness reports missing credentials | Skip candidate |
-| Other eligible fallback readiness or provider-call failure | Continue to the next candidate |
+| Fallback provider call reports missing credentials | Skip candidate, preserving current candidate behavior |
+| Other eligible fallback readiness or `ProviderCallFailure` | Continue to the next candidate |
 | Ineligible fallback failure | Raise immediately |
 | Fallback cache read, postprocessing, or cache write failure | Fail request; do not try another provider |
 | Fallback exhaustion | Apply existing exhausted-error selection, preserving rate-limit retry metadata |
@@ -218,6 +241,7 @@ The production default collector remains disabled. The bounded in-memory collect
 - Raw text and token arrays remain outside execution plans, results, and workflow events.
 - Provider/model identifiers remain excluded from trace metadata because caller-controlled values can resemble credentials.
 - Cache keys and backend identities are never traced.
+- Execution-plan `observability_tags` are never copied into workflow metadata.
 - Domain exceptions are traced only as fixed failure kind, phase, and retryability fields.
 - The existing metadata allowlist, credential-pattern checks, immutable event metadata, generated workflow identifiers, and event bounds remain enforced.
 - No provider secrets, BYOK material, request headers, or provider bodies enter component DTO representations.
@@ -238,23 +262,23 @@ The legacy endpoint implementation is not removed in Stage 2.
 
 ### Stage 2A: Characterization and Contracts (`TASK-12973.1`)
 
-Add missing behavior-first tests before production extraction. Coverage includes preparation order, reservation ordering, primary readiness non-fallback behavior, fallback readiness behavior, cache failure routing, adapter writeback bypass, exact error identity, and exhausted-error precedence. This pull request changes no production execution behavior.
+Add missing behavior-first tests before production extraction. Coverage includes preparation order, reservation and commit accounting, primary readiness non-fallback behavior, fallback readiness behavior, actual endpoint cache exception types, current broad fallback-domain catching, adapter writeback bypass, exact error identity, backend identity timing, and exhausted-error precedence. This pull request changes no production execution behavior.
 
 ### Stage 2B: Preparation and Result Contracts (`TASK-12973.2`)
 
-Extract preparation steps, vector processing, the canonical outcome, a parity-tested endpoint header mapper, and the legacy result adapter. Existing execution and production endpoint wiring remain in place while the pure components gain focused coverage. The endpoint switches to the new mapper in Stage 2E.
+Extract preparation steps, deterministic vector processing, the canonical outcome, a parity-tested endpoint header mapper, and the legacy result adapter. Existing execution and production endpoint wiring remain in place while the extracted boundaries gain focused coverage. The endpoint switches to the new mapper in Stage 2E.
 
 ### Stage 2C: Single-Provider Attempts (`TASK-12973.3`)
 
-Extract readiness and provider-attempt behavior. Differential tests run the new attempt and existing orchestrator scenarios with independent fakes. The production orchestrator may delegate the isolated responsibility only after those tests pass.
+Extract readiness and provider-attempt behavior. Differential tests run the new attempt and existing orchestrator scenarios with independent fakes. Add the approved post-call backend identity correction for fallback writeback, with explicit identity-change tests. The production orchestrator may delegate the isolated responsibility only after those tests pass.
 
 ### Stage 2D: Execution and Fallback Coordinators (`TASK-12973.4`)
 
-Extract adapter, primary, fallback, mapping, eligibility, coherence, and exhausted-error behavior. Differential tests remain until the coordinator fully replaces the old execution branches.
+Extract adapter, primary, fallback, mapping, eligibility, coherence, typed provider-call failure routing, and exhausted-error behavior. Correct the broad fallback catch so cache, validation, postprocessing, and writeback failures cannot activate another provider. Differential tests remain until the coordinator fully replaces the old execution branches.
 
 ### Stage 2E: Runner and Facade Integration (`TASK-12973.5`)
 
-Wire the inline runner to the preparation pipeline, reservation hook, execution coordinator, and result assembler. Move workflow-path HTTP headers to the endpoint mapper, reduce the orchestrator to its compatibility facade, and remove superseded private execution branches.
+Wire the inline runner to the preparation pipeline, reservation hook, execution coordinator, and result assembler. Emit one constant-cardinality execution summary, move workflow-path HTTP headers to the endpoint mapper, preserve endpoint accounting behavior, reduce the orchestrator to its compatibility facade, and remove superseded private execution branches.
 
 ## Test Strategy
 
@@ -265,6 +289,7 @@ Every child pull request runs the focused Embeddings isolated suites and endpoin
 - Reservation ordering for adapter success, cache hit, provider success, and failure.
 - Adapter success, adapter decline, adapter exception, and adapter-originated standard executor output.
 - Primary full and partial cache hits, ordered misses, and canonical raw writeback.
+- Exact cache-key inputs, read-time identity, post-call write identity, and identity changes.
 - Provider vector count mismatch and malformed numeric data before writeback.
 - Request-specific dimension processing over cached provider-native vectors.
 - Primary readiness failures with no fallback.
@@ -273,8 +298,10 @@ Every child pull request runs the focused Embeddings isolated suites and endpoin
 - Nonretryable provider errors and exact exception identity.
 - Rate-limit `retry_after` preservation and exhausted-error selection.
 - Cache read and write failures never activating fallback.
-- Aggregate trace ordering, metadata allowlisting, event bounds, and failure preservation.
-- Workflow-enabled versus legacy endpoint status, body, headers, credential touching, resource accounting, and metric inputs.
+- Fixed-cardinality aggregate trace ordering, metadata allowlisting, long fallback chains, event bounds, and failure preservation.
+- Workflow-enabled versus legacy endpoint status, body, headers, credential touching, resource accounting on success/failure/cancellation, active-request accounting, and metric inputs.
+
+Property-based tests cover cache hit/miss order preservation and prove that trace event count is independent of input size and fallback-chain length.
 
 Tests mock external embedding providers and use deterministic in-memory caches and executors. No external API calls are required.
 

--- a/Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+++ b/Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
@@ -23,9 +23,9 @@ Stage 2 is delivered as five sequential child tasks and pull requests. Each pull
 
 ## Non-Goals
 
-Stage 2 does not add durable workflow storage, Jobs workers, retries across process boundaries, pause/resume, cancellation, leases, persisted item records, media-ingestion migration, vector-store migration, or re-embedding migration. Those remain later stages of the architecture roadmap.
+Stage 2 does not add durable workflow storage, Jobs workers, retries across process boundaries, pause/resume controls, cancellation controls or durable cancellation state, leases, persisted item records, media-ingestion migration, vector-store migration, or re-embedding migration. Those remain later stages of the architecture roadmap.
 
-Stage 2 also does not redesign cache-key inputs, make cache writes transactional, optimize full-cache-hit credential checks, alter provider eligibility policy, remove the legacy endpoint path, or promote the workflow feature flag.
+Stage 2 also does not redesign cache-key inputs or credential-sensitive shared-cache isolation, make cache writes transactional, optimize full-cache-hit credential checks, alter provider eligibility policy, remove the legacy endpoint path, or promote the workflow feature flag.
 
 ## Existing Behavioral Order
 
@@ -42,12 +42,12 @@ Execution currently performs:
 
 1. Run the optional resource-governor reservation hook after planning.
 2. Try the preferred adapter path before provider preflight or cache access.
-3. Preflight the requested primary provider.
-4. Read primary cache entries in request order.
-5. Execute only primary misses.
+3. Preflight the requested primary provider, resolving current provider/model credentials before any shared-cache decision.
+4. Read primary cache entries in request order through the endpoint cache adapter, which dynamically bypasses shared reads and writes when request credentials require isolation.
+5. Execute only primary misses. The injected endpoint executor preserves provider-specific batching, credential refresh, and credential-touch behavior.
 6. If an eligible primary provider-call failure occurs, discard primary partial results and resolve the complete request through fallback candidates.
 7. Validate and canonicalize provider output, apply request-specific dimension processing, then write provider-native vectors to cache.
-8. Assemble the result, touch credentials for the actual provider, record metrics and usage, map HTTP headers, and commit the resource reservation at the endpoint boundary.
+8. Assemble the result, perform the endpoint's idempotent final credential touch for the actual provider/model, record metrics and usage, map HTTP headers, and commit the resource reservation at the endpoint boundary.
 
 The extraction may not reorder these operations unless a child task explicitly identifies, tests, and documents a separate behavior correction.
 
@@ -74,6 +74,8 @@ The compatibility orchestrator calls the same pipeline without a phase sink.
 
 An adapter result must be validated and postprocessed. A successful adapter result bypasses provider preflight and all cache access. A `None` or non-adapter result continues to primary readiness. Adapter exceptions propagate unchanged and never activate provider fallback.
 
+For internal result compatibility, a successful adapter result continues to report `cache_hits=0` and `cache_misses=item_count` even though it performs no cache operations. An adapter decline uses the provider path's actual cache counts. Changing these semantics requires a separately approved correction.
+
 ### EmbeddingProviderReadinessCheck
 
 `EmbeddingProviderReadinessCheck` wraps provider preflight independently from cache and execution. Keeping readiness separate is required because primary and fallback readiness failures have different policy:
@@ -83,6 +85,8 @@ An adapter result must be validated and postprocessed. A successful adapter resu
 - Other fallback readiness failures follow the existing eligibility rules.
 
 Readiness continues to run before cache lookup, including full cache hits.
+
+The injected cache remains authoritative for cache eligibility. In the API path, resolving any private user, team, or organization credentials makes shared-cache reads return misses and shared-cache writes no-op for the request; server-default credentials retain shared-cache behavior. Workflow components must not duplicate or weaken this dynamic isolation policy.
 
 ### EmbeddingVectorProcessor
 
@@ -98,28 +102,31 @@ The attempt performs:
 
 1. Resolve a read-time backend identity after readiness succeeds and derive cache keys.
 2. Read cache entries in request order.
-3. Canonicalize and postprocess each cache hit before provider execution.
+3. Validate each non-`None` cache value. Treat malformed or non-finite cached vectors as misses; canonicalize and postprocess only valid hits.
 4. Execute only missing texts.
 5. Validate the complete miss response before any writeback.
 6. Canonicalize provider-native miss vectors.
 7. Postprocess all miss vectors successfully.
 8. Re-resolve backend identity after provider execution.
-9. Write provider-native miss vectors under the post-execution identity in request order unless the executor marked them as adapter-originated.
-10. Assemble final vectors in original request order.
+9. Place processed misses into the ordered result and validate the complete ordered response.
+10. Write provider-native miss vectors under the post-execution identity in request order unless the executor marked them as adapter-originated.
+11. Return final vectors in original request order.
 
 Cache-key inputs remain exactly text, provider, model, requested dimensions, and backend identity. `cache_namespace` remains outside the current endpoint cache key. The attempt must not use `EmbeddingExecutionPlan.backend_identity` as an authoritative cache identity because that field may have been created before request credentials were resolved. `cache_namespace`, `batch_size`, `execution_path`, and sanitized `observability_tags` remain preserved on the plan for compatibility and later stages, but the tags are never forwarded to workflow trace metadata.
 
+When the injected cache bypasses shared state, the attempt still follows the same cache protocol but observes misses for every item and performs no underlying shared-cache writes. Cache hit/miss accounting therefore reflects the adapter-visible results. An adapter decline after resolving private credentials must continue through readiness with shared caching still bypassed.
+
 Re-resolving identity before writeback is the approved Stage 2C correctness correction. Primary execution already does this; fallback execution currently reuses its pre-call identity. Stage 2C makes both paths consistent so a provider-side credential or endpoint refresh cannot write new vectors under a stale backend identity. An identity change does not restart the request or re-read earlier cache hits; it only controls keys used for new writeback.
 
-The attempt does not promise transactional cache writes. If a later write fails, earlier writes may already exist, matching current behavior. Cache read, postprocessing, and writeback failures are not provider-call failures and must never trigger fallback.
+The attempt does not promise transactional cache writes. If a later write fails, earlier writes may already exist, matching current behavior. Read-time or write-time backend-identity resolution, cache-key derivation, cache access, validation, postprocessing, and writeback failures are not provider-call failures and must never trigger fallback.
 
-Stage 2A must characterize the exception types passed through by the production endpoint cache adapter. Generic cache failures already propagate without fallback. Stage 2D explicitly corrects the current fallback-wide `EmbeddingDomainError` catch so a domain-shaped error originating from cache, postprocessing, or writeback also propagates instead of being misclassified as a provider failure.
+Stage 2A must characterize the exception types passed through by the production endpoint identity resolver, cache-key function, and cache adapter. Generic infrastructure failures already propagate without fallback. Stage 2D explicitly corrects the current fallback-wide `EmbeddingDomainError` catch so a domain-shaped error originating from identity resolution, key derivation, cache access, validation, postprocessing, or writeback also propagates instead of being misclassified as a provider failure.
 
-Provider-call failures are represented by a private frozen `ProviderCallFailure` DTO containing the exact original `EmbeddingDomainError`. `EmbeddingProviderAttempt` returns `ProviderAttemptSuccess | ProviderCallFailure` and catches domain errors only around the executor call. Readiness, cache, validation, postprocessing, writeback, tracing, and resource-governor errors are never converted to this result. If the coordinator ultimately raises the failure, it raises the contained error object unchanged.
+Provider-call failures are represented by a private frozen `ProviderCallFailure` DTO containing the exact original `EmbeddingDomainError`. `EmbeddingProviderAttempt` returns `ProviderAttemptSuccess | ProviderCallFailure` and catches domain errors only around the executor call. Readiness, backend-identity resolution, cache-key derivation, cache access, validation, postprocessing, writeback, tracing, and resource-governor errors are never converted to this result. If the coordinator ultimately raises the failure, it raises the contained error object unchanged.
 
 ### EmbeddingFallbackCoordinator
 
-`EmbeddingFallbackCoordinator` owns fallback candidate traversal only. For each candidate it:
+`EmbeddingFallbackCoordinator` owns fallback candidate traversal only. It derives candidates from the policy-approved fallback chain by excluding the already-attempted primary provider while preserving order. The policy layer already deduplicates the chain, but the coordinator still enforces that the primary provider is never invoked a second time. For each remaining candidate it:
 
 1. Maps the requested model to the candidate provider.
 2. Runs candidate readiness.
@@ -139,7 +146,7 @@ A successful fallback always returns vectors for the complete original input. Pr
 4. Return primary success, or invoke `EmbeddingFallbackCoordinator` for an eligible primary provider-call failure when policy allows fallback.
 5. Preserve the original error object when fallback is denied or exhausted-error selection chooses it.
 
-The coordinator contains no HTTP response formatting, resource-governor reservation, usage logging, or workflow persistence.
+The coordinator contains no HTTP response formatting, credential-resolution or credential-touch policy, resource-governor reservation, usage logging, or workflow persistence. Provider-specific credential refresh and touch behavior remains encapsulated by the injected endpoint executor.
 
 ### EmbeddingExecutionOutcome and Result Assembly
 
@@ -167,7 +174,7 @@ The endpoint maps canonical outcome metadata to:
 - `X-Embeddings-Fallback-From` when fallback changed the provider
 - `X-Embeddings-Dimensions-Policy` when dimensions were requested
 
-Credential touching, cache-hit metrics, duration metrics, usage logging, OpenAI response formatting, and resource-governor commit remain endpoint responsibilities in Stage 2.
+Credential usage remains an endpoint-adapter responsibility in Stage 2. The injected endpoint executor touches the exact credential generation after each validated provider batch, successful adapter result, or accepted late result. After a successful workflow outcome, the endpoint performs an idempotent final touch keyed by the actual provider and model. Cache-hit metrics, duration metrics, usage logging, OpenAI response formatting, and resource-governor commit remain endpoint responsibilities.
 
 ### Endpoint Lifecycle and Resource Accounting
 
@@ -176,9 +183,9 @@ Stage 2 preserves the endpoint lifecycle around the runner:
 1. `active_embedding_requests` is incremented after the service-availability guard and before backpressure and quota admission, then decremented from the endpoint `finally` block.
 2. Resource-governor reservation runs after preparation and before adapter, readiness, cache, or provider work.
 3. On success, committed token actuals use `result.total_tokens`, then `result.prompt_tokens`, then the reserved token count when the earlier values are zero or absent.
-4. After a reservation succeeds, any later failure or cancellation commits the reserved token count because no successful result supplied actuals.
+4. After a reservation succeeds, any later failure or cancellation causes the endpoint to attempt a commit using the reserved token count because no successful result supplied actuals.
 5. Resource-governor commit remains in the endpoint `finally` block and commit failures remain noncritical.
-6. Credential touching, metrics, usage logging, response headers, and response formatting run only after a successful outcome, in their existing order.
+6. The endpoint's final provider/model credential touch, metrics, usage logging, response headers, and response formatting run only after a successful outcome, in their existing order. Executor-owned touches may already have occurred for validated batches or adapter results, including before a later request-level failure.
 
 The inline runner does not own reservation commit or active-request accounting.
 
@@ -193,7 +200,9 @@ The inline runner sequences:
 5. Result assembly.
 6. Workflow completion or failure.
 
-The truthful Stage 2 top-level phase order is:
+Stage 2 adds `resolving_intent` to the canonical request-phase vocabulary. `completed` remains a request status and is never used as a phase. Request phases are monotonic; fallback repeats attempt-local work without moving the request phase backward.
+
+The truthful Stage 2 success phase order is:
 
 ```text
 created
@@ -203,16 +212,31 @@ created
   -> planning
   -> executing
   -> finalizing
-  -> completed
+
+terminal status: completed
 ```
 
-The `pre_execute` hook runs while the workflow is in `planning`. Its failure is recorded as a planning failure and prevents adapter, readiness, cache, and provider work.
+When trace collection is enabled and collector calls succeed, the successful event sequence is exact:
+
+1. `workflow_started` in `created` with status `running`.
+2. `phase_changed` for `resolving_intent`, `normalizing`, `resolving_policy`, and `planning`.
+3. `prepare_completed` in `planning`.
+4. The `pre_execute` hook runs while still in `planning`.
+5. `phase_changed` for `executing`.
+6. The execution coordinator and result assembler run.
+7. `execute_completed` is emitted in `executing`.
+8. `phase_changed` for `finalizing`.
+9. `workflow_completed` is emitted in `finalizing` with status `completed`.
+
+A non-cancellation request failure after workflow start attempts to emit `workflow_failed` with status `failed` and the last entered phase. Failure-event recording remains best effort. The `pre_execute` hook's failure is therefore recorded as a planning failure when collection succeeds and prevents adapter, readiness, cache, and provider work.
 
 Cache lookup, provider call, postprocessing, and cache writeback are attempt-local stages under `executing`. Fallback repeats attempt-local stages without moving the top-level workflow phase backward. Existing `serving_cache`, `postprocessing`, and `persisting_outputs` phase literals, plus `item_state_changed` and item-state literals, remain accepted through Stage 2 for compatibility but are not emitted by the inline runner. The Stage 3 durable design will decide which become persisted states.
 
 Stage 2 adds no per-attempt or per-item events. A successful workflow emits exactly one `execute_completed` event containing aggregate `attempt_count`, `fallback_attempt_count`, vector count, cache hit count, cache miss count, and adapter use. It removes the HTTP-derived `response_header_count` field. Event count therefore remains constant regardless of input size or fallback-chain length. Trace metadata must not include provider names, model names, raw input, token arrays, cache keys, credentials, provider response bodies, caller-controlled headers, or execution-plan observability tags.
 
 The production default collector remains disabled. The bounded in-memory collector remains fail-closed when enabled. Collector failures are never interpreted as provider failures and never trigger fallback. Failure-event recording remains best effort so a collector failure cannot replace the original request exception.
+
+Stage 2 preserves current task-cancellation behavior. `asyncio.CancelledError` propagates unchanged, is not converted to `workflow_failed`, and does not emit the future durable `cancelled` status. The trace ends at the last successfully recorded event. The endpoint `finally` block still runs active-request cleanup and, when a reservation was acquired, attempts the reserved-unit commit. Stage 3 owns explicit durable cancellation state and terminal cancellation events.
 
 ## Error Routing Matrix
 
@@ -223,6 +247,8 @@ The production default collector remains disabled. The bounded in-memory collect
 | Preferred adapter exception | Fail request unchanged; no provider fallback |
 | Preferred adapter returns no result | Continue to primary readiness |
 | Primary readiness failure | Fail request unchanged; no fallback |
+| Primary backend-identity or cache-key derivation failure | Fail request; no fallback |
+| Malformed or non-finite primary cached vector | Treat as a miss and replace through provider execution |
 | Primary cache read, postprocessing, or cache write failure | Fail request; no fallback |
 | Eligible primary provider-call failure with fallback allowed | Start fallback with the complete input |
 | Ineligible primary provider-call failure | Raise the original error unchanged |
@@ -230,10 +256,13 @@ The production default collector remains disabled. The bounded in-memory collect
 | Fallback provider call reports missing credentials | Skip candidate, preserving current candidate behavior |
 | Other eligible fallback readiness or `ProviderCallFailure` | Continue to the next candidate |
 | Ineligible fallback failure | Raise immediately |
+| Fallback backend-identity or cache-key derivation failure | Fail request; do not try another provider |
+| Malformed or non-finite fallback cached vector | Treat as a miss and replace through that fallback candidate |
 | Fallback cache read, postprocessing, or cache write failure | Fail request; do not try another provider |
 | Fallback exhaustion | Apply existing exhausted-error selection, preserving rate-limit retry metadata |
 | Trace collector failure during normal tracing | Fail closed, but never enter provider fallback |
 | Failure-event collector failure | Preserve and re-raise the original request error |
+| Task cancellation | Propagate unchanged; no provider fallback or Stage 2 terminal trace event |
 | Resource-governor commit failure | Log as noncritical at the endpoint boundary |
 
 ## Security and Privacy
@@ -241,6 +270,7 @@ The production default collector remains disabled. The bounded in-memory collect
 - Raw text and token arrays remain outside execution plans, results, and workflow events.
 - Provider/model identifiers remain excluded from trace metadata because caller-controlled values can resemble credentials.
 - Cache keys and backend identities are never traced.
+- Private user, team, or organization credentials continue to bypass shared embedding-cache reads and writes.
 - Execution-plan `observability_tags` are never copied into workflow metadata.
 - Domain exceptions are traced only as fixed failure kind, phase, and retryability fields.
 - The existing metadata allowlist, credential-pattern checks, immutable event metadata, generated workflow identifiers, and event bounds remain enforced.
@@ -258,11 +288,13 @@ Within the workflow-enabled path:
 
 The legacy endpoint implementation is not removed in Stage 2.
 
+Parity tests are split into two groups. Unchanged scenarios require workflow-enabled and legacy paths to match status, body, headers, metrics inputs, credential touching, and accounting. Correction scenarios explicitly assert the approved divergence: Stage 2C changes only fallback writeback identity, and Stage 2D changes only source-aware failure routing. A parity assertion must not encode the old behavior for either correction.
+
 ## Delivery Plan
 
 ### Stage 2A: Characterization and Contracts (`TASK-12973.1`)
 
-Add missing behavior-first tests before production extraction. Coverage includes preparation order, reservation and commit accounting, primary readiness non-fallback behavior, fallback readiness behavior, actual endpoint cache exception types, current broad fallback-domain catching, adapter writeback bypass, exact error identity, backend identity timing, and exhausted-error precedence. This pull request changes no production execution behavior.
+Add missing behavior-first tests before production extraction. Coverage includes preparation and current Stage 1 event order, reservation and commit accounting, current cancellation trace behavior, primary readiness non-fallback behavior, fallback readiness behavior, private-credential shared-cache bypass, malformed cached-vector replacement, complete-result validation before writeback, provider/model credential-touch timing, actual endpoint identity/key/cache exception types, current broad fallback-domain catching, adapter cache-count and writeback bypass semantics, primary-call cardinality, exact error identity, backend identity timing, and exhausted-error precedence. This pull request changes no production execution behavior.
 
 ### Stage 2B: Preparation and Result Contracts (`TASK-12973.2`)
 
@@ -270,11 +302,11 @@ Extract preparation steps, deterministic vector processing, the canonical outcom
 
 ### Stage 2C: Single-Provider Attempts (`TASK-12973.3`)
 
-Extract readiness and provider-attempt behavior. Differential tests run the new attempt and existing orchestrator scenarios with independent fakes. Add the approved post-call backend identity correction for fallback writeback, with explicit identity-change tests. The production orchestrator may delegate the isolated responsibility only after those tests pass.
+Extract readiness and provider-attempt behavior. Differential tests run the new attempt and existing orchestrator scenarios with independent fakes. Add the approved post-call backend identity correction to the existing fallback writeback path, with explicit identity-change tests. The new provider-attempt component remains side-by-side and does not replace primary or fallback production routing until Stage 2D; Stage 2C does not make source-aware routing authoritative in production.
 
 ### Stage 2D: Execution and Fallback Coordinators (`TASK-12973.4`)
 
-Extract adapter, primary, fallback, mapping, eligibility, coherence, typed provider-call failure routing, and exhausted-error behavior. Correct the broad fallback catch so cache, validation, postprocessing, and writeback failures cannot activate another provider. Differential tests remain until the coordinator fully replaces the old execution branches.
+Extract adapter, primary, fallback-tail traversal, mapping, eligibility, coherence, typed provider-call failure routing, and exhausted-error behavior. Correct the broad fallback catch so identity resolution, key derivation, cache access, validation, postprocessing, and writeback failures cannot activate another provider. Differential tests remain until the coordinator fully replaces the old execution branches.
 
 ### Stage 2E: Runner and Facade Integration (`TASK-12973.5`)
 
@@ -287,19 +319,25 @@ Every child pull request runs the focused Embeddings isolated suites and endpoin
 - Provider/model intent resolution before model-dependent normalization.
 - Existing preparation error precedence.
 - Reservation ordering for adapter success, cache hit, provider success, and failure.
-- Adapter success, adapter decline, adapter exception, and adapter-originated standard executor output.
+- Adapter success with compatibility cache counts, adapter decline, adapter exception, and adapter-originated standard executor output.
 - Primary full and partial cache hits, ordered misses, and canonical raw writeback.
+- Malformed or non-finite cached vectors becoming misses and being replaced.
+- Private-credential shared-cache bypass for provider and adapter-decline paths.
 - Exact cache-key inputs, read-time identity, post-call write identity, and identity changes.
 - Provider vector count mismatch and malformed numeric data before writeback.
 - Request-specific dimension processing over cached provider-native vectors.
 - Primary readiness failures with no fallback.
+- Primary execution occurs once before fallback-tail traversal.
 - Fallback candidate missing credentials and retryable readiness failures.
 - Whole-request fallback after partial primary cache hits.
 - Nonretryable provider errors and exact exception identity.
 - Rate-limit `retry_after` preservation and exhausted-error selection.
-- Cache read and write failures never activating fallback.
+- Backend-identity, cache-key, cache read, and cache write failures never activating fallback.
 - Fixed-cardinality aggregate trace ordering, metadata allowlisting, long fallback chains, event bounds, and failure preservation.
-- Workflow-enabled versus legacy endpoint status, body, headers, credential touching, resource accounting on success/failure/cancellation, active-request accounting, and metric inputs.
+- Exact cancellation propagation and non-terminal Stage 2 trace behavior.
+- Workflow-enabled versus legacy endpoint parity for unchanged scenarios, plus explicit expected divergence for the two approved corrections.
+- Executor credential touching for validated batches, adapter success, accepted late results, and partial request failure.
+- Endpoint final credential touching by actual provider/model, resource accounting on success/failure/cancellation, active-request accounting, and metric inputs.
 
 Property-based tests cover cache hit/miss order preservation and prove that trace event count is independent of input size and fallback-chain length.
 

--- a/backlog/tasks/task-12973 - Extract-concrete-API-workflow-steps-for-Embeddings.md
+++ b/backlog/tasks/task-12973 - Extract-concrete-API-workflow-steps-for-Embeddings.md
@@ -4,7 +4,7 @@ title: Extract concrete API workflow steps for Embeddings
 status: In Progress
 assignee: []
 created_date: '2026-07-19 02:31'
-updated_date: '2026-07-26 05:19'
+updated_date: '2026-07-26 19:35'
 labels:
   - embeddings
   - workflow
@@ -13,6 +13,7 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/rmusser01/tldw_server/pull/2733'
+  - 'https://github.com/rmusser01/tldw_server/pull/2762'
 documentation:
   - Docs/superpowers/specs/2026-07-03-embeddings-workflow-architecture-design.md
   - >-
@@ -28,8 +29,8 @@ Stage 2 of the approved Embeddings workflow architecture. Extract preparation, p
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The approved Stage 2 design is documented and reviewed before implementation planning.
-- [ ] #2 Five sequential child tasks cover characterization, pure contracts, provider attempts, fallback coordination, and runner/facade integration.
+- [x] #1 The approved Stage 2 design is documented and reviewed before implementation planning.
+- [x] #2 Five sequential child tasks cover characterization, pure contracts, provider attempts, fallback coordination, and runner/facade integration.
 - [ ] #3 EmbeddingRequestOrchestrator ends Stage 2 as a delegation and compatibility facade with no cache, provider, fallback, or vector-postprocessing decisions.
 - [ ] #4 Workflow-enabled and legacy endpoint behavior remain equivalent across the validated parity matrix.
 - [ ] #5 HTTP header mapping is owned by the endpoint boundary while the compatibility facade preserves the legacy internal result contract.
@@ -45,11 +46,9 @@ Deliver through child tasks 2A-2E in dependency order. Each child must pass focu
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-07-18: Created child tasks TASK-12973.1 through TASK-12973.5 with sequential dependencies after PR #2733 established the Stage 1 workflow boundary.
 
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
-2026-07-18: Created isolated branch codex/embeddings-workflow-stage2a-contracts from origin/dev at merge commit 29acaca8c7 (PR #2733). Created child tasks TASK-12973.1 through TASK-12973.5 with sequential dependencies. Baseline verification passed: 93 focused Embeddings orchestration, workflow, runner, and endpoint-parity tests. Written Stage 2 spec completed and self-reviewed; user review is pending before implementation planning.
+2026-07-23 to 2026-07-26: The Stage 2 concrete-steps design completed iterative user review, written-spec review, specification review, and quality review. The user approved the design and Stage 2A implementation plan. TASK-12973.1 characterization is complete in PR #2762; Stage 2B through Stage 2E remain pending and continue in dependency order.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12973 - Extract-concrete-API-workflow-steps-for-Embeddings.md
+++ b/backlog/tasks/task-12973 - Extract-concrete-API-workflow-steps-for-Embeddings.md
@@ -4,7 +4,7 @@ title: Extract concrete API workflow steps for Embeddings
 status: In Progress
 assignee: []
 created_date: '2026-07-19 02:31'
-updated_date: '2026-07-19 02:43'
+updated_date: '2026-07-26 05:19'
 labels:
   - embeddings
   - workflow
@@ -55,11 +55,7 @@ Deliver through child tasks 2A-2E in dependency order. Each child must pass focu
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
-<!-- SECTION:FINAL_SUMMARY:END -->
-<!-- SECTION:FINAL_SUMMARY:END -->
-
+Stage 2 is in progress; child-task summaries remain authoritative until the parent is complete.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973 - Extract-concrete-API-workflow-steps-for-Embeddings.md
+++ b/backlog/tasks/task-12973 - Extract-concrete-API-workflow-steps-for-Embeddings.md
@@ -1,0 +1,73 @@
+---
+id: TASK-12973
+title: Extract concrete API workflow steps for Embeddings
+status: In Progress
+assignee: []
+created_date: '2026-07-19 02:31'
+updated_date: '2026-07-19 02:43'
+labels:
+  - embeddings
+  - workflow
+  - architecture
+  - refactor
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2733'
+documentation:
+  - Docs/superpowers/specs/2026-07-03-embeddings-workflow-architecture-design.md
+  - >-
+    Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Stage 2 of the approved Embeddings workflow architecture. Extract preparation, provider-attempt, fallback, result, and inline-runner responsibilities from EmbeddingRequestOrchestrator through five sequential child PRs. Preserve API behavior and leave durable persistence, retries, pause/resume, and Jobs execution for Stage 3.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The approved Stage 2 design is documented and reviewed before implementation planning.
+- [ ] #2 Five sequential child tasks cover characterization, pure contracts, provider attempts, fallback coordination, and runner/facade integration.
+- [ ] #3 EmbeddingRequestOrchestrator ends Stage 2 as a delegation and compatibility facade with no cache, provider, fallback, or vector-postprocessing decisions.
+- [ ] #4 Workflow-enabled and legacy endpoint behavior remain equivalent across the validated parity matrix.
+- [ ] #5 HTTP header mapping is owned by the endpoint boundary while the compatibility facade preserves the legacy internal result contract.
+- [ ] #6 No durable workflow persistence or Jobs integration is introduced.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Deliver through child tasks 2A-2E in dependency order. Each child must pass focused parity tests and remain independently reviewable.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+2026-07-18: Created isolated branch codex/embeddings-workflow-stage2a-contracts from origin/dev at merge commit 29acaca8c7 (PR #2733). Created child tasks TASK-12973.1 through TASK-12973.5 with sequential dependencies. Baseline verification passed: 93 focused Embeddings orchestration, workflow, runner, and endpoint-parity tests. Written Stage 2 spec completed and self-reviewed; user review is pending before implementation planning.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -4,7 +4,7 @@ title: Characterize Embeddings workflow execution contracts
 status: Done
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-26 18:13'
+updated_date: '2026-07-26 18:28'
 labels:
   - embeddings
   - workflow
@@ -45,19 +45,15 @@ Stage 2A. Add behavior-first characterization coverage for uncovered orchestrati
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-2026-07-23: Written design approved. The branch was initially rebased onto origin/dev at 1b9518c68c, rebased onto 0f3983788c before final review, and rebased again onto the latest origin/dev at d710e5a5ee before handoff. Stage 2A remains test/design/tracking only; latest-dev credential-sensitive cache bypass, adapter and partial-batch credential touches, and public malformed-cache replacement are reused rather than duplicated.
+2026-07-23 to 2026-07-26: The approved Stage 2A work added behavior-first characterization for Embeddings orchestration without changing production execution code. The whole-branch remediation removed over-specified call-trace assertions, added direct and integrated endpoint identity/cache-key characterization, covered reservation-denial and noncritical commit cleanup, preserved credential isolation and malformed-cache contracts, and passed specification, code-quality, and final whole-branch reviews.
 
-Final rebased implementation commits: Task 1 a6cd9510ab, Task 2 6208aa4653, Task 3 c54fff4826, Task 4 8ecb071192, Task 5 eb41b384a8. The reviewed remediation commit is cac5c2b547 before this final metadata commit. Each implementation task passed focused tests, Ruff, Bandit excluding B101, specification review, and code-quality review.
-
-The whole-branch remediation removed over-specified call-trace assertions, added direct and integrated production endpoint identity/cache-key characterization, covered reservation-denial and noncritical commit cleanup, and normalized parent and child Backlog metadata after explicit user approval. Specification, code-quality, and final whole-branch re-reviews approved the result.
-
-Post-rebase verification on origin/dev d710e5a5ee passed 186/186 touched-module tests in 154.78s with 4139 warnings, 176/176 Embeddings_isolated tests in 10.13s with 370 warnings, and 11/11 credential/cache evidence tests in 10.90s with 128 deselected and 297 warnings. Ruff reported All checks passed. Bandit with B101 excluded reported zero findings across 6140 LOC at /tmp/bandit_embeddings_stage2a_rebased.json. git diff --check origin/dev passed; the branch was 12 commits ahead and 0 behind before this metadata commit; no tldw_Server_API/app path changed. Expected legacy SINGLE_USER_API_KEY and isolated USER_DB_BASE_DIR warnings remained; no skips or failures occurred.
+PR #2762 was rebased conflict-free at user request onto latest origin/dev 76481b2939. Fresh post-rebase verification passed 186/186 touched-module tests in 157.77s with 4139 warnings, 176/176 Embeddings_isolated tests in 11.20s with 370 warnings, and 11/11 explicit credential/cache tests in 10.70s with 128 deselected and 297 warnings. Ruff reported All checks passed. Bandit with B101 excluded reported zero findings across 6140 LOC at /tmp/bandit_embeddings_stage2a_pr_rebase.json. git diff --check origin/dev passed; the branch was 14 commits ahead and 0 behind before this metadata commit; no tldw_Server_API/app path changed. Expected legacy SINGLE_USER_API_KEY and isolated USER_DB_BASE_DIR warnings remained; no skips or failures occurred.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 2A is complete and rebased onto origin/dev d710e5a5ee. The branch changes characterization tests, the approved design/plan, and Backlog tracking only; no production execution code changed. Post-rebase verification passed 186/186 touched-module tests, 176/176 Embeddings_isolated tests, and 11/11 explicit credential/cache cases; Ruff clean; Bandit zero findings at /tmp/bandit_embeddings_stage2a_rebased.json with B101 excluded; diff and scope checks clean. Final specification, quality, and whole-branch reviews approved. Any eventual AI-authored PR still requires a human requester-authored Change summary under repository policy.
+Stage 2A is complete and rebased onto origin/dev 76481b2939 for PR #2762. The branch changes characterization tests, the approved design/plan, and Backlog tracking only; no production application code changed. Fresh verification passed 186 touched-module tests, 176 Embeddings_isolated tests, and 11 explicit credential/cache cases; Ruff and diff checks are clean; Bandit reports zero findings with B101 excluded. GitHub currently marks the PR ready, but its human-authored Change summary remains a placeholder, so the repository merge gate is not yet satisfied.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -4,7 +4,7 @@ title: Characterize Embeddings workflow execution contracts
 status: Done
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-26 14:46'
+updated_date: '2026-07-26 14:54'
 labels:
   - embeddings
   - workflow
@@ -44,19 +44,19 @@ Stage 2A. Add behavior-first characterization coverage for uncovered orchestrati
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-2026-07-23: Written design approved. The branch was initially rebased onto origin/dev at 1b9518c68c and later rebased onto the final reviewed origin/dev base 0f3983788c. Stage 2A remains test/design/tracking only; latest-dev credential-sensitive cache bypass, adapter and partial-batch credential touches, and public malformed-cache replacement are reused rather than duplicated.
+2026-07-23: Written design approved. The branch was initially rebased onto origin/dev at 1b9518c68c, rebased onto 0f3983788c before final review, and rebased again onto the latest origin/dev at d710e5a5ee before handoff. Stage 2A remains test/design/tracking only; latest-dev credential-sensitive cache bypass, adapter and partial-batch credential touches, and public malformed-cache replacement are reused rather than duplicated.
 
-Rebased implementation commits: Task 1 ddbf5ad138, Task 2 17cfe39007, Task 3 d528f172de, Task 4 befdedcbed, Task 5 45c079a938. Each task passed focused tests, Ruff, Bandit excluding B101, specification review, and code-quality review.
+Final rebased implementation commits: Task 1 a6cd9510ab, Task 2 6208aa4653, Task 3 c54fff4826, Task 4 8ecb071192, Task 5 eb41b384a8. The reviewed remediation commit is cac5c2b547 before this final metadata commit. Each implementation task passed focused tests, Ruff, Bandit excluding B101, specification review, and code-quality review.
 
-Task 6 verification at implementation head 5426d11cd2 passed 179/179 touched tests, 176/176 Embeddings_isolated tests, and 11/11 explicit credential/cache cases; Ruff clean; Bandit zero findings at /tmp/bandit_embeddings_stage2a.json with B101 excluded; git diff --check clean; no tldw_Server_API/app path changed.
+The whole-branch remediation removed over-specified call-trace assertions, added direct and integrated production endpoint identity/cache-key characterization, covered reservation-denial and noncritical commit cleanup, and normalized parent and child Backlog metadata after explicit user approval. Specification, code-quality, and final whole-branch re-reviews approved the result.
 
-2026-07-26 final remediation completed after whole-branch review. Validated work removed two over-specified call-trace assertions, added direct and integrated production endpoint identity/cache-key characterization, covered reservation-denial and noncritical commit cleanup, refreshed rebase metadata, and normalized the parent Backlog markers. Final verification passed 186/186 touched-module tests in 161.36s with 4139 warnings, 176/176 Embeddings_isolated tests in 10.65s with 370 warnings, and 11/11 credential/cache evidence tests with 128 deselected and 297 warnings. Ruff reported All checks passed. Bandit with B101 excluded reported zero findings across 6140 LOC at /tmp/bandit_embeddings_stage2a_final.json. git diff --check origin/dev passed; origin/dev remained 0f3983788c; no tldw_Server_API/app path changed. Specification, code-quality, and final whole-branch re-reviews approved. Expected legacy SINGLE_USER_API_KEY and isolated USER_DB_BASE_DIR warnings remained; no skips or failures occurred.
+Post-rebase verification on origin/dev d710e5a5ee passed 186/186 touched-module tests in 154.78s with 4139 warnings, 176/176 Embeddings_isolated tests in 10.13s with 370 warnings, and 11/11 credential/cache evidence tests in 10.90s with 128 deselected and 297 warnings. Ruff reported All checks passed. Bandit with B101 excluded reported zero findings across 6140 LOC at /tmp/bandit_embeddings_stage2a_rebased.json. git diff --check origin/dev passed; the branch was 12 commits ahead and 0 behind before this metadata commit; no tldw_Server_API/app path changed. Expected legacy SINGLE_USER_API_KEY and isolated USER_DB_BASE_DIR warnings remained; no skips or failures occurred.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 2A is complete. The branch changes characterization tests, the approved design/plan, and Backlog tracking only; no production execution code changed. Final verification passed 186/186 touched-module tests, 176/176 Embeddings_isolated tests, and 11/11 explicit credential/cache cases; Ruff clean; Bandit zero findings at /tmp/bandit_embeddings_stage2a_final.json with B101 excluded; git diff checks clean; no tldw_Server_API/app path changed. Final specification, quality, and whole-branch reviews approved. The parent Backlog marker defect was normalized after explicit user approval. Any eventual AI-authored PR still requires a human requester-authored Change summary under repository policy.
+Stage 2A is complete and rebased onto origin/dev d710e5a5ee. The branch changes characterization tests, the approved design/plan, and Backlog tracking only; no production execution code changed. Post-rebase verification passed 186/186 touched-module tests, 176/176 Embeddings_isolated tests, and 11/11 explicit credential/cache cases; Ruff clean; Bandit zero findings at /tmp/bandit_embeddings_stage2a_rebased.json with B101 excluded; diff and scope checks clean. Final specification, quality, and whole-branch reviews approved. Any eventual AI-authored PR still requires a human requester-authored Change summary under repository policy.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -4,6 +4,7 @@ title: Characterize Embeddings workflow execution contracts
 status: To Do
 assignee: []
 created_date: '2026-07-19 02:33'
+updated_date: '2026-07-20 19:38'
 labels:
   - embeddings
   - workflow
@@ -26,9 +27,10 @@ Stage 2A. Add behavior-first characterization coverage for uncovered orchestrati
 <!-- AC:BEGIN -->
 - [ ] #1 Tests characterize primary preflight errors as non-fallback behavior.
 - [ ] #2 Tests characterize fallback candidate preflight skip and retry behavior.
-- [ ] #3 Tests prove reservation occurs after planning and before adapter, cache, or provider work.
-- [ ] #4 Tests prove cache read/write and non-provider failures do not trigger fallback.
-- [ ] #5 No production execution behavior changes are included.
+- [ ] #3 No production execution behavior changes are included.
+- [ ] #4 Tests prove reservation occurs after planning and characterize success, post-reservation failure, cancellation, and active-request accounting.
+- [ ] #5 Tests characterize endpoint cache exception types and the current fallback-wide domain-error catch without changing production behavior.
+- [ ] #6 Tests characterize successful zero-token accounting as falling back to reserved units.
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -4,7 +4,7 @@ title: Characterize Embeddings workflow execution contracts
 status: Done
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-26 14:54'
+updated_date: '2026-07-26 18:13'
 labels:
   - embeddings
   - workflow
@@ -13,6 +13,7 @@ dependencies: []
 references:
   - >-
     Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
+  - 'https://github.com/rmusser01/tldw_server/pull/2762'
 documentation:
   - >-
     Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-12973.1
 title: Characterize Embeddings workflow execution contracts
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-26 04:27'
+updated_date: '2026-07-26 04:52'
 labels:
   - embeddings
   - workflow
@@ -28,17 +28,17 @@ Stage 2A. Add behavior-first characterization coverage for uncovered orchestrati
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Tests characterize primary preflight errors as non-fallback behavior.
-- [ ] #2 Tests characterize fallback candidate preflight skip and retry behavior.
-- [ ] #3 No production execution behavior changes are included.
-- [ ] #4 Tests prove reservation occurs after planning and characterize success, post-reservation failure, cancellation, and active-request accounting.
-- [ ] #5 Tests characterize endpoint cache exception types and the current fallback-wide domain-error catch without changing production behavior.
-- [ ] #6 Tests characterize successful zero-token accounting as falling back to reserved units.
-- [ ] #7 Tests preserve adapter success accounting as zero cache hits and one cache miss per input while proving the primary provider executes only once before fallback traversal.
-- [ ] #8 Tests characterize backend-identity and cache-key exception types alongside cache adapter failures.
-- [ ] #9 Tests pin the current Stage 1 event sequence and characterize cancellation as propagating without a terminal trace event.
-- [ ] #10 Tests preserve private-credential shared-cache bypass and provider/model credential-touch timing, including adapter success and partial request failure.
-- [ ] #11 Tests characterize malformed or non-finite cached vectors as misses and pin complete ordered-result validation before the first cache write.
+- [x] #1 Tests characterize primary preflight errors as non-fallback behavior.
+- [x] #2 Tests characterize fallback candidate preflight skip and retry behavior.
+- [x] #3 No production execution behavior changes are included.
+- [x] #4 Tests prove reservation occurs after planning and characterize success, post-reservation failure, cancellation, and active-request accounting.
+- [x] #5 Tests characterize endpoint cache exception types and the current fallback-wide domain-error catch without changing production behavior.
+- [x] #6 Tests characterize successful zero-token accounting as falling back to reserved units.
+- [x] #7 Tests preserve adapter success accounting as zero cache hits and one cache miss per input while proving the primary provider executes only once before fallback traversal.
+- [x] #8 Tests characterize backend-identity and cache-key exception types alongside cache adapter failures.
+- [x] #9 Tests pin the current Stage 1 event sequence and characterize cancellation as propagating without a terminal trace event.
+- [x] #10 Tests preserve private-credential shared-cache bypass and provider/model credential-touch timing, including adapter success and partial request failure.
+- [x] #11 Tests characterize malformed or non-finite cached vectors as misses and pin complete ordered-result validation before the first cache write.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -57,14 +57,22 @@ Task 3 complete at e2a19c0b14: 7 focused and 36 full isolated-orchestrator tests
 Task 4 complete at 9e22f92608: targeted cancellation and all 11 workflow-runner tests passed; Ruff, Bandit excluding B101, spec review, and quality review approved.
 
 Task 5 complete at 95dbae7f55: 4 focused and 132 full endpoint-parity tests passed; actual fallback credential identity, zero-token reserved-unit accounting, real task cancellation cleanup, Ruff, Bandit excluding B101, spec review, and quality review passed.
+
+Task 6 final verification was executed against the rebased implementation head 5426d11cd2 before the closeout metadata commit. The combined touched test modules passed 179/179 in 148.81s with 4017 warnings and no skips or failures. The broader tldw_Server_API/tests/Embeddings_isolated suite passed 176/176 in 8.46s with 370 warnings and no skips or failures. The explicit latest-dev credential/cache evidence selected 11 and passed 11, with 121 deselected, 297 warnings, and no skips or failures. Ruff reported All checks passed. Bandit used --skip B101 and wrote /tmp/bandit_embeddings_stage2a.json; results_count=0 with all severity and confidence counts zero. git diff --check passed; the origin/dev...HEAD scope contained the three touched test files plus approved design, plan, and Backlog files, with no tldw_Server_API/app/ path. Observed warnings were test/configuration warnings only, including the expected legacy SINGLE_USER_API_KEY warning and isolated USER_DB_BASE_DIR fallback warning; no unexpected pytest skips or failures.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 2A complete. Tests and tracking only changed: the three Embeddings characterization test modules plus approved design/plan/Backlog tracking files; no production execution code changed. Final verification passed: 179/179 touched tests, 176/176 isolated Embeddings tests, and 11/11 explicit latest-dev credential/cache cases; Ruff clean; Bandit zero findings at /tmp/bandit_embeddings_stage2a.json with B101 excluded; git diff --check clean and no tldw_Server_API/app/ path. Rebased implementation commit SHAs: Task 1 ddbf5ad138, Task 2 17cfe39007, Task 3 d528f172de, Task 4 befdedcbed, Task 5 45c079a938. The task is marked Done. Any eventual AI-authored PR still requires the human requester's own Change summary under repository policy.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -1,0 +1,42 @@
+---
+id: TASK-12973.1
+title: Characterize Embeddings workflow execution contracts
+status: To Do
+assignee: []
+created_date: '2026-07-19 02:33'
+labels:
+  - embeddings
+  - workflow
+  - stage-2
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+parent_task_id: TASK-12973
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Stage 2A. Add behavior-first characterization coverage for uncovered orchestration boundaries before extracting production logic. Cover preparation order, resource reservation timing, primary and fallback preflight asymmetry, cache failure classification, adapter cache bypass, and fallback error precedence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Tests characterize primary preflight errors as non-fallback behavior.
+- [ ] #2 Tests characterize fallback candidate preflight skip and retry behavior.
+- [ ] #3 Tests prove reservation occurs after planning and before adapter, cache, or provider work.
+- [ ] #4 Tests prove cache read/write and non-provider failures do not trigger fallback.
+- [ ] #5 No production execution behavior changes are included.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -4,7 +4,7 @@ title: Characterize Embeddings workflow execution contracts
 status: In Progress
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-24 00:16'
+updated_date: '2026-07-26 04:27'
 labels:
   - embeddings
   - workflow
@@ -47,6 +47,16 @@ Stage 2A. Add behavior-first characterization coverage for uncovered orchestrati
 2026-07-23: Written design approved and branch rebased onto origin/dev at 1b9518c68c. Preparing the Stage 2A test-only implementation plan; latest dev already covers credential-sensitive cache bypass, adapter and partial-batch credential touches, and public malformed-cache replacement.
 
 Plan scope is test-only: modify the isolated orchestrator and runner tests plus endpoint parity tests; reuse latest-dev credential/cache coverage rather than duplicating it.
+
+Task 1 complete at bad72daf37: preparation/readiness characterization passed 23 isolated orchestrator tests, Ruff, Bandit excluding B101, specification review, and code-quality review.
+
+Task 2 complete at 58fa46f096: 11 focused, 30 isolated-orchestrator, and 130 endpoint-parity tests passed; Ruff and Bandit excluding B101 passed; specification and code-quality reviews approved.
+
+Task 3 complete at e2a19c0b14: 7 focused and 36 full isolated-orchestrator tests passed; the reviewed fallback case reaches merged-result validation before writeback; Ruff, Bandit excluding B101, spec review, and quality review passed.
+
+Task 4 complete at 9e22f92608: targeted cancellation and all 11 workflow-runner tests passed; Ruff, Bandit excluding B101, spec review, and quality review approved.
+
+Task 5 complete at 95dbae7f55: 4 focused and 132 full endpoint-parity tests passed; actual fallback credential identity, zero-token reserved-unit accounting, real task cancellation cleanup, Ruff, Bandit excluding B101, spec review, and quality review passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -1,15 +1,18 @@
 ---
 id: TASK-12973.1
 title: Characterize Embeddings workflow execution contracts
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-23 23:59'
+updated_date: '2026-07-24 00:16'
 labels:
   - embeddings
   - workflow
   - stage-2
 dependencies: []
+references:
+  - >-
+    Docs/superpowers/plans/2026-07-23-embeddings-workflow-stage2a-characterization-implementation-plan.md
 documentation:
   - >-
     Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
@@ -37,6 +40,14 @@ Stage 2A. Add behavior-first characterization coverage for uncovered orchestrati
 - [ ] #10 Tests preserve private-credential shared-cache bypass and provider/model credential-touch timing, including adapter success and partial request failure.
 - [ ] #11 Tests characterize malformed or non-finite cached vectors as misses and pin complete ordered-result validation before the first cache write.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-07-23: Written design approved and branch rebased onto origin/dev at 1b9518c68c. Preparing the Stage 2A test-only implementation plan; latest dev already covers credential-sensitive cache bypass, adapter and partial-batch credential touches, and public malformed-cache replacement.
+
+Plan scope is test-only: modify the isolated orchestrator and runner tests plus endpoint parity tests; reuse latest-dev credential/cache coverage rather than duplicating it.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -4,7 +4,7 @@ title: Characterize Embeddings workflow execution contracts
 status: Done
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-26 18:28'
+updated_date: '2026-07-26 19:50'
 labels:
   - embeddings
   - workflow
@@ -45,15 +45,17 @@ Stage 2A. Add behavior-first characterization coverage for uncovered orchestrati
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-2026-07-23 to 2026-07-26: The approved Stage 2A work added behavior-first characterization for Embeddings orchestration without changing production execution code. The whole-branch remediation removed over-specified call-trace assertions, added direct and integrated endpoint identity/cache-key characterization, covered reservation-denial and noncritical commit cleanup, preserved credential isolation and malformed-cache contracts, and passed specification, code-quality, and final whole-branch reviews.
+2026-07-23 to 2026-07-26: The approved Stage 2A work added behavior-first characterization for Embeddings orchestration without changing production execution code. Reviews removed over-specified call traces, added direct endpoint identity/cache-key coverage, covered reservation and active-request cleanup, preserved credential isolation and malformed-cache contracts, and reconciled parent Stage 2 approval tracking. GitHub PR #2762 has no actionable inline review threads; Qodo reported zero issues and other bot comments are informational.
 
-PR #2762 was rebased conflict-free at user request onto latest origin/dev 76481b2939. Fresh post-rebase verification passed 186/186 touched-module tests in 157.77s with 4139 warnings, 176/176 Embeddings_isolated tests in 11.20s with 370 warnings, and 11/11 explicit credential/cache tests in 10.70s with 128 deselected and 297 warnings. Ruff reported All checks passed. Bandit with B101 excluded reported zero findings across 6140 LOC at /tmp/bandit_embeddings_stage2a_pr_rebase.json. git diff --check origin/dev passed; the branch was 14 commits ahead and 0 behind before this metadata commit; no tldw_Server_API/app path changed. Expected legacy SINGLE_USER_API_KEY and isolated USER_DB_BASE_DIR warnings remained; no skips or failures occurred.
+Pre-merge remediation distinguishes resource-governor actual-token precedence across total, prompt, and reserved values; observes active-request accounting during backpressure rejection; and removes exact private validator-call coupling while retaining malformed-result and no-write evidence. Mutation checks failed as intended when total/prompt order, prompt/reserved order, and active-request/backpressure order were reversed, then passed after production code was restored. No production application diff remains.
+
+Fresh verification on origin/dev 76481b2939 passed 188/188 touched-module tests in 156.12s with 4215 warnings, 176/176 Embeddings_isolated tests in 9.42s with 370 warnings, and 11/11 credential/cache evidence tests in 10.74s with 129 deselected and 297 warnings. Ruff reported All checks passed. Bandit with B101 excluded reported zero findings across 6181 LOC at /tmp/bandit_embeddings_stage2a_review_remediation.json. git diff --check origin/dev passed; the branch was 15 commits ahead and 0 behind before the remediation commit; no tldw_Server_API/app path changed. Expected legacy SINGLE_USER_API_KEY and isolated USER_DB_BASE_DIR warnings remained; no skips or failures occurred.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 2A is complete and rebased onto origin/dev 76481b2939 for PR #2762. The branch changes characterization tests, the approved design/plan, and Backlog tracking only; no production application code changed. Fresh verification passed 186 touched-module tests, 176 Embeddings_isolated tests, and 11 explicit credential/cache cases; Ruff and diff checks are clean; Bandit reports zero findings with B101 excluded. GitHub currently marks the PR ready, but its human-authored Change summary remains a placeholder, so the repository merge gate is not yet satisfied.
+Stage 2A technical work is complete for PR #2762 on origin/dev 76481b2939. The branch changes characterization tests, approved design/planning, and Backlog tracking only; no production application code changed. Pre-merge review findings were resolved with mutation-sensitive coverage for total, prompt, and reserved token precedence plus active-request ordering during backpressure rejection, and private validator-call coupling was removed. Fresh verification passed 188 touched-module tests, 176 Embeddings_isolated tests, and 11 credential/cache cases; Ruff and diff checks are clean; Bandit reports zero findings with B101 excluded. The PR merge remains gated on required CI and the requester replacing the human-authored Change summary placeholder.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -4,7 +4,7 @@ title: Characterize Embeddings workflow execution contracts
 status: To Do
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-20 19:38'
+updated_date: '2026-07-23 23:59'
 labels:
   - embeddings
   - workflow
@@ -31,6 +31,11 @@ Stage 2A. Add behavior-first characterization coverage for uncovered orchestrati
 - [ ] #4 Tests prove reservation occurs after planning and characterize success, post-reservation failure, cancellation, and active-request accounting.
 - [ ] #5 Tests characterize endpoint cache exception types and the current fallback-wide domain-error catch without changing production behavior.
 - [ ] #6 Tests characterize successful zero-token accounting as falling back to reserved units.
+- [ ] #7 Tests preserve adapter success accounting as zero cache hits and one cache miss per input while proving the primary provider executes only once before fallback traversal.
+- [ ] #8 Tests characterize backend-identity and cache-key exception types alongside cache adapter failures.
+- [ ] #9 Tests pin the current Stage 1 event sequence and characterize cancellation as propagating without a terminal trace event.
+- [ ] #10 Tests preserve private-credential shared-cache bypass and provider/model credential-touch timing, including adapter success and partial request failure.
+- [ ] #11 Tests characterize malformed or non-finite cached vectors as misses and pin complete ordered-result validation before the first cache write.
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
+++ b/backlog/tasks/task-12973.1 - Characterize-Embeddings-workflow-execution-contracts.md
@@ -4,7 +4,7 @@ title: Characterize Embeddings workflow execution contracts
 status: Done
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-26 04:52'
+updated_date: '2026-07-26 14:46'
 labels:
   - embeddings
   - workflow
@@ -44,27 +44,19 @@ Stage 2A. Add behavior-first characterization coverage for uncovered orchestrati
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-2026-07-23: Written design approved and branch rebased onto origin/dev at 1b9518c68c. Preparing the Stage 2A test-only implementation plan; latest dev already covers credential-sensitive cache bypass, adapter and partial-batch credential touches, and public malformed-cache replacement.
+2026-07-23: Written design approved. The branch was initially rebased onto origin/dev at 1b9518c68c and later rebased onto the final reviewed origin/dev base 0f3983788c. Stage 2A remains test/design/tracking only; latest-dev credential-sensitive cache bypass, adapter and partial-batch credential touches, and public malformed-cache replacement are reused rather than duplicated.
 
-Plan scope is test-only: modify the isolated orchestrator and runner tests plus endpoint parity tests; reuse latest-dev credential/cache coverage rather than duplicating it.
+Rebased implementation commits: Task 1 ddbf5ad138, Task 2 17cfe39007, Task 3 d528f172de, Task 4 befdedcbed, Task 5 45c079a938. Each task passed focused tests, Ruff, Bandit excluding B101, specification review, and code-quality review.
 
-Task 1 complete at bad72daf37: preparation/readiness characterization passed 23 isolated orchestrator tests, Ruff, Bandit excluding B101, specification review, and code-quality review.
+Task 6 verification at implementation head 5426d11cd2 passed 179/179 touched tests, 176/176 Embeddings_isolated tests, and 11/11 explicit credential/cache cases; Ruff clean; Bandit zero findings at /tmp/bandit_embeddings_stage2a.json with B101 excluded; git diff --check clean; no tldw_Server_API/app path changed.
 
-Task 2 complete at 58fa46f096: 11 focused, 30 isolated-orchestrator, and 130 endpoint-parity tests passed; Ruff and Bandit excluding B101 passed; specification and code-quality reviews approved.
-
-Task 3 complete at e2a19c0b14: 7 focused and 36 full isolated-orchestrator tests passed; the reviewed fallback case reaches merged-result validation before writeback; Ruff, Bandit excluding B101, spec review, and quality review passed.
-
-Task 4 complete at 9e22f92608: targeted cancellation and all 11 workflow-runner tests passed; Ruff, Bandit excluding B101, spec review, and quality review approved.
-
-Task 5 complete at 95dbae7f55: 4 focused and 132 full endpoint-parity tests passed; actual fallback credential identity, zero-token reserved-unit accounting, real task cancellation cleanup, Ruff, Bandit excluding B101, spec review, and quality review passed.
-
-Task 6 final verification was executed against the rebased implementation head 5426d11cd2 before the closeout metadata commit. The combined touched test modules passed 179/179 in 148.81s with 4017 warnings and no skips or failures. The broader tldw_Server_API/tests/Embeddings_isolated suite passed 176/176 in 8.46s with 370 warnings and no skips or failures. The explicit latest-dev credential/cache evidence selected 11 and passed 11, with 121 deselected, 297 warnings, and no skips or failures. Ruff reported All checks passed. Bandit used --skip B101 and wrote /tmp/bandit_embeddings_stage2a.json; results_count=0 with all severity and confidence counts zero. git diff --check passed; the origin/dev...HEAD scope contained the three touched test files plus approved design, plan, and Backlog files, with no tldw_Server_API/app/ path. Observed warnings were test/configuration warnings only, including the expected legacy SINGLE_USER_API_KEY warning and isolated USER_DB_BASE_DIR fallback warning; no unexpected pytest skips or failures.
+2026-07-26 final remediation completed after whole-branch review. Validated work removed two over-specified call-trace assertions, added direct and integrated production endpoint identity/cache-key characterization, covered reservation-denial and noncritical commit cleanup, refreshed rebase metadata, and normalized the parent Backlog markers. Final verification passed 186/186 touched-module tests in 161.36s with 4139 warnings, 176/176 Embeddings_isolated tests in 10.65s with 370 warnings, and 11/11 credential/cache evidence tests with 128 deselected and 297 warnings. Ruff reported All checks passed. Bandit with B101 excluded reported zero findings across 6140 LOC at /tmp/bandit_embeddings_stage2a_final.json. git diff --check origin/dev passed; origin/dev remained 0f3983788c; no tldw_Server_API/app path changed. Specification, code-quality, and final whole-branch re-reviews approved. Expected legacy SINGLE_USER_API_KEY and isolated USER_DB_BASE_DIR warnings remained; no skips or failures occurred.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 2A complete. Tests and tracking only changed: the three Embeddings characterization test modules plus approved design/plan/Backlog tracking files; no production execution code changed. Final verification passed: 179/179 touched tests, 176/176 isolated Embeddings tests, and 11/11 explicit latest-dev credential/cache cases; Ruff clean; Bandit zero findings at /tmp/bandit_embeddings_stage2a.json with B101 excluded; git diff --check clean and no tldw_Server_API/app/ path. Rebased implementation commit SHAs: Task 1 ddbf5ad138, Task 2 17cfe39007, Task 3 d528f172de, Task 4 befdedcbed, Task 5 45c079a938. The task is marked Done. Any eventual AI-authored PR still requires the human requester's own Change summary under repository policy.
+Stage 2A is complete. The branch changes characterization tests, the approved design/plan, and Backlog tracking only; no production execution code changed. Final verification passed 186/186 touched-module tests, 176/176 Embeddings_isolated tests, and 11/11 explicit credential/cache cases; Ruff clean; Bandit zero findings at /tmp/bandit_embeddings_stage2a_final.json with B101 excluded; git diff checks clean; no tldw_Server_API/app path changed. Final specification, quality, and whole-branch reviews approved. The parent Backlog marker defect was normalized after explicit user approval. Any eventual AI-authored PR still requires a human requester-authored Change summary under repository policy.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
+++ b/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
@@ -4,7 +4,7 @@ title: Extract Embeddings preparation and result contracts
 status: To Do
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-19 02:43'
+updated_date: '2026-07-20 19:33'
 labels:
   - embeddings
   - workflow
@@ -21,7 +21,7 @@ priority: high
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Stage 2B. Extract the ordered preparation pipeline, pure vector processing, canonical HTTP-independent execution outcome, endpoint response-header mapping, and temporary legacy result adapter without changing execution behavior.
+Stage 2B. Extract the ordered preparation pipeline, deterministic vector processing, canonical HTTP-independent execution outcome, endpoint response-header mapping, and temporary legacy result adapter without changing execution behavior.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -31,6 +31,9 @@ Stage 2B. Extract the ordered preparation pipeline, pure vector processing, cano
 - [ ] #3 The compatibility adapter preserves the existing EmbeddingExecutionResult contract.
 - [ ] #4 Focused and endpoint parity tests pass.
 - [ ] #5 A pure endpoint header mapper is defined and parity-tested; production wiring is deferred to Stage 2E.
+- [ ] #6 Preparation phase reporting receives phase identifiers only and never forwards request data or execution-plan observability tags.
+- [ ] #7 Stateless boundaries use functions, narrow protocols, or immutable DTOs unless meaningful injected state requires a class.
+- [ ] #8 The legacy response-header mapper is documented as a Stage 6 compatibility exception outside the canonical runner path.
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
+++ b/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
@@ -1,0 +1,44 @@
+---
+id: TASK-12973.2
+title: Extract Embeddings preparation and result contracts
+status: To Do
+assignee: []
+created_date: '2026-07-19 02:33'
+updated_date: '2026-07-19 02:43'
+labels:
+  - embeddings
+  - workflow
+  - stage-2
+dependencies:
+  - TASK-12973.1
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+parent_task_id: TASK-12973
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Stage 2B. Extract the ordered preparation pipeline, pure vector processing, canonical HTTP-independent execution outcome, endpoint response-header mapping, and temporary legacy result adapter without changing execution behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Preparation preserves resolve-intent, normalize, policy, and planning order and error precedence.
+- [ ] #2 Canonical execution outcomes contain domain metadata and no HTTP headers.
+- [ ] #3 The compatibility adapter preserves the existing EmbeddingExecutionResult contract.
+- [ ] #4 Focused and endpoint parity tests pass.
+- [ ] #5 A pure endpoint header mapper is defined and parity-tested; production wiring is deferred to Stage 2E.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
+++ b/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
@@ -4,7 +4,7 @@ title: Extract Embeddings preparation and result contracts
 status: To Do
 assignee: []
 created_date: '2026-07-19 02:33'
-updated_date: '2026-07-20 19:33'
+updated_date: '2026-07-23 23:53'
 labels:
   - embeddings
   - workflow
@@ -34,6 +34,8 @@ Stage 2B. Extract the ordered preparation pipeline, deterministic vector process
 - [ ] #6 Preparation phase reporting receives phase identifiers only and never forwards request data or execution-plan observability tags.
 - [ ] #7 Stateless boundaries use functions, narrow protocols, or immutable DTOs unless meaningful injected state requires a class.
 - [ ] #8 The legacy response-header mapper is documented as a Stage 6 compatibility exception outside the canonical runner path.
+- [ ] #9 Workflow phase contracts add resolving_intent, keep completed as a status, and define finalizing event semantics explicitly.
+- [ ] #10 Canonical outcomes preserve successful adapter cache counts as zero hits and item-count misses.
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
+++ b/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
@@ -4,6 +4,7 @@ title: Extract single-provider Embeddings execution attempts
 status: To Do
 assignee: []
 created_date: '2026-07-19 02:35'
+updated_date: '2026-07-20 19:30'
 labels:
   - embeddings
   - workflow
@@ -30,6 +31,9 @@ Stage 2C. Extract provider readiness checks and a single-provider attempt compon
 - [ ] #3 All returned vectors are validated and postprocessed before cache writeback begins.
 - [ ] #4 Provider-native float vectors, not encoded or adjusted vectors, are cached.
 - [ ] #5 Cache and non-provider failures never trigger fallback.
+- [ ] #6 Cache keys retain exactly text, provider, model, requested dimensions, and runtime backend identity; cache_namespace remains excluded.
+- [ ] #7 Read identity is resolved after readiness and write identity is re-resolved after provider execution for primary and fallback attempts.
+- [ ] #8 EmbeddingExecutionPlan.backend_identity is not used as the authoritative runtime cache identity.
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
+++ b/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
@@ -1,0 +1,43 @@
+---
+id: TASK-12973.3
+title: Extract single-provider Embeddings execution attempts
+status: To Do
+assignee: []
+created_date: '2026-07-19 02:35'
+labels:
+  - embeddings
+  - workflow
+  - stage-2
+dependencies:
+  - TASK-12973.2
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+parent_task_id: TASK-12973
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Stage 2C. Extract provider readiness checks and a single-provider attempt component that preserves ordered cache lookup, miss execution, full response validation, request-specific postprocessing, and provider-native cache writeback.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Primary and candidate readiness checks are independently callable.
+- [ ] #2 Cache hits preserve request order and only misses reach the executor.
+- [ ] #3 All returned vectors are validated and postprocessed before cache writeback begins.
+- [ ] #4 Provider-native float vectors, not encoded or adjusted vectors, are cached.
+- [ ] #5 Cache and non-provider failures never trigger fallback.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
+++ b/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
@@ -4,7 +4,7 @@ title: Extract single-provider Embeddings execution attempts
 status: To Do
 assignee: []
 created_date: '2026-07-19 02:35'
-updated_date: '2026-07-20 19:30'
+updated_date: '2026-07-23 23:59'
 labels:
   - embeddings
   - workflow
@@ -34,6 +34,10 @@ Stage 2C. Extract provider readiness checks and a single-provider attempt compon
 - [ ] #6 Cache keys retain exactly text, provider, model, requested dimensions, and runtime backend identity; cache_namespace remains excluded.
 - [ ] #7 Read identity is resolved after readiness and write identity is re-resolved after provider execution for primary and fallback attempts.
 - [ ] #8 EmbeddingExecutionPlan.backend_identity is not used as the authoritative runtime cache identity.
+- [ ] #9 Isolated provider-attempt tests classify backend-identity and cache-key derivation failures as non-provider failures without fallback or writeback.
+- [ ] #10 Stage 2C production behavior changes only fallback write identity; the new provider-attempt component remains side-by-side until Stage 2D.
+- [ ] #11 Provider attempts delegate dynamic cache eligibility to the injected cache so private-credential bypass yields misses without underlying shared writes.
+- [ ] #12 Malformed or non-finite cached vectors become misses and are replaced without reaching vector postprocessing as cache hits.
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
+++ b/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
@@ -4,6 +4,7 @@ title: Extract Embeddings fallback and execution coordinators
 status: To Do
 assignee: []
 created_date: '2026-07-19 02:36'
+updated_date: '2026-07-20 19:30'
 labels:
   - embeddings
   - workflow
@@ -30,6 +31,8 @@ Stage 2D. Extract adapter, primary execution, fallback candidate traversal, mode
 - [ ] #3 Fallback candidates perform readiness checks and skip missing credentials.
 - [ ] #4 A fallback provider resolves the complete request without mixed-provider vectors.
 - [ ] #5 Rate-limit retry metadata and exhausted-error precedence remain unchanged.
+- [ ] #6 Only executor-originated domain failures become typed ProviderCallFailure results eligible for fallback decisions.
+- [ ] #7 Fallback missing-credential errors from readiness or provider calls skip the candidate while cache, validation, postprocessing, and writeback errors propagate.
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
+++ b/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
@@ -4,7 +4,7 @@ title: Extract Embeddings fallback and execution coordinators
 status: To Do
 assignee: []
 created_date: '2026-07-19 02:36'
-updated_date: '2026-07-20 19:30'
+updated_date: '2026-07-23 23:53'
 labels:
   - embeddings
   - workflow
@@ -33,6 +33,8 @@ Stage 2D. Extract adapter, primary execution, fallback candidate traversal, mode
 - [ ] #5 Rate-limit retry metadata and exhausted-error precedence remain unchanged.
 - [ ] #6 Only executor-originated domain failures become typed ProviderCallFailure results eligible for fallback decisions.
 - [ ] #7 Fallback missing-credential errors from readiness or provider calls skip the candidate while cache, validation, postprocessing, and writeback errors propagate.
+- [ ] #8 Fallback traversal excludes the already-attempted primary provider and preserves the ordered policy-approved chain tail.
+- [ ] #9 Identity resolution and cache-key derivation failures never become ProviderCallFailure or activate another provider.
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
+++ b/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
@@ -1,0 +1,43 @@
+---
+id: TASK-12973.4
+title: Extract Embeddings fallback and execution coordinators
+status: To Do
+assignee: []
+created_date: '2026-07-19 02:36'
+labels:
+  - embeddings
+  - workflow
+  - stage-2
+dependencies:
+  - TASK-12973.3
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+parent_task_id: TASK-12973
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Stage 2D. Extract adapter, primary execution, fallback candidate traversal, model mapping, error eligibility, exhausted-error selection, and coherent whole-request fallback into explicit coordinators.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Adapter execution remains before primary preflight and cache access.
+- [ ] #2 Primary preflight failures do not enter fallback.
+- [ ] #3 Fallback candidates perform readiness checks and skip missing credentials.
+- [ ] #4 A fallback provider resolves the complete request without mixed-provider vectors.
+- [ ] #5 Rate-limit retry metadata and exhausted-error precedence remain unchanged.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12973.5 - Integrate-concrete-Embeddings-steps-with-the-inline-runner.md
+++ b/backlog/tasks/task-12973.5 - Integrate-concrete-Embeddings-steps-with-the-inline-runner.md
@@ -4,7 +4,7 @@ title: Integrate concrete Embeddings steps with the inline runner
 status: To Do
 assignee: []
 created_date: '2026-07-19 02:36'
-updated_date: '2026-07-20 19:38'
+updated_date: '2026-07-24 00:01'
 labels:
   - embeddings
   - workflow
@@ -28,14 +28,16 @@ Stage 2E. Make the inline workflow runner sequence the approved preparation, res
 <!-- AC:BEGIN -->
 - [ ] #1 The reservation hook remains after planning and before adapter, preflight, cache, or provider work.
 - [ ] #2 EmbeddingRequestOrchestrator contains delegation and compatibility mapping only.
-- [ ] #3 Workflow-enabled and legacy endpoint outputs, headers, metrics inputs, and credential touching remain equivalent.
-- [ ] #4 The feature flag remains the operational rollback and no Stage 3 durability behavior is introduced.
-- [ ] #5 Successful tracing emits one execute_completed summary with attempt counts and no per-attempt or per-item events.
-- [ ] #6 Trace event cardinality is independent of input size and fallback-chain length, and response_header_count is removed.
-- [ ] #7 Resource-governor actuals, failure charging, cancellation cleanup, and active-request accounting remain endpoint-owned and behaviorally equivalent.
-- [ ] #8 Legacy header synthesis remains isolated to the temporary compatibility mapper scheduled for Stage 6 removal.
-- [ ] #9 Successful commit actuals preserve total-token, prompt-token, then reserved-unit fallback order.
-- [ ] #10 The runner emits only safe Stage 2 lifecycle metadata and aggregate execution-summary metadata.
+- [ ] #3 The feature flag remains the operational rollback and no Stage 3 durability behavior is introduced.
+- [ ] #4 Successful tracing emits one execute_completed summary with attempt counts and no per-attempt or per-item events.
+- [ ] #5 Trace event cardinality is independent of input size and fallback-chain length, and response_header_count is removed.
+- [ ] #6 Resource-governor actuals, failure charging, cancellation cleanup, and active-request accounting remain endpoint-owned and behaviorally equivalent.
+- [ ] #7 Legacy header synthesis remains isolated to the temporary compatibility mapper scheduled for Stage 6 removal.
+- [ ] #8 Successful commit actuals preserve total-token, prompt-token, then reserved-unit fallback order.
+- [ ] #9 The runner emits only safe Stage 2 lifecycle metadata and aggregate execution-summary metadata.
+- [ ] #10 Success events follow the exact approved phase sequence, while cancellation propagates without a Stage 2 terminal trace event.
+- [ ] #11 Credential touching preserves executor-owned validated-batch, adapter, and late-result behavior plus the endpoint's idempotent final provider/model touch.
+- [ ] #12 Parity tests require equivalence for unchanged scenarios and assert only the approved Stage 2C fallback-write-identity and Stage 2D source-routing divergences.
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.5 - Integrate-concrete-Embeddings-steps-with-the-inline-runner.md
+++ b/backlog/tasks/task-12973.5 - Integrate-concrete-Embeddings-steps-with-the-inline-runner.md
@@ -4,6 +4,7 @@ title: Integrate concrete Embeddings steps with the inline runner
 status: To Do
 assignee: []
 created_date: '2026-07-19 02:36'
+updated_date: '2026-07-20 19:38'
 labels:
   - embeddings
   - workflow
@@ -26,10 +27,15 @@ Stage 2E. Make the inline workflow runner sequence the approved preparation, res
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 The reservation hook remains after planning and before adapter, preflight, cache, or provider work.
-- [ ] #2 The runner emits only aggregate safe Stage 2 lifecycle and attempt metadata.
-- [ ] #3 EmbeddingRequestOrchestrator contains delegation and compatibility mapping only.
-- [ ] #4 Workflow-enabled and legacy endpoint outputs, headers, metrics inputs, and credential touching remain equivalent.
-- [ ] #5 The feature flag remains the operational rollback and no Stage 3 durability behavior is introduced.
+- [ ] #2 EmbeddingRequestOrchestrator contains delegation and compatibility mapping only.
+- [ ] #3 Workflow-enabled and legacy endpoint outputs, headers, metrics inputs, and credential touching remain equivalent.
+- [ ] #4 The feature flag remains the operational rollback and no Stage 3 durability behavior is introduced.
+- [ ] #5 Successful tracing emits one execute_completed summary with attempt counts and no per-attempt or per-item events.
+- [ ] #6 Trace event cardinality is independent of input size and fallback-chain length, and response_header_count is removed.
+- [ ] #7 Resource-governor actuals, failure charging, cancellation cleanup, and active-request accounting remain endpoint-owned and behaviorally equivalent.
+- [ ] #8 Legacy header synthesis remains isolated to the temporary compatibility mapper scheduled for Stage 6 removal.
+- [ ] #9 Successful commit actuals preserve total-token, prompt-token, then reserved-unit fallback order.
+- [ ] #10 The runner emits only safe Stage 2 lifecycle metadata and aggregate execution-summary metadata.
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12973.5 - Integrate-concrete-Embeddings-steps-with-the-inline-runner.md
+++ b/backlog/tasks/task-12973.5 - Integrate-concrete-Embeddings-steps-with-the-inline-runner.md
@@ -1,0 +1,43 @@
+---
+id: TASK-12973.5
+title: Integrate concrete Embeddings steps with the inline runner
+status: To Do
+assignee: []
+created_date: '2026-07-19 02:36'
+labels:
+  - embeddings
+  - workflow
+  - stage-2
+dependencies:
+  - TASK-12973.4
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+parent_task_id: TASK-12973
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Stage 2E. Make the inline workflow runner sequence the approved preparation, reservation, execution, and result components; reduce EmbeddingRequestOrchestrator to a compatibility facade; and complete endpoint-level parity verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The reservation hook remains after planning and before adapter, preflight, cache, or provider work.
+- [ ] #2 The runner emits only aggregate safe Stage 2 lifecycle and attempt metadata.
+- [ ] #3 EmbeddingRequestOrchestrator contains delegation and compatibility mapping only.
+- [ ] #4 Workflow-enabled and legacy endpoint outputs, headers, metrics inputs, and credential touching remain equivalent.
+- [ ] #5 The feature flag remains the operational rollback and no Stage 3 durability behavior is introduced.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
@@ -6,7 +6,7 @@ import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import numpy as np
 import pytest
@@ -360,6 +360,194 @@ async def test_endpoint_cache_adapter_propagates_dependency_error_unchanged(
         dependency.assert_awaited_once_with("cache-key")
     else:
         dependency.assert_awaited_once_with("cache-key", [0.1, 0.2])
+
+
+def test_orchestrator_backend_identity_collapses_allowlisted_construction_failure(
+    monkeypatch,
+):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    original = RuntimeError("provider configuration unavailable")
+    build_config = Mock(side_effect=original)
+    monkeypatch.setattr(mod, "build_provider_config", build_config)
+
+    assert (
+        mod._orchestrator_backend_identity(
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        )
+        is None
+    )
+    build_config.assert_called_once()
+
+
+def test_orchestrator_backend_identity_propagates_domain_construction_failure_unchanged(
+    monkeypatch,
+):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    original = EmbeddingExecutionError(
+        "internal_execution_failure",
+        "provider configuration failed",
+        retryable=True,
+    )
+    build_config = Mock(side_effect=original)
+    monkeypatch.setattr(mod, "build_provider_config", build_config)
+
+    with pytest.raises(EmbeddingExecutionError) as exc_info:
+        mod._orchestrator_backend_identity(
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        )
+
+    assert exc_info.value is original
+    build_config.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        pytest.param(
+            lambda: RuntimeError("cache key secret unavailable"),
+            id="runtime",
+        ),
+        pytest.param(
+            lambda: EmbeddingExecutionError(
+                "internal_execution_failure",
+                "cache key generation failed",
+                retryable=True,
+            ),
+            id="domain",
+        ),
+    ],
+)
+def test_get_cache_key_propagates_secret_dependency_failure_unchanged(
+    monkeypatch,
+    error_factory,
+):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    original = error_factory()
+
+    def raise_secret():
+        raise original
+
+    monkeypatch.setattr(mod, "_embedding_cache_key_secret", raise_secret)
+
+    with pytest.raises(type(original)) as exc_info:
+        mod.get_cache_key(
+            "cache boundary",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        )
+
+    assert exc_info.value is original
+
+
+@pytest.mark.parametrize(
+    ("error_factory", "expected_outcome", "expected_detail"),
+    [
+        pytest.param(
+            lambda: RuntimeError("endpoint cache key secret unavailable"),
+            "reraises",
+            None,
+            id="runtime-reraises",
+        ),
+        pytest.param(
+            lambda: EmbeddingExecutionError(
+                "internal_execution_failure",
+                "Embedding execution failed",
+                retryable=True,
+            ),
+            "http_503",
+            "Embedding execution failed",
+            id="domain-maps-to-503",
+        ),
+    ],
+)
+def test_orchestrator_endpoint_cache_key_secret_failure_propagates_without_fallback(
+    client,
+    monkeypatch,
+    error_factory,
+    expected_outcome,
+    expected_detail,
+):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    original = error_factory()
+    preflight_providers: list[str] = []
+    provider_calls: list[str] = []
+    fallback_chain = {"openai": ["openai", "huggingface"]}
+    fallback_model_map = {
+        "openai:text-embedding-3-small": {
+            "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+        }
+    }
+
+    def policy_setting(name, default):
+        if name == "EMBEDDINGS_FALLBACK_CHAIN":
+            return fallback_chain
+        if name == "EMBEDDINGS_FALLBACK_MODEL_MAP":
+            return fallback_model_map
+        return default
+
+    def raise_secret():
+        raise original
+
+    async def record_preflight(_executor, provider, _model):
+        preflight_providers.append(provider)
+
+    async def record_create(
+        _executor,
+        texts,
+        *,
+        provider,
+        model,
+        dimensions,
+    ):
+        del model, dimensions
+        provider_calls.append(provider)
+        return [[0.1, 0.2] for _ in texts]
+
+    monkeypatch.setenv("EMBEDDINGS_ORCHESTRATOR_ENABLED", "true")
+    monkeypatch.setenv("EMBEDDINGS_ALLOW_FALLBACK_WITH_HEADER", "true")
+    monkeypatch.setenv("LLM_EMBEDDINGS_ADAPTERS_ENABLED", "false")
+    monkeypatch.setattr(mod, "_embedding_policy_setting", policy_setting)
+    monkeypatch.setattr(mod, "_embedding_cache_key_secret", raise_secret)
+    monkeypatch.setattr(
+        mod._EndpointEmbeddingExecutor,
+        "preflight_provider",
+        record_preflight,
+    )
+    monkeypatch.setattr(mod._EndpointEmbeddingExecutor, "create", record_create)
+
+    if expected_outcome == "reraises":
+        with pytest.raises(RuntimeError) as exc_info:
+            client.post(
+                "/api/v1/embeddings",
+                headers={"x-provider": "openai"},
+                json={"model": "text-embedding-3-small", "input": "key failure"},
+            )
+        assert exc_info.value is original
+    else:
+        response = client.post(
+            "/api/v1/embeddings",
+            headers={"x-provider": "openai"},
+            json={"model": "text-embedding-3-small", "input": "key failure"},
+        )
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert response.json() == {"detail": expected_detail}
+
+    assert preflight_providers == ["openai"]
+    assert provider_calls == []
 
 
 def _run_dual_path_embedding_request(
@@ -1110,6 +1298,8 @@ def test_orchestrator_path_does_not_execute_or_commit_after_rg_denial(client, mo
 
     monkeypatch.setenv("EMBEDDINGS_ORCHESTRATOR_ENABLED", "true")
     fake_orchestrator = FakeOrchestrator()
+    active_requests = _RecordingGauge()
+    monkeypatch.setattr(mod, "active_embedding_requests", active_requests)
     monkeypatch.setattr(
         mod,
         "_build_embedding_request_orchestrator",
@@ -1139,6 +1329,64 @@ def test_orchestrator_path_does_not_execute_or_commit_after_rg_denial(client, mo
 
     assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
     assert fake_orchestrator.execute_calls == []
+    assert active_requests.inc_count == 1
+    assert active_requests.dec_count == 1
+
+
+def test_orchestrator_success_survives_noncritical_rg_commit_failure(client, monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanced as mod
+
+    monkeypatch.setenv("EMBEDDINGS_ORCHESTRATOR_ENABLED", "true")
+    fake_orchestrator = FakeOrchestrator(
+        result=EmbeddingExecutionResult(
+            vectors=[[0.25, 0.75]],
+            provider="huggingface",
+            model="sentence-transformers/all-MiniLM-L6-v2",
+            prompt_tokens=3,
+            total_tokens=3,
+            cache_hits=0,
+            cache_misses=1,
+        )
+    )
+    commit = AsyncMock(side_effect=RuntimeError("RG commit unavailable"))
+    governor = SimpleNamespace(commit=commit)
+    active_requests = _RecordingGauge()
+    endpoint_executor = SimpleNamespace(touch_resolved_credentials=AsyncMock())
+    monkeypatch.setattr(mod, "active_embedding_requests", active_requests)
+    monkeypatch.setattr(
+        mod,
+        "_EndpointEmbeddingExecutor",
+        lambda **_kwargs: endpoint_executor,
+    )
+    monkeypatch.setattr(
+        mod,
+        "_build_embedding_request_orchestrator",
+        lambda *_args, **_kwargs: fake_orchestrator,
+    )
+
+    async def reserve(*, request, current_user, token_total):
+        del request, current_user
+        return governor, "commit-failure-handle", "commit-failure-op", token_total
+
+    monkeypatch.setattr(mod, "_reserve_embedding_rg_tokens", reserve)
+
+    response = client.post(
+        "/api/v1/embeddings",
+        headers={"x-provider": "huggingface"},
+        json={
+            "model": "sentence-transformers/all-MiniLM-L6-v2",
+            "input": "commit failure remains noncritical",
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    commit.assert_awaited_once_with(
+        "commit-failure-handle",
+        actuals={"tokens": 3},
+        op_id="commit-failure-op",
+    )
+    assert active_requests.inc_count == 1
+    assert active_requests.dec_count == 1
 
 
 def test_orchestrator_input_error_maps_to_current_400_shape(client, monkeypatch):

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
@@ -97,10 +97,18 @@ class FakePrepared:
 
 
 class FakeOrchestrator:
-    def __init__(self, *, result=None, prepare_error=None, execute_error=None) -> None:
+    def __init__(
+        self,
+        *,
+        result=None,
+        prepare_error=None,
+        execute_error=None,
+        prepared_total_tokens: int = 3,
+    ) -> None:
         self.result = result
         self.prepare_error = prepare_error
         self.execute_error = execute_error
+        self.prepared_total_tokens = prepared_total_tokens
         self.prepare_calls = []
         self.execute_calls = []
 
@@ -108,7 +116,7 @@ class FakeOrchestrator:
         self.prepare_calls.append((raw_input, context))
         if self.prepare_error is not None:
             raise self.prepare_error
-        return FakePrepared(total_tokens=3)
+        return FakePrepared(total_tokens=self.prepared_total_tokens)
 
     async def execute(self, prepared):
         self.execute_calls.append(prepared)
@@ -184,6 +192,18 @@ class _NoopMetric:
 
     def observe(self, *_args, **_kwargs):
         return None
+
+
+class _RecordingGauge(_NoopMetric):
+    def __init__(self) -> None:
+        self.inc_count = 0
+        self.dec_count = 0
+
+    def inc(self, *_args, **_kwargs):
+        self.inc_count += 1
+
+    def dec(self, *_args, **_kwargs):
+        self.dec_count += 1
 
 
 class _RecordingCounter:
@@ -799,12 +819,19 @@ def test_orchestrator_path_uses_inline_workflow_runner_and_preserves_rg_reservat
     )
     runner_calls: list[tuple[str, object]] = []
     rg_governor = SimpleNamespace(commit=AsyncMock())
+    active_requests = _RecordingGauge()
+    endpoint_executor = SimpleNamespace(touch_resolved_credentials=AsyncMock())
+    monkeypatch.setattr(mod, "active_embedding_requests", active_requests)
+    monkeypatch.setattr(
+        mod,
+        "_EndpointEmbeddingExecutor",
+        lambda **_kwargs: endpoint_executor,
+    )
 
     monkeypatch.setattr(
         mod,
         "_build_embedding_request_orchestrator",
         lambda *_args, **_kwargs: fake_orchestrator,
-        raising=False,
     )
 
     async def fake_reserve_embedding_rg_tokens(*, request, current_user, token_total):
@@ -816,7 +843,6 @@ def test_orchestrator_path_uses_inline_workflow_runner_and_preserves_rg_reservat
         mod,
         "_reserve_embedding_rg_tokens",
         fake_reserve_embedding_rg_tokens,
-        raising=False,
     )
 
     class RunnerProbe:
@@ -835,12 +861,12 @@ def test_orchestrator_path_uses_inline_workflow_runner_and_preserves_rg_reservat
             runner_calls.append(("executed", result.provider))
             return result
 
-    monkeypatch.setattr(mod, "EmbeddingInlineWorkflowRunner", RunnerProbe, raising=False)
+    monkeypatch.setattr(mod, "EmbeddingInlineWorkflowRunner", RunnerProbe)
 
     response = client.post(
         "/api/v1/embeddings",
-        headers={"x-provider": "huggingface"},
-        json={"model": "sentence-transformers/all-MiniLM-L6-v2", "input": "workflow facade"},
+        headers={"x-provider": "openai"},
+        json={"model": "text-embedding-3-small", "input": "workflow facade"},
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -856,6 +882,12 @@ def test_orchestrator_path_uses_inline_workflow_runner_and_preserves_rg_reservat
         actuals={"tokens": 3},
         op_id="rg-op",
     )
+    endpoint_executor.touch_resolved_credentials.assert_awaited_once_with(
+        "huggingface",
+        "sentence-transformers/all-MiniLM-L6-v2",
+    )
+    assert active_requests.inc_count == 1
+    assert active_requests.dec_count == 1
 
 
 def test_orchestrator_path_commits_reserved_units_after_execute_failure(client, monkeypatch):
@@ -871,11 +903,12 @@ def test_orchestrator_path_commits_reserved_units_after_execute_failure(client, 
         )
     )
     rg_governor = SimpleNamespace(commit=AsyncMock())
+    active_requests = _RecordingGauge()
+    monkeypatch.setattr(mod, "active_embedding_requests", active_requests)
     monkeypatch.setattr(
         mod,
         "_build_embedding_request_orchestrator",
         lambda *_args, **_kwargs: fake_orchestrator,
-        raising=False,
     )
 
     async def fake_reserve_embedding_rg_tokens(*, request, current_user, token_total):
@@ -886,7 +919,6 @@ def test_orchestrator_path_commits_reserved_units_after_execute_failure(client, 
         mod,
         "_reserve_embedding_rg_tokens",
         fake_reserve_embedding_rg_tokens,
-        raising=False,
     )
 
     response = client.post(
@@ -901,6 +933,176 @@ def test_orchestrator_path_commits_reserved_units_after_execute_failure(client, 
         actuals={"tokens": 3},
         op_id="rg-op",
     )
+    assert active_requests.inc_count == 1
+    assert active_requests.dec_count == 1
+
+
+def test_orchestrator_zero_token_success_commits_reserved_unit(client, monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    monkeypatch.setenv("EMBEDDINGS_ORCHESTRATOR_ENABLED", "true")
+    fake_orchestrator = FakeOrchestrator(
+        prepared_total_tokens=0,
+        result=EmbeddingExecutionResult(
+            vectors=[[0.25, 0.75]],
+            provider="huggingface",
+            model="sentence-transformers/all-MiniLM-L6-v2",
+            prompt_tokens=0,
+            total_tokens=0,
+            cache_hits=0,
+            cache_misses=1,
+        ),
+    )
+    active_requests = _RecordingGauge()
+    endpoint_executor = SimpleNamespace(touch_resolved_credentials=AsyncMock())
+    governor = SimpleNamespace(commit=AsyncMock())
+    monkeypatch.setattr(mod, "active_embedding_requests", active_requests)
+    monkeypatch.setattr(
+        mod,
+        "_EndpointEmbeddingExecutor",
+        lambda **_kwargs: endpoint_executor,
+    )
+    monkeypatch.setattr(
+        mod,
+        "_build_embedding_request_orchestrator",
+        lambda *_args, **_kwargs: fake_orchestrator,
+    )
+
+    async def reserve(*, request, current_user, token_total):
+        del request, current_user
+        assert token_total == 1
+        return governor, "zero-handle", "zero-op", 1
+
+    monkeypatch.setattr(mod, "_reserve_embedding_rg_tokens", reserve)
+
+    response = client.post(
+        "/api/v1/embeddings",
+        headers={"x-provider": "openai"},
+        json={
+            "model": "text-embedding-3-small",
+            "input": "zero accounting",
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    governor.commit.assert_awaited_once_with(
+        "zero-handle",
+        actuals={"tokens": 1},
+        op_id="zero-op",
+    )
+    assert active_requests.inc_count == 1
+    assert active_requests.dec_count == 1
+    endpoint_executor.touch_resolved_credentials.assert_awaited_once_with(
+        "huggingface",
+        "sentence-transformers/all-MiniLM-L6-v2",
+    )
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_cancellation_commits_reserved_units_and_decrements_active(
+    monkeypatch,
+):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    active_requests = _RecordingGauge()
+    endpoint_executor = SimpleNamespace(touch_resolved_credentials=AsyncMock())
+    success_metric = _RecordingCounter()
+    governor = SimpleNamespace(commit=AsyncMock())
+    execute_entered = asyncio.Event()
+    execute_release = asyncio.Event()
+    reservation_entered = asyncio.Event()
+
+    class BlockingOrchestrator(FakeOrchestrator):
+        async def execute(self, prepared):
+            self.execute_calls.append(prepared)
+            execute_entered.set()
+            await execute_release.wait()
+            return self.result or EmbeddingExecutionResult(
+                vectors=[[0.25, 0.75]],
+                provider="huggingface",
+                model="sentence-transformers/all-MiniLM-L6-v2",
+                prompt_tokens=3,
+                total_tokens=3,
+                cache_hits=0,
+                cache_misses=1,
+            )
+
+    fake_orchestrator = BlockingOrchestrator(prepared_total_tokens=3)
+
+    async def no_backpressure(*_args, **_kwargs):
+        return None
+
+    async def reserve(*, request, current_user, token_total):
+        del request, current_user
+        assert token_total == 3
+        reservation_entered.set()
+        return governor, "cancel-handle", "cancel-op", token_total
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(),
+        headers={},
+        method="POST",
+        url=SimpleNamespace(path="/api/v1/embeddings"),
+    )
+    monkeypatch.setattr(mod, "EMBEDDINGS_AVAILABLE", True)
+    monkeypatch.setattr(mod, "active_embedding_requests", active_requests)
+    monkeypatch.setattr(mod, "embedding_requests_total", success_metric)
+    monkeypatch.setattr(mod, "embedding_request_duration", _NoopMetric())
+    monkeypatch.setattr(mod, "_check_backpressure_and_quotas", no_backpressure)
+    monkeypatch.setattr(mod, "_reserve_embedding_rg_tokens", reserve)
+    monkeypatch.setattr(
+        mod,
+        "_EndpointEmbeddingExecutor",
+        lambda **_kwargs: endpoint_executor,
+    )
+    monkeypatch.setattr(
+        mod,
+        "_build_embedding_request_orchestrator",
+        lambda *_args, **_kwargs: fake_orchestrator,
+    )
+
+    task = asyncio.create_task(
+        mod._create_embedding_with_orchestrator(
+            request=request,
+            embedding_request=mod.CreateEmbeddingRequest(
+                input="cancel endpoint",
+                model="sentence-transformers/all-MiniLM-L6-v2",
+            ),
+            current_user=_user(),
+            background_tasks=SimpleNamespace(),
+            x_provider="huggingface",
+            response=SimpleNamespace(headers={}),
+        )
+    )
+    try:
+        await asyncio.wait_for(execute_entered.wait(), timeout=1)
+        assert reservation_entered.is_set()
+        task.cancel("endpoint cancellation")
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        execute_release.set()
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    governor.commit.assert_awaited_once_with(
+        "cancel-handle",
+        actuals={"tokens": 3},
+        op_id="cancel-op",
+    )
+    assert active_requests.inc_count == 1
+    assert active_requests.dec_count == 1
+    assert len(fake_orchestrator.execute_calls) == 1
+    endpoint_executor.touch_resolved_credentials.assert_not_awaited()
+    assert success_metric.inc_calls == []
 
 
 def test_orchestrator_path_does_not_execute_or_commit_after_rg_denial(client, monkeypatch):

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
@@ -296,6 +296,52 @@ def _assert_response_parity(result):
     ]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["get", "set"])
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        pytest.param(
+            lambda: RuntimeError("cache dependency failed"),
+            id="unexpected",
+        ),
+        pytest.param(
+            lambda: EmbeddingExecutionError(
+                "internal_execution_failure",
+                "domain-shaped cache failure",
+                retryable=True,
+            ),
+            id="domain",
+        ),
+    ],
+)
+async def test_endpoint_cache_adapter_propagates_dependency_error_unchanged(
+    monkeypatch,
+    method_name,
+    error_factory,
+):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    original = error_factory()
+    dependency = AsyncMock(side_effect=original)
+    monkeypatch.setattr(mod.embedding_cache, method_name, dependency)
+    cache = mod._EndpointEmbeddingCache()
+
+    with pytest.raises(type(original)) as exc_info:
+        if method_name == "get":
+            await cache.get("cache-key")
+        else:
+            await cache.set("cache-key", [0.1, 0.2])
+
+    assert exc_info.value is original
+    if method_name == "get":
+        dependency.assert_awaited_once_with("cache-key")
+    else:
+        dependency.assert_awaited_once_with("cache-key", [0.1, 0.2])
+
+
 def _run_dual_path_embedding_request(
     client,
     monkeypatch,

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
@@ -990,7 +990,10 @@ def test_flag_true_calls_orchestrator_path(client, monkeypatch):
     assert orchestrator.await_count == 1
 
 
-def test_orchestrator_path_uses_inline_workflow_runner_and_preserves_rg_reservation(client, monkeypatch):
+def test_orchestrator_path_uses_inline_runner_and_prefers_total_token_actuals(
+    client,
+    monkeypatch,
+):
     from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanced as mod
 
     monkeypatch.setenv("EMBEDDINGS_ORCHESTRATOR_ENABLED", "true")
@@ -999,8 +1002,8 @@ def test_orchestrator_path_uses_inline_workflow_runner_and_preserves_rg_reservat
             vectors=[[0.25, 0.75]],
             provider="huggingface",
             model="sentence-transformers/all-MiniLM-L6-v2",
-            prompt_tokens=3,
-            total_tokens=3,
+            prompt_tokens=2,
+            total_tokens=5,
             cache_hits=0,
             cache_misses=1,
         )
@@ -1067,7 +1070,7 @@ def test_orchestrator_path_uses_inline_workflow_runner_and_preserves_rg_reservat
     ]
     rg_governor.commit.assert_awaited_once_with(
         "rg-handle",
-        actuals={"tokens": 3},
+        actuals={"tokens": 5},
         op_id="rg-op",
     )
     endpoint_executor.touch_resolved_credentials.assert_awaited_once_with(
@@ -1125,19 +1128,34 @@ def test_orchestrator_path_commits_reserved_units_after_execute_failure(client, 
     assert active_requests.dec_count == 1
 
 
-def test_orchestrator_zero_token_success_commits_reserved_unit(client, monkeypatch):
+@pytest.mark.parametrize(
+    ("prepared_tokens", "prompt_tokens", "reserved_tokens", "expected_actual"),
+    [
+        (2, 4, 2, 4),
+        (0, 0, 1, 1),
+    ],
+    ids=["prompt-token-fallback", "reserved-unit-fallback"],
+)
+def test_orchestrator_zero_total_commits_prompt_then_reserved_units(
+    client,
+    monkeypatch,
+    prepared_tokens,
+    prompt_tokens,
+    reserved_tokens,
+    expected_actual,
+):
     from tldw_Server_API.app.api.v1.endpoints import (
         embeddings_v5_production_enhanced as mod,
     )
 
     monkeypatch.setenv("EMBEDDINGS_ORCHESTRATOR_ENABLED", "true")
     fake_orchestrator = FakeOrchestrator(
-        prepared_total_tokens=0,
+        prepared_total_tokens=prepared_tokens,
         result=EmbeddingExecutionResult(
             vectors=[[0.25, 0.75]],
             provider="huggingface",
             model="sentence-transformers/all-MiniLM-L6-v2",
-            prompt_tokens=0,
+            prompt_tokens=prompt_tokens,
             total_tokens=0,
             cache_hits=0,
             cache_misses=1,
@@ -1160,8 +1178,8 @@ def test_orchestrator_zero_token_success_commits_reserved_unit(client, monkeypat
 
     async def reserve(*, request, current_user, token_total):
         del request, current_user
-        assert token_total == 1
-        return governor, "zero-handle", "zero-op", 1
+        assert token_total == reserved_tokens
+        return governor, "zero-handle", "zero-op", reserved_tokens
 
     monkeypatch.setattr(mod, "_reserve_embedding_rg_tokens", reserve)
 
@@ -1177,7 +1195,7 @@ def test_orchestrator_zero_token_success_commits_reserved_unit(client, monkeypat
     assert response.status_code == status.HTTP_200_OK
     governor.commit.assert_awaited_once_with(
         "zero-handle",
-        actuals={"tokens": 1},
+        actuals={"tokens": expected_actual},
         op_id="zero-op",
     )
     assert active_requests.inc_count == 1
@@ -1291,6 +1309,54 @@ async def test_orchestrator_cancellation_commits_reserved_units_and_decrements_a
     assert len(fake_orchestrator.execute_calls) == 1
     endpoint_executor.touch_resolved_credentials.assert_not_awaited()
     assert success_metric.inc_calls == []
+
+
+def test_orchestrator_path_counts_active_request_during_backpressure_rejection(
+    client,
+    monkeypatch,
+):
+    from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanced as mod
+
+    monkeypatch.setenv("EMBEDDINGS_ORCHESTRATOR_ENABLED", "true")
+    active_requests = _RecordingGauge()
+    build_orchestrator = Mock(
+        side_effect=AssertionError("orchestrator should not be built after backpressure rejection")
+    )
+    monkeypatch.setattr(mod, "active_embedding_requests", active_requests)
+    monkeypatch.setattr(
+        mod,
+        "_build_embedding_request_orchestrator",
+        build_orchestrator,
+    )
+
+    async def reject_for_backpressure(*_args, **_kwargs):
+        assert active_requests.inc_count == 1
+        assert active_requests.dec_count == 0
+        return HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Backpressure: queue overload",
+        )
+
+    monkeypatch.setattr(
+        mod,
+        "_check_backpressure_and_quotas",
+        reject_for_backpressure,
+    )
+
+    response = client.post(
+        "/api/v1/embeddings",
+        headers={"x-provider": "huggingface"},
+        json={
+            "model": "sentence-transformers/all-MiniLM-L6-v2",
+            "input": "workflow backpressure",
+        },
+    )
+
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert response.json()["detail"] == "Backpressure: queue overload"
+    assert active_requests.inc_count == 1
+    assert active_requests.dec_count == 1
+    build_orchestrator.assert_not_called()
 
 
 def test_orchestrator_path_does_not_execute_or_commit_after_rg_denial(client, monkeypatch):

--- a/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -683,24 +683,11 @@ async def test_fallback_complete_result_is_validated_before_first_cache_write(
     )
     real_validate = orchestrator_module.validated_embedding_vectors
     validation_calls: list[tuple[object, int, object]] = []
-    cache_key_calls: list[tuple[str, str, str, int | None, str | None]] = []
 
     def validation_probe(vectors: object, *, expected: int):
         validated = real_validate(vectors, expected=expected)
         validation_calls.append((vectors, expected, validated))
         return validated
-
-    def cache_key_probe(
-        text: str,
-        provider: str,
-        model: str,
-        dimensions: int | None,
-        backend_identity: str | None,
-    ) -> str:
-        cache_key_calls.append(
-            (text, provider, model, dimensions, backend_identity)
-        )
-        return _cache_key(text, provider, model, dimensions, backend_identity)
 
     monkeypatch.setattr(
         orchestrator_module,
@@ -710,7 +697,6 @@ async def test_fallback_complete_result_is_validated_before_first_cache_write(
     orchestrator = _orchestrator(
         cache=cache,
         executor=executor,
-        cache_key_fn=cache_key_probe,
         settings_fallback_chain={"openai": ["huggingface"]},
         settings_fallback_model_map={
             "openai:text-embedding-3-small": {
@@ -759,43 +745,6 @@ async def test_fallback_complete_result_is_validated_before_first_cache_write(
         ([[0.1, 0.2]], 1, [[0.1, 0.2]]),
         ([[0.3, 0.4, 0.5]], 1, [[0.3, 0.4, 0.5]]),
         ([[0.1, 0.2], [0.3, 0.4, 0.5]], 2, None),
-    ]
-    assert cache_key_calls == [
-        (
-            "one",
-            "openai",
-            "text-embedding-3-small",
-            None,
-            "openai:text-embedding-3-small:backend",
-        ),
-        (
-            "two",
-            "openai",
-            "text-embedding-3-small",
-            None,
-            "openai:text-embedding-3-small:backend",
-        ),
-        (
-            "one",
-            "huggingface",
-            "sentence-transformers/all-MiniLM-L6-v2",
-            None,
-            "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend",
-        ),
-        (
-            "two",
-            "huggingface",
-            "sentence-transformers/all-MiniLM-L6-v2",
-            None,
-            "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend",
-        ),
-        (
-            "two",
-            "huggingface",
-            "sentence-transformers/all-MiniLM-L6-v2",
-            None,
-            "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend",
-        ),
     ]
     assert cache.set_calls == []
 
@@ -1226,54 +1175,52 @@ async def test_retryable_fallback_preflight_failure_continues_to_next_candidate(
         ("cohere", "embed-english-v3.0"),
         ("huggingface", "sentence-transformers/all-MiniLM-L6-v2"),
     ]
-    assert events == [
-        ("preflight", "openai", "text-embedding-3-small"),
-        ("identity", "openai", "text-embedding-3-small"),
-        ("cache_key", "openai", "text-embedding-3-small"),
-        ("cache_get", "openai", "text-embedding-3-small"),
-        ("executor", "openai", "text-embedding-3-small"),
-        ("executor_error", "openai", "text-embedding-3-small"),
-        ("preflight", "cohere", "embed-english-v3.0"),
-        ("preflight_error", "cohere", "embed-english-v3.0"),
-        (
-            "preflight",
-            "huggingface",
-            "sentence-transformers/all-MiniLM-L6-v2",
-        ),
-        (
-            "identity",
-            "huggingface",
-            "sentence-transformers/all-MiniLM-L6-v2",
-        ),
-        (
-            "cache_key",
-            "huggingface",
-            "sentence-transformers/all-MiniLM-L6-v2",
-        ),
-        (
-            "cache_get",
-            "huggingface",
-            "sentence-transformers/all-MiniLM-L6-v2",
-        ),
-        (
-            "executor",
-            "huggingface",
-            "sentence-transformers/all-MiniLM-L6-v2",
-        ),
-        (
-            "cache_key",
-            "huggingface",
-            "sentence-transformers/all-MiniLM-L6-v2",
-        ),
-        (
-            "cache_set",
-            "huggingface",
-            "sentence-transformers/all-MiniLM-L6-v2",
-        ),
-    ]
+    primary = ("openai", "text-embedding-3-small")
+    cohere = ("cohere", "embed-english-v3.0")
+    fallback = ("huggingface", "sentence-transformers/all-MiniLM-L6-v2")
+
+    def event_index(action: str, provider_model: tuple[str, str]) -> int:
+        provider, model = provider_model
+        return events.index((action, provider, model))
+
+    primary_preflight = event_index("preflight", primary)
+    primary_identity = event_index("identity", primary)
+    primary_cache_key = event_index("cache_key", primary)
+    primary_cache_get = event_index("cache_get", primary)
+    primary_executor = event_index("executor", primary)
+    primary_executor_error = event_index("executor_error", primary)
+    assert (
+        primary_preflight
+        < primary_identity
+        < primary_cache_key
+        < primary_cache_get
+        < primary_executor
+        < primary_executor_error
+    )
+
+    cohere_preflight = event_index("preflight", cohere)
+    cohere_preflight_error = event_index("preflight_error", cohere)
+    assert primary_executor_error < cohere_preflight < cohere_preflight_error
     assert not any(
-        action in {"cache_get", "cache_set"} and provider == "cohere"
+        action in {"identity", "cache_key", "cache_get", "cache_set", "executor"}
+        and provider == cohere[0]
         for action, provider, _ in events
+    )
+
+    fallback_preflight = event_index("preflight", fallback)
+    fallback_identity = event_index("identity", fallback)
+    fallback_cache_key = event_index("cache_key", fallback)
+    fallback_cache_get = event_index("cache_get", fallback)
+    fallback_executor = event_index("executor", fallback)
+    fallback_cache_set = event_index("cache_set", fallback)
+    assert (
+        cohere_preflight_error
+        < fallback_preflight
+        < fallback_identity
+        < fallback_cache_key
+        < fallback_cache_get
+        < fallback_executor
+        < fallback_cache_set
     )
     assert [call["provider"] for call in executor.calls] == [
         "openai",

--- a/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -492,6 +492,53 @@ async def test_dimension_policy_is_applied_to_provider_native_cache_hits_per_req
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_successful_adapter_reports_compatibility_cache_counts_and_bypasses_provider():
+    cache = RecordingCache()
+    preflight_calls: list[tuple[str, str]] = []
+
+    async def provider_preflight(provider: str, model: str) -> None:
+        preflight_calls.append((provider, model))
+
+    executor = AdapterAwareExecutor(
+        vectors=[[9.0, 9.0]],
+        adapter_output=EmbeddingExecutorOutput(
+            vectors=[[0.1, 0.2], [0.3, 0.4]],
+            embeddings_from_adapter=True,
+        ),
+    )
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        execution_path="adapter",
+        provider_preflight=provider_preflight,
+    )
+    prepared = orchestrator.prepare(
+        ["one", "two"],
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    result = await orchestrator.execute(prepared)
+
+    assert result.vectors == [[0.1, 0.2], [0.3, 0.4]]
+    assert result.embeddings_from_adapter is True
+    assert result.cache_hits == 0
+    assert result.cache_misses == 2
+    assert executor.adapter_calls == [
+        {
+            "texts": ["one", "two"],
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dimensions": None,
+        }
+    ]
+    assert preflight_calls == []
+    assert cache.get_keys == []
+    assert cache.set_calls == []
+    assert executor.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_adapter_preferred_path_uses_provider_cache_when_adapter_returns_no_vectors():
     cache = RecordingCache(
         {
@@ -588,6 +635,7 @@ async def test_fallback_execution_maps_model_and_returns_fallback_headers():
 
     result = await orchestrator.execute(prepared)
 
+    assert prepared.execution_plan.fallback_chain == ["openai", "huggingface"]
     assert executor.calls == [
         {
             "texts": ["fallback mapping"],
@@ -602,11 +650,154 @@ async def test_fallback_execution_maps_model_and_returns_fallback_headers():
             "dimensions": None,
         },
     ]
+    assert [call["provider"] for call in executor.calls].count("openai") == 1
     assert result.provider == "huggingface"
     assert result.model == "sentence-transformers/all-MiniLM-L6-v2"
     assert result.fallback_from == "openai"
     assert result.response_headers["X-Embeddings-Provider"] == "huggingface"
     assert result.response_headers["X-Embeddings-Fallback-From"] == "openai"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_complete_result_is_validated_before_first_cache_write(
+    monkeypatch,
+):
+    primary_error = EmbeddingProviderError(
+        "provider_unavailable",
+        "primary unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+    fallback_hit_key = (
+        "one|huggingface|sentence-transformers/all-MiniLM-L6-v2|"
+        "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend"
+    )
+    cache = RecordingCache({fallback_hit_key: [0.1, 0.2]})
+    executor = RecordingExecutor(
+        failures={"openai": primary_error},
+        provider_vectors={
+            "huggingface": [[0.3, 0.4, 0.5]],
+        },
+    )
+    real_validate = orchestrator_module.validated_embedding_vectors
+    validation_calls: list[tuple[object, int, object]] = []
+    cache_key_calls: list[tuple[str, str, str, int | None, str | None]] = []
+
+    def validation_probe(vectors: object, *, expected: int):
+        validated = real_validate(vectors, expected=expected)
+        validation_calls.append((vectors, expected, validated))
+        return validated
+
+    def cache_key_probe(
+        text: str,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+        backend_identity: str | None,
+    ) -> str:
+        cache_key_calls.append(
+            (text, provider, model, dimensions, backend_identity)
+        )
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "validated_embedding_vectors",
+        validation_probe,
+    )
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        cache_key_fn=cache_key_probe,
+        settings_fallback_chain={"openai": ["huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        ["one", "two"],
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        await orchestrator.execute(prepared)
+
+    assert exc_info.value.code == "provider_malformed_response"
+    assert exc_info.value.message == (
+        "Embedding provider returned malformed embedding vectors"
+    )
+    assert exc_info.value.provider == "huggingface"
+    assert exc_info.value.model == "sentence-transformers/all-MiniLM-L6-v2"
+    assert executor.calls == [
+        {
+            "texts": ["one", "two"],
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dimensions": None,
+        },
+        {
+            "texts": ["two"],
+            "provider": "huggingface",
+            "model": "sentence-transformers/all-MiniLM-L6-v2",
+            "dimensions": None,
+        },
+    ]
+    assert cache.get_keys == [
+        "one|openai|text-embedding-3-small|openai:text-embedding-3-small:backend",
+        "two|openai|text-embedding-3-small|openai:text-embedding-3-small:backend",
+        fallback_hit_key,
+        (
+            "two|huggingface|sentence-transformers/all-MiniLM-L6-v2|"
+            "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend"
+        ),
+    ]
+    assert validation_calls == [
+        ([[0.1, 0.2]], 1, [[0.1, 0.2]]),
+        ([[0.3, 0.4, 0.5]], 1, [[0.3, 0.4, 0.5]]),
+        ([[0.1, 0.2], [0.3, 0.4, 0.5]], 2, None),
+    ]
+    assert cache_key_calls == [
+        (
+            "one",
+            "openai",
+            "text-embedding-3-small",
+            None,
+            "openai:text-embedding-3-small:backend",
+        ),
+        (
+            "two",
+            "openai",
+            "text-embedding-3-small",
+            None,
+            "openai:text-embedding-3-small:backend",
+        ),
+        (
+            "one",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+            None,
+            "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend",
+        ),
+        (
+            "two",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+            None,
+            "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend",
+        ),
+        (
+            "two",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+            None,
+            "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend",
+        ),
+    ]
+    assert cache.set_calls == []
 
 
 @pytest.mark.unit
@@ -1428,6 +1619,49 @@ async def test_base64_requested_dimensions_force_reduce_even_when_configured_pol
     assert result.vectors == [[0.25, 0.75]]
     assert cache.set_calls[0][1] == [0.25, 0.75, 0.5]
     assert result.response_headers["X-Embeddings-Dimensions-Policy"] == "reduce"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cached_values",
+    [
+        pytest.param((), id="empty"),
+        pytest.param(("not-a-number",), id="nonnumeric"),
+        pytest.param((float("nan"), 0.0), id="nan"),
+        pytest.param((float("inf"), 0.0), id="infinite"),
+    ],
+)
+async def test_malformed_cached_vector_becomes_miss_and_is_replaced(
+    cached_values: tuple[object, ...],
+):
+    cache_key = (
+        "replace|huggingface|sentence-transformers/all-MiniLM-L6-v2|"
+        "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend"
+    )
+    cache = RecordingCache(
+        {cache_key: list(cached_values)}  # type: ignore[dict-item]
+    )
+    executor = RecordingExecutor(vectors=[[0.25, 0.75]])
+    orchestrator = _orchestrator(cache=cache, executor=executor)
+    prepared = orchestrator.prepare("replace", _context())
+
+    result = await orchestrator.execute(prepared)
+
+    assert result.vectors == [[0.25, 0.75]]
+    assert result.cache_hits == 0
+    assert result.cache_misses == 1
+    assert cache.get_keys == [cache_key]
+    assert executor.calls == [
+        {
+            "texts": ["replace"],
+            "provider": "huggingface",
+            "model": "sentence-transformers/all-MiniLM-L6-v2",
+            "dimensions": None,
+        }
+    ]
+    assert cache.set_calls == [(cache_key, [0.25, 0.75])]
+    assert cache.values[cache_key] == [0.25, 0.75]
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -660,9 +660,7 @@ async def test_fallback_execution_maps_model_and_returns_fallback_headers():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_fallback_complete_result_is_validated_before_first_cache_write(
-    monkeypatch,
-):
+async def test_fallback_complete_result_is_validated_before_first_cache_write():
     primary_error = EmbeddingProviderError(
         "provider_unavailable",
         "primary unavailable",
@@ -680,19 +678,6 @@ async def test_fallback_complete_result_is_validated_before_first_cache_write(
         provider_vectors={
             "huggingface": [[0.3, 0.4, 0.5]],
         },
-    )
-    real_validate = orchestrator_module.validated_embedding_vectors
-    validation_calls: list[tuple[object, int, object]] = []
-
-    def validation_probe(vectors: object, *, expected: int):
-        validated = real_validate(vectors, expected=expected)
-        validation_calls.append((vectors, expected, validated))
-        return validated
-
-    monkeypatch.setattr(
-        orchestrator_module,
-        "validated_embedding_vectors",
-        validation_probe,
     )
     orchestrator = _orchestrator(
         cache=cache,
@@ -740,11 +725,6 @@ async def test_fallback_complete_result_is_validated_before_first_cache_write(
             "two|huggingface|sentence-transformers/all-MiniLM-L6-v2|"
             "huggingface:sentence-transformers/all-MiniLM-L6-v2:backend"
         ),
-    ]
-    assert validation_calls == [
-        ([[0.1, 0.2]], 1, [[0.1, 0.2]]),
-        ([[0.3, 0.4, 0.5]], 1, [[0.3, 0.4, 0.5]]),
-        ([[0.1, 0.2], [0.3, 0.4, 0.5]], 2, None),
     ]
     assert cache.set_calls == []
 

--- a/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -4,6 +4,7 @@ import asyncio
 
 import pytest
 
+from tldw_Server_API.app.core.Embeddings import orchestrator as orchestrator_module
 from tldw_Server_API.app.core.Embeddings.orchestrator import (
     EmbeddingExecutionResult,
     EmbeddingExecutorOutput,
@@ -154,21 +155,29 @@ def _orchestrator(
     *,
     cache: RecordingCache | None = None,
     executor: RecordingExecutor | None = None,
+    cache_key_fn=None,
     settings_fallback_chain: dict[str, object] | None = None,
     settings_fallback_model_map: dict[str, object] | None = None,
     dimension_policy: str = "reduce",
+    backend_identity_resolver=None,
     provider_preflight=None,
     execution_path: str = "legacy",
 ) -> EmbeddingRequestOrchestrator:
     return EmbeddingRequestOrchestrator(
         count_tokens=_count_tokens,
         tokens_to_texts=_tokens_to_texts,
-        cache_key_fn=_cache_key,
+        cache_key_fn=_cache_key if cache_key_fn is None else cache_key_fn,
         cache=cache or RecordingCache(),
         executor=executor or RecordingExecutor(),
         settings_config={},
         max_tokens=100,
-        implemented_providers={"openai", "huggingface", "onnx", "local_api"},
+        implemented_providers={
+            "openai",
+            "cohere",
+            "huggingface",
+            "onnx",
+            "local_api",
+        },
         allowed_providers=None,
         allowed_models=None,
         enforce_policy=True,
@@ -176,7 +185,11 @@ def _orchestrator(
         settings_fallback_chain=settings_fallback_chain,
         settings_fallback_model_map=settings_fallback_model_map,
         dimension_policy=dimension_policy,
-        backend_identity_resolver=lambda provider, model: f"{provider}:{model}:backend",
+        backend_identity_resolver=(
+            backend_identity_resolver
+            if backend_identity_resolver is not None
+            else lambda provider, model: f"{provider}:{model}:backend"
+        ),
         provider_preflight=provider_preflight,
         execution_path=execution_path,  # type: ignore[arg-type]
     )
@@ -199,6 +212,58 @@ def test_prepare_normalizes_input_and_returns_token_totals_without_execution():
     assert cache.get_keys == []
     assert cache.set_calls == []
     assert executor.calls == []
+
+
+@pytest.mark.unit
+def test_prepare_orders_intent_normalization_policy_and_plan_identity(monkeypatch):
+    calls: list[str] = []
+    real_resolve_provider_model = orchestrator_module.resolve_provider_model
+    real_normalize_embedding_input = orchestrator_module.normalize_embedding_input
+    real_enforce_embedding_policy = orchestrator_module.enforce_embedding_policy
+
+    def resolve_provider_model_probe(*args, **kwargs):
+        calls.append("resolve_intent")
+        return real_resolve_provider_model(*args, **kwargs)
+
+    def normalize_embedding_input_probe(*args, **kwargs):
+        calls.append("normalize")
+        return real_normalize_embedding_input(*args, **kwargs)
+
+    def enforce_embedding_policy_probe(*args, **kwargs):
+        calls.append("resolve_policy")
+        return real_enforce_embedding_policy(*args, **kwargs)
+
+    def backend_identity_probe(provider: str, model: str) -> str:
+        calls.append("plan_identity")
+        return f"{provider}:{model}:backend"
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "resolve_provider_model",
+        resolve_provider_model_probe,
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "normalize_embedding_input",
+        normalize_embedding_input_probe,
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "enforce_embedding_policy",
+        enforce_embedding_policy_probe,
+    )
+    orchestrator = _orchestrator(
+        backend_identity_resolver=backend_identity_probe,
+    )
+
+    orchestrator.prepare("ordered preparation", _context())
+
+    assert calls == [
+        "resolve_intent",
+        "normalize",
+        "resolve_policy",
+        "plan_identity",
+    ]
 
 
 @pytest.mark.unit
@@ -581,6 +646,74 @@ async def test_fallback_execution_uses_retryable_execution_failures():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_primary_preflight_failure_propagates_without_cache_or_fallback():
+    preflight_error = EmbeddingExecutionError(
+        "circuit_breaker_open",
+        "openai circuit open",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+    preflight_calls: list[tuple[str, str]] = []
+    backend_identity_calls: list[tuple[str, str]] = []
+    cache_key_calls: list[tuple[str, str, str, int | None, str | None]] = []
+    cache = RecordingCache()
+    executor = RecordingExecutor(provider_vectors={"huggingface": [[0.5, 0.25]]})
+
+    async def provider_preflight(provider: str, model: str) -> None:
+        preflight_calls.append((provider, model))
+        raise preflight_error
+
+    def backend_identity_resolver(provider: str, model: str) -> str:
+        backend_identity_calls.append((provider, model))
+        return f"{provider}:{model}:backend"
+
+    def cache_key_probe(
+        text: str,
+        provider: str,
+        model: str,
+        dimensions: int | None = None,
+        backend_identity: str | None = None,
+    ) -> str:
+        cache_key_calls.append(
+            (text, provider, model, dimensions, backend_identity)
+        )
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        cache_key_fn=cache_key_probe,
+        backend_identity_resolver=backend_identity_resolver,
+        provider_preflight=provider_preflight,
+        settings_fallback_chain={"openai": ["huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "huggingface": "sentence-transformers/all-MiniLM-L6-v2"
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        "preflight failure",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+    assert backend_identity_calls == [("openai", "text-embedding-3-small")]
+    backend_identity_calls.clear()
+
+    with pytest.raises(EmbeddingExecutionError) as exc_info:
+        await orchestrator.execute(prepared)
+
+    assert exc_info.value is preflight_error
+    assert preflight_calls == [("openai", "text-embedding-3-small")]
+    assert backend_identity_calls == []
+    assert cache_key_calls == []
+    assert cache.get_keys == []
+    assert cache.set_calls == []
+    assert executor.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_fallback_full_cache_hit_skips_fallback_executor_and_sets_adapter_origin():
     cache = RecordingCache(
         {
@@ -692,6 +825,169 @@ async def test_missing_credentials_for_non_requested_fallback_provider_is_skippe
             "model": "sentence-transformers/all-MiniLM-L6-v2",
             "dimensions": None,
         },
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_retryable_fallback_preflight_failure_continues_to_next_candidate():
+    openai_failure = EmbeddingProviderError(
+        "provider_unavailable",
+        "openai unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+    events: list[tuple[str, str, str]] = []
+    preflight_calls: list[tuple[str, str]] = []
+
+    class EventRecordingCache(RecordingCache):
+        async def get(self, key: str) -> list[float] | None:
+            _, provider, model, _ = key.split("|", maxsplit=3)
+            events.append(("cache_get", provider, model))
+            return await super().get(key)
+
+        async def set(self, key: str, value: list[float]) -> object:
+            _, provider, model, _ = key.split("|", maxsplit=3)
+            events.append(("cache_set", provider, model))
+            return await super().set(key, value)
+
+    class EventRecordingExecutor(RecordingExecutor):
+        async def create(
+            self,
+            texts: list[str],
+            *,
+            provider: str,
+            model: str,
+            dimensions: int | None,
+        ) -> list[list[float]]:
+            events.append(("executor", provider, model))
+            try:
+                return await super().create(
+                    texts,
+                    provider=provider,
+                    model=model,
+                    dimensions=dimensions,
+                )
+            except EmbeddingProviderError:
+                events.append(("executor_error", provider, model))
+                raise
+
+    cache = EventRecordingCache()
+    executor = EventRecordingExecutor(
+        failures={"openai": openai_failure},
+        provider_vectors={"huggingface": [[0.5, 0.25]]},
+    )
+
+    async def provider_preflight(provider: str, model: str) -> None:
+        preflight_calls.append((provider, model))
+        events.append(("preflight", provider, model))
+        if provider == "cohere":
+            events.append(("preflight_error", provider, model))
+            raise EmbeddingExecutionError(
+                "circuit_breaker_open",
+                "cohere circuit open",
+                provider=provider,
+                model=model,
+                retryable=True,
+            )
+
+    def backend_identity_resolver(provider: str, model: str) -> str:
+        events.append(("identity", provider, model))
+        return f"{provider}:{model}:backend"
+
+    def cache_key_probe(
+        text: str,
+        provider: str,
+        model: str,
+        dimensions: int | None = None,
+        backend_identity: str | None = None,
+    ) -> str:
+        events.append(("cache_key", provider, model))
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        cache_key_fn=cache_key_probe,
+        backend_identity_resolver=backend_identity_resolver,
+        provider_preflight=provider_preflight,
+        settings_fallback_chain={"openai": ["cohere", "huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "cohere": "embed-english-v3.0",
+                "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        "fallback after circuit breaker",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+    assert events == [("identity", "openai", "text-embedding-3-small")]
+    events.clear()
+
+    result = await orchestrator.execute(prepared)
+
+    assert result.provider == "huggingface"
+    assert result.vectors == [[0.5, 0.25]]
+    assert preflight_calls == [
+        ("openai", "text-embedding-3-small"),
+        ("cohere", "embed-english-v3.0"),
+        ("huggingface", "sentence-transformers/all-MiniLM-L6-v2"),
+    ]
+    assert events == [
+        ("preflight", "openai", "text-embedding-3-small"),
+        ("identity", "openai", "text-embedding-3-small"),
+        ("cache_key", "openai", "text-embedding-3-small"),
+        ("cache_get", "openai", "text-embedding-3-small"),
+        ("executor", "openai", "text-embedding-3-small"),
+        ("executor_error", "openai", "text-embedding-3-small"),
+        ("preflight", "cohere", "embed-english-v3.0"),
+        ("preflight_error", "cohere", "embed-english-v3.0"),
+        (
+            "preflight",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ),
+        (
+            "identity",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ),
+        (
+            "cache_key",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ),
+        (
+            "cache_get",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ),
+        (
+            "executor",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ),
+        (
+            "cache_key",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ),
+        (
+            "cache_set",
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ),
+    ]
+    assert not any(
+        action in {"cache_get", "cache_set"} and provider == "cohere"
+        for action, provider, _ in events
+    )
+    assert [call["provider"] for call in executor.calls] == [
+        "openai",
+        "huggingface",
     ]
 
 

--- a/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -714,6 +714,105 @@ async def test_primary_preflight_failure_propagates_without_cache_or_fallback():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "boundary",
+    ["backend_identity", "cache_key", "cache_get"],
+)
+async def test_primary_runtime_infrastructure_failure_propagates_without_fallback(
+    boundary,
+):
+    original = RuntimeError(f"{boundary} failed")
+    events: list[tuple[str, str, str]] = []
+    raised_errors: list[RuntimeError] = []
+    identity_calls = 0
+
+    def raise_original(provider: str, model: str) -> None:
+        events.append((f"raise_{boundary}", provider, model))
+        raised_errors.append(original)
+        raise original
+
+    def identity_resolver(provider: str, model: str) -> str:
+        nonlocal identity_calls
+        identity_calls += 1
+        events.append(("backend_identity", provider, model))
+        if boundary == "backend_identity" and identity_calls > 1:
+            raise_original(provider, model)
+        return f"{provider}:{model}:backend"
+
+    def cache_key_fn(
+        text: str,
+        provider: str,
+        model: str,
+        dimensions: int | None = None,
+        backend_identity: str | None = None,
+    ) -> str:
+        events.append(("cache_key", provider, model))
+        if boundary == "cache_key":
+            raise_original(provider, model)
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    class FailingGetCache(RecordingCache):
+        async def get(self, key: str) -> list[float] | None:
+            _, provider, model, _ = key.split("|", maxsplit=3)
+            events.append(("cache_get", provider, model))
+            if boundary == "cache_get":
+                raise_original(provider, model)
+            return await super().get(key)
+
+    cache = FailingGetCache()
+    executor = RecordingExecutor(
+        provider_vectors={"huggingface": [[0.5, 0.25]]},
+    )
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        cache_key_fn=cache_key_fn,
+        backend_identity_resolver=identity_resolver,
+        settings_fallback_chain={"openai": ["huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "huggingface": "sentence-transformers/all-MiniLM-L6-v2"
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        "primary infrastructure failure",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+    assert events == [
+        ("backend_identity", "openai", "text-embedding-3-small"),
+    ]
+    events.clear()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await orchestrator.execute(prepared)
+
+    expected_events = {
+        "backend_identity": [
+            ("backend_identity", "openai", "text-embedding-3-small"),
+            ("raise_backend_identity", "openai", "text-embedding-3-small"),
+        ],
+        "cache_key": [
+            ("backend_identity", "openai", "text-embedding-3-small"),
+            ("cache_key", "openai", "text-embedding-3-small"),
+            ("raise_cache_key", "openai", "text-embedding-3-small"),
+        ],
+        "cache_get": [
+            ("backend_identity", "openai", "text-embedding-3-small"),
+            ("cache_key", "openai", "text-embedding-3-small"),
+            ("cache_get", "openai", "text-embedding-3-small"),
+            ("raise_cache_get", "openai", "text-embedding-3-small"),
+        ],
+    }
+    assert exc_info.value is original
+    assert raised_errors == [original]
+    assert events == expected_events[boundary]
+    assert executor.calls == []
+    assert cache.set_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_fallback_full_cache_hit_skips_fallback_executor_and_sets_adapter_origin():
     cache = RecordingCache(
         {
@@ -989,6 +1088,154 @@ async def test_retryable_fallback_preflight_failure_continues_to_next_candidate(
         "openai",
         "huggingface",
     ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "boundary",
+    ["backend_identity", "cache_key", "cache_get", "cache_set"],
+)
+async def test_current_fallback_wide_domain_catch_advances_after_infrastructure_failure(
+    boundary,
+):
+    """Pin current behavior that Stage 2D will intentionally correct."""
+    cohere_model = "embed-english-v3.0"
+    original = EmbeddingExecutionError(
+        "internal_execution_failure",
+        f"{boundary} failed",
+        provider="cohere",
+        model=cohere_model,
+        retryable=True,
+    )
+    primary_error = EmbeddingProviderError(
+        "provider_unavailable",
+        "primary unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+    events: list[tuple[str, str, str]] = []
+    raised_errors: list[EmbeddingExecutionError] = []
+
+    def raise_original(provider: str, model: str) -> None:
+        events.append((f"raise_{boundary}", provider, model))
+        raised_errors.append(original)
+        raise original
+
+    async def provider_preflight(provider: str, model: str) -> None:
+        events.append(("candidate", provider, model))
+
+    def identity_resolver(provider: str, model: str) -> str:
+        events.append(("backend_identity", provider, model))
+        if boundary == "backend_identity" and provider == "cohere":
+            raise_original(provider, model)
+        return f"{provider}:{model}:backend"
+
+    def cache_key_fn(
+        text: str,
+        provider: str,
+        model: str,
+        dimensions: int | None = None,
+        backend_identity: str | None = None,
+    ) -> str:
+        events.append(("cache_key", provider, model))
+        if boundary == "cache_key" and provider == "cohere":
+            raise_original(provider, model)
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    class BoundaryCache(RecordingCache):
+        async def get(self, key: str) -> list[float] | None:
+            _, provider, model, _ = key.split("|", maxsplit=3)
+            events.append(("cache_get", provider, model))
+            self.get_keys.append(key)
+            if boundary == "cache_get" and provider == "cohere":
+                raise_original(provider, model)
+            return self.values.get(key)
+
+        async def set(self, key: str, value: list[float]) -> object:
+            _, provider, model, _ = key.split("|", maxsplit=3)
+            events.append(("cache_set", provider, model))
+            if boundary == "cache_set" and provider == "cohere":
+                raise_original(provider, model)
+            return await super().set(key, value)
+
+    class EventRecordingExecutor(RecordingExecutor):
+        async def create(
+            self,
+            texts: list[str],
+            *,
+            provider: str,
+            model: str,
+            dimensions: int | None,
+        ) -> list[list[float]]:
+            events.append(("executor", provider, model))
+            return await super().create(
+                texts,
+                provider=provider,
+                model=model,
+                dimensions=dimensions,
+            )
+
+    cache = BoundaryCache()
+    executor = EventRecordingExecutor(
+        failures={"openai": primary_error},
+        provider_vectors={
+            "cohere": [[0.4, 0.6]],
+            "huggingface": [[0.5, 0.25]],
+        },
+    )
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        cache_key_fn=cache_key_fn,
+        backend_identity_resolver=identity_resolver,
+        provider_preflight=provider_preflight,
+        settings_fallback_chain={"openai": ["cohere", "huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "cohere": cohere_model,
+                "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        "fallback infrastructure failure",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+    assert events == [
+        ("backend_identity", "openai", "text-embedding-3-small"),
+    ]
+    events.clear()
+
+    result = await orchestrator.execute(prepared)
+
+    expected_executor_providers = (
+        ["openai", "cohere", "huggingface"]
+        if boundary == "cache_set"
+        else ["openai", "huggingface"]
+    )
+    assert result.provider == "huggingface"
+    assert result.vectors == [[0.5, 0.25]]
+    assert result.fallback_from == "openai"
+    assert [
+        provider
+        for action, provider, _ in events
+        if action == "candidate"
+    ] == ["openai", "cohere", "huggingface"]
+    assert [call["provider"] for call in executor.calls] == expected_executor_providers
+    assert [call["provider"] for call in executor.calls].count("openai") == 1
+    assert [
+        event
+        for event in events
+        if event == (boundary, "cohere", cohere_model)
+    ] == [(boundary, "cohere", cohere_model)]
+    assert [
+        event
+        for event in events
+        if event == (f"raise_{boundary}", "cohere", cohere_model)
+    ] == [(f"raise_{boundary}", "cohere", cohere_model)]
+    assert raised_errors == [original]
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -15,7 +16,6 @@ from tldw_Server_API.app.core.Embeddings.workflow_types import (
     EmbeddingInMemoryWorkflowTraceCollector,
     EmbeddingNoopWorkflowTraceCollector,
 )
-
 
 pytestmark = pytest.mark.unit
 
@@ -141,6 +141,15 @@ async def test_runner_returns_orchestrator_result_and_records_safe_success_event
         "executing",
         "executing",
         "finalizing",
+    ]
+    assert [event.status for event in collector.events] == [
+        "running",
+        "running",
+        "running",
+        "running",
+        "running",
+        "running",
+        "completed",
     ]
     workflow_ids = {event.workflow_id for event in collector.events}
     assert len(workflow_ids) == 1
@@ -300,6 +309,37 @@ async def test_unexpected_exceptions_trace_failure_kind_and_phase_only_then_rera
     }
     assert "sk-secret" not in repr(collector.events)
     assert "raw provider body" not in repr(collector.events)
+
+
+@pytest.mark.asyncio
+async def test_execute_cancellation_propagates_without_terminal_trace_event():
+    cancellation = asyncio.CancelledError("cancelled")
+    orchestrator = FakeOrchestrator(execute_error=cancellation)
+    collector = EmbeddingInMemoryWorkflowTraceCollector()
+    runner = EmbeddingInlineWorkflowRunner(orchestrator, trace_collector=collector)
+
+    with pytest.raises(asyncio.CancelledError) as exc_info:
+        await runner.run(["one", "two"], _request_context())
+
+    assert exc_info.value is cancellation
+    assert len(orchestrator.prepare_calls) == 1
+    assert len(orchestrator.execute_calls) == 1
+    assert [event.event_type for event in collector.events] == [
+        "workflow_started",
+        "phase_changed",
+        "phase_changed",
+        "prepare_completed",
+        "phase_changed",
+    ]
+    assert [event.phase for event in collector.events] == [
+        "created",
+        "normalizing",
+        "planning",
+        "planning",
+        "executing",
+    ]
+    assert collector.events[-1].phase == "executing"
+    assert all(event.event_type not in {"workflow_failed", "workflow_completed"} for event in collector.events)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change summary

**Human-authored summary required before merge.** Please describe what changed and why these implementation choices were made in your own words.

## Review scope

- Characterizes Embeddings preparation, provider readiness, cache and fallback failure boundaries.
- Pins endpoint reservation, cancellation, credential-touch, and active-request accounting behavior.
- Keeps the approved Stage 2C identity correction possible by avoiding brittle call-count assertions.
- Updates the Stage 2 design and Backlog tracking; no production execution code changes.

## Validation

- 188/188 touched-module tests passed.
- 176/176 Embeddings isolated tests passed.
- 11/11 explicit credential/cache cases passed.
- Ruff passed.
- Bandit reported zero findings with test assertion rule B101 excluded.
- The branch was rebased and verified on origin/dev at 76481b2939.

## Tracking

- TASK-12973.1
- Stage 2A characterization and contracts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds behavior-first tests and docs to lock down Embeddings Stage 2A workflow contracts: preparation→readiness order, adapter/cache validation, cache↔fallback boundaries, failure-source precedence, inline-runner cancellation, endpoint reservation/cancellation and credential-touch, and active-request accounting. No production code changes; adds the Stage 2 concrete steps spec and a Stage 2A implementation plan, hardens the state model with a resolving_intent phase, and updates the Stage 2 backlog (TASK-12973, TASK-12973.1).

<sup>Written for commit 69097a4b726562dafe0839b216f333d77af08ea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


