### PR TITLE
fix(mcp): complete Windows portable validation for 0.2.1

### DIFF
--- a/.github/workflows/mcp-unified-rc.yml
+++ b/.github/workflows/mcp-unified-rc.yml
@@ -95,7 +95,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: mcp-unified-rc
-          path: .artifacts/mcp-unified-rc/**
+          path: |
+            .artifacts/mcp-unified-rc/**
+            apps/mcp-unified/dist/**
           if-no-files-found: error
 
   portable-stdio:
@@ -153,5 +155,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: mcp-unified-portable-${{ matrix.os }}-py${{ matrix.python }}
-          path: .artifacts/mcp-unified-rc/**
+          path: |
+            .artifacts/mcp-unified-rc/**
+            apps/mcp-unified/dist/**
           if-no-files-found: error

--- a/.github/workflows/mcp-unified-rc.yml
+++ b/.github/workflows/mcp-unified-rc.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install packaging tools
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build twine setuptools wheel pytest pytest-asyncio bandit
+          python -m pip install build twine "setuptools>=79.0.1" wheel pytest pytest-asyncio bandit
           python -m pip install "pydantic>=2.0.0" "loguru>=0.7.0" "PyYAML>=6.0.0" "httpx>=0.24.0" "websockets>=12.0"
 
       - name: Run internal RC
@@ -144,7 +144,7 @@ jobs:
       - name: Install package-only RC dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build twine setuptools wheel pytest pytest-asyncio bandit
+          python -m pip install build twine "setuptools>=79.0.1" wheel pytest pytest-asyncio bandit
           python -m pip install "pydantic>=2.0.0" "loguru>=0.7.0" "PyYAML>=6.0.0" "httpx>=0.24.0" "websockets>=12.0" "jsonschema>=4.23,<5"
 
       - name: Run installed protocol and portable stdio contracts

--- a/Docs/ADR/033-mcp-unified-stdio-contract-hardening.md
+++ b/Docs/ADR/033-mcp-unified-stdio-contract-hardening.md
@@ -39,6 +39,14 @@ duplicate identities, uses deterministic ordering, and binds an integrity-
 protected cursor to method, profile, configured page size, offset, and
 normalized catalog fingerprint; a moving catalog invalidates the cursor.
 
+POSIX hosts use the multiprocessing `spawn` worker. Native Windows hosts use
+an equivalent fixed-argument Python subprocess because protected official-SDK
+stdio execution demonstrated that nested multiprocessing reconstruction could
+not complete reliably there. The Windows handoff is an exact-length,
+owner-only temporary payload; the child has no shell, stdin, inherited stdio,
+or network resolver, emits only the same bounded verdict, and the parent
+removes the payload only as part of bounded child cleanup.
+
 `GatewayToolExecutionError` remains a protocol-valid `isError: true` tool
 result. Its safe stable classification is carried under the gateway-owned
 result metadata key `io.github.rmusser01.mcp-unified/error` with bounded

--- a/Docs/superpowers/plans/2026-08-08-mcp-unified-multi-revision-stdio-implementation.md
+++ b/Docs/superpowers/plans/2026-08-08-mcp-unified-multi-revision-stdio-implementation.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Add a strict protocol stack beside the existing `GatewayStdioServer`: immutable revision profiles and public contracts feed bounded schema validation, descriptor/result projection, and cursor pagination; `GatewayProtocolConnection` owns lifecycle, in-flight work, rate limits, cancellation, and serialized output; `GatewayProtocolStdioServer` owns binary stream framing and shutdown. Existing `GatewayRuntime`, `GatewayStdioServer`, `handle_stdio_line`, FastAPI, and WebSocket paths remain on their current dispatch implementation.
 
-**Tech Stack:** Python 3.10-3.13, asyncio, multiprocessing `spawn`, Pydantic, `jsonschema>=4.23,<5`, pytest/pytest-asyncio, Bandit, setuptools/build/twine.
+**Tech Stack:** Python 3.10-3.13, asyncio, multiprocessing `spawn`, fixed-argument Windows subprocess workers, Pydantic, `jsonschema>=4.23,<5`, pytest/pytest-asyncio, Bandit, setuptools/build/twine.
 
 ## Global Constraints
 
@@ -289,7 +289,7 @@
 
   Parent-side preflight serializes with `allow_nan=False`, walks JSON iteratively, counts schema nodes/refs/pattern characters, and rejects network/unresolved external references before spawn. A module-level worker entrypoint constructs `Draft202012Validator`, returns only a bounded success/error tuple through a one-way pipe, and performs no network resolution.
 
-  The concrete manager stores `asyncio.Semaphore(limits.max_schema_validation_processes)` and a set of live `multiprocessing.Process` objects. Its `validate(schema, instance)` method performs preflight, acquires the semaphore, spawns exactly one worker, reads a bounded verdict under `schema_validation_timeout_seconds`, and calls one shared cleanup path. That cleanup terminates then kills when needed, joins the child, removes it from the live set, and only then releases the semaphore. `close()` rejects new work and applies the same cleanup to every live child. No executor thread may outlive `close()`.
+  The concrete manager stores `asyncio.Semaphore(limits.max_schema_validation_processes)` and exact live-child accounting. Its `validate(schema, instance)` method performs preflight, acquires the semaphore, spawns exactly one worker, reads a bounded verdict under `schema_validation_timeout_seconds`, and calls one shared cleanup path. POSIX uses a live `multiprocessing.Process` plus one-way pipe. Native Windows uses a fixed-argument `sys.executable -m mcp_unified._schema_worker` subprocess plus an exact-length owner-only temporary payload because the protected nested official-SDK stdio launch proved multiprocessing reconstruction unreliable there. That cleanup terminates then kills when needed, reaps the child, removes the private payload, removes it from the live set, and only then releases the semaphore. `close()` rejects new work and applies the same cleanup to every live child. No executor thread may outlive `close()`.
 
   ```python
   SchemaWorkerVerdict: TypeAlias = tuple[Literal["ok", "invalid", "internal"], str]

--- a/Docs/superpowers/specs/2026-08-08-mcp-unified-multi-revision-stdio-protocol-design.md
+++ b/Docs/superpowers/specs/2026-08-08-mcp-unified-multi-revision-stdio-protocol-design.md
@@ -369,7 +369,7 @@ defaults:
 | `max_schema_refs` | `int` | `256` | `1..4_096` |
 | `max_schema_pattern_chars` | `int` | `4_096` | `1..65_536` |
 | `max_schema_validation_processes` | `int` | `4` | `1..32` |
-| `schema_validation_timeout_seconds` | `float` | `10.0` | finite and `(0, 10]` |
+| `schema_validation_timeout_seconds` | `float` | `1.0` | finite and `(0, 10]` |
 | `graceful_shutdown_timeout_seconds` | `float` | `5.0` | finite and `(0, 60]` |
 
 Integer fields reject booleans and values outside their accepted ranges.

--- a/Docs/superpowers/specs/2026-08-08-mcp-unified-multi-revision-stdio-protocol-design.md
+++ b/Docs/superpowers/specs/2026-08-08-mcp-unified-multi-revision-stdio-protocol-design.md
@@ -369,10 +369,14 @@ defaults:
 | `max_schema_refs` | `int` | `256` | `1..4_096` |
 | `max_schema_pattern_chars` | `int` | `4_096` | `1..65_536` |
 | `max_schema_validation_processes` | `int` | `4` | `1..32` |
-| `schema_validation_timeout_seconds` | `float` | `1.0` | finite and `(0, 10]` |
+| `schema_validation_timeout_seconds` | `float` | `5.0` | finite and `(0, 10]` |
 | `graceful_shutdown_timeout_seconds` | `float` | `5.0` | finite and `(0, 60]` |
 
 Integer fields reject booleans and values outside their accepted ranges.
+The validation timeout default was raised from `1.0` to `5.0` in `0.2.1`
+after the protected Windows SDK smoke demonstrated that a clean spawned worker
+can need more than one second to import before validation begins; the `10.0`
+second upper bound is unchanged.
 Cross-field relationships in the table are validated. Construction fails
 before serving; values are never silently clamped. `max_json_depth` applies to
 decoded requests, runtime results, and metadata; `max_schema_depth` separately

--- a/Docs/superpowers/specs/2026-08-08-mcp-unified-multi-revision-stdio-protocol-design.md
+++ b/Docs/superpowers/specs/2026-08-08-mcp-unified-multi-revision-stdio-protocol-design.md
@@ -369,7 +369,7 @@ defaults:
 | `max_schema_refs` | `int` | `256` | `1..4_096` |
 | `max_schema_pattern_chars` | `int` | `4_096` | `1..65_536` |
 | `max_schema_validation_processes` | `int` | `4` | `1..32` |
-| `schema_validation_timeout_seconds` | `float` | `1.0` | finite and `(0, 10]` |
+| `schema_validation_timeout_seconds` | `float` | `5.0` | finite and `(0, 10]` |
 | `graceful_shutdown_timeout_seconds` | `float` | `5.0` | finite and `(0, 60]` |
 
 Integer fields reject booleans and values outside their accepted ranges.

--- a/Docs/superpowers/specs/2026-08-08-mcp-unified-multi-revision-stdio-protocol-design.md
+++ b/Docs/superpowers/specs/2026-08-08-mcp-unified-multi-revision-stdio-protocol-design.md
@@ -369,7 +369,7 @@ defaults:
 | `max_schema_refs` | `int` | `256` | `1..4_096` |
 | `max_schema_pattern_chars` | `int` | `4_096` | `1..65_536` |
 | `max_schema_validation_processes` | `int` | `4` | `1..32` |
-| `schema_validation_timeout_seconds` | `float` | `5.0` | finite and `(0, 10]` |
+| `schema_validation_timeout_seconds` | `float` | `10.0` | finite and `(0, 10]` |
 | `graceful_shutdown_timeout_seconds` | `float` | `5.0` | finite and `(0, 60]` |
 
 Integer fields reject booleans and values outside their accepted ranges.

--- a/Docs/superpowers/specs/2026-08-08-mcp-unified-multi-revision-stdio-protocol-design.md
+++ b/Docs/superpowers/specs/2026-08-08-mcp-unified-multi-revision-stdio-protocol-design.md
@@ -374,9 +374,11 @@ defaults:
 
 Integer fields reject booleans and values outside their accepted ranges.
 The validation timeout default was raised from `1.0` to `5.0` in `0.2.1`
-after the protected Windows SDK smoke demonstrated that a clean spawned worker
-can need more than one second to import before validation begins; the `10.0`
-second upper bound is unchanged.
+during protected Windows SDK diagnosis after clean child startup exceeded one
+second. The later root cause was nested multiprocessing reconstruction, now
+avoided by the Windows worker transport, but the five-second default remains a
+conservative cross-platform cold-start bound; the `10.0` second upper bound is
+unchanged.
 Cross-field relationships in the table are validated. Construction fails
 before serving; values are never silently clamped. `max_json_depth` applies to
 decoded requests, runtime results, and metadata; `max_schema_depth` separately
@@ -598,6 +600,19 @@ Queue admission remains bounded by the process limit and request cancellation;
 cancelled requests discard the verdict and reap their worker. Shutdown rejects
 new validation work, terminates any live validation children with the same
 bounded terminate/kill escalation, reaps them, and then releases their permits.
+
+The worker transport is platform-specific without changing those guarantees.
+POSIX uses `multiprocessing` with the `spawn` context and a one-way pipe.
+Native Windows uses `sys.executable -m mcp_unified._schema_worker` with fixed
+arguments and no shell because the protected official-SDK stdio gate proved
+that a nested multiprocessing child could not reconstruct reliably inside the
+already spawned server. The Windows parent writes only the preflighted schema
+and optional instance to an exact-length owner-only temporary binary payload,
+passes only its generated path and the allowlisted dialect, ignores child
+stderr, bounds stdout to the verdict ceiling, and removes the payload during
+the same terminate/kill/reap cleanup. No payload or path enters diagnostics.
+Explicit process-context/worker injections retain the multiprocessing backend
+for deterministic lifecycle tests on every platform.
 
 Dialect support does not loosen MCP descriptor shapes. Every tool
 `inputSchema` is a valid object schema with an object root. A `2026-07-28`

--- a/Helper_Scripts/Testing-related/mcp_official_sdk_stdio_smoke.py
+++ b/Helper_Scripts/Testing-related/mcp_official_sdk_stdio_smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import inspect
+import multiprocessing
 import os
 import sys
 import sysconfig
@@ -139,4 +140,5 @@ async def _main() -> None:
 
 
 if __name__ == "__main__":
+    multiprocessing.freeze_support()
     asyncio.run(_main())

--- a/Helper_Scripts/Testing-related/mcp_official_sdk_stdio_smoke.py
+++ b/Helper_Scripts/Testing-related/mcp_official_sdk_stdio_smoke.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import inspect
-import multiprocessing
 import os
 import sys
 import sysconfig
@@ -140,5 +139,4 @@ async def _main() -> None:
 
 
 if __name__ == "__main__":
-    multiprocessing.freeze_support()
     asyncio.run(_main())

--- a/Helper_Scripts/mcp_unified_rc.py
+++ b/Helper_Scripts/mcp_unified_rc.py
@@ -988,7 +988,7 @@ def _distribution_metadata(artifact: Path, *, kind: str) -> Message:
 def _jsonschema_base_dependency(metadata: Message) -> str:
     """Return the exact unmarked jsonschema base requirement or fail closed."""
 
-    matches: set[str] = set()
+    matches: dict[frozenset[str], str] = {}
     for value in metadata.get_all("Requires-Dist") or []:
         requirement, separator, marker = value.partition(";")
         name_match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement)
@@ -996,13 +996,14 @@ def _jsonschema_base_dependency(metadata: Message) -> str:
             continue
         name = name_match.group(1).lower().replace("_", "-")
         if name == "jsonschema" and (not separator or not marker.strip()):
-            matches.add(requirement.strip())
+            normalized = requirement.strip()
+            specifier_text = normalized[name_match.end() :].replace(" ", "").strip("()")
+            specifiers = frozenset(part for part in specifier_text.split(",") if part)
+            matches.setdefault(specifiers, normalized)
     if len(matches) != 1:
         raise ValueError("metadata must declare one unmarked jsonschema base dependency")
 
-    requirement = next(iter(matches))
-    specifier_text = requirement[len("jsonschema") :].replace(" ", "")
-    specifiers = frozenset(part for part in specifier_text.split(",") if part)
+    specifiers, requirement = next(iter(matches.items()))
     if specifiers != JSONSCHEMA_REQUIREMENT_BOUNDS:
         raise ValueError("jsonschema base dependency must be bounded to >=4.23,<5")
     return requirement

--- a/Helper_Scripts/mcp_unified_rc.py
+++ b/Helper_Scripts/mcp_unified_rc.py
@@ -988,7 +988,7 @@ def _distribution_metadata(artifact: Path, *, kind: str) -> Message:
 def _jsonschema_base_dependency(metadata: Message) -> str:
     """Return the exact unmarked jsonschema base requirement or fail closed."""
 
-    matches: list[str] = []
+    matches: set[str] = set()
     for value in metadata.get_all("Requires-Dist") or []:
         requirement, separator, marker = value.partition(";")
         name_match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement)
@@ -996,11 +996,11 @@ def _jsonschema_base_dependency(metadata: Message) -> str:
             continue
         name = name_match.group(1).lower().replace("_", "-")
         if name == "jsonschema" and (not separator or not marker.strip()):
-            matches.append(requirement.strip())
+            matches.add(requirement.strip())
     if len(matches) != 1:
         raise ValueError("metadata must declare one unmarked jsonschema base dependency")
 
-    requirement = matches[0]
+    requirement = next(iter(matches))
     specifier_text = requirement[len("jsonschema") :].replace(" ", "")
     specifiers = frozenset(part for part in specifier_text.split(",") if part)
     if specifiers != JSONSCHEMA_REQUIREMENT_BOUNDS:

--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -186,6 +186,15 @@ self-reported client identity as authorization.
 | `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
+Schema compilation and instance validation run in disposable bounded child
+processes. On native Windows, the preflighted schema and complete validation
+instance are briefly stored in an owner-only file in the operating-system
+temporary directory so the nested stdio server can launch the child reliably.
+The file is never logged, is removed during the same bounded child cleanup,
+and is not retained after success, failure, timeout, cancellation, or shutdown.
+Applications handling data that must never touch temporary storage should
+account for this Windows behavior before enabling strict tool calls.
+
 Modern responses use conservative private cache hints
 `{"ttlMs": 0, "cacheScope": "private"}`; legacy projections omit modern cache
 fields. Errors expose only stable, allowlisted classifications and safe limit

--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -183,7 +183,7 @@ self-reported client identity as authorization.
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 10.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 1.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 Modern responses use conservative private cache hints

--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -183,7 +183,7 @@ self-reported client identity as authorization.
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 10.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 Modern responses use conservative private cache hints

--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -4,9 +4,9 @@ MCP Unified is the standalone package boundary for the Model Context Protocol
 runtime and gateway being extracted from `tldw-server`.
 
 The package status is `public-alpha`, and the publishing status is `published`.
-Version `0.2.0` remains a release candidate until the protected PyPI publish
-succeeds. The package is published on PyPI and built and tested inside the
-`tldw-server` repository; the
+Released versions are published on PyPI; repository versions remain release
+candidates until their protected publish succeeds. The package is built and
+tested inside the `tldw-server` repository; the
 former internal/experimental phase remains relevant only to earlier releases.
 
 This package does not currently ship an end-user standalone gateway server
@@ -60,8 +60,8 @@ recognize the inline type annotations when consuming built artifacts.
 ## Publishing Readiness
 
 Standalone package publishing is live but guarded. Package metadata reports
-`public-alpha` and publishing state `published`; the `0.2.0` build is a release
-candidate until the protected publish succeeds.
+`public-alpha` and publishing state `published`; repository builds remain
+release candidates until their protected publish succeeds.
 
 Run the full internal release candidate gate:
 
@@ -105,7 +105,7 @@ python -m pip install "mcp-unified[gateway]"
 Downstream applications should use a compatible-minor pin:
 
 ```bash
-python -m pip install "mcp-unified[gateway]~=0.2.0"
+python -m pip install "mcp-unified[gateway]~=0.2.1"
 ```
 
 For development tooling, install the optional development extras:

--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -183,7 +183,7 @@ self-reported client identity as authorization.
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 1.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 Modern responses use conservative private cache hints

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -149,7 +149,7 @@ The exact `GatewayLimits` defaults are:
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 10.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 The modern profile emits private, zero-TTL cache hints:

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -5,9 +5,9 @@ Unified standalone gateway boundary. It focuses on profiles, external servers,
 credential grants, configuration snapshots, and remote runtime commands.
 
 The package status is `public-alpha`, and its publishing status is `published`.
-Version `0.2.0` remains a release candidate until the protected PyPI publish
-succeeds. The package is published on PyPI; the former internal/experimental
-phase applies only to earlier
+Released versions are published on PyPI; repository versions remain release
+candidates until their protected publish succeeds. The former
+internal/experimental phase applies only to earlier
 releases. The package CLI does not launch a supported end-user gateway server;
 remote runtime commands require an already running package-local gateway
 mounted by a host application.
@@ -15,9 +15,8 @@ mounted by a host application.
 ## Publishing Readiness
 
 The standalone package has publishing status `published` and package status
-`public-alpha`. New users can install the released package from PyPI;
-developers testing the `0.2.0` release candidate before its protected publish
-should install from the repository.
+`public-alpha`. New users can install released versions from PyPI; developers
+testing an unpublished repository version should install from the repository.
 
 Run the full internal release candidate gate from the repository root:
 
@@ -58,7 +57,7 @@ python -m pip install "mcp-unified[gateway]"
 Downstream applications should use a compatible-minor pin:
 
 ```bash
-python -m pip install "mcp-unified[gateway]~=0.2.0"
+python -m pip install "mcp-unified[gateway]~=0.2.1"
 ```
 
 From the repository root, when testing unpublished changes:

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -152,6 +152,15 @@ The exact `GatewayLimits` defaults are:
 | `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
+Schema compilation and instance validation run in disposable bounded child
+processes. On native Windows, the preflighted schema and complete validation
+instance are briefly stored in an owner-only file in the operating-system
+temporary directory so the nested stdio server can launch the child reliably.
+The file is never logged, is removed during the same bounded child cleanup,
+and is not retained after success, failure, timeout, cancellation, or shutdown.
+Applications handling data that must never touch temporary storage should
+account for this Windows behavior before enabling strict tool calls.
+
 The modern profile emits private, zero-TTL cache hints:
 `{"ttlMs": 0, "cacheScope": "private"}`. Legacy profiles omit those modern
 fields. Public errors are typed and bounded; they allowlist stable reason,

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -149,7 +149,7 @@ The exact `GatewayLimits` defaults are:
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 10.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 1.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 The modern profile emits private, zero-TTL cache hints:

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -149,7 +149,7 @@ The exact `GatewayLimits` defaults are:
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 1.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 The modern profile emits private, zero-TTL cache hints:

--- a/apps/mcp-unified/pyproject.toml
+++ b/apps/mcp-unified/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unified"
-version = "0.2.0"
+version = "0.2.1"
 description = "Standalone MCP Unified runtime and gateway package boundary."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/apps/mcp-unified/pyproject.toml
+++ b/apps/mcp-unified/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=79.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -80,7 +80,7 @@ gateway = [
 ]
 dev = [
   "build>=1.0.0",
-  "setuptools>=61.0",
+  "setuptools>=79.0.1",
   "wheel>=0.41.0",
   "tomli>=2.0.0; python_version < '3.11'",
   "pytest>=9.0.3",

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -186,6 +186,15 @@ self-reported client identity as authorization.
 | `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
+Schema compilation and instance validation run in disposable bounded child
+processes. On native Windows, the preflighted schema and complete validation
+instance are briefly stored in an owner-only file in the operating-system
+temporary directory so the nested stdio server can launch the child reliably.
+The file is never logged, is removed during the same bounded child cleanup,
+and is not retained after success, failure, timeout, cancellation, or shutdown.
+Applications handling data that must never touch temporary storage should
+account for this Windows behavior before enabling strict tool calls.
+
 Modern responses use conservative private cache hints
 `{"ttlMs": 0, "cacheScope": "private"}`; legacy projections omit modern cache
 fields. Errors expose only stable, allowlisted classifications and safe limit

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -183,7 +183,7 @@ self-reported client identity as authorization.
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 10.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 1.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 Modern responses use conservative private cache hints

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -183,7 +183,7 @@ self-reported client identity as authorization.
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 10.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 Modern responses use conservative private cache hints

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -4,9 +4,9 @@ MCP Unified is the standalone package boundary for the Model Context Protocol
 runtime and gateway being extracted from `tldw-server`.
 
 The package status is `public-alpha`, and the publishing status is `published`.
-Version `0.2.0` remains a release candidate until the protected PyPI publish
-succeeds. The package is published on PyPI and built and tested inside the
-`tldw-server` repository; the
+Released versions are published on PyPI; repository versions remain release
+candidates until their protected publish succeeds. The package is built and
+tested inside the `tldw-server` repository; the
 former internal/experimental phase remains relevant only to earlier releases.
 
 This package does not currently ship an end-user standalone gateway server
@@ -60,8 +60,8 @@ recognize the inline type annotations when consuming built artifacts.
 ## Publishing Readiness
 
 Standalone package publishing is live but guarded. Package metadata reports
-`public-alpha` and publishing state `published`; the `0.2.0` build is a release
-candidate until the protected publish succeeds.
+`public-alpha` and publishing state `published`; repository builds remain
+release candidates until their protected publish succeeds.
 
 Run the full internal release candidate gate:
 
@@ -105,7 +105,7 @@ python -m pip install "mcp-unified[gateway]"
 Downstream applications should use a compatible-minor pin:
 
 ```bash
-python -m pip install "mcp-unified[gateway]~=0.2.0"
+python -m pip install "mcp-unified[gateway]~=0.2.1"
 ```
 
 For development tooling, install the optional development extras:

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -183,7 +183,7 @@ self-reported client identity as authorization.
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 1.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 Modern responses use conservative private cache hints

--- a/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+++ b/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
@@ -149,7 +149,7 @@ The exact `GatewayLimits` defaults are:
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 10.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 The modern profile emits private, zero-TTL cache hints:

--- a/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+++ b/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
@@ -5,9 +5,9 @@ Unified standalone gateway boundary. It focuses on profiles, external servers,
 credential grants, configuration snapshots, and remote runtime commands.
 
 The package status is `public-alpha`, and its publishing status is `published`.
-Version `0.2.0` remains a release candidate until the protected PyPI publish
-succeeds. The package is published on PyPI; the former internal/experimental
-phase applies only to earlier
+Released versions are published on PyPI; repository versions remain release
+candidates until their protected publish succeeds. The former
+internal/experimental phase applies only to earlier
 releases. The package CLI does not launch a supported end-user gateway server;
 remote runtime commands require an already running package-local gateway
 mounted by a host application.
@@ -15,9 +15,8 @@ mounted by a host application.
 ## Publishing Readiness
 
 The standalone package has publishing status `published` and package status
-`public-alpha`. New users can install the released package from PyPI;
-developers testing the `0.2.0` release candidate before its protected publish
-should install from the repository.
+`public-alpha`. New users can install released versions from PyPI; developers
+testing an unpublished repository version should install from the repository.
 
 Run the full internal release candidate gate from the repository root:
 
@@ -58,7 +57,7 @@ python -m pip install "mcp-unified[gateway]"
 Downstream applications should use a compatible-minor pin:
 
 ```bash
-python -m pip install "mcp-unified[gateway]~=0.2.0"
+python -m pip install "mcp-unified[gateway]~=0.2.1"
 ```
 
 From the repository root, when testing unpublished changes:

--- a/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+++ b/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
@@ -152,6 +152,15 @@ The exact `GatewayLimits` defaults are:
 | `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
+Schema compilation and instance validation run in disposable bounded child
+processes. On native Windows, the preflighted schema and complete validation
+instance are briefly stored in an owner-only file in the operating-system
+temporary directory so the nested stdio server can launch the child reliably.
+The file is never logged, is removed during the same bounded child cleanup,
+and is not retained after success, failure, timeout, cancellation, or shutdown.
+Applications handling data that must never touch temporary storage should
+account for this Windows behavior before enabling strict tool calls.
+
 The modern profile emits private, zero-TTL cache hints:
 `{"ttlMs": 0, "cacheScope": "private"}`. Legacy profiles omit those modern
 fields. Public errors are typed and bounded; they allowlist stable reason,

--- a/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+++ b/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
@@ -149,7 +149,7 @@ The exact `GatewayLimits` defaults are:
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 10.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 1.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 The modern profile emits private, zero-TTL cache hints:

--- a/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+++ b/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
@@ -149,7 +149,7 @@ The exact `GatewayLimits` defaults are:
 | `request_burst` | 32 | `max_schema_bytes` | 262,144 |
 | `max_schema_depth` | 32 | `max_schema_subschemas` | 1,024 |
 | `max_schema_refs` | 256 | `max_schema_pattern_chars` | 4,096 |
-| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 1.0 |
+| `max_schema_validation_processes` | 4 | `schema_validation_timeout_seconds` | 5.0 |
 | `graceful_shutdown_timeout_seconds` | 5.0 | | |
 
 The modern profile emits private, zero-TTL cache hints:

--- a/apps/mcp-unified/src/mcp_unified/__init__.py
+++ b/apps/mcp-unified/src/mcp_unified/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/apps/mcp-unified/src/mcp_unified/_schema_worker.py
+++ b/apps/mcp-unified/src/mcp_unified/_schema_worker.py
@@ -1,0 +1,73 @@
+"""Lightweight spawned-process entrypoint for bounded schema validation."""
+
+from __future__ import annotations
+
+import json
+from multiprocessing.connection import Connection
+from typing import Any, Literal, TypeAlias
+
+from jsonschema import Draft7Validator, Draft202012Validator
+from jsonschema.exceptions import SchemaError, ValidationError
+from referencing import Registry
+from referencing.exceptions import NoSuchResource
+
+SchemaWorkerVerdict: TypeAlias = tuple[Literal["ok", "invalid", "internal"], str]
+
+_MAX_VERDICT_BYTES = 4_096
+_DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
+_DRAFT_7 = "http://json-schema.org/draft-07/schema#"
+_VALIDATORS = {
+    _DRAFT_2020_12: Draft202012Validator,
+    _DRAFT_7: Draft7Validator,
+}
+
+
+def _deny_schema_retrieval(uri: str) -> Any:
+    """Fail every registry retrieval without consulting network-capable defaults."""
+
+    raise NoSuchResource(ref=uri)
+
+
+def _send_verdict(connection: Connection, verdict: SchemaWorkerVerdict) -> None:
+    """Send one small JSON verdict and never expose validator diagnostics."""
+
+    payload = json.dumps(verdict, separators=(",", ":")).encode("utf-8")
+    if len(payload) > _MAX_VERDICT_BYTES:
+        payload = b'["internal","schema_validation_worker_failed"]'
+    try:
+        connection.send_bytes(payload)
+    except (BrokenPipeError, EOFError, OSError):
+        pass
+
+
+def schema_validation_worker(
+    connection: Connection,
+    schema_json: bytes,
+    instance_json: bytes | None,
+    dialect: str,
+) -> None:
+    """Compile a schema and optionally validate one value in a disposable child."""
+
+    verdict: SchemaWorkerVerdict
+    try:
+        schema = json.loads(schema_json)
+        validator_class = _VALIDATORS[dialect]
+        registry: Registry[Any] = Registry(retrieve=_deny_schema_retrieval)
+        validator = validator_class(schema, registry=registry)
+        validator_class.check_schema(schema)
+        if instance_json is not None:
+            validator.validate(json.loads(instance_json))
+        verdict = ("ok", "")
+    except KeyError:
+        verdict = ("internal", "schema_validation_worker_failed")
+    except SchemaError:
+        verdict = ("invalid", "invalid_schema")
+    except ValidationError:
+        verdict = ("invalid", "schema_validation_failed")
+    except Exception:  # noqa: BLE001 - child must reduce every validator failure to a safe verdict
+        verdict = ("internal", "schema_validation_worker_failed")
+    _send_verdict(connection, verdict)
+    connection.close()
+
+
+__all__ = ["schema_validation_worker"]

--- a/apps/mcp-unified/src/mcp_unified/_schema_worker.py
+++ b/apps/mcp-unified/src/mcp_unified/_schema_worker.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import json
+import struct
+import sys
 from multiprocessing.connection import Connection
+from pathlib import Path
 from typing import Any, Literal, TypeAlias
 
 SchemaWorkerVerdict: TypeAlias = tuple[Literal["ok", "invalid", "internal"], str]
 
 _MAX_VERDICT_BYTES = 4_096
+_MAX_PAYLOAD_BYTES = 20_971_528
+_PAYLOAD_HEADER = struct.Struct(">II")
+_NO_INSTANCE = 0xFFFFFFFF
 _DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
 _DRAFT_7 = "http://json-schema.org/draft-07/schema#"
 
@@ -21,25 +27,30 @@ def _deny_schema_retrieval(uri: str) -> Any:
     raise NoSuchResource(ref=uri)
 
 
-def _send_verdict(connection: Connection, verdict: SchemaWorkerVerdict) -> None:
-    """Send one small JSON verdict and never expose validator diagnostics."""
+def _encode_verdict(verdict: SchemaWorkerVerdict) -> bytes:
+    """Encode one small verdict without exposing validator diagnostics."""
 
     payload = json.dumps(verdict, separators=(",", ":")).encode("utf-8")
     if len(payload) > _MAX_VERDICT_BYTES:
-        payload = b'["internal","schema_validation_worker_failed"]'
+        return b'["internal","schema_validation_worker_failed"]'
+    return payload
+
+
+def _send_verdict(connection: Connection, verdict: SchemaWorkerVerdict) -> None:
+    """Send one small JSON verdict and never expose validator diagnostics."""
+
     try:
-        connection.send_bytes(payload)
+        connection.send_bytes(_encode_verdict(verdict))
     except (BrokenPipeError, EOFError, OSError):
         pass
 
 
-def schema_validation_worker(
-    connection: Connection,
+def _validate(
     schema_json: bytes,
     instance_json: bytes | None,
     dialect: str,
-) -> None:
-    """Compile a schema and optionally validate one value in a disposable child."""
+) -> SchemaWorkerVerdict:
+    """Compile a schema and optionally validate one value."""
 
     try:
         from jsonschema import Draft7Validator, Draft202012Validator
@@ -58,19 +69,70 @@ def schema_validation_worker(
             validator_class.check_schema(schema)
             if instance_json is not None:
                 validator.validate(json.loads(instance_json))
-            verdict: SchemaWorkerVerdict = ("ok", "")
+            return ("ok", "")
         except KeyError:
-            verdict = ("internal", "schema_validation_worker_failed")
+            return ("internal", "schema_validation_worker_failed")
         except SchemaError:
-            verdict = ("invalid", "invalid_schema")
+            return ("invalid", "invalid_schema")
         except ValidationError:
-            verdict = ("invalid", "schema_validation_failed")
-        except Exception:  # noqa: BLE001 - child must reduce validator failures to a safe verdict
-            verdict = ("internal", "schema_validation_worker_failed")
-    except Exception:  # noqa: BLE001 - child must reduce every validator failure to a safe verdict
-        verdict = ("internal", "schema_validation_worker_failed")
-    _send_verdict(connection, verdict)
+            return ("invalid", "schema_validation_failed")
+        except Exception:  # noqa: BLE001 - reduce validator failures to a safe verdict
+            return ("internal", "schema_validation_worker_failed")
+    except Exception:  # noqa: BLE001 - reduce import failures to a safe verdict
+        return ("internal", "schema_validation_worker_failed")
+
+
+def _read_exec_payload(path: Path) -> tuple[bytes, bytes | None]:
+    """Read one bounded, exact-length payload created by the parent process."""
+
+    with path.open("rb") as payload_file:
+        payload = payload_file.read(_MAX_PAYLOAD_BYTES + 1)
+    if len(payload) > _MAX_PAYLOAD_BYTES or len(payload) < _PAYLOAD_HEADER.size:
+        raise ValueError("invalid schema worker payload")
+    schema_length, instance_length = _PAYLOAD_HEADER.unpack_from(payload)
+    expected = _PAYLOAD_HEADER.size + schema_length
+    if instance_length != _NO_INSTANCE:
+        expected += instance_length
+    if expected != len(payload):
+        raise ValueError("invalid schema worker payload")
+    schema_start = _PAYLOAD_HEADER.size
+    schema_end = schema_start + schema_length
+    instance = None if instance_length == _NO_INSTANCE else payload[schema_end:]
+    return payload[schema_start:schema_end], instance
+
+
+def schema_validation_worker(
+    connection: Connection,
+    schema_json: bytes,
+    instance_json: bytes | None,
+    dialect: str,
+) -> None:
+    """Compile a schema and optionally validate one value in a disposable child."""
+
+    _send_verdict(connection, _validate(schema_json, instance_json, dialect))
     connection.close()
+
+
+def _main(argv: list[str]) -> int:
+    """Run the fixed-argument subprocess backend used on Windows."""
+
+    verdict: SchemaWorkerVerdict = ("internal", "schema_validation_worker_failed")
+    if len(argv) == 3:
+        try:
+            schema_json, instance_json = _read_exec_payload(Path(argv[1]))
+            verdict = _validate(schema_json, instance_json, argv[2])
+        except Exception:  # noqa: BLE001 - CLI must emit only a stable safe verdict
+            verdict = ("internal", "schema_validation_worker_failed")
+    try:
+        sys.stdout.buffer.write(_encode_verdict(verdict))
+        sys.stdout.buffer.flush()
+    except (BrokenPipeError, OSError):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv))
 
 
 __all__ = ["schema_validation_worker"]

--- a/apps/mcp-unified/src/mcp_unified/_schema_worker.py
+++ b/apps/mcp-unified/src/mcp_unified/_schema_worker.py
@@ -6,24 +6,17 @@ import json
 from multiprocessing.connection import Connection
 from typing import Any, Literal, TypeAlias
 
-from jsonschema import Draft7Validator, Draft202012Validator
-from jsonschema.exceptions import SchemaError, ValidationError
-from referencing import Registry
-from referencing.exceptions import NoSuchResource
-
 SchemaWorkerVerdict: TypeAlias = tuple[Literal["ok", "invalid", "internal"], str]
 
 _MAX_VERDICT_BYTES = 4_096
 _DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
 _DRAFT_7 = "http://json-schema.org/draft-07/schema#"
-_VALIDATORS = {
-    _DRAFT_2020_12: Draft202012Validator,
-    _DRAFT_7: Draft7Validator,
-}
 
 
 def _deny_schema_retrieval(uri: str) -> Any:
     """Fail every registry retrieval without consulting network-capable defaults."""
+
+    from referencing.exceptions import NoSuchResource
 
     raise NoSuchResource(ref=uri)
 
@@ -48,22 +41,32 @@ def schema_validation_worker(
 ) -> None:
     """Compile a schema and optionally validate one value in a disposable child."""
 
-    verdict: SchemaWorkerVerdict
     try:
-        schema = json.loads(schema_json)
-        validator_class = _VALIDATORS[dialect]
-        registry: Registry[Any] = Registry(retrieve=_deny_schema_retrieval)
-        validator = validator_class(schema, registry=registry)
-        validator_class.check_schema(schema)
-        if instance_json is not None:
-            validator.validate(json.loads(instance_json))
-        verdict = ("ok", "")
-    except KeyError:
-        verdict = ("internal", "schema_validation_worker_failed")
-    except SchemaError:
-        verdict = ("invalid", "invalid_schema")
-    except ValidationError:
-        verdict = ("invalid", "schema_validation_failed")
+        from jsonschema import Draft7Validator, Draft202012Validator
+        from jsonschema.exceptions import SchemaError, ValidationError
+        from referencing import Registry
+
+        validators = {
+            _DRAFT_2020_12: Draft202012Validator,
+            _DRAFT_7: Draft7Validator,
+        }
+        try:
+            schema = json.loads(schema_json)
+            validator_class = validators[dialect]
+            registry: Registry[Any] = Registry(retrieve=_deny_schema_retrieval)
+            validator = validator_class(schema, registry=registry)
+            validator_class.check_schema(schema)
+            if instance_json is not None:
+                validator.validate(json.loads(instance_json))
+            verdict: SchemaWorkerVerdict = ("ok", "")
+        except KeyError:
+            verdict = ("internal", "schema_validation_worker_failed")
+        except SchemaError:
+            verdict = ("invalid", "invalid_schema")
+        except ValidationError:
+            verdict = ("invalid", "schema_validation_failed")
+        except Exception:  # noqa: BLE001 - child must reduce validator failures to a safe verdict
+            verdict = ("internal", "schema_validation_worker_failed")
     except Exception:  # noqa: BLE001 - child must reduce every validator failure to a safe verdict
         verdict = ("internal", "schema_validation_worker_failed")
     _send_verdict(connection, verdict)

--- a/apps/mcp-unified/src/mcp_unified/gateway/protocol_limits.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/protocol_limits.py
@@ -59,7 +59,7 @@ class GatewayLimits:
     max_schema_refs: int = 256
     max_schema_pattern_chars: int = 4_096
     max_schema_validation_processes: int = 4
-    schema_validation_timeout_seconds: float = 5.0
+    schema_validation_timeout_seconds: float = 10.0
     graceful_shutdown_timeout_seconds: float = 5.0
 
     def __post_init__(self) -> None:

--- a/apps/mcp-unified/src/mcp_unified/gateway/protocol_limits.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/protocol_limits.py
@@ -59,7 +59,7 @@ class GatewayLimits:
     max_schema_refs: int = 256
     max_schema_pattern_chars: int = 4_096
     max_schema_validation_processes: int = 4
-    schema_validation_timeout_seconds: float = 10.0
+    schema_validation_timeout_seconds: float = 1.0
     graceful_shutdown_timeout_seconds: float = 5.0
 
     def __post_init__(self) -> None:

--- a/apps/mcp-unified/src/mcp_unified/gateway/protocol_limits.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/protocol_limits.py
@@ -59,7 +59,7 @@ class GatewayLimits:
     max_schema_refs: int = 256
     max_schema_pattern_chars: int = 4_096
     max_schema_validation_processes: int = 4
-    schema_validation_timeout_seconds: float = 1.0
+    schema_validation_timeout_seconds: float = 5.0
     graceful_shutdown_timeout_seconds: float = 5.0
 
     def __post_init__(self) -> None:

--- a/apps/mcp-unified/src/mcp_unified/gateway/protocol_validation.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/protocol_validation.py
@@ -13,6 +13,7 @@ from multiprocessing.connection import Connection
 from typing import Any, Literal, TypeAlias
 from urllib.parse import unquote, urldefrag, urljoin
 
+from jsonschema import Draft7Validator, Draft202012Validator
 from referencing.jsonschema import DRAFT7 as REFERENCING_DRAFT7
 from referencing.jsonschema import DRAFT202012 as REFERENCING_DRAFT202012
 
@@ -28,7 +29,10 @@ SchemaInstanceRole: TypeAlias = Literal["input", "output"]
 _SCHEMA_WORKER_MAX_VERDICT_BYTES = 4_096
 _DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
 _DRAFT_7 = "http://json-schema.org/draft-07/schema#"
-_VALIDATORS = frozenset({_DRAFT_2020_12, _DRAFT_7})
+_VALIDATORS = {
+    _DRAFT_2020_12: Draft202012Validator,
+    _DRAFT_7: Draft7Validator,
+}
 _WORKER_INVALID_CODES = frozenset({"invalid_schema", "schema_validation_failed"})
 _SPECIFICATIONS = {
     _DRAFT_2020_12: REFERENCING_DRAFT202012,

--- a/apps/mcp-unified/src/mcp_unified/gateway/protocol_validation.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/protocol_validation.py
@@ -6,10 +6,16 @@ import asyncio
 import json
 import math
 import multiprocessing
+import os
+import struct
+import subprocess  # nosec B404
+import sys
+import tempfile
 import time
 from collections.abc import Callable
 from dataclasses import replace
 from multiprocessing.connection import Connection
+from pathlib import Path
 from typing import Any, Literal, TypeAlias
 from urllib.parse import unquote, urldefrag, urljoin
 
@@ -27,6 +33,8 @@ SchemaWorkerVerdict: TypeAlias = tuple[Literal["ok", "invalid", "internal"], str
 SchemaRootMode: TypeAlias = Literal["any", "object"]
 SchemaInstanceRole: TypeAlias = Literal["input", "output"]
 _SCHEMA_WORKER_MAX_VERDICT_BYTES = 4_096
+_SCHEMA_WORKER_PAYLOAD_HEADER = struct.Struct(">II")
+_SCHEMA_WORKER_NO_INSTANCE = 0xFFFFFFFF
 _DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
 _DRAFT_7 = "http://json-schema.org/draft-07/schema#"
 _VALIDATORS = {
@@ -102,6 +110,23 @@ def _validation_error(reason_code: str, message: str) -> GatewayApplicationError
     """Build a bounded safe validation error without input or schema details."""
 
     return GatewayApplicationError(message, reason_code=reason_code)
+
+
+def _decode_worker_verdict(payload: bytes) -> SchemaWorkerVerdict:
+    """Decode one bounded worker verdict into a stable safe result."""
+
+    try:
+        decoded = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return ("internal", "schema_validation_worker_failed")
+    if (
+        isinstance(decoded, list)
+        and len(decoded) == 2
+        and decoded[0] in {"ok", "invalid", "internal"}
+        and isinstance(decoded[1], str)
+    ):
+        return (decoded[0], decoded[1])
+    return ("internal", "schema_validation_worker_failed")
 
 
 def _validate_json_structure(value: object, *, max_depth: int) -> None:
@@ -473,21 +498,34 @@ class GatewaySchemaValidationManager:
         process_context: Any | None = None,
         _worker_target: Callable[..., None] | None = None,
         _clock: Callable[[], float] = time.monotonic,
+        _use_exec_worker: bool | None = None,
+        _exec_worker_command: tuple[str, ...] | None = None,
     ) -> None:
         self._limits = limits
         self._context = process_context or multiprocessing.get_context("spawn")
         self._worker_target = _worker_target or _schema_validation_worker
         self._clock = _clock
+        explicit_process_backend = process_context is not None or _worker_target is not None
+        self._use_exec_worker = (
+            os.name == "nt" and not explicit_process_backend if _use_exec_worker is None else _use_exec_worker
+        )
+        self._exec_worker_command = _exec_worker_command or (
+            sys.executable,
+            "-m",
+            "mcp_unified._schema_worker",
+        )
         self._semaphore = asyncio.Semaphore(limits.max_schema_validation_processes)
         self._live_processes: set[multiprocessing.Process] = set()
         self._receivers: dict[multiprocessing.Process, Connection] = {}
+        self._live_exec_processes: set[subprocess.Popen[bytes]] = set()
+        self._exec_payloads: dict[subprocess.Popen[bytes], Path] = {}
         self._closed = False
 
     @property
     def live_process_count(self) -> int:
         """Return the number of validation children not yet reaped."""
 
-        return len(self._live_processes)
+        return len(self._live_processes) + len(self._live_exec_processes)
 
     async def validate_schema(
         self,
@@ -577,6 +615,10 @@ class GatewaySchemaValidationManager:
     ) -> None:
         """Run one compile or validation job through the shared process lifecycle."""
 
+        if self._use_exec_worker:
+            await self._run_exec_worker(schema_json, instance_json, dialect)
+            return
+
         await self._semaphore.acquire()
         process: multiprocessing.Process | None = None
         receiver: Connection | None = None
@@ -627,6 +669,209 @@ class GatewaySchemaValidationManager:
             if permit_owned:
                 self._semaphore.release()
 
+    async def _run_exec_worker(
+        self,
+        schema_json: bytes,
+        instance_json: bytes | None,
+        dialect: str,
+    ) -> None:
+        """Run one validation in a fixed-argument subprocess on Windows."""
+
+        await self._semaphore.acquire()
+        process: subprocess.Popen[bytes] | None = None
+        payload_path: Path | None = None
+        permit_owned = True
+        cancelled = False
+        cleanup_cancelled = False
+        if self._closed:
+            self._semaphore.release()
+            raise _validation_error("schema_validator_closed", "Schema validator is closed")
+
+        try:
+            payload_path = self._write_exec_payload(schema_json, instance_json)
+            command = (*self._exec_worker_command, str(payload_path), dialect)
+            # The executable prefix is private/fixed; only a generated path and known
+            # dialect are appended, and shell execution is never enabled.
+            process = subprocess.Popen(  # noqa: S603  # nosec B603
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                close_fds=True,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            self._live_exec_processes.add(process)
+            self._exec_payloads[process] = payload_path
+            permit_owned = False
+            verdict = await self._receive_exec_verdict(process)
+            if verdict[0] == "ok":
+                return
+            if verdict[0] == "invalid" and verdict[1] in _WORKER_INVALID_CODES:
+                raise _validation_error(verdict[1], "Schema validation failed")
+            raise _validation_error(
+                "schema_validation_worker_failed",
+                "Schema validation worker failed",
+            )
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+        finally:
+            if process is not None and (process in self._live_exec_processes or process in self._exec_payloads):
+                cleanup_errors, cleanup_cancelled = await self._await_exec_cleanup(
+                    process,
+                    deadline=self._clock() + self._limits.graceful_shutdown_timeout_seconds,
+                )
+                if cleanup_errors and not cancelled and not cleanup_cancelled:
+                    raise RuntimeError("; ".join(cleanup_errors))
+            elif payload_path is not None:
+                try:
+                    payload_path.unlink(missing_ok=True)
+                except OSError:
+                    if not cancelled:
+                        raise RuntimeError("schema validation payload cleanup failed") from None
+            if permit_owned:
+                self._semaphore.release()
+            if cleanup_cancelled and not cancelled:
+                raise asyncio.CancelledError
+
+    def _write_exec_payload(
+        self,
+        schema_json: bytes,
+        instance_json: bytes | None,
+    ) -> Path:
+        """Create one owner-only, exact-length subprocess payload."""
+
+        descriptor, raw_path = tempfile.mkstemp(
+            prefix="mcp-unified-schema-",
+            suffix=".bin",
+        )
+        path = Path(raw_path)
+        instance_length = _SCHEMA_WORKER_NO_INSTANCE if instance_json is None else len(instance_json)
+        try:
+            with os.fdopen(descriptor, "wb") as payload_file:
+                payload_file.write(_SCHEMA_WORKER_PAYLOAD_HEADER.pack(len(schema_json), instance_length))
+                payload_file.write(schema_json)
+                if instance_json is not None:
+                    payload_file.write(instance_json)
+        except BaseException:
+            path.unlink(missing_ok=True)
+            raise
+        return path
+
+    async def _receive_exec_verdict(
+        self,
+        process: subprocess.Popen[bytes],
+    ) -> SchemaWorkerVerdict:
+        """Poll a subprocess without an executor thread or unbounded read."""
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._limits.schema_validation_timeout_seconds
+        while True:
+            if self._closed:
+                raise _validation_error(
+                    "schema_validator_closed",
+                    "Schema validator is closed",
+                )
+            if process.poll() is not None:
+                if process.stdout is None:
+                    return ("internal", "schema_validation_worker_failed")
+                try:
+                    payload = process.stdout.read(_SCHEMA_WORKER_MAX_VERDICT_BYTES + 1)
+                except OSError:
+                    return ("internal", "schema_validation_worker_failed")
+                if len(payload) > _SCHEMA_WORKER_MAX_VERDICT_BYTES:
+                    return ("internal", "schema_validation_worker_failed")
+                return _decode_worker_verdict(payload)
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise _validation_error(
+                    "schema_validation_timeout",
+                    "Schema validation timed out",
+                )
+            await asyncio.sleep(min(0.005, remaining))
+
+    async def _await_exec_cleanup(
+        self,
+        process: subprocess.Popen[bytes],
+        *,
+        deadline: float,
+    ) -> tuple[list[str], bool]:
+        """Keep bounded cleanup attached through repeated task cancellation."""
+
+        task = asyncio.create_task(self._cleanup_exec_process(process, deadline=deadline))
+        interrupted = False
+        while True:
+            try:
+                return await asyncio.shield(task), interrupted
+            except asyncio.CancelledError:
+                interrupted = True
+
+    async def _cleanup_exec_process(
+        self,
+        process: subprocess.Popen[bytes],
+        *,
+        deadline: float,
+        terminate_first: bool = True,
+    ) -> list[str]:
+        """Terminate, kill, reap, close, and unlink one exec worker."""
+
+        if process not in self._live_exec_processes:
+            return self._cleanup_exec_payload(process)
+        errors: list[str] = []
+        if process.poll() is None and terminate_first:
+            try:
+                process.terminate()
+            except OSError as exc:
+                errors.append(f"schema validation child terminate failed: {type(exc).__name__}")
+        remaining = max(0.0, deadline - self._clock())
+        await self._poll_exec_process(process, self._clock() + remaining / 2)
+        if process.poll() is None:
+            try:
+                process.kill()
+            except OSError as exc:
+                errors.append(f"schema validation child kill failed: {type(exc).__name__}")
+        await self._poll_exec_process(process, deadline)
+        reaped = process.poll() is not None
+        if not reaped:
+            errors.append("schema validation child could not be reaped")
+        if process.stdout is not None:
+            try:
+                process.stdout.close()
+            except OSError as exc:
+                errors.append(f"schema validation stdout close failed: {type(exc).__name__}")
+        if reaped:
+            if process in self._live_exec_processes:
+                self._live_exec_processes.remove(process)
+                self._semaphore.release()
+            errors.extend(self._cleanup_exec_payload(process))
+        return errors
+
+    async def _poll_exec_process(
+        self,
+        process: subprocess.Popen[bytes],
+        deadline: float,
+    ) -> None:
+        """Poll until a subprocess is reaped or the shared deadline expires."""
+
+        while process.poll() is None:
+            remaining = deadline - self._clock()
+            if remaining <= 0:
+                return
+            await asyncio.sleep(min(0.005, remaining))
+
+    def _cleanup_exec_payload(self, process: subprocess.Popen[bytes]) -> list[str]:
+        """Remove one exact payload path without exposing it in diagnostics."""
+
+        path = self._exec_payloads.get(process)
+        if path is None:
+            return []
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            return [f"schema validation payload cleanup failed: {type(exc).__name__}"]
+        self._exec_payloads.pop(process, None)
+        return []
+
     async def _receive_verdict(
         self,
         process: multiprocessing.Process,
@@ -649,17 +894,9 @@ class GatewaySchemaValidationManager:
             if verdict_ready:
                 try:
                     payload = receiver.recv_bytes(_SCHEMA_WORKER_MAX_VERDICT_BYTES)
-                    decoded = json.loads(payload)
-                except (EOFError, OSError, UnicodeDecodeError, json.JSONDecodeError):
+                except (EOFError, OSError):
                     return ("internal", "schema_validation_worker_failed")
-                if (
-                    isinstance(decoded, list)
-                    and len(decoded) == 2
-                    and decoded[0] in {"ok", "invalid", "internal"}
-                    and isinstance(decoded[1], str)
-                ):
-                    return (decoded[0], decoded[1])
-                return ("internal", "schema_validation_worker_failed")
+                return _decode_worker_verdict(payload)
             if not process.is_alive():
                 return ("internal", "schema_validation_worker_failed")
             remaining = deadline - loop.time()
@@ -736,7 +973,7 @@ class GatewaySchemaValidationManager:
     async def close(self) -> None:
         """Reject new work and reap every currently running validation child."""
 
-        if self._closed and not self._live_processes:
+        if self._closed and not self._live_processes and not self._live_exec_processes and not self._exec_payloads:
             return
         self._closed = True
         errors: list[str] = []
@@ -744,6 +981,7 @@ class GatewaySchemaValidationManager:
         deadline = started + self._limits.graceful_shutdown_timeout_seconds
         graceful_cutoff = started + self._limits.graceful_shutdown_timeout_seconds / 2
         processes = tuple(self._live_processes)
+        exec_processes = tuple(self._live_exec_processes | self._exec_payloads.keys())
         for process in processes:
             try:
                 alive = process.is_alive()
@@ -755,7 +993,14 @@ class GatewaySchemaValidationManager:
                     process.terminate()
                 except Exception as exc:  # noqa: BLE001 - siblings must still be signaled
                     errors.append(f"schema validation child terminate failed: {type(exc).__name__}")
+        for exec_process in exec_processes:
+            if exec_process.poll() is None:
+                try:
+                    exec_process.terminate()
+                except OSError as exc:
+                    errors.append(f"schema validation child terminate failed: {type(exc).__name__}")
         self._join_process_phase(processes, graceful_cutoff, errors)
+        await self._poll_exec_processes(exec_processes, graceful_cutoff)
 
         survivors: list[multiprocessing.Process] = []
         for process in processes:
@@ -770,7 +1015,14 @@ class GatewaySchemaValidationManager:
                     process.kill()
                 except Exception as exc:  # noqa: BLE001 - siblings must still be killed
                     errors.append(f"schema validation child kill failed: {type(exc).__name__}")
+        for exec_process in exec_processes:
+            if exec_process.poll() is None:
+                try:
+                    exec_process.kill()
+                except OSError as exc:
+                    errors.append(f"schema validation child kill failed: {type(exc).__name__}")
         self._join_process_phase(tuple(survivors), deadline, errors)
+        await self._poll_exec_processes(exec_processes, deadline)
 
         for process in processes:
             receiver = self._receivers.get(process)
@@ -792,8 +1044,35 @@ class GatewaySchemaValidationManager:
         for process in processes:
             if process not in self._live_processes:
                 self._semaphore.release()
+        for exec_process in exec_processes:
+            reaped = exec_process.poll() is not None
+            if not reaped:
+                errors.append("schema validation child could not be reaped")
+            if exec_process.stdout is not None:
+                try:
+                    exec_process.stdout.close()
+                except OSError as exc:
+                    errors.append(f"schema validation stdout close failed: {type(exc).__name__}")
+            if reaped and exec_process in self._live_exec_processes:
+                self._live_exec_processes.remove(exec_process)
+                self._semaphore.release()
+            if reaped:
+                errors.extend(self._cleanup_exec_payload(exec_process))
         if errors:
             raise RuntimeError("; ".join(errors))
+
+    async def _poll_exec_processes(
+        self,
+        processes: tuple[subprocess.Popen[bytes], ...],
+        deadline: float,
+    ) -> None:
+        """Fairly poll all exec children within one shared phase deadline."""
+
+        while any(process.poll() is None for process in processes):
+            remaining = deadline - self._clock()
+            if remaining <= 0:
+                return
+            await asyncio.sleep(min(0.005, remaining))
 
     def _join_process_phase(
         self,

--- a/apps/mcp-unified/src/mcp_unified/gateway/protocol_validation.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/protocol_validation.py
@@ -13,13 +13,10 @@ from multiprocessing.connection import Connection
 from typing import Any, Literal, TypeAlias
 from urllib.parse import unquote, urldefrag, urljoin
 
-from jsonschema import Draft7Validator, Draft202012Validator
-from jsonschema.exceptions import SchemaError, ValidationError
-from referencing import Registry
-from referencing.exceptions import NoSuchResource
 from referencing.jsonschema import DRAFT7 as REFERENCING_DRAFT7
 from referencing.jsonschema import DRAFT202012 as REFERENCING_DRAFT202012
 
+from .._schema_worker import schema_validation_worker as _schema_validation_worker
 from .protocol_errors import GatewayApplicationError
 from .protocol_limits import GatewayLimits
 from .protocol_profiles import GatewayProtocolProfile
@@ -31,10 +28,7 @@ SchemaInstanceRole: TypeAlias = Literal["input", "output"]
 _SCHEMA_WORKER_MAX_VERDICT_BYTES = 4_096
 _DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
 _DRAFT_7 = "http://json-schema.org/draft-07/schema#"
-_VALIDATORS = {
-    _DRAFT_2020_12: Draft202012Validator,
-    _DRAFT_7: Draft7Validator,
-}
+_VALIDATORS = frozenset({_DRAFT_2020_12, _DRAFT_7})
 _WORKER_INVALID_CODES = frozenset({"invalid_schema", "schema_validation_failed"})
 _SPECIFICATIONS = {
     _DRAFT_2020_12: REFERENCING_DRAFT202012,
@@ -104,61 +98,6 @@ def _validation_error(reason_code: str, message: str) -> GatewayApplicationError
     """Build a bounded safe validation error without input or schema details."""
 
     return GatewayApplicationError(message, reason_code=reason_code)
-
-
-def _send_worker_verdict(connection: Connection, verdict: SchemaWorkerVerdict) -> None:
-    """Send one small JSON verdict and never expose validator diagnostics."""
-
-    payload = json.dumps(verdict, separators=(",", ":")).encode("utf-8")
-    if len(payload) > _SCHEMA_WORKER_MAX_VERDICT_BYTES:
-        payload = b'["internal","schema_validation_worker_failed"]'
-    try:
-        connection.send_bytes(payload)
-    except (BrokenPipeError, EOFError, OSError):
-        pass
-
-
-def _deny_schema_retrieval(uri: str) -> Any:
-    """Fail every registry retrieval without consulting network-capable defaults."""
-
-    raise NoSuchResource(ref=uri)
-
-
-def _validator_for_dialect(dialect: str) -> type[Draft7Validator] | type[Draft202012Validator]:
-    """Select only the two explicitly accepted schema dialects."""
-
-    try:
-        return _VALIDATORS[dialect]
-    except KeyError as exc:
-        raise ValueError("unsupported schema dialect") from exc
-
-
-def _schema_validation_worker(
-    connection: Connection,
-    schema_json: bytes,
-    instance_json: bytes | None,
-    dialect: str,
-) -> None:
-    """Compile a schema and optionally validate one value in a disposable child."""
-
-    verdict: SchemaWorkerVerdict
-    try:
-        schema = json.loads(schema_json)
-        validator_class = _validator_for_dialect(dialect)
-        registry: Registry[Any] = Registry(retrieve=_deny_schema_retrieval)
-        validator = validator_class(schema, registry=registry)
-        validator_class.check_schema(schema)
-        if instance_json is not None:
-            validator.validate(json.loads(instance_json))
-        verdict = ("ok", "")
-    except SchemaError:
-        verdict = ("invalid", "invalid_schema")
-    except ValidationError:
-        verdict = ("invalid", "schema_validation_failed")
-    except Exception:  # noqa: BLE001 - child must reduce every validator failure to a safe verdict
-        verdict = ("internal", "schema_validation_worker_failed")
-    _send_worker_verdict(connection, verdict)
-    connection.close()
 
 
 def _validate_json_structure(value: object, *, max_depth: int) -> None:

--- a/apps/mcp-unified/src/mcp_unified/gateway/protocol_validation.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/protocol_validation.py
@@ -699,7 +699,11 @@ class GatewaySchemaValidationManager:
                     "schema_validator_closed",
                     "Schema validator is closed",
                 )
-            if receiver.poll(0):
+            try:
+                verdict_ready = receiver.poll(0)
+            except (EOFError, OSError):
+                return ("internal", "schema_validation_worker_failed")
+            if verdict_ready:
                 try:
                     payload = receiver.recv_bytes(_SCHEMA_WORKER_MAX_VERDICT_BYTES)
                     decoded = json.loads(payload)

--- a/backlog/tasks/task-13009 - Implement-MCP-Unified-multi-revision-stdio-protocol.md
+++ b/backlog/tasks/task-13009 - Implement-MCP-Unified-multi-revision-stdio-protocol.md
@@ -87,3 +87,36 @@ A final fresh PyPI query and final full RC could not start because the approval 
 Fix-round release evidence includes 388 passing focused protocol/artifact tests; successful clean wheel and sdist installed-suite runs of 362 tests apiece; 26 passing artifact-consumer/security cases with independently strict wheel and sdist stdout/stderr checks; a 24/24 focused confidentiality, fixture-confinement, routing, noisy-output, and utility-side-effect set; and a 4/4 sparse dev artifact gate. The corrected authoritative Python 3.11.13 RC-helper `all` run passed 48/48 top-level gates, and `make mcp-unified-publish-dry-run` succeeded without upload. The RC-verified wheel and sdist SHA-256 values are `9743109056e8b16bf6de080d6b1d57d76b92b951df61b5c9c74a958a258f4e52` and `a37813d35780ebb3e822de4a9cfcdf22bbbf17b8996cfaa76bda9df4661bb4d9`. Ruff checks, Python 3.10/3.11 compile checks, and docs parity/contracts passed. The authoritative command `python -m bandit -r apps/mcp-unified/src/mcp_unified/gateway Helper_Scripts/mcp_unified_rc.py -f json -o <ignored-json>` scanned exactly the gateway plus RC helper: 20,990 lines, zero findings, zero errors, and two skipped tests. The new utility is mypy-clean while three pre-existing RC-helper mypy findings remain documented. The authoritative 3,694-test package/docs partition was not rerun because the review fix changes only release tooling/tests/routing; its five accepted package-boundary failures, seven independently reproducible broader baseline failures, order/global-state contamination, and expected external-federation skip remain recorded in the Task 5 implementer report.
 
 ADR-033 remains the governing decision. GPL package metadata was preserved, publish protection still requires the protected environment, manual `MCP_UNIFIED_PUBLISH`, duplicate-version guard, and `MCP_UNIFIED_ALLOW_PUBLISH=1`, and no live upload was attempted. The release-routing manifest, side-effect-free test utility, official SDK smoke, mirrored consumer isolation, and the two reviewed strict-protocol corrections were added to Task 5 scope during review hardening. The task intentionally remains **In Progress**: the five-job Python 3.10-3.13/Windows artifact matrix and official SDK scenarios must run in protected CI, followed by merge, protected publish, and fresh PyPI install/metadata verification before acceptance criteria 9-10, DoD 1, and task completion can be checked.
+
+The protected `0.2.0` publish subsequently completed and fresh macOS/Linux
+installation plus the official SDK smoke passed, but the required Windows
+portable job exposed a nested-process defect before the downstream migration
+was allowed to begin. The Windows named-pipe failure, source-only POSIX test,
+sdist dependency metadata, artifact-consumer path matching, and SDK launch
+diagnostics were corrected incrementally for `0.2.1`. The decisive evidence
+was that the SDK call failed at the exact schema-worker timeout even after
+raising the bound, preloading validator dependencies, and moving the target to
+a lightweight top-level module: nested `multiprocessing` reconstruction was
+the incompatible boundary, not schema evaluation. Native Windows validation
+therefore uses the same disposable fail-closed worker through a fixed-argument
+Python subprocess with an exact-length owner-only temporary payload and
+bounded verdict; POSIX and explicit process-test seams retain
+`multiprocessing spawn`. Timeout, cancellation, active shutdown, reaping,
+permit release, payload deletion, malformed verdict, and dialect behavior
+remain bounded. The task remains **In Progress** until the corrected protected
+matrix, merge, `0.2.1` publish, and fresh PyPI artifact verification pass.
+
+Corrective local verification is green before protected execution: all five
+source protocol suites pass 381/381; the RC helper passes 34/34; the package
+boundary retains exactly its accepted 45 passing plus five unchanged legacy
+failures. The clean `portable-gate` passes 18/18 required checks with wheel and
+sdist each running 381 installed protocol tests, separate official SDK stdio
+smokes, and the 29-case installed-artifact consumer. The wheel SHA-256 is
+`696f4dd43dfbc86f8fa6f0a20acf357669bbd5ce3528c687c22198802c3b77cc`;
+the sdist SHA-256 is
+`80e4adc729470a5c9370aee0bc33a7747601dfd7718b09618c9deb0b1978f033`.
+Ruff, formatting, expanded Bandit, Python 3.10/3.11 compilation, README and
+USER_GUIDE package-copy parity, and diff checks pass. The public docs disclose
+that native Windows briefly uses an owner-only temporary validation payload so
+applications with stricter no-temporary-storage requirements can make an
+informed privacy decision.

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_artifact_consumer.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_artifact_consumer.py
@@ -41,12 +41,12 @@ _assert_strict_consumer_output = _ARTIFACT_UTILS["assert_strict_consumer_output"
 _build_standalone_distributions = _ARTIFACT_UTILS["build_standalone_distributions"]
 
 
-def test_official_sdk_smoke_prepares_windows_multiprocessing() -> None:
-    """The real stdio entrypoint must prepare nested schema workers on Windows."""
+def test_official_sdk_smoke_does_not_require_nested_multiprocessing() -> None:
+    """The real stdio entrypoint must not depend on nested Windows spawn setup."""
 
     source = (REPO_ROOT / OFFICIAL_SDK_SMOKE).read_text(encoding="utf-8")
 
-    assert "multiprocessing.freeze_support()" in source
+    assert "multiprocessing.freeze_support()" not in source
 
 
 _DOWNSTREAM_CONSUMER = r"""
@@ -450,10 +450,7 @@ def test_rc_artifact_gate_requires_installed_protocol_suites_and_provenance(
         calls.append({"command": command, "cwd": cwd, "timeout": timeout, "env": env})
         stdout = (
             "MCP_UNIFIED_OFFICIAL_SDK_STDIO_OK\n"
-            if any(
-                str(argument).replace("\\", "/").endswith(OFFICIAL_SDK_SMOKE.as_posix())
-                for argument in command
-            )
+            if any(str(argument).replace("\\", "/").endswith(OFFICIAL_SDK_SMOKE.as_posix()) for argument in command)
             else ""
         )
         return mcp_unified_rc.RcCommandResult(
@@ -793,10 +790,13 @@ def test_protected_portable_gate_uses_isolated_rc_command_and_exact_routing() ->
     workflow_path = REPO_ROOT / ".github" / "workflows" / "mcp-unified-rc.yml"
     workflow_text = workflow_path.read_text(encoding="utf-8")
     assert "python Helper_Scripts/mcp_unified_rc.py portable-gate" in workflow_text
-    assert "tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_contracts.py" not in workflow_text.split(
-        "- name: Run installed protocol and portable stdio contracts",
-        1,
-    )[1]
+    assert (
+        "tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_contracts.py"
+        not in workflow_text.split(
+            "- name: Run installed protocol and portable stdio contracts",
+            1,
+        )[1]
+    )
 
     import yaml
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_artifact_consumer.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_artifact_consumer.py
@@ -41,6 +41,14 @@ _assert_strict_consumer_output = _ARTIFACT_UTILS["assert_strict_consumer_output"
 _build_standalone_distributions = _ARTIFACT_UTILS["build_standalone_distributions"]
 
 
+def test_official_sdk_smoke_prepares_windows_multiprocessing() -> None:
+    """The real stdio entrypoint must prepare nested schema workers on Windows."""
+
+    source = (REPO_ROOT / OFFICIAL_SDK_SMOKE).read_text(encoding="utf-8")
+
+    assert "multiprocessing.freeze_support()" in source
+
+
 _DOWNSTREAM_CONSUMER = r"""
 from __future__ import annotations
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_artifact_consumer.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_artifact_consumer.py
@@ -450,7 +450,10 @@ def test_rc_artifact_gate_requires_installed_protocol_suites_and_provenance(
         calls.append({"command": command, "cwd": cwd, "timeout": timeout, "env": env})
         stdout = (
             "MCP_UNIFIED_OFFICIAL_SDK_STDIO_OK\n"
-            if any(str(argument).endswith(OFFICIAL_SDK_SMOKE.as_posix()) for argument in command)
+            if any(
+                str(argument).replace("\\", "/").endswith(OFFICIAL_SDK_SMOKE.as_posix())
+                for argument in command
+            )
             else ""
         )
         return mcp_unified_rc.RcCommandResult(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_contracts.py
@@ -176,7 +176,7 @@ def test_gateway_limits_expose_every_approved_default() -> None:
         max_schema_refs=256,
         max_schema_pattern_chars=4_096,
         max_schema_validation_processes=4,
-        schema_validation_timeout_seconds=10.0,
+        schema_validation_timeout_seconds=1.0,
         graceful_shutdown_timeout_seconds=5.0,
     )
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_contracts.py
@@ -176,7 +176,7 @@ def test_gateway_limits_expose_every_approved_default() -> None:
         max_schema_refs=256,
         max_schema_pattern_chars=4_096,
         max_schema_validation_processes=4,
-        schema_validation_timeout_seconds=5.0,
+        schema_validation_timeout_seconds=10.0,
         graceful_shutdown_timeout_seconds=5.0,
     )
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_contracts.py
@@ -176,7 +176,7 @@ def test_gateway_limits_expose_every_approved_default() -> None:
         max_schema_refs=256,
         max_schema_pattern_chars=4_096,
         max_schema_validation_processes=4,
-        schema_validation_timeout_seconds=1.0,
+        schema_validation_timeout_seconds=5.0,
         graceful_shutdown_timeout_seconds=5.0,
     )
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
@@ -853,6 +853,7 @@ def _fd_is_open(fd: int) -> bool:
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(os.name != "posix", reason="native pipe registration is POSIX-only")
 async def test_native_second_dup_failure_closes_first_duplicate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
@@ -243,7 +243,7 @@ def test_strict_stdio_public_contract_is_exact() -> None:
         "max_catalog_items=10000, max_batch_items=100, max_requests_per_minute=600, "
         "request_burst=32, max_schema_bytes=262144, max_schema_depth=32, "
         "max_schema_subschemas=1024, max_schema_refs=256, max_schema_pattern_chars=4096, "
-        "max_schema_validation_processes=4, schema_validation_timeout_seconds=5.0, "
+        "max_schema_validation_processes=4, schema_validation_timeout_seconds=10.0, "
         "graceful_shutdown_timeout_seconds=5.0), "
         "metadata: 'Mapping[str, Any] | None' = None) -> 'int'"
     )
@@ -776,7 +776,10 @@ def test_rc_workflow_runs_installed_stdio_contracts_on_linux_and_windows() -> No
     assert setup_python["with"]["python-version"] == "${{ matrix.python }}"
     run_blocks = "\n".join(step["run"] for step in job["steps"] if "run" in step)
     assert 'python -m pip install "./apps/mcp-unified[dev]"' not in run_blocks
-    assert "python -m pip install build twine setuptools wheel pytest pytest-asyncio bandit" in run_blocks
+    assert (
+        'python -m pip install build twine "setuptools>=79.0.1" wheel pytest pytest-asyncio bandit'
+        in run_blocks
+    )
     assert '"jsonschema>=4.23,<5"' in run_blocks
     assert "python Helper_Scripts/mcp_unified_rc.py portable-gate" in run_blocks
     assert "tldw_Server_API/app/core/MCP_unified/tests/" not in run_blocks

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
@@ -784,7 +784,10 @@ def test_rc_workflow_runs_installed_stdio_contracts_on_linux_and_windows() -> No
     assert upload["if"] == "always()"
     assert re.fullmatch(r"actions/upload-artifact@[0-9a-f]{40}", upload["uses"])
     assert upload["with"]["name"] == "mcp-unified-portable-${{ matrix.os }}-py${{ matrix.python }}"
-    assert upload["with"]["path"] == ".artifacts/mcp-unified-rc/**"
+    assert upload["with"]["path"] == (
+        ".artifacts/mcp-unified-rc/**\n"
+        "apps/mcp-unified/dist/**\n"
+    )
     assert upload["with"]["if-no-files-found"] == "error"
     assert (
         "tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_artifact_consumer.py"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
@@ -243,7 +243,7 @@ def test_strict_stdio_public_contract_is_exact() -> None:
         "max_catalog_items=10000, max_batch_items=100, max_requests_per_minute=600, "
         "request_burst=32, max_schema_bytes=262144, max_schema_depth=32, "
         "max_schema_subschemas=1024, max_schema_refs=256, max_schema_pattern_chars=4096, "
-        "max_schema_validation_processes=4, schema_validation_timeout_seconds=1.0, "
+        "max_schema_validation_processes=4, schema_validation_timeout_seconds=5.0, "
         "graceful_shutdown_timeout_seconds=5.0), "
         "metadata: 'Mapping[str, Any] | None' = None) -> 'int'"
     )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_stdio.py
@@ -243,7 +243,7 @@ def test_strict_stdio_public_contract_is_exact() -> None:
         "max_catalog_items=10000, max_batch_items=100, max_requests_per_minute=600, "
         "request_burst=32, max_schema_bytes=262144, max_schema_depth=32, "
         "max_schema_subschemas=1024, max_schema_refs=256, max_schema_pattern_chars=4096, "
-        "max_schema_validation_processes=4, schema_validation_timeout_seconds=10.0, "
+        "max_schema_validation_processes=4, schema_validation_timeout_seconds=1.0, "
         "graceful_shutdown_timeout_seconds=5.0), "
         "metadata: 'Mapping[str, Any] | None' = None) -> 'int'"
     )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_validation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_validation.py
@@ -1001,6 +1001,17 @@ def test_default_worker_target_uses_lightweight_top_level_spawn_module() -> None
     assert manager._worker_target.__module__ == "mcp_unified._schema_worker"  # noqa: SLF001
 
 
+def test_parent_preloads_validator_classes_before_bounded_spawn() -> None:
+    """Windows workers should not pay a cold jsonschema import inside the timeout."""
+
+    api = _validation_api()
+
+    assert {validator.__name__ for validator in api._VALIDATORS.values()} == {  # noqa: SLF001
+        "Draft7Validator",
+        "Draft202012Validator",
+    }
+
+
 @pytest.mark.asyncio
 async def test_schema_keywords_inside_instance_payload_keywords_are_not_traversed() -> None:
     """Annotation payloads named like schema keywords must not consume schema limits."""

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_validation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_validation.py
@@ -9,6 +9,7 @@ import json
 import multiprocessing
 import os
 import signal
+import sys
 import time
 from dataclasses import replace
 from functools import partial
@@ -1022,6 +1023,148 @@ def test_worker_target_defers_validator_imports_until_after_spawn_reconstruction
     assert "Draft202012Validator" not in worker_globals
     assert "Registry" not in worker_globals
     assert "NoSuchResource" not in worker_globals
+
+
+def test_windows_defaults_to_exec_worker_without_overriding_explicit_process_seams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows uses exec by default while injected process tests remain authoritative."""
+
+    api = _validation_api()
+    monkeypatch.setattr(api.os, "name", "nt")
+
+    default_manager = api.GatewaySchemaValidationManager()
+    injected_manager = api.GatewaySchemaValidationManager(process_context=multiprocessing.get_context("spawn"))
+
+    assert default_manager._use_exec_worker is True  # noqa: SLF001
+    assert injected_manager._use_exec_worker is False  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_exec_worker_backend_validates_and_removes_its_payload() -> None:
+    """The Windows backend must return verdicts and leave no process or payload."""
+
+    api = _validation_api()
+    manager = api.GatewaySchemaValidationManager(_use_exec_worker=True)
+    try:
+        await manager.validate(
+            {"type": "integer"},
+            7,
+            profile=PROTOCOL_PROFILES["2026-07-28"],
+        )
+        with pytest.raises(GatewayApplicationError) as raised:
+            await manager.validate(
+                {"type": "integer"},
+                "wrong",
+                profile=PROTOCOL_PROFILES["2026-07-28"],
+            )
+        assert raised.value.reason_code == "schema_validation_failed"
+        assert manager.live_process_count == 0
+        assert manager._exec_payloads == {}  # noqa: SLF001
+    finally:
+        await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_exec_worker_backend_times_out_and_reaps_before_release() -> None:
+    """A stuck Windows subprocess must be killed, reaped, and cleaned."""
+
+    api = _validation_api()
+    limits = replace(
+        GatewayLimits(),
+        schema_validation_timeout_seconds=0.05,
+        graceful_shutdown_timeout_seconds=0.2,
+    )
+    manager = api.GatewaySchemaValidationManager(
+        limits=limits,
+        _use_exec_worker=True,
+        _exec_worker_command=(sys.executable, "-c", "import time; time.sleep(60)"),
+    )
+    try:
+        with pytest.raises(GatewayApplicationError) as raised:
+            await manager.validate_schema(
+                {"type": "integer"},
+                profile=PROTOCOL_PROFILES["2026-07-28"],
+            )
+        assert raised.value.reason_code == "schema_validation_timeout"
+        assert manager.live_process_count == 0
+        assert manager._exec_payloads == {}  # noqa: SLF001
+        assert manager._semaphore._value == 4  # noqa: SLF001
+    finally:
+        await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_exec_worker_backend_cancellation_reaps_and_cleans() -> None:
+    """Cancelling a Windows subprocess validation must not detach the child."""
+
+    api = _validation_api()
+    manager = api.GatewaySchemaValidationManager(
+        limits=replace(GatewayLimits(), graceful_shutdown_timeout_seconds=0.2),
+        _use_exec_worker=True,
+        _exec_worker_command=(sys.executable, "-c", "import time; time.sleep(60)"),
+    )
+    task = asyncio.create_task(
+        manager.validate_schema(
+            {"type": "integer"},
+            profile=PROTOCOL_PROFILES["2026-07-28"],
+        )
+    )
+    for _ in range(200):
+        if manager.live_process_count == 1:
+            break
+        await asyncio.sleep(0.005)
+    else:
+        pytest.fail("exec validation worker did not start")
+    if os.name == "posix":
+        payload_path = next(iter(manager._exec_payloads.values()))  # noqa: SLF001
+        assert payload_path.stat().st_mode & 0o777 == 0o600
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert manager.live_process_count == 0
+    assert manager._exec_payloads == {}  # noqa: SLF001
+    manager._exec_worker_command = (  # noqa: SLF001
+        sys.executable,
+        "-m",
+        "mcp_unified._schema_worker",
+    )
+    await manager.validate_schema(
+        {"type": "integer"},
+        profile=PROTOCOL_PROFILES["2026-07-28"],
+    )
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_exec_worker_backend_close_reaps_active_child_and_cleans() -> None:
+    """Closing the manager must synchronously account for an active exec child."""
+
+    api = _validation_api()
+    manager = api.GatewaySchemaValidationManager(
+        limits=replace(GatewayLimits(), graceful_shutdown_timeout_seconds=0.2),
+        _use_exec_worker=True,
+        _exec_worker_command=(sys.executable, "-c", "import time; time.sleep(60)"),
+    )
+    task = asyncio.create_task(
+        manager.validate_schema(
+            {"type": "integer"},
+            profile=PROTOCOL_PROFILES["2026-07-28"],
+        )
+    )
+    for _ in range(200):
+        if manager.live_process_count == 1:
+            break
+        await asyncio.sleep(0.005)
+    else:
+        pytest.fail("exec validation worker did not start")
+
+    await manager.close()
+    with pytest.raises(GatewayApplicationError) as raised:
+        await task
+    assert raised.value.reason_code == "schema_validator_closed"
+    assert manager.live_process_count == 0
+    assert manager._exec_payloads == {}  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_validation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_validation.py
@@ -174,6 +174,13 @@ class _FakeReceiver:
         self.closed = True
 
 
+class _BrokenPipeReceiver(_FakeReceiver):
+    """Model Windows reporting a crashed child as a broken named pipe."""
+
+    def poll(self, _timeout: float = 0) -> bool:
+        raise BrokenPipeError(109, "The pipe has been ended")
+
+
 class _FakeProcess:
     """Controllable process double for cleanup ordering and deadline tests."""
 
@@ -245,6 +252,22 @@ def test_validate_schema_exposes_the_compile_only_public_signature() -> None:
     assert list(signature.parameters) == ["self", "schema", "profile", "root_mode"]
     assert signature.parameters["profile"].kind is inspect.Parameter.KEYWORD_ONLY
     assert signature.parameters["root_mode"].default == "any"
+
+
+@pytest.mark.asyncio
+async def test_receive_verdict_translates_a_broken_worker_pipe() -> None:
+    """A Windows named-pipe crash must become the bounded worker-failure verdict."""
+
+    api = _validation_api()
+    manager = api.GatewaySchemaValidationManager()
+    process = _FakeProcess()
+    process.alive = False
+    process.exitcode = 7
+
+    verdict = await manager._receive_verdict(process, _BrokenPipeReceiver())
+
+    assert verdict == ("internal", "schema_validation_worker_failed")
+    await manager.close()
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_validation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_validation.py
@@ -1012,6 +1012,18 @@ def test_parent_preloads_validator_classes_before_bounded_spawn() -> None:
     }
 
 
+def test_worker_target_defers_validator_imports_until_after_spawn_reconstruction() -> None:
+    """The Windows child target module must remain stdlib-only while unpickling."""
+
+    api = _validation_api()
+    worker_globals = api._schema_validation_worker.__globals__  # noqa: SLF001
+
+    assert "Draft7Validator" not in worker_globals
+    assert "Draft202012Validator" not in worker_globals
+    assert "Registry" not in worker_globals
+    assert "NoSuchResource" not in worker_globals
+
+
 @pytest.mark.asyncio
 async def test_schema_keywords_inside_instance_payload_keywords_are_not_traversed() -> None:
     """Annotation payloads named like schema keywords must not consume schema limits."""

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_validation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_protocol_validation.py
@@ -992,6 +992,15 @@ def test_worker_registry_never_uses_default_url_retrieval(monkeypatch: pytest.Mo
     assert retrieved == []
 
 
+def test_default_worker_target_uses_lightweight_top_level_spawn_module() -> None:
+    """Windows spawn must not import the broad gateway package before worker entry."""
+
+    api = _validation_api()
+    manager = api.GatewaySchemaValidationManager()
+
+    assert manager._worker_target.__module__ == "mcp_unified._schema_worker"  # noqa: SLF001
+
+
 @pytest.mark.asyncio
 async def test_schema_keywords_inside_instance_payload_keywords_are_not_traversed() -> None:
     """Annotation payloads named like schema keywords must not consume schema limits."""

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
@@ -60,7 +60,7 @@ def test_jsonschema_dependency_accepts_duplicate_identical_metadata_headers() ->
 
     metadata = Parser().parsestr(
         "Requires-Dist: jsonschema<5,>=4.23\n"
-        "Requires-Dist: jsonschema<5,>=4.23\n"
+        "Requires-Dist: jsonschema>=4.23,<5\n"
         'Requires-Dist: jsonschema<5,>=4.23; extra == "dev"\n'
         "\n"
     )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
@@ -1075,6 +1075,8 @@ def test_mcp_unified_dev_extra_declares_artifact_gate_dependencies() -> None:
 
     assert "build" in dev_dependency_names  # nosec B101
     assert "tomli" in dev_dependency_names  # nosec B101
+    assert "setuptools>=79.0.1" in build_dependencies  # nosec B101
+    assert "setuptools>=79.0.1" in dev_dependencies  # nosec B101
     assert build_dependency_names.issubset(dev_dependency_names)  # nosec B101
     assert any(  # nosec B101
         "python_version" in dependency

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import os
 import sys
+from email.parser import Parser
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -52,6 +53,19 @@ def test_default_paths_point_to_apps_package() -> None:
     assert paths.package_project == Path("/repo/apps/mcp-unified")  # nosec B101
     assert paths.package_src == Path("/repo/apps/mcp-unified/src/mcp_unified")  # nosec B101
     assert paths.evidence_dir == Path("/repo/.artifacts/mcp-unified-rc")  # nosec B101
+
+
+def test_jsonschema_dependency_accepts_duplicate_identical_metadata_headers() -> None:
+    """Equivalent repeated sdist headers must represent one semantic dependency."""
+
+    metadata = Parser().parsestr(
+        "Requires-Dist: jsonschema<5,>=4.23\n"
+        "Requires-Dist: jsonschema<5,>=4.23\n"
+        'Requires-Dist: jsonschema<5,>=4.23; extra == "dev"\n'
+        "\n"
+    )
+
+    assert mcp_unified_rc._jsonschema_base_dependency(metadata) == "jsonschema<5,>=4.23"
 
 
 def _create_publish_plan_artifacts(tmp_path: Path) -> mcp_unified_rc.RcPaths:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -728,7 +728,7 @@ def test_mcp_unified_standalone_pyproject_matches_release_metadata() -> None:
     pyproject = _load_standalone_pyproject()
     project = pyproject["project"]
 
-    assert pyproject["build-system"]["requires"] == ["setuptools>=61.0"]
+    assert pyproject["build-system"]["requires"] == ["setuptools>=79.0.1"]
     assert project["name"] == metadata.PACKAGE_NAME
     assert project["version"] == mcp_unified.__version__
     assert project["readme"] == "README.md"


### PR DESCRIPTION
## Summary

- Replace the unreliable nested Windows multiprocessing schema validator with a bounded fixed-argument Python subprocess while retaining multiprocessing spawn on POSIX and explicit test seams.
- Preserve exact timeout, cancellation, terminate/kill/reap, concurrency-permit, safe-verdict, and fail-closed schema behavior.
- Use an exact-length owner-only temporary payload on Windows, delete it on every bounded exit path, and disclose that privacy trade-off in the packaged docs.
- Remove the now-obsolete official SDK freeze-support workaround and retain the 0.2.1 metadata/build corrections from the preceding commits.

## Verification

- Five source protocol suites: 381 passed.
- Clean portable release gate: 18/18 required checks.
- Wheel installed protocol suite: 381 passed plus official MCP SDK stdio smoke.
- Sdist installed protocol suite: 381 passed plus official MCP SDK stdio smoke.
- Installed downstream artifact consumer: 29 passed.
- RC helper: 34 passed.
- Package boundary: 45 passed plus the same five accepted legacy failures.
- Ruff, formatting, Bandit, Python 3.10/3.11 compilation, docs parity, and diff checks pass.

## Release scope

This is the corrective 0.2.1 release candidate after the published 0.2.0 artifact exposed the Windows-only nested-process failure. Chatbook migration remains blocked until the protected Windows job passes and 0.2.1 is merged, published, and freshly verified from PyPI.

This PR was prepared and operated by Codex at the repository owner’s explicit direction. The repository owner reviewed the scope and accepts responsibility for merging and release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows schema validation by replacing nested multiprocessing with a bounded subprocess worker, restoring the protected Windows portable gate and releasing `0.2.1`. Also raises the default validation timeout to 5s and updates packaging/workflow to ship clean artifacts.

- **Bug Fixes**
  - Windows uses a fixed-argument subprocess (`python -m mcp_unified._schema_worker`) with an owner-only, exact-length temp payload; no shell, no inherited stdio, and a bounded verdict; cleanup terminates/kills, reaps, and deletes the payload.
  - POSIX retains `multiprocessing` spawn; explicit process seams remain available for tests on all platforms.
  - Default `schema_validation_timeout_seconds` increased from 1.0 to 5.0 to cover cold starts; verdict decoding hardened for broken pipes/malformed payloads.
  - CI portable gate restored for Windows; uploads now include built dists; workflow and tests updated for strict path matching and SDK smoke.
  - Behavior note: on native Windows, validation briefly writes the preflighted schema/instance to a private temp file; it’s deleted during bounded cleanup. See docs for the privacy trade-off.

- **Dependencies**
  - Bump package to `0.2.1` and require `setuptools>=79.0.1` in build/dev/CI.
  - Keep `jsonschema>=4.23,<5`; sdist metadata parser now treats duplicate unmarked `Requires-Dist` lines as one semantic dependency.

<sup>Written for commit 4cbd2b3fc906b9e0be13760a4df2a3ca07dca0e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

