### PR TITLE
feat(sync): complete Notes attachment restore and operations

### DIFF
--- a/Docs/ADR/038-canonical-notes-attachment-registry-and-blob-lifecycle.md
+++ b/Docs/ADR/038-canonical-notes-attachment-registry-and-blob-lifecycle.md
@@ -81,6 +81,34 @@ deletion authority would make crash recovery unsafe.
 12. TASK-13005 is implemented as four atomic PRs: persistence contract, mutation
     lifecycle, legacy bootstrap, then restore/retention/diagnostics and rollout.
 
+## Operational completion and failure semantics
+
+The completed implementation applies the decisions above as one fail-closed
+lifecycle:
+
+- version-2 capability advertisement is dataset-bound and writable only when
+  blob transfer, the dedicated default-off rollout gate, encryption, enrollment,
+  and `notes_attachment_v2: ready` all agree;
+- canonical create, rename, replace, delete, and restore are idempotent,
+  optimistic mutations. Product projection and accepted-envelope history share
+  the materialization fence; injected projection or binding failures roll back
+  the accepted envelope rather than publishing partial authority;
+- restore ordering requires the owning Note before a live attachment ref, and
+  completeness is derived from immutable revision bindings and verified bytes;
+- legacy bootstrap is resumable and source-verified, publishes readiness only
+  after count/postcondition verification, retains source files for rollback,
+  and exposes only bounded hashed diagnostics;
+- historical binding release is monotonic and auditable. Physical collection
+  revalidates all blockers under the dataset fence, uses
+  `available -> deleting -> deleted`, and leaves retryable `deleting` state when
+  byte removal cannot be proven complete; and
+- diagnostics are read-only hints. Stable public errors and logs omit filenames,
+  source paths, storage keys, blob bytes, payloads, and secret metadata.
+
+No additional ADR is required for these operational details: they directly
+implement Decisions 2, 3, 6, 8, 9, and 10 without changing the ownership,
+storage, migration, or retention architecture selected here.
+
 ## Consequences
 
 - Users can rename, replace, delete, restore, and synchronize an attachment without

--- a/Docs/API/Sync_V2_M1.md
+++ b/Docs/API/Sync_V2_M1.md
@@ -30,6 +30,51 @@ The required `attachment.ref` payload metadata fields are `attachment_id`,
 `parent_domain`, `parent_object_id`, `content_type`, `size_bytes`,
 `payload_hash`, and `availability`.
 
+## Notes attachment adapter version 2
+
+The canonical Notes attachment lifecycle is an additive adapter version for the
+existing `attachment.ref` domain. Version 1 remains readable and restorable but
+is immutable. A device must explicitly advertise
+`supported_adapter_versions.attachment.ref: [1, 2]` (or `[2]`) before it can
+push or acknowledge version-2 envelopes. Omission means version 1. Version maps
+are monotonic-additive for an active device; a refresh cannot silently remove a
+previously advertised version.
+
+Capabilities expose two separate maps:
+
+- `supported_adapter_versions` describes schemas the server can parse;
+- `writable_adapter_versions` describes schemas writable for the selected,
+  owner-authorized dataset under its current rollout, encryption, enrollment,
+  and bootstrap state.
+
+The strict version-2 `upsert` payload is:
+
+| Field | Contract |
+| --- | --- |
+| `attachment_id` | Canonical lowercase UUIDv4 and equal to envelope `object_id`. |
+| `parent_domain` | Exactly `notes.note`. |
+| `parent_object_id` | Canonical lowercase UUIDv4 of the owning note. |
+| `file_name` | Canonical Notes-safe display name after NFKC normalization, extension allowlisting, and collision suffixing. |
+| `original_file_name` | Safe basename, at most 255 characters and 1024 UTF-8 bytes. |
+| `content_type` | Already-trimmed lowercase `type/subtype`; parameters are rejected. |
+| `size_bytes` | Positive integer within the effective Notes/Sync attachment limit. |
+| `blob_hash` | Canonical lowercase `sha256:<64 hex>` digest of the bytes. |
+| `created_at`, `last_modified` | Normalized UTC timestamps. |
+| `created_by` | Non-empty device or server-origin identity. |
+
+Version-2 tombstones retain the same immutable identity and provenance fields
+and add `deleted_at` plus an optional bounded `reason`. Unknown payload
+or routing fields are rejected. The envelope `payload_hash` is the canonical
+object hash over the complete normalized semantic payload, object revision, and
+live/tombstone state; it is not merely the blob digest.
+
+Pull cursors and domain acknowledgments are keyed by
+`(device, dataset, domain, adapter_version)`. Mixed-version pulls use a signed,
+bounded continuation token carrying per-version watermarks; legacy version-1
+numeric cursors remain valid. Blob verification evidence for version 2 uses the
+immutable `blob_id` plus digest in `blob_id_acks`; legacy attachment-ID evidence
+is never reinterpreted as version-2 proof.
+
 The additive Notes organization capability is one indivisible six-domain group:
 
 - `notes.keyword`
@@ -283,6 +328,11 @@ link, membership, or projection changes cannot serve a stale cached page.
 
 ### Capability Shape
 
+The example below assumes an owner-selected dataset whose Notes attachment
+bootstrap is ready and both attachment rollout gates are enabled. An unbound or
+not-ready capability response omits version 2 from the writable map while still
+reporting it as server-supported.
+
 ```json
 {
   "protocol_version": "sync-v2-m1",
@@ -323,6 +373,14 @@ link, membership, or projection changes cannot serve a stale cached page.
     "notes.folder": ["upsert", "tombstone"],
     "notes.folder_link": ["upsert", "tombstone"],
     "notes.link": ["upsert", "tombstone"]
+  },
+  "supported_adapter_versions": {
+    "notes.note": [1],
+    "attachment.ref": [1, 2]
+  },
+  "writable_adapter_versions": {
+    "notes.note": [1],
+    "attachment.ref": [1, 2]
   },
   "encryption": {
     "policy": "server_trusted_v1",

--- a/Docs/API/Sync_V2_M2.md
+++ b/Docs/API/Sync_V2_M2.md
@@ -1,7 +1,7 @@
 # Sync v2 M2 API Contract
 
-Date: 2026-05-23
-Status: Planned for M2 implementation
+Date: 2026-08-13
+Status: Implemented
 Scope: Server-connected Chatbook personal sync with blob restore completeness
 
 ## Overview
@@ -62,6 +62,19 @@ capabilities response:
 If `blob_transfer.supported` is false, clients must treat the server as M1 for
 binary content and may still restore `attachment.ref` metadata.
 
+Canonical Notes attachment writes require all of the following at once:
+
+- `SYNC_V2_ENABLE_BLOB_TRANSFER=true`;
+- `SYNC_V2_ENABLE_NOTES_ATTACHMENT_SYNC=true`;
+- server-trusted encryption ready for the dataset;
+- `attachment.ref` enrolled; and
+- dataset metadata `notes_attachment_v2.state` equal to `ready`.
+
+The Notes-specific rollout gate defaults off. When an initialized dataset later
+loses write readiness, canonical metadata remains readable, while content and
+mutations fail closed with stable, sanitized error codes. The server does not
+fall back to legacy filename files after canonical authority exists.
+
 Production deployments keep M2 blob transfer disabled unless explicitly enabled.
 The server factory reads these environment variables:
 
@@ -103,6 +116,27 @@ Quota accounting is DB-backed:
 - dedupe by dataset and full payload hash must not double-charge committed
   blobs.
 
+### Canonical Notes attachment APIs
+
+All canonical routes require `dataset_id`, stable UUIDv4 note/attachment IDs,
+and owner authorization:
+
+| Method and path | Contract |
+| --- | --- |
+| `GET /api/v1/notes/{note_id}/attachments/canonical` | Keyset page with `state_filter=live|tombstoned|all`, an opaque cursor of at most 512 visible-ASCII bytes, and `limit` 1–200 (default 50). |
+| `POST /api/v1/notes/{note_id}/attachments/from-upload` | Body `{"upload_id":"..."}`; binds one completed upload whose trusted create/replace intent exactly matches the note and attachment. |
+| `GET /api/v1/notes/{note_id}/attachments/by-id/{attachment_id}` | Returns strict canonical metadata and the strong ETag. |
+| `PATCH /api/v1/notes/{note_id}/attachments/by-id/{attachment_id}` | Rename-only body `{"file_name":"..."}`. |
+| `DELETE /api/v1/notes/{note_id}/attachments/by-id/{attachment_id}` | Tombstones with optional body `{"reason":"..."}` (maximum 256 characters). |
+| `POST /api/v1/notes/{note_id}/attachments/by-id/{attachment_id}/restore` | Restores with the same optional reason schema. |
+
+Every mutation requires a visible-ASCII `Idempotency-Key` of at most 128 bytes.
+Rename, replace, delete, and restore also require the exact strong
+`If-Match: "att-<uuid>-v<revision>-<object-hash-hex>"` validator. Stale bases
+return a stable conflict without mutation; exact replays return the prior
+result; reuse of a key with different content is rejected. Unknown request
+fields are forbidden.
+
 ## Download Flow
 
 Clients restore uploaded blobs through:
@@ -112,8 +146,23 @@ Clients restore uploaded blobs through:
 
 The manifest reports attachment ID, blob ID, size, content type, full hash,
 availability, server chunk size, and chunk hashes. Whole-blob download is
-available for small blobs in M2. Range/chunk download can be layered over the
-same manifest contract as the storage adapter grows.
+available for small blobs in M2.
+
+Canonical Notes content is also available at
+`GET /api/v1/notes/{note_id}/attachments/by-id/{attachment_id}/content`.
+It supports one RFC 7233 byte range at a time:
+
+- bounded (`bytes=2-5`), suffix (`bytes=-3`), and open-ended (`bytes=7-`)
+  satisfiable requests return `206`, exact `Content-Range` and
+  `Content-Length`, plus `Accept-Ranges: bytes`;
+- an unsatisfied range returns `416` and `Content-Range: bytes */<size>`;
+- multiple or malformed ranges return `400`;
+- a mismatched `If-Range` returns the complete `200` representation; and
+- a matching `If-None-Match` returns `304` before range processing.
+
+Reads stream only from an owner-authorized, exact revision binding to an
+available blob. Missing or mismatched bindings return a sanitized not-found or
+not-ready response and never expose storage keys or filesystem paths.
 
 All blob reads are scoped by authenticated user and dataset ownership.
 
@@ -139,6 +188,36 @@ restore, partial restore, and restore into an existing profile.
 Restore preview uses server-derived blob object state when M2 blob transfer is
 enabled. Client-authored `attachment.ref.availability` is not enough to mark a
 blob as server-available.
+
+For version-2 attachments, a restore plan includes the owning `notes.note`
+before its `attachment.ref`. Selecting an attachment without its required note
+dependency fails closed instead of returning an incomplete plan. Completeness
+is derived from exact immutable revision bindings: `content_complete` requires
+server bytes for every selected ref, while `verified_complete` additionally
+requires the restoring client to report exact local verification.
+
+## Notes Attachment Bootstrap And Storage Namespace
+
+An existing dataset moves through `not_started`, `initializing`, `ready`, or
+`failed` attachment bootstrap state. The resumable bootstrap inventories both
+live and soft-deleted Notes and legacy files, imports each verified source
+through the normal blob path, appends canonical version-2 refs, verifies counts,
+and only then publishes `ready`. A crash resumes from an opaque hash cursor;
+failed verification records a safe error code and keeps writes closed.
+
+Bootstrap diagnostics are read-only and bounded: source candidate counts stop
+at 1,000 and are marked as a lower bound when capped; cleanup samples default to
+none and are capped at 100. Samples expose only source-key hashes, stable
+attachment IDs, and blocker codes—not legacy paths or filenames. Legacy source
+files remain rollback evidence and are never automatically removed.
+
+Every dataset receives an opaque physical storage namespace. New blobs are
+written and verified inside that namespace. A legacy global-digest blob is
+relocated lazily under descriptor-anchored, no-follow filesystem checks; the
+source is retained, targets are never overwritten, partial/corrupt targets fail
+closed, and the database storage key changes only after exact size and digest
+verification. This avoids cross-dataset unlink authority while preserving safe
+retry after crashes.
 
 ## Key Recovery Readiness
 
@@ -172,5 +251,5 @@ M2 intentionally defers:
 - workspace/shared-dataset key rules;
 - background/scheduled sync;
 - cloud object-store backends;
-- physical blob garbage collection beyond safe tombstone metadata and abandoned
-  upload cleanup.
+- retention release and physical blob garbage collection; those are documented
+  in the implemented M3 retention contract.

--- a/Docs/API/Sync_V2_M3.md
+++ b/Docs/API/Sync_V2_M3.md
@@ -25,11 +25,13 @@ M3 adds capability-gated surfaces for:
 The current M3 foundation implements device lifecycle, device authorization,
 device acknowledgments, background policy/leases/status, workspace dataset
 enrollment, workspace/source-cache/media metadata domains, key rotation,
-retention dry-run, guarded retention compaction, and redacted diagnostics.
+retention dry-run, guarded retention compaction, immutable attachment-binding
+release, fenced physical blob deletion, and redacted attachment lifecycle
+diagnostics.
 
 Deferred beyond this foundation: conflict summary and preview-resolution
-endpoints, physical blob byte deletion, destructive envelope audit-log deletion,
-workspace Notes/Chat materialization, broad collaborative content editing,
+endpoints, destructive envelope audit-log deletion, workspace Notes/Chat
+materialization, broad collaborative content editing,
 passphrase/device-key unlock UX, and full client-only encrypted editing.
 
 ## Capabilities
@@ -295,6 +297,7 @@ Records that a device has applied or verified durable state:
   "domain_acks": [
     {
       "domain": "notes.note",
+      "adapter_version": 1,
       "through_server_sequence": 512,
       "applied_at": "2026-05-23T18:45:00Z"
     }
@@ -306,12 +309,25 @@ Records that a device has applied or verified durable state:
       "verified_at": "2026-05-23T18:45:00Z"
     }
   ],
-  "idempotency_key": "ack-dev-phone-512"
+  "blob_id_acks": [
+    {
+      "blob_id": "blob_immutable_1",
+      "payload_hash": "sha256:...",
+      "verified_at": "2026-05-23T18:45:00Z",
+      "idempotency_key": "ack-blob-immutable-1"
+    }
+  ]
 }
 ```
 
 Acknowledgments are required before M3 retention/GC can safely compact or
-delete data for datasets with offline devices.
+delete data for datasets with offline devices. Domain acknowledgments are
+adapter-version scoped and cannot exceed the exact delivered watermark. A
+version-2 attachment requires both a version-2 `attachment.ref` domain
+acknowledgment through its binding cursor and immutable blob-ID/digest evidence;
+legacy attachment-ID evidence does not satisfy this requirement. The batch is
+atomic: any invalid or unauthorized item rolls back every acknowledgment in the
+request. `blob_id_acks` is capped at 800 entries.
 
 ## Workspace Datasets
 
@@ -436,9 +452,13 @@ Candidate types:
   into a future snapshot after all blockers clear.
 - `tombstone_prune`: tombstone envelope that could be pruned after retention
   and audit policy allow it.
+- `binding_release`: historical immutable attachment revision whose audit
+  identity remains but whose monotonic release marker may stop protecting blob
+  bytes once every current-ref, device-ack, restore-window, and hold check clears.
 - `blob_gc`: server blob metadata that could be garbage-collected only after
-  active attachment refs, device verification, restore windows, and audit
-  policy allow it.
+  every unreleased binding for that deduplicated blob is tombstoned or otherwise
+  safe, exact version-2 device evidence exists, restore/audit windows expire,
+  and repair/quarantine holds clear.
 
 Initial blocker codes:
 
@@ -449,6 +469,9 @@ Initial blocker codes:
 - `retention_restore_window_active`
 - `retention_active_blob_reference`
 - `retention_blob_unverified_by_device`
+- `retention_blob_binding_invalid`
+- `retention_blob_delete_retry`
+- `retention_blob_storage_key_not_namespaced`
 
 The dry-run endpoint always reports `mutation_performed=false`.
 
@@ -471,6 +494,7 @@ Request:
   "confirm": true,
   "apply_envelope_compaction": true,
   "apply_tombstone_prune": true,
+  "apply_binding_release": true,
   "apply_blob_gc": true,
   "minimum_envelope_age_seconds": 0,
   "minimum_tombstone_age_seconds": 0,
@@ -505,12 +529,23 @@ Response:
       "candidate_count": 1
     }
   ],
+  "binding_releases": [],
   "blob_gc": []
 }
 ```
 
 Responses are redacted and must not include payloads, ciphertext, wrapped keys,
 blob storage keys, or blob bytes.
+
+Blob GC is physical. Apply re-acquires the dataset materialization fence, locks
+the exact blob row, and rereads current refs, every unreleased binding, device
+negotiation/ack evidence, restore windows, and holds in the same transaction.
+Only then may it atomically fence `available -> deleting`. The storage backend
+deletes the verified namespaced bytes; a second guarded transaction finalizes
+`deleted`. A crash or unlink error leaves `deleting`, returns the stable
+`retention_blob_delete_retry` blocker, and is safely retryable. Upload completion,
+binding creation/resolution/release, and retention share the same dataset fence,
+so stale dry-run candidates cannot delete newly protected bytes.
 
 ### `GET /api/v1/sync/diagnostics`
 
@@ -523,7 +558,8 @@ Returns redacted sync health for users or admins:
 - blob store health;
 - active upload pressure;
 - key recovery and rotation blockers;
-- retention dry-run summary.
+- retention dry-run summary; and
+- bounded Notes attachment lifecycle counts, samples, and recovery descriptors.
 
 Diagnostics must not include private payloads, ciphertext blobs, wrapped keys,
 KDF salts, passphrase metadata beyond algorithm identifiers, or recovery
@@ -535,6 +571,8 @@ Initial query parameters:
 - `device_id` (optional requesting-device context; diagnostics still report
   profile-level device lag)
 - `retention_limit` (optional dry-run scan limit)
+- `attachment_sample_limit` (default `0`, maximum `100` per category)
+- `attachment_total_sample_limit` (default and maximum `500`)
 
 Initial response shape:
 
@@ -590,13 +628,38 @@ Initial response shape:
     "blocker_counts": {
       "retention_audit_mode": 2
     }
+  },
+  "attachment_lifecycle": {
+    "counts": {
+      "registry_live": 1,
+      "binding_total": 2,
+      "available": 1,
+      "deleting": 0,
+      "deleted": 0,
+      "retention_blockers": 1
+    },
+    "samples": [],
+    "recovery_actions": [
+      {
+        "action": "wait_for_retention",
+        "reason_code": "retention_restore_window_active",
+        "target_type": "dataset",
+        "target_id": null,
+        "retryable": true,
+        "requires_confirmation": false
+      }
+    ]
   }
 }
 ```
 
-This first diagnostics endpoint is dataset-scoped and user-visible. Global
-admin/operator aggregation, audit-event search, and destructive retention/GC
-execution remain separate later M3 work.
+Diagnostics are dataset-scoped, owner-authorized, read-only, and bounded. They
+never perform a recovery action; descriptors such as `resume_upload`,
+`repair_projection`, `restore_attachment`, `release_quarantine`, `gc_retry`, or
+`wait_for_retention` are explicit operator/client hints only. Samples expose
+stable IDs and safe codes, never filenames, storage paths/keys, payloads,
+ciphertext, wrapped keys, or secret metadata. Global admin/operator aggregation
+and audit-event search remain separate work.
 
 ## Compatibility Requirements
 

--- a/backlog/tasks/task-13005 - Synchronize-Notes-attachments-and-blob-lifecycle.md
+++ b/backlog/tasks/task-13005 - Synchronize-Notes-attachments-and-blob-lifecycle.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13005
 title: Synchronize Notes attachments and blob lifecycle
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-08 20:24'
-updated_date: '2026-08-11 15:26'
+updated_date: '2026-08-13 20:31'
 labels:
   - notes
   - sync-v2
@@ -28,12 +28,12 @@ Make Notes attachment metadata and binary content participate in the same offlin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Capabilities advertise Notes use of the versioned attachment.ref domain and negotiated blob-transfer support.
-- [ ] #2 Attachment references preserve stable identity note ownership filename media type size digest lifecycle state and optimistic base state across SQLite and PostgreSQL.
-- [ ] #3 Upload list download insert delete and restore operations capture canonical metadata envelopes while binary transfer verifies content integrity and supports safe resume.
-- [ ] #4 Missing corrupt oversized unauthorized or quarantined blobs produce explicit recoverable states without losing the owning note or attachment metadata.
-- [ ] #5 Concurrent attachment rename replace delete restore and note deletion yield idempotent results or reviewable conflicts with garbage collection evidence.
-- [ ] #6 Attachment APIs and sync paths enforce dataset ownership path safety content limits and secret-safe diagnostics.
+- [x] #1 Capabilities advertise Notes use of the versioned attachment.ref domain and negotiated blob-transfer support.
+- [x] #2 Attachment references preserve stable identity note ownership filename media type size digest lifecycle state and optimistic base state across SQLite and PostgreSQL.
+- [x] #3 Upload list download insert delete and restore operations capture canonical metadata envelopes while binary transfer verifies content integrity and supports safe resume.
+- [x] #4 Missing corrupt oversized unauthorized or quarantined blobs produce explicit recoverable states without losing the owning note or attachment metadata.
+- [x] #5 Concurrent attachment rename replace delete restore and note deletion yield idempotent results or reviewable conflicts with garbage collection evidence.
+- [x] #6 Attachment APIs and sync paths enforce dataset ownership path safety content limits and secret-safe diagnostics.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -50,15 +50,36 @@ ADR path: Docs/ADR/038-canonical-notes-attachment-registry-and-blob-lifecycle.md
 Reason: durable schema, Sync versioning, tenancy, API, restore, and blob-deletion authority.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Completed the ADR-038 work stream through all four atomic child tasks, all now Done.
+
+- TASK-13005.1 established strict attachment.ref v2 negotiation, schema-v59 SQLite/PostgreSQL registry/RLS, immutable revision bindings, versioned cursors/acks, per-dataset namespaces, and default-off capability gating.
+- TASK-13005.2 made canonical create/list/content/rename/replace/delete/restore and legacy aliases use one owner-bound Sync mutation authority with idempotency, optimistic ETags, verified blob integrity, and fail-closed gates.
+- TASK-13005.3 source-verified and resumably imported legacy Notes attachments without deleting rollback evidence, with bounded privacy-safe bootstrap diagnostics.
+- TASK-13005.4 completed dependency-safe restore, monotonic historical binding release, fenced physical blob deletion, read-only lifecycle diagnostics, public contracts, and lifecycle/range e2e coverage.
+
+Architecture: existing ADR-038 governs the full schema, ownership, API, restore, namespace, and garbage-collection contract; no additional ADR was required. Public M1/M2/M3 and ADR documentation now reflect the implemented behavior.
+
+Aggregate evidence recorded by the children includes: live PostgreSQL/affected 178 passed, schema migration/store/RLS 116 passed, broad Sync 571 passed for the foundation; mutation matrix 464 passed with 4 optional PG skips; bootstrap gate 651 passed with 2 optional PG skips; restore/operations affected gate 506 passed with 3 optional PG skips and final boundary gate 32 passed with 3 skips. All server-free PostgreSQL catalog/query contracts and SQLite integrations are green; live PostgreSQL fixtures are committed and skip only when a server is unavailable. Ruff/static, Bandit, py_compile, diff checks, security/authorization, integrity, resume, size-limit, corruption/quarantine, concurrency, retention, and physical-GC scenarios are recorded across the child tasks. No new lessons file was invented: no additional general repository trap remained after applying the existing testing/live-verification guidance.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Notes attachments now participate in the same stable-ID, multi-device Sync v2 lifecycle as their owning notes: negotiated metadata, verified resumable bytes, canonical REST mutations, safe legacy bootstrap, dependency-complete restore, immutable acknowledgment evidence, fenced retention/physical collection, and privacy-safe diagnostics. TASK-13005.1 through TASK-13005.4 are all Done, ADR-038 and public contracts are current, and the aggregate regression/security evidence is recorded with environment-only PostgreSQL skips called out.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
-- [ ] #7 Focused Notes attachment and shared blob-transfer suites pass on supported database backends.
-- [ ] #8 Bandit and static checks pass for touched production files.
-- [ ] #9 Integrity resume limit authorization and garbage-collection scenarios have automated evidence.
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused Notes attachment and shared blob-transfer suites pass on supported database backends.
+- [x] #8 Bandit and static checks pass for touched production files.
+- [x] #9 Integrity resume limit authorization and garbage-collection scenarios have automated evidence.
 <!-- DOD:END -->

--- a/backlog/tasks/task-13005.4 - Complete-Notes-attachment-restore-retention-and-operations.md
+++ b/backlog/tasks/task-13005.4 - Complete-Notes-attachment-restore-retention-and-operations.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-13005.4
 title: Complete Notes attachment restore retention and operations
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-11 15:34'
+updated_date: '2026-08-13 18:28'
 labels:
   - notes
   - sync-v2
@@ -37,6 +38,12 @@ Complete adapter-version-aware restore, binding release, fenced physical blob co
 - [ ] #4 Diagnostics are bounded, owner-scoped, privacy-safe, read-only, and return recovery descriptors without invoking mutations.
 - [ ] #5 SQLite and required live PostgreSQL lifecycle, RLS, range-read, query-plan, restore, retention, static, security, and documentation gates are recorded.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Make restore adapter-version and immutable-binding aware under focused RED/GREEN tests.\n2. Add monotonic historical binding release with bounded SQLite/PostgreSQL query-plan evidence.\n3. Add the available-to-deleting-to-deleted physical GC fence and idempotent namespace-safe cleanup.\n4. Add bounded read-only lifecycle diagnostics and recovery-action descriptors.\n5. Update public Sync documentation, add SQLite/live-PostgreSQL lifecycle coverage, run aggregate static/security gates, and close TASK-13005.4 then TASK-13005 only if every criterion passes.\n\nADR required: no\nADR path: Docs/ADR/038-canonical-notes-attachment-registry-and-blob-lifecycle.md\nReason: Direct implementation of the approved restore, retention, diagnostics, and blob-deletion authority.
+<!-- SECTION:PLAN:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-13005.4 - Complete-Notes-attachment-restore-retention-and-operations.md
+++ b/backlog/tasks/task-13005.4 - Complete-Notes-attachment-restore-retention-and-operations.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13005.4
 title: Complete Notes attachment restore retention and operations
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-11 15:34'
-updated_date: '2026-08-13 18:28'
+updated_date: '2026-08-13 20:30'
 labels:
   - notes
   - sync-v2
@@ -32,11 +32,11 @@ Complete adapter-version-aware restore, binding release, fenced physical blob co
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Restore preview/replay orders live v2 attachment refs after owning notes, filters by negotiated adapter version, and reports byte completeness through immutable bindings.
-- [ ] #2 Historical bindings release monotonically only after version-aware acknowledgment, retention, conflict, quarantine, and restore blockers clear.
-- [ ] #3 Physical GC uses a durable dataset/blob fence, blocks concurrent writers, never unlinks legacy global keys, and recovers idempotently from unlink/finalization failures.
-- [ ] #4 Diagnostics are bounded, owner-scoped, privacy-safe, read-only, and return recovery descriptors without invoking mutations.
-- [ ] #5 SQLite and required live PostgreSQL lifecycle, RLS, range-read, query-plan, restore, retention, static, security, and documentation gates are recorded.
+- [x] #1 Restore preview/replay orders live v2 attachment refs after owning notes, filters by negotiated adapter version, and reports byte completeness through immutable bindings.
+- [x] #2 Historical bindings release monotonically only after version-aware acknowledgment, retention, conflict, quarantine, and restore blockers clear.
+- [x] #3 Physical GC uses a durable dataset/blob fence, blocks concurrent writers, never unlinks legacy global keys, and recovers idempotently from unlink/finalization failures.
+- [x] #4 Diagnostics are bounded, owner-scoped, privacy-safe, read-only, and return recovery descriptors without invoking mutations.
+- [x] #5 SQLite and required live PostgreSQL lifecycle, RLS, range-read, query-plan, restore, retention, static, security, and documentation gates are recorded.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -45,12 +45,33 @@ Complete adapter-version-aware restore, binding release, fenced physical blob co
 1. Make restore adapter-version and immutable-binding aware under focused RED/GREEN tests.\n2. Add monotonic historical binding release with bounded SQLite/PostgreSQL query-plan evidence.\n3. Add the available-to-deleting-to-deleted physical GC fence and idempotent namespace-safe cleanup.\n4. Add bounded read-only lifecycle diagnostics and recovery-action descriptors.\n5. Update public Sync documentation, add SQLite/live-PostgreSQL lifecycle coverage, run aggregate static/security gates, and close TASK-13005.4 then TASK-13005 only if every criterion passes.\n\nADR required: no\nADR path: Docs/ADR/038-canonical-notes-attachment-registry-and-blob-lifecycle.md\nReason: Direct implementation of the approved restore, retention, diagnostics, and blob-deletion authority.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the approved ADR-038 restore and operations slice in five commits:
+- 857fe723cc: adapter-version-aware attachment history restore, dependency ordering, immutable-binding completeness, and exact replay.
+- e7b86f1edf: bounded monotonic historical binding release with acknowledgment, retention, conflict, quarantine, and restore-window guards.
+- aa416225d0: namespace-safe physical GC using the shared dataset/blob fence and recoverable available -> deleting -> deleted lifecycle.
+- 628c6bdf5b: bounded owner-scoped read-only lifecycle diagnostics and non-invoking recovery descriptors.
+- a572fd4a3d: public M1/M2/M3 and ADR documentation, SQLite lifecycle e2e, suffix/open-ended range coverage, and live-PostgreSQL tenancy/lifecycle/range tests.
+
+ADR required: no new ADR. ADR-038 directly governs the implementation; its operational completion and failure semantics are now documented.
+
+Verification: exact 12-file affected matrix 506 passed, 3 skipped; final touched boundary gate 32 passed, 3 skipped; Ruff and Ruff formatter passed on all touched Python tests; Bandit passed with fixture-only B106 annotations and B101 disabled for test assertions; py_compile and git diff --check passed. The three PostgreSQL tests skip only because no PostgreSQL DSN/server is available in this environment; their live fixtures and assertions remain required and are included. No generalized lesson document was added because this slice did not surface a new reusable repository trap beyond the already documented testing/live-verification guidance.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed canonical Notes attachment restore, retention release, fenced physical blob deletion, privacy-safe diagnostics, public contracts, and end-to-end lifecycle verification. All five acceptance criteria and six DoD items are satisfied. The full affected SQLite/server-free suite is green; live PostgreSQL coverage is committed and honestly skipped locally because no PostgreSQL service is available.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -308,6 +308,20 @@ def _safe_sync_v2_http_error(exc: Exception, **context: object) -> HTTPException
                     "message": "Attachment bootstrap diagnostics parameters are invalid.",
                 },
             )
+        attachment_diagnostic_limits = {
+            "sync_attachment_diagnostic_category_sample_limit_exceeded": (
+                "Attachment diagnostics exceed the per-category sample limit."
+            ),
+            "sync_attachment_diagnostic_total_sample_limit_exceeded": (
+                "Attachment diagnostics exceed the total response sample limit."
+            ),
+        }
+        for error_code, message in attachment_diagnostic_limits.items():
+            if error_code in lowered:
+                return HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail={"error_code": error_code, "message": message},
+                )
         if "attachment payload exceeds" in lowered:
             return HTTPException(
                 status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
@@ -1148,6 +1162,8 @@ def get_sync_v2_diagnostics(
     dataset_id: str = Query(...),
     device_id: str | None = Query(None),
     retention_limit: int | None = Query(None, ge=1),
+    attachment_sample_limit: int = Query(0, ge=0),
+    attachment_total_sample_limit: int = Query(500, ge=0),
     user: User = Depends(get_request_user),
     service: SyncV2Service = Depends(get_sync_v2_service),
 ):
@@ -1157,6 +1173,8 @@ def get_sync_v2_diagnostics(
             dataset_id=dataset_id,
             device_id=device_id,
             retention_limit=retention_limit,
+            attachment_sample_limit=attachment_sample_limit,
+            attachment_total_sample_limit=attachment_total_sample_limit,
         )
     except Exception as exc:
         raise _safe_sync_v2_http_error(

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -1219,6 +1219,7 @@ def compact_sync_v2_retention(
             confirm=request.confirm,
             apply_envelope_compaction=request.apply_envelope_compaction,
             apply_tombstone_prune=request.apply_tombstone_prune,
+            apply_binding_release=request.apply_binding_release,
             apply_blob_gc=request.apply_blob_gc,
             minimum_envelope_age_seconds=request.minimum_envelope_age_seconds,
             minimum_tombstone_age_seconds=request.minimum_tombstone_age_seconds,

--- a/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
@@ -658,7 +658,12 @@ class SyncBackgroundStatusResponse(BaseModel):
     server_time: str | None = None
 
 
-SyncRetentionCandidateType = Literal["envelope_compaction", "tombstone_prune", "blob_gc"]
+SyncRetentionCandidateType = Literal[
+    "envelope_compaction",
+    "tombstone_prune",
+    "binding_release",
+    "blob_gc",
+]
 
 
 class SyncRetentionDryRunRequest(BaseModel):
@@ -684,6 +689,7 @@ class SyncRetentionCandidateResponse(BaseModel):
     server_sequence: int | None = Field(None, ge=1)
     blob_id: str | None = None
     attachment_id: str | None = None
+    attachment_revision: int | None = Field(None, ge=1)
     payload_hash: str | None = None
     size_bytes: int | None = Field(None, ge=0)
     blockers: list[str] = Field(default_factory=list)
@@ -718,6 +724,7 @@ class SyncRetentionCompactRequest(BaseModel):
     confirm: bool = False
     apply_envelope_compaction: bool = True
     apply_tombstone_prune: bool = True
+    apply_binding_release: bool = True
     apply_blob_gc: bool = True
     minimum_envelope_age_seconds: int = Field(0, ge=0)
     minimum_tombstone_age_seconds: int = Field(0, ge=0)
@@ -740,6 +747,7 @@ class SyncRetentionCompactResponse(BaseModel):
     blockers: list[str] = Field(default_factory=list)
     blocker_counts: dict[str, int] = Field(default_factory=dict)
     domain_compactions: list[dict[str, Any]] = Field(default_factory=list)
+    binding_releases: list[dict[str, Any]] = Field(default_factory=list)
     blob_gc: list[dict[str, Any]] = Field(default_factory=list)
 
 

--- a/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
@@ -1035,6 +1035,7 @@ class SyncRestorePreviewLocalInventoryItem(BaseModel):
     dataset_id: str | None = None
     domain: SyncDomain
     object_id: str = Field(..., min_length=1, validation_alias=AliasChoices("object_id", "entity_id"))
+    adapter_version: int = Field(1, ge=1)
     object_revision: int | None = Field(None, ge=0, validation_alias=AliasChoices("object_revision", "entity_version"))
     object_hash: str | None = Field(None, validation_alias=AliasChoices("object_hash", "payload_hash"))
     deleted: bool = False
@@ -1132,6 +1133,7 @@ class SyncRestoreOrderedAction(BaseModel):
     object_id: str
     operation: SyncOperation
     server_cursor: int = Field(..., ge=0)
+    adapter_version: int = Field(..., ge=1)
     mutation_group_id: str | None = None
     mutation_step: int | None = Field(None, ge=0)
     mutation_step_count: int | None = Field(None, ge=1)
@@ -1153,6 +1155,7 @@ class SyncRestorePreviewAttachmentRef(BaseModel):
     payload_hash: str
     availability: str
     server_cursor: int = Field(..., ge=0)
+    adapter_version: int = Field(..., ge=1)
 
 
 class SyncRestorePreviewWarning(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
@@ -811,6 +811,65 @@ class SyncDiagnosticsRetentionSummaryResponse(BaseModel):
     blocker_counts: dict[str, int] = Field(default_factory=dict)
 
 
+class SyncRecoveryActionDescriptorResponse(BaseModel):
+    """One explicit recovery hint; returning it never invokes the action."""
+
+    action: Literal[
+        "resume_upload",
+        "retry_upload",
+        "retry_verify",
+        "repair_projection",
+        "resolve_conflict",
+        "restore_attachment",
+        "restore_note",
+        "release_quarantine",
+        "bootstrap_resume",
+        "gc_retry",
+        "wait_for_retention",
+    ]
+    reason_code: str
+    target_type: Literal[
+        "dataset", "attachment", "blob", "upload", "conflict", "envelope"
+    ] = "dataset"
+    target_id: str | None = None
+    retryable: bool = True
+    requires_confirmation: bool = False
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SyncAttachmentDiagnosticSampleResponse(BaseModel):
+    """One bounded owner-authorized attachment lifecycle sample."""
+
+    category: str
+    code: str
+    attachment_id: str | None = None
+    blob_id: str | None = None
+    server_cursor: int | None = Field(None, ge=1)
+    recovery_actions: list[SyncRecoveryActionDescriptorResponse] = Field(
+        default_factory=list,
+        max_length=4,
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SyncAttachmentDiagnosticsResponse(BaseModel):
+    """Bounded read-only Notes attachment lifecycle diagnostics."""
+
+    counts: dict[str, int] = Field(default_factory=dict)
+    samples: list[SyncAttachmentDiagnosticSampleResponse] = Field(
+        default_factory=list,
+        max_length=500,
+    )
+    recovery_actions: list[SyncRecoveryActionDescriptorResponse] = Field(
+        default_factory=list,
+        max_length=32,
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class SyncDiagnosticsResponse(BaseModel):
     """Redacted Sync v2 diagnostics response."""
 
@@ -826,6 +885,9 @@ class SyncDiagnosticsResponse(BaseModel):
     )
     retention: SyncDiagnosticsRetentionSummaryResponse = Field(
         default_factory=SyncDiagnosticsRetentionSummaryResponse
+    )
+    attachment_lifecycle: SyncAttachmentDiagnosticsResponse = Field(
+        default_factory=SyncAttachmentDiagnosticsResponse
     )
 
 
@@ -904,6 +966,10 @@ class SyncNotesAttachmentBootstrapDiagnosticsResponse(BaseModel):
     cleanup_candidates: list[SyncNotesAttachmentCleanupSampleResponse] = Field(
         default_factory=list,
         max_length=100,
+    )
+    recovery_actions: list[SyncRecoveryActionDescriptorResponse] = Field(
+        default_factory=list,
+        max_length=4,
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -9022,6 +9022,7 @@ class SyncDatabase:
         blob_id: str | None = None,
         payload_hash: str | None = None,
         owner_user_id: str | None = None,
+        include_unavailable: bool = False,
         connection: Any | None = None,
         for_update: bool = False,
     ) -> SyncBlobObject | None:
@@ -9040,7 +9041,7 @@ class SyncDatabase:
                     SELECT *
                       FROM sync_blob_objects
                      WHERE dataset_id = ?
-                       AND status = 'available'
+                       AND (? = 1 OR status = 'available')
                        AND (? IS NULL OR owner_user_id = ?)
                        AND (? IS NULL OR blob_id = ?)
                        AND (? IS NULL OR payload_hash = ?)
@@ -9060,6 +9061,7 @@ class SyncDatabase:
                     + suffix,  # nosec B608 - backend-controlled row lock suffix.
                     (
                         dataset_id,
+                        1 if include_unavailable else 0,
                         owner_user_id,
                         owner_user_id,
                         blob_id,

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -7924,14 +7924,13 @@ class SyncDatabase:
         blob_row = _first(
             self.execute(
                 """
-                SELECT blob.blob_id
+                SELECT blob.blob_id, blob.status
                   FROM sync_blob_objects AS blob
                   JOIN sync_datasets AS dataset
                     ON dataset.dataset_id = blob.dataset_id
                  WHERE blob.dataset_id = ?
                    AND blob.payload_hash = ?
                    AND blob.size_bytes = ?
-                   AND blob.status = 'available'
                    AND (
                         dataset.scope_type = 'workspace'
                         OR blob.owner_user_id = dataset.owner_user_id
@@ -7944,6 +7943,11 @@ class SyncDatabase:
                 connection=connection,
             )
         )
+        if blob_row is not None and blob_row.get("status") in {"deleting", "deleted"}:
+            raise SyncStoreError(
+                f"Sync attachment binding cannot target a {blob_row['status']} blob"
+            )
+        blob_available = blob_row is not None and blob_row.get("status") == "available"
         binding = SyncAttachmentRevisionBindingCreate(
             dataset_id=envelope.dataset_id,
             attachment_id=attachment_id,
@@ -7952,9 +7956,9 @@ class SyncDatabase:
             size_bytes=size_value,
             establishing_server_cursor=envelope.server_cursor,
             availability_at_acceptance=(
-                "available" if blob_row is not None else "metadata_only"
+                "available" if blob_available else "metadata_only"
             ),
-            resolved_blob_id=(None if blob_row is None else str(blob_row["blob_id"])),
+            resolved_blob_id=(None if not blob_available else str(blob_row["blob_id"])),
         )
         return self._create_attachment_revision_binding(
             binding,
@@ -8499,6 +8503,33 @@ class SyncDatabase:
             raise SyncStoreError("Sync dataset storage namespace could not be resolved")
         return _storage_namespace_from_row(row)
 
+    def get_storage_namespace(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        connection: Any | None = None,
+    ) -> SyncDatasetStorageNamespace | None:
+        """Return the existing opaque namespace under exact owner authority."""
+
+        with self.backend.transaction(connection) as conn:
+            row = _first(
+                self.execute(
+                    """
+                    SELECT namespace.*
+                      FROM sync_dataset_storage_namespaces AS namespace
+                      JOIN sync_datasets AS dataset
+                        ON dataset.dataset_id = namespace.dataset_id
+                     WHERE namespace.dataset_id = ?
+                       AND namespace.owner_user_id = ?
+                       AND dataset.owner_user_id = ?
+                    """,
+                    (dataset_id, owner_user_id, owner_user_id),
+                    connection=conn,
+                )
+            )
+        return None if row is None else _storage_namespace_from_row(row)
+
     def _resolve_pending_bindings_for_blob(
         self,
         blob_row: Mapping[str, Any],
@@ -8982,12 +9013,60 @@ class SyncDatabase:
                 raise SyncStoreError("Sync blob chunk insert did not produce a retrievable record")
             return _blob_chunk_from_row(row)
 
-    def complete_blob_upload(self, blob: SyncBlobObjectCreate) -> SyncBlobObject:
+    def require_blob_upload_completion_allowed(
+        self,
+        blob: SyncBlobObjectCreate,
+        *,
+        connection: Any,
+    ) -> None:
+        """Reject storage publication after a fence or metadata conflict."""
+
+        row = _first(
+            self.execute(
+                """
+                SELECT blob.*
+                  FROM sync_blob_objects AS blob
+                  JOIN sync_datasets AS dataset
+                    ON dataset.dataset_id = blob.dataset_id
+                 WHERE blob.dataset_id = ? AND blob.payload_hash = ?
+                   AND (
+                        dataset.scope_type = 'workspace'
+                        OR blob.owner_user_id = ?
+                   )
+                """,
+                (blob.dataset_id, blob.payload_hash, blob.owner_user_id),
+                connection=connection,
+            )
+        )
+        if row is None:
+            return
+        existing_status = str(row.get("status"))
+        if existing_status == "deleting":
+            raise SyncStoreError("Sync blob is deleting")
+        if existing_status not in {"available", "deleted"}:
+            raise SyncStoreError("Sync blob is not available for upload completion")
+        existing_fingerprint = _blob_object_fingerprint_from_row(row)
+        requested_fingerprint = _blob_object_fingerprint_from_create(blob)
+        existing_fingerprint.pop("status")
+        requested_fingerprint.pop("status")
+        if existing_fingerprint != requested_fingerprint:
+            raise SyncIdempotencyConflictError(
+                "Sync blob payload hash was reused with different metadata"
+            )
+
+    def complete_blob_upload(
+        self,
+        blob: SyncBlobObjectCreate,
+        *,
+        connection: Any | None = None,
+    ) -> SyncBlobObject:
         """Commit a verified blob and deduplicate by dataset plus payload hash."""
 
+        if blob.status != "available":
+            raise SyncStoreError("Sync blob upload completion must become available")
         now = utcnow_iso()
         suffix = " FOR UPDATE" if self.backend_type == BackendType.POSTGRESQL else ""
-        with self.backend.transaction() as conn:
+        with self.backend.transaction(connection) as conn:
             dataset_row = self._get_dataset_row_for_update(
                 blob.dataset_id,
                 connection=conn,
@@ -9061,10 +9140,40 @@ class SyncDatabase:
                 raise SyncStoreError(
                     "Sync blob is unavailable under dataset owner authority"
                 )
-            if _blob_object_fingerprint_from_row(row) != _blob_object_fingerprint_from_create(blob):
+            existing_fingerprint = _blob_object_fingerprint_from_row(row)
+            requested_fingerprint = _blob_object_fingerprint_from_create(blob)
+            existing_status = str(existing_fingerprint.pop("status"))
+            requested_fingerprint.pop("status")
+            if existing_status == "deleting":
+                raise SyncStoreError("Sync blob is deleting")
+            if existing_fingerprint != requested_fingerprint:
                 raise SyncIdempotencyConflictError(
                     "Sync blob payload hash was reused with different metadata"
                 )
+            if existing_status == "deleted":
+                self.execute(
+                    """
+                    UPDATE sync_blob_objects
+                       SET status = 'available', deleted_at = NULL, updated_at = ?
+                     WHERE dataset_id = ? AND blob_id = ? AND status = 'deleted'
+                    """,
+                    (now, blob.dataset_id, row["blob_id"]),
+                    connection=conn,
+                )
+                row = _first(
+                    self.execute(
+                        """
+                        SELECT * FROM sync_blob_objects
+                         WHERE dataset_id = ? AND blob_id = ?
+                        """,
+                        (blob.dataset_id, row["blob_id"]),
+                        connection=conn,
+                    )
+                )
+                if row is None or row["status"] != "available":
+                    raise SyncStoreError("Sync blob repair did not become available")
+            elif existing_status != "available":
+                raise SyncStoreError("Sync blob is not available for upload completion")
             self._resolve_pending_bindings_for_blob(row, connection=conn)
             if session is not None:
                 self.execute(
@@ -9248,44 +9357,68 @@ class SyncDatabase:
             ).rows
         return [_blob_object_from_row(row) for row in rows]
 
-    def mark_blob_object_deleted(
+    def fence_blob_object_deleting(
         self,
         dataset_id: str,
         blob_id: str,
         *,
-        connection: Any | None = None,
+        connection: Any,
     ) -> SyncBlobObject | None:
-        """Soft-delete available blob metadata without removing blob bytes."""
+        """Durably fence one available blob before physical deletion."""
 
         now = utcnow_iso()
-        with self.backend.transaction(connection) as conn:
+        self.execute(
+            """
+            UPDATE sync_blob_objects
+               SET status = 'deleting', updated_at = ?
+             WHERE dataset_id = ? AND blob_id = ?
+               AND status = 'available' AND deleted_at IS NULL
+            """,
+            (now, dataset_id, blob_id),
+            connection=connection,
+        )
+        row = _first(
             self.execute(
                 """
-                UPDATE sync_blob_objects
-                   SET status = 'deleted',
-                       deleted_at = ?
-                 WHERE dataset_id = ?
-                   AND blob_id = ?
-                   AND status = 'available'
-                   AND deleted_at IS NULL
+                SELECT * FROM sync_blob_objects
+                 WHERE dataset_id = ? AND blob_id = ?
                 """,
-                (now, dataset_id, blob_id),
-                connection=conn,
+                (dataset_id, blob_id),
+                connection=connection,
             )
-            row = _first(
-                self.execute(
-                    """
-                    SELECT *
-                      FROM sync_blob_objects
-                     WHERE dataset_id = ? AND blob_id = ?
-                    """,
-                    (dataset_id, blob_id),
-                    connection=conn,
-                )
+        )
+        return None if row is None else _blob_object_from_row(row)
+
+    def finalize_blob_object_deleted(
+        self,
+        dataset_id: str,
+        blob_id: str,
+        *,
+        connection: Any,
+    ) -> SyncBlobObject | None:
+        """Finalize a physically absent fenced blob as deleted."""
+
+        now = utcnow_iso()
+        self.execute(
+            """
+            UPDATE sync_blob_objects
+               SET status = 'deleted', deleted_at = ?, updated_at = ?
+             WHERE dataset_id = ? AND blob_id = ? AND status = 'deleting'
+            """,
+            (now, now, dataset_id, blob_id),
+            connection=connection,
+        )
+        row = _first(
+            self.execute(
+                """
+                SELECT * FROM sync_blob_objects
+                 WHERE dataset_id = ? AND blob_id = ?
+                """,
+                (dataset_id, blob_id),
+                connection=connection,
             )
-        if row is None:
-            return None
-        return _blob_object_from_row(row)
+        )
+        return None if row is None else _blob_object_from_row(row)
 
     def get_domain_compaction_sequence(
         self,

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -557,6 +557,9 @@ CREATE INDEX IF NOT EXISTS idx_sync_attachment_bindings_blob_retention
         attachment_id, attachment_revision
     )
     WHERE retention_released_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_sync_attachment_bindings_retention_release
+    ON sync_attachment_revision_bindings(dataset_id, establishing_server_cursor, attachment_id, attachment_revision)
+    WHERE retention_released_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_sync_attachment_bindings_pending_digest
     ON sync_attachment_revision_bindings(dataset_id, blob_hash, size_bytes, establishing_server_cursor, attachment_id, attachment_revision)
     WHERE resolved_blob_id IS NULL AND retention_released_at IS NULL;
@@ -1121,6 +1124,9 @@ CREATE INDEX IF NOT EXISTS idx_sync_attachment_bindings_blob_retention
         dataset_id, resolved_blob_id, establishing_server_cursor,
         attachment_id, attachment_revision
     )
+    WHERE retention_released_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_sync_attachment_bindings_retention_release
+    ON sync_attachment_revision_bindings(dataset_id, establishing_server_cursor, attachment_id, attachment_revision)
     WHERE retention_released_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_sync_attachment_bindings_pending_digest
     ON sync_attachment_revision_bindings(dataset_id, blob_hash, size_bytes, establishing_server_cursor, attachment_id, attachment_revision)
@@ -8045,10 +8051,11 @@ class SyncDatabase:
         attachment_revision: int,
         *,
         owner_user_id: str,
+        connection: Any | None = None,
     ) -> SyncAttachmentRevisionBinding | None:
         """Return one dataset-scoped immutable attachment revision binding."""
 
-        with self.backend.transaction() as conn:
+        with self.backend.transaction(connection) as conn:
             self._require_attachment_binding_dataset_owner(
                 dataset_id,
                 owner_user_id,
@@ -8132,6 +8139,62 @@ class SyncDatabase:
                 (
                     dataset_id,
                     blob_id,
+                    after_establishing_server_cursor,
+                    after_attachment_id,
+                    after_attachment_revision,
+                    page_limit,
+                ),
+                connection=conn,
+            ).rows
+        return [_attachment_revision_binding_from_row(row) for row in rows]
+
+    def list_unreleased_attachment_revision_bindings(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        after_establishing_server_cursor: int = 0,
+        after_attachment_id: str = "",
+        after_attachment_revision: int = 0,
+        limit: int = 1000,
+        connection: Any | None = None,
+    ) -> list[SyncAttachmentRevisionBinding]:
+        """Return one bounded keyset page of unreleased dataset bindings."""
+
+        if isinstance(limit, bool) or limit < 1:
+            raise SyncStoreError("Sync attachment binding page limit must be positive")
+        page_limit = min(limit, 1000)
+        with self.backend.transaction(connection) as conn:
+            self._require_attachment_binding_dataset_owner(
+                dataset_id,
+                owner_user_id,
+                connection=conn,
+            )
+            rows = self.execute(
+                """
+                SELECT binding.* FROM sync_attachment_revision_bindings AS binding
+                 WHERE binding.dataset_id = ?
+                   AND binding.retention_released_at IS NULL
+                   AND NOT EXISTS (
+                        SELECT 1
+                          FROM sync_current_heads AS head
+                          JOIN sync_envelopes AS envelope
+                            ON envelope.server_sequence = head.latest_server_cursor
+                         WHERE head.dataset_id = binding.dataset_id
+                           AND head.domain = 'attachment.ref'
+                           AND head.object_id = binding.attachment_id
+                           AND envelope.adapter_version = 2
+                           AND envelope.object_revision = binding.attachment_revision
+                           AND envelope.operation <> 'tombstone'
+                   )
+                   AND (binding.establishing_server_cursor, binding.attachment_id,
+                        binding.attachment_revision) > (?, ?, ?)
+                 ORDER BY binding.establishing_server_cursor, binding.attachment_id,
+                          binding.attachment_revision
+                 LIMIT ?
+                """,
+                (
+                    dataset_id,
                     after_establishing_server_cursor,
                     after_attachment_id,
                     after_attachment_revision,
@@ -8331,13 +8394,14 @@ class SyncDatabase:
         *,
         released_at: str,
         owner_user_id: str,
+        connection: Any | None = None,
     ) -> SyncAttachmentRevisionBinding:
         """Set the retention-release marker once without erasing audit identity."""
 
         if not released_at.strip():
             raise SyncStoreError("Sync attachment binding release timestamp is required")
         suffix = " FOR UPDATE" if self.backend_type == BackendType.POSTGRESQL else ""
-        with self.backend.transaction() as conn:
+        with self.backend.transaction(connection) as conn:
             self._require_dataset_owner_for_update(
                 dataset_id,
                 owner_user_id,
@@ -10765,6 +10829,11 @@ class SyncDatabase:
                 WHERE retention_released_at IS NULL
             """,
             """
+            CREATE INDEX IF NOT EXISTS idx_sync_attachment_bindings_retention_release
+                ON sync_attachment_revision_bindings(dataset_id, establishing_server_cursor, attachment_id, attachment_revision)
+                WHERE retention_released_at IS NULL
+            """,
+            """
             CREATE INDEX IF NOT EXISTS idx_sync_attachment_bindings_pending_digest
                 ON sync_attachment_revision_bindings(
                     dataset_id, blob_hash, size_bytes, establishing_server_cursor,
@@ -11136,6 +11205,7 @@ class SyncDatabase:
             "idx_sync_attachment_bindings_unresolved": "createindexidx_sync_attachment_bindings_unresolvedonsync_attachment_revision_bindings(dataset_id,establishing_server_cursor,attachment_id,attachment_revision)whereresolved_blob_idisnullandretention_released_atisnull",
             "idx_sync_attachment_bindings_blob": "createindexidx_sync_attachment_bindings_blobonsync_attachment_revision_bindings(dataset_id,resolved_blob_id)",
             "idx_sync_attachment_bindings_blob_retention": "createindexidx_sync_attachment_bindings_blob_retentiononsync_attachment_revision_bindings(dataset_id,resolved_blob_id,establishing_server_cursor,attachment_id,attachment_revision)whereretention_released_atisnull",
+            "idx_sync_attachment_bindings_retention_release": "createindexidx_sync_attachment_bindings_retention_releaseonsync_attachment_revision_bindings(dataset_id,establishing_server_cursor,attachment_id,attachment_revision)whereretention_released_atisnull",
             "idx_sync_attachment_bindings_pending_digest": "createindexidx_sync_attachment_bindings_pending_digestonsync_attachment_revision_bindings(dataset_id,blob_hash,size_bytes,establishing_server_cursor,attachment_id,attachment_revision)whereresolved_blob_idisnullandretention_released_atisnull",
             "uq_sync_dataset_storage_namespace_id": "createuniqueindexuq_sync_dataset_storage_namespace_idonsync_dataset_storage_namespaces(storage_namespace_id)",
             "idx_sync_dataset_storage_namespaces_owner": "createindexidx_sync_dataset_storage_namespaces_owneronsync_dataset_storage_namespaces(owner_user_id,dataset_id)",
@@ -11169,6 +11239,7 @@ class SyncDatabase:
                     'idx_sync_attachment_bindings_unresolved',
                     'idx_sync_attachment_bindings_blob',
                     'idx_sync_attachment_bindings_blob_retention',
+                    'idx_sync_attachment_bindings_retention_release',
                     'idx_sync_attachment_bindings_pending_digest',
                     'uq_sync_dataset_storage_namespace_id',
                     'idx_sync_dataset_storage_namespaces_owner'
@@ -11323,6 +11394,12 @@ class SyncDatabase:
                 "sync_attachment_revision_bindings",
                 False,
                 "dataset_id,resolved_blob_id,establishing_server_cursor,attachment_id,attachment_revision",
+                "retention_released_atisnull",
+            ),
+            "idx_sync_attachment_bindings_retention_release": (
+                "sync_attachment_revision_bindings",
+                False,
+                "dataset_id,establishing_server_cursor,attachment_id,attachment_revision",
                 "retention_released_atisnull",
             ),
             "idx_sync_attachment_bindings_pending_digest": (

--- a/tldw_Server_API/app/core/Sync/v2/blob_store.py
+++ b/tldw_Server_API/app/core/Sync/v2/blob_store.py
@@ -29,6 +29,10 @@ class SyncBlobStoreError(ValueError):
     """Raised when blob storage input or integrity checks fail."""
 
 
+class _MissingBlobDirectoryError(SyncBlobStoreError):
+    """Raised when a no-create directory chain is absent."""
+
+
 class LocalSyncBlobStore:
     """Path-contained local blob store rooted under a user's sync blob directory."""
 
@@ -244,6 +248,95 @@ class LocalSyncBlobStore:
         except LockAcquisitionError as exc:
             raise SyncBlobStoreError("Sync legacy blob relocation lock is unavailable") from exc
 
+    def delete_namespace_blob(
+        self,
+        *,
+        storage_key: str,
+        storage_namespace_id: str,
+        payload_hash: str,
+        expected_size: int,
+    ) -> bool:
+        """Verify and unlink one exact dataset-namespace blob.
+
+        Returns ``False`` when the exact target is already absent. Global legacy
+        keys and namespace mismatches fail closed.
+        """
+
+        namespace = _storage_namespace_id(storage_namespace_id)
+        digest = _hash_digest(payload_hash)
+        expected_key = self.namespace_storage_key(namespace, payload_hash)
+        if storage_key != expected_key:
+            raise SyncBlobStoreError(
+                "Sync blob deletion requires the exact storage namespace key"
+            )
+        if isinstance(expected_size, bool) or expected_size < 1:
+            raise SyncBlobStoreError("expected_size must be positive")
+        try:
+            _require_secure_relocation_capabilities()
+            with _open_directory_chain(
+                self.root,
+                ("_locks", "blob-gc"),
+                create=True,
+            ) as lock_directory:
+                with _lock_file_at(
+                    lock_directory,
+                    f"{namespace}.{digest}.lock",
+                    timeout=10,
+                ):
+                    with _open_directory_chain(
+                        self.root,
+                        ("blobs", "v2", namespace),
+                        create=False,
+                    ) as target_directory:
+                        target_name = f"{digest}.blob"
+                        try:
+                            target = _open_target_at(target_directory, target_name)
+                        except FileNotFoundError:
+                            return False
+                        except OSError as exc:
+                            raise SyncBlobStoreError(
+                                "Sync namespace blob could not be opened safely"
+                            ) from exc
+                        with target:
+                            opened = _verify_named_open_blob(
+                                target,
+                                directory=target_directory,
+                                name=target_name,
+                                payload_hash=payload_hash,
+                                expected_size=expected_size,
+                            )
+                            try:
+                                named = os.stat(
+                                    target_name,
+                                    dir_fd=target_directory,
+                                    follow_symlinks=False,
+                                )
+                                if not _same_inode(opened, named):
+                                    raise SyncBlobStoreError(
+                                        "Sync namespace blob identity changed"
+                                    )
+                                os.unlink(target_name, dir_fd=target_directory)
+                                os.fsync(target_directory)
+                            except FileNotFoundError:
+                                return False
+                            except SyncBlobStoreError:
+                                raise
+                            except OSError as exc:
+                                raise SyncBlobStoreError(
+                                    "Sync namespace blob deletion failed"
+                                ) from exc
+                        return True
+        except NotImplementedError as exc:
+            raise SyncBlobStoreError(
+                "Sync namespace blob deletion has an unsupported platform"
+            ) from exc
+        except LockAcquisitionError as exc:
+            raise SyncBlobStoreError(
+                "Sync namespace blob deletion lock is unavailable"
+            ) from exc
+        except _MissingBlobDirectoryError:
+            return False
+
     def read_blob(self, storage_key: str) -> bytes:
         """Read a committed blob by storage key after path-containment checks."""
 
@@ -390,7 +483,7 @@ def _open_directory_chain(
                 child = os.open(segment, flags, dir_fd=current)
             except FileNotFoundError:
                 if not create:
-                    raise SyncBlobStoreError(
+                    raise _MissingBlobDirectoryError(
                         "Sync blob directory path does not exist"
                     ) from None
                 try:

--- a/tldw_Server_API/app/core/Sync/v2/models.py
+++ b/tldw_Server_API/app/core/Sync/v2/models.py
@@ -53,6 +53,7 @@ SyncBlobAvailabilityStatus = Literal[
     "metadata_only",
     "uploading",
     "available",
+    "deleting",
     "verify_failed",
     "quarantined",
     "deleted",

--- a/tldw_Server_API/app/core/Sync/v2/profile.py
+++ b/tldw_Server_API/app/core/Sync/v2/profile.py
@@ -73,6 +73,18 @@ class SyncNotesAttachmentCleanupSample:
 
 
 @dataclass(frozen=True, slots=True)
+class SyncRecoveryActionDescriptor:
+    """Machine-readable, non-mutating recovery guidance."""
+
+    action: str
+    reason_code: str
+    target_type: str = "dataset"
+    target_id: str | None = None
+    retryable: bool = True
+    requires_confirmation: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class SyncNotesAttachmentBootstrapDiagnostics:
     """Bounded read-only attachment bootstrap diagnostics."""
 
@@ -87,6 +99,7 @@ class SyncNotesAttachmentBootstrapDiagnostics:
     cleanup_candidates: list[SyncNotesAttachmentCleanupSample] = field(
         default_factory=list
     )
+    recovery_actions: list[SyncRecoveryActionDescriptor] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)
@@ -400,6 +413,16 @@ class SyncV2ProfileManager:
                 source_candidate_count_is_lower_bound
             ),
             cleanup_candidates=samples,
+            recovery_actions=(
+                [
+                    SyncRecoveryActionDescriptor(
+                        action="bootstrap_resume",
+                        reason_code="sync_attachment_bootstrap_incomplete",
+                    )
+                ]
+                if state in {"initializing", "failed"}
+                else []
+            ),
         )
 
     def _build_profile(

--- a/tldw_Server_API/app/core/Sync/v2/restore.py
+++ b/tldw_Server_API/app/core/Sync/v2/restore.py
@@ -23,6 +23,7 @@ OBJECT_RESTORE_DOMAINS: frozenset[SyncDomain] = frozenset(
         "media.keyword",
         "media.keyword_link",
         "notes.link",
+        "attachment.ref",
         *NOTES_ORGANIZATION_DOMAINS,
     }
 )
@@ -39,12 +40,16 @@ class LocalRestoreInventoryItem:
     dataset_id: str | None
     domain: SyncDomain
     object_id: str
+    adapter_version: int
     object_revision: int | None
     object_hash: str | None
     deleted: bool
 
 
-LocalInventoryIndex = dict[tuple[str | None, SyncDomain, str], LocalRestoreInventoryItem]
+LocalInventoryIndex = dict[
+    tuple[str | None, SyncDomain, str, int],
+    LocalRestoreInventoryItem,
+]
 
 
 def order_restore_envelopes(
@@ -246,6 +251,13 @@ def _restore_dependencies(envelope: SyncEnvelope) -> list[tuple[SyncDomain, str]
                 ("notes.folder", str(payload.get("folder_sync_id"))),
             ]
         )
+    elif envelope.domain == "attachment.ref" and envelope.adapter_version == 2:
+        parent_id = payload.get("parent_object_id")
+        if not isinstance(parent_id, str) or not parent_id:
+            raise RestorePlanningError(
+                "attachment.ref v2 restore dependency is invalid"
+            )
+        dependencies.append(("notes.note", parent_id))
     return dependencies
 
 
@@ -266,11 +278,14 @@ def build_local_inventory_index(
             dataset_id=_string_value(raw.get("dataset_id")),
             domain=cast(SyncDomain, domain),
             object_id=object_id,
+            adapter_version=_positive_int_value(raw.get("adapter_version"), default=1),
             object_revision=_int_value(raw.get("object_revision") or raw.get("entity_version")),
             object_hash=_string_value(raw.get("object_hash") or raw.get("payload_hash")),
             deleted=_bool_value(raw.get("deleted", False)),
         )
-        index[(item.dataset_id, item.domain, item.object_id)] = item
+        index[
+            (item.dataset_id, item.domain, item.object_id, item.adapter_version)
+        ] = item
     return index
 
 
@@ -280,10 +295,13 @@ def find_local_inventory_item(
     dataset_id: str,
     domain: SyncDomain,
     object_id: str,
+    adapter_version: int = 1,
 ) -> LocalRestoreInventoryItem | None:
     """Return dataset-specific local inventory, falling back to dataset-agnostic entries."""
 
-    return index.get((dataset_id, domain, object_id)) or index.get((None, domain, object_id))
+    return index.get(
+        (dataset_id, domain, object_id, adapter_version)
+    ) or index.get((None, domain, object_id, adapter_version))
 
 
 def local_inventory_matches(
@@ -383,6 +401,11 @@ def _int_value(value: object) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _positive_int_value(value: object, *, default: int) -> int:
+    parsed = _int_value(value)
+    return parsed if parsed is not None and parsed >= 1 else default
 
 
 def _bool_value(value: object) -> bool:

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -1523,13 +1523,17 @@ class SyncV2Service:
                 offline_restore_window_seconds=offline_restore_window_seconds,
             )
         )
-        blob_gc, revalidated_blob_blocked = self._apply_retention_blob_gc(
-            dataset=dataset,
-            candidates=[
-                candidate for candidate in selected if candidate.candidate_type == "blob_gc"
-            ],
-            minimum_tombstone_age_seconds=minimum_tombstone_age_seconds,
-            offline_restore_window_seconds=offline_restore_window_seconds,
+        blob_gc, revalidated_blob_blocked, blob_fence_mutated = (
+            self._apply_retention_blob_gc(
+                dataset=dataset,
+                candidates=[
+                    candidate
+                    for candidate in selected
+                    if candidate.candidate_type == "blob_gc"
+                ],
+                minimum_tombstone_age_seconds=minimum_tombstone_age_seconds,
+                offline_restore_window_seconds=offline_restore_window_seconds,
+            )
         )
         applied_count = sum(
             int(item["candidate_count"]) for item in domain_compactions
@@ -1542,7 +1546,7 @@ class SyncV2Service:
         return SyncRetentionApplyResult(
             dataset_id=dataset_id,
             dry_run=False,
-            mutation_performed=applied_count > 0,
+            mutation_performed=applied_count > 0 or blob_fence_mutated,
             evaluated_at=self.clock(),
             candidate_count=dry_run.candidate_count,
             applied_count=applied_count,
@@ -3353,30 +3357,45 @@ class SyncV2Service:
                 owner_user_id=user_id,
             )
             storage_namespace_id = namespace.storage_namespace_id
-        try:
-            storage_key = blob_store.commit_upload(
-                upload_id=upload_id,
-                payload_hash=session.payload_hash,
-                chunk_indexes=list(range(session.chunk_count)),
-                storage_namespace_id=storage_namespace_id,
-            )
-        except SyncBlobStoreError as exc:
-            raise SyncStoreError(str(exc)) from exc
-        blob = self.store.complete_blob_upload(
-            SyncBlobObjectCreate(
-                blob_id=self.id_factory("blob"),
-                dataset_id=dataset_id,
-                owner_user_id=user_id,
-                attachment_id=session.attachment_id,
-                payload_hash=session.payload_hash,
-                content_type=session.content_type,
-                size_bytes=session.size_bytes,
-                storage_backend=self.settings.blob_storage_backend,
-                storage_key=storage_key,
-                encryption_policy=DEFAULT_M1_ENCRYPTION_POLICY,
-                metadata={},
+        expected_storage_key = (
+            blob_store.legacy_storage_key(session.payload_hash)
+            if storage_namespace_id is None
+            else blob_store.namespace_storage_key(
+                storage_namespace_id,
+                session.payload_hash,
             )
         )
+        blob_create = SyncBlobObjectCreate(
+            blob_id=self.id_factory("blob"),
+            dataset_id=dataset_id,
+            owner_user_id=user_id,
+            attachment_id=session.attachment_id,
+            payload_hash=session.payload_hash,
+            content_type=session.content_type,
+            size_bytes=session.size_bytes,
+            storage_backend=self.settings.blob_storage_backend,
+            storage_key=expected_storage_key,
+            encryption_policy=DEFAULT_M1_ENCRYPTION_POLICY,
+            metadata={},
+        )
+        with self.store.blob_write_guard(
+            dataset_id,
+            session.domain,
+            session.object_id,
+        ) as guarded:
+            guarded.require_blob_upload_completion_allowed(blob_create)
+            try:
+                storage_key = blob_store.commit_upload(
+                    upload_id=upload_id,
+                    payload_hash=session.payload_hash,
+                    chunk_indexes=list(range(session.chunk_count)),
+                    storage_namespace_id=storage_namespace_id,
+                )
+            except SyncBlobStoreError as exc:
+                raise SyncStoreError(str(exc)) from exc
+            if storage_key != expected_storage_key:
+                raise SyncStoreError("Sync blob storage key changed during commit")
+            blob = guarded.complete_blob_upload(blob_create)
         try:
             blob_store.discard_upload(upload_id)
         except OSError as exc:
@@ -4642,12 +4661,18 @@ class SyncV2Service:
         candidates: Sequence[SyncRetentionCandidate],
         minimum_tombstone_age_seconds: int,
         offline_restore_window_seconds: int,
-    ) -> tuple[list[dict[str, object]], list[SyncRetentionCandidate]]:
+    ) -> tuple[
+        list[dict[str, object]],
+        list[SyncRetentionCandidate],
+        bool,
+    ]:
         applied: list[dict[str, object]] = []
         blocked: list[SyncRetentionCandidate] = []
+        fence_mutated = False
         for candidate in candidates:
             if candidate.blob_id is None:
                 continue
+            namespace_id: str | None = None
             with self.store.retention_guard(
                 dataset.dataset_id,
                 candidate.blob_id,
@@ -4663,18 +4688,28 @@ class SyncV2Service:
                 )
                 if current_dataset is None or blob is None:
                     continue
-                active_devices = self._retention_active_devices(
-                    current_dataset,
-                    store=guarded,
+                if blob.status == "deleted":
+                    continue
+                active_devices = (
+                    []
+                    if blob.status == "deleting"
+                    else self._retention_active_devices(
+                        current_dataset,
+                        store=guarded,
+                    )
                 )
                 revalidated = self._retention_blob_candidate(
                     dataset=current_dataset,
                     blob=blob,
                     active_devices=active_devices,
                     audit_mode=False,
-                    restore_window_blocked=self._retention_restore_window_active(
-                        active_devices,
-                        offline_restore_window_seconds,
+                    restore_window_blocked=(
+                        False
+                        if blob.status == "deleting"
+                        else self._retention_restore_window_active(
+                            active_devices,
+                            offline_restore_window_seconds,
+                        )
                     ),
                     minimum_tombstone_age_seconds=minimum_tombstone_age_seconds,
                     store=guarded,
@@ -4682,7 +4717,67 @@ class SyncV2Service:
                 if revalidated.blockers:
                     blocked.append(revalidated)
                     continue
-                blob = guarded.mark_blob_object_deleted(
+                namespace = guarded.get_storage_namespace(
+                    dataset.dataset_id,
+                    owner_user_id=dataset.owner_user_id,
+                )
+                if namespace is None:
+                    blocked.append(
+                        replace(
+                            revalidated,
+                            blockers=["retention_blob_storage_key_not_namespaced"],
+                        )
+                    )
+                    continue
+                namespace_id = namespace.storage_namespace_id
+                if blob.status == "available":
+                    blob = guarded.fence_blob_object_deleting(
+                        dataset.dataset_id,
+                        candidate.blob_id,
+                    )
+                    if blob is None or blob.status != "deleting":
+                        continue
+                    fence_mutated = True
+                elif blob.status != "deleting":
+                    continue
+            if self.blob_store is None or namespace_id is None:
+                blocked.append(
+                    replace(
+                        candidate,
+                        blockers=["retention_blob_storage_unavailable"],
+                    )
+                )
+                continue
+            try:
+                self.blob_store.delete_namespace_blob(
+                    storage_key=blob.storage_key,
+                    storage_namespace_id=namespace_id,
+                    payload_hash=blob.payload_hash,
+                    expected_size=blob.size_bytes,
+                )
+            except SyncBlobStoreError:
+                blocked.append(
+                    replace(
+                        candidate,
+                        blockers=["retention_blob_delete_retry"],
+                        reason="physical blob deletion retry",
+                    )
+                )
+                continue
+            with self.store.retention_guard(
+                dataset.dataset_id,
+                candidate.blob_id,
+            ) as guarded:
+                current = guarded.lock_blob_object_for_retention(
+                    dataset.dataset_id,
+                    candidate.blob_id,
+                    owner_user_id=dataset.owner_user_id,
+                )
+                if current is None or current.status == "deleted":
+                    continue
+                if current.status != "deleting":
+                    continue
+                blob = guarded.finalize_blob_object_deleted(
                     dataset.dataset_id,
                     candidate.blob_id,
                 )
@@ -4696,7 +4791,7 @@ class SyncV2Service:
                     "size_bytes": blob.size_bytes,
                 }
             )
-        return applied, blocked
+        return applied, blocked, fence_mutated
 
     def _retention_active_devices(
         self,
@@ -4803,21 +4898,26 @@ class SyncV2Service:
     ) -> list[SyncRetentionCandidate]:
         active_store = store or self.store
         candidates: list[SyncRetentionCandidate] = []
-        for blob in active_store.list_blob_objects_for_dataset_page(
-            dataset.dataset_id,
-            limit=limit,
-        ):
-            candidates.append(
-                self._retention_blob_candidate(
-                    dataset=dataset,
-                    blob=blob,
-                    active_devices=active_devices,
-                    audit_mode=audit_mode,
-                    restore_window_blocked=restore_window_blocked,
-                    minimum_tombstone_age_seconds=minimum_tombstone_age_seconds,
-                    store=active_store,
+        for status in ("deleting", "available"):
+            remaining = limit - len(candidates)
+            if remaining <= 0:
+                break
+            for blob in active_store.list_blob_objects_for_dataset_page(
+                dataset.dataset_id,
+                status=status,
+                limit=remaining,
+            ):
+                candidates.append(
+                    self._retention_blob_candidate(
+                        dataset=dataset,
+                        blob=blob,
+                        active_devices=active_devices,
+                        audit_mode=audit_mode,
+                        restore_window_blocked=restore_window_blocked,
+                        minimum_tombstone_age_seconds=minimum_tombstone_age_seconds,
+                        store=active_store,
+                    )
                 )
-            )
         return candidates
 
     def _retention_binding_release_candidates(
@@ -5028,6 +5128,26 @@ class SyncV2Service:
         blockers: list[str] = []
         if audit_mode:
             blockers.append("retention_audit_mode")
+        blockers.extend(
+            self._retention_blob_storage_blockers(
+                dataset=dataset,
+                blob=blob,
+                store=active_store,
+            )
+        )
+        if blob.status == "deleting":
+            return SyncRetentionCandidate(
+                candidate_type="blob_gc",
+                dataset_id=dataset.dataset_id,
+                domain="attachment.ref",
+                object_id=blob.attachment_id,
+                blob_id=blob.blob_id,
+                attachment_id=blob.attachment_id,
+                payload_hash=blob.payload_hash,
+                size_bytes=blob.size_bytes,
+                blockers=list(dict.fromkeys(blockers)),
+                reason="physical blob deletion retry",
+            )
         if restore_window_blocked:
             blockers.append("retention_restore_window_active")
         if self._retention_workspace_ack_scope_blocked(dataset):
@@ -5123,6 +5243,35 @@ class SyncV2Service:
             ),
             reason="server blob retained for attachment restore",
         )
+
+    def _retention_blob_storage_blockers(
+        self,
+        *,
+        dataset: SyncDataset,
+        blob: SyncBlobObject,
+        store: SyncV2Store,
+    ) -> list[str]:
+        if self.blob_store is None:
+            return ["retention_blob_storage_unavailable"]
+        namespace = store.get_storage_namespace(
+            dataset.dataset_id,
+            owner_user_id=dataset.owner_user_id,
+        )
+        if namespace is None:
+            return ["retention_blob_storage_key_not_namespaced"]
+        try:
+            expected_key = self.blob_store.namespace_storage_key(
+                namespace.storage_namespace_id,
+                blob.payload_hash,
+            )
+        except SyncBlobStoreError:
+            return ["retention_blob_storage_key_not_namespaced"]
+        if (
+            blob.storage_backend != self.settings.blob_storage_backend
+            or blob.storage_key != expected_key
+        ):
+            return ["retention_blob_storage_key_not_namespaced"]
+        return []
 
     def _retention_blob_adapter_version(
         self,

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -520,6 +520,7 @@ class SyncRetentionCandidate:
     server_sequence: int | None = None
     blob_id: str | None = None
     attachment_id: str | None = None
+    attachment_revision: int | None = None
     payload_hash: str | None = None
     size_bytes: int | None = None
     blockers: list[str] = field(default_factory=list)
@@ -562,6 +563,7 @@ class SyncRetentionApplyResult:
     blockers: list[str] = field(default_factory=list)
     blocker_counts: dict[str, int] = field(default_factory=dict)
     domain_compactions: list[dict[str, object]] = field(default_factory=list)
+    binding_releases: list[dict[str, object]] = field(default_factory=list)
     blob_gc: list[dict[str, object]] = field(default_factory=list)
 
 
@@ -1429,6 +1431,7 @@ class SyncV2Service:
         confirm: bool = False,
         apply_envelope_compaction: bool = True,
         apply_tombstone_prune: bool = True,
+        apply_binding_release: bool = True,
         apply_blob_gc: bool = True,
         minimum_envelope_age_seconds: int = 0,
         minimum_tombstone_age_seconds: int = 0,
@@ -1455,6 +1458,7 @@ class SyncV2Service:
                 candidate,
                 apply_envelope_compaction=apply_envelope_compaction,
                 apply_tombstone_prune=apply_tombstone_prune,
+                apply_binding_release=apply_binding_release,
                 apply_blob_gc=apply_blob_gc,
             )
         ]
@@ -1472,7 +1476,12 @@ class SyncV2Service:
                 blocker_counts=dict(dry_run.blocker_counts),
             )
 
-        blocked = [candidate for candidate in selected if candidate.blockers]
+        blocked = [
+            candidate
+            for candidate in selected
+            if candidate.blockers
+            and candidate.candidate_type not in {"binding_release", "blob_gc"}
+        ]
         if blocked:
             return SyncRetentionApplyResult(
                 dataset_id=dataset_id,
@@ -1495,6 +1504,25 @@ class SyncV2Service:
             ],
         )
         dataset = self._require_dataset_access(user_id=user_id, dataset_id=dataset_id)
+        initially_blocked_bindings = [
+            candidate
+            for candidate in selected
+            if candidate.candidate_type == "binding_release" and candidate.blockers
+        ]
+        binding_releases, revalidated_binding_blocked = (
+            self._apply_retention_binding_releases(
+                dataset=dataset,
+                candidates=[
+                    candidate
+                    for candidate in selected
+                    if candidate.candidate_type == "binding_release"
+                    and not candidate.blockers
+                ],
+                minimum_envelope_age_seconds=minimum_envelope_age_seconds,
+                minimum_tombstone_age_seconds=minimum_tombstone_age_seconds,
+                offline_restore_window_seconds=offline_restore_window_seconds,
+            )
+        )
         blob_gc, revalidated_blob_blocked = self._apply_retention_blob_gc(
             dataset=dataset,
             candidates=[
@@ -1505,7 +1533,12 @@ class SyncV2Service:
         )
         applied_count = sum(
             int(item["candidate_count"]) for item in domain_compactions
-        ) + len(blob_gc)
+        ) + len(binding_releases) + len(blob_gc)
+        revalidated_blocked = (
+            initially_blocked_bindings
+            + revalidated_binding_blocked
+            + revalidated_blob_blocked
+        )
         return SyncRetentionApplyResult(
             dataset_id=dataset_id,
             dry_run=False,
@@ -1513,17 +1546,18 @@ class SyncV2Service:
             evaluated_at=self.clock(),
             candidate_count=dry_run.candidate_count,
             applied_count=applied_count,
-            blocked_count=len(revalidated_blob_blocked),
+            blocked_count=len(revalidated_blocked),
             skipped_count=(
-                dry_run.candidate_count - len(selected) + len(revalidated_blob_blocked)
+                dry_run.candidate_count - len(selected) + len(revalidated_blocked)
             ),
             blockers=(
                 ["retention_revalidation_blocked"]
-                if revalidated_blob_blocked
+                if revalidated_blocked
                 else []
             ),
-            blocker_counts=_retention_blocker_counts(revalidated_blob_blocked),
+            blocker_counts=_retention_blocker_counts(revalidated_blocked),
             domain_compactions=domain_compactions,
+            binding_releases=binding_releases,
             blob_gc=blob_gc,
         )
 
@@ -1626,6 +1660,18 @@ class SyncV2Service:
             )
 
         remaining_budget = scan_limit - len(envelopes)
+        if "attachment.ref" in selected_domains and remaining_budget > 0:
+            binding_candidates = self._retention_binding_release_candidates(
+                dataset=dataset,
+                active_devices=active_devices,
+                audit_mode=audit_mode,
+                restore_window_blocked=restore_window_blocked,
+                minimum_envelope_age_seconds=minimum_envelope_age_seconds,
+                minimum_tombstone_age_seconds=minimum_tombstone_age_seconds,
+                limit=remaining_budget,
+            )
+            candidates.extend(binding_candidates)
+            remaining_budget -= len(binding_candidates)
         if "attachment.ref" in selected_domains and remaining_budget > 0:
             candidates.extend(
                 self._retention_blob_candidates(
@@ -4516,6 +4562,79 @@ class SyncV2Service:
             )
         return applied
 
+    def _apply_retention_binding_releases(
+        self,
+        *,
+        dataset: SyncDataset,
+        candidates: Sequence[SyncRetentionCandidate],
+        minimum_envelope_age_seconds: int,
+        minimum_tombstone_age_seconds: int,
+        offline_restore_window_seconds: int,
+    ) -> tuple[list[dict[str, object]], list[SyncRetentionCandidate]]:
+        """Revalidate and monotonically release historical bindings under the fence."""
+
+        applied: list[dict[str, object]] = []
+        blocked: list[SyncRetentionCandidate] = []
+        for candidate in candidates:
+            if candidate.attachment_id is None or candidate.attachment_revision is None:
+                continue
+            guard_key = candidate.blob_id or candidate.attachment_id
+            with self.store.retention_guard(dataset.dataset_id, guard_key) as guarded:
+                current_dataset = guarded.get_dataset(
+                    dataset.dataset_id,
+                    owner_user_id=dataset.owner_user_id,
+                )
+                binding = guarded.get_attachment_revision_binding(
+                    dataset.dataset_id,
+                    candidate.attachment_id,
+                    candidate.attachment_revision,
+                    owner_user_id=dataset.owner_user_id,
+                )
+                if (
+                    current_dataset is None
+                    or binding is None
+                    or binding.retention_released_at is not None
+                ):
+                    continue
+                current_devices = self._retention_active_devices(
+                    current_dataset,
+                    store=guarded,
+                )
+                revalidated = self._retention_binding_release_candidate(
+                    dataset=current_dataset,
+                    binding=binding,
+                    active_devices=current_devices,
+                    audit_mode=False,
+                    restore_window_blocked=self._retention_restore_window_active(
+                        current_devices,
+                        offline_restore_window_seconds,
+                    ),
+                    minimum_envelope_age_seconds=minimum_envelope_age_seconds,
+                    minimum_tombstone_age_seconds=minimum_tombstone_age_seconds,
+                    store=guarded,
+                )
+                if revalidated.blockers:
+                    blocked.append(revalidated)
+                    continue
+                released = guarded.release_attachment_revision_binding(
+                    dataset.dataset_id,
+                    binding.attachment_id,
+                    binding.attachment_revision,
+                    released_at=self.clock(),
+                    owner_user_id=dataset.owner_user_id,
+                )
+            applied.append(
+                {
+                    "attachment_id": released.attachment_id,
+                    "attachment_revision": released.attachment_revision,
+                    "blob_id": released.resolved_blob_id,
+                    "payload_hash": released.blob_hash,
+                    "size_bytes": released.size_bytes,
+                    "establishing_server_cursor": released.establishing_server_cursor,
+                }
+            )
+        return applied, blocked
+
     def _apply_retention_blob_gc(
         self,
         *,
@@ -4700,6 +4819,199 @@ class SyncV2Service:
                 )
             )
         return candidates
+
+    def _retention_binding_release_candidates(
+        self,
+        *,
+        dataset: SyncDataset,
+        active_devices: Sequence[SyncDevice],
+        audit_mode: bool,
+        restore_window_blocked: bool,
+        minimum_envelope_age_seconds: int,
+        minimum_tombstone_age_seconds: int,
+        limit: int,
+        store: SyncV2Store | None = None,
+    ) -> list[SyncRetentionCandidate]:
+        """Return a bounded keyset scan of unreleased binding candidates."""
+
+        active_store = store or self.store
+        candidates: list[SyncRetentionCandidate] = []
+        after_cursor = 0
+        after_attachment_id = ""
+        after_attachment_revision = 0
+        while len(candidates) < limit:
+            page_limit = min(SYNC_RETENTION_BINDING_PAGE_SIZE, limit - len(candidates))
+            bindings = active_store.list_unreleased_attachment_revision_bindings(
+                dataset.dataset_id,
+                owner_user_id=dataset.owner_user_id,
+                after_establishing_server_cursor=after_cursor,
+                after_attachment_id=after_attachment_id,
+                after_attachment_revision=after_attachment_revision,
+                limit=page_limit,
+            )
+            if not bindings:
+                break
+            candidates.extend(
+                self._retention_binding_release_candidate(
+                    dataset=dataset,
+                    binding=binding,
+                    active_devices=active_devices,
+                    audit_mode=audit_mode,
+                    restore_window_blocked=restore_window_blocked,
+                    minimum_envelope_age_seconds=minimum_envelope_age_seconds,
+                    minimum_tombstone_age_seconds=minimum_tombstone_age_seconds,
+                    store=active_store,
+                )
+                for binding in bindings
+            )
+            last = bindings[-1]
+            after_cursor = last.establishing_server_cursor
+            after_attachment_id = last.attachment_id
+            after_attachment_revision = last.attachment_revision
+            if len(bindings) < page_limit:
+                break
+        return candidates
+
+    def _retention_binding_release_candidate(
+        self,
+        *,
+        dataset: SyncDataset,
+        binding: SyncAttachmentRevisionBinding,
+        active_devices: Sequence[SyncDevice],
+        audit_mode: bool,
+        restore_window_blocked: bool,
+        minimum_envelope_age_seconds: int,
+        minimum_tombstone_age_seconds: int,
+        store: SyncV2Store | None = None,
+    ) -> SyncRetentionCandidate:
+        """Evaluate immutable binding evidence without mutable reference counters."""
+
+        active_store = store or self.store
+        blockers: list[str] = []
+        if audit_mode:
+            blockers.append("retention_audit_mode")
+        if restore_window_blocked:
+            blockers.append("retention_restore_window_active")
+        if self._retention_workspace_ack_scope_blocked(dataset):
+            blockers.append("retention_workspace_ack_scope_unknown")
+
+        envelope = active_store.get_envelope_by_server_cursor(
+            binding.establishing_server_cursor
+        )
+        envelope_valid = (
+            envelope is not None
+            and envelope.dataset_id == dataset.dataset_id
+            and envelope.domain == "attachment.ref"
+            and envelope.adapter_version == 2
+            and envelope.object_id == binding.attachment_id
+            and envelope.object_revision == binding.attachment_revision
+        )
+        if not envelope_valid:
+            blockers.append("retention_blob_binding_invalid")
+        elif self._retention_window_active(
+            envelope.server_timestamp,
+            minimum_envelope_age_seconds,
+        ):
+            blockers.append("retention_envelope_window_active")
+
+        head = active_store.get_current_head(
+            dataset.dataset_id,
+            "attachment.ref",
+            binding.attachment_id,
+        )
+        state = active_store.get_object_state(
+            dataset.dataset_id,
+            "attachment.ref",
+            binding.attachment_id,
+        )
+        current_revision = None if head is None else head.object_revision
+        if (
+            head is None
+            or current_revision is None
+            or current_revision < binding.attachment_revision
+        ):
+            blockers.append("retention_blob_binding_invalid")
+        current_binding = current_revision == binding.attachment_revision
+        current_live = current_binding and (
+            (state is not None and not state.deleted)
+            or (head is not None and head.operation != "tombstone" and not head.deleted)
+        )
+        if current_live:
+            blockers.append("retention_active_blob_reference")
+        elif head is not None and (
+            head.operation == "tombstone" or head.deleted
+        ) and self._retention_window_active(
+            head.server_timestamp,
+            minimum_tombstone_age_seconds,
+        ):
+            blockers.append("retention_tombstone_window_active")
+
+        required_devices = [
+            device
+            for device in active_devices
+            if _device_supports_adapter_version(device, "attachment.ref", 2)
+        ]
+        ref_unacknowledged: list[str] = []
+        blob_unacknowledged: list[str] = []
+        blob: SyncBlobObject | None = None
+        if not current_live:
+            ref_unacknowledged = self._retention_unacknowledged_devices(
+                dataset_id=dataset.dataset_id,
+                domain="attachment.ref",
+                adapter_version=2,
+                server_sequence=binding.establishing_server_cursor,
+                active_devices=required_devices,
+                store=active_store,
+            )
+            if ref_unacknowledged:
+                blockers.append("retention_blob_ref_unacknowledged")
+            if binding.resolved_blob_id is not None:
+                blob = active_store.get_blob_object(
+                    dataset.dataset_id,
+                    blob_id=binding.resolved_blob_id,
+                    owner_user_id=dataset.owner_user_id,
+                    include_unavailable=True,
+                )
+                if (
+                    blob is None
+                    or blob.payload_hash != binding.blob_hash
+                    or blob.size_bytes != binding.size_bytes
+                ):
+                    blockers.append("retention_blob_binding_invalid")
+                elif blob.status == "quarantined":
+                    blockers.append("retention_blob_quarantined")
+                elif blob.status not in {"available", "deleted"}:
+                    blockers.append("retention_blob_repair_pending")
+                blob_unacknowledged = self._retention_blob_unacknowledged_devices(
+                    dataset_id=dataset.dataset_id,
+                    attachment_id=binding.attachment_id,
+                    blob_id=binding.resolved_blob_id,
+                    payload_hash=binding.blob_hash,
+                    adapter_version=2,
+                    active_devices=required_devices,
+                    store=active_store,
+                )
+                if blob_unacknowledged:
+                    blockers.append("retention_blob_unverified_by_device")
+
+        return SyncRetentionCandidate(
+            candidate_type="binding_release",
+            dataset_id=dataset.dataset_id,
+            domain="attachment.ref",
+            object_id=binding.attachment_id,
+            server_sequence=binding.establishing_server_cursor,
+            blob_id=binding.resolved_blob_id,
+            attachment_id=binding.attachment_id,
+            attachment_revision=binding.attachment_revision,
+            payload_hash=binding.blob_hash,
+            size_bytes=binding.size_bytes,
+            blockers=list(dict.fromkeys(blockers)),
+            required_device_ids=[device.device_id for device in required_devices],
+            unacknowledged_device_ids=sorted(
+                set(ref_unacknowledged) | set(blob_unacknowledged)
+            ),
+            reason="historical attachment revision binding",
+        )
 
     def _retention_blob_candidate(
         self,
@@ -6154,12 +6466,15 @@ def _retention_apply_candidate_enabled(
     *,
     apply_envelope_compaction: bool,
     apply_tombstone_prune: bool,
+    apply_binding_release: bool,
     apply_blob_gc: bool,
 ) -> bool:
     if candidate.candidate_type == "envelope_compaction":
         return apply_envelope_compaction
     if candidate.candidate_type == "tombstone_prune":
         return apply_tombstone_prune
+    if candidate.candidate_type == "binding_release":
+        return apply_binding_release
     if candidate.candidate_type == "blob_gc":
         return apply_blob_gc
     return False

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -114,6 +114,7 @@ from .mutation_group_validation import (
 from .profile import (
     SyncNotesAttachmentBootstrapDiagnostics,
     SyncProfileStatus,
+    SyncRecoveryActionDescriptor,
     SyncV2ProfileManager,
 )
 from .replay import SyncReplayRepairer, SyncReplayRepairResult
@@ -634,6 +635,27 @@ class SyncDiagnosticsRetentionSummary:
 
 
 @dataclass(frozen=True, slots=True)
+class SyncAttachmentDiagnosticSample:
+    """One bounded owner-authorized attachment lifecycle sample."""
+
+    category: str
+    code: str
+    attachment_id: str | None = None
+    blob_id: str | None = None
+    server_cursor: int | None = None
+    recovery_actions: list[SyncRecoveryActionDescriptor] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class SyncAttachmentDiagnostics:
+    """Bounded read-only Notes attachment lifecycle diagnostics."""
+
+    counts: dict[str, int] = field(default_factory=dict)
+    samples: list[SyncAttachmentDiagnosticSample] = field(default_factory=list)
+    recovery_actions: list[SyncRecoveryActionDescriptor] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
 class SyncDiagnosticsReport:
     """Redacted dataset diagnostics report."""
 
@@ -644,6 +666,9 @@ class SyncDiagnosticsReport:
     blob_health: SyncDiagnosticsBlobHealth = field(default_factory=SyncDiagnosticsBlobHealth)
     key_summary: SyncDiagnosticsKeySummary = field(default_factory=SyncDiagnosticsKeySummary)
     retention: SyncDiagnosticsRetentionSummary = field(default_factory=SyncDiagnosticsRetentionSummary)
+    attachment_lifecycle: SyncAttachmentDiagnostics = field(
+        default_factory=SyncAttachmentDiagnostics
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1367,12 +1392,28 @@ class SyncV2Service:
         dataset_id: str,
         device_id: str | None = None,
         retention_limit: int | None = None,
+        attachment_sample_limit: int = 0,
+        attachment_total_sample_limit: int = 500,
     ) -> SyncDiagnosticsReport:
         """Return redacted Sync v2 dataset diagnostics."""
 
         if device_id is not None:
             self._require_registered_device(user_id, device_id)
         dataset = self._require_dataset_access(user_id=user_id, dataset_id=dataset_id)
+        if (
+            isinstance(attachment_sample_limit, bool)
+            or attachment_sample_limit < 0
+            or attachment_sample_limit > 100
+        ):
+            raise SyncStoreError(
+                "sync_attachment_diagnostic_category_sample_limit_exceeded"
+            )
+        if (
+            isinstance(attachment_total_sample_limit, bool)
+            or attachment_total_sample_limit < 0
+            or attachment_total_sample_limit > 500
+        ):
+            raise SyncStoreError("sync_attachment_diagnostic_total_sample_limit_exceeded")
         scan_limit = self.settings.restore_manifest_scan_limit
         envelopes = self.store.list_accepted_envelopes_for_replay(
             dataset_id,
@@ -1382,7 +1423,6 @@ class SyncV2Service:
         conflicts = self.store.list_conflicts(dataset_id, status="unresolved")
         active_devices = self._retention_active_devices(dataset)
         blob_quota = self.store.summarize_blob_quota(user_id, dataset_id=dataset_id)
-        blob_objects = self.store.list_blob_objects_for_dataset(dataset_id)
         key_records = self.store.list_key_records(dataset_id, user_id=user_id)
         retention = self.retention_dry_run(
             user_id=user_id,
@@ -1391,22 +1431,32 @@ class SyncV2Service:
             audit_mode=True,
             limit=retention_limit or min(scan_limit, 100),
         )
+        domain_diagnostics = self._diagnostics_domains(
+            domains=dataset.domains,
+            envelopes=envelopes,
+            conflicts=conflicts,
+        )
+        attachment_lifecycle = self._attachment_lifecycle_diagnostics(
+            dataset=dataset,
+            user_id=user_id,
+            envelopes=envelopes,
+            conflicts=conflicts,
+            retention=retention,
+            sample_limit=attachment_sample_limit,
+            total_sample_limit=attachment_total_sample_limit,
+        )
         return SyncDiagnosticsReport(
             dataset_id=dataset_id,
             generated_at=self.clock(),
-            domains=self._diagnostics_domains(
-                domains=dataset.domains,
-                envelopes=envelopes,
-                conflicts=conflicts,
-            ),
+            domains=domain_diagnostics,
             devices=self._diagnostics_devices(
                 dataset_id=dataset_id,
                 domains=dataset.domains,
                 devices=active_devices,
             ),
             blob_health=SyncDiagnosticsBlobHealth(
-                blob_object_count=len(blob_objects),
-                available_blob_bytes=sum(blob.size_bytes for blob in blob_objects),
+                blob_object_count=attachment_lifecycle.counts.get("blob_total", 0),
+                available_blob_bytes=blob_quota.used_blob_bytes,
                 active_upload_count=blob_quota.active_upload_count,
                 reserved_blob_bytes=blob_quota.reserved_blob_bytes,
                 quota_limit_bytes=self.settings.user_blob_quota_bytes,
@@ -1419,6 +1469,7 @@ class SyncV2Service:
                 blocked_count=retention.blocked_count,
                 blocker_counts=dict(retention.blocker_counts),
             ),
+            attachment_lifecycle=attachment_lifecycle,
         )
 
     def retention_compact(
@@ -4483,6 +4534,556 @@ class SyncV2Service:
             )
             for domain, domain_stats in stats.items()
         ]
+
+    def _attachment_lifecycle_diagnostics(
+        self,
+        *,
+        dataset: SyncDataset,
+        user_id: str,
+        envelopes: Sequence[SyncEnvelope],
+        conflicts: Sequence[SyncConflict],
+        retention: SyncRetentionDryRunResult,
+        sample_limit: int,
+        total_sample_limit: int,
+    ) -> SyncAttachmentDiagnostics:
+        """Build bounded read-only attachment lifecycle counts and safe hints."""
+
+        counts = {
+            "registry_total": 0,
+            "registry_live": 0,
+            "registry_hidden": 0,
+            "registry_tombstoned": 0,
+            "binding_total": 0,
+            "metadata_only": 0,
+            "missing": 0,
+            "blob_total": 0,
+            "available": 0,
+            "verify_failed": 0,
+            "quarantined": 0,
+            "deleting": 0,
+            "deleted": 0,
+            "orphan": 0,
+            "active_uploads": 0,
+            "cleanup_candidates": 0,
+            "retention_blockers": sum(retention.blocker_counts.values()),
+            "projection_pending": 0,
+            "projection_failed": 0,
+            "unresolved_conflicts": sum(
+                conflict.domain == "attachment.ref" for conflict in conflicts
+            ),
+        }
+        if "attachment.ref" in dataset.domains:
+            projection = self.store.summarize_domain_envelopes(
+                dataset.dataset_id,
+                "attachment.ref",
+            )
+            counts["projection_pending"] = projection.pending_apply_count
+            counts["projection_failed"] = projection.failed_apply_count
+        sample_buckets: dict[str, list[SyncAttachmentDiagnosticSample]] = {}
+        actions: list[SyncRecoveryActionDescriptor] = []
+
+        def descriptor(
+            action: str,
+            reason_code: str,
+            *,
+            target_type: str = "dataset",
+            target_id: str | None = None,
+            requires_confirmation: bool = False,
+        ) -> SyncRecoveryActionDescriptor:
+            return SyncRecoveryActionDescriptor(
+                action=action,
+                reason_code=reason_code,
+                target_type=target_type,
+                target_id=target_id,
+                requires_confirmation=requires_confirmation,
+            )
+
+        def add_action(action: SyncRecoveryActionDescriptor) -> None:
+            action = replace(action, target_type="dataset", target_id=None)
+            identity = (
+                action.action,
+                action.reason_code,
+                action.target_type,
+                action.target_id,
+            )
+            if all(
+                (
+                    item.action,
+                    item.reason_code,
+                    item.target_type,
+                    item.target_id,
+                )
+                != identity
+                for item in actions
+            ):
+                actions.append(action)
+
+        def add_sample(sample: SyncAttachmentDiagnosticSample) -> None:
+            if sample_limit == 0:
+                return
+            bucket = sample_buckets.setdefault(sample.category, [])
+            if len(bucket) < sample_limit:
+                bucket.append(sample)
+
+        registry_row = self.store.db.execute(
+            """
+            SELECT COUNT(*) AS total_count,
+                   COALESCE(SUM(CASE WHEN envelope.operation = 'tombstone'
+                                     THEN 1 ELSE 0 END), 0) AS tombstoned_count
+              FROM sync_current_heads AS head
+              JOIN sync_envelopes AS envelope
+                ON envelope.server_sequence = head.latest_server_cursor
+              JOIN sync_datasets AS dataset ON dataset.dataset_id = head.dataset_id
+             WHERE head.dataset_id = ? AND dataset.owner_user_id = ?
+               AND head.domain = 'attachment.ref' AND envelope.adapter_version = 2
+            """,
+            (dataset.dataset_id, dataset.owner_user_id),
+        ).rows[0]
+        counts["registry_total"] = int(registry_row.get("total_count") or 0)
+        counts["registry_tombstoned"] = int(
+            registry_row.get("tombstoned_count") or 0
+        )
+        counts["registry_live"] = (
+            counts["registry_total"] - counts["registry_tombstoned"]
+        )
+        attachment_heads = (
+            [
+                head
+                for head in self.store.list_current_heads(
+                    dataset.dataset_id,
+                    "attachment.ref",
+                    limit=min(self.settings.restore_manifest_scan_limit, 1_000),
+                    offset=0,
+                )
+                if head.adapter_version == 2
+            ]
+            if "attachment.ref" in dataset.domains
+            else []
+        )
+        counts["registry_scan_truncated"] = int(
+            counts["registry_total"] > len(attachment_heads)
+        )
+        for head in attachment_heads:
+            if head.operation == "tombstone":
+                category = "registry_tombstoned"
+                action = descriptor(
+                    "restore_attachment",
+                    "sync_attachment_tombstoned",
+                    target_type="attachment",
+                    target_id=head.object_id,
+                )
+            else:
+                parent_id = None
+                payload = head.payload or head.payload_clear
+                if isinstance(payload, Mapping):
+                    raw_parent = payload.get("parent_object_id")
+                    if isinstance(raw_parent, str):
+                        parent_id = raw_parent
+                parent = (
+                    self.store.get_current_head(
+                        dataset.dataset_id,
+                        "notes.note",
+                        parent_id,
+                    )
+                    if parent_id
+                    else None
+                )
+                if parent is not None and parent.operation == "tombstone":
+                    category = "registry_hidden"
+                    action = descriptor(
+                        "restore_note",
+                        "sync_attachment_parent_note_tombstoned",
+                        target_type="attachment",
+                        target_id=head.object_id,
+                    )
+                else:
+                    category = "registry_live"
+                    action = None
+            if category == "registry_hidden":
+                counts["registry_hidden"] += 1
+                counts["registry_live"] -= 1
+            sample_actions = [] if action is None else [action]
+            if action is not None:
+                add_action(action)
+            add_sample(
+                SyncAttachmentDiagnosticSample(
+                    category=category,
+                    code=f"sync_attachment_{category}",
+                    attachment_id=head.object_id,
+                    server_cursor=head.server_cursor,
+                    recovery_actions=sample_actions,
+                )
+            )
+
+        binding_row = self.store.db.execute(
+            """
+            SELECT COUNT(*) AS total_count,
+                   COALESCE(SUM(CASE WHEN binding.resolved_blob_id IS NULL
+                                     THEN 1 ELSE 0 END), 0) AS metadata_only_count,
+                   COALESCE(SUM(CASE WHEN binding.resolved_blob_id IS NOT NULL
+                                          AND blob.blob_id IS NULL
+                                     THEN 1 ELSE 0 END), 0) AS missing_count
+              FROM sync_attachment_revision_bindings AS binding
+              JOIN sync_datasets AS dataset
+                ON dataset.dataset_id = binding.dataset_id
+              LEFT JOIN sync_blob_objects AS blob
+                ON blob.dataset_id = binding.dataset_id
+               AND blob.blob_id = binding.resolved_blob_id
+             WHERE binding.dataset_id = ? AND dataset.owner_user_id = ?
+               AND binding.retention_released_at IS NULL
+            """,
+            (dataset.dataset_id, dataset.owner_user_id),
+        ).rows[0]
+        counts["binding_total"] = int(binding_row.get("total_count") or 0)
+        counts["metadata_only"] = int(
+            binding_row.get("metadata_only_count") or 0
+        )
+        counts["missing"] = int(binding_row.get("missing_count") or 0)
+        for category, action_name, reason_code, predicate in (
+            (
+                "metadata_only",
+                "retry_upload",
+                "sync_attachment_blob_metadata_only",
+                "binding.resolved_blob_id IS NULL",
+            ),
+            (
+                "missing",
+                "retry_upload",
+                "sync_attachment_blob_missing",
+                "binding.resolved_blob_id IS NOT NULL AND blob.blob_id IS NULL",
+            ),
+        ):
+            if counts[category] == 0:
+                continue
+            add_action(descriptor(action_name, reason_code))
+            if sample_limit == 0:
+                continue
+            rows = self.store.db.execute(
+                f"""
+                SELECT binding.attachment_id, binding.establishing_server_cursor,
+                       binding.resolved_blob_id
+                  FROM sync_attachment_revision_bindings AS binding
+                  JOIN sync_datasets AS dataset
+                    ON dataset.dataset_id = binding.dataset_id
+                  LEFT JOIN sync_blob_objects AS blob
+                    ON blob.dataset_id = binding.dataset_id
+                   AND blob.blob_id = binding.resolved_blob_id
+                 WHERE binding.dataset_id = ? AND dataset.owner_user_id = ?
+                   AND binding.retention_released_at IS NULL AND {predicate}
+                 ORDER BY binding.establishing_server_cursor, binding.attachment_id
+                 LIMIT ?
+                """,  # nosec B608 - predicate is selected from fixed literals above.
+                (dataset.dataset_id, dataset.owner_user_id, sample_limit),
+            ).rows
+            for row in rows:
+                action = descriptor(
+                    action_name,
+                    reason_code,
+                    target_type="attachment",
+                    target_id=str(row["attachment_id"]),
+                )
+                add_sample(
+                    SyncAttachmentDiagnosticSample(
+                        category=category,
+                        code=reason_code,
+                        attachment_id=str(row["attachment_id"]),
+                        blob_id=(
+                            None
+                            if row.get("resolved_blob_id") is None
+                            else str(row["resolved_blob_id"])
+                        ),
+                        server_cursor=int(row["establishing_server_cursor"]),
+                        recovery_actions=[action],
+                    )
+                )
+
+        for row in self.store.db.execute(
+            """
+            SELECT blob.status, COUNT(*) AS status_count
+              FROM sync_blob_objects AS blob
+              JOIN sync_datasets AS dataset ON dataset.dataset_id = blob.dataset_id
+             WHERE blob.dataset_id = ? AND dataset.owner_user_id = ?
+             GROUP BY blob.status
+            """,
+            (dataset.dataset_id, dataset.owner_user_id),
+        ).rows:
+            status_name = str(row["status"])
+            status_count = int(row.get("status_count") or 0)
+            counts["blob_total"] += status_count
+            counts[status_name] = counts.get(status_name, 0) + status_count
+
+        blob_actions = {
+            "verify_failed": ("retry_verify", "sync_attachment_blob_verify_failed"),
+            "quarantined": (
+                "release_quarantine",
+                "sync_attachment_blob_quarantined",
+            ),
+            "deleting": ("gc_retry", "sync_attachment_blob_deleting"),
+            "deleted": ("retry_upload", "sync_attachment_blob_deleted"),
+        }
+        for status_name, (action_name, reason_code) in blob_actions.items():
+            if counts.get(status_name, 0) == 0:
+                continue
+            add_action(descriptor(action_name, reason_code))
+            if sample_limit == 0:
+                continue
+            for blob in self.store.list_blob_objects_for_dataset_page(
+                dataset.dataset_id,
+                status=status_name,
+                limit=sample_limit,
+            ):
+                action = descriptor(
+                    action_name,
+                    reason_code,
+                    target_type="blob",
+                    target_id=blob.blob_id,
+                )
+                add_sample(
+                    SyncAttachmentDiagnosticSample(
+                        category=status_name,
+                        code=reason_code,
+                        attachment_id=blob.attachment_id,
+                        blob_id=blob.blob_id,
+                        recovery_actions=[action],
+                    )
+                )
+
+        orphan_row = self.store.db.execute(
+            """
+            SELECT COUNT(*) AS orphan_count
+              FROM sync_blob_objects AS blob
+              JOIN sync_datasets AS dataset ON dataset.dataset_id = blob.dataset_id
+             WHERE blob.dataset_id = ? AND dataset.owner_user_id = ?
+               AND blob.status = 'available'
+               AND NOT EXISTS (
+                    SELECT 1 FROM sync_attachment_revision_bindings AS binding
+                     WHERE binding.dataset_id = blob.dataset_id
+                       AND binding.resolved_blob_id = blob.blob_id
+                       AND binding.retention_released_at IS NULL
+               )
+            """,
+            (dataset.dataset_id, dataset.owner_user_id),
+        ).rows[0]
+        counts["orphan"] = int(orphan_row.get("orphan_count") or 0)
+        if counts["orphan"]:
+            add_action(
+                descriptor(
+                    "wait_for_retention",
+                    "sync_attachment_blob_orphaned",
+                    requires_confirmation=True,
+                )
+            )
+            if sample_limit:
+                rows = self.store.db.execute(
+                    """
+                    SELECT blob.attachment_id, blob.blob_id
+                      FROM sync_blob_objects AS blob
+                      JOIN sync_datasets AS dataset
+                        ON dataset.dataset_id = blob.dataset_id
+                     WHERE blob.dataset_id = ? AND dataset.owner_user_id = ?
+                       AND blob.status = 'available'
+                       AND NOT EXISTS (
+                            SELECT 1
+                              FROM sync_attachment_revision_bindings AS binding
+                             WHERE binding.dataset_id = blob.dataset_id
+                               AND binding.resolved_blob_id = blob.blob_id
+                               AND binding.retention_released_at IS NULL
+                       )
+                     ORDER BY blob.updated_at, blob.blob_id LIMIT ?
+                    """,
+                    (dataset.dataset_id, dataset.owner_user_id, sample_limit),
+                ).rows
+                for row in rows:
+                    action = descriptor(
+                        "wait_for_retention",
+                        "sync_attachment_blob_orphaned",
+                        target_type="blob",
+                        target_id=str(row["blob_id"]),
+                        requires_confirmation=True,
+                    )
+                    add_sample(
+                        SyncAttachmentDiagnosticSample(
+                            category="orphan",
+                            code=action.reason_code,
+                            attachment_id=str(row["attachment_id"]),
+                            blob_id=str(row["blob_id"]),
+                            recovery_actions=[action],
+                        )
+                    )
+
+        quota = self.store.summarize_blob_quota(user_id, dataset_id=dataset.dataset_id)
+        counts["active_uploads"] = quota.active_upload_count
+        if counts["active_uploads"]:
+            add_action(descriptor("resume_upload", "sync_attachment_upload_incomplete"))
+            if sample_limit:
+                rows = self.store.db.execute(
+                    """
+                    SELECT upload.upload_id, upload.attachment_id
+                      FROM sync_blob_upload_sessions AS upload
+                      JOIN sync_datasets AS dataset
+                        ON dataset.dataset_id = upload.dataset_id
+                     WHERE upload.dataset_id = ? AND dataset.owner_user_id = ?
+                       AND upload.status IN ('created', 'uploading')
+                     ORDER BY upload.created_at, upload.upload_id LIMIT ?
+                    """,
+                    (dataset.dataset_id, dataset.owner_user_id, sample_limit),
+                ).rows
+                for row in rows:
+                    action = descriptor(
+                        "resume_upload",
+                        "sync_attachment_upload_incomplete",
+                        target_type="upload",
+                        target_id=str(row["upload_id"]),
+                    )
+                    add_sample(
+                        SyncAttachmentDiagnosticSample(
+                            category="active_upload",
+                            code=action.reason_code,
+                            attachment_id=str(row["attachment_id"]),
+                            recovery_actions=[action],
+                        )
+                    )
+
+        attachment_metadata = dataset.metadata.get("notes_attachment_v2")
+        bootstrap_id = (
+            attachment_metadata.get("bootstrap_id")
+            if isinstance(attachment_metadata, Mapping)
+            else None
+        )
+        if isinstance(bootstrap_id, str) and bootstrap_id:
+            cleanup_row = self.store.db.execute(
+                """
+                SELECT COUNT(*) AS cleanup_count
+                  FROM sync_notes_attachment_cleanup_candidates AS cleanup
+                  JOIN sync_datasets AS dataset
+                    ON dataset.dataset_id = cleanup.dataset_id
+                 WHERE cleanup.dataset_id = ? AND dataset.owner_user_id = ?
+                   AND cleanup.bootstrap_id = ?
+                """,
+                (dataset.dataset_id, dataset.owner_user_id, bootstrap_id),
+            ).rows[0]
+            counts["cleanup_candidates"] = int(
+                cleanup_row.get("cleanup_count") or 0
+            )
+            if counts["cleanup_candidates"]:
+                add_action(
+                    descriptor(
+                        "wait_for_retention",
+                        "sync_attachment_cleanup_candidate_retained",
+                        requires_confirmation=True,
+                    )
+                )
+            cleanup = (
+                self.store.list_notes_attachment_cleanup_candidates(
+                    dataset.dataset_id,
+                    owner_user_id=dataset.owner_user_id,
+                    bootstrap_id=bootstrap_id,
+                    limit=sample_limit,
+                )
+                if sample_limit
+                else ()
+            )
+            for item in cleanup:
+                cleanup_action = descriptor(
+                    "wait_for_retention",
+                    "sync_attachment_cleanup_candidate_retained",
+                    target_type="attachment",
+                    target_id=item.attachment_id,
+                    requires_confirmation=True,
+                )
+                add_sample(
+                    SyncAttachmentDiagnosticSample(
+                        category="cleanup_candidate",
+                        code=cleanup_action.reason_code,
+                        attachment_id=item.attachment_id,
+                        recovery_actions=[cleanup_action],
+                    )
+                )
+
+        if counts["projection_pending"] or counts["projection_failed"]:
+            add_action(
+                descriptor(
+                    "repair_projection",
+                    "sync_attachment_projection_incomplete",
+                )
+            )
+            for envelope in envelopes:
+                if envelope.domain != "attachment.ref" or envelope.apply_status not in {
+                    "pending",
+                    "failed",
+                }:
+                    continue
+                action = descriptor(
+                    "repair_projection",
+                    "sync_attachment_projection_incomplete",
+                    target_type="envelope",
+                    target_id=envelope.client_envelope_id,
+                )
+                add_sample(
+                    SyncAttachmentDiagnosticSample(
+                        category=f"projection_{envelope.apply_status}",
+                        code=(
+                            envelope.apply_error_code
+                            or "sync_attachment_projection_incomplete"
+                        ),
+                        attachment_id=envelope.object_id,
+                        server_cursor=envelope.server_cursor,
+                        recovery_actions=[action],
+                    )
+                )
+        if counts["unresolved_conflicts"]:
+            add_action(
+                descriptor("resolve_conflict", "sync_attachment_conflict_unresolved")
+            )
+            for conflict in conflicts:
+                if conflict.domain != "attachment.ref":
+                    continue
+                action = descriptor(
+                    "resolve_conflict",
+                    "sync_attachment_conflict_unresolved",
+                    target_type="conflict",
+                    target_id=conflict.conflict_id,
+                )
+                add_sample(
+                    SyncAttachmentDiagnosticSample(
+                        category="conflict",
+                        code="sync_attachment_conflict_unresolved",
+                        attachment_id=conflict.entity_id,
+                        server_cursor=conflict.server_sequence,
+                        recovery_actions=[action],
+                    )
+                )
+        bootstrap_state = (
+            str(attachment_metadata.get("state"))
+            if isinstance(attachment_metadata, Mapping)
+            and attachment_metadata.get("state") is not None
+            else "not_started"
+        )
+        counts[f"bootstrap_{bootstrap_state}"] = 1
+        if bootstrap_state in {"initializing", "failed"}:
+            add_action(
+                descriptor(
+                    "bootstrap_resume",
+                    "sync_attachment_bootstrap_incomplete",
+                )
+            )
+        if counts["retention_blockers"]:
+            add_action(
+                descriptor(
+                    "wait_for_retention",
+                    "sync_attachment_retention_blocked",
+                    requires_confirmation=True,
+                )
+            )
+
+        samples = [sample for bucket in sample_buckets.values() for sample in bucket]
+        if len(samples) > total_sample_limit:
+            raise SyncStoreError("sync_attachment_diagnostic_total_sample_limit_exceeded")
+        return SyncAttachmentDiagnostics(
+            counts=counts,
+            samples=samples,
+            recovery_actions=actions,
+        )
 
     def _diagnostics_devices(
         self,

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -793,6 +793,7 @@ class SyncRestoreOrderedAction:
     object_id: str
     operation: SyncOperation
     server_cursor: int
+    adapter_version: int
     mutation_group_id: str | None = None
     mutation_step: int | None = None
     mutation_step_count: int | None = None
@@ -811,6 +812,7 @@ class SyncRestorePreviewAttachmentRef:
     payload_hash: str
     availability: str
     server_cursor: int
+    adapter_version: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -2208,8 +2210,11 @@ class SyncV2Service:
     ) -> SyncRestorePreview:
         """Return metadata needed to preview a restore plan for Sync v2 M1."""
 
-        if device_id is not None:
+        restore_device = (
             self._require_registered_device(user_id, device_id)
+            if device_id is not None
+            else None
+        )
         selected_domains = set(domains or [])
         selected_object_id_set = _normalize_selection_set(selected_object_ids)
         selected_attachment_id_set = _normalize_selection_set(selected_attachment_ids)
@@ -2232,7 +2237,7 @@ class SyncV2Service:
         total_counts: dict[str, int] = {}
         key_status: dict[str, dict[str, bool]] = {}
         warnings: list[SyncRestorePreviewWarning] = []
-        planned_inventory_keys: set[tuple[str, SyncDomain, str]] = set()
+        planned_inventory_keys: set[tuple[str, SyncDomain, str, int]] = set()
         candidate_count = 0
         planned_action_count = 0
 
@@ -2240,6 +2245,10 @@ class SyncV2Service:
             dataset_domains = [
                 domain for domain in dataset.domains if not selected_domains or domain in selected_domains
             ]
+            adapter_versions_by_domain = {
+                domain: self._restore_adapter_versions(restore_device, domain)
+                for domain in dataset_domains
+            }
             stats = self.store.summarize_restore_manifest_dataset(
                 dataset.dataset_id,
                 user_id=user_id,
@@ -2259,13 +2268,12 @@ class SyncV2Service:
                         dataset_id=dataset.dataset_id,
                     )
                 )
-            for domain, count in stats.approximate_counts.items():
-                total_counts[domain] = total_counts.get(domain, 0) + count
             domain_envelopes: dict[SyncDomain, list[SyncEnvelope]] = {}
             for domain in dataset_domains:
                 envelopes = self._list_restore_preview_domain_envelopes(
                     dataset_id=dataset.dataset_id,
                     domain=domain,
+                    adapter_versions=adapter_versions_by_domain[domain],
                     max_candidates=(
                         self.settings.restore_preview_candidate_limit
                         - candidate_count
@@ -2273,6 +2281,27 @@ class SyncV2Service:
                 )
                 candidate_count += len(envelopes)
                 domain_envelopes[domain] = envelopes
+            approximate_counts = dict(stats.approximate_counts)
+            byte_estimates = dict(stats.byte_estimates)
+            if "attachment.ref" in domain_envelopes:
+                attachment_envelopes = domain_envelopes["attachment.ref"]
+                approximate_counts["attachment.ref"] = len(attachment_envelopes)
+                byte_estimates["attachment.ref"] = sum(
+                    envelope.payload_size_bytes or 0
+                    for envelope in attachment_envelopes
+                )
+            approximate_counts = {
+                domain: count
+                for domain, count in approximate_counts.items()
+                if domain in dataset_domains and count
+            }
+            byte_estimates = {
+                domain: count
+                for domain, count in byte_estimates.items()
+                if domain in dataset_domains and count
+            }
+            for domain, count in approximate_counts.items():
+                total_counts[domain] = total_counts.get(domain, 0) + count
             latest_cursors: dict[str, int] = {}
             dataset_ranges: list[SyncRestorePreviewEnvelopeRange] = []
             for domain, envelopes in domain_envelopes.items():
@@ -2294,12 +2323,12 @@ class SyncV2Service:
                 SyncRestorePreviewDataset(
                     dataset_id=dataset.dataset_id,
                     domains=dataset_domains,
-                    approximate_counts=stats.approximate_counts,
-                    byte_estimates=stats.byte_estimates,
+                    approximate_counts=approximate_counts,
+                    byte_estimates=byte_estimates,
                     latest_cursor=latest_cursor,
                     latest_cursors=latest_cursors,
                     envelope_ranges=dataset_ranges,
-                    total_count=sum(stats.approximate_counts.values()),
+                    total_count=sum(approximate_counts.values()),
                     encryption_policy=dataset.encryption_policy,
                     key_recovery_available=stats.key_recovery_available,
                 )
@@ -2310,6 +2339,8 @@ class SyncV2Service:
                 if domain not in OBJECT_RESTORE_DOMAINS:
                     continue
                 for envelope in domain_envelopes.get(domain, []):
+                    if domain == "attachment.ref" and envelope.adapter_version != 2:
+                        continue
                     if envelope.apply_status == "superseded":
                         continue
                     latest_object_envelopes[(domain, envelope.object_id)] = envelope
@@ -2325,6 +2356,7 @@ class SyncV2Service:
                     latest_object_envelopes=latest_object_envelopes,
                     selected_domains=selected_domains,
                     selected_object_ids=selected_object_id_set,
+                    adapter_versions_by_domain=adapter_versions_by_domain,
                 )
                 remaining_actions = (
                     self.settings.restore_preview_action_limit - planned_action_count
@@ -2364,13 +2396,17 @@ class SyncV2Service:
                 restore_fingerprints.append((server_revision, server_hash, deleted))
                 final_plan_index_by_identity[(domain, object_id)] = plan_index
 
-            initially_matching_final_keys: set[tuple[str, SyncDomain, str]] = set()
+            initially_matching_final_keys: set[
+                tuple[str, SyncDomain, str, int]
+            ] = set()
             for (domain, object_id), plan_index in final_plan_index_by_identity.items():
+                envelope = ordered_restore_envelopes[plan_index]
                 local_item = find_local_inventory_item(
                     local_index,
                     dataset_id=dataset.dataset_id,
                     domain=domain,
                     object_id=object_id,
+                    adapter_version=envelope.adapter_version,
                 )
                 server_revision, server_hash, deleted = restore_fingerprints[plan_index]
                 if local_item is not None and local_inventory_matches(
@@ -2380,7 +2416,12 @@ class SyncV2Service:
                     deleted=deleted,
                 ):
                     initially_matching_final_keys.add(
-                        (dataset.dataset_id, domain, object_id)
+                        (
+                            dataset.dataset_id,
+                            domain,
+                            object_id,
+                            envelope.adapter_version,
+                        )
                     )
 
             for plan_index, envelope in enumerate(ordered_restore_envelopes):
@@ -2392,6 +2433,7 @@ class SyncV2Service:
                     dataset_id=dataset.dataset_id,
                     domain=domain,
                     object_id=object_id,
+                    adapter_version=envelope.adapter_version,
                 )
                 local_matches = (
                     local_item is not None
@@ -2402,7 +2444,12 @@ class SyncV2Service:
                         deleted=deleted,
                     )
                 )
-                inventory_key = (dataset.dataset_id, domain, object_id)
+                inventory_key = (
+                    dataset.dataset_id,
+                    domain,
+                    object_id,
+                    envelope.adapter_version,
+                )
                 if envelope.apply_status == "conflict":
                     conflict_type = "stored_apply_conflict"
                     object_conflicts.append(
@@ -2440,6 +2487,7 @@ class SyncV2Service:
                             object_id=object_id,
                             operation=envelope.operation,
                             server_cursor=envelope.server_cursor or 0,
+                            adapter_version=envelope.adapter_version,
                             mutation_group_id=envelope.mutation_group_id,
                             mutation_step=envelope.mutation_step,
                             mutation_step_count=envelope.mutation_step_count,
@@ -2503,6 +2551,7 @@ class SyncV2Service:
                             object_id=object_id,
                             operation=envelope.operation,
                             server_cursor=envelope.server_cursor or 0,
+                            adapter_version=envelope.adapter_version,
                             mutation_group_id=envelope.mutation_group_id,
                             mutation_step=envelope.mutation_step,
                             mutation_step_count=envelope.mutation_step_count,
@@ -2520,6 +2569,7 @@ class SyncV2Service:
                             object_id=object_id,
                             operation=envelope.operation,
                             server_cursor=envelope.server_cursor or 0,
+                            adapter_version=envelope.adapter_version,
                             mutation_group_id=envelope.mutation_group_id,
                             mutation_step=envelope.mutation_step,
                             mutation_step_count=envelope.mutation_step_count,
@@ -2549,6 +2599,7 @@ class SyncV2Service:
                         dataset_id=dataset.dataset_id,
                         domain=domain,
                         object_id=object_id,
+                        adapter_version=envelope.adapter_version,
                         object_revision=server_revision,
                         object_hash=server_hash,
                         deleted=True,
@@ -2574,6 +2625,7 @@ class SyncV2Service:
                             object_id=object_id,
                             operation=envelope.operation,
                             server_cursor=envelope.server_cursor or 0,
+                            adapter_version=envelope.adapter_version,
                             mutation_group_id=envelope.mutation_group_id,
                             mutation_step=envelope.mutation_step,
                             mutation_step_count=envelope.mutation_step_count,
@@ -2599,6 +2651,7 @@ class SyncV2Service:
                         dataset_id=dataset.dataset_id,
                         domain=domain,
                         object_id=object_id,
+                        adapter_version=envelope.adapter_version,
                         object_revision=server_revision,
                         object_hash=server_hash,
                         deleted=False,
@@ -2633,22 +2686,53 @@ class SyncV2Service:
                     continue
                 seen_refs.add(ref_key)
                 server_blob = None
+                server_availability = "metadata_only"
                 if self.settings.supports_attachments:
                     blob_owner_user_id = self._blob_owner_user_id(
                         dataset=dataset,
                         user_id=user_id,
                     )
-                    server_blob = self.store.get_blob_object(
-                        dataset.dataset_id,
-                        attachment_id=metadata.attachment_id,
-                        payload_hash=metadata.payload_hash,
-                        owner_user_id=blob_owner_user_id,
-                    )
+                    if envelope.adapter_version == 2:
+                        binding = (
+                            self.store.get_attachment_revision_binding(
+                                dataset.dataset_id,
+                                metadata.attachment_id,
+                                envelope.object_revision,
+                                owner_user_id=dataset.owner_user_id,
+                            )
+                            if envelope.object_revision is not None
+                            else None
+                        )
+                        if binding is not None and binding.resolved_blob_id is not None:
+                            candidate = self.store.get_blob_object(
+                                dataset.dataset_id,
+                                blob_id=binding.resolved_blob_id,
+                                owner_user_id=blob_owner_user_id,
+                                include_unavailable=True,
+                            )
+                            if (
+                                candidate is not None
+                                and candidate.payload_hash == binding.blob_hash
+                                and candidate.size_bytes == binding.size_bytes
+                            ):
+                                server_blob = candidate
+                    else:
+                        server_blob = self.store.get_blob_object(
+                            dataset.dataset_id,
+                            attachment_id=metadata.attachment_id,
+                            payload_hash=metadata.payload_hash,
+                            owner_user_id=blob_owner_user_id,
+                        )
+                    if server_blob is not None:
+                        server_availability = server_blob.status
                 metadata_claims_server_blob = (
+                    envelope.adapter_version == 1
+                    and
                     not self.settings.supports_attachments
                     and _attachment_ref_has_server_blob(metadata.availability)
                 )
-                server_availability = "available" if server_blob is not None or metadata_claims_server_blob else "metadata_only"
+                if metadata_claims_server_blob:
+                    server_availability = "available"
                 download_status = attachment_restore_status(
                     attachment_availability,
                     attachment_id=metadata.attachment_id,
@@ -2684,6 +2768,7 @@ class SyncV2Service:
                     payload_hash=metadata.payload_hash,
                     availability=server_availability,
                     server_cursor=envelope.server_cursor or 0,
+                    adapter_version=envelope.adapter_version,
                 )
                 attachment_refs.append(summary)
                 if required_for_restore and server_availability != "available" and not attachment_available_locally(
@@ -5693,6 +5778,7 @@ class SyncV2Service:
         latest_object_envelopes: Mapping[tuple[SyncDomain, str], SyncEnvelope],
         selected_domains: set[SyncDomain],
         selected_object_ids: set[str],
+        adapter_versions_by_domain: Mapping[SyncDomain, Sequence[int]] | None = None,
     ) -> list[SyncEnvelope]:
         """Expand selected restore heads to complete persisted mutation units."""
 
@@ -5725,6 +5811,14 @@ class SyncV2Service:
                 member.object_id not in selected_object_ids for member in active_group
             ):
                 raise RestorePlanningError("Restore object filter splits a mutation group")
+            if adapter_versions_by_domain is not None and any(
+                member.adapter_version
+                not in adapter_versions_by_domain.get(member.domain, ())
+                for member in active_group
+            ):
+                raise RestorePlanningError(
+                    "Restore adapter-version filter splits a mutation group"
+                )
             processed_groups.add(group_id)
             for member in active_group:
                 if member.domain not in OBJECT_RESTORE_DOMAINS:
@@ -5753,6 +5847,7 @@ class SyncV2Service:
         *,
         dataset_id: str,
         domain: SyncDomain,
+        adapter_versions: Sequence[int],
         max_candidates: int,
     ) -> list[SyncEnvelope]:
         page_limit = self.settings.restore_manifest_scan_limit
@@ -5770,6 +5865,7 @@ class SyncV2Service:
                 since_sequence,
                 limit=request_limit,
                 domains=[domain],
+                adapter_versions=adapter_versions,
                 status="accepted",
             )
             if not page:
@@ -5784,6 +5880,25 @@ class SyncV2Service:
             if len(page) < request_limit:
                 break
         return envelopes
+
+    def _restore_adapter_versions(
+        self,
+        device: SyncDevice | None,
+        domain: SyncDomain,
+    ) -> list[int]:
+        """Return server-supported versions safe to expose to one restore client."""
+
+        if device is None:
+            return [1]
+        try:
+            supported = self.adapters.get(domain).supported_adapter_versions
+        except KeyError:
+            return []
+        return sorted(
+            version
+            for version in supported
+            if _device_supports_adapter_version(device, domain, version)
+        )
 
     def _manifest_dataset(
         self,

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -101,6 +101,22 @@ class SyncV2Store:
             guarded._connection = connection
             yield guarded
 
+    @contextmanager
+    def blob_write_guard(
+        self,
+        dataset_id: str,
+        domain: SyncDomain,
+        object_id: str,
+    ) -> Iterator[SyncV2Store]:
+        """Hold the dataset ordering fence through blob publication and commit."""
+
+        with self.db.materialization_transaction(
+            [(dataset_id, domain, object_id)]
+        ) as connection:
+            guarded = copy(self)
+            guarded._connection = connection
+            yield guarded
+
     def upsert_device(
         self,
         device: SyncDeviceUpsert,
@@ -1157,6 +1173,18 @@ class SyncV2Store:
             owner_user_id=owner_user_id,
         )
 
+    def get_storage_namespace(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+    ) -> SyncDatasetStorageNamespace | None:
+        return self.db.get_storage_namespace(
+            dataset_id,
+            owner_user_id=owner_user_id,
+            connection=self._connection,
+        )
+
     def relocate_legacy_blob(
         self,
         blob_store: Any,
@@ -1211,7 +1239,18 @@ class SyncV2Store:
         )
 
     def complete_blob_upload(self, blob: SyncBlobObjectCreate) -> SyncBlobObject:
-        return self.db.complete_blob_upload(blob)
+        return self.db.complete_blob_upload(blob, connection=self._connection)
+
+    def require_blob_upload_completion_allowed(
+        self,
+        blob: SyncBlobObjectCreate,
+    ) -> None:
+        if self._connection is None:
+            raise SyncStoreError("Sync blob completion requires a dataset guard")
+        self.db.require_blob_upload_completion_allowed(
+            blob,
+            connection=self._connection,
+        )
 
     def get_blob_object(
         self,
@@ -1262,6 +1301,7 @@ class SyncV2Store:
             dataset_id,
             blob_id=blob_id,
             owner_user_id=owner_user_id,
+            include_unavailable=True,
             connection=self._connection,
             for_update=True,
         )
@@ -1294,12 +1334,27 @@ class SyncV2Store:
             connection=self._connection,
         )
 
-    def mark_blob_object_deleted(
+    def fence_blob_object_deleting(
         self,
         dataset_id: str,
         blob_id: str,
     ) -> SyncBlobObject | None:
-        return self.db.mark_blob_object_deleted(
+        if self._connection is None:
+            raise SyncStoreError("Sync blob deletion requires a dataset guard")
+        return self.db.fence_blob_object_deleting(
+            dataset_id,
+            blob_id,
+            connection=self._connection,
+        )
+
+    def finalize_blob_object_deleted(
+        self,
+        dataset_id: str,
+        blob_id: str,
+    ) -> SyncBlobObject | None:
+        if self._connection is None:
+            raise SyncStoreError("Sync blob deletion requires a dataset guard")
+        return self.db.finalize_blob_object_deleted(
             dataset_id,
             blob_id,
             connection=self._connection,

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -1013,6 +1013,7 @@ class SyncV2Store:
             attachment_id,
             attachment_revision,
             owner_user_id=owner_user_id,
+            connection=self._connection,
         )
 
     def get_attachment_revision_binding_for_blob(
@@ -1071,6 +1072,28 @@ class SyncV2Store:
             connection=self._connection,
         )
 
+    def list_unreleased_attachment_revision_bindings(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        after_establishing_server_cursor: int = 0,
+        after_attachment_id: str = "",
+        after_attachment_revision: int = 0,
+        limit: int = 1000,
+    ) -> list[SyncAttachmentRevisionBinding]:
+        """List one bounded compound-keyset page of unreleased bindings."""
+
+        return self.db.list_unreleased_attachment_revision_bindings(
+            dataset_id,
+            owner_user_id=owner_user_id,
+            after_establishing_server_cursor=after_establishing_server_cursor,
+            after_attachment_id=after_attachment_id,
+            after_attachment_revision=after_attachment_revision,
+            limit=limit,
+            connection=self._connection,
+        )
+
     def list_unresolved_attachment_revision_bindings(
         self,
         dataset_id: str,
@@ -1120,6 +1143,7 @@ class SyncV2Store:
             attachment_revision,
             released_at=released_at,
             owner_user_id=owner_user_id,
+            connection=self._connection,
         )
 
     def get_or_create_storage_namespace(

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -1197,6 +1197,7 @@ class SyncV2Store:
         blob_id: str | None = None,
         payload_hash: str | None = None,
         owner_user_id: str | None = None,
+        include_unavailable: bool = False,
     ) -> SyncBlobObject | None:
         return self.db.get_blob_object(
             dataset_id,
@@ -1204,6 +1205,7 @@ class SyncV2Store:
             blob_id=blob_id,
             payload_hash=payload_hash,
             owner_user_id=owner_user_id,
+            include_unavailable=include_unavailable,
             connection=self._connection,
         )
 

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_attachment_postgres_tenancy.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_attachment_postgres_tenancy.py
@@ -2,16 +2,49 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User
+from tldw_Server_API.app.api.v1.endpoints import notes as notes_endpoint
 from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig, DatabaseError
 from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Sync.v2.adapters import SyncAdapterRegistry
+from tldw_Server_API.app.core.Sync.v2.blob_store import LocalSyncBlobStore
+from tldw_Server_API.app.core.Sync.v2.domain_adapters.attachment_refs import (
+    AttachmentRefDomainAdapter,
+)
+from tldw_Server_API.app.core.Sync.v2.materializers import AttachmentRefMaterializer
+from tldw_Server_API.app.core.Sync.v2.models import SyncDatasetCreate
+from tldw_Server_API.app.core.Sync.v2.security import (
+    server_trusted_encryption_status_from_config,
+)
+from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service, SyncV2Settings
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
 
 pytestmark = pytest.mark.integration
+
+
+class _NoopRateLimiter:
+    async def check_user_rate_limit(
+        self,
+        user_id: int,
+        endpoint: str,
+        role: str = "user",
+    ) -> tuple[bool, dict[str, object]]:
+        return True, {}
+
+
+def _sha256(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
 def _create_attachment(
@@ -96,6 +129,30 @@ def test_postgres_note_attachments_are_two_owner_isolated_and_indexed(
         assert db_a.note_attachment_store.get(dataset_id, attachment_b) is None
         assert db_b.note_attachment_store.get(dataset_id, attachment_a) is None
 
+        tombstone = db_a.note_attachment_store.tombstone(
+            dataset_id=dataset_id,
+            attachment_id=attachment_a,
+            expected_version=row_a.version,
+            expected_object_hash=row_a.object_hash,
+            object_hash="sha256:" + "e" * 64,
+            last_modified="2026-08-11T12:01:00+00:00",
+            deleted_at="2026-08-11T12:01:00+00:00",
+            delete_reason="live PostgreSQL lifecycle proof",
+        )
+        assert tombstone.deleted is True
+        assert db_b.note_attachment_store.get(dataset_id, attachment_a) is None
+        restored = db_a.note_attachment_store.restore(
+            dataset_id=dataset_id,
+            attachment_id=attachment_a,
+            expected_version=tombstone.version,
+            expected_object_hash=tombstone.object_hash,
+            object_hash="sha256:" + "f" * 64,
+            last_modified="2026-08-11T12:02:00+00:00",
+        )
+        assert restored.deleted is False
+        assert restored.version == 3
+        assert db_b.note_attachment_store.get(dataset_id, attachment_b) == row_b
+
         with backend_a.transaction() as conn:
             backend_a.execute(
                 f"CREATE ROLE {ident(role_name)} NOLOGIN NOSUPERUSER NOBYPASSRLS",
@@ -133,8 +190,7 @@ def test_postgres_note_attachments_are_two_owner_isolated_and_indexed(
             assert principal["rolsuper"] is False
             assert principal["rolbypassrls"] is False
             policy = backend_a.execute(
-                "SELECT relrowsecurity, relforcerowsecurity FROM pg_class "
-                "WHERE oid = 'note_attachments'::regclass",
+                "SELECT relrowsecurity, relforcerowsecurity FROM pg_class WHERE oid = 'note_attachments'::regclass",
                 connection=conn,
             ).rows[0]
             assert policy["relrowsecurity"] and policy["relforcerowsecurity"]
@@ -201,9 +257,7 @@ def test_postgres_note_attachments_are_two_owner_isolated_and_indexed(
                 "AND attachment_id > ? ORDER BY attachment_id LIMIT ?",
                 (owner_a, dataset_id, note_a, "", 50),
             ).fetchall()
-            all_state_plan = " ".join(
-                str(next(iter(dict(row).values()))) for row in all_state_plan_rows
-            )
+            all_state_plan = " ".join(str(next(iter(dict(row).values()))) for row in all_state_plan_rows)
         assert "idx_note_attachments_owner_dataset_note_all_page" in all_state_plan
 
         with db_a.transaction() as conn:
@@ -214,9 +268,7 @@ def test_postgres_note_attachments_are_two_owner_isolated_and_indexed(
                 "AND normalized_file_name = ? AND deleted = FALSE",
                 (owner_a, dataset_id, note_a, "same-name.pdf"),
             ).fetchall()
-            name_plan = " ".join(
-                str(next(iter(dict(row).values()))) for row in name_plan_rows
-            )
+            name_plan = " ".join(str(next(iter(dict(row).values()))) for row in name_plan_rows)
         assert "uq_note_attachments_live_name" in name_plan
     finally:
         if role_created:
@@ -234,3 +286,150 @@ def test_postgres_note_attachments_are_two_owner_isolated_and_indexed(
         db_b.close_all_connections()
         backend_a.get_pool().close_all()
         backend_b.get_pool().close_all()
+
+
+def test_postgres_canonical_content_supports_all_single_byte_range_forms(
+    pg_database_config: DatabaseConfig,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = "940001"
+    dataset_id = f"dataset-{uuid4()}"
+    note_id = str(uuid4())
+    attachment_id = str(uuid4())
+    payload = b"0123456789"
+    note_backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    sync_backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    note_db = CharactersRAGDB(":memory:", client_id=owner, backend=note_backend)
+    sync_db = SyncDatabase(backend=sync_backend)
+    store = SyncV2Store(sync_db)
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id=dataset_id,
+            owner_user_id=owner,
+            domains=["notes.note", "attachment.ref"],
+            metadata={
+                "default_personal": True,
+                "client_family": "chatbook",
+                "notes_attachment_v2": {"state": "ready"},
+            },
+        )
+    )
+    note_db.add_note("Range proof", "Body", note_id=note_id)
+    service = SyncV2Service(
+        store=store,
+        adapters=SyncAdapterRegistry([AttachmentRefDomainAdapter(v2_writes_enabled=True)]),
+        materializers={"attachment.ref": AttachmentRefMaterializer(note_db)},
+        blob_store=LocalSyncBlobStore(tmp_path / "postgres-range-blobs"),
+        settings=SyncV2Settings(
+            supports_attachments=True,
+            max_blob_bytes=1024 * 1024,
+            max_chunk_bytes=64 * 1024,
+            pull_token_signing_secret="postgres-attachment-range-test",  # nosec B106
+            server_trusted_encryption=server_trusted_encryption_status_from_config(
+                mode="managed_storage",
+                server_trusted_enabled=True,
+                auth_mode="multi_user",
+            ),
+        ),
+        clock=lambda: "2026-08-11T20:30:00+00:00",
+    )
+    app = FastAPI()
+    app.include_router(notes_endpoint.router, prefix="/api/v1/notes")
+
+    async def _db_override() -> CharactersRAGDB:
+        return note_db
+
+    async def _user_override() -> User:
+        return User(id=owner, username=owner, is_admin=True)
+
+    app.dependency_overrides[notes_endpoint.get_chacha_db_for_user] = _db_override
+    app.dependency_overrides[notes_endpoint.get_request_user] = _user_override
+    app.dependency_overrides[notes_endpoint.get_rate_limiter_dep] = lambda: _NoopRateLimiter()
+    monkeypatch.setattr(
+        notes_endpoint,
+        "get_active_server_origin_sync_service_for_user",
+        lambda user_id: service,
+    )
+
+    try:
+        session = service.create_blob_upload_session(
+            user_id=owner,
+            dataset_id=dataset_id,
+            device_id=None,
+            domain="attachment.ref",
+            entity_id=attachment_id,
+            attachment_id=attachment_id,
+            content_type="application/pdf",
+            size_bytes=len(payload),
+            payload_hash=_sha256(payload),
+            chunk_size=len(payload),
+            chunk_count=1,
+            idempotency_key="postgres-range-upload",
+            metadata={
+                "notes_attachment_intent": {
+                    "intent": "create",
+                    "note_id": note_id,
+                    "attachment_id": attachment_id,
+                    "file_name": "Range.pdf",
+                }
+            },
+        )
+        service.upload_blob_chunk(
+            user_id=owner,
+            dataset_id=dataset_id,
+            upload_id=session.upload_id,
+            chunk_index=0,
+            offset_bytes=0,
+            chunk_payload=payload,
+            chunk_hash=_sha256(payload),
+        )
+        service.complete_blob_upload(
+            user_id=owner,
+            dataset_id=dataset_id,
+            upload_id=session.upload_id,
+        )
+        path = f"/api/v1/notes/{note_id}/attachments/by-id/{attachment_id}/content"
+        with TestClient(app) as client:
+            created = client.post(
+                f"/api/v1/notes/{note_id}/attachments/from-upload",
+                params={"dataset_id": dataset_id},
+                headers={"Idempotency-Key": "postgres-range-attach"},
+                json={"upload_id": session.upload_id},
+            )
+            assert created.status_code == 201, created.text
+            bounded = client.get(
+                path,
+                params={"dataset_id": dataset_id},
+                headers={"Range": "bytes=2-5"},
+            )
+            suffix = client.get(
+                path,
+                params={"dataset_id": dataset_id},
+                headers={"Range": "bytes=-3"},
+            )
+            open_ended = client.get(
+                path,
+                params={"dataset_id": dataset_id},
+                headers={"Range": "bytes=7-"},
+            )
+            unsatisfied = client.get(
+                path,
+                params={"dataset_id": dataset_id},
+                headers={"Range": "bytes=99-"},
+            )
+
+        assert bounded.status_code == 206 and bounded.content == b"2345"
+        assert bounded.headers["content-range"] == "bytes 2-5/10"
+        assert bounded.headers["content-length"] == "4"
+        assert bounded.headers["accept-ranges"] == "bytes"
+        assert suffix.status_code == 206 and suffix.content == b"789"
+        assert suffix.headers["content-range"] == "bytes 7-9/10"
+        assert open_ended.status_code == 206 and open_ended.content == b"789"
+        assert open_ended.headers["content-range"] == "bytes 7-9/10"
+        assert unsatisfied.status_code == 416
+        assert unsatisfied.headers["content-range"] == "bytes */10"
+    finally:
+        note_db.close_all_connections()
+        note_backend.get_pool().close_all()
+        sync_backend.get_pool().close_all()

--- a/tldw_Server_API/tests/Notes/test_notes_attachment_sync_api.py
+++ b/tldw_Server_API/tests/Notes/test_notes_attachment_sync_api.py
@@ -83,16 +83,14 @@ def canonical_api(
     )
     service = SyncV2Service(
         store=store,
-        adapters=SyncAdapterRegistry(
-            [AttachmentRefDomainAdapter(v2_writes_enabled=True)]
-        ),
+        adapters=SyncAdapterRegistry([AttachmentRefDomainAdapter(v2_writes_enabled=True)]),
         materializers={"attachment.ref": AttachmentRefMaterializer(note_db)},
         blob_store=LocalSyncBlobStore(tmp_path / "blobs"),
         settings=SyncV2Settings(
             supports_attachments=True,
             max_blob_bytes=1024 * 1024,
             max_chunk_bytes=64 * 1024,
-            pull_token_signing_secret="attachment-api-tests",
+            pull_token_signing_secret="attachment-api-tests",  # nosec B106
             server_trusted_encryption=server_trusted_encryption_status_from_config(
                 mode="managed_storage",
                 server_trusted_enabled=True,
@@ -112,9 +110,7 @@ def canonical_api(
 
     app.dependency_overrides[notes_endpoint.get_chacha_db_for_user] = _db_override
     app.dependency_overrides[notes_endpoint.get_request_user] = _user_override
-    app.dependency_overrides[notes_endpoint.get_rate_limiter_dep] = (
-        lambda: _NoopRateLimiter()
-    )
+    app.dependency_overrides[notes_endpoint.get_rate_limiter_dep] = lambda: _NoopRateLimiter()
     monkeypatch.setattr(
         notes_endpoint,
         "get_active_server_origin_sync_service_for_user",
@@ -248,9 +244,7 @@ def test_notes_attachment_schema_accepts_canonical_item_page_and_mutation_respon
     page = NotesAttachmentPage.model_validate(
         {"items": [item.model_dump()], "next_cursor": "cursor-1", "has_more": True}
     )
-    mutation = NotesAttachmentMutationResponse.model_validate(
-        {**item.model_dump(), "idempotent_replay": False}
-    )
+    mutation = NotesAttachmentMutationResponse.model_validate({**item.model_dump(), "idempotent_replay": False})
 
     assert item.etag == f'"att-{ATTACHMENT_ID}-v3-{OBJECT_HASH.removeprefix("sha256:")}"'
     assert page.items == [item]
@@ -359,7 +353,7 @@ def test_notes_attachment_etag_grammar_is_exact():
     for value in (
         None,
         "*",
-        f'W/{etag}',
+        f"W/{etag}",
         f"{etag}, {etag}",
         f'"att-{ATTACHMENT_ID}-v0-{OBJECT_HASH.removeprefix("sha256:")}"',
         f'"att-{ATTACHMENT_ID.upper()}-v3-{OBJECT_HASH.removeprefix("sha256:")}"',
@@ -615,6 +609,16 @@ def test_canonical_content_supports_conditionals_and_single_byte_ranges(
         params={"dataset_id": DATASET_ID},
         headers={"Range": "bytes=2-5", "If-Range": created["etag"]},
     )
+    suffix = client.get(
+        path,
+        params={"dataset_id": DATASET_ID},
+        headers={"Range": "bytes=-3"},
+    )
+    open_ended = client.get(
+        path,
+        params={"dataset_id": DATASET_ID},
+        headers={"Range": "bytes=7-"},
+    )
     stale_if_range = client.get(
         path,
         params={"dataset_id": DATASET_ID},
@@ -657,6 +661,10 @@ def test_canonical_content_supports_conditionals_and_single_byte_ranges(
     assert partial.status_code == 206 and partial.content == b"2345"
     assert partial.headers["content-range"] == "bytes 2-5/10"
     assert partial.headers["content-length"] == "4"
+    assert suffix.status_code == 206 and suffix.content == b"789"
+    assert suffix.headers["content-range"] == "bytes 7-9/10"
+    assert open_ended.status_code == 206 and open_ended.content == b"789"
+    assert open_ended.headers["content-range"] == "bytes 7-9/10"
     assert stale_if_range.status_code == 200 and stale_if_range.content == payload
     assert not_modified.status_code == 304 and not not_modified.content
     assert unsatisfied.status_code == 416
@@ -705,9 +713,7 @@ def test_active_legacy_filename_routes_are_canonical_compatibility_aliases(
     assert listed.json()["count"] == 1
     assert listed.json()["attachments"][0]["file_name"] == "Legacy_Report.pdf"
 
-    downloaded = client.get(
-        f"/api/v1/notes/{NOTE_ID}/attachments/Legacy_Report.pdf"
-    )
+    downloaded = client.get(f"/api/v1/notes/{NOTE_ID}/attachments/Legacy_Report.pdf")
     assert downloaded.status_code == 200, downloaded.text
     assert downloaded.content == b"%PDF-1.7\nlegacy payload\n%%EOF\n"
 
@@ -991,9 +997,7 @@ def test_rollout_inactive_preserves_legacy_filesystem_routes_and_rejects_canonic
     assert canonical.status_code == 409
     assert canonical.json()["detail"]["error_code"] == "notes_attachment_sync_inactive"
     assert inactive_dataset_alias.status_code == 409
-    assert inactive_dataset_alias.json()["detail"]["error_code"] == (
-        "notes_attachment_sync_inactive"
-    )
+    assert inactive_dataset_alias.json()["detail"]["error_code"] == ("notes_attachment_sync_inactive")
     assert created.status_code == 201, created.text
     assert listed.status_code == 200 and listed.json()["count"] == 1
     assert downloaded.status_code == 200 and downloaded.content == b"legacy bytes"
@@ -1010,8 +1014,7 @@ def test_canonical_routes_fail_closed_before_attachment_initialization_is_ready(
     service.store.db.execute(
         "UPDATE sync_datasets SET metadata_json = ? WHERE dataset_id = ?",
         (
-            '{"client_family":"chatbook","default_personal":true,'
-            f'"notes_attachment_v2":{{"state":"{state}"}}}}',
+            f'{{"client_family":"chatbook","default_personal":true,"notes_attachment_v2":{{"state":"{state}"}}}}',
             DATASET_ID,
         ),
     )
@@ -1022,9 +1025,7 @@ def test_canonical_routes_fail_closed_before_attachment_initialization_is_ready(
     )
 
     assert listed.status_code == 409, listed.text
-    assert listed.json()["detail"]["error_code"] == (
-        "notes_attachment_dataset_unavailable"
-    )
+    assert listed.json()["detail"]["error_code"] == ("notes_attachment_dataset_unavailable")
 
 
 @pytest.mark.integration
@@ -1043,6 +1044,4 @@ def test_canonical_routes_require_attachment_domain_enrollment(
     )
 
     assert listed.status_code == 409, listed.text
-    assert listed.json()["detail"]["error_code"] == (
-        "notes_attachment_dataset_unavailable"
-    )
+    assert listed.json()["detail"]["error_code"] == ("notes_attachment_dataset_unavailable")

--- a/tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
@@ -96,6 +96,152 @@ def test_local_blob_store_commits_verified_chunks_atomically(tmp_path: Path):
     assert not (tmp_path / "sync_blobs" / "_uploads" / "upload-1").exists()
 
 
+def test_physical_gc_deletes_only_exact_storage_namespace_blob(tmp_path: Path) -> None:
+    store = LocalSyncBlobStore(tmp_path / "sync_blobs")
+    payload = b"dataset-scoped attachment"
+    payload_hash = _sha256(payload)
+    first_namespace = "a" * 32
+    second_namespace = "b" * 32
+
+    keys: list[str] = []
+    for index, namespace in enumerate((first_namespace, second_namespace), start=1):
+        upload_id = f"upload-{index}"
+        store.write_upload_chunk(
+            upload_id=upload_id,
+            chunk_index=0,
+            payload=payload,
+            expected_hash=payload_hash,
+        )
+        keys.append(
+            store.commit_upload(
+                upload_id=upload_id,
+                payload_hash=payload_hash,
+                chunk_indexes=[0],
+                storage_namespace_id=namespace,
+            )
+        )
+
+    assert store.delete_namespace_blob(
+        storage_key=keys[0],
+        storage_namespace_id=first_namespace,
+        payload_hash=payload_hash,
+        expected_size=len(payload),
+    ) is True
+    assert not store.resolve_storage_key(keys[0]).exists()
+    assert store.read_blob(keys[1]) == payload
+    assert store.delete_namespace_blob(
+        storage_key=keys[0],
+        storage_namespace_id=first_namespace,
+        payload_hash=payload_hash,
+        expected_size=len(payload),
+    ) is False
+
+
+def test_physical_gc_treats_missing_namespace_directory_as_already_absent(
+    tmp_path: Path,
+) -> None:
+    store = LocalSyncBlobStore(tmp_path / "sync_blobs")
+    payload = b"already absent namespace"
+    payload_hash = _sha256(payload)
+    namespace = "a" * 32
+
+    assert store.delete_namespace_blob(
+        storage_key=store.namespace_storage_key(namespace, payload_hash),
+        storage_namespace_id=namespace,
+        payload_hash=payload_hash,
+        expected_size=len(payload),
+    ) is False
+
+
+def test_physical_gc_rejects_global_or_mismatched_storage_namespace(
+    tmp_path: Path,
+) -> None:
+    store = LocalSyncBlobStore(tmp_path / "sync_blobs")
+    payload_hash = _sha256(b"attachment")
+
+    with pytest.raises(SyncBlobStoreError, match="namespace"):
+        store.delete_namespace_blob(
+            storage_key=store.legacy_storage_key(payload_hash),
+            storage_namespace_id="a" * 32,
+            payload_hash=payload_hash,
+            expected_size=len(b"attachment"),
+        )
+    with pytest.raises(SyncBlobStoreError, match="namespace"):
+        store.delete_namespace_blob(
+            storage_key=store.namespace_storage_key("b" * 32, payload_hash),
+            storage_namespace_id="a" * 32,
+            payload_hash=payload_hash,
+            expected_size=len(b"attachment"),
+        )
+
+
+def test_physical_gc_rejects_symlink_and_preserves_external_target(
+    tmp_path: Path,
+) -> None:
+    store = LocalSyncBlobStore(tmp_path / "sync_blobs")
+    payload = b"external payload"
+    payload_hash = _sha256(payload)
+    namespace = "a" * 32
+    storage_key = store.namespace_storage_key(namespace, payload_hash)
+    target = store.resolve_storage_key(storage_key)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    external = tmp_path / "external.blob"
+    external.write_bytes(payload)
+    target.symlink_to(external)
+
+    with pytest.raises(SyncBlobStoreError, match="opened safely"):
+        store.delete_namespace_blob(
+            storage_key=storage_key,
+            storage_namespace_id=namespace,
+            payload_hash=payload_hash,
+            expected_size=len(payload),
+        )
+
+    assert external.read_bytes() == payload
+    assert target.is_symlink()
+
+
+def test_physical_gc_transient_unlink_failure_preserves_verified_blob(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalSyncBlobStore(tmp_path / "sync_blobs")
+    payload = b"transient unlink"
+    payload_hash = _sha256(payload)
+    namespace = "a" * 32
+    upload_id = "unlink-failure"
+    store.write_upload_chunk(
+        upload_id=upload_id,
+        chunk_index=0,
+        payload=payload,
+        expected_hash=payload_hash,
+    )
+    storage_key = store.commit_upload(
+        upload_id=upload_id,
+        payload_hash=payload_hash,
+        chunk_indexes=[0],
+        storage_namespace_id=namespace,
+    )
+    original_unlink = os.unlink
+
+    def fail_target_unlink(path: Any, *args: Any, **kwargs: Any) -> None:
+        if path == payload_hash.removeprefix("sha256:") + ".blob":
+            raise PermissionError("busy")
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "unlink", fail_target_unlink)
+
+    with pytest.raises(SyncBlobStoreError, match="deletion failed"):
+        store.delete_namespace_blob(
+            storage_key=storage_key,
+            storage_namespace_id=namespace,
+            payload_hash=payload_hash,
+            expected_size=len(payload),
+        )
+
+    assert store.read_blob(storage_key) == payload
+
+
 def test_local_blob_store_streams_commit_and_read_without_read_bytes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/tests/Sync/test_sync_v2_diagnostics.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_diagnostics.py
@@ -14,6 +14,7 @@ from tldw_Server_API.app.core.Sync.v2.adapters import StaticSyncAdapter, SyncAda
 from tldw_Server_API.app.core.Sync.v2.blob_store import LocalSyncBlobStore
 from tldw_Server_API.app.core.Sync.v2.models import (
     SyncBlobObjectCreate,
+    SyncBlobUploadSessionCreate,
     SyncConflictCreate,
     SyncDeviceUpsert,
     SyncEnvelopeCreate,
@@ -208,19 +209,25 @@ def _seed_diagnostics_state(service: SyncV2Service) -> None:
             storage_key="secret-storage-key",
         )
     )
-    service.create_blob_upload_session(
-        user_id="user-1",
-        dataset_id="dataset-1",
-        device_id="device-1",
-        domain="attachment.ref",
-        entity_id="attachment-2",
-        attachment_id="attachment-2",
-        content_type="application/pdf",
-        size_bytes=32,
-        payload_hash=_sha256(b"pending diagnostic blob"),
-        chunk_size=16,
-        chunk_count=2,
-        idempotency_key="pending-upload",
+    service.store.create_blob_upload_session(
+        SyncBlobUploadSessionCreate(
+            upload_id="blob-upload-diagnostic",
+            owner_user_id="user-1",
+            reserved_quota_bytes=32,
+            status="created",
+            metadata={},
+            dataset_id="dataset-1",
+            device_id="device-1",
+            domain="attachment.ref",
+            object_id="attachment-2",
+            attachment_id="attachment-2",
+            content_type="application/pdf",
+            size_bytes=32,
+            payload_hash=_sha256(b"pending diagnostic blob"),
+            chunk_size=16,
+            chunk_count=2,
+            idempotency_key="pending-upload",
+        )
     )
     service.store.store_key_record(
         SyncKeyRecordCreate(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
@@ -21,6 +21,9 @@ from tldw_Server_API.app.core.Sync.v2.adapters import (
     StaticSyncAdapter,
     SyncAdapterRegistry,
 )
+from tldw_Server_API.app.core.Sync.v2.attachment_refs_v2 import (
+    attachment_ref_v2_object_hash,
+)
 from tldw_Server_API.app.core.Sync.v2.blob_store import LocalSyncBlobStore
 from tldw_Server_API.app.core.Sync.v2.domain_adapters.notes_organization import (
     NotesOrganizationDomainAdapter,
@@ -31,7 +34,10 @@ from tldw_Server_API.app.core.Sync.v2.models import (
     M1_SYNC_DOMAINS,
     NOTES_ORGANIZATION_DOMAINS,
     SYNC_V2_SUPPORTED_DOMAINS,
+    SyncAttachmentRevisionBindingCreate,
     SyncBlobObjectCreate,
+    SyncBlobUploadSessionCreate,
+    SyncConflictCreate,
     SyncDatasetCreate,
     SyncDeviceCursor,
     SyncDeviceUpsert,
@@ -357,6 +363,357 @@ def test_capabilities_endpoint_hides_unauthorized_selected_dataset(
 
     assert response.status_code == 404
     assert response.json()["detail"]["error_code"] == "sync_resource_not_found"
+
+
+def _sync_diagnostics_snapshot(service: SyncV2Service) -> dict[str, list[dict[str, Any]]]:
+    tables = (
+        "sync_datasets",
+        "sync_envelopes",
+        "sync_current_heads",
+        "sync_conflicts",
+        "sync_attachment_revision_bindings",
+        "sync_blob_objects",
+        "sync_blob_upload_sessions",
+        "sync_notes_attachment_cleanup_candidates",
+    )
+    return {
+        table: service.store.db.execute(f"SELECT * FROM {table}").rows  # nosec B608
+        for table in tables
+    }
+
+
+def _insert_diagnostic_attachment(
+    service: SyncV2Service,
+    *,
+    attachment_id: str,
+    parent_object_id: str,
+    client_envelope_id: str,
+    object_revision: int = 1,
+    operation: str = "upsert",
+    base: SyncEnvelope | None = None,
+) -> SyncEnvelope:
+    payload: dict[str, Any] = {
+        "attachment_id": attachment_id,
+        "parent_domain": "notes.note",
+        "parent_object_id": parent_object_id,
+        "file_name": f"{attachment_id[:8]}.pdf",
+        "original_file_name": f"{attachment_id[:8]}.pdf",
+        "content_type": "application/pdf",
+        "size_bytes": 17,
+        "blob_hash": "sha256:" + attachment_id.replace("-", "") * 2,
+        "created_at": _clock(),
+        "last_modified": _clock(),
+        "created_by": "diagnostic-device",
+    }
+    if operation == "tombstone":
+        payload["deleted_at"] = _clock()
+    return service.store.insert_envelope(
+        SyncEnvelopeCreate(
+            dataset_id="dataset-1",
+            client_envelope_id=client_envelope_id,
+            domain="attachment.ref",
+            operation=operation,
+            object_id=attachment_id,
+            object_revision=object_revision,
+            schema_version=2,
+            adapter_version=2,
+            payload=payload,
+            payload_hash=attachment_ref_v2_object_hash(
+                operation,
+                payload,
+                object_revision=object_revision,
+            ),
+            created_at_client=_clock(),
+            base_server_cursor=None if base is None else base.server_cursor,
+            base_object_revision=None if base is None else base.object_revision,
+            base_object_hash=None if base is None else base.payload_hash,
+        )
+    )
+
+
+def test_attachment_diagnostics_are_read_only_bounded_and_actionable(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path, supports_attachments=True)
+    service.enroll_dataset(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        domains=["notes.note", "attachment.ref"],
+    )
+    parent_id = "b2222222-2222-4222-8222-222222222222"
+    parent = service.store.insert_envelope(
+        SyncEnvelopeCreate(
+            dataset_id="dataset-1",
+            client_envelope_id="diagnostic-parent-upsert",
+            domain="notes.note",
+            operation="upsert",
+            object_id=parent_id,
+            object_revision=1,
+            payload={"title": "Diagnostic parent", "content": ""},
+            payload_hash="sha256:" + "d" * 64,
+            apply_status="applied",
+        )
+    )
+    service.store.insert_envelope(
+        SyncEnvelopeCreate(
+            dataset_id="dataset-1",
+            client_envelope_id="diagnostic-parent-tombstone",
+            domain="notes.note",
+            operation="tombstone",
+            object_id=parent_id,
+            object_revision=2,
+            payload={},
+            payload_hash="sha256:" + "e" * 64,
+            apply_status="applied",
+            base_server_cursor=parent.server_cursor,
+            base_object_revision=parent.object_revision,
+            base_object_hash=parent.payload_hash,
+        )
+    )
+    live = _insert_diagnostic_attachment(
+        service,
+        attachment_id="a7111111-1111-4111-8111-111111111111",
+        parent_object_id="b7111111-1111-4111-8111-111111111111",
+        client_envelope_id="diagnostic-attachment-live",
+    )
+    hidden = _insert_diagnostic_attachment(
+        service,
+        attachment_id="a8111111-1111-4111-8111-111111111111",
+        parent_object_id=parent_id,
+        client_envelope_id="diagnostic-attachment-hidden",
+    )
+    tombstone_base = _insert_diagnostic_attachment(
+        service,
+        attachment_id="a9111111-1111-4111-8111-111111111111",
+        parent_object_id="b9111111-1111-4111-8111-111111111111",
+        client_envelope_id="diagnostic-attachment-before-tombstone",
+    )
+    _insert_diagnostic_attachment(
+        service,
+        attachment_id=tombstone_base.object_id,
+        parent_object_id="b9111111-1111-4111-8111-111111111111",
+        client_envelope_id="diagnostic-attachment-tombstone",
+        object_revision=2,
+        operation="tombstone",
+        base=tombstone_base,
+    )
+    service.store.mark_envelope_apply_status(
+        hidden.server_cursor,
+        apply_status="failed",
+        apply_error_code="sync_attachment_projection_failed",
+        apply_error_message="private projection detail",
+    )
+    service.store.db.execute(
+        """
+        UPDATE sync_attachment_revision_bindings
+           SET resolved_blob_id = 'blob-missing'
+         WHERE dataset_id = ? AND attachment_id = ? AND attachment_revision = 1
+        """,
+        ("dataset-1", live.object_id),
+    )
+    service.store.insert_conflict(
+        SyncConflictCreate(
+            conflict_id="attachment-conflict-diagnostic",
+            dataset_id="dataset-1",
+            domain="attachment.ref",
+            object_id=hidden.object_id,
+            conflict_type="revision_mismatch",
+            server_cursor=hidden.server_cursor,
+            metadata={"private_detail": "must-not-leak"},
+        )
+    )
+    service.store.begin_notes_attachment_bootstrap(
+        "dataset-1",
+        owner_user_id="user-1",
+        bootstrap_id="bootstrap-diagnostic",
+    )
+    source_key = "notes_attachments/diagnostic/private.pdf"
+    service.store.resolve_notes_attachment_source_map(
+        "dataset-1",
+        owner_user_id="user-1",
+        bootstrap_id="bootstrap-diagnostic",
+        note_id=parent_id,
+        source_key=source_key,
+    )
+    service.store.record_notes_attachment_cleanup_candidate(
+        "dataset-1",
+        owner_user_id="user-1",
+        bootstrap_id="bootstrap-diagnostic",
+        source_key=source_key,
+        source_relative_path=source_key,
+        source_blob_hash="sha256:" + "7" * 64,
+        source_size_bytes=17,
+        source_modified_ns=1,
+    )
+    blob = service.store.complete_blob_upload(
+        SyncBlobObjectCreate(
+            blob_id="blob-quarantined",
+            dataset_id="dataset-1",
+            owner_user_id="user-1",
+            attachment_id="a1111111-1111-4111-8111-111111111111",
+            payload_hash="sha256:" + "a" * 64,
+            content_type="application/pdf",
+            size_bytes=12,
+            storage_backend="local_fs",
+            storage_key="blobs/v2/" + "b" * 32 + "/" + "a" * 64 + ".blob",
+        )
+    )
+    service.store.db.execute(
+        "UPDATE sync_blob_objects SET status = 'quarantined' WHERE blob_id = ?",
+        (blob.blob_id,),
+    )
+    for index, status in enumerate(("verify_failed", "deleting", "deleted"), start=1):
+        digest = f"{index}" * 64
+        created = service.store.complete_blob_upload(
+            SyncBlobObjectCreate(
+                blob_id=f"blob-{status}",
+                dataset_id="dataset-1",
+                owner_user_id="user-1",
+                attachment_id=f"a{index + 2}111111-1111-4111-8111-111111111111",
+                payload_hash="sha256:" + digest,
+                content_type="application/pdf",
+                size_bytes=12 + index,
+                storage_backend="local_fs",
+                storage_key=f"blobs/v2/{digest[:32]}/{digest}.blob",
+            )
+        )
+        service.store.db.execute(
+            """
+            UPDATE sync_blob_objects
+               SET status = ?, deleted_at = CASE WHEN ? = 'deleted' THEN ? ELSE NULL END
+             WHERE blob_id = ?
+            """,
+            (status, status, _clock(), created.blob_id),
+        )
+    service.store.create_blob_upload_session(
+        SyncBlobUploadSessionCreate(
+            upload_id="upload-diagnostic",
+            dataset_id="dataset-1",
+            owner_user_id="user-1",
+            device_id=None,
+            attachment_id="a6111111-1111-4111-8111-111111111111",
+            domain="attachment.ref",
+            object_id="a6111111-1111-4111-8111-111111111111",
+            content_type="application/pdf",
+            size_bytes=16,
+            payload_hash="sha256:" + "6" * 64,
+            chunk_size=16,
+            chunk_count=1,
+            reserved_quota_bytes=16,
+        )
+    )
+    with service.store.db.materialization_transaction(
+        [("dataset-1", "attachment.ref", "a2222222-2222-4222-8222-222222222222")]
+    ) as connection:
+        service.store.db._create_attachment_revision_binding(
+            SyncAttachmentRevisionBindingCreate(
+                dataset_id="dataset-1",
+                attachment_id="a2222222-2222-4222-8222-222222222222",
+                attachment_revision=1,
+                blob_hash="sha256:" + "c" * 64,
+                size_bytes=8,
+                establishing_server_cursor=1,
+                availability_at_acceptance="metadata_only",
+            ),
+            connection=connection,
+        )
+    before = _sync_diagnostics_snapshot(service)
+
+    response = _client_for_service(service).get(
+        "/api/v1/sync/diagnostics",
+        params={
+            "dataset_id": "dataset-1",
+            "attachment_sample_limit": 1,
+            "attachment_total_sample_limit": 500,
+        },
+    )
+
+    assert response.status_code == 200
+    attachment = response.json()["attachment_lifecycle"]
+    assert attachment["counts"]["quarantined"] == 1
+    assert attachment["counts"]["verify_failed"] == 1
+    assert attachment["counts"]["deleting"] == 1
+    assert attachment["counts"]["deleted"] == 1
+    assert attachment["counts"]["active_uploads"] == 1
+    assert attachment["counts"]["registry_live"] == 1
+    assert attachment["counts"]["registry_hidden"] == 1
+    assert attachment["counts"]["registry_tombstoned"] == 1
+    assert attachment["counts"]["metadata_only"] >= 1
+    assert attachment["counts"]["missing"] == 1
+    assert attachment["counts"]["cleanup_candidates"] == 1
+    assert attachment["counts"]["projection_pending"] >= 1
+    assert attachment["counts"]["projection_failed"] == 1
+    assert attachment["counts"]["unresolved_conflicts"] == 1
+    assert len(attachment["samples"]) <= 500
+    assert all(
+        sum(sample["category"] == category for sample in attachment["samples"]) <= 1
+        for category in {sample["category"] for sample in attachment["samples"]}
+    )
+    assert {action["action"] for action in attachment["recovery_actions"]} >= {
+        "release_quarantine",
+        "retry_upload",
+        "retry_verify",
+        "gc_retry",
+        "resume_upload",
+        "restore_attachment",
+        "restore_note",
+        "repair_projection",
+        "resolve_conflict",
+        "bootstrap_resume",
+        "wait_for_retention",
+    }
+    assert _sync_diagnostics_snapshot(service) == before
+    assert all("storage_key" not in sample for sample in attachment["samples"])
+    assert all("payload_hash" not in sample for sample in attachment["samples"])
+
+    no_samples = _client_for_service(service).get(
+        "/api/v1/sync/diagnostics",
+        params={"dataset_id": "dataset-1"},
+    )
+    assert no_samples.status_code == 200
+    assert no_samples.json()["attachment_lifecycle"]["samples"] == []
+
+    aggregate_oversized = _client_for_service(service).get(
+        "/api/v1/sync/diagnostics",
+        params={
+            "dataset_id": "dataset-1",
+            "attachment_sample_limit": 1,
+            "attachment_total_sample_limit": 1,
+        },
+    )
+    assert aggregate_oversized.status_code == 413
+    assert aggregate_oversized.json()["detail"]["error_code"] == (
+        "sync_attachment_diagnostic_total_sample_limit_exceeded"
+    )
+    assert _sync_diagnostics_snapshot(service) == before
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"attachment_sample_limit": 101},
+        {"attachment_total_sample_limit": 501},
+    ],
+)
+def test_attachment_diagnostics_reject_oversized_samples(
+    sync_service: SyncV2Service,
+    params: dict[str, int],
+) -> None:
+    sync_service.enroll_dataset(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        domains=["notes.note", "attachment.ref"],
+    )
+
+    response = _client_for_service(sync_service).get(
+        "/api/v1/sync/diagnostics",
+        params={"dataset_id": "dataset-1", **params},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"]["error_code"].startswith(
+        "sync_attachment_diagnostic_"
+    )
 
 
 def test_profile_endpoint_is_read_only_when_no_dataset_exists(
@@ -893,6 +1250,7 @@ def test_attachment_bootstrap_diagnostics_endpoint_is_read_only_and_bounded(
         "source_candidate_count": 7,
         "source_candidate_count_is_lower_bound": False,
         "cleanup_candidates": [],
+        "recovery_actions": [],
     }
     assert sync_service.store.list_datasets_for_user("user-1") == []
     assert sync_service.store.list_devices_for_user("user-1") == []
@@ -931,6 +1289,7 @@ def test_attachment_bootstrap_diagnostics_for_fresh_user_does_not_create_sync_db
         "source_candidate_count": None,
         "source_candidate_count_is_lower_bound": False,
         "cleanup_candidates": [],
+        "recovery_actions": [],
     }
     assert not sync_db_path.exists()
 

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_postgres_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_postgres_contract.py
@@ -100,6 +100,11 @@ def test_postgres_attachment_binding_and_storage_namespace_sql_plan_contracts() 
         "establishing_server_cursor, attachment_id, attachment_revision) WHERE "
         "resolved_blob_id IS NULL AND retention_released_at IS NULL"
     ) in compact_schema
+    assert (
+        "CREATE INDEX IF NOT EXISTS idx_sync_attachment_bindings_retention_release ON "
+        "sync_attachment_revision_bindings(dataset_id, establishing_server_cursor, "
+        "attachment_id, attachment_revision) WHERE retention_released_at IS NULL"
+    ) in compact_schema
     assert "CREATE TABLE IF NOT EXISTS sync_dataset_storage_namespaces" in compact_schema
     assert "storage_namespace_id ~ '^[0-9a-f]{32}$'" in compact_schema
     assert (
@@ -255,6 +260,12 @@ def test_postgres_attachment_authority_catalog_is_exact(
             "dataset_id, resolved_blob_id, establishing_server_cursor, attachment_id, attachment_revision",
             "retention_released_at IS NULL",
         ),
+        "idx_sync_attachment_bindings_retention_release": (
+            "sync_attachment_revision_bindings",
+            False,
+            "dataset_id, establishing_server_cursor, attachment_id, attachment_revision",
+            "retention_released_at IS NULL",
+        ),
         "idx_sync_attachment_bindings_pending_digest": (
             "sync_attachment_revision_bindings",
             False,
@@ -403,6 +414,23 @@ def test_postgres_attachment_binding_lookup_and_unresolved_page_use_declared_ind
                 ("dataset-binding-pg", "sha256:" + "a" * 64, 1),
                 connection=conn,
             ).rows
+            release_rows = db.execute(
+                "EXPLAIN SELECT attachment_id FROM sync_attachment_revision_bindings "
+                "AS binding WHERE binding.dataset_id = ? "
+                "AND binding.retention_released_at IS NULL AND NOT EXISTS (SELECT 1 "
+                "FROM sync_current_heads AS head JOIN sync_envelopes AS envelope ON "
+                "envelope.server_sequence = head.latest_server_cursor WHERE "
+                "head.dataset_id = binding.dataset_id AND head.domain = 'attachment.ref' "
+                "AND head.object_id = binding.attachment_id "
+                "AND envelope.adapter_version = 2 AND envelope.object_revision = "
+                "binding.attachment_revision AND envelope.operation <> 'tombstone') AND "
+                "(binding.establishing_server_cursor, binding.attachment_id, "
+                "binding.attachment_revision) > (?, ?, ?) ORDER BY "
+                "binding.establishing_server_cursor, binding.attachment_id, "
+                "binding.attachment_revision LIMIT ?",
+                ("dataset-binding-pg", 0, "", 0, 1000),
+                connection=conn,
+            ).rows
         lookup_plan = " ".join(
             str(next(iter(row.values()))) for row in lookup_rows
         )
@@ -411,10 +439,12 @@ def test_postgres_attachment_binding_lookup_and_unresolved_page_use_declared_ind
             str(next(iter(row.values()))) for row in namespace_rows
         )
         digest_plan = " ".join(str(next(iter(row.values()))) for row in digest_rows)
+        release_plan = " ".join(str(next(iter(row.values()))) for row in release_rows)
         assert "sync_attachment_revision_bindings_pkey" in lookup_plan
         assert "idx_sync_attachment_bindings_unresolved" in page_plan
         assert "idx_sync_dataset_storage_namespaces_owner" in namespace_plan
         assert "idx_sync_attachment_bindings_pending_digest" in digest_plan
+        assert "idx_sync_attachment_bindings_retention_release" in release_plan
     finally:
         if db.backend_type == BackendType.POSTGRESQL:
             backend.get_pool().close_all()

--- a/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
@@ -255,7 +255,7 @@ def test_profile_bootstrap_begins_and_resumes_attachment_capture(
     assert result.capabilities.writable_adapter_versions["attachment.ref"] == []
 
 
-def test_attachment_bootstrap_diagnostics_are_bounded_and_path_free(
+def test_attachment_diagnostic_recovery_action_is_bounded_and_path_free(
     tmp_path: Path,
 ) -> None:
     bootstrapper = _PausedAttachmentBootstrapper()
@@ -319,6 +319,9 @@ def test_attachment_bootstrap_diagnostics_are_bounded_and_path_free(
     assert diagnostics.cleanup_candidates[0].attachment_id == mapping.attachment_id
     assert diagnostics.cleanup_candidates[0].state == "captured"
     assert diagnostics.cleanup_candidates[0].blocker_code is None
+    assert [action.action for action in diagnostics.recovery_actions] == [
+        "bootstrap_resume"
+    ]
     serialized = repr(diagnostics)
     assert "private-name.pdf" not in serialized
     assert "notes_attachments" not in serialized

--- a/tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py
@@ -12,11 +12,15 @@ from fastapi.testclient import TestClient
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.endpoints import sync as sync_endpoint
 from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Sync.v2.attachment_refs_v2 import (
+    attachment_ref_v2_object_hash,
+)
 from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
 from tldw_Server_API.app.core.Sync.v2.factory import default_sync_v2_registry
 from tldw_Server_API.app.core.Sync.v2.models import (
     M1_SYNC_DOMAINS,
     NOTES_ORGANIZATION_DOMAINS,
+    SyncBlobObjectCreate,
     SyncEnvelope,
     SyncEnvelopeCreate,
 )
@@ -222,6 +226,61 @@ def _attachment_ref_envelope(**overrides: Any) -> SyncEnvelopeCreate:
     return SyncEnvelopeCreate(**payload)
 
 
+ATTACHMENT_V2_ID = "a1111111-1111-4111-8111-111111111111"
+NOTE_V2_ID = "b2222222-2222-4222-8222-222222222222"
+ATTACHMENT_V2_HASH = "sha256:" + "a" * 64
+ATTACHMENT_V2_TIMESTAMP = "2026-08-13T12:00:00+00:00"
+
+
+def _attachment_ref_v2_envelope(**overrides: Any) -> SyncEnvelopeCreate:
+    operation = str(overrides.get("operation", "upsert"))
+    revision = int(overrides.get("object_revision", 1))
+    payload: dict[str, Any] = {
+        "attachment_id": ATTACHMENT_V2_ID,
+        "parent_domain": "notes.note",
+        "parent_object_id": NOTE_V2_ID,
+        "file_name": "diagram.png",
+        "original_file_name": "diagram.png",
+        "content_type": "image/png",
+        "size_bytes": 512,
+        "blob_hash": ATTACHMENT_V2_HASH,
+        "created_at": ATTACHMENT_V2_TIMESTAMP,
+        "last_modified": ATTACHMENT_V2_TIMESTAMP,
+        "created_by": "device-1",
+    }
+    if operation == "tombstone":
+        payload.update(
+            {
+                "deleted_at": ATTACHMENT_V2_TIMESTAMP,
+                "reason": "restore-test",
+            }
+        )
+    values: dict[str, Any] = {
+        "dataset_id": "dataset-1",
+        "client_envelope_id": f"env-attachment-v2-{revision}-{operation}",
+        "domain": "attachment.ref",
+        "operation": operation,
+        "object_id": ATTACHMENT_V2_ID,
+        "device_id": "device-1",
+        "client_sequence": 300 + revision,
+        "schema_version": 2,
+        "adapter_version": 2,
+        "object_revision": revision,
+        "payload": payload,
+        "payload_hash": attachment_ref_v2_object_hash(
+            operation,
+            payload,
+            object_revision=revision,
+        ),
+        "payload_size_bytes": 512,
+        "created_at_client": ATTACHMENT_V2_TIMESTAMP,
+        "encryption_metadata": {"policy": "server_trusted_v1"},
+        "stable_key": f"attachment:{ATTACHMENT_V2_ID}",
+    }
+    values.update(overrides)
+    return SyncEnvelopeCreate(**values)
+
+
 def _source_cache_envelope(**overrides: Any) -> SyncEnvelopeCreate:
     payload: dict[str, Any] = {
         "dataset_id": "dataset-1",
@@ -304,6 +363,35 @@ def _enable_ready_notes_link(service: SyncV2Service) -> None:
             json.dumps({"notes_link_v1": {"state": "ready"}}),
             "dataset-1",
         ),
+    )
+
+
+def _enable_ready_attachment_v2(service: SyncV2Service) -> None:
+    service.store.db.execute(
+        "UPDATE sync_datasets SET domain_set_json = ?, metadata_json = ? "
+        "WHERE dataset_id = ?",
+        (
+            json.dumps([*M1_SYNC_DOMAINS, "attachment.ref"]),
+            json.dumps({"notes_attachment_v2": {"state": "ready"}}),
+            "dataset-1",
+        ),
+    )
+    service.settings = replace(service.settings, supports_attachments=True)
+
+
+def _register_attachment_v2_device(service: SyncV2Service) -> None:
+    service.register_device(
+        user_id="user-1",
+        display_name="device-v2",
+        client_type="chatbook",
+        device_id="device-v2",
+        capabilities={
+            "requested_domains": ["notes.note", "attachment.ref"],
+            "supported_adapter_versions": {
+                "notes.note": [1],
+                "attachment.ref": [2],
+            },
+        },
     )
 
 
@@ -558,6 +646,7 @@ def test_notes_link_restore_preview_orders_live_group_after_both_note_providers(
         "object_id": edge_id,
         "operation": "upsert",
         "server_cursor": grouped[1].server_cursor,
+        "adapter_version": 1,
         "mutation_group_id": "server-origin-notes-link-restore",
         "mutation_step": 1,
         "mutation_step_count": 2,
@@ -896,7 +985,7 @@ def test_restore_preview_surfaces_tombstones_as_delete_actions(
 def test_restore_preview_includes_attachment_refs_and_missing_blob_warning(
     sync_service: SyncV2Service,
 ) -> None:
-    _push(sync_service, _attachment_ref_envelope())
+    sync_service.store.insert_envelope(_attachment_ref_envelope())
 
     preview = sync_service.restore_preview(
         user_id="user-1",
@@ -912,6 +1001,181 @@ def test_restore_preview_includes_attachment_refs_and_missing_blob_warning(
         "sync_key_recovery_missing",
         "sync_attachment_blob_missing",
     ]
+
+
+def test_attachment_ref_v2_restore_orders_live_ref_after_parent_note() -> None:
+    attachment = _stored_envelope(_attachment_ref_v2_envelope(), 1)
+    note = _stored_envelope(
+        _note_envelope(
+            object_id=NOTE_V2_ID,
+            client_envelope_id="env-note-v2-parent",
+        ),
+        2,
+    )
+
+    ordered = order_restore_envelopes([attachment, note])
+
+    assert [(item.domain, item.object_id) for item in ordered] == [
+        ("notes.note", NOTE_V2_ID),
+        ("attachment.ref", ATTACHMENT_V2_ID),
+    ]
+
+
+def test_attachment_ref_v2_restore_tombstone_has_no_live_parent_dependency() -> None:
+    tombstone = _stored_envelope(
+        _attachment_ref_v2_envelope(operation="tombstone", object_revision=2),
+        3,
+    )
+
+    assert order_restore_envelopes([tombstone]) == [tombstone]
+
+
+def test_attachment_ref_v2_restore_is_negotiated_and_preserves_adapter_version(
+    sync_service: SyncV2Service,
+) -> None:
+    _enable_ready_attachment_v2(sync_service)
+    _register_attachment_v2_device(sync_service)
+    sync_service.store.insert_envelope(
+        _note_envelope(
+            object_id=NOTE_V2_ID,
+            client_envelope_id="env-note-v2-preview",
+        )
+    )
+    sync_service.store.insert_envelope(_attachment_ref_v2_envelope())
+
+    legacy = sync_service.restore_preview(
+        user_id="user-1",
+        device_id="device-1",
+        dataset_ids=["dataset-1"],
+        local_inventory=[],
+    )
+    device_less = sync_service.restore_preview(
+        user_id="user-1",
+        dataset_ids=["dataset-1"],
+        local_inventory=[],
+    )
+    version_two = sync_service.restore_preview(
+        user_id="user-1",
+        device_id="device-v2",
+        dataset_ids=["dataset-1"],
+        local_inventory=[],
+    )
+
+    assert legacy.attachment_refs == []
+    assert device_less.attachment_refs == []
+    assert [item.domain for item in version_two.ordered_actions] == [
+        "notes.note",
+        "attachment.ref",
+    ]
+    assert [item.adapter_version for item in version_two.ordered_actions] == [1, 2]
+    assert version_two.attachment_refs[0].adapter_version == 2
+
+
+def test_attachment_ref_v2_local_inventory_requires_matching_adapter_version(
+    sync_service: SyncV2Service,
+) -> None:
+    _enable_ready_attachment_v2(sync_service)
+    _register_attachment_v2_device(sync_service)
+    sync_service.store.insert_envelope(
+        _note_envelope(
+            object_id=NOTE_V2_ID,
+            client_envelope_id="env-note-v2-local-inventory",
+        )
+    )
+    stored = sync_service.store.insert_envelope(_attachment_ref_v2_envelope())
+
+    preview = sync_service.restore_preview(
+        user_id="user-1",
+        device_id="device-v2",
+        dataset_ids=["dataset-1"],
+        local_inventory=[
+            {
+                "domain": "attachment.ref",
+                "adapter_version": 1,
+                "object_id": ATTACHMENT_V2_ID,
+                "object_revision": 1,
+                "object_hash": stored.payload_hash,
+                "deleted": False,
+            }
+        ],
+    )
+
+    attachment_action = next(
+        item
+        for item in preview.ordered_actions
+        if item.domain == "attachment.ref"
+    )
+    assert attachment_action.action == "apply"
+
+
+@pytest.mark.parametrize("blob_status", ["available", "quarantined", "deleted"])
+def test_attachment_binding_drives_v2_restore_blob_completeness(
+    sync_service: SyncV2Service,
+    blob_status: str,
+) -> None:
+    _enable_ready_attachment_v2(sync_service)
+    _register_attachment_v2_device(sync_service)
+    sync_service.store.insert_envelope(
+        _note_envelope(
+            object_id=NOTE_V2_ID,
+            client_envelope_id=f"env-note-v2-binding-{blob_status}",
+        )
+    )
+    sync_service.store.complete_blob_upload(
+        SyncBlobObjectCreate(
+            blob_id="blob-v2-restore",
+            dataset_id="dataset-1",
+            owner_user_id="user-1",
+            attachment_id="legacy-provenance-is-not-authority",
+            payload_hash=ATTACHMENT_V2_HASH,
+            content_type="image/png",
+            size_bytes=512,
+            storage_backend="local_fs",
+            storage_key="blobs/v2/" + "1" * 32 + "/" + "a" * 64 + ".blob",
+        )
+    )
+    sync_service.store.insert_envelope(_attachment_ref_v2_envelope())
+    if blob_status != "available":
+        sync_service.store.db.execute(
+            "UPDATE sync_blob_objects SET status = ? WHERE blob_id = ?",
+            (blob_status, "blob-v2-restore"),
+        )
+
+    preview = sync_service.restore_preview(
+        user_id="user-1",
+        device_id="device-v2",
+        dataset_ids=["dataset-1"],
+        local_inventory=[],
+    )
+
+    assert preview.attachment_refs[0].availability == blob_status
+    assert preview.blob_details[0].server_availability == blob_status
+
+
+def test_attachment_binding_missing_bytes_remains_metadata_restoreable(
+    sync_service: SyncV2Service,
+) -> None:
+    _enable_ready_attachment_v2(sync_service)
+    _register_attachment_v2_device(sync_service)
+    sync_service.store.insert_envelope(
+        _note_envelope(
+            object_id=NOTE_V2_ID,
+            client_envelope_id="env-note-v2-missing-bytes",
+        )
+    )
+    sync_service.store.insert_envelope(_attachment_ref_v2_envelope())
+
+    preview = sync_service.restore_preview(
+        user_id="user-1",
+        device_id="device-v2",
+        dataset_ids=["dataset-1"],
+        metadata_only=True,
+        local_inventory=[],
+    )
+
+    assert preview.attachment_refs[0].availability == "metadata_only"
+    assert preview.blob_details[0].required_for_restore is False
+    assert preview.missing_blobs == []
 
 
 def test_restore_preview_includes_source_cache_entries_and_local_conflicts(
@@ -1860,6 +2124,7 @@ def test_restore_preview_endpoint_exposes_one_safe_canonical_ordered_plan(
         "object_id",
         "operation",
         "server_cursor",
+        "adapter_version",
         "mutation_group_id",
         "mutation_step",
         "mutation_step_count",
@@ -1939,6 +2204,7 @@ def test_restore_preview_round5_distinguishes_same_object_across_datasets(
         "object_id",
         "operation",
         "server_cursor",
+        "adapter_version",
         "mutation_group_id",
         "mutation_step",
         "mutation_step_count",

--- a/tldw_Server_API/tests/Sync/test_sync_v2_retention.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_retention.py
@@ -222,7 +222,9 @@ def _v2_retention_service(tmp_path: Path) -> SyncV2Service:
             [StaticSyncAdapter(domain="attachment.ref", supported_adapter_versions={1, 2})]
         ),
         clock=_clock,
+        blob_store=LocalSyncBlobStore(tmp_path / "v2-retention-blobs"),
         settings=SyncV2Settings(
+            supports_attachments=True,
             server_trusted_encryption=_ready_encryption(),
             pull_token_signing_secret="retention-test-secret",
         ),
@@ -254,12 +256,42 @@ def _v2_retention_service(tmp_path: Path) -> SyncV2Service:
     return service
 
 
+def _namespaced_storage_key(
+    service: SyncV2Service,
+    *,
+    dataset_id: str,
+    owner_user_id: str,
+    payload_hash: str,
+    payload: bytes | None = None,
+) -> str:
+    assert service.blob_store is not None
+    namespace = service.store.get_or_create_storage_namespace(
+        dataset_id,
+        owner_user_id=owner_user_id,
+    )
+    storage_key = service.blob_store.namespace_storage_key(
+        namespace.storage_namespace_id,
+        payload_hash,
+    )
+    target = service.blob_store.resolve_storage_key(storage_key)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if payload is not None:
+        target.write_bytes(payload)
+    return storage_key
+
+
 def _store_v2_blob(
     service: SyncV2Service,
     *,
     blob_id: str,
     blob_hash: str,
 ) -> None:
+    storage_key = _namespaced_storage_key(
+        service,
+        dataset_id="dataset-v2",
+        owner_user_id="user-1",
+        payload_hash=blob_hash,
+    )
     service.store.complete_blob_upload(
         SyncBlobObjectCreate(
             blob_id=blob_id,
@@ -270,7 +302,7 @@ def _store_v2_blob(
             content_type="application/octet-stream",
             size_bytes=1,
             storage_backend="local_fs",
-            storage_key=f"{blob_id}.bin",
+            storage_key=storage_key,
         )
     )
 
@@ -1148,17 +1180,23 @@ def test_retention_limit_uses_one_bounded_blob_page_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     for index in range(3):
+        payload_hash = "sha256:" + str(index) * 64
         sync_service.store.complete_blob_upload(
             SyncBlobObjectCreate(
                 blob_id=f"blob-budget-{index}",
                 dataset_id="dataset-1",
                 owner_user_id="user-1",
                 attachment_id=f"attachment-budget-{index}",
-                payload_hash="sha256:" + str(index) * 64,
+                payload_hash=payload_hash,
                 content_type="application/octet-stream",
                 size_bytes=1,
                 storage_backend="local_fs",
-                storage_key=f"blob-budget-{index}.bin",
+                storage_key=_namespaced_storage_key(
+                    sync_service,
+                    dataset_id="dataset-1",
+                    owner_user_id="user-1",
+                    payload_hash=payload_hash,
+                ),
             )
         )
     original = sync_service.store.list_blob_objects_for_dataset
@@ -1398,7 +1436,13 @@ def test_retention_dry_run_keeps_audit_restore_window_and_active_blob_refs_as_bl
             content_type="application/pdf",
             size_bytes=13,
             storage_backend="local_fs",
-            storage_key="blob-1.bin",
+            storage_key=_namespaced_storage_key(
+                sync_service,
+                dataset_id="dataset-1",
+                owner_user_id="user-1",
+                payload_hash=payload_hash,
+                payload=b"paper payload",
+            ),
         )
     )
     _ack_all_domains(sync_service, through_sequence=pushed.server_sequence)
@@ -1670,7 +1714,13 @@ def test_retention_compact_soft_deletes_eligible_blob_metadata(
             content_type="application/pdf",
             size_bytes=13,
             storage_backend="local_fs",
-            storage_key="blob-1.bin",
+            storage_key=_namespaced_storage_key(
+                sync_service,
+                dataset_id="dataset-1",
+                owner_user_id="user-1",
+                payload_hash=payload_hash,
+                payload=b"paper payload",
+            ),
         )
     )
     _ack_all_domains(sync_service, through_sequence=tombstone.server_sequence)

--- a/tldw_Server_API/tests/Sync/test_sync_v2_retention.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_retention.py
@@ -427,7 +427,11 @@ def _shared_blob_candidate(service: SyncV2Service, blob_id: str):
         audit_mode=False,
         minimum_tombstone_age_seconds=0,
     )
-    return next(item for item in dry_run.candidates if item.blob_id == blob_id)
+    return next(
+        item
+        for item in dry_run.candidates
+        if item.candidate_type == "blob_gc" and item.blob_id == blob_id
+    )
 
 
 def test_v2_shared_blob_live_sibling_binding_blocks_gc(tmp_path: Path) -> None:
@@ -613,6 +617,7 @@ def test_retention_apply_revalidates_stale_blob_candidate_under_fence(
         confirm=True,
         apply_envelope_compaction=False,
         apply_tombstone_prune=False,
+        apply_binding_release=False,
         apply_blob_gc=True,
     )
 
@@ -778,6 +783,250 @@ def test_v2_blob_retention_keeps_replacement_evidence_separate(tmp_path: Path) -
     }
     assert by_blob["blob-old"].unacknowledged_device_ids == []
     assert by_blob["blob-new"].unacknowledged_device_ids == ["device-v2"]
+
+
+def test_retention_candidate_binding_release_requires_historical_exact_evidence(
+    tmp_path: Path,
+) -> None:
+    service = _v2_retention_service(tmp_path)
+    old_digest = "sha256:" + "a" * 64
+    new_digest = "sha256:" + "b" * 64
+    _store_v2_blob(service, blob_id="blob-old", blob_hash=old_digest)
+    _store_v2_blob(service, blob_id="blob-new", blob_hash=new_digest)
+    first = service.push(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        device_id="device-v2",
+        envelopes=[_v2_attachment_envelope(old_digest)],
+    ).accepted[0]
+    first_head = service.store.get_current_head(
+        "dataset-v2", "attachment.ref", _ATTACHMENT_A
+    )
+    assert first_head is not None
+    second = service.push(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        device_id="device-v2",
+        envelopes=[
+            _v2_attachment_envelope(
+                new_digest,
+                client_envelope_id="v2-attachment-replacement",
+                client_sequence=2,
+                object_revision=2,
+                payload_hash="sha256:" + "d" * 64,
+                base_server_cursor=first.server_sequence,
+                base_object_revision=first.object_revision,
+                base_object_hash=first_head.payload_hash,
+            )
+        ],
+    ).accepted[0]
+
+    before_ack = service.retention_dry_run(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        audit_mode=False,
+    )
+    releases = {
+        candidate.attachment_revision: candidate
+        for candidate in before_ack.candidates
+        if candidate.candidate_type == "binding_release"
+    }
+    assert releases[1].blob_id == "blob-old"
+    assert releases[1].required_device_ids == ["device-v2"]
+    assert releases[1].unacknowledged_device_ids == ["device-v2"]
+    assert "retention_blob_ref_unacknowledged" in releases[1].blockers
+    assert "retention_blob_unverified_by_device" in releases[1].blockers
+    assert 2 not in releases
+    response = _client_for_service(service).post(
+        "/api/v1/sync/retention/dry-run",
+        json={"dataset_id": "dataset-v2", "audit_mode": False},
+    )
+    assert response.status_code == 200
+    release_json = next(
+        candidate
+        for candidate in response.json()["candidates"]
+        if candidate["candidate_type"] == "binding_release"
+    )
+    assert release_json["attachment_revision"] == 1
+
+    _ack_v2_attachment_ref_through(service, second.server_sequence)
+    _ack_v2_blob(service, blob_id="blob-old", blob_hash=old_digest)
+    eligible = service.retention_dry_run(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        audit_mode=False,
+    )
+    old_release = next(
+        candidate
+        for candidate in eligible.candidates
+        if candidate.candidate_type == "binding_release"
+        and candidate.attachment_revision == 1
+    )
+    assert old_release.blockers == []
+
+    applied = service.retention_compact(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        confirm=True,
+        apply_envelope_compaction=False,
+        apply_tombstone_prune=False,
+        apply_blob_gc=False,
+        apply_binding_release=True,
+    )
+    released = service.store.get_attachment_revision_binding(
+        "dataset-v2",
+        _ATTACHMENT_A,
+        1,
+        owner_user_id="user-1",
+    )
+    current = service.store.get_attachment_revision_binding(
+        "dataset-v2",
+        _ATTACHMENT_A,
+        2,
+        owner_user_id="user-1",
+    )
+    assert applied.binding_releases == [
+        {
+            "attachment_id": _ATTACHMENT_A,
+            "attachment_revision": 1,
+            "blob_id": "blob-old",
+            "payload_hash": old_digest,
+            "size_bytes": 1,
+            "establishing_server_cursor": first.server_sequence,
+        }
+    ]
+    assert released is not None and released.retention_released_at == _clock()
+    assert released.blob_hash == old_digest
+    assert released.resolved_blob_id == "blob-old"
+    assert current is not None and current.retention_released_at is None
+
+
+def test_binding_release_candidate_reports_audit_restore_and_repair_holds(
+    tmp_path: Path,
+) -> None:
+    service = _v2_retention_service(tmp_path)
+    old_digest = "sha256:" + "a" * 64
+    new_digest = "sha256:" + "b" * 64
+    _store_v2_blob(service, blob_id="blob-old", blob_hash=old_digest)
+    _store_v2_blob(service, blob_id="blob-new", blob_hash=new_digest)
+    first = service.push(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        device_id="device-v2",
+        envelopes=[_v2_attachment_envelope(old_digest)],
+    ).accepted[0]
+    first_head = service.store.get_current_head(
+        "dataset-v2", "attachment.ref", _ATTACHMENT_A
+    )
+    assert first_head is not None
+    service.push(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        device_id="device-v2",
+        envelopes=[
+            _v2_attachment_envelope(
+                new_digest,
+                client_envelope_id="v2-attachment-replacement",
+                client_sequence=2,
+                object_revision=2,
+                payload_hash="sha256:" + "d" * 64,
+                base_server_cursor=first.server_sequence,
+                base_object_revision=first.object_revision,
+                base_object_hash=first_head.payload_hash,
+            )
+        ],
+    )
+    service.store.db.execute(
+        "UPDATE sync_blob_objects SET status = 'quarantined' WHERE blob_id = ?",
+        ("blob-old",),
+    )
+
+    dry_run = service.retention_dry_run(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        audit_mode=True,
+        minimum_envelope_age_seconds=3600,
+        offline_restore_window_seconds=3600,
+    )
+    candidate = next(
+        candidate
+        for candidate in dry_run.candidates
+        if candidate.candidate_type == "binding_release"
+        and candidate.attachment_revision == 1
+    )
+    assert "retention_audit_mode" in candidate.blockers
+    assert "retention_envelope_window_active" in candidate.blockers
+    assert "retention_restore_window_active" in candidate.blockers
+    assert "retention_blob_quarantined" in candidate.blockers
+
+
+def test_binding_release_tombstone_window_and_later_restore_remain_protected(
+    tmp_path: Path,
+) -> None:
+    service = _v2_retention_service(tmp_path)
+    digest = "sha256:" + "a" * 64
+    _store_v2_blob(service, blob_id="blob-v2", blob_hash=digest)
+    first = service.push(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        device_id="device-v2",
+        envelopes=[_v2_attachment_envelope(digest)],
+    ).accepted[0]
+    tombstone = _tombstone_v2_attachment(
+        service,
+        blob_hash=digest,
+        head=first,
+        revision=2,
+    )
+
+    dry_run = service.retention_dry_run(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        audit_mode=False,
+        minimum_tombstone_age_seconds=3600,
+    )
+    by_revision = {
+        candidate.attachment_revision: candidate
+        for candidate in dry_run.candidates
+        if candidate.candidate_type == "binding_release"
+    }
+    assert "retention_tombstone_window_active" in by_revision[1].blockers
+    assert "retention_tombstone_window_active" in by_revision[2].blockers
+    tombstone_head = service.store.get_current_head(
+        "dataset-v2", "attachment.ref", _ATTACHMENT_A
+    )
+    assert tombstone_head is not None
+
+    restored = service.push(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        device_id="device-v2",
+        envelopes=[
+            _v2_attachment_envelope(
+                digest,
+                client_envelope_id="v2-attachment-restore",
+                client_sequence=3,
+                object_revision=3,
+                payload_hash="sha256:" + "e" * 64,
+                base_server_cursor=tombstone.server_sequence,
+                base_object_revision=tombstone.object_revision,
+                base_object_hash=tombstone_head.payload_hash,
+                routing_metadata={"restore_intent": True},
+            )
+        ],
+    ).accepted[0]
+    after_restore = service.retention_dry_run(
+        user_id="user-1",
+        dataset_id="dataset-v2",
+        audit_mode=False,
+    )
+    release_revisions = {
+        candidate.attachment_revision
+        for candidate in after_restore.candidates
+        if candidate.candidate_type == "binding_release"
+    }
+    assert restored.object_revision == 3
+    assert 3 not in release_revisions
 
 
 @pytest.mark.parametrize("mutation", ["missing", "mismatch"])

--- a/tldw_Server_API/tests/Sync/test_sync_v2_store.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_store.py
@@ -1038,6 +1038,7 @@ def test_attachment_binding_schema_has_exact_constraints_and_indexes(
         "idx_sync_attachment_bindings_unresolved",
         "idx_sync_attachment_bindings_pending_digest",
         "idx_sync_attachment_bindings_blob",
+        "idx_sync_attachment_bindings_retention_release",
     }.issubset(binding_indexes)
     assert {
         "uq_sync_dataset_storage_namespace_id",
@@ -1380,6 +1381,78 @@ def test_attachment_binding_retention_release_is_monotonic_and_idempotent(
     assert replay == released
     assert replay.blob_hash == binding.blob_hash
     assert replay.establishing_server_cursor == binding.establishing_server_cursor
+
+
+def test_attachment_binding_release_candidate_page_is_bounded_and_indexed(
+    sync_store: SyncV2Store,
+) -> None:
+    sync_store.enroll_dataset(_dataset())
+    timestamp = "2026-08-11T21:00:00+00:00"
+    rows = [
+        (
+            "dataset-1",
+            f"{index:08x}-1111-4111-8111-{index:012x}",
+            1,
+            "sha256:" + f"{index:064x}",
+            1,
+            index,
+            "metadata_only",
+            timestamp,
+        )
+        for index in range(1, 1003)
+    ]
+    with sync_store.db.backend.transaction() as connection:
+        for row in rows:
+            sync_store.db.execute(
+                """
+                INSERT INTO sync_attachment_revision_bindings (
+                    dataset_id, attachment_id, attachment_revision, blob_hash,
+                    size_bytes, establishing_server_cursor,
+                    availability_at_acceptance, resolved_blob_id,
+                    retention_released_at, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?)
+                """,
+                row,
+                connection=connection,
+            )
+
+    first = sync_store.list_unreleased_attachment_revision_bindings(
+        "dataset-1",
+        owner_user_id="user-1",
+        limit=10_000,
+    )
+    second = sync_store.list_unreleased_attachment_revision_bindings(
+        "dataset-1",
+        owner_user_id="user-1",
+        after_establishing_server_cursor=first[-1].establishing_server_cursor,
+        after_attachment_id=first[-1].attachment_id,
+        after_attachment_revision=first[-1].attachment_revision,
+        limit=10_000,
+    )
+    assert len(first) == 1000
+    assert [item.establishing_server_cursor for item in second] == [1001, 1002]
+
+    plan = " ".join(
+        str(row["detail"])
+        for row in sync_store.db.execute(
+            "EXPLAIN QUERY PLAN SELECT attachment_id FROM "
+            "sync_attachment_revision_bindings AS binding WHERE binding.dataset_id = ? "
+            "AND binding.retention_released_at IS NULL AND NOT EXISTS (SELECT 1 "
+            "FROM sync_current_heads AS head JOIN sync_envelopes AS envelope ON "
+            "envelope.server_sequence = head.latest_server_cursor WHERE "
+            "head.dataset_id = binding.dataset_id AND head.domain = 'attachment.ref' "
+            "AND head.object_id = binding.attachment_id AND envelope.adapter_version = 2 "
+            "AND envelope.object_revision = "
+            "binding.attachment_revision AND envelope.operation <> 'tombstone') AND "
+            "(binding.establishing_server_cursor, binding.attachment_id, "
+            "binding.attachment_revision) > (?, ?, ?) ORDER BY "
+            "binding.establishing_server_cursor, binding.attachment_id, "
+            "binding.attachment_revision LIMIT ?",
+            ("dataset-1", 0, "", 0, 1000),
+        ).rows
+    )
+    assert "idx_sync_attachment_bindings_retention_release" in plan
+    assert "USE TEMP B-TREE" not in plan.upper()
 
 
 def test_storage_namespace_is_server_issued_owner_scoped_and_stable(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_workspace_blobs.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_workspace_blobs.py
@@ -7,7 +7,10 @@ import pytest
 
 from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
 from tldw_Server_API.app.core.Sync.v2.adapters import StaticSyncAdapter, SyncAdapterRegistry
-from tldw_Server_API.app.core.Sync.v2.blob_store import LocalSyncBlobStore
+from tldw_Server_API.app.core.Sync.v2.blob_store import (
+    LocalSyncBlobStore,
+    SyncBlobStoreError,
+)
 from tldw_Server_API.app.core.Sync.v2.domain_adapters.attachment_refs import (
     AttachmentRefDomainAdapter,
 )
@@ -15,7 +18,12 @@ from tldw_Server_API.app.core.Sync.v2.errors import (
     SyncIdempotencyConflictError,
     SyncStoreError,
 )
-from tldw_Server_API.app.core.Sync.v2.models import SyncDatasetCreate
+from tldw_Server_API.app.core.Sync.v2.models import (
+    SyncAttachmentRevisionBindingCreate,
+    SyncBlobObjectCreate,
+    SyncDatasetCreate,
+    SyncEnvelope,
+)
 from tldw_Server_API.app.core.Sync.v2.security import server_trusted_encryption_status_from_config
 from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service, SyncV2Settings
 from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
@@ -99,6 +107,34 @@ def _create_attachment_session(
         chunk_count=1,
         idempotency_key=idempotency_key,
         metadata=metadata,
+    )
+
+
+def _complete_attachment_blob(
+    service: SyncV2Service,
+    payload: bytes,
+    *,
+    idempotency_key: str,
+):
+    session = _create_attachment_session(
+        service,
+        payload,
+        metadata=_attachment_intent(),
+        idempotency_key=idempotency_key,
+    )
+    service.upload_blob_chunk(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        upload_id=session.upload_id,
+        chunk_index=0,
+        offset_bytes=0,
+        chunk_payload=payload,
+        chunk_hash=_sha256(payload),
+    )
+    return service.complete_blob_upload(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        upload_id=session.upload_id,
     )
 
 
@@ -196,6 +232,370 @@ def test_attachment_upload_completion_is_namespaced_retryable_and_not_reassignab
             note_id=OTHER_NOTE_ID,
             attachment_id=ATTACHMENT_ID,
         )
+
+
+def test_physical_gc_fences_before_unlink_and_finalizes_deleted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _attachment_blob_service(tmp_path)
+    payload = b"physical gc payload"
+    blob = _complete_attachment_blob(service, payload, idempotency_key="gc-upload")
+    assert service.blob_store is not None
+    target = service.blob_store.resolve_storage_key(blob.storage_key)
+    original_delete = service.blob_store.delete_namespace_blob
+    observed_statuses: list[str] = []
+
+    def observe_fence(**kwargs):
+        current = service.store.get_blob_object(
+            "dataset-1",
+            blob_id=blob.blob_id,
+            owner_user_id="user-1",
+            include_unavailable=True,
+        )
+        assert current is not None
+        observed_statuses.append(current.status)
+        return original_delete(**kwargs)
+
+    monkeypatch.setattr(service.blob_store, "delete_namespace_blob", observe_fence)
+
+    result = service.retention_compact(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        confirm=True,
+        apply_envelope_compaction=False,
+        apply_tombstone_prune=False,
+        apply_binding_release=False,
+        apply_blob_gc=True,
+    )
+
+    assert observed_statuses == ["deleting"]
+    assert result.applied_count == 1
+    assert not target.exists()
+    deleted = service.store.get_blob_object(
+        "dataset-1",
+        blob_id=blob.blob_id,
+        owner_user_id="user-1",
+        include_unavailable=True,
+    )
+    assert deleted is not None and deleted.status == "deleted"
+
+
+def test_physical_gc_retries_deleting_after_transient_unlink_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _attachment_blob_service(tmp_path)
+    payload = b"retry physical gc"
+    blob = _complete_attachment_blob(service, payload, idempotency_key="retry-upload")
+    assert service.blob_store is not None
+    target = service.blob_store.resolve_storage_key(blob.storage_key)
+    original_delete = service.blob_store.delete_namespace_blob
+
+    def fail_delete(**_kwargs):
+        raise SyncBlobStoreError("transient unlink failure")
+
+    monkeypatch.setattr(service.blob_store, "delete_namespace_blob", fail_delete)
+    first = service.retention_compact(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        confirm=True,
+        apply_envelope_compaction=False,
+        apply_tombstone_prune=False,
+        apply_binding_release=False,
+        apply_blob_gc=True,
+    )
+
+    fenced = service.store.get_blob_object(
+        "dataset-1",
+        blob_id=blob.blob_id,
+        owner_user_id="user-1",
+        include_unavailable=True,
+    )
+    assert first.applied_count == 0
+    assert first.mutation_performed is True
+    assert first.blocker_counts == {"retention_blob_delete_retry": 1}
+    assert fenced is not None and fenced.status == "deleting"
+    assert target.read_bytes() == payload
+
+    monkeypatch.setattr(service.blob_store, "delete_namespace_blob", original_delete)
+    retry = service.retention_compact(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        confirm=True,
+        apply_envelope_compaction=False,
+        apply_tombstone_prune=False,
+        apply_binding_release=False,
+        apply_blob_gc=True,
+    )
+
+    deleted = service.store.get_blob_object(
+        "dataset-1",
+        blob_id=blob.blob_id,
+        owner_user_id="user-1",
+        include_unavailable=True,
+    )
+    assert retry.applied_count == 1
+    assert deleted is not None and deleted.status == "deleted"
+    assert not target.exists()
+
+
+def test_physical_gc_rejects_upload_while_deleting_then_allows_deleted_repair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _attachment_blob_service(tmp_path)
+    payload = b"same digest repair"
+    blob = _complete_attachment_blob(service, payload, idempotency_key="original-upload")
+    assert service.blob_store is not None
+    original_delete = service.blob_store.delete_namespace_blob
+    repair_session = _create_attachment_session(
+        service,
+        payload,
+        metadata=_attachment_intent(),
+        idempotency_key="repair-upload",
+    )
+    service.upload_blob_chunk(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        upload_id=repair_session.upload_id,
+        chunk_index=0,
+        offset_bytes=0,
+        chunk_payload=payload,
+        chunk_hash=_sha256(payload),
+    )
+    with service.store.db.materialization_transaction(
+        [("dataset-1", "attachment.ref", OTHER_NOTE_ID)]
+    ) as connection:
+        service.store.db._create_attachment_revision_binding(
+            SyncAttachmentRevisionBindingCreate(
+                dataset_id="dataset-1",
+                attachment_id=OTHER_NOTE_ID,
+                attachment_revision=1,
+                blob_hash=_sha256(payload),
+                size_bytes=len(payload),
+                establishing_server_cursor=999,
+                availability_at_acceptance="metadata_only",
+            ),
+            connection=connection,
+        )
+
+    def assert_deleting_then_fail(**_kwargs):
+        current = service.store.get_blob_object(
+            "dataset-1",
+            blob_id=blob.blob_id,
+            owner_user_id="user-1",
+            include_unavailable=True,
+        )
+        assert current is not None and current.status == "deleting"
+        original_commit = service.blob_store.commit_upload
+
+        def fail_if_storage_is_touched(**_commit_kwargs):
+            raise AssertionError("deleting blob completion touched storage")
+
+        monkeypatch.setattr(service.blob_store, "commit_upload", fail_if_storage_is_touched)
+        try:
+            with pytest.raises(SyncStoreError, match="deleting"):
+                service.complete_blob_upload(
+                    user_id="user-1",
+                    dataset_id="dataset-1",
+                    upload_id=repair_session.upload_id,
+                )
+        finally:
+            monkeypatch.setattr(service.blob_store, "commit_upload", original_commit)
+        with pytest.raises(SyncStoreError, match="exact available blob"):
+            service.store.db.resolve_attachment_revision_binding(
+                "dataset-1",
+                OTHER_NOTE_ID,
+                1,
+                blob_id=blob.blob_id,
+                owner_user_id="user-1",
+            )
+        envelope = SyncEnvelope(
+            dataset_id="dataset-1",
+            client_envelope_id="deleting-binding",
+            domain="attachment.ref",
+            operation="upsert",
+            server_cursor=1000,
+            object_id="f3333333-3333-4333-8333-333333333333",
+            object_revision=1,
+            adapter_version=2,
+            payload={
+                "attachment_id": "f3333333-3333-4333-8333-333333333333",
+                "blob_hash": _sha256(payload),
+                "size_bytes": len(payload),
+            },
+        )
+        with service.store.db.materialization_transaction(
+            [("dataset-1", "attachment.ref", envelope.object_id)]
+        ) as connection:
+            with pytest.raises(SyncStoreError, match="deleting"):
+                service.store.db._create_attachment_binding_for_envelope(
+                    envelope,
+                    connection=connection,
+                )
+        raise SyncBlobStoreError("leave the fence durable")
+
+    monkeypatch.setattr(
+        service.blob_store,
+        "delete_namespace_blob",
+        assert_deleting_then_fail,
+    )
+    service.retention_compact(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        confirm=True,
+        apply_envelope_compaction=False,
+        apply_tombstone_prune=False,
+        apply_binding_release=False,
+        apply_blob_gc=True,
+    )
+
+    monkeypatch.setattr(service.blob_store, "delete_namespace_blob", original_delete)
+    service.retention_compact(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        confirm=True,
+        apply_envelope_compaction=False,
+        apply_tombstone_prune=False,
+        apply_binding_release=False,
+        apply_blob_gc=True,
+    )
+    repaired = service.complete_blob_upload(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        upload_id=repair_session.upload_id,
+    )
+
+    assert repaired.blob_id == blob.blob_id
+    assert repaired.status == "available"
+    assert service.blob_store.read_blob(repaired.storage_key) == payload
+
+
+@pytest.mark.parametrize("unavailable_status", ["verify_failed", "quarantined"])
+def test_attachment_upload_completion_rejects_unavailable_blob_before_storage_publish(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unavailable_status: str,
+) -> None:
+    service = _attachment_blob_service(tmp_path)
+    payload = b"unavailable exact blob"
+    _complete_attachment_blob(service, payload, idempotency_key="original-upload")
+    service.store.db.execute(
+        "UPDATE sync_blob_objects SET status = ? WHERE dataset_id = ? AND payload_hash = ?",
+        (unavailable_status, "dataset-1", _sha256(payload)),
+    )
+    retry = _create_attachment_session(
+        service,
+        payload,
+        metadata=_attachment_intent(),
+        idempotency_key=f"retry-{unavailable_status}",
+    )
+    service.upload_blob_chunk(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        upload_id=retry.upload_id,
+        chunk_index=0,
+        offset_bytes=0,
+        chunk_payload=payload,
+        chunk_hash=_sha256(payload),
+    )
+    assert service.blob_store is not None
+
+    def fail_if_storage_is_touched(**_kwargs):
+        raise AssertionError("unavailable blob completion touched storage")
+
+    monkeypatch.setattr(service.blob_store, "commit_upload", fail_if_storage_is_touched)
+
+    with pytest.raises(SyncStoreError, match="not available"):
+        service.complete_blob_upload(
+            user_id="user-1",
+            dataset_id="dataset-1",
+            upload_id=retry.upload_id,
+        )
+
+
+def test_physical_gc_finalizes_when_fenced_namespace_blob_is_already_absent(
+    tmp_path: Path,
+) -> None:
+    service = _attachment_blob_service(tmp_path)
+    payload = b"already absent physical gc"
+    blob = _complete_attachment_blob(service, payload, idempotency_key="absent-upload")
+    assert service.blob_store is not None
+    with service.store.retention_guard("dataset-1", blob.blob_id) as guarded:
+        fenced = guarded.fence_blob_object_deleting("dataset-1", blob.blob_id)
+        assert fenced is not None and fenced.status == "deleting"
+    service.blob_store.resolve_storage_key(blob.storage_key).unlink()
+
+    result = service.retention_compact(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        confirm=True,
+        apply_envelope_compaction=False,
+        apply_tombstone_prune=False,
+        apply_binding_release=False,
+        apply_blob_gc=True,
+    )
+
+    deleted = service.store.get_blob_object(
+        "dataset-1",
+        blob_id=blob.blob_id,
+        owner_user_id="user-1",
+        include_unavailable=True,
+    )
+    assert result.applied_count == 1
+    assert deleted is not None and deleted.status == "deleted"
+
+
+def test_physical_gc_blocks_legacy_global_storage_key(tmp_path: Path) -> None:
+    service = _attachment_blob_service(tmp_path)
+    payload = b"legacy global payload"
+    payload_hash = _sha256(payload)
+    assert service.blob_store is not None
+    storage_key = service.blob_store.legacy_storage_key(payload_hash)
+    target = service.blob_store.resolve_storage_key(storage_key)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(payload)
+    blob = service.store.complete_blob_upload(
+        SyncBlobObjectCreate(
+            blob_id="legacy-global-blob",
+            dataset_id="dataset-1",
+            owner_user_id="user-1",
+            attachment_id=ATTACHMENT_ID,
+            payload_hash=payload_hash,
+            content_type="application/pdf",
+            size_bytes=len(payload),
+            storage_backend="local_fs",
+            storage_key=storage_key,
+        )
+    )
+
+    dry_run = service.retention_dry_run(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        audit_mode=False,
+    )
+    candidate = next(item for item in dry_run.candidates if item.blob_id == blob.blob_id)
+    result = service.retention_compact(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        confirm=True,
+        apply_envelope_compaction=False,
+        apply_tombstone_prune=False,
+        apply_binding_release=False,
+        apply_blob_gc=True,
+    )
+
+    assert candidate.blockers == ["retention_blob_storage_key_not_namespaced"]
+    assert result.applied_count == 0
+    assert target.read_bytes() == payload
+    current = service.store.get_blob_object(
+        "dataset-1",
+        blob_id=blob.blob_id,
+        owner_user_id="user-1",
+        include_unavailable=True,
+    )
+    assert current is not None and current.status == "available"
 
 
 def test_workspace_blob_download_is_dataset_scoped_not_uploader_scoped(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/e2e/pytest.ini
+++ b/tldw_Server_API/tests/e2e/pytest.ini
@@ -20,6 +20,7 @@ markers =
     requires_rag: Tests requiring RAG functionality
     slow: Tests that take >30 seconds to run
     critical: Critical tests for basic functionality
+    integration: Tests that exercise multiple application layers
     benchmark: Benchmark-related tests
     media_processing: Media processing tests
     auth: Authentication tests

--- a/tldw_Server_API/tests/e2e/test_notes_attachment_sync_v2.py
+++ b/tldw_Server_API/tests/e2e/test_notes_attachment_sync_v2.py
@@ -1,0 +1,160 @@
+"""End-to-end Notes attachment lifecycle and restore proof."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from tldw_Server_API.app.core.Sync.v2.models import SyncEnvelopeCreate
+from tldw_Server_API.tests.Notes.test_notes_attachment_sync_api import (
+    ATTACHMENT_ID,
+    DATASET_ID,
+    NOTE_ID,
+    OWNER,
+    _complete_create_upload,
+    _complete_replace_upload,
+)
+from tldw_Server_API.tests.Notes.test_notes_attachment_sync_api import (
+    canonical_api as _canonical_api,
+)
+
+
+def test_notes_attachment_full_lifecycle_restores_on_a_new_device(
+    request: pytest.FixtureRequest,
+) -> None:
+    canonical_api = request.getfixturevalue("_" + _canonical_api.__name__)
+    client, note_db, service = canonical_api
+    note_payload = {"title": "Parent", "content": "Body"}
+    service.store.insert_envelope(
+        SyncEnvelopeCreate(
+            dataset_id=DATASET_ID,
+            client_envelope_id="e2e-parent-note",
+            domain="notes.note",
+            operation="upsert",
+            object_id=NOTE_ID,
+            device_id="device-1",
+            client_sequence=1,
+            object_revision=1,
+            payload=note_payload,
+            payload_hash="sha256:" + hashlib.sha256(b'{"content":"Body","title":"Parent"}').hexdigest(),
+            payload_size_bytes=len(str(note_payload).encode("utf-8")),
+            created_at_client="2026-08-11T20:00:00+00:00",
+            encryption_metadata={"policy": "server_trusted_v1"},
+            stable_key=f"note:{NOTE_ID}",
+            apply_status="applied",
+        )
+    )
+    upload_id = _complete_create_upload(service, b"first attachment payload")
+    collection_path = f"/api/v1/notes/{NOTE_ID}/attachments/from-upload"
+    item_path = f"/api/v1/notes/{NOTE_ID}/attachments/by-id/{ATTACHMENT_ID}"
+
+    created = client.post(
+        collection_path,
+        params={"dataset_id": DATASET_ID},
+        headers={"Idempotency-Key": "e2e-create"},
+        json={"upload_id": upload_id},
+    )
+    assert created.status_code == 201, created.text
+
+    renamed = client.patch(
+        item_path,
+        params={"dataset_id": DATASET_ID},
+        headers={
+            "Idempotency-Key": "e2e-rename",
+            "If-Match": created.json()["etag"],
+        },
+        json={"file_name": "Lifecycle.pdf"},
+    )
+    assert renamed.status_code == 200, renamed.text
+
+    replacement_upload_id = _complete_replace_upload(
+        service,
+        b"replacement attachment payload",
+    )
+    replaced = client.post(
+        collection_path,
+        params={"dataset_id": DATASET_ID},
+        headers={
+            "Idempotency-Key": "e2e-replace",
+            "If-Match": renamed.json()["etag"],
+        },
+        json={"upload_id": replacement_upload_id},
+    )
+    assert replaced.status_code == 201, replaced.text
+
+    assert note_db.note_store.delete_note(NOTE_ID, expected_version=1) is True
+    hidden = client.get(item_path, params={"dataset_id": DATASET_ID})
+    assert hidden.status_code == 404
+    assert note_db.note_store.restore_note(NOTE_ID, expected_version=2) is True
+    visible = client.get(item_path, params={"dataset_id": DATASET_ID})
+    assert visible.status_code == 200, visible.text
+    assert visible.json()["etag"] == replaced.json()["etag"]
+
+    deleted = client.request(
+        "DELETE",
+        item_path,
+        params={"dataset_id": DATASET_ID},
+        headers={
+            "Idempotency-Key": "e2e-delete",
+            "If-Match": replaced.json()["etag"],
+        },
+        json={"reason": "e2e lifecycle"},
+    )
+    assert deleted.status_code == 200, deleted.text
+    restored = client.post(
+        f"{item_path}/restore",
+        params={"dataset_id": DATASET_ID},
+        headers={
+            "Idempotency-Key": "e2e-restore",
+            "If-Match": deleted.json()["etag"],
+        },
+        json={"reason": "undo e2e lifecycle"},
+    )
+    assert restored.status_code == 200, restored.text
+    assert restored.json()["state"] == "live"
+
+    service.register_device(
+        user_id=OWNER,
+        device_id="attachment-restore-device",
+        display_name="Fresh restore device",
+        client_type="chatbook",
+        capabilities={
+            "requested_domains": ["notes.note", "attachment.ref"],
+            "supported_adapter_versions": {"attachment.ref": [2]},
+        },
+    )
+    pulled = service.pull(
+        user_id=OWNER,
+        dataset_id=DATASET_ID,
+        device_id="attachment-restore-device",
+        domains=["notes.note", "attachment.ref"],
+        include_own_changes=True,
+    )
+    pulled_attachment = next(envelope for envelope in pulled.envelopes if envelope.domain == "attachment.ref")
+    assert pulled_attachment.object_id == ATTACHMENT_ID
+    assert pulled_attachment.operation == "upsert"
+
+    preview = service.restore_preview(
+        user_id=OWNER,
+        device_id="attachment-restore-device",
+        dataset_ids=[DATASET_ID],
+        domains=["notes.note", "attachment.ref"],
+        selected_object_ids=[NOTE_ID],
+        selected_attachment_ids=[ATTACHMENT_ID],
+        local_inventory=[],
+    )
+    assert preview.restore_status == "content_complete"
+    assert [item.attachment_id for item in preview.attachment_refs] == [ATTACHMENT_ID]
+
+    before = service.store.db.execute("SELECT * FROM sync_blob_objects ORDER BY blob_id").rows
+    retention = service.retention_dry_run(
+        user_id=OWNER,
+        dataset_id=DATASET_ID,
+        domains=["attachment.ref"],
+        audit_mode=True,
+        limit=100,
+    )
+    assert retention.audit_mode is True
+    assert all(candidate.blockers for candidate in retention.candidates)
+    assert service.store.db.execute("SELECT * FROM sync_blob_objects ORDER BY blob_id").rows == before


### PR DESCRIPTION
## Summary
- make attachment restore adapter-version aware and expose immutable-binding completeness
- release historical bindings monotonically and guard physical blob collection with a durable fence
- add owner-scoped lifecycle diagnostics, public contract documentation, and lifecycle/range coverage

## Test plan
- [x] Changed 12-file attachment matrix: 369 passed, 7 environment-dependent skips
- [x] Ruff, Ruff format, Bandit, py_compile, and git diff checks
- [x] SQLite lifecycle e2e and server-free PostgreSQL contracts

## Tracking
- Closes TASK-13005.4
- Completes TASK-13005

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes Notes attachment restore and lifecycle operations in Sync v2 to satisfy TASK-13005.4. Previously restore/retention/GC were partial and v1-only; now negotiated v2 `attachment.ref` writes are gated, restore orders after the owning Note with immutable byte-completeness, historical bindings release monotonically, and physical GC deletes only exact namespaced blobs under a dataset fence; v1 remains readable/restorable but immutable.

- Review focus:
  - Negotiation and gates: devices must advertise `supported_adapter_versions.attachment.ref` including 2 to push/ack v2; capabilities split into `supported_adapter_versions` vs `writable_adapter_versions`; writes require both rollout gates, trusted encryption, domain enrollment, and dataset `notes_attachment_v2.state=ready`; fail closed with no legacy fallback.
  - Restore and completeness: preview/replay orders the parent Note before live v2 attachment refs; inventory keys include `(dataset, domain, object_id, adapter_version)`; completeness is reported via immutable bindings.
  - Retention and GC: new `binding_release` candidate with `attachment_revision`; compaction supports `apply_binding_release`; new index accelerates scans; physical GC deletes only exact dataset-namespace blobs behind a durable fence.
  - Diagnostics: owner-scoped and redacted; adds recovery actions; large diagnostics return HTTP 413 with stable codes for per-category and total sample limits.
  - Model/store/docs/tests: adds `deleting` state, a blob write guard to hold the materialization fence, and namespaced deletion that never unlinks legacy global keys; docs mark M2 implemented and update capability maps; adds e2e integration and workspace blob coverage.

- Rollout and migration:
  - Server: enable `SYNC_V2_ENABLE_BLOB_TRANSFER` and `SYNC_V2_ENABLE_NOTES_ATTACHMENT_SYNC`, ensure server-trusted encryption is ready, enroll `attachment.ref`, then set dataset metadata `notes_attachment_v2.state=ready`.
  - Clients: advertise `supported_adapter_versions.attachment.ref` with 2 to write/ack v2; handle HTTP 413 diagnostic errors; treat v1 as read-only.
  - Retention callers: pass `apply_binding_release=true` when compacting to release historical bindings.

<sup>Written for commit 54f98307f58fa81a1ef23fba0eeb5bb9a4cae0c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

