### PR TITLE
refactor(embeddings): extract workflow execution coordinators

### DIFF
--- a/Docs/Published/ADR/037-canonical-notes-link-sync-and-derived-graph-projections.md
+++ b/Docs/Published/ADR/037-canonical-notes-link-sync-and-derived-graph-projections.md
@@ -1,0 +1,102 @@
+# ADR-037: Canonical Notes link Sync and derived graph projections
+
+- **Status:** Accepted
+- **Date:** 2026-08-10
+- **Task:** TASK-13004
+- **Depends on:** ADR-031 and ADR-034
+- **Design:** `Docs/superpowers/specs/2026-08-10-notes-link-sync-and-graph-lifecycle-design.md`
+
+## Context
+
+Notes already has an explicit `note_edges` product table and graph APIs, but manual
+edges are physically deleted, have no optimistic lifecycle, and are not a Sync v2
+domain. Graph reads parse wikilinks opportunistically and currently include deleted
+notes. Shared PostgreSQL does not give the legacy edge table the ownership/RLS
+contract required for synchronized multi-tenant data.
+
+Synchronizing manual links while also synchronizing backlinks, orphan flags, or
+graph summaries would create competing mutable authorities. Conversely, keeping
+link lifecycle only in Sync bookkeeping would split product truth and make inactive
+behavior, restore, and optimistic edits difficult to reason about.
+
+## Decision
+
+1. `notes.link` adapter version 1 is the sole canonical Sync domain for explicit
+   note-to-note `manual` links. It supports `upsert` and `tombstone`.
+2. Stable edge identity is independent of mutable label, weight, and properties.
+   Source, target, type, and direction are immutable. Logical identity remains
+   unique across tombstones.
+3. Schema version 58 extends `note_edges` in place with versioned soft-delete state,
+   bounded mutable presentation fields, explicit owner checks, and forced
+   PostgreSQL RLS. Ownership is derived from authenticated dataset authority, not
+   client payload.
+4. Note trash leaves incident explicit links intact. Graph visibility requires both
+   endpoints to be live, so restore reveals the same links without link churn.
+5. Wikilinks, backlinks, orphan state, graph summaries, dirty queues, parser state,
+   and graph revision are deterministic local projections and are never Sync
+   domains.
+6. Normal note-content mutations update the derived projection in the same product
+   transaction. Owner-scoped bounded maintenance repairs direct-write/crash drift;
+   read endpoints never perform maintenance writes.
+7. Graph and lifecycle APIs resolve an optional default-personal dataset, enforce
+   owner authorization, reject aliases to other same-owner datasets, and use
+   bounded revision-bound pagination and cache keys.
+8. Migration is transactional and fail-closed. It locks before inspection, verifies
+   same-owner endpoints and exact RLS state, temporarily relaxes FORCE only when
+   required under verified schema ownership, restores it before version advance,
+   and never guesses, deletes, or silently repairs legacy rows.
+9. `notes.link` uses a separate versioned `notes_link_v1` enrollment/bootstrap
+   state. Existing organization-ready datasets atomically add and source-verify the
+   new domain without reopening or blocking the six-domain
+   `notes_organization_v1` group.
+10. PostgreSQL `note_edges` policies validate the authenticated owner and both note
+    endpoints in `USING` and `WITH CHECK`; soft-deleted endpoints remain valid
+    identities but are excluded by graph visibility joins.
+11. Link creation provenance is client-signable but not freely client-selectable:
+    canonical `created_at`/`last_modified` bind to the submitted envelope timestamp
+    and `created_by` binds to the authenticated device. Trusted bootstrap alone may
+    preserve source-verified legacy provenance.
+
+## Consequences
+
+- Existing manual links keep their identity and API compatibility while gaining
+  optimistic update, tombstone, and restore semantics.
+- Already-ready default-personal datasets have a resumable upgrade path; this is
+  not a fresh-install-only capability.
+- Two clients cannot silently replace the same logical edge. Divergent edits and
+  recreate/restore races are reviewable conflicts.
+- A deleted note may still have canonical live links, but no graph surface exposes
+  those links until both endpoints are live.
+- Derived graph queries can temporarily return a retryable rebuilding state after
+  migration, parser change, or detected direct-write drift.
+- Schema v58 temporarily blocks affected Notes writes during its PostgreSQL
+  preflight/DDL transaction and therefore requires explicit operational approval.
+- Permanent hard purge requires a future explicit policy for incident link audit
+  history; it is not silently cascaded here.
+
+## Alternatives considered
+
+### Create a replacement canonical links table
+
+Rejected because it adds a second storage surface, migration/reconciliation risk,
+and compatibility work without improving the public contract.
+
+### Keep product rows unchanged and store lifecycle only in Sync
+
+Rejected because authority would be split between `note_edges` and Sync state,
+especially in inactive mode and during exact restore or crash repair.
+
+### Synchronize wikilinks, backlinks, or graph summaries
+
+Rejected because they are deterministic functions of note content and explicit
+links. Synchronizing them would permit drift and duplicate conflict surfaces.
+
+### Cascade link tombstones on note trash
+
+Rejected because it destroys existing restore behavior, creates large mutation
+groups, and introduces link churn for a visibility-only lifecycle change.
+
+### Add arbitrary relationship targets or types in version 1
+
+Rejected as unnecessary scope that would broaden identity, authorization, schema,
+and conflict semantics before a concrete product requirement exists.

--- a/Docs/Published/ADR/README.md
+++ b/Docs/Published/ADR/README.md
@@ -68,3 +68,4 @@ Small bug fixes, local implementation details, product copy, temporary experimen
 | [ADR-034](034-durable-server-origin-sync-mutation-batches.md) | Accepted | Persist complete server-origin Sync mutation plans atomically, then materialize them in ordered, resumable steps. |
 | [ADR-035](035-canonical-folder-link-suppression-preserves-source-provenance.md) | Accepted | Materialize canonical folder-link tombstones with local suppressions while preserving source-ingestion provenance. |
 | [ADR-036](036-web-clipper-external-identity-mapping.md) | Accepted | Map owner-scoped public Web Clipper IDs to separate canonical Notes UUIDs and migrate legacy mappings safely. |
+| [ADR-037](037-canonical-notes-link-sync-and-derived-graph-projections.md) | Accepted | Synchronize explicit manual note links while keeping wikilinks, backlinks, orphan state, and graph summaries deterministic local projections. |

--- a/Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md
@@ -1,12 +1,14 @@
 # Embeddings Workflow Stage 2D Coordinators Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkboxes for tracking.
 
 **Goal:** Replace the Embeddings orchestrator's production execution routing with explicit adapter, fallback, and execution coordinators while preserving all existing behavior except the approved source-aware fallback correction.
 
 **Architecture:** Add one focused `execution_coordinator.py` module alongside the Stage 2C provider-attempt boundary. The adapter component owns only preferred-adapter invocation and validation, the fallback component owns ordered candidate traversal and provider-failure policy, and the execution coordinator owns sequencing plus canonical outcome assembly. `EmbeddingRequestOrchestrator.execute()` delegates to the coordinator and the existing legacy result mapper; its superseded private methods remain temporarily for Stage 2E removal so this PR stays reviewable and rollback-friendly.
 
 **Tech Stack:** Python 3.14, frozen dataclasses, structural protocols, async/await, pytest with pytest-asyncio, Ruff, compileall, Bandit.
+
+**Status:** Complete 2026-08-08. Tasks 1-5 and final verification are complete. The approved temporary compatibility-facade duplication remains until Stage 2E, which owns runner integration and cleanup.
 
 ## Global Constraints
 
@@ -35,7 +37,7 @@
 - Consumes: `PreparedEmbeddingRequest`, `EmbeddingExecutorOutput`, and `EmbeddingVectorProcessor`.
 - Produces: `AdapterAttemptResult(attempted: bool, success: ProviderAttemptSuccess | None)` and `EmbeddingAdapterAttempt.execute(prepared) -> AdapterAttemptResult`.
 
-- [ ] **Step 1: Add explicit coordinator test scaffolding**
+- [x] **Step 1: Add explicit coordinator test scaffolding**
 
 Build prepared requests directly from the frozen Stage 2B contracts so tests do not depend on the compatibility orchestrator:
 
@@ -124,7 +126,7 @@ class RecordingExecutor:
 
 Later tasks extend this file with `RecordingReadiness`, `RecordingProviderAttempt`, and `RecordingFallbackCoordinator`; each exposes a `calls` list and returns or raises the exact configured result object.
 
-- [ ] **Step 2: Write adapter ordering and result tests**
+- [x] **Step 2: Write adapter ordering and result tests**
 
 Add focused tests that instantiate `EmbeddingAdapterAttempt` directly:
 
@@ -178,7 +180,7 @@ async def test_adapter_attempt_validates_and_processes_success():
 
 Also assert that an adapter exception is the exact exception re-raised and that `EmbeddingExecutorOutput(..., embeddings_from_adapter=False)` is an attempted decline.
 
-- [ ] **Step 3: Run adapter tests and verify RED**
+- [x] **Step 3: Run adapter tests and verify RED**
 
 Run:
 
@@ -188,7 +190,7 @@ Run:
 
 Expected: collection fails because `execution_coordinator.py` and its adapter contracts do not exist.
 
-- [ ] **Step 4: Implement the minimal adapter boundary**
+- [x] **Step 4: Implement the minimal adapter boundary**
 
 Accept the existing provider executor object and discover its optional adapter capability dynamically, matching the compatibility orchestrator. Add the frozen result DTO:
 
@@ -212,11 +214,11 @@ Implement `EmbeddingAdapterAttempt.execute()` so it:
 5. Returns a `ProviderAttemptSuccess` with compatibility cache counts on success.
 6. Does not catch exceptions.
 
-- [ ] **Step 5: Run adapter tests and verify GREEN**
+- [x] **Step 5: Run adapter tests and verify GREEN**
 
 Run the Step 3 command. Expected: all adapter-selected tests pass.
 
-- [ ] **Step 6: Commit the adapter boundary**
+- [x] **Step 6: Commit the adapter boundary**
 
 ```bash
 git add tldw_Server_API/app/core/Embeddings/execution_coordinator.py tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
@@ -233,7 +235,7 @@ git commit -m "refactor(embeddings): extract adapter attempt boundary"
 - Consumes: `EmbeddingProviderReadinessCheck.check(provider, model)`, `EmbeddingProviderAttempt.execute(prepared, provider=..., model=...)`, and the primary `ProviderCallFailure`.
 - Produces: `FallbackExecutionSuccess(success: ProviderAttemptSuccess, attempt_count: int)` and `EmbeddingFallbackCoordinator.execute(prepared, primary_failure) -> FallbackExecutionSuccess`.
 
-- [ ] **Step 1: Write failing fallback traversal tests**
+- [x] **Step 1: Write failing fallback traversal tests**
 
 Add the provider-result helpers and recording fakes used by fallback tests:
 
@@ -362,7 +364,7 @@ Add separate tests proving:
 - a fallback success always receives the complete prepared request;
 - backend identity, key, cache, validation, postprocessing, and writeback errors escaping `EmbeddingProviderAttempt` are not caught and do not advance to another candidate.
 
-- [ ] **Step 2: Run fallback tests and verify RED**
+- [x] **Step 2: Run fallback tests and verify RED**
 
 Run:
 
@@ -372,7 +374,7 @@ Run:
 
 Expected: failures because the fallback coordinator contracts are absent.
 
-- [ ] **Step 3: Implement policy helpers and fallback traversal**
+- [x] **Step 3: Implement policy helpers and fallback traversal**
 
 Copy the existing eligibility constants and behavior into the new module without changing values. Retain the orchestrator's private copies until Stage 2E removes its superseded private execution branches:
 
@@ -444,11 +446,11 @@ if not _is_fallback_eligible(error):
 
 Do not wrap the provider-attempt call in a broad `EmbeddingDomainError` catch. This is the approved Stage 2D source-routing correction.
 
-- [ ] **Step 4: Run fallback tests and verify GREEN**
+- [x] **Step 4: Run fallback tests and verify GREEN**
 
 Run the Step 2 command. Expected: all fallback-selected tests pass.
 
-- [ ] **Step 5: Commit the fallback coordinator**
+- [x] **Step 5: Commit the fallback coordinator**
 
 ```bash
 git add tldw_Server_API/app/core/Embeddings/execution_coordinator.py tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
@@ -465,7 +467,7 @@ git commit -m "refactor(embeddings): extract fallback coordinator"
 - Consumes: `EmbeddingAdapterAttempt`, `EmbeddingProviderReadinessCheck`, `EmbeddingProviderAttempt`, `EmbeddingFallbackCoordinator`, and `assemble_embedding_execution_outcome`.
 - Produces: `EmbeddingExecutionCoordinator.execute(prepared) -> EmbeddingExecutionOutcome`.
 
-- [ ] **Step 1: Write failing execution-order and counter tests**
+- [x] **Step 1: Write failing execution-order and counter tests**
 
 Add execution-level adapter and fallback fakes plus a single constructor helper:
 
@@ -581,7 +583,7 @@ async def test_eligible_primary_provider_failure_uses_complete_request_fallback(
 
 Also cover adapter success, full primary cache hit, non-retryable primary failure, fallback-disabled primary failure, and successful primary execution. Assert exact `cache_hits`, `cache_misses`, provider/model, adapter flag, and vector order in every resulting outcome.
 
-- [ ] **Step 2: Run execution tests and verify RED**
+- [x] **Step 2: Run execution tests and verify RED**
 
 Run:
 
@@ -591,7 +593,7 @@ Run:
 
 Expected: failures because `EmbeddingExecutionCoordinator` does not exist.
 
-- [ ] **Step 3: Implement execution sequencing**
+- [x] **Step 3: Implement execution sequencing**
 
 Implement the coordinator in this exact order:
 
@@ -640,7 +642,7 @@ return self._assemble(
 
 Use `assemble_embedding_execution_outcome()` for all three success paths. Do not create HTTP headers in this module.
 
-- [ ] **Step 4: Run the full coordinator test file and verify GREEN**
+- [x] **Step 4: Run the full coordinator test file and verify GREEN**
 
 Run:
 
@@ -650,7 +652,7 @@ Run:
 
 Expected: all coordinator tests pass.
 
-- [ ] **Step 5: Commit the execution coordinator**
+- [x] **Step 5: Commit the execution coordinator**
 
 ```bash
 git add tldw_Server_API/app/core/Embeddings/execution_coordinator.py tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
@@ -668,7 +670,7 @@ git commit -m "refactor(embeddings): extract execution coordinator"
 - Consumes: `EmbeddingExecutionCoordinator.execute(prepared) -> EmbeddingExecutionOutcome` and `map_outcome_to_legacy_execution_result(outcome) -> EmbeddingExecutionResult`.
 - Produces: unchanged `EmbeddingRequestOrchestrator.execute(prepared) -> EmbeddingExecutionResult` public behavior, with approved source-aware fallback routing.
 
-- [ ] **Step 1: Rewrite the Stage 2D guardrail as the new expected behavior**
+- [x] **Step 1: Rewrite the Stage 2D guardrail as the new expected behavior**
 
 Change `test_current_fallback_wide_domain_catch_advances_after_infrastructure_failure` into a source-routing regression that expects the exact fallback infrastructure error to propagate and prevents later fallback candidates:
 
@@ -690,7 +692,7 @@ async def test_fallback_non_provider_failure_propagates_without_advancing(bounda
 
 Add an endpoint parity correction case that asserts the workflow-enabled path now propagates fallback cache/identity failures rather than silently activating another provider. Do not modify unchanged parity scenarios.
 
-- [ ] **Step 2: Run production-routing tests and verify RED**
+- [x] **Step 2: Run production-routing tests and verify RED**
 
 Run:
 
@@ -700,7 +702,7 @@ Run:
 
 Expected: the orchestrator regression fails because the old broad fallback catch still advances; the parity suite otherwise remains green.
 
-- [ ] **Step 3: Construct and delegate to the coordinator**
+- [x] **Step 3: Construct and delegate to the coordinator**
 
 In `EmbeddingRequestOrchestrator.__init__`, build one shared vector processor, readiness check, provider attempt, adapter attempt, fallback coordinator, and execution coordinator from the existing injected dependencies. Keep constructor arguments unchanged.
 
@@ -715,7 +717,7 @@ async def execute(self, prepared: PreparedEmbeddingRequest) -> EmbeddingExecutio
 
 Leave `_execute_misses`, `_execute_coherent_fallback`, `_execute_adapter`, `_cache_key`, `_response_headers`, and their compatibility helpers in place for Stage 2E removal. They must be unreachable from the public `execute()` path after this step.
 
-- [ ] **Step 4: Run focused orchestrator and parity tests**
+- [x] **Step 4: Run focused orchestrator and parity tests**
 
 Run:
 
@@ -725,7 +727,7 @@ Run:
 
 Expected: all selected tests pass. The only approved assertion change is source-aware fallback failure routing.
 
-- [ ] **Step 5: Commit production delegation**
+- [x] **Step 5: Commit production delegation**
 
 ```bash
 git add tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
@@ -746,7 +748,7 @@ git commit -m "refactor(embeddings): route execution through coordinators"
 - Consumes: completed Stage 2D production and test changes.
 - Produces: verified, reviewable Stage 2D branch with authoritative Backlog evidence.
 
-- [ ] **Step 1: Run the focused Stage 2D regression suite**
+- [x] **Step 1: Run the focused Stage 2D regression suite**
 
 Run:
 
@@ -756,7 +758,7 @@ Run:
 
 Expected: all selected tests pass.
 
-- [ ] **Step 2: Run static and security checks**
+- [x] **Step 2: Run static and security checks**
 
 Run:
 
@@ -768,7 +770,7 @@ Run:
 
 Expected: Ruff and compileall exit zero; Bandit reports zero findings in touched production code.
 
-- [ ] **Step 3: Run diff and scope review**
+- [x] **Step 3: Run diff and scope review**
 
 Run:
 
@@ -780,7 +782,7 @@ git status --short
 
 Confirm the diff contains only the Stage 2D coordinator, focused tests, orchestrator delegation, approved source-routing assertion change, spec status correction, implementation plan, and Backlog updates.
 
-- [ ] **Step 4: Finalize Backlog.md through the CLI**
+- [x] **Step 4: Finalize Backlog.md through the official Backlog workflow**
 
 Use `backlog task edit 12973.4` to:
 
@@ -791,7 +793,7 @@ Use `backlog task edit 12973.4` to:
 5. Add a final summary that explains both the source-aware routing correction and why Stage 2E retains endpoint/runner integration ownership.
 6. Set status to `Done` only after all verification succeeds.
 
-- [ ] **Step 5: Commit final documentation and tracking**
+- [x] **Step 5: Commit final documentation and tracking**
 
 ```bash
 git add Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md "backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md"

--- a/Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md
@@ -1,0 +1,809 @@
+# Embeddings Workflow Stage 2D Coordinators Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Embeddings orchestrator's production execution routing with explicit adapter, fallback, and execution coordinators while preserving all existing behavior except the approved source-aware fallback correction.
+
+**Architecture:** Add one focused `execution_coordinator.py` module alongside the Stage 2C provider-attempt boundary. The adapter component owns only preferred-adapter invocation and validation, the fallback component owns ordered candidate traversal and provider-failure policy, and the execution coordinator owns sequencing plus canonical outcome assembly. `EmbeddingRequestOrchestrator.execute()` delegates to the coordinator and the existing legacy result mapper; its superseded private methods remain temporarily for Stage 2E removal so this PR stays reviewable and rollback-friendly.
+
+**Tech Stack:** Python 3.14, frozen dataclasses, structural protocols, async/await, pytest with pytest-asyncio, Ruff, compileall, Bandit.
+
+## Global Constraints
+
+- Preserve adapter execution before primary readiness, cache access, and provider execution.
+- Primary readiness failures propagate unchanged and never enter fallback.
+- Only an `EmbeddingDomainError` raised by `ProviderAttemptExecutor.create()` becomes `ProviderCallFailure`.
+- Identity resolution, cache-key derivation, cache access, vector validation, postprocessing, and writeback failures propagate unchanged and never activate another provider.
+- Fallback candidates use the complete normalized request; primary cache hits and partial primary state never enter a fallback result.
+- Exclude the already-attempted primary provider while preserving the remaining policy-approved fallback order.
+- Skip `missing_provider_credentials` from fallback readiness or provider calls; apply existing eligibility and exhausted-error precedence to other domain failures.
+- Preserve the exact selected error object, including rate-limit retry metadata.
+- Preserve current adapter compatibility accounting: zero cache hits and one cache miss per input item on adapter success.
+- Do not add workflow persistence, Jobs integration, durable retries, endpoint header migration, trace-summary changes, or Stage 2E runner wiring.
+- Do not remove the old private execution branches in this stage; Stage 2E owns compatibility-facade cleanup.
+- Raw input, cache keys, backend identities, credentials, and provider bodies must not enter DTO representations, logs, or trace metadata.
+
+---
+
+### Task 1: Adapter Attempt Boundary
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Embeddings/execution_coordinator.py`
+- Create: `tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py`
+
+**Interfaces:**
+- Consumes: `PreparedEmbeddingRequest`, `EmbeddingExecutorOutput`, and `EmbeddingVectorProcessor`.
+- Produces: `AdapterAttemptResult(attempted: bool, success: ProviderAttemptSuccess | None)` and `EmbeddingAdapterAttempt.execute(prepared) -> AdapterAttemptResult`.
+
+- [ ] **Step 1: Add explicit coordinator test scaffolding**
+
+Build prepared requests directly from the frozen Stage 2B contracts so tests do not depend on the compatibility orchestrator:
+
+```python
+def _prepared(
+    *,
+    texts: list[str] | None = None,
+    provider: str = "openai",
+    model: str = "text-embedding-3-small",
+    fallback_chain: list[str] | None = None,
+    fallback_allowed: bool = True,
+    execution_path: Literal["legacy", "adapter"] = "legacy",
+) -> PreparedEmbeddingRequest:
+    ordered_texts = texts or ["alpha"]
+    chain = list(fallback_chain or [provider])
+    return PreparedEmbeddingRequest(
+        normalized_input=NormalizedEmbeddingInput(
+            texts=ordered_texts,
+            token_counts=[1 for _ in ordered_texts],
+            total_tokens=len(ordered_texts),
+        ),
+        provider_intent=ProviderModelIntent(
+            provider=provider,
+            model=model,
+            requested_provider=provider,
+            requested_model=model,
+            provider_was_explicit=True,
+            model_was_provider_qualified=False,
+        ),
+        policy_decision=EmbeddingPolicyDecision(
+            provider=provider,
+            model=model,
+            dimensions=None,
+            fallback_chain=chain,
+            fallback_allowed=fallback_allowed,
+            enforce_policy=True,
+        ),
+        execution_plan=EmbeddingExecutionPlan(
+            provider=provider,
+            model=model,
+            dimensions=None,
+            backend_identity="stale-plan-identity",
+            fallback_chain=chain,
+            execution_path=execution_path,
+        ),
+        effective_dimension_policy="reduce",
+        prompt_tokens=len(ordered_texts),
+        total_tokens=len(ordered_texts),
+    )
+```
+
+Use recording fakes with explicit async methods and stable call records:
+
+```python
+@dataclass(frozen=True, slots=True)
+class AttemptCall:
+    prepared: PreparedEmbeddingRequest
+    provider: str
+    model: str
+
+
+class RecordingExecutor:
+    def __init__(
+        self,
+        *,
+        adapter_output: EmbeddingExecutorOutput | None = None,
+        adapter_error: Exception | None = None,
+    ) -> None:
+        self.adapter_output = adapter_output
+        self.adapter_error = adapter_error
+        self.adapter_calls: list[tuple[list[str], str, str, int | None]] = []
+
+    async def create_adapter(
+        self,
+        texts: list[str],
+        *,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+    ) -> EmbeddingExecutorOutput | None:
+        self.adapter_calls.append((texts, provider, model, dimensions))
+        if self.adapter_error is not None:
+            raise self.adapter_error
+        return self.adapter_output
+```
+
+Later tasks extend this file with `RecordingReadiness`, `RecordingProviderAttempt`, and `RecordingFallbackCoordinator`; each exposes a `calls` list and returns or raises the exact configured result object.
+
+- [ ] **Step 2: Write adapter ordering and result tests**
+
+Add focused tests that instantiate `EmbeddingAdapterAttempt` directly:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_attempt_skips_non_adapter_execution_plan():
+    executor = RecordingExecutor()
+    attempt = EmbeddingAdapterAttempt(executor=executor)
+
+    result = await attempt.execute(_prepared(execution_path="legacy"))
+
+    assert result == AdapterAttemptResult(attempted=False)
+    assert executor.adapter_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_attempt_decline_is_counted_without_provider_result():
+    executor = RecordingExecutor(adapter_output=None)
+    attempt = EmbeddingAdapterAttempt(executor=executor)
+
+    result = await attempt.execute(_prepared(execution_path="adapter"))
+
+    assert result == AdapterAttemptResult(attempted=True)
+    assert len(executor.adapter_calls) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_attempt_validates_and_processes_success():
+    executor = RecordingExecutor(
+        adapter_output=EmbeddingExecutorOutput(
+            vectors=[[3.0, 4.0]],
+            embeddings_from_adapter=True,
+        )
+    )
+    attempt = EmbeddingAdapterAttempt(executor=executor)
+
+    result = await attempt.execute(_prepared(execution_path="adapter"))
+
+    assert result.success == ProviderAttemptSuccess(
+        vectors=[[3.0, 4.0]],
+        provider="openai",
+        model="text-embedding-3-small",
+        cache_hits=0,
+        cache_misses=1,
+        embeddings_from_adapter=True,
+    )
+```
+
+Also assert that an adapter exception is the exact exception re-raised and that `EmbeddingExecutorOutput(..., embeddings_from_adapter=False)` is an attempted decline.
+
+- [ ] **Step 3: Run adapter tests and verify RED**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py -k adapter -q
+```
+
+Expected: collection fails because `execution_coordinator.py` and its adapter contracts do not exist.
+
+- [ ] **Step 4: Implement the minimal adapter boundary**
+
+Accept the existing provider executor object and discover its optional adapter capability dynamically, matching the compatibility orchestrator. Add the frozen result DTO:
+
+```python
+@dataclass(frozen=True, slots=True)
+class AdapterAttemptResult:
+    attempted: bool
+    success: ProviderAttemptSuccess | None = None
+
+    def __post_init__(self) -> None:
+        if self.success is not None and not self.attempted:
+            raise ValueError("adapter success requires an attempted adapter path")
+```
+
+Implement `EmbeddingAdapterAttempt.execute()` so it:
+
+1. Stores the injected `ProviderAttemptExecutor` and returns `attempted=False` when the plan is not `adapter` or `getattr(executor, "create_adapter", None)` is not callable.
+2. Invokes `create_adapter` with the complete ordered input when available.
+3. Returns `attempted=True, success=None` for `None` or non-adapter output.
+4. Validates vector count and applies request-specific postprocessing.
+5. Returns a `ProviderAttemptSuccess` with compatibility cache counts on success.
+6. Does not catch exceptions.
+
+- [ ] **Step 5: Run adapter tests and verify GREEN**
+
+Run the Step 3 command. Expected: all adapter-selected tests pass.
+
+- [ ] **Step 6: Commit the adapter boundary**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/execution_coordinator.py tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
+git commit -m "refactor(embeddings): extract adapter attempt boundary"
+```
+
+### Task 2: Source-Aware Fallback Coordinator
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Embeddings/execution_coordinator.py`
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py`
+
+**Interfaces:**
+- Consumes: `EmbeddingProviderReadinessCheck.check(provider, model)`, `EmbeddingProviderAttempt.execute(prepared, provider=..., model=...)`, and the primary `ProviderCallFailure`.
+- Produces: `FallbackExecutionSuccess(success: ProviderAttemptSuccess, attempt_count: int)` and `EmbeddingFallbackCoordinator.execute(prepared, primary_failure) -> FallbackExecutionSuccess`.
+
+- [ ] **Step 1: Write failing fallback traversal tests**
+
+Add the provider-result helpers and recording fakes used by fallback tests:
+
+```python
+def _retryable(provider: str) -> EmbeddingProviderError:
+    return EmbeddingProviderError(
+        "provider_unavailable",
+        "provider unavailable",
+        provider=provider,
+        model={
+            "openai": "text-embedding-3-small",
+            "cohere": "embed-english-v3.0",
+            "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+        }[provider],
+        retryable=True,
+    )
+
+
+def _success(provider: str) -> ProviderAttemptSuccess:
+    return ProviderAttemptSuccess(
+        vectors=[[0.25, 0.75]],
+        provider=provider,
+        model={
+            "cohere": "embed-english-v3.0",
+            "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+        }.get(provider, "text-embedding-3-small"),
+        cache_hits=0,
+        cache_misses=1,
+    )
+
+
+def _model_map() -> dict[str, object]:
+    return {
+        "openai:text-embedding-3-small": {
+            "cohere": "embed-english-v3.0",
+            "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+        }
+    }
+
+
+class RecordingReadiness:
+    def __init__(
+        self,
+        errors: dict[str, EmbeddingDomainError] | None = None,
+        events: list[str] | None = None,
+    ) -> None:
+        self.errors = errors or {}
+        self.events = events
+        self.calls: list[tuple[str, str]] = []
+
+    async def check(self, provider: str, model: str) -> None:
+        self.calls.append((provider, model))
+        if self.events is not None:
+            self.events.append(f"readiness:{provider}")
+        error = self.errors.get(provider)
+        if error is not None:
+            raise error
+
+
+class RecordingProviderAttempt:
+    def __init__(
+        self,
+        outcomes: dict[str, ProviderAttemptSuccess | ProviderCallFailure],
+        raised: dict[str, EmbeddingDomainError] | None = None,
+        events: list[str] | None = None,
+    ) -> None:
+        self.outcomes = outcomes
+        self.raised = raised or {}
+        self.events = events
+        self.calls: list[AttemptCall] = []
+
+    async def execute(
+        self,
+        prepared: PreparedEmbeddingRequest,
+        *,
+        provider: str,
+        model: str,
+    ) -> ProviderAttemptSuccess | ProviderCallFailure:
+        self.calls.append(AttemptCall(prepared, provider, model))
+        if self.events is not None:
+            self.events.append(f"attempt:{provider}")
+        error = self.raised.get(provider)
+        if error is not None:
+            raise error
+        return self.outcomes[provider]
+```
+
+Cover these behaviors with those fakes:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_excludes_primary_and_preserves_candidate_order():
+    readiness = RecordingReadiness()
+    attempt = RecordingProviderAttempt(
+        outcomes={
+            "cohere": ProviderCallFailure(_retryable("cohere")),
+            "huggingface": _success("huggingface"),
+        }
+    )
+    coordinator = EmbeddingFallbackCoordinator(
+        readiness=readiness,
+        provider_attempt=attempt,
+        settings_fallback_model_map=_model_map(),
+    )
+
+    result = await coordinator.execute(
+        _prepared(fallback_chain=["openai", "cohere", "openai", "huggingface"]),
+        ProviderCallFailure(_retryable("openai")),
+    )
+
+    assert readiness.calls == [
+        ("cohere", "embed-english-v3.0"),
+        ("huggingface", "sentence-transformers/all-MiniLM-L6-v2"),
+    ]
+    assert [call.provider for call in attempt.calls] == ["cohere", "huggingface"]
+    assert result.attempt_count == 2
+```
+
+Add separate tests proving:
+
+- readiness and provider-call missing credentials skip the candidate;
+- eligible readiness and `ProviderCallFailure` results continue;
+- ineligible failures raise the exact original object immediately;
+- a rate-limit error is selected on exhaustion with its original `retry_after` value;
+- a fallback success always receives the complete prepared request;
+- backend identity, key, cache, validation, postprocessing, and writeback errors escaping `EmbeddingProviderAttempt` are not caught and do not advance to another candidate.
+
+- [ ] **Step 2: Run fallback tests and verify RED**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py -k fallback -q
+```
+
+Expected: failures because the fallback coordinator contracts are absent.
+
+- [ ] **Step 3: Implement policy helpers and fallback traversal**
+
+Copy the existing eligibility constants and behavior into the new module without changing values. Retain the orchestrator's private copies until Stage 2E removes its superseded private execution branches:
+
+```python
+_NON_FALLBACKABLE_ERROR_CODES = frozenset(
+    {
+        "empty_input",
+        "invalid_input_type",
+        "too_many_inputs",
+        "input_too_long",
+        "invalid_token_array",
+        "unknown_provider",
+        "provider_model_mismatch",
+        "invalid_dimensions",
+        "provider_denied",
+        "model_denied",
+        "model_required",
+        "provider_unsupported",
+        "missing_provider_credentials",
+        "provider_malformed_response",
+    }
+)
+
+
+def _is_fallback_eligible(error: EmbeddingDomainError) -> bool:
+    return bool(error.retryable) and error.code not in _NON_FALLBACKABLE_ERROR_CODES
+
+
+def _select_exhausted_error(
+    errors: Sequence[EmbeddingDomainError],
+) -> EmbeddingDomainError | None:
+    for error in errors:
+        if isinstance(error, EmbeddingProviderError) and not error.retryable:
+            return error
+    for error in errors:
+        if error.code == "provider_rate_limited":
+            return error
+    return errors[-1] if errors else None
+```
+
+Implement candidate traversal with this exception boundary:
+
+```python
+try:
+    await self._readiness.check(provider, model)
+except EmbeddingDomainError as error:
+    if error.code == "missing_provider_credentials":
+        continue
+    errors.append(error)
+    if not _is_fallback_eligible(error):
+        raise
+    continue
+
+attempt_result = await self._provider_attempt.execute(
+    prepared,
+    provider=provider,
+    model=model,
+)
+if isinstance(attempt_result, ProviderAttemptSuccess):
+    return FallbackExecutionSuccess(attempt_result, attempt_count)
+
+error = attempt_result.error
+if error.code == "missing_provider_credentials":
+    continue
+errors.append(error)
+if not _is_fallback_eligible(error):
+    raise error
+```
+
+Do not wrap the provider-attempt call in a broad `EmbeddingDomainError` catch. This is the approved Stage 2D source-routing correction.
+
+- [ ] **Step 4: Run fallback tests and verify GREEN**
+
+Run the Step 2 command. Expected: all fallback-selected tests pass.
+
+- [ ] **Step 5: Commit the fallback coordinator**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/execution_coordinator.py tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
+git commit -m "refactor(embeddings): extract fallback coordinator"
+```
+
+### Task 3: Primary Execution Coordinator and Canonical Outcome
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Embeddings/execution_coordinator.py`
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py`
+
+**Interfaces:**
+- Consumes: `EmbeddingAdapterAttempt`, `EmbeddingProviderReadinessCheck`, `EmbeddingProviderAttempt`, `EmbeddingFallbackCoordinator`, and `assemble_embedding_execution_outcome`.
+- Produces: `EmbeddingExecutionCoordinator.execute(prepared) -> EmbeddingExecutionOutcome`.
+
+- [ ] **Step 1: Write failing execution-order and counter tests**
+
+Add execution-level adapter and fallback fakes plus a single constructor helper:
+
+```python
+class RecordingAdapterAttempt:
+    def __init__(self, result: AdapterAttemptResult, events: list[str]) -> None:
+        self.result = result
+        self.events = events
+
+    async def execute(self, prepared: PreparedEmbeddingRequest) -> AdapterAttemptResult:
+        del prepared
+        if self.result.attempted:
+            self.events.append("adapter")
+        return self.result
+
+
+class RecordingFallbackCoordinator:
+    def __init__(
+        self,
+        result: FallbackExecutionSuccess | None = None,
+    ) -> None:
+        self.result = result or FallbackExecutionSuccess(_success("huggingface"), 1)
+        self.calls: list[tuple[PreparedEmbeddingRequest, ProviderCallFailure]] = []
+
+    async def execute(
+        self,
+        prepared: PreparedEmbeddingRequest,
+        primary_failure: ProviderCallFailure,
+    ) -> FallbackExecutionSuccess:
+        self.calls.append((prepared, primary_failure))
+        return self.result
+
+
+def _coordinator(
+    *,
+    events: list[str] | None = None,
+    adapter_declines: bool = False,
+    readiness_error: EmbeddingDomainError | None = None,
+    primary_result: ProviderAttemptSuccess | ProviderCallFailure | None = None,
+    fallback_result: FallbackExecutionSuccess | None = None,
+    fallback: RecordingFallbackCoordinator | None = None,
+) -> EmbeddingExecutionCoordinator:
+    ordered_events = events if events is not None else []
+    adapter = RecordingAdapterAttempt(
+        AdapterAttemptResult(attempted=adapter_declines),
+        ordered_events,
+    )
+    readiness = RecordingReadiness(
+        errors={"openai": readiness_error} if readiness_error is not None else None,
+        events=ordered_events,
+    )
+    attempt = RecordingProviderAttempt(
+        outcomes={"openai": primary_result or _success("openai")},
+        events=ordered_events,
+    )
+    fallback_coordinator = fallback or RecordingFallbackCoordinator(fallback_result)
+    return EmbeddingExecutionCoordinator(
+        adapter_attempt=adapter,
+        readiness=readiness,
+        provider_attempt=attempt,
+        fallback_coordinator=fallback_coordinator,
+    )
+```
+
+Add tests for the exact sequencing and aggregate counters:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_orders_adapter_before_primary_readiness_and_attempt():
+    events: list[str] = []
+    coordinator = _coordinator(events=events, adapter_declines=True)
+
+    outcome = await coordinator.execute(_prepared(execution_path="adapter"))
+
+    assert events == ["adapter", "readiness:openai", "attempt:openai"]
+    assert outcome.attempt_count == 2
+    assert outcome.fallback_attempt_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_primary_readiness_failure_does_not_enter_fallback():
+    error = _retryable("openai")
+    fallback = RecordingFallbackCoordinator()
+    coordinator = _coordinator(readiness_error=error, fallback=fallback)
+
+    with pytest.raises(EmbeddingDomainError) as raised:
+        await coordinator.execute(_prepared())
+
+    assert raised.value is error
+    assert fallback.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_eligible_primary_provider_failure_uses_complete_request_fallback():
+    coordinator = _coordinator(
+        primary_result=ProviderCallFailure(_retryable("openai")),
+        fallback_result=FallbackExecutionSuccess(
+            success=_success("huggingface"),
+            attempt_count=2,
+        ),
+    )
+
+    outcome = await coordinator.execute(_prepared())
+
+    assert outcome.provider == "huggingface"
+    assert outcome.fallback_from == "openai"
+    assert outcome.attempt_count == 3
+    assert outcome.fallback_attempt_count == 2
+```
+
+Also cover adapter success, full primary cache hit, non-retryable primary failure, fallback-disabled primary failure, and successful primary execution. Assert exact `cache_hits`, `cache_misses`, provider/model, adapter flag, and vector order in every resulting outcome.
+
+- [ ] **Step 2: Run execution tests and verify RED**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py -k execution -q
+```
+
+Expected: failures because `EmbeddingExecutionCoordinator` does not exist.
+
+- [ ] **Step 3: Implement execution sequencing**
+
+Implement the coordinator in this exact order:
+
+```python
+adapter_result = await self._adapter_attempt.execute(prepared)
+base_attempt_count = int(adapter_result.attempted)
+if adapter_result.success is not None:
+    return self._assemble(
+        prepared,
+        adapter_result.success,
+        attempt_count=base_attempt_count,
+        fallback_attempt_count=0,
+        fallback_from=None,
+    )
+
+plan = prepared.execution_plan
+await self._readiness.check(plan.provider, plan.model)
+base_attempt_count += 1
+primary = await self._provider_attempt.execute(
+    prepared,
+    provider=plan.provider,
+    model=plan.model,
+)
+if isinstance(primary, ProviderAttemptSuccess):
+    return self._assemble(
+        prepared,
+        primary,
+        attempt_count=base_attempt_count,
+        fallback_attempt_count=0,
+        fallback_from=None,
+    )
+
+error = primary.error
+if not prepared.policy_decision.fallback_allowed or not _is_fallback_eligible(error):
+    raise error
+
+fallback = await self._fallback.execute(prepared, primary)
+return self._assemble(
+    prepared,
+    fallback.success,
+    attempt_count=base_attempt_count + fallback.attempt_count,
+    fallback_attempt_count=fallback.attempt_count,
+    fallback_from=plan.provider,
+)
+```
+
+Use `assemble_embedding_execution_outcome()` for all three success paths. Do not create HTTP headers in this module.
+
+- [ ] **Step 4: Run the full coordinator test file and verify GREEN**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py -q
+```
+
+Expected: all coordinator tests pass.
+
+- [ ] **Step 5: Commit the execution coordinator**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/execution_coordinator.py tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
+git commit -m "refactor(embeddings): extract execution coordinator"
+```
+
+### Task 4: Production Orchestrator Delegation and Source-Routing Correction
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Embeddings/orchestrator.py`
+- Modify: `tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py`
+- Modify: `tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py`
+
+**Interfaces:**
+- Consumes: `EmbeddingExecutionCoordinator.execute(prepared) -> EmbeddingExecutionOutcome` and `map_outcome_to_legacy_execution_result(outcome) -> EmbeddingExecutionResult`.
+- Produces: unchanged `EmbeddingRequestOrchestrator.execute(prepared) -> EmbeddingExecutionResult` public behavior, with approved source-aware fallback routing.
+
+- [ ] **Step 1: Rewrite the Stage 2D guardrail as the new expected behavior**
+
+Change `test_current_fallback_wide_domain_catch_advances_after_infrastructure_failure` into a source-routing regression that expects the exact fallback infrastructure error to propagate and prevents later fallback candidates:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "boundary",
+    ["backend_identity", "cache_key", "cache_get", "cache_set"],
+)
+async def test_fallback_non_provider_failure_propagates_without_advancing(boundary):
+    # Existing fixture setup remains, including a successful later provider.
+    with pytest.raises(EmbeddingExecutionError) as raised:
+        await orchestrator.execute(prepared)
+
+    assert raised.value is original
+    assert "huggingface" not in [call["provider"] for call in executor.calls]
+```
+
+Add an endpoint parity correction case that asserts the workflow-enabled path now propagates fallback cache/identity failures rather than silently activating another provider. Do not modify unchanged parity scenarios.
+
+- [ ] **Step 2: Run production-routing tests and verify RED**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py -k "fallback_non_provider_failure" tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py -q
+```
+
+Expected: the orchestrator regression fails because the old broad fallback catch still advances; the parity suite otherwise remains green.
+
+- [ ] **Step 3: Construct and delegate to the coordinator**
+
+In `EmbeddingRequestOrchestrator.__init__`, build one shared vector processor, readiness check, provider attempt, adapter attempt, fallback coordinator, and execution coordinator from the existing injected dependencies. Keep constructor arguments unchanged.
+
+Replace the public execution body with:
+
+```python
+async def execute(self, prepared: PreparedEmbeddingRequest) -> EmbeddingExecutionResult:
+    """Execute a prepared request through the Stage 2 coordinator boundary."""
+    outcome = await self._execution_coordinator.execute(prepared)
+    return map_outcome_to_legacy_execution_result(outcome)
+```
+
+Leave `_execute_misses`, `_execute_coherent_fallback`, `_execute_adapter`, `_cache_key`, `_response_headers`, and their compatibility helpers in place for Stage 2E removal. They must be unreachable from the public `execute()` path after this step.
+
+- [ ] **Step 4: Run focused orchestrator and parity tests**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py tldw_Server_API/tests/Embeddings_isolated/test_request_types.py tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py -q
+```
+
+Expected: all selected tests pass. The only approved assertion change is source-aware fallback failure routing.
+
+- [ ] **Step 5: Commit production delegation**
+
+```bash
+git add tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
+git commit -m "refactor(embeddings): route execution through coordinators"
+```
+
+### Task 5: Documentation, Regression, Security, and Backlog Finalization
+
+**Files:**
+- Modify: `Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md`
+- Modify: `Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md`
+- Modify: `backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md`
+- Verify: `tldw_Server_API/app/core/Embeddings/execution_coordinator.py`
+- Verify: `tldw_Server_API/app/core/Embeddings/orchestrator.py`
+- Verify: `tldw_Server_API/app/core/Embeddings/provider_attempt.py`
+
+**Interfaces:**
+- Consumes: completed Stage 2D production and test changes.
+- Produces: verified, reviewable Stage 2D branch with authoritative Backlog evidence.
+
+- [ ] **Step 1: Run the focused Stage 2D regression suite**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py tldw_Server_API/tests/Embeddings_isolated/test_provider_attempt.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_request_types.py tldw_Server_API/tests/Embeddings_isolated/test_result_mapping.py tldw_Server_API/tests/Embeddings_isolated/test_workflow_types.py tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 2: Run static and security checks**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m ruff check tldw_Server_API/app/core/Embeddings/execution_coordinator.py tldw_Server_API/app/core/Embeddings/orchestrator.py tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m compileall -q tldw_Server_API/app/core/Embeddings/execution_coordinator.py tldw_Server_API/app/core/Embeddings/orchestrator.py
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Embeddings/execution_coordinator.py tldw_Server_API/app/core/Embeddings/orchestrator.py -f json -o /tmp/bandit_embeddings_stage2d.json
+```
+
+Expected: Ruff and compileall exit zero; Bandit reports zero findings in touched production code.
+
+- [ ] **Step 3: Run diff and scope review**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat origin/dev
+git status --short
+```
+
+Confirm the diff contains only the Stage 2D coordinator, focused tests, orchestrator delegation, approved source-routing assertion change, spec status correction, implementation plan, and Backlog updates.
+
+- [ ] **Step 4: Finalize Backlog.md through the CLI**
+
+Use `backlog task edit 12973.4` to:
+
+1. Check acceptance criteria 1 through 9.
+2. Check Definition of Done items 1 through 6.
+3. Record exact test totals, Ruff/compileall/Bandit results, and any known skips.
+4. Set modified files and the plan reference if supported by the installed CLI; otherwise record them in implementation notes.
+5. Add a final summary that explains both the source-aware routing correction and why Stage 2E retains endpoint/runner integration ownership.
+6. Set status to `Done` only after all verification succeeds.
+
+- [ ] **Step 5: Commit final documentation and tracking**
+
+```bash
+git add Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md "backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md"
+git commit -m "docs(embeddings): finalize stage 2d coordinators"
+```
+
+## Self-Review Checklist
+
+- Spec coverage: adapter ordering, primary readiness policy, full-request fallback, missing-credential skipping, source-aware provider failures, primary exclusion, model mapping, eligibility, error identity, rate-limit precedence, canonical attempt counters, and privacy constraints all map to explicit tasks.
+- Scope check: no inline runner, endpoint header migration, trace-summary event, resource-governor, credential-touch, Jobs, persistence, or Stage 3 behavior is introduced.
+- Placeholder scan: no `TBD`, `TODO`, generic error-handling step, or undefined implementation dependency remains.
+- Type consistency: adapter and fallback result DTOs carry `ProviderAttemptSuccess`; the execution coordinator returns `EmbeddingExecutionOutcome`; the orchestrator maps that outcome to `EmbeddingExecutionResult`.
+- Source-routing check: the fallback coordinator catches readiness domain errors and inspects `ProviderCallFailure`, but never broadly catches domain errors escaping provider attempts.
+- Compatibility check: the orchestrator public constructor and return type remain unchanged, and the legacy result mapper remains the temporary header-compatibility boundary.
+- Verification check: focused regression, Ruff, compileall, Bandit, diff review, and Backlog finalization commands are explicit.

--- a/Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+++ b/Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
@@ -1,6 +1,6 @@
 # Embeddings Workflow Stage 2: Concrete API Steps Design
 
-**Status:** Approved design; written-spec review pending
+**Status:** Approved design; written-spec review complete
 
 **Parent task:** `TASK-12973`
 

--- a/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
+++ b/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
@@ -4,7 +4,7 @@ title: Extract Embeddings fallback and execution coordinators
 status: Done
 assignee: []
 created_date: 2026-07-19 02:36
-updated_date: 2026-08-08 19:01
+updated_date: 2026-08-08 21:39
 labels:
 - embeddings
 - workflow
@@ -25,6 +25,8 @@ modified_files:
 - tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
 - tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
 - tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
+references:
+- https://github.com/rmusser01/tldw_server/pull/2774
 ---
 
 ## Description

--- a/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
+++ b/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
@@ -4,7 +4,7 @@ title: Extract Embeddings fallback and execution coordinators
 status: Done
 assignee: []
 created_date: 2026-07-19 02:36
-updated_date: 2026-08-08 18:40
+updated_date: 2026-08-08 19:01
 labels:
 - embeddings
 - workflow
@@ -56,7 +56,7 @@ Execute Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinato
 
 <!-- SECTION:NOTES:BEGIN -->
 2026-08-01: Started Stage 2D from merged PR #2767 in worktree codex/embeddings-workflow-stage2d-coordinators. Focused Stage 2C baseline passed: 251 tests. Planning coordinator extraction and source-aware failure routing before production edits.
-2026-08-08: Finalized Stage 2D coordinator extraction. The focused regression suite passed 326 tests in 185.57s with 4,635 warnings and no failures or skips. Ruff and compileall passed. Bandit reported 0 findings over 702 LOC with 0 skipped tests. git diff --check passed. The exact origin/dev comparison includes unrelated upstream changes because origin/dev advanced past merge base f15365c7bbbcd212733551e5f56d2ed6486fffe2; the merge-base scope contains the eight Stage 2D files recorded in modified_files. The approved Stage 2E boundary retains temporary private compatibility-facade duplication until Stage 2E owns inline-runner integration, endpoint header migration, and cleanup. Deferred non-blocking improvement: add an execution-level provider-attempt exception regression.
+2026-08-08: Finalized Stage 2D coordinator extraction. The focused regression suite passed 326 tests in 185.57s with 4,635 warnings and no failures or skips. Ruff and compileall passed. Bandit reported 0 findings over 702 LOC with 0 skipped tests. git diff --check passed. The exact origin/dev comparison includes unrelated upstream changes because origin/dev advanced past merge base f15365c7bbbcd212733551e5f56d2ed6486fffe2; the merge-base scope contains the eight Stage 2D files recorded in modified_files. The approved Stage 2E boundary retains temporary private compatibility-facade duplication until Stage 2E owns inline-runner integration, endpoint header migration, and cleanup. Final review found one non-blocking execution-level exception-routing test gap; commit 8caa1b9de9 added the regression, and scoped re-review found no remaining issues.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
@@ -72,5 +72,5 @@ Execute Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinato
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 2D routes Embeddings execution through explicit adapter, fallback, and execution coordinators while preserving the orchestrator constructor and legacy result boundary. Source-aware routing was chosen so only executor-originated provider failures become fallback candidates; identity, cache, validation, postprocessing, and writeback failures now propagate unchanged instead of incorrectly activating another provider. Stage 2E intentionally retains ownership of inline-runner integration, endpoint header migration, and removal of the temporary compatibility branches.
+Stage 2D routes Embeddings execution through explicit adapter, fallback, and execution coordinators while preserving the orchestrator constructor and legacy result boundary. Source-aware routing was chosen so only executor-originated provider failures become fallback candidates; identity, cache, validation, postprocessing, and writeback failures now propagate unchanged instead of incorrectly activating another provider. Final independent review found no production defects; its one test-localization gap was addressed with direct execution-level exception identity and no-fallback coverage, and scoped re-review found no remaining issues. Stage 2E intentionally retains ownership of inline-runner integration, endpoint header migration, and removal of the temporary compatibility branches.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
+++ b/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
@@ -4,7 +4,7 @@ title: Extract Embeddings fallback and execution coordinators
 status: Done
 assignee: []
 created_date: 2026-07-19 02:36
-updated_date: 2026-08-08 21:39
+updated_date: 2026-08-09 00:30
 labels:
 - embeddings
 - workflow
@@ -74,5 +74,5 @@ Execute Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinato
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Stage 2D routes Embeddings execution through explicit adapter, fallback, and execution coordinators while preserving the orchestrator constructor and legacy result boundary. Source-aware routing was chosen so only executor-originated provider failures become fallback candidates; identity, cache, validation, postprocessing, and writeback failures now propagate unchanged instead of incorrectly activating another provider. Final independent review found no production defects; its one test-localization gap was addressed with direct execution-level exception identity and no-fallback coverage, and scoped re-review found no remaining issues. Stage 2E intentionally retains ownership of inline-runner integration, endpoint header migration, and removal of the temporary compatibility branches.
+Stage 2D routes Embeddings execution through explicit adapter, fallback, and execution coordinators while preserving the orchestrator constructor and legacy result boundary. Source-aware routing was chosen so only executor-originated provider failures become fallback candidates; identity, cache, validation, postprocessing, and writeback failures now propagate unchanged instead of incorrectly activating another provider. Final independent review found no production defects, and its test-localization gap was addressed. PR #2774 review follow-up documented the intentionally retained compatibility block as Stage 2E removal scope and collapsed redundant fake-boundary parameterization while preserving concrete boundary coverage. Stage 2E retains ownership of inline-runner integration, endpoint header migration, and removal of the temporary compatibility branches.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
+++ b/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-12973.4
 title: Extract Embeddings fallback and execution coordinators
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-19 02:36'
-updated_date: '2026-07-23 23:53'
+updated_date: '2026-08-01 20:40'
 labels:
   - embeddings
   - workflow
@@ -14,6 +14,8 @@ dependencies:
 documentation:
   - >-
     Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+  - >-
+    Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md
 parent_task_id: TASK-12973
 priority: high
 ---
@@ -36,6 +38,18 @@ Stage 2D. Extract adapter, primary execution, fallback candidate traversal, mode
 - [ ] #8 Fallback traversal excludes the already-attempted primary provider and preserves the ordered policy-approved chain tail.
 - [ ] #9 Identity resolution and cache-key derivation failures never become ProviderCallFailure or activate another provider.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Execute Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md with TDD. Keep Stage 2E runner integration and compatibility cleanup out of scope.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-08-01: Started Stage 2D from merged PR #2767 in worktree codex/embeddings-workflow-stage2d-coordinators. Focused Stage 2C baseline passed: 251 tests. Planning coordinator extraction and source-aware failure routing before production edits.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
+++ b/backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
@@ -1,23 +1,30 @@
 ---
 id: TASK-12973.4
 title: Extract Embeddings fallback and execution coordinators
-status: In Progress
+status: Done
 assignee: []
-created_date: '2026-07-19 02:36'
-updated_date: '2026-08-01 20:40'
+created_date: 2026-07-19 02:36
+updated_date: 2026-08-08 18:40
 labels:
-  - embeddings
-  - workflow
-  - stage-2
+- embeddings
+- workflow
+- stage-2
 dependencies:
-  - TASK-12973.3
+- TASK-12973.3
 documentation:
-  - >-
-    Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
-  - >-
-    Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md
+- Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+- Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md
 parent_task_id: TASK-12973
 priority: high
+modified_files:
+- Docs/superpowers/specs/2026-07-18-embeddings-workflow-stage2-concrete-api-steps-design.md
+- Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinators-implementation-plan.md
+- backlog/tasks/task-12973.4 - Extract-Embeddings-fallback-and-execution-coordinators.md
+- tldw_Server_API/app/core/Embeddings/execution_coordinator.py
+- tldw_Server_API/app/core/Embeddings/orchestrator.py
+- tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
+- tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+- tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
 ---
 
 ## Description
@@ -28,15 +35,15 @@ Stage 2D. Extract adapter, primary execution, fallback candidate traversal, mode
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Adapter execution remains before primary preflight and cache access.
-- [ ] #2 Primary preflight failures do not enter fallback.
-- [ ] #3 Fallback candidates perform readiness checks and skip missing credentials.
-- [ ] #4 A fallback provider resolves the complete request without mixed-provider vectors.
-- [ ] #5 Rate-limit retry metadata and exhausted-error precedence remain unchanged.
-- [ ] #6 Only executor-originated domain failures become typed ProviderCallFailure results eligible for fallback decisions.
-- [ ] #7 Fallback missing-credential errors from readiness or provider calls skip the candidate while cache, validation, postprocessing, and writeback errors propagate.
-- [ ] #8 Fallback traversal excludes the already-attempted primary provider and preserves the ordered policy-approved chain tail.
-- [ ] #9 Identity resolution and cache-key derivation failures never become ProviderCallFailure or activate another provider.
+- [x] #1 Adapter execution remains before primary preflight and cache access.
+- [x] #2 Primary preflight failures do not enter fallback.
+- [x] #3 Fallback candidates perform readiness checks and skip missing credentials.
+- [x] #4 A fallback provider resolves the complete request without mixed-provider vectors.
+- [x] #5 Rate-limit retry metadata and exhausted-error precedence remain unchanged.
+- [x] #6 Only executor-originated domain failures become typed ProviderCallFailure results eligible for fallback decisions.
+- [x] #7 Fallback missing-credential errors from readiness or provider calls skip the candidate while cache, validation, postprocessing, and writeback errors propagate.
+- [x] #8 Fallback traversal excludes the already-attempted primary provider and preserves the ordered policy-approved chain tail.
+- [x] #9 Identity resolution and cache-key derivation failures never become ProviderCallFailure or activate another provider.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -49,14 +56,21 @@ Execute Docs/superpowers/plans/2026-08-01-embeddings-workflow-stage2d-coordinato
 
 <!-- SECTION:NOTES:BEGIN -->
 2026-08-01: Started Stage 2D from merged PR #2767 in worktree codex/embeddings-workflow-stage2d-coordinators. Focused Stage 2C baseline passed: 251 tests. Planning coordinator extraction and source-aware failure routing before production edits.
+2026-08-08: Finalized Stage 2D coordinator extraction. The focused regression suite passed 326 tests in 185.57s with 4,635 warnings and no failures or skips. Ruff and compileall passed. Bandit reported 0 findings over 702 LOC with 0 skipped tests. git diff --check passed. The exact origin/dev comparison includes unrelated upstream changes because origin/dev advanced past merge base f15365c7bbbcd212733551e5f56d2ed6486fffe2; the merge-base scope contains the eight Stage 2D files recorded in modified_files. The approved Stage 2E boundary retains temporary private compatibility-facade duplication until Stage 2E owns inline-runner integration, endpoint header migration, and cleanup. Deferred non-blocking improvement: add an execution-level provider-attempt exception regression.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stage 2D routes Embeddings execution through explicit adapter, fallback, and execution coordinators while preserving the orchestrator constructor and legacy result boundary. Source-aware routing was chosen so only executor-originated provider failures become fallback candidates; identity, cache, validation, postprocessing, and writeback failures now propagate unchanged instead of incorrectly activating another provider. Stage 2E intentionally retains ownership of inline-runner integration, endpoint header migration, and removal of the temporary compatibility branches.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-13008 - Track-Published-mirror-for-ADR-031-after-dev-sync-merge.md
+++ b/backlog/tasks/task-13008 - Track-Published-mirror-for-ADR-031-after-dev-sync-merge.md
@@ -1,0 +1,52 @@
+---
+id: TASK-13008
+title: Track Published mirror for ADR 031 after dev sync merge
+status: Done
+created_date: 2026-08-09 00:23
+labels:
+- docs
+- ci
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/2774
+- https://github.com/rmusser01/tldw_server/pull/2775
+modified_files:
+- Docs/Published/ADR/031-notes-capability-sync-domains.md
+- Docs/Published/ADR/README.md
+- backlog/tasks/task-13008 - Track-Published-mirror-for-ADR-031-after-dev-sync-merge.md
+updated_date: 2026-08-09 00:26
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Repair the onboarding-docs-gate failure inherited from dev merge PR #2775 by generating and tracking the canonical Docs/Published mirror for Docs/ADR/031-notes-capability-sync-domains.md. Keep the fix limited to generated documentation and verify the exact failing docs refresh contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Docs/Published/ADR/031-notes-capability-sync-domains.md is generated from the canonical Docs source and tracked.
+- [x] #2 test_refresh_output_matches_tracked_published_files passes.
+- [x] #3 The full Docs test suite passes or unrelated failures are documented.
+- [x] #4 No unrelated generated documentation changes are committed.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-08-09: Root cause confirmed from onboarding-docs-gate run 31285834592/job/93174357704 and reproduced locally under PYTEST_DISABLE_PLUGIN_AUTOLOAD=1: dev merge PR #2775 added canonical ADR 031 and its canonical ADR index entry without tracking the generated Docs/Published counterparts. Ran Helper_Scripts/refresh_docs_published.sh. The exact failing manifest test changed from 1 failed to 1 passed after staging the generated ADR mirror and index. Full local Docs suite: 189 passed, 1 failed only because mkdocs is not installed in the project virtual environment; CI installs mkdocs and had no other Docs failures. git diff checks passed. Bandit skipped because the fix contains generated Markdown and task metadata only. The two unrelated untracked Watchlists templates were not touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Generated and tracked Docs/Published/ADR/031-notes-capability-sync-domains.md plus the ADR-031 entry in Docs/Published/ADR/README.md, repairing the onboarding-docs-gate manifest failure inherited from dev PR #2775. No Embeddings production behavior changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Verification results recorded
+- [x] #3 Modified files recorded
+- [x] #4 Final summary added
+<!-- DOD:END -->

--- a/backlog/tasks/task-13010 - Track-Published-mirror-for-ADR-037-after-latest-dev-rebase.md
+++ b/backlog/tasks/task-13010 - Track-Published-mirror-for-ADR-037-after-latest-dev-rebase.md
@@ -1,0 +1,61 @@
+---
+id: TASK-13010
+title: Track Published mirror for ADR 037 after latest dev rebase
+status: Done
+created_date: 2026-08-12 00:46
+labels:
+- docs
+- ci
+- adr
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/2774
+- TASK-13004
+- Docs/ADR/037-canonical-notes-link-sync-and-derived-graph-projections.md
+modified_files:
+- Docs/Published/ADR/037-canonical-notes-link-sync-and-derived-graph-projections.md
+- Docs/Published/ADR/README.md
+updated_date: 2026-08-12 00:49
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Repair the exact Docs Published manifest failure exposed after rebasing PR #2774 onto latest dev: ADR 037 exists in Docs/ADR but its generated Docs/Published mirror and index entry are absent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Docs/Published/ADR/037-canonical-notes-link-sync-and-derived-graph-projections.md matches the canonical source ADR.
+- [x] #2 Docs/Published/ADR/README.md includes ADR 037 without removing later upstream entries.
+- [x] #3 The exact published-refresh manifest test passes.
+- [x] #4 The repair is committed and linked to PR #2774.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce and verify the missing Published ADR 037 manifest entry. 2. Run the repository's published-docs refresh workflow. 3. Inspect the generated diff to keep only the required tracked mirror/index changes. 4. Run the exact manifest test and diff checks, then record verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reproduced after rebasing PR #2774 onto origin/dev@414e81a12a: the exact Published manifest test failed because ADR 037 was generated but untracked. Ran Helper_Scripts/refresh_docs_published.sh; the only generated changes were the exact ADR 037 mirror and one README index line. Verified source/mirror byte equality with cmp, exact manifest test passed (1 passed), and git diff checks passed. This is a docs-only repair, so no additional Bandit scope applies; the PR's touched Embeddings production files separately passed Bandit with zero findings across 702 LOC.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the missing generated Published mirror for ADR 037 and its ADR index entry after the latest dev rebase exposed an upstream docs-manifest failure. Used the canonical refresh workflow so the mirror remains byte-identical to the source and preserved all newer upstream ADR entries. The exact manifest test and diff checks pass, and the repair is included in PR #2774.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Embeddings/execution_coordinator.py
+++ b/tldw_Server_API/app/core/Embeddings/execution_coordinator.py
@@ -1,0 +1,89 @@
+"""Explicit execution boundaries for the embeddings workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tldw_Server_API.app.core.Embeddings.provider_attempt import (
+    ProviderAttemptExecutor,
+    ProviderAttemptSuccess,
+)
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutorOutput,
+    PreparedEmbeddingRequest,
+)
+from tldw_Server_API.app.core.Embeddings.vector_processing import (
+    EmbeddingVectorProcessor,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterAttemptResult:
+    """Record whether the adapter path ran and whether it produced vectors."""
+
+    attempted: bool
+    success: ProviderAttemptSuccess | None = None
+
+    def __post_init__(self) -> None:
+        if self.success is not None and not self.attempted:
+            raise ValueError("adapter success requires an attempted adapter path")
+
+
+class EmbeddingAdapterAttempt:
+    """Execute an optional adapter path for one prepared embedding request."""
+
+    def __init__(
+        self,
+        *,
+        executor: ProviderAttemptExecutor,
+        vector_processor: EmbeddingVectorProcessor | None = None,
+    ) -> None:
+        self._executor = executor
+        self._vector_processor = vector_processor or EmbeddingVectorProcessor()
+
+    async def execute(self, prepared: PreparedEmbeddingRequest) -> AdapterAttemptResult:
+        """Attempt adapter execution, preserving adapter exceptions for the caller."""
+        plan = prepared.execution_plan
+        if plan.execution_path != "adapter":
+            return AdapterAttemptResult(attempted=False)
+
+        create_adapter = getattr(self._executor, "create_adapter", None)
+        if not callable(create_adapter):
+            return AdapterAttemptResult(attempted=False)
+
+        output = await create_adapter(
+            prepared.normalized_input.texts,
+            provider=plan.provider,
+            model=plan.model,
+            dimensions=plan.dimensions,
+        )
+        if not isinstance(output, EmbeddingExecutorOutput) or not output.embeddings_from_adapter:
+            return AdapterAttemptResult(attempted=True)
+
+        vectors = self._vector_processor.validate_vector_count(
+            output.vectors,
+            expected=len(prepared.normalized_input.texts),
+            provider=plan.provider,
+            model=plan.model,
+        )
+        processed_vectors = self._vector_processor.process_vectors(
+            vectors,
+            provider=plan.provider,
+            model=plan.model,
+            dimensions=plan.dimensions,
+            dimension_policy=prepared.effective_dimension_policy,
+        )
+        return AdapterAttemptResult(
+            attempted=True,
+            success=ProviderAttemptSuccess(
+                vectors=processed_vectors,
+                provider=plan.provider,
+                model=plan.model,
+                cache_hits=0,
+                cache_misses=len(prepared.normalized_input.texts),
+                embeddings_from_adapter=True,
+            ),
+        )
+
+
+__all__ = ["AdapterAttemptResult", "EmbeddingAdapterAttempt"]

--- a/tldw_Server_API/app/core/Embeddings/execution_coordinator.py
+++ b/tldw_Server_API/app/core/Embeddings/execution_coordinator.py
@@ -18,9 +18,13 @@ from tldw_Server_API.app.core.Embeddings.provider_attempt import (
 from tldw_Server_API.app.core.Embeddings.request_types import (
     EmbeddingDomainError,
     EmbeddingExecutionError,
+    EmbeddingExecutionOutcome,
     EmbeddingExecutorOutput,
     EmbeddingProviderError,
     PreparedEmbeddingRequest,
+)
+from tldw_Server_API.app.core.Embeddings.result_mapping import (
+    assemble_embedding_execution_outcome,
 )
 from tldw_Server_API.app.core.Embeddings.vector_processing import (
     EmbeddingVectorProcessor,
@@ -176,6 +180,92 @@ class EmbeddingFallbackCoordinator:
         )
 
 
+class EmbeddingExecutionCoordinator:
+    """Run adapter, primary, and fallback execution into one canonical outcome."""
+
+    def __init__(
+        self,
+        *,
+        adapter_attempt: EmbeddingAdapterAttempt,
+        readiness: EmbeddingProviderReadinessCheck,
+        provider_attempt: EmbeddingProviderAttempt,
+        fallback_coordinator: EmbeddingFallbackCoordinator,
+    ) -> None:
+        self._adapter_attempt = adapter_attempt
+        self._readiness = readiness
+        self._provider_attempt = provider_attempt
+        self._fallback = fallback_coordinator
+
+    async def execute(
+        self,
+        prepared: PreparedEmbeddingRequest,
+    ) -> EmbeddingExecutionOutcome:
+        """Execute the prepared request through the ordered provider boundaries."""
+        adapter_result = await self._adapter_attempt.execute(prepared)
+        base_attempt_count = int(adapter_result.attempted)
+        if adapter_result.success is not None:
+            return self._assemble(
+                prepared,
+                adapter_result.success,
+                attempt_count=base_attempt_count,
+                fallback_attempt_count=0,
+                fallback_from=None,
+            )
+
+        plan = prepared.execution_plan
+        base_attempt_count += 1
+        await self._readiness.check(plan.provider, plan.model)
+        primary = await self._provider_attempt.execute(
+            prepared,
+            provider=plan.provider,
+            model=plan.model,
+        )
+        if isinstance(primary, ProviderAttemptSuccess):
+            return self._assemble(
+                prepared,
+                primary,
+                attempt_count=base_attempt_count,
+                fallback_attempt_count=0,
+                fallback_from=None,
+            )
+
+        error = primary.error
+        if not prepared.policy_decision.fallback_allowed or not _is_fallback_eligible(error):
+            raise error
+
+        fallback = await self._fallback.execute(prepared, primary)
+        return self._assemble(
+            prepared,
+            fallback.success,
+            attempt_count=base_attempt_count + fallback.attempt_count,
+            fallback_attempt_count=fallback.attempt_count,
+            fallback_from=plan.provider,
+        )
+
+    @staticmethod
+    def _assemble(
+        prepared: PreparedEmbeddingRequest,
+        success: ProviderAttemptSuccess,
+        *,
+        attempt_count: int,
+        fallback_attempt_count: int,
+        fallback_from: str | None,
+    ) -> EmbeddingExecutionOutcome:
+        """Map a successful attempt to the immutable execution outcome."""
+        return assemble_embedding_execution_outcome(
+            prepared,
+            vectors=success.vectors,
+            provider=success.provider,
+            model=success.model,
+            cache_hits=success.cache_hits,
+            cache_misses=success.cache_misses,
+            fallback_from=fallback_from,
+            embeddings_from_adapter=success.embeddings_from_adapter,
+            attempt_count=attempt_count,
+            fallback_attempt_count=fallback_attempt_count,
+        )
+
+
 _NON_FALLBACKABLE_ERROR_CODES = frozenset(
     {
         "empty_input",
@@ -215,6 +305,7 @@ def _select_exhausted_error(
 __all__ = [
     "AdapterAttemptResult",
     "EmbeddingAdapterAttempt",
+    "EmbeddingExecutionCoordinator",
     "EmbeddingFallbackCoordinator",
     "FallbackExecutionSuccess",
 ]

--- a/tldw_Server_API/app/core/Embeddings/execution_coordinator.py
+++ b/tldw_Server_API/app/core/Embeddings/execution_coordinator.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
+from tldw_Server_API.app.core.Embeddings.embedding_policy import (
+    map_model_for_provider,
+)
 from tldw_Server_API.app.core.Embeddings.provider_attempt import (
+    EmbeddingProviderAttempt,
+    EmbeddingProviderReadinessCheck,
     ProviderAttemptExecutor,
     ProviderAttemptSuccess,
+    ProviderCallFailure,
 )
 from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingDomainError,
+    EmbeddingExecutionError,
     EmbeddingExecutorOutput,
+    EmbeddingProviderError,
     PreparedEmbeddingRequest,
 )
 from tldw_Server_API.app.core.Embeddings.vector_processing import (
@@ -27,6 +37,14 @@ class AdapterAttemptResult:
     def __post_init__(self) -> None:
         if self.success is not None and not self.attempted:
             raise ValueError("adapter success requires an attempted adapter path")
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackExecutionSuccess:
+    """Successful fallback result plus the candidates whose readiness began."""
+
+    success: ProviderAttemptSuccess
+    attempt_count: int
 
 
 class EmbeddingAdapterAttempt:
@@ -86,4 +104,117 @@ class EmbeddingAdapterAttempt:
         )
 
 
-__all__ = ["AdapterAttemptResult", "EmbeddingAdapterAttempt"]
+class EmbeddingFallbackCoordinator:
+    """Route a failed primary provider through ordered fallback candidates."""
+
+    def __init__(
+        self,
+        *,
+        readiness: EmbeddingProviderReadinessCheck,
+        provider_attempt: EmbeddingProviderAttempt,
+        settings_fallback_model_map: Mapping[str, object] | None,
+    ) -> None:
+        self._readiness = readiness
+        self._provider_attempt = provider_attempt
+        self._settings_fallback_model_map = settings_fallback_model_map
+
+    async def execute(
+        self,
+        prepared: PreparedEmbeddingRequest,
+        primary_failure: ProviderCallFailure,
+    ) -> FallbackExecutionSuccess:
+        """Attempt every non-primary candidate until one returns complete vectors."""
+        plan = prepared.execution_plan
+        errors: list[EmbeddingDomainError] = [primary_failure.error]
+        attempt_count = 0
+
+        for provider in plan.fallback_chain:
+            if provider == plan.provider:
+                continue
+
+            model = map_model_for_provider(
+                plan.provider,
+                provider,
+                plan.model,
+                settings_fallback_model_map=self._settings_fallback_model_map,
+            )
+            attempt_count += 1
+            try:
+                await self._readiness.check(provider, model)
+            except EmbeddingDomainError as error:
+                if error.code == "missing_provider_credentials":
+                    continue
+                errors.append(error)
+                if not _is_fallback_eligible(error):
+                    raise
+                continue
+
+            attempt_result = await self._provider_attempt.execute(
+                prepared,
+                provider=provider,
+                model=model,
+            )
+            if isinstance(attempt_result, ProviderAttemptSuccess):
+                return FallbackExecutionSuccess(attempt_result, attempt_count)
+
+            error = attempt_result.error
+            if error.code == "missing_provider_credentials":
+                continue
+            errors.append(error)
+            if not _is_fallback_eligible(error):
+                raise error
+
+        selected_error = _select_exhausted_error(errors)
+        if selected_error is not None:
+            raise selected_error
+        raise EmbeddingExecutionError(
+            "fallback_exhausted",
+            "Embedding providers unavailable",
+            retryable=True,
+            provider=plan.provider,
+            model=plan.model,
+        )
+
+
+_NON_FALLBACKABLE_ERROR_CODES = frozenset(
+    {
+        "empty_input",
+        "invalid_input_type",
+        "too_many_inputs",
+        "input_too_long",
+        "invalid_token_array",
+        "unknown_provider",
+        "provider_model_mismatch",
+        "invalid_dimensions",
+        "provider_denied",
+        "model_denied",
+        "model_required",
+        "provider_unsupported",
+        "missing_provider_credentials",
+        "provider_malformed_response",
+    }
+)
+
+
+def _is_fallback_eligible(error: EmbeddingDomainError) -> bool:
+    return bool(error.retryable) and error.code not in _NON_FALLBACKABLE_ERROR_CODES
+
+
+def _select_exhausted_error(
+    errors: Sequence[EmbeddingDomainError],
+) -> EmbeddingDomainError | None:
+    for error in errors:
+        if isinstance(error, EmbeddingProviderError) and not error.retryable:
+            return error
+    for error in errors:
+        if error.code == "provider_rate_limited":
+            return error
+    return errors[-1] if errors else None
+
+
+__all__ = [
+    "AdapterAttemptResult",
+    "EmbeddingAdapterAttempt",
+    "EmbeddingFallbackCoordinator",
+    "FallbackExecutionSuccess",
+]

--- a/tldw_Server_API/app/core/Embeddings/orchestrator.py
+++ b/tldw_Server_API/app/core/Embeddings/orchestrator.py
@@ -9,11 +9,20 @@ from typing import Any, Literal, Protocol
 from tldw_Server_API.app.core.Embeddings.embedding_policy import (
     map_model_for_provider,
 )
+from tldw_Server_API.app.core.Embeddings.execution_coordinator import (
+    EmbeddingAdapterAttempt,
+    EmbeddingExecutionCoordinator,
+    EmbeddingFallbackCoordinator,
+)
 from tldw_Server_API.app.core.Embeddings.preparation import (
     BackendIdentityResolver,
     EmbeddingPreparationPipeline,
     TokenCounter,
     TokenDecoder,
+)
+from tldw_Server_API.app.core.Embeddings.provider_attempt import (
+    EmbeddingProviderAttempt,
+    EmbeddingProviderReadinessCheck,
 )
 from tldw_Server_API.app.core.Embeddings.provider_resolution import ProviderGuesser
 from tldw_Server_API.app.core.Embeddings.request_types import (
@@ -24,6 +33,9 @@ from tldw_Server_API.app.core.Embeddings.request_types import (
     EmbeddingProviderError,
     EmbeddingRequestContext,
     PreparedEmbeddingRequest,
+)
+from tldw_Server_API.app.core.Embeddings.result_mapping import (
+    map_outcome_to_legacy_execution_result,
 )
 from tldw_Server_API.app.core.Embeddings.vector_processing import (
     DimensionAdjustmentRecorder,
@@ -117,6 +129,29 @@ class EmbeddingRequestOrchestrator:
         self._backend_identity_resolver = backend_identity_resolver or _no_backend_identity
         self._provider_preflight = provider_preflight or _no_provider_preflight
         self._vector_processor = EmbeddingVectorProcessor(record_dimension_adjustment=record_dimension_adjustment)
+        readiness = EmbeddingProviderReadinessCheck(self._provider_preflight)
+        provider_attempt = EmbeddingProviderAttempt(
+            cache_key_fn=cache_key_fn,
+            cache=cache,
+            executor=executor,
+            backend_identity_resolver=self._backend_identity_resolver,
+            vector_processor=self._vector_processor,
+        )
+        adapter_attempt = EmbeddingAdapterAttempt(
+            executor=executor,
+            vector_processor=self._vector_processor,
+        )
+        fallback_coordinator = EmbeddingFallbackCoordinator(
+            readiness=readiness,
+            provider_attempt=provider_attempt,
+            settings_fallback_model_map=settings_fallback_model_map,
+        )
+        self._execution_coordinator = EmbeddingExecutionCoordinator(
+            adapter_attempt=adapter_attempt,
+            readiness=readiness,
+            provider_attempt=provider_attempt,
+            fallback_coordinator=fallback_coordinator,
+        )
         self._preparation_pipeline = EmbeddingPreparationPipeline(
             count_tokens=count_tokens,
             tokens_to_texts=tokens_to_texts,
@@ -143,114 +178,9 @@ class EmbeddingRequestOrchestrator:
         return self._preparation_pipeline.prepare(raw_input, context)
 
     async def execute(self, prepared: PreparedEmbeddingRequest) -> EmbeddingExecutionResult:
-        """Execute a prepared request through cache and provider executor."""
-        plan = prepared.execution_plan
-        adapter_execution = await self._execute_adapter(prepared)
-        if adapter_execution is not None:
-            headers = self._response_headers(
-                actual_provider=adapter_execution.provider,
-                fallback_from=adapter_execution.fallback_from,
-                dimensions=plan.dimensions,
-                dimension_policy=prepared.effective_dimension_policy,
-            )
-            return EmbeddingExecutionResult(
-                vectors=adapter_execution.vectors,
-                provider=adapter_execution.provider,
-                model=adapter_execution.model,
-                prompt_tokens=prepared.prompt_tokens,
-                total_tokens=prepared.total_tokens,
-                cache_hits=0,
-                cache_misses=len(prepared.normalized_input.texts),
-                fallback_from=adapter_execution.fallback_from,
-                response_headers=headers,
-                embeddings_from_adapter=True,
-            )
-
-        results: list[list[float] | None] = []
-        miss_indices: list[int] = []
-        miss_texts: list[str] = []
-
-        await self._provider_preflight(plan.provider, plan.model)
-        primary_backend_identity = self._backend_identity_resolver(plan.provider, plan.model)
-        for index, text in enumerate(prepared.normalized_input.texts):
-            key = self._cache_key(text, plan.provider, plan.model, plan.dimensions, primary_backend_identity)
-            cached = await self._cache.get(key)
-            cached_vector = self._vector_processor.validate_cached_vector(cached)
-            if cached_vector is not None:
-                results.append(
-                    self._vector_processor.process_cached_vector(
-                        cached_vector,
-                        provider=plan.provider,
-                        model=plan.model,
-                        dimensions=plan.dimensions,
-                        dimension_policy=prepared.effective_dimension_policy,
-                    )
-                )
-                continue
-            results.append(None)
-            miss_indices.append(index)
-            miss_texts.append(text)
-
-        actual_provider = plan.provider
-        actual_model = plan.model
-        fallback_from: str | None = None
-        embeddings_from_adapter = False
-        pending_cache_writes: list[tuple[str, list[float]]] = []
-        if miss_texts:
-            execution = await self._execute_misses(prepared, miss_texts)
-            actual_provider = execution.provider
-            actual_model = execution.model
-            fallback_from = execution.fallback_from
-            embeddings_from_adapter = execution.embeddings_from_adapter
-            if execution.complete_response:
-                results = list(execution.vectors)
-                cache_hits = execution.cache_hits
-                cache_misses = execution.cache_misses
-            else:
-                backend_identity = self._backend_identity_resolver(actual_provider, actual_model)
-                cache_vectors = execution.cache_vectors or execution.vectors
-                for index, text, vector, cache_vector in zip(
-                    miss_indices,
-                    miss_texts,
-                    execution.vectors,
-                    cache_vectors,
-                ):
-                    results[index] = vector
-                    if not execution.embeddings_from_adapter:
-                        key = self._cache_key(text, actual_provider, actual_model, plan.dimensions, backend_identity)
-                        pending_cache_writes.append((key, cache_vector))
-                cache_hits = len(results) - len(miss_indices)
-                cache_misses = len(miss_indices)
-        else:
-            cache_hits = len(results)
-            cache_misses = 0
-
-        vectors = self._vector_processor.validate_vector_count(
-            results,
-            expected=len(prepared.normalized_input.texts),
-            provider=actual_provider,
-            model=actual_model,
-        )
-        for key, cache_vector in pending_cache_writes:
-            await self._cache.set(key, cache_vector)
-        headers = self._response_headers(
-            actual_provider=actual_provider,
-            fallback_from=fallback_from,
-            dimensions=plan.dimensions,
-            dimension_policy=prepared.effective_dimension_policy,
-        )
-        return EmbeddingExecutionResult(
-            vectors=vectors,
-            provider=actual_provider,
-            model=actual_model,
-            prompt_tokens=prepared.prompt_tokens,
-            total_tokens=prepared.total_tokens,
-            cache_hits=cache_hits,
-            cache_misses=cache_misses,
-            fallback_from=fallback_from,
-            response_headers=headers,
-            embeddings_from_adapter=embeddings_from_adapter,
-        )
+        """Execute a prepared request through the Stage 2 coordinator boundary."""
+        outcome = await self._execution_coordinator.execute(prepared)
+        return map_outcome_to_legacy_execution_result(outcome)
 
     async def _execute_misses(
         self,

--- a/tldw_Server_API/app/core/Embeddings/orchestrator.py
+++ b/tldw_Server_API/app/core/Embeddings/orchestrator.py
@@ -79,6 +79,8 @@ CacheKeyFn = Callable[[str, str, str, int | None, str | None], str]
 ProviderPreflight = Callable[[str, str], Awaitable[None]]
 
 
+# Stage 2D compatibility only: these private execution members are unreachable
+# from execute(). Stage 2E removes them after runner and header migration.
 @dataclass(frozen=True, slots=True)
 class _ProviderExecution:
     vectors: list[list[float]]

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_orchestrator_endpoint_parity.py
@@ -550,6 +550,119 @@ def test_orchestrator_endpoint_cache_key_secret_failure_propagates_without_fallb
     assert provider_calls == []
 
 
+@pytest.mark.parametrize(
+    "boundary",
+    ["backend_identity", "cache_key", "cache_get", "cache_set"],
+)
+def test_orchestrator_endpoint_fallback_infrastructure_failure_stops_provider_activation(
+    client,
+    monkeypatch,
+    boundary,
+):
+    from tldw_Server_API.app.api.v1.endpoints import (
+        embeddings_v5_production_enhanced as mod,
+    )
+
+    original = EmbeddingExecutionError(
+        "internal_execution_failure",
+        f"fallback {boundary} failed",
+        retryable=True,
+        provider="cohere",
+        model="embed-english-v3.0",
+    )
+    preflight_providers: list[str] = []
+    provider_calls: list[str] = []
+    fallback_chain = {"openai": ["openai", "cohere", "huggingface"]}
+    fallback_model_map = {
+        "openai:text-embedding-3-small": {
+            "cohere": "embed-english-v3.0",
+            "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+        }
+    }
+
+    def policy_setting(name, default):
+        if name == "EMBEDDINGS_FALLBACK_CHAIN":
+            return fallback_chain
+        if name == "EMBEDDINGS_FALLBACK_MODEL_MAP":
+            return fallback_model_map
+        return default
+
+    def backend_identity(_executor, provider, model):
+        if boundary == "backend_identity" and provider == "cohere":
+            raise original
+        return f"{provider}:{model}:backend"
+
+    def cache_key(text, provider, model, dimensions=None, backend_identity=None):
+        if boundary == "cache_key" and provider == "cohere":
+            raise original
+        return _friendly_cache_key(
+            text,
+            provider,
+            model,
+            dimensions,
+            backend_identity,
+        )
+
+    async def cache_get(key):
+        if boundary == "cache_get" and key.startswith("cohere|"):
+            raise original
+        return None
+
+    async def cache_set(key, _value):
+        if boundary == "cache_set" and key.startswith("cohere|"):
+            raise original
+        return None
+
+    async def record_preflight(_executor, provider, _model):
+        preflight_providers.append(provider)
+
+    async def record_create(
+        _executor,
+        texts,
+        *,
+        provider,
+        model,
+        dimensions,
+    ):
+        del dimensions
+        provider_calls.append(provider)
+        if provider == "openai":
+            raise EmbeddingProviderError(
+                "provider_unavailable",
+                "primary unavailable",
+                retryable=True,
+                provider=provider,
+                model=model,
+            )
+        return [[0.1, 0.2] for _ in texts]
+
+    monkeypatch.setenv("EMBEDDINGS_ORCHESTRATOR_ENABLED", "true")
+    monkeypatch.setenv("EMBEDDINGS_ALLOW_FALLBACK_WITH_HEADER", "true")
+    monkeypatch.setenv("LLM_EMBEDDINGS_ADAPTERS_ENABLED", "false")
+    monkeypatch.setattr(mod, "_embedding_policy_setting", policy_setting)
+    monkeypatch.setattr(mod, "get_cache_key", cache_key)
+    monkeypatch.setattr(mod.embedding_cache, "get", cache_get)
+    monkeypatch.setattr(mod.embedding_cache, "set", cache_set)
+    monkeypatch.setattr(mod._EndpointEmbeddingExecutor, "backend_identity", backend_identity)
+    monkeypatch.setattr(
+        mod._EndpointEmbeddingExecutor,
+        "preflight_provider",
+        record_preflight,
+    )
+    monkeypatch.setattr(mod._EndpointEmbeddingExecutor, "create", record_create)
+
+    response = client.post(
+        "/api/v1/embeddings",
+        headers={"x-provider": "openai"},
+        json={"model": "text-embedding-3-small", "input": "fallback boundary"},
+    )
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert response.json() == {"detail": f"fallback {boundary} failed"}
+    assert preflight_providers == ["openai", "cohere"]
+    assert "huggingface" not in provider_calls
+
+
 def _run_dual_path_embedding_request(
     client,
     monkeypatch,

--- a/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_embedding_orchestrator.py
@@ -1331,10 +1331,10 @@ async def test_retryable_fallback_preflight_failure_continues_to_next_candidate(
     "boundary",
     ["backend_identity", "cache_key", "cache_get", "cache_set"],
 )
-async def test_current_fallback_wide_domain_catch_advances_after_infrastructure_failure(
+async def test_fallback_non_provider_failure_propagates_without_advancing(
     boundary,
 ):
-    """Pin current behavior that Stage 2D will intentionally correct."""
+    """Fallback infrastructure failures must not activate a later provider."""
     cohere_model = "embed-english-v3.0"
     original = EmbeddingExecutionError(
         "internal_execution_failure",
@@ -1443,22 +1443,16 @@ async def test_current_fallback_wide_domain_catch_advances_after_infrastructure_
     ]
     events.clear()
 
-    result = await orchestrator.execute(prepared)
+    with pytest.raises(EmbeddingExecutionError) as raised:
+        await orchestrator.execute(prepared)
 
-    expected_executor_providers = (
-        ["openai", "cohere", "huggingface"]
-        if boundary == "cache_set"
-        else ["openai", "huggingface"]
-    )
-    assert result.provider == "huggingface"
-    assert result.vectors == [[0.5, 0.25]]
-    assert result.fallback_from == "openai"
+    assert raised.value is original
     assert [
         provider
         for action, provider, _ in events
         if action == "candidate"
-    ] == ["openai", "cohere", "huggingface"]
-    assert [call["provider"] for call in executor.calls] == expected_executor_providers
+    ] == ["openai", "cohere"]
+    assert "huggingface" not in [call["provider"] for call in executor.calls]
     assert [call["provider"] for call in executor.calls].count("openai") == 1
     assert [
         event

--- a/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+
+from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingExecutionPlan,
+    EmbeddingExecutorOutput,
+    EmbeddingPolicyDecision,
+    NormalizedEmbeddingInput,
+    PreparedEmbeddingRequest,
+    ProviderModelIntent,
+)
+from tldw_Server_API.app.core.Embeddings.provider_attempt import ProviderAttemptSuccess
+from tldw_Server_API.app.core.Embeddings.execution_coordinator import (
+    AdapterAttemptResult,
+    EmbeddingAdapterAttempt,
+)
+
+
+def _prepared(
+    *,
+    texts: list[str] | None = None,
+    provider: str = "openai",
+    model: str = "text-embedding-3-small",
+    fallback_chain: list[str] | None = None,
+    fallback_allowed: bool = True,
+    execution_path: Literal["legacy", "adapter"] = "legacy",
+) -> PreparedEmbeddingRequest:
+    ordered_texts = texts or ["alpha"]
+    chain = list(fallback_chain or [provider])
+    return PreparedEmbeddingRequest(
+        normalized_input=NormalizedEmbeddingInput(
+            texts=ordered_texts,
+            token_counts=[1 for _ in ordered_texts],
+            total_tokens=len(ordered_texts),
+        ),
+        provider_intent=ProviderModelIntent(
+            provider=provider,
+            model=model,
+            requested_provider=provider,
+            requested_model=model,
+            provider_was_explicit=True,
+            model_was_provider_qualified=False,
+        ),
+        policy_decision=EmbeddingPolicyDecision(
+            provider=provider,
+            model=model,
+            dimensions=None,
+            fallback_chain=chain,
+            fallback_allowed=fallback_allowed,
+            enforce_policy=True,
+        ),
+        execution_plan=EmbeddingExecutionPlan(
+            provider=provider,
+            model=model,
+            dimensions=None,
+            backend_identity="stale-plan-identity",
+            fallback_chain=chain,
+            execution_path=execution_path,
+        ),
+        effective_dimension_policy="reduce",
+        prompt_tokens=len(ordered_texts),
+        total_tokens=len(ordered_texts),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptCall:
+    prepared: PreparedEmbeddingRequest
+    provider: str
+    model: str
+
+
+class RecordingExecutor:
+    def __init__(
+        self,
+        *,
+        adapter_output: EmbeddingExecutorOutput | None = None,
+        adapter_error: Exception | None = None,
+    ) -> None:
+        self.adapter_output = adapter_output
+        self.adapter_error = adapter_error
+        self.adapter_calls: list[tuple[list[str], str, str, int | None]] = []
+
+    async def create_adapter(
+        self,
+        texts: list[str],
+        *,
+        provider: str,
+        model: str,
+        dimensions: int | None,
+    ) -> EmbeddingExecutorOutput | None:
+        self.adapter_calls.append((texts, provider, model, dimensions))
+        if self.adapter_error is not None:
+            raise self.adapter_error
+        return self.adapter_output
+
+
+class ExecutorWithoutAdapter:
+    pass
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_attempt_skips_non_adapter_execution_plan():
+    executor = RecordingExecutor()
+    attempt = EmbeddingAdapterAttempt(executor=executor)
+
+    result = await attempt.execute(_prepared(execution_path="legacy"))
+
+    assert result == AdapterAttemptResult(attempted=False)
+    assert executor.adapter_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_attempt_skips_executor_without_create_adapter():
+    executor = ExecutorWithoutAdapter()
+    attempt = EmbeddingAdapterAttempt(executor=executor)
+
+    result = await attempt.execute(_prepared(execution_path="adapter"))
+
+    assert result == AdapterAttemptResult(attempted=False)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_attempt_decline_is_counted_without_provider_result():
+    executor = RecordingExecutor(adapter_output=None)
+    attempt = EmbeddingAdapterAttempt(executor=executor)
+
+    result = await attempt.execute(_prepared(execution_path="adapter"))
+
+    assert result == AdapterAttemptResult(attempted=True)
+    assert len(executor.adapter_calls) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_attempt_non_adapter_output_is_a_decline():
+    executor = RecordingExecutor(
+        adapter_output=EmbeddingExecutorOutput(
+            vectors=[[3.0, 4.0]],
+            embeddings_from_adapter=False,
+        )
+    )
+    attempt = EmbeddingAdapterAttempt(executor=executor)
+
+    result = await attempt.execute(_prepared(execution_path="adapter"))
+
+    assert result == AdapterAttemptResult(attempted=True)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_attempt_validates_and_processes_success():
+    executor = RecordingExecutor(
+        adapter_output=EmbeddingExecutorOutput(
+            vectors=[[3.0, 4.0]],
+            embeddings_from_adapter=True,
+        )
+    )
+    attempt = EmbeddingAdapterAttempt(executor=executor)
+
+    result = await attempt.execute(_prepared(execution_path="adapter"))
+
+    assert result.success == ProviderAttemptSuccess(
+        vectors=[[3.0, 4.0]],
+        provider="openai",
+        model="text-embedding-3-small",
+        cache_hits=0,
+        cache_misses=1,
+        embeddings_from_adapter=True,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_adapter_attempt_reraises_exact_adapter_exception():
+    error = RuntimeError("adapter failed")
+    executor = RecordingExecutor(adapter_error=error)
+    attempt = EmbeddingAdapterAttempt(executor=executor)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await attempt.execute(_prepared(execution_path="adapter"))
+
+    assert exc_info.value is error

--- a/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
@@ -802,16 +802,10 @@ async def test_fallback_passes_the_complete_prepared_request_to_successful_attem
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "boundary",
-    ["backend_identity", "cache_key", "cache", "validation", "postprocessing", "writeback"],
-)
-async def test_fallback_propagates_attempt_boundary_errors_without_advancing(
-    boundary: str,
-):
+async def test_fallback_propagates_attempt_exception_without_advancing():
     error = EmbeddingExecutionError(
         "internal_execution_failure",
-        f"{boundary} failed",
+        "attempt boundary failed",
         retryable=True,
     )
     readiness = RecordingReadiness()

--- a/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
@@ -244,6 +244,7 @@ def _coordinator(
     primary_result: ProviderAttemptSuccess | ProviderCallFailure | None = None,
     fallback_result: FallbackExecutionSuccess | None = None,
     fallback: RecordingFallbackCoordinator | None = None,
+    provider_attempt: RecordingProviderAttempt | None = None,
 ) -> EmbeddingExecutionCoordinator:
     ordered_events = events if events is not None else []
     adapter = RecordingAdapterAttempt(
@@ -254,9 +255,8 @@ def _coordinator(
         errors={"openai": readiness_error} if readiness_error is not None else None,
         events=ordered_events,
     )
-    attempt = RecordingProviderAttempt(
-        outcomes={"openai": primary_result or _success("openai")},
-        events=ordered_events,
+    attempt = provider_attempt or RecordingProviderAttempt(
+        outcomes={"openai": primary_result or _success("openai")}, events=ordered_events
     )
     fallback_coordinator = fallback or RecordingFallbackCoordinator(fallback_result)
     return EmbeddingExecutionCoordinator(
@@ -325,6 +325,32 @@ async def test_execution_primary_readiness_failure_does_not_enter_fallback():
         await coordinator.execute(_prepared())
 
     assert raised.value is error
+    assert fallback.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_reraises_primary_provider_attempt_exception_without_fallback():
+    error = EmbeddingExecutionError(
+        "internal_execution_failure",
+        "primary provider attempt failed",
+        retryable=True,
+    )
+    prepared = _prepared()
+    attempt = RecordingProviderAttempt(
+        outcomes={},
+        raised={"openai": error},
+    )
+    fallback = RecordingFallbackCoordinator()
+    coordinator = _coordinator(provider_attempt=attempt, fallback=fallback)
+
+    with pytest.raises(EmbeddingExecutionError) as raised:
+        await coordinator.execute(prepared)
+
+    assert raised.value is error
+    assert attempt.calls == [
+        AttemptCall(prepared, "openai", "text-embedding-3-small")
+    ]
     assert fallback.calls == []
 
 

--- a/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
@@ -8,7 +8,9 @@ import pytest
 from tldw_Server_API.app.core.Embeddings.execution_coordinator import (
     AdapterAttemptResult,
     EmbeddingAdapterAttempt,
+    EmbeddingExecutionCoordinator,
     EmbeddingFallbackCoordinator,
+    FallbackExecutionSuccess,
 )
 from tldw_Server_API.app.core.Embeddings.provider_attempt import (
     ProviderAttemptSuccess,
@@ -127,16 +129,24 @@ def _retryable(provider: str) -> EmbeddingProviderError:
     )
 
 
-def _success(provider: str) -> ProviderAttemptSuccess:
+def _success(
+    provider: str,
+    *,
+    vectors: list[list[float]] | None = None,
+    cache_hits: int = 0,
+    cache_misses: int = 1,
+    embeddings_from_adapter: bool = False,
+) -> ProviderAttemptSuccess:
     return ProviderAttemptSuccess(
-        vectors=[[0.25, 0.75]],
+        vectors=vectors or [[0.25, 0.75]],
         provider=provider,
         model={
             "cohere": "embed-english-v3.0",
             "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
         }.get(provider, "text-embedding-3-small"),
-        cache_hits=0,
-        cache_misses=1,
+        cache_hits=cache_hits,
+        cache_misses=cache_misses,
+        embeddings_from_adapter=embeddings_from_adapter,
     )
 
 
@@ -194,6 +204,249 @@ class RecordingProviderAttempt:
         if error is not None:
             raise error
         return self.outcomes[provider]
+
+
+class RecordingAdapterAttempt:
+    def __init__(self, result: AdapterAttemptResult, events: list[str]) -> None:
+        self.result = result
+        self.events = events
+
+    async def execute(self, prepared: PreparedEmbeddingRequest) -> AdapterAttemptResult:
+        del prepared
+        if self.result.attempted:
+            self.events.append("adapter")
+        return self.result
+
+
+class RecordingFallbackCoordinator:
+    def __init__(
+        self,
+        result: FallbackExecutionSuccess | None = None,
+    ) -> None:
+        self.result = result or FallbackExecutionSuccess(_success("huggingface"), 1)
+        self.calls: list[tuple[PreparedEmbeddingRequest, ProviderCallFailure]] = []
+
+    async def execute(
+        self,
+        prepared: PreparedEmbeddingRequest,
+        primary_failure: ProviderCallFailure,
+    ) -> FallbackExecutionSuccess:
+        self.calls.append((prepared, primary_failure))
+        return self.result
+
+
+def _coordinator(
+    *,
+    events: list[str] | None = None,
+    adapter_declines: bool = False,
+    adapter_result: AdapterAttemptResult | None = None,
+    readiness_error: EmbeddingDomainError | None = None,
+    primary_result: ProviderAttemptSuccess | ProviderCallFailure | None = None,
+    fallback_result: FallbackExecutionSuccess | None = None,
+    fallback: RecordingFallbackCoordinator | None = None,
+) -> EmbeddingExecutionCoordinator:
+    ordered_events = events if events is not None else []
+    adapter = RecordingAdapterAttempt(
+        adapter_result or AdapterAttemptResult(attempted=adapter_declines),
+        ordered_events,
+    )
+    readiness = RecordingReadiness(
+        errors={"openai": readiness_error} if readiness_error is not None else None,
+        events=ordered_events,
+    )
+    attempt = RecordingProviderAttempt(
+        outcomes={"openai": primary_result or _success("openai")},
+        events=ordered_events,
+    )
+    fallback_coordinator = fallback or RecordingFallbackCoordinator(fallback_result)
+    return EmbeddingExecutionCoordinator(
+        adapter_attempt=adapter,
+        readiness=readiness,
+        provider_attempt=attempt,
+        fallback_coordinator=fallback_coordinator,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_orders_adapter_before_primary_readiness_and_attempt():
+    events: list[str] = []
+    coordinator = _coordinator(events=events, adapter_declines=True)
+
+    outcome = await coordinator.execute(_prepared(execution_path="adapter"))
+
+    assert events == ["adapter", "readiness:openai", "attempt:openai"]
+    assert outcome.attempt_count == 2
+    assert outcome.fallback_attempt_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_returns_adapter_success_with_adapter_cache_accounting():
+    events: list[str] = []
+    coordinator = _coordinator(
+        events=events,
+        adapter_result=AdapterAttemptResult(
+            attempted=True,
+            success=_success(
+                "openai",
+                vectors=[[0.1, 0.9]],
+                cache_hits=1,
+                cache_misses=0,
+                embeddings_from_adapter=True,
+            ),
+        ),
+    )
+
+    outcome = await coordinator.execute(_prepared(execution_path="adapter"))
+
+    assert events == ["adapter"]
+    assert outcome.vectors == ((0.1, 0.9),)
+    assert outcome.provider == "openai"
+    assert outcome.model == "text-embedding-3-small"
+    assert outcome.cache_hits == 1
+    assert outcome.cache_misses == 0
+    assert outcome.embeddings_from_adapter is True
+    assert outcome.attempt_count == 1
+    assert outcome.fallback_attempt_count == 0
+    assert outcome.fallback_from is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_primary_readiness_failure_does_not_enter_fallback():
+    error = _retryable("openai")
+    fallback = RecordingFallbackCoordinator()
+    coordinator = _coordinator(readiness_error=error, fallback=fallback)
+
+    with pytest.raises(EmbeddingDomainError) as raised:
+        await coordinator.execute(_prepared())
+
+    assert raised.value is error
+    assert fallback.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_returns_full_primary_cache_hit_in_input_order():
+    primary = _success(
+        "openai",
+        vectors=[[0.7, 0.3], [0.2, 0.8]],
+        cache_hits=2,
+        cache_misses=0,
+    )
+    coordinator = _coordinator(primary_result=primary)
+
+    outcome = await coordinator.execute(_prepared(texts=["first", "second"]))
+
+    assert outcome.vectors == ((0.7, 0.3), (0.2, 0.8))
+    assert outcome.provider == "openai"
+    assert outcome.model == "text-embedding-3-small"
+    assert outcome.cache_hits == 2
+    assert outcome.cache_misses == 0
+    assert outcome.embeddings_from_adapter is False
+    assert outcome.attempt_count == 1
+    assert outcome.fallback_attempt_count == 0
+    assert outcome.fallback_from is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_reraises_non_retryable_primary_failure_without_fallback():
+    error = EmbeddingProviderError(
+        "provider_denied",
+        "provider denied request",
+        provider="openai",
+        model="text-embedding-3-small",
+        retryable=False,
+    )
+    fallback = RecordingFallbackCoordinator()
+    coordinator = _coordinator(
+        primary_result=ProviderCallFailure(error),
+        fallback=fallback,
+    )
+
+    with pytest.raises(EmbeddingProviderError) as raised:
+        await coordinator.execute(_prepared())
+
+    assert raised.value is error
+    assert fallback.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_reraises_fallback_disabled_primary_failure():
+    error = _retryable("openai")
+    fallback = RecordingFallbackCoordinator()
+    coordinator = _coordinator(
+        primary_result=ProviderCallFailure(error),
+        fallback=fallback,
+    )
+
+    with pytest.raises(EmbeddingProviderError) as raised:
+        await coordinator.execute(_prepared(fallback_allowed=False))
+
+    assert raised.value is error
+    assert fallback.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_uses_complete_request_for_eligible_primary_failure_fallback():
+    prepared = _prepared(texts=["first", "second"])
+    fallback = RecordingFallbackCoordinator(
+        FallbackExecutionSuccess(
+            success=_success(
+                "huggingface",
+                vectors=[[0.8, 0.2], [0.6, 0.4]],
+                cache_hits=1,
+                cache_misses=1,
+            ),
+            attempt_count=2,
+        )
+    )
+    coordinator = _coordinator(
+        primary_result=ProviderCallFailure(_retryable("openai")),
+        fallback=fallback,
+    )
+
+    outcome = await coordinator.execute(prepared)
+
+    assert fallback.calls[0][0] is prepared
+    assert outcome.vectors == ((0.8, 0.2), (0.6, 0.4))
+    assert outcome.provider == "huggingface"
+    assert outcome.model == "sentence-transformers/all-MiniLM-L6-v2"
+    assert outcome.cache_hits == 1
+    assert outcome.cache_misses == 1
+    assert outcome.embeddings_from_adapter is False
+    assert outcome.fallback_from == "openai"
+    assert outcome.attempt_count == 3
+    assert outcome.fallback_attempt_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_returns_successful_primary_execution():
+    coordinator = _coordinator(
+        primary_result=_success(
+            "openai",
+            vectors=[[0.4, 0.6]],
+            cache_hits=0,
+            cache_misses=1,
+        )
+    )
+
+    outcome = await coordinator.execute(_prepared())
+
+    assert outcome.vectors == ((0.4, 0.6),)
+    assert outcome.provider == "openai"
+    assert outcome.model == "text-embedding-3-small"
+    assert outcome.cache_hits == 0
+    assert outcome.cache_misses == 1
+    assert outcome.embeddings_from_adapter is False
+    assert outcome.attempt_count == 1
+    assert outcome.fallback_attempt_count == 0
+    assert outcome.fallback_from is None
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
@@ -5,7 +5,18 @@ from typing import Literal
 
 import pytest
 
+from tldw_Server_API.app.core.Embeddings.execution_coordinator import (
+    AdapterAttemptResult,
+    EmbeddingAdapterAttempt,
+    EmbeddingFallbackCoordinator,
+)
+from tldw_Server_API.app.core.Embeddings.provider_attempt import (
+    ProviderAttemptSuccess,
+    ProviderCallFailure,
+)
 from tldw_Server_API.app.core.Embeddings.request_types import (
+    EmbeddingDomainError,
+    EmbeddingExecutionError,
     EmbeddingExecutionPlan,
     EmbeddingExecutorOutput,
     EmbeddingPolicyDecision,
@@ -13,10 +24,9 @@ from tldw_Server_API.app.core.Embeddings.request_types import (
     PreparedEmbeddingRequest,
     ProviderModelIntent,
 )
-from tldw_Server_API.app.core.Embeddings.provider_attempt import ProviderAttemptSuccess
-from tldw_Server_API.app.core.Embeddings.execution_coordinator import (
-    AdapterAttemptResult,
-    EmbeddingAdapterAttempt,
+from tldw_Server_API.app.core.exceptions import (
+    EmbeddingProviderError,
+    EmbeddingRateLimitError,
 )
 
 
@@ -101,6 +111,89 @@ class RecordingExecutor:
 
 class ExecutorWithoutAdapter:
     pass
+
+
+def _retryable(provider: str) -> EmbeddingProviderError:
+    return EmbeddingProviderError(
+        "provider_unavailable",
+        "provider unavailable",
+        provider=provider,
+        model={
+            "openai": "text-embedding-3-small",
+            "cohere": "embed-english-v3.0",
+            "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+        }[provider],
+        retryable=True,
+    )
+
+
+def _success(provider: str) -> ProviderAttemptSuccess:
+    return ProviderAttemptSuccess(
+        vectors=[[0.25, 0.75]],
+        provider=provider,
+        model={
+            "cohere": "embed-english-v3.0",
+            "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+        }.get(provider, "text-embedding-3-small"),
+        cache_hits=0,
+        cache_misses=1,
+    )
+
+
+def _model_map() -> dict[str, object]:
+    return {
+        "openai:text-embedding-3-small": {
+            "cohere": "embed-english-v3.0",
+            "huggingface": "sentence-transformers/all-MiniLM-L6-v2",
+        }
+    }
+
+
+class RecordingReadiness:
+    def __init__(
+        self,
+        errors: dict[str, EmbeddingDomainError] | None = None,
+        events: list[str] | None = None,
+    ) -> None:
+        self.errors = errors or {}
+        self.events = events
+        self.calls: list[tuple[str, str]] = []
+
+    async def check(self, provider: str, model: str) -> None:
+        self.calls.append((provider, model))
+        if self.events is not None:
+            self.events.append(f"readiness:{provider}")
+        error = self.errors.get(provider)
+        if error is not None:
+            raise error
+
+
+class RecordingProviderAttempt:
+    def __init__(
+        self,
+        outcomes: dict[str, ProviderAttemptSuccess | ProviderCallFailure],
+        raised: dict[str, EmbeddingDomainError] | None = None,
+        events: list[str] | None = None,
+    ) -> None:
+        self.outcomes = outcomes
+        self.raised = raised or {}
+        self.events = events
+        self.calls: list[AttemptCall] = []
+
+    async def execute(
+        self,
+        prepared: PreparedEmbeddingRequest,
+        *,
+        provider: str,
+        model: str,
+    ) -> ProviderAttemptSuccess | ProviderCallFailure:
+        self.calls.append(AttemptCall(prepared, provider, model))
+        if self.events is not None:
+            self.events.append(f"attempt:{provider}")
+        error = self.raised.get(provider)
+        if error is not None:
+            raise error
+        return self.outcomes[provider]
 
 
 @pytest.mark.unit
@@ -188,3 +281,274 @@ async def test_adapter_attempt_reraises_exact_adapter_exception():
         await attempt.execute(_prepared(execution_path="adapter"))
 
     assert exc_info.value is error
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_excludes_primary_and_preserves_candidate_order():
+    readiness = RecordingReadiness()
+    attempt = RecordingProviderAttempt(
+        outcomes={
+            "cohere": ProviderCallFailure(_retryable("cohere")),
+            "huggingface": _success("huggingface"),
+        }
+    )
+    coordinator = EmbeddingFallbackCoordinator(
+        readiness=readiness,
+        provider_attempt=attempt,
+        settings_fallback_model_map=_model_map(),
+    )
+
+    result = await coordinator.execute(
+        _prepared(fallback_chain=["openai", "cohere", "openai", "huggingface"]),
+        ProviderCallFailure(_retryable("openai")),
+    )
+
+    assert readiness.calls == [
+        ("cohere", "embed-english-v3.0"),
+        ("huggingface", "sentence-transformers/all-MiniLM-L6-v2"),
+    ]
+    assert [call.provider for call in attempt.calls] == ["cohere", "huggingface"]
+    assert result.attempt_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_skips_missing_credentials_from_readiness_and_provider_call():
+    missing_readiness = EmbeddingProviderError(
+        "missing_provider_credentials",
+        "cohere credentials missing",
+        provider="cohere",
+        model="embed-english-v3.0",
+    )
+    missing_attempt = EmbeddingProviderError(
+        "missing_provider_credentials",
+        "huggingface credentials missing",
+        provider="huggingface",
+        model="sentence-transformers/all-MiniLM-L6-v2",
+    )
+    readiness = RecordingReadiness(errors={"cohere": missing_readiness})
+    attempt = RecordingProviderAttempt(
+        outcomes={
+            "huggingface": ProviderCallFailure(missing_attempt),
+            "mistral": _success("mistral"),
+        }
+    )
+    coordinator = EmbeddingFallbackCoordinator(
+        readiness=readiness,
+        provider_attempt=attempt,
+        settings_fallback_model_map=_model_map(),
+    )
+
+    result = await coordinator.execute(
+        _prepared(fallback_chain=["cohere", "huggingface", "mistral"]),
+        ProviderCallFailure(_retryable("openai")),
+    )
+
+    assert readiness.calls == [
+        ("cohere", "embed-english-v3.0"),
+        ("huggingface", "sentence-transformers/all-MiniLM-L6-v2"),
+        ("mistral", "text-embedding-3-small"),
+    ]
+    assert [call.provider for call in attempt.calls] == ["huggingface", "mistral"]
+    assert result.attempt_count == 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_continues_after_eligible_readiness_failure():
+    readiness = RecordingReadiness(errors={"cohere": _retryable("cohere")})
+    attempt = RecordingProviderAttempt(outcomes={"huggingface": _success("huggingface")})
+    coordinator = EmbeddingFallbackCoordinator(
+        readiness=readiness,
+        provider_attempt=attempt,
+        settings_fallback_model_map=_model_map(),
+    )
+
+    result = await coordinator.execute(
+        _prepared(fallback_chain=["cohere", "huggingface"]),
+        ProviderCallFailure(_retryable("openai")),
+    )
+
+    assert result.success == _success("huggingface")
+    assert result.attempt_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_continues_after_eligible_provider_call_failure():
+    readiness = RecordingReadiness()
+    attempt = RecordingProviderAttempt(
+        outcomes={
+            "cohere": ProviderCallFailure(_retryable("cohere")),
+            "huggingface": _success("huggingface"),
+        }
+    )
+    coordinator = EmbeddingFallbackCoordinator(
+        readiness=readiness,
+        provider_attempt=attempt,
+        settings_fallback_model_map=_model_map(),
+    )
+
+    result = await coordinator.execute(
+        _prepared(fallback_chain=["cohere", "huggingface"]),
+        ProviderCallFailure(_retryable("openai")),
+    )
+
+    assert result.success == _success("huggingface")
+    assert result.attempt_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["readiness", "provider_call"])
+async def test_fallback_reraises_ineligible_failure_without_trying_another_candidate(
+    source: str,
+):
+    error = EmbeddingProviderError(
+        "provider_denied",
+        "provider denied request",
+        provider="cohere",
+        model="embed-english-v3.0",
+        retryable=False,
+    )
+    readiness = RecordingReadiness(errors={"cohere": error} if source == "readiness" else None)
+    attempt = RecordingProviderAttempt(
+        outcomes={
+            "cohere": ProviderCallFailure(error),
+            "huggingface": _success("huggingface"),
+        }
+    )
+    coordinator = EmbeddingFallbackCoordinator(
+        readiness=readiness,
+        provider_attempt=attempt,
+        settings_fallback_model_map=_model_map(),
+    )
+
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        await coordinator.execute(
+            _prepared(fallback_chain=["cohere", "huggingface"]),
+            ProviderCallFailure(_retryable("openai")),
+        )
+
+    assert exc_info.value is error
+    assert [call.provider for call in attempt.calls] == ([] if source == "readiness" else ["cohere"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_selects_original_rate_limit_error_on_exhaustion():
+    rate_limit = EmbeddingRateLimitError(
+        "provider_rate_limited",
+        "huggingface rate limited",
+        provider="huggingface",
+        model="sentence-transformers/all-MiniLM-L6-v2",
+        retryable=True,
+        retry_after=37,
+    )
+    readiness = RecordingReadiness()
+    attempt = RecordingProviderAttempt(
+        outcomes={
+            "cohere": ProviderCallFailure(_retryable("cohere")),
+            "huggingface": ProviderCallFailure(rate_limit),
+        }
+    )
+    coordinator = EmbeddingFallbackCoordinator(
+        readiness=readiness,
+        provider_attempt=attempt,
+        settings_fallback_model_map=_model_map(),
+    )
+
+    with pytest.raises(EmbeddingRateLimitError) as exc_info:
+        await coordinator.execute(
+            _prepared(fallback_chain=["cohere", "huggingface"]),
+            ProviderCallFailure(_retryable("openai")),
+        )
+
+    assert exc_info.value is rate_limit
+    assert exc_info.value.retry_after == 37
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_uses_exact_primary_failure_when_candidates_are_skipped():
+    primary_error = _retryable("openai")
+    missing_credentials = EmbeddingProviderError(
+        "missing_provider_credentials",
+        "cohere credentials missing",
+        provider="cohere",
+        model="embed-english-v3.0",
+    )
+    readiness = RecordingReadiness(errors={"cohere": missing_credentials})
+    attempt = RecordingProviderAttempt(outcomes={})
+    coordinator = EmbeddingFallbackCoordinator(
+        readiness=readiness,
+        provider_attempt=attempt,
+        settings_fallback_model_map=_model_map(),
+    )
+
+    with pytest.raises(EmbeddingProviderError) as exc_info:
+        await coordinator.execute(
+            _prepared(fallback_chain=["cohere"]),
+            ProviderCallFailure(primary_error),
+        )
+
+    assert exc_info.value is primary_error
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_passes_the_complete_prepared_request_to_successful_attempt():
+    prepared = _prepared(texts=["first", "second"], fallback_chain=["huggingface"])
+    readiness = RecordingReadiness()
+    attempt = RecordingProviderAttempt(outcomes={"huggingface": _success("huggingface")})
+    coordinator = EmbeddingFallbackCoordinator(
+        readiness=readiness,
+        provider_attempt=attempt,
+        settings_fallback_model_map=_model_map(),
+    )
+
+    await coordinator.execute(prepared, ProviderCallFailure(_retryable("openai")))
+
+    assert attempt.calls == [
+        AttemptCall(
+            prepared,
+            "huggingface",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        )
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "boundary",
+    ["backend_identity", "cache_key", "cache", "validation", "postprocessing", "writeback"],
+)
+async def test_fallback_propagates_attempt_boundary_errors_without_advancing(
+    boundary: str,
+):
+    error = EmbeddingExecutionError(
+        "internal_execution_failure",
+        f"{boundary} failed",
+        retryable=True,
+    )
+    readiness = RecordingReadiness()
+    attempt = RecordingProviderAttempt(
+        outcomes={"huggingface": _success("huggingface")},
+        raised={"cohere": error},
+    )
+    coordinator = EmbeddingFallbackCoordinator(
+        readiness=readiness,
+        provider_attempt=attempt,
+        settings_fallback_model_map=_model_map(),
+    )
+
+    with pytest.raises(EmbeddingExecutionError) as exc_info:
+        await coordinator.execute(
+            _prepared(fallback_chain=["cohere", "huggingface"]),
+            ProviderCallFailure(_retryable("openai")),
+        )
+
+    assert exc_info.value is error
+    assert [call.provider for call in attempt.calls] == ["cohere"]

--- a/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_execution_coordinator.py
@@ -290,22 +290,24 @@ async def test_execution_returns_adapter_success_with_adapter_cache_accounting()
             attempted=True,
             success=_success(
                 "openai",
-                vectors=[[0.1, 0.9]],
-                cache_hits=1,
-                cache_misses=0,
+                vectors=[[0.1, 0.9], [0.3, 0.7]],
+                cache_hits=0,
+                cache_misses=2,
                 embeddings_from_adapter=True,
             ),
         ),
     )
 
-    outcome = await coordinator.execute(_prepared(execution_path="adapter"))
+    outcome = await coordinator.execute(
+        _prepared(texts=["first", "second"], execution_path="adapter")
+    )
 
     assert events == ["adapter"]
-    assert outcome.vectors == ((0.1, 0.9),)
+    assert outcome.vectors == ((0.1, 0.9), (0.3, 0.7))
     assert outcome.provider == "openai"
     assert outcome.model == "text-embedding-3-small"
-    assert outcome.cache_hits == 1
-    assert outcome.cache_misses == 0
+    assert outcome.cache_hits == 0
+    assert outcome.cache_misses == 2
     assert outcome.embeddings_from_adapter is True
     assert outcome.attempt_count == 1
     assert outcome.fallback_attempt_count == 0


### PR DESCRIPTION
## Change summary (human-written)

_Required before this PR can be marked ready or merged. The human requester must replace this line with their own explanation of what changed and why these implementation choices were made._

## Summary

- What changed: Added explicit adapter-attempt, fallback, and execution coordinators for the Embeddings workflow, then routed the public orchestrator through them while preserving its constructor and legacy result contract.
- Why: Isolate execution policy from the compatibility facade and ensure only typed executor-originated provider failures can activate fallback. Identity, cache, validation, postprocessing, and writeback errors now propagate unchanged.
- Scope boundary: Stage 2E retains inline-runner integration, endpoint header migration, and removal of the temporary private compatibility branches.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally: 322 passed after removing five redundant parameterized cases
- [x] Docs, implementation plan, and Backlog tasks updated
- [x] Published docs manifest test passes after tracking the upstream ADR 037 mirror
- [x] Ruff and compileall pass
- [x] Bandit reports 0 findings across 702 production LOC
- [x] Independent final review completed; the sole test-localization finding was addressed and scoped re-review found no remaining issues

## UX Audit Checklist

Not applicable: this PR contains no WebUI, extension, Flashcards, or Watchlists UI changes.

## Risk & Rollback

- Risk level: Medium
- Main risk: fallback activation is intentionally narrowed to executor-originated provider failures; endpoint parity tests cover the corrected propagation behavior.
- Rollback plan: revert this PR to restore the previous compatibility-orchestrator execution path.

## Tracking

- Backlog: `TASK-12973.4`
- Base: `dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Embeddings workflow to run through explicit adapter, fallback, and execution coordinators, with the orchestrator delegating to them. Fallback now only activates on executor-originated provider failures; infrastructure and provider-attempt exceptions propagate. Aligns with `TASK-12973.4`.

- **Refactors**
  - Added EmbeddingAdapterAttempt, EmbeddingFallbackCoordinator, and EmbeddingExecutionCoordinator in execution_coordinator.py; orchestrator now delegates and maps outcomes via the legacy result mapper with no public API changes.
  - Preserves adapter-before-readiness/cache order and attempt counters; corrected adapter cache accounting to 0 hits and 1 miss per input item on adapter success.
  - Added focused coordinator unit tests and expanded endpoint-parity coverage.
  - Docs: added Stage 2D implementation plan; mirrored ADR-031 and ADR-037 to Published with index entries to satisfy the docs gate (`TASK-13008`, `TASK-13010`).

- **Bug Fixes**
  - Source-aware fallback: only `ProviderCallFailure` from the executor can trigger fallback; provider-attempt exceptions, identity, cache key/get/set, validation, postprocessing, and writeback errors now surface unchanged.
  - Fallback readiness/provider-call missing credentials skip the candidate; preserves error identity and rate-limit metadata on exhaustion.
  - New tests assert no provider activation on infrastructure failures and cover provider-attempt exception routing.

<sup>Written for commit 734a5231485e96538a5151b27c547756e686a889. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

