### PR TITLE
feat(sync): bootstrap legacy Notes attachments into v2

### DIFF
--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -1,7 +1,7 @@
 {
   "note": "Regenerate with `make openapi-fingerprint`. A change here means the backend API contract drifted; regenerate the frontend types (`bun run generate:api-types` in apps/tldw-frontend) and review.",
   "openapi_version": "3.1.0",
-  "path_count": 2009,
-  "schema_count": 2931,
-  "sha256": "def9b462e24624c5fae37912b9cc3bdf62daf66cd8bc3cb4c9909f0295d98618"
+  "path_count": 2010,
+  "schema_count": 2933,
+  "sha256": "064bfde3ac3e876fca5c198c61a88b62c2c01d21bb72943287843b7ddf2828da"
 }

--- a/backlog/tasks/task-13005.3 - Bootstrap-legacy-Notes-attachments-into-Sync-v2.md
+++ b/backlog/tasks/task-13005.3 - Bootstrap-legacy-Notes-attachments-into-Sync-v2.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13005.3
 title: Bootstrap legacy Notes attachments into Sync v2
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-11 15:33'
-updated_date: '2026-08-13 13:36'
+updated_date: '2026-08-13 15:45'
 labels:
   - notes
   - sync-v2
@@ -31,11 +31,11 @@ Source-verify and resumably import confined legacy Notes attachment files into c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Bootstrap readiness is independent, resumable, fail-closed, and keeps v2 mutation unavailable until count and canonical fingerprint verification succeed.
-- [ ] #2 Legacy enumeration is owner- and note-scoped, path-confined, symlink-safe, bounded, source-verified, and never deletes or rewrites legacy files.
-- [ ] #3 Each source key receives one durable stable attachment identity and idempotent verified blob/envelope projection across interruptions and retries.
-- [ ] #4 Cleanup candidates and diagnostics expose safe hashes/codes only and remain non-authoritative evidence.
-- [ ] #5 Gate-off, partial, failed, ready, rollback, bootstrap API, and static/security regression evidence is recorded.
+- [x] #1 Bootstrap readiness is independent, resumable, fail-closed, and keeps v2 mutation unavailable until count and canonical fingerprint verification succeed.
+- [x] #2 Legacy enumeration is owner- and note-scoped, path-confined, symlink-safe, bounded, source-verified, and never deletes or rewrites legacy files.
+- [x] #3 Each source key receives one durable stable attachment identity and idempotent verified blob/envelope projection across interruptions and retries.
+- [x] #4 Cleanup candidates and diagnostics expose safe hashes/codes only and remain non-authoritative evidence.
+- [x] #5 Gate-off, partial, failed, ready, rollback, bootstrap API, and static/security regression evidence is recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,12 +44,24 @@ Source-verify and resumably import confined legacy Notes attachment files into c
 1. Add a bounded, read-only, owner/note-scoped legacy attachment source seam under RED→GREEN tests.\n2. Persist independent notes_attachment_v2 readiness, immutable source mappings, and safe cleanup diagnostics with transactional verification.\n3. Implement resumable source verification, existing verified blob import, trusted server-origin v2 projection, and canonical count/fingerprint readiness.\n4. Reuse the profile bootstrap API for bounded dry-run/start/resume/status responses with no local-path leakage.\n5. Prove gate-off, partial, failed, ready, and rollback behavior; run focused/broad tests, Ruff, formatter check, Bandit, compile, and diff checks.\n\nADR required: no\nADR path: Docs/ADR/038-canonical-notes-attachment-registry-and-blob-lifecycle.md\nReason: ADR-038 already defines the bootstrap authority, source verification, non-destructive rollout, and cleanup-candidate boundaries.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the ADR-038 legacy Notes attachment bootstrap as a bounded, resumable, fail-closed migration. Added owner/note-scoped symlink-safe legacy enumeration; durable readiness, source-map, cleanup-candidate, and verification state; verified canonical registry/blob/server-origin attachment.ref v2 projection; canonical count/fingerprint readiness; and safe profile-bootstrap plus read-only diagnostic surfaces. Rollout remains default-off, disabling it after readiness preserves canonical metadata and legacy source files, and cleanup evidence is hash/code-only and non-authoritative. Hardened signed attachment cursor decoding to reject noncanonical Base64URL encodings discovered by the final gate. ADR required: no; ADR-038 already governs the authority, migration, and non-destructive rollout boundaries.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verification: 651 passed, 2 optional live-PostgreSQL tests skipped, 45 warnings in the final 13-file task gate; Notes attachment API 31 passed; focused rollout gate 137 passed/139 deselected. Ruff check, Bandit, py_compile, and git diff --check passed. Black and Ruff formatter checks were executed and reported the existing whole-file formatting baseline across the 21 touched paths; no unrelated mass reformat was applied. The two skips are environment-only live-PostgreSQL coverage; server-free PostgreSQL contracts and SQLite integration coverage passed. No lessons documents exist in this repository, so none was invented.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13005.3 - Bootstrap-legacy-Notes-attachments-into-Sync-v2.md
+++ b/backlog/tasks/task-13005.3 - Bootstrap-legacy-Notes-attachments-into-Sync-v2.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-13005.3
 title: Bootstrap legacy Notes attachments into Sync v2
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-11 15:33'
+updated_date: '2026-08-13 13:36'
 labels:
   - notes
   - sync-v2
@@ -36,6 +37,12 @@ Source-verify and resumably import confined legacy Notes attachment files into c
 - [ ] #4 Cleanup candidates and diagnostics expose safe hashes/codes only and remain non-authoritative evidence.
 - [ ] #5 Gate-off, partial, failed, ready, rollback, bootstrap API, and static/security regression evidence is recorded.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a bounded, read-only, owner/note-scoped legacy attachment source seam under RED→GREEN tests.\n2. Persist independent notes_attachment_v2 readiness, immutable source mappings, and safe cleanup diagnostics with transactional verification.\n3. Implement resumable source verification, existing verified blob import, trusted server-origin v2 projection, and canonical count/fingerprint readiness.\n4. Reuse the profile bootstrap API for bounded dry-run/start/resume/status responses with no local-path leakage.\n5. Prove gate-off, partial, failed, ready, and rollback behavior; run focused/broad tests, Ruff, formatter check, Bandit, compile, and diff checks.\n\nADR required: no\nADR path: Docs/ADR/038-canonical-notes-attachment-registry-and-blob-lifecycle.md\nReason: ADR-038 already defines the bootstrap authority, source verification, non-destructive rollout, and cleanup-candidate boundaries.
+<!-- SECTION:PLAN:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -835,6 +835,17 @@ def _decode_attachment_cursor(
         signature = base64.urlsafe_b64decode(
             signature_segment + "=" * (-len(signature_segment) % 4)
         )
+        if any(
+            base64.urlsafe_b64encode(decoded_segment)
+            .decode("ascii")
+            .rstrip("=")
+            != encoded_segment
+            for decoded_segment, encoded_segment in (
+                (payload, payload_segment),
+                (signature, signature_segment),
+            )
+        ):
+            raise ValueError("noncanonical base64url")
         expected = hmac.digest(_attachment_cursor_secret(), payload, "sha256")
         if not hmac.compare_digest(signature, expected):
             raise ValueError("signature mismatch")

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -150,6 +150,15 @@ from tldw_Server_API.app.core.Notes.attachment_policy import (
     validate_note_attachment_original_file_name,
     validate_note_attachment_upload_content,
 )
+from tldw_Server_API.app.core.Notes.legacy_attachment_source import (
+    LEGACY_ATTACHMENT_META_SUFFIX as _NOTES_ATTACHMENT_META_SUFFIX,
+)
+from tldw_Server_API.app.core.Notes.legacy_attachment_source import (
+    legacy_attachment_base_directory,
+    legacy_attachment_metadata_path,
+    legacy_attachment_note_directory,
+    safe_legacy_note_attachment_dirname,
+)
 from tldw_Server_API.app.core.Notes.organization_capture import (
     compound_note_id,
     compound_note_request_fingerprint,
@@ -202,7 +211,6 @@ from tldw_Server_API.app.core.Sync.v2.server_origin_batch import (
     SyncServerOriginBatchMaterializationError,
 )
 from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service
-from tldw_Server_API.app.core.Utils.Utils import sanitize_filename
 from tldw_Server_API.app.core.Writing.note_title import TitleGenOptions, generate_note_title
 
 #
@@ -235,8 +243,6 @@ _NOTES_NONCRITICAL_EXCEPTIONS = (
 
 router = APIRouter()
 
-_NOTES_ATTACHMENTS_DIRNAME = "notes_attachments"
-_NOTES_ATTACHMENT_META_SUFFIX = ".meta.json"
 _NOTES_ATTACHMENT_DEFAULT_MAX_BYTES = 25 * 1024 * 1024
 _NOTES_ATTACHMENT_COMPATIBILITY_LIST_LIMIT = 1000
 _NOTES_ATTACHMENT_RANGE_RE = re.compile(r"bytes=(\d*)-(\d*)\Z")
@@ -1047,31 +1053,32 @@ def _reconcile_note_tasks_after_save(
 
 
 def _safe_note_attachment_dirname(note_id: str) -> str:
-    text = str(note_id or "").strip()
-    if not text:
-        return "note"
-    safe = sanitize_filename(text, max_total_length=96).replace(" ", "_").strip("._")
-    if safe and safe not in {".", ".."}:
-        return safe
-    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
-    return f"note_{digest}"
+    return safe_legacy_note_attachment_dirname(note_id)
 
 
 def _get_note_attachments_base_dir(user_id: int | str) -> Path:
-    user_base_dir = DatabasePaths.get_user_base_directory(user_id)
-    base_dir = (user_base_dir / _NOTES_ATTACHMENTS_DIRNAME).resolve()
-    user_base_resolved = user_base_dir.resolve()
+    user_root = DatabasePaths.get_user_base_directory(user_id)
+    base_dir = legacy_attachment_base_directory(user_id, user_root=user_root)
+    user_root_resolved = user_root.resolve()
+    base_dir_resolved = base_dir.resolve()
     try:
-        base_dir.relative_to(user_base_resolved)
+        base_dir_resolved.relative_to(user_root_resolved)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Invalid attachment storage path") from exc
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Invalid attachment storage path",
+        ) from exc
     base_dir.mkdir(parents=True, exist_ok=True)
-    return base_dir
+    return base_dir_resolved
 
 
 def _get_note_attachments_dir(user_id: int | str, note_id: str, *, create: bool = False) -> Path:
     base_dir = _get_note_attachments_base_dir(user_id)
-    note_dir = (base_dir / _safe_note_attachment_dirname(note_id)).resolve()
+    note_dir = legacy_attachment_note_directory(
+        user_id,
+        note_id,
+        user_root=base_dir.parent,
+    ).resolve()
     try:
         note_dir.relative_to(base_dir)
     except ValueError as exc:
@@ -1119,7 +1126,7 @@ def _resolve_unique_attachment_path(note_dir: Path, file_name: str) -> Path:
 
 
 def _attachment_metadata_path(file_path: Path) -> Path:
-    return file_path.with_name(f"{file_path.name}{_NOTES_ATTACHMENT_META_SUFFIX}")
+    return legacy_attachment_metadata_path(file_path)
 
 
 def _parse_uploaded_at(value: Any, fallback: datetime) -> datetime:

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -72,6 +72,7 @@ from tldw_Server_API.app.api.v1.schemas.sync_v2_models import (
     SyncKeyRotationCommitRequest,
     SyncKeyRotationPreviewRequest,
     SyncKeyRotationResponse,
+    SyncNotesAttachmentBootstrapDiagnosticsResponse,
     SyncProfileBootstrapRequest,
     SyncProfileBootstrapResponse,
     SyncProfileResponse,
@@ -287,6 +288,22 @@ def _safe_sync_v2_http_error(exc: Exception, **context: object) -> HTTPException
                     status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                     detail={"error_code": error_code, "message": message},
                 )
+        if "sync_attachment_bootstrap_sample_limit_exceeded" in lowered:
+            return HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail={
+                    "error_code": "sync_attachment_bootstrap_sample_limit_exceeded",
+                    "message": "Attachment bootstrap diagnostics exceed the sample limit.",
+                },
+            )
+        if "sync_attachment_bootstrap_sample_limit_invalid" in lowered:
+            return HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "error_code": "sync_attachment_bootstrap_sample_limit_invalid",
+                    "message": "Attachment bootstrap diagnostics parameters are invalid.",
+                },
+            )
         if "attachment payload exceeds" in lowered:
             return HTTPException(
                 status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
@@ -468,6 +485,12 @@ def _api_bootstrap_profile_from_core(profile: Any) -> SyncProfileBootstrapRespon
     return SyncProfileBootstrapResponse(**asdict(profile))
 
 
+def _api_attachment_bootstrap_diagnostics_from_core(
+    diagnostics: Any,
+) -> SyncNotesAttachmentBootstrapDiagnosticsResponse:
+    return SyncNotesAttachmentBootstrapDiagnosticsResponse(**asdict(diagnostics))
+
+
 def _api_blob_session_from_core(session: Any) -> SyncBlobUploadSessionResponse:
     return SyncBlobUploadSessionResponse(**asdict(session))
 
@@ -627,6 +650,35 @@ def get_sync_v2_profile(
             device_id=device_id,
         ) from exc
     return _api_profile_from_core(profile)
+
+
+@router.get(
+    "/profile/attachment-bootstrap",
+    response_model=SyncNotesAttachmentBootstrapDiagnosticsResponse,
+    summary="Return bounded Notes attachment bootstrap diagnostics",
+)
+def get_sync_v2_attachment_bootstrap_diagnostics(
+    dataset_id: str | None = Query(None),
+    sample_limit: int = Query(0),
+    dry_run: bool = Query(False),
+    user: User = Depends(get_request_user),
+    service: SyncV2Service = Depends(get_sync_v2_service),
+):
+    user_id = _sync_user_id(user)
+    try:
+        diagnostics = service.notes_attachment_bootstrap_diagnostics(
+            user_id=user_id,
+            dataset_id=dataset_id,
+            sample_limit=sample_limit,
+            dry_run=dry_run,
+        )
+    except Exception as exc:
+        raise _safe_sync_v2_http_error(
+            exc,
+            user_id=user_id,
+            dataset_id=dataset_id,
+        ) from exc
+    return _api_attachment_bootstrap_diagnostics_from_core(diagnostics)
 
 
 @router.post(

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -24,7 +24,11 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 from pydantic import ValidationError
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    User,
+    check_rate_limit,
+    get_request_user,
+)
 from tldw_Server_API.app.api.v1.schemas.sync_server_models import (
     ALLOWED_SYNC_OPERATIONS,
     ALLOWED_SYNC_SEND_ENTITIES,
@@ -491,6 +495,18 @@ def _api_attachment_bootstrap_diagnostics_from_core(
     return SyncNotesAttachmentBootstrapDiagnosticsResponse(**asdict(diagnostics))
 
 
+def _api_empty_attachment_bootstrap_diagnostics(
+    *,
+    dry_run: bool,
+) -> SyncNotesAttachmentBootstrapDiagnosticsResponse:
+    """Return diagnostics without initializing Sync v2 storage."""
+
+    return SyncNotesAttachmentBootstrapDiagnosticsResponse(
+        state="not_started",
+        dry_run=dry_run,
+    )
+
+
 def _api_blob_session_from_core(session: Any) -> SyncBlobUploadSessionResponse:
     return SyncBlobUploadSessionResponse(**asdict(session))
 
@@ -656,15 +672,30 @@ def get_sync_v2_profile(
     "/profile/attachment-bootstrap",
     response_model=SyncNotesAttachmentBootstrapDiagnosticsResponse,
     summary="Return bounded Notes attachment bootstrap diagnostics",
+    dependencies=[Depends(check_rate_limit)],
 )
 def get_sync_v2_attachment_bootstrap_diagnostics(
     dataset_id: str | None = Query(None),
     sample_limit: int = Query(0),
     dry_run: bool = Query(False),
     user: User = Depends(get_request_user),
-    service: SyncV2Service = Depends(get_sync_v2_service),
-):
+    service: SyncV2Service | None = Depends(get_sync_v2_profile_service),
+) -> SyncNotesAttachmentBootstrapDiagnosticsResponse:
     user_id = _sync_user_id(user)
+    if sample_limit < 0:
+        raise _safe_sync_v2_http_error(
+            SyncStoreError("sync_attachment_bootstrap_sample_limit_invalid"),
+            user_id=user_id,
+            dataset_id=dataset_id,
+        )
+    if sample_limit > 100:
+        raise _safe_sync_v2_http_error(
+            SyncStoreError("sync_attachment_bootstrap_sample_limit_exceeded"),
+            user_id=user_id,
+            dataset_id=dataset_id,
+        )
+    if service is None:
+        return _api_empty_attachment_bootstrap_diagnostics(dry_run=dry_run)
     try:
         diagnostics = service.notes_attachment_bootstrap_diagnostics(
             user_id=user_id,

--- a/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
@@ -871,6 +871,36 @@ class SyncNotesOrganizationStatusResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class SyncNotesAttachmentCleanupSampleResponse(BaseModel):
+    """One bounded public-safe legacy cleanup candidate."""
+
+    source_key_hash: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    attachment_id: str
+    state: Literal["captured"] = "captured"
+    blocker_code: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SyncNotesAttachmentBootstrapDiagnosticsResponse(BaseModel):
+    """Read-only bounded legacy attachment bootstrap diagnostics."""
+
+    state: Literal["not_started", "initializing", "ready", "failed"]
+    captured_count: int = Field(0, ge=0)
+    expected_count: int = Field(0, ge=0)
+    cursor: str | None = Field(None, pattern=r"^sha256:[0-9a-f]{64}$")
+    error_code: str | None = None
+    dry_run: bool = False
+    source_candidate_count: int | None = Field(None, ge=0, le=1_000)
+    source_candidate_count_is_lower_bound: bool = False
+    cleanup_candidates: list[SyncNotesAttachmentCleanupSampleResponse] = Field(
+        default_factory=list,
+        max_length=100,
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class SyncProfileDatasetStatusResponse(BaseModel):
     """Default personal dataset metadata in profile responses."""
 
@@ -886,6 +916,7 @@ class SyncProfileDatasetStatusResponse(BaseModel):
     server_frontend_mutation_blockers: list[str] = Field(default_factory=list)
     notes_organization: SyncNotesOrganizationStatusResponse | None = None
     notes_link: SyncNotesOrganizationStatusResponse | None = None
+    notes_attachment: SyncNotesOrganizationStatusResponse | None = None
 
 
 class SyncProfileDomainStatusResponse(BaseModel):
@@ -2077,6 +2108,8 @@ __all__ = [
     "SyncProfileBootstrapMode",
     "SyncProfileBootstrapRequest",
     "SyncProfileBootstrapResponse",
+    "SyncNotesAttachmentBootstrapDiagnosticsResponse",
+    "SyncNotesAttachmentCleanupSampleResponse",
     "SyncNotesOrganizationStatusResponse",
     "SyncProfileDatasetStatusResponse",
     "SyncProfileDeviceStatusResponse",

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -5095,7 +5095,7 @@ class SyncDatabase:
                 or captured_count < current_captured
                 or not isinstance(current_expected, int)
                 or isinstance(current_expected, bool)
-                or (current_expected != 0 and expected_count != current_expected)
+                or expected_count < current_expected
             ):
                 raise SyncStoreError("notes_attachment_bootstrap_progress_regressed")
             current_hash = current.get("source_hash")
@@ -5303,6 +5303,66 @@ class SyncDatabase:
             if created is None:
                 raise SyncStoreError("Notes attachment cleanup candidate was not persisted")
             return _notes_attachment_cleanup_candidate_from_row(created)
+
+    def get_notes_attachment_bootstrap_source_by_hash(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+        source_key_hash: str,
+    ) -> tuple[
+        SyncNotesAttachmentSourceMap,
+        SyncNotesAttachmentCleanupCandidate,
+    ] | None:
+        """Resolve one internal bootstrap source without exposing its path publicly."""
+
+        self._validate_notes_attachment_bootstrap_id(bootstrap_id)
+        if re.fullmatch(r"sha256:[0-9a-f]{64}", source_key_hash) is None:
+            raise ValueError("Notes attachment source cursor is invalid")
+        with self.backend.transaction() as conn:
+            row = self._require_attachment_binding_dataset_owner(
+                dataset_id,
+                owner_user_id,
+                connection=conn,
+            )
+            self._notes_attachment_bootstrap_metadata(row, bootstrap_id)
+            source = _first(
+                self.execute(
+                    "SELECT source_map.*, cleanup.source_relative_path, "
+                    "cleanup.source_path_hash, cleanup.source_blob_hash, "
+                    "cleanup.source_size_bytes, cleanup.source_modified_ns, "
+                    "cleanup.created_at AS cleanup_created_at "
+                    "FROM sync_notes_attachment_source_map AS source_map "
+                    "JOIN sync_notes_attachment_cleanup_candidates AS cleanup "
+                    "ON cleanup.dataset_id = source_map.dataset_id "
+                    "AND cleanup.bootstrap_id = source_map.bootstrap_id "
+                    "AND cleanup.source_key_hash = source_map.source_key_hash "
+                    "WHERE source_map.dataset_id = ? "
+                    "AND source_map.bootstrap_id = ? "
+                    "AND source_map.source_key_hash = ?",
+                    (dataset_id, bootstrap_id, source_key_hash),
+                    connection=conn,
+                )
+            )
+            if source is None:
+                return None
+            cleanup_row = {
+                "dataset_id": source["dataset_id"],
+                "bootstrap_id": source["bootstrap_id"],
+                "source_key_hash": source["source_key_hash"],
+                "attachment_id": source["attachment_id"],
+                "source_relative_path": source["source_relative_path"],
+                "source_path_hash": source["source_path_hash"],
+                "source_blob_hash": source["source_blob_hash"],
+                "source_size_bytes": source["source_size_bytes"],
+                "source_modified_ns": source["source_modified_ns"],
+                "created_at": source["cleanup_created_at"],
+            }
+            return (
+                _notes_attachment_source_map_from_row(source),
+                _notes_attachment_cleanup_candidate_from_row(cleanup_row),
+            )
 
     def list_notes_attachment_cleanup_candidates(
         self,

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import typing
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -79,6 +80,8 @@ from tldw_Server_API.app.core.Sync.v2.models import (
     SyncKeyRecord,
     SyncKeyRecordCreate,
     SyncKeyRotationEnvelopeRange,
+    SyncNotesAttachmentCleanupCandidate,
+    SyncNotesAttachmentSourceMap,
     SyncObjectState,
     SyncRestoreManifestStats,
     normalize_sync_timestamp,
@@ -573,6 +576,83 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_sync_dataset_storage_namespace_id
 CREATE INDEX IF NOT EXISTS idx_sync_dataset_storage_namespaces_owner
     ON sync_dataset_storage_namespaces(owner_user_id, dataset_id);
 
+CREATE TABLE IF NOT EXISTS sync_notes_attachment_source_map (
+    dataset_id TEXT NOT NULL,
+    bootstrap_id TEXT NOT NULL,
+    source_key_hash TEXT NOT NULL,
+    note_id TEXT NOT NULL,
+    attachment_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (dataset_id, bootstrap_id, source_key_hash),
+    CHECK (length(dataset_id) > 0),
+    CHECK (length(bootstrap_id) BETWEEN 1 AND 128),
+    CHECK (length(source_key_hash) = 71),
+    CHECK (substr(source_key_hash, 1, 7) = 'sha256:'),
+    CHECK (substr(source_key_hash, 8) NOT GLOB '*[^0-9a-f]*'),
+    CHECK (length(note_id) > 0),
+    CHECK (
+        length(attachment_id) = 36
+        AND lower(attachment_id) = attachment_id
+        AND substr(attachment_id, 9, 1) = '-'
+        AND substr(attachment_id, 14, 1) = '-'
+        AND substr(attachment_id, 15, 1) = '4'
+        AND substr(attachment_id, 19, 1) = '-'
+        AND substr(attachment_id, 20, 1) IN ('8', '9', 'a', 'b')
+        AND substr(attachment_id, 24, 1) = '-'
+        AND length(replace(attachment_id, '-', '')) = 32
+        AND replace(attachment_id, '-', '') NOT GLOB '*[^0-9a-f]*'
+    )
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_sync_notes_attachment_source_id
+    ON sync_notes_attachment_source_map(dataset_id, attachment_id);
+
+CREATE TABLE IF NOT EXISTS sync_notes_attachment_cleanup_candidates (
+    dataset_id TEXT NOT NULL,
+    bootstrap_id TEXT NOT NULL,
+    source_key_hash TEXT NOT NULL,
+    attachment_id TEXT NOT NULL,
+    source_relative_path TEXT NOT NULL,
+    source_path_hash TEXT NOT NULL,
+    source_blob_hash TEXT NOT NULL,
+    source_size_bytes INTEGER NOT NULL,
+    source_modified_ns INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (dataset_id, bootstrap_id, source_key_hash),
+    CHECK (length(dataset_id) > 0),
+    CHECK (length(bootstrap_id) BETWEEN 1 AND 128),
+    CHECK (length(source_key_hash) = 71),
+    CHECK (substr(source_key_hash, 1, 7) = 'sha256:'),
+    CHECK (substr(source_key_hash, 8) NOT GLOB '*[^0-9a-f]*'),
+    CHECK (
+        length(attachment_id) = 36
+        AND lower(attachment_id) = attachment_id
+        AND substr(attachment_id, 9, 1) = '-'
+        AND substr(attachment_id, 14, 1) = '-'
+        AND substr(attachment_id, 15, 1) = '4'
+        AND substr(attachment_id, 19, 1) = '-'
+        AND substr(attachment_id, 20, 1) IN ('8', '9', 'a', 'b')
+        AND substr(attachment_id, 24, 1) = '-'
+        AND length(replace(attachment_id, '-', '')) = 32
+        AND replace(attachment_id, '-', '') NOT GLOB '*[^0-9a-f]*'
+    ),
+    CHECK (length(source_relative_path) BETWEEN 1 AND 4096),
+    CHECK (length(source_path_hash) = 71),
+    CHECK (substr(source_path_hash, 1, 7) = 'sha256:'),
+    CHECK (substr(source_path_hash, 8) NOT GLOB '*[^0-9a-f]*'),
+    CHECK (source_path_hash = source_key_hash),
+    CHECK (length(source_blob_hash) = 71),
+    CHECK (substr(source_blob_hash, 1, 7) = 'sha256:'),
+    CHECK (substr(source_blob_hash, 8) NOT GLOB '*[^0-9a-f]*'),
+    CHECK (typeof(source_size_bytes) = 'integer'),
+    CHECK (typeof(source_modified_ns) = 'integer'),
+    CHECK (source_size_bytes > 0),
+    CHECK (source_modified_ns >= 0)
+);
+CREATE INDEX IF NOT EXISTS idx_sync_notes_attachment_cleanup_page
+    ON sync_notes_attachment_cleanup_candidates(
+        dataset_id, bootstrap_id, source_key_hash
+    );
+
 CREATE TABLE IF NOT EXISTS sync_blob_upload_sessions (
     upload_id TEXT PRIMARY KEY,
     dataset_id TEXT NOT NULL,
@@ -1059,6 +1139,51 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_sync_dataset_storage_namespace_id
     ON sync_dataset_storage_namespaces(storage_namespace_id);
 CREATE INDEX IF NOT EXISTS idx_sync_dataset_storage_namespaces_owner
     ON sync_dataset_storage_namespaces(owner_user_id, dataset_id);
+
+CREATE TABLE IF NOT EXISTS sync_notes_attachment_source_map (
+    dataset_id TEXT NOT NULL,
+    bootstrap_id TEXT NOT NULL,
+    source_key_hash TEXT NOT NULL,
+    note_id TEXT NOT NULL,
+    attachment_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (dataset_id, bootstrap_id, source_key_hash),
+    CHECK (length(dataset_id) > 0),
+    CHECK (length(bootstrap_id) BETWEEN 1 AND 128),
+    CHECK (source_key_hash ~ '^sha256:[0-9a-f]{64}$'),
+    CHECK (length(note_id) > 0),
+    CHECK (attachment_id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_sync_notes_attachment_source_id
+    ON sync_notes_attachment_source_map(dataset_id, attachment_id);
+
+CREATE TABLE IF NOT EXISTS sync_notes_attachment_cleanup_candidates (
+    dataset_id TEXT NOT NULL,
+    bootstrap_id TEXT NOT NULL,
+    source_key_hash TEXT NOT NULL,
+    attachment_id TEXT NOT NULL,
+    source_relative_path TEXT NOT NULL,
+    source_path_hash TEXT NOT NULL,
+    source_blob_hash TEXT NOT NULL,
+    source_size_bytes BIGINT NOT NULL,
+    source_modified_ns BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (dataset_id, bootstrap_id, source_key_hash),
+    CHECK (length(dataset_id) > 0),
+    CHECK (length(bootstrap_id) BETWEEN 1 AND 128),
+    CHECK (source_key_hash ~ '^sha256:[0-9a-f]{64}$'),
+    CHECK (attachment_id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'),
+    CHECK (length(source_relative_path) BETWEEN 1 AND 4096),
+    CHECK (source_path_hash ~ '^sha256:[0-9a-f]{64}$'),
+    CHECK (source_path_hash = source_key_hash),
+    CHECK (source_blob_hash ~ '^sha256:[0-9a-f]{64}$'),
+    CHECK (source_size_bytes > 0),
+    CHECK (source_modified_ns >= 0)
+);
+CREATE INDEX IF NOT EXISTS idx_sync_notes_attachment_cleanup_page
+    ON sync_notes_attachment_cleanup_candidates(
+        dataset_id, bootstrap_id, source_key_hash
+    );
 
 CREATE TABLE IF NOT EXISTS sync_blob_upload_sessions (
     upload_id TEXT PRIMARY KEY,
@@ -1650,6 +1775,36 @@ def _storage_namespace_from_row(row: dict[str, Any]) -> SyncDatasetStorageNamesp
     )
 
 
+def _notes_attachment_source_map_from_row(
+    row: dict[str, Any],
+) -> SyncNotesAttachmentSourceMap:
+    return SyncNotesAttachmentSourceMap(
+        dataset_id=row["dataset_id"],
+        bootstrap_id=row["bootstrap_id"],
+        source_key_hash=row["source_key_hash"],
+        note_id=row["note_id"],
+        attachment_id=row["attachment_id"],
+        created_at=_timestamp_to_string(row.get("created_at")) or "",
+    )
+
+
+def _notes_attachment_cleanup_candidate_from_row(
+    row: dict[str, Any],
+) -> SyncNotesAttachmentCleanupCandidate:
+    return SyncNotesAttachmentCleanupCandidate(
+        dataset_id=row["dataset_id"],
+        bootstrap_id=row["bootstrap_id"],
+        source_key_hash=row["source_key_hash"],
+        attachment_id=row["attachment_id"],
+        source_relative_path=row["source_relative_path"],
+        source_path_hash=row["source_path_hash"],
+        source_blob_hash=row["source_blob_hash"],
+        source_size_bytes=int(row["source_size_bytes"]),
+        source_modified_ns=int(row["source_modified_ns"]),
+        created_at=_timestamp_to_string(row.get("created_at")) or "",
+    )
+
+
 def _object_state_from_row(row: dict[str, Any]) -> SyncObjectState:
     return SyncObjectState(
         dataset_id=row["dataset_id"],
@@ -2132,6 +2287,7 @@ class SyncDatabase:
             if self.backend.table_exists("sync_key_records", connection=conn):
                 self._ensure_key_record_user_id_column(connection=conn)
                 self._ensure_key_record_rotation_columns(connection=conn)
+            self._preflight_notes_attachment_bootstrap_tables(connection=conn)
             self.backend.create_tables(schema, connection=conn)
             self._ensure_device_lifecycle_columns(connection=conn)
             self._ensure_device_lifecycle_tables(connection=conn)
@@ -2143,6 +2299,7 @@ class SyncDatabase:
             )
             self._ensure_sync_materialization_locks_table(connection=conn)
             self._ensure_attachment_binding_tables(connection=conn)
+            self._ensure_notes_attachment_bootstrap_tables(connection=conn)
             self._ensure_envelope_m1_indexes(connection=conn)
             self._ensure_conflict_indexes(connection=conn)
             self._ensure_key_record_user_id_column(connection=conn)
@@ -4768,6 +4925,421 @@ class SyncDatabase:
             if updated is None:
                 raise SyncStoreError("Sync dataset link bootstrap transition was not persisted")
             return _dataset_from_row(updated)
+
+    @staticmethod
+    def _validate_notes_attachment_bootstrap_id(bootstrap_id: str) -> None:
+        if (
+            not isinstance(bootstrap_id, str)
+            or not bootstrap_id.strip()
+            or bootstrap_id != bootstrap_id.strip()
+            or len(bootstrap_id.encode("utf-8")) > 128
+        ):
+            raise SyncStoreError("Notes attachment bootstrap ID is invalid")
+
+    @staticmethod
+    def _notes_attachment_source_hash(source_key: str) -> str:
+        if not isinstance(source_key, str) or not source_key:
+            raise SyncStoreError("Notes attachment source key is invalid")
+        if len(source_key.encode("utf-8")) > 4_096:
+            raise SyncStoreError("Notes attachment source key is too large")
+        path = PurePosixPath(source_key)
+        if (
+            path.is_absolute()
+            or "\\" in source_key
+            or any(part in {"", ".", ".."} for part in path.parts)
+        ):
+            raise SyncStoreError("Notes attachment source key is invalid")
+        return f"sha256:{hashlib.sha256(source_key.encode('utf-8')).hexdigest()}"
+
+    @staticmethod
+    def _notes_attachment_bootstrap_metadata(
+        row: Mapping[str, Any],
+        bootstrap_id: str,
+    ) -> tuple[dict[str, Any], Mapping[str, Any]]:
+        metadata = decode_json(row.get("metadata_json"), default={})
+        current = metadata.get("notes_attachment_v2")
+        if not isinstance(current, Mapping) or current.get("bootstrap_id") != bootstrap_id:
+            raise SyncStoreError("notes_attachment_bootstrap_compare_and_set_failed")
+        return metadata, current
+
+    def begin_notes_attachment_bootstrap(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+    ) -> SyncDataset:
+        """Enroll attachment.ref v2 and establish one stable bootstrap identity."""
+
+        self._validate_notes_attachment_bootstrap_id(bootstrap_id)
+        with self.backend.transaction() as conn:
+            row = self._require_dataset_owner_for_update(
+                dataset_id,
+                owner_user_id,
+                connection=conn,
+            )
+            if row.get("scope_type") != "personal":
+                raise SyncStoreError("Sync dataset was not found or is not accessible")
+            metadata = decode_json(row.get("metadata_json"), default={})
+            current = metadata.get("notes_attachment_v2")
+            if isinstance(current, Mapping):
+                if (
+                    current.get("state") not in {"initializing", "ready", "failed"}
+                    or current.get("target_adapter_version") != 2
+                    or not isinstance(current.get("bootstrap_id"), str)
+                ):
+                    raise SyncStoreError("notes_attachment_bootstrap_state_invalid")
+                return _dataset_from_row(row)
+            enrolled = list(decode_json(row.get("domain_set_json"), default=[]))
+            if "notes.note" not in enrolled:
+                raise SyncStoreError("notes_attachment_note_domain_missing")
+            if "attachment.ref" not in enrolled:
+                enrolled.append("attachment.ref")
+            metadata["notes_attachment_v2"] = {
+                "bootstrap_id": bootstrap_id,
+                "state": "initializing",
+                "target_adapter_version": 2,
+                "captured_count": 0,
+                "expected_count": 0,
+                "source_hash": None,
+                "source_cursor": None,
+                "error_code": None,
+            }
+            self.execute(
+                "UPDATE sync_datasets SET domain_set_json = ?, metadata_json = ?, "
+                "updated_at = ? WHERE dataset_id = ? AND owner_user_id = ?",
+                (
+                    encode_json(enrolled, default=[]),
+                    encode_json(metadata, default={}),
+                    utcnow_iso(),
+                    dataset_id,
+                    owner_user_id,
+                ),
+                connection=conn,
+            )
+            self._ensure_domain_state(
+                dataset_id=dataset_id,
+                domain="attachment.ref",
+                adapter_version=2,
+                server_sequence=0,
+                connection=conn,
+            )
+            updated = self._get_dataset_row(dataset_id, connection=conn)
+            if updated is None:
+                raise SyncStoreError("Sync dataset attachment bootstrap was not persisted")
+            return _dataset_from_row(updated)
+
+    def transition_notes_attachment_bootstrap(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+        expected_state: str,
+        state: str,
+        captured_count: int,
+        expected_count: int,
+        source_hash: str | None,
+        source_cursor: str | None,
+        error_code: str | None = None,
+        ready_verifier: Callable[[], bool] | None = None,
+    ) -> SyncDataset:
+        """Compare-and-set one durable attachment bootstrap transition."""
+
+        self._validate_notes_attachment_bootstrap_id(bootstrap_id)
+        valid_states = {"initializing", "ready", "failed"}
+        if expected_state not in valid_states or state not in valid_states:
+            raise SyncStoreError("Notes attachment bootstrap state is invalid")
+        if (
+            isinstance(captured_count, bool)
+            or isinstance(expected_count, bool)
+            or captured_count < 0
+            or expected_count < 0
+            or captured_count > expected_count
+        ):
+            raise SyncStoreError("Notes attachment bootstrap counts are invalid")
+        if source_hash is not None and re.fullmatch(r"[0-9a-f]{64}", source_hash) is None:
+            raise SyncStoreError("Notes attachment bootstrap source hash is invalid")
+        if source_cursor is not None and (
+            not isinstance(source_cursor, str)
+            or len(source_cursor.encode("utf-8")) > 64 * 1_024
+        ):
+            raise SyncStoreError("Notes attachment bootstrap cursor is invalid")
+        if state == "failed":
+            if error_code is None or re.fullmatch(r"[a-z][a-z0-9_]{0,127}", error_code) is None:
+                raise SyncStoreError("Notes attachment bootstrap failure code is invalid")
+        elif error_code is not None:
+            raise SyncStoreError("Notes attachment bootstrap failure code is invalid")
+        with self.backend.transaction() as conn:
+            row = self._require_dataset_owner_for_update(
+                dataset_id,
+                owner_user_id,
+                connection=conn,
+            )
+            metadata, current = self._notes_attachment_bootstrap_metadata(
+                row,
+                bootstrap_id,
+            )
+            if current.get("state") != expected_state:
+                raise SyncStoreError("notes_attachment_bootstrap_compare_and_set_failed")
+            if (
+                current.get("target_adapter_version") != 2
+                or "attachment.ref" not in _dataset_domains_from_row(row)
+            ):
+                raise SyncStoreError("notes_attachment_bootstrap_state_invalid")
+            current_captured = current.get("captured_count")
+            current_expected = current.get("expected_count")
+            if (
+                not isinstance(current_captured, int)
+                or isinstance(current_captured, bool)
+                or captured_count < current_captured
+                or not isinstance(current_expected, int)
+                or isinstance(current_expected, bool)
+                or (current_expected != 0 and expected_count != current_expected)
+            ):
+                raise SyncStoreError("notes_attachment_bootstrap_progress_regressed")
+            current_hash = current.get("source_hash")
+            if current_hash not in {None, source_hash}:
+                raise SyncStoreError("notes_attachment_bootstrap_source_changed")
+            if state == "ready":
+                if (
+                    source_hash is None
+                    or captured_count != expected_count
+                    or ready_verifier is None
+                    or not ready_verifier()
+                ):
+                    raise SyncStoreError("notes_attachment_bootstrap_verification_failed")
+                undrained = _first(
+                    self.execute(
+                        "SELECT COUNT(*) AS count FROM sync_envelopes "
+                        "WHERE dataset_id = ? AND domain = 'attachment.ref' "
+                        "AND status = 'accepted' "
+                        "AND apply_status NOT IN ('applied', 'superseded')",
+                        (dataset_id,),
+                        connection=conn,
+                    )
+                )
+                if undrained is None or int(undrained.get("count") or 0) != 0:
+                    raise SyncStoreError("notes_attachment_bootstrap_verification_failed")
+            metadata["notes_attachment_v2"] = {
+                "bootstrap_id": bootstrap_id,
+                "state": state,
+                "target_adapter_version": 2,
+                "captured_count": captured_count,
+                "expected_count": expected_count,
+                "source_hash": source_hash,
+                "source_cursor": source_cursor,
+                "error_code": error_code,
+            }
+            self.execute(
+                "UPDATE sync_datasets SET metadata_json = ?, updated_at = ? "
+                "WHERE dataset_id = ? AND owner_user_id = ?",
+                (
+                    encode_json(metadata, default={}),
+                    utcnow_iso(),
+                    dataset_id,
+                    owner_user_id,
+                ),
+                connection=conn,
+            )
+            updated = self._get_dataset_row(dataset_id, connection=conn)
+            if updated is None:
+                raise SyncStoreError("Sync dataset attachment bootstrap transition was not persisted")
+            return _dataset_from_row(updated)
+
+    def resolve_notes_attachment_source_map(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+        note_id: str,
+        source_key: str,
+    ) -> SyncNotesAttachmentSourceMap:
+        """Allocate one immutable UUIDv4 for one hashed bootstrap source key."""
+
+        self._validate_notes_attachment_bootstrap_id(bootstrap_id)
+        if not isinstance(note_id, str) or not note_id.strip():
+            raise SyncStoreError("Notes attachment source note ID is invalid")
+        source_key_hash = self._notes_attachment_source_hash(source_key)
+        with self.backend.transaction() as conn:
+            row = self._require_dataset_owner_for_update(
+                dataset_id,
+                owner_user_id,
+                connection=conn,
+            )
+            self._notes_attachment_bootstrap_metadata(row, bootstrap_id)
+            existing = _first(
+                self.execute(
+                    "SELECT * FROM sync_notes_attachment_source_map "
+                    "WHERE dataset_id = ? AND bootstrap_id = ? AND source_key_hash = ?",
+                    (dataset_id, bootstrap_id, source_key_hash),
+                    connection=conn,
+                )
+            )
+            if existing is not None:
+                if existing.get("note_id") != note_id:
+                    raise SyncStoreError("notes_attachment_source_map_identity_conflict")
+                return _notes_attachment_source_map_from_row(existing)
+            self.execute(
+                "INSERT INTO sync_notes_attachment_source_map "
+                "(dataset_id, bootstrap_id, source_key_hash, note_id, attachment_id, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    dataset_id,
+                    bootstrap_id,
+                    source_key_hash,
+                    note_id,
+                    str(uuid4()),
+                    utcnow_iso(),
+                ),
+                connection=conn,
+            )
+            created = _first(
+                self.execute(
+                    "SELECT * FROM sync_notes_attachment_source_map "
+                    "WHERE dataset_id = ? AND bootstrap_id = ? AND source_key_hash = ?",
+                    (dataset_id, bootstrap_id, source_key_hash),
+                    connection=conn,
+                )
+            )
+            if created is None:
+                raise SyncStoreError("Notes attachment source map was not persisted")
+            return _notes_attachment_source_map_from_row(created)
+
+    def record_notes_attachment_cleanup_candidate(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+        source_key: str,
+        source_relative_path: str,
+        source_blob_hash: str,
+        source_size_bytes: int,
+        source_modified_ns: int,
+    ) -> SyncNotesAttachmentCleanupCandidate:
+        """Persist immutable, non-authoritative cleanup evidence for one source."""
+
+        self._validate_notes_attachment_bootstrap_id(bootstrap_id)
+        source_key_hash = self._notes_attachment_source_hash(source_key)
+        source_path_hash = self._notes_attachment_source_hash(source_relative_path)
+        if source_path_hash != source_key_hash:
+            raise SyncStoreError("Notes attachment cleanup source path does not match")
+        if re.fullmatch(r"sha256:[0-9a-f]{64}", source_blob_hash) is None:
+            raise SyncStoreError("Notes attachment cleanup blob hash is invalid")
+        if (
+            isinstance(source_size_bytes, bool)
+            or source_size_bytes < 1
+            or isinstance(source_modified_ns, bool)
+            or source_modified_ns < 0
+        ):
+            raise SyncStoreError("Notes attachment cleanup source stat is invalid")
+        with self.backend.transaction() as conn:
+            row = self._require_dataset_owner_for_update(
+                dataset_id,
+                owner_user_id,
+                connection=conn,
+            )
+            self._notes_attachment_bootstrap_metadata(row, bootstrap_id)
+            mapping = _first(
+                self.execute(
+                    "SELECT * FROM sync_notes_attachment_source_map "
+                    "WHERE dataset_id = ? AND bootstrap_id = ? AND source_key_hash = ?",
+                    (dataset_id, bootstrap_id, source_key_hash),
+                    connection=conn,
+                )
+            )
+            if mapping is None:
+                raise SyncStoreError("notes_attachment_source_map_missing")
+            existing = _first(
+                self.execute(
+                    "SELECT * FROM sync_notes_attachment_cleanup_candidates "
+                    "WHERE dataset_id = ? AND bootstrap_id = ? AND source_key_hash = ?",
+                    (dataset_id, bootstrap_id, source_key_hash),
+                    connection=conn,
+                )
+            )
+            expected = {
+                "attachment_id": mapping["attachment_id"],
+                "source_relative_path": source_relative_path,
+                "source_path_hash": source_path_hash,
+                "source_blob_hash": source_blob_hash,
+                "source_size_bytes": source_size_bytes,
+                "source_modified_ns": source_modified_ns,
+            }
+            if existing is not None:
+                if any(existing.get(key) != value for key, value in expected.items()):
+                    raise SyncStoreError("notes_attachment_cleanup_candidate_conflict")
+                return _notes_attachment_cleanup_candidate_from_row(existing)
+            self.execute(
+                "INSERT INTO sync_notes_attachment_cleanup_candidates "
+                "(dataset_id, bootstrap_id, source_key_hash, attachment_id, "
+                "source_relative_path, source_path_hash, source_blob_hash, "
+                "source_size_bytes, source_modified_ns, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    dataset_id,
+                    bootstrap_id,
+                    source_key_hash,
+                    mapping["attachment_id"],
+                    source_relative_path,
+                    source_path_hash,
+                    source_blob_hash,
+                    source_size_bytes,
+                    source_modified_ns,
+                    utcnow_iso(),
+                ),
+                connection=conn,
+            )
+            created = _first(
+                self.execute(
+                    "SELECT * FROM sync_notes_attachment_cleanup_candidates "
+                    "WHERE dataset_id = ? AND bootstrap_id = ? AND source_key_hash = ?",
+                    (dataset_id, bootstrap_id, source_key_hash),
+                    connection=conn,
+                )
+            )
+            if created is None:
+                raise SyncStoreError("Notes attachment cleanup candidate was not persisted")
+            return _notes_attachment_cleanup_candidate_from_row(created)
+
+    def list_notes_attachment_cleanup_candidates(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+        after_source_key_hash: str | None = None,
+        limit: int = 1_000,
+    ) -> tuple[SyncNotesAttachmentCleanupCandidate, ...]:
+        """Return one bounded owner-scoped cleanup-candidate keyset page."""
+
+        self._validate_notes_attachment_bootstrap_id(bootstrap_id)
+        if isinstance(limit, bool) or not 1 <= limit <= 1_000:
+            raise ValueError("cleanup candidate page limit must be 1..1000")
+        if after_source_key_hash is not None and re.fullmatch(
+            r"sha256:[0-9a-f]{64}", after_source_key_hash
+        ) is None:
+            raise ValueError("cleanup candidate cursor is invalid")
+        with self.backend.transaction() as conn:
+            row = self._require_attachment_binding_dataset_owner(
+                dataset_id,
+                owner_user_id,
+                connection=conn,
+            )
+            self._notes_attachment_bootstrap_metadata(row, bootstrap_id)
+            cursor = after_source_key_hash or ""
+            rows = self.execute(
+                "SELECT * FROM sync_notes_attachment_cleanup_candidates "
+                "WHERE dataset_id = ? AND bootstrap_id = ? AND source_key_hash > ? "
+                "ORDER BY source_key_hash LIMIT ?",
+                (dataset_id, bootstrap_id, cursor, limit),
+                connection=conn,
+            ).rows
+            return tuple(
+                _notes_attachment_cleanup_candidate_from_row(item) for item in rows
+            )
 
     def _find_existing_envelope_for_idempotency(
         self,
@@ -10156,6 +10728,307 @@ class SyncDatabase:
                 connection=connection,
                 canonical_schema=schema,
             )
+
+    def _ensure_notes_attachment_bootstrap_tables(self, *, connection: Any) -> None:
+        """Verify bounded legacy-source identity and cleanup evidence authority."""
+
+        if self.backend_type == BackendType.POSTGRESQL:
+            self._verify_notes_attachment_bootstrap_tables_postgres(
+                connection=connection,
+            )
+        else:
+            self._verify_notes_attachment_bootstrap_tables_sqlite(
+                connection=connection,
+                canonical_schema=SYNC_SQLITE_SCHEMA,
+                verify_indexes=True,
+            )
+
+    def _preflight_notes_attachment_bootstrap_tables(self, *, connection: Any) -> None:
+        """Reject partial or malformed pre-existing bootstrap authority."""
+
+        table_names = (
+            "sync_notes_attachment_source_map",
+            "sync_notes_attachment_cleanup_candidates",
+        )
+        existing = [
+            self.backend.table_exists(table_name, connection=connection)
+            for table_name in table_names
+        ]
+        if not any(existing):
+            return
+        if not all(existing):
+            raise SyncStoreError("Sync attachment bootstrap catalog is malformed")
+        self._ensure_notes_attachment_bootstrap_tables(connection=connection)
+
+    def _verify_notes_attachment_bootstrap_tables_sqlite(
+        self,
+        *,
+        connection: Any,
+        canonical_schema: str,
+        verify_indexes: bool,
+    ) -> None:
+        expected_columns = {
+            "sync_notes_attachment_source_map": [
+                ("dataset_id", "TEXT", 1, 1),
+                ("bootstrap_id", "TEXT", 1, 2),
+                ("source_key_hash", "TEXT", 1, 3),
+                ("note_id", "TEXT", 1, 0),
+                ("attachment_id", "TEXT", 1, 0),
+                ("created_at", "TEXT", 1, 0),
+            ],
+            "sync_notes_attachment_cleanup_candidates": [
+                ("dataset_id", "TEXT", 1, 1),
+                ("bootstrap_id", "TEXT", 1, 2),
+                ("source_key_hash", "TEXT", 1, 3),
+                ("attachment_id", "TEXT", 1, 0),
+                ("source_relative_path", "TEXT", 1, 0),
+                ("source_path_hash", "TEXT", 1, 0),
+                ("source_blob_hash", "TEXT", 1, 0),
+                ("source_size_bytes", "INTEGER", 1, 0),
+                ("source_modified_ns", "INTEGER", 1, 0),
+                ("created_at", "TEXT", 1, 0),
+            ],
+        }
+        expected_table_sql: dict[str, str] = {}
+        for statement in canonical_schema.split(";"):
+            compact = self._compact_catalog_sql(statement)
+            for table_name in expected_columns:
+                if f"createtableifnotexists{table_name}(" in compact:
+                    expected_table_sql[table_name] = compact.replace(
+                        "createtableifnotexists",
+                        "createtable",
+                        1,
+                    )
+        for table_name, expected in expected_columns.items():
+            actual = [
+                (row["name"], row["type"], int(row["notnull"]), int(row["pk"]))
+                for row in self.execute(
+                    f"PRAGMA table_info({table_name})",  # nosec B608 - fixed names.
+                    connection=connection,
+                ).rows
+            ]
+            table_row = _first(
+                self.execute(
+                    "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+                    (table_name,),
+                    connection=connection,
+                )
+            )
+            table_sql = self._compact_catalog_sql(
+                None if table_row is None else table_row.get("sql")
+            )
+            if actual != expected or table_sql != expected_table_sql.get(table_name):
+                raise SyncStoreError("Sync attachment bootstrap catalog is malformed")
+        if not verify_indexes:
+            return
+        rows = self.execute(
+            "SELECT name, sql FROM sqlite_master WHERE type = 'index' "
+            "AND name IN (?, ?) ORDER BY name",
+            (
+                "idx_sync_notes_attachment_cleanup_page",
+                "uq_sync_notes_attachment_source_id",
+            ),
+            connection=connection,
+        ).rows
+        actual_indexes = {
+            row["name"]: self._compact_catalog_sql(row["sql"]) for row in rows
+        }
+        expected_indexes = {
+            "idx_sync_notes_attachment_cleanup_page": "createindexidx_sync_notes_attachment_cleanup_pageonsync_notes_attachment_cleanup_candidates(dataset_id,bootstrap_id,source_key_hash)",
+            "uq_sync_notes_attachment_source_id": "createuniqueindexuq_sync_notes_attachment_source_idonsync_notes_attachment_source_map(dataset_id,attachment_id)",
+        }
+        if actual_indexes != expected_indexes:
+            raise SyncStoreError("Sync attachment bootstrap catalog is malformed")
+
+    def _verify_notes_attachment_bootstrap_tables_postgres(
+        self,
+        *,
+        connection: Any,
+    ) -> None:
+        expected_columns = {
+            "sync_notes_attachment_cleanup_candidates": [
+                ("dataset_id", "text", True),
+                ("bootstrap_id", "text", True),
+                ("source_key_hash", "text", True),
+                ("attachment_id", "text", True),
+                ("source_relative_path", "text", True),
+                ("source_path_hash", "text", True),
+                ("source_blob_hash", "text", True),
+                ("source_size_bytes", "bigint", True),
+                ("source_modified_ns", "bigint", True),
+                ("created_at", "timestamp with time zone", True),
+            ],
+            "sync_notes_attachment_source_map": [
+                ("dataset_id", "text", True),
+                ("bootstrap_id", "text", True),
+                ("source_key_hash", "text", True),
+                ("note_id", "text", True),
+                ("attachment_id", "text", True),
+                ("created_at", "timestamp with time zone", True),
+            ],
+        }
+        rows = self.execute(
+            """
+            SELECT relation.relname AS table_name,
+                   attribute.attname AS column_name,
+                   pg_catalog.format_type(attribute.atttypid, attribute.atttypmod) AS data_type,
+                   attribute.attnotnull AS is_not_null
+              FROM pg_catalog.pg_class AS relation
+              JOIN pg_catalog.pg_namespace AS namespace
+                ON namespace.oid = relation.relnamespace
+              JOIN pg_catalog.pg_attribute AS attribute
+                ON attribute.attrelid = relation.oid
+             WHERE namespace.nspname = current_schema()
+               AND relation.relname IN (
+                    'sync_notes_attachment_source_map',
+                    'sync_notes_attachment_cleanup_candidates'
+               )
+               AND relation.relkind = 'r'
+               AND attribute.attnum > 0
+               AND NOT attribute.attisdropped
+             ORDER BY relation.relname, attribute.attnum
+            """,
+            connection=connection,
+        ).rows
+        actual_columns = {name: [] for name in expected_columns}
+        for row in rows:
+            actual_columns[row["table_name"]].append(
+                (row["column_name"], row["data_type"], bool(row["is_not_null"]))
+            )
+        if actual_columns != expected_columns:
+            raise SyncStoreError("Sync attachment bootstrap catalog is malformed")
+        constraints = self.execute(
+            """
+            SELECT relation.relname AS table_name,
+                   constraint_record.contype AS kind,
+                   constraint_record.convalidated AS is_validated,
+                   pg_catalog.pg_get_constraintdef(
+                       constraint_record.oid, true
+                   ) AS definition
+              FROM pg_catalog.pg_constraint AS constraint_record
+              JOIN pg_catalog.pg_class AS relation
+                ON relation.oid = constraint_record.conrelid
+              JOIN pg_catalog.pg_namespace AS namespace
+                ON namespace.oid = relation.relnamespace
+             WHERE namespace.nspname = current_schema()
+               AND relation.relname IN (
+                    'sync_notes_attachment_source_map',
+                    'sync_notes_attachment_cleanup_candidates'
+               )
+               AND constraint_record.contype IN ('p', 'c')
+             ORDER BY relation.relname,
+                      constraint_record.contype,
+                      constraint_record.conname
+            """,
+            connection=connection,
+        ).rows
+        uuid_definition = (
+            "checkattachment_id~"
+            "'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-"
+            "[89ab][0-9a-f]{3}-[0-9a-f]{12}$'"
+        )
+        expected_constraints = {
+            "sync_notes_attachment_source_map": {
+                ("p", "primarykeydataset_id,bootstrap_id,source_key_hash"),
+                ("c", "checklengthdataset_id>0"),
+                (
+                    "c",
+                    "checklengthbootstrap_id>=1andlengthbootstrap_id<=128",
+                ),
+                ("c", "checksource_key_hash~'^sha256:[0-9a-f]{64}$'"),
+                ("c", "checklengthnote_id>0"),
+                ("c", uuid_definition),
+            },
+            "sync_notes_attachment_cleanup_candidates": {
+                ("p", "primarykeydataset_id,bootstrap_id,source_key_hash"),
+                ("c", "checklengthdataset_id>0"),
+                (
+                    "c",
+                    "checklengthbootstrap_id>=1andlengthbootstrap_id<=128",
+                ),
+                ("c", "checksource_key_hash~'^sha256:[0-9a-f]{64}$'"),
+                ("c", uuid_definition),
+                (
+                    "c",
+                    "checklengthsource_relative_path>=1and"
+                    "lengthsource_relative_path<=4096",
+                ),
+                ("c", "checksource_path_hash~'^sha256:[0-9a-f]{64}$'"),
+                ("c", "checksource_path_hash=source_key_hash"),
+                ("c", "checksource_blob_hash~'^sha256:[0-9a-f]{64}$'"),
+                ("c", "checksource_size_bytes>0"),
+                ("c", "checksource_modified_ns>=0"),
+            },
+        }
+        actual_constraints = {
+            table_name: {
+                (
+                    str(row["kind"]),
+                    self._compact_postgres_catalog_sql(row["definition"]),
+                )
+                for row in constraints
+                if row["table_name"] == table_name
+                and bool(row["is_validated"])
+            }
+            for table_name in expected_constraints
+        }
+        if actual_constraints != expected_constraints or not all(
+            bool(row["is_validated"]) for row in constraints
+        ):
+            raise SyncStoreError("Sync attachment bootstrap catalog is malformed")
+        indexes = self.execute(
+            """
+            SELECT index_relation.relname AS index_name,
+                   table_relation.relname AS table_name,
+                   index_record.indisunique AS is_unique,
+                   index_record.indisvalid AS is_valid,
+                   index_record.indisready AS is_ready,
+                   pg_catalog.pg_get_indexdef(index_record.indexrelid) AS definition
+              FROM pg_catalog.pg_index AS index_record
+              JOIN pg_catalog.pg_class AS index_relation
+                ON index_relation.oid = index_record.indexrelid
+              JOIN pg_catalog.pg_class AS table_relation
+                ON table_relation.oid = index_record.indrelid
+              JOIN pg_catalog.pg_namespace AS namespace
+                ON namespace.oid = table_relation.relnamespace
+             WHERE namespace.nspname = current_schema()
+               AND index_relation.relname IN (
+                    'idx_sync_notes_attachment_cleanup_page',
+                    'uq_sync_notes_attachment_source_id'
+               )
+             ORDER BY index_relation.relname
+            """,
+            connection=connection,
+        ).rows
+        expected_indexes = {
+            "idx_sync_notes_attachment_cleanup_page": (
+                "sync_notes_attachment_cleanup_candidates",
+                False,
+                "dataset_id,bootstrap_id,source_key_hash",
+            ),
+            "uq_sync_notes_attachment_source_id": (
+                "sync_notes_attachment_source_map",
+                True,
+                "dataset_id,attachment_id",
+            ),
+        }
+        if {row["index_name"] for row in indexes} != set(expected_indexes):
+            raise SyncStoreError("Sync attachment bootstrap catalog is malformed")
+        for row in indexes:
+            table_name, unique, columns = expected_indexes[row["index_name"]]
+            definition = self._compact_postgres_catalog_sql(row["definition"])
+            try:
+                definition_tail = definition.split("usingbtree", 1)[1]
+            except IndexError:
+                definition_tail = ""
+            if (
+                row["table_name"] != table_name
+                or bool(row["is_unique"]) != unique
+                or not row["is_valid"]
+                or not row["is_ready"]
+                or definition_tail != columns
+            ):
+                raise SyncStoreError("Sync attachment bootstrap catalog is malformed")
 
     @staticmethod
     def _compact_catalog_sql(value: Any) -> str:

--- a/tldw_Server_API/app/core/DB_Management/chacha/note_attachment_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/note_attachment_store.py
@@ -405,6 +405,7 @@ class NoteAttachmentStore:
         last_modified: str,
         created_by: str,
         source_kind: str,
+        allow_deleted_note: bool = False,
         conn: Any | None = None,
     ) -> NoteAttachment:
         """Create a live revision-one attachment for one owned note."""
@@ -425,7 +426,11 @@ class NoteAttachmentStore:
         context = nullcontext(conn) if conn is not None else self._db.transaction()
         try:
             with context as transaction_conn:
-                self._require_owned_note(transaction_conn, note_id, allow_deleted=False)
+                self._require_owned_note(
+                    transaction_conn,
+                    note_id,
+                    allow_deleted=allow_deleted_note,
+                )
                 transaction_conn.execute(
                     "INSERT INTO note_attachments("
                     "client_id, dataset_id, attachment_id, note_id, file_name, "

--- a/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
@@ -748,6 +748,36 @@ class NoteStore:
         cursor = self._db.execute_query(query, tuple(params))
         return [dict(row) for row in cursor.fetchall()]
 
+    def list_note_ids_page(
+        self,
+        *,
+        after_note_id: str | None,
+        limit: int,
+    ) -> tuple[str, ...]:
+        """List owned note IDs, including trash, in stable keyset order."""
+
+        if not 1 <= limit <= 200:
+            raise ValueError("note page limit must be 1..200")
+        query = "SELECT id FROM notes WHERE id > ?"
+        params: list[Any] = [after_note_id or ""]
+        if self._db.backend_type == BackendType.POSTGRESQL:
+            query += " AND client_id = ?"
+            params.append(self._db.client_id)
+        query += " ORDER BY id LIMIT ?"
+        params.append(limit)
+        rows = self._db.execute_query(query, tuple(params)).fetchall()
+        return tuple(str(row["id"]) for row in rows)
+
+    def owns_note_id(self, note_id: str) -> bool:
+        """Return whether this database owner has the note, including trash."""
+
+        query = "SELECT 1 FROM notes WHERE id = ?"
+        params: list[Any] = [note_id]
+        if self._db.backend_type == BackendType.POSTGRESQL:
+            query += " AND client_id = ?"
+            params.append(self._db.client_id)
+        return self._db.execute_query(query, tuple(params)).fetchone() is not None
+
     def list_deleted_notes(self, limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
         """List only soft-deleted notes (trash)."""
         return self.list_notes(limit=limit, offset=offset, only_deleted=True)

--- a/tldw_Server_API/app/core/Notes/legacy_attachment_source.py
+++ b/tldw_Server_API/app/core/Notes/legacy_attachment_source.py
@@ -1,0 +1,323 @@
+"""Bounded, read-only access to legacy Notes attachment files."""
+
+from __future__ import annotations
+
+import hashlib
+import heapq
+import json
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.exceptions import LegacyAttachmentSourceError
+from tldw_Server_API.app.core.Utils.Utils import sanitize_filename
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+LEGACY_ATTACHMENTS_DIRNAME = "notes_attachments"
+LEGACY_ATTACHMENT_META_SUFFIX = ".meta.json"
+LEGACY_ATTACHMENT_NOTE_PAGE_LIMIT = 200
+LEGACY_ATTACHMENT_CANDIDATE_LIMIT = 1_000
+LEGACY_ATTACHMENT_SIDECAR_LIMIT_BYTES = 64 * 1024
+LEGACY_ATTACHMENT_CURSOR_LIMIT_BYTES = 4_096
+_READ_CHUNK_BYTES = 64 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyAttachmentCandidate:
+    """Immutable snapshot of one confined legacy attachment source."""
+
+    note_id: str
+    file_name: str
+    source_key: str
+    relative_path: str
+    size_bytes: int
+    modified_ns: int
+    sha256: str
+    metadata: dict[str, Any]
+
+
+def safe_legacy_note_attachment_dirname(note_id: str) -> str:
+    """Derive the existing legacy directory name from an authoritative note ID."""
+
+    text = str(note_id or "").strip()
+    if not text:
+        return "note"
+    safe = sanitize_filename(text, max_total_length=96).replace(" ", "_").strip("._")
+    if safe and safe not in {".", ".."}:
+        return safe
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+    return f"note_{digest}"
+
+
+def legacy_attachment_base_directory(
+    user_id: int | str,
+    *,
+    user_root: Path | None = None,
+) -> Path:
+    """Return the legacy attachment root without creating it."""
+
+    root = (
+        Path(user_root)
+        if user_root is not None
+        else DatabasePaths.resolve_user_base_directory(user_id)
+    ).absolute()
+    return root / LEGACY_ATTACHMENTS_DIRNAME
+
+
+def legacy_attachment_note_directory(
+    user_id: int | str,
+    note_id: str,
+    *,
+    user_root: Path | None = None,
+) -> Path:
+    """Return the lexically confined legacy directory for an owned note ID."""
+
+    base = legacy_attachment_base_directory(user_id, user_root=user_root)
+    note_dir = base / safe_legacy_note_attachment_dirname(note_id)
+    if not note_dir.absolute().is_relative_to(base.absolute()):
+        raise LegacyAttachmentSourceError("notes_attachment_source_unsafe")
+    return note_dir
+
+
+def legacy_attachment_metadata_path(file_path: Path) -> Path:
+    """Return the legacy sidecar path for an attachment path."""
+
+    return file_path.with_name(f"{file_path.name}{LEGACY_ATTACHMENT_META_SUFFIX}")
+
+
+class LegacyAttachmentSource:
+    """Enumerate and hash owned legacy attachment files without mutating them."""
+
+    def __init__(
+        self,
+        note_db: CharactersRAGDB,
+        *,
+        owner_user_id: str,
+        user_root: Path | None = None,
+    ) -> None:
+        if str(note_db.client_id) != str(owner_user_id):
+            raise LegacyAttachmentSourceError("notes_attachment_source_owner_mismatch")
+        self._notes = note_db.note_store
+        self._owner_user_id = str(owner_user_id)
+        self._user_root = (
+            Path(user_root)
+            if user_root is not None
+            else DatabasePaths.resolve_user_base_directory(owner_user_id)
+        ).absolute()
+        self._base_dir = legacy_attachment_base_directory(
+            owner_user_id,
+            user_root=self._user_root,
+        )
+
+    def note_directory(self, note_id: str) -> Path:
+        """Return the confined legacy directory derived from the owned note ID."""
+
+        return legacy_attachment_note_directory(
+            self._owner_user_id,
+            note_id,
+            user_root=self._user_root,
+        )
+
+    def list_note_ids(
+        self,
+        *,
+        after_note_id: str | None = None,
+        limit: int = LEGACY_ATTACHMENT_NOTE_PAGE_LIMIT,
+    ) -> tuple[str, ...]:
+        """List owned live and soft-deleted note IDs in bounded keyset order."""
+
+        if not 1 <= limit <= LEGACY_ATTACHMENT_NOTE_PAGE_LIMIT:
+            raise ValueError("note page limit must be 1..200")
+        return self._notes.list_note_ids_page(
+            after_note_id=after_note_id,
+            limit=limit,
+        )
+
+    def list_candidates(
+        self,
+        note_id: str,
+        *,
+        after_source_key: str | None = None,
+        limit: int = LEGACY_ATTACHMENT_CANDIDATE_LIMIT,
+    ) -> tuple[LegacyAttachmentCandidate, ...]:
+        """Return a bounded page of sorted, immutable source snapshots."""
+
+        if not 1 <= limit <= LEGACY_ATTACHMENT_CANDIDATE_LIMIT:
+            raise ValueError("candidate limit must be 1..1000")
+        self._validate_cursor(note_id, after_source_key)
+        if not self._notes.owns_note_id(note_id):
+            raise LegacyAttachmentSourceError(
+                "notes_attachment_source_note_not_found"
+            )
+        note_dir = self.note_directory(note_id)
+        if not note_dir.exists():
+            return ()
+        base_fd = self._open_directory(self._base_dir)
+        try:
+            note_fd = self._open_directory(
+                safe_legacy_note_attachment_dirname(note_id),
+                dir_fd=base_fd,
+            )
+            try:
+                names = heapq.nsmallest(
+                    limit,
+                    self._candidate_names(note_fd, note_id, after_source_key),
+                    key=lambda item: item[0],
+                )
+                return tuple(
+                    self._snapshot_candidate(note_fd, note_id, name, source_key)
+                    for source_key, name in names
+                )
+            finally:
+                os.close(note_fd)
+        finally:
+            os.close(base_fd)
+
+    def _validate_cursor(self, note_id: str, cursor: str | None) -> None:
+        if cursor is None:
+            return
+        if not isinstance(cursor, str):
+            raise LegacyAttachmentSourceError("notes_attachment_source_cursor_invalid")
+        if len(cursor.encode("utf-8")) > LEGACY_ATTACHMENT_CURSOR_LIMIT_BYTES:
+            raise LegacyAttachmentSourceError(
+                "notes_attachment_source_cursor_too_large"
+            )
+        prefix = self._source_prefix(note_id)
+        if not cursor.startswith(prefix) or not cursor.removeprefix(prefix):
+            raise LegacyAttachmentSourceError(
+                "notes_attachment_source_cursor_invalid"
+            )
+
+    def _candidate_names(
+        self,
+        note_fd: int,
+        note_id: str,
+        after_source_key: str | None,
+    ):
+        with os.scandir(note_fd) as entries:
+            for entry in entries:
+                if entry.is_symlink():
+                    raise LegacyAttachmentSourceError(
+                        "notes_attachment_source_unsafe"
+                    )
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                if entry.name.endswith(LEGACY_ATTACHMENT_META_SUFFIX):
+                    continue
+                source_key = self._source_key(note_id, entry.name)
+                if after_source_key is None or source_key > after_source_key:
+                    yield source_key, entry.name
+
+    def _source_key(self, note_id: str, file_name: str) -> str:
+        relative_path = f"{self._source_prefix(note_id)}{file_name}"
+        if len(relative_path.encode("utf-8")) > LEGACY_ATTACHMENT_CURSOR_LIMIT_BYTES:
+            raise LegacyAttachmentSourceError("notes_attachment_source_key_too_large")
+        return relative_path
+
+    @staticmethod
+    def _source_prefix(note_id: str) -> str:
+        return (
+            f"{LEGACY_ATTACHMENTS_DIRNAME}/"
+            f"{safe_legacy_note_attachment_dirname(note_id)}/"
+        )
+
+    def _snapshot_candidate(
+        self,
+        note_fd: int,
+        note_id: str,
+        file_name: str,
+        source_key: str,
+    ) -> LegacyAttachmentCandidate:
+        file_fd = self._open_regular(file_name, dir_fd=note_fd)
+        try:
+            before = os.fstat(file_fd)
+            digest = hashlib.sha256()
+            while chunk := os.read(file_fd, _READ_CHUNK_BYTES):
+                digest.update(chunk)
+            after = os.fstat(file_fd)
+            if self._stat_identity(before) != self._stat_identity(after):
+                raise LegacyAttachmentSourceError("notes_attachment_source_changed")
+        finally:
+            os.close(file_fd)
+        metadata = self._read_sidecar(note_fd, file_name)
+        return LegacyAttachmentCandidate(
+            note_id=note_id,
+            file_name=file_name,
+            source_key=source_key,
+            relative_path=source_key,
+            size_bytes=int(after.st_size),
+            modified_ns=int(after.st_mtime_ns),
+            sha256=f"sha256:{digest.hexdigest()}",
+            metadata=metadata,
+        )
+
+    def _read_sidecar(self, note_fd: int, file_name: str) -> dict[str, Any]:
+        sidecar_name = f"{file_name}{LEGACY_ATTACHMENT_META_SUFFIX}"
+        try:
+            sidecar_fd = self._open_regular(sidecar_name, dir_fd=note_fd)
+        except FileNotFoundError:
+            return {}
+        try:
+            sidecar_stat = os.fstat(sidecar_fd)
+            if sidecar_stat.st_size > LEGACY_ATTACHMENT_SIDECAR_LIMIT_BYTES:
+                raise LegacyAttachmentSourceError(
+                    "notes_attachment_sidecar_too_large"
+                )
+            payload = os.read(
+                sidecar_fd,
+                LEGACY_ATTACHMENT_SIDECAR_LIMIT_BYTES + 1,
+            )
+            if len(payload) > LEGACY_ATTACHMENT_SIDECAR_LIMIT_BYTES:
+                raise LegacyAttachmentSourceError(
+                    "notes_attachment_sidecar_too_large"
+                )
+        finally:
+            os.close(sidecar_fd)
+        try:
+            decoded = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise LegacyAttachmentSourceError(
+                "notes_attachment_sidecar_invalid"
+            ) from exc
+        if not isinstance(decoded, dict):
+            raise LegacyAttachmentSourceError("notes_attachment_sidecar_invalid")
+        return decoded
+
+    @staticmethod
+    def _secure_open_flags(*, directory: bool) -> int:
+        required = ("O_NOFOLLOW", "O_NONBLOCK")
+        if directory:
+            required += ("O_DIRECTORY",)
+        if any(not hasattr(os, name) for name in required):
+            raise LegacyAttachmentSourceError(
+                "notes_attachment_source_platform_unsupported"
+            )
+        flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK
+        if directory:
+            flags |= os.O_DIRECTORY
+        return flags
+
+    @classmethod
+    def _open_directory(cls, path: str | Path, *, dir_fd: int | None = None) -> int:
+        try:
+            return os.open(path, cls._secure_open_flags(directory=True), dir_fd=dir_fd)
+        except (NotADirectoryError, OSError) as exc:
+            raise LegacyAttachmentSourceError("notes_attachment_source_unsafe") from exc
+
+    @classmethod
+    def _open_regular(cls, name: str, *, dir_fd: int) -> int:
+        file_fd = os.open(name, cls._secure_open_flags(directory=False), dir_fd=dir_fd)
+        if not stat.S_ISREG(os.fstat(file_fd).st_mode):
+            os.close(file_fd)
+            raise LegacyAttachmentSourceError("notes_attachment_source_unsafe")
+        return file_fd
+
+    @staticmethod
+    def _stat_identity(value: os.stat_result) -> tuple[int, int, int, int]:
+        return (value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns)

--- a/tldw_Server_API/app/core/Notes/legacy_attachment_source.py
+++ b/tldw_Server_API/app/core/Notes/legacy_attachment_source.py
@@ -7,6 +7,7 @@ import heapq
 import json
 import os
 import stat
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -178,6 +179,69 @@ class LegacyAttachmentSource:
                 os.close(note_fd)
         finally:
             os.close(base_fd)
+
+    def iter_candidate_chunks(
+        self,
+        candidate: LegacyAttachmentCandidate,
+        *,
+        chunk_size: int,
+    ) -> Iterator[bytes]:
+        """Stream one unchanged candidate through confined no-follow descriptors."""
+
+        if chunk_size < 1 or chunk_size > 64 * 1024:
+            raise ValueError("candidate chunk size must be 1..65536")
+        if not self._notes.owns_note_id(candidate.note_id):
+            raise LegacyAttachmentSourceError(
+                "notes_attachment_source_note_not_found"
+            )
+        expected_key = self._source_key(candidate.note_id, candidate.file_name)
+        if candidate.source_key != expected_key or candidate.relative_path != expected_key:
+            raise LegacyAttachmentSourceError("notes_attachment_source_unsafe")
+        base_fd = self._open_directory(self._base_dir)
+        try:
+            note_fd = self._open_directory(
+                safe_legacy_note_attachment_dirname(candidate.note_id),
+                dir_fd=base_fd,
+            )
+            try:
+                file_fd = self._open_regular(candidate.file_name, dir_fd=note_fd)
+                try:
+                    before = os.fstat(file_fd)
+                    if (
+                        int(before.st_size) != candidate.size_bytes
+                        or int(before.st_mtime_ns) != candidate.modified_ns
+                    ):
+                        raise LegacyAttachmentSourceError(
+                            "notes_attachment_source_changed"
+                        )
+                    digest = hashlib.sha256()
+                    while chunk := os.read(file_fd, chunk_size):
+                        digest.update(chunk)
+                        yield chunk
+                    after = os.fstat(file_fd)
+                    if (
+                        self._stat_identity(before) != self._stat_identity(after)
+                        or f"sha256:{digest.hexdigest()}" != candidate.sha256
+                    ):
+                        raise LegacyAttachmentSourceError(
+                            "notes_attachment_source_changed"
+                        )
+                finally:
+                    os.close(file_fd)
+            finally:
+                os.close(note_fd)
+        finally:
+            os.close(base_fd)
+
+    def verify_candidate(self, candidate: LegacyAttachmentCandidate) -> bool:
+        """Re-read and verify one immutable candidate snapshot."""
+
+        for _chunk in self.iter_candidate_chunks(
+            candidate,
+            chunk_size=_READ_CHUNK_BYTES,
+        ):
+            pass
+        return True
 
     def _validate_cursor(self, note_id: str, cursor: str | None) -> None:
         if cursor is None:

--- a/tldw_Server_API/app/core/Sync/v2/factory.py
+++ b/tldw_Server_API/app/core/Sync/v2/factory.py
@@ -44,6 +44,7 @@ from .models import (
     WORKSPACE_SYNC_DOMAINS,
     SyncDomain,
 )
+from .notes_attachment_bootstrap import NotesAttachmentBootstrapper
 from .notes_link_bootstrap import NotesLinkBootstrapper
 from .notes_organization_bootstrap import NotesOrganizationBootstrapper
 from .security import server_trusted_encryption_status_from_env
@@ -124,6 +125,7 @@ def sync_v2_service_for_user(user_id: str) -> SyncV2Service:
         workspace_access_checker=_workspace_access_checker,
         dataset_bootstrapper=NotesOrganizationBootstrapper(note_db),
         notes_link_bootstrapper=NotesLinkBootstrapper(note_db),
+        notes_attachment_bootstrapper=NotesAttachmentBootstrapper(note_db),
     )
 
 

--- a/tldw_Server_API/app/core/Sync/v2/materializers/attachment_refs.py
+++ b/tldw_Server_API/app/core/Sync/v2/materializers/attachment_refs.py
@@ -147,6 +147,9 @@ class AttachmentRefMaterializer:
                         if envelope.device_id == "server-origin"
                         else "sync"
                     ),
+                    allow_deleted_note=(
+                        envelope.routing_metadata.get("bootstrap_capture") is True
+                    ),
                 )
             elif envelope.operation == "tombstone":
                 if not isinstance(payload, AttachmentRefV2TombstonePayload):

--- a/tldw_Server_API/app/core/Sync/v2/models.py
+++ b/tldw_Server_API/app/core/Sync/v2/models.py
@@ -1621,6 +1621,67 @@ class SyncAttachmentRevisionBinding:
 
 
 @dataclass(frozen=True, slots=True)
+class SyncNotesAttachmentSourceMap:
+    """Stable bootstrap attachment identity for one hashed legacy source key."""
+
+    dataset_id: str
+    bootstrap_id: str
+    source_key_hash: str
+    note_id: str
+    attachment_id: str
+    created_at: str
+
+    def __post_init__(self) -> None:
+        if not self.dataset_id.strip() or not self.bootstrap_id.strip():
+            raise ValueError("attachment source map identity must be non-empty")
+        if not self.note_id.strip():
+            raise ValueError("attachment source map note_id must be non-empty")
+        if re.fullmatch(r"sha256:[0-9a-f]{64}", self.source_key_hash) is None:
+            raise ValueError("attachment source map hash must be lowercase SHA-256")
+        try:
+            parsed_attachment_id = UUID(self.attachment_id)
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ValueError("attachment source map ID must be canonical UUIDv4") from exc
+        if parsed_attachment_id.version != 4 or str(parsed_attachment_id) != self.attachment_id:
+            raise ValueError("attachment source map ID must be canonical UUIDv4")
+
+
+@dataclass(frozen=True, slots=True)
+class SyncNotesAttachmentCleanupCandidate:
+    """Non-authoritative legacy source evidence retained after canonical import."""
+
+    dataset_id: str
+    bootstrap_id: str
+    source_key_hash: str
+    attachment_id: str
+    source_relative_path: str = field(repr=False)
+    source_path_hash: str
+    source_blob_hash: str
+    source_size_bytes: int
+    source_modified_ns: int
+    created_at: str
+
+    def __post_init__(self) -> None:
+        if not self.dataset_id.strip() or not self.bootstrap_id.strip():
+            raise ValueError("attachment cleanup identity must be non-empty")
+        if not self.source_relative_path.strip():
+            raise ValueError("attachment cleanup source path must be non-empty")
+        for value in (self.source_key_hash, self.source_path_hash, self.source_blob_hash):
+            if re.fullmatch(r"sha256:[0-9a-f]{64}", value) is None:
+                raise ValueError("attachment cleanup hash must be lowercase SHA-256")
+        try:
+            parsed_attachment_id = UUID(self.attachment_id)
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ValueError("attachment cleanup ID must be canonical UUIDv4") from exc
+        if parsed_attachment_id.version != 4 or str(parsed_attachment_id) != self.attachment_id:
+            raise ValueError("attachment cleanup ID must be canonical UUIDv4")
+        if isinstance(self.source_size_bytes, bool) or self.source_size_bytes < 1:
+            raise ValueError("attachment cleanup size must be positive")
+        if isinstance(self.source_modified_ns, bool) or self.source_modified_ns < 0:
+            raise ValueError("attachment cleanup modified time is invalid")
+
+
+@dataclass(frozen=True, slots=True)
 class SyncDatasetStorageNamespace:
     """Server-issued opaque physical storage namespace for one dataset."""
 
@@ -1864,6 +1925,8 @@ __all__ = [
     "SyncAttachmentCreate",
     "SyncAttachmentRevisionBinding",
     "SyncAttachmentRevisionBindingCreate",
+    "SyncNotesAttachmentCleanupCandidate",
+    "SyncNotesAttachmentSourceMap",
     "SyncBackgroundDomainStatus",
     "SyncBackgroundLease",
     "SyncBackgroundLeaseCreate",

--- a/tldw_Server_API/app/core/Sync/v2/notes_attachment_bootstrap.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_attachment_bootstrap.py
@@ -87,6 +87,69 @@ class NotesAttachmentBootstrapper:
         self._after_upload = after_upload
         self._after_capture = after_capture
 
+    def dry_run(
+        self,
+        *,
+        service: SyncV2Service,
+        user_id: str,
+    ) -> dict[str, object]:
+        """Return one bounded source count without mutating Sync or legacy state."""
+
+        source = LegacyAttachmentSource(
+            self._note_db,
+            owner_user_id=user_id,
+            user_root=self._user_root,
+        )
+        count = 0
+        lower_bound = False
+        try:
+            note_ids = source.list_note_ids(
+                after_note_id=None,
+                limit=LEGACY_ATTACHMENT_NOTE_PAGE_LIMIT,
+            )
+            for note_id in note_ids:
+                remaining = self._max_candidates_per_run - count
+                if remaining == 0:
+                    lower_bound = True
+                    break
+                candidates = source.list_candidates(
+                    note_id,
+                    after_source_key=None,
+                    limit=remaining,
+                )
+                for candidate in candidates:
+                    if candidate.size_bytes > min(
+                        service.settings.max_attachment_bytes,
+                        service.settings.max_blob_bytes,
+                    ):
+                        raise LegacyAttachmentSourceError(_SAFE_SOURCE_TOO_LARGE)
+                    validate_note_attachment_original_file_name(candidate.file_name)
+                    canonicalize_note_attachment_file_name(candidate.file_name)
+                    _content_type(candidate)
+                    source.verify_candidate(candidate)
+                count += len(candidates)
+                if len(candidates) == remaining:
+                    lower_bound = True
+                    break
+            if len(note_ids) == LEGACY_ATTACHMENT_NOTE_PAGE_LIMIT:
+                lower_bound = True
+            return {
+                "candidate_count": count,
+                "candidate_count_is_lower_bound": lower_bound,
+                "error_code": None,
+            }
+        except (LegacyAttachmentSourceError, NoteAttachmentPolicyError, ValueError) as exc:
+            error_code = (
+                _safe_source_error(exc.error_code)
+                if isinstance(exc, LegacyAttachmentSourceError)
+                else _SAFE_SOURCE_ERROR
+            )
+            return {
+                "candidate_count": count,
+                "candidate_count_is_lower_bound": lower_bound,
+                "error_code": error_code,
+            }
+
     def bootstrap(
         self,
         *,

--- a/tldw_Server_API/app/core/Sync/v2/notes_attachment_bootstrap.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_attachment_bootstrap.py
@@ -1,0 +1,916 @@
+"""Resumable source-verified bootstrap for legacy Notes attachments."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import mimetypes
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.exceptions import (
+    LegacyAttachmentSourceError,
+    NoteAttachmentPolicyError,
+)
+from tldw_Server_API.app.core.Notes.attachment_policy import (
+    canonicalize_note_attachment_file_name,
+    validate_note_attachment_content_type,
+    validate_note_attachment_original_file_name,
+)
+from tldw_Server_API.app.core.Notes.legacy_attachment_source import (
+    LEGACY_ATTACHMENT_NOTE_PAGE_LIMIT,
+    LegacyAttachmentCandidate,
+    LegacyAttachmentSource,
+)
+
+from .attachment_refs_v2 import parse_attachment_ref_v2_payload
+from .errors import SyncStoreError
+from .models import SyncDataset, SyncEnvelope
+from .server_origin import SERVER_ORIGIN_DEVICE_ID
+from .server_origin_batch import (
+    ServerOriginMutationStep,
+    SyncServerOriginBatchMaterializationError,
+    capture_server_origin_mutation_batch,
+)
+from .service import SyncV2Service
+
+_SAFE_SOURCE_ERROR = "notes_attachment_source_invalid"
+_SAFE_SOURCE_CHANGED = "notes_attachment_source_changed"
+_SAFE_SOURCE_TOO_LARGE = "notes_attachment_source_too_large"
+_SAFE_CAPTURE_ERROR = "notes_attachment_capture_failed"
+_CANDIDATE_PAGE_SIZE = 1_000
+_STREAM_CHUNK_SIZE = 64 * 1024
+_EMPTY_SOURCE_HASH = hashlib.sha256(b"").hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class _BootstrapCursor:
+    phase: str
+    note_id: str | None
+    source_key_hash: str | None
+    rolling_hash: str
+    processed_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class _SourcePage:
+    candidates: tuple[LegacyAttachmentCandidate, ...]
+    cursor_note_id: str | None
+    cursor_source_key: str | None
+    exhausted: bool
+
+
+class NotesAttachmentBootstrapInterrupted(RuntimeError):
+    """Testable interruption that deliberately leaves durable progress resumable."""
+
+
+class NotesAttachmentBootstrapper:
+    """Import legacy files through verified blobs and trusted v2 projection."""
+
+    def __init__(
+        self,
+        note_db: CharactersRAGDB,
+        *,
+        user_root: Path | None = None,
+        max_candidates_per_run: int = 1_000,
+        after_upload: Callable[[LegacyAttachmentCandidate], None] | None = None,
+        after_capture: Callable[[LegacyAttachmentCandidate], None] | None = None,
+    ) -> None:
+        if not 1 <= max_candidates_per_run <= 1_000:
+            raise ValueError("Notes attachment bootstrap limit must be 1..1000")
+        self._note_db = note_db
+        self._user_root = user_root
+        self._max_candidates_per_run = max_candidates_per_run
+        self._after_upload = after_upload
+        self._after_capture = after_capture
+
+    def bootstrap(
+        self,
+        *,
+        service: SyncV2Service,
+        user_id: str,
+        dataset: SyncDataset,
+    ) -> SyncDataset:
+        """Resume one bounded source page or persist a sanitized failed state."""
+
+        if dataset.owner_user_id != user_id:
+            raise SyncStoreError("Sync dataset was not found or is not accessible")
+        metadata = dataset.metadata.get("notes_attachment_v2")
+        if not isinstance(metadata, Mapping):
+            raise SyncStoreError("notes_attachment_sync_not_ready")
+        if metadata.get("state") == "ready":
+            return dataset
+        bootstrap_id = metadata.get("bootstrap_id")
+        if (
+            metadata.get("state") != "initializing"
+            or not isinstance(bootstrap_id, str)
+            or not bootstrap_id
+        ):
+            raise SyncStoreError("notes_attachment_sync_not_ready")
+
+        captured_count = _non_negative_int(metadata.get("captured_count"))
+        expected_count = _non_negative_int(metadata.get("expected_count"))
+        established_hash = metadata.get("source_hash")
+        source = LegacyAttachmentSource(
+            self._note_db,
+            owner_user_id=user_id,
+            user_root=self._user_root,
+        )
+        try:
+            cursor = _decode_cursor(
+                metadata.get("source_cursor"),
+                captured_count=captured_count,
+                source_hash=established_hash,
+            )
+            remaining = self._max_candidates_per_run
+            if cursor.phase == "capture":
+                page = _source_page(
+                    source,
+                    service=service,
+                    dataset=dataset,
+                    user_id=user_id,
+                    bootstrap_id=bootstrap_id,
+                    cursor=cursor,
+                    limit=remaining,
+                )
+                for candidate in page.candidates:
+                    self._capture_candidate(
+                        source=source,
+                        candidate=candidate,
+                        service=service,
+                        user_id=user_id,
+                        dataset=dataset,
+                        bootstrap_id=bootstrap_id,
+                    )
+                    captured_count += 1
+                    expected_count = captured_count
+                    remaining -= 1
+                    cursor = _advanced_cursor(cursor, candidate)
+                    dataset = self._persist_progress(
+                        service,
+                        dataset,
+                        user_id=user_id,
+                        bootstrap_id=bootstrap_id,
+                        captured_count=captured_count,
+                        expected_count=expected_count,
+                        source_hash=None,
+                        cursor=cursor,
+                    )
+                if not page.exhausted:
+                    if page.cursor_source_key is None and page.cursor_note_id is not None:
+                        cursor = _cursor_after_empty_notes(cursor, page.cursor_note_id)
+                        dataset = self._persist_progress(
+                            service,
+                            dataset,
+                            user_id=user_id,
+                            bootstrap_id=bootstrap_id,
+                            captured_count=captured_count,
+                            expected_count=expected_count,
+                            source_hash=None,
+                            cursor=cursor,
+                        )
+                    return dataset
+                established_hash = cursor.rolling_hash
+                cursor = _initial_cursor("verify")
+                dataset = self._persist_progress(
+                    service,
+                    dataset,
+                    user_id=user_id,
+                    bootstrap_id=bootstrap_id,
+                    captured_count=captured_count,
+                    expected_count=expected_count,
+                    source_hash=established_hash,
+                    cursor=cursor,
+                )
+
+            if remaining == 0:
+                return dataset
+            page = _source_page(
+                source,
+                service=service,
+                dataset=dataset,
+                user_id=user_id,
+                bootstrap_id=bootstrap_id,
+                cursor=cursor,
+                limit=remaining,
+            )
+            for candidate in page.candidates:
+                self._verify_candidate(
+                    source=source,
+                    candidate=candidate,
+                    service=service,
+                    user_id=user_id,
+                    dataset=dataset,
+                    bootstrap_id=bootstrap_id,
+                )
+                cursor = _advanced_cursor(cursor, candidate)
+                if cursor.processed_count > expected_count:
+                    raise LegacyAttachmentSourceError(_SAFE_SOURCE_CHANGED)
+                dataset = self._persist_progress(
+                    service,
+                    dataset,
+                    user_id=user_id,
+                    bootstrap_id=bootstrap_id,
+                    captured_count=captured_count,
+                    expected_count=expected_count,
+                    source_hash=(
+                        established_hash if isinstance(established_hash, str) else None
+                    ),
+                    cursor=cursor,
+                )
+            if not page.exhausted:
+                if page.cursor_source_key is None and page.cursor_note_id is not None:
+                    cursor = _cursor_after_empty_notes(cursor, page.cursor_note_id)
+                    dataset = self._persist_progress(
+                        service,
+                        dataset,
+                        user_id=user_id,
+                        bootstrap_id=bootstrap_id,
+                        captured_count=captured_count,
+                        expected_count=expected_count,
+                        source_hash=(
+                            established_hash
+                            if isinstance(established_hash, str)
+                            else None
+                        ),
+                        cursor=cursor,
+                    )
+                return dataset
+            if (
+                cursor.processed_count != expected_count
+                or cursor.rolling_hash != established_hash
+            ):
+                raise LegacyAttachmentSourceError(_SAFE_SOURCE_CHANGED)
+            return service.store.transition_notes_attachment_bootstrap(
+                dataset.dataset_id,
+                owner_user_id=user_id,
+                bootstrap_id=bootstrap_id,
+                expected_state="initializing",
+                state="ready",
+                captured_count=expected_count,
+                expected_count=expected_count,
+                source_hash=established_hash,
+                source_cursor=None,
+                ready_verifier=lambda: True,
+            )
+        except LegacyAttachmentSourceError as exc:
+            return self._fail(
+                service,
+                dataset,
+                user_id=user_id,
+                bootstrap_id=bootstrap_id,
+                captured_count=captured_count,
+                expected_count=expected_count,
+                source_hash=(established_hash if isinstance(established_hash, str) else None),
+                error_code=_safe_source_error(exc.error_code),
+            )
+        except (NoteAttachmentPolicyError, ValueError):
+            return self._fail(
+                service,
+                dataset,
+                user_id=user_id,
+                bootstrap_id=bootstrap_id,
+                captured_count=captured_count,
+                expected_count=expected_count,
+                source_hash=(established_hash if isinstance(established_hash, str) else None),
+                error_code=_SAFE_SOURCE_ERROR,
+            )
+        except SyncServerOriginBatchMaterializationError as exc:
+            if exc.retryable:
+                return dataset
+            return self._fail(
+                service,
+                dataset,
+                user_id=user_id,
+                bootstrap_id=bootstrap_id,
+                captured_count=captured_count,
+                expected_count=expected_count,
+                source_hash=(established_hash if isinstance(established_hash, str) else None),
+                error_code=_SAFE_CAPTURE_ERROR,
+            )
+        except NotesAttachmentBootstrapInterrupted:
+            return service.store.get_dataset(
+                dataset.dataset_id,
+                owner_user_id=user_id,
+            ) or dataset
+        except Exception:  # noqa: BLE001 - durable state exposes only safe codes.
+            return self._fail(
+                service,
+                dataset,
+                user_id=user_id,
+                bootstrap_id=bootstrap_id,
+                captured_count=captured_count,
+                expected_count=expected_count,
+                source_hash=(established_hash if isinstance(established_hash, str) else None),
+                error_code=_SAFE_CAPTURE_ERROR,
+            )
+
+    @staticmethod
+    def _persist_progress(
+        service: SyncV2Service,
+        dataset: SyncDataset,
+        *,
+        user_id: str,
+        bootstrap_id: str,
+        captured_count: int,
+        expected_count: int,
+        source_hash: str | None,
+        cursor: _BootstrapCursor,
+    ) -> SyncDataset:
+        return service.store.transition_notes_attachment_bootstrap(
+            dataset.dataset_id,
+            owner_user_id=user_id,
+            bootstrap_id=bootstrap_id,
+            expected_state="initializing",
+            state="initializing",
+            captured_count=captured_count,
+            expected_count=expected_count,
+            source_hash=source_hash,
+            source_cursor=_encode_cursor(cursor),
+        )
+
+    def _capture_candidate(
+        self,
+        *,
+        source: LegacyAttachmentSource,
+        candidate: LegacyAttachmentCandidate,
+        service: SyncV2Service,
+        user_id: str,
+        dataset: SyncDataset,
+        bootstrap_id: str,
+    ) -> None:
+        if candidate.size_bytes > min(
+            service.settings.max_attachment_bytes,
+            service.settings.max_blob_bytes,
+        ):
+            raise LegacyAttachmentSourceError(_SAFE_SOURCE_TOO_LARGE)
+        mapping = service.store.resolve_notes_attachment_source_map(
+            dataset.dataset_id,
+            owner_user_id=user_id,
+            bootstrap_id=bootstrap_id,
+            source_key=candidate.source_key,
+            note_id=candidate.note_id,
+        )
+        file_name = _available_file_name(
+            self._note_db,
+            dataset.dataset_id,
+            candidate,
+            attachment_id=mapping.attachment_id,
+        )
+        original_file_name = validate_note_attachment_original_file_name(
+            candidate.file_name
+        )
+        content_type = _content_type(candidate)
+        timestamp = datetime.fromtimestamp(candidate.modified_ns / 1_000_000_000, UTC).isoformat()
+        upload = service.create_blob_upload_session(
+            user_id=user_id,
+            dataset_id=dataset.dataset_id,
+            device_id=None,
+            domain="attachment.ref",
+            entity_id=mapping.attachment_id,
+            attachment_id=mapping.attachment_id,
+            content_type=content_type,
+            size_bytes=candidate.size_bytes,
+            payload_hash=candidate.sha256,
+            chunk_size=min(service.settings.max_chunk_bytes, _STREAM_CHUNK_SIZE),
+            chunk_count=(
+                candidate.size_bytes
+                + min(service.settings.max_chunk_bytes, _STREAM_CHUNK_SIZE)
+                - 1
+            )
+            // min(service.settings.max_chunk_bytes, _STREAM_CHUNK_SIZE),
+            idempotency_key=f"{bootstrap_id}:{mapping.source_key_hash}",
+            metadata={
+                "notes_attachment_intent": {
+                    "intent": "create",
+                    "note_id": candidate.note_id,
+                    "attachment_id": mapping.attachment_id,
+                    "file_name": file_name,
+                }
+            },
+            trusted_notes_attachment_bootstrap_id=bootstrap_id,
+        )
+        if upload.status != "complete":
+            offset = 0
+            for chunk_index, chunk in enumerate(
+                source.iter_candidate_chunks(
+                    candidate,
+                    chunk_size=upload.chunk_size,
+                )
+            ):
+                service.upload_blob_chunk(
+                    user_id=user_id,
+                    dataset_id=dataset.dataset_id,
+                    upload_id=upload.upload_id,
+                    chunk_index=chunk_index,
+                    offset_bytes=offset,
+                    chunk_payload=chunk,
+                    chunk_hash="sha256:" + hashlib.sha256(chunk).hexdigest(),
+                )
+                offset += len(chunk)
+        blob = service.complete_blob_upload(
+            user_id=user_id,
+            dataset_id=dataset.dataset_id,
+            upload_id=upload.upload_id,
+        )
+        if self._after_upload is not None:
+            self._after_upload(candidate)
+        source.verify_candidate(candidate)
+
+        payload = {
+            "attachment_id": mapping.attachment_id,
+            "parent_domain": "notes.note",
+            "parent_object_id": candidate.note_id,
+            "file_name": file_name,
+            "original_file_name": original_file_name,
+            "content_type": content_type,
+            "size_bytes": candidate.size_bytes,
+            "blob_hash": candidate.sha256,
+            "created_at": timestamp,
+            "last_modified": timestamp,
+            "created_by": SERVER_ORIGIN_DEVICE_ID,
+        }
+        capture_server_origin_mutation_batch(
+            service=service,
+            user_id=user_id,
+            steps=(
+                ServerOriginMutationStep(
+                    domain="attachment.ref",
+                    operation="upsert",
+                    object_id=mapping.attachment_id,
+                    parent_id=candidate.note_id,
+                    payload=payload,
+                    routing_metadata={
+                        "bootstrap_capture": True,
+                        "bootstrap_id": bootstrap_id,
+                    },
+                    stable_key=f"attachment.ref:{mapping.attachment_id}",
+                    created_at_client=timestamp,
+                    schema_version=2,
+                    adapter_version=2,
+                ),
+            ),
+            source="notes-attachment-bootstrap",
+            idempotency_key=f"{bootstrap_id}:{mapping.source_key_hash}",
+            trusted_notes_attachment_bootstrap_id=bootstrap_id,
+            bootstrap_step_verifier=lambda envelope: self._step_matches_source(
+                envelope,
+                source=source,
+                candidate=candidate,
+                payload=payload,
+                service=service,
+                blob_storage_key=blob.storage_key,
+            ),
+        )
+        if self._after_capture is not None:
+            self._after_capture(candidate)
+        service.store.record_notes_attachment_cleanup_candidate(
+            dataset.dataset_id,
+            owner_user_id=user_id,
+            bootstrap_id=bootstrap_id,
+            source_key=candidate.source_key,
+            source_relative_path=candidate.relative_path,
+            source_blob_hash=candidate.sha256,
+            source_size_bytes=candidate.size_bytes,
+            source_modified_ns=candidate.modified_ns,
+        )
+
+    def _step_matches_source(
+        self,
+        envelope: SyncEnvelope,
+        *,
+        source: LegacyAttachmentSource,
+        candidate: LegacyAttachmentCandidate,
+        payload: Mapping[str, object],
+        service: SyncV2Service,
+        blob_storage_key: str,
+    ) -> bool:
+        try:
+            source.verify_candidate(candidate)
+            if service.blob_store is None:
+                return False
+            service.blob_store.verify_blob(
+                blob_storage_key,
+                payload_hash=candidate.sha256,
+                expected_size=candidate.size_bytes,
+            )
+            parsed = parse_attachment_ref_v2_payload(envelope.operation, envelope.payload)
+            blob_store = envelope.payload.get("blob_hash")
+            service_blob = parsed.blob_hash
+            if blob_store != candidate.sha256 or service_blob != candidate.sha256:
+                return False
+            # The canonical blob path is verified independently of source bytes.
+            return (
+                envelope.adapter_version == 2
+                and envelope.schema_version == 2
+                and envelope.object_id == payload["attachment_id"]
+                and dict(envelope.payload) == dict(payload)
+                and bool(blob_storage_key)
+            )
+        except (LegacyAttachmentSourceError, ValueError):
+            return False
+
+    def _verify_candidate(
+        self,
+        *,
+        source: LegacyAttachmentSource,
+        candidate: LegacyAttachmentCandidate,
+        service: SyncV2Service,
+        dataset: SyncDataset,
+        user_id: str,
+        bootstrap_id: str,
+    ) -> None:
+        source.verify_candidate(candidate)
+        persisted = service.store.get_notes_attachment_bootstrap_source_by_hash(
+            dataset.dataset_id,
+            owner_user_id=user_id,
+            bootstrap_id=bootstrap_id,
+            source_key_hash=_source_key_hash(candidate.source_key),
+        )
+        if persisted is None:
+            raise LegacyAttachmentSourceError(_SAFE_SOURCE_CHANGED)
+        mapping, cleanup = persisted
+        head = service.store.get_current_head(
+            dataset.dataset_id,
+            "attachment.ref",
+            mapping.attachment_id,
+        )
+        projected = self._note_db.note_attachment_store.get(
+            dataset.dataset_id,
+            mapping.attachment_id,
+        )
+        if (
+            mapping.note_id != candidate.note_id
+            or cleanup.source_relative_path != candidate.relative_path
+            or cleanup.source_blob_hash != candidate.sha256
+            or cleanup.source_size_bytes != candidate.size_bytes
+            or cleanup.source_modified_ns != candidate.modified_ns
+            or head is None
+            or head.adapter_version != 2
+            or head.schema_version != 2
+            or head.operation != "upsert"
+            or projected is None
+            or projected.source_kind != "legacy_bootstrap"
+            or projected.note_id != candidate.note_id
+            or projected.blob_hash != candidate.sha256
+            or projected.size_bytes != candidate.size_bytes
+        ):
+            raise LegacyAttachmentSourceError(_SAFE_SOURCE_CHANGED)
+        revision = head.object_revision
+        if revision is None:
+            raise LegacyAttachmentSourceError(_SAFE_SOURCE_CHANGED)
+        binding = service.store.get_attachment_revision_binding(
+            dataset.dataset_id,
+            mapping.attachment_id,
+            revision,
+            owner_user_id=user_id,
+        )
+        if binding is None or binding.resolved_blob_id is None:
+            raise LegacyAttachmentSourceError(_SAFE_SOURCE_CHANGED)
+        blob = service.store.get_blob_object(
+            dataset.dataset_id,
+            blob_id=binding.resolved_blob_id,
+            owner_user_id=user_id,
+        )
+        if (
+            blob is None
+            or blob.payload_hash != candidate.sha256
+            or blob.size_bytes != candidate.size_bytes
+            or service.blob_store is None
+        ):
+            raise LegacyAttachmentSourceError(_SAFE_SOURCE_CHANGED)
+        service.blob_store.verify_blob(
+            blob.storage_key,
+            payload_hash=candidate.sha256,
+            expected_size=candidate.size_bytes,
+        )
+
+    @staticmethod
+    def _fail(
+        service: SyncV2Service,
+        dataset: SyncDataset,
+        *,
+        user_id: str,
+        bootstrap_id: str,
+        captured_count: int,
+        expected_count: int,
+        source_hash: str | None,
+        error_code: str,
+    ) -> SyncDataset:
+        current = service.store.get_dataset(
+            dataset.dataset_id,
+            owner_user_id=user_id,
+        ) or dataset
+        metadata = current.metadata.get("notes_attachment_v2")
+        current_hash = metadata.get("source_hash") if isinstance(metadata, Mapping) else None
+        return service.store.transition_notes_attachment_bootstrap(
+            dataset.dataset_id,
+            owner_user_id=user_id,
+            bootstrap_id=bootstrap_id,
+            expected_state="initializing",
+            state="failed",
+            captured_count=min(captured_count, expected_count),
+            expected_count=expected_count,
+            source_hash=(current_hash if isinstance(current_hash, str) else source_hash),
+            source_cursor=None,
+            error_code=error_code,
+        )
+
+
+def _source_page(
+    source: LegacyAttachmentSource,
+    *,
+    service: SyncV2Service,
+    dataset: SyncDataset,
+    user_id: str,
+    bootstrap_id: str,
+    cursor: _BootstrapCursor,
+    limit: int,
+) -> _SourcePage:
+    """Read at most one note page and ``limit`` immutable candidates."""
+
+    if not 1 <= limit <= _CANDIDATE_PAGE_SIZE:
+        raise ValueError("Notes attachment source page limit must be 1..1000")
+    candidates: list[LegacyAttachmentCandidate] = []
+    last_note_id = cursor.note_id
+    last_source_key: str | None = None
+    note_budget = LEGACY_ATTACHMENT_NOTE_PAGE_LIMIT
+
+    if cursor.note_id is not None and cursor.source_key_hash is not None:
+        persisted = service.store.get_notes_attachment_bootstrap_source_by_hash(
+            dataset.dataset_id,
+            owner_user_id=user_id,
+            bootstrap_id=bootstrap_id,
+            source_key_hash=cursor.source_key_hash,
+        )
+        if persisted is None or persisted[0].note_id != cursor.note_id:
+            raise LegacyAttachmentSourceError("notes_attachment_source_cursor_invalid")
+        after_source_key = persisted[1].source_relative_path
+        current_page = source.list_candidates(
+            cursor.note_id,
+            after_source_key=after_source_key,
+            limit=limit,
+        )
+        candidates.extend(current_page)
+        note_budget -= 1
+        if current_page:
+            last_source_key = current_page[-1].source_key
+        if len(candidates) == limit:
+            return _SourcePage(
+                tuple(candidates),
+                cursor.note_id,
+                last_source_key,
+                False,
+            )
+        last_source_key = None
+
+    note_ids = source.list_note_ids(
+        after_note_id=cursor.note_id,
+        limit=max(1, note_budget),
+    )
+    for note_id in note_ids:
+        last_note_id = note_id
+        remaining = limit - len(candidates)
+        current_page = source.list_candidates(
+            note_id,
+            after_source_key=None,
+            limit=remaining,
+        )
+        candidates.extend(current_page)
+        if current_page:
+            last_source_key = current_page[-1].source_key
+        else:
+            last_source_key = None
+        if len(candidates) == limit:
+            return _SourcePage(
+                tuple(candidates),
+                last_note_id,
+                last_source_key,
+                False,
+            )
+    exhausted = len(note_ids) < max(1, note_budget)
+    return _SourcePage(
+        tuple(candidates),
+        last_note_id,
+        last_source_key,
+        exhausted,
+    )
+
+
+def _initial_cursor(phase: str) -> _BootstrapCursor:
+    return _BootstrapCursor(
+        phase=phase,
+        note_id=None,
+        source_key_hash=None,
+        rolling_hash=_EMPTY_SOURCE_HASH,
+        processed_count=0,
+    )
+
+
+def _decode_cursor(
+    value: object,
+    *,
+    captured_count: int,
+    source_hash: object,
+) -> _BootstrapCursor:
+    if value is None:
+        if captured_count != 0:
+            raise LegacyAttachmentSourceError("notes_attachment_source_cursor_invalid")
+        return _initial_cursor("verify" if isinstance(source_hash, str) else "capture")
+    if not isinstance(value, str):
+        raise LegacyAttachmentSourceError("notes_attachment_source_cursor_invalid")
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise LegacyAttachmentSourceError(
+            "notes_attachment_source_cursor_invalid"
+        ) from exc
+    if not isinstance(decoded, dict) or set(decoded) != {
+        "note_id",
+        "phase",
+        "processed_count",
+        "rolling_hash",
+        "source_key_hash",
+    }:
+        raise LegacyAttachmentSourceError("notes_attachment_source_cursor_invalid")
+    cursor = _BootstrapCursor(
+        phase=decoded["phase"],
+        note_id=decoded["note_id"],
+        source_key_hash=decoded["source_key_hash"],
+        rolling_hash=decoded["rolling_hash"],
+        processed_count=decoded["processed_count"],
+    )
+    if (
+        cursor.phase not in {"capture", "verify"}
+        or (cursor.note_id is not None and not isinstance(cursor.note_id, str))
+        or (
+            cursor.source_key_hash is not None
+            and (
+                not isinstance(cursor.source_key_hash, str)
+                or not cursor.source_key_hash.startswith("sha256:")
+                or len(cursor.source_key_hash) != 71
+            )
+        )
+        or not isinstance(cursor.rolling_hash, str)
+        or len(cursor.rolling_hash) != 64
+        or any(character not in "0123456789abcdef" for character in cursor.rolling_hash)
+        or isinstance(cursor.processed_count, bool)
+        or not isinstance(cursor.processed_count, int)
+        or cursor.processed_count < 0
+        or (cursor.phase == "capture" and cursor.processed_count != captured_count)
+        or (cursor.phase == "capture" and source_hash is not None)
+        or (cursor.phase == "verify" and not isinstance(source_hash, str))
+    ):
+        raise LegacyAttachmentSourceError("notes_attachment_source_cursor_invalid")
+    return cursor
+
+
+def _encode_cursor(cursor: _BootstrapCursor) -> str:
+    return json.dumps(
+        {
+            "note_id": cursor.note_id,
+            "phase": cursor.phase,
+            "processed_count": cursor.processed_count,
+            "rolling_hash": cursor.rolling_hash,
+            "source_key_hash": cursor.source_key_hash,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _advanced_cursor(
+    cursor: _BootstrapCursor,
+    candidate: LegacyAttachmentCandidate,
+) -> _BootstrapCursor:
+    record = json.dumps(
+        {
+            "file_name": candidate.file_name,
+            "metadata": candidate.metadata,
+            "modified_ns": candidate.modified_ns,
+            "note_id": candidate.note_id,
+            "sha256": candidate.sha256,
+            "size_bytes": candidate.size_bytes,
+            "source_key": candidate.source_key,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    rolling = hashlib.sha256(
+        bytes.fromhex(cursor.rolling_hash)
+        + len(record).to_bytes(8, "big")
+        + record
+    ).hexdigest()
+    return _BootstrapCursor(
+        phase=cursor.phase,
+        note_id=candidate.note_id,
+        source_key_hash=_source_key_hash(candidate.source_key),
+        rolling_hash=rolling,
+        processed_count=cursor.processed_count + 1,
+    )
+
+
+def _cursor_after_empty_notes(
+    cursor: _BootstrapCursor,
+    note_id: str,
+) -> _BootstrapCursor:
+    return _BootstrapCursor(
+        phase=cursor.phase,
+        note_id=note_id,
+        source_key_hash=None,
+        rolling_hash=cursor.rolling_hash,
+        processed_count=cursor.processed_count,
+    )
+
+
+def _source_key_hash(source_key: str) -> str:
+    return "sha256:" + hashlib.sha256(source_key.encode("utf-8")).hexdigest()
+
+
+def _content_type(candidate: LegacyAttachmentCandidate) -> str:
+    supplied = candidate.metadata.get("content_type")
+    guessed = mimetypes.guess_type(candidate.file_name, strict=False)[0]
+    value = supplied if supplied is not None else guessed or "application/octet-stream"
+    return validate_note_attachment_content_type(value)
+
+
+def _available_file_name(
+    note_db: CharactersRAGDB,
+    dataset_id: str,
+    candidate: LegacyAttachmentCandidate,
+    *,
+    attachment_id: str,
+) -> str:
+    existing = note_db.note_attachment_store.get(dataset_id, attachment_id)
+    if existing is not None:
+        if (
+            existing.note_id != candidate.note_id
+            or existing.original_file_name != candidate.file_name
+            or existing.blob_hash != candidate.sha256
+        ):
+            raise LegacyAttachmentSourceError("notes_attachment_source_ambiguous")
+        return existing.file_name
+    base_name, base_key = canonicalize_note_attachment_file_name(candidate.file_name)
+    occupied = _occupied_name_keys(note_db, dataset_id, candidate.note_id)
+    if base_key not in occupied:
+        return base_name
+    suffixes = Path(base_name).suffixes
+    extension = "".join(suffixes) if suffixes else ""
+    stem = base_name[: -len(extension)] if extension else base_name
+    for index in range(1, 1_000):
+        suffix = f"-{index}"
+        trimmed = stem[: max(1, 180 - len(extension) - len(suffix))]
+        display, key = canonicalize_note_attachment_file_name(
+            f"{trimmed}{suffix}{extension}"
+        )
+        if key not in occupied:
+            return display
+    raise LegacyAttachmentSourceError("notes_attachment_source_ambiguous")
+
+
+def _occupied_name_keys(
+    note_db: CharactersRAGDB,
+    dataset_id: str,
+    note_id: str,
+) -> set[str]:
+    occupied: set[str] = set()
+    after_attachment_id: str | None = None
+    while True:
+        page = note_db.note_attachment_store.list_page(
+            dataset_id,
+            note_id,
+            after_attachment_id=after_attachment_id,
+            limit=200,
+            state="live",
+            include_deleted_note=True,
+        )
+        if not page:
+            return occupied
+        occupied.update(item.normalized_file_name for item in page)
+        after_attachment_id = page[-1].attachment_id
+        if len(page) < 200:
+            return occupied
+
+
+def _non_negative_int(value: object) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _safe_source_error(error_code: str) -> str:
+    if error_code in {
+        "notes_attachment_source_changed",
+        "notes_attachment_source_too_large",
+        "notes_attachment_source_ambiguous",
+    }:
+        return error_code
+    if "too_large" in error_code:
+        return _SAFE_SOURCE_TOO_LARGE
+    return _SAFE_SOURCE_ERROR
+
+
+__all__ = ["NotesAttachmentBootstrapInterrupted", "NotesAttachmentBootstrapper"]

--- a/tldw_Server_API/app/core/Sync/v2/notes_attachment_bootstrap.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_attachment_bootstrap.py
@@ -14,6 +14,7 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGD
 from tldw_Server_API.app.core.exceptions import (
     LegacyAttachmentSourceError,
     NoteAttachmentPolicyError,
+    NotesAttachmentBootstrapInterrupted,
 )
 from tldw_Server_API.app.core.Notes.attachment_policy import (
     canonicalize_note_attachment_file_name,
@@ -61,10 +62,6 @@ class _SourcePage:
     cursor_note_id: str | None
     cursor_source_key: str | None
     exhausted: bool
-
-
-class NotesAttachmentBootstrapInterrupted(RuntimeError):
-    """Testable interruption that deliberately leaves durable progress resumable."""
 
 
 class NotesAttachmentBootstrapper:
@@ -764,6 +761,8 @@ def _source_page(
 
 
 def _initial_cursor(phase: str) -> _BootstrapCursor:
+    """Create an empty bootstrap cursor for the requested processing phase."""
+
     return _BootstrapCursor(
         phase=phase,
         note_id=None,

--- a/tldw_Server_API/app/core/Sync/v2/profile.py
+++ b/tldw_Server_API/app/core/Sync/v2/profile.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 """Profile bootstrap and status helpers for Sync v2 M1."""
 
-from collections.abc import Callable, Sequence
+import hashlib
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -58,6 +59,34 @@ class SyncProfileDatasetStatus:
     server_frontend_mutation_blockers: list[str] = field(default_factory=list)
     notes_organization: dict[str, object] | None = None
     notes_link: dict[str, object] | None = None
+    notes_attachment: dict[str, object] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SyncNotesAttachmentCleanupSample:
+    """Public-safe cleanup evidence with no legacy name or path."""
+
+    source_key_hash: str
+    attachment_id: str
+    state: str = "captured"
+    blocker_code: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SyncNotesAttachmentBootstrapDiagnostics:
+    """Bounded read-only attachment bootstrap diagnostics."""
+
+    state: str
+    captured_count: int = 0
+    expected_count: int = 0
+    cursor: str | None = None
+    error_code: str | None = None
+    dry_run: bool = False
+    source_candidate_count: int | None = None
+    source_candidate_count_is_lower_bound: bool = False
+    cleanup_candidates: list[SyncNotesAttachmentCleanupSample] = field(
+        default_factory=list
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -272,6 +301,107 @@ class SyncV2ProfileManager:
             created=None,
         )
 
+    def notes_attachment_bootstrap_diagnostics(
+        self,
+        *,
+        user_id: str,
+        dataset_id: str | None = None,
+        sample_limit: int = 0,
+        dry_run: bool = False,
+    ) -> SyncNotesAttachmentBootstrapDiagnostics:
+        """Return bounded source/bootstrap evidence without mutating state."""
+
+        if isinstance(sample_limit, bool) or sample_limit < 0:
+            raise SyncStoreError("sync_attachment_bootstrap_sample_limit_invalid")
+        if sample_limit > 100:
+            raise SyncStoreError("sync_attachment_bootstrap_sample_limit_exceeded")
+        if dataset_id is None:
+            dataset = self._default_personal_dataset(user_id)
+        else:
+            dataset = self.store.get_dataset(dataset_id, owner_user_id=user_id)
+            if dataset is None:
+                raise SyncStoreError(
+                    "Sync dataset was not found or is not accessible"
+                )
+
+        status = _safe_notes_attachment_status(dataset) if dataset is not None else None
+        state = str(status["state"]) if status is not None else "not_started"
+        captured_count = (
+            _safe_non_negative_int(status.get("captured_count")) if status else 0
+        )
+        expected_count = (
+            _safe_non_negative_int(status.get("expected_count")) if status else 0
+        )
+        error_code = status.get("error_code") if status else None
+        cursor = None
+        if dataset is not None:
+            attachment_metadata = dataset.metadata.get("notes_attachment_v2")
+            source_cursor = (
+                attachment_metadata.get("source_cursor")
+                if isinstance(attachment_metadata, Mapping)
+                else None
+            )
+            if isinstance(source_cursor, str) and source_cursor:
+                cursor = "sha256:" + hashlib.sha256(
+                    source_cursor.encode("utf-8")
+                ).hexdigest()
+        samples: list[SyncNotesAttachmentCleanupSample] = []
+        if dataset is not None and sample_limit:
+            metadata = dataset.metadata.get("notes_attachment_v2")
+            bootstrap_id = (
+                metadata.get("bootstrap_id") if isinstance(metadata, Mapping) else None
+            )
+            if isinstance(bootstrap_id, str) and bootstrap_id:
+                samples = [
+                    SyncNotesAttachmentCleanupSample(
+                        source_key_hash=item.source_key_hash,
+                        attachment_id=item.attachment_id,
+                    )
+                    for item in self.store.list_notes_attachment_cleanup_candidates(
+                        dataset.dataset_id,
+                        owner_user_id=user_id,
+                        bootstrap_id=bootstrap_id,
+                        limit=sample_limit,
+                    )
+                ]
+
+        source_candidate_count: int | None = None
+        source_candidate_count_is_lower_bound = False
+        if dry_run:
+            if self.service is None or self.notes_attachment_bootstrapper is None:
+                raise SyncStoreError(
+                    "Notes attachment bootstrap diagnostics are unavailable"
+                )
+            raw = self.notes_attachment_bootstrapper.dry_run(
+                service=self.service,
+                user_id=user_id,
+            )
+            if not isinstance(raw, Mapping):
+                raise SyncStoreError("notes_attachment_bootstrap_dry_run_invalid")
+            source_candidate_count = _safe_non_negative_int(
+                raw.get("candidate_count")
+            )
+            source_candidate_count_is_lower_bound = (
+                raw.get("candidate_count_is_lower_bound") is True
+            )
+            dry_run_error = raw.get("error_code")
+            if isinstance(dry_run_error, str):
+                error_code = dry_run_error
+
+        return SyncNotesAttachmentBootstrapDiagnostics(
+            state=state,
+            captured_count=captured_count,
+            expected_count=expected_count,
+            cursor=cursor if isinstance(cursor, str) else None,
+            error_code=error_code if isinstance(error_code, str) else None,
+            dry_run=dry_run,
+            source_candidate_count=source_candidate_count,
+            source_candidate_count_is_lower_bound=(
+                source_candidate_count_is_lower_bound
+            ),
+            cleanup_candidates=samples,
+        )
+
     def _build_profile(
         self,
         *,
@@ -450,6 +580,7 @@ def _dataset_status(dataset: SyncDataset) -> SyncProfileDatasetStatus:
         ),
         notes_organization=_safe_notes_organization_status(dataset),
         notes_link=_safe_notes_link_status(dataset),
+        notes_attachment=_safe_notes_attachment_status(dataset),
     )
 
 
@@ -479,6 +610,25 @@ def _safe_notes_link_status(dataset: SyncDataset) -> dict[str, object] | None:
     if state not in {"initializing", "ready", "failed"}:
         state = "failed"
         error_code = "notes_link_bootstrap_state_invalid"
+    return {
+        "state": state,
+        "captured_count": _safe_non_negative_int(metadata.get("captured_count")),
+        "expected_count": _safe_non_negative_int(metadata.get("expected_count")),
+        "error_code": error_code if isinstance(error_code, str) else None,
+    }
+
+
+def _safe_notes_attachment_status(
+    dataset: SyncDataset,
+) -> dict[str, object] | None:
+    metadata = dataset.metadata.get("notes_attachment_v2")
+    if not isinstance(metadata, Mapping):
+        return None
+    state = metadata.get("state")
+    error_code = metadata.get("error_code")
+    if state not in {"initializing", "ready", "failed"}:
+        state = "failed"
+        error_code = "notes_attachment_bootstrap_state_invalid"
     return {
         "state": state,
         "captured_count": _safe_non_negative_int(metadata.get("captured_count")),
@@ -553,6 +703,8 @@ __all__ = [
     "BOOTSTRAP_MODES",
     "DEFAULT_CLIENT_FAMILY",
     "SYNC_V2_M1_PROTOCOL_VERSION",
+    "SyncNotesAttachmentBootstrapDiagnostics",
+    "SyncNotesAttachmentCleanupSample",
     "SyncProfileDatasetStatus",
     "SyncProfileDeviceStatus",
     "SyncProfileDomainStatus",

--- a/tldw_Server_API/app/core/Sync/v2/profile.py
+++ b/tldw_Server_API/app/core/Sync/v2/profile.py
@@ -109,6 +109,7 @@ class SyncV2ProfileManager:
         service: Any | None = None,
         dataset_bootstrapper: Any | None = None,
         notes_link_bootstrapper: Any | None = None,
+        notes_attachment_bootstrapper: Any | None = None,
     ) -> None:
         self.store = store
         self.capabilities_factory = capabilities_factory
@@ -117,6 +118,7 @@ class SyncV2ProfileManager:
         self.service = service
         self.dataset_bootstrapper = dataset_bootstrapper
         self.notes_link_bootstrapper = notes_link_bootstrapper
+        self.notes_attachment_bootstrapper = notes_attachment_bootstrapper
 
     def profile(self, *, user_id: str, device_id: str | None = None) -> SyncProfileStatus:
         """Return current profile state without creating devices or datasets."""
@@ -161,6 +163,7 @@ class SyncV2ProfileManager:
         if organization_requested and organization_requested != set(NOTES_ORGANIZATION_DOMAINS):
             raise SyncStoreError("notes_organization_sync_domains_incomplete")
         notes_link_requested = bool(set(requested).intersection(NOTES_LINK_DOMAINS))
+        notes_attachment_requested = "attachment.ref" in requested
         encryption = getattr(capabilities, "encryption", {})
         if not encryption.get("ready", False):
             raise SyncStoreError(
@@ -223,6 +226,22 @@ class SyncV2ProfileManager:
                 if self.service is None:
                     raise SyncStoreError("Notes link bootstrap service is unavailable")
                 dataset = self.notes_link_bootstrapper.bootstrap(
+                    service=self.service,
+                    user_id=user_id,
+                    dataset=dataset,
+                )
+        if notes_attachment_requested:
+            dataset = self.store.begin_notes_attachment_bootstrap(
+                dataset.dataset_id,
+                owner_user_id=user_id,
+                bootstrap_id=self.id_factory("notes-attachment-bootstrap"),
+            )
+            if self.notes_attachment_bootstrapper is not None:
+                if self.service is None:
+                    raise SyncStoreError(
+                        "Notes attachment bootstrap service is unavailable"
+                    )
+                dataset = self.notes_attachment_bootstrapper.bootstrap(
                     service=self.service,
                     user_id=user_id,
                     dataset=dataset,

--- a/tldw_Server_API/app/core/Sync/v2/server_origin_batch.py
+++ b/tldw_Server_API/app/core/Sync/v2/server_origin_batch.py
@@ -15,6 +15,7 @@ from .adapters import (
     SyncAdapterContext,
     SyncHead,
 )
+from .attachment_refs_v2 import attachment_ref_v2_object_hash
 from .errors import (
     SyncIdempotencyConflictError,
     SyncMaterializationPredecessorError,
@@ -57,6 +58,8 @@ class ServerOriginMutationStep:
     routing_metadata: Mapping[str, object] = field(default_factory=dict)
     stable_key: str | None = None
     created_at_client: str | None = None
+    schema_version: int = 1
+    adapter_version: int = 1
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,6 +111,7 @@ def capture_server_origin_mutation_batch(
     idempotency_key: str,
     trusted_notes_organization_bootstrap_id: str | None = None,
     trusted_notes_link_bootstrap_id: str | None = None,
+    trusted_notes_attachment_bootstrap_id: str | None = None,
     bootstrap_relationship_verifier: Callable[[SyncDomain, str, Mapping[str, object]], bool]
     | None = None,
     bootstrap_relationship_absence_verifier: Callable[
@@ -124,13 +128,21 @@ def capture_server_origin_mutation_batch(
     normalized_key = idempotency_key.strip()
     if not normalized_key:
         raise SyncStoreError("Sync server-origin mutation batch requires an idempotency key")
-    if (
-        trusted_notes_organization_bootstrap_id is not None
-        and trusted_notes_link_bootstrap_id is not None
-    ):
+    trusted_contexts = tuple(
+        item
+        for item in (
+            trusted_notes_organization_bootstrap_id,
+            trusted_notes_link_bootstrap_id,
+            trusted_notes_attachment_bootstrap_id,
+        )
+        if item is not None
+    )
+    if len(trusted_contexts) > 1:
         raise SyncStoreError("Only one trusted bootstrap context may be supplied")
     trusted_bootstrap_id = (
-        trusted_notes_organization_bootstrap_id or trusted_notes_link_bootstrap_id
+        trusted_notes_organization_bootstrap_id
+        or trusted_notes_link_bootstrap_id
+        or trusted_notes_attachment_bootstrap_id
     )
     if trusted_bootstrap_id is not None and bootstrap_step_verifier is None:
         raise SyncStoreError("Sync bootstrap capture requires a source-step verifier")
@@ -171,6 +183,9 @@ def capture_server_origin_mutation_batch(
             envelopes=existing,
             bootstrap_id=trusted_bootstrap_id,
             bootstrap_step_verifier=bootstrap_step_verifier,
+            materialize_verified_bootstrap=(
+                trusted_notes_attachment_bootstrap_id is not None
+            ),
         )
 
     envelopes = _evaluate_plan(
@@ -181,6 +196,9 @@ def capture_server_origin_mutation_batch(
         mutation_plan_hash=mutation_plan_hash,
         bootstrap_id=trusted_bootstrap_id,
         notes_link_bootstrap=trusted_notes_link_bootstrap_id is not None,
+        notes_attachment_bootstrap=(
+            trusted_notes_attachment_bootstrap_id is not None
+        ),
         bootstrap_relationship_verifier=bootstrap_relationship_verifier,
         bootstrap_relationship_absence_verifier=(
             bootstrap_relationship_absence_verifier
@@ -204,6 +222,9 @@ def capture_server_origin_mutation_batch(
         envelopes=inserted,
         bootstrap_id=trusted_bootstrap_id,
         bootstrap_step_verifier=bootstrap_step_verifier,
+        materialize_verified_bootstrap=(
+            trusted_notes_attachment_bootstrap_id is not None
+        ),
     )
 
 
@@ -285,6 +306,7 @@ def _evaluate_plan(
     mutation_plan_hash: str,
     bootstrap_id: str | None = None,
     notes_link_bootstrap: bool = False,
+    notes_attachment_bootstrap: bool = False,
     bootstrap_relationship_verifier: Callable[[SyncDomain, str, Mapping[str, object]], bool]
     | None = None,
     bootstrap_relationship_absence_verifier: Callable[
@@ -324,8 +346,14 @@ def _evaluate_plan(
     step_count = len(canonical_steps)
     for index, step in enumerate(canonical_steps):
         prior_head = get_head(step.domain, step.object_id)
-        payload_hash, payload_size = canonical_payload_hash(dict(step.payload))
         object_revision = _next_object_revision(prior_head)
+        payload_hash, payload_size = canonical_payload_hash(dict(step.payload))
+        if notes_attachment_bootstrap and step.domain == "attachment.ref":
+            payload_hash = attachment_ref_v2_object_hash(
+                step.operation,
+                step.payload,
+                object_revision=object_revision,
+            )
         base_server_cursor = prior_head.server_cursor if prior_head is not None else None
         if isinstance(prior_head, SyncEnvelopeCreate) and base_server_cursor is None:
             # Cursor zero is outside stored history and marks an in-plan virtual head;
@@ -355,7 +383,8 @@ def _evaluate_plan(
             object_revision=object_revision,
             entity_version=(object_revision if step.domain == "notes.link" else None),
             parent_id=step.parent_id,
-            schema_version=1,
+            schema_version=step.schema_version,
+            adapter_version=step.adapter_version,
             payload=dict(step.payload),
             payload_hash=payload_hash,
             payload_size_bytes=payload_size,
@@ -385,8 +414,15 @@ def _evaluate_plan(
             list_heads=list_heads,
             trusted_server_origin=bootstrap_id is not None,
             organization_group_state=("initializing" if bootstrap_id is not None else None),
-            organization_bootstrap_id=(None if notes_link_bootstrap else bootstrap_id),
+            organization_bootstrap_id=(
+                bootstrap_id
+                if not notes_link_bootstrap and not notes_attachment_bootstrap
+                else None
+            ),
             notes_link_bootstrap_id=(bootstrap_id if notes_link_bootstrap else None),
+            attachment_ref_bootstrap_id=(
+                bootstrap_id if notes_attachment_bootstrap else None
+            ),
             bootstrap_relationship_verifier=bootstrap_relationship_verifier,
             bootstrap_relationship_absence_verifier=(
                 bootstrap_relationship_absence_verifier
@@ -412,6 +448,7 @@ def _materialize_group(
     envelopes: Sequence[SyncEnvelope],
     bootstrap_id: str | None = None,
     bootstrap_step_verifier: Callable[[SyncEnvelope], bool] | None = None,
+    materialize_verified_bootstrap: bool = False,
 ) -> ServerOriginBatchResult:
     group = list(envelopes)
     _validate_stored_group(
@@ -436,6 +473,7 @@ def _materialize_group(
                 group=group,
                 bootstrap_id=bootstrap_id,
                 bootstrap_step_verifier=bootstrap_step_verifier,
+                materialize_verified_bootstrap=materialize_verified_bootstrap,
             )
     except SyncIdempotencyConflictError:
         raise
@@ -456,6 +494,7 @@ def _materialize_group_guarded(
     group: list[SyncEnvelope],
     bootstrap_id: str | None,
     bootstrap_step_verifier: Callable[[SyncEnvelope], bool] | None,
+    materialize_verified_bootstrap: bool,
 ) -> tuple[ServerOriginBatchResult, bool | None]:
     """Project a complete group while the caller retains all object locks."""
 
@@ -467,10 +506,22 @@ def _materialize_group_guarded(
         if bootstrap_id is not None and bootstrap_step_verifier is not None:
             if envelope.server_cursor is None or not bootstrap_step_verifier(envelope):
                 return _materialization_result(dataset, group), True
-            store.mark_bootstrap_envelope_verified(
-                envelope.server_cursor,
-                bootstrap_id=bootstrap_id,
-            )
+            if materialize_verified_bootstrap:
+                materialization = service._materialize_envelope(
+                    envelope,
+                    store=store,
+                )
+                if materialization.status != "applied":
+                    group = store.list_mutation_group(
+                        dataset.dataset_id,
+                        envelope.mutation_group_id or "",
+                    )
+                    return _materialization_result(dataset, group), True
+            else:
+                store.mark_bootstrap_envelope_verified(
+                    envelope.server_cursor,
+                    bootstrap_id=bootstrap_id,
+                )
             group = store.list_mutation_group(
                 dataset.dataset_id,
                 envelope.mutation_group_id or "",
@@ -599,14 +650,15 @@ def _canonical_step(
     user_id: str,
 ) -> ServerOriginMutationStep:
     routing_metadata = dict(step.routing_metadata)
-    routing_metadata.update(
-        {
-            "source": source,
-            "origin": "server",
-            "server_device_id": SERVER_ORIGIN_DEVICE_ID,
-            "server_owner_user_id": user_id,
-        }
-    )
+    if not (step.domain == "attachment.ref" and step.adapter_version == 2):
+        routing_metadata.update(
+            {
+                "source": source,
+                "origin": "server",
+                "server_device_id": SERVER_ORIGIN_DEVICE_ID,
+                "server_owner_user_id": user_id,
+            }
+        )
     return ServerOriginMutationStep(
         domain=step.domain,
         operation=step.operation,
@@ -616,6 +668,8 @@ def _canonical_step(
         routing_metadata=routing_metadata,
         stable_key=step.stable_key,
         created_at_client=step.created_at_client,
+        schema_version=step.schema_version,
+        adapter_version=step.adapter_version,
     )
 
 
@@ -629,23 +683,29 @@ def _canonical_step_from_envelope(envelope: SyncEnvelope) -> ServerOriginMutatio
         routing_metadata=dict(envelope.routing_metadata),
         stable_key=envelope.stable_key,
         created_at_client=envelope.created_at_client,
+        schema_version=envelope.schema_version,
+        adapter_version=envelope.adapter_version,
     )
 
 
 def _mutation_plan_hash(steps: Sequence[ServerOriginMutationStep]) -> str:
+    plan: list[dict[str, object]] = []
+    for step in steps:
+        encoded_step: dict[str, object] = {
+            "domain": step.domain,
+            "operation": step.operation,
+            "object_id": step.object_id,
+            "payload": step.payload,
+            "parent_id": step.parent_id,
+            "routing_metadata": step.routing_metadata,
+            "stable_key": step.stable_key,
+        }
+        if step.schema_version != 1 or step.adapter_version != 1:
+            encoded_step["schema_version"] = step.schema_version
+            encoded_step["adapter_version"] = step.adapter_version
+        plan.append(encoded_step)
     encoded = json.dumps(
-        [
-            {
-                "domain": step.domain,
-                "operation": step.operation,
-                "object_id": step.object_id,
-                "payload": step.payload,
-                "parent_id": step.parent_id,
-                "routing_metadata": step.routing_metadata,
-                "stable_key": step.stable_key,
-            }
-            for step in steps
-        ],
+        plan,
         sort_keys=True,
         separators=(",", ":"),
         default=str,
@@ -716,6 +776,18 @@ def _require_batch_write_ready(
             or current_bootstrap_id != trusted_bootstrap_id
         ):
             raise SyncStoreError("notes_link_sync_not_ready")
+    if "attachment.ref" in domains:
+        metadata = dataset.metadata.get("notes_attachment_v2")
+        state = metadata.get("state") if isinstance(metadata, Mapping) else None
+        current_bootstrap_id = (
+            metadata.get("bootstrap_id") if isinstance(metadata, Mapping) else None
+        )
+        if state != "ready" and (
+            state != "initializing"
+            or trusted_bootstrap_id is None
+            or current_bootstrap_id != trusted_bootstrap_id
+        ):
+            raise SyncStoreError("notes_attachment_sync_not_ready")
     if domains.intersection(NOTES_ORGANIZATION_DOMAINS):
         metadata = dataset.metadata.get("notes_organization_v1")
         state = metadata.get("state") if isinstance(metadata, Mapping) else None

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -111,7 +111,11 @@ from .mutation_group_validation import (
     StoredMutationGroupValidationError,
     validate_stored_mutation_group,
 )
-from .profile import SyncProfileStatus, SyncV2ProfileManager
+from .profile import (
+    SyncNotesAttachmentBootstrapDiagnostics,
+    SyncProfileStatus,
+    SyncV2ProfileManager,
+)
 from .replay import SyncReplayRepairer, SyncReplayRepairResult
 from .restore import (
     OBJECT_RESTORE_DOMAINS,
@@ -1748,6 +1752,23 @@ class SyncV2Service:
             user_id=user_id,
             dataset_id=dataset_id,
             device_id=device_id,
+        )
+
+    def notes_attachment_bootstrap_diagnostics(
+        self,
+        *,
+        user_id: str,
+        dataset_id: str | None = None,
+        sample_limit: int = 0,
+        dry_run: bool = False,
+    ) -> SyncNotesAttachmentBootstrapDiagnostics:
+        """Return bounded read-only diagnostics for legacy attachment bootstrap."""
+
+        return self._profile_manager().notes_attachment_bootstrap_diagnostics(
+            user_id=user_id,
+            dataset_id=dataset_id,
+            sample_limit=sample_limit,
+            dry_run=dry_run,
         )
 
     def push(

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -857,6 +857,7 @@ class SyncV2Service:
         workspace_access_checker: WorkspaceAccessChecker | None = None,
         dataset_bootstrapper: object | None = None,
         notes_link_bootstrapper: object | None = None,
+        notes_attachment_bootstrapper: object | None = None,
     ) -> None:
         self.store = store
         self.adapters = adapters
@@ -868,6 +869,7 @@ class SyncV2Service:
         self.workspace_access_checker = workspace_access_checker
         self.dataset_bootstrapper = dataset_bootstrapper
         self.notes_link_bootstrapper = notes_link_bootstrapper
+        self.notes_attachment_bootstrapper = notes_attachment_bootstrapper
 
     def capabilities(
         self,
@@ -2888,6 +2890,7 @@ class SyncV2Service:
         idempotency_key: str | None = None,
         encryption_policy: EncryptionPolicy = DEFAULT_M1_ENCRYPTION_POLICY,
         metadata: dict[str, object] | None = None,
+        trusted_notes_attachment_bootstrap_id: str | None = None,
     ) -> SyncBlobUploadSession:
         """Create or resume a quota-checked M2 blob upload session."""
 
@@ -2917,6 +2920,7 @@ class SyncV2Service:
                 attachment_id=attachment_id,
                 content_type=content_type,
                 metadata=normalized_metadata,
+                trusted_bootstrap_id=trusted_notes_attachment_bootstrap_id,
             )
         elif "notes_attachment_intent" in normalized_metadata:
             raise SyncStoreError(
@@ -2950,6 +2954,7 @@ class SyncV2Service:
         attachment_id: str,
         content_type: str,
         metadata: dict[str, object],
+        trusted_bootstrap_id: str | None = None,
     ) -> dict[str, object]:
         """Validate and bind one strict immutable Notes attachment upload intent."""
 
@@ -2957,7 +2962,14 @@ class SyncV2Service:
             adapter = self.adapters.get("attachment.ref")
         except KeyError as exc:
             raise SyncStoreError("Notes attachment upload intent is unavailable") from exc
-        if not sync_v2_attachment_ref_v2_is_writable(
+        state = dataset.metadata.get("notes_attachment_v2")
+        trusted_bootstrap = bool(
+            trusted_bootstrap_id is not None
+            and isinstance(state, Mapping)
+            and state.get("state") == "initializing"
+            and state.get("bootstrap_id") == trusted_bootstrap_id
+        )
+        if not trusted_bootstrap and not sync_v2_attachment_ref_v2_is_writable(
             dataset,
             notes_attachment_sync_enabled=bool(
                 getattr(adapter, "v2_writes_enabled", False)
@@ -5577,6 +5589,7 @@ class SyncV2Service:
             service=self,
             dataset_bootstrapper=self.dataset_bootstrapper,
             notes_link_bootstrapper=self.notes_link_bootstrapper,
+            notes_attachment_bootstrapper=self.notes_attachment_bootstrapper,
         )
 
     def _update_cursors(

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -53,6 +53,8 @@ from .models import (
     SyncKeyRecord,
     SyncKeyRecordCreate,
     SyncKeyRotationEnvelopeRange,
+    SyncNotesAttachmentCleanupCandidate,
+    SyncNotesAttachmentSourceMap,
     SyncObjectState,
     SyncRestoreManifestStats,
 )
@@ -369,6 +371,105 @@ class SyncV2Store:
             source_hash=source_hash,
             error_code=error_code,
             ready_verifier=ready_verifier,
+        )
+
+    def begin_notes_attachment_bootstrap(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+    ) -> SyncDataset:
+        return self.db.begin_notes_attachment_bootstrap(
+            dataset_id,
+            owner_user_id=owner_user_id,
+            bootstrap_id=bootstrap_id,
+        )
+
+    def transition_notes_attachment_bootstrap(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+        expected_state: str,
+        state: str,
+        captured_count: int,
+        expected_count: int,
+        source_hash: str | None,
+        source_cursor: str | None,
+        error_code: str | None = None,
+        ready_verifier: Callable[[], bool] | None = None,
+    ) -> SyncDataset:
+        return self.db.transition_notes_attachment_bootstrap(
+            dataset_id,
+            owner_user_id=owner_user_id,
+            bootstrap_id=bootstrap_id,
+            expected_state=expected_state,
+            state=state,
+            captured_count=captured_count,
+            expected_count=expected_count,
+            source_hash=source_hash,
+            source_cursor=source_cursor,
+            error_code=error_code,
+            ready_verifier=ready_verifier,
+        )
+
+    def resolve_notes_attachment_source_map(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+        note_id: str,
+        source_key: str,
+    ) -> SyncNotesAttachmentSourceMap:
+        return self.db.resolve_notes_attachment_source_map(
+            dataset_id,
+            owner_user_id=owner_user_id,
+            bootstrap_id=bootstrap_id,
+            note_id=note_id,
+            source_key=source_key,
+        )
+
+    def record_notes_attachment_cleanup_candidate(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+        source_key: str,
+        source_relative_path: str,
+        source_blob_hash: str,
+        source_size_bytes: int,
+        source_modified_ns: int,
+    ) -> SyncNotesAttachmentCleanupCandidate:
+        return self.db.record_notes_attachment_cleanup_candidate(
+            dataset_id,
+            owner_user_id=owner_user_id,
+            bootstrap_id=bootstrap_id,
+            source_key=source_key,
+            source_relative_path=source_relative_path,
+            source_blob_hash=source_blob_hash,
+            source_size_bytes=source_size_bytes,
+            source_modified_ns=source_modified_ns,
+        )
+
+    def list_notes_attachment_cleanup_candidates(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+        after_source_key_hash: str | None = None,
+        limit: int = 1_000,
+    ) -> tuple[SyncNotesAttachmentCleanupCandidate, ...]:
+        return self.db.list_notes_attachment_cleanup_candidates(
+            dataset_id,
+            owner_user_id=owner_user_id,
+            bootstrap_id=bootstrap_id,
+            after_source_key_hash=after_source_key_hash,
+            limit=limit,
         )
 
     def insert_envelope(self, envelope: SyncEnvelopeCreate) -> SyncEnvelope:

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -472,6 +472,26 @@ class SyncV2Store:
             limit=limit,
         )
 
+    def get_notes_attachment_bootstrap_source_by_hash(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        bootstrap_id: str,
+        source_key_hash: str,
+    ) -> tuple[
+        SyncNotesAttachmentSourceMap,
+        SyncNotesAttachmentCleanupCandidate,
+    ] | None:
+        """Resolve one internal bootstrap source by its public-safe hash."""
+
+        return self.db.get_notes_attachment_bootstrap_source_by_hash(
+            dataset_id,
+            owner_user_id=owner_user_id,
+            bootstrap_id=bootstrap_id,
+            source_key_hash=source_key_hash,
+        )
+
     def insert_envelope(self, envelope: SyncEnvelopeCreate) -> SyncEnvelope:
         return self.db.insert_envelope(envelope, connection=self._connection)
 

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -59,6 +59,14 @@ class NoteAttachmentPolicyError(ValueError):
     """Raised when attachment metadata is outside the canonical Notes policy."""
 
 
+class LegacyAttachmentSourceError(RuntimeError):
+    """Sanitized failure while reading a legacy Notes attachment source."""
+
+    def __init__(self, error_code: str) -> None:
+        super().__init__(error_code)
+        self.error_code = error_code
+
+
 class NotesAttachmentMutationError(RuntimeError):
     """Stable failure for a coordinated Notes attachment mutation."""
 

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -67,6 +67,10 @@ class LegacyAttachmentSourceError(RuntimeError):
         self.error_code = error_code
 
 
+class NotesAttachmentBootstrapInterrupted(RuntimeError):
+    """Testable interruption that deliberately leaves durable progress resumable."""
+
+
 class NotesAttachmentMutationError(RuntimeError):
     """Stable failure for a coordinated Notes attachment mutation."""
 

--- a/tldw_Server_API/tests/Notes/test_legacy_attachment_source.py
+++ b/tldw_Server_API/tests/Notes/test_legacy_attachment_source.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+OWNER_ID = "owner-1"
+
+
+def _source_type() -> type[Any]:
+    try:
+        module = importlib.import_module(
+            "tldw_Server_API.app.core.Notes.legacy_attachment_source"
+        )
+    except ModuleNotFoundError:
+        pytest.fail("legacy attachment source seam is missing")
+    return module.LegacyAttachmentSource
+
+
+def _source_error_code(exc: BaseException) -> str | None:
+    return getattr(exc, "error_code", None)
+
+
+def _note_dir(user_root: Path, note_id: str) -> Path:
+    from tldw_Server_API.app.api.v1.endpoints.notes import (
+        _safe_note_attachment_dirname,
+    )
+
+    return user_root / "notes_attachments" / _safe_note_attachment_dirname(note_id)
+
+
+@pytest.fixture()
+def note_db(tmp_path: Path):
+    db = CharactersRAGDB(tmp_path / "notes.db", client_id=OWNER_ID)
+    try:
+        yield db
+    finally:
+        db.close_connection()
+
+
+@pytest.mark.unit
+def test_note_pages_are_id_ordered_bounded_and_include_soft_deleted(
+    tmp_path: Path,
+    note_db: CharactersRAGDB,
+) -> None:
+    note_ids = [f"note-{index:03d}" for index in range(202, 0, -1)]
+    for note_id in note_ids:
+        note_db.note_store.add_note(note_id, "body", note_id=note_id)
+    assert note_db.note_store.soft_delete_note("note-002", expected_version=1)
+    source = _source_type()(note_db, owner_user_id=OWNER_ID, user_root=tmp_path / "owner")
+
+    first = source.list_note_ids(limit=200)
+    second = source.list_note_ids(after_note_id=first[-1], limit=200)
+
+    assert first == tuple(sorted(note_ids)[:200])
+    assert second == tuple(sorted(note_ids)[200:])
+    assert "note-002" in first
+    with pytest.raises(ValueError, match="1..200"):
+        source.list_note_ids(limit=201)
+
+
+@pytest.mark.unit
+def test_candidates_use_authoritative_note_directory_and_sorted_stable_keys(
+    tmp_path: Path,
+    note_db: CharactersRAGDB,
+) -> None:
+    note_id = "../../note-owned"
+    note_db.note_store.add_note("owned", "body", note_id=note_id)
+    user_root = tmp_path / "owner"
+    note_dir = _note_dir(user_root, note_id)
+    note_dir.mkdir(parents=True)
+    (note_dir / "zeta.txt").write_bytes(b"zeta")
+    (note_dir / "alpha.txt").write_bytes(b"alpha")
+    (note_dir / "alpha.txt.meta.json").write_text(
+        json.dumps({"content_type": "text/plain"}),
+        encoding="utf-8",
+    )
+    source = _source_type()(note_db, owner_user_id=OWNER_ID, user_root=user_root)
+
+    before = {item.name: item.read_bytes() for item in note_dir.iterdir()}
+    candidates = source.list_candidates(note_id)
+    (note_dir / "alpha.txt").touch()
+    repeated = source.list_candidates(note_id)
+
+    assert source.note_directory(note_id) == note_dir
+    assert source.note_directory(note_id).is_relative_to(user_root / "notes_attachments")
+    assert [item.file_name for item in candidates] == ["alpha.txt", "zeta.txt"]
+    assert [item.source_key for item in repeated] == [item.source_key for item in candidates]
+    assert candidates[0].sha256 == "sha256:" + hashlib.sha256(b"alpha").hexdigest()
+    assert candidates[0].metadata == {"content_type": "text/plain"}
+    assert {item.name: item.read_bytes() for item in note_dir.iterdir()} == before
+
+
+@pytest.mark.unit
+def test_candidate_enumeration_is_capped_per_note_and_cursor_is_bounded(
+    tmp_path: Path,
+    note_db: CharactersRAGDB,
+) -> None:
+    note_id = "note-many"
+    note_db.note_store.add_note("many", "body", note_id=note_id)
+    user_root = tmp_path / "owner"
+    note_dir = _note_dir(user_root, note_id)
+    note_dir.mkdir(parents=True)
+    for index in range(1001):
+        (note_dir / f"item-{index:04d}.txt").write_text("x", encoding="utf-8")
+    source = _source_type()(note_db, owner_user_id=OWNER_ID, user_root=user_root)
+
+    first = source.list_candidates(note_id)
+    second = source.list_candidates(note_id, after_source_key=first[-1].source_key)
+
+    assert len(first) == 1000
+    assert len(second) == 1
+    with pytest.raises(Exception) as raised:
+        source.list_candidates(note_id, after_source_key="x" * 4097)
+    assert _source_error_code(raised.value) == "notes_attachment_source_cursor_too_large"
+    with pytest.raises(Exception) as malformed:
+        source.list_candidates(note_id, after_source_key="../foreign-source")
+    assert _source_error_code(malformed.value) == "notes_attachment_source_cursor_invalid"
+
+
+@pytest.mark.unit
+def test_legacy_route_helper_rejects_attachment_root_symlink_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import notes as notes_endpoint
+
+    user_root = tmp_path / "owner"
+    outside = tmp_path / "outside"
+    user_root.mkdir()
+    outside.mkdir()
+    try:
+        (user_root / "notes_attachments").symlink_to(
+            outside,
+            target_is_directory=True,
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("filesystem symlinks are unavailable")
+    monkeypatch.setattr(
+        notes_endpoint.DatabasePaths,
+        "get_user_base_directory",
+        lambda _user_id: user_root,
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        notes_endpoint._get_note_attachments_base_dir(OWNER_ID)
+
+    assert raised.value.status_code == 500
+
+
+@pytest.mark.unit
+def test_sidecar_is_read_with_a_64_kib_limit(
+    tmp_path: Path,
+    note_db: CharactersRAGDB,
+) -> None:
+    note_id = "note-sidecar"
+    note_db.note_store.add_note("sidecar", "body", note_id=note_id)
+    user_root = tmp_path / "owner"
+    note_dir = _note_dir(user_root, note_id)
+    note_dir.mkdir(parents=True)
+    (note_dir / "payload.txt").write_text("body", encoding="utf-8")
+    (note_dir / "payload.txt.meta.json").write_bytes(b"{" + b"x" * 65536)
+    source = _source_type()(note_db, owner_user_id=OWNER_ID, user_root=user_root)
+
+    with pytest.raises(Exception) as raised:
+        source.list_candidates(note_id)
+
+    assert _source_error_code(raised.value) == "notes_attachment_sidecar_too_large"
+
+
+@pytest.mark.unit
+def test_symlinked_note_directory_and_candidate_fail_closed(
+    tmp_path: Path,
+    note_db: CharactersRAGDB,
+) -> None:
+    note_id = "note-link"
+    note_db.note_store.add_note("link", "body", note_id=note_id)
+    user_root = tmp_path / "owner"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret", encoding="utf-8")
+    note_dir = _note_dir(user_root, note_id)
+    note_dir.parent.mkdir(parents=True)
+    try:
+        note_dir.symlink_to(outside, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("filesystem symlinks are unavailable")
+    source = _source_type()(note_db, owner_user_id=OWNER_ID, user_root=user_root)
+
+    with pytest.raises(Exception) as directory_error:
+        source.list_candidates(note_id)
+    assert _source_error_code(directory_error.value) == "notes_attachment_source_unsafe"
+
+    note_dir.unlink()
+    note_dir.mkdir()
+    (note_dir / "secret.txt").symlink_to(outside / "secret.txt")
+    with pytest.raises(Exception) as candidate_error:
+        source.list_candidates(note_id)
+    assert _source_error_code(candidate_error.value) == "notes_attachment_source_unsafe"
+
+
+@pytest.mark.unit
+def test_source_rejects_note_ids_not_owned_by_the_database(
+    tmp_path: Path,
+    note_db: CharactersRAGDB,
+) -> None:
+    source = _source_type()(note_db, owner_user_id=OWNER_ID, user_root=tmp_path / "owner")
+
+    with pytest.raises(Exception) as raised:
+        source.list_candidates("unknown-note")
+
+    assert _source_error_code(raised.value) == "notes_attachment_source_note_not_found"

--- a/tldw_Server_API/tests/Notes/test_notes_attachment_sync_api.py
+++ b/tldw_Server_API/tests/Notes/test_notes_attachment_sync_api.py
@@ -886,9 +886,11 @@ def test_canonical_keyset_pages_batch_availability_and_reject_bad_cursors(
     assert len(second.json()["items"]) == 1
     assert availability_queries == 2
 
+    base64url_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    noncanonical_last = base64url_alphabet[base64url_alphabet.index(cursor[-1]) + 1]
     tampered = client.get(
         f"/api/v1/notes/{NOTE_ID}/attachments/canonical",
-        params={"dataset_id": DATASET_ID, "cursor": cursor[:-1] + "x"},
+        params={"dataset_id": DATASET_ID, "cursor": cursor[:-1] + noncanonical_last},
     )
     oversized = client.get(
         f"/api/v1/notes/{NOTE_ID}/attachments/canonical",

--- a/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
@@ -5,11 +5,15 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    User,
+    check_rate_limit,
+    get_request_user,
+)
 from tldw_Server_API.app.api.v1.endpoints import sync as sync_endpoint
 from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
 from tldw_Server_API.app.core.Sync.v2.adapters import (
@@ -901,6 +905,61 @@ def test_attachment_bootstrap_diagnostics_endpoint_is_read_only_and_bounded(
     assert oversized.json()["detail"]["error_code"] == (
         "sync_attachment_bootstrap_sample_limit_exceeded"
     )
+
+
+def test_attachment_bootstrap_diagnostics_for_fresh_user_does_not_create_sync_db(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sync_db_path = tmp_path / "fresh_attachment_diagnostics.db"
+    monkeypatch.setenv("SYNC_V2_SQLITE_PATH", str(sync_db_path))
+    app = FastAPI()
+    app.include_router(sync_endpoint.router, prefix="/api/v1/sync")
+    app.dependency_overrides[get_request_user] = _test_user
+    client = TestClient(app)
+
+    response = client.get("/api/v1/sync/profile/attachment-bootstrap")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "state": "not_started",
+        "captured_count": 0,
+        "expected_count": 0,
+        "cursor": None,
+        "error_code": None,
+        "dry_run": False,
+        "source_candidate_count": None,
+        "source_candidate_count_is_lower_bound": False,
+        "cleanup_candidates": [],
+    }
+    assert not sync_db_path.exists()
+
+    oversized = client.get(
+        "/api/v1/sync/profile/attachment-bootstrap",
+        params={"sample_limit": 101},
+    )
+    assert oversized.status_code == 413
+    assert not sync_db_path.exists()
+
+
+def test_attachment_bootstrap_diagnostics_enforces_ingress_rate_limit(
+    sync_service: SyncV2Service,
+) -> None:
+    async def _deny_rate_limit() -> None:
+        raise HTTPException(status_code=429, detail="rate limited")
+
+    app = FastAPI()
+    app.include_router(sync_endpoint.router, prefix="/api/v1/sync")
+    app.dependency_overrides[get_request_user] = _test_user
+    app.dependency_overrides[sync_endpoint.get_sync_v2_profile_service] = (
+        lambda: sync_service
+    )
+    app.dependency_overrides[check_rate_limit] = _deny_rate_limit
+    client = TestClient(app)
+
+    response = client.get("/api/v1/sync/profile/attachment-bootstrap")
+
+    assert response.status_code == 429
 
 
 def test_profile_bootstrap_and_status_expose_safe_attachment_progress(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
@@ -857,6 +857,182 @@ def test_profile_bootstrap_endpoint_idempotently_creates_dataset_and_device(
     assert len(sync_service.store.list_devices_for_user("user-1")) == 1
 
 
+def test_attachment_bootstrap_diagnostics_endpoint_is_read_only_and_bounded(
+    client: TestClient,
+    sync_service: SyncV2Service,
+) -> None:
+    class _DryRunBootstrapper:
+        def dry_run(self, *, service: SyncV2Service, user_id: str):
+            assert service is sync_service
+            assert user_id == "user-1"
+            return {
+                "candidate_count": 7,
+                "candidate_count_is_lower_bound": False,
+                "error_code": None,
+            }
+
+    sync_service.notes_attachment_bootstrapper = _DryRunBootstrapper()
+
+    response = client.get(
+        "/api/v1/sync/profile/attachment-bootstrap",
+        params={"dry_run": "true", "sample_limit": 0},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "state": "not_started",
+        "captured_count": 0,
+        "expected_count": 0,
+        "cursor": None,
+        "error_code": None,
+        "dry_run": True,
+        "source_candidate_count": 7,
+        "source_candidate_count_is_lower_bound": False,
+        "cleanup_candidates": [],
+    }
+    assert sync_service.store.list_datasets_for_user("user-1") == []
+    assert sync_service.store.list_devices_for_user("user-1") == []
+
+    oversized = client.get(
+        "/api/v1/sync/profile/attachment-bootstrap",
+        params={"sample_limit": 101},
+    )
+    assert oversized.status_code == 413
+    assert oversized.json()["detail"]["error_code"] == (
+        "sync_attachment_bootstrap_sample_limit_exceeded"
+    )
+
+
+def test_profile_bootstrap_and_status_expose_safe_attachment_progress(
+    client: TestClient,
+    sync_service: SyncV2Service,
+) -> None:
+    started = client.post(
+        "/api/v1/sync/profile/bootstrap",
+        json={
+            "mode": "offline_sync",
+            "device_id": "device-1",
+            "requested_domains": [*M1_SYNC_DOMAINS, "attachment.ref"],
+        },
+    )
+    status_response = client.get("/api/v1/sync/profile")
+
+    assert started.status_code == status_response.status_code == 200
+    expected = {
+        "state": "initializing",
+        "captured_count": 0,
+        "expected_count": 0,
+        "error_code": None,
+    }
+    assert started.json()["dataset"]["notes_attachment"] == expected
+    assert status_response.json()["dataset"]["notes_attachment"] == expected
+    assert "bootstrap_id" not in started.text
+    assert "source_cursor" not in started.text
+
+    dataset_id = started.json()["dataset"]["dataset_id"]
+    dataset = sync_service.store.get_dataset(dataset_id, owner_user_id="user-1")
+    assert dataset is not None
+    bootstrap_id = dataset.metadata["notes_attachment_v2"]["bootstrap_id"]
+    empty_hash = hashlib.sha256(b"").hexdigest()
+    sync_service.store.transition_notes_attachment_bootstrap(
+        dataset_id,
+        owner_user_id="user-1",
+        bootstrap_id=bootstrap_id,
+        expected_state="initializing",
+        state="ready",
+        captured_count=0,
+        expected_count=0,
+        source_hash=empty_hash,
+        source_cursor=None,
+        ready_verifier=lambda: True,
+    )
+    ready = client.get("/api/v1/sync/profile")
+    assert ready.json()["dataset"]["notes_attachment"]["state"] == "ready"
+
+    sync_service.store.transition_notes_attachment_bootstrap(
+        dataset_id,
+        owner_user_id="user-1",
+        bootstrap_id=bootstrap_id,
+        expected_state="ready",
+        state="failed",
+        captured_count=0,
+        expected_count=0,
+        source_hash=empty_hash,
+        source_cursor=None,
+        error_code="notes_attachment_source_changed",
+    )
+    failed = client.get("/api/v1/sync/profile")
+    assert failed.json()["dataset"]["notes_attachment"] == {
+        "state": "failed",
+        "captured_count": 0,
+        "expected_count": 0,
+        "error_code": "notes_attachment_source_changed",
+    }
+
+
+def test_attachment_bootstrap_diagnostics_enforce_owner_and_hide_legacy_path(
+    client: TestClient,
+    sync_service: SyncV2Service,
+) -> None:
+    own = sync_service.store.get_or_create_default_personal_dataset("user-1")
+    own = sync_service.store.begin_notes_attachment_bootstrap(
+        own.dataset_id,
+        owner_user_id="user-1",
+        bootstrap_id="bootstrap-private",
+    )
+    source_key = "notes_attachments/note-secret/private-name.pdf"
+    mapping = sync_service.store.resolve_notes_attachment_source_map(
+        own.dataset_id,
+        owner_user_id="user-1",
+        bootstrap_id="bootstrap-private",
+        note_id="note-secret",
+        source_key=source_key,
+    )
+    sync_service.store.record_notes_attachment_cleanup_candidate(
+        own.dataset_id,
+        owner_user_id="user-1",
+        bootstrap_id="bootstrap-private",
+        source_key=source_key,
+        source_relative_path=source_key,
+        source_blob_hash="sha256:" + "2" * 64,
+        source_size_bytes=10,
+        source_modified_ns=1,
+    )
+    other = sync_service.store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="other-dataset",
+            owner_user_id="other-user",
+            scope_type="personal",
+            domains=list(M1_SYNC_DOMAINS),
+        )
+    )
+
+    response = client.get(
+        "/api/v1/sync/profile/attachment-bootstrap",
+        params={"dataset_id": own.dataset_id, "sample_limit": 1},
+    )
+    denied = client.get(
+        "/api/v1/sync/profile/attachment-bootstrap",
+        params={"dataset_id": other.dataset_id, "sample_limit": 1},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["cleanup_candidates"] == [
+        {
+            "source_key_hash": "sha256:"
+            + hashlib.sha256(source_key.encode()).hexdigest(),
+            "attachment_id": mapping.attachment_id,
+            "state": "captured",
+            "blocker_code": None,
+        }
+    ]
+    assert "private-name.pdf" not in response.text
+    assert "notes_attachments" not in response.text
+    assert "bootstrap-private" not in response.text
+    assert denied.status_code == 404
+    assert "other-dataset" not in denied.text
+
+
 @pytest.mark.parametrize(
     "version_map",
     [

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_attachment_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_attachment_bootstrap.py
@@ -1,0 +1,667 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+import tldw_Server_API.app.core.DB_Management.Sync_DB as sync_db_module
+from tldw_Server_API.app.core.DB_Management.backends.base import QueryResult
+from tldw_Server_API.app.core.DB_Management.Sync_DB import (
+    SYNC_POSTGRES_SCHEMA,
+    SYNC_SQLITE_SCHEMA,
+    SyncDatabase,
+)
+from tldw_Server_API.app.core.Sync.v2.errors import (
+    SyncDatasetNotFoundError,
+    SyncStoreError,
+)
+from tldw_Server_API.app.core.Sync.v2.models import (
+    SyncDatasetCreate,
+    SyncEnvelopeCreate,
+    sync_v2_attachment_ref_v2_is_writable,
+)
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
+
+
+@pytest.fixture()
+def sync_store(tmp_path: Path) -> SyncV2Store:
+    return SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "sync.db"))
+
+
+def _enroll_notes_dataset(sync_store: SyncV2Store) -> None:
+    sync_store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-1",
+            owner_user_id="owner-1",
+            domains=["notes.note"],
+        )
+    )
+
+
+@pytest.mark.unit
+def test_attachment_bootstrap_begin_is_idempotent_and_enrolls_v2(
+    sync_store: SyncV2Store,
+) -> None:
+    _enroll_notes_dataset(sync_store)
+
+    begun = sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+    )
+    replay = sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-replacement-must-not-win",
+    )
+
+    assert begun.metadata["notes_attachment_v2"] == {
+        "bootstrap_id": "bootstrap-stable",
+        "state": "initializing",
+        "target_adapter_version": 2,
+        "captured_count": 0,
+        "expected_count": 0,
+        "source_hash": None,
+        "source_cursor": None,
+        "error_code": None,
+    }
+    assert replay.metadata["notes_attachment_v2"] == begun.metadata["notes_attachment_v2"]
+    assert "attachment.ref" in replay.domains
+    states = sync_store.db.execute(
+        "SELECT adapter_version, server_sequence FROM sync_domain_state "
+        "WHERE dataset_id = ? AND domain = ? ORDER BY adapter_version",
+        ("dataset-1", "attachment.ref"),
+    ).rows
+    assert states == [{"adapter_version": 2, "server_sequence": 0}]
+
+
+@pytest.mark.unit
+def test_attachment_bootstrap_transition_is_cas_and_failure_code_is_safe(
+    sync_store: SyncV2Store,
+) -> None:
+    _enroll_notes_dataset(sync_store)
+    sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+    )
+    source_hash = hashlib.sha256(b"source-set").hexdigest()
+
+    progressed = sync_store.transition_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        expected_state="initializing",
+        state="initializing",
+        captured_count=1,
+        expected_count=2,
+        source_hash=source_hash,
+        source_cursor='{"note_id":"note-1","source_key_hash":"safe"}',
+    )
+
+    assert progressed.metadata["notes_attachment_v2"]["captured_count"] == 1
+    assert progressed.metadata["notes_attachment_v2"]["source_hash"] == source_hash
+    with pytest.raises(
+        SyncStoreError,
+        match="notes_attachment_bootstrap_compare_and_set_failed",
+    ):
+        sync_store.transition_notes_attachment_bootstrap(
+            "dataset-1",
+            owner_user_id="owner-1",
+            bootstrap_id="wrong-bootstrap",
+            expected_state="initializing",
+            state="failed",
+            captured_count=1,
+            expected_count=2,
+            source_hash=source_hash,
+            source_cursor=None,
+            error_code="notes_attachment_source_changed",
+        )
+    with pytest.raises(SyncStoreError, match="failure code is invalid"):
+        sync_store.transition_notes_attachment_bootstrap(
+            "dataset-1",
+            owner_user_id="owner-1",
+            bootstrap_id="bootstrap-stable",
+            expected_state="initializing",
+            state="failed",
+            captured_count=1,
+            expected_count=2,
+            source_hash=source_hash,
+            source_cursor=None,
+            error_code="/private/owner/notes/file.txt",
+        )
+    failed = sync_store.transition_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        expected_state="initializing",
+        state="failed",
+        captured_count=1,
+        expected_count=2,
+        source_hash=source_hash,
+        source_cursor=None,
+        error_code="notes_attachment_source_changed",
+    )
+    assert failed.metadata["notes_attachment_v2"]["error_code"] == (
+        "notes_attachment_source_changed"
+    )
+
+
+@pytest.mark.unit
+def test_attachment_bootstrap_progress_and_source_hash_are_monotonic(
+    sync_store: SyncV2Store,
+) -> None:
+    _enroll_notes_dataset(sync_store)
+    sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+    )
+    first_hash = hashlib.sha256(b"source-set").hexdigest()
+    sync_store.transition_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        expected_state="initializing",
+        state="initializing",
+        captured_count=1,
+        expected_count=2,
+        source_hash=first_hash,
+        source_cursor='{"source_key_hash":"safe"}',
+    )
+
+    with pytest.raises(SyncStoreError, match="progress_regressed"):
+        sync_store.transition_notes_attachment_bootstrap(
+            "dataset-1",
+            owner_user_id="owner-1",
+            bootstrap_id="bootstrap-stable",
+            expected_state="initializing",
+            state="initializing",
+            captured_count=0,
+            expected_count=2,
+            source_hash=first_hash,
+            source_cursor=None,
+        )
+    with pytest.raises(SyncStoreError, match="source_changed"):
+        sync_store.transition_notes_attachment_bootstrap(
+            "dataset-1",
+            owner_user_id="owner-1",
+            bootstrap_id="bootstrap-stable",
+            expected_state="initializing",
+            state="initializing",
+            captured_count=1,
+            expected_count=2,
+            source_hash=hashlib.sha256(b"different").hexdigest(),
+            source_cursor=None,
+        )
+
+
+@pytest.mark.unit
+def test_attachment_bootstrap_ready_requires_exact_counts_and_verification(
+    sync_store: SyncV2Store,
+) -> None:
+    _enroll_notes_dataset(sync_store)
+    sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+    )
+    source_hash = hashlib.sha256(b"source-set").hexdigest()
+
+    with pytest.raises(
+        SyncStoreError,
+        match="notes_attachment_bootstrap_verification_failed",
+    ):
+        sync_store.transition_notes_attachment_bootstrap(
+            "dataset-1",
+            owner_user_id="owner-1",
+            bootstrap_id="bootstrap-stable",
+            expected_state="initializing",
+            state="ready",
+            captured_count=2,
+            expected_count=2,
+            source_hash=source_hash,
+            source_cursor=None,
+            ready_verifier=lambda: False,
+        )
+    ready = sync_store.transition_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        expected_state="initializing",
+        state="ready",
+        captured_count=2,
+        expected_count=2,
+        source_hash=source_hash,
+        source_cursor=None,
+        ready_verifier=lambda: True,
+    )
+    assert ready.metadata["notes_attachment_v2"]["state"] == "ready"
+    assert ready.metadata["notes_attachment_v2"]["target_adapter_version"] == 2
+
+
+@pytest.mark.unit
+def test_attachment_bootstrap_transition_requires_owner_at_sql_boundary(
+    sync_store: SyncV2Store,
+) -> None:
+    _enroll_notes_dataset(sync_store)
+    sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+    )
+
+    with pytest.raises(SyncDatasetNotFoundError):
+        sync_store.transition_notes_attachment_bootstrap(
+            "dataset-1",
+            owner_user_id="owner-2",
+            bootstrap_id="bootstrap-stable",
+            expected_state="initializing",
+            state="failed",
+            captured_count=0,
+            expected_count=0,
+            source_hash=None,
+            source_cursor=None,
+            error_code="notes_attachment_source_changed",
+        )
+
+
+@pytest.mark.unit
+def test_attachment_bootstrap_keeps_v1_pullable_and_v2_closed_until_ready(
+    sync_store: SyncV2Store,
+) -> None:
+    sync_store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-1",
+            owner_user_id="owner-1",
+            domains=["notes.note", "attachment.ref"],
+        )
+    )
+    legacy = sync_store.insert_envelope(
+        SyncEnvelopeCreate(
+            dataset_id="dataset-1",
+            client_envelope_id="legacy-ref-1",
+            domain="attachment.ref",
+            operation="upsert",
+            object_id="8b61cb20-92b5-4a41-8f38-763b24e7c2d0",
+            adapter_version=1,
+            payload={
+                "attachment_id": "8b61cb20-92b5-4a41-8f38-763b24e7c2d0",
+                "parent_domain": "notes.note",
+                "parent_object_id": "note-1",
+                "content_type": "application/pdf",
+                "size_bytes": 7,
+                "payload_hash": "sha256:" + "a" * 64,
+                "availability": "available",
+            },
+            payload_hash="sha256:" + "a" * 64,
+        )
+    )
+
+    initializing = sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+    )
+
+    assert sync_store.list_envelopes_after(
+        "dataset-1",
+        0,
+        domains=["attachment.ref"],
+        adapter_versions=[1],
+    ) == [legacy]
+    assert not sync_v2_attachment_ref_v2_is_writable(
+        initializing,
+        notes_attachment_sync_enabled=True,
+        supports_attachments=True,
+    )
+
+
+@pytest.mark.unit
+def test_source_map_allocates_one_uuid4_per_source_key(
+    sync_store: SyncV2Store,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enroll_notes_dataset(sync_store)
+    sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+    )
+    allocated: list[str] = []
+    real_uuid4 = sync_db_module.uuid4
+
+    def tracked_uuid4():
+        value = real_uuid4()
+        allocated.append(str(value))
+        return value
+
+    monkeypatch.setattr(sync_db_module, "uuid4", tracked_uuid4)
+
+    first = sync_store.resolve_notes_attachment_source_map(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        note_id="note-1",
+        source_key="notes_attachments/note-1/report.pdf",
+    )
+    replay = sync_store.resolve_notes_attachment_source_map(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        note_id="note-1",
+        source_key="notes_attachments/note-1/report.pdf",
+    )
+    second = sync_store.resolve_notes_attachment_source_map(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        note_id="note-1",
+        source_key="notes_attachments/note-1/appendix.pdf",
+    )
+
+    assert replay == first
+    assert len(allocated) == 2
+    assert first.attachment_id != second.attachment_id
+    assert UUID(first.attachment_id).version == 4
+    assert first.source_key_hash == "sha256:" + hashlib.sha256(
+        b"notes_attachments/note-1/report.pdf"
+    ).hexdigest()
+    columns = sync_store.db.execute(
+        "PRAGMA table_info(sync_notes_attachment_source_map)"
+    ).rows
+    assert "source_key" not in {row["name"] for row in columns}
+
+
+@pytest.mark.unit
+def test_cleanup_candidate_keeps_internal_path_out_of_repr_and_pages_bounded(
+    sync_store: SyncV2Store,
+) -> None:
+    _enroll_notes_dataset(sync_store)
+    sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+    )
+    mapping = sync_store.resolve_notes_attachment_source_map(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        note_id="note-1",
+        source_key="notes_attachments/note-1/report.pdf",
+    )
+    candidate = sync_store.record_notes_attachment_cleanup_candidate(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        source_key="notes_attachments/note-1/report.pdf",
+        source_relative_path="notes_attachments/note-1/report.pdf",
+        source_blob_hash="sha256:" + hashlib.sha256(b"payload").hexdigest(),
+        source_size_bytes=7,
+        source_modified_ns=123,
+    )
+    replay = sync_store.record_notes_attachment_cleanup_candidate(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        source_key="notes_attachments/note-1/report.pdf",
+        source_relative_path="notes_attachments/note-1/report.pdf",
+        source_blob_hash="sha256:" + hashlib.sha256(b"payload").hexdigest(),
+        source_size_bytes=7,
+        source_modified_ns=123,
+    )
+
+    assert replay == candidate
+    assert candidate.attachment_id == mapping.attachment_id
+    assert candidate.source_path_hash == mapping.source_key_hash
+    assert candidate.source_relative_path == "notes_attachments/note-1/report.pdf"
+    assert candidate.source_relative_path not in repr(candidate)
+    assert candidate.source_path_hash in repr(candidate)
+    assert sync_store.list_notes_attachment_cleanup_candidates(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        limit=1,
+    ) == (candidate,)
+    with pytest.raises(ValueError, match="1..1000"):
+        sync_store.list_notes_attachment_cleanup_candidates(
+            "dataset-1",
+            owner_user_id="owner-1",
+            bootstrap_id="bootstrap-stable",
+            limit=1_001,
+        )
+
+
+@pytest.mark.unit
+def test_cleanup_candidate_rejects_source_key_path_mismatch(
+    sync_store: SyncV2Store,
+) -> None:
+    _enroll_notes_dataset(sync_store)
+    sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+    )
+    sync_store.resolve_notes_attachment_source_map(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        note_id="note-1",
+        source_key="notes_attachments/note-1/report.pdf",
+    )
+
+    with pytest.raises(SyncStoreError, match="source path does not match"):
+        sync_store.record_notes_attachment_cleanup_candidate(
+            "dataset-1",
+            owner_user_id="owner-1",
+            bootstrap_id="bootstrap-stable",
+            source_key="notes_attachments/note-1/report.pdf",
+            source_relative_path="notes_attachments/note-1/other.pdf",
+            source_blob_hash="sha256:" + hashlib.sha256(b"payload").hexdigest(),
+            source_size_bytes=7,
+            source_modified_ns=123,
+        )
+
+
+@pytest.mark.unit
+def test_cleanup_candidate_schema_rejects_path_hash_identity_drift(
+    sync_store: SyncV2Store,
+) -> None:
+    _enroll_notes_dataset(sync_store)
+    sync_store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+    )
+    mapping = sync_store.resolve_notes_attachment_source_map(
+        "dataset-1",
+        owner_user_id="owner-1",
+        bootstrap_id="bootstrap-stable",
+        note_id="note-1",
+        source_key="notes_attachments/note-1/report.pdf",
+    )
+
+    with pytest.raises(Exception, match="CHECK constraint failed"):
+        sync_store.db.execute(
+            "INSERT INTO sync_notes_attachment_cleanup_candidates "
+            "(dataset_id, bootstrap_id, source_key_hash, attachment_id, "
+            "source_relative_path, source_path_hash, source_blob_hash, "
+            "source_size_bytes, source_modified_ns, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "dataset-1",
+                "bootstrap-stable",
+                mapping.source_key_hash,
+                mapping.attachment_id,
+                "notes_attachments/note-1/report.pdf",
+                "sha256:" + "b" * 64,
+                "sha256:" + "a" * 64,
+                7,
+                123,
+                "2026-08-13T00:00:00+00:00",
+            ),
+        )
+
+
+@pytest.mark.unit
+def test_attachment_bootstrap_tables_are_in_both_fresh_schema_contracts() -> None:
+    for schema in (SYNC_SQLITE_SCHEMA, SYNC_POSTGRES_SCHEMA):
+        assert "sync_notes_attachment_source_map" in schema
+        assert "sync_notes_attachment_cleanup_candidates" in schema
+        assert "uq_sync_notes_attachment_source_id" in schema
+        assert "idx_sync_notes_attachment_cleanup_page" in schema
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "malformed_table",
+    [
+        "sync_notes_attachment_source_map",
+        "sync_notes_attachment_cleanup_candidates",
+    ],
+)
+def test_attachment_bootstrap_catalog_rejects_malformed_existing_table(
+    tmp_path: Path,
+    malformed_table: str,
+) -> None:
+    database_path = tmp_path / "malformed.db"
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(f"CREATE TABLE {malformed_table} (dataset_id TEXT)")
+
+    with pytest.raises(SyncStoreError, match="bootstrap catalog is malformed"):
+        SyncDatabase(sqlite_path=database_path)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("weaken_constraint", [False, True])
+def test_postgres_attachment_bootstrap_catalog_checks_are_exact(
+    weaken_constraint: bool,
+) -> None:
+    database = object.__new__(SyncDatabase)
+    columns = [
+        {
+            "table_name": table,
+            "column_name": name,
+            "data_type": data_type,
+            "is_not_null": True,
+        }
+        for table, specs in {
+            "sync_notes_attachment_cleanup_candidates": [
+                ("dataset_id", "text"),
+                ("bootstrap_id", "text"),
+                ("source_key_hash", "text"),
+                ("attachment_id", "text"),
+                ("source_relative_path", "text"),
+                ("source_path_hash", "text"),
+                ("source_blob_hash", "text"),
+                ("source_size_bytes", "bigint"),
+                ("source_modified_ns", "bigint"),
+                ("created_at", "timestamp with time zone"),
+            ],
+            "sync_notes_attachment_source_map": [
+                ("dataset_id", "text"),
+                ("bootstrap_id", "text"),
+                ("source_key_hash", "text"),
+                ("note_id", "text"),
+                ("attachment_id", "text"),
+                ("created_at", "timestamp with time zone"),
+            ],
+        }.items()
+        for name, data_type in specs
+    ]
+    uuid_check = (
+        "CHECK (attachment_id ~ "
+        "'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'::text)"
+    )
+    hash_check = "CHECK ({column} ~ '^sha256:[0-9a-f]{{64}}$'::text)"
+    constraints = [
+        {
+            "table_name": table,
+            "kind": kind,
+            "is_validated": True,
+            "definition": definition,
+        }
+        for table, definitions in {
+            "sync_notes_attachment_source_map": [
+                ("p", "PRIMARY KEY (dataset_id, bootstrap_id, source_key_hash)"),
+                ("c", "CHECK (length(dataset_id) > 0)"),
+                (
+                    "c",
+                    "CHECK ((length(bootstrap_id) >= 1) AND "
+                    "(length(bootstrap_id) <= 128))",
+                ),
+                ("c", hash_check.format(column="source_key_hash")),
+                ("c", "CHECK (length(note_id) > 0)"),
+                ("c", uuid_check),
+            ],
+            "sync_notes_attachment_cleanup_candidates": [
+                ("p", "PRIMARY KEY (dataset_id, bootstrap_id, source_key_hash)"),
+                ("c", "CHECK (length(dataset_id) > 0)"),
+                (
+                    "c",
+                    "CHECK ((length(bootstrap_id) >= 1) AND "
+                    "(length(bootstrap_id) <= 128))",
+                ),
+                ("c", hash_check.format(column="source_key_hash")),
+                ("c", uuid_check),
+                (
+                    "c",
+                    "CHECK ((length(source_relative_path) >= 1) AND "
+                    "(length(source_relative_path) <= 4096))",
+                ),
+                ("c", hash_check.format(column="source_path_hash")),
+                ("c", "CHECK (source_path_hash = source_key_hash)"),
+                ("c", hash_check.format(column="source_blob_hash")),
+                ("c", "CHECK (source_size_bytes > 0)"),
+                ("c", "CHECK (source_modified_ns >= 0)"),
+            ],
+        }.items()
+        for kind, definition in definitions
+    ]
+    if weaken_constraint:
+        constraints[-2]["definition"] += " OR true"
+    indexes = [
+        {
+            "index_name": "idx_sync_notes_attachment_cleanup_page",
+            "table_name": "sync_notes_attachment_cleanup_candidates",
+            "is_unique": False,
+            "is_valid": True,
+            "is_ready": True,
+            "definition": "CREATE INDEX idx_sync_notes_attachment_cleanup_page "
+            "ON public.sync_notes_attachment_cleanup_candidates "
+            "USING btree (dataset_id, bootstrap_id, source_key_hash)",
+        },
+        {
+            "index_name": "uq_sync_notes_attachment_source_id",
+            "table_name": "sync_notes_attachment_source_map",
+            "is_unique": True,
+            "is_valid": True,
+            "is_ready": True,
+            "definition": "CREATE UNIQUE INDEX uq_sync_notes_attachment_source_id "
+            "ON public.sync_notes_attachment_source_map "
+            "USING btree (dataset_id, attachment_id)",
+        },
+    ]
+
+    def fake_execute(query: str, *_args, **_kwargs) -> QueryResult:
+        if "pg_catalog.pg_attribute" in query:
+            rows = columns
+        elif "pg_catalog.pg_constraint" in query:
+            rows = constraints
+        else:
+            rows = indexes
+        return QueryResult(rows=rows, rowcount=len(rows))
+
+    database.execute = fake_execute
+    if not weaken_constraint:
+        database._verify_notes_attachment_bootstrap_tables_postgres(
+            connection=object()
+        )
+        return
+    with pytest.raises(SyncStoreError, match="bootstrap catalog is malformed"):
+        database._verify_notes_attachment_bootstrap_tables_postgres(
+            connection=object()
+        )

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_attachment_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_attachment_bootstrap.py
@@ -652,6 +652,24 @@ def test_attachment_bootstrap_tables_are_in_both_fresh_schema_contracts() -> Non
 
 
 @pytest.mark.unit
+def test_sync_schema_initialization_creates_no_attachment_authority_rows(
+    tmp_path: Path,
+) -> None:
+    database = SyncDatabase(sqlite_path=tmp_path / "schema-only.sqlite")
+
+    for table in (
+        "sync_notes_attachment_source_map",
+        "sync_notes_attachment_cleanup_candidates",
+        "sync_attachment_revision_bindings",
+        "sync_blob_objects",
+        "sync_envelopes",
+    ):
+        assert database.execute(f"SELECT COUNT(*) AS total FROM {table}").rows == [  # nosec B608
+            {"total": 0}
+        ]
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "malformed_table",
     [
@@ -922,6 +940,46 @@ def test_attachment_bootstrap_resumes_and_reuses_blob_envelope_and_identity(
         ).rows == [{"total": 2}]
         assert first_path.read_bytes() == b"alpha"
         assert second_path.read_bytes() == b"beta"
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_disabling_rollout_after_ready_preserves_canonical_metadata_and_source(
+    tmp_path: Path,
+) -> None:
+    env = _bootstrap_environment(tmp_path)
+    adapter = env.service.adapters.get("attachment.ref")
+    assert isinstance(adapter, AttachmentRefAdapter)
+    adapter.v2_writes_enabled = True
+    source_path = _write_legacy_attachment(env, "rollback.txt", b"rollback-safe")
+    try:
+        ready = _run_attachment_bootstrap_until_ready(env)
+        mapping = env.store.resolve_notes_attachment_source_map(
+            _DATASET_ID,
+            owner_user_id=_OWNER_ID,
+            bootstrap_id="bootstrap-stable",
+            note_id=_NOTE_ID,
+            source_key=f"notes_attachments/{_NOTE_ID}/rollback.txt",
+        )
+        before = env.note_db.note_attachment_store.get(
+            _DATASET_ID,
+            mapping.attachment_id,
+        )
+        adapter.v2_writes_enabled = False
+        after = env.note_db.note_attachment_store.get(
+            _DATASET_ID,
+            mapping.attachment_id,
+        )
+
+        assert ready.metadata["notes_attachment_v2"]["state"] == "ready"
+        assert before is not None and after == before
+        assert source_path.read_bytes() == b"rollback-safe"
+        assert not sync_v2_attachment_ref_v2_is_writable(
+            ready,
+            notes_attachment_sync_enabled=adapter.v2_writes_enabled,
+            supports_attachments=True,
+        )
     finally:
         env.note_db.close_connection()
 

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_attachment_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_attachment_bootstrap.py
@@ -1,28 +1,50 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 from uuid import UUID
 
 import pytest
 
 import tldw_Server_API.app.core.DB_Management.Sync_DB as sync_db_module
 from tldw_Server_API.app.core.DB_Management.backends.base import QueryResult
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.Sync_DB import (
     SYNC_POSTGRES_SCHEMA,
     SYNC_SQLITE_SCHEMA,
     SyncDatabase,
 )
+from tldw_Server_API.app.core.Notes.legacy_attachment_source import (
+    LegacyAttachmentSource,
+    legacy_attachment_note_directory,
+)
+from tldw_Server_API.app.core.Sync.v2.adapters import (
+    AttachmentRefAdapter,
+    StaticSyncAdapter,
+    SyncAdapterRegistry,
+)
+from tldw_Server_API.app.core.Sync.v2.blob_store import LocalSyncBlobStore
 from tldw_Server_API.app.core.Sync.v2.errors import (
     SyncDatasetNotFoundError,
     SyncStoreError,
 )
+from tldw_Server_API.app.core.Sync.v2.materializers.attachment_refs import (
+    AttachmentRefMaterializer,
+)
+from tldw_Server_API.app.core.Sync.v2.materializers.base import MaterializationResult
 from tldw_Server_API.app.core.Sync.v2.models import (
     SyncDatasetCreate,
     SyncEnvelopeCreate,
     sync_v2_attachment_ref_v2_is_writable,
 )
+from tldw_Server_API.app.core.Sync.v2.notes_attachment_bootstrap import (
+    NotesAttachmentBootstrapInterrupted,
+    NotesAttachmentBootstrapper,
+)
+from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service, SyncV2Settings
 from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
 
 
@@ -39,6 +61,120 @@ def _enroll_notes_dataset(sync_store: SyncV2Store) -> None:
             domains=["notes.note"],
         )
     )
+
+
+_OWNER_ID = "owner-1"
+_DATASET_ID = "dataset-1"
+_NOTE_ID = "22222222-2222-4222-8222-222222222222"
+_NOW = "2026-08-11T12:00:00+00:00"
+
+
+def _bootstrap_environment(
+    tmp_path: Path,
+    *,
+    max_candidates_per_run: int = 1_000,
+    after_upload=None,
+    after_capture=None,
+    attachment_materializer=None,
+):
+    id_counts: dict[str, int] = {}
+
+    def next_id(prefix: str) -> str:
+        id_counts[prefix] = id_counts.get(prefix, 0) + 1
+        return f"{prefix}-{id_counts[prefix]}"
+
+    note_db = CharactersRAGDB(tmp_path / "notes.db", client_id=_OWNER_ID)
+    note_db.note_store.add_note("Owned", "body", note_id=_NOTE_ID)
+    store = SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "sync.db"))
+    adapters = SyncAdapterRegistry(
+        [
+            StaticSyncAdapter(domain="notes.note", supported_adapter_versions={1}),
+            AttachmentRefAdapter(v2_writes_enabled=False),
+        ]
+    )
+    service = SyncV2Service(
+        store=store,
+        adapters=adapters,
+        materializers={
+            "attachment.ref": attachment_materializer
+            or AttachmentRefMaterializer(note_db)
+        },
+        blob_store=LocalSyncBlobStore(tmp_path / "blobs"),
+        clock=lambda: _NOW,
+        id_factory=next_id,
+        settings=SyncV2Settings(
+            supports_attachments=True,
+            max_attachment_bytes=2 * 1024 * 1024,
+            max_blob_bytes=2 * 1024 * 1024,
+            max_chunk_bytes=64 * 1024,
+        ),
+    )
+    dataset = store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id=_DATASET_ID,
+            owner_user_id=_OWNER_ID,
+            scope_type="personal",
+            domains=["notes.note"],
+            metadata={"default_personal": True, "client_family": "chatbook"},
+        )
+    )
+    dataset = store.begin_notes_attachment_bootstrap(
+        dataset.dataset_id,
+        owner_user_id=_OWNER_ID,
+        bootstrap_id="bootstrap-stable",
+    )
+    user_root = tmp_path / "owner"
+    bootstrapper = NotesAttachmentBootstrapper(
+        note_db,
+        user_root=user_root,
+        max_candidates_per_run=max_candidates_per_run,
+        after_upload=after_upload,
+        after_capture=after_capture,
+    )
+    return SimpleNamespace(
+        note_db=note_db,
+        store=store,
+        service=service,
+        dataset=dataset,
+        user_root=user_root,
+        bootstrapper=bootstrapper,
+    )
+
+
+def _write_legacy_attachment(
+    env,
+    file_name: str,
+    payload: bytes,
+    *,
+    metadata: dict[str, object] | None = None,
+) -> Path:
+    note_dir = legacy_attachment_note_directory(
+        _OWNER_ID,
+        _NOTE_ID,
+        user_root=env.user_root,
+    )
+    note_dir.mkdir(parents=True, exist_ok=True)
+    path = note_dir / file_name
+    path.write_bytes(payload)
+    if metadata is not None:
+        path.with_name(f"{file_name}.meta.json").write_text(
+            json.dumps(metadata),
+            encoding="utf-8",
+        )
+    return path
+
+
+def _run_attachment_bootstrap_until_ready(env, dataset=None, *, attempts: int = 12):
+    current = dataset or env.dataset
+    for _ in range(attempts):
+        current = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=current,
+        )
+        if current.metadata["notes_attachment_v2"]["state"] != "initializing":
+            return current
+    pytest.fail("attachment bootstrap did not leave initializing state")
 
 
 @pytest.mark.unit
@@ -665,3 +801,443 @@ def test_postgres_attachment_bootstrap_catalog_checks_are_exact(
         database._verify_notes_attachment_bootstrap_tables_postgres(
             connection=object()
         )
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_empty_source_reaches_ready(tmp_path: Path) -> None:
+    env = _bootstrap_environment(tmp_path)
+    try:
+        result = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=env.dataset,
+        )
+
+        state = result.metadata["notes_attachment_v2"]
+        assert state["state"] == "ready"
+        assert state["captured_count"] == 0
+        assert state["expected_count"] == 0
+        assert state["source_hash"] == hashlib.sha256(b"").hexdigest()
+        assert state["source_cursor"] is None
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_resumes_and_reuses_blob_envelope_and_identity(
+    tmp_path: Path,
+) -> None:
+    env = _bootstrap_environment(tmp_path, max_candidates_per_run=1)
+    first_path = _write_legacy_attachment(
+        env,
+        "alpha.txt",
+        b"alpha",
+        metadata={"content_type": "text/plain"},
+    )
+    second_path = _write_legacy_attachment(
+        env,
+        "beta.txt",
+        b"beta",
+        metadata={"content_type": "text/plain"},
+    )
+    try:
+        partial = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=env.dataset,
+        )
+        assert partial.metadata["notes_attachment_v2"]["state"] == "initializing"
+        ready = partial
+        for _ in range(8):
+            ready = env.bootstrapper.bootstrap(
+                service=env.service,
+                user_id=_OWNER_ID,
+                dataset=ready,
+            )
+            if ready.metadata["notes_attachment_v2"]["state"] == "ready":
+                break
+        assert ready.metadata["notes_attachment_v2"]["state"] == "ready", ready.metadata[
+            "notes_attachment_v2"
+        ]
+        replay = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=ready,
+        )
+
+        assert partial.metadata["notes_attachment_v2"]["state"] == "initializing"
+        assert partial.metadata["notes_attachment_v2"]["captured_count"] == 1
+        assert ready.metadata["notes_attachment_v2"]["state"] == "ready", ready.metadata[
+            "notes_attachment_v2"
+        ]
+        assert ready.metadata["notes_attachment_v2"]["captured_count"] == 2
+        assert replay.metadata["notes_attachment_v2"] == ready.metadata["notes_attachment_v2"]
+        mappings = env.store.db.execute(
+            "SELECT attachment_id FROM sync_notes_attachment_source_map "
+            "ORDER BY source_key_hash"
+        ).rows
+        assert len(mappings) == 2
+        assert all(UUID(row["attachment_id"]).version == 4 for row in mappings)
+        assert env.store.db.execute("SELECT COUNT(*) AS total FROM sync_blob_objects").rows == [
+            {"total": 2}
+        ]
+        assert env.store.db.execute(
+            "SELECT COUNT(*) AS total FROM sync_envelopes WHERE domain = 'attachment.ref'"
+        ).rows == [{"total": 2}]
+        assert first_path.read_bytes() == b"alpha"
+        assert second_path.read_bytes() == b"beta"
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_source_change_fails_closed_and_preserves_source(
+    tmp_path: Path,
+) -> None:
+    source_path: Path | None = None
+
+    def mutate_after_upload(_candidate) -> None:
+        assert source_path is not None
+        source_path.write_bytes(b"changed")
+
+    env = _bootstrap_environment(tmp_path, after_upload=mutate_after_upload)
+    source_path = _write_legacy_attachment(
+        env,
+        "mutable.txt",
+        b"original",
+        metadata={"content_type": "text/plain"},
+    )
+    try:
+        failed = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=env.dataset,
+        )
+
+        state = failed.metadata["notes_attachment_v2"]
+        assert state["state"] == "failed"
+        assert state["error_code"] == "notes_attachment_source_changed"
+        assert source_path.read_bytes() == b"changed"
+        assert env.store.db.execute(
+            "SELECT COUNT(*) AS total FROM sync_envelopes WHERE domain = 'attachment.ref'"
+        ).rows == [{"total": 0}]
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_source_change_after_capture_blocks_readiness(
+    tmp_path: Path,
+) -> None:
+    source_path: Path | None = None
+
+    def mutate_after_capture(_candidate) -> None:
+        assert source_path is not None
+        source_path.write_bytes(b"changed-after-capture")
+
+    env = _bootstrap_environment(tmp_path, after_capture=mutate_after_capture)
+    source_path = _write_legacy_attachment(env, "captured.txt", b"original")
+    try:
+        failed = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=env.dataset,
+        )
+
+        assert failed.metadata["notes_attachment_v2"]["state"] == "failed"
+        assert failed.metadata["notes_attachment_v2"]["error_code"] == (
+            "notes_attachment_source_changed"
+        )
+        assert source_path.read_bytes() == b"changed-after-capture"
+        assert env.store.db.execute(
+            "SELECT COUNT(*) AS total FROM sync_envelopes WHERE domain = 'attachment.ref'"
+        ).rows == [{"total": 1}]
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_fails_closed_on_legacy_identity_collision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env = _bootstrap_environment(tmp_path)
+    collision_id = "11111111-1111-4111-8111-111111111111"
+    env.store.insert_envelope(
+        SyncEnvelopeCreate(
+            dataset_id=_DATASET_ID,
+            client_envelope_id="legacy-collision",
+            domain="attachment.ref",
+            operation="upsert",
+            object_id=collision_id,
+            adapter_version=1,
+            payload={
+                "attachment_id": collision_id,
+                "parent_domain": "notes.note",
+                "parent_object_id": _NOTE_ID,
+                "content_type": "text/plain",
+                "size_bytes": 6,
+                "payload_hash": "sha256:" + "a" * 64,
+                "availability": "available",
+            },
+            payload_hash="sha256:" + "a" * 64,
+        )
+    )
+    monkeypatch.setattr(sync_db_module, "uuid4", lambda: UUID(collision_id))
+    source_path = _write_legacy_attachment(env, "collision.txt", b"source")
+    try:
+        failed = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=env.dataset,
+        )
+
+        assert failed.metadata["notes_attachment_v2"]["state"] == "failed"
+        assert failed.metadata["notes_attachment_v2"]["error_code"] == (
+            "notes_attachment_capture_failed"
+        )
+        assert source_path.read_bytes() == b"source"
+        assert env.store.db.execute(
+            "SELECT COUNT(*) AS total FROM sync_envelopes WHERE domain = 'attachment.ref'"
+        ).rows == [{"total": 1}]
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_caps_each_resumable_capture_and_verify_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env = _bootstrap_environment(tmp_path, max_candidates_per_run=2)
+    for index in range(3):
+        _write_legacy_attachment(env, f"bounded-{index}.txt", f"body-{index}".encode())
+    original = LegacyAttachmentSource.list_candidates
+    returned_in_run = 0
+
+    def tracked_list_candidates(self, *args, **kwargs):
+        nonlocal returned_in_run
+        page = original(self, *args, **kwargs)
+        returned_in_run += len(page)
+        return page
+
+    monkeypatch.setattr(
+        LegacyAttachmentSource,
+        "list_candidates",
+        tracked_list_candidates,
+    )
+    try:
+        dataset = env.dataset
+        for _ in range(10):
+            returned_in_run = 0
+            dataset = env.bootstrapper.bootstrap(
+                service=env.service,
+                user_id=_OWNER_ID,
+                dataset=dataset,
+            )
+            assert returned_in_run <= 2
+            if dataset.metadata["notes_attachment_v2"]["state"] == "ready":
+                break
+        else:
+            pytest.fail("bounded bootstrap did not converge")
+
+        state = dataset.metadata["notes_attachment_v2"]
+        assert state["captured_count"] == 3
+        assert state["expected_count"] == 3
+        assert state["source_hash"] is not None
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_projects_sources_for_soft_deleted_parent(
+    tmp_path: Path,
+) -> None:
+    env = _bootstrap_environment(tmp_path)
+    _write_legacy_attachment(env, "deleted-parent.txt", b"retained")
+    assert env.note_db.note_store.soft_delete_note(_NOTE_ID, expected_version=1)
+    try:
+        result = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=env.dataset,
+        )
+
+        assert result.metadata["notes_attachment_v2"]["state"] == "ready"
+        rows = env.store.db.execute(
+            "SELECT attachment_id FROM sync_notes_attachment_source_map"
+        ).rows
+        projected = env.note_db.note_attachment_store.get(
+            _DATASET_ID,
+            rows[0]["attachment_id"],
+        )
+        assert projected is not None
+        assert projected.source_kind == "legacy_bootstrap"
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_resumes_after_completed_upload_interruption(
+    tmp_path: Path,
+) -> None:
+    armed = True
+
+    def interrupt_once(_candidate) -> None:
+        nonlocal armed
+        if armed:
+            armed = False
+            raise NotesAttachmentBootstrapInterrupted
+
+    env = _bootstrap_environment(tmp_path, after_upload=interrupt_once)
+    _write_legacy_attachment(env, "upload-interrupted.txt", b"recoverable")
+    try:
+        interrupted = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=env.dataset,
+        )
+        assert interrupted.metadata["notes_attachment_v2"]["state"] == "initializing"
+        assert interrupted.metadata["notes_attachment_v2"]["captured_count"] == 0
+
+        ready = _run_attachment_bootstrap_until_ready(env, interrupted)
+        assert ready.metadata["notes_attachment_v2"]["state"] == "ready", ready.metadata[
+            "notes_attachment_v2"
+        ]
+        assert env.store.db.execute("SELECT COUNT(*) AS total FROM sync_blob_objects").rows == [
+            {"total": 1}
+        ]
+        assert env.store.db.execute(
+            "SELECT COUNT(*) AS total FROM sync_envelopes WHERE domain = 'attachment.ref'"
+        ).rows == [{"total": 1}]
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_resumes_after_append_before_progress(
+    tmp_path: Path,
+) -> None:
+    armed = True
+
+    def interrupt_once(_candidate) -> None:
+        nonlocal armed
+        if armed:
+            armed = False
+            raise NotesAttachmentBootstrapInterrupted
+
+    env = _bootstrap_environment(tmp_path, after_capture=interrupt_once)
+    _write_legacy_attachment(env, "append-interrupted.txt", b"recoverable")
+    try:
+        interrupted = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=env.dataset,
+        )
+        assert interrupted.metadata["notes_attachment_v2"]["state"] == "initializing"
+        assert interrupted.metadata["notes_attachment_v2"]["captured_count"] == 0
+        assert env.store.db.execute(
+            "SELECT COUNT(*) AS total FROM sync_envelopes WHERE domain = 'attachment.ref'"
+        ).rows == [{"total": 1}]
+
+        ready = _run_attachment_bootstrap_until_ready(env, interrupted)
+        assert ready.metadata["notes_attachment_v2"]["state"] == "ready", ready.metadata[
+            "notes_attachment_v2"
+        ]
+        assert env.store.db.execute(
+            "SELECT COUNT(*) AS total FROM sync_envelopes WHERE domain = 'attachment.ref'"
+        ).rows == [{"total": 1}]
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_resumes_retryable_projection(tmp_path: Path) -> None:
+    env = _bootstrap_environment(tmp_path)
+    delegate = env.service.materializers["attachment.ref"]
+    attempts = 0
+
+    class FlakyMaterializer:
+        def apply(self, envelope, *, store):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                return MaterializationResult(status="failed")
+            return delegate.apply(envelope, store=store)
+
+    env.service.materializers["attachment.ref"] = FlakyMaterializer()
+    _write_legacy_attachment(env, "projection-interrupted.txt", b"recoverable")
+    try:
+        interrupted = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=env.dataset,
+        )
+        assert interrupted.metadata["notes_attachment_v2"]["state"] == "initializing"
+        ready = _run_attachment_bootstrap_until_ready(env, interrupted)
+
+        assert ready.metadata["notes_attachment_v2"]["state"] == "ready"
+        assert attempts >= 2
+        assert env.store.db.execute(
+            "SELECT COUNT(*) AS total FROM sync_envelopes WHERE domain = 'attachment.ref'"
+        ).rows == [{"total": 1}]
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+def test_attachment_bootstrap_canonicalizes_same_name_collisions(
+    tmp_path: Path,
+) -> None:
+    env = _bootstrap_environment(tmp_path)
+    _write_legacy_attachment(env, "report?.txt", b"first")
+    _write_legacy_attachment(env, "report*.txt", b"second")
+    try:
+        ready = _run_attachment_bootstrap_until_ready(env)
+        mappings = env.store.db.execute(
+            "SELECT attachment_id FROM sync_notes_attachment_source_map"
+        ).rows
+        names = {
+            env.note_db.note_attachment_store.get(
+                _DATASET_ID,
+                row["attachment_id"],
+            ).file_name
+            for row in mappings
+        }
+
+        assert ready.metadata["notes_attachment_v2"]["state"] == "ready"
+        assert len(names) == 2
+        assert any("-1" in name for name in names)
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("payload", "metadata", "expected_code"),
+    [
+        (b"ok", {"content_type": " Text/Plain "}, "notes_attachment_source_invalid"),
+        (b"x" * (2 * 1024 * 1024 + 1), None, "notes_attachment_source_too_large"),
+    ],
+    ids=["noncanonical-content-type", "oversized-file"],
+)
+def test_attachment_bootstrap_rejects_malformed_or_oversized_source(
+    tmp_path: Path,
+    payload: bytes,
+    metadata: dict[str, object] | None,
+    expected_code: str,
+) -> None:
+    env = _bootstrap_environment(tmp_path)
+    path = _write_legacy_attachment(env, "invalid.txt", payload, metadata=metadata)
+    try:
+        failed = env.bootstrapper.bootstrap(
+            service=env.service,
+            user_id=_OWNER_ID,
+            dataset=env.dataset,
+        )
+
+        assert failed.metadata["notes_attachment_v2"]["state"] == "failed"
+        assert failed.metadata["notes_attachment_v2"]["error_code"] == expected_code
+        assert path.exists()
+    finally:
+        env.note_db.close_connection()

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_attachment_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_attachment_bootstrap.py
@@ -824,6 +824,42 @@ def test_attachment_bootstrap_empty_source_reaches_ready(tmp_path: Path) -> None
 
 
 @pytest.mark.integration
+def test_attachment_bootstrap_dry_run_is_bounded_and_does_not_advance_state(
+    tmp_path: Path,
+) -> None:
+    env = _bootstrap_environment(tmp_path, max_candidates_per_run=1)
+    _write_legacy_attachment(env, "alpha.txt", b"alpha")
+    _write_legacy_attachment(env, "beta.txt", b"beta")
+    before = env.service.store.get_dataset(
+        env.dataset.dataset_id,
+        owner_user_id=_OWNER_ID,
+    )
+    try:
+        result = env.bootstrapper.dry_run(
+            service=env.service,
+            user_id=_OWNER_ID,
+        )
+
+        assert result == {
+            "candidate_count": 1,
+            "candidate_count_is_lower_bound": True,
+            "error_code": None,
+        }
+        assert env.service.store.get_dataset(
+            env.dataset.dataset_id,
+            owner_user_id=_OWNER_ID,
+        ) == before
+        assert env.service.store.list_envelopes_after(
+            env.dataset.dataset_id,
+            0,
+            domains=["attachment.ref"],
+            limit=10,
+        ) == []
+    finally:
+        env.note_db.close_connection()
+
+
+@pytest.mark.integration
 def test_attachment_bootstrap_resumes_and_reuses_blob_envelope_and_identity(
     tmp_path: Path,
 ) -> None:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
@@ -99,7 +99,14 @@ class _PausedOrganizationBootstrapper:
 
 
 class _PausedAttachmentBootstrapper(_PausedOrganizationBootstrapper):
-    pass
+    def dry_run(self, *, service: SyncV2Service, user_id: str):
+        del service
+        self.calls.append((user_id, "dry-run"))
+        return {
+            "candidate_count": 1_000,
+            "candidate_count_is_lower_bound": True,
+            "error_code": None,
+        }
 
 
 def _note_envelope(**overrides) -> SyncEnvelopeCreate:
@@ -244,6 +251,129 @@ def test_profile_bootstrap_begins_and_resumes_attachment_capture(
     assert dataset.metadata["notes_attachment_v2"]["state"] == "initializing"
     assert dataset.metadata["notes_attachment_v2"]["target_adapter_version"] == 2
     assert result.capabilities.writable_adapter_versions["attachment.ref"] == []
+
+
+def test_attachment_bootstrap_diagnostics_are_bounded_and_path_free(
+    tmp_path: Path,
+) -> None:
+    bootstrapper = _PausedAttachmentBootstrapper()
+    service, store = _service(
+        tmp_path,
+        notes_attachment_bootstrapper=bootstrapper,
+    )
+    profile = service.bootstrap_profile(
+        user_id="user-1",
+        mode="offline_sync",
+        device_id="device-1",
+        requested_domains=[*M1_SYNC_DOMAINS, "attachment.ref"],
+    )
+    assert profile.dataset is not None
+    dataset_id = profile.dataset.dataset_id
+    dataset = store.get_dataset(dataset_id, owner_user_id="user-1")
+    assert dataset is not None
+    bootstrap_id = dataset.metadata["notes_attachment_v2"]["bootstrap_id"]
+    source_key = "notes_attachments/note-1/private-name.pdf"
+    mapping = store.resolve_notes_attachment_source_map(
+        dataset_id,
+        owner_user_id="user-1",
+        bootstrap_id=bootstrap_id,
+        note_id="note-1",
+        source_key=source_key,
+    )
+    store.record_notes_attachment_cleanup_candidate(
+        dataset_id,
+        owner_user_id="user-1",
+        bootstrap_id=bootstrap_id,
+        source_key=source_key,
+        source_relative_path=source_key,
+        source_blob_hash="sha256:" + "1" * 64,
+        source_size_bytes=12,
+        source_modified_ns=42,
+    )
+    store.transition_notes_attachment_bootstrap(
+        dataset_id,
+        owner_user_id="user-1",
+        bootstrap_id=bootstrap_id,
+        expected_state="initializing",
+        state="initializing",
+        captured_count=1,
+        expected_count=1,
+        source_hash=None,
+        source_cursor='{"private":"notes_attachments/note-1/private-name.pdf"}',
+    )
+
+    diagnostics = service.notes_attachment_bootstrap_diagnostics(
+        user_id="user-1",
+        dataset_id=dataset_id,
+        sample_limit=1,
+        dry_run=False,
+    )
+
+    assert diagnostics.state == "initializing"
+    assert diagnostics.captured_count == diagnostics.expected_count == 1
+    assert diagnostics.cursor is not None
+    assert diagnostics.cursor.startswith("sha256:")
+    assert diagnostics.cleanup_candidates[0].source_key_hash.startswith("sha256:")
+    assert diagnostics.cleanup_candidates[0].attachment_id == mapping.attachment_id
+    assert diagnostics.cleanup_candidates[0].state == "captured"
+    assert diagnostics.cleanup_candidates[0].blocker_code is None
+    serialized = repr(diagnostics)
+    assert "private-name.pdf" not in serialized
+    assert "notes_attachments" not in serialized
+    assert bootstrap_id not in serialized
+
+
+def test_attachment_bootstrap_dry_run_is_read_only_and_owner_scoped(
+    tmp_path: Path,
+) -> None:
+    bootstrapper = _PausedAttachmentBootstrapper()
+    service, store = _service(
+        tmp_path,
+        notes_attachment_bootstrapper=bootstrapper,
+    )
+
+    diagnostics = service.notes_attachment_bootstrap_diagnostics(
+        user_id="user-1",
+        sample_limit=0,
+        dry_run=True,
+    )
+
+    assert diagnostics.state == "not_started"
+    assert diagnostics.dry_run is True
+    assert diagnostics.source_candidate_count == 1_000
+    assert diagnostics.source_candidate_count_is_lower_bound is True
+    assert store.list_datasets_for_user("user-1") == []
+    assert store.list_devices_for_user("user-1") == []
+    assert bootstrapper.calls == [("user-1", "dry-run")]
+
+    other = store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="other-dataset",
+            owner_user_id="other-user",
+            scope_type="personal",
+            domains=list(M1_SYNC_DOMAINS),
+        )
+    )
+    with pytest.raises(SyncStoreError, match="not found or is not accessible"):
+        service.notes_attachment_bootstrap_diagnostics(
+            user_id="user-1",
+            dataset_id=other.dataset_id,
+        )
+
+
+def test_attachment_bootstrap_diagnostics_reject_oversized_samples(
+    tmp_path: Path,
+) -> None:
+    service, _store = _service(tmp_path)
+
+    with pytest.raises(
+        SyncStoreError,
+        match="sync_attachment_bootstrap_sample_limit_exceeded",
+    ):
+        service.notes_attachment_bootstrap_diagnostics(
+            user_id="user-1",
+            sample_limit=101,
+        )
 
 
 def test_bootstrap_creates_default_dataset_and_is_idempotent(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
@@ -31,6 +31,8 @@ from tldw_Server_API.app.core.Sync.v2.security import (
 from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service, SyncV2Settings
 from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
 
+pytestmark = pytest.mark.unit
+
 
 def _clock() -> str:
     return "2026-05-23T18:12:00+00:00"

--- a/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
@@ -65,6 +65,7 @@ def _service(
     id_factory=None,
     scan_limit: int = 100,
     dataset_bootstrapper=None,
+    notes_attachment_bootstrapper=None,
 ) -> tuple[SyncV2Service, SyncV2Store]:
     store = SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "sync_v2_profile.db"))
     service = SyncV2Service(
@@ -77,6 +78,7 @@ def _service(
             restore_manifest_scan_limit=scan_limit,
         ),
         dataset_bootstrapper=dataset_bootstrapper,
+        notes_attachment_bootstrapper=notes_attachment_bootstrapper,
     )
     return service, store
 
@@ -94,6 +96,10 @@ class _PausedOrganizationBootstrapper:
     ) -> SyncDataset:
         self.calls.append((user_id, dataset.dataset_id))
         return service.store.get_dataset(dataset.dataset_id) or dataset
+
+
+class _PausedAttachmentBootstrapper(_PausedOrganizationBootstrapper):
+    pass
 
 
 def _note_envelope(**overrides) -> SyncEnvelopeCreate:
@@ -183,7 +189,17 @@ def test_profile_capabilities_are_bound_to_active_ready_dataset(tmp_path: Path) 
             metadata={
                 "default_personal": True,
                 "client_family": "chatbook",
-                "notes_attachment_v2": {"state": "ready"},
+                "notes_attachment_v2": {
+                    "bootstrap_id": "bootstrap-ready",
+                    "state": "ready",
+                    "target_adapter_version": 2,
+                    "captured_count": 0,
+                    "expected_count": 0,
+                    "source_hash": "e3b0c44298fc1c149afbf4c8996fb924"
+                    "27ae41e4649b934ca495991b7852b855",
+                    "source_cursor": None,
+                    "error_code": None,
+                },
             },
         )
     )
@@ -201,6 +217,33 @@ def test_profile_capabilities_are_bound_to_active_ready_dataset(tmp_path: Path) 
         requested_domains=["notes.note", "attachment.ref"],
     )
     assert bootstrap.capabilities.writable_adapter_versions["attachment.ref"] == [2]
+
+
+def test_profile_bootstrap_begins_and_resumes_attachment_capture(
+    tmp_path: Path,
+) -> None:
+    bootstrapper = _PausedAttachmentBootstrapper()
+    service, store = _service(
+        tmp_path,
+        notes_attachment_bootstrapper=bootstrapper,
+    )
+
+    result = service.bootstrap_profile(
+        user_id="user-1",
+        mode="offline_sync",
+        device_id="device-1",
+        requested_domains=["notes.note", "attachment.ref"],
+        client_instance={
+            "supported_adapter_versions": {"attachment.ref": [2]},
+        },
+    )
+
+    assert bootstrapper.calls == [("user-1", result.active_dataset_id)]
+    dataset = store.get_dataset(result.active_dataset_id or "", owner_user_id="user-1")
+    assert dataset is not None
+    assert dataset.metadata["notes_attachment_v2"]["state"] == "initializing"
+    assert dataset.metadata["notes_attachment_v2"]["target_adapter_version"] == 2
+    assert result.capabilities.writable_adapter_versions["attachment.ref"] == []
 
 
 def test_bootstrap_creates_default_dataset_and_is_idempotent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- add a bounded, resumable, fail-closed migration from legacy Notes attachment files into the canonical registry, namespaced blob store, and Sync v2 envelopes\n- persist immutable source mappings, cleanup evidence, independent readiness, and canonical count/fingerprint verification under ADR-038\n- expose safe bootstrap dry-run/start/resume/status diagnostics while keeping rollout default-off and preserving legacy source files\n- reject noncanonical signed attachment cursor encodings found during final verification\n\n## Test plan\n- [x] Final 13-file task gate: 651 passed, 2 optional live-PostgreSQL tests skipped\n- [x] Notes attachment API: 31 passed\n- [x] Focused rollout gate: 137 passed, 139 deselected\n- [x] Ruff check\n- [x] Bandit\n- [x] py_compile\n- [x] git diff --check\n\n## Notes\n- ADR-038 remains the governing decision; no new ADR was needed.\n- Optional live-PostgreSQL tests were unavailable locally; server-free PostgreSQL contracts and SQLite integration tests passed.\n- Black/Ruff formatter checks expose the repository's existing whole-file formatting baseline on touched legacy files; no unrelated mass-format diff is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps legacy Notes attachments into Sync v2 with a resumable, fail‑closed process and bounded diagnostics. Previously v2 ignored legacy attachments and accepted noncanonical cursors; now v2 imports into the canonical registry/blob store/envelopes, rejects noncanonical cursors, and leaves legacy files untouched.

- Adds a bounded `LegacyAttachmentSource` that enumerates owner/note‑scoped candidates under the confined `notes_attachments` tree, hashes source keys, and never rewrites or deletes legacy files.
- Persists immutable source→attachment mappings, bootstrap state, and cleanup candidates in new additive tables; idempotently materializes attachment refs with `bootstrap_capture` routing metadata and allows deleted notes only during capture.
- Exposes GET `/api/v1/sync/profile/attachment-bootstrap` diagnostics (states: not_started|initializing|ready|failed, counts, optional `cursor`, safe `source_key_hash` samples); supports `dry_run` and `sample_limit` with 413; surfaces sanitized legacy read error codes; endpoint is rate limited.
- Rejects noncanonical signed attachment cursor encodings in Notes attachment listing; clients that tamper cursors now receive 400.
- Updates server‑origin batch to include `trusted_notes_attachment_bootstrap_id` and to stamp `schema_version`/`adapter_version`; wires the bootstrapper in the Sync v2 factory; extends the attachment materializer to pass `allow_deleted_note` during bootstrap.
- Connects to TASK‑13005.3 by meeting ACs for independent readiness, resumability, bounded source verification, immutable mapping, cleanup evidence, and default‑off rollout.
- Refreshes OpenAPI fingerprint to reflect the new endpoint and schemas.

**Rollout and migration**
- Default‑off: first call diagnostics with `dry_run=true`, then enable/start bootstrap for the target workspace.
- Schema changes are additive and created on startup; no data is dropped and no legacy files are removed.
- Client action: ensure attachment cursors are canonical; invalid or tampered cursors fail fast.
- Frontend action: regenerate API types after OpenAPI fingerprint drift.

<sup>Written for commit 9e8e855705c5033d7ead524257743cac1838f709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

