### PR TITLE
refactor(embeddings): extract provider execution attempts

### DIFF
--- a/Docs/superpowers/plans/2026-07-26-embeddings-workflow-stage2b-contracts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-26-embeddings-workflow-stage2b-contracts-implementation-plan.md
@@ -710,7 +710,7 @@ Expected: no endpoint diff; the mapper deferral and removal stage are explicit; 
 
 Review the complete `origin/dev...HEAD` diff for behavior drift, DTO mutability, import cycles, phase/error precedence, accidental endpoint wiring, and missing parity tests. Apply only findings reproduced against current code, then rerun Steps 1–4.
 
-- [ ] **Step 6: Finalize task evidence through Backlog.md tooling**
+- [x] **Step 6: Finalize task evidence through Backlog.md tooling**
 
 Check all satisfied acceptance criteria and definition-of-done items on `TASK-12973.2`. Record exact test counts, Ruff/Bandit results, known warnings/skips, changed files, commits, and the final summary. Keep parent `TASK-12973` in progress because Stage 2C–2E remain.
 

--- a/Docs/superpowers/plans/2026-07-26-embeddings-workflow-stage2b-contracts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-26-embeddings-workflow-stage2b-contracts-implementation-plan.md
@@ -1,0 +1,724 @@
+# Embeddings Workflow Stage 2B Contracts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the Embeddings preparation pipeline, deterministic vector processor, canonical HTTP-independent outcome, endpoint header mapper, and temporary legacy result adapter without changing endpoint or provider execution behavior.
+
+**Architecture:** Move immutable request/outcome DTOs into `request_types.py`; put stateful preparation and vector dependencies behind focused components; keep result assembly and response mapping as pure functions. `EmbeddingRequestOrchestrator.prepare` and vector handling delegate to the extracted components, while its existing execute flow and the production endpoint continue returning `EmbeddingExecutionResult` until later Stage 2 work. The canonical outcome/header mapper are introduced with focused parity tests but are not wired into the endpoint or inline runner in this stage.
+
+**Tech Stack:** Python 3.14, frozen dataclasses, typing protocols/literals, pytest, pytest-asyncio, Ruff, Bandit.
+
+**Tracking:** `TASK-12973.2`
+
+**Approved design:** `Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md`
+
+---
+
+## Scope Guardrails
+
+- Do not change FastAPI endpoint wiring, public response formatting, resource-governor accounting, metrics, credential touching, cache semantics, provider traversal, or fallback routing.
+- Do not implement the Stage 2C post-call identity correction or the Stage 2D source-aware fallback correction.
+- Keep `response_header_count` accepted and emitted by the current legacy inline runner until Stage 2E replaces its result contract.
+- Define `attempt_count` and `fallback_attempt_count` on the canonical outcome, but require callers to supply them; do not infer incomplete counts from the current orchestrator.
+- Preserve `EmbeddingExecutionResult` and re-export `PreparedEmbeddingRequest` from `orchestrator.py` for existing imports.
+- Keep the endpoint header mapper pure and unwired until Stage 2E.
+- Document the legacy result adapter as the sole Stage 6 compatibility exception to endpoint-owned headers.
+
+## File Map
+
+- Create `tldw_Server_API/app/core/Embeddings/preparation.py`: ordered preparation pipeline and one-argument phase sink.
+- Create `tldw_Server_API/app/core/Embeddings/vector_processing.py`: vector validation, canonicalization, and dimension processing.
+- Create `tldw_Server_API/app/core/Embeddings/result_mapping.py`: canonical outcome assembly, endpoint header mapping, and Stage 6 legacy adapter.
+- Modify `tldw_Server_API/app/core/Embeddings/request_types.py`: move `PreparedEmbeddingRequest` here and add `EmbeddingExecutionOutcome`.
+- Modify `tldw_Server_API/app/core/Embeddings/workflow_types.py`: add `resolving_intent`, aggregate attempt counters, and completed-event validation.
+- Modify `tldw_Server_API/app/core/Embeddings/orchestrator.py`: delegate preparation and vector processing; preserve execute behavior and legacy exports.
+- Modify `tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py`: phase/status/finalization contract tests.
+- Create `tldw_Server_API/tests/Embeddings_isolated/test_preparation_pipeline.py`: order, phase-sink, and error-precedence tests.
+- Create `tldw_Server_API/tests/Embeddings_isolated/test_vector_processing.py`: deterministic vector behavior tests.
+- Create `tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py`: outcome immutability, header parity, adapter compatibility, and adapter cache-count tests.
+- Modify `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`: point ordering probes at the extracted preparation module and retain behavioral parity.
+- Modify `backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md`: record progress, evidence, touched files, and final status through Backlog.md tooling only.
+
+### Task 1: Extend Workflow Contract Vocabulary
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Embeddings/workflow_types.py`
+- Test: `tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py`
+
+- [x] **Step 1: Write failing phase and finalization tests**
+
+Add tests that inspect the literal contracts and validate terminal event construction:
+
+```python
+from typing import get_args
+
+
+def test_stage2_phase_contract_adds_resolving_intent_without_completed_phase():
+    assert "resolving_intent" in get_args(workflow_types.EmbeddingWorkflowPhase)
+    assert "completed" not in get_args(workflow_types.EmbeddingWorkflowPhase)
+    assert "completed" in get_args(workflow_types.EmbeddingWorkflowStatus)
+    assert "resolving_intent" in workflow_types.SAFE_METADATA_ENUM_VALUES["phase"]
+
+
+def test_stage2_trace_metadata_accepts_aggregate_attempt_counts():
+    metadata = safe_workflow_metadata({"attempt_count": 3, "fallback_attempt_count": 2})
+    assert metadata == {"attempt_count": 3, "fallback_attempt_count": 2}
+
+
+def test_workflow_completed_requires_finalizing_completed_contract():
+    event = EmbeddingWorkflowEvent(
+        event_type="workflow_completed",
+        workflow_id=WORKFLOW_ID,
+        phase="finalizing",
+        status="completed",
+    )
+    assert event.phase == "finalizing"
+    assert event.status == "completed"
+
+    with pytest.raises(EmbeddingWorkflowTraceError):
+        EmbeddingWorkflowEvent(
+            event_type="workflow_completed",
+            workflow_id=WORKFLOW_ID,
+            phase="executing",
+            status="completed",
+        )
+
+    with pytest.raises(EmbeddingWorkflowTraceError):
+        EmbeddingWorkflowEvent(
+            event_type="workflow_completed",
+            workflow_id=WORKFLOW_ID,
+            phase="finalizing",
+            status="running",
+        )
+```
+
+- [x] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py -q
+```
+
+Expected: failures because `resolving_intent` and attempt counters are absent and `workflow_completed` does not validate its finalizing contract.
+
+- [x] **Step 3: Implement the minimal workflow contract changes**
+
+In `workflow_types.py`:
+
+```python
+EmbeddingWorkflowPhase = Literal[
+    "created",
+    "resolving_intent",
+    "normalizing",
+    "resolving_policy",
+    "planning",
+    "serving_cache",
+    "executing",
+    "postprocessing",
+    "persisting_outputs",
+    "finalizing",
+]
+```
+
+Add `resolving_intent` to the safe `phase` enum and add `attempt_count` plus `fallback_attempt_count` to `SAFE_METADATA_NONNEGATIVE_INTEGER_FIELDS`. Preserve `response_header_count` for the still-legacy Stage 2B runner.
+
+In `EmbeddingWorkflowEvent.__post_init__`, reject a `workflow_completed` event unless `phase == "finalizing"` and `status == "completed"`, then perform the existing workflow-ID and metadata validation. Update the existing bounded-collector overflow test so its third `workflow_completed` event supplies `phase="finalizing"` and `status="completed"`; the event must be valid and the assertion must continue proving the collector itself fails closed at its configured cap.
+
+- [x] **Step 4: Run the workflow contract tests and verify GREEN**
+
+Run the command from Step 2. Expected: all tests pass.
+
+- [x] **Step 5: Commit the workflow contract slice**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/workflow_types.py tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py
+git commit -m "refactor(embeddings): extend stage 2 workflow contracts"
+```
+
+### Task 2: Add Canonical Outcome and Mapping Boundaries
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Embeddings/request_types.py`
+- Create: `tldw_Server_API/app/core/Embeddings/result_mapping.py`
+- Create: `tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py`
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_request_types.py`
+
+- [x] **Step 1: Write failing outcome and mapper tests**
+
+Cover these behaviors:
+
+```python
+def _prepared_request() -> PreparedEmbeddingRequest:
+    return PreparedEmbeddingRequest(
+        normalized_input=NormalizedEmbeddingInput(
+            texts=["one", "two"],
+            token_counts=[1, 1],
+            total_tokens=2,
+        ),
+        provider_intent=ProviderModelIntent(
+            provider="openai",
+            model="text-embedding-3-small",
+            requested_provider="openai",
+            requested_model="text-embedding-3-small",
+            provider_was_explicit=True,
+            model_was_provider_qualified=False,
+        ),
+        policy_decision=EmbeddingPolicyDecision(
+            provider="openai",
+            model="text-embedding-3-small",
+            dimensions=None,
+            fallback_chain=["openai", "huggingface"],
+            fallback_allowed=True,
+            enforce_policy=True,
+        ),
+        execution_plan=EmbeddingExecutionPlan(
+            provider="openai",
+            model="text-embedding-3-small",
+            dimensions=None,
+            backend_identity="openai:test",
+            fallback_chain=["openai", "huggingface"],
+        ),
+        effective_dimension_policy="reduce",
+        prompt_tokens=2,
+        total_tokens=2,
+    )
+
+
+def _outcome(
+    *,
+    fallback_from: str | None = None,
+    requested_dimensions: int | None = None,
+) -> EmbeddingExecutionOutcome:
+    return EmbeddingExecutionOutcome(
+        vectors=((0.1, 0.2),),
+        provider="huggingface" if fallback_from else "openai",
+        model="all-MiniLM-L6-v2" if fallback_from else "text-embedding-3-small",
+        prompt_tokens=2,
+        total_tokens=2,
+        cache_hits=0,
+        cache_misses=1,
+        requested_dimensions=requested_dimensions,
+        effective_dimension_policy="reduce",
+        attempt_count=2 if fallback_from else 1,
+        fallback_attempt_count=1 if fallback_from else 0,
+        fallback_from=fallback_from,
+    )
+
+
+def test_canonical_outcome_has_no_http_header_contract():
+    hints = get_type_hints(EmbeddingExecutionOutcome)
+    assert "response_headers" not in hints
+    assert hints["vectors"] == tuple[tuple[float, ...], ...]
+    assert hints["attempt_count"] is int
+    assert hints["fallback_attempt_count"] is int
+
+
+def test_result_assembly_freezes_vectors_and_preserves_adapter_cache_counts():
+    vectors = [[0.1, 0.2], [0.3, 0.4]]
+    outcome = assemble_embedding_execution_outcome(
+        _prepared_request(),
+        vectors=vectors,
+        provider="huggingface",
+        model="all-MiniLM-L6-v2",
+        cache_hits=0,
+        cache_misses=2,
+        fallback_from=None,
+        embeddings_from_adapter=True,
+        attempt_count=1,
+        fallback_attempt_count=0,
+    )
+    vectors[0][0] = 9.0
+    assert outcome.vectors == ((0.1, 0.2), (0.3, 0.4))
+    assert (outcome.cache_hits, outcome.cache_misses) == (0, 2)
+
+
+@pytest.mark.parametrize(
+    ("fallback_from", "dimensions", "expected"),
+    [
+        (None, None, {"X-Embeddings-Provider": "openai"}),
+        (
+            None,
+            2,
+            {
+                "X-Embeddings-Provider": "openai",
+                "X-Embeddings-Dimensions-Policy": "reduce",
+            },
+        ),
+        ("huggingface", None, {"X-Embeddings-Provider": "huggingface"}),
+        (
+            "openai",
+            2,
+            {
+                "X-Embeddings-Provider": "huggingface",
+                "X-Embeddings-Fallback-From": "openai",
+                "X-Embeddings-Dimensions-Policy": "reduce",
+            },
+        ),
+    ],
+)
+def test_endpoint_header_mapper_matches_legacy_contract(fallback_from, dimensions, expected):
+    outcome = _outcome(fallback_from=fallback_from, requested_dimensions=dimensions)
+    assert map_embedding_response_headers(outcome) == expected
+
+
+def test_legacy_adapter_preserves_result_shape_without_sharing_mutable_vectors():
+    outcome = _outcome()
+    legacy = map_outcome_to_legacy_execution_result(outcome)
+    assert legacy == EmbeddingExecutionResult(
+        vectors=[[0.1, 0.2]],
+        provider=outcome.provider,
+        model=outcome.model,
+        prompt_tokens=outcome.prompt_tokens,
+        total_tokens=outcome.total_tokens,
+        cache_hits=outcome.cache_hits,
+        cache_misses=outcome.cache_misses,
+        fallback_from=outcome.fallback_from,
+        response_headers=map_embedding_response_headers(outcome),
+        embeddings_from_adapter=outcome.embeddings_from_adapter,
+    )
+    legacy.vectors[0][0] = 9.0
+    assert outcome.vectors[0][0] == 0.1
+```
+
+- [x] **Step 2: Run the focused tests and verify RED**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_request_types.py tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py -q
+```
+
+Expected: import failures because the outcome and mapping module do not exist.
+
+- [x] **Step 3: Add immutable outcome contracts**
+
+Move `PreparedEmbeddingRequest` from `orchestrator.py` into `request_types.py` without changing its fields. Add:
+
+```python
+@dataclass(frozen=True, slots=True)
+class EmbeddingExecutionOutcome:
+    vectors: tuple[tuple[float, ...], ...]
+    provider: str
+    model: str
+    prompt_tokens: int
+    total_tokens: int
+    cache_hits: int
+    cache_misses: int
+    requested_dimensions: int | None
+    effective_dimension_policy: str
+    attempt_count: int
+    fallback_attempt_count: int
+    fallback_from: str | None = None
+    embeddings_from_adapter: bool = False
+```
+
+Do not add HTTP headers. Export both DTOs from `request_types.py`.
+
+- [x] **Step 4: Implement pure result assembly and mapping**
+
+Create `result_mapping.py` with:
+
+```python
+def assemble_embedding_execution_outcome(
+    prepared: PreparedEmbeddingRequest,
+    *,
+    vectors: Sequence[Sequence[float]],
+    provider: str,
+    model: str,
+    cache_hits: int,
+    cache_misses: int,
+    fallback_from: str | None,
+    embeddings_from_adapter: bool,
+    attempt_count: int,
+    fallback_attempt_count: int,
+) -> EmbeddingExecutionOutcome:
+    return EmbeddingExecutionOutcome(
+        vectors=tuple(tuple(vector) for vector in vectors),
+        provider=provider,
+        model=model,
+        prompt_tokens=prepared.prompt_tokens,
+        total_tokens=prepared.total_tokens,
+        cache_hits=cache_hits,
+        cache_misses=cache_misses,
+        requested_dimensions=prepared.execution_plan.dimensions,
+        effective_dimension_policy=prepared.effective_dimension_policy,
+        fallback_from=fallback_from,
+        embeddings_from_adapter=embeddings_from_adapter,
+        attempt_count=attempt_count,
+        fallback_attempt_count=fallback_attempt_count,
+    )
+
+
+def map_embedding_response_headers(outcome: EmbeddingExecutionOutcome) -> dict[str, str]:
+    headers = {"X-Embeddings-Provider": outcome.provider}
+    if outcome.fallback_from and outcome.fallback_from != outcome.provider:
+        headers["X-Embeddings-Fallback-From"] = outcome.fallback_from
+    if outcome.requested_dimensions is not None:
+        headers["X-Embeddings-Dimensions-Policy"] = outcome.effective_dimension_policy
+    return headers
+
+
+def map_outcome_to_legacy_execution_result(
+    outcome: EmbeddingExecutionOutcome,
+) -> EmbeddingExecutionResult:
+    """Stage 6 compatibility exception for callers that still require headers."""
+    return EmbeddingExecutionResult(
+        vectors=[list(vector) for vector in outcome.vectors],
+        provider=outcome.provider,
+        model=outcome.model,
+        prompt_tokens=outcome.prompt_tokens,
+        total_tokens=outcome.total_tokens,
+        cache_hits=outcome.cache_hits,
+        cache_misses=outcome.cache_misses,
+        fallback_from=outcome.fallback_from,
+        response_headers=map_embedding_response_headers(outcome),
+        embeddings_from_adapter=outcome.embeddings_from_adapter,
+    )
+```
+
+Document explicitly that the header mapper is endpoint-owned but remains unwired until Stage 2E, and the legacy mapper is scheduled for Stage 6 removal.
+
+- [x] **Step 5: Run focused tests and verify GREEN**
+
+Run the command from Step 2. Expected: all tests pass.
+
+- [x] **Step 6: Commit the result-contract slice**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/request_types.py tldw_Server_API/app/core/Embeddings/result_mapping.py tldw_Server_API/tests/Embeddings_isolated/test_request_types.py tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py
+git commit -m "refactor(embeddings): add canonical result contracts"
+```
+
+### Task 3: Extract the Ordered Preparation Pipeline
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Embeddings/preparation.py`
+- Modify: `tldw_Server_API/app/core/Embeddings/orchestrator.py`
+- Create: `tldw_Server_API/tests/Embeddings_isolated/test_preparation_pipeline.py`
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+
+- [x] **Step 1: Write failing pipeline order and phase-safety tests**
+
+Build a pipeline through a local test factory with the same lightweight token/config fixtures as `test_embedding_orchestrator.py`. Patch the four module boundaries and assert:
+
+```python
+def _context() -> EmbeddingRequestContext:
+    return EmbeddingRequestContext(
+        user_id="u1",
+        model_field="sentence-transformers/all-MiniLM-L6-v2",
+        provider_header="huggingface",
+        dimensions=None,
+        encoding_format="float",
+        request_id="req-1",
+    )
+
+
+def _tokens_to_texts(tokens_input, model):
+    del model
+    if tokens_input and isinstance(tokens_input[0], int):
+        return ["decoded"], len(tokens_input), [len(tokens_input)]
+    return [f"decoded-{index}" for index, _ in enumerate(tokens_input)], 0, [
+        len(item) for item in tokens_input
+    ]
+
+
+def _pipeline(**overrides) -> EmbeddingPreparationPipeline:
+    kwargs = {
+        "count_tokens": lambda text, model: len(text.split()),
+        "tokens_to_texts": _tokens_to_texts,
+        "settings_config": {},
+        "max_tokens": 128,
+        "implemented_providers": {"huggingface", "openai"},
+        "allowed_providers": None,
+        "allowed_models": None,
+        "enforce_policy": True,
+        "allow_fallback_with_header": True,
+        "settings_fallback_chain": None,
+        "settings_fallback_model_map": None,
+        "dimension_policy": "reduce",
+        "require_model": True,
+        "guess_provider": None,
+        "backend_identity_resolver": lambda provider, model: f"{provider}:{model}:backend",
+        "cache_namespace": None,
+        "batch_size": None,
+        "execution_path": "legacy",
+    }
+    kwargs.update(overrides)
+    return EmbeddingPreparationPipeline(**kwargs)
+
+
+def test_pipeline_reports_only_phase_identifiers_in_execution_order(monkeypatch):
+    calls = []
+    phases = []
+    real_resolve = preparation_module.resolve_provider_model
+    real_normalize = preparation_module.normalize_embedding_input
+    real_policy = preparation_module.enforce_embedding_policy
+
+    def resolve_probe(*args, **kwargs):
+        calls.append("resolve_intent")
+        return real_resolve(*args, **kwargs)
+
+    def normalize_probe(*args, **kwargs):
+        calls.append("normalize")
+        return real_normalize(*args, **kwargs)
+
+    def policy_probe(*args, **kwargs):
+        calls.append("resolve_policy")
+        return real_policy(*args, **kwargs)
+
+    def identity_probe(provider, model):
+        calls.append("plan_identity")
+        return f"{provider}:{model}:backend"
+
+    monkeypatch.setattr(preparation_module, "resolve_provider_model", resolve_probe)
+    monkeypatch.setattr(preparation_module, "normalize_embedding_input", normalize_probe)
+    monkeypatch.setattr(preparation_module, "enforce_embedding_policy", policy_probe)
+    prepared = _pipeline(backend_identity_resolver=identity_probe).prepare(
+        "ordered preparation",
+        _context(),
+        phase_sink=lambda phase: phases.append(phase),
+    )
+    assert calls == ["resolve_intent", "normalize", "resolve_policy", "plan_identity"]
+    assert phases == ["resolving_intent", "normalizing", "resolving_policy", "planning"]
+    assert all(isinstance(phase, str) for phase in phases)
+    assert "ordered preparation" not in repr(phases)
+    assert prepared.execution_plan.observability_tags not in phases
+```
+
+Add a parameterized test that raises one sentinel exception from each preparation boundary, asserts object identity is preserved, and asserts no later boundary or phase is entered.
+
+- [x] **Step 2: Run the pipeline tests and verify RED**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_preparation_pipeline.py -q
+```
+
+Expected: import failure because `preparation.py` does not exist.
+
+- [x] **Step 3: Implement `EmbeddingPreparationPipeline`**
+
+Create a class with meaningful injected configuration: token counter/decoder, provider settings and policy allowlists, fallback settings, default dimension policy, provider guesser, backend identity resolver, cache namespace, batch size, and execution path. Its synchronous `prepare` method must:
+
+1. Report `resolving_intent`, then call `resolve_provider_model`.
+2. Report `normalizing`, then call `normalize_embedding_input` with the resolved model.
+3. Report `resolving_policy`, then call `enforce_embedding_policy`.
+4. Report `planning`, compute effective dimension policy, resolve plan identity, build `EmbeddingExecutionPlan`, and return `PreparedEmbeddingRequest`.
+
+Define `PhaseSink = Callable[[EmbeddingWorkflowPhase], None]` and accept `phase_sink: PhaseSink | None = None`; never pass raw input, intent, context, prepared data, or observability tags to it. Export a pure `effective_dimension_policy(encoding_format, dimensions, configured_policy)` helper so base64 plus explicit dimensions always returns `reduce`.
+
+- [x] **Step 4: Delegate orchestrator preparation**
+
+Construct one `EmbeddingPreparationPipeline` in `EmbeddingRequestOrchestrator.__init__` and replace the inline `prepare` algorithm with:
+
+```python
+def prepare(self, raw_input: Any, context: EmbeddingRequestContext) -> PreparedEmbeddingRequest:
+    return self._preparation_pipeline.prepare(raw_input, context)
+```
+
+Keep the compatibility facade call free of a phase sink. Import and re-export `PreparedEmbeddingRequest` from `orchestrator.py` so endpoint and test imports remain valid. Update the existing order probe to patch `preparation` module functions rather than deleted orchestrator globals.
+
+- [x] **Step 5: Run focused preparation and orchestrator tests**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_preparation_pipeline.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py -q
+```
+
+Expected: all tests pass with unchanged preparation outputs and error identity.
+
+- [x] **Step 6: Commit the preparation slice**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/preparation.py tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_preparation_pipeline.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+git commit -m "refactor(embeddings): extract preparation pipeline"
+```
+
+### Task 4: Extract Deterministic Vector Processing
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Embeddings/vector_processing.py`
+- Modify: `tldw_Server_API/app/core/Embeddings/orchestrator.py`
+- Create: `tldw_Server_API/tests/Embeddings_isolated/test_vector_processing.py`
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+
+- [x] **Step 1: Write failing vector processor tests**
+
+Cover count errors, malformed/non-finite values, float canonicalization, dimension reduction/padding, recorder calls, and cached-vector processing:
+
+```python
+def test_validate_vector_count_canonicalizes_finite_numeric_vectors():
+    processor = EmbeddingVectorProcessor()
+    assert processor.validate_vector_count(
+        [[1, 2], [3.5, 4]], expected=2, provider="p", model="m"
+    ) == [[1.0, 2.0], [3.5, 4.0]]
+
+
+def test_validate_vector_count_raises_existing_domain_error_for_count_mismatch():
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        EmbeddingVectorProcessor().validate_vector_count(
+            [[1.0]], expected=2, provider="p", model="m"
+        )
+    assert exc_info.value.code == "provider_malformed_response"
+
+
+@pytest.mark.parametrize("vectors", [[[float("nan"), 1.0]], [[float("inf"), 1.0]], [[True, 1.0]]])
+def test_validate_vector_count_rejects_malformed_numeric_values(vectors):
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        EmbeddingVectorProcessor().validate_vector_count(
+            vectors, expected=1, provider="p", model="m"
+        )
+    assert exc_info.value.code == "provider_malformed_response"
+
+
+@pytest.mark.parametrize(
+    "vector",
+    [None, [], ["not-a-number"], [float("nan"), 0.0], [float("inf"), 0.0], [True, 0.0]],
+)
+def test_validate_cached_vector_returns_none_for_malformed_cache_values(vector):
+    assert EmbeddingVectorProcessor().validate_cached_vector(vector) is None
+
+
+def test_validate_cached_vector_returns_canonical_finite_vector():
+    assert EmbeddingVectorProcessor().validate_cached_vector([1, 2.5]) == [1.0, 2.5]
+
+
+def test_process_vectors_applies_dimensions_and_records_adjustment():
+    calls = []
+    processor = EmbeddingVectorProcessor(record_dimension_adjustment=lambda *args: calls.append(args))
+    assert processor.process_vectors(
+        [[1, 2, 3]], provider="p", model="m", dimensions=2, dimension_policy="reduce"
+    ) == [[1.0, 2.0]]
+    assert calls == [("p", "m", "reduce")]
+```
+
+- [x] **Step 2: Run the vector tests and verify RED**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_vector_processing.py -q
+```
+
+Expected: import failure because `vector_processing.py` does not exist.
+
+- [x] **Step 3: Implement `EmbeddingVectorProcessor`**
+
+The class owns only the optional dimension-adjustment recorder. Implement:
+
+- `validate_vector_count(vectors, expected, provider, model)` using `validated_embedding_vectors` and the existing exact `provider_malformed_response` messages.
+- `validate_cached_vector(vector) -> list[float] | None` using `validated_embedding_vectors([vector], expected=1)` so malformed, non-finite, boolean, empty, and missing cache values remain misses rather than becoming request errors.
+- `process_vectors(vectors, provider, model, dimensions, dimension_policy)` using float canonicalization before and after `adjust_dimensions`.
+- `process_cached_vector(...)` by applying `process_vectors` only after `validate_cached_vector` has returned a canonical vector.
+
+Keep cache, executor, endpoint response, and workflow collector dependencies out of this module.
+
+- [x] **Step 4: Delegate all orchestrator vector operations**
+
+Construct `EmbeddingVectorProcessor(record_dimension_adjustment=record_dimension_adjustment)` in the orchestrator. Replace provider-response validation/postprocessing/canonicalization call sites with processor methods or the module’s canonicalization function. Replace both primary and fallback cache-read validation with `validate_cached_vector`; a `None` result must continue through the existing miss path. Remove the superseded private methods and direct `adjust_dimensions`/`validated_embedding_vectors` imports.
+
+Add a fallback-path parity test beside the existing primary `test_malformed_cached_vector_becomes_miss_and_is_replaced`: force an eligible primary provider failure, seed a malformed fallback cache value, return a valid fallback provider vector, and assert the malformed value is treated as a miss, replaced under the existing fallback identity, and returned successfully. Do not change fallback identity timing in this stage.
+
+- [x] **Step 5: Run vector, orchestrator, and endpoint parity tests**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_vector_processing.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py -q
+```
+
+Expected: all tests pass; error codes/messages, cache write values, headers, and endpoint bodies remain unchanged.
+
+- [x] **Step 6: Commit the vector slice**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/vector_processing.py tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_vector_processing.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+git commit -m "refactor(embeddings): extract vector processing"
+```
+
+### Task 5: Verify Scope, Update Tracking, and Prepare Review
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-07-26-embeddings-workflow-stage2b-contracts-implementation-plan.md`
+- Modify through Backlog.md tooling: `backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md`
+
+- [x] **Step 1: Run the full focused Stage 2B contract suite**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Embeddings_isolated/test_request_types.py \
+  tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py \
+  tldw_Server_API/tests/Embeddings_isolated/test_workflow_runner.py \
+  tldw_Server_API/tests/Embeddings_isolated/test_preparation_pipeline.py \
+  tldw_Server_API/tests/Embeddings_isolated/test_vector_processing.py \
+  tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py \
+  tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py \
+  tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py -q
+```
+
+- [x] **Step 2: Run the full isolated Embeddings suite**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Embeddings_isolated -q
+```
+
+- [x] **Step 3: Run static and security checks**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m ruff check \
+  tldw_Server_API/app/core/Embeddings/request_types.py \
+  tldw_Server_API/app/core/Embeddings/workflow_types.py \
+  tldw_Server_API/app/core/Embeddings/preparation.py \
+  tldw_Server_API/app/core/Embeddings/vector_processing.py \
+  tldw_Server_API/app/core/Embeddings/result_mapping.py \
+  tldw_Server_API/app/core/Embeddings/orchestrator.py \
+  tldw_Server_API/tests/Embeddings_isolated
+python -m ruff format --check \
+  tldw_Server_API/app/core/Embeddings/request_types.py \
+  tldw_Server_API/app/core/Embeddings/workflow_types.py \
+  tldw_Server_API/app/core/Embeddings/preparation.py \
+  tldw_Server_API/app/core/Embeddings/vector_processing.py \
+  tldw_Server_API/app/core/Embeddings/result_mapping.py \
+  tldw_Server_API/app/core/Embeddings/orchestrator.py \
+  tldw_Server_API/tests/Embeddings_isolated
+python -m bandit -r \
+  tldw_Server_API/app/core/Embeddings/request_types.py \
+  tldw_Server_API/app/core/Embeddings/workflow_types.py \
+  tldw_Server_API/app/core/Embeddings/preparation.py \
+  tldw_Server_API/app/core/Embeddings/vector_processing.py \
+  tldw_Server_API/app/core/Embeddings/result_mapping.py \
+  tldw_Server_API/app/core/Embeddings/orchestrator.py \
+  -f json -o /tmp/bandit_embeddings_stage2b.json
+git diff --check origin/dev
+```
+
+- [x] **Step 4: Audit scope and compatibility**
+
+Confirm:
+
+```bash
+git diff --name-only origin/dev
+git diff origin/dev -- tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+rg -n "Stage 6 compatibility|Stage 2E" tldw_Server_API/app/core/Embeddings/result_mapping.py
+```
+
+Expected: no endpoint diff; the mapper deferral and removal stage are explicit; no Stage 2C/2D behavior appears in the diff.
+
+- [x] **Step 5: Request independent code review and address validated findings**
+
+Review the complete `origin/dev...HEAD` diff for behavior drift, DTO mutability, import cycles, phase/error precedence, accidental endpoint wiring, and missing parity tests. Apply only findings reproduced against current code, then rerun Steps 1–4.
+
+- [ ] **Step 6: Finalize task evidence through Backlog.md tooling**
+
+Check all satisfied acceptance criteria and definition-of-done items on `TASK-12973.2`. Record exact test counts, Ruff/Bandit results, known warnings/skips, changed files, commits, and the final summary. Keep parent `TASK-12973` in progress because Stage 2C–2E remain.
+
+- [ ] **Step 7: Commit final plan/tracking updates and prepare the PR**
+
+```bash
+git add Docs/superpowers/plans/2026-07-26-embeddings-workflow-stage2b-contracts-implementation-plan.md backlog/tasks/task-12973.2\ -\ Extract-Embeddings-preparation-and-result-contracts.md
+git commit -m "docs(embeddings): finalize stage 2b evidence"
+```
+
+Before creating the PR, rebase on current `origin/dev`, rerun the focused suite and required static/security checks, and require a requester-authored Change summary that explains both what changed and why these boundaries were chosen.

--- a/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
@@ -995,7 +995,7 @@ git commit -m "fix(embeddings): re-resolve fallback write identity"
 - Verify: `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py`
 - Verify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
 
-- [ ] **Step 1: Run the focused Stage 2C regression suite**
+- [x] **Step 1: Run the focused Stage 2C regression suite**
 
 Run:
 
@@ -1005,7 +1005,7 @@ Run:
 
 Expected: all selected tests pass. Investigate and fix failures before continuing.
 
-- [ ] **Step 2: Run Bandit on touched production code**
+- [x] **Step 2: Run Bandit on touched production code**
 
 Run:
 
@@ -1015,7 +1015,7 @@ Run:
 
 Expected: no new security findings in touched production code.
 
-- [ ] **Step 3: Run a git self-review**
+- [x] **Step 3: Run a git self-review**
 
 Run:
 
@@ -1026,7 +1026,7 @@ git diff origin/codex/embeddings-workflow-stage2b-contracts -- tldw_Server_API/a
 
 Expected: no whitespace errors; diff shows only Stage 2C provider-attempt extraction, shared executor-output relocation, fallback write identity correction, tests, plan, and backlog updates.
 
-- [ ] **Step 4: Update Backlog acceptance criteria and notes**
+- [x] **Step 4: Update Backlog acceptance criteria and notes**
 
 Use Backlog.md tooling, not manual edits, to check completed acceptance criteria, append verification output, and add touched files. Example:
 
@@ -1034,7 +1034,7 @@ Use Backlog.md tooling, not manual edits, to check completed acceptance criteria
 /opt/homebrew/bin/backlog task edit 12973.3 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 --check-ac 6 --check-ac 7 --check-ac 8 --check-ac 9 --check-ac 10 --check-ac 11 --check-ac 12 --check-dod 1 --check-dod 2 --check-dod 3 --check-dod 4 --append-notes "Verification: provider-attempt, orchestrator, workflow-types, endpoint parity focused tests passed; Bandit touched scope passed."
 ```
 
-- [ ] **Step 5: Commit final tracking updates**
+- [x] **Step 5: Commit final tracking updates**
 
 If the plan has not yet been committed, include it with the final tracking commit:
 

--- a/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
@@ -189,7 +189,7 @@ git commit -m "refactor(embeddings): add provider readiness boundary"
 - Modify: `tldw_Server_API/app/core/Embeddings/provider_attempt.py`
 - Modify: `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py`
 
-- [ ] **Step 1: Write failing ordered cache and miss tests**
+- [x] **Step 1: Write failing ordered cache and miss tests**
 
 Extend `test_provider_attempt.py` with the helper fakes and tests:
 
@@ -405,7 +405,7 @@ async def test_provider_attempt_cache_keys_exclude_plan_identity_and_namespace()
     assert all("ns" not in key for key in cache.get_keys)
 ```
 
-- [ ] **Step 2: Run the new tests and verify RED**
+- [x] **Step 2: Run the new tests and verify RED**
 
 Run:
 
@@ -415,7 +415,7 @@ Run:
 
 Expected: failures because `EmbeddingProviderAttempt` and `ProviderAttemptSuccess` do not exist.
 
-- [ ] **Step 3: Implement provider-attempt DTOs and ordered cache/miss execution**
+- [x] **Step 3: Implement provider-attempt DTOs and ordered cache/miss execution**
 
 In `provider_attempt.py`, add:
 
@@ -588,11 +588,11 @@ def _coerce_executor_output(
 
 Export the new protocols and DTOs in `provider_attempt.__all__`.
 
-- [ ] **Step 4: Run provider-attempt tests and verify GREEN**
+- [x] **Step 4: Run provider-attempt tests and verify GREEN**
 
 Run the command from Step 2. Expected: all provider-attempt tests pass.
 
-- [ ] **Step 5: Commit the ordered attempt slice**
+- [x] **Step 5: Commit the ordered attempt slice**
 
 ```bash
 git add tldw_Server_API/app/core/Embeddings/provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py

--- a/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
@@ -863,7 +863,7 @@ git commit -m "test(embeddings): cover provider attempt failure routing"
 - Modify: `tldw_Server_API/app/core/Embeddings/orchestrator.py`
 - Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
 
-- [ ] **Step 1: Write the failing fallback write-identity correction test**
+- [x] **Step 1: Write the failing fallback write-identity correction test**
 
 Add this test near the fallback identity coverage in `test_embedding_orchestrator.py`:
 
@@ -933,7 +933,7 @@ async def test_fallback_writeback_re_resolves_backend_identity_after_provider_ex
     ]
 ```
 
-- [ ] **Step 2: Run the test and verify RED**
+- [x] **Step 2: Run the test and verify RED**
 
 Run:
 
@@ -943,7 +943,7 @@ Run:
 
 Expected: failure because fallback cache writeback uses the read-time identity.
 
-- [ ] **Step 3: Apply the minimal fallback correction**
+- [x] **Step 3: Apply the minimal fallback correction**
 
 In `_execute_coherent_fallback`, keep the existing read identity before cache lookup. After executor success, vector-count validation, and request-specific postprocessing, resolve a second identity before building cache write keys:
 
@@ -969,7 +969,7 @@ In `_execute_coherent_fallback`, keep the existing read identity before cache lo
 
 Do not change primary execution or fallback exception classification in this task.
 
-- [ ] **Step 4: Run the correction and guardrail tests**
+- [x] **Step 4: Run the correction and guardrail tests**
 
 Run:
 
@@ -979,7 +979,7 @@ Run:
 
 Expected: the new correction test passes and the Stage 2D guardrail test still passes.
 
-- [ ] **Step 5: Commit the correction**
+- [x] **Step 5: Commit the correction**
 
 ```bash
 git add tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py

--- a/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
@@ -44,7 +44,7 @@
 - Create: `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py`
 - Test: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
 
-- [ ] **Step 1: Write the failing readiness and executor-output import tests**
+- [x] **Step 1: Write the failing readiness and executor-output import tests**
 
 Create `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py` with the initial helper fixtures and tests:
 
@@ -111,7 +111,7 @@ def test_executor_output_contract_is_shared_from_request_types():
     assert output.embeddings_from_adapter is True
 ```
 
-- [ ] **Step 2: Run the tests and verify RED**
+- [x] **Step 2: Run the tests and verify RED**
 
 Run:
 
@@ -121,7 +121,7 @@ Run:
 
 Expected: import failures because `provider_attempt.py` does not exist and `EmbeddingExecutorOutput` is not exported from `request_types.py`.
 
-- [ ] **Step 3: Implement the minimal shared contract and readiness wrapper**
+- [x] **Step 3: Implement the minimal shared contract and readiness wrapper**
 
 Move the existing frozen `EmbeddingExecutorOutput` dataclass from `orchestrator.py` to `request_types.py`:
 
@@ -172,11 +172,11 @@ __all__ = [
 ]
 ```
 
-- [ ] **Step 4: Run the focused tests and verify GREEN**
+- [x] **Step 4: Run the focused tests and verify GREEN**
 
 Run the command from Step 2. Expected: all selected tests pass.
 
-- [ ] **Step 5: Commit the shared contract slice**
+- [x] **Step 5: Commit the shared contract slice**
 
 ```bash
 git add tldw_Server_API/app/core/Embeddings/request_types.py tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/app/core/Embeddings/provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py

--- a/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
@@ -605,7 +605,7 @@ git commit -m "refactor(embeddings): extract provider attempt cache execution"
 - Modify: `tldw_Server_API/app/core/Embeddings/provider_attempt.py`
 - Modify: `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py`
 
-- [ ] **Step 1: Write failing validation and adapter-origin tests**
+- [x] **Step 1: Write failing validation and adapter-origin tests**
 
 Add these tests:
 
@@ -729,7 +729,7 @@ async def test_provider_attempt_skips_cache_write_for_adapter_originated_executo
     assert cache.set_calls == []
 ```
 
-- [ ] **Step 2: Run the tests and verify RED where behavior is incomplete**
+- [x] **Step 2: Run the tests and verify RED where behavior is incomplete**
 
 Run:
 
@@ -739,7 +739,7 @@ Run:
 
 Expected: any missing validation/writeback behavior fails. If all tests pass because Task 2 implementation already covered them, record that the RED requirement was satisfied by adding the tests before any further production changes in this task.
 
-- [ ] **Step 3: Write failing provider-call and non-provider failure tests**
+- [x] **Step 3: Write failing provider-call and non-provider failure tests**
 
 Add:
 
@@ -830,7 +830,7 @@ async def test_provider_attempt_non_provider_failures_propagate_without_call_fai
     assert exc_info.value is original
 ```
 
-- [ ] **Step 4: Implement the minimal missing behavior**
+- [x] **Step 4: Implement the minimal missing behavior**
 
 If the tests from Steps 1 or 3 fail, adjust only `provider_attempt.py` so:
 
@@ -840,7 +840,7 @@ If the tests from Steps 1 or 3 fail, adjust only `provider_attempt.py` so:
 - The complete ordered result is validated before any `cache.set`.
 - `EmbeddingExecutorOutput(..., embeddings_from_adapter=True)` skips writeback but still returns processed vectors and miss counts.
 
-- [ ] **Step 5: Run provider-attempt tests and verify GREEN**
+- [x] **Step 5: Run provider-attempt tests and verify GREEN**
 
 Run:
 
@@ -850,7 +850,7 @@ Run:
 
 Expected: all provider-attempt tests pass.
 
-- [ ] **Step 6: Commit validation and failure classification**
+- [x] **Step 6: Commit validation and failure classification**
 
 ```bash
 git add tldw_Server_API/app/core/Embeddings/provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py

--- a/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
@@ -1,0 +1,1059 @@
+# Embeddings Workflow Stage 2C Provider Attempts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract provider readiness and single-provider execution attempts into workflow-compatible components while preserving production routing, except for the approved fallback writeback backend-identity correction.
+
+**Architecture:** Add a side-by-side `EmbeddingProviderReadinessCheck` and `EmbeddingProviderAttempt` that depend on narrow cache, executor, cache-key, identity, and vector-processing contracts. The new attempt returns either a complete ordered provider result or an exact provider-call failure DTO, and it catches domain errors only around the executor call. Existing `EmbeddingRequestOrchestrator.execute` remains the production coordinator until Stage 2D; Stage 2C only patches `_execute_coherent_fallback` to re-resolve backend identity before fallback cache writeback.
+
+**Tech Stack:** Python 3.14, frozen dataclasses, typing protocols, pytest, pytest-asyncio, focused isolated tests, Bandit.
+
+**Tracking:** `TASK-12973.3`
+
+**Approved design:** `Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md`
+
+**Base:** stacked on `origin/codex/embeddings-workflow-stage2b-contracts`; do not recreate or edit the Stage 2B PR branch.
+
+---
+
+## Scope Guardrails
+
+- Do not wire the new provider-attempt component into the inline runner or production orchestrator execution path until Stage 2D.
+- Do not fix the Stage 2D source-aware fallback catch in this task. The existing `test_current_fallback_wide_domain_catch_advances_after_infrastructure_failure` must keep pinning the current legacy behavior.
+- Do not change endpoint response formatting, resource-governor accounting, metrics, credential touch policy, cache-key inputs, fallback candidate ordering, or the workflow feature flag.
+- Do not make cache writes transactional. Validate the complete ordered response before writeback, but preserve existing partial write behavior if a later cache write fails.
+- Keep cache eligibility delegated to the injected cache. The attempt should call `get` and `set`; request-private cache bypass remains an adapter/cache concern.
+- Use read-time backend identity only for cache reads and write-time backend identity only for cache writes. Never use `EmbeddingExecutionPlan.backend_identity` as authoritative runtime identity.
+- The only production behavior correction in Stage 2C is fallback writeback identity re-resolution in `_execute_coherent_fallback`.
+
+## File Map
+
+- Create `tldw_Server_API/app/core/Embeddings/provider_attempt.py`: readiness wrapper, provider-attempt result DTOs, protocols, executor-output coercion, ordered cache/miss execution, and writeback.
+- Modify `tldw_Server_API/app/core/Embeddings/request_types.py`: move `EmbeddingExecutorOutput` here if needed so both the orchestrator and provider-attempt component can share the executor-output contract without a future circular import.
+- Modify `tldw_Server_API/app/core/Embeddings/orchestrator.py`: re-export `EmbeddingExecutorOutput` if moved, and apply only the fallback writeback identity correction.
+- Create `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py`: direct tests for readiness and single-provider attempts.
+- Modify `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`: add the fallback write-identity correction regression test.
+- Modify `backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md`: record plan path, progress, verification, touched files, and final summary through Backlog.md tooling.
+
+### Task 1: Shared Executor Output Contract and Readiness Wrapper
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Embeddings/request_types.py`
+- Modify: `tldw_Server_API/app/core/Embeddings/orchestrator.py`
+- Create: `tldw_Server_API/app/core/Embeddings/provider_attempt.py`
+- Create: `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py`
+- Test: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+
+- [ ] **Step 1: Write the failing readiness and executor-output import tests**
+
+Create `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py` with the initial helper fixtures and tests:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Embeddings.provider_attempt import (
+    EmbeddingProviderReadinessCheck,
+)
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutionError,
+    EmbeddingExecutorOutput,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_readiness_check_delegates_to_preflight():
+    calls: list[tuple[str, str]] = []
+
+    async def preflight(provider: str, model: str) -> None:
+        calls.append((provider, model))
+
+    readiness = EmbeddingProviderReadinessCheck(preflight)
+
+    await readiness.check("openai", "text-embedding-3-small")
+
+    assert calls == [("openai", "text-embedding-3-small")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_readiness_check_propagates_exact_error():
+    error = EmbeddingExecutionError(
+        "circuit_breaker_open",
+        "provider unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+
+    async def preflight(provider: str, model: str) -> None:
+        del provider, model
+        raise error
+
+    readiness = EmbeddingProviderReadinessCheck(preflight)
+
+    with pytest.raises(EmbeddingExecutionError) as exc_info:
+        await readiness.check("openai", "text-embedding-3-small")
+
+    assert exc_info.value is error
+
+
+@pytest.mark.unit
+def test_executor_output_contract_is_shared_from_request_types():
+    output = EmbeddingExecutorOutput(
+        vectors=[[0.1, 0.2]],
+        embeddings_from_adapter=True,
+    )
+
+    assert output.vectors == [[0.1, 0.2]]
+    assert output.embeddings_from_adapter is True
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py::test_successful_adapter_reports_compatibility_cache_counts_and_bypasses_provider -q
+```
+
+Expected: import failures because `provider_attempt.py` does not exist and `EmbeddingExecutorOutput` is not exported from `request_types.py`.
+
+- [ ] **Step 3: Implement the minimal shared contract and readiness wrapper**
+
+Move the existing frozen `EmbeddingExecutorOutput` dataclass from `orchestrator.py` to `request_types.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class EmbeddingExecutorOutput:
+    vectors: list[list[float]]
+    embeddings_from_adapter: bool = False
+```
+
+Add `"EmbeddingExecutorOutput"` to `request_types.__all__`.
+
+In `orchestrator.py`, import `EmbeddingExecutorOutput` from `request_types.py` and leave it in `orchestrator.__all__` so existing callers continue to import it from the old location.
+
+Create `provider_attempt.py` with:
+
+```python
+"""Provider readiness and single-provider execution attempts for embeddings."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutorOutput,
+)
+
+
+ProviderPreflight = Callable[[str, str], Awaitable[None]]
+
+
+async def _no_provider_preflight(provider: str, model: str) -> None:
+    del provider, model
+
+
+class EmbeddingProviderReadinessCheck:
+    """Run provider readiness checks without cache or execution side effects."""
+
+    def __init__(self, provider_preflight: ProviderPreflight | None = None) -> None:
+        self._provider_preflight = provider_preflight or _no_provider_preflight
+
+    async def check(self, provider: str, model: str) -> None:
+        await self._provider_preflight(provider, model)
+
+
+__all__ = [
+    "EmbeddingProviderReadinessCheck",
+    "EmbeddingExecutorOutput",
+]
+```
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run the command from Step 2. Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit the shared contract slice**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/request_types.py tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/app/core/Embeddings/provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py
+git commit -m "refactor(embeddings): add provider readiness boundary"
+```
+
+### Task 2: Ordered Single-Provider Cache and Miss Execution
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Embeddings/provider_attempt.py`
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py`
+
+- [ ] **Step 1: Write failing ordered cache and miss tests**
+
+Extend `test_provider_attempt.py` with the helper fakes and tests:
+
+```python
+from tldw_Server_API.app.core.Embeddings.provider_attempt import (
+    EmbeddingProviderAttempt,
+    ProviderAttemptSuccess,
+)
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutionPlan,
+    EmbeddingPolicyDecision,
+    NormalizedEmbeddingInput,
+    PreparedEmbeddingRequest,
+    ProviderModelIntent,
+)
+from tldw_Server_API.app.core.Embeddings.vector_processing import (
+    EmbeddingVectorProcessor,
+)
+
+
+class RecordingCache:
+    def __init__(self, values: dict[str, list[float]] | None = None) -> None:
+        self.values = values or {}
+        self.get_keys: list[str] = []
+        self.set_calls: list[tuple[str, list[float]]] = []
+
+    async def get(self, key: str) -> list[float] | None:
+        self.get_keys.append(key)
+        return self.values.get(key)
+
+    async def set(self, key: str, value: list[float]) -> object:
+        self.set_calls.append((key, value))
+        self.values[key] = value
+        return None
+
+
+class RecordingExecutor:
+    def __init__(self, vectors: list[list[float]] | None = None) -> None:
+        self.vectors = vectors or []
+        self.calls: list[dict[str, object]] = []
+
+    async def create(
+        self,
+        texts: list[str],
+        *,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+    ) -> list[list[float]]:
+        self.calls.append(
+            {
+                "texts": texts,
+                "provider": provider,
+                "model": model,
+                "dimensions": dimensions,
+            }
+        )
+        return self.vectors
+
+
+def _cache_key(
+    text: str,
+    provider: str,
+    model: str,
+    dimensions: int | None,
+    backend_identity: str | None,
+) -> str:
+    parts = [text, provider, model]
+    if dimensions is not None:
+        parts.append(str(dimensions))
+    if backend_identity is not None:
+        parts.append(backend_identity)
+    return "|".join(parts)
+
+
+def _prepared(
+    texts: list[str],
+    *,
+    provider: str = "openai",
+    model: str = "text-embedding-3-small",
+    dimensions: int | None = None,
+    backend_identity: str | None = "stale-plan-identity",
+    cache_namespace: str | None = "ignored-namespace",
+) -> PreparedEmbeddingRequest:
+    return PreparedEmbeddingRequest(
+        normalized_input=NormalizedEmbeddingInput(
+            texts=texts,
+            token_counts=[1 for _ in texts],
+            total_tokens=len(texts),
+        ),
+        provider_intent=ProviderModelIntent(
+            provider=provider,
+            model=model,
+            requested_provider=provider,
+            requested_model=model,
+            provider_was_explicit=True,
+            model_was_provider_qualified=False,
+        ),
+        policy_decision=EmbeddingPolicyDecision(
+            provider=provider,
+            model=model,
+            dimensions=dimensions,
+            fallback_chain=[provider],
+            fallback_allowed=True,
+            enforce_policy=True,
+        ),
+        execution_plan=EmbeddingExecutionPlan(
+            provider=provider,
+            model=model,
+            dimensions=dimensions,
+            backend_identity=backend_identity,
+            fallback_chain=[provider],
+            cache_namespace=cache_namespace,
+        ),
+        effective_dimension_policy="reduce",
+        prompt_tokens=len(texts),
+        total_tokens=len(texts),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_preserves_order_and_executes_only_cache_misses():
+    cache = RecordingCache(
+        {
+            "hit|openai|text-embedding-3-small|read-openai": [1.0, 0.0],
+            "hit2|openai|text-embedding-3-small|read-openai": [0.0, 1.0],
+        }
+    )
+    executor = RecordingExecutor(vectors=[[0.25, 0.75]])
+    identity_calls: list[tuple[str, str]] = []
+
+    def backend_identity(provider: str, model: str) -> str:
+        identity_calls.append((provider, model))
+        return "read-openai" if len(identity_calls) == 1 else "write-openai"
+
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=backend_identity,
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    result = await attempt.execute(
+        _prepared(["hit", "miss", "hit2"]),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert isinstance(result, ProviderAttemptSuccess)
+    assert result.vectors == [[1.0, 0.0], [0.25, 0.75], [0.0, 1.0]]
+    assert result.cache_hits == 2
+    assert result.cache_misses == 1
+    assert executor.calls == [
+        {
+            "texts": ["miss"],
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dimensions": None,
+        }
+    ]
+    assert cache.get_keys == [
+        "hit|openai|text-embedding-3-small|read-openai",
+        "miss|openai|text-embedding-3-small|read-openai",
+        "hit2|openai|text-embedding-3-small|read-openai",
+    ]
+    assert cache.set_calls == [
+        ("miss|openai|text-embedding-3-small|write-openai", [0.25, 0.75])
+    ]
+    assert identity_calls == [
+        ("openai", "text-embedding-3-small"),
+        ("openai", "text-embedding-3-small"),
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_cache_keys_exclude_plan_identity_and_namespace():
+    cache = RecordingCache()
+    executor = RecordingExecutor(vectors=[[0.1, 0.2]])
+    cache_key_calls: list[tuple[str, str, str, int | None, str | None]] = []
+
+    def cache_key_probe(
+        text: str,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+        backend_identity: str | None,
+    ) -> str:
+        cache_key_calls.append((text, provider, model, dimensions, backend_identity))
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=cache_key_probe,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=lambda provider, model: f"runtime:{provider}:{model}",
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    await attempt.execute(
+        _prepared(["one"], dimensions=2, backend_identity="stale-plan", cache_namespace="ns"),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert cache_key_calls == [
+        ("one", "openai", "text-embedding-3-small", 2, "runtime:openai:text-embedding-3-small"),
+        ("one", "openai", "text-embedding-3-small", 2, "runtime:openai:text-embedding-3-small"),
+    ]
+    assert all("stale-plan" not in key for key in cache.get_keys)
+    assert all("ns" not in key for key in cache.get_keys)
+```
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py -q
+```
+
+Expected: failures because `EmbeddingProviderAttempt` and `ProviderAttemptSuccess` do not exist.
+
+- [ ] **Step 3: Implement provider-attempt DTOs and ordered cache/miss execution**
+
+In `provider_attempt.py`, add:
+
+```python
+from dataclasses import dataclass
+
+from tldw_Server_API.app.core.Embeddings.preparation import BackendIdentityResolver
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingDomainError,
+    PreparedEmbeddingRequest,
+)
+from tldw_Server_API.app.core.Embeddings.vector_processing import (
+    EmbeddingVectorProcessor,
+)
+
+
+CacheKeyFn = Callable[[str, str, str, int | None, str | None], str]
+
+
+class ProviderAttemptCache(Protocol):
+    async def get(self, key: str) -> list[float] | None:
+        raise NotImplementedError
+
+    async def set(self, key: str, value: list[float]) -> object:
+        raise NotImplementedError
+
+
+class ProviderAttemptExecutor(Protocol):
+    async def create(
+        self,
+        texts: list[str],
+        *,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+    ) -> list[list[float]] | EmbeddingExecutorOutput:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAttemptSuccess:
+    vectors: list[list[float]]
+    provider: str
+    model: str
+    cache_hits: int
+    cache_misses: int
+    embeddings_from_adapter: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCallFailure:
+    error: EmbeddingDomainError
+
+
+class EmbeddingProviderAttempt:
+    def __init__(
+        self,
+        *,
+        cache_key_fn: CacheKeyFn,
+        cache: ProviderAttemptCache,
+        executor: ProviderAttemptExecutor,
+        backend_identity_resolver: BackendIdentityResolver,
+        vector_processor: EmbeddingVectorProcessor | None = None,
+    ) -> None:
+        self._cache_key_fn = cache_key_fn
+        self._cache = cache
+        self._executor = executor
+        self._backend_identity_resolver = backend_identity_resolver
+        self._vector_processor = vector_processor or EmbeddingVectorProcessor()
+
+    async def execute(
+        self,
+        prepared: PreparedEmbeddingRequest,
+        *,
+        provider: str,
+        model: str,
+    ) -> ProviderAttemptSuccess | ProviderCallFailure:
+        plan = prepared.execution_plan
+        read_identity = self._backend_identity_resolver(provider, model)
+        results: list[list[float] | None] = []
+        miss_indices: list[int] = []
+        miss_texts: list[str] = []
+
+        for index, text in enumerate(prepared.normalized_input.texts):
+            key = self._cache_key_fn(text, provider, model, plan.dimensions, read_identity)
+            cached = await self._cache.get(key)
+            cached_vector = self._vector_processor.validate_cached_vector(cached)
+            if cached_vector is None:
+                results.append(None)
+                miss_indices.append(index)
+                miss_texts.append(text)
+                continue
+            results.append(
+                self._vector_processor.process_cached_vector(
+                    cached_vector,
+                    provider=provider,
+                    model=model,
+                    dimensions=plan.dimensions,
+                    dimension_policy=prepared.effective_dimension_policy,
+                )
+            )
+
+        embeddings_from_adapter = False
+        pending_cache_writes: list[tuple[str, list[float]]] = []
+        if miss_texts:
+            try:
+                output = await self._executor.create(
+                    miss_texts,
+                    provider=provider,
+                    model=model,
+                    dimensions=plan.dimensions,
+                )
+            except EmbeddingDomainError as exc:
+                return ProviderCallFailure(exc)
+
+            miss_vectors, embeddings_from_adapter = _coerce_executor_output(output)
+            cache_vectors = self._vector_processor.validate_vector_count(
+                miss_vectors,
+                expected=len(miss_texts),
+                provider=provider,
+                model=model,
+            )
+            processed_misses = self._vector_processor.process_vectors(
+                cache_vectors,
+                provider=provider,
+                model=model,
+                dimensions=plan.dimensions,
+                dimension_policy=prepared.effective_dimension_policy,
+            )
+            write_identity = self._backend_identity_resolver(provider, model)
+            for index, text, vector, cache_vector in zip(
+                miss_indices,
+                miss_texts,
+                processed_misses,
+                cache_vectors,
+            ):
+                results[index] = vector
+                if not embeddings_from_adapter:
+                    key = self._cache_key_fn(text, provider, model, plan.dimensions, write_identity)
+                    pending_cache_writes.append((key, cache_vector))
+
+        vectors = self._vector_processor.validate_vector_count(
+            results,
+            expected=len(prepared.normalized_input.texts),
+            provider=provider,
+            model=model,
+        )
+        for key, vector in pending_cache_writes:
+            await self._cache.set(key, vector)
+        return ProviderAttemptSuccess(
+            vectors=vectors,
+            provider=provider,
+            model=model,
+            cache_hits=len(results) - len(miss_indices),
+            cache_misses=len(miss_indices),
+            embeddings_from_adapter=embeddings_from_adapter,
+        )
+```
+
+Also add `_coerce_executor_output` locally:
+
+```python
+def _coerce_executor_output(
+    output: list[list[float]] | EmbeddingExecutorOutput,
+) -> tuple[list[list[float]], bool]:
+    if isinstance(output, EmbeddingExecutorOutput):
+        return output.vectors, output.embeddings_from_adapter
+    return output, False
+```
+
+Export the new protocols and DTOs in `provider_attempt.__all__`.
+
+- [ ] **Step 4: Run provider-attempt tests and verify GREEN**
+
+Run the command from Step 2. Expected: all provider-attempt tests pass.
+
+- [ ] **Step 5: Commit the ordered attempt slice**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py
+git commit -m "refactor(embeddings): extract provider attempt cache execution"
+```
+
+### Task 3: Validation, Writeback, Adapter-Origin, and Failure Classification
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Embeddings/provider_attempt.py`
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py`
+
+- [ ] **Step 1: Write failing validation and adapter-origin tests**
+
+Add these tests:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_writes_provider_native_vectors_after_full_response_validation():
+    cache = RecordingCache({"hit|openai|text-embedding-3-small|read": [1.0, 0.0, 0.0]})
+    executor = RecordingExecutor(vectors=[[0.25, 0.75, 0.5]])
+
+    identities = iter(["read", "write"])
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=lambda provider, model: next(identities),
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    result = await attempt.execute(
+        _prepared(["hit", "miss"], dimensions=2),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert result.vectors == [[1.0, 0.0], [0.25, 0.75]]
+    assert cache.set_calls == [
+        ("miss|openai|text-embedding-3-small|2|write", [0.25, 0.75, 0.5])
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_rejects_provider_malformed_response_before_writeback():
+    cache = RecordingCache({"hit|openai|text-embedding-3-small|read": [1.0, 0.0]})
+    executor = RecordingExecutor(vectors=[[0.25, 0.75, 0.5]])
+
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=lambda provider, model: "read",
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        await attempt.execute(
+            _prepared(["hit", "miss"]),
+            provider="openai",
+            model="text-embedding-3-small",
+        )
+
+    assert exc_info.value.code == "provider_malformed_response"
+    assert cache.set_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_treats_malformed_cached_vector_as_miss():
+    cache = RecordingCache({"bad|openai|text-embedding-3-small|read": [float("nan")]})
+    executor = RecordingExecutor(vectors=[[0.1, 0.2]])
+
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=lambda provider, model: "read",
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    result = await attempt.execute(
+        _prepared(["bad"]),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert result.vectors == [[0.1, 0.2]]
+    assert result.cache_hits == 0
+    assert result.cache_misses == 1
+    assert executor.calls[0]["texts"] == ["bad"]
+    assert cache.set_calls == [("bad|openai|text-embedding-3-small|read", [0.1, 0.2])]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_skips_cache_write_for_adapter_originated_executor_output():
+    cache = RecordingCache()
+
+    class AdapterOriginExecutor(RecordingExecutor):
+        async def create(self, texts, *, provider, model, dimensions):
+            self.calls.append(
+                {
+                    "texts": texts,
+                    "provider": provider,
+                    "model": model,
+                    "dimensions": dimensions,
+                }
+            )
+            return EmbeddingExecutorOutput(
+                vectors=[[0.1, 0.2]],
+                embeddings_from_adapter=True,
+            )
+
+    executor = AdapterOriginExecutor()
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=lambda provider, model: "identity",
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    result = await attempt.execute(
+        _prepared(["adapter-origin"]),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert result.vectors == [[0.1, 0.2]]
+    assert result.embeddings_from_adapter is True
+    assert cache.set_calls == []
+```
+
+- [ ] **Step 2: Run the tests and verify RED where behavior is incomplete**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py -q
+```
+
+Expected: any missing validation/writeback behavior fails. If all tests pass because Task 2 implementation already covered them, record that the RED requirement was satisfied by adding the tests before any further production changes in this task.
+
+- [ ] **Step 3: Write failing provider-call and non-provider failure tests**
+
+Add:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_returns_exact_provider_call_failure_from_executor():
+    error = EmbeddingProviderError(
+        "provider_unavailable",
+        "provider down",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+
+    class FailingExecutor(RecordingExecutor):
+        async def create(self, texts, *, provider, model, dimensions):
+            self.calls.append(
+                {
+                    "texts": texts,
+                    "provider": provider,
+                    "model": model,
+                    "dimensions": dimensions,
+                }
+            )
+            raise error
+
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=RecordingCache(),
+        executor=FailingExecutor(),
+        backend_identity_resolver=lambda provider, model: "identity",
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    result = await attempt.execute(
+        _prepared(["one"]),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert isinstance(result, ProviderCallFailure)
+    assert result.error is error
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["identity", "cache_key", "cache_get", "cache_set"])
+async def test_provider_attempt_non_provider_failures_propagate_without_call_failure(boundary):
+    original = RuntimeError(f"{boundary} failed")
+
+    def identity(provider: str, model: str) -> str:
+        if boundary == "identity":
+            raise original
+        return "identity"
+
+    def cache_key(text: str, provider: str, model: str, dimensions: int | None, backend_identity: str | None) -> str:
+        if boundary == "cache_key":
+            raise original
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    class BoundaryCache(RecordingCache):
+        async def get(self, key: str) -> list[float] | None:
+            if boundary == "cache_get":
+                raise original
+            return await super().get(key)
+
+        async def set(self, key: str, value: list[float]) -> object:
+            if boundary == "cache_set":
+                raise original
+            return await super().set(key, value)
+
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=cache_key,
+        cache=BoundaryCache(),
+        executor=RecordingExecutor(vectors=[[0.1, 0.2]]),
+        backend_identity_resolver=identity,
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await attempt.execute(
+            _prepared(["one"]),
+            provider="openai",
+            model="text-embedding-3-small",
+        )
+
+    assert exc_info.value is original
+```
+
+- [ ] **Step 4: Implement the minimal missing behavior**
+
+If the tests from Steps 1 or 3 fail, adjust only `provider_attempt.py` so:
+
+- `EmbeddingDomainError` is caught only around `executor.create`.
+- `ProviderCallFailure.error` is the exact original exception object.
+- Identity resolution, cache-key derivation, cache access, vector validation, vector postprocessing, and cache writeback exceptions propagate.
+- The complete ordered result is validated before any `cache.set`.
+- `EmbeddingExecutorOutput(..., embeddings_from_adapter=True)` skips writeback but still returns processed vectors and miss counts.
+
+- [ ] **Step 5: Run provider-attempt tests and verify GREEN**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py -q
+```
+
+Expected: all provider-attempt tests pass.
+
+- [ ] **Step 6: Commit validation and failure classification**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py
+git commit -m "test(embeddings): cover provider attempt failure routing"
+```
+
+### Task 4: Legacy Fallback Write Identity Correction
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Embeddings/orchestrator.py`
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+
+- [ ] **Step 1: Write the failing fallback write-identity correction test**
+
+Add this test near the fallback identity coverage in `test_embedding_orchestrator.py`:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_writeback_re_resolves_backend_identity_after_provider_execution():
+    fallback_model = "sentence-transformers/all-MiniLM-L6-v2"
+    primary_error = EmbeddingProviderError(
+        "provider_unavailable",
+        "openai unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+    cache = RecordingCache()
+    executor = RecordingExecutor(
+        failures={"openai": primary_error},
+        provider_vectors={"huggingface": [[0.25, 0.75]]},
+    )
+    identity_calls: list[tuple[str, str]] = []
+
+    def backend_identity_resolver(provider: str, model: str) -> str:
+        identity_calls.append((provider, model))
+        if provider == "huggingface":
+            count = sum(1 for call in identity_calls if call == (provider, model))
+            return f"{provider}:{model}:{'read' if count == 1 else 'write'}"
+        return f"{provider}:{model}:identity"
+
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=backend_identity_resolver,
+        settings_fallback_chain={"openai": ["huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "huggingface": fallback_model,
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        "identity correction",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    result = await orchestrator.execute(prepared)
+
+    assert result.provider == "huggingface"
+    assert cache.get_keys == [
+        "identity correction|openai|text-embedding-3-small|"
+        "openai:text-embedding-3-small:identity",
+        f"identity correction|huggingface|{fallback_model}|"
+        f"huggingface:{fallback_model}:read",
+    ]
+    assert cache.set_calls == [
+        (
+            f"identity correction|huggingface|{fallback_model}|"
+            f"huggingface:{fallback_model}:write",
+            [0.25, 0.75],
+        )
+    ]
+    assert identity_calls == [
+        ("openai", "text-embedding-3-small"),
+        ("openai", "text-embedding-3-small"),
+        ("huggingface", fallback_model),
+        ("huggingface", fallback_model),
+    ]
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py::test_fallback_writeback_re_resolves_backend_identity_after_provider_execution -q
+```
+
+Expected: failure because fallback cache writeback uses the read-time identity.
+
+- [ ] **Step 3: Apply the minimal fallback correction**
+
+In `_execute_coherent_fallback`, keep the existing read identity before cache lookup. After executor success, vector-count validation, and request-specific postprocessing, resolve a second identity before building cache write keys:
+
+```python
+            write_backend_identity = self._backend_identity_resolver(provider, model)
+            for index, text, vector, cache_vector in zip(
+                miss_indices,
+                miss_texts,
+                canonical_vectors,
+                cache_vectors,
+            ):
+                results[index] = vector
+                if not embeddings_from_adapter:
+                    key = self._cache_key(
+                        text,
+                        provider,
+                        model,
+                        plan.dimensions,
+                        write_backend_identity,
+                    )
+                    pending_cache_writes.append((key, cache_vector))
+```
+
+Do not change primary execution or fallback exception classification in this task.
+
+- [ ] **Step 4: Run the correction and guardrail tests**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py::test_fallback_writeback_re_resolves_backend_identity_after_provider_execution tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py::test_current_fallback_wide_domain_catch_advances_after_infrastructure_failure -q
+```
+
+Expected: the new correction test passes and the Stage 2D guardrail test still passes.
+
+- [ ] **Step 5: Commit the correction**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+git commit -m "fix(embeddings): re-resolve fallback write identity"
+```
+
+### Task 5: Focused Regression, Bandit, and Tracking Finalization
+
+**Files:**
+- Modify: `backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md`
+- Verify: `tldw_Server_API/app/core/Embeddings/provider_attempt.py`
+- Verify: `tldw_Server_API/app/core/Embeddings/orchestrator.py`
+- Verify: `tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py`
+- Verify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+
+- [ ] **Step 1: Run the focused Stage 2C regression suite**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py -q
+```
+
+Expected: all selected tests pass. Investigate and fix failures before continuing.
+
+- [ ] **Step 2: Run Bandit on touched production code**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Embeddings/provider_attempt.py tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/app/core/Embeddings/request_types.py -f json -o /tmp/bandit_embeddings_stage2c.json
+```
+
+Expected: no new security findings in touched production code.
+
+- [ ] **Step 3: Run a git self-review**
+
+Run:
+
+```bash
+git diff --check
+git diff origin/codex/embeddings-workflow-stage2b-contracts -- tldw_Server_API/app/core/Embeddings/provider_attempt.py tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/app/core/Embeddings/request_types.py tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+```
+
+Expected: no whitespace errors; diff shows only Stage 2C provider-attempt extraction, shared executor-output relocation, fallback write identity correction, tests, plan, and backlog updates.
+
+- [ ] **Step 4: Update Backlog acceptance criteria and notes**
+
+Use Backlog.md tooling, not manual edits, to check completed acceptance criteria, append verification output, and add touched files. Example:
+
+```bash
+/opt/homebrew/bin/backlog task edit 12973.3 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 --check-ac 6 --check-ac 7 --check-ac 8 --check-ac 9 --check-ac 10 --check-ac 11 --check-ac 12 --check-dod 1 --check-dod 2 --check-dod 3 --check-dod 4 --append-notes "Verification: provider-attempt, orchestrator, workflow-types, endpoint parity focused tests passed; Bandit touched scope passed."
+```
+
+- [ ] **Step 5: Commit final tracking updates**
+
+If the plan has not yet been committed, include it with the final tracking commit:
+
+```bash
+git add Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md "backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md"
+git commit -m "docs(embeddings): plan stage 2c provider attempts"
+```
+
+If the plan was already committed before implementation, commit only the final backlog updates:
+
+```bash
+git add "backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md"
+git commit -m "docs(embeddings): record stage 2c verification"
+```
+
+## Self-Review Checklist
+
+- Spec coverage: maps to Stage 2C readiness, cache order, provider-native writeback, identity timing, provider-call failure DTO, cache failure propagation, and side-by-side production isolation.
+- Scope check: leaves Stage 2D fallback source-aware routing and Stage 2E runner wiring untouched.
+- Type consistency: shared executor-output contract is imported from `request_types.py` and re-exported by `orchestrator.py`.
+- Privacy check: no workflow events, trace metadata, raw input logging, cache keys in traces, provider response bodies, or credential material are added.
+- Verification check: focused tests and Bandit commands are explicit and runnable from the Stage 2C worktree with the repository venv.

--- a/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
+++ b/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
@@ -1,19 +1,19 @@
 ---
 id: TASK-12973.2
 title: Extract Embeddings preparation and result contracts
-status: To Do
+status: In Progress
 assignee: []
-created_date: '2026-07-19 02:33'
-updated_date: '2026-07-23 23:53'
+created_date: 2026-07-19 02:33
+updated_date: 2026-07-27 01:00
 labels:
-  - embeddings
-  - workflow
-  - stage-2
+- embeddings
+- workflow
+- stage-2
 dependencies:
-  - TASK-12973.1
+- TASK-12973.1
 documentation:
-  - >-
-    Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+- Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+- Docs/superpowers/plans/2026-07-26-embeddings-workflow-stage2b-contracts-implementation-plan.md
 parent_task_id: TASK-12973
 priority: high
 ---
@@ -47,3 +47,14 @@ Stage 2B. Extract the ordered preparation pipeline, deterministic vector process
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-07-26: Started Stage 2B in isolated worktree `.worktrees/embeddings-workflow-stage2b-contracts` on branch `codex/embeddings-workflow-stage2b-contracts`, based on merge commit `1f456e5e0f` from current `origin/dev`. Planning and baseline verification in progress.
+Baseline on merge commit `1f456e5e0f`: 226 focused preparation/request/workflow/orchestrator/endpoint-parity tests passed in 163.05s. The implementation plan keeps endpoint wiring and Stage 2C/2D corrections out of scope, preserves current legacy runner header-count metadata through Stage 2E, and requires explicit aggregate attempt counters on the canonical outcome.
+2026-07-26: Completed and committed workflow contract slice `e98fb075f2` and canonical result-contract slice `211bca9d30`. Canonical outcomes are deeply immutable, header-free, require explicit attempt counters, validate successful aggregate invariants while preserving zero-total endpoint accounting and mixed cache/adapter-origin semantics, and map to independent legacy results. Verification: 80 focused Task 2 tests passed; combined Task 2 plus endpoint parity run passed 222 tests; Ruff, diff-check, and scoped Bandit were clean. Independent spec and quality reviews approved the final slice.
+2026-07-26: Completed and committed ordered preparation extraction `e09c36917a`. `EmbeddingPreparationPipeline` preserves resolve-intent, normalize, policy, and planning order; phase sinks receive only phase identifiers; sink/boundary errors preserve identity and stop later work; orchestrator constructs one pipeline and delegates without a sink. Verification: 53 focused tests passed, worker endpoint parity 141 passed, Ruff and diff checks clean, scoped Bandit zero findings. Existing test file retains baseline formatter drift to avoid unrelated reformatting. Independent spec and quality reviews approved.
+2026-07-26: Completed and committed deterministic vector extraction `df94811463`. `EmbeddingVectorProcessor` owns count/malformed validation, nullable cache validation, numeric canonicalization, dimension adjustment, and recorder propagation; orchestrator delegates all primary/fallback/adapter vector boundaries. Added fallback malformed-cache miss/replacement regression without changing current identity timing. Verification: final combined processor/orchestrator/endpoint-parity run 202 passed in 155.57s; Ruff, format check on new/production files, diff-check, and scoped Bandit clean. Independent spec and quality reviews approved.
+2026-07-26 final pre-rebase verification: 305 focused Stage 2B plus endpoint-parity tests passed in 155.43s; all 255 Embeddings_isolated tests passed in 9.03s. Final whole-diff review found contradictory attempt metadata was still representable; fixed in `3a5efb5979` by enforcing fallback presence/count agreement, one-or-two non-fallback paths, and finite rectangular float-vector canonicalization. Focused request/result recheck passed 63 tests; final reviewer approved with no remaining Critical or Important findings. Changed-file Ruff passed, full source Bandit reported zero findings, diff-check passed, and no endpoint diff exists. Whole-directory Ruff/format checks surfaced only baseline issues in untouched `test_embedding_policy.py`, `test_review_findings_hardening.py`, `test_provider_resolution.py`, and pre-existing formatting lines in `test_embedding_orchestrator.py`; these were not expanded into unrelated churn. Test warnings are existing deprecation/runtime warnings; no skips or blockers.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
+++ b/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-12973.2
 title: Extract Embeddings preparation and result contracts
-status: In Progress
+status: Done
 assignee: []
 created_date: 2026-07-19 02:33
-updated_date: 2026-07-27 01:00
+updated_date: 2026-07-27 01:05
 labels:
 - embeddings
 - workflow
@@ -16,6 +16,21 @@ documentation:
 - Docs/superpowers/plans/2026-07-26-embeddings-workflow-stage2b-contracts-implementation-plan.md
 parent_task_id: TASK-12973
 priority: high
+modified_files:
+- Docs/superpowers/plans/2026-07-26-embeddings-workflow-stage2b-contracts-implementation-plan.md
+- backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
+- tldw_Server_API/app/core/Embeddings/orchestrator.py
+- tldw_Server_API/app/core/Embeddings/preparation.py
+- tldw_Server_API/app/core/Embeddings/request_types.py
+- tldw_Server_API/app/core/Embeddings/result_mapping.py
+- tldw_Server_API/app/core/Embeddings/vector_processing.py
+- tldw_Server_API/app/core/Embeddings/workflow_types.py
+- tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+- tldw_Server_API/tests/Embeddings_isolated/test_preparation_pipeline.py
+- tldw_Server_API/tests/Embeddings_isolated/test_request_types.py
+- tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py
+- tldw_Server_API/tests/Embeddings_isolated/test_vector_processing.py
+- tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py
 ---
 
 ## Description
@@ -26,26 +41,26 @@ Stage 2B. Extract the ordered preparation pipeline, deterministic vector process
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Preparation preserves resolve-intent, normalize, policy, and planning order and error precedence.
-- [ ] #2 Canonical execution outcomes contain domain metadata and no HTTP headers.
-- [ ] #3 The compatibility adapter preserves the existing EmbeddingExecutionResult contract.
-- [ ] #4 Focused and endpoint parity tests pass.
-- [ ] #5 A pure endpoint header mapper is defined and parity-tested; production wiring is deferred to Stage 2E.
-- [ ] #6 Preparation phase reporting receives phase identifiers only and never forwards request data or execution-plan observability tags.
-- [ ] #7 Stateless boundaries use functions, narrow protocols, or immutable DTOs unless meaningful injected state requires a class.
-- [ ] #8 The legacy response-header mapper is documented as a Stage 6 compatibility exception outside the canonical runner path.
-- [ ] #9 Workflow phase contracts add resolving_intent, keep completed as a status, and define finalizing event semantics explicitly.
-- [ ] #10 Canonical outcomes preserve successful adapter cache counts as zero hits and item-count misses.
+- [x] #1 Preparation preserves resolve-intent, normalize, policy, and planning order and error precedence.
+- [x] #2 Canonical execution outcomes contain domain metadata and no HTTP headers.
+- [x] #3 The compatibility adapter preserves the existing EmbeddingExecutionResult contract.
+- [x] #4 Focused and endpoint parity tests pass.
+- [x] #5 A pure endpoint header mapper is defined and parity-tested; production wiring is deferred to Stage 2E.
+- [x] #6 Preparation phase reporting receives phase identifiers only and never forwards request data or execution-plan observability tags.
+- [x] #7 Stateless boundaries use functions, narrow protocols, or immutable DTOs unless meaningful injected state requires a class.
+- [x] #8 The legacy response-header mapper is documented as a Stage 6 compatibility exception outside the canonical runner path.
+- [x] #9 Workflow phase contracts add resolving_intent, keep completed as a status, and define finalizing event semantics explicitly.
+- [x] #10 Canonical outcomes preserve successful adapter cache counts as zero hits and item-count misses.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
 
 ## Implementation Notes
@@ -57,4 +72,11 @@ Baseline on merge commit `1f456e5e0f`: 226 focused preparation/request/workflow/
 2026-07-26: Completed and committed ordered preparation extraction `e09c36917a`. `EmbeddingPreparationPipeline` preserves resolve-intent, normalize, policy, and planning order; phase sinks receive only phase identifiers; sink/boundary errors preserve identity and stop later work; orchestrator constructs one pipeline and delegates without a sink. Verification: 53 focused tests passed, worker endpoint parity 141 passed, Ruff and diff checks clean, scoped Bandit zero findings. Existing test file retains baseline formatter drift to avoid unrelated reformatting. Independent spec and quality reviews approved.
 2026-07-26: Completed and committed deterministic vector extraction `df94811463`. `EmbeddingVectorProcessor` owns count/malformed validation, nullable cache validation, numeric canonicalization, dimension adjustment, and recorder propagation; orchestrator delegates all primary/fallback/adapter vector boundaries. Added fallback malformed-cache miss/replacement regression without changing current identity timing. Verification: final combined processor/orchestrator/endpoint-parity run 202 passed in 155.57s; Ruff, format check on new/production files, diff-check, and scoped Bandit clean. Independent spec and quality reviews approved.
 2026-07-26 final pre-rebase verification: 305 focused Stage 2B plus endpoint-parity tests passed in 155.43s; all 255 Embeddings_isolated tests passed in 9.03s. Final whole-diff review found contradictory attempt metadata was still representable; fixed in `3a5efb5979` by enforcing fallback presence/count agreement, one-or-two non-fallback paths, and finite rectangular float-vector canonicalization. Focused request/result recheck passed 63 tests; final reviewer approved with no remaining Critical or Important findings. Changed-file Ruff passed, full source Bandit reported zero findings, diff-check passed, and no endpoint diff exists. Whole-directory Ruff/format checks surfaced only baseline issues in untouched `test_embedding_policy.py`, `test_review_findings_hardening.py`, `test_provider_resolution.py`, and pre-existing formatting lines in `test_embedding_orchestrator.py`; these were not expanded into unrelated churn. Test warnings are existing deprecation/runtime warnings; no skips or blockers.
+2026-07-26 post-rebase verification: rebased without conflicts onto `origin/dev` commit `616d6dd35d`. The expanded focused Stage 2B plus endpoint-parity suite passed 324 tests in 155.02s. Changed-file Ruff passed, scoped Bandit reported zero findings, `git diff --check origin/dev` passed, branch is 0 behind/6 ahead, and the production embeddings endpoint has no diff. Branch is implementation-complete; PR creation still requires the requester-authored Change summary mandated by repository policy.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 2B extracted Embeddings workflow contracts, a canonical immutable HTTP-free outcome with pure response/legacy mappings, an ordered phase-safe preparation pipeline, and deterministic vector processing. Existing execution and endpoint behavior remain in place; endpoint mapper adoption stays deferred to Stage 2E, and Stage 2C/2D identity/routing corrections were not introduced. Final review findings were addressed, including strict attempt/fallback invariants and runtime vector-shape immutability. Verification passed 324 focused/post-rebase tests and 255 full isolated Embeddings tests, with changed-file Ruff, diff checks, and Bandit clean. Known whole-directory lint/format findings are pre-existing baseline issues documented in the task; no skips or blockers remain.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
+++ b/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
@@ -4,7 +4,7 @@ title: Extract Embeddings preparation and result contracts
 status: Done
 assignee: []
 created_date: 2026-07-19 02:33
-updated_date: 2026-07-27 01:05
+updated_date: 2026-07-27 15:48
 labels:
 - embeddings
 - workflow
@@ -31,6 +31,8 @@ modified_files:
 - tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py
 - tldw_Server_API/tests/Embeddings_isolated/test_vector_processing.py
 - tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py
+references:
+- https://github.com/rmusser01/tldw_server/pull/2766
 ---
 
 ## Description
@@ -73,6 +75,7 @@ Baseline on merge commit `1f456e5e0f`: 226 focused preparation/request/workflow/
 2026-07-26: Completed and committed deterministic vector extraction `df94811463`. `EmbeddingVectorProcessor` owns count/malformed validation, nullable cache validation, numeric canonicalization, dimension adjustment, and recorder propagation; orchestrator delegates all primary/fallback/adapter vector boundaries. Added fallback malformed-cache miss/replacement regression without changing current identity timing. Verification: final combined processor/orchestrator/endpoint-parity run 202 passed in 155.57s; Ruff, format check on new/production files, diff-check, and scoped Bandit clean. Independent spec and quality reviews approved.
 2026-07-26 final pre-rebase verification: 305 focused Stage 2B plus endpoint-parity tests passed in 155.43s; all 255 Embeddings_isolated tests passed in 9.03s. Final whole-diff review found contradictory attempt metadata was still representable; fixed in `3a5efb5979` by enforcing fallback presence/count agreement, one-or-two non-fallback paths, and finite rectangular float-vector canonicalization. Focused request/result recheck passed 63 tests; final reviewer approved with no remaining Critical or Important findings. Changed-file Ruff passed, full source Bandit reported zero findings, diff-check passed, and no endpoint diff exists. Whole-directory Ruff/format checks surfaced only baseline issues in untouched `test_embedding_policy.py`, `test_review_findings_hardening.py`, `test_provider_resolution.py`, and pre-existing formatting lines in `test_embedding_orchestrator.py`; these were not expanded into unrelated churn. Test warnings are existing deprecation/runtime warnings; no skips or blockers.
 2026-07-26 post-rebase verification: rebased without conflicts onto `origin/dev` commit `616d6dd35d`. The expanded focused Stage 2B plus endpoint-parity suite passed 324 tests in 155.02s. Changed-file Ruff passed, scoped Bandit reported zero findings, `git diff --check origin/dev` passed, branch is 0 behind/6 ahead, and the production embeddings endpoint has no diff. Branch is implementation-complete; PR creation still requires the requester-authored Change summary mandated by repository policy.
+2026-07-27 PR handoff: Draft PR #2766 opened against `dev`: https://github.com/rmusser01/tldw_server/pull/2766. Fresh PR-creation verification in this worktree passed the focused Stage 2B plus endpoint-parity suite (`324 passed`, 4487 warnings, 192.21s), full `tldw_Server_API/tests/Embeddings_isolated` (`274 passed`, 566 warnings, 14.12s), exact changed-file Ruff check, scoped Bandit with 0 findings/0 errors, and `git diff --check origin/dev...HEAD`. Whole isolated-test-directory Ruff/format checks still show the documented baseline issues in untouched tests and existing formatter drift in `test_embedding_orchestrator.py`; these were not expanded into unrelated churn. The PR is draft and remains blocked on the requester-authored `Change summary` required by repository policy. Two local untracked watchlist template files remain outside the branch and PR.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
+++ b/backlog/tasks/task-12973.2 - Extract-Embeddings-preparation-and-result-contracts.md
@@ -4,7 +4,7 @@ title: Extract Embeddings preparation and result contracts
 status: Done
 assignee: []
 created_date: 2026-07-19 02:33
-updated_date: 2026-07-27 15:48
+updated_date: 2026-08-01 17:31
 labels:
 - embeddings
 - workflow
@@ -81,5 +81,5 @@ Baseline on merge commit `1f456e5e0f`: 226 focused preparation/request/workflow/
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 2B extracted Embeddings workflow contracts, a canonical immutable HTTP-free outcome with pure response/legacy mappings, an ordered phase-safe preparation pipeline, and deterministic vector processing. Existing execution and endpoint behavior remain in place; endpoint mapper adoption stays deferred to Stage 2E, and Stage 2C/2D identity/routing corrections were not introduced. Final review findings were addressed, including strict attempt/fallback invariants and runtime vector-shape immutability. Verification passed 324 focused/post-rebase tests and 255 full isolated Embeddings tests, with changed-file Ruff, diff checks, and Bandit clean. Known whole-directory lint/format findings are pre-existing baseline issues documented in the task; no skips or blockers remain.
+Stage 2B extracted Embeddings workflow contracts, a canonical immutable HTTP-free outcome with pure response/legacy mappings, an ordered phase-safe preparation pipeline, and deterministic vector processing. Existing execution and endpoint behavior remain in place; endpoint mapper adoption stays deferred to Stage 2E, and Stage 2C/2D identity/routing corrections were not introduced. Final review findings were addressed, including strict attempt/fallback invariants and runtime vector-shape immutability. Verification passed 324 focused/post-rebase tests and 274 full isolated Embeddings tests, with changed-file Ruff, diff checks, and Bandit clean. Known whole-directory lint/format findings are pre-existing baseline issues documented in the task; no code or test blockers remain. PR integration remains blocked on the requester-authored Change summary required by repository policy.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
+++ b/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
@@ -4,13 +4,15 @@ title: Extract single-provider Embeddings execution attempts
 status: In Progress
 assignee: []
 created_date: '2026-07-19 02:35'
-updated_date: '2026-07-27 16:07'
+updated_date: '2026-07-27 17:28'
 labels:
   - embeddings
   - workflow
   - stage-2
 dependencies:
   - TASK-12973.2
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2767'
 documentation:
   - >-
     Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
@@ -52,6 +54,8 @@ Stage 2C. Extract provider readiness checks and a single-provider attempt compon
 2026-07-27: Implemented side-by-side provider readiness and provider-attempt components; moved EmbeddingExecutorOutput to request_types with orchestrator re-export; corrected fallback writeback to re-resolve backend identity after provider execution. Touched files: provider_attempt.py, request_types.py, orchestrator.py, provider-attempt tests, orchestrator characterization tests, Stage 2C plan.
 
 Verification: focused Stage 2C regression passed: 230 passed, 4299 warnings. Bandit touched production scope passed with zero findings: /tmp/bandit_embeddings_stage2c.json. git diff --check passed.
+
+2026-07-27: Opened stacked draft PR #2767 against codex/embeddings-workflow-stage2b-contracts; retarget to dev after Stage 2B merges.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
+++ b/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
@@ -4,7 +4,7 @@ title: Extract single-provider Embeddings execution attempts
 status: In Progress
 assignee: []
 created_date: '2026-07-19 02:35'
-updated_date: '2026-07-27 17:28'
+updated_date: '2026-08-01 17:31'
 labels:
   - embeddings
   - workflow
@@ -56,6 +56,8 @@ Stage 2C. Extract provider readiness checks and a single-provider attempt compon
 Verification: focused Stage 2C regression passed: 230 passed, 4299 warnings. Bandit touched production scope passed with zero findings: /tmp/bandit_embeddings_stage2c.json. git diff --check passed.
 
 2026-07-27: Opened stacked draft PR #2767 against codex/embeddings-workflow-stage2b-contracts; retarget to dev after Stage 2B merges.
+
+2026-08-01 review and integration preparation: retargeted PR #2767 to dev after confirming the branch already contains origin/dev commit 616d6dd35d, so the requested rebase was a no-op. Qodo docstring findings were validated and remediated; its multiple-marker claim was rejected because unit plus asyncio/parametrize is established repository practice and parametrize controls test coverage. CodeRabbit backlog-count finding was fixed; its request to wire EmbeddingProviderAttempt into the orchestrator was rejected because acceptance criterion 10 explicitly keeps the component side-by-side until Stage 2D. Full combined Stage 2B/2C regression passed 328 tests with 4495 warnings in 154.15s.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
+++ b/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-12973.3
 title: Extract single-provider Embeddings execution attempts
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-19 02:35'
-updated_date: '2026-07-23 23:59'
+updated_date: '2026-07-27 15:52'
 labels:
   - embeddings
   - workflow
@@ -14,6 +14,8 @@ dependencies:
 documentation:
   - >-
     Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+  - >-
+    Docs/superpowers/plans/2026-07-27-embeddings-workflow-stage2c-provider-attempts-implementation-plan.md
 parent_task_id: TASK-12973
 priority: high
 ---
@@ -39,6 +41,14 @@ Stage 2C. Extract provider readiness checks and a single-provider attempt compon
 - [ ] #11 Provider attempts delegate dynamic cache eligibility to the injected cache so private-credential bypass yields misses without underlying shared writes.
 - [ ] #12 Malformed or non-finite cached vectors become misses and are replaced without reaching vector postprocessing as cache hits.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-07-27: Started Stage 2C in worktree .worktrees/embeddings-workflow-stage2c-attempts from origin/codex/embeddings-workflow-stage2b-contracts. Baseline passed: 117 focused Embeddings_isolated tests.
+
+2026-07-27: Wrote Stage 2C provider-attempt implementation plan and self-reviewed it for placeholders, scope drift, and type/path consistency.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
+++ b/backlog/tasks/task-12973.3 - Extract-single-provider-Embeddings-execution-attempts.md
@@ -4,7 +4,7 @@ title: Extract single-provider Embeddings execution attempts
 status: In Progress
 assignee: []
 created_date: '2026-07-19 02:35'
-updated_date: '2026-07-27 15:52'
+updated_date: '2026-07-27 16:07'
 labels:
   - embeddings
   - workflow
@@ -28,18 +28,18 @@ Stage 2C. Extract provider readiness checks and a single-provider attempt compon
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Primary and candidate readiness checks are independently callable.
-- [ ] #2 Cache hits preserve request order and only misses reach the executor.
-- [ ] #3 All returned vectors are validated and postprocessed before cache writeback begins.
-- [ ] #4 Provider-native float vectors, not encoded or adjusted vectors, are cached.
-- [ ] #5 Cache and non-provider failures never trigger fallback.
-- [ ] #6 Cache keys retain exactly text, provider, model, requested dimensions, and runtime backend identity; cache_namespace remains excluded.
-- [ ] #7 Read identity is resolved after readiness and write identity is re-resolved after provider execution for primary and fallback attempts.
-- [ ] #8 EmbeddingExecutionPlan.backend_identity is not used as the authoritative runtime cache identity.
-- [ ] #9 Isolated provider-attempt tests classify backend-identity and cache-key derivation failures as non-provider failures without fallback or writeback.
-- [ ] #10 Stage 2C production behavior changes only fallback write identity; the new provider-attempt component remains side-by-side until Stage 2D.
-- [ ] #11 Provider attempts delegate dynamic cache eligibility to the injected cache so private-credential bypass yields misses without underlying shared writes.
-- [ ] #12 Malformed or non-finite cached vectors become misses and are replaced without reaching vector postprocessing as cache hits.
+- [x] #1 Primary and candidate readiness checks are independently callable.
+- [x] #2 Cache hits preserve request order and only misses reach the executor.
+- [x] #3 All returned vectors are validated and postprocessed before cache writeback begins.
+- [x] #4 Provider-native float vectors, not encoded or adjusted vectors, are cached.
+- [x] #5 Cache and non-provider failures never trigger fallback.
+- [x] #6 Cache keys retain exactly text, provider, model, requested dimensions, and runtime backend identity; cache_namespace remains excluded.
+- [x] #7 Read identity is resolved after readiness and write identity is re-resolved after provider execution for primary and fallback attempts.
+- [x] #8 EmbeddingExecutionPlan.backend_identity is not used as the authoritative runtime cache identity.
+- [x] #9 Isolated provider-attempt tests classify backend-identity and cache-key derivation failures as non-provider failures without fallback or writeback.
+- [x] #10 Stage 2C production behavior changes only fallback write identity; the new provider-attempt component remains side-by-side until Stage 2D.
+- [x] #11 Provider attempts delegate dynamic cache eligibility to the injected cache so private-credential bypass yields misses without underlying shared writes.
+- [x] #12 Malformed or non-finite cached vectors become misses and are replaced without reaching vector postprocessing as cache hits.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -48,14 +48,24 @@ Stage 2C. Extract provider readiness checks and a single-provider attempt compon
 2026-07-27: Started Stage 2C in worktree .worktrees/embeddings-workflow-stage2c-attempts from origin/codex/embeddings-workflow-stage2b-contracts. Baseline passed: 117 focused Embeddings_isolated tests.
 
 2026-07-27: Wrote Stage 2C provider-attempt implementation plan and self-reviewed it for placeholders, scope drift, and type/path consistency.
+
+2026-07-27: Implemented side-by-side provider readiness and provider-attempt components; moved EmbeddingExecutorOutput to request_types with orchestrator re-export; corrected fallback writeback to re-resolve backend identity after provider execution. Touched files: provider_attempt.py, request_types.py, orchestrator.py, provider-attempt tests, orchestrator characterization tests, Stage 2C plan.
+
+Verification: focused Stage 2C regression passed: 230 passed, 4299 warnings. Bandit touched production scope passed with zero findings: /tmp/bandit_embeddings_stage2c.json. git diff --check passed.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 2C extracted single-provider readiness and attempt boundaries side-by-side without production runner wiring, added focused behavior coverage for cache ordering, provider-native writeback, adapter-origin skip-write, provider-call failure DTOs, and non-provider failure propagation, and applied the approved fallback writeback backend-identity re-resolution correction.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/core/Embeddings/orchestrator.py
+++ b/tldw_Server_API/app/core/Embeddings/orchestrator.py
@@ -383,6 +383,7 @@ class EmbeddingRequestOrchestrator:
                 dimensions=plan.dimensions,
                 dimension_policy=prepared.effective_dimension_policy,
             )
+            write_backend_identity = self._backend_identity_resolver(provider, model)
             for index, text, vector, cache_vector in zip(
                 miss_indices,
                 miss_texts,
@@ -391,7 +392,13 @@ class EmbeddingRequestOrchestrator:
             ):
                 results[index] = vector
                 if not embeddings_from_adapter:
-                    key = self._cache_key(text, provider, model, plan.dimensions, backend_identity)
+                    key = self._cache_key(
+                        text,
+                        provider,
+                        model,
+                        plan.dimensions,
+                        write_backend_identity,
+                    )
                     pending_cache_writes.append((key, cache_vector))
 
         vectors = self._vector_processor.validate_vector_count(

--- a/tldw_Server_API/app/core/Embeddings/orchestrator.py
+++ b/tldw_Server_API/app/core/Embeddings/orchestrator.py
@@ -21,11 +21,9 @@ from tldw_Server_API.app.core.Embeddings.request_types import (
     EmbeddingExecutionError,
     EmbeddingExecutionPlan,
     EmbeddingExecutionResult,
-    EmbeddingPolicyDecision,
     EmbeddingProviderError,
     EmbeddingRequestContext,
-    NormalizedEmbeddingInput,
-    ProviderModelIntent,
+    PreparedEmbeddingRequest,
 )
 from tldw_Server_API.app.core.Embeddings.vector_validation import (
     validated_embedding_vectors,
@@ -70,17 +68,6 @@ TokenDecoder = Callable[[list[int] | list[list[int]], str], object]
 BackendIdentityResolver = Callable[[str, str], str | None]
 DimensionAdjustmentRecorder = Callable[[str, str, str], None]
 ProviderPreflight = Callable[[str, str], Awaitable[None]]
-
-
-@dataclass(frozen=True, slots=True)
-class PreparedEmbeddingRequest:
-    normalized_input: NormalizedEmbeddingInput
-    provider_intent: ProviderModelIntent
-    policy_decision: EmbeddingPolicyDecision
-    execution_plan: EmbeddingExecutionPlan
-    effective_dimension_policy: str
-    prompt_tokens: int
-    total_tokens: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -242,11 +229,7 @@ class EmbeddingRequestOrchestrator:
         for index, text in enumerate(prepared.normalized_input.texts):
             key = self._cache_key(text, plan.provider, plan.model, plan.dimensions, primary_backend_identity)
             cached = await self._cache.get(key)
-            validated_cached = (
-                validated_embedding_vectors([cached], expected=1)
-                if cached is not None
-                else None
-            )
+            validated_cached = validated_embedding_vectors([cached], expected=1) if cached is not None else None
             if validated_cached is not None:
                 results.append(
                     self._postprocess_cached_vector(
@@ -414,11 +397,7 @@ class EmbeddingRequestOrchestrator:
         for index, text in enumerate(prepared.normalized_input.texts):
             key = self._cache_key(text, provider, model, plan.dimensions, backend_identity)
             cached = await self._cache.get(key)
-            validated_cached = (
-                validated_embedding_vectors([cached], expected=1)
-                if cached is not None
-                else None
-            )
+            validated_cached = validated_embedding_vectors([cached], expected=1) if cached is not None else None
             if validated_cached is not None:
                 results.append(
                     self._postprocess_cached_vector(

--- a/tldw_Server_API/app/core/Embeddings/orchestrator.py
+++ b/tldw_Server_API/app/core/Embeddings/orchestrator.py
@@ -20,6 +20,7 @@ from tldw_Server_API.app.core.Embeddings.request_types import (
     EmbeddingDomainError,
     EmbeddingExecutionError,
     EmbeddingExecutionResult,
+    EmbeddingExecutorOutput,
     EmbeddingProviderError,
     EmbeddingRequestContext,
     PreparedEmbeddingRequest,
@@ -64,12 +65,6 @@ class EmbeddingAdapterExecutor(Protocol):
 
 CacheKeyFn = Callable[[str, str, str, int | None, str | None], str]
 ProviderPreflight = Callable[[str, str], Awaitable[None]]
-
-
-@dataclass(frozen=True, slots=True)
-class EmbeddingExecutorOutput:
-    vectors: list[list[float]]
-    embeddings_from_adapter: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/tldw_Server_API/app/core/Embeddings/orchestrator.py
+++ b/tldw_Server_API/app/core/Embeddings/orchestrator.py
@@ -8,18 +8,18 @@ from typing import Any, Literal, Protocol
 
 from tldw_Server_API.app.core.Embeddings.embedding_policy import (
     adjust_dimensions,
-    enforce_embedding_policy,
     map_model_for_provider,
 )
-from tldw_Server_API.app.core.Embeddings.input_normalizer import normalize_embedding_input
-from tldw_Server_API.app.core.Embeddings.provider_resolution import (
-    ProviderGuesser,
-    resolve_provider_model,
+from tldw_Server_API.app.core.Embeddings.preparation import (
+    BackendIdentityResolver,
+    EmbeddingPreparationPipeline,
+    TokenCounter,
+    TokenDecoder,
 )
+from tldw_Server_API.app.core.Embeddings.provider_resolution import ProviderGuesser
 from tldw_Server_API.app.core.Embeddings.request_types import (
     EmbeddingDomainError,
     EmbeddingExecutionError,
-    EmbeddingExecutionPlan,
     EmbeddingExecutionResult,
     EmbeddingProviderError,
     EmbeddingRequestContext,
@@ -63,9 +63,6 @@ class EmbeddingAdapterExecutor(Protocol):
 
 
 CacheKeyFn = Callable[[str, str, str, int | None, str | None], str]
-TokenCounter = Callable[[str, str], int]
-TokenDecoder = Callable[[list[int] | list[list[int]], str], object]
-BackendIdentityResolver = Callable[[str, str], str | None]
 DimensionAdjustmentRecorder = Callable[[str, str, str], None]
 ProviderPreflight = Callable[[str, str], Awaitable[None]]
 
@@ -119,82 +116,37 @@ class EmbeddingRequestOrchestrator:
         batch_size: int | None = None,
         execution_path: Literal["legacy", "adapter"] = "legacy",
     ) -> None:
-        self._count_tokens = count_tokens
-        self._tokens_to_texts = tokens_to_texts
         self._cache_key_fn = cache_key_fn
         self._cache = cache
         self._executor = executor
-        self._settings_config = settings_config
-        self._max_tokens = max_tokens
-        self._implemented_providers = implemented_providers
-        self._allowed_providers = allowed_providers
-        self._allowed_models = allowed_models
-        self._enforce_policy = enforce_policy
-        self._allow_fallback_with_header = allow_fallback_with_header
-        self._settings_fallback_chain = settings_fallback_chain
         self._settings_fallback_model_map = settings_fallback_model_map
-        self._dimension_policy = dimension_policy
-        self._require_model = require_model
-        self._guess_provider = guess_provider
         self._backend_identity_resolver = backend_identity_resolver or _no_backend_identity
         self._record_dimension_adjustment = record_dimension_adjustment
         self._provider_preflight = provider_preflight or _no_provider_preflight
-        self._cache_namespace = cache_namespace
-        self._batch_size = batch_size
-        self._execution_path = execution_path
+        self._preparation_pipeline = EmbeddingPreparationPipeline(
+            count_tokens=count_tokens,
+            tokens_to_texts=tokens_to_texts,
+            settings_config=settings_config,
+            max_tokens=max_tokens,
+            implemented_providers=implemented_providers,
+            allowed_providers=allowed_providers,
+            allowed_models=allowed_models,
+            enforce_policy=enforce_policy,
+            allow_fallback_with_header=allow_fallback_with_header,
+            settings_fallback_chain=settings_fallback_chain,
+            settings_fallback_model_map=settings_fallback_model_map,
+            dimension_policy=dimension_policy,
+            require_model=require_model,
+            guess_provider=guess_provider,
+            backend_identity_resolver=self._backend_identity_resolver,
+            cache_namespace=cache_namespace,
+            batch_size=batch_size,
+            execution_path=execution_path,
+        )
 
     def prepare(self, raw_input: Any, context: EmbeddingRequestContext) -> PreparedEmbeddingRequest:
         """Normalize, resolve, validate, and plan an embedding request."""
-        intent = resolve_provider_model(
-            context.model_field,
-            context.provider_header,
-            settings_config=self._settings_config,
-            require_model=self._require_model,
-            guess_provider=self._guess_provider,
-        )
-        normalized_input = normalize_embedding_input(
-            raw_input,
-            model=intent.model,
-            max_tokens=self._max_tokens,
-            count_tokens=self._count_tokens,
-            tokens_to_texts=self._tokens_to_texts,
-        )
-        decision = enforce_embedding_policy(
-            intent,
-            context,
-            allowed_providers=self._allowed_providers,
-            allowed_models=self._allowed_models,
-            implemented_providers=self._implemented_providers,
-            enforce_policy=self._enforce_policy,
-            allow_fallback_with_header=self._allow_fallback_with_header,
-            settings_fallback_chain=self._settings_fallback_chain,
-            settings_fallback_model_map=self._settings_fallback_model_map,
-        )
-        effective_dimension_policy = self._effective_dimension_policy(context.encoding_format, decision.dimensions)
-        execution_plan = EmbeddingExecutionPlan(
-            provider=decision.provider,
-            model=decision.model,
-            dimensions=decision.dimensions,
-            backend_identity=self._backend_identity_resolver(decision.provider, decision.model),
-            fallback_chain=list(decision.fallback_chain),
-            cache_namespace=self._cache_namespace,
-            batch_size=self._batch_size,
-            execution_path=self._execution_path,
-            observability_tags={
-                "provider": decision.provider,
-                "model": decision.model,
-                "fallback_allowed": decision.fallback_allowed,
-            },
-        )
-        return PreparedEmbeddingRequest(
-            normalized_input=normalized_input,
-            provider_intent=intent,
-            policy_decision=decision,
-            execution_plan=execution_plan,
-            effective_dimension_policy=effective_dimension_policy,
-            prompt_tokens=normalized_input.total_tokens,
-            total_tokens=normalized_input.total_tokens,
-        )
+        return self._preparation_pipeline.prepare(raw_input, context)
 
     async def execute(self, prepared: PreparedEmbeddingRequest) -> EmbeddingExecutionResult:
         """Execute a prepared request through cache and provider executor."""
@@ -594,11 +546,6 @@ class EmbeddingRequestOrchestrator:
         if dimensions is not None:
             headers["X-Embeddings-Dimensions-Policy"] = dimension_policy
         return headers
-
-    def _effective_dimension_policy(self, encoding_format: str | None, dimensions: int | None) -> str:
-        if dimensions is not None and encoding_format == "base64":
-            return "reduce"
-        return self._dimension_policy
 
 
 def _canonical_vector(vector: object) -> list[float]:

--- a/tldw_Server_API/app/core/Embeddings/orchestrator.py
+++ b/tldw_Server_API/app/core/Embeddings/orchestrator.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
 from tldw_Server_API.app.core.Embeddings.embedding_policy import (
-    adjust_dimensions,
     map_model_for_provider,
 )
 from tldw_Server_API.app.core.Embeddings.preparation import (
@@ -25,8 +24,9 @@ from tldw_Server_API.app.core.Embeddings.request_types import (
     EmbeddingRequestContext,
     PreparedEmbeddingRequest,
 )
-from tldw_Server_API.app.core.Embeddings.vector_validation import (
-    validated_embedding_vectors,
+from tldw_Server_API.app.core.Embeddings.vector_processing import (
+    DimensionAdjustmentRecorder,
+    EmbeddingVectorProcessor,
 )
 
 
@@ -63,7 +63,6 @@ class EmbeddingAdapterExecutor(Protocol):
 
 
 CacheKeyFn = Callable[[str, str, str, int | None, str | None], str]
-DimensionAdjustmentRecorder = Callable[[str, str, str], None]
 ProviderPreflight = Callable[[str, str], Awaitable[None]]
 
 
@@ -121,8 +120,8 @@ class EmbeddingRequestOrchestrator:
         self._executor = executor
         self._settings_fallback_model_map = settings_fallback_model_map
         self._backend_identity_resolver = backend_identity_resolver or _no_backend_identity
-        self._record_dimension_adjustment = record_dimension_adjustment
         self._provider_preflight = provider_preflight or _no_provider_preflight
+        self._vector_processor = EmbeddingVectorProcessor(record_dimension_adjustment=record_dimension_adjustment)
         self._preparation_pipeline = EmbeddingPreparationPipeline(
             count_tokens=count_tokens,
             tokens_to_texts=tokens_to_texts,
@@ -181,15 +180,15 @@ class EmbeddingRequestOrchestrator:
         for index, text in enumerate(prepared.normalized_input.texts):
             key = self._cache_key(text, plan.provider, plan.model, plan.dimensions, primary_backend_identity)
             cached = await self._cache.get(key)
-            validated_cached = validated_embedding_vectors([cached], expected=1) if cached is not None else None
-            if validated_cached is not None:
+            cached_vector = self._vector_processor.validate_cached_vector(cached)
+            if cached_vector is not None:
                 results.append(
-                    self._postprocess_cached_vector(
-                        validated_cached[0],
-                        plan.provider,
-                        plan.model,
-                        plan.dimensions,
-                        prepared.effective_dimension_policy,
+                    self._vector_processor.process_cached_vector(
+                        cached_vector,
+                        provider=plan.provider,
+                        model=plan.model,
+                        dimensions=plan.dimensions,
+                        dimension_policy=prepared.effective_dimension_policy,
                     )
                 )
                 continue
@@ -231,7 +230,7 @@ class EmbeddingRequestOrchestrator:
             cache_hits = len(results)
             cache_misses = 0
 
-        vectors = self._validate_vector_count(
+        vectors = self._vector_processor.validate_vector_count(
             results,
             expected=len(prepared.normalized_input.texts),
             provider=actual_provider,
@@ -299,19 +298,19 @@ class EmbeddingRequestOrchestrator:
                     raise
                 continue
 
-            vectors = self._validate_vector_count(
+            vectors = self._vector_processor.validate_vector_count(
                 vectors,
                 expected=len(miss_texts),
                 provider=provider,
                 model=model,
             )
-            cache_vectors = [_canonical_vector(vector) for vector in vectors]
-            canonical_vectors = self._postprocess_vectors(
+            cache_vectors = vectors
+            canonical_vectors = self._vector_processor.process_vectors(
                 cache_vectors,
-                provider,
-                model,
-                plan.dimensions,
-                prepared.effective_dimension_policy,
+                provider=provider,
+                model=model,
+                dimensions=plan.dimensions,
+                dimension_policy=prepared.effective_dimension_policy,
             )
             return _ProviderExecution(
                 vectors=canonical_vectors,
@@ -349,15 +348,15 @@ class EmbeddingRequestOrchestrator:
         for index, text in enumerate(prepared.normalized_input.texts):
             key = self._cache_key(text, provider, model, plan.dimensions, backend_identity)
             cached = await self._cache.get(key)
-            validated_cached = validated_embedding_vectors([cached], expected=1) if cached is not None else None
-            if validated_cached is not None:
+            cached_vector = self._vector_processor.validate_cached_vector(cached)
+            if cached_vector is not None:
                 results.append(
-                    self._postprocess_cached_vector(
-                        validated_cached[0],
-                        provider,
-                        model,
-                        plan.dimensions,
-                        prepared.effective_dimension_policy,
+                    self._vector_processor.process_cached_vector(
+                        cached_vector,
+                        provider=provider,
+                        model=model,
+                        dimensions=plan.dimensions,
+                        dimension_policy=prepared.effective_dimension_policy,
                     )
                 )
                 continue
@@ -375,19 +374,19 @@ class EmbeddingRequestOrchestrator:
                 dimensions=plan.dimensions,
             )
             vectors, embeddings_from_adapter = _coerce_executor_output(output)
-            vectors = self._validate_vector_count(
+            vectors = self._vector_processor.validate_vector_count(
                 vectors,
                 expected=len(miss_texts),
                 provider=provider,
                 model=model,
             )
-            cache_vectors = [_canonical_vector(vector) for vector in vectors]
-            canonical_vectors = self._postprocess_vectors(
+            cache_vectors = vectors
+            canonical_vectors = self._vector_processor.process_vectors(
                 cache_vectors,
-                provider,
-                model,
-                plan.dimensions,
-                prepared.effective_dimension_policy,
+                provider=provider,
+                model=model,
+                dimensions=plan.dimensions,
+                dimension_policy=prepared.effective_dimension_policy,
             )
             for index, text, vector, cache_vector in zip(
                 miss_indices,
@@ -400,7 +399,7 @@ class EmbeddingRequestOrchestrator:
                     key = self._cache_key(text, provider, model, plan.dimensions, backend_identity)
                     pending_cache_writes.append((key, cache_vector))
 
-        vectors = self._validate_vector_count(
+        vectors = self._vector_processor.validate_vector_count(
             results,
             expected=len(prepared.normalized_input.texts),
             provider=provider,
@@ -439,18 +438,18 @@ class EmbeddingRequestOrchestrator:
         vectors, embeddings_from_adapter = _coerce_executor_output(output)
         if not embeddings_from_adapter:
             return None
-        vectors = self._validate_vector_count(
+        vectors = self._vector_processor.validate_vector_count(
             vectors,
             expected=len(prepared.normalized_input.texts),
             provider=plan.provider,
             model=plan.model,
         )
-        canonical_vectors = self._postprocess_vectors(
+        canonical_vectors = self._vector_processor.process_vectors(
             vectors,
-            plan.provider,
-            plan.model,
-            plan.dimensions,
-            prepared.effective_dimension_policy,
+            provider=plan.provider,
+            model=plan.model,
+            dimensions=plan.dimensions,
+            dimension_policy=prepared.effective_dimension_policy,
         )
         return _ProviderExecution(
             vectors=canonical_vectors,
@@ -460,67 +459,6 @@ class EmbeddingRequestOrchestrator:
             complete_response=True,
             embeddings_from_adapter=True,
         )
-
-    def _postprocess_vectors(
-        self,
-        vectors: list[list[float]],
-        provider: str,
-        model: str,
-        dimensions: int | None,
-        dimension_policy: str,
-    ) -> list[list[float]]:
-        canonical = [_canonical_vector(vector) for vector in vectors]
-        if dimensions is None:
-            return canonical
-        adjusted = adjust_dimensions(
-            canonical,
-            dimensions,
-            provider,
-            model,
-            dimension_policy=dimension_policy,
-            record_adjustment=self._record_dimension_adjustment,
-        )
-        return [_canonical_vector(vector) for vector in adjusted]
-
-    def _postprocess_cached_vector(
-        self,
-        vector: list[float],
-        provider: str,
-        model: str,
-        dimensions: int | None,
-        dimension_policy: str,
-    ) -> list[float]:
-        return self._postprocess_vectors(
-            [_canonical_vector(vector)],
-            provider,
-            model,
-            dimensions,
-            dimension_policy,
-        )[0]
-
-    @staticmethod
-    def _validate_vector_count(
-        vectors: object,
-        *,
-        expected: int,
-        provider: str,
-        model: str,
-    ) -> list[list[float]]:
-        validated = validated_embedding_vectors(vectors, expected=expected)
-        if validated is None:
-            count: int | str = len(vectors) if isinstance(vectors, list) else "invalid"
-            message = (
-                f"Embedding provider returned {count} embeddings, expected {expected}"
-                if count != expected
-                else "Embedding provider returned malformed embedding vectors"
-            )
-            raise EmbeddingProviderError(
-                "provider_malformed_response",
-                message,
-                provider=provider,
-                model=model,
-            )
-        return validated
 
     def _cache_key(
         self,
@@ -546,21 +484,6 @@ class EmbeddingRequestOrchestrator:
         if dimensions is not None:
             headers["X-Embeddings-Dimensions-Policy"] = dimension_policy
         return headers
-
-
-def _canonical_vector(vector: object) -> list[float]:
-    if not isinstance(vector, (list, tuple)):
-        raise EmbeddingProviderError(
-            "provider_malformed_response",
-            "Embedding provider returned a malformed vector",
-        )
-    try:
-        return [float(item) for item in vector]
-    except (TypeError, ValueError) as exc:
-        raise EmbeddingProviderError(
-            "provider_malformed_response",
-            "Embedding provider returned a malformed vector",
-        ) from exc
 
 
 def _coerce_executor_output(

--- a/tldw_Server_API/app/core/Embeddings/preparation.py
+++ b/tldw_Server_API/app/core/Embeddings/preparation.py
@@ -1,0 +1,163 @@
+"""Ordered preparation pipeline for embedding requests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Literal
+
+from tldw_Server_API.app.core.Embeddings.embedding_policy import enforce_embedding_policy
+from tldw_Server_API.app.core.Embeddings.input_normalizer import normalize_embedding_input
+from tldw_Server_API.app.core.Embeddings.provider_resolution import (
+    ProviderGuesser,
+    resolve_provider_model,
+)
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutionPlan,
+    EmbeddingRequestContext,
+    PreparedEmbeddingRequest,
+)
+from tldw_Server_API.app.core.Embeddings.workflow_types import EmbeddingWorkflowPhase
+
+TokenCounter = Callable[[str, str], int]
+TokenDecoder = Callable[[list[int] | list[list[int]], str], object]
+BackendIdentityResolver = Callable[[str, str], str | None]
+PhaseSink = Callable[[EmbeddingWorkflowPhase], None]
+
+
+def effective_dimension_policy(
+    encoding_format: str | None,
+    dimensions: int | None,
+    configured_policy: str,
+) -> str:
+    """Return the request's effective dimension adjustment policy."""
+    if dimensions is not None and encoding_format == "base64":
+        return "reduce"
+    return configured_policy
+
+
+class EmbeddingPreparationPipeline:
+    """Resolve, normalize, validate, and plan an embedding request."""
+
+    def __init__(
+        self,
+        *,
+        count_tokens: TokenCounter,
+        tokens_to_texts: TokenDecoder,
+        settings_config: Mapping[str, object] | None,
+        max_tokens: int,
+        implemented_providers: Sequence[str] | set[str],
+        allowed_providers: Sequence[str] | set[str] | None,
+        allowed_models: Sequence[str] | set[str] | None,
+        enforce_policy: bool,
+        allow_fallback_with_header: bool,
+        settings_fallback_chain: Mapping[str, object] | None,
+        settings_fallback_model_map: Mapping[str, object] | None,
+        dimension_policy: str,
+        require_model: bool,
+        guess_provider: ProviderGuesser | None,
+        backend_identity_resolver: BackendIdentityResolver,
+        cache_namespace: str | None,
+        batch_size: int | None,
+        execution_path: Literal["legacy", "adapter"],
+    ) -> None:
+        self._count_tokens = count_tokens
+        self._tokens_to_texts = tokens_to_texts
+        self._settings_config = settings_config
+        self._max_tokens = max_tokens
+        self._implemented_providers = implemented_providers
+        self._allowed_providers = allowed_providers
+        self._allowed_models = allowed_models
+        self._enforce_policy = enforce_policy
+        self._allow_fallback_with_header = allow_fallback_with_header
+        self._settings_fallback_chain = settings_fallback_chain
+        self._settings_fallback_model_map = settings_fallback_model_map
+        self._dimension_policy = dimension_policy
+        self._require_model = require_model
+        self._guess_provider = guess_provider
+        self._backend_identity_resolver = backend_identity_resolver
+        self._cache_namespace = cache_namespace
+        self._batch_size = batch_size
+        self._execution_path = execution_path
+
+    def prepare(
+        self,
+        raw_input: Any,
+        context: EmbeddingRequestContext,
+        phase_sink: PhaseSink | None = None,
+    ) -> PreparedEmbeddingRequest:
+        """Prepare a request while reporting each phase before its boundary."""
+        if phase_sink is not None:
+            phase_sink("resolving_intent")
+        intent = resolve_provider_model(
+            context.model_field,
+            context.provider_header,
+            settings_config=self._settings_config,
+            require_model=self._require_model,
+            guess_provider=self._guess_provider,
+        )
+
+        if phase_sink is not None:
+            phase_sink("normalizing")
+        normalized_input = normalize_embedding_input(
+            raw_input,
+            model=intent.model,
+            max_tokens=self._max_tokens,
+            count_tokens=self._count_tokens,
+            tokens_to_texts=self._tokens_to_texts,
+        )
+
+        if phase_sink is not None:
+            phase_sink("resolving_policy")
+        decision = enforce_embedding_policy(
+            intent,
+            context,
+            allowed_providers=self._allowed_providers,
+            allowed_models=self._allowed_models,
+            implemented_providers=self._implemented_providers,
+            enforce_policy=self._enforce_policy,
+            allow_fallback_with_header=self._allow_fallback_with_header,
+            settings_fallback_chain=self._settings_fallback_chain,
+            settings_fallback_model_map=self._settings_fallback_model_map,
+        )
+
+        if phase_sink is not None:
+            phase_sink("planning")
+        dimension_policy = effective_dimension_policy(
+            context.encoding_format,
+            decision.dimensions,
+            self._dimension_policy,
+        )
+        execution_plan = EmbeddingExecutionPlan(
+            provider=decision.provider,
+            model=decision.model,
+            dimensions=decision.dimensions,
+            backend_identity=self._backend_identity_resolver(decision.provider, decision.model),
+            fallback_chain=list(decision.fallback_chain),
+            cache_namespace=self._cache_namespace,
+            batch_size=self._batch_size,
+            execution_path=self._execution_path,
+            observability_tags={
+                "provider": decision.provider,
+                "model": decision.model,
+                "fallback_allowed": decision.fallback_allowed,
+            },
+        )
+        return PreparedEmbeddingRequest(
+            normalized_input=normalized_input,
+            provider_intent=intent,
+            policy_decision=decision,
+            execution_plan=execution_plan,
+            effective_dimension_policy=dimension_policy,
+            prompt_tokens=normalized_input.total_tokens,
+            total_tokens=normalized_input.total_tokens,
+        )
+
+
+__all__ = [
+    "BackendIdentityResolver",
+    "EmbeddingPreparationPipeline",
+    "PhaseSink",
+    "TokenCounter",
+    "TokenDecoder",
+    "effective_dimension_policy",
+]

--- a/tldw_Server_API/app/core/Embeddings/preparation.py
+++ b/tldw_Server_API/app/core/Embeddings/preparation.py
@@ -60,6 +60,7 @@ class EmbeddingPreparationPipeline:
         batch_size: int | None,
         execution_path: Literal["legacy", "adapter"],
     ) -> None:
+        """Configure ordered preparation with policy and runtime dependencies."""
         self._count_tokens = count_tokens
         self._tokens_to_texts = tokens_to_texts
         self._settings_config = settings_config

--- a/tldw_Server_API/app/core/Embeddings/provider_attempt.py
+++ b/tldw_Server_API/app/core/Embeddings/provider_attempt.py
@@ -1,0 +1,32 @@
+"""Provider readiness and single-provider execution attempts for embeddings."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutorOutput,
+)
+
+ProviderPreflight = Callable[[str, str], Awaitable[None]]
+
+
+async def _no_provider_preflight(provider: str, model: str) -> None:
+    del provider, model
+
+
+class EmbeddingProviderReadinessCheck:
+    """Run provider readiness checks without cache or execution side effects."""
+
+    def __init__(self, provider_preflight: ProviderPreflight | None = None) -> None:
+        self._provider_preflight = provider_preflight or _no_provider_preflight
+
+    async def check(self, provider: str, model: str) -> None:
+        await self._provider_preflight(provider, model)
+
+
+__all__ = [
+    "EmbeddingExecutorOutput",
+    "EmbeddingProviderReadinessCheck",
+    "ProviderPreflight",
+]

--- a/tldw_Server_API/app/core/Embeddings/provider_attempt.py
+++ b/tldw_Server_API/app/core/Embeddings/provider_attempt.py
@@ -21,6 +21,7 @@ ProviderPreflight = Callable[[str, str], Awaitable[None]]
 
 
 async def _no_provider_preflight(provider: str, model: str) -> None:
+    """Accept a provider/model pair when no readiness check is configured."""
     del provider, model
 
 
@@ -28,21 +29,29 @@ class EmbeddingProviderReadinessCheck:
     """Run provider readiness checks without cache or execution side effects."""
 
     def __init__(self, provider_preflight: ProviderPreflight | None = None) -> None:
+        """Create a readiness check backed by an optional preflight callable."""
         self._provider_preflight = provider_preflight or _no_provider_preflight
 
     async def check(self, provider: str, model: str) -> None:
+        """Validate that the provider/model pair is ready for execution."""
         await self._provider_preflight(provider, model)
 
 
 class ProviderAttemptCache(Protocol):
+    """Cache boundary required by a single provider attempt."""
+
     async def get(self, key: str) -> list[float] | None:
+        """Return a cached provider-native vector, or ``None`` on a miss."""
         raise NotImplementedError
 
     async def set(self, key: str, value: list[float]) -> object:
+        """Store a validated provider-native vector under ``key``."""
         raise NotImplementedError
 
 
 class ProviderAttemptExecutor(Protocol):
+    """Provider execution boundary required by a single attempt."""
+
     async def create(
         self,
         texts: list[str],
@@ -51,11 +60,14 @@ class ProviderAttemptExecutor(Protocol):
         model: str,
         dimensions: int | None,
     ) -> list[list[float]] | EmbeddingExecutorOutput:
+        """Create embeddings for cache misses using one provider/model pair."""
         raise NotImplementedError
 
 
 @dataclass(frozen=True, slots=True)
 class ProviderAttemptSuccess:
+    """Successful provider attempt with ordered vectors and cache totals."""
+
     vectors: list[list[float]]
     provider: str
     model: str
@@ -66,6 +78,8 @@ class ProviderAttemptSuccess:
 
 @dataclass(frozen=True, slots=True)
 class ProviderCallFailure:
+    """Provider-domain failure that may be considered by fallback routing."""
+
     error: EmbeddingDomainError
 
 
@@ -81,6 +95,7 @@ class EmbeddingProviderAttempt:
         backend_identity_resolver: BackendIdentityResolver,
         vector_processor: EmbeddingVectorProcessor | None = None,
     ) -> None:
+        """Create an attempt runner with injected cache and execution boundaries."""
         self._cache_key_fn = cache_key_fn
         self._cache = cache
         self._executor = executor
@@ -94,6 +109,7 @@ class EmbeddingProviderAttempt:
         provider: str,
         model: str,
     ) -> ProviderAttemptSuccess | ProviderCallFailure:
+        """Execute one provider/model attempt while preserving input order."""
         plan = prepared.execution_plan
         read_identity = self._backend_identity_resolver(provider, model)
         results: list[list[float] | None] = []
@@ -191,6 +207,7 @@ class EmbeddingProviderAttempt:
 def _coerce_executor_output(
     output: list[list[float]] | EmbeddingExecutorOutput,
 ) -> tuple[list[list[float]], bool]:
+    """Normalize executor output to vectors plus adapter-origin metadata."""
     if isinstance(output, EmbeddingExecutorOutput):
         return output.vectors, output.embeddings_from_adapter
     return output, False

--- a/tldw_Server_API/app/core/Embeddings/provider_attempt.py
+++ b/tldw_Server_API/app/core/Embeddings/provider_attempt.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Protocol
 
+from tldw_Server_API.app.core.Embeddings.preparation import BackendIdentityResolver
 from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingDomainError,
     EmbeddingExecutorOutput,
+    PreparedEmbeddingRequest,
+)
+from tldw_Server_API.app.core.Embeddings.vector_processing import (
+    EmbeddingVectorProcessor,
 )
 
+CacheKeyFn = Callable[[str, str, str, int | None, str | None], str]
 ProviderPreflight = Callable[[str, str], Awaitable[None]]
 
 
@@ -25,8 +34,176 @@ class EmbeddingProviderReadinessCheck:
         await self._provider_preflight(provider, model)
 
 
+class ProviderAttemptCache(Protocol):
+    async def get(self, key: str) -> list[float] | None:
+        raise NotImplementedError
+
+    async def set(self, key: str, value: list[float]) -> object:
+        raise NotImplementedError
+
+
+class ProviderAttemptExecutor(Protocol):
+    async def create(
+        self,
+        texts: list[str],
+        *,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+    ) -> list[list[float]] | EmbeddingExecutorOutput:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAttemptSuccess:
+    vectors: list[list[float]]
+    provider: str
+    model: str
+    cache_hits: int
+    cache_misses: int
+    embeddings_from_adapter: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCallFailure:
+    error: EmbeddingDomainError
+
+
+class EmbeddingProviderAttempt:
+    """Execute one provider/model against ordered input and cache boundaries."""
+
+    def __init__(
+        self,
+        *,
+        cache_key_fn: CacheKeyFn,
+        cache: ProviderAttemptCache,
+        executor: ProviderAttemptExecutor,
+        backend_identity_resolver: BackendIdentityResolver,
+        vector_processor: EmbeddingVectorProcessor | None = None,
+    ) -> None:
+        self._cache_key_fn = cache_key_fn
+        self._cache = cache
+        self._executor = executor
+        self._backend_identity_resolver = backend_identity_resolver
+        self._vector_processor = vector_processor or EmbeddingVectorProcessor()
+
+    async def execute(
+        self,
+        prepared: PreparedEmbeddingRequest,
+        *,
+        provider: str,
+        model: str,
+    ) -> ProviderAttemptSuccess | ProviderCallFailure:
+        plan = prepared.execution_plan
+        read_identity = self._backend_identity_resolver(provider, model)
+        results: list[list[float] | None] = []
+        miss_indices: list[int] = []
+        miss_texts: list[str] = []
+
+        for index, text in enumerate(prepared.normalized_input.texts):
+            key = self._cache_key_fn(
+                text,
+                provider,
+                model,
+                plan.dimensions,
+                read_identity,
+            )
+            cached = await self._cache.get(key)
+            cached_vector = self._vector_processor.validate_cached_vector(cached)
+            if cached_vector is None:
+                results.append(None)
+                miss_indices.append(index)
+                miss_texts.append(text)
+                continue
+            results.append(
+                self._vector_processor.process_cached_vector(
+                    cached_vector,
+                    provider=provider,
+                    model=model,
+                    dimensions=plan.dimensions,
+                    dimension_policy=prepared.effective_dimension_policy,
+                )
+            )
+
+        embeddings_from_adapter = False
+        pending_cache_writes: list[tuple[str, list[float]]] = []
+        if miss_texts:
+            try:
+                output = await self._executor.create(
+                    miss_texts,
+                    provider=provider,
+                    model=model,
+                    dimensions=plan.dimensions,
+                )
+            except EmbeddingDomainError as exc:
+                return ProviderCallFailure(exc)
+
+            miss_vectors, embeddings_from_adapter = _coerce_executor_output(output)
+            cache_vectors = self._vector_processor.validate_vector_count(
+                miss_vectors,
+                expected=len(miss_texts),
+                provider=provider,
+                model=model,
+            )
+            processed_misses = self._vector_processor.process_vectors(
+                cache_vectors,
+                provider=provider,
+                model=model,
+                dimensions=plan.dimensions,
+                dimension_policy=prepared.effective_dimension_policy,
+            )
+            write_identity = self._backend_identity_resolver(provider, model)
+            for index, text, vector, cache_vector in zip(
+                miss_indices,
+                miss_texts,
+                processed_misses,
+                cache_vectors,
+            ):
+                results[index] = vector
+                if not embeddings_from_adapter:
+                    key = self._cache_key_fn(
+                        text,
+                        provider,
+                        model,
+                        plan.dimensions,
+                        write_identity,
+                    )
+                    pending_cache_writes.append((key, cache_vector))
+
+        vectors = self._vector_processor.validate_vector_count(
+            results,
+            expected=len(prepared.normalized_input.texts),
+            provider=provider,
+            model=model,
+        )
+        for key, vector in pending_cache_writes:
+            await self._cache.set(key, vector)
+        return ProviderAttemptSuccess(
+            vectors=vectors,
+            provider=provider,
+            model=model,
+            cache_hits=len(results) - len(miss_indices),
+            cache_misses=len(miss_indices),
+            embeddings_from_adapter=embeddings_from_adapter,
+        )
+
+
+def _coerce_executor_output(
+    output: list[list[float]] | EmbeddingExecutorOutput,
+) -> tuple[list[list[float]], bool]:
+    if isinstance(output, EmbeddingExecutorOutput):
+        return output.vectors, output.embeddings_from_adapter
+    return output, False
+
+
 __all__ = [
+    "CacheKeyFn",
     "EmbeddingExecutorOutput",
+    "EmbeddingProviderAttempt",
     "EmbeddingProviderReadinessCheck",
+    "ProviderAttemptCache",
+    "ProviderAttemptExecutor",
+    "ProviderAttemptSuccess",
+    "ProviderCallFailure",
     "ProviderPreflight",
 ]

--- a/tldw_Server_API/app/core/Embeddings/request_types.py
+++ b/tldw_Server_API/app/core/Embeddings/request_types.py
@@ -87,6 +87,8 @@ class EmbeddingExecutionPlan:
 
 @dataclass(frozen=True, slots=True)
 class PreparedEmbeddingRequest:
+    """Canonical request state produced by the ordered preparation pipeline."""
+
     normalized_input: NormalizedEmbeddingInput
     provider_intent: ProviderModelIntent
     policy_decision: EmbeddingPolicyDecision
@@ -98,12 +100,16 @@ class PreparedEmbeddingRequest:
 
 @dataclass(frozen=True, slots=True)
 class EmbeddingExecutorOutput:
+    """Provider vectors and whether an adapter execution path produced them."""
+
     vectors: list[list[float]]
     embeddings_from_adapter: bool = False
 
 
 @dataclass(frozen=True, slots=True)
 class EmbeddingExecutionOutcome:
+    """Immutable successful outcome with validated vectors and attempt totals."""
+
     vectors: tuple[tuple[float, ...], ...]
     provider: str
     model: str
@@ -119,6 +125,7 @@ class EmbeddingExecutionOutcome:
     embeddings_from_adapter: bool = False
 
     def __post_init__(self) -> None:
+        """Canonicalize vectors and enforce cache, attempt, and fallback invariants."""
         invalid_vectors_message = "vectors must contain equally sized, non-empty vectors of finite numbers"
         try:
             vector_lists = [list(vector) for vector in self.vectors]

--- a/tldw_Server_API/app/core/Embeddings/request_types.py
+++ b/tldw_Server_API/app/core/Embeddings/request_types.py
@@ -83,6 +83,60 @@ class EmbeddingExecutionPlan:
 
 
 @dataclass(frozen=True, slots=True)
+class PreparedEmbeddingRequest:
+    normalized_input: NormalizedEmbeddingInput
+    provider_intent: ProviderModelIntent
+    policy_decision: EmbeddingPolicyDecision
+    execution_plan: EmbeddingExecutionPlan
+    effective_dimension_policy: str
+    prompt_tokens: int
+    total_tokens: int
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingExecutionOutcome:
+    vectors: tuple[tuple[float, ...], ...]
+    provider: str
+    model: str
+    prompt_tokens: int
+    total_tokens: int
+    cache_hits: int
+    cache_misses: int
+    requested_dimensions: int | None
+    effective_dimension_policy: str
+    attempt_count: int
+    fallback_attempt_count: int
+    fallback_from: str | None = None
+    embeddings_from_adapter: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "vectors",
+            tuple(tuple(vector) for vector in self.vectors),
+        )
+
+        for field_name, value in (
+            ("prompt_tokens", self.prompt_tokens),
+            ("total_tokens", self.total_tokens),
+            ("cache_hits", self.cache_hits),
+            ("cache_misses", self.cache_misses),
+            ("attempt_count", self.attempt_count),
+            ("fallback_attempt_count", self.fallback_attempt_count),
+        ):
+            if type(value) is not int:
+                raise ValueError(f"{field_name} must be an exact int")
+            if value < 0:
+                raise ValueError(f"{field_name} must be nonnegative")
+        if self.attempt_count < 1:
+            raise ValueError("attempt_count must be at least 1 for a successful outcome")
+        if self.fallback_attempt_count >= self.attempt_count:
+            raise ValueError("fallback_attempt_count must be less than attempt_count")
+        if self.cache_hits + self.cache_misses != len(self.vectors):
+            raise ValueError("cache_hits + cache_misses must equal the number of vectors")
+
+
+@dataclass(frozen=True, slots=True)
 class EmbeddingExecutionResult:
     vectors: list[list[float]]
     provider: str
@@ -100,6 +154,7 @@ __all__ = [
     "EmbeddingDomainError",
     "EmbeddingErrorCode",
     "EmbeddingExecutionError",
+    "EmbeddingExecutionOutcome",
     "EmbeddingExecutionPlan",
     "EmbeddingExecutionResult",
     "EmbeddingInputError",
@@ -111,5 +166,6 @@ __all__ = [
     "SafeDetail",
     "SafeJsonScalar",
     "NormalizedEmbeddingInput",
+    "PreparedEmbeddingRequest",
     "ProviderModelIntent",
 ]

--- a/tldw_Server_API/app/core/Embeddings/request_types.py
+++ b/tldw_Server_API/app/core/Embeddings/request_types.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
+from tldw_Server_API.app.core.Embeddings.vector_validation import (
+    validated_embedding_vectors,
+)
 from tldw_Server_API.app.core.exceptions import (
     EmbeddingDomainError,
     EmbeddingErrorCode,
@@ -110,10 +113,21 @@ class EmbeddingExecutionOutcome:
     embeddings_from_adapter: bool = False
 
     def __post_init__(self) -> None:
+        invalid_vectors_message = "vectors must contain equally sized, non-empty vectors of finite numbers"
+        try:
+            vector_lists = [list(vector) for vector in self.vectors]
+        except TypeError as exc:
+            raise ValueError(invalid_vectors_message) from exc
+        validated_vectors = validated_embedding_vectors(
+            vector_lists,
+            expected=len(vector_lists),
+        )
+        if validated_vectors is None:
+            raise ValueError(invalid_vectors_message)
         object.__setattr__(
             self,
             "vectors",
-            tuple(tuple(vector) for vector in self.vectors),
+            tuple(tuple(vector) for vector in validated_vectors),
         )
 
         for field_name, value in (
@@ -132,6 +146,13 @@ class EmbeddingExecutionOutcome:
             raise ValueError("attempt_count must be at least 1 for a successful outcome")
         if self.fallback_attempt_count >= self.attempt_count:
             raise ValueError("fallback_attempt_count must be less than attempt_count")
+        if self.fallback_from is not None and self.fallback_attempt_count == 0:
+            raise ValueError("fallback_from requires a positive fallback_attempt_count")
+        if self.fallback_attempt_count > 0 and self.fallback_from is None:
+            raise ValueError("positive fallback_attempt_count requires fallback_from")
+        non_fallback_attempt_count = self.attempt_count - self.fallback_attempt_count
+        if non_fallback_attempt_count not in (1, 2):
+            raise ValueError("attempt_count - fallback_attempt_count must be 1 or 2")
         if self.cache_hits + self.cache_misses != len(self.vectors):
             raise ValueError("cache_hits + cache_misses must equal the number of vectors")
 

--- a/tldw_Server_API/app/core/Embeddings/request_types.py
+++ b/tldw_Server_API/app/core/Embeddings/request_types.py
@@ -97,6 +97,12 @@ class PreparedEmbeddingRequest:
 
 
 @dataclass(frozen=True, slots=True)
+class EmbeddingExecutorOutput:
+    vectors: list[list[float]]
+    embeddings_from_adapter: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class EmbeddingExecutionOutcome:
     vectors: tuple[tuple[float, ...], ...]
     provider: str
@@ -178,6 +184,7 @@ __all__ = [
     "EmbeddingExecutionOutcome",
     "EmbeddingExecutionPlan",
     "EmbeddingExecutionResult",
+    "EmbeddingExecutorOutput",
     "EmbeddingInputError",
     "EmbeddingPolicyDecision",
     "EmbeddingPolicyError",

--- a/tldw_Server_API/app/core/Embeddings/result_mapping.py
+++ b/tldw_Server_API/app/core/Embeddings/result_mapping.py
@@ -1,0 +1,90 @@
+"""Pure mappings from canonical embedding outcomes to boundary contracts.
+
+HTTP response-header construction is endpoint-owned. The endpoint does not switch
+to the pure header mapper until Stage 2E. ``map_outcome_to_legacy_execution_result``
+is the sole temporary exception: it lives outside the canonical runner path and is
+scheduled for removal in Stage 6.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutionOutcome,
+    EmbeddingExecutionResult,
+    PreparedEmbeddingRequest,
+)
+
+
+def assemble_embedding_execution_outcome(
+    prepared: PreparedEmbeddingRequest,
+    *,
+    vectors: Sequence[Sequence[float]],
+    provider: str,
+    model: str,
+    cache_hits: int,
+    cache_misses: int,
+    fallback_from: str | None,
+    embeddings_from_adapter: bool,
+    attempt_count: int,
+    fallback_attempt_count: int,
+) -> EmbeddingExecutionOutcome:
+    """Assemble an immutable outcome from already-processed execution values."""
+    return EmbeddingExecutionOutcome(
+        vectors=tuple(tuple(vector) for vector in vectors),
+        provider=provider,
+        model=model,
+        prompt_tokens=prepared.prompt_tokens,
+        total_tokens=prepared.total_tokens,
+        cache_hits=cache_hits,
+        cache_misses=cache_misses,
+        requested_dimensions=prepared.execution_plan.dimensions,
+        effective_dimension_policy=prepared.effective_dimension_policy,
+        attempt_count=attempt_count,
+        fallback_attempt_count=fallback_attempt_count,
+        fallback_from=fallback_from,
+        embeddings_from_adapter=embeddings_from_adapter,
+    )
+
+
+def map_embedding_response_headers(
+    outcome: EmbeddingExecutionOutcome,
+) -> dict[str, str]:
+    """Build endpoint-owned headers for endpoint adoption deferred until Stage 2E."""
+    headers = {"X-Embeddings-Provider": outcome.provider}
+    if outcome.fallback_from and outcome.fallback_from != outcome.provider:
+        headers["X-Embeddings-Fallback-From"] = outcome.fallback_from
+    if outcome.requested_dimensions is not None:
+        headers["X-Embeddings-Dimensions-Policy"] = outcome.effective_dimension_policy
+    return headers
+
+
+def map_outcome_to_legacy_execution_result(
+    outcome: EmbeddingExecutionOutcome,
+) -> EmbeddingExecutionResult:
+    """Return the sole temporary exception to endpoint-owned header construction.
+
+    This mapper lives outside the canonical runner path and is scheduled for
+    removal in Stage 6. The endpoint remains on its existing header path until
+    Stage 2E.
+    """
+    return EmbeddingExecutionResult(
+        vectors=[list(vector) for vector in outcome.vectors],
+        provider=outcome.provider,
+        model=outcome.model,
+        prompt_tokens=outcome.prompt_tokens,
+        total_tokens=outcome.total_tokens,
+        cache_hits=outcome.cache_hits,
+        cache_misses=outcome.cache_misses,
+        fallback_from=outcome.fallback_from,
+        response_headers=map_embedding_response_headers(outcome),
+        embeddings_from_adapter=outcome.embeddings_from_adapter,
+    )
+
+
+__all__ = [
+    "assemble_embedding_execution_outcome",
+    "map_embedding_response_headers",
+    "map_outcome_to_legacy_execution_result",
+]

--- a/tldw_Server_API/app/core/Embeddings/vector_processing.py
+++ b/tldw_Server_API/app/core/Embeddings/vector_processing.py
@@ -1,0 +1,103 @@
+"""Validation and request-specific processing for embedding vectors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from tldw_Server_API.app.core.Embeddings.embedding_policy import adjust_dimensions
+from tldw_Server_API.app.core.Embeddings.request_types import EmbeddingProviderError
+from tldw_Server_API.app.core.Embeddings.vector_validation import (
+    validated_embedding_vectors,
+)
+
+DimensionAdjustmentRecorder = Callable[[str, str, str], None]
+
+
+class EmbeddingVectorProcessor:
+    """Validate, canonicalize, and dimension-adjust embedding vectors."""
+
+    def __init__(
+        self,
+        *,
+        record_dimension_adjustment: DimensionAdjustmentRecorder | None = None,
+    ) -> None:
+        self._record_dimension_adjustment = record_dimension_adjustment
+
+    def validate_vector_count(
+        self,
+        vectors: object,
+        *,
+        expected: int,
+        provider: str,
+        model: str,
+    ) -> list[list[float]]:
+        """Return canonical vectors or raise the existing provider domain error."""
+        validated = validated_embedding_vectors(vectors, expected=expected)
+        if validated is not None:
+            return validated
+
+        count: int | str = len(vectors) if isinstance(vectors, list) else "invalid"
+        message = (
+            f"Embedding provider returned {count} embeddings, expected {expected}"
+            if count != expected
+            else "Embedding provider returned malformed embedding vectors"
+        )
+        raise EmbeddingProviderError(
+            "provider_malformed_response",
+            message,
+            provider=provider,
+            model=model,
+        )
+
+    def validate_cached_vector(self, vector: object) -> list[float] | None:
+        """Return one canonical cache vector, or ``None`` for a cache miss."""
+        validated = validated_embedding_vectors([vector], expected=1)
+        return validated[0] if validated is not None else None
+
+    def process_vectors(
+        self,
+        vectors: list[list[float]],
+        *,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+        dimension_policy: str,
+    ) -> list[list[float]]:
+        """Apply request-specific dimension processing to canonical vectors."""
+        canonical = _canonical_vectors(vectors)
+        if dimensions is None:
+            return canonical
+        adjusted = adjust_dimensions(
+            canonical,
+            dimensions,
+            provider,
+            model,
+            dimension_policy=dimension_policy,
+            record_adjustment=self._record_dimension_adjustment,
+        )
+        return _canonical_vectors(adjusted)
+
+    def process_cached_vector(
+        self,
+        canonical_vector: list[float],
+        *,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+        dimension_policy: str,
+    ) -> list[float]:
+        """Postprocess a vector already accepted by ``validate_cached_vector``."""
+        return self.process_vectors(
+            [canonical_vector],
+            provider=provider,
+            model=model,
+            dimensions=dimensions,
+            dimension_policy=dimension_policy,
+        )[0]
+
+
+def _canonical_vectors(vectors: list[list[float]]) -> list[list[float]]:
+    return [[float(value) for value in vector] for vector in vectors]
+
+
+__all__ = ["DimensionAdjustmentRecorder", "EmbeddingVectorProcessor"]

--- a/tldw_Server_API/app/core/Embeddings/vector_processing.py
+++ b/tldw_Server_API/app/core/Embeddings/vector_processing.py
@@ -21,6 +21,7 @@ class EmbeddingVectorProcessor:
         *,
         record_dimension_adjustment: DimensionAdjustmentRecorder | None = None,
     ) -> None:
+        """Configure vector processing with optional adjustment recording."""
         self._record_dimension_adjustment = record_dimension_adjustment
 
     def validate_vector_count(
@@ -97,6 +98,7 @@ class EmbeddingVectorProcessor:
 
 
 def _canonical_vectors(vectors: list[list[float]]) -> list[list[float]]:
+    """Return a detached float-only copy of the supplied vectors."""
     return [[float(value) for value in vector] for vector in vectors]
 
 

--- a/tldw_Server_API/app/core/Embeddings/workflow_types.py
+++ b/tldw_Server_API/app/core/Embeddings/workflow_types.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.core.exceptions import EmbeddingWorkflowTraceError
 
 EmbeddingWorkflowPhase = Literal[
     "created",
+    "resolving_intent",
     "normalizing",
     "resolving_policy",
     "planning",
@@ -81,9 +82,7 @@ FORBIDDEN_VALUE_SUBSTRINGS = (
     "secret",
 )
 FORBIDDEN_METADATA_FIELD_FRAGMENTS = FORBIDDEN_METADATA_FIELDS
-SAFE_TOKEN_COUNT_FIELDS = frozenset(
-    {"token_count", "token_counts", "total_tokens", "prompt_tokens"}
-)
+SAFE_TOKEN_COUNT_FIELDS = frozenset({"token_count", "token_counts", "total_tokens", "prompt_tokens"})
 SAFE_METADATA_ENUM_VALUES: Mapping[str, frozenset[str]] = MappingProxyType(
     {
         "endpoint_path": frozenset({"/api/v1/embeddings"}),
@@ -93,6 +92,7 @@ SAFE_METADATA_ENUM_VALUES: Mapping[str, frozenset[str]] = MappingProxyType(
             {
                 "created",
                 "normalizing",
+                "resolving_intent",
                 "resolving_policy",
                 "planning",
                 "serving_cache",
@@ -107,9 +107,11 @@ SAFE_METADATA_ENUM_VALUES: Mapping[str, frozenset[str]] = MappingProxyType(
 )
 SAFE_METADATA_NONNEGATIVE_INTEGER_FIELDS = frozenset(
     {
+        "attempt_count",
         "cache_hits",
         "cache_misses",
         "fallback_chain_length",
+        "fallback_attempt_count",
         "item_count",
         "prompt_tokens",
         "response_header_count",
@@ -119,9 +121,7 @@ SAFE_METADATA_NONNEGATIVE_INTEGER_FIELDS = frozenset(
     }
 )
 SAFE_METADATA_OPTIONAL_NONNEGATIVE_INTEGER_FIELDS = frozenset({"dimensions"})
-SAFE_METADATA_BOOLEAN_FIELDS = frozenset(
-    {"adapter_used", "fallback_allowed", "retryable"}
-)
+SAFE_METADATA_BOOLEAN_FIELDS = frozenset({"adapter_used", "fallback_allowed", "retryable"})
 SAFE_METADATA_INTEGER_SEQUENCE_FIELDS = frozenset({"token_counts"})
 SAFE_METADATA_FIELDS = frozenset(SAFE_METADATA_ENUM_VALUES).union(
     SAFE_METADATA_NONNEGATIVE_INTEGER_FIELDS,
@@ -173,18 +173,14 @@ def _safe_metadata_string(value: str, *, field_name: str) -> str:
     if not value or SAFE_METADATA_STRING_PATTERN.fullmatch(value) is None:
         raise EmbeddingWorkflowTraceError("Workflow metadata string values must be safe identifiers")
     if value not in SAFE_METADATA_ENUM_VALUES[field_name]:
-        raise EmbeddingWorkflowTraceError(
-            f"Unsupported workflow metadata value for field: {field_name}"
-        )
+        raise EmbeddingWorkflowTraceError(f"Unsupported workflow metadata value for field: {field_name}")
     return value
 
 
 def _safe_nonnegative_integer(value: object, *, field_name: str) -> int:
     """Return a strict non-negative integer or reject the trace value."""
     if type(value) is not int or value < 0:
-        raise EmbeddingWorkflowTraceError(
-            f"Workflow metadata field {field_name} must be a non-negative integer"
-        )
+        raise EmbeddingWorkflowTraceError(f"Workflow metadata field {field_name} must be a non-negative integer")
     return value
 
 
@@ -192,15 +188,11 @@ def _safe_metadata_value(field_name: str, value: object) -> SafeWorkflowMetadata
     """Validate and freeze one allowlisted metadata value."""
     if field_name in SAFE_METADATA_ENUM_VALUES:
         if not isinstance(value, str):
-            raise EmbeddingWorkflowTraceError(
-                f"Workflow metadata field {field_name} must be an approved identifier"
-            )
+            raise EmbeddingWorkflowTraceError(f"Workflow metadata field {field_name} must be an approved identifier")
         return _safe_metadata_string(value, field_name=field_name)
     if field_name in SAFE_METADATA_BOOLEAN_FIELDS:
         if type(value) is not bool:
-            raise EmbeddingWorkflowTraceError(
-                f"Workflow metadata field {field_name} must be a boolean"
-            )
+            raise EmbeddingWorkflowTraceError(f"Workflow metadata field {field_name} must be a boolean")
         return value
     if field_name in SAFE_METADATA_NONNEGATIVE_INTEGER_FIELDS:
         return _safe_nonnegative_integer(value, field_name=field_name)
@@ -275,6 +267,8 @@ class EmbeddingWorkflowEvent:
     def __post_init__(self) -> None:
         """Validate identity and freeze metadata before collection."""
         _validate_workflow_id(self.workflow_id)
+        if self.event_type == "workflow_completed" and (self.phase != "finalizing" or self.status != "completed"):
+            raise EmbeddingWorkflowTraceError("workflow_completed events require finalizing phase and completed status")
         object.__setattr__(self, "metadata", safe_workflow_metadata(dict(self.metadata)))
 
 

--- a/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -4,17 +4,22 @@ import asyncio
 
 import pytest
 
+import tldw_Server_API.app.core.Embeddings.preparation as preparation_module
 from tldw_Server_API.app.core.Embeddings import orchestrator as orchestrator_module
 from tldw_Server_API.app.core.Embeddings.orchestrator import (
     EmbeddingExecutionResult,
     EmbeddingExecutorOutput,
     EmbeddingRequestOrchestrator,
 )
+from tldw_Server_API.app.core.Embeddings.orchestrator import (
+    PreparedEmbeddingRequest as OrchestratorPreparedEmbeddingRequest,
+)
 from tldw_Server_API.app.core.Embeddings.request_types import (
     EmbeddingExecutionError,
     EmbeddingProviderError,
     EmbeddingRateLimitError,
     EmbeddingRequestContext,
+    PreparedEmbeddingRequest,
 )
 
 
@@ -217,9 +222,9 @@ def test_prepare_normalizes_input_and_returns_token_totals_without_execution():
 @pytest.mark.unit
 def test_prepare_orders_intent_normalization_policy_and_plan_identity(monkeypatch):
     calls: list[str] = []
-    real_resolve_provider_model = orchestrator_module.resolve_provider_model
-    real_normalize_embedding_input = orchestrator_module.normalize_embedding_input
-    real_enforce_embedding_policy = orchestrator_module.enforce_embedding_policy
+    real_resolve_provider_model = preparation_module.resolve_provider_model
+    real_normalize_embedding_input = preparation_module.normalize_embedding_input
+    real_enforce_embedding_policy = preparation_module.enforce_embedding_policy
 
     def resolve_provider_model_probe(*args, **kwargs):
         calls.append("resolve_intent")
@@ -238,17 +243,17 @@ def test_prepare_orders_intent_normalization_policy_and_plan_identity(monkeypatc
         return f"{provider}:{model}:backend"
 
     monkeypatch.setattr(
-        orchestrator_module,
+        preparation_module,
         "resolve_provider_model",
         resolve_provider_model_probe,
     )
     monkeypatch.setattr(
-        orchestrator_module,
+        preparation_module,
         "normalize_embedding_input",
         normalize_embedding_input_probe,
     )
     monkeypatch.setattr(
-        orchestrator_module,
+        preparation_module,
         "enforce_embedding_policy",
         enforce_embedding_policy_probe,
     )
@@ -264,6 +269,118 @@ def test_prepare_orders_intent_normalization_policy_and_plan_identity(monkeypatc
         "resolve_policy",
         "plan_identity",
     ]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("use_default_backend_identity", [False, True])
+def test_prepare_delegates_to_one_pipeline_without_phase_sink(
+    monkeypatch,
+    use_default_backend_identity,
+):
+    prepared_sentinel = object()
+    created: list[dict[str, object]] = []
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    pipeline_values = {
+        name: object()
+        for name in (
+            "count_tokens",
+            "tokens_to_texts",
+            "settings_config",
+            "max_tokens",
+            "implemented_providers",
+            "allowed_providers",
+            "allowed_models",
+            "enforce_policy",
+            "allow_fallback_with_header",
+            "settings_fallback_chain",
+            "settings_fallback_model_map",
+            "dimension_policy",
+            "require_model",
+            "guess_provider",
+            "backend_identity_resolver",
+            "cache_namespace",
+            "batch_size",
+            "execution_path",
+        )
+    }
+
+    def default_backend_identity(provider: str, model: str) -> None:
+        del provider, model
+        return None
+
+    class RecordingPreparationPipeline:
+        def __init__(self, **kwargs: object) -> None:
+            created.append(kwargs)
+
+        def prepare(self, *args: object, **kwargs: object) -> object:
+            calls.append((args, kwargs))
+            return prepared_sentinel
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "EmbeddingPreparationPipeline",
+        RecordingPreparationPipeline,
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "_no_backend_identity",
+        default_backend_identity,
+    )
+    requested_backend_identity = (
+        None
+        if use_default_backend_identity
+        else pipeline_values["backend_identity_resolver"]
+    )
+    expected_pipeline_values = {
+        **pipeline_values,
+        "backend_identity_resolver": (
+            default_backend_identity
+            if use_default_backend_identity
+            else pipeline_values["backend_identity_resolver"]
+        ),
+    }
+    orchestrator = EmbeddingRequestOrchestrator(
+        count_tokens=pipeline_values["count_tokens"],
+        tokens_to_texts=pipeline_values["tokens_to_texts"],
+        cache_key_fn=_cache_key,
+        cache=RecordingCache(),
+        executor=RecordingExecutor(),
+        settings_config=pipeline_values["settings_config"],
+        max_tokens=pipeline_values["max_tokens"],
+        implemented_providers=pipeline_values["implemented_providers"],
+        allowed_providers=pipeline_values["allowed_providers"],
+        allowed_models=pipeline_values["allowed_models"],
+        enforce_policy=pipeline_values["enforce_policy"],
+        allow_fallback_with_header=pipeline_values["allow_fallback_with_header"],
+        settings_fallback_chain=pipeline_values["settings_fallback_chain"],
+        settings_fallback_model_map=pipeline_values[
+            "settings_fallback_model_map"
+        ],
+        dimension_policy=pipeline_values["dimension_policy"],
+        require_model=pipeline_values["require_model"],
+        guess_provider=pipeline_values["guess_provider"],
+        backend_identity_resolver=requested_backend_identity,
+        cache_namespace=pipeline_values["cache_namespace"],
+        batch_size=pipeline_values["batch_size"],
+        execution_path=pipeline_values["execution_path"],
+    )
+    raw_input = object()
+    context = _context()
+
+    assert orchestrator.prepare(raw_input, context) is prepared_sentinel
+    assert orchestrator.prepare(raw_input, context) is prepared_sentinel
+    assert len(created) == 1
+    assert created[0].keys() == expected_pipeline_values.keys()
+    assert all(
+        created[0][name] is expected_value
+        for name, expected_value in expected_pipeline_values.items()
+    )
+    assert calls == [((raw_input, context), {}), ((raw_input, context), {})]
+
+
+@pytest.mark.unit
+def test_orchestrator_reexports_prepared_embedding_request_contract():
+    assert OrchestratorPreparedEmbeddingRequest is PreparedEmbeddingRequest
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -1710,6 +1710,86 @@ async def test_malformed_cached_vector_becomes_miss_and_is_replaced(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_malformed_fallback_cached_vector_becomes_miss_and_is_replaced():
+    fallback_model = "sentence-transformers/all-MiniLM-L6-v2"
+    fallback_cache_key = (
+        f"replace fallback|huggingface|{fallback_model}|"
+        f"huggingface:{fallback_model}:backend"
+    )
+    cache = RecordingCache(
+        {fallback_cache_key: [True, 0.0]}  # type: ignore[dict-item]
+    )
+    primary_error = EmbeddingProviderError(
+        "provider_unavailable",
+        "openai unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+    executor = RecordingExecutor(
+        failures={"openai": primary_error},
+        provider_vectors={"huggingface": [[0.25, 0.75]]},
+    )
+    identity_calls: list[tuple[str, str]] = []
+
+    def backend_identity_resolver(provider: str, model: str) -> str:
+        identity_calls.append((provider, model))
+        return f"{provider}:{model}:backend"
+
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=backend_identity_resolver,
+        settings_fallback_chain={"openai": ["huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "huggingface": fallback_model,
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        "replace fallback",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    result = await orchestrator.execute(prepared)
+
+    assert result.vectors == [[0.25, 0.75]]
+    assert result.provider == "huggingface"
+    assert result.model == fallback_model
+    assert result.fallback_from == "openai"
+    assert result.cache_hits == 0
+    assert result.cache_misses == 1
+    assert cache.get_keys == [
+        "replace fallback|openai|text-embedding-3-small|"
+        "openai:text-embedding-3-small:backend",
+        fallback_cache_key,
+    ]
+    assert executor.calls == [
+        {
+            "texts": ["replace fallback"],
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dimensions": None,
+        },
+        {
+            "texts": ["replace fallback"],
+            "provider": "huggingface",
+            "model": fallback_model,
+            "dimensions": None,
+        },
+    ]
+    assert cache.set_calls == [(fallback_cache_key, [0.25, 0.75])]
+    assert cache.values[fallback_cache_key] == [0.25, 0.75]
+    assert identity_calls == [
+        ("openai", "text-embedding-3-small"),
+        ("openai", "text-embedding-3-small"),
+        ("huggingface", fallback_model),
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_malformed_numeric_string_vector_is_rejected_without_cache_writeback():
     cache = RecordingCache()
     executor = RecordingExecutor(vectors=["123"])  # type: ignore[list-item]

--- a/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -1785,6 +1785,7 @@ async def test_malformed_fallback_cached_vector_becomes_miss_and_is_replaced():
         ("openai", "text-embedding-3-small"),
         ("openai", "text-embedding-3-small"),
         ("huggingface", fallback_model),
+        ("huggingface", fallback_model),
     ]
 
 

--- a/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -1790,6 +1790,74 @@ async def test_malformed_fallback_cached_vector_becomes_miss_and_is_replaced():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_fallback_writeback_re_resolves_backend_identity_after_provider_execution():
+    fallback_model = "sentence-transformers/all-MiniLM-L6-v2"
+    primary_error = EmbeddingProviderError(
+        "provider_unavailable",
+        "openai unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+    cache = RecordingCache()
+    executor = RecordingExecutor(
+        failures={"openai": primary_error},
+        provider_vectors={"huggingface": [[0.25, 0.75]]},
+    )
+    identity_calls: list[tuple[str, str]] = []
+
+    def backend_identity_resolver(provider: str, model: str) -> str:
+        identity_calls.append((provider, model))
+        if provider == "huggingface":
+            fallback_identity_count = sum(
+                1 for call in identity_calls if call == (provider, model)
+            )
+            suffix = "read" if fallback_identity_count == 1 else "write"
+            return f"{provider}:{model}:{suffix}"
+        return f"{provider}:{model}:identity"
+
+    orchestrator = _orchestrator(
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=backend_identity_resolver,
+        settings_fallback_chain={"openai": ["huggingface"]},
+        settings_fallback_model_map={
+            "openai:text-embedding-3-small": {
+                "huggingface": fallback_model,
+            }
+        },
+    )
+    prepared = orchestrator.prepare(
+        "identity correction",
+        _context(model="text-embedding-3-small", provider="openai"),
+    )
+
+    result = await orchestrator.execute(prepared)
+
+    assert result.provider == "huggingface"
+    assert cache.get_keys == [
+        "identity correction|openai|text-embedding-3-small|"
+        "openai:text-embedding-3-small:identity",
+        f"identity correction|huggingface|{fallback_model}|"
+        f"huggingface:{fallback_model}:read",
+    ]
+    assert cache.set_calls == [
+        (
+            f"identity correction|huggingface|{fallback_model}|"
+            f"huggingface:{fallback_model}:write",
+            [0.25, 0.75],
+        )
+    ]
+    assert identity_calls == [
+        ("openai", "text-embedding-3-small"),
+        ("openai", "text-embedding-3-small"),
+        ("huggingface", fallback_model),
+        ("huggingface", fallback_model),
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_malformed_numeric_string_vector_is_rejected_without_cache_writeback():
     cache = RecordingCache()
     executor = RecordingExecutor(vectors=["123"])  # type: ignore[list-item]

--- a/tldw_Server_API/tests/Embeddings_isolated/test_preparation_pipeline.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_preparation_pipeline.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from tldw_Server_API.app.core.Embeddings import preparation as preparation_module
+from tldw_Server_API.app.core.Embeddings.preparation import (
+    EmbeddingPreparationPipeline,
+    effective_dimension_policy,
+)
+from tldw_Server_API.app.core.Embeddings.request_types import EmbeddingRequestContext
+
+
+def _context() -> EmbeddingRequestContext:
+    return EmbeddingRequestContext(
+        user_id="sensitive-user-marker",
+        model_field="sentence-transformers/all-MiniLM-L6-v2",
+        provider_header="huggingface",
+        dimensions=None,
+        encoding_format="float",
+        request_id="sensitive-request-marker",
+    )
+
+
+def _tokens_to_texts(
+    tokens_input: list[int] | list[list[int]],
+    model: str,
+) -> tuple[list[str], int, list[int]]:
+    del model
+    if tokens_input and isinstance(tokens_input[0], int):
+        return ["decoded"], len(tokens_input), [len(tokens_input)]
+    token_batches = tokens_input
+    return [f"decoded-{index}" for index, _ in enumerate(token_batches)], 0, [len(item) for item in token_batches]
+
+
+def _pipeline(**overrides: object) -> EmbeddingPreparationPipeline:
+    kwargs: dict[str, object] = {
+        "count_tokens": lambda text, model: len(text.split()),
+        "tokens_to_texts": _tokens_to_texts,
+        "settings_config": {},
+        "max_tokens": 128,
+        "implemented_providers": {"huggingface", "openai"},
+        "allowed_providers": None,
+        "allowed_models": None,
+        "enforce_policy": True,
+        "allow_fallback_with_header": True,
+        "settings_fallback_chain": None,
+        "settings_fallback_model_map": None,
+        "dimension_policy": "reduce",
+        "require_model": True,
+        "guess_provider": None,
+        "backend_identity_resolver": lambda provider, model: f"{provider}:{model}:backend",
+        "cache_namespace": None,
+        "batch_size": None,
+        "execution_path": "legacy",
+    }
+    kwargs.update(overrides)
+    return EmbeddingPreparationPipeline(**kwargs)
+
+
+def _install_boundary_probes(
+    monkeypatch: pytest.MonkeyPatch,
+    calls: list[str],
+    *,
+    failing_boundary: str | None = None,
+    failure: Exception | None = None,
+) -> Callable[[str, str], str]:
+    real_resolve = preparation_module.resolve_provider_model
+    real_normalize = preparation_module.normalize_embedding_input
+    real_policy = preparation_module.enforce_embedding_policy
+
+    def maybe_raise(boundary: str) -> None:
+        if boundary == failing_boundary:
+            assert failure is not None
+            raise failure
+
+    def resolve_probe(*args, **kwargs):
+        calls.append("resolve_provider_model")
+        maybe_raise("resolve_provider_model")
+        return real_resolve(*args, **kwargs)
+
+    def normalize_probe(*args, **kwargs):
+        calls.append("normalize_embedding_input")
+        maybe_raise("normalize_embedding_input")
+        return real_normalize(*args, **kwargs)
+
+    def policy_probe(*args, **kwargs):
+        calls.append("enforce_embedding_policy")
+        maybe_raise("enforce_embedding_policy")
+        return real_policy(*args, **kwargs)
+
+    def identity_probe(provider: str, model: str) -> str:
+        calls.append("backend_identity_resolver")
+        maybe_raise("backend_identity_resolver")
+        return f"{provider}:{model}:backend"
+
+    monkeypatch.setattr(preparation_module, "resolve_provider_model", resolve_probe)
+    monkeypatch.setattr(preparation_module, "normalize_embedding_input", normalize_probe)
+    monkeypatch.setattr(preparation_module, "enforce_embedding_policy", policy_probe)
+    return identity_probe
+
+
+@pytest.mark.unit
+def test_pipeline_reports_only_phase_strings_before_boundaries_in_exact_order(monkeypatch):
+    events: list[str] = []
+    sink_calls: list[tuple[object, ...]] = []
+    identity_probe = _install_boundary_probes(monkeypatch, events)
+
+    def phase_sink(*args: object) -> None:
+        sink_calls.append(args)
+        events.append(f"phase:{args[0]}")
+
+    prepared = _pipeline(backend_identity_resolver=identity_probe).prepare(
+        "sensitive-raw-input-marker",
+        _context(),
+        phase_sink=phase_sink,
+    )
+
+    assert events == [
+        "phase:resolving_intent",
+        "resolve_provider_model",
+        "phase:normalizing",
+        "normalize_embedding_input",
+        "phase:resolving_policy",
+        "enforce_embedding_policy",
+        "phase:planning",
+        "backend_identity_resolver",
+    ]
+    assert sink_calls == [
+        ("resolving_intent",),
+        ("normalizing",),
+        ("resolving_policy",),
+        ("planning",),
+    ]
+    assert all(isinstance(args[0], str) for args in sink_calls)
+    assert "sensitive-raw-input-marker" not in repr(sink_calls)
+    assert "sensitive-user-marker" not in repr(sink_calls)
+    assert "sensitive-request-marker" not in repr(sink_calls)
+    assert prepared.execution_plan.observability_tags not in sink_calls
+
+
+@pytest.mark.unit
+def test_pipeline_phase_sink_is_optional_and_does_not_change_prepared_output():
+    without_sink = _pipeline().prepare("optional sink", _context())
+    phases: list[str] = []
+
+    with_sink = _pipeline().prepare("optional sink", _context(), phase_sink=phases.append)
+
+    assert without_sink == with_sink
+    assert phases == ["resolving_intent", "normalizing", "resolving_policy", "planning"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("failing_boundary", "expected_phases", "expected_calls"),
+    [
+        ("resolve_provider_model", ["resolving_intent"], ["resolve_provider_model"]),
+        (
+            "normalize_embedding_input",
+            ["resolving_intent", "normalizing"],
+            ["resolve_provider_model", "normalize_embedding_input"],
+        ),
+        (
+            "enforce_embedding_policy",
+            ["resolving_intent", "normalizing", "resolving_policy"],
+            [
+                "resolve_provider_model",
+                "normalize_embedding_input",
+                "enforce_embedding_policy",
+            ],
+        ),
+        (
+            "backend_identity_resolver",
+            ["resolving_intent", "normalizing", "resolving_policy", "planning"],
+            [
+                "resolve_provider_model",
+                "normalize_embedding_input",
+                "enforce_embedding_policy",
+                "backend_identity_resolver",
+            ],
+        ),
+    ],
+)
+def test_pipeline_boundary_failure_preserves_identity_and_stops_later_work(
+    monkeypatch,
+    failing_boundary,
+    expected_phases,
+    expected_calls,
+):
+    sentinel = RuntimeError(f"sentinel:{failing_boundary}")
+    calls: list[str] = []
+    phases: list[str] = []
+    identity_probe = _install_boundary_probes(
+        monkeypatch,
+        calls,
+        failing_boundary=failing_boundary,
+        failure=sentinel,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _pipeline(backend_identity_resolver=identity_probe).prepare(
+            "boundary failure",
+            _context(),
+            phase_sink=phases.append,
+        )
+
+    assert exc_info.value is sentinel
+    assert phases == expected_phases
+    assert calls == expected_calls
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("failing_phase", "expected_phases", "expected_calls"),
+    [
+        ("resolving_intent", ["resolving_intent"], []),
+        ("normalizing", ["resolving_intent", "normalizing"], ["resolve_provider_model"]),
+        (
+            "resolving_policy",
+            ["resolving_intent", "normalizing", "resolving_policy"],
+            ["resolve_provider_model", "normalize_embedding_input"],
+        ),
+        (
+            "planning",
+            ["resolving_intent", "normalizing", "resolving_policy", "planning"],
+            [
+                "resolve_provider_model",
+                "normalize_embedding_input",
+                "enforce_embedding_policy",
+            ],
+        ),
+    ],
+)
+def test_pipeline_sink_failure_preserves_identity_and_skips_associated_boundary(
+    monkeypatch,
+    failing_phase,
+    expected_phases,
+    expected_calls,
+):
+    sentinel = RuntimeError(f"sentinel:{failing_phase}")
+    calls: list[str] = []
+    phases: list[str] = []
+    identity_probe = _install_boundary_probes(monkeypatch, calls)
+
+    def failing_sink(phase: str) -> None:
+        phases.append(phase)
+        if phase == failing_phase:
+            raise sentinel
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _pipeline(backend_identity_resolver=identity_probe).prepare(
+            "sink failure",
+            _context(),
+            phase_sink=failing_sink,
+        )
+
+    assert exc_info.value is sentinel
+    assert phases == expected_phases
+    assert calls == expected_calls
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("encoding_format", "dimensions", "configured_policy", "expected"),
+    [
+        ("base64", 128, "ignore", "reduce"),
+        ("base64", None, "pad", "pad"),
+        ("float", 128, "ignore", "ignore"),
+        (None, 128, "pad", "pad"),
+    ],
+)
+def test_effective_dimension_policy(
+    encoding_format,
+    dimensions,
+    configured_policy,
+    expected,
+):
+    assert effective_dimension_policy(encoding_format, dimensions, configured_policy) == expected

--- a/tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py
@@ -3,11 +3,21 @@ from __future__ import annotations
 import pytest
 
 from tldw_Server_API.app.core.Embeddings.provider_attempt import (
+    EmbeddingProviderAttempt,
     EmbeddingProviderReadinessCheck,
+    ProviderAttemptSuccess,
 )
 from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutionPlan,
     EmbeddingExecutionError,
     EmbeddingExecutorOutput,
+    EmbeddingPolicyDecision,
+    NormalizedEmbeddingInput,
+    PreparedEmbeddingRequest,
+    ProviderModelIntent,
+)
+from tldw_Server_API.app.core.Embeddings.vector_processing import (
+    EmbeddingVectorProcessor,
 )
 
 
@@ -58,3 +68,207 @@ def test_executor_output_contract_is_shared_from_request_types():
 
     assert output.vectors == [[0.1, 0.2]]
     assert output.embeddings_from_adapter is True
+
+
+class RecordingCache:
+    def __init__(self, values: dict[str, list[float]] | None = None) -> None:
+        self.values = values or {}
+        self.get_keys: list[str] = []
+        self.set_calls: list[tuple[str, list[float]]] = []
+
+    async def get(self, key: str) -> list[float] | None:
+        self.get_keys.append(key)
+        return self.values.get(key)
+
+    async def set(self, key: str, value: list[float]) -> object:
+        self.set_calls.append((key, value))
+        self.values[key] = value
+        return None
+
+
+class RecordingExecutor:
+    def __init__(self, vectors: list[list[float]] | None = None) -> None:
+        self.vectors = vectors or []
+        self.calls: list[dict[str, object]] = []
+
+    async def create(
+        self,
+        texts: list[str],
+        *,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+    ) -> list[list[float]]:
+        self.calls.append(
+            {
+                "texts": texts,
+                "provider": provider,
+                "model": model,
+                "dimensions": dimensions,
+            }
+        )
+        return self.vectors
+
+
+def _cache_key(
+    text: str,
+    provider: str,
+    model: str,
+    dimensions: int | None,
+    backend_identity: str | None,
+) -> str:
+    parts = [text, provider, model]
+    if dimensions is not None:
+        parts.append(str(dimensions))
+    if backend_identity is not None:
+        parts.append(backend_identity)
+    return "|".join(parts)
+
+
+def _prepared(
+    texts: list[str],
+    *,
+    provider: str = "openai",
+    model: str = "text-embedding-3-small",
+    dimensions: int | None = None,
+    backend_identity: str | None = "stale-plan-identity",
+    cache_namespace: str | None = "ignored-namespace",
+) -> PreparedEmbeddingRequest:
+    return PreparedEmbeddingRequest(
+        normalized_input=NormalizedEmbeddingInput(
+            texts=texts,
+            token_counts=[1 for _ in texts],
+            total_tokens=len(texts),
+        ),
+        provider_intent=ProviderModelIntent(
+            provider=provider,
+            model=model,
+            requested_provider=provider,
+            requested_model=model,
+            provider_was_explicit=True,
+            model_was_provider_qualified=False,
+        ),
+        policy_decision=EmbeddingPolicyDecision(
+            provider=provider,
+            model=model,
+            dimensions=dimensions,
+            fallback_chain=[provider],
+            fallback_allowed=True,
+            enforce_policy=True,
+        ),
+        execution_plan=EmbeddingExecutionPlan(
+            provider=provider,
+            model=model,
+            dimensions=dimensions,
+            backend_identity=backend_identity,
+            fallback_chain=[provider],
+            cache_namespace=cache_namespace,
+        ),
+        effective_dimension_policy="reduce",
+        prompt_tokens=len(texts),
+        total_tokens=len(texts),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_preserves_order_and_executes_only_cache_misses():
+    cache = RecordingCache(
+        {
+            "hit|openai|text-embedding-3-small|read-openai": [1.0, 0.0],
+            "hit2|openai|text-embedding-3-small|read-openai": [0.0, 1.0],
+        }
+    )
+    executor = RecordingExecutor(vectors=[[0.25, 0.75]])
+    identity_calls: list[tuple[str, str]] = []
+
+    def backend_identity(provider: str, model: str) -> str:
+        identity_calls.append((provider, model))
+        return "read-openai" if len(identity_calls) == 1 else "write-openai"
+
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=backend_identity,
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    result = await attempt.execute(
+        _prepared(["hit", "miss", "hit2"]),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert isinstance(result, ProviderAttemptSuccess)
+    assert result.vectors == [[1.0, 0.0], [0.25, 0.75], [0.0, 1.0]]
+    assert result.cache_hits == 2
+    assert result.cache_misses == 1
+    assert executor.calls == [
+        {
+            "texts": ["miss"],
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dimensions": None,
+        }
+    ]
+    assert cache.get_keys == [
+        "hit|openai|text-embedding-3-small|read-openai",
+        "miss|openai|text-embedding-3-small|read-openai",
+        "hit2|openai|text-embedding-3-small|read-openai",
+    ]
+    assert cache.set_calls == [
+        ("miss|openai|text-embedding-3-small|write-openai", [0.25, 0.75])
+    ]
+    assert identity_calls == [
+        ("openai", "text-embedding-3-small"),
+        ("openai", "text-embedding-3-small"),
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_cache_keys_exclude_plan_identity_and_namespace():
+    cache = RecordingCache()
+    executor = RecordingExecutor(vectors=[[0.1, 0.2]])
+    cache_key_calls: list[tuple[str, str, str, int | None, str | None]] = []
+
+    def cache_key_probe(
+        text: str,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+        backend_identity: str | None,
+    ) -> str:
+        cache_key_calls.append((text, provider, model, dimensions, backend_identity))
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=cache_key_probe,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=lambda provider, model: (
+            f"runtime:{provider}:{model}"
+        ),
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    await attempt.execute(
+        _prepared(
+            ["one"],
+            dimensions=2,
+            backend_identity="stale-plan",
+            cache_namespace="ns",
+        ),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    runtime_identity = "runtime:openai:text-embedding-3-small"
+    assert cache_key_calls == [
+        ("one", "openai", "text-embedding-3-small", 2, runtime_identity),
+        ("one", "openai", "text-embedding-3-small", 2, runtime_identity),
+    ]
+    observed_keys = cache.get_keys + [key for key, _ in cache.set_calls]
+    assert all("stale-plan" not in key for key in observed_keys)
+    assert all("ns" not in key for key in observed_keys)

--- a/tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py
@@ -6,12 +6,14 @@ from tldw_Server_API.app.core.Embeddings.provider_attempt import (
     EmbeddingProviderAttempt,
     EmbeddingProviderReadinessCheck,
     ProviderAttemptSuccess,
+    ProviderCallFailure,
 )
 from tldw_Server_API.app.core.Embeddings.request_types import (
     EmbeddingExecutionPlan,
     EmbeddingExecutionError,
     EmbeddingExecutorOutput,
     EmbeddingPolicyDecision,
+    EmbeddingProviderError,
     NormalizedEmbeddingInput,
     PreparedEmbeddingRequest,
     ProviderModelIntent,
@@ -272,3 +274,236 @@ async def test_provider_attempt_cache_keys_exclude_plan_identity_and_namespace()
     observed_keys = cache.get_keys + [key for key, _ in cache.set_calls]
     assert all("stale-plan" not in key for key in observed_keys)
     assert all("ns" not in key for key in observed_keys)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_writes_provider_native_vectors_after_full_response_validation():
+    cache = RecordingCache(
+        {"hit|openai|text-embedding-3-small|2|read": [1.0, 0.0, 0.0]}
+    )
+    executor = RecordingExecutor(vectors=[[0.25, 0.75, 0.5]])
+    identities = iter(["read", "write"])
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=lambda provider, model: next(identities),
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    result = await attempt.execute(
+        _prepared(["hit", "miss"], dimensions=2),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert isinstance(result, ProviderAttemptSuccess)
+    assert result.vectors == [[1.0, 0.0], [0.25, 0.75]]
+    assert cache.set_calls == [
+        ("miss|openai|text-embedding-3-small|2|write", [0.25, 0.75, 0.5])
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_rejects_provider_malformed_response_before_writeback():
+    cache = RecordingCache({"hit|openai|text-embedding-3-small|read": [1.0, 0.0]})
+    executor = RecordingExecutor(vectors=[[0.25, 0.75, 0.5]])
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=lambda provider, model: "read",
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        await attempt.execute(
+            _prepared(["hit", "miss"]),
+            provider="openai",
+            model="text-embedding-3-small",
+        )
+
+    assert exc_info.value.code == "provider_malformed_response"
+    assert cache.set_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_treats_malformed_cached_vector_as_miss():
+    cache = RecordingCache(
+        {"bad|openai|text-embedding-3-small|read": [float("nan")]}
+    )
+    executor = RecordingExecutor(vectors=[[0.1, 0.2]])
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=lambda provider, model: "read",
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    result = await attempt.execute(
+        _prepared(["bad"]),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert isinstance(result, ProviderAttemptSuccess)
+    assert result.vectors == [[0.1, 0.2]]
+    assert result.cache_hits == 0
+    assert result.cache_misses == 1
+    assert executor.calls[0]["texts"] == ["bad"]
+    assert cache.set_calls == [
+        ("bad|openai|text-embedding-3-small|read", [0.1, 0.2])
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_skips_cache_write_for_adapter_originated_executor_output():
+    class AdapterOriginExecutor(RecordingExecutor):
+        async def create(
+            self,
+            texts: list[str],
+            *,
+            provider: str,
+            model: str,
+            dimensions: int | None,
+        ) -> EmbeddingExecutorOutput:
+            self.calls.append(
+                {
+                    "texts": texts,
+                    "provider": provider,
+                    "model": model,
+                    "dimensions": dimensions,
+                }
+            )
+            return EmbeddingExecutorOutput(
+                vectors=[[0.1, 0.2]],
+                embeddings_from_adapter=True,
+            )
+
+    cache = RecordingCache()
+    executor = AdapterOriginExecutor()
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=cache,
+        executor=executor,
+        backend_identity_resolver=lambda provider, model: "identity",
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    result = await attempt.execute(
+        _prepared(["adapter-origin"]),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert isinstance(result, ProviderAttemptSuccess)
+    assert result.vectors == [[0.1, 0.2]]
+    assert result.embeddings_from_adapter is True
+    assert cache.set_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_attempt_returns_exact_provider_call_failure_from_executor():
+    error = EmbeddingProviderError(
+        "provider_unavailable",
+        "provider down",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+
+    class FailingExecutor(RecordingExecutor):
+        async def create(
+            self,
+            texts: list[str],
+            *,
+            provider: str,
+            model: str,
+            dimensions: int | None,
+        ) -> list[list[float]]:
+            self.calls.append(
+                {
+                    "texts": texts,
+                    "provider": provider,
+                    "model": model,
+                    "dimensions": dimensions,
+                }
+            )
+            raise error
+
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=_cache_key,
+        cache=RecordingCache(),
+        executor=FailingExecutor(),
+        backend_identity_resolver=lambda provider, model: "identity",
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    result = await attempt.execute(
+        _prepared(["one"]),
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+
+    assert isinstance(result, ProviderCallFailure)
+    assert result.error is error
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["identity", "cache_key", "cache_get", "cache_set"])
+async def test_provider_attempt_non_provider_failures_propagate_without_call_failure(
+    boundary,
+):
+    original = RuntimeError(f"{boundary} failed")
+
+    def identity(provider: str, model: str) -> str:
+        del provider, model
+        if boundary == "identity":
+            raise original
+        return "identity"
+
+    def cache_key(
+        text: str,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+        backend_identity: str | None,
+    ) -> str:
+        if boundary == "cache_key":
+            raise original
+        return _cache_key(text, provider, model, dimensions, backend_identity)
+
+    class BoundaryCache(RecordingCache):
+        async def get(self, key: str) -> list[float] | None:
+            if boundary == "cache_get":
+                raise original
+            return await super().get(key)
+
+        async def set(self, key: str, value: list[float]) -> object:
+            if boundary == "cache_set":
+                raise original
+            return await super().set(key, value)
+
+    attempt = EmbeddingProviderAttempt(
+        cache_key_fn=cache_key,
+        cache=BoundaryCache(),
+        executor=RecordingExecutor(vectors=[[0.1, 0.2]]),
+        backend_identity_resolver=identity,
+        vector_processor=EmbeddingVectorProcessor(),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await attempt.execute(
+            _prepared(["one"]),
+            provider="openai",
+            model="text-embedding-3-small",
+        )
+
+    assert exc_info.value is original

--- a/tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Embeddings.provider_attempt import (
+    EmbeddingProviderReadinessCheck,
+)
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutionError,
+    EmbeddingExecutorOutput,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_readiness_check_delegates_to_preflight():
+    calls: list[tuple[str, str]] = []
+
+    async def preflight(provider: str, model: str) -> None:
+        calls.append((provider, model))
+
+    readiness = EmbeddingProviderReadinessCheck(preflight)
+
+    await readiness.check("openai", "text-embedding-3-small")
+
+    assert calls == [("openai", "text-embedding-3-small")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_readiness_check_propagates_exact_error():
+    error = EmbeddingExecutionError(
+        "circuit_breaker_open",
+        "provider unavailable",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=True,
+    )
+
+    async def preflight(provider: str, model: str) -> None:
+        del provider, model
+        raise error
+
+    readiness = EmbeddingProviderReadinessCheck(preflight)
+
+    with pytest.raises(EmbeddingExecutionError) as exc_info:
+        await readiness.check("openai", "text-embedding-3-small")
+
+    assert exc_info.value is error
+
+
+@pytest.mark.unit
+def test_executor_output_contract_is_shared_from_request_types():
+    output = EmbeddingExecutorOutput(
+        vectors=[[0.1, 0.2]],
+        embeddings_from_adapter=True,
+    )
+
+    assert output.vectors == [[0.1, 0.2]]
+    assert output.embeddings_from_adapter is True

--- a/tldw_Server_API/tests/Embeddings_isolated/test_request_types.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_request_types.py
@@ -1,20 +1,42 @@
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import MISSING, asdict, fields
 from typing import Literal, get_type_hints
 
 import pytest
 
+from tldw_Server_API.app.core.Embeddings.orchestrator import (
+    PreparedEmbeddingRequest as OrchestratorPreparedEmbeddingRequest,
+)
 from tldw_Server_API.app.core.Embeddings.request_types import (
     EmbeddingDomainError,
+    EmbeddingExecutionOutcome,
     EmbeddingExecutionPlan,
     EmbeddingExecutionResult,
     EmbeddingPolicyDecision,
     EmbeddingRequestContext,
     NormalizedEmbeddingInput,
+    PreparedEmbeddingRequest,
 )
 
 TelemetryScalar = str | int | float | bool | None
+
+
+def _valid_execution_outcome_values() -> dict[str, object]:
+    return {
+        "vectors": ((0.1, 0.2),),
+        "provider": "openai",
+        "model": "text-embedding-3-small",
+        "prompt_tokens": 1,
+        "total_tokens": 1,
+        "cache_hits": 0,
+        "cache_misses": 1,
+        "requested_dimensions": None,
+        "effective_dimension_policy": "reduce",
+        "attempt_count": 1,
+        "fallback_attempt_count": 0,
+        "embeddings_from_adapter": False,
+    }
 
 
 @pytest.mark.unit
@@ -92,6 +114,160 @@ def test_request_contract_annotations_match_approved_plan_shapes():
 
     error_details_hint = get_type_hints(EmbeddingDomainError.__init__)["details"]
     assert error_details_hint == list[dict[str, TelemetryScalar]] | None
+
+
+@pytest.mark.unit
+def test_execution_outcome_is_deeply_immutable_and_has_no_http_headers():
+    hints = get_type_hints(EmbeddingExecutionOutcome)
+    outcome_fields = {field.name: field for field in fields(EmbeddingExecutionOutcome)}
+
+    assert "response_headers" not in hints
+    assert hints["vectors"] == tuple[tuple[float, ...], ...]
+    assert hints["attempt_count"] is int
+    assert hints["fallback_attempt_count"] is int
+    assert outcome_fields["attempt_count"].default is MISSING
+    assert outcome_fields["fallback_attempt_count"].default is MISSING
+    assert EmbeddingExecutionOutcome.__dataclass_params__.frozen is True
+    assert set(EmbeddingExecutionOutcome.__slots__) == set(hints)
+
+
+@pytest.mark.unit
+def test_execution_outcome_copies_mutable_vectors_into_nested_tuples():
+    source_vectors = [[0.1, 0.2], [0.3, 0.4]]
+    outcome = EmbeddingExecutionOutcome(
+        vectors=source_vectors,
+        provider="openai",
+        model="text-embedding-3-small",
+        prompt_tokens=2,
+        total_tokens=2,
+        cache_hits=0,
+        cache_misses=2,
+        requested_dimensions=None,
+        effective_dimension_policy="reduce",
+        attempt_count=1,
+        fallback_attempt_count=0,
+    )
+
+    source_vectors[0][0] = 9.0
+    source_vectors.append([0.5, 0.6])
+
+    assert outcome.vectors == ((0.1, 0.2), (0.3, 0.4))
+    assert type(outcome.vectors) is tuple
+    assert all(type(vector) is tuple for vector in outcome.vectors)
+
+
+@pytest.mark.unit
+def test_execution_outcome_accepts_zero_total_with_positive_prompt_tokens():
+    outcome = EmbeddingExecutionOutcome(
+        vectors=((0.1, 0.2),),
+        provider="openai",
+        model="text-embedding-3-small",
+        prompt_tokens=2,
+        total_tokens=0,
+        cache_hits=0,
+        cache_misses=1,
+        requested_dimensions=None,
+        effective_dimension_policy="reduce",
+        attempt_count=1,
+        fallback_attempt_count=0,
+    )
+
+    assert outcome.prompt_tokens == 2
+    assert outcome.total_tokens == 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("overrides", "expected_message"),
+    [
+        ({"prompt_tokens": -1}, "prompt_tokens must be nonnegative"),
+        ({"cache_hits": -1}, "cache_hits must be nonnegative"),
+        ({"cache_misses": -1}, "cache_misses must be nonnegative"),
+        ({"attempt_count": -1}, "attempt_count must be nonnegative"),
+        (
+            {"fallback_attempt_count": -1},
+            "fallback_attempt_count must be nonnegative",
+        ),
+        ({"total_tokens": -1}, "total_tokens must be nonnegative"),
+        (
+            {"attempt_count": 0},
+            "attempt_count must be at least 1 for a successful outcome",
+        ),
+        (
+            {"fallback_attempt_count": 2},
+            "fallback_attempt_count must be less than attempt_count",
+        ),
+        (
+            {"fallback_attempt_count": 1},
+            "fallback_attempt_count must be less than attempt_count",
+        ),
+        (
+            {"cache_hits": 1, "cache_misses": 1},
+            "cache_hits + cache_misses must equal the number of vectors",
+        ),
+    ],
+)
+def test_execution_outcome_rejects_invalid_success_invariants(
+    overrides: dict[str, int],
+    expected_message: str,
+):
+    values = _valid_execution_outcome_values()
+    values.update(overrides)
+
+    with pytest.raises(ValueError) as exc_info:
+        EmbeddingExecutionOutcome(**values)
+
+    assert str(exc_info.value) == expected_message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field_name",
+    (
+        "prompt_tokens",
+        "total_tokens",
+        "cache_hits",
+        "cache_misses",
+        "attempt_count",
+        "fallback_attempt_count",
+    ),
+)
+@pytest.mark.parametrize("invalid_value", (True, 1.0), ids=("bool", "float"))
+def test_execution_outcome_requires_exact_builtin_integer_counters(
+    field_name: str,
+    invalid_value: bool | float,
+):
+    values = _valid_execution_outcome_values()
+    values[field_name] = invalid_value
+
+    with pytest.raises(ValueError) as exc_info:
+        EmbeddingExecutionOutcome(**values)
+
+    assert str(exc_info.value) == f"{field_name} must be an exact int"
+
+
+@pytest.mark.unit
+def test_execution_outcome_accepts_mixed_cache_counts_with_adapter_origin():
+    values = _valid_execution_outcome_values()
+    values.update(
+        {
+            "vectors": ((0.1, 0.2), (0.3, 0.4)),
+            "cache_hits": 1,
+            "cache_misses": 1,
+            "embeddings_from_adapter": True,
+        }
+    )
+
+    outcome = EmbeddingExecutionOutcome(**values)
+
+    assert outcome.embeddings_from_adapter is True
+    assert (outcome.cache_hits, outcome.cache_misses) == (1, 1)
+    assert len(outcome.vectors) == 2
+
+
+@pytest.mark.unit
+def test_orchestrator_reexports_prepared_request_contract():
+    assert OrchestratorPreparedEmbeddingRequest is PreparedEmbeddingRequest
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Embeddings_isolated/test_request_types.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_request_types.py
@@ -157,6 +157,59 @@ def test_execution_outcome_copies_mutable_vectors_into_nested_tuples():
 
 
 @pytest.mark.unit
+def test_execution_outcome_canonicalizes_numeric_vector_leaves_to_floats():
+    values = _valid_execution_outcome_values()
+    values.update(
+        {
+            "vectors": [[1, 2], [3.5, 4]],
+            "cache_misses": 2,
+        }
+    )
+
+    outcome = EmbeddingExecutionOutcome(**values)
+
+    assert outcome.vectors == ((1.0, 2.0), (3.5, 4.0))
+    assert all(type(value) is float for vector in outcome.vectors for value in vector)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("vectors", "cache_misses"),
+    [
+        ([[[1.0], 2.0]], 1),
+        ([["not-a-number"]], 1),
+        ([[True]], 1),
+        ([[float("nan")]], 1),
+        ([[float("inf")]], 1),
+        ([[1.0], [2.0, 3.0]], 2),
+        ([[]], 1),
+        ([1.0], 1),
+    ],
+    ids=(
+        "nested-mutable-leaf",
+        "non-numeric-leaf",
+        "boolean-leaf",
+        "nan-leaf",
+        "infinite-leaf",
+        "non-rectangular",
+        "empty-vector",
+        "non-vector-item",
+    ),
+)
+def test_execution_outcome_rejects_malformed_vectors(
+    vectors: object,
+    cache_misses: int,
+):
+    values = _valid_execution_outcome_values()
+    values.update({"vectors": vectors, "cache_misses": cache_misses})
+
+    with pytest.raises(ValueError) as exc_info:
+        EmbeddingExecutionOutcome(**values)
+
+    assert str(exc_info.value) == ("vectors must contain equally sized, non-empty vectors of finite numbers")
+
+
+@pytest.mark.unit
 def test_execution_outcome_accepts_zero_total_with_positive_prompt_tokens():
     outcome = EmbeddingExecutionOutcome(
         vectors=((0.1, 0.2),),
@@ -218,6 +271,77 @@ def test_execution_outcome_rejects_invalid_success_invariants(
         EmbeddingExecutionOutcome(**values)
 
     assert str(exc_info.value) == expected_message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("overrides", "expected_message"),
+    [
+        (
+            {"fallback_from": "openai"},
+            "fallback_from requires a positive fallback_attempt_count",
+        ),
+        (
+            {"attempt_count": 2, "fallback_attempt_count": 1},
+            "positive fallback_attempt_count requires fallback_from",
+        ),
+        (
+            {"attempt_count": 99},
+            "attempt_count - fallback_attempt_count must be 1 or 2",
+        ),
+        (
+            {
+                "attempt_count": 4,
+                "fallback_attempt_count": 1,
+                "fallback_from": "openai",
+            },
+            "attempt_count - fallback_attempt_count must be 1 or 2",
+        ),
+    ],
+)
+def test_execution_outcome_rejects_inconsistent_attempt_metadata(
+    overrides: dict[str, object],
+    expected_message: str,
+):
+    values = _valid_execution_outcome_values()
+    values.update(overrides)
+
+    with pytest.raises(ValueError) as exc_info:
+        EmbeddingExecutionOutcome(**values)
+
+    assert str(exc_info.value) == expected_message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("attempt_count", "fallback_attempt_count", "fallback_from"),
+    [
+        (1, 0, None),
+        (2, 0, None),
+        (2, 1, "openai"),
+        (3, 1, "openai"),
+        (3, 2, "openai"),
+        (4, 2, "openai"),
+    ],
+)
+def test_execution_outcome_accepts_attempt_count_boundaries(
+    attempt_count: int,
+    fallback_attempt_count: int,
+    fallback_from: str | None,
+):
+    values = _valid_execution_outcome_values()
+    values.update(
+        {
+            "attempt_count": attempt_count,
+            "fallback_attempt_count": fallback_attempt_count,
+            "fallback_from": fallback_from,
+        }
+    )
+
+    outcome = EmbeddingExecutionOutcome(**values)
+
+    assert outcome.attempt_count - outcome.fallback_attempt_count in (1, 2)
+    assert outcome.fallback_from == fallback_from
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutionOutcome,
+    EmbeddingExecutionPlan,
+    EmbeddingExecutionResult,
+    EmbeddingPolicyDecision,
+    NormalizedEmbeddingInput,
+    PreparedEmbeddingRequest,
+    ProviderModelIntent,
+)
+from tldw_Server_API.app.core.Embeddings.result_mapping import (
+    assemble_embedding_execution_outcome,
+    map_embedding_response_headers,
+    map_outcome_to_legacy_execution_result,
+)
+
+
+def _prepared_request(*, dimensions: int | None = None) -> PreparedEmbeddingRequest:
+    return PreparedEmbeddingRequest(
+        normalized_input=NormalizedEmbeddingInput(
+            texts=["one", "two"],
+            token_counts=[1, 1],
+            total_tokens=2,
+        ),
+        provider_intent=ProviderModelIntent(
+            provider="openai",
+            model="text-embedding-3-small",
+            requested_provider="openai",
+            requested_model="text-embedding-3-small",
+            provider_was_explicit=True,
+            model_was_provider_qualified=False,
+        ),
+        policy_decision=EmbeddingPolicyDecision(
+            provider="openai",
+            model="text-embedding-3-small",
+            dimensions=dimensions,
+            fallback_chain=["openai", "huggingface"],
+            fallback_allowed=True,
+            enforce_policy=True,
+        ),
+        execution_plan=EmbeddingExecutionPlan(
+            provider="openai",
+            model="text-embedding-3-small",
+            dimensions=dimensions,
+            backend_identity="openai:test",
+            fallback_chain=["openai", "huggingface"],
+        ),
+        effective_dimension_policy="reduce",
+        prompt_tokens=2,
+        total_tokens=2,
+    )
+
+
+def _outcome(
+    *,
+    provider: str = "openai",
+    fallback_from: str | None = None,
+    requested_dimensions: int | None = None,
+) -> EmbeddingExecutionOutcome:
+    return EmbeddingExecutionOutcome(
+        vectors=((0.1, 0.2),),
+        provider=provider,
+        model=("text-embedding-3-small" if provider == "openai" else "all-MiniLM-L6-v2"),
+        prompt_tokens=2,
+        total_tokens=2,
+        cache_hits=0,
+        cache_misses=1,
+        requested_dimensions=requested_dimensions,
+        effective_dimension_policy="reduce",
+        attempt_count=2 if fallback_from else 1,
+        fallback_attempt_count=1 if fallback_from else 0,
+        fallback_from=fallback_from,
+        embeddings_from_adapter=False,
+    )
+
+
+@pytest.mark.unit
+def test_result_assembly_freezes_vectors_and_preserves_adapter_cache_counts():
+    vectors = [[0.1, 0.2], [0.3, 0.4]]
+
+    outcome = assemble_embedding_execution_outcome(
+        _prepared_request(),
+        vectors=vectors,
+        provider="openai",
+        model="text-embedding-3-small",
+        cache_hits=0,
+        cache_misses=2,
+        fallback_from=None,
+        embeddings_from_adapter=True,
+        attempt_count=1,
+        fallback_attempt_count=0,
+    )
+    vectors[0][0] = 9.0
+
+    assert outcome.vectors == ((0.1, 0.2), (0.3, 0.4))
+    assert (outcome.cache_hits, outcome.cache_misses) == (0, 2)
+    assert outcome.embeddings_from_adapter is True
+
+
+@pytest.mark.unit
+def test_result_assembly_relies_on_canonical_outcome_invariants():
+    with pytest.raises(ValueError) as exc_info:
+        assemble_embedding_execution_outcome(
+            _prepared_request(),
+            vectors=[[0.1, 0.2], [0.3, 0.4]],
+            provider="openai",
+            model="text-embedding-3-small",
+            cache_hits=0,
+            cache_misses=1,
+            fallback_from=None,
+            embeddings_from_adapter=False,
+            attempt_count=1,
+            fallback_attempt_count=0,
+        )
+
+    assert str(exc_info.value) == ("cache_hits + cache_misses must equal the number of vectors")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("provider", "fallback_from", "dimensions", "expected"),
+    [
+        ("openai", None, None, {"X-Embeddings-Provider": "openai"}),
+        (
+            "openai",
+            None,
+            2,
+            {
+                "X-Embeddings-Provider": "openai",
+                "X-Embeddings-Dimensions-Policy": "reduce",
+            },
+        ),
+        (
+            "huggingface",
+            "huggingface",
+            None,
+            {"X-Embeddings-Provider": "huggingface"},
+        ),
+        (
+            "huggingface",
+            "openai",
+            2,
+            {
+                "X-Embeddings-Provider": "huggingface",
+                "X-Embeddings-Fallback-From": "openai",
+                "X-Embeddings-Dimensions-Policy": "reduce",
+            },
+        ),
+    ],
+)
+def test_header_mapper_matches_legacy_contract(
+    provider: str,
+    fallback_from: str | None,
+    dimensions: int | None,
+    expected: dict[str, str],
+):
+    outcome = _outcome(
+        provider=provider,
+        fallback_from=fallback_from,
+        requested_dimensions=dimensions,
+    )
+
+    assert map_embedding_response_headers(outcome) == expected
+
+
+@pytest.mark.unit
+def test_legacy_mapper_preserves_all_legacy_fields():
+    outcome = _outcome(
+        provider="huggingface",
+        fallback_from="openai",
+        requested_dimensions=2,
+    )
+
+    legacy = map_outcome_to_legacy_execution_result(outcome)
+
+    assert legacy == EmbeddingExecutionResult(
+        vectors=[[0.1, 0.2]],
+        provider=outcome.provider,
+        model=outcome.model,
+        prompt_tokens=outcome.prompt_tokens,
+        total_tokens=outcome.total_tokens,
+        cache_hits=outcome.cache_hits,
+        cache_misses=outcome.cache_misses,
+        fallback_from=outcome.fallback_from,
+        response_headers=map_embedding_response_headers(outcome),
+        embeddings_from_adapter=outcome.embeddings_from_adapter,
+    )
+
+
+@pytest.mark.unit
+def test_legacy_mapper_returns_independent_vectors_and_headers():
+    outcome = _outcome(
+        provider="huggingface",
+        fallback_from="openai",
+        requested_dimensions=2,
+    )
+    first_result = map_outcome_to_legacy_execution_result(outcome)
+    second_result = map_outcome_to_legacy_execution_result(outcome)
+
+    first_result.vectors[0][0] = 9.0
+    first_result.response_headers["X-Embeddings-Provider"] = "mutated"
+
+    assert outcome.vectors == ((0.1, 0.2),)
+    assert second_result.vectors == [[0.1, 0.2]]
+    assert second_result.response_headers == {
+        "X-Embeddings-Provider": "huggingface",
+        "X-Embeddings-Fallback-From": "openai",
+        "X-Embeddings-Dimensions-Policy": "reduce",
+    }

--- a/tldw_Server_API/tests/Embeddings_isolated/test_vector_processing.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_vector_processing.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import pytest
+
+import tldw_Server_API.app.core.Embeddings.vector_processing as vector_processing_module
+from tldw_Server_API.app.core.Embeddings.request_types import EmbeddingProviderError
+from tldw_Server_API.app.core.Embeddings.vector_processing import (
+    EmbeddingVectorProcessor,
+)
+
+
+@pytest.mark.unit
+def test_validate_vector_count_canonicalizes_finite_numeric_vectors():
+    result = EmbeddingVectorProcessor().validate_vector_count(
+        [[1, 2], [3.5, 4]],
+        expected=2,
+        provider="p",
+        model="m",
+    )
+
+    assert result == [[1.0, 2.0], [3.5, 4.0]]
+    assert all(isinstance(value, float) for vector in result for value in vector)
+
+
+@pytest.mark.unit
+def test_validate_vector_count_preserves_exact_count_mismatch_error():
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        EmbeddingVectorProcessor().validate_vector_count(
+            [[1.0]],
+            expected=2,
+            provider="p",
+            model="m",
+        )
+
+    error = exc_info.value
+    assert error.code == "provider_malformed_response"
+    assert error.message == "Embedding provider returned 1 embeddings, expected 2"
+    assert error.provider == "p"
+    assert error.model == "m"
+
+
+@pytest.mark.unit
+def test_validate_vector_count_preserves_exact_same_count_malformed_error():
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        EmbeddingVectorProcessor().validate_vector_count(
+            [[1.0, 2.0], [3.0]],
+            expected=2,
+            provider="p",
+            model="m",
+        )
+
+    error = exc_info.value
+    assert error.code == "provider_malformed_response"
+    assert error.message == "Embedding provider returned malformed embedding vectors"
+    assert error.provider == "p"
+    assert error.model == "m"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "vectors",
+    [
+        pytest.param([[True, 1.0]], id="bool"),
+        pytest.param([[float("nan"), 1.0]], id="nan"),
+        pytest.param([[float("inf"), 1.0]], id="infinite"),
+        pytest.param([["not-a-number", 1.0]], id="nonnumeric"),
+    ],
+)
+def test_validate_vector_count_rejects_malformed_numeric_values(vectors):
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        EmbeddingVectorProcessor().validate_vector_count(
+            vectors,
+            expected=1,
+            provider="p",
+            model="m",
+        )
+
+    error = exc_info.value
+    assert error.code == "provider_malformed_response"
+    assert error.message == "Embedding provider returned malformed embedding vectors"
+    assert error.provider == "p"
+    assert error.model == "m"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "vector",
+    [
+        pytest.param(None, id="none"),
+        pytest.param([], id="empty"),
+        pytest.param((1.0, 2.0), id="non-list"),
+        pytest.param(["not-a-number"], id="nonnumeric"),
+        pytest.param([True, 0.0], id="bool"),
+        pytest.param([float("nan"), 0.0], id="nan"),
+        pytest.param([float("inf"), 0.0], id="infinite"),
+    ],
+)
+def test_validate_cached_vector_returns_none_for_nullable_or_malformed_values(vector):
+    assert EmbeddingVectorProcessor().validate_cached_vector(vector) is None
+
+
+@pytest.mark.unit
+def test_validate_cached_vector_returns_canonical_finite_vector():
+    result = EmbeddingVectorProcessor().validate_cached_vector([1, 2.5])
+
+    assert result == [1.0, 2.5]
+    assert result is not None
+    assert all(isinstance(value, float) for value in result)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("dimensions", "dimension_policy", "expected", "expected_calls"),
+    [
+        pytest.param(2, "reduce", [[1.0, 2.0]], [("p", "m", "reduce")], id="reduce"),
+        pytest.param(
+            4,
+            "pad",
+            [[1.0, 2.0, 3.0, 0.0]],
+            [("p", "m", "pad")],
+            id="pad",
+        ),
+        pytest.param(None, "reduce", [[1.0, 2.0, 3.0]], [], id="no-dimensions"),
+    ],
+)
+def test_process_vectors_applies_dimensions_and_records_adjustments(
+    dimensions,
+    dimension_policy,
+    expected,
+    expected_calls,
+):
+    calls: list[tuple[str, str, str]] = []
+    processor = EmbeddingVectorProcessor(record_dimension_adjustment=lambda *args: calls.append(args))
+
+    result = processor.process_vectors(
+        [[1, 2, 3]],
+        provider="p",
+        model="m",
+        dimensions=dimensions,
+        dimension_policy=dimension_policy,
+    )
+
+    assert result == expected
+    assert all(isinstance(value, float) for vector in result for value in vector)
+    assert calls == expected_calls
+
+
+@pytest.mark.unit
+def test_process_vectors_canonicalizes_before_and_after_dimension_adjustment(monkeypatch):
+    def adjust_dimensions_probe(vectors, target_dim, provider, model, **kwargs):
+        assert vectors == [[1.0, 2.0]]
+        assert all(isinstance(value, float) for value in vectors[0])
+        assert (target_dim, provider, model) == (2, "p", "m")
+        assert kwargs["dimension_policy"] == "reduce"
+        return [[3, 4]]
+
+    monkeypatch.setattr(
+        vector_processing_module,
+        "adjust_dimensions",
+        adjust_dimensions_probe,
+    )
+
+    result = EmbeddingVectorProcessor().process_vectors(
+        [[1, 2]],
+        provider="p",
+        model="m",
+        dimensions=2,
+        dimension_policy="reduce",
+    )
+
+    assert result == [[3.0, 4.0]]
+    assert all(isinstance(value, float) for value in result[0])
+
+
+@pytest.mark.unit
+def test_process_cached_vector_postprocesses_an_already_canonical_vector():
+    processor = EmbeddingVectorProcessor()
+    canonical = processor.validate_cached_vector([1, 2, 3])
+    assert canonical is not None
+
+    result = processor.process_cached_vector(
+        canonical,
+        provider="p",
+        model="m",
+        dimensions=2,
+        dimension_policy="reduce",
+    )
+
+    assert result == [1.0, 2.0]
+
+
+@pytest.mark.unit
+def test_process_vectors_propagates_recorder_exception_identity():
+    original = RuntimeError("recorder failed")
+
+    def raise_original(provider: str, model: str, method: str) -> None:
+        del provider, model, method
+        raise original
+
+    processor = EmbeddingVectorProcessor(record_dimension_adjustment=raise_original)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        processor.process_vectors(
+            [[1.0, 2.0, 3.0]],
+            provider="p",
+            model="m",
+            dimensions=2,
+            dimension_policy="reduce",
+        )
+
+    assert exc_info.value is original

--- a/tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import get_args
+
 import pytest
 
 from tldw_Server_API.app.core import exceptions as core_exceptions
@@ -33,6 +35,22 @@ def test_workflow_trace_error_uses_central_exception_contract():
         "EmbeddingWorkflowTraceError",
         None,
     )
+
+
+def test_workflow_phase_and_status_literals_keep_completion_distinct():
+    phases = get_args(workflow_types.EmbeddingWorkflowPhase)
+    statuses = set(get_args(workflow_types.EmbeddingWorkflowStatus))
+
+    assert phases[:5] == (
+        "created",
+        "resolving_intent",
+        "normalizing",
+        "resolving_policy",
+        "planning",
+    )
+    assert "completed" not in phases
+    assert "completed" in statuses
+    assert "resolving_intent" in workflow_types.SAFE_METADATA_ENUM_VALUES["phase"]
 
 
 def test_workflow_context_generates_id_without_retaining_request_or_user_identifiers():
@@ -134,6 +152,22 @@ def test_safe_workflow_metadata_allows_token_count_fields():
         "prompt_tokens": 3,
         "runner_mode": "inline",
         "execution_path": "legacy",
+    }
+
+
+def test_safe_workflow_metadata_allows_attempt_counters_and_legacy_header_count():
+    metadata = safe_workflow_metadata(
+        {
+            "attempt_count": 2,
+            "fallback_attempt_count": 1,
+            "response_header_count": 3,
+        }
+    )
+
+    assert metadata == {
+        "attempt_count": 2,
+        "fallback_attempt_count": 1,
+        "response_header_count": 3,
     }
 
 
@@ -240,6 +274,38 @@ def test_event_rejects_unsafe_metadata_on_construction():
         )
 
 
+def test_workflow_completed_event_accepts_finalizing_completed_contract():
+    event = EmbeddingWorkflowEvent(
+        event_type="workflow_completed",
+        workflow_id=WORKFLOW_ID,
+        phase="finalizing",
+        status="completed",
+    )
+
+    assert event.phase == "finalizing"
+    assert event.status == "completed"
+
+
+def test_workflow_completed_event_rejects_wrong_phase():
+    with pytest.raises(EmbeddingWorkflowTraceError):
+        EmbeddingWorkflowEvent(
+            event_type="workflow_completed",
+            workflow_id=WORKFLOW_ID,
+            phase="executing",
+            status="completed",
+        )
+
+
+def test_workflow_completed_event_rejects_wrong_status():
+    with pytest.raises(EmbeddingWorkflowTraceError):
+        EmbeddingWorkflowEvent(
+            event_type="workflow_completed",
+            workflow_id=WORKFLOW_ID,
+            phase="finalizing",
+            status="running",
+        )
+
+
 def test_in_memory_collector_preserves_event_order_and_fails_closed_at_bound():
     collector = EmbeddingInMemoryWorkflowTraceCollector(max_events=2)
 
@@ -268,6 +334,7 @@ def test_in_memory_collector_preserves_event_order_and_fails_closed_at_bound():
             EmbeddingWorkflowEvent(
                 event_type="workflow_completed",
                 workflow_id=WORKFLOW_ID,
+                phase="finalizing",
                 status="completed",
             )
         )


### PR DESCRIPTION
## Summary
- Introduce provider readiness and single-provider attempt boundaries alongside the legacy orchestrator.
- Preserve ordered cache behavior, validate provider-native vectors before writeback, and keep non-provider failures outside fallback routing.
- Re-resolve runtime backend identity before fallback cache writeback and cover the behavior with focused regression tests.

## Change summary
Human-authored summary required before merge: explain what changed and why these provider-attempt and cache-identity boundaries were chosen.

## Test plan
- [x] `python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py -q` (230 passed)
- [x] `python -m bandit -r tldw_Server_API/app/core/Embeddings/provider_attempt.py tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/app/core/Embeddings/request_types.py -f json` (0 findings)
- [x] `git diff --check origin/codex/embeddings-workflow-stage2b-contracts...HEAD`

## Stack
Base PR branch: `codex/embeddings-workflow-stage2b-contracts`. Retarget this PR to `dev` after Stage 2B merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted provider readiness and single-provider execution into `EmbeddingProviderAttempt`, preserving cache order and validating provider-native vectors. Also fixed fallback cache writeback to re-resolve backend identity; no other production routing changes.

- **Refactors**
  - Added `EmbeddingProviderReadinessCheck` and `EmbeddingProviderAttempt` with ordered cache hits, miss-only execution, full vector validation, and skip-write when `embeddings_from_adapter` is true.
  - Moved `EmbeddingExecutorOutput` to `request_types` and re-exported by the orchestrator.
  - Cache keys use runtime backend identity; exclude plan identity and `cache_namespace`.
  - Non-provider failures (identity, cache key, cache get/set) propagate; provider call errors return `ProviderCallFailure`.

- **Bug Fixes**
  - Fallback writeback re-resolves runtime backend identity before cache set, while keeping read identity for cache lookups.

<sup>Written for commit fd4ca44e8f5973802fecce5b87f696a789ab7b6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

