### PR TITLE
fix(mcp): retain portable RC failure evidence

### DIFF
--- a/.github/workflows/mcp-unified-rc.yml
+++ b/.github/workflows/mcp-unified-rc.yml
@@ -147,3 +147,11 @@ jobs:
 
       - name: Run installed protocol and portable stdio contracts
         run: python Helper_Scripts/mcp_unified_rc.py portable-gate
+
+      - name: Upload portable RC evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: mcp-unified-portable-${{ matrix.os }}-py${{ matrix.python }}
+          path: .artifacts/mcp-unified-rc/**
+          if-no-files-found: error

--- a/Helper_Scripts/mcp_unified_rc.py
+++ b/Helper_Scripts/mcp_unified_rc.py
@@ -2046,7 +2046,12 @@ def _write_and_report(recorder: RcEvidenceRecorder) -> int:
     logger.info("Wrote RC evidence JSON: {}", json_path)
     logger.info("Wrote RC evidence Markdown: {}", markdown_path)
     if recorder.has_required_failures():
-        logger.error("RC status: failed")
+        failed_checks = ", ".join(
+            f"{result['phase']}/{result['name']}"
+            for result in recorder.results
+            if result.get("required", True) and result["status"] == "failed"
+        )
+        logger.error("RC status: failed ({})", failed_checks)
         return 1
     logger.info("RC status: ok")
     return 0

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
@@ -780,6 +780,12 @@ def test_rc_workflow_runs_installed_stdio_contracts_on_linux_and_windows() -> No
     assert '"jsonschema>=4.23,<5"' in run_blocks
     assert "python Helper_Scripts/mcp_unified_rc.py portable-gate" in run_blocks
     assert "tldw_Server_API/app/core/MCP_unified/tests/" not in run_blocks
+    upload = next(step for step in job["steps"] if step["name"] == "Upload portable RC evidence")
+    assert upload["if"] == "always()"
+    assert re.fullmatch(r"actions/upload-artifact@[0-9a-f]{40}", upload["uses"])
+    assert upload["with"]["name"] == "mcp-unified-portable-${{ matrix.os }}-py${{ matrix.python }}"
+    assert upload["with"]["path"] == ".artifacts/mcp-unified-rc/**"
+    assert upload["with"]["if-no-files-found"] == "error"
     assert (
         "tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_artifact_consumer.py"
         in workflow["on"]["pull_request"]["paths"]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
@@ -1126,6 +1126,40 @@ def test_result_recorder_marks_required_failure(tmp_path: Path) -> None:
     assert payload["summary"] == {"passed": 0, "failed": 1, "skipped": 0}  # nosec B101
 
 
+def test_failed_rc_logs_only_failed_check_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CI must identify failed checks without disclosing captured command output."""
+
+    recorder = mcp_unified_rc.RcEvidenceRecorder(
+        evidence_dir=tmp_path,
+        package_name="mcp-unified",
+        package_version="0.2.0",
+        package_status="public-alpha",
+        publishing_status="published",
+        commit="deadbeef",
+        source_path="apps/mcp-unified",
+        layout="src",
+    )
+    recorder.record(
+        phase="artifact_gate",
+        name="windows_stdio",
+        status="failed",
+        duration_ms=1,
+        reason="private failure payload",
+    )
+    messages: list[str] = []
+    monkeypatch.setattr(
+        mcp_unified_rc.logger,
+        "error",
+        lambda message, *args: messages.append(message.format(*args)),
+    )
+
+    assert mcp_unified_rc._write_and_report(recorder) == 1  # nosec B101
+    assert messages == ["RC status: failed (artifact_gate/windows_stdio)"]  # nosec B101
+
+
 def test_result_recorder_includes_artifact_hashes(tmp_path: Path) -> None:
     """Artifact records should include filenames and SHA256 hashes."""
 


### PR DESCRIPTION
## Summary

- log only fixed phase/check identifiers when a required MCP RC check fails
- upload the sanitized portable RC evidence bundle on every matrix exit
- preserve existing output redaction and avoid logging captured subprocess content

## Why

The protected Windows/Python 3.11 portability job failed after `mcp-unified 0.2.0` publication, but the job retained its sanitized failure evidence only on the ephemeral runner and logged no failing check identifier. This narrow change makes the existing evidence observable so the actual Windows defect can be diagnosed without weakening confidentiality controls.

## Verification

- TDD RED: both new diagnostic contracts failed against current `dev`
- GREEN: RC-helper + protocol stdio suites: 74 passed
- Ruff: clean
- `git diff --check`: clean

## Release handling

This PR does not change the published package runtime. After merge, the MCP portability workflow will be rerun on `dev`; any actual artifact/runtime fix will be a separate tested change and corrective package release if required.

> Repository-owner disclosure: the repository owner directed Codex to author and submit this PR statement and accepts responsibility for the change summary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make portable RC failures debuggable by always uploading sanitized evidence and logging which required checks failed. This keeps confidentiality while allowing Windows portability issues to be diagnosed.

- **Bug Fixes**
  - Workflow: added an `always()` artifact upload using pinned `actions/upload-artifact` for the portable matrix; uploads `.artifacts/mcp-unified-rc/**` and errors if missing.
  - Logging/tests: `_write_and_report` now logs only failed required check IDs as "phase/name" and never emits captured subprocess output; tests assert the upload config and the new logging contract.

<sup>Written for commit 540509a40ef87bcb74ec2b317c874d6a2b3061a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

