### PR TITLE
docs: file TASK-13020 (transcription provider/translate gap) and TASK-13021 (silent discard of unknown form fields)

### DIFF
--- a/backlog/tasks/task-13020 - Media-API-does-not-expose-transcription-provider-or-translate-to-English.md
+++ b/backlog/tasks/task-13020 - Media-API-does-not-expose-transcription-provider-or-translate-to-English.md
@@ -1,0 +1,72 @@
+---
+id: TASK-13020
+title: Media API does not expose transcription provider or translate-to-English
+status: To Do
+assignee: []
+created_date: '2026-08-11'
+labels:
+  - media
+  - api
+  - transcription
+dependencies: []
+---
+
+## Description
+
+The transcription core supports choosing an STT provider and running Whisper's
+translate task, but **no media HTTP endpoint lets a client ask for either**. A
+caller can select the model, the language, diarization, timestamps and VAD, and
+then cannot say which provider should run it or that the output should be
+translated to English.
+
+Found from the client side: `tldw_chatbook`'s Library ingest canvas offers
+"Transcription provider" and "Translate to English" controls, forwarded them as
+form fields, and they were silently discarded because the endpoint does not
+declare them. The client now drops them and tells the user they cannot be
+honoured — but the capability exists here, so the honest fix is on this side.
+
+**The core already does both:**
+
+- `Audio_Transcription_Lib.transcribe_audio(audio_data, transcription_provider,
+  ...)` takes the provider as a positional parameter.
+- `stt_provider_adapter` takes `task: str = "transcribe"` and handles
+  `"translate"` explicitly (`selected_lang = None if task == "translate" else
+  language`, and `target_language="en" if task == "translate" else None`).
+
+**Nothing above that layer carries them.** Checked, in order:
+
+1. `AudioVideoOptions` (`schemas/media_request_models.py`) declares
+   `transcription_model`, `transcription_language`, `hotwords`, `diarize`,
+   `timestamp_option`, `vad_use` — no provider, no translate.
+2. `get_add_media_form` (`API_Deps/media_add_deps.py`) binds each field with an
+   explicit `Form(...)` and never reads `request.form()`, so an undeclared field
+   cannot arrive by any route.
+3. `Audio_Files.process_audio_files(...)` — the ingestion entry point — takes
+   `transcription_model`, `transcription_language` and `diarize`, but no
+   provider and no task.
+
+So the plumbing is missing across two layers, not one: the request schema and
+the ingestion function both need to carry the values down to the adapter that
+already understands them.
+
+Confirmed against a live instance: every endpoint under `/api/v1/media/` was
+enumerated from `/openapi.json`, and neither `transcription_provider` nor
+`translate_to_english` (nor any synonym) appears on `/media/add`,
+`/media/ingest/jobs`, or any `process-*` route. `/media/add` is a strict subset
+of `/media/ingest/jobs`, so there is no fuller surface a client could use
+instead.
+
+Note for whoever picks this up: the endpoint's silent-discard behaviour is what
+made this invisible for so long. An undeclared form field produces no error and
+a `200`, so a client asking for an unsupported option gets a successful-looking
+job that ignored the request. Worth considering whether unknown form fields
+should be rejected, or at least reported in the response, independently of this
+task.
+
+## Acceptance Criteria
+
+- [ ] A client can select the transcription provider for an audio/video ingest, and the chosen provider is the one that runs
+- [ ] A client can request translate-to-English, and the resulting transcript is English for non-English input
+- [ ] Both options are accepted on the same endpoints that already accept `transcription_model` (`/media/add` and `/media/ingest/jobs`)
+- [ ] An invalid provider value is rejected with a validation error naming the field, rather than ignored
+- [ ] The values reach `stt_provider_adapter` — asserted end to end, not only at the schema boundary

--- a/backlog/tasks/task-13020 - Media-API-does-not-expose-transcription-provider-or-translate-to-English.md
+++ b/backlog/tasks/task-13020 - Media-API-does-not-expose-transcription-provider-or-translate-to-English.md
@@ -59,9 +59,8 @@ instead.
 Note for whoever picks this up: the endpoint's silent-discard behaviour is what
 made this invisible for so long. An undeclared form field produces no error and
 a `200`, so a client asking for an unsupported option gets a successful-looking
-job that ignored the request. Worth considering whether unknown form fields
-should be rejected, or at least reported in the response, independently of this
-task.
+job that ignored the request. That is tracked separately as **TASK-13021** —
+it is a property of the media form endpoints as a family, not of this gap.
 
 ## Acceptance Criteria
 

--- a/backlog/tasks/task-13021 - Unknown-form-fields-are-silently-discarded-instead-of-rejected.md
+++ b/backlog/tasks/task-13021 - Unknown-form-fields-are-silently-discarded-instead-of-rejected.md
@@ -1,0 +1,73 @@
+---
+id: TASK-13021
+title: Unknown form fields are silently discarded instead of rejected
+status: To Do
+assignee: []
+created_date: '2026-08-11'
+labels:
+  - api
+  - media
+  - dx
+dependencies: []
+---
+
+## Description
+
+A client can send any form field it likes to the media endpoints and get a
+`200` back with the field ignored. There is no error, no warning, and nothing
+in the response distinguishes "your option was applied" from "your option was
+dropped on the floor".
+
+This is not a hypothetical. It hid a real defect in `tldw_chatbook` for months:
+nineteen ingest options — OCR language, speaker diarization, timestamps, VAD
+filter, PDF engine and more — were being posted under names this API does not
+declare. Every submission returned `200`, every job ran, and none of those
+settings ever took effect. Nobody could tell, because a successful-looking job
+is exactly what a working one looks like.
+
+Demonstrated on a live instance:
+
+    POST /api/v1/media/ingest/jobs -F pdf_parsing_engine=bogus
+      -> 422 {"loc":["body","pdf_parsing_engine"],
+              "msg":"Input should be 'pymupdf4llm', 'pymupdf' or 'docling'"}
+
+    POST /api/v1/media/ingest/jobs -F pdf_engine=bogus     # undeclared name
+      -> 200 {"batch_id":"...","jobs":[{"id":285,"status":"queued"}],"errors":[]}
+
+Same value, same intent, one character of difference in the key. One is
+validated; the other is accepted and ignored.
+
+The cause is ordinary FastAPI behaviour rather than a bug in any one handler:
+`get_add_media_form` (and its siblings) bind each field with an explicit
+`Form(...)` and never read `request.form()`, so anything undeclared is dropped
+during parsing. That is a sensible default for a browser form and a poor one for
+a versioned API with independent clients, where a field name drifting out of
+sync is the normal failure and it currently fails invisibly.
+
+Worth deciding deliberately, because each option trades strictness against
+compatibility:
+
+1. **Reject** unknown fields with a 422 naming them. Strictest and catches drift
+   immediately, but any client sending a field a newer/older server does not
+   know breaks outright — including older clients against a newer server.
+2. **Report** them: accept the request, echo the ignored field names in the
+   response. Nothing breaks, and a client can surface "these settings were not
+   applied". Weaker than rejection, since a client has to look.
+3. **Warn** server-side only (log). Cheapest, invisible to clients, and would
+   not have surfaced this incident to the people affected by it.
+
+Option 2 is the one that would have caught the `tldw_chatbook` case without a
+compatibility cliff, but the choice belongs to whoever owns the API's
+compatibility policy. Whatever is chosen should apply to the media form
+endpoints as a family, not to one handler.
+
+Related: TASK-13020, the transcription provider/translate gap this same
+behaviour concealed.
+
+## Acceptance Criteria
+
+- [ ] A decision is recorded on reject-vs-report-vs-warn, with the compatibility reasoning
+- [ ] Sending an undeclared form field to the media endpoints no longer produces a response indistinguishable from one where every field was honoured
+- [ ] The chosen behaviour is consistent across the media form endpoints, not added to one handler
+- [ ] A test asserts an undeclared field is surfaced (rejected or reported), so the silent path cannot return
+- [ ] If rejection is chosen, the compatibility impact on existing clients is stated and a migration path given


### PR DESCRIPTION
## What

Files two backlog tasks. No code changes.

- **TASK-13020** — the media API exposes no way to choose a transcription provider or request translate-to-English, though the core supports both.
- **TASK-13021** — unknown form fields are silently discarded instead of rejected. This is the one that matters most.

## TASK-13021: silent discard

**This should not be a thing.** A client can send any form field it likes and get a `200` with the field ignored — no error, no warning, and nothing in the response that distinguishes "your option was applied" from "your option was dropped on the floor".

It is not hypothetical. It concealed a real defect in `tldw_chatbook` for months: nineteen ingest options — OCR language, speaker diarization, timestamps, VAD filter, PDF engine and more — were posted under names this API does not declare. Every submission returned `200`, every job ran, and none of those settings ever took effect. Nobody could tell, because a successful-looking job is exactly what a working one looks like.

Live, on a running instance:

```
POST /api/v1/media/ingest/jobs -F pdf_parsing_engine=bogus
  -> 422  {"loc":["body","pdf_parsing_engine"],
           "msg":"Input should be 'pymupdf4llm', 'pymupdf' or 'docling'"}

POST /api/v1/media/ingest/jobs -F pdf_engine=bogus      # undeclared name
  -> 200  {"batch_id":"...","jobs":[{"id":285,"status":"queued"}],"errors":[]}
```

Same value, same intent, one character of difference in the key. One is validated; the other is accepted and ignored.

The cause is ordinary FastAPI behaviour, not a bug in any single handler: `get_add_media_form` and its siblings bind each field with an explicit `Form(...)` and never read `request.form()`, so undeclared fields are dropped during parsing. Sensible for a browser form; poor for a versioned API with independent clients, where a field name drifting out of sync is the *normal* failure — and it currently fails invisibly.

The task lays out the three options with their trade-offs rather than assuming one:

| | catches drift | breaks clients |
|---|---|---|
| **Reject** (422 naming the field) | immediately | yes — any client sending a field the server does not know, in either version direction |
| **Report** (accept, echo ignored names) | when the client looks | no |
| **Warn** (server log only) | only for whoever reads logs | no — and would not have surfaced this incident to the people affected |

Report is the one that would have caught the `tldw_chatbook` case without a compatibility cliff, but the choice belongs to whoever owns the API's compatibility policy. Whatever is chosen should apply to the media form endpoints as a family, not to one handler.

## TASK-13020: transcription provider / translate

The core supports both and no endpoint surfaces either:

- `Audio_Transcription_Lib.transcribe_audio(audio_data, transcription_provider, ...)` takes the provider directly.
- `stt_provider_adapter` takes `task: str = "transcribe"` and handles `"translate"` explicitly (`selected_lang = None if task == "translate" else language`, `target_language="en" if task == "translate" else None`).

The gap spans two layers, so plumbing is needed through both:

1. `AudioVideoOptions` declares `transcription_model`, `transcription_language`, `hotwords`, `diarize`, `timestamp_option`, `vad_use` — no provider, no translate.
2. `Audio_Files.process_audio_files(...)` takes `transcription_model`, `transcription_language`, `diarize` — also no provider, no task.

Every `/api/v1/media/` endpoint was enumerated from the running instance's `/openapi.json`. `/media/add` is a strict subset of `/media/ingest/jobs` (68 vs 72 fields), so there is no fuller surface a client could switch to instead.

## Client side

`tldw_chatbook` has been fixed to stop sending what this API cannot accept, and to tell the user which options will not be honoured rather than implying they took effect. But provider selection and translate are capabilities that exist here, so the real fix for those belongs on this side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)