### PR TITLE
refactor(jobs): extract atomic batch lease renewal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -979,6 +979,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_quizzes_basic.py
               tldw_Server_API/tests/ChaChaNotesDB/test_source_review_plans*.py
               tldw_Server_API/tests/ChaChaNotesDB/test_web_clipper_db.py
+              tldw_Server_API/tests/ChaChaNotesDB/test_notes_link_migration_v58.py
               tldw_Server_API/tests/ChaChaNotesDB/test_notes_organization_migration_v55.py
               tldw_Server_API/tests/ChaChaNotesDB/test_notes_organization_migration_v57.py
               tldw_Server_API/tests/ChaChaNotesDB/test_web_clipper_migration_v56.py
@@ -1754,6 +1755,7 @@ jobs:
               tldw_Server_API/tests/Services/test_lifecycle_*.py
               tldw_Server_API/tests/Services/test_loop_*.py
               tldw_Server_API/tests/Services/test_media_*.py
+              tldw_Server_API/tests/Services/test_notes_graph_projection_worker.py
               tldw_Server_API/tests/Services/test_outputs_*.py
               tldw_Server_API/tests/Services/test_persona_*.py
               tldw_Server_API/tests/Services/test_placeholder_*.py
@@ -2444,6 +2446,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_quizzes_basic.py
               tldw_Server_API/tests/ChaChaNotesDB/test_source_review_plans*.py
               tldw_Server_API/tests/ChaChaNotesDB/test_web_clipper_db.py
+              tldw_Server_API/tests/ChaChaNotesDB/test_notes_link_migration_v58.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_source_saved_views_db.py
@@ -3215,6 +3218,7 @@ jobs:
               tldw_Server_API/tests/Services/test_lifecycle_*.py
               tldw_Server_API/tests/Services/test_loop_*.py
               tldw_Server_API/tests/Services/test_media_*.py
+              tldw_Server_API/tests/Services/test_notes_graph_projection_worker.py
               tldw_Server_API/tests/Services/test_outputs_*.py
               tldw_Server_API/tests/Services/test_persona_*.py
               tldw_Server_API/tests/Services/test_placeholder_*.py
@@ -3776,6 +3780,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_quizzes_basic.py
               tldw_Server_API/tests/ChaChaNotesDB/test_source_review_plans*.py
               tldw_Server_API/tests/ChaChaNotesDB/test_web_clipper_db.py
+              tldw_Server_API/tests/ChaChaNotesDB/test_notes_link_migration_v58.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_source_saved_views_db.py
@@ -4547,6 +4552,7 @@ jobs:
               tldw_Server_API/tests/Services/test_lifecycle_*.py
               tldw_Server_API/tests/Services/test_loop_*.py
               tldw_Server_API/tests/Services/test_media_*.py
+              tldw_Server_API/tests/Services/test_notes_graph_projection_worker.py
               tldw_Server_API/tests/Services/test_outputs_*.py
               tldw_Server_API/tests/Services/test_persona_*.py
               tldw_Server_API/tests/Services/test_placeholder_*.py
@@ -5031,6 +5037,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_quizzes_basic.py
               tldw_Server_API/tests/ChaChaNotesDB/test_source_review_plans*.py
               tldw_Server_API/tests/ChaChaNotesDB/test_web_clipper_db.py
+              tldw_Server_API/tests/ChaChaNotesDB/test_notes_link_migration_v58.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_source_saved_views_db.py
@@ -5802,6 +5809,7 @@ jobs:
               tldw_Server_API/tests/Services/test_lifecycle_*.py
               tldw_Server_API/tests/Services/test_loop_*.py
               tldw_Server_API/tests/Services/test_media_*.py
+              tldw_Server_API/tests/Services/test_notes_graph_projection_worker.py
               tldw_Server_API/tests/Services/test_outputs_*.py
               tldw_Server_API/tests/Services/test_persona_*.py
               tldw_Server_API/tests/Services/test_placeholder_*.py
@@ -6292,6 +6300,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_quizzes_basic.py
               tldw_Server_API/tests/ChaChaNotesDB/test_source_review_plans*.py
               tldw_Server_API/tests/ChaChaNotesDB/test_web_clipper_db.py
+              tldw_Server_API/tests/ChaChaNotesDB/test_notes_link_migration_v58.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_source_saved_views_db.py
@@ -7063,6 +7072,7 @@ jobs:
               tldw_Server_API/tests/Services/test_lifecycle_*.py
               tldw_Server_API/tests/Services/test_loop_*.py
               tldw_Server_API/tests/Services/test_media_*.py
+              tldw_Server_API/tests/Services/test_notes_graph_projection_worker.py
               tldw_Server_API/tests/Services/test_outputs_*.py
               tldw_Server_API/tests/Services/test_persona_*.py
               tldw_Server_API/tests/Services/test_placeholder_*.py

--- a/Docs/superpowers/plans/2026-08-08-jobs-batch-lease-renewal-extraction.md
+++ b/Docs/superpowers/plans/2026-08-08-jobs-batch-lease-renewal-extraction.md
@@ -4,7 +4,7 @@
 
 **Goal:** Extract `JobManager.batch_renew_leases` into typed, backend-owned SQLite and PostgreSQL operations while preserving its public integer result, input-order behavior, clock timing, no-op semantics, duration clamping, and whole-batch atomicity.
 
-**Architecture:** `JobManager` remains the compatibility facade: it resolves enforcement, opens the connection, normalizes and clamps every item into an immutable command, selects the backend operation, maps `applied_count` to `int`, and closes nonfatally. Each backend operation owns one transaction around the complete ordered tuple, samples the injected clock with the existing backend cadence, executes fixed bound SQL without no-op classification reads, and returns an immutable count result. Single and batch renewal share only a pure statement-and-parameter builder; their transaction and result handling remain separate.
+**Architecture:** `JobManager` remains the compatibility facade: it resolves enforcement, opens the connection, normalizes and clamps every item into an immutable command, selects the backend operation, maps `applied_count` to `int`, and closes nonfatally. Each backend operation owns one atomic scope around the complete ordered tuple, samples the injected clock with the existing backend cadence, executes fixed bound SQL without no-op classification reads, and returns an immutable count result. The normal facade path uses a native transaction; a direct SQLite call inside a caller-owned transaction uses a savepoint and leaves that transaction open. Single and batch renewal share only a pure statement-and-parameter builder; their transaction and result handling remain separate.
 
 **Tech Stack:** Python 3.14, frozen dataclasses, sqlite3, psycopg 3, pytest, Hypothesis, existing Jobs PostgreSQL fixtures, Ruff, compileall, Bandit.
 
@@ -17,6 +17,7 @@
 - Open the backend connection before item normalization to preserve connection-failure precedence.
 - Complete normalization of every item before dispatching any backend mutation.
 - Preserve input order, duplicate update-attempt counting, expected zero-row no-ops, non-shortening leases, and one atomic transaction for the complete batch.
+- Direct SQLite calls made inside an active caller transaction must isolate the batch with a savepoint, preserving both the outer transaction and unrelated caller-owned work.
 - Preserve PostgreSQL one-clock-sample-per-batch behavior, including one clock call for an empty batch.
 - Preserve SQLite one-clock-sample-per-item behavior, including zero clock calls for an empty batch.
 - Read and apply `JOBS_LEASE_MAX_SECONDS` once per item in the facade; backend operations do not read settings or reclamp durations.
@@ -193,13 +194,18 @@ Seed two processing jobs and call with a valid first item followed by `{"job_id"
 
 - [ ] **Step 5: Characterize database-triggered rollback**
 
-For SQLite, create a `BEFORE UPDATE ON jobs` trigger scoped to the second job that executes `RAISE(ABORT, 'forced batch renewal failure')`. For PostgreSQL, generate identifier-safe names with `uuid.uuid4().hex`, create a function that raises `forced batch renewal failure`, and create the scoped trigger with:
+For SQLite, assign the second job a unique constant worker identity and create a fixed `BEFORE UPDATE ON jobs` trigger scoped to that identity that executes `RAISE(ABORT, 'forced batch renewal failure')`. For PostgreSQL, generate unique names with `uuid.uuid4().hex`, create a function that raises `forced batch renewal failure`, and compose all dynamic identifiers and the scoped job literal with `psycopg.sql`:
 
 ```python
 cur.execute(
-    f'CREATE TRIGGER "{trigger_name}" BEFORE UPDATE ON jobs '
-    f'FOR EACH ROW WHEN (OLD.id = {int(second_job_id)}) '
-    f'EXECUTE FUNCTION "{function_name}"()'
+    psycopg_sql.SQL(
+        "CREATE TRIGGER {} BEFORE UPDATE ON jobs "
+        "FOR EACH ROW WHEN (OLD.id = {}) EXECUTE FUNCTION {}()"
+    ).format(
+        psycopg_sql.Identifier(trigger_name),
+        psycopg_sql.Literal(second_job_id),
+        psycopg_sql.Identifier(function_name),
+    )
 )
 ```
 
@@ -207,8 +213,16 @@ Call the public method with the first and second jobs in that order. Assert `sql
 
 ```python
 with cleanup_connection, manager._pg_cursor(cleanup_connection) as cur:
-    cur.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}" ON jobs')
-    cur.execute(f'DROP FUNCTION IF EXISTS "{function_name}"()')
+    cur.execute(
+        psycopg_sql.SQL("DROP TRIGGER IF EXISTS {} ON jobs").format(
+            psycopg_sql.Identifier(trigger_name)
+        )
+    )
+    cur.execute(
+        psycopg_sql.SQL("DROP FUNCTION IF EXISTS {}()").format(
+            psycopg_sql.Identifier(function_name)
+        )
+    )
 ```
 
 The generated names contain only a fixed ASCII prefix plus `uuid4().hex`; do not interpolate caller-controlled identifiers.
@@ -433,7 +447,7 @@ def test_sqlite_batch_renew_counts_attempts_and_commits_expected_noops(conn):
     assert conn.execute("SELECT leased_until FROM jobs WHERE id = ?", (long_id,)).fetchone()[0] == "2026-01-02 13:00:00"
 ```
 
-Add a `RecordingClock` assertion that calls equal item count, including no-op items; an empty command returns `(0, 0)` with zero calls. Add `FailOnSecondClock` that returns `NOW` once and then raises `RuntimeError("forced clock failure")`; query from a fresh connection and prove the first update rolled back.
+Add a `RecordingClock` assertion that calls equal item count, including no-op items; an empty command returns `(0, 0)` with zero calls. Add `FailOnSecondClock` that returns `NOW` once and then raises `RuntimeError("forced clock failure")`; query from a fresh connection and prove the first update rolled back. Add direct-call coverage proving success and failure leave a caller-owned transaction open, with failure rolling back only the batch savepoint while preserving unrelated caller-owned work.
 
 Add a trigger test scoped to the second job using `RAISE(ABORT, 'forced batch renewal failure')`. After the exception, query from a fresh connection and assert both leases are unchanged.
 
@@ -485,7 +499,7 @@ def renew_leases_batch(
     """Renew an ordered SQLite lease batch in one transaction."""
 
     applied_count = 0
-    with conn:
+    with _batch_renew_transaction(conn):
         for item in command.items:
             item_command = RenewLeaseCommand(
                 job_id=item.job_id,
@@ -503,7 +517,7 @@ def renew_leases_batch(
         )
 ```
 
-Import `Callable` and the three batch contracts. Export `renew_leases_batch` from `operations/sqlite/__init__.py`. Do not call `_classify_lifecycle_no_transition` in the batch path.
+Implement `_batch_renew_transaction` so a fresh connection uses the native connection context, while an already-active connection uses a fixed-name SQLite savepoint that is released on success and rolled back on failure. Import `Callable` and the three batch contracts. Export `renew_leases_batch` from `operations/sqlite/__init__.py`. Do not call `_classify_lifecycle_no_transition` in the batch path.
 
 - [ ] **Step 5: Verify SQLite green and single-renewal compatibility**
 

--- a/Docs/superpowers/plans/2026-08-08-jobs-batch-lease-renewal-extraction.md
+++ b/Docs/superpowers/plans/2026-08-08-jobs-batch-lease-renewal-extraction.md
@@ -10,12 +10,14 @@
 
 ## Global Constraints
 
-- Tracking task: `TASK-12989`.
+- Tracking task: `TASK-13010`.
 - Approved design: `Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md`.
 - Implementation base: `origin/dev` at `5605b9d990` after the design branch rebase.
 - Preserve `JobManager.batch_renew_leases(items: list[dict[str, Any]], *, enforce: bool | None = None) -> int`.
 - Open the backend connection before item normalization to preserve connection-failure precedence.
 - Complete normalization of every item before dispatching any backend mutation.
+- Malformed-item normalization errors intentionally precede backend clock reads,
+  PostgreSQL cursor/RLS setup, and backend dispatch.
 - Preserve input order, duplicate update-attempt counting, expected zero-row no-ops, non-shortening leases, and one atomic transaction for the complete batch.
 - Direct SQLite calls made inside an active caller transaction must isolate the batch with a savepoint, preserving both the outer transaction and unrelated caller-owned work.
 - Preserve PostgreSQL one-clock-sample-per-batch behavior, including one clock call for an empty batch.
@@ -28,7 +30,7 @@
 - Real PostgreSQL evidence is mandatory. Run it with `TLDW_TEST_POSTGRES_REQUIRED=1`; a skip is a failed gate.
 - Run Bandit on every touched production path before completion.
 - The pull request cannot merge until the human requester supplies a `Change summary` explaining what changed and why these transaction and compatibility choices were used.
-- The current Backlog CLI/MCP rewrites duplicate section markers in `TASK-12989`. If that remains true during execution, stop and obtain explicit requester approval before a narrowly scoped manual task-file repair; do not commit malformed tracker output.
+- The original provisional `TASK-12989` collided with two records already on `dev`. The Jobs record was manually renumbered to unique `TASK-13010` after independent review, using the requester's prior approval for narrowly scoped manual repair of this specific task file.
 
 ---
 
@@ -103,7 +105,7 @@ The SQLite result came from the existing batch lifecycle, direct renewal/release
   - Unit coverage for normalization, connection precedence, typed dispatch, and integer mapping.
 - Modify: `tldw_Server_API/app/core/Jobs/manager.py`
   - Replace inline SQL with connection-first normalization and backend dispatch.
-- Modify through Backlog tooling: `TASK-12989`
+- Modify through Backlog tooling: `TASK-13010`
   - Record the approved plan, changed files, verification evidence, pull request, and final summary.
 
 ---
@@ -447,7 +449,7 @@ def test_sqlite_batch_renew_counts_attempts_and_commits_expected_noops(conn):
     assert conn.execute("SELECT leased_until FROM jobs WHERE id = ?", (long_id,)).fetchone()[0] == "2026-01-02 13:00:00"
 ```
 
-Add a `RecordingClock` assertion that calls equal item count, including no-op items; an empty command returns `(0, 0)` with zero calls. Add `FailOnSecondClock` that returns `NOW` once and then raises `RuntimeError("forced clock failure")`; query from a fresh connection and prove the first update rolled back. Add direct-call coverage proving success and failure leave a caller-owned transaction open, with failure rolling back only the batch savepoint while preserving unrelated caller-owned work.
+Add a `RecordingClock` assertion that calls equal item count, including no-op items; an empty command returns `(0, 0)` with zero calls. Add `FailOnSecondClock` that returns `NOW` once and then raises `RuntimeError("forced clock failure")`; query from a fresh connection and prove the first update rolled back. Add direct-call coverage proving success and ordinary statement failure leave a caller-owned transaction open, with failure rolling back only the batch savepoint while preserving unrelated caller-owned work. Add a `RAISE(ROLLBACK, ...)` trigger case proving a whole-transaction abort keeps the original `IntegrityError` primary, chains the missing-savepoint cleanup failure, and necessarily closes the caller transaction.
 
 Add a trigger test scoped to the second job using `RAISE(ABORT, 'forced batch renewal failure')`. After the exception, query from a fresh connection and assert both leases are unchanged.
 
@@ -496,7 +498,7 @@ def renew_leases_batch(
     command: BatchRenewLeasesCommand,
     clock: Callable[[], datetime],
 ) -> BatchRenewLeasesResult:
-    """Renew an ordered SQLite lease batch in one transaction."""
+    """Renew an ordered SQLite lease batch in one atomic scope."""
 
     applied_count = 0
     with _batch_renew_transaction(conn):
@@ -517,7 +519,7 @@ def renew_leases_batch(
         )
 ```
 
-Implement `_batch_renew_transaction` so a fresh connection uses the native connection context, while an already-active connection uses a fixed-name SQLite savepoint that is released on success and rolled back on failure. Import `Callable` and the three batch contracts. Export `renew_leases_batch` from `operations/sqlite/__init__.py`. Do not call `_classify_lifecycle_no_transition` in the batch path.
+Implement `_batch_renew_transaction` so a fresh connection uses the native connection context, while an already-active connection uses a fixed-name SQLite savepoint that is released on success and rolled back on failure. If SQLite aborts the complete transaction and removes the savepoint, re-raise the primary database error with the cleanup error chained. Import `Callable` and the three batch contracts. Export `renew_leases_batch` from `operations/sqlite/__init__.py`. Do not call `_classify_lifecycle_no_transition` in the batch path.
 
 - [ ] **Step 5: Verify SQLite green and single-renewal compatibility**
 
@@ -746,8 +748,9 @@ def test_batch_renew_opens_connection_before_normalizing_invalid_input(monkeypat
         manager.batch_renew_leases([{"job_id": "invalid", "seconds": 30}], enforce=False)
 
 
-def test_batch_renew_normalizes_every_item_before_backend_dispatch(monkeypatch):
+def test_batch_renew_normalizes_before_clock_cursor_or_backend_dispatch(monkeypatch):
     manager, connection = _minimal_manager("sqlite")
+    manager._clock = ExplodingClock()
     called = False
 
     def backend(*args, **kwargs):
@@ -767,6 +770,7 @@ def test_batch_renew_normalizes_every_item_before_backend_dispatch(monkeypatch):
         )
 
     assert called is False
+    assert manager._clock.calls == 0
     assert connection.closed is True
 ```
 
@@ -855,7 +859,7 @@ git commit -m "refactor(jobs): route batch renewal through operations"
 ### Task 6: Run Final Gates And Prepare Review
 
 **Files:**
-- Modify through Backlog tooling: `TASK-12989`
+- Modify through Backlog tooling: `TASK-13010`
 - Review all files listed in the File Structure section.
 
 **Interfaces:**
@@ -953,11 +957,13 @@ Use `superpowers:requesting-code-review` against `origin/dev...HEAD`. Review tra
 
 - [ ] **Step 7: Record verification and prepare the pull request**
 
-Update `TASK-12989` through Backlog tooling with changed files, exact pass/skip counts, Bandit output location, review findings, commit IDs, and the PR URL. Ask the requester for the mandatory human-authored `Change summary`; do not merge without it.
+Update `TASK-13010` through Backlog tooling with changed files, exact pass/skip counts, Bandit output location, review findings, commit IDs, and the PR URL. Ask the requester for the mandatory human-authored `Change summary`; do not merge without it.
 
 If task metadata changes after verification, commit it separately:
 
 ```bash
-git add "backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md"
+git add -A -- \
+  "backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md" \
+  "backlog/tasks/task-13010 - Extract-Jobs-batch-lease-renewal-operations-atomically.md"
 git commit -m "chore(jobs): record batch renewal verification"
 ```

--- a/Docs/superpowers/plans/2026-08-08-jobs-batch-lease-renewal-extraction.md
+++ b/Docs/superpowers/plans/2026-08-08-jobs-batch-lease-renewal-extraction.md
@@ -1,0 +1,949 @@
+# Jobs Batch Lease Renewal Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `JobManager.batch_renew_leases` into typed, backend-owned SQLite and PostgreSQL operations while preserving its public integer result, input-order behavior, clock timing, no-op semantics, duration clamping, and whole-batch atomicity.
+
+**Architecture:** `JobManager` remains the compatibility facade: it resolves enforcement, opens the connection, normalizes and clamps every item into an immutable command, selects the backend operation, maps `applied_count` to `int`, and closes nonfatally. Each backend operation owns one transaction around the complete ordered tuple, samples the injected clock with the existing backend cadence, executes fixed bound SQL without no-op classification reads, and returns an immutable count result. Single and batch renewal share only a pure statement-and-parameter builder; their transaction and result handling remain separate.
+
+**Tech Stack:** Python 3.14, frozen dataclasses, sqlite3, psycopg 3, pytest, Hypothesis, existing Jobs PostgreSQL fixtures, Ruff, compileall, Bandit.
+
+## Global Constraints
+
+- Tracking task: `TASK-12989`.
+- Approved design: `Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md`.
+- Implementation base: `origin/dev` at `5605b9d990` after the design branch rebase.
+- Preserve `JobManager.batch_renew_leases(items: list[dict[str, Any]], *, enforce: bool | None = None) -> int`.
+- Open the backend connection before item normalization to preserve connection-failure precedence.
+- Complete normalization of every item before dispatching any backend mutation.
+- Preserve input order, duplicate update-attempt counting, expected zero-row no-ops, non-shortening leases, and one atomic transaction for the complete batch.
+- Preserve PostgreSQL one-clock-sample-per-batch behavior, including one clock call for an empty batch.
+- Preserve SQLite one-clock-sample-per-item behavior, including zero clock calls for an empty batch.
+- Read and apply `JOBS_LEASE_MAX_SECONDS` once per item in the facade; backend operations do not read settings or reclamp durations.
+- Do not add batch limits, sorting, deduplication, set-based bulk SQL, schema changes, migrations, events, counters, metrics, or `JobsSettings` adoption.
+- Backend operation modules must not import or reference `JobManager`.
+- SQL must use fixed variants and bound parameters. Single and batch paths may share only pure SQL/parameter construction, never execution, cursors, transaction contexts, classification reads, or result mapping.
+- Each new test module carries exactly one test-type marker. PostgreSQL modules additionally carry `pytest.mark.pg_jobs` as infrastructure metadata.
+- Real PostgreSQL evidence is mandatory. Run it with `TLDW_TEST_POSTGRES_REQUIRED=1`; a skip is a failed gate.
+- Run Bandit on every touched production path before completion.
+- The pull request cannot merge until the human requester supplies a `Change summary` explaining what changed and why these transaction and compatibility choices were used.
+- The current Backlog CLI/MCP rewrites duplicate section markers in `TASK-12989`. If that remains true during execution, stop and obtain explicit requester approval before a narrowly scoped manual task-file repair; do not commit malformed tracker output.
+
+---
+
+## Observed Baseline
+
+The documentation-only branch was tested before planning:
+
+```text
+SQLite/contracts/property matrix: 69 passed, 144 warnings
+PostgreSQL matrix:                26 skipped because PostgreSQL was unreachable
+```
+
+The SQLite result came from the existing batch lifecycle, direct renewal/release, contract, and operation-contract property suites. The PostgreSQL skip is an environment limitation, not acceptable final evidence; all PostgreSQL commands below set `TLDW_TEST_POSTGRES_REQUIRED=1` so that the same condition fails visibly during implementation.
+
+## Stage Map
+
+### Stage 1: Public Characterization
+**Goal:** Lock current facade behavior before moving SQL.
+**Success Criteria:** Focused SQLite and required PostgreSQL tests pass against the inline implementation, including rollback and clock cadence.
+**Tests:** New public batch-renew characterization modules.
+**Status:** Not Started
+
+### Stage 2: Typed Contracts
+**Goal:** Add immutable batch item, command, and result contracts with enforced invariants.
+**Success Criteria:** Contract and narrow property tests pass; operation modules remain independent of `JobManager`.
+**Tests:** Unit contract tests and Hypothesis result-invariant test.
+**Status:** Not Started
+
+### Stage 3: Backend Operations
+**Goal:** Add atomic SQLite and PostgreSQL batch operations behind pure SQL builders.
+**Success Criteria:** Direct operation tests prove exact counts, no-ops, clock timing, non-shortening, and rollback.
+**Tests:** Existing direct renewal/release modules extended per backend.
+**Status:** Not Started
+
+### Stage 4: Facade Routing
+**Goal:** Replace inline SQL with normalized typed dispatch while retaining the public contract.
+**Success Criteria:** Routing tests and all public characterization tests pass unchanged.
+**Tests:** Focused unit routing module plus both public characterization modules.
+**Status:** Not Started
+
+### Stage 5: Verification And Review
+**Goal:** Prove compatibility, security hygiene, and branch readiness.
+**Success Criteria:** Required PostgreSQL runs with zero skips; focused and neighboring Jobs suites, Ruff, compileall, Bandit, diff checks, and independent review pass.
+**Tests:** Full matrix listed in Task 6.
+**Status:** Not Started
+
+## File Structure
+
+- Create: `tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py`
+  - Public SQLite compatibility and durable rollback coverage against `JobManager`.
+- Create: `tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py`
+  - Equivalent required real-PostgreSQL public coverage with unique trigger cleanup.
+- Modify: `tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py`
+  - Unit coverage for immutable batch contracts and operation import boundaries.
+- Modify: `tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py`
+  - Narrow generated coverage for requested/applied count invariants.
+- Modify: `tldw_Server_API/app/core/Jobs/operations/contracts.py`
+  - Add `BatchRenewLeaseItem`, `BatchRenewLeasesCommand`, and `BatchRenewLeasesResult`.
+- Modify: `tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py`
+  - Direct SQLite batch operation behavior, clock, and rollback coverage.
+- Modify: `tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py`
+  - Extract the pure renewal statement builder and add atomic `renew_leases_batch`.
+- Modify: `tldw_Server_API/app/core/Jobs/operations/sqlite/__init__.py`
+  - Export SQLite `renew_leases_batch`.
+- Modify: `tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py`
+  - Direct real-PostgreSQL batch operation behavior, clock, and trigger rollback coverage.
+- Modify: `tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py`
+  - Extract the pure renewal statement builder and add atomic `renew_leases_batch`.
+- Modify: `tldw_Server_API/app/core/Jobs/operations/postgres/__init__.py`
+  - Export PostgreSQL `renew_leases_batch`.
+- Create: `tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py`
+  - Unit coverage for normalization, connection precedence, typed dispatch, and integer mapping.
+- Modify: `tldw_Server_API/app/core/Jobs/manager.py`
+  - Replace inline SQL with connection-first normalization and backend dispatch.
+- Modify through Backlog tooling: `TASK-12989`
+  - Record the approved plan, changed files, verification evidence, pull request, and final summary.
+
+---
+
+### Task 1: Characterize The Existing Public Batch Contract
+
+**Files:**
+- Create: `tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py`
+- Create: `tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py`
+
+**Interfaces:**
+- Consumes: existing `JobManager.batch_renew_leases(items, *, enforce=None) -> int`.
+- Produces: green compatibility tests that remain unchanged when Task 5 routes through backend operations.
+
+- [ ] **Step 1: Add deterministic public test helpers**
+
+Both modules must define a fixed clock and backend-appropriate helpers that insert processing and queued rows, fetch leases through a fresh connection, and return worker/lease identities. Use this clock shape:
+
+```python
+class RecordingClock:
+    def __init__(self, now: datetime) -> None:
+        self.now = now
+        self.calls = 0
+
+    def now_utc(self) -> datetime:
+        self.calls += 1
+        return self.now
+```
+
+Use `NOW = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)`. SQLite creates a database with `ensure_jobs_tables`, sets `row_factory = sqlite3.Row`, and constructs `JobManager(db_path, clock=clock)`. PostgreSQL uses `jobs_pg_dsn`, disables counters/outbox, and constructs `JobManager(None, backend="postgres", db_url=jobs_pg_dsn, clock=clock)`.
+
+Declare markers exactly as follows:
+
+```python
+# SQLite module
+pytestmark = pytest.mark.integration
+
+# PostgreSQL module
+pytestmark = [pytest.mark.integration, pytest.mark.pg_jobs]
+```
+
+- [ ] **Step 2: Characterize counts, no-ops, duplicates, and non-shortening**
+
+Add `test_batch_renew_counts_ordered_attempts_and_preserves_longer_lease_sqlite`
+and `test_batch_renew_counts_ordered_attempts_and_preserves_longer_lease_postgres`.
+Seed:
+
+```python
+valid_id = _insert_job(status="processing", worker_id="worker-1", lease_id="lease-1")
+queued_id = _insert_job(status="queued", worker_id=None, lease_id=None)
+stale_id = _insert_job(status="processing", worker_id="worker-1", lease_id="lease-1")
+long_id = _insert_job(
+    status="processing",
+    worker_id="worker-1",
+    lease_id="lease-1",
+    leased_until=NOW + timedelta(minutes=10),
+)
+
+items = [
+    {"job_id": valid_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+    {"job_id": 999_999, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+    {"job_id": queued_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+    {"job_id": stale_id, "seconds": 30, "worker_id": "worker-2", "lease_id": "lease-1"},
+    {"job_id": valid_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+    {"job_id": long_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+]
+```
+
+Set enforcement explicitly with `enforce=True`. Assert the returned count is `3`: two attempts against `valid_id` plus one against `long_id`. Assert the queued and stale rows are unchanged and `long_id` remains at `NOW + 10 minutes`.
+
+- [ ] **Step 3: Characterize per-item clamping and backend clock cadence**
+
+Set `JOBS_LEASE_MAX_SECONDS=60`, seed three expired processing jobs, and submit durations `0`, `30`, and `120`. Assert exact count `3` and durable leases at `NOW + 1 second`, `NOW + 30 seconds`, and `NOW + 60 seconds`. Assert:
+
+```python
+# PostgreSQL
+assert clock.calls == 1
+
+# SQLite
+assert clock.calls == 3
+```
+
+Add an empty-batch test per backend. Assert result `0`; PostgreSQL clock calls equal `1`, SQLite clock calls equal `0`, and a monkeypatched `os.getenv` guard for `JOBS_LEASE_MAX_SECONDS` is never reached.
+
+- [ ] **Step 4: Characterize malformed-item rollback**
+
+Seed two processing jobs and call with a valid first item followed by `{"job_id": "not-an-int", "seconds": 30}`. Assert `ValueError` and query through a fresh connection to prove the first lease did not change. This test must pass against the inline implementation before extraction.
+
+- [ ] **Step 5: Characterize database-triggered rollback**
+
+For SQLite, create a `BEFORE UPDATE ON jobs` trigger scoped to the second job that executes `RAISE(ABORT, 'forced batch renewal failure')`. For PostgreSQL, generate identifier-safe names with `uuid.uuid4().hex`, create a function that raises `forced batch renewal failure`, and create the scoped trigger with:
+
+```python
+cur.execute(
+    f'CREATE TRIGGER "{trigger_name}" BEFORE UPDATE ON jobs '
+    f'FOR EACH ROW WHEN (OLD.id = {int(second_job_id)}) '
+    f'EXECUTE FUNCTION "{function_name}"()'
+)
+```
+
+Call the public method with the first and second jobs in that order. Assert `sqlite3.IntegrityError` or `psycopg.Error`, then verify both original leases through a fresh connection. PostgreSQL cleanup must run in `finally` through another fresh connection:
+
+```python
+with cleanup_connection, manager._pg_cursor(cleanup_connection) as cur:
+    cur.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}" ON jobs')
+    cur.execute(f'DROP FUNCTION IF EXISTS "{function_name}"()')
+```
+
+The generated names contain only a fixed ASCII prefix plus `uuid4().hex`; do not interpolate caller-controlled identifiers.
+
+- [ ] **Step 6: Run characterization against the inline implementation**
+
+Run SQLite:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py -q
+```
+
+Expected: all tests pass before production routing changes.
+
+Run required PostgreSQL:
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py -q
+```
+
+Expected: all tests pass with zero skips. If PostgreSQL is unreachable, stop and repair the test environment; do not proceed with skipped evidence.
+
+- [ ] **Step 7: Commit the compatibility safety net**
+
+```bash
+git add tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py
+git commit -m "test(jobs): characterize batch lease renewal"
+```
+
+---
+
+### Task 2: Add Immutable Batch Renewal Contracts
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py`
+- Modify: `tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py`
+- Modify: `tldw_Server_API/app/core/Jobs/operations/contracts.py:91-108,273-283`
+
+**Interfaces:**
+- Produces: `BatchRenewLeaseItem`, `BatchRenewLeasesCommand`, and `BatchRenewLeasesResult` exactly as defined below.
+- Consumed by: Tasks 3-5 backend operations and facade routing.
+
+- [ ] **Step 1: Write failing unit contract tests**
+
+Import the three new types and add tests with these exact behaviors:
+
+```python
+def test_batch_renew_command_snapshots_items_and_is_frozen() -> None:
+    source = [BatchRenewLeaseItem(job_id=1, seconds=30)]
+    command = BatchRenewLeasesCommand(items=source, enforce=True)  # type: ignore[arg-type]
+    source.append(BatchRenewLeaseItem(job_id=2, seconds=45))
+
+    assert command.items == (BatchRenewLeaseItem(job_id=1, seconds=30),)
+    with pytest.raises(FrozenInstanceError):
+        command.enforce = False
+
+
+@pytest.mark.parametrize("seconds", [0, -1])
+def test_batch_renew_item_rejects_non_positive_normalized_duration(seconds: int) -> None:
+    with pytest.raises(ValueError, match="seconds must be positive"):
+        BatchRenewLeaseItem(job_id=1, seconds=seconds)
+
+
+@pytest.mark.parametrize(
+    ("requested", "applied"),
+    [(-1, 0), (0, -1), (1, 2)],
+)
+def test_batch_renew_result_rejects_invalid_counts(requested: int, applied: int) -> None:
+    with pytest.raises(ValueError):
+        BatchRenewLeasesResult(requested_count=requested, applied_count=applied)
+```
+
+Also assert an item is frozen, command item order is retained, `BatchRenewLeasesResult(3, 0)` and `(3, 3)` construct successfully, and all three names appear in `contracts.__all__`. Keep the existing AST import-boundary test unchanged; it will cover new operation code later.
+
+- [ ] **Step 2: Write the narrow failing property test**
+
+Extend `test_operation_contract_properties.py`:
+
+```python
+@_COMMON
+@given(
+    requested=st.integers(min_value=-5, max_value=100),
+    applied=st.integers(min_value=-5, max_value=105),
+)
+def test_batch_renew_result_constructs_only_for_valid_count_pairs(
+    requested: int,
+    applied: int,
+) -> None:
+    valid = requested >= 0 and 0 <= applied <= requested
+    if valid:
+        result = BatchRenewLeasesResult(requested_count=requested, applied_count=applied)
+        assert result.requested_count == requested
+        assert result.applied_count == applied
+    else:
+        with pytest.raises(ValueError):
+            BatchRenewLeasesResult(requested_count=requested, applied_count=applied)
+```
+
+- [ ] **Step 3: Run tests and verify red**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py -q
+```
+
+Expected: collection fails because the three batch contract names do not exist.
+
+- [ ] **Step 4: Implement the minimal frozen contracts**
+
+Add after `RenewLeaseCommand`:
+
+```python
+@dataclass(frozen=True)
+class BatchRenewLeaseItem:
+    """One facade-normalized lease renewal attempt."""
+
+    job_id: int
+    seconds: int
+    worker_id: str | None = None
+    lease_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.seconds < 1:
+            raise ValueError("seconds must be positive")
+
+
+@dataclass(frozen=True)
+class BatchRenewLeasesCommand:
+    """Ordered immutable lease renewal attempts for one transaction."""
+
+    items: tuple[BatchRenewLeaseItem, ...]
+    enforce: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "items", tuple(self.items))
+
+
+@dataclass(frozen=True)
+class BatchRenewLeasesResult:
+    """Counts produced by one atomic batch renewal operation."""
+
+    requested_count: int
+    applied_count: int
+
+    def __post_init__(self) -> None:
+        if self.requested_count < 0:
+            raise ValueError("requested_count must be non-negative")
+        if not 0 <= self.applied_count <= self.requested_count:
+            raise ValueError("applied_count must be between zero and requested_count")
+```
+
+Export all three through `__all__`. Do not clamp durations or convert job IDs in these contracts; facade normalization owns those policies.
+
+- [ ] **Step 5: Verify green and commit**
+
+```bash
+RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py -q
+git add tldw_Server_API/app/core/Jobs/operations/contracts.py tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py
+git commit -m "feat(jobs): add batch lease renewal contracts"
+```
+
+---
+
+### Task 3: Implement The Atomic SQLite Batch Operation
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py`
+- Modify: `tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py:36-81,218-259`
+- Modify: `tldw_Server_API/app/core/Jobs/operations/sqlite/__init__.py:3-6`
+
+**Interfaces:**
+- Consumes: `BatchRenewLeasesCommand` and `Callable[[], datetime]`.
+- Produces: `renew_leases_batch(conn, *, command, clock) -> BatchRenewLeasesResult`.
+- Preserves: `renew_lease(conn, *, command, now) -> LifecycleResult`.
+
+- [ ] **Step 1: Write failing direct SQLite batch tests**
+
+Import `BatchRenewLeaseItem`, `BatchRenewLeasesCommand`, and `renew_leases_batch`. Extend `_insert_job` to accept unique UUIDs so several rows can coexist. Add direct tests for:
+
+Change the SQLite fixtures so rollback tests can reopen the same database:
+
+```python
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return ensure_jobs_tables(tmp_path / "jobs.db")
+
+
+@pytest.fixture()
+def conn(db_path: Path) -> Iterator[sqlite3.Connection]:
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    try:
+        yield connection
+    finally:
+        connection.close()
+```
+
+Rollback tests open `sqlite3.connect(db_path)` after the raised exception, set `row_factory`, query the persisted leases, and close that fresh connection in `finally`.
+
+```python
+def test_sqlite_batch_renew_counts_attempts_and_commits_expected_noops(conn):
+    valid_id = _insert_job(conn, uuid="valid")
+    queued_id = _insert_job(conn, uuid="queued", status="queued")
+    stale_id = _insert_job(conn, uuid="stale")
+    long_id = _insert_job(conn, uuid="long", leased_until="2026-01-02 13:00:00")
+    command = BatchRenewLeasesCommand(
+        items=(
+            BatchRenewLeaseItem(valid_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(999_999, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(queued_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(stale_id, 30, "worker-2", "lease-1"),
+            BatchRenewLeaseItem(valid_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(long_id, 30, "worker-1", "lease-1"),
+        ),
+        enforce=True,
+    )
+
+    result = renew_leases_batch(conn, command=command, clock=lambda: NOW)
+
+    assert result == BatchRenewLeasesResult(requested_count=6, applied_count=3)
+    assert conn.execute("SELECT leased_until FROM jobs WHERE id = ?", (long_id,)).fetchone()[0] == "2026-01-02 13:00:00"
+```
+
+Add a `RecordingClock` assertion that calls equal item count, including no-op items; an empty command returns `(0, 0)` with zero calls. Add `FailOnSecondClock` that returns `NOW` once and then raises `RuntimeError("forced clock failure")`; query from a fresh connection and prove the first update rolled back.
+
+Add a trigger test scoped to the second job using `RAISE(ABORT, 'forced batch renewal failure')`. After the exception, query from a fresh connection and assert both leases are unchanged.
+
+- [ ] **Step 2: Run the direct tests and verify red**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py -q
+```
+
+Expected: collection fails because `renew_leases_batch` is not exported.
+
+- [ ] **Step 3: Extract a pure SQLite renewal statement builder**
+
+Move only SQL selection and parameter construction from `renew_lease` into:
+
+```python
+def _renew_lease_statement(
+    command: RenewLeaseCommand,
+    *,
+    now: datetime,
+) -> tuple[str, tuple[Any, ...]]:
+    now_sql = _sqlite_timestamp(now)
+    has_percent = command.progress_percent is not None
+    has_message = command.progress_message is not None
+    sql = _RENEW_SQL_VARIANTS[(command.enforce, has_percent, has_message)]
+    params: list[Any] = [now_sql, now_sql, command.seconds]
+    if has_percent:
+        params.append(float(command.progress_percent))
+    if has_message:
+        params.append(str(command.progress_message))
+    params.append(command.job_id)
+    if command.enforce:
+        params.extend((command.worker_id, command.lease_id))
+    return sql, tuple(params)
+```
+
+Change existing `renew_lease` to call this helper, leaving its transaction, classification query, selected row, and `LifecycleResult` mapping unchanged.
+
+- [ ] **Step 4: Implement SQLite `renew_leases_batch`**
+
+```python
+def renew_leases_batch(
+    conn: sqlite3.Connection,
+    *,
+    command: BatchRenewLeasesCommand,
+    clock: Callable[[], datetime],
+) -> BatchRenewLeasesResult:
+    """Renew an ordered SQLite lease batch in one transaction."""
+
+    applied_count = 0
+    with conn:
+        for item in command.items:
+            item_command = RenewLeaseCommand(
+                job_id=item.job_id,
+                seconds=item.seconds,
+                enforce=command.enforce,
+                worker_id=item.worker_id,
+                lease_id=item.lease_id,
+            )
+            sql, params = _renew_lease_statement(item_command, now=clock())
+            changed = conn.execute(sql, params)
+            applied_count += int(changed.rowcount or 0)
+        return BatchRenewLeasesResult(
+            requested_count=len(command.items),
+            applied_count=applied_count,
+        )
+```
+
+Import `Callable` and the three batch contracts. Export `renew_leases_batch` from `operations/sqlite/__init__.py`. Do not call `_classify_lifecycle_no_transition` in the batch path.
+
+- [ ] **Step 5: Verify SQLite green and single-renewal compatibility**
+
+```bash
+RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py -q
+```
+
+Expected: direct tests pass; public tests still exercise the inline manager and remain green.
+
+- [ ] **Step 6: Commit the SQLite operation**
+
+```bash
+git add tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py tldw_Server_API/app/core/Jobs/operations/sqlite/__init__.py tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
+git commit -m "refactor(jobs): add atomic SQLite batch renewal"
+```
+
+---
+
+### Task 4: Implement The Atomic PostgreSQL Batch Operation
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py`
+- Modify: `tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py:56-109,192-225`
+- Modify: `tldw_Server_API/app/core/Jobs/operations/postgres/__init__.py:3-6`
+
+**Interfaces:**
+- Consumes: `BatchRenewLeasesCommand`, the established cursor factory, and `Callable[[], datetime]`.
+- Produces: `renew_leases_batch(conn, cursor_factory, *, command, clock) -> BatchRenewLeasesResult`.
+- Preserves: `renew_lease(conn, cursor_factory, *, command, now) -> LifecycleResult`.
+
+- [ ] **Step 1: Write failing direct PostgreSQL batch tests**
+
+Use the existing real `jobs_pg_dsn`, `manager`, `_insert_job`, `_execute`, and
+`_fetch_job` helpers. Extend `_insert_job` only if needed to seed distinct status,
+identity, and lease values. Construct the direct command explicitly:
+
+```python
+valid_id = _insert_job(manager)
+queued_id = _insert_job(manager, status="queued", worker_id=None, lease_id=None)
+stale_id = _insert_job(manager)
+long_expiry = NOW + timedelta(hours=1)
+long_id = _insert_job(manager, leased_until=long_expiry)
+command = BatchRenewLeasesCommand(
+    items=(
+        BatchRenewLeaseItem(valid_id, 30, "worker-1", "lease-1"),
+        BatchRenewLeaseItem(999_999, 30, "worker-1", "lease-1"),
+        BatchRenewLeaseItem(queued_id, 30, "worker-1", "lease-1"),
+        BatchRenewLeaseItem(stale_id, 30, "worker-2", "lease-1"),
+        BatchRenewLeaseItem(valid_id, 30, "worker-1", "lease-1"),
+        BatchRenewLeaseItem(long_id, 30, "worker-1", "lease-1"),
+    ),
+    enforce=True,
+)
+clock = RecordingClock(NOW)
+
+result = renew_leases_batch(
+    conn,
+    manager._pg_cursor,
+    command=command,
+    clock=clock,
+)
+```
+
+Assert exact attempt counts, expected no-ops, duplicates, and the longer lease:
+
+```python
+assert result == BatchRenewLeasesResult(requested_count=6, applied_count=3)
+assert clock.calls == 1
+assert _fetch_job(manager, long_id)["leased_until"] == long_expiry
+```
+
+Add a second test using `BatchRenewLeasesCommand(items=(), enforce=False)`;
+assert `(requested_count, applied_count) == (0, 0)` and one clock call. Wrap
+`manager._pg_cursor` in a context manager that increments `cursor_entries` and
+delegates to the real factory; assert one entry so the operation cannot bypass
+the RLS/session cursor setup.
+
+Add a later-item trigger failure using unique function/trigger names and a fresh cleanup connection in `finally`. Verify both earlier and failing-row leases through `_fetch_job` after rollback. Do not add a fake-cursor transaction test; real PostgreSQL is the required evidence.
+
+- [ ] **Step 2: Run the direct PostgreSQL tests and verify red**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+TLDW_TEST_POSTGRES_REQUIRED=1 RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py -q
+```
+
+Expected: collection fails because `renew_leases_batch` is not exported. PostgreSQL unavailability is an environment failure, not the expected red state.
+
+- [ ] **Step 3: Extract a pure PostgreSQL renewal statement builder**
+
+Add this builder using PostgreSQL `_RENEW_SQL_VARIANTS` and native aware
+datetimes:
+
+```python
+def _renew_lease_statement(
+    command: RenewLeaseCommand,
+    *,
+    now: datetime,
+) -> tuple[str, tuple[Any, ...]]:
+    has_percent = command.progress_percent is not None
+    has_message = command.progress_message is not None
+    sql = _RENEW_SQL_VARIANTS[(command.enforce, has_percent, has_message)]
+    params: list[Any] = [now, now, command.seconds]
+    if has_percent:
+        params.append(float(command.progress_percent))
+    if has_message:
+        params.append(str(command.progress_message))
+    params.append(command.job_id)
+    if command.enforce:
+        params.extend((command.worker_id, command.lease_id))
+    return sql, tuple(params)
+```
+
+Change existing `renew_lease` to use the builder without changing its
+transaction, `fetchone`, no-transition classification, or `LifecycleResult`
+mapping.
+
+- [ ] **Step 4: Implement PostgreSQL `renew_leases_batch`**
+
+```python
+def renew_leases_batch(
+    conn: Any,
+    cursor_factory: Callable[[Any], AbstractContextManager[Any]],
+    *,
+    command: BatchRenewLeasesCommand,
+    clock: Callable[[], datetime],
+) -> BatchRenewLeasesResult:
+    """Renew an ordered PostgreSQL lease batch in one transaction."""
+
+    applied_count = 0
+    with conn:
+        with cursor_factory(conn) as cur:
+            now = clock()
+            for item in command.items:
+                item_command = RenewLeaseCommand(
+                    job_id=item.job_id,
+                    seconds=item.seconds,
+                    enforce=command.enforce,
+                    worker_id=item.worker_id,
+                    lease_id=item.lease_id,
+                )
+                sql, params = _renew_lease_statement(item_command, now=now)
+                cur.execute(sql, params)
+                if cur.fetchone() is not None:
+                    applied_count += 1
+            return BatchRenewLeasesResult(
+                requested_count=len(command.items),
+                applied_count=applied_count,
+            )
+```
+
+Consuming the existing `RETURNING` row keeps cursor state clean while retaining separate batch result handling. Do not run `_classify_lifecycle_no_transition`; zero returned rows are expected no-ops. Export the function from `operations/postgres/__init__.py`.
+
+- [ ] **Step 5: Verify PostgreSQL green and single-renewal compatibility**
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py -q
+```
+
+Expected: all tests pass with zero skips; public characterization still uses the inline manager at this stage.
+
+- [ ] **Step 6: Commit the PostgreSQL operation**
+
+```bash
+git add tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py tldw_Server_API/app/core/Jobs/operations/postgres/__init__.py tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
+git commit -m "refactor(jobs): add atomic PostgreSQL batch renewal"
+```
+
+---
+
+### Task 5: Route `JobManager.batch_renew_leases`
+
+**Files:**
+- Create: `tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py`
+- Modify: `tldw_Server_API/app/core/Jobs/manager.py:62-78,4590-4670`
+
+**Interfaces:**
+- Consumes: both backend `renew_leases_batch` functions and all three batch contracts.
+- Produces: unchanged public `batch_renew_leases(...) -> int` with connection-first normalization and typed dispatch.
+
+- [ ] **Step 1: Write failing routing tests**
+
+Use `pytestmark = pytest.mark.unit`. Build a minimal manager with `object.__new__(JobManager)` and a fake connection whose `close()` records closure. Monkeypatch the module-level backend function, not transaction internals:
+
+```python
+class FakeConnection:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FixedClock:
+    def now_utc(self) -> datetime:
+        return NOW
+
+
+def _minimal_manager(backend: str) -> tuple[JobManager, FakeConnection]:
+    manager = object.__new__(JobManager)
+    connection = FakeConnection()
+    manager.backend = backend
+    manager._clock = FixedClock()
+    manager._connect = lambda: connection
+    manager._pg_cursor = lambda conn: nullcontext(conn)
+    manager._should_enforce_ack = lambda: True
+    return manager, connection
+```
+
+Add a parametrized SQLite/PostgreSQL test that supplies ordered seconds `0`, `30`, and `120`, and captures the dispatched command. Wrap `manager_module.os.getenv` so it delegates all other names to the real function, returns `"60"` for `JOBS_LEASE_MAX_SECONDS`, and increments `lease_max_reads`. The backend stub returns:
+
+```python
+BatchRenewLeasesResult(requested_count=3, applied_count=2)
+```
+
+Assert the facade returns `2`, the command contains job IDs in input order, normalized seconds are `(1, 30, 60)`, `lease_max_reads == 3`, resolved enforcement appears once on the command, worker/lease values are preserved, the correct backend function was called, and the connection closed.
+
+Add these separate behavior tests:
+
+```python
+def test_batch_renew_opens_connection_before_normalizing_invalid_input(monkeypatch):
+    manager, _ = _minimal_manager("sqlite")
+    monkeypatch.setattr(manager, "_connect", lambda: (_ for _ in ()).throw(ConnectionError("offline")))
+
+    with pytest.raises(ConnectionError, match="offline"):
+        manager.batch_renew_leases([{"job_id": "invalid", "seconds": 30}], enforce=False)
+
+
+def test_batch_renew_normalizes_every_item_before_backend_dispatch(monkeypatch):
+    manager, connection = _minimal_manager("sqlite")
+    called = False
+
+    def backend(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("backend must not run")
+
+    monkeypatch.setattr(manager_module, "_sqlite_renew_leases_batch", backend)
+
+    with pytest.raises(ValueError):
+        manager.batch_renew_leases(
+            [
+                {"job_id": 1, "seconds": 30},
+                {"job_id": "invalid", "seconds": 30},
+            ],
+            enforce=False,
+        )
+
+    assert called is False
+    assert connection.closed is True
+```
+
+Add an empty-command routing test to prove the backend still receives `items=()` instead of the facade returning early. Do not assert cursor contexts, transaction wrappers, function signatures through introspection, or event/metric calls.
+
+- [ ] **Step 2: Run routing tests and verify red**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py -q
+```
+
+Expected: tests fail because the manager still executes inline SQL and does not dispatch typed commands.
+
+- [ ] **Step 3: Add imports and replace the inline implementation**
+
+Import the batch contracts and backend functions using aliases `_sqlite_renew_leases_batch` and `_postgres_renew_leases_batch`. Replace only the body of `batch_renew_leases`:
+
+```python
+def batch_renew_leases(
+    self,
+    items: list[dict[str, Any]],
+    *,
+    enforce: bool | None = None,
+) -> int:
+    if enforce is None:
+        enforce = self._should_enforce_ack()
+    conn = self._connect()
+    try:
+        command = BatchRenewLeasesCommand(
+            items=tuple(
+                BatchRenewLeaseItem(
+                    seconds=max(
+                        1,
+                        min(
+                            int(os.getenv("JOBS_LEASE_MAX_SECONDS", "3600") or "3600"),
+                            int(item.get("seconds") or 0),
+                        ),
+                    ),
+                    job_id=int(item.get("job_id")),
+                    worker_id=item.get("worker_id"),
+                    lease_id=item.get("lease_id"),
+                )
+                for item in items
+            ),
+            enforce=bool(enforce),
+        )
+        if self.backend == "postgres":
+            result = _postgres_renew_leases_batch(
+                conn,
+                self._pg_cursor,
+                command=command,
+                clock=self._clock.now_utc,
+            )
+        else:
+            result = _sqlite_renew_leases_batch(
+                conn,
+                command=command,
+                clock=self._clock.now_utc,
+            )
+        return int(result.applied_count)
+    finally:
+        _close_connection_nonfatal(conn, operation="batch lease renewal")
+```
+
+Preserve the existing public signature on one line if project formatting keeps it that way. Do not add facade events or early-return the empty command.
+
+- [ ] **Step 4: Verify routing and unchanged public behavior**
+
+```bash
+RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py -q
+TLDW_TEST_POSTGRES_REQUIRED=1 RUN_JOBS=1 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py -q
+```
+
+Expected: all tests pass, with zero PostgreSQL skips.
+
+- [ ] **Step 5: Commit facade routing**
+
+```bash
+git add tldw_Server_API/app/core/Jobs/manager.py tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py
+git commit -m "refactor(jobs): route batch renewal through operations"
+```
+
+---
+
+### Task 6: Run Final Gates And Prepare Review
+
+**Files:**
+- Modify through Backlog tooling: `TASK-12989`
+- Review all files listed in the File Structure section.
+
+**Interfaces:**
+- Consumes: the complete branch implementation.
+- Produces: verified, review-ready commits without changing public behavior.
+
+- [ ] **Step 1: Run the complete focused SQLite/contracts matrix**
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+RUN_JOBS=1 python -m pytest \
+  tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py \
+  tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py \
+  tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py \
+  tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py \
+  tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py \
+  tldw_Server_API/tests/Jobs/test_jobs_batch_lifecycle_sqlite.py \
+  -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run required real PostgreSQL coverage**
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 RUN_JOBS=1 python -m pytest \
+  tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py \
+  tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py \
+  tldw_Server_API/tests/Jobs/test_jobs_batch_lifecycle_postgres.py \
+  tldw_Server_API/tests/Jobs/test_jobs_rls_postgres.py \
+  -q
+```
+
+Expected: all pass and the pytest summary contains zero skips.
+
+- [ ] **Step 3: Run neighboring lifecycle and parity regressions**
+
+```bash
+RUN_JOBS=1 python -m pytest \
+  tldw_Server_API/tests/Jobs/parity/test_sqlite_parity.py \
+  tldw_Server_API/tests/Jobs/test_jobs_lifecycle_side_effects.py \
+  tldw_Server_API/tests/Jobs/test_jobs_complete_fail_transaction_boundaries.py \
+  tldw_Server_API/tests/Jobs/test_jobs_finalize_cancelled_transaction_boundaries.py \
+  -q
+
+TLDW_TEST_POSTGRES_REQUIRED=1 RUN_JOBS=1 python -m pytest \
+  tldw_Server_API/tests/Jobs/parity/test_postgres_parity.py \
+  -q
+```
+
+Expected: all pass with zero PostgreSQL skips.
+
+- [ ] **Step 4: Run static and security gates**
+
+```bash
+python -m ruff check \
+  tldw_Server_API/app/core/Jobs/manager.py \
+  tldw_Server_API/app/core/Jobs/operations \
+  tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py \
+  tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py \
+  tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py \
+  tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py \
+  tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py \
+  tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py \
+  tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
+
+python -m compileall -q \
+  tldw_Server_API/app/core/Jobs/manager.py \
+  tldw_Server_API/app/core/Jobs/operations
+
+python -m bandit -r \
+  tldw_Server_API/app/core/Jobs/manager.py \
+  tldw_Server_API/app/core/Jobs/operations/contracts.py \
+  tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py \
+  tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py \
+  -f json -o /tmp/bandit_task_12989.json
+```
+
+Expected: Ruff and compileall exit zero; Bandit reports no new finding in touched production code.
+
+- [ ] **Step 5: Run diff and boundary checks**
+
+```bash
+git diff --check origin/dev...HEAD
+rg -n "JobManager|Jobs\.manager|from .*manager|import .*manager" tldw_Server_API/app/core/Jobs/operations
+git diff --stat origin/dev...HEAD
+git status --short
+```
+
+Expected: diff check is clean; the boundary scan finds no `JobManager` dependency; only task-scoped files are changed; worktree is clean after commits.
+
+- [ ] **Step 6: Request independent whole-branch code review**
+
+Use `superpowers:requesting-code-review` against `origin/dev...HEAD`. Review transaction ownership, PostgreSQL RLS cursor use, empty-batch clock behavior, connection/error precedence, SQL parameterization, result invariants, and test durability. Validate each finding with `superpowers:receiving-code-review` before changing code.
+
+- [ ] **Step 7: Record verification and prepare the pull request**
+
+Update `TASK-12989` through Backlog tooling with changed files, exact pass/skip counts, Bandit output location, review findings, commit IDs, and the PR URL. Ask the requester for the mandatory human-authored `Change summary`; do not merge without it.
+
+If task metadata changes after verification, commit it separately:
+
+```bash
+git add "backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md"
+git commit -m "chore(jobs): record batch renewal verification"
+```

--- a/Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md
+++ b/Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md
@@ -71,15 +71,18 @@ path but do not read the lease maximum.
 ### Recommended: Dedicated backend batch operations
 
 Add one typed batch operation to each lifecycle backend. Each operation owns
-the complete transaction and iterates its immutable command items in order.
+the complete atomic scope and iterates its immutable command items in order.
+The normal `JobManager` path supplies a fresh connection, so that scope is a
+native transaction. A direct SQLite call inside a caller-owned transaction
+uses a savepoint and leaves the outer transaction open.
 Single and batch renewal may share only transaction-neutral SQL construction
 through a pure statement-and-parameter builder. Execution and result handling
 remain separate.
 
 Benefits:
 
-- transaction ownership is obvious and directly testable
-- no nested transaction or per-item commit ambiguity
+- transaction or savepoint ownership is obvious and directly testable
+- no caller-transaction commit or per-item commit ambiguity
 - backend differences remain explicit
 - the public facade becomes smaller without changing callers
 - the change remains independently reviewable and revertible
@@ -114,10 +117,12 @@ Backend lifecycle operations own:
 
 - backend-specific fixed SQL variants and bound parameters
 - backend-specific clock sampling
-- one transaction around the complete ordered item tuple
+- one atomic scope around the complete ordered item tuple
+- a native transaction on fresh connections and a savepoint for direct SQLite
+  calls made inside a caller-owned transaction
 - update execution and exact applied-attempt counting
-- rollback through the native connection context on unexpected errors
-- result construction before the transaction context exits
+- rollback through the native transaction or savepoint on unexpected errors
+- result construction before the atomic context exits
 
 Backend operation modules must not import or reference `JobManager`.
 
@@ -174,15 +179,18 @@ Duplicate job IDs therefore retain current counting semantics.
    seconds to `[1, current JOBS_LEASE_MAX_SECONDS]`. The environment value
    remains an operation-time per-item read; this task does not adopt
    `JobsSettings` snapshot behavior.
-6. The selected backend operation enters one transaction, opens its backend
-   cursor (thereby preserving PostgreSQL RLS setup), and processes every command
-   item in input order.
+6. The selected backend operation enters one atomic scope, opens its backend
+   cursor where applicable (thereby preserving PostgreSQL RLS setup), and
+   processes every command item in input order. Direct SQLite calls inside an
+   existing transaction use a savepoint without committing or rolling back the
+   caller's surrounding work.
 7. PostgreSQL samples the provided clock once before its loop. SQLite samples
    the provided clock before each item update.
 8. Matching updates increment `applied_count`; expected no-transitions add
    zero and processing continues.
-9. The operation constructs a valid result before leaving the transaction
-   context. Normal exit commits; unexpected exit rolls back.
+9. The operation constructs a valid result before leaving the atomic context.
+   Normal exit commits or releases its savepoint; unexpected exit rolls back
+   the owned transaction or only the batch savepoint.
 10. The facade returns `result.applied_count` and closes the connection through
     the established non-fatal cleanup path.
 
@@ -220,8 +228,9 @@ it must not issue extra classification queries for expected no-ops.
   completes normalization before dispatch, so malformed input cannot occur after
   a backend operation starts mutating rows.
 - Clock failures and unexpected SQLite/PostgreSQL errors propagate unchanged.
-- The backend transaction context rolls back every earlier update before an
-  unexpected exception reaches the facade.
+- The backend atomic context rolls back every earlier batch update before an
+  unexpected exception reaches the facade without closing a caller-owned
+  SQLite transaction.
 - No error is logged and suppressed in the backend operation.
 - Connection-close failures retain the existing non-fatal cleanup behavior.
 
@@ -292,8 +301,10 @@ modules additionally use `pg_jobs` as an infrastructure marker.
 
 ### Accidental per-item commits
 
-Mitigation: backend operations own one outer transaction, and durable
+Mitigation: backend operations own one atomic scope, and durable
 database-trigger tests verify rollback after an earlier successful update.
+Direct SQLite tests additionally prove a savepoint preserves the caller's
+transaction and unrelated uncommitted work.
 
 ### Single-job regression from helper reuse
 

--- a/Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md
+++ b/Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md
@@ -1,0 +1,325 @@
+# Jobs Batch Lease Renewal Extraction Design
+
+Date: 2026-08-01
+Topic: Atomic Jobs batch lease renewal extraction
+Status: Approved design
+Tracking: TASK-12989
+
+## Objective
+
+Extract `JobManager.batch_renew_leases` into dedicated SQLite and PostgreSQL
+lifecycle operations without changing its public signature or integer return
+contract. Make the existing whole-batch transaction boundary explicit and
+testable while preserving input-order processing, backend-specific clock
+timing, duration clamping, lease-identity enforcement, and row-count behavior.
+
+This is the first deferred lifecycle slice after single-job acquisition,
+renewal, and release extraction. It is intentionally limited to batch lease
+renewal. Batch completion/failure and terminal transition families remain in
+`JobManager`.
+
+## Goals
+
+- Keep `JobManager.batch_renew_leases(items, *, enforce=None) -> int` stable.
+- Preserve one atomic transaction for the complete batch.
+- Treat missing, non-processing, and stale-lease rows as non-fatal no-ops.
+- Roll back every earlier renewal when a later clock or database operation
+  fails unexpectedly.
+- Preserve SQLite and PostgreSQL timing and SQL behavior where they currently
+  differ.
+- Introduce immutable typed batch commands and results.
+- Keep backend SQL and transaction details out of `JobManager`.
+- Add durable SQLite and required real-PostgreSQL evidence before routing the
+  facade through the new operations.
+
+## Non-Goals
+
+- Do not change the public method signature, accepted item keys, or return
+  shape.
+- Do not extract `batch_complete_jobs`, `batch_fail_jobs`, terminal
+  transitions, retry, quarantine, pruning, or admin-owned SQL.
+- Do not introduce a batch-size limit, sorting, deduplication, or new lock
+  ordering.
+- Do not add schema or migration changes.
+- Do not integrate the existing `JobsSettings` scaffold.
+- Do not add events, counters, metrics, or other renewal side effects.
+- Do not replace the ordered loop with backend-specific set-based bulk SQL.
+- Do not unify SQLite and PostgreSQL clock sampling in this extraction.
+
+## Existing Behavior
+
+The current facade opens one connection and one backend transaction, then
+updates each item in input order. It sums statement row counts and returns the
+sum as an integer.
+
+Expected no-transition cases do not raise. An update contributes zero when the
+job is missing, not processing, or has a stale worker/lease identity while
+enforcement is enabled. Other valid updates in the same batch still commit.
+
+Unexpected exceptions leave the transaction context and roll back all earlier
+updates. Duplicate job identifiers are separate ordered attempts and may each
+contribute to the returned count. Renewal uses `MAX`/`GREATEST`, so a shorter
+requested extension does not shorten an existing longer lease.
+
+PostgreSQL samples `self._clock.now_utc()` once per batch. SQLite samples it
+once per item. `JOBS_LEASE_MAX_SECONDS` is currently read while processing each
+item. Empty batches still acquire a connection and enter the backend operation
+path but do not read the lease maximum.
+
+## Approaches Considered
+
+### Recommended: Dedicated backend batch operations
+
+Add one typed batch operation to each lifecycle backend. Each operation owns
+the complete transaction and iterates its immutable command items in order.
+Single and batch renewal may share only transaction-neutral SQL construction
+through a pure statement-and-parameter builder. Execution and result handling
+remain separate.
+
+Benefits:
+
+- transaction ownership is obvious and directly testable
+- no nested transaction or per-item commit ambiguity
+- backend differences remain explicit
+- the public facade becomes smaller without changing callers
+- the change remains independently reviewable and revertible
+
+### Alternative: Loop over the single-job operation
+
+This would reduce visible SQL but requires making the single-job operation
+transaction-aware. Its current transaction wrappers could commit per item or
+create backend-specific nested-context behavior. The abstraction would hide
+rather than clarify the batch boundary.
+
+### Alternative: Set-based bulk SQL
+
+A set-based statement could reduce round trips, but per-item durations,
+optional lease enforcement, duplicate attempts, ordered clock sampling, and
+exact row-count compatibility make the SQL substantially more complex. That
+optimization is not justified without measured batch-size or contention data.
+
+## Architecture
+
+`JobManager` remains the public facade and owns:
+
+- default `enforce` resolution
+- item field extraction and existing `int(...)` conversions
+- per-item duration clamping using `JOBS_LEASE_MAX_SECONDS`
+- immutable command construction
+- backend selection and connection setup
+- mapping `BatchRenewLeasesResult.applied_count` to the public integer
+- non-fatal connection cleanup
+
+Backend lifecycle operations own:
+
+- backend-specific fixed SQL variants and bound parameters
+- backend-specific clock sampling
+- one transaction around the complete ordered item tuple
+- update execution and exact applied-attempt counting
+- rollback through the native connection context on unexpected errors
+- result construction before the transaction context exits
+
+Backend operation modules must not import or reference `JobManager`.
+
+## Typed Contracts
+
+Add immutable contracts in `operations/contracts.py`:
+
+```python
+@dataclass(frozen=True)
+class BatchRenewLeaseItem:
+    job_id: int
+    seconds: int
+    worker_id: str | None = None
+    lease_id: str | None = None
+
+
+@dataclass(frozen=True)
+class BatchRenewLeasesCommand:
+    items: tuple[BatchRenewLeaseItem, ...]
+    enforce: bool
+
+
+@dataclass(frozen=True)
+class BatchRenewLeasesResult:
+    requested_count: int
+    applied_count: int
+```
+
+`BatchRenewLeasesCommand.__post_init__` snapshots any supplied sequence as an
+immutable tuple, and each item rejects non-positive normalized durations.
+`BatchRenewLeaseItem.seconds` is a facade-normalized value that is already
+clamped to the applicable per-item maximum. Backend operations neither read
+`JOBS_LEASE_MAX_SECONDS` nor clamp item durations again. The result enforces:
+
+```text
+0 <= applied_count <= requested_count
+```
+
+`applied_count` means successful update attempts, not distinct job rows.
+Duplicate job IDs therefore retain current counting semantics.
+
+## Data Flow
+
+1. A caller invokes `JobManager.batch_renew_leases` with the existing item
+   dictionaries and optional `enforce` override.
+2. The facade resolves default enforcement exactly once.
+3. The facade opens the existing backend connection before consuming items,
+   preserving current connection-failure precedence, and supplies the
+   established PostgreSQL cursor factory where applicable.
+4. Before dispatching any backend mutation, the facade consumes the declared
+   list in order and extracts only `job_id`, `seconds`, `worker_id`, and
+   `lease_id` into immutable items.
+5. For each item, the facade preserves the existing conversions and clamps
+   seconds to `[1, current JOBS_LEASE_MAX_SECONDS]`. The environment value
+   remains an operation-time per-item read; this task does not adopt
+   `JobsSettings` snapshot behavior.
+6. The selected backend operation enters one transaction, opens its backend
+   cursor (thereby preserving PostgreSQL RLS setup), and processes every command
+   item in input order.
+7. PostgreSQL samples the provided clock once before its loop. SQLite samples
+   the provided clock before each item update.
+8. Matching updates increment `applied_count`; expected no-transitions add
+   zero and processing continues.
+9. The operation constructs a valid result before leaving the transaction
+   context. Normal exit commits; unexpected exit rolls back.
+10. The facade returns `result.applied_count` and closes the connection through
+    the established non-fatal cleanup path.
+
+An empty item tuple still follows the connection and backend operation path.
+It returns zero and does not read `JOBS_LEASE_MAX_SECONDS`. PostgreSQL retains
+its current once-per-batch clock sampling; SQLite performs no per-item clock
+calls for an empty tuple.
+
+## SQL Reuse Boundary
+
+Single and batch renewal may share only a private, pure helper that selects the
+fixed SQL variant and builds its bound parameters. The helper must not execute
+SQL, inspect row counts, classify outcomes, or own a cursor, connection, or
+transaction. Single and batch operations retain separate execution and result
+handling. They must not share:
+
+- connection acquisition
+- transaction contexts
+- no-transition classification reads
+- public result mapping
+- post-operation side effects
+
+The single-job operation continues to return `LifecycleResult` and classify a
+zero-row update. The batch operation only needs exact applied-attempt counts;
+it must not issue extra classification queries for expected no-ops.
+
+## Error Handling
+
+- Missing, wrong-status, and stale enforced identities are expected zero-row
+  outcomes and do not abort the batch.
+- Existing `int(...)` conversion failures retain their built-in exception
+  classes. Exact interpreter-specific messages are not part of the contract.
+- The facade opens the connection before item normalization, preserving current
+  precedence when both connection setup and input conversion would fail. It
+  completes normalization before dispatch, so malformed input cannot occur after
+  a backend operation starts mutating rows.
+- Clock failures and unexpected SQLite/PostgreSQL errors propagate unchanged.
+- The backend transaction context rolls back every earlier update before an
+  unexpected exception reaches the facade.
+- No error is logged and suppressed in the backend operation.
+- Connection-close failures retain the existing non-fatal cleanup behavior.
+
+## Test Strategy
+
+### Public characterization before extraction
+
+Add or strengthen SQLite and required real-PostgreSQL coverage for:
+
+- exact count for several valid items
+- mixed valid, missing, wrong-status, and stale-identity items
+- duplicate job IDs as separate update attempts
+- lease non-shortening
+- duration clamping below, within, and above the configured maximum
+- representative malformed inputs with matching exception classes and no
+  durable mutation
+- empty-batch behavior
+- whole-batch rollback after a later database-triggered failure, verified from
+  a fresh connection
+
+These tests must pass against the inline implementation before routing changes.
+
+### Typed contracts and direct operations
+
+Contract and direct-operation tests begin red because the new types and entry
+points do not exist. They cover:
+
+- immutable command item snapshots
+- requested/applied count invariants, including a narrow property test
+- import boundaries that exclude `JobManager`
+- exact result counts and durable lease values
+- logical no-ops alongside committed valid renewals
+- duplicate attempts and non-shortening behavior
+- rollback after a later database-triggered failure
+- rollback after a later SQLite clock failure
+- PostgreSQL once-per-batch and SQLite per-item clock sampling at the operation
+  boundary
+
+Database-triggered and clock-failure rollback tests are the behavioral evidence
+that the complete mutation loop remains inside one transaction. Tests must not
+spy on result construction or transaction-wrapper internals.
+
+PostgreSQL trigger and function names must be unique. Cleanup runs in `finally`
+through a fresh connection so failed transactions cannot leak test objects.
+SQLite uses a disposable per-test database.
+
+### Facade routing
+
+Small routing tests verify typed command dispatch to each backend and mapping
+of `applied_count` to the public integer. They do not assert transaction-wrapper
+internals, introspect the Python signature, or add side-effect spies.
+
+### Verification gates
+
+- New focused contract, facade, SQLite, and required real-PostgreSQL tests with
+  zero PostgreSQL skips.
+- Existing single-job renewal/release operation and parity suites.
+- The established neighboring Jobs regression matrix.
+- Ruff and compileall on touched Python paths.
+- Bandit on every touched production path.
+- `git diff --check` and operation-module `JobManager` boundary scans.
+- Independent whole-branch review before pull request preparation.
+
+Each new test module carries exactly one accepted test-type marker. PostgreSQL
+modules additionally use `pg_jobs` as an infrastructure marker.
+
+## Risks And Mitigations
+
+### Accidental per-item commits
+
+Mitigation: backend operations own one outer transaction, and durable
+database-trigger tests verify rollback after an earlier successful update.
+
+### Single-job regression from helper reuse
+
+Mitigation: share only pure statement-and-parameter construction and rerun
+existing single-job renewal/release suites unchanged.
+
+### Settings semantics drift
+
+Mitigation: preserve per-item environment reads and defer any snapshot policy
+to the dedicated `JobsSettings` adoption slice.
+
+### Backend timing drift
+
+Mitigation: inject the existing manager clock and preserve PostgreSQL batch
+sampling versus SQLite per-item sampling in direct-operation tests.
+
+### Deadlocks or oversized transactions
+
+The extraction preserves current input ordering and unbounded batch size. A
+future change may add deterministic lock ordering, chunking, or limits only
+after production batch-size and contention measurements establish the need.
+
+## Delivery Boundary
+
+The implementation should remain one reviewable PR after this design and its
+implementation plan are approved. It may contain separate commits for public
+characterization, contracts, SQLite extraction, PostgreSQL extraction, facade
+routing, and final tracking. No terminal or other batch lifecycle family may
+be added to the PR.

--- a/Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md
+++ b/Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md
@@ -3,7 +3,7 @@
 Date: 2026-08-01
 Topic: Atomic Jobs batch lease renewal extraction
 Status: Approved design
-Tracking: TASK-12989
+Tracking: TASK-13010
 
 ## Objective
 
@@ -227,10 +227,16 @@ it must not issue extra classification queries for expected no-ops.
   precedence when both connection setup and input conversion would fail. It
   completes normalization before dispatch, so malformed input cannot occur after
   a backend operation starts mutating rows.
+- Complete normalization intentionally precedes backend clock sampling and
+  PostgreSQL cursor/RLS setup. A malformed item therefore wins over a backend
+  clock or cursor failure, and neither backend hook runs for that command.
 - Clock failures and unexpected SQLite/PostgreSQL errors propagate unchanged.
 - The backend atomic context rolls back every earlier batch update before an
   unexpected exception reaches the facade without closing a caller-owned
   SQLite transaction.
+- If SQLite itself aborts the complete transaction, the savepoint no longer
+  exists and caller-owned work cannot remain open. The original database error
+  remains primary and any savepoint-cleanup failure is chained as its cause.
 - No error is logged and suppressed in the backend operation.
 - Connection-close failures retain the existing non-fatal cleanup behavior.
 
@@ -266,6 +272,8 @@ points do not exist. They cover:
 - duplicate attempts and non-shortening behavior
 - rollback after a later database-triggered failure
 - rollback after a later SQLite clock failure
+- preservation of the primary SQLite error when a trigger aborts the complete
+  caller-owned transaction
 - PostgreSQL once-per-batch and SQLite per-item clock sampling at the operation
   boundary
 
@@ -281,7 +289,8 @@ SQLite uses a disposable per-test database.
 
 Small routing tests verify typed command dispatch to each backend and mapping
 of `applied_count` to the public integer. They do not assert transaction-wrapper
-internals, introspect the Python signature, or add side-effect spies.
+internals or introspect the Python signature. They verify that complete command
+normalization precedes backend clock, cursor, and operation dispatch.
 
 ### Verification gates
 
@@ -304,7 +313,9 @@ modules additionally use `pg_jobs` as an infrastructure marker.
 Mitigation: backend operations own one atomic scope, and durable
 database-trigger tests verify rollback after an earlier successful update.
 Direct SQLite tests additionally prove a savepoint preserves the caller's
-transaction and unrelated uncommitted work.
+transaction and unrelated uncommitted work for ordinary statement failures.
+An explicit whole-transaction abort test proves the original database error is
+preserved even though SQLite necessarily discards the caller transaction.
 
 ### Single-job regression from helper reuse
 

--- a/backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md
+++ b/backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12989
 title: Extract Jobs batch lease renewal operations atomically
-status: In Progress
+status: Done
 created_date: 2026-08-02 02:14
 labels:
 - jobs
@@ -17,15 +17,20 @@ references:
 - https://github.com/rmusser01/tldw_server/pull/2765
 documentation:
 - Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md
+- Docs/superpowers/plans/2026-08-08-jobs-batch-lease-renewal-extraction.md
 modified_files:
 - tldw_Server_API/app/core/Jobs/manager.py
 - tldw_Server_API/app/core/Jobs/operations/contracts.py
 - tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
 - tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py
+- tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py
+- tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py
+- tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py
 - tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py
+- tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py
 - tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
 - tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
-updated_date: 2026-08-02 02:17
+updated_date: 2026-08-08 19:02
 ---
 
 ## Description
@@ -36,13 +41,13 @@ Characterize and extract JobManager.batch_renew_leases into dedicated SQLite and
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 JobManager.batch_renew_leases keeps its public signature and integer return contract.
-- [ ] #2 SQLite and PostgreSQL batch renewal route through dedicated backend lifecycle operations that do not import JobManager.
-- [ ] #3 Unexpected backend or clock failures roll back every earlier renewal in the batch.
-- [ ] #4 Missing, non-processing, and stale-lease items remain non-fatal no-ops while valid items commit.
-- [ ] #5 Duration clamping, duplicate-item counting, empty-batch behavior, and backend-specific clock timing remain compatible.
-- [ ] #6 Focused SQLite and required real PostgreSQL suites pass with zero PostgreSQL skips.
-- [ ] #7 The established neighboring Jobs matrix, Ruff, compileall, Bandit, and diff hygiene pass.
+- [x] #1 JobManager.batch_renew_leases keeps its public signature and integer return contract.
+- [x] #2 SQLite and PostgreSQL batch renewal route through dedicated backend lifecycle operations that do not import JobManager.
+- [x] #3 Unexpected backend or clock failures roll back every earlier renewal in the batch.
+- [x] #4 Missing, non-processing, and stale-lease items remain non-fatal no-ops while valid items commit.
+- [x] #5 Duration clamping, duplicate-item counting, empty-batch behavior, and backend-specific clock timing remain compatible.
+- [x] #6 Focused SQLite and required real PostgreSQL suites pass with zero PostgreSQL skips.
+- [x] #7 The established neighboring Jobs matrix, Ruff, compileall, Bandit, and diff hygiene pass.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -54,21 +59,21 @@ Characterize and extract JobManager.batch_renew_leases into dedicated SQLite and
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Approved design recorded at Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md. Work starts from fresh origin/dev f15365c7bbbcd212733551e5f56d2ed6486fffe2 on branch codex/jobs-batch-renewal-extraction. No production code changed in the design commit.
+Approved design recorded at Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md. Work started on branch codex/jobs-batch-renewal-extraction and was rebased cleanly onto origin/dev 45490da82e. Post-rebase verification at 2c6a987b40 passed 93 focused SQLite/contracts tests, 43 required PostgreSQL/RLS tests with zero skips, 50 neighboring lifecycle/parity tests with 13 PostgreSQL-only skips confined to the non-required SQLite matrix, and 11 required PostgreSQL parity tests with zero skips. Ruff, compileall, diff hygiene, and operation/manager boundary checks passed. Bandit reported zero findings across 9,273 lines in /tmp/bandit_task_12989_post_rebase.json. Independent task and whole-branch reviews found no remaining code issues.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Extracted atomic batch lease renewal into dedicated SQLite and PostgreSQL lifecycle operations while preserving the JobManager public contract, ordered duplicate attempts, expected no-ops, non-shortening leases, duration clamping, backend-specific clock behavior, PostgreSQL RLS cursor setup, and one transaction per batch. Added immutable contracts plus public characterization, direct backend, routing, property, and real-database rollback coverage. The rebased branch is 0 behind current dev and technically review-clean. Merge remains blocked until the requester adds the required human-authored Change summary to the pull request; this tracker summary is verification metadata and does not satisfy that policy.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md
+++ b/backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md
@@ -1,0 +1,74 @@
+---
+id: TASK-12989
+title: Extract Jobs batch lease renewal operations atomically
+status: In Progress
+created_date: 2026-08-02 02:14
+labels:
+- jobs
+- refactor
+- stability
+- postgresql
+- sqlite
+priority: medium
+references:
+- TASK-12988
+- Docs/superpowers/specs/2026-06-24-jobs-backend-parity-refactor-design.md
+- Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md
+- https://github.com/rmusser01/tldw_server/pull/2765
+documentation:
+- Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md
+modified_files:
+- tldw_Server_API/app/core/Jobs/manager.py
+- tldw_Server_API/app/core/Jobs/operations/contracts.py
+- tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
+- tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py
+- tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py
+- tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
+- tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
+updated_date: 2026-08-02 02:17
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Characterize and extract JobManager.batch_renew_leases into dedicated SQLite and PostgreSQL lifecycle operations while preserving the public facade, input-order processing, exact row-count semantics, backend-specific clock timing, expected no-op behavior, and one atomic transaction for the complete batch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 JobManager.batch_renew_leases keeps its public signature and integer return contract.
+- [ ] #2 SQLite and PostgreSQL batch renewal route through dedicated backend lifecycle operations that do not import JobManager.
+- [ ] #3 Unexpected backend or clock failures roll back every earlier renewal in the batch.
+- [ ] #4 Missing, non-processing, and stale-lease items remain non-fatal no-ops while valid items commit.
+- [ ] #5 Duration clamping, duplicate-item counting, empty-batch behavior, and backend-specific clock timing remain compatible.
+- [ ] #6 Focused SQLite and required real PostgreSQL suites pass with zero PostgreSQL skips.
+- [ ] #7 The established neighboring Jobs matrix, Ruff, compileall, Bandit, and diff hygiene pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Commit the approved design and detailed TDD implementation plan. 2. Add green public characterization coverage. 3. Add red typed-contract and direct backend-operation tests. 4. Implement transaction-neutral renewal SQL helpers and atomic backend batch operations. 5. Route the unchanged JobManager facade. 6. Run required SQLite/PostgreSQL, neighboring Jobs, lint, compile, Bandit, diff, and independent review gates.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Approved design recorded at Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md. Work starts from fresh origin/dev f15365c7bbbcd212733551e5f56d2ed6486fffe2 on branch codex/jobs-batch-renewal-extraction. No production code changed in the design commit.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md
+++ b/backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12989
 title: Extract Jobs batch lease renewal operations atomically
-status: Done
+status: In Progress
 created_date: 2026-08-02 02:14
 labels:
 - jobs
@@ -31,13 +31,13 @@ modified_files:
 - tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py
 - tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
 - tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
-updated_date: 2026-08-08 14:36
+updated_date: 2026-08-10 19:17
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Characterize and extract JobManager.batch_renew_leases into dedicated SQLite and PostgreSQL lifecycle operations while preserving the public facade, input-order processing, exact row-count semantics, backend-specific clock timing, expected no-op behavior, and one atomic transaction for the complete batch.
+Characterize and extract JobManager.batch_renew_leases into dedicated SQLite and PostgreSQL lifecycle operations while preserving the public facade, input-order processing, exact row-count semantics, backend-specific clock timing, expected no-op behavior, and one atomic scope for the complete batch.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -60,13 +60,13 @@ Characterize and extract JobManager.batch_renew_leases into dedicated SQLite and
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Approved design recorded at Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md. Work started on branch codex/jobs-batch-renewal-extraction and was rebased cleanly onto origin/dev 45490da82e. Post-rebase verification at 2c6a987b40 passed 93 focused SQLite/contracts tests, 43 required PostgreSQL/RLS tests with zero skips, 50 neighboring lifecycle/parity tests with 13 PostgreSQL-only skips confined to the non-required SQLite matrix, and 11 required PostgreSQL parity tests with zero skips. Ruff, compileall, diff hygiene, and operation/manager boundary checks passed. Bandit reported zero findings across 9,273 lines in /tmp/bandit_task_12989_post_rebase.json. Independent task and whole-branch reviews found no remaining code issues.
+Approved design recorded at Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md. Work started on branch codex/jobs-batch-renewal-extraction and was rebased cleanly onto origin/dev 45490da82e. Post-rebase verification at 2c6a987b40 passed 93 focused SQLite/contracts tests, 43 required PostgreSQL/RLS tests with zero skips, 50 neighboring lifecycle/parity tests with 13 PostgreSQL-only skips confined to the non-required SQLite matrix, and 11 required PostgreSQL parity tests with zero skips. Ruff, compileall, diff hygiene, and operation/manager boundary checks passed. Bandit reported zero findings across 9,273 lines in /tmp/bandit_task_12989_post_rebase.json. Independent task and whole-branch reviews found no remaining code issues. PR #2773 follow-up reopened on 2026-08-10 to validate and address three Qodo comments. Validation rejected the fixture-isolation claim because jobs_pg_dsn already depends on the canonical function-scoped pg_temp_db fixture. The validated SQL-construction concern is addressed with psycopg.sql composition for PostgreSQL and fixed SQLite trigger SQL keyed to a constant test identity. The validated SQLite transaction concern is addressed with a savepoint for direct calls inside caller-owned transactions, including regression tests that prove success and failure leave the outer transaction open and failure preserves unrelated caller work. Pre-rebase follow-up verification passed 38 SQLite tests and 35 required real-PostgreSQL tests with zero skips; Ruff, compileall, diff hygiene, and Bandit with zero findings also passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Extracted atomic batch lease renewal into dedicated SQLite and PostgreSQL lifecycle operations while preserving the JobManager public contract, ordered duplicate attempts, expected no-ops, non-shortening leases, duration clamping, backend-specific clock behavior, PostgreSQL RLS cursor setup, and one transaction per batch. Added immutable contracts plus public characterization, direct backend, routing, property, and real-database rollback coverage. The rebased branch is 0 behind current dev and technically review-clean. Draft pull request: https://github.com/rmusser01/tldw_server/pull/2773. Merge remains blocked until the requester adds the required human-authored Change summary to the pull request; this tracker summary is verification metadata and does not satisfy that policy.
+Extracted atomic batch lease renewal into dedicated SQLite and PostgreSQL lifecycle operations while preserving the JobManager public contract, ordered duplicate attempts, expected no-ops, non-shortening leases, duration clamping, backend-specific clock behavior, PostgreSQL RLS cursor setup, and one atomic scope per batch. Added immutable contracts plus public characterization, direct backend, routing, property, and real-database rollback coverage. Draft pull request: https://github.com/rmusser01/tldw_server/pull/2773. Final rebase and review verification remain in progress. Merge remains blocked until the requester adds the required human-authored Change summary to the pull request; this tracker summary is verification metadata and does not satisfy that policy.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md
+++ b/backlog/tasks/task-12989 - Extract-Jobs-batch-lease-renewal-operations-atomically.md
@@ -15,6 +15,7 @@ references:
 - Docs/superpowers/specs/2026-06-24-jobs-backend-parity-refactor-design.md
 - Docs/superpowers/plans/2026-07-14-jobs-admission-hardening-and-lease-lifecycle.md
 - https://github.com/rmusser01/tldw_server/pull/2765
+- https://github.com/rmusser01/tldw_server/pull/2773
 documentation:
 - Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md
 - Docs/superpowers/plans/2026-08-08-jobs-batch-lease-renewal-extraction.md
@@ -30,7 +31,7 @@ modified_files:
 - tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py
 - tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
 - tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
-updated_date: 2026-08-08 19:02
+updated_date: 2026-08-08 14:36
 ---
 
 ## Description
@@ -65,7 +66,7 @@ Approved design recorded at Docs/superpowers/specs/2026-08-01-jobs-batch-lease-r
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Extracted atomic batch lease renewal into dedicated SQLite and PostgreSQL lifecycle operations while preserving the JobManager public contract, ordered duplicate attempts, expected no-ops, non-shortening leases, duration clamping, backend-specific clock behavior, PostgreSQL RLS cursor setup, and one transaction per batch. Added immutable contracts plus public characterization, direct backend, routing, property, and real-database rollback coverage. The rebased branch is 0 behind current dev and technically review-clean. Merge remains blocked until the requester adds the required human-authored Change summary to the pull request; this tracker summary is verification metadata and does not satisfy that policy.
+Extracted atomic batch lease renewal into dedicated SQLite and PostgreSQL lifecycle operations while preserving the JobManager public contract, ordered duplicate attempts, expected no-ops, non-shortening leases, duration clamping, backend-specific clock behavior, PostgreSQL RLS cursor setup, and one transaction per batch. Added immutable contracts plus public characterization, direct backend, routing, property, and real-database rollback coverage. The rebased branch is 0 behind current dev and technically review-clean. Draft pull request: https://github.com/rmusser01/tldw_server/pull/2773. Merge remains blocked until the requester adds the required human-authored Change summary to the pull request; this tracker summary is verification metadata and does not satisfy that policy.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13010 - Extract-Jobs-batch-lease-renewal-operations-atomically.md
+++ b/backlog/tasks/task-13010 - Extract-Jobs-batch-lease-renewal-operations-atomically.md
@@ -1,7 +1,7 @@
 ---
-id: TASK-12989
+id: TASK-13010
 title: Extract Jobs batch lease renewal operations atomically
-status: In Progress
+status: Done
 created_date: 2026-08-02 02:14
 labels:
 - jobs
@@ -31,7 +31,7 @@ modified_files:
 - tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py
 - tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
 - tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
-updated_date: 2026-08-10 19:17
+updated_date: 2026-08-10 19:38
 ---
 
 ## Description
@@ -60,13 +60,13 @@ Characterize and extract JobManager.batch_renew_leases into dedicated SQLite and
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Approved design recorded at Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md. Work started on branch codex/jobs-batch-renewal-extraction and was rebased cleanly onto origin/dev 45490da82e. Post-rebase verification at 2c6a987b40 passed 93 focused SQLite/contracts tests, 43 required PostgreSQL/RLS tests with zero skips, 50 neighboring lifecycle/parity tests with 13 PostgreSQL-only skips confined to the non-required SQLite matrix, and 11 required PostgreSQL parity tests with zero skips. Ruff, compileall, diff hygiene, and operation/manager boundary checks passed. Bandit reported zero findings across 9,273 lines in /tmp/bandit_task_12989_post_rebase.json. Independent task and whole-branch reviews found no remaining code issues. PR #2773 follow-up reopened on 2026-08-10 to validate and address three Qodo comments. Validation rejected the fixture-isolation claim because jobs_pg_dsn already depends on the canonical function-scoped pg_temp_db fixture. The validated SQL-construction concern is addressed with psycopg.sql composition for PostgreSQL and fixed SQLite trigger SQL keyed to a constant test identity. The validated SQLite transaction concern is addressed with a savepoint for direct calls inside caller-owned transactions, including regression tests that prove success and failure leave the outer transaction open and failure preserves unrelated caller work. Pre-rebase follow-up verification passed 38 SQLite tests and 35 required real-PostgreSQL tests with zero skips; Ruff, compileall, diff hygiene, and Bandit with zero findings also passed.
+Approved design recorded at Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md. Work started on branch codex/jobs-batch-renewal-extraction and was rebased cleanly onto origin/dev 45490da82e, then rebased cleanly again onto origin/dev 7b48bcb04f for PR #2773 follow-up. The provisional TASK-12989 identity collided with two records already on dev; independent review validated the tooling problem and this Jobs task was manually renumbered to unique TASK-13010 under the requester's prior approval for narrowly scoped repair of this record. Qodo follow-up validation rejected the fixture-isolation claim because jobs_pg_dsn already depends on the canonical function-scoped pg_temp_db fixture. The validated SQL-construction concern is addressed with psycopg.sql composition for PostgreSQL and fixed SQLite trigger SQL keyed to a constant test identity. The validated SQLite transaction concern is addressed with a savepoint for direct calls inside caller-owned transactions. Independent review then found that a SQLite whole-transaction abort could let cleanup mask the primary error; the final helper preserves the primary error and chains cleanup failure, with RAISE(ROLLBACK) regression coverage. The review also confirmed complete normalization before clock, cursor/RLS, and backend dispatch is the approved behavior; explicit SQLite/PostgreSQL routing coverage and compatibility documentation now lock that precedence. Final post-rebase verification passed 97 focused SQLite/contracts tests, 43 required PostgreSQL/RLS tests with zero skips, 50 neighboring lifecycle/parity tests with 13 PostgreSQL-only skips confined to the non-required SQLite matrix, and 11 required PostgreSQL parity tests with zero skips. Ruff, compileall, diff hygiene, unique-task-ID, and operation/manager boundary checks passed. Bandit reported zero findings across 9,290 lines in /tmp/bandit_task_12989_post_rebase_qodo.json and zero findings for the final 432-line SQLite scope in /tmp/bandit_task_13010_final.json. Independent remediation re-review found no remaining code, test, documentation, or tracker issue.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Extracted atomic batch lease renewal into dedicated SQLite and PostgreSQL lifecycle operations while preserving the JobManager public contract, ordered duplicate attempts, expected no-ops, non-shortening leases, duration clamping, backend-specific clock behavior, PostgreSQL RLS cursor setup, and one atomic scope per batch. Added immutable contracts plus public characterization, direct backend, routing, property, and real-database rollback coverage. Draft pull request: https://github.com/rmusser01/tldw_server/pull/2773. Final rebase and review verification remain in progress. Merge remains blocked until the requester adds the required human-authored Change summary to the pull request; this tracker summary is verification metadata and does not satisfy that policy.
+Extracted atomic batch lease renewal into dedicated SQLite and PostgreSQL lifecycle operations while preserving the JobManager public contract, ordered duplicate attempts, expected no-ops, non-shortening leases, duration clamping, backend-specific clock behavior, PostgreSQL RLS cursor setup, and one atomic scope per batch. Added immutable contracts plus public characterization, direct backend, routing, property, real-database rollback, caller-owned savepoint, and primary-error-precedence coverage. The branch is rebased onto dev 7b48bcb04f and local verification and independent review are clean. Pull request: https://github.com/rmusser01/tldw_server/pull/2773. Merge remains blocked until the requester replaces the pending PR Summary with their required human-authored Change summary; this tracker summary is verification metadata and does not satisfy that policy.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13012 - Assign-Notes-link-sync-tests-to-CI-shards.md
+++ b/backlog/tasks/task-13012 - Assign-Notes-link-sync-tests-to-CI-shards.md
@@ -1,0 +1,54 @@
+---
+id: TASK-13012
+title: Assign Notes link-sync tests to CI shards
+status: Done
+assignee: []
+created_date: '2026-08-12 01:08'
+updated_date: '2026-08-12 01:11'
+labels:
+  - ci
+  - notes
+  - tests
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2773'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR #2773 rebased onto dev after PR #2782, which added two Notes test files without assigning them to the full-suite shard matrix. Add those tests to the existing ChaChaNotesDB and Services shards so the shard coverage guard passes without ignoring coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The Notes link migration test is assigned to every duplicated chacha-content-persona shard matrix.
+- [x] #2 The Notes graph projection worker test is assigned to every duplicated platform-services-core shard matrix.
+- [x] #3 The shard coverage guard passes with zero newly uncovered tests.
+- [x] #4 The affected tests pass locally.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Discovered while rebasing PR #2773 onto dev 414e81a12a; local reproduction reports exactly the two tests introduced by PR #2782.
+
+Verification: each new test path appears in all five duplicated shard matrices. Helper_Scripts/ci/check_shard_coverage.py passes with shards=773, test_files=4251, ignored=4, baseline=130, new_uncovered=0. The two affected test files pass: 29 passed. Bandit is not applicable because only CI YAML and task metadata changed. A broader CI policy run had five unrelated current-dev failures; the branch diff confirms this task changes only shard path entries.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Assigned the Notes link migration v58 test to every chacha-content-persona shard and the Notes graph projection worker test to every platform-services-core shard. This restores shard coverage without adding ignores or weakening the baseline. The shard guard and all 29 affected tests pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -63,6 +63,8 @@ from .operations.contracts import (
     AcquireJobCommand,
     AdmissionRejectionReason,
     AdmissionResult,
+    BatchRenewLeaseItem,
+    BatchRenewLeasesCommand,
     CreateJobCommand,
     OperationOutcome,
     ReleaseJobCommand,
@@ -72,10 +74,12 @@ from .operations.postgres import acquire_job as _postgres_acquire_job
 from .operations.postgres import create_job_admission as _postgres_create_job_admission
 from .operations.postgres import release_job as _postgres_release_job
 from .operations.postgres import renew_lease as _postgres_renew_lease
+from .operations.postgres import renew_leases_batch as _postgres_renew_leases_batch
 from .operations.sqlite import acquire_job as _sqlite_acquire_job
 from .operations.sqlite import create_job_admission as _sqlite_create_job_admission
 from .operations.sqlite import release_job as _sqlite_release_job
 from .operations.sqlite import renew_lease as _sqlite_renew_lease
+from .operations.sqlite import renew_leases_batch as _sqlite_renew_leases_batch
 from .pg_migrations import (
     POSTGRES_ARCHIVE_CURSOR_TIME_SQL,
     ensure_job_counters_pg,
@@ -4591,83 +4595,41 @@ class JobManager:
         if enforce is None:
             enforce = self._should_enforce_ack()
         conn = self._connect()
-        affected = 0
         try:
-            if self.backend == "postgres":
-                with conn:  # noqa: SIM117
-                    with self._pg_cursor(conn) as cur:
-                        now_ts = self._clock.now_utc()
-                        for it in items:
-                            secs = max(
-                                1,
-                                min(
-                                    int(os.getenv("JOBS_LEASE_MAX_SECONDS", "3600") or "3600"),
-                                    int(it.get("seconds") or 0),
-                                ),
-                            )
-                            if enforce:
-                                cur.execute(
-                                    (
-                                        "UPDATE jobs SET leased_until = GREATEST(COALESCE(leased_until, %s), %s + (%s || ' seconds')::interval) "
-                                        "WHERE id = %s AND status='processing' AND worker_id = %s AND lease_id = %s"
-                                    ),
-                                    (
-                                        now_ts,
-                                        now_ts,
-                                        secs,
-                                        int(it.get("job_id")),
-                                        it.get("worker_id"),
-                                        it.get("lease_id"),
-                                    ),
-                                )
-                            else:
-                                cur.execute(
-                                    (
-                                        "UPDATE jobs SET leased_until = GREATEST(COALESCE(leased_until, %s), %s + (%s || ' seconds')::interval) "
-                                        "WHERE id = %s AND status='processing'"
-                                    ),
-                                    (now_ts, now_ts, secs, int(it.get("job_id"))),
-                                )
-                            affected += cur.rowcount or 0
-            else:
-                with conn:
-                    for it in items:
-                        secs = max(
+            command = BatchRenewLeasesCommand(
+                items=tuple(
+                    BatchRenewLeaseItem(
+                        seconds=max(
                             1,
                             min(
-                                int(os.getenv("JOBS_LEASE_MAX_SECONDS", "3600") or "3600"), int(it.get("seconds") or 0)
+                                int(os.getenv("JOBS_LEASE_MAX_SECONDS", "3600") or "3600"),
+                                int(item.get("seconds") or 0),
                             ),
-                        )
-                        now_str = self._clock.now_utc().astimezone(_tz.utc).strftime("%Y-%m-%d %H:%M:%S")
-                        if enforce:
-                            cur = conn.execute(
-                                (
-                                    "UPDATE jobs SET leased_until = MAX(COALESCE(leased_until, DATETIME(?)), DATETIME(?, ?)) "
-                                    "WHERE id = ? AND status='processing' AND worker_id = ? AND lease_id = ?"
-                                ),
-                                (
-                                    now_str,
-                                    now_str,
-                                    f"+{secs} seconds",
-                                    int(it.get("job_id")),
-                                    it.get("worker_id"),
-                                    it.get("lease_id"),
-                                ),
-                            )
-                            affected += int(cur.rowcount or 0)
-                        else:
-                            cur = conn.execute(
-                                (
-                                    "UPDATE jobs SET leased_until = MAX(COALESCE(leased_until, DATETIME(?)), DATETIME(?, ?)) "
-                                    "WHERE id = ? AND status='processing'"
-                                ),
-                                (now_str, now_str, f"+{secs} seconds", int(it.get("job_id"))),
-                            )
-                            affected += int(cur.rowcount or 0)
-            return int(affected)
+                        ),
+                        job_id=int(item.get("job_id")),
+                        worker_id=item.get("worker_id"),
+                        lease_id=item.get("lease_id"),
+                    )
+                    for item in items
+                ),
+                enforce=bool(enforce),
+            )
+            if self.backend == "postgres":
+                result = _postgres_renew_leases_batch(
+                    conn,
+                    self._pg_cursor,
+                    command=command,
+                    clock=self._clock.now_utc,
+                )
+            else:
+                result = _sqlite_renew_leases_batch(
+                    conn,
+                    command=command,
+                    clock=self._clock.now_utc,
+                )
+            return int(result.applied_count)
         finally:
-            with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                conn.close()
+            _close_connection_nonfatal(conn, operation="batch lease renewal")
 
     def batch_complete_jobs(self, items: list[dict[str, Any]], *, enforce: bool | None = None) -> int:
         if enforce is None:

--- a/tldw_Server_API/app/core/Jobs/operations/contracts.py
+++ b/tldw_Server_API/app/core/Jobs/operations/contracts.py
@@ -108,6 +108,45 @@ class RenewLeaseCommand:
 
 
 @dataclass(frozen=True)
+class BatchRenewLeaseItem:
+    """One facade-normalized lease renewal attempt."""
+
+    job_id: int
+    seconds: int
+    worker_id: str | None = None
+    lease_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.seconds < 1:
+            raise ValueError("seconds must be positive")
+
+
+@dataclass(frozen=True)
+class BatchRenewLeasesCommand:
+    """Ordered immutable lease renewal attempts for one transaction."""
+
+    items: tuple[BatchRenewLeaseItem, ...]
+    enforce: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "items", tuple(self.items))
+
+
+@dataclass(frozen=True)
+class BatchRenewLeasesResult:
+    """Counts produced by one atomic batch renewal operation."""
+
+    requested_count: int
+    applied_count: int
+
+    def __post_init__(self) -> None:
+        if self.requested_count < 0:
+            raise ValueError("requested_count must be non-negative")
+        if not 0 <= self.applied_count <= self.requested_count:
+            raise ValueError("applied_count must be between zero and requested_count")
+
+
+@dataclass(frozen=True)
 class ReleaseJobCommand:
     """Backend-neutral command payload for releasing one processing job."""
 
@@ -274,6 +313,9 @@ __all__ = [
     "AdmissionRejectionReason",
     "AdmissionResult",
     "AcquireJobCommand",
+    "BatchRenewLeaseItem",
+    "BatchRenewLeasesCommand",
+    "BatchRenewLeasesResult",
     "CreateJobCommand",
     "LifecycleResult",
     "NoTransitionReason",

--- a/tldw_Server_API/app/core/Jobs/operations/postgres/__init__.py
+++ b/tldw_Server_API/app/core/Jobs/operations/postgres/__init__.py
@@ -1,6 +1,12 @@
 """Postgres Jobs operations."""
 
 from .admission import create_job_admission
-from .lifecycle import acquire_job, release_job, renew_lease
+from .lifecycle import acquire_job, release_job, renew_lease, renew_leases_batch
 
-__all__ = ["acquire_job", "create_job_admission", "release_job", "renew_lease"]
+__all__ = [
+    "acquire_job",
+    "create_job_admission",
+    "release_job",
+    "renew_lease",
+    "renew_leases_batch",
+]

--- a/tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py
+++ b/tldw_Server_API/app/core/Jobs/operations/postgres/lifecycle.py
@@ -12,6 +12,8 @@ from loguru import logger
 
 from tldw_Server_API.app.core.Jobs.operations.contracts import (
     AcquireJobCommand,
+    BatchRenewLeasesCommand,
+    BatchRenewLeasesResult,
     LifecycleResult,
     NoTransitionReason,
     ReleaseJobCommand,
@@ -189,14 +191,12 @@ def _classify_lifecycle_no_transition(
     return LifecycleResult.no_transition(NoTransitionReason.WRONG_STATUS, row=current)
 
 
-def renew_lease(
-    conn: Any,
-    cursor_factory: Callable[[Any], AbstractContextManager[Any]],
-    *,
+def _renew_lease_statement(
     command: RenewLeaseCommand,
+    *,
     now: datetime,
-) -> LifecycleResult:
-    """Renew one processing Postgres job lease without shortening it."""
+) -> tuple[str, tuple[Any, ...]]:
+    """Build the PostgreSQL statement for one lease renewal attempt."""
 
     has_percent = command.progress_percent is not None
     has_message = command.progress_message is not None
@@ -209,10 +209,23 @@ def renew_lease(
     params.append(command.job_id)
     if command.enforce:
         params.extend((command.worker_id, command.lease_id))
+    return sql, tuple(params)
+
+
+def renew_lease(
+    conn: Any,
+    cursor_factory: Callable[[Any], AbstractContextManager[Any]],
+    *,
+    command: RenewLeaseCommand,
+    now: datetime,
+) -> LifecycleResult:
+    """Renew one processing Postgres job lease without shortening it."""
+
+    sql, params = _renew_lease_statement(command, now=now)
 
     with conn:
         with cursor_factory(conn) as cur:
-            cur.execute(sql, tuple(params))
+            cur.execute(sql, params)
             row = cur.fetchone()
             if row is None:
                 return _classify_lifecycle_no_transition(
@@ -223,6 +236,37 @@ def renew_lease(
                     lease_id=command.lease_id,
                 )
             return LifecycleResult.applied(row=dict(row))
+
+
+def renew_leases_batch(
+    conn: Any,
+    cursor_factory: Callable[[Any], AbstractContextManager[Any]],
+    *,
+    command: BatchRenewLeasesCommand,
+    clock: Callable[[], datetime],
+) -> BatchRenewLeasesResult:
+    """Renew an ordered PostgreSQL lease batch in one transaction."""
+
+    applied_count = 0
+    with conn:
+        with cursor_factory(conn) as cur:
+            now = clock()
+            for item in command.items:
+                item_command = RenewLeaseCommand(
+                    job_id=item.job_id,
+                    seconds=item.seconds,
+                    enforce=command.enforce,
+                    worker_id=item.worker_id,
+                    lease_id=item.lease_id,
+                )
+                sql, params = _renew_lease_statement(item_command, now=now)
+                cur.execute(sql, params)
+                if cur.fetchone() is not None:
+                    applied_count += 1
+            return BatchRenewLeasesResult(
+                requested_count=len(command.items),
+                applied_count=applied_count,
+            )
 
 
 def release_job(

--- a/tldw_Server_API/app/core/Jobs/operations/sqlite/__init__.py
+++ b/tldw_Server_API/app/core/Jobs/operations/sqlite/__init__.py
@@ -1,6 +1,12 @@
 """SQLite Jobs backend operations."""
 
 from .admission import create_job_admission
-from .lifecycle import acquire_job, release_job, renew_lease
+from .lifecycle import acquire_job, release_job, renew_lease, renew_leases_batch
 
-__all__ = ["acquire_job", "create_job_admission", "release_job", "renew_lease"]
+__all__ = [
+    "acquire_job",
+    "create_job_admission",
+    "release_job",
+    "renew_lease",
+    "renew_leases_batch",
+]

--- a/tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
+++ b/tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
@@ -252,9 +252,12 @@ def _batch_renew_transaction(conn: sqlite3.Connection) -> Iterator[None]:
     conn.execute("SAVEPOINT jobs_batch_renew_leases")
     try:
         yield
-    except BaseException:
-        conn.execute("ROLLBACK TO SAVEPOINT jobs_batch_renew_leases")
-        conn.execute("RELEASE SAVEPOINT jobs_batch_renew_leases")
+    except BaseException as primary_error:
+        try:
+            conn.execute("ROLLBACK TO SAVEPOINT jobs_batch_renew_leases")
+            conn.execute("RELEASE SAVEPOINT jobs_batch_renew_leases")
+        except BaseException as cleanup_error:
+            raise primary_error from cleanup_error
         raise
     else:
         conn.execute("RELEASE SAVEPOINT jobs_batch_renew_leases")
@@ -299,7 +302,7 @@ def renew_leases_batch(
     command: BatchRenewLeasesCommand,
     clock: Callable[[], datetime],
 ) -> BatchRenewLeasesResult:
-    """Renew an ordered SQLite lease batch in one transaction."""
+    """Renew an ordered SQLite lease batch in one atomic scope."""
 
     applied_count = 0
     with _batch_renew_transaction(conn):

--- a/tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
+++ b/tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import sqlite3
-from contextlib import nullcontext
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, nullcontext
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import Any
 
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     begin_immediate_if_needed,
@@ -239,6 +240,26 @@ def _renew_lease_statement(
     return sql, tuple(params)
 
 
+@contextmanager
+def _batch_renew_transaction(conn: sqlite3.Connection) -> Iterator[None]:
+    """Own a transaction or isolate the batch inside the caller's transaction."""
+
+    if not conn.in_transaction:
+        with conn:
+            yield
+        return
+
+    conn.execute("SAVEPOINT jobs_batch_renew_leases")
+    try:
+        yield
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT jobs_batch_renew_leases")
+        conn.execute("RELEASE SAVEPOINT jobs_batch_renew_leases")
+        raise
+    else:
+        conn.execute("RELEASE SAVEPOINT jobs_batch_renew_leases")
+
+
 def renew_lease(
     conn: sqlite3.Connection,
     *,
@@ -281,7 +302,7 @@ def renew_leases_batch(
     """Renew an ordered SQLite lease batch in one transaction."""
 
     applied_count = 0
-    with conn:
+    with _batch_renew_transaction(conn):
         for item in command.items:
             item_command = RenewLeaseCommand(
                 job_id=item.job_id,

--- a/tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
+++ b/tldw_Server_API/app/core/Jobs/operations/sqlite/lifecycle.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import sqlite3
 from contextlib import nullcontext
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Callable
 
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     begin_immediate_if_needed,
 )
 from tldw_Server_API.app.core.Jobs.operations.contracts import (
     AcquireJobCommand,
+    BatchRenewLeasesCommand,
+    BatchRenewLeasesResult,
     LifecycleResult,
     NoTransitionReason,
     ReleaseJobCommand,
@@ -215,13 +217,12 @@ def _classify_lifecycle_no_transition(
     return LifecycleResult.no_transition(NoTransitionReason.WRONG_STATUS, row=current)
 
 
-def renew_lease(
-    conn: sqlite3.Connection,
-    *,
+def _renew_lease_statement(
     command: RenewLeaseCommand,
+    *,
     now: datetime,
-) -> LifecycleResult:
-    """Renew one processing SQLite job lease without shortening it."""
+) -> tuple[str, tuple[Any, ...]]:
+    """Build the SQLite statement for one lease renewal attempt."""
 
     now_sql = _sqlite_timestamp(now)
     has_percent = command.progress_percent is not None
@@ -235,10 +236,22 @@ def renew_lease(
     params.append(command.job_id)
     if command.enforce:
         params.extend((command.worker_id, command.lease_id))
+    return sql, tuple(params)
+
+
+def renew_lease(
+    conn: sqlite3.Connection,
+    *,
+    command: RenewLeaseCommand,
+    now: datetime,
+) -> LifecycleResult:
+    """Renew one processing SQLite job lease without shortening it."""
+
+    sql, params = _renew_lease_statement(command, now=now)
 
     transaction = nullcontext(conn) if conn.in_transaction else conn
     with transaction:
-        changed = conn.execute(sql, tuple(params))
+        changed = conn.execute(sql, params)
         if changed.rowcount != 1:
             return _classify_lifecycle_no_transition(
                 conn,
@@ -257,6 +270,33 @@ def renew_lease(
         if row is None:
             return LifecycleResult.no_transition(NoTransitionReason.MISSING)
         return LifecycleResult.applied(row=dict(row))
+
+
+def renew_leases_batch(
+    conn: sqlite3.Connection,
+    *,
+    command: BatchRenewLeasesCommand,
+    clock: Callable[[], datetime],
+) -> BatchRenewLeasesResult:
+    """Renew an ordered SQLite lease batch in one transaction."""
+
+    applied_count = 0
+    with conn:
+        for item in command.items:
+            item_command = RenewLeaseCommand(
+                job_id=item.job_id,
+                seconds=item.seconds,
+                enforce=command.enforce,
+                worker_id=item.worker_id,
+                lease_id=item.lease_id,
+            )
+            sql, params = _renew_lease_statement(item_command, now=clock())
+            changed = conn.execute(sql, params)
+            applied_count += int(changed.rowcount or 0)
+        return BatchRenewLeasesResult(
+            requested_count=len(command.items),
+            applied_count=applied_count,
+        )
 
 
 def release_job(

--- a/tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py
+++ b/tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py
@@ -17,6 +17,7 @@ from hypothesis import given, settings as hyp_settings, strategies as st
 from tldw_Server_API.app.core.Jobs.operations.contracts import (
     AdmissionRejectionReason,
     AdmissionResult,
+    BatchRenewLeasesResult,
     LifecycleResult,
     NoTransitionReason,
     OperationOutcome,
@@ -229,3 +230,22 @@ class TestLifecycleResultContract:
     def test_impossible_states_raise(self, kwargs: dict) -> None:
         with pytest.raises(ValueError):
             LifecycleResult(**kwargs)
+
+
+@_COMMON
+@given(
+    requested=st.integers(min_value=-5, max_value=100),
+    applied=st.integers(min_value=-5, max_value=105),
+)
+def test_batch_renew_result_constructs_only_for_valid_count_pairs(
+    requested: int,
+    applied: int,
+) -> None:
+    valid = requested >= 0 and 0 <= applied <= requested
+    if valid:
+        result = BatchRenewLeasesResult(requested_count=requested, applied_count=applied)
+        assert result.requested_count == requested
+        assert result.applied_count == applied
+    else:
+        with pytest.raises(ValueError):
+            BatchRenewLeasesResult(requested_count=requested, applied_count=applied)

--- a/tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py
+++ b/tldw_Server_API/tests/Jobs/property/test_operation_contract_properties.py
@@ -12,7 +12,9 @@ satisfies every invariant (an independent oracle, so a dropped guard fails).
 from __future__ import annotations
 
 import pytest
-from hypothesis import given, settings as hyp_settings, strategies as st
+from hypothesis import given
+from hypothesis import settings as hyp_settings
+from hypothesis import strategies as st
 
 from tldw_Server_API.app.core.Jobs.operations.contracts import (
     AdmissionRejectionReason,
@@ -63,9 +65,7 @@ def _admission_is_consistent(
         return False
     if outcome is OperationOutcome.ADMISSION_REJECTED and admission_rejection_reason is None:
         return False
-    if outcome is not OperationOutcome.ADMISSION_REJECTED and admission_rejection_reason is not None:
-        return False
-    return True
+    return not (outcome is not OperationOutcome.ADMISSION_REJECTED and admission_rejection_reason is not None)
 
 
 def _lifecycle_is_consistent(
@@ -84,9 +84,7 @@ def _lifecycle_is_consistent(
             return False
     if outcome is OperationOutcome.NO_TRANSITION and no_transition_reason is None:
         return False
-    if outcome is not OperationOutcome.NO_TRANSITION and no_transition_reason is not None:
-        return False
-    return True
+    return not (outcome is not OperationOutcome.NO_TRANSITION and no_transition_reason is not None)
 
 
 class TestAdmissionResultContract:

--- a/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py
@@ -1,0 +1,230 @@
+"""Characterize the public PostgreSQL batch lease renewal contract."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import psycopg
+import pytest
+
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+
+pytestmark = [pytest.mark.integration, pytest.mark.pg_jobs]
+
+NOW = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+WORKER_ID = "worker-1"
+LEASE_ID = "lease-1"
+
+
+class RecordingClock:
+    def __init__(self, now: datetime) -> None:
+        self.now = now
+        self.calls = 0
+
+    def now_utc(self) -> datetime:
+        self.calls += 1
+        return self.now
+
+
+def _manager(jobs_pg_dsn: str, clock: RecordingClock, monkeypatch: pytest.MonkeyPatch) -> JobManager:
+    monkeypatch.setenv("JOBS_COUNTERS_ENABLED", "false")
+    monkeypatch.setenv("JOBS_EVENTS_OUTBOX", "false")
+    return JobManager(None, backend="postgres", db_url=jobs_pg_dsn, clock=clock)
+
+
+def _execute(manager: JobManager, sql: str, params: tuple[Any, ...] = ()) -> None:
+    connection = manager._connect()
+    try:
+        with connection, manager._pg_cursor(connection) as cursor:
+            cursor.execute(sql, params)
+    finally:
+        connection.close()
+
+
+def _insert_job(
+    manager: JobManager,
+    *,
+    status: str = "processing",
+    worker_id: str | None = WORKER_ID,
+    lease_id: str | None = LEASE_ID,
+    leased_until: datetime | None = NOW - timedelta(minutes=1),
+) -> int:
+    job = manager.create_job(
+        domain="characterization",
+        queue="default",
+        job_type="renew",
+        payload={},
+        owner_user_id="owner-1",
+    )
+    job_id = int(job["id"])
+    _execute(
+        manager,
+        "UPDATE jobs SET status = %s, worker_id = %s, lease_id = %s, leased_until = %s WHERE id = %s",
+        (status, worker_id, lease_id, leased_until, job_id),
+    )
+    return job_id
+
+
+def _fetch_lease(manager: JobManager, job_id: int) -> datetime | None:
+    connection = manager._connect()
+    try:
+        with connection, manager._pg_cursor(connection) as cursor:
+            cursor.execute("SELECT leased_until FROM jobs WHERE id = %s", (job_id,))
+            row = cursor.fetchone()
+    finally:
+        connection.close()
+    assert row is not None
+    return row["leased_until"]
+
+
+def test_batch_renew_counts_ordered_attempts_and_preserves_longer_lease_postgres(
+    jobs_pg_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = RecordingClock(NOW)
+    manager = _manager(jobs_pg_dsn, clock, monkeypatch)
+    valid_id = _insert_job(manager, status="processing", worker_id="worker-1", lease_id="lease-1")
+    queued_id = _insert_job(manager, status="queued", worker_id=None, lease_id=None, leased_until=None)
+    stale_id = _insert_job(manager, status="processing", worker_id="worker-1", lease_id="lease-1")
+    long_id = _insert_job(
+        manager,
+        status="processing",
+        worker_id="worker-1",
+        lease_id="lease-1",
+        leased_until=NOW + timedelta(minutes=10),
+    )
+
+    items = [
+        {"job_id": valid_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+        {"job_id": 999_999, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+        {"job_id": queued_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+        {"job_id": stale_id, "seconds": 30, "worker_id": "worker-2", "lease_id": "lease-1"},
+        {"job_id": valid_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+        {"job_id": long_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+    ]
+
+    assert manager.batch_renew_leases(items, enforce=True) == 3
+    assert _fetch_lease(manager, valid_id) == NOW + timedelta(seconds=30)
+    assert _fetch_lease(manager, queued_id) is None
+    assert _fetch_lease(manager, stale_id) == NOW - timedelta(minutes=1)
+    assert _fetch_lease(manager, long_id) == NOW + timedelta(minutes=10)
+
+
+def test_batch_renew_clamps_each_item_and_reads_the_clock_once_postgres(
+    jobs_pg_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JOBS_LEASE_MAX_SECONDS", "60")
+    clock = RecordingClock(NOW)
+    manager = _manager(jobs_pg_dsn, clock, monkeypatch)
+    one_second_id = _insert_job(manager)
+    thirty_second_id = _insert_job(manager)
+    sixty_second_id = _insert_job(manager)
+    clock.calls = 0
+
+    assert manager.batch_renew_leases(
+        [
+            {"job_id": one_second_id, "seconds": 0, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+            {"job_id": thirty_second_id, "seconds": 30, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+            {"job_id": sixty_second_id, "seconds": 120, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+        ],
+        enforce=True,
+    ) == 3
+    assert _fetch_lease(manager, one_second_id) == NOW + timedelta(seconds=1)
+    assert _fetch_lease(manager, thirty_second_id) == NOW + timedelta(seconds=30)
+    assert _fetch_lease(manager, sixty_second_id) == NOW + timedelta(seconds=60)
+    assert clock.calls == 1
+
+
+def test_batch_renew_empty_batch_reads_the_clock_without_lease_cap_lookup_postgres(
+    jobs_pg_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_getenv = os.getenv
+
+    def guarded_getenv(key: str, default: Any = None) -> Any:
+        if key == "JOBS_LEASE_MAX_SECONDS":
+            raise AssertionError("empty batch must not read the lease cap")
+        return original_getenv(key, default)
+
+    monkeypatch.setattr(os, "getenv", guarded_getenv)
+    clock = RecordingClock(NOW)
+    manager = _manager(jobs_pg_dsn, clock, monkeypatch)
+
+    assert manager.batch_renew_leases([], enforce=True) == 0
+    assert clock.calls == 1
+
+
+def test_batch_renew_rolls_back_prior_update_when_a_later_item_is_malformed_postgres(
+    jobs_pg_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = RecordingClock(NOW)
+    manager = _manager(jobs_pg_dsn, clock, monkeypatch)
+    first_job_id = _insert_job(manager)
+    second_job_id = _insert_job(manager)
+    original_first_lease = _fetch_lease(manager, first_job_id)
+    original_second_lease = _fetch_lease(manager, second_job_id)
+
+    with pytest.raises(ValueError):
+        manager.batch_renew_leases(
+            [
+                {"job_id": first_job_id, "seconds": 30, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+                {"job_id": "not-an-int", "seconds": 30},
+            ],
+            enforce=True,
+        )
+
+    assert _fetch_lease(manager, first_job_id) == original_first_lease
+    assert _fetch_lease(manager, second_job_id) == original_second_lease
+
+
+def test_batch_renew_rolls_back_every_update_on_database_failure_postgres(
+    jobs_pg_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = RecordingClock(NOW)
+    manager = _manager(jobs_pg_dsn, clock, monkeypatch)
+    first_job_id = _insert_job(manager)
+    second_job_id = _insert_job(manager)
+    original_first_lease = _fetch_lease(manager, first_job_id)
+    original_second_lease = _fetch_lease(manager, second_job_id)
+    function_name = f"force_batch_renew_function_{uuid.uuid4().hex}"
+    trigger_name = f"force_batch_renew_trigger_{uuid.uuid4().hex}"
+    connection = manager._connect()
+    try:
+        with connection, manager._pg_cursor(connection) as cursor:
+            cursor.execute(
+                f'CREATE FUNCTION "{function_name}"() RETURNS trigger LANGUAGE plpgsql AS $$ '
+                "BEGIN RAISE EXCEPTION 'forced batch renewal failure'; END; $$"
+            )
+            cursor.execute(
+                f'CREATE TRIGGER "{trigger_name}" BEFORE UPDATE ON jobs '
+                f'FOR EACH ROW WHEN (OLD.id = {int(second_job_id)}) '
+                f'EXECUTE FUNCTION "{function_name}"()'
+            )
+    finally:
+        connection.close()
+
+    try:
+        with pytest.raises(psycopg.Error, match="forced batch renewal failure"):
+            manager.batch_renew_leases(
+                [
+                    {"job_id": first_job_id, "seconds": 30, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+                    {"job_id": second_job_id, "seconds": 30, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+                ],
+                enforce=True,
+            )
+        assert _fetch_lease(manager, first_job_id) == original_first_lease
+        assert _fetch_lease(manager, second_job_id) == original_second_lease
+    finally:
+        cleanup_connection = manager._connect()
+        try:
+            with cleanup_connection, manager._pg_cursor(cleanup_connection) as cursor:
+                cursor.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}" ON jobs')
+                cursor.execute(f'DROP FUNCTION IF EXISTS "{function_name}"()')
+        finally:
+            cleanup_connection.close()

--- a/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_postgres.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import psycopg
 import pytest
+from psycopg import sql as psycopg_sql
 
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 
@@ -198,13 +199,20 @@ def test_batch_renew_rolls_back_every_update_on_database_failure_postgres(
     try:
         with connection, manager._pg_cursor(connection) as cursor:
             cursor.execute(
-                f'CREATE FUNCTION "{function_name}"() RETURNS trigger LANGUAGE plpgsql AS $$ '
-                "BEGIN RAISE EXCEPTION 'forced batch renewal failure'; END; $$"
+                psycopg_sql.SQL(
+                    "CREATE FUNCTION {}() RETURNS trigger LANGUAGE plpgsql AS $$ "
+                    "BEGIN RAISE EXCEPTION 'forced batch renewal failure'; END; $$"
+                ).format(psycopg_sql.Identifier(function_name))
             )
             cursor.execute(
-                f'CREATE TRIGGER "{trigger_name}" BEFORE UPDATE ON jobs '
-                f'FOR EACH ROW WHEN (OLD.id = {int(second_job_id)}) '
-                f'EXECUTE FUNCTION "{function_name}"()'
+                psycopg_sql.SQL(
+                    "CREATE TRIGGER {} BEFORE UPDATE ON jobs "
+                    "FOR EACH ROW WHEN (OLD.id = {}) EXECUTE FUNCTION {}()"
+                ).format(
+                    psycopg_sql.Identifier(trigger_name),
+                    psycopg_sql.Literal(second_job_id),
+                    psycopg_sql.Identifier(function_name),
+                )
             )
     finally:
         connection.close()
@@ -224,7 +232,15 @@ def test_batch_renew_rolls_back_every_update_on_database_failure_postgres(
         cleanup_connection = manager._connect()
         try:
             with cleanup_connection, manager._pg_cursor(cleanup_connection) as cursor:
-                cursor.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}" ON jobs')
-                cursor.execute(f'DROP FUNCTION IF EXISTS "{function_name}"()')
+                cursor.execute(
+                    psycopg_sql.SQL("DROP TRIGGER IF EXISTS {} ON jobs").format(
+                        psycopg_sql.Identifier(trigger_name)
+                    )
+                )
+                cursor.execute(
+                    psycopg_sql.SQL("DROP FUNCTION IF EXISTS {}()").format(
+                        psycopg_sql.Identifier(function_name)
+                    )
+                )
         finally:
             cleanup_connection.close()

--- a/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py
@@ -186,14 +186,14 @@ def test_batch_renew_rolls_back_every_update_on_database_failure_sqlite(db_path:
     clock = RecordingClock(NOW)
     manager = _manager(db_path, clock)
     first_job_id = _insert_job(db_path)
-    second_job_id = _insert_job(db_path)
+    second_job_id = _insert_job(db_path, worker_id="worker-2")
     original_first_lease = _fetch_lease(db_path, first_job_id)
     original_second_lease = _fetch_lease(db_path, second_job_id)
     connection = sqlite3.connect(db_path)
     try:
         connection.execute(
             "CREATE TRIGGER force_batch_renew_failure BEFORE UPDATE ON jobs "
-            f"WHEN OLD.id = {second_job_id} "
+            "WHEN OLD.worker_id = 'worker-2' "
             "BEGIN SELECT RAISE(ABORT, 'forced batch renewal failure'); END"
         )
         connection.commit()
@@ -204,7 +204,7 @@ def test_batch_renew_rolls_back_every_update_on_database_failure_sqlite(db_path:
         manager.batch_renew_leases(
             [
                 {"job_id": first_job_id, "seconds": 30, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
-                {"job_id": second_job_id, "seconds": 30, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+                {"job_id": second_job_id, "seconds": 30, "worker_id": "worker-2", "lease_id": LEASE_ID},
             ],
             enforce=True,
         )

--- a/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_characterization_sqlite.py
@@ -1,0 +1,213 @@
+"""Characterize the public SQLite batch lease renewal contract."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
+
+pytestmark = pytest.mark.integration
+
+NOW = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+WORKER_ID = "worker-1"
+LEASE_ID = "lease-1"
+
+
+class RecordingClock:
+    def __init__(self, now: datetime) -> None:
+        self.now = now
+        self.calls = 0
+
+    def now_utc(self) -> datetime:
+        self.calls += 1
+        return self.now
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "jobs.db"
+    ensure_jobs_tables(path)
+    return path
+
+
+def _format_sqlite_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _insert_job(
+    db_path: Path,
+    *,
+    status: str = "processing",
+    worker_id: str | None = WORKER_ID,
+    lease_id: str | None = LEASE_ID,
+    leased_until: datetime | None = NOW - timedelta(minutes=1),
+) -> int:
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    try:
+        with connection:
+            row_count = connection.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
+            cursor = connection.execute(
+                "INSERT INTO jobs (uuid, domain, queue, job_type, payload, status, "
+                "worker_id, lease_id, leased_until) "
+                "VALUES (?, 'characterization', 'default', 'renew', '{}', ?, ?, ?, ?)",
+                (
+                    f"characterization-{row_count + 1}",
+                    status,
+                    worker_id,
+                    lease_id,
+                    _format_sqlite_datetime(leased_until) if leased_until else None,
+                ),
+            )
+            return int(cursor.lastrowid)
+    finally:
+        connection.close()
+
+
+def _fetch_lease(db_path: Path, job_id: int) -> str | None:
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    try:
+        row = connection.execute(
+            "SELECT leased_until FROM jobs WHERE id = ?", (job_id,)
+        ).fetchone()
+    finally:
+        connection.close()
+    assert row is not None
+    return row["leased_until"]
+
+
+def _manager(db_path: Path, clock: RecordingClock) -> JobManager:
+    return JobManager(db_path, clock=clock)
+
+
+def test_batch_renew_counts_ordered_attempts_and_preserves_longer_lease_sqlite(db_path: Path) -> None:
+    clock = RecordingClock(NOW)
+    manager = _manager(db_path, clock)
+    valid_id = _insert_job(db_path, status="processing", worker_id="worker-1", lease_id="lease-1")
+    queued_id = _insert_job(db_path, status="queued", worker_id=None, lease_id=None, leased_until=None)
+    stale_id = _insert_job(db_path, status="processing", worker_id="worker-1", lease_id="lease-1")
+    long_id = _insert_job(
+        db_path,
+        status="processing",
+        worker_id="worker-1",
+        lease_id="lease-1",
+        leased_until=NOW + timedelta(minutes=10),
+    )
+
+    items = [
+        {"job_id": valid_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+        {"job_id": 999_999, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+        {"job_id": queued_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+        {"job_id": stale_id, "seconds": 30, "worker_id": "worker-2", "lease_id": "lease-1"},
+        {"job_id": valid_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+        {"job_id": long_id, "seconds": 30, "worker_id": "worker-1", "lease_id": "lease-1"},
+    ]
+
+    assert manager.batch_renew_leases(items, enforce=True) == 3
+    assert _fetch_lease(db_path, valid_id) == _format_sqlite_datetime(NOW + timedelta(seconds=30))
+    assert _fetch_lease(db_path, queued_id) is None
+    assert _fetch_lease(db_path, stale_id) == _format_sqlite_datetime(NOW - timedelta(minutes=1))
+    assert _fetch_lease(db_path, long_id) == _format_sqlite_datetime(NOW + timedelta(minutes=10))
+
+
+def test_batch_renew_clamps_each_item_and_reads_the_clock_per_item_sqlite(
+    monkeypatch: pytest.MonkeyPatch,
+    db_path: Path,
+) -> None:
+    monkeypatch.setenv("JOBS_LEASE_MAX_SECONDS", "60")
+    clock = RecordingClock(NOW)
+    manager = _manager(db_path, clock)
+    one_second_id = _insert_job(db_path)
+    thirty_second_id = _insert_job(db_path)
+    sixty_second_id = _insert_job(db_path)
+
+    assert manager.batch_renew_leases(
+        [
+            {"job_id": one_second_id, "seconds": 0, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+            {"job_id": thirty_second_id, "seconds": 30, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+            {"job_id": sixty_second_id, "seconds": 120, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+        ],
+        enforce=True,
+    ) == 3
+    assert _fetch_lease(db_path, one_second_id) == _format_sqlite_datetime(NOW + timedelta(seconds=1))
+    assert _fetch_lease(db_path, thirty_second_id) == _format_sqlite_datetime(NOW + timedelta(seconds=30))
+    assert _fetch_lease(db_path, sixty_second_id) == _format_sqlite_datetime(NOW + timedelta(seconds=60))
+    assert clock.calls == 3
+
+
+def test_batch_renew_empty_batch_skips_clock_and_lease_cap_lookup_sqlite(
+    monkeypatch: pytest.MonkeyPatch,
+    db_path: Path,
+) -> None:
+    original_getenv = os.getenv
+
+    def guarded_getenv(key: str, default: Any = None) -> Any:
+        if key == "JOBS_LEASE_MAX_SECONDS":
+            raise AssertionError("empty batch must not read the lease cap")
+        return original_getenv(key, default)
+
+    monkeypatch.setattr(os, "getenv", guarded_getenv)
+    clock = RecordingClock(NOW)
+
+    assert _manager(db_path, clock).batch_renew_leases([], enforce=True) == 0
+    assert clock.calls == 0
+
+
+def test_batch_renew_rolls_back_prior_update_when_a_later_item_is_malformed_sqlite(db_path: Path) -> None:
+    clock = RecordingClock(NOW)
+    manager = _manager(db_path, clock)
+    first_job_id = _insert_job(db_path)
+    second_job_id = _insert_job(db_path)
+    original_first_lease = _fetch_lease(db_path, first_job_id)
+    original_second_lease = _fetch_lease(db_path, second_job_id)
+
+    with pytest.raises(ValueError):
+        manager.batch_renew_leases(
+            [
+                {"job_id": first_job_id, "seconds": 30, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+                {"job_id": "not-an-int", "seconds": 30},
+            ],
+            enforce=True,
+        )
+
+    assert _fetch_lease(db_path, first_job_id) == original_first_lease
+    assert _fetch_lease(db_path, second_job_id) == original_second_lease
+
+
+def test_batch_renew_rolls_back_every_update_on_database_failure_sqlite(db_path: Path) -> None:
+    clock = RecordingClock(NOW)
+    manager = _manager(db_path, clock)
+    first_job_id = _insert_job(db_path)
+    second_job_id = _insert_job(db_path)
+    original_first_lease = _fetch_lease(db_path, first_job_id)
+    original_second_lease = _fetch_lease(db_path, second_job_id)
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            "CREATE TRIGGER force_batch_renew_failure BEFORE UPDATE ON jobs "
+            f"WHEN OLD.id = {second_job_id} "
+            "BEGIN SELECT RAISE(ABORT, 'forced batch renewal failure'); END"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(sqlite3.IntegrityError, match="forced batch renewal failure"):
+        manager.batch_renew_leases(
+            [
+                {"job_id": first_job_id, "seconds": 30, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+                {"job_id": second_job_id, "seconds": 30, "worker_id": WORKER_ID, "lease_id": LEASE_ID},
+            ],
+            enforce=True,
+        )
+
+    assert _fetch_lease(db_path, first_job_id) == original_first_lease
+    assert _fetch_lease(db_path, second_job_id) == original_second_lease

--- a/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py
@@ -35,6 +35,17 @@ class FixedClock:
         return NOW
 
 
+class ExplodingClock:
+    """Record an unexpected clock read before backend dispatch."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def now_utc(self) -> datetime:
+        self.calls += 1
+        raise RuntimeError("clock must not run")
+
+
 def _minimal_manager(backend: str) -> tuple[JobManager, FakeConnection]:
     manager = object.__new__(JobManager)
     connection = FakeConnection()
@@ -127,20 +138,35 @@ def test_batch_renew_opens_connection_before_normalizing_invalid_input(
         )
 
 
-def test_batch_renew_normalizes_every_item_before_backend_dispatch(
+@pytest.mark.parametrize(
+    ("backend", "backend_name"),
+    [("sqlite", "_sqlite_renew_leases_batch"), ("postgres", "_postgres_renew_leases_batch")],
+)
+def test_batch_renew_normalizes_before_clock_cursor_or_backend_dispatch(
     monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+    backend_name: str,
 ) -> None:
-    """A later malformed item prevents all backend work and closes the connection."""
+    """A later malformed item wins before clock, cursor, or backend work."""
 
-    manager, connection = _minimal_manager("sqlite")
+    manager, connection = _minimal_manager(backend)
+    clock = ExplodingClock()
+    manager._clock = clock
     called = False
+    cursor_calls = 0
 
-    def backend(*args: Any, **kwargs: Any) -> BatchRenewLeasesResult:
+    def backend_operation(*args: Any, **kwargs: Any) -> BatchRenewLeasesResult:
         nonlocal called
         called = True
         raise AssertionError("backend must not run")
 
-    monkeypatch.setattr(manager_module, "_sqlite_renew_leases_batch", backend, raising=False)
+    def cursor(*args: Any, **kwargs: Any) -> Any:
+        nonlocal cursor_calls
+        cursor_calls += 1
+        raise AssertionError("cursor must not open")
+
+    manager._pg_cursor = cursor
+    monkeypatch.setattr(manager_module, backend_name, backend_operation, raising=False)
 
     with pytest.raises(ValueError):
         manager.batch_renew_leases(
@@ -152,6 +178,8 @@ def test_batch_renew_normalizes_every_item_before_backend_dispatch(
         )
 
     assert called is False
+    assert clock.calls == 0
+    assert cursor_calls == 0
     assert connection.closed is True
 
 

--- a/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_batch_renew_routing.py
@@ -1,0 +1,176 @@
+"""Routing tests for JobManager batch lease renewal."""
+
+from __future__ import annotations
+
+import os
+from contextlib import nullcontext
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+import tldw_Server_API.app.core.Jobs.manager as manager_module
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Jobs.operations.contracts import BatchRenewLeasesResult
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+
+
+class FakeConnection:
+    """Record connection closure without providing transaction internals."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FixedClock:
+    """Supply a deterministic clock callable to backend operations."""
+
+    def now_utc(self) -> datetime:
+        return NOW
+
+
+def _minimal_manager(backend: str) -> tuple[JobManager, FakeConnection]:
+    manager = object.__new__(JobManager)
+    connection = FakeConnection()
+    manager.backend = backend
+    manager._clock = FixedClock()
+    manager._connect = lambda: connection
+    manager._pg_cursor = lambda conn: nullcontext(conn)
+    manager._should_enforce_ack = lambda: True
+    return manager, connection
+
+
+@pytest.mark.parametrize(
+    ("backend", "backend_name"),
+    [("sqlite", "_sqlite_renew_leases_batch"), ("postgres", "_postgres_renew_leases_batch")],
+)
+def test_batch_renew_routes_normalized_ordered_items_to_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+    backend_name: str,
+) -> None:
+    """A facade call dispatches one immutable normalized command to its backend."""
+
+    manager, connection = _minimal_manager(backend)
+    dispatched: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    lease_max_reads = 0
+    enforcement_resolutions = 0
+    real_getenv = os.getenv
+
+    def backend_operation(*args: Any, **kwargs: Any) -> BatchRenewLeasesResult:
+        dispatched.append((args, kwargs))
+        return BatchRenewLeasesResult(requested_count=3, applied_count=2)
+
+    def getenv(name: str, default: str | None = None) -> str | None:
+        nonlocal lease_max_reads
+        if name == "JOBS_LEASE_MAX_SECONDS":
+            lease_max_reads += 1
+            return "60"
+        return real_getenv(name, default)
+
+    def should_enforce_ack() -> bool:
+        nonlocal enforcement_resolutions
+        enforcement_resolutions += 1
+        return True
+
+    monkeypatch.setattr(manager_module, backend_name, backend_operation, raising=False)
+    monkeypatch.setattr(manager_module.os, "getenv", getenv)
+    monkeypatch.setattr(manager, "_should_enforce_ack", should_enforce_ack)
+
+    applied_count = manager.batch_renew_leases(
+        [
+            {"job_id": 3, "seconds": 0, "worker_id": "worker-a", "lease_id": "lease-a"},
+            {"job_id": 2, "seconds": 30, "worker_id": "worker-b", "lease_id": "lease-b"},
+            {"job_id": 1, "seconds": 120, "worker_id": "worker-c", "lease_id": "lease-c"},
+        ]
+    )
+
+    assert applied_count == 2
+    assert len(dispatched) == 1
+    args, kwargs = dispatched[0]
+    expected_args = (connection, manager._pg_cursor) if backend == "postgres" else (connection,)
+    assert args == expected_args
+    command = kwargs["command"]
+    assert tuple(item.job_id for item in command.items) == (3, 2, 1)
+    assert tuple(item.seconds for item in command.items) == (1, 30, 60)
+    assert tuple(item.worker_id for item in command.items) == ("worker-a", "worker-b", "worker-c")
+    assert tuple(item.lease_id for item in command.items) == ("lease-a", "lease-b", "lease-c")
+    assert command.enforce is True
+    assert kwargs["clock"] == manager._clock.now_utc
+    assert lease_max_reads == 3
+    assert enforcement_resolutions == 1
+    assert connection.closed is True
+
+
+def test_batch_renew_opens_connection_before_normalizing_invalid_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Connection failures win over malformed batch items."""
+
+    manager, _ = _minimal_manager("sqlite")
+    monkeypatch.setattr(
+        manager,
+        "_connect",
+        lambda: (_ for _ in ()).throw(ConnectionError("offline")),
+    )
+
+    with pytest.raises(ConnectionError, match="offline"):
+        manager.batch_renew_leases(
+            [{"job_id": "invalid", "seconds": 30}],
+            enforce=False,
+        )
+
+
+def test_batch_renew_normalizes_every_item_before_backend_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later malformed item prevents all backend work and closes the connection."""
+
+    manager, connection = _minimal_manager("sqlite")
+    called = False
+
+    def backend(*args: Any, **kwargs: Any) -> BatchRenewLeasesResult:
+        nonlocal called
+        called = True
+        raise AssertionError("backend must not run")
+
+    monkeypatch.setattr(manager_module, "_sqlite_renew_leases_batch", backend, raising=False)
+
+    with pytest.raises(ValueError):
+        manager.batch_renew_leases(
+            [
+                {"job_id": 1, "seconds": 30},
+                {"job_id": "invalid", "seconds": 30},
+            ],
+            enforce=False,
+        )
+
+    assert called is False
+    assert connection.closed is True
+
+
+def test_batch_renew_routes_empty_command_to_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty batch still reaches the backend transaction boundary."""
+
+    manager, connection = _minimal_manager("sqlite")
+    dispatched: list[dict[str, Any]] = []
+
+    def backend(*args: Any, **kwargs: Any) -> BatchRenewLeasesResult:
+        dispatched.append(kwargs)
+        return BatchRenewLeasesResult(requested_count=0, applied_count=0)
+
+    monkeypatch.setattr(manager_module, "_sqlite_renew_leases_batch", backend, raising=False)
+
+    assert manager.batch_renew_leases([], enforce=False) == 0
+    assert len(dispatched) == 1
+    assert dispatched[0]["command"].items == ()
+    assert dispatched[0]["command"].enforce is False
+    assert connection.closed is True

--- a/tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_operation_contracts.py
@@ -10,10 +10,14 @@ from pathlib import Path
 
 import pytest
 
+from tldw_Server_API.app.core.Jobs.operations import contracts
 from tldw_Server_API.app.core.Jobs.operations.contracts import (
     AcquireJobCommand,
     AdmissionRejectionReason,
     AdmissionResult,
+    BatchRenewLeaseItem,
+    BatchRenewLeasesCommand,
+    BatchRenewLeasesResult,
     CreateJobCommand,
     LifecycleResult,
     NoTransitionReason,
@@ -332,6 +336,55 @@ def test_release_job_command_is_frozen() -> None:
 
     with pytest.raises(FrozenInstanceError):
         command.reason = "other"
+
+
+def test_batch_renew_command_snapshots_items_and_is_frozen() -> None:
+    source = [BatchRenewLeaseItem(job_id=1, seconds=30)]
+    command = BatchRenewLeasesCommand(items=source, enforce=True)  # type: ignore[arg-type]
+    source.append(BatchRenewLeaseItem(job_id=2, seconds=45))
+
+    assert command.items == (BatchRenewLeaseItem(job_id=1, seconds=30),)
+    with pytest.raises(FrozenInstanceError):
+        command.enforce = False
+
+
+def test_batch_renew_item_is_frozen_and_preserves_order() -> None:
+    first = BatchRenewLeaseItem(job_id=1, seconds=30)
+    second = BatchRenewLeaseItem(job_id=2, seconds=45)
+    command = BatchRenewLeasesCommand(items=(first, second), enforce=False)
+
+    assert first.worker_id is None
+    assert command.items == (first, second)
+    with pytest.raises(FrozenInstanceError):
+        first.seconds = 60
+
+
+@pytest.mark.parametrize("seconds", [0, -1])
+def test_batch_renew_item_rejects_non_positive_normalized_duration(seconds: int) -> None:
+    with pytest.raises(ValueError, match="seconds must be positive"):
+        BatchRenewLeaseItem(job_id=1, seconds=seconds)
+
+
+@pytest.mark.parametrize(
+    ("requested", "applied"),
+    [(-1, 0), (0, -1), (1, 2)],
+)
+def test_batch_renew_result_rejects_invalid_counts(requested: int, applied: int) -> None:
+    with pytest.raises(ValueError):
+        BatchRenewLeasesResult(requested_count=requested, applied_count=applied)
+
+
+def test_batch_renew_result_accepts_zero_and_complete_counts() -> None:
+    assert BatchRenewLeasesResult(3, 0).applied_count == 0
+    assert BatchRenewLeasesResult(3, 3).applied_count == 3
+
+
+def test_batch_renew_contracts_are_exported() -> None:
+    assert {
+        "BatchRenewLeaseItem",
+        "BatchRenewLeasesCommand",
+        "BatchRenewLeasesResult",
+    }.issubset(contracts.__all__)
 
 
 def test_lifecycle_result_supports_no_eligible_job_reason() -> None:

--- a/tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Iterator
+import uuid
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -12,11 +13,15 @@ import pytest
 
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Jobs.operations.contracts import (
+    BatchRenewLeaseItem,
+    BatchRenewLeasesCommand,
+    BatchRenewLeasesResult,
     NoTransitionReason,
     OperationOutcome,
     ReleaseJobCommand,
     RenewLeaseCommand,
 )
+from tldw_Server_API.app.core.Jobs.operations.postgres import renew_leases_batch
 from tldw_Server_API.app.core.Jobs.operations.postgres.lifecycle import (
     release_job,
     renew_lease,
@@ -169,6 +174,183 @@ def _release_command(
         lease_id=lease_id,
         reason="yield",
     )
+
+
+class RecordingClock:
+    def __init__(self, now: datetime) -> None:
+        self.now = now
+        self.calls = 0
+
+    def __call__(self) -> datetime:
+        self.calls += 1
+        return self.now
+
+
+def _run_batch_renew_cleanup(
+    cleanup: Callable[[], None],
+    *,
+    primary_error: BaseException | None,
+) -> None:
+    """Run trigger cleanup without obscuring an earlier test-body failure."""
+
+    try:
+        cleanup()
+    except BaseException as cleanup_error:
+        if primary_error is None:
+            raise
+        primary_error.__cause__ = cleanup_error
+
+
+def test_batch_renew_cleanup_preserves_primary_error_and_chains_cleanup_failure() -> None:
+    primary_error = AssertionError("expected lease rollback")
+
+    def fail_cleanup() -> None:
+        raise RuntimeError("forced cleanup failure")
+
+    def fail_test_body() -> None:
+        try:
+            raise primary_error
+        except BaseException as error:
+            _run_batch_renew_cleanup(fail_cleanup, primary_error=error)
+            raise
+
+    with pytest.raises(AssertionError, match="expected lease rollback") as exc_info:
+        fail_test_body()
+
+    assert exc_info.value is primary_error
+    assert isinstance(primary_error.__cause__, RuntimeError)
+    assert str(primary_error.__cause__) == "forced cleanup failure"
+
+
+def test_batch_renew_cleanup_raises_failure_without_primary_error() -> None:
+    def fail_cleanup() -> None:
+        raise RuntimeError("forced cleanup failure")
+
+    with pytest.raises(RuntimeError, match="forced cleanup failure"):
+        _run_batch_renew_cleanup(fail_cleanup, primary_error=None)
+
+
+def test_postgres_batch_renew_counts_ordered_attempts_and_preserves_longer_lease(
+    manager: JobManager,
+    conn: Any,
+) -> None:
+    valid_id = _insert_job(manager)
+    queued_id = _insert_job(manager, status="queued", worker_id=None, lease_id=None)
+    stale_id = _insert_job(manager)
+    long_expiry = NOW + timedelta(hours=1)
+    long_id = _insert_job(manager, leased_until=long_expiry)
+    command = BatchRenewLeasesCommand(
+        items=(
+            BatchRenewLeaseItem(valid_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(999_999, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(queued_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(stale_id, 30, "worker-2", "lease-1"),
+            BatchRenewLeaseItem(valid_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(long_id, 30, "worker-1", "lease-1"),
+        ),
+        enforce=True,
+    )
+    clock = RecordingClock(NOW)
+
+    result = renew_leases_batch(
+        conn,
+        manager._pg_cursor,
+        command=command,
+        clock=clock,
+    )
+
+    assert result == BatchRenewLeasesResult(requested_count=6, applied_count=3)
+    assert clock.calls == 1
+    assert _fetch_job(manager, valid_id)["leased_until"] == NOW + timedelta(seconds=30)
+    assert _fetch_job(manager, queued_id)["leased_until"] == NOW - timedelta(minutes=15)
+    assert _fetch_job(manager, stale_id)["leased_until"] == NOW - timedelta(minutes=15)
+    assert _fetch_job(manager, long_id)["leased_until"] == long_expiry
+
+
+def test_postgres_batch_renew_empty_command_reads_clock_and_enters_cursor_once(
+    manager: JobManager,
+    conn: Any,
+) -> None:
+    cursor_entries = 0
+    clock = RecordingClock(NOW)
+
+    @contextmanager
+    def tracking_cursor_factory(connection: Any) -> Iterator[Any]:
+        nonlocal cursor_entries
+        cursor_entries += 1
+        with manager._pg_cursor(connection) as cur:
+            yield cur
+
+    result = renew_leases_batch(
+        conn,
+        tracking_cursor_factory,
+        command=BatchRenewLeasesCommand(items=(), enforce=False),
+        clock=clock,
+    )
+
+    assert result == BatchRenewLeasesResult(requested_count=0, applied_count=0)
+    assert clock.calls == 1
+    assert cursor_entries == 1
+
+
+def test_postgres_batch_renew_rolls_back_when_later_update_trigger_fails(
+    manager: JobManager,
+    conn: Any,
+) -> None:
+    first_job_id = _insert_job(manager)
+    second_job_id = _insert_job(manager)
+    original_first_lease = _fetch_job(manager, first_job_id)["leased_until"]
+    original_second_lease = _fetch_job(manager, second_job_id)["leased_until"]
+    function_name = f"force_direct_batch_renew_function_{uuid.uuid4().hex}"
+    trigger_name = f"force_direct_batch_renew_trigger_{uuid.uuid4().hex}"
+    setup_connection = manager._connect()
+    try:
+        with setup_connection, manager._pg_cursor(setup_connection) as cur:
+            cur.execute(
+                f'CREATE FUNCTION "{function_name}"() RETURNS trigger LANGUAGE plpgsql AS $$ '
+                "BEGIN RAISE EXCEPTION 'forced direct batch renewal failure'; END; $$"
+            )
+            cur.execute(
+                f'CREATE TRIGGER "{trigger_name}" BEFORE UPDATE ON jobs '
+                f'FOR EACH ROW WHEN (OLD.id = {int(second_job_id)}) '
+                f'EXECUTE FUNCTION "{function_name}"()'
+            )
+    finally:
+        setup_connection.close()
+
+    command = BatchRenewLeasesCommand(
+        items=(
+            BatchRenewLeaseItem(first_job_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(second_job_id, 30, "worker-1", "lease-1"),
+        ),
+        enforce=True,
+    )
+    primary_error: BaseException | None = None
+
+    def cleanup_trigger() -> None:
+        cleanup_connection = manager._connect()
+        try:
+            with cleanup_connection, manager._pg_cursor(cleanup_connection) as cur:
+                cur.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}" ON jobs')
+                cur.execute(f'DROP FUNCTION IF EXISTS "{function_name}"()')
+        finally:
+            cleanup_connection.close()
+
+    try:
+        with pytest.raises(psycopg.Error, match="forced direct batch renewal failure"):
+            renew_leases_batch(
+                conn,
+                manager._pg_cursor,
+                command=command,
+                clock=RecordingClock(NOW),
+            )
+        assert _fetch_job(manager, first_job_id)["leased_until"] == original_first_lease
+        assert _fetch_job(manager, second_job_id)["leased_until"] == original_second_lease
+    except BaseException as error:
+        primary_error = error
+        raise
+    finally:
+        _run_batch_renew_cleanup(cleanup_trigger, primary_error=primary_error)
 
 
 @pytest.mark.parametrize(

--- a/tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_postgres.py
@@ -28,6 +28,7 @@ from tldw_Server_API.app.core.Jobs.operations.postgres.lifecycle import (
 )
 
 psycopg = pytest.importorskip("psycopg")
+psycopg_sql = pytest.importorskip("psycopg.sql")
 pytestmark = [pytest.mark.integration, pytest.mark.pg_jobs]
 
 NOW = datetime(2026, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
@@ -307,13 +308,20 @@ def test_postgres_batch_renew_rolls_back_when_later_update_trigger_fails(
     try:
         with setup_connection, manager._pg_cursor(setup_connection) as cur:
             cur.execute(
-                f'CREATE FUNCTION "{function_name}"() RETURNS trigger LANGUAGE plpgsql AS $$ '
-                "BEGIN RAISE EXCEPTION 'forced direct batch renewal failure'; END; $$"
+                psycopg_sql.SQL(
+                    "CREATE FUNCTION {}() RETURNS trigger LANGUAGE plpgsql AS $$ "
+                    "BEGIN RAISE EXCEPTION 'forced direct batch renewal failure'; END; $$"
+                ).format(psycopg_sql.Identifier(function_name))
             )
             cur.execute(
-                f'CREATE TRIGGER "{trigger_name}" BEFORE UPDATE ON jobs '
-                f'FOR EACH ROW WHEN (OLD.id = {int(second_job_id)}) '
-                f'EXECUTE FUNCTION "{function_name}"()'
+                psycopg_sql.SQL(
+                    "CREATE TRIGGER {} BEFORE UPDATE ON jobs "
+                    "FOR EACH ROW WHEN (OLD.id = {}) EXECUTE FUNCTION {}()"
+                ).format(
+                    psycopg_sql.Identifier(trigger_name),
+                    psycopg_sql.Literal(second_job_id),
+                    psycopg_sql.Identifier(function_name),
+                )
             )
     finally:
         setup_connection.close()
@@ -331,8 +339,16 @@ def test_postgres_batch_renew_rolls_back_when_later_update_trigger_fails(
         cleanup_connection = manager._connect()
         try:
             with cleanup_connection, manager._pg_cursor(cleanup_connection) as cur:
-                cur.execute(f'DROP TRIGGER IF EXISTS "{trigger_name}" ON jobs')
-                cur.execute(f'DROP FUNCTION IF EXISTS "{function_name}"()')
+                cur.execute(
+                    psycopg_sql.SQL("DROP TRIGGER IF EXISTS {} ON jobs").format(
+                        psycopg_sql.Identifier(trigger_name)
+                    )
+                )
+                cur.execute(
+                    psycopg_sql.SQL("DROP FUNCTION IF EXISTS {}()").format(
+                        psycopg_sql.Identifier(function_name)
+                    )
+                )
         finally:
             cleanup_connection.close()
 

--- a/tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
@@ -12,11 +12,15 @@ import pytest
 
 from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
 from tldw_Server_API.app.core.Jobs.operations.contracts import (
+    BatchRenewLeaseItem,
+    BatchRenewLeasesCommand,
+    BatchRenewLeasesResult,
     NoTransitionReason,
     OperationOutcome,
     ReleaseJobCommand,
     RenewLeaseCommand,
 )
+from tldw_Server_API.app.core.Jobs.operations.sqlite import renew_leases_batch
 from tldw_Server_API.app.core.Jobs.operations.sqlite.lifecycle import (
     release_job,
     renew_lease,
@@ -49,8 +53,12 @@ RELEASE_RESULT_FIELDS = {
 
 
 @pytest.fixture()
-def conn(tmp_path: Path) -> sqlite3.Connection:
-    db_path = ensure_jobs_tables(tmp_path / "jobs.db")
+def db_path(tmp_path: Path) -> Path:
+    return ensure_jobs_tables(tmp_path / "jobs.db")
+
+
+@pytest.fixture()
+def conn(db_path: Path) -> sqlite3.Connection:
     connection = sqlite3.connect(db_path)
     connection.row_factory = sqlite3.Row
     try:
@@ -130,6 +138,138 @@ def _release_command(
         lease_id=lease_id,
         reason="yield",
     )
+
+
+class RecordingClock:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> datetime:
+        self.calls += 1
+        return NOW
+
+
+class FailOnSecondClock:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> datetime:
+        self.calls += 1
+        if self.calls == 2:
+            raise RuntimeError("forced clock failure")
+        return NOW
+
+
+def test_sqlite_batch_renew_counts_attempts_and_commits_expected_noops(
+    conn: sqlite3.Connection,
+) -> None:
+    valid_id = _insert_job(conn, uuid="valid")
+    queued_id = _insert_job(conn, uuid="queued", status="queued")
+    stale_id = _insert_job(conn, uuid="stale")
+    long_id = _insert_job(conn, uuid="long", leased_until="2026-01-02 13:00:00")
+    command = BatchRenewLeasesCommand(
+        items=(
+            BatchRenewLeaseItem(valid_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(999_999, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(queued_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(stale_id, 30, "worker-2", "lease-1"),
+            BatchRenewLeaseItem(valid_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(long_id, 30, "worker-1", "lease-1"),
+        ),
+        enforce=True,
+    )
+    clock = RecordingClock()
+
+    result = renew_leases_batch(conn, command=command, clock=clock)
+
+    assert result == BatchRenewLeasesResult(requested_count=6, applied_count=3)
+    assert clock.calls == 6
+    assert conn.execute("SELECT leased_until FROM jobs WHERE id = ?", (long_id,)).fetchone()[0] == "2026-01-02 13:00:00"
+
+
+def test_sqlite_batch_renew_empty_command_skips_clock(
+    conn: sqlite3.Connection,
+) -> None:
+    clock = RecordingClock()
+
+    result = renew_leases_batch(
+        conn,
+        command=BatchRenewLeasesCommand(items=(), enforce=True),
+        clock=clock,
+    )
+
+    assert result == BatchRenewLeasesResult(requested_count=0, applied_count=0)
+    assert clock.calls == 0
+
+
+def test_sqlite_batch_renew_rolls_back_when_clock_fails(
+    conn: sqlite3.Connection,
+    db_path: Path,
+) -> None:
+    first_job_id = _insert_job(conn, uuid="first")
+    second_job_id = _insert_job(conn, uuid="second")
+    command = BatchRenewLeasesCommand(
+        items=(
+            BatchRenewLeaseItem(first_job_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(second_job_id, 30, "worker-1", "lease-1"),
+        ),
+        enforce=True,
+    )
+
+    with pytest.raises(RuntimeError, match="forced clock failure"):
+        renew_leases_batch(conn, command=command, clock=FailOnSecondClock())
+
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    try:
+        leases = connection.execute(
+            "SELECT id, leased_until FROM jobs WHERE id IN (?, ?) ORDER BY id",
+            (first_job_id, second_job_id),
+        ).fetchall()
+    finally:
+        connection.close()
+    assert [(row["id"], row["leased_until"]) for row in leases] == [
+        (first_job_id, "2026-01-02 11:45:00"),
+        (second_job_id, "2026-01-02 11:45:00"),
+    ]
+
+
+def test_sqlite_batch_renew_rolls_back_when_second_update_fails(
+    conn: sqlite3.Connection,
+    db_path: Path,
+) -> None:
+    first_job_id = _insert_job(conn, uuid="first")
+    second_job_id = _insert_job(conn, uuid="second")
+    conn.execute(
+        "CREATE TRIGGER fail_batch_renewal BEFORE UPDATE ON jobs "
+        f"WHEN OLD.id = {second_job_id} "
+        "BEGIN SELECT RAISE(ABORT, 'forced batch renewal failure'); END"
+    )
+    conn.commit()
+    command = BatchRenewLeasesCommand(
+        items=(
+            BatchRenewLeaseItem(first_job_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(second_job_id, 30, "worker-1", "lease-1"),
+        ),
+        enforce=True,
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="forced batch renewal failure"):
+        renew_leases_batch(conn, command=command, clock=RecordingClock())
+
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    try:
+        leases = connection.execute(
+            "SELECT id, leased_until FROM jobs WHERE id IN (?, ?) ORDER BY id",
+            (first_job_id, second_job_id),
+        ).fetchall()
+    finally:
+        connection.close()
+    assert [(row["id"], row["leased_until"]) for row in leases] == [
+        (first_job_id, "2026-01-02 11:45:00"),
+        (second_job_id, "2026-01-02 11:45:00"),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
@@ -202,6 +202,70 @@ def test_sqlite_batch_renew_empty_command_skips_clock(
     assert clock.calls == 0
 
 
+def test_sqlite_batch_renew_leaves_caller_transaction_open(
+    conn: sqlite3.Connection,
+) -> None:
+    job_id = _insert_job(conn, uuid="caller-transaction")
+    conn.execute("BEGIN IMMEDIATE")
+
+    result = renew_leases_batch(
+        conn,
+        command=BatchRenewLeasesCommand(
+            items=(BatchRenewLeaseItem(job_id, 30, "worker-1", "lease-1"),),
+            enforce=True,
+        ),
+        clock=RecordingClock(),
+    )
+
+    assert result == BatchRenewLeasesResult(requested_count=1, applied_count=1)
+    assert conn.in_transaction is True
+    conn.rollback()
+    current = conn.execute(
+        "SELECT leased_until FROM jobs WHERE id = ?",
+        (job_id,),
+    ).fetchone()
+    assert current[0] == "2026-01-02 11:45:00"
+
+
+def test_sqlite_batch_renew_failure_rolls_back_savepoint_only(
+    conn: sqlite3.Connection,
+) -> None:
+    first_job_id = _insert_job(conn, uuid="first")
+    second_job_id = _insert_job(conn, uuid="second")
+    conn.execute("BEGIN IMMEDIATE")
+    conn.execute(
+        "UPDATE jobs SET progress_message = 'caller-owned' WHERE id = ?",
+        (second_job_id,),
+    )
+    command = BatchRenewLeasesCommand(
+        items=(
+            BatchRenewLeaseItem(first_job_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(second_job_id, 30, "worker-1", "lease-1"),
+        ),
+        enforce=True,
+    )
+
+    with pytest.raises(RuntimeError, match="forced clock failure"):
+        renew_leases_batch(conn, command=command, clock=FailOnSecondClock())
+
+    assert conn.in_transaction is True
+    rows = conn.execute(
+        "SELECT leased_until, progress_message FROM jobs WHERE id IN (?, ?) ORDER BY id",
+        (first_job_id, second_job_id),
+    ).fetchall()
+    assert [row["leased_until"] for row in rows] == [
+        "2026-01-02 11:45:00",
+        "2026-01-02 11:45:00",
+    ]
+    assert rows[1]["progress_message"] == "caller-owned"
+    conn.rollback()
+    persisted = conn.execute(
+        "SELECT progress_message FROM jobs WHERE id = ?",
+        (second_job_id,),
+    ).fetchone()
+    assert persisted[0] == "old progress"
+
+
 def test_sqlite_batch_renew_rolls_back_when_clock_fails(
     conn: sqlite3.Connection,
     db_path: Path,
@@ -239,17 +303,17 @@ def test_sqlite_batch_renew_rolls_back_when_second_update_fails(
     db_path: Path,
 ) -> None:
     first_job_id = _insert_job(conn, uuid="first")
-    second_job_id = _insert_job(conn, uuid="second")
+    second_job_id = _insert_job(conn, uuid="second", worker_id="worker-2")
     conn.execute(
         "CREATE TRIGGER fail_batch_renewal BEFORE UPDATE ON jobs "
-        f"WHEN OLD.id = {second_job_id} "
+        "WHEN OLD.worker_id = 'worker-2' "
         "BEGIN SELECT RAISE(ABORT, 'forced batch renewal failure'); END"
     )
     conn.commit()
     command = BatchRenewLeasesCommand(
         items=(
             BatchRenewLeaseItem(first_job_id, 30, "worker-1", "lease-1"),
-            BatchRenewLeaseItem(second_job_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(second_job_id, 30, "worker-2", "lease-1"),
         ),
         enforce=True,
     )

--- a/tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_renew_release_operations_sqlite.py
@@ -266,6 +266,46 @@ def test_sqlite_batch_renew_failure_rolls_back_savepoint_only(
     assert persisted[0] == "old progress"
 
 
+def test_sqlite_batch_renew_preserves_error_when_transaction_is_aborted(
+    conn: sqlite3.Connection,
+) -> None:
+    first_job_id = _insert_job(conn, uuid="first")
+    second_job_id = _insert_job(conn, uuid="second", worker_id="worker-2")
+    conn.execute(
+        "CREATE TRIGGER abort_batch_transaction BEFORE UPDATE ON jobs "
+        "WHEN OLD.worker_id = 'worker-2' "
+        "BEGIN SELECT RAISE(ROLLBACK, 'forced full rollback'); END"
+    )
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    conn.execute(
+        "UPDATE jobs SET progress_message = 'caller-owned' WHERE id = ?",
+        (first_job_id,),
+    )
+    command = BatchRenewLeasesCommand(
+        items=(
+            BatchRenewLeaseItem(first_job_id, 30, "worker-1", "lease-1"),
+            BatchRenewLeaseItem(second_job_id, 30, "worker-2", "lease-1"),
+        ),
+        enforce=True,
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="forced full rollback") as exc_info:
+        renew_leases_batch(conn, command=command, clock=RecordingClock())
+
+    assert isinstance(exc_info.value.__cause__, sqlite3.OperationalError)
+    assert "no such savepoint" in str(exc_info.value.__cause__)
+    assert conn.in_transaction is False
+    rows = conn.execute(
+        "SELECT leased_until, progress_message FROM jobs WHERE id IN (?, ?) ORDER BY id",
+        (first_job_id, second_job_id),
+    ).fetchall()
+    assert [(row["leased_until"], row["progress_message"]) for row in rows] == [
+        ("2026-01-02 11:45:00", "old progress"),
+        ("2026-01-02 11:45:00", "old progress"),
+    ]
+
+
 def test_sqlite_batch_renew_rolls_back_when_clock_fails(
     conn: sqlite3.Connection,
     db_path: Path,


### PR DESCRIPTION
## Summary

- Change summary (requester-authored; required before merge): **Pending**
- What changed: _Requester will add._
- Why: _Requester will add._

## Implementation Inventory

- Added immutable batch lease-renewal command/result contracts and invariant coverage.
- Extracted SQLite and PostgreSQL batch renewal into dedicated lifecycle operations.
- Preserved whole-batch atomicity, backend-specific clock semantics, ordered duplicate attempts, expected no-ops, non-shortening leases, and PostgreSQL RLS cursor setup.
- Preserved caller-owned SQLite transactions with savepoints and primary database error precedence when SQLite aborts the complete transaction.
- Routed the unchanged `JobManager.batch_renew_leases` facade through typed backend operations.
- Added public characterization, direct backend, routing, property, and real PostgreSQL rollback tests.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated

Post-rebase verification at `d677950520` against `dev` `7b48bcb04f`:

- 97 focused SQLite/contracts tests passed.
- 43 required PostgreSQL/RLS tests passed with zero skips.
- 50 neighboring lifecycle/parity tests passed; 13 PostgreSQL-only skips were confined to the non-required SQLite matrix.
- 11 required PostgreSQL parity tests passed with zero skips.
- Ruff, compileall, diff hygiene, unique-task-ID, and operation/manager boundary checks passed.
- Bandit reported zero findings across the 9,290-line full production scope and the final 432-line SQLite scope.
- Independent whole-branch review findings were validated and addressed; remediation re-review found no remaining code, test, documentation, or tracker issue.
- All three Qodo review threads have evidence-backed replies and are resolved.

## Tracking

- `TASK-13010` is the unique Jobs task ID; the provisional `TASK-12989` collided with two records already on `dev` and was renumbered during review.
- Design: `Docs/superpowers/specs/2026-08-01-jobs-batch-lease-renewal-extraction-design.md`
- Plan: `Docs/superpowers/plans/2026-08-08-jobs-batch-lease-renewal-extraction.md`
- Merge gate: requester must replace the pending Summary with their human-authored explanation before merge.

## UX Audit Checklist (v2 Stage 5)

Not applicable; backend Jobs refactor with no WebUI or extension changes.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

Not applicable.

## Watchlists Scale Checklist (Group 10 Stage 5)

Not applicable.

## Risk & Rollback

- Risk level: Medium
- Rollback plan: revert the branch commits to restore the prior inline batch-renewal implementation.
