### PR TITLE
feat(sync): complete core Notes restore contract

### DIFF
--- a/Docs/ADR/031-notes-capability-sync-domains.md
+++ b/Docs/ADR/031-notes-capability-sync-domains.md
@@ -1,0 +1,48 @@
+# ADR-031: Canonical synchronized Notes capability domains
+
+**Status:** Accepted
+**Date:** 2026-08-08
+**Backfilled from:** `tldw_chatbook/backlog/decisions/046-synchronized-database-notes-parity.md`
+**Decision owner:** TASK-13002 requester and implementation review
+**Related task:** TASK-13002
+**Related spec:** `tldw_chatbook/Docs/superpowers/specs/2026-08-08-notes-server-parity-design.md`
+
+## Decision
+
+Treat Sync v2 as the ownership boundary for every mutable personal Notes capability, beginning with one canonical `notes.note` version-1 contract.
+
+A `notes.note` upsert carries `title`, `content`, nullable `conversation_id`, and nullable `message_id` under `server_trusted_v1`. The server validates the field types and documented title/content limits without trimming, escaping, truncating, or otherwise rewriting accepted Markdown. Tombstones retain the existing `tombstone` operation.
+
+Restore is not a new wire operation. It is an `upsert` with `routing_metadata.restore_intent` set to `true`, a complete base tuple that exactly references the current tombstone head, and the full canonical note payload. An ordinary upsert against a tombstone, a restore without the exact current base, or a restore against an active object is a whole-object conflict.
+
+Client-origin pushes and normal server REST mutations pass through the same domain adapter, append-only envelope store, materializer, and object-state update. Server-origin metadata identifies the owner outside the canonical note payload. Keyword mutations remain blocked while Sync is active until their independent synchronized domains are available; a partial note payload never implies ownership of keyword state.
+
+Later Notes capabilities use independent versioned domains for independently mutable resources. Derived indexes such as FTS and parsed wikilinks are rebuilt from canonical state rather than synchronized as competing authorities.
+
+## Context
+
+The server already projected `notes.note` envelopes into ChaChaNotes and captured normal REST create, update, and delete mutations. However, production composition used an accept-anything adapter, the projection accepted a legacy `body` alias and rewrote titles with whitespace stripping, and active-Sync REST restore was rejected. That combination could accept malformed payloads, produce different canonical envelopes by origin, and prevent a legitimate current-head restore while still needing to reject stale resurrection.
+
+Chatbook parity also includes keywords, folders, manual links, attachments, tasks, activity, moodboards, and Studio documents. Folding those independently mutable resources into the base note object would create avoidable whole-note conflicts and silent partial synchronization.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Add a `restore` wire operation | It expands the protocol when existing upsert plus explicit intent and base lineage expresses the state transition safely. |
+| Permit any upsert against a tombstone | A delayed ordinary edit could silently resurrect a note after a newer delete. |
+| Keep REST restore outside Sync | The database projection and envelope log would diverge, so another device could not reproduce server state. |
+| Keep using the generic static adapter | It cannot enforce domain payload shape, content limits, or restore intent before persistence. |
+| Put keywords, folders, links, and other resources inside `notes.note` | Independently mutable state would conflict as one large object and partial clients could overwrite capabilities they do not own. |
+| Normalize or sanitize Markdown during sync | Canonical bytes would differ across devices and derived wikilinks/backlinks could change meaning. Rendering is the correct escaping boundary. |
+
+## Consequences
+
+All accepted core note mutations have one reproducible envelope and object-state path, and a valid restore can be replayed idempotently. Clients must send complete current base metadata for updates, tombstones, and restores. Existing producers using the legacy `body` alias must migrate to `content`; invalid or oversized payloads are rejected before append.
+
+The synchronized Notes programme must add separately owned resource domains before claiming full capability parity. Server REST endpoints must keep rejecting keyword mutations under active Sync until those domains land.
+
+## Follow-up
+
+- TASK-13003 through TASK-13007 add the remaining server Notes domains.
+- Chatbook TASK-3701 consumes this core contract and proves an exact two-client round trip.

--- a/Docs/ADR/README.md
+++ b/Docs/ADR/README.md
@@ -62,3 +62,4 @@ Small bug fixes, local implementation details, product copy, temporary experimen
 | [ADR-028](028-security-restricted-legacy-pickle-compatibility.md) | Accepted | Use Security restricted pickle helpers only for explicitly gated legacy compatibility paths, not as a general-purpose serialization format. |
 | [ADR-029](029-tldw-frontend-static-pypi-bundle.md) | Proposed | Allow a guarded static `tldw-frontend` export in `tldw-server` PyPI releases while forbidding source, cache, standalone, model, database, and admin UI artifacts. |
 | [ADR-030](030-configured-local-llm-egress-policy.md) | Accepted | Allow only an exact server-configured local LLM origin through scoped checked egress without weakening global SSRF defaults. |
+| [ADR-031](031-notes-capability-sync-domains.md) | Accepted | Use versioned Sync v2 domains for mutable Notes capabilities, with lossless core-note payloads and base-aware restore intent. |

--- a/Docs/API/Sync_V2_M1.md
+++ b/Docs/API/Sync_V2_M1.md
@@ -937,9 +937,9 @@ conflict that requires explicit review.
   "schema_version": 1,
   "payload": {
     "title": "Trip notes",
-    "body": "Updated outline.",
-    "tags": ["travel", "research"],
-    "updated_at": "2026-05-23T18:30:00Z"
+    "content": "Updated outline.\n\n[[Packing list]]",
+    "conversation_id": "conv_trip_planning",
+    "message_id": "msg_source_42"
   },
   "payload_hash": "sha256:note-upsert",
   "created_at_client": "2026-05-23T18:30:00Z",
@@ -949,6 +949,14 @@ conflict that requires explicit review.
   }
 }
 ```
+
+The canonical version-1 payload contains only `title`, `content`, nullable
+`conversation_id`, and nullable `message_id`. Accepted title and Markdown bytes
+are preserved exactly within the limits advertised by
+`capabilities.domain_schemas.notes.note`; unknown fields are rejected. To
+restore a deleted note, send an `upsert` with the full payload,
+`routing_metadata.restore_intent` set to `true`, and a base cursor, revision,
+and hash that exactly reference the current tombstone head.
 
 ### `chat.conversation` Upsert
 

--- a/Docs/API/sync-v2.md
+++ b/Docs/API/sync-v2.md
@@ -37,6 +37,26 @@ bodies, chat content, source-cache text, wrapped keys, and similar private
 values must not appear in `payload_clear`, restore manifests, error details, or
 logs.
 
+### `notes.note` contract
+
+The `GET /api/v1/sync/capabilities` response advertises the versioned payload
+contract in `domain_schemas.notes.note`. A version-1 `server_trusted_v1` upsert
+uses exactly these fields:
+
+- required strings: `title`, `content`
+- optional nullable strings: `conversation_id`, `message_id`
+
+The server preserves accepted title and Markdown content exactly. It rejects
+unknown fields and values beyond the advertised limits rather than trimming,
+escaping, or truncating them. A tombstone remains the `tombstone` operation.
+
+Restore is an `upsert` with the full canonical payload and
+`routing_metadata.restore_intent: true`. Its base cursor, object revision, and
+object hash must identify the current tombstone head. Ordinary upserts against
+deleted notes, stale restores, and restore requests against active notes become
+whole-object conflicts. Replaying the same accepted restore envelope is
+idempotent.
+
 ## Restore Manifest
 
 `GET /api/v1/sync/restore-manifest` accepts repeated `dataset_id` and `domain`

--- a/backlog/tasks/task-13002 - Extend-Notes-Sync-v2-core-contract-for-backlinks-and-restore.md
+++ b/backlog/tasks/task-13002 - Extend-Notes-Sync-v2-core-contract-for-backlinks-and-restore.md
@@ -4,7 +4,7 @@ title: Extend Notes Sync v2 core contract for backlinks and restore
 status: Done
 assignee: []
 created_date: '2026-08-08 20:21'
-updated_date: '2026-08-08 21:56'
+updated_date: '2026-08-08 22:14'
 labels:
   - notes
   - sync-v2
@@ -59,6 +59,10 @@ Reason: Establishes the public notes.note payload, restore-intent semantics, and
 - Verification: 215 focused tests passed and 1 PostgreSQL test skipped because neither a local PostgreSQL server nor Docker daemon was available. Ruff passed for new/reworked Sync files; compileall and `git diff --check` passed; Bandit reported 0 findings across 13,190 production lines. Full-file Ruff on the two legacy Notes files reports the same pre-existing `I001`, `BLE001`, `F841`, and `C409` baseline as `HEAD`, with no new finding introduced by this task.
 
 Review: PR #2775 targets dev from codex/task-13002-notes-core-contract.
+
+Review remediation: validating PR #2775 restore-path feedback before merge.
+
+Review remediation: moved active-Sync note restore validation/capture into the reusable server-origin coordinator; active-note and stale-version restore attempts now return a stable 409 without appending an envelope; all restore-path database calls now run through the async thread helper. Evidence: focused active/inactive restore tests passed (2/2), the complete server-origin capture file passed (28/28), Ruff passed for the new/reworked core and test files, compileall and git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13002 - Extend-Notes-Sync-v2-core-contract-for-backlinks-and-restore.md
+++ b/backlog/tasks/task-13002 - Extend-Notes-Sync-v2-core-contract-for-backlinks-and-restore.md
@@ -4,7 +4,7 @@ title: Extend Notes Sync v2 core contract for backlinks and restore
 status: Done
 assignee: []
 created_date: '2026-08-08 20:21'
-updated_date: '2026-08-08 21:46'
+updated_date: '2026-08-08 21:56'
 labels:
   - notes
   - sync-v2
@@ -13,6 +13,7 @@ dependencies: []
 references:
   - >-
     https://github.com/rmusser01/tldw_chatbook/blob/dev/backlog/decisions/046-synchronized-database-notes-parity.md
+  - 'https://github.com/rmusser01/tldw_server/pull/2775'
 documentation:
   - >-
     https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/superpowers/specs/2026-08-08-notes-server-parity-design.md
@@ -56,6 +57,8 @@ Reason: Establishes the public notes.note payload, restore-intent semantics, and
 - Wired the production Notes adapter and materializer to enforce canonical payloads, current-tombstone-only restore intent, whole-object stale conflicts, idempotency, and server/client-origin parity while preserving the existing keyword-write block.
 - Preserved accepted Markdown and title bytes in ChaChaNotes, included `message_id` in batch reads, and added focused SQLite plus PostgreSQL contract coverage for the complete mutation lifecycle.
 - Verification: 215 focused tests passed and 1 PostgreSQL test skipped because neither a local PostgreSQL server nor Docker daemon was available. Ruff passed for new/reworked Sync files; compileall and `git diff --check` passed; Bandit reported 0 findings across 13,190 production lines. Full-file Ruff on the two legacy Notes files reports the same pre-existing `I001`, `BLE001`, `F841`, and `C409` baseline as `HEAD`, with no new finding introduced by this task.
+
+Review: PR #2775 targets dev from codex/task-13002-notes-core-contract.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13002 - Extend-Notes-Sync-v2-core-contract-for-backlinks-and-restore.md
+++ b/backlog/tasks/task-13002 - Extend-Notes-Sync-v2-core-contract-for-backlinks-and-restore.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-13002
 title: Extend Notes Sync v2 core contract for backlinks and restore
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-08 20:21'
+updated_date: '2026-08-08 21:46'
 labels:
   - notes
   - sync-v2
@@ -26,23 +27,46 @@ Make the existing notes.note domain a lossless production contract for title, co
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Capabilities and envelope schemas expose notes.note upsert/tombstone with title, content, conversation_id, and message_id under server_trusted_v1.
-- [ ] #2 A restore-intent upsert can resurrect only the current tombstone head; stale ordinary updates against deleted notes remain whole-object conflicts.
-- [ ] #3 Server-origin note create, update, delete, and restore produce the same canonical envelopes and materialized object state as client-origin mutations.
-- [ ] #4 Accepted note title/content are preserved exactly within documented limits; validation never truncates, escapes, or rewrites canonical Markdown.
-- [ ] #5 SQLite and PostgreSQL contract tests cover create, update, tombstone, stale conflict, restore, idempotency, and exact payload materialization.
-- [ ] #6 Keyword writes remain explicitly blocked until their separately synchronized domain is enabled; no partial ownership is implied.
+- [x] #1 Capabilities and envelope schemas expose notes.note upsert/tombstone with title, content, conversation_id, and message_id under server_trusted_v1.
+- [x] #2 A restore-intent upsert can resurrect only the current tombstone head; stale ordinary updates against deleted notes remain whole-object conflicts.
+- [x] #3 Server-origin note create, update, delete, and restore produce the same canonical envelopes and materialized object state as client-origin mutations.
+- [x] #4 Accepted note title/content are preserved exactly within documented limits; validation never truncates, escapes, or rewrites canonical Markdown.
+- [x] #5 SQLite and PostgreSQL contract tests cover create, update, tombstone, stale conflict, restore, idempotency, and exact payload materialization.
+- [x] #6 Keyword writes remain explicitly blocked until their separately synchronized domain is enabled; no partial ownership is implied.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: Docs/ADR/031-notes-capability-sync-domains.md
+Reason: Establishes the public notes.note payload, restore-intent semantics, and server-origin ownership boundary.
+
+1. Characterize the existing Sync v2 Notes adapter, materializer, server-origin capture, REST restore, and ChaChaNotes persistence paths.
+2. Add focused failing tests for the canonical four-field payload, exact title/content persistence, current-tombstone restore, stale conflict behavior, idempotency, and server-origin parity.
+3. Implement the shared payload validator, production Notes adapter wiring, base-aware restore materialization, lossless storage, and REST restore capture; keep keyword writes blocked.
+4. Document ADR-031 and the public contract, then run focused SQLite and configured PostgreSQL tests plus Ruff and Bandit.
+5. Record verification, self-review the diff, and complete task hygiene before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added one discoverable, validated `notes.note` version-1 payload for exact title/content plus nullable conversation/message backlinks, and documented the ownership boundary in ADR-031 and the public Sync v2 API guides.
+- Wired the production Notes adapter and materializer to enforce canonical payloads, current-tombstone-only restore intent, whole-object stale conflicts, idempotency, and server/client-origin parity while preserving the existing keyword-write block.
+- Preserved accepted Markdown and title bytes in ChaChaNotes, included `message_id` in batch reads, and added focused SQLite plus PostgreSQL contract coverage for the complete mutation lifecycle.
+- Verification: 215 focused tests passed and 1 PostgreSQL test skipped because neither a local PostgreSQL server nor Docker daemon was available. Ruff passed for new/reworked Sync files; compileall and `git diff --check` passed; Bandit reported 0 findings across 13,190 production lines. Full-file Ruff on the two legacy Notes files reports the same pre-existing `I001`, `BLE001`, `F841`, and `C409` baseline as `HEAD`, with no new finding introduced by this task.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
-- [ ] #7 Focused Sync v2 and Notes tests pass on supported database backends.
-- [ ] #8 Bandit and static checks pass for touched production files.
-- [ ] #9 ADR-031 and Sync v2 public contract documentation are updated.
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused Sync v2 and Notes tests pass on supported database backends.
+- [x] #8 Bandit and static checks pass for touched production files.
+- [x] #9 ADR-031 and Sync v2 public contract documentation are updated.
 <!-- DOD:END -->

--- a/backlog/tasks/task-13002 - Extend-Notes-Sync-v2-core-contract-for-backlinks-and-restore.md
+++ b/backlog/tasks/task-13002 - Extend-Notes-Sync-v2-core-contract-for-backlinks-and-restore.md
@@ -1,0 +1,48 @@
+---
+id: TASK-13002
+title: Extend Notes Sync v2 core contract for backlinks and restore
+status: To Do
+assignee: []
+created_date: '2026-08-08 20:21'
+labels:
+  - notes
+  - sync-v2
+  - parity
+dependencies: []
+references:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/backlog/decisions/046-synchronized-database-notes-parity.md
+documentation:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/superpowers/specs/2026-08-08-notes-server-parity-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the existing notes.note domain a lossless production contract for title, content, conversation/message backlinks, tombstones, and base-aware restore so Chatbook can synchronize one personal Database Notes collection without server-side ambiguity.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Capabilities and envelope schemas expose notes.note upsert/tombstone with title, content, conversation_id, and message_id under server_trusted_v1.
+- [ ] #2 A restore-intent upsert can resurrect only the current tombstone head; stale ordinary updates against deleted notes remain whole-object conflicts.
+- [ ] #3 Server-origin note create, update, delete, and restore produce the same canonical envelopes and materialized object state as client-origin mutations.
+- [ ] #4 Accepted note title/content are preserved exactly within documented limits; validation never truncates, escapes, or rewrites canonical Markdown.
+- [ ] #5 SQLite and PostgreSQL contract tests cover create, update, tombstone, stale conflict, restore, idempotency, and exact payload materialization.
+- [ ] #6 Keyword writes remain explicitly blocked until their separately synchronized domain is enabled; no partial ownership is implied.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+- [ ] #7 Focused Sync v2 and Notes tests pass on supported database backends.
+- [ ] #8 Bandit and static checks pass for touched production files.
+- [ ] #9 ADR-031 and Sync v2 public contract documentation are updated.
+<!-- DOD:END -->

--- a/backlog/tasks/task-13003 - Synchronize-Notes-keywords-collections-and-folders.md
+++ b/backlog/tasks/task-13003 - Synchronize-Notes-keywords-collections-and-folders.md
@@ -1,0 +1,50 @@
+---
+id: TASK-13003
+title: Synchronize Notes keywords collections and folders
+status: To Do
+assignee: []
+created_date: '2026-08-08 20:21'
+labels:
+  - notes
+  - sync-v2
+  - parity
+  - organization
+dependencies:
+  - TASK-13002
+references:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/backlog/decisions/046-synchronized-database-notes-parity.md
+documentation:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/Parity/2026-08-08-notes-server-capability-matrix.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add first-class Sync v2 ownership for Notes keywords, keyword links and collections, folders, and note-folder membership so organization state survives offline and multi-device use instead of remaining REST-only.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Capabilities advertise versioned notes.keyword, notes.keyword_link, notes.keyword_collection, notes.keyword_collection_link, notes.folder, and notes.folder_link domains with upsert/tombstone operations.
+- [ ] #2 Domain adapters and materializers preserve stable object identity, hierarchy, membership, optimistic base state, and user ownership on SQLite and PostgreSQL.
+- [ ] #3 Server-origin keyword, collection, folder, and membership REST mutations capture canonical envelopes when Sync v2 is active.
+- [ ] #4 Keyword writes no longer return the active-sync unsupported error only when all required organization domains are enabled for the dataset.
+- [ ] #5 Concurrent rename, hierarchy, membership, merge, and delete/update cases produce deterministic idempotent results or reviewable conflicts.
+- [ ] #6 Restore preview, repair, and capability documentation include every organization domain.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+- [ ] #7 Focused Notes organization and Sync v2 suites pass on supported database backends.
+- [ ] #8 Bandit and static checks pass for touched production files.
+- [ ] #9 Public schemas and examples contain no note content or secret-bearing fixtures.
+<!-- DOD:END -->

--- a/backlog/tasks/task-13004 - Synchronize-Notes-relationships-graph-and-restore-lifecycle.md
+++ b/backlog/tasks/task-13004 - Synchronize-Notes-relationships-graph-and-restore-lifecycle.md
@@ -1,0 +1,50 @@
+---
+id: TASK-13004
+title: Synchronize Notes relationships graph and restore lifecycle
+status: To Do
+assignee: []
+created_date: '2026-08-08 20:23'
+labels:
+  - notes
+  - sync-v2
+  - parity
+  - graph
+dependencies:
+  - TASK-13003
+references:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/backlog/decisions/046-synchronized-database-notes-parity.md
+documentation:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/Parity/2026-08-08-notes-server-capability-matrix.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add first-class Sync v2 ownership for explicit Notes relationships while keeping wikilink parsing, backlinks, and graph summaries deterministic projections, and complete the conflict-aware trash/restore lifecycle for synchronized notes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Capabilities advertise a versioned `notes.link` domain with upsert and tombstone operations.
+- [ ] #2 Explicit relationship payloads preserve stable edge identity, source, target, type, label, properties, ownership, and optimistic base state across SQLite and PostgreSQL.
+- [ ] #3 Wikilinks, backlinks, orphan reports, and graph summaries are rebuilt deterministically from synchronized notes and explicit links rather than synchronized as mutable duplicates.
+- [ ] #4 Server-origin link mutations and note trash or restore mutations capture canonical envelopes when Sync v2 is active.
+- [ ] #5 Delete-versus-update, restore-versus-recreate, and concurrent edge edits yield idempotent outcomes or reviewable conflicts with restore-preview evidence.
+- [ ] #6 Graph and lifecycle endpoints remain paginated, bounded, and authorized for the selected dataset.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+- [ ] #7 Focused Notes relationship, graph, and lifecycle suites pass on supported database backends.
+- [ ] #8 Bandit and static checks pass for touched production files.
+- [ ] #9 Performance checks demonstrate bounded, paginated graph and orphan queries.
+<!-- DOD:END -->

--- a/backlog/tasks/task-13005 - Synchronize-Notes-attachments-and-blob-lifecycle.md
+++ b/backlog/tasks/task-13005 - Synchronize-Notes-attachments-and-blob-lifecycle.md
@@ -1,0 +1,50 @@
+---
+id: TASK-13005
+title: Synchronize Notes attachments and blob lifecycle
+status: To Do
+assignee: []
+created_date: '2026-08-08 20:24'
+labels:
+  - notes
+  - sync-v2
+  - parity
+  - attachments
+dependencies:
+  - TASK-13004
+references:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/backlog/decisions/046-synchronized-database-notes-parity.md
+documentation:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/Parity/2026-08-08-notes-server-capability-matrix.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make Notes attachment metadata and binary content participate in the same offline and multi-device lifecycle as their owning notes, using the existing attachment reference and resumable blob-transfer contracts rather than a separate Notes-only transport.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Capabilities advertise Notes use of the versioned attachment.ref domain and negotiated blob-transfer support.
+- [ ] #2 Attachment references preserve stable identity note ownership filename media type size digest lifecycle state and optimistic base state across SQLite and PostgreSQL.
+- [ ] #3 Upload list download insert delete and restore operations capture canonical metadata envelopes while binary transfer verifies content integrity and supports safe resume.
+- [ ] #4 Missing corrupt oversized unauthorized or quarantined blobs produce explicit recoverable states without losing the owning note or attachment metadata.
+- [ ] #5 Concurrent attachment rename replace delete restore and note deletion yield idempotent results or reviewable conflicts with garbage collection evidence.
+- [ ] #6 Attachment APIs and sync paths enforce dataset ownership path safety content limits and secret-safe diagnostics.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+- [ ] #7 Focused Notes attachment and shared blob-transfer suites pass on supported database backends.
+- [ ] #8 Bandit and static checks pass for touched production files.
+- [ ] #9 Integrity resume limit authorization and garbage-collection scenarios have automated evidence.
+<!-- DOD:END -->

--- a/backlog/tasks/task-13006 - Synchronize-Notes-tasks-checklists-and-activity.md
+++ b/backlog/tasks/task-13006 - Synchronize-Notes-tasks-checklists-and-activity.md
@@ -1,0 +1,50 @@
+---
+id: TASK-13006
+title: Synchronize Notes tasks checklists and activity
+status: To Do
+assignee: []
+created_date: '2026-08-08 20:25'
+labels:
+  - notes
+  - sync-v2
+  - parity
+  - tasks
+dependencies:
+  - TASK-13005
+references:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/backlog/decisions/046-synchronized-database-notes-parity.md
+documentation:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/Parity/2026-08-08-notes-server-capability-matrix.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Give explicit Notes tasks, checklist state, and task activity a synchronized lifecycle so task workflows remain coherent offline and across clients while Markdown-derived task projections remain rebuildable rather than duplicated mutable state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Capabilities advertise versioned `notes.task` and `notes.task_activity` domains using only their supported `upsert` and `tombstone` operations; immutable activity is created under a new stable event ID rather than a third wire operation.
+- [ ] #2 Task payloads preserve stable identity note linkage title description status priority due dates completion recurrence assignee tags metadata and optimistic base state across SQLite and PostgreSQL.
+- [ ] #3 Task activity preserves ordered immutable event identity actor timestamp transition and source without allowing history rewrites through ordinary updates.
+- [ ] #4 Markdown checklist projections are rebuilt deterministically and reconciliation reports drift without silently overwriting an explicit user-authored task.
+- [ ] #5 Server-origin task checklist reconciliation and activity mutations capture canonical envelopes when Sync v2 is active.
+- [ ] #6 Concurrent transitions recurrence completion delete restore and checklist edits yield idempotent results or reviewable conflicts with authorized bounded queries.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+- [ ] #7 Focused Notes task activity recurrence and checklist projection suites pass on supported database backends.
+- [ ] #8 Bandit and static checks pass for touched production files.
+- [ ] #9 Event immutability reconciliation conflict and pagination scenarios have automated evidence.
+<!-- DOD:END -->

--- a/backlog/tasks/task-13007 - Synchronize-Notes-moodboards-and-Studio-documents.md
+++ b/backlog/tasks/task-13007 - Synchronize-Notes-moodboards-and-Studio-documents.md
@@ -1,0 +1,51 @@
+---
+id: TASK-13007
+title: Synchronize Notes moodboards and Studio documents
+status: To Do
+assignee: []
+created_date: '2026-08-08 20:25'
+labels:
+  - notes
+  - sync-v2
+  - parity
+  - moodboards
+  - studio
+dependencies:
+  - TASK-13006
+references:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/backlog/decisions/046-synchronized-database-notes-parity.md
+documentation:
+  - >-
+    https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/Parity/2026-08-08-notes-server-capability-matrix.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Synchronize Notes moodboards, note placement, and persisted Studio document state so visual organization and accepted AI-assisted outputs survive offline and multi-device use without synchronizing transient generation requests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Capabilities advertise versioned notes.moodboard notes.moodboard_note and notes.studio_document domains with supported upsert and tombstone operations.
+- [ ] #2 Moodboard payloads preserve stable identity name description canvas metadata ownership and optimistic base state while placement payloads preserve note identity position size order and display metadata.
+- [ ] #3 Studio documents preserve stable identity source note title content document type revision metadata ownership and optimistic base state across SQLite and PostgreSQL.
+- [ ] #4 Server-origin moodboard placement and Studio document mutations capture canonical envelopes when Sync v2 is active.
+- [ ] #5 AI title suggestion summarization and Studio generation requests remain operations while only explicitly accepted persisted output enters synchronized state with provenance.
+- [ ] #6 Concurrent board layout document revision note deletion restore and placement edits yield idempotent outcomes or reviewable conflicts with authorized bounded queries.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+- [ ] #7 Focused Notes moodboard placement Studio and accepted-output suites pass on supported database backends.
+- [ ] #8 Bandit and static checks pass for touched production files.
+- [ ] #9 Transient-request exclusion provenance conflict and pagination scenarios have automated evidence.
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -123,6 +123,8 @@ from tldw_Server_API.app.core.Sync.v2.server_origin import (
     SyncServerOriginIdempotencyConflictError,
     SyncServerOriginMaterializationError,
     SyncServerOriginMutationNotSupportedError,
+    SyncServerOriginRestoreConflictError,
+    capture_server_origin_note_restore,
     capture_server_origin_mutation,
     get_active_server_origin_sync_service_for_user,
     server_origin_object_id,
@@ -225,6 +227,15 @@ def _ensure_note_exists_or_404(db: CharactersRAGDB, note_id: str) -> None:
 
 
 def _note_sync_http_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, SyncServerOriginRestoreConflictError):
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error_code": exc.error_code,
+                "message": str(exc),
+                "object_id": exc.object_id,
+            },
+        )
     if isinstance(exc, SyncServerOriginIdempotencyConflictError):
         envelope = exc.envelope
         return HTTPException(
@@ -4226,7 +4237,11 @@ async def restore_note(
     Returns the restored note on success.
     """
     try:
-        existing_note = db.get_note_by_id(note_id=note_id, include_deleted=True)
+        existing_note = await _run_db_call(
+            db.get_note_by_id,
+            note_id=note_id,
+            include_deleted=True,
+        )
         was_deleted = bool(existing_note) and bool(existing_note.get("deleted"))
         # Rate limit: notes.restore
         try:
@@ -4245,31 +4260,22 @@ async def restore_note(
         if sync_service is not None:
             if not existing_note:
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Note not found")
-            if was_deleted:
-                current_version = existing_note.get("version")
-                if current_version is not None and int(current_version) != int(expected_version):
-                    raise ConflictError(
-                        f"Restore for Note ID {note_id} failed: version mismatch.",
-                        entity="notes",
-                        entity_id=note_id,
-                    )
-                try:
-                    capture_server_origin_mutation(
-                        sync_service,
-                        user_id=str(current_user.id),
-                        domain="notes.note",
-                        operation="upsert",
-                        object_id=note_id,
-                        payload=_note_payload_from_row(existing_note),
-                        source="server_api",
-                        routing_metadata={"restore_intent": True},
-                    )
-                except Exception as sync_exc:
-                    raise _note_sync_http_error(sync_exc) from sync_exc
+            try:
+                capture_server_origin_note_restore(
+                    sync_service,
+                    user_id=str(current_user.id),
+                    object_id=note_id,
+                    note=existing_note,
+                    expected_version=expected_version,
+                    source="server_api",
+                )
+            except Exception as sync_exc:
+                raise _note_sync_http_error(sync_exc) from sync_exc
         else:
-            success = db.restore_note(
+            success = await _run_db_call(
+                db.restore_note,
                 note_id=note_id,
-                expected_version=expected_version
+                expected_version=expected_version,
             )
             if not success:
                 raise CharactersRAGDBError("Note restore reported non-success without specific exception.")
@@ -4278,13 +4284,13 @@ async def restore_note(
             f"Note '{note_id}' restored successfully for user (DB client_id: {db.client_id}).")
 
         # Fetch the restored note to return it
-        restored_note = db.get_note_by_id(note_id)
+        restored_note = await _run_db_call(db.get_note_by_id, note_id)
         if not restored_note:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                                 detail=f"Note '{note_id}' not found after restore.")
 
-        keywords = db.get_keywords_for_note(note_id)
-        folders = db.get_note_folders_for_note(note_id)
+        keywords = await _run_db_call(db.get_keywords_for_note, note_id)
+        folders = await _run_db_call(db.get_note_folders_for_note, note_id)
         if was_deleted:
             restored_note_for_activity = dict(restored_note)
             restored_note_for_activity["keywords"] = list(keywords or [])

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -286,24 +286,12 @@ def _note_keywords_sync_unsupported_error() -> HTTPException:
     )
 
 
-def _note_restore_sync_unsupported_error() -> HTTPException:
-    return HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail={
-            "error_code": "sync_v2_note_restore_not_supported",
-            "message": "Sync v2 M1 does not support restoring notes through this endpoint.",
-        },
-    )
-
-
 def _note_payload_from_row(note: dict[str, Any]) -> dict[str, object]:
     return {
         "title": str(note.get("title") or ""),
         "content": str(note.get("content") or ""),
         "conversation_id": note.get("conversation_id"),
         "message_id": note.get("message_id"),
-        "client_id": note.get("client_id"),
-        "owner_user_id": note.get("owner_user_id") or note.get("client_id"),
     }
 
 
@@ -1368,8 +1356,6 @@ async def create_note(
                         "content": note_in.content,
                         "conversation_id": conversation_id,
                         "message_id": message_id,
-                        "client_id": str(current_user.id),
-                        "owner_user_id": str(current_user.id),
                     },
                     source="server_api",
                     stable_key=stable_key,
@@ -2161,8 +2147,6 @@ async def import_notes(
                                     "content": parsed_note["content"],
                                     "conversation_id": None,
                                     "message_id": None,
-                                    "client_id": str(current_user.id),
-                                    "owner_user_id": str(current_user.id),
                                 },
                                 source="server_api",
                             )
@@ -4189,10 +4173,9 @@ async def delete_note(
                     operation="tombstone",
                     object_id=note_id,
                     payload={
-                        "id": note_id,
-                        "deleted": True,
-                        "client_id": str(current_user.id),
-                        "owner_user_id": str(current_user.id),
+                        "deleted_at": sync_service.clock()
+                        or datetime.now(timezone.utc).isoformat(),
+                        "reason": "user_deleted",
                     },
                     source="server_api",
                 )
@@ -4258,15 +4241,38 @@ async def restore_note(
         logger.info(
             f"User (DB client_id: {db.client_id}) restoring note: ID='{note_id}', Version={expected_version}")
 
-        if _active_notes_sync_service(current_user) is not None:
-            raise _note_restore_sync_unsupported_error()
-
-        success = db.restore_note(
-            note_id=note_id,
-            expected_version=expected_version
-        )
-        if not success:
-            raise CharactersRAGDBError("Note restore reported non-success without specific exception.")
+        sync_service = _active_notes_sync_service(current_user)
+        if sync_service is not None:
+            if not existing_note:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Note not found")
+            if was_deleted:
+                current_version = existing_note.get("version")
+                if current_version is not None and int(current_version) != int(expected_version):
+                    raise ConflictError(
+                        f"Restore for Note ID {note_id} failed: version mismatch.",
+                        entity="notes",
+                        entity_id=note_id,
+                    )
+                try:
+                    capture_server_origin_mutation(
+                        sync_service,
+                        user_id=str(current_user.id),
+                        domain="notes.note",
+                        operation="upsert",
+                        object_id=note_id,
+                        payload=_note_payload_from_row(existing_note),
+                        source="server_api",
+                        routing_metadata={"restore_intent": True},
+                    )
+                except Exception as sync_exc:
+                    raise _note_sync_http_error(sync_exc) from sync_exc
+        else:
+            success = db.restore_note(
+                note_id=note_id,
+                expected_version=expected_version
+            )
+            if not success:
+                raise CharactersRAGDBError("Note restore reported non-success without specific exception.")
 
         logger.info(
             f"Note '{note_id}' restored successfully for user (DB client_id: {db.client_id}).")
@@ -4308,6 +4314,8 @@ async def restore_note(
             deleted=bool(restored_note.get('deleted', False)),
             keywords=keyword_responses,
             folders=list(folders or []),
+            conversation_id=restored_note.get("conversation_id"),
+            message_id=restored_note.get("message_id"),
         )
     except HTTPException:
         raise
@@ -4418,8 +4426,6 @@ async def bulk_create_notes(
                             "content": item.content,
                             "conversation_id": conversation_id,
                             "message_id": message_id,
-                            "client_id": str(current_user.id),
-                            "owner_user_id": str(current_user.id),
                         },
                         source="server_api",
                     )

--- a/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
@@ -6,6 +6,11 @@ from typing import Any, Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from tldw_Server_API.app.core.Sync.v2.models import (
+    sync_v2_domain_schemas,
+    validate_notes_note_upsert_payload,
+)
+
 SyncDomain = Literal[
     "notes.note",
     "chat.conversation",
@@ -267,6 +272,9 @@ class SyncCapabilitiesResponse(BaseModel):
     )
     operations: dict[SyncDomain, list[SyncOperation]] = Field(
         default_factory=lambda: {domain: list(operations) for domain, operations in SYNC_V2_SUPPORTED_OPERATIONS.items()}
+    )
+    domain_schemas: dict[SyncDomain, dict[str, Any]] = Field(
+        default_factory=sync_v2_domain_schemas
     )
     encryption: dict[str, Any] = Field(default_factory=_default_encryption)
     encryption_policies: list[EncryptionPolicy] = Field(default_factory=lambda: [DEFAULT_M1_ENCRYPTION_POLICY])
@@ -1243,6 +1251,9 @@ class SyncV2Envelope(BaseModel):
             self.operation == "append" and (not self.object_id.strip() or not self.payload_hash.strip())
         ):
             raise ValueError("chat.message append envelopes require object_id and payload_hash")
+
+        if self.domain == "notes.note" and self.operation == "upsert":
+            validate_notes_note_upsert_payload(self.payload)
 
         if self.domain == "attachment.ref":
             missing = _ATTACHMENT_REF_REQUIRED_PAYLOAD_KEYS.difference(self.payload)

--- a/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
@@ -118,10 +118,10 @@ class NoteStore:
 
         del object_hash
         normalized_note_id = str(note_id).strip()
-        normalized_title = title.strip() if isinstance(title, str) else ""
+        exact_title = title if isinstance(title, str) else ""
         if not normalized_note_id:
             raise InputError("note_id cannot be empty.")  # noqa: TRY003
-        if not normalized_title:
+        if not exact_title.strip():
             raise InputError("Note title cannot be empty.")  # noqa: TRY003
         if content is None:
             raise InputError("Note content cannot be None.")  # noqa: TRY003
@@ -149,7 +149,7 @@ class NoteStore:
         """
         params = (
             normalized_note_id,
-            normalized_title,
+            exact_title,
             content,
             now,
             sync_client_id,
@@ -608,7 +608,7 @@ class NoteStore:
                 deleted_clause = " AND deleted = ?"
                 params.append(self._deleted_value(False))
             query = (
-                f"SELECT id, title, content, created_at, last_modified, deleted, conversation_id "  # nosec B608
+                f"SELECT id, title, content, created_at, last_modified, deleted, conversation_id, message_id "  # nosec B608
                 f"FROM notes WHERE id IN ({ph}){deleted_clause}"
             )
             cur = self._db.execute_query(query, tuple(params))
@@ -617,6 +617,7 @@ class NoteStore:
                     "id": row[0], "title": row[1], "content": row[2],
                     "created_at": row[3], "last_modified": row[4],
                     "deleted": row[5], "conversation_id": row[6],
+                    "message_id": row[7],
                 }
                 results.append(r)
         return results

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes.py
@@ -6,8 +6,20 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any
 
-from ..adapters import AdapterAccepted, AdapterConflict, SyncAdapterContext, SyncAdapterOutcome
-from ..models import SyncDataset, SyncDomain, SyncEnvelope, SyncEnvelopeCreate
+from ..adapters import (
+    AdapterAccepted,
+    AdapterConflict,
+    AdapterRejected,
+    SyncAdapterContext,
+    SyncAdapterOutcome,
+)
+from ..models import (
+    SyncDataset,
+    SyncDomain,
+    SyncEnvelope,
+    SyncEnvelopeCreate,
+    validate_notes_note_upsert_payload,
+)
 from ._lineage import (
     current_head,
     delete_update_conflict,
@@ -44,6 +56,31 @@ class NotesDomainAdapter:
         """Accept metadata-only changes and conflict concurrent encrypted edits."""
 
         del dataset
+        if envelope.domain == "notes.note" and envelope.operation == "upsert":
+            try:
+                validate_notes_note_upsert_payload(envelope.payload)
+            except ValueError as exc:
+                return AdapterRejected(
+                    client_envelope_id=envelope.client_envelope_id,
+                    error_code="notes_note_payload_invalid",
+                    message=str(exc),
+                )
+        restore_intent = (
+            envelope.routing_metadata.get("restore_intent")
+            if envelope.domain == "notes.note"
+            else None
+        )
+        if restore_intent is not None and (
+            restore_intent is not True or envelope.operation != "upsert"
+        ):
+            return AdapterRejected(
+                client_envelope_id=envelope.client_envelope_id,
+                error_code="notes_note_restore_intent_invalid",
+                message=(
+                    "notes.note restore_intent must be the boolean true on an upsert "
+                    "when supplied"
+                ),
+            )
         prior = prior_envelopes(envelope, context)
         delete_conflict = delete_update_conflict(
             envelope,
@@ -53,6 +90,15 @@ class NotesDomainAdapter:
         )
         if delete_conflict is not None:
             return delete_conflict
+        if restore_intent is True:
+            head = current_head(prior)
+            if (
+                head is None
+                or not _is_delete(head)
+                or not incoming_references_head(envelope, head)
+            ):
+                return _restore_target_conflict(envelope)
+            return AdapterAccepted(client_envelope_id=envelope.client_envelope_id)
         if _is_content_bearing(envelope) and not incoming_references_head(
             envelope, _current_content_head(prior)
         ):
@@ -83,6 +129,16 @@ def _manual_delete_conflict(envelope: SyncEnvelopeCreate) -> AdapterConflict:
     )
 
 
+def _restore_target_conflict(envelope: SyncEnvelopeCreate) -> AdapterConflict:
+    return AdapterConflict(
+        client_envelope_id=envelope.client_envelope_id,
+        domain=envelope.domain,
+        entity_id=envelope.entity_id,
+        conflict_type="restore_target_conflict",
+        message="Note restore requires the exact current tombstone head.",
+    )
+
+
 def _is_delete(envelope: SyncEnvelope | SyncEnvelopeCreate) -> bool:
     return envelope.operation == "tombstone" or bool(
         envelope.payload_clear.get("deleted")
@@ -92,6 +148,8 @@ def _is_delete(envelope: SyncEnvelope | SyncEnvelopeCreate) -> bool:
 
 
 def _is_content_bearing(envelope: SyncEnvelope | SyncEnvelopeCreate) -> bool:
+    if envelope.domain == "notes.note" and envelope.operation == "upsert":
+        return True
     update_kind = _metadata_string(envelope, "update_kind") or _metadata_string(
         envelope, "change_kind"
     )

--- a/tldw_Server_API/app/core/Sync/v2/factory.py
+++ b/tldw_Server_API/app/core/Sync/v2/factory.py
@@ -18,6 +18,7 @@ from tldw_Server_API.app.core.Utils.path_utils import safe_join
 from .adapters import AttachmentRefAdapter, StaticSyncAdapter, SyncAdapterRegistry
 from .blob_store import LocalSyncBlobStore
 from .domain_adapters.media import MediaMetadataAdapter
+from .domain_adapters.notes import NotesDomainAdapter
 from .domain_adapters.source_cache import SourceCacheAdapter
 from .domain_adapters.workspaces import WorkspacesDomainAdapter
 from .materializers import (
@@ -43,6 +44,8 @@ def default_sync_v2_registry() -> SyncAdapterRegistry:
             (
                 AttachmentRefAdapter()
                 if domain == "attachment.ref"
+                else NotesDomainAdapter()
+                if domain == "notes.note"
                 else StaticSyncAdapter(domain=domain, supported_adapter_versions={1})
             )
             for domain in M1_SYNC_DOMAINS

--- a/tldw_Server_API/app/core/Sync/v2/materializers/notes.py
+++ b/tldw_Server_API/app/core/Sync/v2/materializers/notes.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 
-from ..models import SyncEnvelope, SyncObjectState
+from ..models import SyncEnvelope, SyncObjectState, validate_notes_note_upsert_payload
 from ..store import SyncV2Store
 from .base import MaterializationResult
 
@@ -49,7 +49,7 @@ class NotesMaterializer:
                     envelope.server_cursor,
                     apply_status="applied",
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 - projection state must record every backend failure
                 logger.warning(
                     "Failed to complete notes.note apply status for envelope {} "
                     "on object {}: {}",
@@ -91,16 +91,15 @@ class NotesMaterializer:
                     content=payload["content"],
                     conversation_id=payload.get("conversation_id"),
                     message_id=payload.get("message_id"),
-                    sync_client_id=_projection_client_id(envelope, payload),
+                    sync_client_id=_projection_client_id(envelope),
                     object_revision=object_revision,
                     object_hash=object_hash,
                 )
                 deleted = False
             elif envelope.operation == "tombstone":
-                payload = _note_payload_for_owner(envelope.payload)
                 self.note_db.tombstone_note_from_sync(
                     note_id=envelope.object_id,
-                    sync_client_id=_projection_client_id(envelope, payload),
+                    sync_client_id=_projection_client_id(envelope),
                     object_revision=object_revision,
                     object_hash=object_hash,
                 )
@@ -123,7 +122,7 @@ class NotesMaterializer:
                 envelope.server_cursor,
                 apply_status="applied",
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - projection failures are persisted for replay
             logger.warning(
                 "Failed to materialize notes.note envelope {} for object {}: {}",
                 envelope.client_envelope_id,
@@ -155,8 +154,12 @@ class NotesMaterializer:
             envelope.base_object_hash,
         )
         has_base = all(value is not None for value in base_values)
+        restore_requested = (
+            envelope.operation == "upsert"
+            and envelope.routing_metadata.get("restore_intent") is True
+        )
         if current_state is None:
-            if any(value is not None for value in base_values):
+            if restore_requested or any(value is not None for value in base_values):
                 return _conflict_result(
                     reason="missing_server_object",
                     envelope=envelope,
@@ -170,17 +173,26 @@ class NotesMaterializer:
                 envelope=envelope,
                 current_state=current_state,
             )
+        base_matches = (
+            envelope.base_server_cursor == current_state.latest_server_cursor
+            and envelope.base_object_revision == current_state.object_revision
+            and envelope.base_object_hash == current_state.object_hash
+        )
+        if restore_requested and not current_state.deleted:
+            return _conflict_result(
+                reason="restore_target_not_deleted",
+                envelope=envelope,
+                current_state=current_state,
+            )
+        if restore_requested and current_state.deleted and base_matches:
+            return None
         if envelope.operation == "upsert" and current_state.deleted:
             return _conflict_result(
                 reason="server_object_deleted",
                 envelope=envelope,
                 current_state=current_state,
             )
-        if (
-            envelope.base_server_cursor != current_state.latest_server_cursor
-            or envelope.base_object_revision != current_state.object_revision
-            or envelope.base_object_hash != current_state.object_hash
-        ):
+        if not base_matches:
             return _conflict_result(
                 reason="stale_base_state",
                 envelope=envelope,
@@ -219,44 +231,15 @@ class NotesMaterializer:
 
 
 def _note_payload(payload: dict[str, Any]) -> dict[str, str | None]:
-    title = payload.get("title")
-    content = payload.get("content", payload.get("body", ""))
-    if not isinstance(title, str) or not title.strip():
-        raise ValueError("notes.note payload requires a non-empty title")
-    if not isinstance(content, str):
-        raise ValueError("notes.note payload content must be a string")
-    conversation_id = payload.get("conversation_id")
-    message_id = payload.get("message_id")
-    return {
-        "title": title,
-        "content": content,
-        "conversation_id": str(conversation_id) if conversation_id is not None else None,
-        "message_id": str(message_id) if message_id is not None else None,
-        "client_id": _optional_text(payload.get("client_id")),
-        "owner_user_id": _optional_text(payload.get("owner_user_id")),
-    }
+    return validate_notes_note_upsert_payload(payload)
 
 
-def _note_payload_for_owner(payload: dict[str, Any]) -> dict[str, str | None]:
-    return {
-        "client_id": _optional_text(payload.get("client_id")),
-        "owner_user_id": _optional_text(payload.get("owner_user_id")),
-    }
-
-
-def _projection_client_id(envelope: SyncEnvelope, payload: dict[str, Any]) -> str:
+def _projection_client_id(envelope: SyncEnvelope) -> str:
     if envelope.routing_metadata.get("origin") == "server":
-        client_id = payload.get("client_id") or payload.get("owner_user_id")
+        client_id = envelope.routing_metadata.get("server_owner_user_id")
         if isinstance(client_id, str) and client_id.strip():
             return client_id.strip()
     return envelope.device_id or "sync-v2"
-
-
-def _optional_text(value: Any) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
 
 
 def _conflict_result(

--- a/tldw_Server_API/app/core/Sync/v2/models.py
+++ b/tldw_Server_API/app/core/Sync/v2/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Internal storage models for Sync v2 M1."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -120,6 +120,11 @@ CLIENT_PRIVATE_SERVER_FRONTEND_LIMITATION_MESSAGE = (
     "Server-front-end mutation is disabled for client_private_v1 datasets "
     "because opaque fields cannot be inspected or re-encrypted by the server."
 )
+NOTES_NOTE_TITLE_MAX_CHARS = 255
+NOTES_NOTE_CONTENT_MAX_CHARS = 5_000_000
+NOTES_NOTE_CANONICAL_PAYLOAD_FIELDS: frozenset[str] = frozenset(
+    {"title", "content", "conversation_id", "message_id"}
+)
 SYNC_KEY_WRAPPED_FOR_VALUES: list[SyncKeyWrappedFor] = [
     "server",
     "passphrase",
@@ -133,6 +138,33 @@ SYNC_KEY_REWRAP_STATUSES: list[SyncKeyRewrapStatus] = [
     "failed",
     "blocked",
 ]
+
+
+def sync_v2_domain_schemas() -> dict[SyncDomain, dict[str, object]]:
+    """Return client-discoverable payload contracts for versioned Sync domains."""
+
+    return {
+        "notes.note": {
+            "schema_version": 1,
+            "encryption_policy": DEFAULT_M1_ENCRYPTION_POLICY,
+            "upsert": {
+                "required": ["title", "content"],
+                "properties": {
+                    "title": {"type": "string", "max_length": NOTES_NOTE_TITLE_MAX_CHARS},
+                    "content": {"type": "string", "max_length": NOTES_NOTE_CONTENT_MAX_CHARS},
+                    "conversation_id": {"type": ["string", "null"]},
+                    "message_id": {"type": ["string", "null"]},
+                },
+                "additional_properties": False,
+            },
+            "tombstone": {"operation": "tombstone"},
+            "restore": {
+                "operation": "upsert",
+                "routing_metadata": {"restore_intent": True},
+                "requires_current_base": True,
+            },
+        }
+    }
 
 
 def server_frontend_mutation_enabled_for_policy(policy: EncryptionPolicy | str) -> bool:
@@ -155,6 +187,47 @@ def client_private_server_frontend_limitation_warning() -> dict[str, str]:
     return {
         "code": CLIENT_PRIVATE_SERVER_FRONTEND_LIMITATION_CODE,
         "message": CLIENT_PRIVATE_SERVER_FRONTEND_LIMITATION_MESSAGE,
+    }
+
+
+def validate_notes_note_upsert_payload(
+    payload: Mapping[str, object],
+) -> dict[str, str | None]:
+    """Validate and return the lossless version-1 ``notes.note`` payload."""
+
+    unexpected = set(payload).difference(NOTES_NOTE_CANONICAL_PAYLOAD_FIELDS)
+    if unexpected:
+        raise ValueError(
+            "notes.note upsert payload contains unsupported fields: "
+            + ", ".join(sorted(unexpected))
+        )
+
+    title = payload.get("title")
+    content = payload.get("content")
+    if not isinstance(title, str) or not title.strip():
+        raise ValueError("notes.note upsert payload requires a non-empty string title")
+    if len(title) > NOTES_NOTE_TITLE_MAX_CHARS:
+        raise ValueError(
+            f"notes.note title must be at most {NOTES_NOTE_TITLE_MAX_CHARS} characters"
+        )
+    if not isinstance(content, str) or not content:
+        raise ValueError("notes.note upsert payload requires non-empty string content")
+    if len(content) > NOTES_NOTE_CONTENT_MAX_CHARS:
+        raise ValueError(
+            f"notes.note content must be at most {NOTES_NOTE_CONTENT_MAX_CHARS} characters"
+        )
+
+    backlinks: dict[str, str | None] = {}
+    for field_name in ("conversation_id", "message_id"):
+        value = payload.get(field_name)
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"notes.note {field_name} must be a string or null")
+        backlinks[field_name] = value
+
+    return {
+        "title": title,
+        "content": content,
+        **backlinks,
     }
 
 
@@ -1139,6 +1212,9 @@ __all__ = [
     "EncryptionPolicy",
     "M1_SYNC_DOMAINS",
     "M1_SYNC_OPERATIONS",
+    "NOTES_NOTE_CANONICAL_PAYLOAD_FIELDS",
+    "NOTES_NOTE_CONTENT_MAX_CHARS",
+    "NOTES_NOTE_TITLE_MAX_CHARS",
     "MEDIA_SYNC_DOMAINS",
     "MEDIA_SYNC_OPERATIONS",
     "STRICT_ENCRYPTION_POLICIES",
@@ -1199,4 +1275,6 @@ __all__ = [
     "client_private_server_frontend_limitation_warning",
     "server_frontend_mutation_blockers_for_policy",
     "server_frontend_mutation_enabled_for_policy",
+    "sync_v2_domain_schemas",
+    "validate_notes_note_upsert_payload",
 ]

--- a/tldw_Server_API/app/core/Sync/v2/server_origin.py
+++ b/tldw_Server_API/app/core/Sync/v2/server_origin.py
@@ -52,6 +52,15 @@ class SyncServerOriginMutationNotSupportedError(SyncStoreError):
         self.error_code = CLIENT_PRIVATE_SERVER_FRONTEND_LIMITATION_CODE
 
 
+class SyncServerOriginRestoreConflictError(SyncStoreError):
+    """Raised when a server-origin restore does not target the current tombstone."""
+
+    def __init__(self, object_id: str) -> None:
+        super().__init__("Note restore requires the current deleted note version.")
+        self.object_id = object_id
+        self.error_code = "sync_server_origin_restore_conflict"
+
+
 @dataclass(frozen=True, slots=True)
 class ServerOriginCaptureResult:
     """Result of accepting and materializing a server-origin mutation."""
@@ -161,6 +170,42 @@ def capture_server_origin_mutation(
     return ServerOriginCaptureResult(dataset=dataset, envelope=inserted)
 
 
+def capture_server_origin_note_restore(
+    service: SyncV2Service,
+    *,
+    user_id: str,
+    object_id: str,
+    note: Mapping[str, object],
+    expected_version: int,
+    source: str,
+) -> ServerOriginCaptureResult:
+    """Validate and capture a restore of the current Notes tombstone."""
+
+    current_version = note.get("version")
+    try:
+        version_matches = int(current_version) == int(expected_version)
+    except (TypeError, ValueError):
+        version_matches = False
+    if not bool(note.get("deleted")) or not version_matches:
+        raise SyncServerOriginRestoreConflictError(object_id)
+
+    return capture_server_origin_mutation(
+        service,
+        user_id=user_id,
+        domain="notes.note",
+        operation="upsert",
+        object_id=object_id,
+        payload={
+            "title": str(note.get("title") or ""),
+            "content": str(note.get("content") or ""),
+            "conversation_id": note.get("conversation_id"),
+            "message_id": note.get("message_id"),
+        },
+        source=source,
+        routing_metadata={"restore_intent": True},
+    )
+
+
 def server_origin_stable_key(
     *,
     source: str,
@@ -260,7 +305,9 @@ __all__ = [
     "CLIENT_PRIVATE_SERVER_FRONTEND_LIMITATION_CODE",
     "SyncServerOriginMaterializationError",
     "SyncServerOriginMutationNotSupportedError",
+    "SyncServerOriginRestoreConflictError",
     "canonical_payload_hash",
+    "capture_server_origin_note_restore",
     "capture_server_origin_mutation",
     "get_active_server_origin_sync_service_for_user",
 ]

--- a/tldw_Server_API/app/core/Sync/v2/server_origin.py
+++ b/tldw_Server_API/app/core/Sync/v2/server_origin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from uuid import uuid4
 
@@ -70,6 +71,7 @@ def capture_server_origin_mutation(
     source: str,
     parent_id: str | None = None,
     stable_key: str | None = None,
+    routing_metadata: Mapping[str, object] | None = None,
 ) -> ServerOriginCaptureResult:
     """Append and materialize one trusted server-origin Sync v2 mutation."""
 
@@ -108,6 +110,15 @@ def capture_server_origin_mutation(
         if stable_key
         else f"server-origin-{uuid4().hex}"
     )
+    canonical_routing_metadata = dict(routing_metadata or {})
+    canonical_routing_metadata.update(
+        {
+            "source": source,
+            "origin": "server",
+            "server_device_id": SERVER_ORIGIN_DEVICE_ID,
+            "server_owner_user_id": user_id,
+        }
+    )
     envelope = SyncEnvelopeCreate(
         dataset_id=dataset.dataset_id,
         client_envelope_id=client_envelope_id,
@@ -128,11 +139,7 @@ def capture_server_origin_mutation(
         created_at_client=now,
         deleted=operation == "tombstone",
         encryption_metadata={"policy": DEFAULT_M1_ENCRYPTION_POLICY},
-        routing_metadata={
-            "source": source,
-            "origin": "server",
-            "server_device_id": SERVER_ORIGIN_DEVICE_ID,
-        },
+        routing_metadata=canonical_routing_metadata,
         stable_key=stable_key,
     )
 

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -81,6 +81,7 @@ from .models import (
     SyncRestoreCompletenessStatus,
     SyncRestoreDomainCompleteness,
     client_private_server_frontend_limitation_warning,
+    sync_v2_domain_schemas,
 )
 from .profile import SyncProfileStatus, SyncV2ProfileManager
 from .replay import SyncReplayRepairer, SyncReplayRepairResult
@@ -178,6 +179,9 @@ class SyncV2Capabilities:
     max_batch_size: int
     max_envelope_payload_bytes: int
     max_attachment_bytes: int
+    domain_schemas: dict[SyncDomain, dict[str, object]] = field(
+        default_factory=sync_v2_domain_schemas
+    )
     quota: dict[str, object] = field(default_factory=dict)
     supports_restore_manifest: bool = True
     supports_conflicts: bool = True
@@ -600,6 +604,7 @@ class SyncV2Service:
             max_batch_size=self.settings.max_batch_size,
             max_envelope_payload_bytes=self.settings.max_envelope_payload_bytes,
             max_attachment_bytes=self.settings.max_attachment_bytes,
+            domain_schemas=sync_v2_domain_schemas(),
             quota=quota,
             supports_attachments=self.settings.supports_attachments,
             compatibility_flags=compatibility_flags,

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_note_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_note_store.py
@@ -261,6 +261,37 @@ class TestNoteStoreSearch:
 
 
 class TestNoteStoreGraphHelpers:
+    def test_notes_batch_preserves_conversation_and_message_backlinks(self, store, db):
+        conversation_id = db.add_conversation({"title": "Source conversation"})
+        message_id = db.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "content": "Source message",
+            }
+        )
+        note_id = store.add_note(
+            title="Linked note",
+            content="Linked content",
+            conversation_id=conversation_id,
+            message_id=message_id,
+        )
+
+        rows = store.get_notes_batch([note_id])
+
+        assert rows == [
+            {
+                "id": note_id,
+                "title": "Linked note",
+                "content": "Linked content",
+                "created_at": rows[0]["created_at"],
+                "last_modified": rows[0]["last_modified"],
+                "deleted": rows[0]["deleted"],
+                "conversation_id": conversation_id,
+                "message_id": message_id,
+            }
+        ]
+
     def test_graph_helpers_and_keyword_links(self, store, db):
         character_id = db.add_character_card({"name": "Note Source Character"})
         conversation_id = db.add_conversation(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_domain_adapters.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_domain_adapters.py
@@ -226,6 +226,91 @@ def test_default_attachment_ref_adapter_rejects_invalid_parent_domain():
     assert outcome.error_code == "attachment_ref_parent_domain_invalid"
 
 
+def test_default_notes_note_adapter_rejects_noncanonical_payload_before_append():
+    default_sync_v2_registry.cache_clear()
+    adapter = default_sync_v2_registry().get("notes.note")
+
+    outcome = adapter.evaluate_envelope(
+        _envelope(
+            domain="notes.note",
+            payload_clear={
+                "title": "Research note",
+                "body": "Legacy alias must not enter the canonical log.",
+            },
+        ),
+        dataset=_dataset(domains=list(M1_SYNC_DOMAINS)),
+        context=_context(),
+    )
+
+    assert isinstance(adapter, NotesDomainAdapter)
+    assert isinstance(outcome, AdapterRejected)
+    assert outcome.error_code == "notes_note_payload_invalid"
+
+
+def test_default_notes_note_adapter_rejects_restore_intent_on_tombstone():
+    default_sync_v2_registry.cache_clear()
+    adapter = default_sync_v2_registry().get("notes.note")
+
+    outcome = adapter.evaluate_envelope(
+        _envelope(
+            domain="notes.note",
+            operation="tombstone",
+            routing_metadata={"restore_intent": True},
+            payload_clear={
+                "deleted_at": "2026-05-23T18:35:00+00:00",
+                "reason": "user_deleted",
+            },
+        ),
+        dataset=_dataset(domains=list(M1_SYNC_DOMAINS)),
+        context=_context(),
+    )
+
+    assert isinstance(outcome, AdapterRejected)
+    assert outcome.error_code == "notes_note_restore_intent_invalid"
+
+
+def test_default_notes_note_adapter_accepts_restore_based_on_current_tombstone():
+    default_sync_v2_registry.cache_clear()
+    adapter = default_sync_v2_registry().get("notes.note")
+    created = _stored(
+        _envelope(
+            domain="notes.note",
+            client_envelope_id="env-note-created",
+            payload={"title": "Note", "content": "Original"},
+            payload_hash="sha256:note-created",
+        ),
+        sequence=1,
+    )
+    tombstone = _stored(
+        _envelope(
+            domain="notes.note",
+            client_envelope_id="env-note-deleted",
+            operation="tombstone",
+            payload_clear={
+                "deleted_at": "2026-05-23T18:35:00+00:00",
+                "reason": "user_deleted",
+            },
+            payload_hash="sha256:note-deleted",
+        ),
+        sequence=2,
+    )
+
+    outcome = adapter.evaluate_envelope(
+        _envelope(
+            domain="notes.note",
+            client_envelope_id="env-note-restored",
+            base_server_cursor=2,
+            payload={"title": "Note", "content": "Original"},
+            payload_hash="sha256:note-restored",
+            routing_metadata={"restore_intent": True},
+        ),
+        dataset=_dataset(domains=list(M1_SYNC_DOMAINS)),
+        context=_context(created, tombstone),
+    )
+
+    assert outcome == AdapterAccepted(client_envelope_id="env-note-restored")
+
+
 def test_default_attachment_ref_adapter_conflicts_divergent_stable_payload_hash():
     default_sync_v2_registry.cache_clear()
     adapter = default_sync_v2_registry().get("attachment.ref")
@@ -1101,6 +1186,8 @@ def test_default_sync_v2_registry_advertises_personal_and_workspace_metadata_dom
     for domain in M1_SYNC_DOMAINS:
         if domain == "attachment.ref":
             assert isinstance(registry.get(domain), AttachmentRefAdapter)
+        elif domain == "notes.note":
+            assert isinstance(registry.get(domain), NotesDomainAdapter)
         else:
             assert isinstance(registry.get(domain), StaticSyncAdapter)
     for domain in WORKSPACE_SYNC_DOMAINS:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
@@ -155,6 +155,17 @@ def test_capabilities_endpoint_reports_supported_domains_and_encryption_posture(
     assert body["encryption"]["attestation"]["mode"] == "managed_storage"
     assert body["encryption_policies"] == ["server_trusted_v1"]
     assert body["blob_transfer"] == {"supported": False}
+    assert body["domain_schemas"]["notes.note"]["upsert"]["properties"] == {
+        "title": {"type": "string", "max_length": 255},
+        "content": {"type": "string", "max_length": 5_000_000},
+        "conversation_id": {"type": ["string", "null"]},
+        "message_id": {"type": ["string", "null"]},
+    }
+    assert body["domain_schemas"]["notes.note"]["restore"] == {
+        "operation": "upsert",
+        "routing_metadata": {"restore_intent": True},
+        "requires_current_base": True,
+    }
     assert body["warnings"] == []
 
 

--- a/tldw_Server_API/tests/Sync/test_sync_v2_models.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_models.py
@@ -63,7 +63,12 @@ def _m1_envelope_payload(**overrides):
         "operation": "upsert",
         "parent_id": None,
         "schema_version": 1,
-        "payload": {"title": "Research note"},
+        "payload": {
+            "title": "Research note",
+            "content": "Canonical Markdown",
+            "conversation_id": None,
+            "message_id": None,
+        },
         "payload_hash": "sha256:test",
         "object_revision": None,
         "created_at_client": "2026-05-23T18:12:44Z",
@@ -96,7 +101,73 @@ def test_capabilities_advertise_personal_and_workspace_domains_with_server_trust
     assert capabilities.encryption["ready"] is True
     assert capabilities.encryption_policies == ["server_trusted_v1"]
     assert capabilities.blob_transfer == {"supported": False}
+    assert capabilities.domain_schemas["notes.note"] == {
+        "schema_version": 1,
+        "encryption_policy": "server_trusted_v1",
+        "upsert": {
+            "required": ["title", "content"],
+            "properties": {
+                "title": {"type": "string", "max_length": 255},
+                "content": {"type": "string", "max_length": 5_000_000},
+                "conversation_id": {"type": ["string", "null"]},
+                "message_id": {"type": ["string", "null"]},
+            },
+            "additional_properties": False,
+        },
+        "tombstone": {"operation": "tombstone"},
+        "restore": {
+            "operation": "upsert",
+            "routing_metadata": {"restore_intent": True},
+            "requires_current_base": True,
+        },
+    }
     assert "client_private_v1" not in capabilities.model_dump_json()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "title": 42,
+            "content": "Markdown",
+            "conversation_id": None,
+            "message_id": None,
+        },
+        {
+            "title": "Research note",
+            "content": ["not", "text"],
+            "conversation_id": None,
+            "message_id": None,
+        },
+        {
+            "title": "x" * 256,
+            "content": "Markdown",
+            "conversation_id": None,
+            "message_id": None,
+        },
+        {
+            "title": "Research note",
+            "content": "x" * 5_000_001,
+            "conversation_id": None,
+            "message_id": None,
+        },
+        {
+            "title": "Research note",
+            "content": "Markdown",
+            "conversation_id": 17,
+            "message_id": None,
+        },
+        {
+            "title": "Research note",
+            "content": "Markdown",
+            "conversation_id": None,
+            "message_id": {"id": "message-1"},
+        },
+    ],
+)
+def test_notes_note_upsert_schema_rejects_wrong_types_and_oversized_payloads(payload):
+    with pytest.raises(ValidationError):
+        SyncV2Envelope.model_validate(_m1_envelope_payload(payload=payload))
 
 
 def test_capabilities_normalize_legacy_supported_domains_to_supported_defaults():
@@ -488,7 +559,10 @@ def test_sync_envelope_accepts_m1_fields_and_legacy_transition_aliases():
             object_id=None,
             server_sequence=101,
             payload=None,
-            payload_clear={"title": "Legacy payload alias"},
+            payload_clear={
+                "title": "Legacy payload alias",
+                "content": "Canonical note body",
+            },
         )
     )
 
@@ -496,8 +570,11 @@ def test_sync_envelope_accepts_m1_fields_and_legacy_transition_aliases():
     assert envelope.entity_id == "note-from-old-client"
     assert envelope.server_cursor == 101
     assert envelope.server_sequence == 101
-    assert envelope.payload == {"title": "Legacy payload alias"}
-    assert envelope.payload_clear == {"title": "Legacy payload alias"}
+    assert envelope.payload == {
+        "title": "Legacy payload alias",
+        "content": "Canonical note body",
+    }
+    assert envelope.payload_clear == envelope.payload
     assert envelope.client_sequence == 17
     assert envelope.encryption_metadata == {"policy": "server_trusted_v1"}
 

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_materializer.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_materializer.py
@@ -84,7 +84,7 @@ def _note_envelope(**overrides) -> SyncEnvelopeCreate:
         "object_revision": 1,
         "payload": {
             "title": "Trip notes",
-            "body": "Packed outline and research links.",
+            "content": "Packed outline and research links.",
         },
         "payload_hash": "sha256:note-v1",
         "created_at_client": "2026-05-23T18:12:44+00:00",
@@ -124,6 +124,45 @@ def test_clean_notes_note_upsert_creates_normal_chacha_note(
     assert state.object_revision == 1
     assert state.object_hash == "sha256:note-v1"
     assert state.deleted is False
+
+
+def test_notes_note_upsert_preserves_exact_markdown_title_and_backlinks(
+    sync_service: SyncV2Service,
+    chacha_db: CharactersRAGDB,
+) -> None:
+    conversation_id = chacha_db.add_conversation(
+        {"id": "conversation-1", "title": "Source conversation"}
+    )
+    message_id = chacha_db.add_message(
+        {
+            "id": "message-1",
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": "Source message",
+        }
+    )
+    exact_title = "  Unicode π note  "
+    exact_content = "# Heading\n\n<link target> & 🧠\n\n[[Exact Target]]\n"
+
+    result = _push_one(
+        sync_service,
+        _note_envelope(
+            payload={
+                "title": exact_title,
+                "content": exact_content,
+                "conversation_id": conversation_id,
+                "message_id": message_id,
+            }
+        ),
+    )
+
+    assert [item.client_envelope_id for item in result.accepted] == ["env-create"]
+    note = chacha_db.get_note_by_id("note-1")
+    assert note is not None
+    assert note["title"] == exact_title
+    assert note["content"] == exact_content
+    assert note["conversation_id"] == "conversation-1"
+    assert note["message_id"] == "message-1"
 
 
 def test_exact_retry_of_applied_create_does_not_rematerialize_or_conflict(
@@ -261,7 +300,7 @@ def test_stale_base_creates_whole_object_conflict_without_overwriting_projection
             base_object_revision=base.object_revision,
             base_object_hash=base.object_hash,
             object_revision=2,
-            payload={"title": "Server winner", "body": "Keep this body."},
+            payload={"title": "Server winner", "content": "Keep this body."},
             payload_hash="sha256:note-v2",
         ),
     )
@@ -277,7 +316,7 @@ def test_stale_base_creates_whole_object_conflict_without_overwriting_projection
             base_object_revision=base_revision,
             base_object_hash=base_hash,
             object_revision=3,
-            payload={"title": "Stale edit", "body": "Do not apply."},
+            payload={"title": "Stale edit", "content": "Do not apply."},
             payload_hash=f"sha256:stale-{base_revision}",
         ),
     )
@@ -323,7 +362,7 @@ def test_materialization_conflict_is_not_returned_by_normal_pull(
             base_object_revision=base.object_revision,
             base_object_hash=base.object_hash,
             object_revision=2,
-            payload={"title": "Server winner", "body": "Keep this body."},
+            payload={"title": "Server winner", "content": "Keep this body."},
             payload_hash="sha256:note-v2",
         ),
     )
@@ -337,7 +376,7 @@ def test_materialization_conflict_is_not_returned_by_normal_pull(
             base_object_revision=base.object_revision,
             base_object_hash=base.object_hash,
             object_revision=3,
-            payload={"title": "Stale edit", "body": "Do not apply."},
+            payload={"title": "Stale edit", "content": "Do not apply."},
             payload_hash="sha256:stale-v3",
         ),
     )
@@ -380,7 +419,7 @@ def test_push_stop_on_conflict_rejects_remaining_envelopes(
                 base_object_revision=current.object_revision + 1,
                 base_object_hash=current.object_hash,
                 object_revision=2,
-                payload={"title": "Stale", "body": "Do not apply."},
+                payload={"title": "Stale", "content": "Do not apply."},
                 payload_hash="sha256:stale",
             ),
             _note_envelope(
@@ -388,7 +427,7 @@ def test_push_stop_on_conflict_rejects_remaining_envelopes(
                 object_id="note-2",
                 client_sequence=3,
                 object_revision=1,
-                payload={"title": "Skipped", "body": "Should not be applied."},
+                payload={"title": "Skipped", "content": "Should not be applied."},
                 payload_hash="sha256:note-2",
             ),
         ],
@@ -422,7 +461,7 @@ def test_pull_paginates_across_hidden_materialization_conflict(
             base_object_revision=base.object_revision,
             base_object_hash=base.object_hash,
             object_revision=2,
-            payload={"title": "Stale edit", "body": "Do not apply."},
+            payload={"title": "Stale edit", "content": "Do not apply."},
             payload_hash="sha256:stale-v2",
         ),
     )
@@ -435,7 +474,7 @@ def test_pull_paginates_across_hidden_materialization_conflict(
             base_object_revision=base.object_revision,
             base_object_hash=base.object_hash,
             object_revision=2,
-            payload={"title": "Server winner", "body": "Keep this body."},
+            payload={"title": "Server winner", "content": "Keep this body."},
             payload_hash="sha256:note-v2",
         ),
     )
@@ -592,7 +631,7 @@ def test_tombstoned_note_is_not_resurrected_by_stale_upsert(
             base_object_revision=base.object_revision,
             base_object_hash=base.object_hash,
             object_revision=2,
-            payload={"title": "Stale resurrect", "body": "Do not revive."},
+            payload={"title": "Stale resurrect", "content": "Do not revive."},
             payload_hash="sha256:stale-resurrect",
         ),
     )
@@ -603,6 +642,154 @@ def test_tombstoned_note_is_not_resurrected_by_stale_upsert(
     deleted_note = chacha_db.get_note_by_id("note-1", include_deleted=True)
     assert deleted_note is not None
     assert bool(deleted_note["deleted"]) is True
+
+
+def test_restore_intent_upsert_against_current_tombstone_restores_note(
+    sync_service: SyncV2Service,
+    chacha_db: CharactersRAGDB,
+) -> None:
+    _push_one(sync_service, _note_envelope())
+    created = sync_service.store.get_object_state("dataset-1", "notes.note", "note-1")
+    assert created is not None
+    _push_one(
+        sync_service,
+        _note_envelope(
+            client_envelope_id="env-delete",
+            client_sequence=2,
+            operation="tombstone",
+            base_server_cursor=created.latest_server_cursor,
+            base_object_revision=created.object_revision,
+            base_object_hash=created.object_hash,
+            object_revision=2,
+            payload={"deleted_at": "2026-05-23T18:35:00+00:00"},
+            payload_hash="sha256:note-delete",
+            deleted=True,
+        ),
+    )
+    tombstone = sync_service.store.get_object_state("dataset-1", "notes.note", "note-1")
+    assert tombstone is not None
+    assert tombstone.deleted is True
+
+    result = _push_one(
+        sync_service,
+        _note_envelope(
+            client_envelope_id="env-restore",
+            client_sequence=3,
+            base_server_cursor=tombstone.latest_server_cursor,
+            base_object_revision=tombstone.object_revision,
+            base_object_hash=tombstone.object_hash,
+            object_revision=3,
+            payload={
+                "title": "Restored note",
+                "content": "Restored exactly.",
+                "conversation_id": None,
+                "message_id": None,
+            },
+            payload_hash="sha256:note-restored",
+            routing_metadata={"restore_intent": True},
+        ),
+    )
+
+    assert [item.client_envelope_id for item in result.accepted] == ["env-restore"]
+    assert result.conflicts == []
+    restored = chacha_db.get_note_by_id("note-1")
+    assert restored is not None
+    assert restored["title"] == "Restored note"
+    state = sync_service.store.get_object_state("dataset-1", "notes.note", "note-1")
+    assert state is not None
+    assert state.deleted is False
+    assert state.object_revision == 3
+
+
+def test_ordinary_upsert_against_current_tombstone_does_not_restore_note(
+    sync_service: SyncV2Service,
+    chacha_db: CharactersRAGDB,
+) -> None:
+    _push_one(sync_service, _note_envelope())
+    created = sync_service.store.get_object_state("dataset-1", "notes.note", "note-1")
+    assert created is not None
+    _push_one(
+        sync_service,
+        _note_envelope(
+            client_envelope_id="env-delete",
+            client_sequence=2,
+            operation="tombstone",
+            base_server_cursor=created.latest_server_cursor,
+            base_object_revision=created.object_revision,
+            base_object_hash=created.object_hash,
+            object_revision=2,
+            payload={"deleted_at": "2026-05-23T18:35:00+00:00"},
+            payload_hash="sha256:note-delete",
+            deleted=True,
+        ),
+    )
+    tombstone = sync_service.store.get_object_state("dataset-1", "notes.note", "note-1")
+    assert tombstone is not None
+
+    result = _push_one(
+        sync_service,
+        _note_envelope(
+            client_envelope_id="env-ordinary-after-delete",
+            client_sequence=3,
+            base_server_cursor=tombstone.latest_server_cursor,
+            base_object_revision=tombstone.object_revision,
+            base_object_hash=tombstone.object_hash,
+            object_revision=3,
+            payload={"title": "Ordinary update", "content": "Must stay deleted."},
+            payload_hash="sha256:ordinary-after-delete",
+        ),
+    )
+
+    assert result.accepted == []
+    assert len(result.conflicts) == 1
+    assert chacha_db.get_note_by_id("note-1") is None
+
+
+def test_restore_intent_upsert_against_active_note_is_a_conflict(
+    sync_service: SyncV2Service,
+    chacha_db: CharactersRAGDB,
+) -> None:
+    _push_one(sync_service, _note_envelope())
+    active = sync_service.store.get_object_state("dataset-1", "notes.note", "note-1")
+    assert active is not None
+
+    result = _push_one(
+        sync_service,
+        _note_envelope(
+            client_envelope_id="env-restore-active",
+            client_sequence=2,
+            base_server_cursor=active.latest_server_cursor,
+            base_object_revision=active.object_revision,
+            base_object_hash=active.object_hash,
+            object_revision=2,
+            payload={"title": "Must conflict", "content": "Already active."},
+            payload_hash="sha256:restore-active",
+            routing_metadata={"restore_intent": True},
+        ),
+    )
+
+    assert result.accepted == []
+    assert len(result.conflicts) == 1
+    assert chacha_db.get_note_by_id("note-1")["title"] == "Trip notes"
+
+
+def test_restore_intent_upsert_cannot_create_a_missing_note(
+    sync_service: SyncV2Service,
+    chacha_db: CharactersRAGDB,
+) -> None:
+    result = _push_one(
+        sync_service,
+        _note_envelope(
+            client_envelope_id="env-restore-missing",
+            payload={"title": "Must conflict", "content": "No tombstone exists."},
+            payload_hash="sha256:restore-missing",
+            routing_metadata={"restore_intent": True},
+        ),
+    )
+
+    assert result.accepted == []
+    assert len(result.conflicts) == 1
+    assert chacha_db.get_note_by_id("note-1", include_deleted=True) is None
 
 
 def test_apply_failure_marks_accepted_envelope_failed_and_replayable(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_postgres_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_postgres_contract.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.backends.base import BackendType, DatabaseConfig
+from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Sync.v2.adapters import SyncAdapterRegistry
+from tldw_Server_API.app.core.Sync.v2.domain_adapters.notes import NotesDomainAdapter
+from tldw_Server_API.app.core.Sync.v2.materializers.notes import NotesMaterializer
+from tldw_Server_API.app.core.Sync.v2.models import SyncEnvelopeCreate
+from tldw_Server_API.app.core.Sync.v2.security import (
+    server_trusted_encryption_status_from_config,
+)
+from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service, SyncV2Settings
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
+
+pytestmark = pytest.mark.integration
+
+
+def _ready_encryption():
+    return server_trusted_encryption_status_from_config(
+        mode="managed_storage",
+        server_trusted_enabled=True,
+        auth_mode="multi_user",
+    )
+
+
+def _envelope(**overrides) -> SyncEnvelopeCreate:
+    values = {
+        "dataset_id": "dataset-postgres",
+        "client_envelope_id": "env-create",
+        "domain": "notes.note",
+        "operation": "upsert",
+        "object_id": "note-postgres",
+        "device_id": "device-postgres",
+        "client_sequence": 1,
+        "schema_version": 1,
+        "object_revision": 1,
+        "payload": {
+            "title": "  PostgreSQL π note  ",
+            "content": "# Exact Markdown\n\n[[Linked note]] & <source> 🧠\n",
+            "conversation_id": None,
+            "message_id": None,
+        },
+        "payload_hash": "sha256:pg-note-v1",
+        "created_at_client": "2026-05-23T18:12:44+00:00",
+        "deleted": False,
+        "encryption_metadata": {"policy": "server_trusted_v1"},
+    }
+    values.update(overrides)
+    return SyncEnvelopeCreate(**values)
+
+
+def _push(service: SyncV2Service, envelope: SyncEnvelopeCreate):
+    return service.push(
+        user_id="user-postgres",
+        dataset_id="dataset-postgres",
+        device_id="device-postgres",
+        envelopes=[envelope],
+    )
+
+
+def test_postgresql_notes_sync_contract_round_trip(
+    tmp_path,
+    pg_database_config: DatabaseConfig,
+) -> None:
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    note_db = CharactersRAGDB(
+        db_path=":memory:",
+        client_id="user-postgres",
+        backend=backend,
+    )
+    try:
+        conversation_id = note_db.add_conversation(
+            {"id": "conversation-postgres", "title": "Source conversation"}
+        )
+        message_id = note_db.add_message(
+            {
+                "id": "message-postgres",
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "content": "Source message",
+            }
+        )
+        service = SyncV2Service(
+            store=SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "Sync_v2.db")),
+            adapters=SyncAdapterRegistry([NotesDomainAdapter()]),
+            materializers={"notes.note": NotesMaterializer(note_db)},
+            clock=lambda: "2026-05-23T18:12:00+00:00",
+            settings=SyncV2Settings(
+                supported_domains=["notes.note"],
+                operations={"notes.note": ["upsert", "tombstone"]},
+                server_trusted_encryption=_ready_encryption(),
+            ),
+        )
+        service.register_device(
+            user_id="user-postgres",
+            display_name="PostgreSQL client",
+            client_type="chatbook",
+            device_id="device-postgres",
+        )
+        service.enroll_dataset(
+            user_id="user-postgres",
+            dataset_id="dataset-postgres",
+            domains=["notes.note"],
+        )
+
+        create = _envelope(
+            payload={
+                "title": "  PostgreSQL π note  ",
+                "content": "# Exact Markdown\n\n[[Linked note]] & <source> 🧠\n",
+                "conversation_id": conversation_id,
+                "message_id": message_id,
+            }
+        )
+        assert [item.client_envelope_id for item in _push(service, create).accepted] == [
+            "env-create"
+        ]
+        created = service.store.get_object_state(
+            "dataset-postgres", "notes.note", "note-postgres"
+        )
+        assert created is not None
+
+        update = _envelope(
+            client_envelope_id="env-update",
+            client_sequence=2,
+            base_server_cursor=created.latest_server_cursor,
+            base_object_revision=created.object_revision,
+            base_object_hash=created.object_hash,
+            object_revision=2,
+            payload={
+                "title": "  PostgreSQL π note revised  ",
+                "content": "# Revised exactly\n\n- one\n- two\n",
+                "conversation_id": conversation_id,
+                "message_id": message_id,
+            },
+            payload_hash="sha256:pg-note-v2",
+        )
+        assert [item.client_envelope_id for item in _push(service, update).accepted] == [
+            "env-update"
+        ]
+        updated = service.store.get_object_state(
+            "dataset-postgres", "notes.note", "note-postgres"
+        )
+        assert updated is not None
+
+        tombstone = _envelope(
+            client_envelope_id="env-delete",
+            client_sequence=3,
+            operation="tombstone",
+            base_server_cursor=updated.latest_server_cursor,
+            base_object_revision=updated.object_revision,
+            base_object_hash=updated.object_hash,
+            object_revision=3,
+            payload={"deleted_at": "2026-05-23T18:35:00+00:00", "reason": "user_deleted"},
+            payload_hash="sha256:pg-note-delete",
+            deleted=True,
+        )
+        assert [item.client_envelope_id for item in _push(service, tombstone).accepted] == [
+            "env-delete"
+        ]
+        deleted = service.store.get_object_state(
+            "dataset-postgres", "notes.note", "note-postgres"
+        )
+        assert deleted is not None and deleted.deleted is True
+
+        stale = _envelope(
+            client_envelope_id="env-stale",
+            client_sequence=4,
+            base_server_cursor=updated.latest_server_cursor,
+            base_object_revision=updated.object_revision,
+            base_object_hash=updated.object_hash,
+            object_revision=3,
+            payload={"title": "Stale", "content": "Must not resurrect."},
+            payload_hash="sha256:pg-note-stale",
+        )
+        stale_result = _push(service, stale)
+        assert stale_result.accepted == []
+        assert len(stale_result.conflicts) == 1
+
+        restore = _envelope(
+            client_envelope_id="env-restore",
+            client_sequence=5,
+            base_server_cursor=deleted.latest_server_cursor,
+            base_object_revision=deleted.object_revision,
+            base_object_hash=deleted.object_hash,
+            object_revision=4,
+            payload={
+                "title": "  PostgreSQL π note revised  ",
+                "content": "# Revised exactly\n\n- one\n- two\n",
+                "conversation_id": conversation_id,
+                "message_id": message_id,
+            },
+            payload_hash="sha256:pg-note-restored",
+            routing_metadata={"restore_intent": True},
+        )
+        assert [item.client_envelope_id for item in _push(service, restore).accepted] == [
+            "env-restore"
+        ]
+        envelope_count = len(
+            service.store.list_envelopes_after(
+                "dataset-postgres", 0, domains=["notes.note"], limit=10
+            )
+        )
+        assert [item.client_envelope_id for item in _push(service, restore).accepted] == [
+            "env-restore"
+        ]
+        assert len(
+            service.store.list_envelopes_after(
+                "dataset-postgres", 0, domains=["notes.note"], limit=10
+            )
+        ) == envelope_count
+
+        note = note_db.get_note_by_id("note-postgres")
+        assert note is not None
+        assert note["title"] == "  PostgreSQL π note revised  "
+        assert note["content"] == "# Revised exactly\n\n- one\n- two\n"
+        assert note["conversation_id"] == conversation_id
+        assert note["message_id"] == message_id
+        state = service.store.get_object_state(
+            "dataset-postgres", "notes.note", "note-postgres"
+        )
+        assert state is not None
+        assert state.deleted is False
+        assert state.object_revision == 4
+    finally:
+        note_db.close_connection()
+        if note_db.backend_type == BackendType.POSTGRESQL:
+            backend.get_pool().close_all()

--- a/tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py
@@ -280,12 +280,14 @@ def test_restore_preview_paginates_past_scan_limit_without_truncating_domain(
             client_envelope_id="env-note-2",
             client_sequence=2,
             payload_hash="sha256:note-2",
+            stable_key="note:note-2",
         ),
         _note_envelope(
             object_id="note-3",
             client_envelope_id="env-note-3",
             client_sequence=3,
             payload_hash="sha256:note-3",
+            stable_key="note:note-3",
         ),
     )
 

--- a/tldw_Server_API/tests/Sync/test_sync_v2_server_origin_capture.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_server_origin_capture.py
@@ -906,6 +906,15 @@ def test_active_sync_note_restore_appends_canonical_restore_intent_upsert(
     assert delete_response.status_code == 204
     deleted_note = chacha_db.get_note_by_id("note-restore-active", include_deleted=True)
     assert deleted_note["deleted"] in (1, True)
+    stale_restore_response = client.post(
+        "/api/v1/notes/note-restore-active/restore",
+        params={"expected_version": deleted_note["version"] - 1},
+    )
+
+    assert stale_restore_response.status_code == 409
+    assert stale_restore_response.json()["detail"]["error_code"] == (
+        "sync_server_origin_restore_conflict"
+    )
 
     restore_response = client.post(
         "/api/v1/notes/note-restore-active/restore",
@@ -946,8 +955,8 @@ def test_active_sync_note_restore_appends_canonical_restore_intent_upsert(
         params={"expected_version": deleted_note["version"]},
     )
 
-    assert retry_response.status_code == 200
-    assert retry_response.json() == restore_response.json()
+    assert retry_response.status_code == 409
+    assert retry_response.json()["detail"]["error_code"] == "sync_server_origin_restore_conflict"
     assert len(
         sync_service.store.list_envelopes_after(
             dataset_id,

--- a/tldw_Server_API/tests/Sync/test_sync_v2_server_origin_capture.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_server_origin_capture.py
@@ -585,6 +585,17 @@ def test_normal_notes_create_api_routes_personal_write_through_sync_when_active(
     chacha_db: CharactersRAGDB,
 ) -> None:
     client = _notes_app(monkeypatch, chacha_db=chacha_db, sync_service=sync_service)
+    conversation_id = chacha_db.add_conversation(
+        {"id": "note-api-conversation", "title": "Source conversation"}
+    )
+    message_id = chacha_db.add_message(
+        {
+            "id": "note-api-message",
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": "Source message",
+        }
+    )
 
     response = client.post(
         "/api/v1/notes/",
@@ -592,6 +603,8 @@ def test_normal_notes_create_api_routes_personal_write_through_sync_when_active(
             "id": "note-api-1",
             "title": "API note",
             "content": "Created through the normal Notes API.",
+            "conversation_id": conversation_id,
+            "message_id": message_id,
         },
     )
 
@@ -629,6 +642,31 @@ def test_normal_notes_create_api_routes_personal_write_through_sync_when_active(
         ("notes.note", "note-api-1", SERVER_ORIGIN_DEVICE_ID, "applied"),
         ("notes.note", "note-api-1", SERVER_ORIGIN_DEVICE_ID, "applied"),
     ]
+    assert [item.payload for item in envelopes[:3]] == [
+        {
+            "title": "API note",
+            "content": "Created through the normal Notes API.",
+            "conversation_id": conversation_id,
+            "message_id": message_id,
+        },
+        {
+            "title": "API note renamed",
+            "content": "Updated content.",
+            "conversation_id": conversation_id,
+            "message_id": message_id,
+        },
+        {
+            "title": "API note renamed",
+            "content": "Patched content.",
+            "conversation_id": conversation_id,
+            "message_id": message_id,
+        },
+    ]
+    assert envelopes[3].payload == {
+        "deleted_at": "2026-05-23T18:12:00+00:00",
+        "reason": "user_deleted",
+    }
+    assert all(item.routing_metadata["server_owner_user_id"] == "user-1" for item in envelopes)
 
 
 def test_normal_notes_create_api_reports_client_private_server_frontend_limitation(
@@ -850,7 +888,7 @@ def test_inactive_sync_note_create_ignores_idempotency_key_for_direct_id_generat
     assert chacha_db.get_note_by_id(response.json()["id"]) is not None
 
 
-def test_active_sync_note_restore_is_rejected_without_direct_projection_write(
+def test_active_sync_note_restore_appends_canonical_restore_intent_upsert(
     monkeypatch: pytest.MonkeyPatch,
     sync_service: SyncV2Service,
     chacha_db: CharactersRAGDB,
@@ -874,9 +912,10 @@ def test_active_sync_note_restore_is_rejected_without_direct_projection_write(
         params={"expected_version": deleted_note["version"]},
     )
 
-    assert restore_response.status_code == 400
-    assert restore_response.json()["detail"]["error_code"] == "sync_v2_note_restore_not_supported"
-    assert chacha_db.get_note_by_id("note-restore-active", include_deleted=True)["deleted"] in (1, True)
+    assert restore_response.status_code == 200
+    assert restore_response.json()["deleted"] is False
+    restored_note = chacha_db.get_note_by_id("note-restore-active", include_deleted=True)
+    assert restored_note["deleted"] in (0, False)
     dataset_id = sync_service.profile(user_id="user-1").active_dataset_id or ""
     envelopes = sync_service.store.list_envelopes_after(
         dataset_id,
@@ -887,7 +926,36 @@ def test_active_sync_note_restore_is_rejected_without_direct_projection_write(
     assert [(item.operation, item.object_id) for item in envelopes] == [
         ("upsert", "note-restore-active"),
         ("tombstone", "note-restore-active"),
+        ("upsert", "note-restore-active"),
     ]
+    restore_envelope = envelopes[-1]
+    assert restore_envelope.routing_metadata["restore_intent"] is True
+    assert restore_envelope.payload == {
+        "title": "Restore",
+        "content": "Delete me.",
+        "conversation_id": None,
+        "message_id": None,
+    }
+    state = sync_service.store.get_object_state(dataset_id, "notes.note", "note-restore-active")
+    assert state is not None
+    assert state.deleted is False
+    assert state.object_revision == 3
+
+    retry_response = client.post(
+        "/api/v1/notes/note-restore-active/restore",
+        params={"expected_version": deleted_note["version"]},
+    )
+
+    assert retry_response.status_code == 200
+    assert retry_response.json() == restore_response.json()
+    assert len(
+        sync_service.store.list_envelopes_after(
+            dataset_id,
+            0,
+            domains=["notes.note"],
+            limit=10,
+        )
+    ) == 3
 
 
 def test_inactive_sync_note_restore_keeps_existing_direct_behavior(


### PR DESCRIPTION
## Change summary (human-authored merge gate)

Improved notes preservation, sync contract, and progress towards parity with tldw_server.

## Summary

- What changed: Added the canonical four-field `notes.note` Sync v2 schema, production Notes adapter validation, lossless title/Markdown materialization, conversation/message backlinks, current-tombstone-only restore intent, and symmetric server-origin REST capture. Added ADR/API documentation and focused SQLite/PostgreSQL contract coverage. The prerequisite planning commit also records the serialized Notes parity server backlog.
- Why: Chatbook needs one reproducible server contract before it can implement a durable two-client Notes round trip without REST-only state, malformed envelopes, or stale resurrection.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally: `215 passed, 1 skipped`
- [x] Docs updated (if behavior, routes, or config changed)
- [x] Ruff passed for new/reworked Sync modules
- [x] Bandit reported 0 findings across 13,190 touched production lines
- PostgreSQL contract coverage is included but skipped locally because neither a PostgreSQL server nor Docker daemon was available.
- The two large legacy Notes files retain the same pre-existing full-file Ruff baseline as `dev`; this PR introduces no new Ruff finding there.

## UX Audit Checklist (v2 Stage 5)

Not applicable: server-side Sync/Notes contract change; no WebUI or extension files changed.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

Not applicable: no Watchlists changes.

## Watchlists Scale Checklist (Group 10 Stage 5)

Not applicable: no Watchlists changes.

## Risk & Rollback

- Risk level: Medium
- Rollback plan: Revert commits `3157335500` and `b3e284bf8e`; clients must continue treating active-Sync organization mutations as unavailable until later domains land.

Tracks TASK-13002.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the canonical `notes.note` Sync v2 contract with lossless title/Markdown, backlinks, and base-aware restore, and routes server REST mutations through the same path with hardened server-origin restore conflicts. Enables reliable two-client Notes round trips and satisfies TASK-13002.

- **New Features**
  - Advertises `notes.note` v1 schema in capabilities (`domain_schemas`): required `title`, `content`; optional `conversation_id`, `message_id`; rejects unknown fields; enforces size limits; preserves bytes.
  - Implements restore as `upsert` with `routing_metadata.restore_intent: true` and an exact current-tombstone base; stale restores and ordinary upserts against tombstones conflict; idempotent replay.
  - Adds a production `NotesDomainAdapter` with payload validation and restore rules; materializer uses the canonical payload and preserves exact title/content; `get_notes_batch` now returns `message_id`.
  - Routes server creates/updates/deletes/restores through Sync with symmetric envelopes and `server_owner_user_id` routing metadata; active-Sync restore appends a canonical restore-intent upsert and returns 409 on stale/active targets; docs updated and focused SQLite/PostgreSQL tests added.

- **Migration**
  - Clients must send `content` (not legacy `body`) and only the four canonical fields; restore requires `routing_metadata.restore_intent: true` plus the current tombstone base.
  - Do not include `client_id`/`owner_user_id` in note payloads; the server records ownership in routing metadata.
  - Keyword writes remain blocked while Sync is active until their domains land.

<sup>Written for commit bfc310e41710d91b75dff8269dff698f836c7960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


