### PR TITLE
refactor: extract Moderation shared models

### DIFF
--- a/Docs/superpowers/plans/2026-08-01-moderation-shared-models-extraction-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-01-moderation-shared-models-extraction-implementation-plan.md
@@ -1,0 +1,1224 @@
+# Moderation Shared Models Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Moderation.models` the canonical owner of the three shared policy/result dataclasses without changing supported moderation behavior or established service imports.
+
+**Architecture:** Add a standard-library-only `models.py`, then turn `moderation_service.py` into the compatibility facade for the exact canonical class objects. `PolicyCompiler` and `PolicyEvaluator` use private runtime aliases from the neutral module while retaining their static `policy_types()` descriptors and subclass dispatch; subprocess tests prove those methods no longer load the service.
+
+**Tech Stack:** Python 3, standard-library dataclasses/AST/importlib/subprocess tools, pytest, Black, Ruff, Bandit, Loguru only in the existing service, and the project virtualenv at `/Users/appledev/Documents/GitHub/tldw_server/.venv`.
+
+## Global Constraints
+
+- This is a strict structural extraction. Moderation decisions, scanning, snippets, redaction, configuration, persistence, and endpoint behavior must not change.
+- `models.py` canonically owns exactly `ModerationPolicy`, `PatternRule`, and `ModerationEvaluationResult` and imports only `__future__`, `dataclasses`, `json`, and `re`.
+- `moderation_service.py` continues exporting all three names as the exact canonical objects; established production callers remain on that facade.
+- Preserve dataclass constructors, field order, defaults, factories, annotations, equality, mutability, borrowed list/set/regex identity, and the exact mapping returned by `ModerationPolicy.to_dict()`.
+- The three canonical classes use their natural `tldw_Server_API.app.core.Moderation.models` `__module__`; do not override it.
+- Existing pickles naming the service facade remain resolvable. New pickle bytes and loading new payloads on older releases are outside compatibility and are not exercised in tests.
+- `PolicyCompiler.policy_types()` and `PolicyEvaluator.policy_types()` remain `staticmethod` descriptors with unchanged signatures, tuple order, and internal `self.policy_types()` dispatch.
+- Compiler/evaluator runtime references use underscore-prefixed aliases. Public model names remain absent from those module namespaces and runtime `typing.get_type_hints()` behavior remains unchanged.
+- Rebinding service facade exports and monkeypatching private service globals are outside compatibility. Subclass overrides of `policy_types()` remain supported.
+- `Moderation/__init__.py`, endpoint/schema files, compiler-specific dataclasses, `EvaluationLimits`, and `_ResolvedModerationServiceState` do not move.
+- Do not add regex hardening, validation, normalization, wrappers, duplicate class identities, package re-exports, or caller migrations.
+- `moderation_service.py` and `policy_compiler.py` have pre-existing Black debt at the recorded predecessor. Do not format either whole file in this PR; enforce Black on new files and the already-clean evaluator, and enforce Ruff plus diff review on all touched Python files.
+- Track implementation in `TASK-13011`. The stacked branch boundary is predecessor `285773ea6b05318512f4b004375e394e969e425d`.
+- The implementation PR must not target `dev` until `TASK-12992` is merged and the post-predecessor commits are transplanted onto current `origin/dev`.
+
+---
+
+## Source And Tracking
+
+- Design: `Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md`
+- Design task: `TASK-13010`
+- Implementation task: `TASK-13011`
+- Predecessor task: `TASK-12992`
+- Recorded predecessor head: `285773ea6b05318512f4b004375e394e969e425d`
+
+## File Structure
+
+- Create: `tldw_Server_API/app/core/Moderation/models.py`
+  - Owns exactly the three canonical dataclasses and model-local private constants used by `ModerationPolicy.to_dict()`.
+  - Has no project, service, compiler, evaluator, configuration, or Loguru imports.
+- Modify: `tldw_Server_API/app/core/Moderation/moderation_service.py`
+  - Removes the three class bodies and imports their exact canonical definitions at module scope.
+  - Retains `_ResolvedModerationServiceState`, service exception handling, configuration, locking, persistence, logging, and all service methods.
+- Modify: `tldw_Server_API/app/core/Moderation/policy_compiler.py`
+  - Imports canonical classes under private runtime aliases and under normal names only for `TYPE_CHECKING`.
+  - Keeps `policy_types()` and every internal dynamic call site.
+- Modify: `tldw_Server_API/app/core/Moderation/policy_evaluator.py`
+  - Imports canonical classes under private runtime aliases and under normal names only for `TYPE_CHECKING`.
+  - Keeps `EvaluationLimits`, `policy_types()`, and every internal dynamic call site.
+- Create: `tldw_Server_API/tests/unit/test_moderation_models_characterization.py`
+  - Pre-move oracle for dataclass, aliasing, `to_dict()`, descriptor, tuple, and subclass-dispatch behavior.
+- Create: `tldw_Server_API/tests/unit/test_moderation_models_canonical.py`
+  - Canonical ownership, service identity, natural metadata, source import allowlist, and parent-package runtime isolation.
+- Create: `tldw_Server_API/tests/unit/test_moderation_models_imports.py`
+  - Fresh-process deferred-edge removal and compiler/evaluator public namespace contracts.
+- Modify throughout execution: `backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md`
+  - Records per-task files, focused test results, reviews, verification, rollout state, and final summary.
+
+## Command Conventions
+
+Run commands from the isolated implementation worktree. Use the project interpreter directly so every command uses the configured environment:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --version
+```
+
+Before each task commit:
+
+1. Update `TASK-13011` through Backlog MCP with status, touched files, and focused verification.
+2. Run the task's focused tests and `git diff --check`.
+3. Review staged files against the recorded predecessor boundary.
+4. Commit only the task's files and Backlog record.
+
+---
+
+### Task 1: Add Pre-Move Model And Dispatch Characterization
+
+**Files:**
+- Create: `tldw_Server_API/tests/unit/test_moderation_models_characterization.py`
+- Modify: `backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md`
+
+**Interfaces:**
+- Consumes: service-owned `ModerationPolicy`, `PatternRule`, `ModerationEvaluationResult`, `PolicyCompiler.policy_types()`, and `PolicyEvaluator.policy_types()` as they exist before extraction.
+- Produces: a green, implementation-independent oracle that Tasks 2 and 3 must preserve except for separately approved canonical metadata and service-export rebinding boundaries.
+
+- [ ] **Step 1: Add exact dataclass fixtures and field contracts**
+
+Create the characterization file with these imports, constants, and helper classes:
+
+```python
+from __future__ import annotations
+
+import inspect
+import re
+import typing
+from dataclasses import fields
+
+import pytest
+
+from tldw_Server_API.app.core.Moderation.moderation_service import (
+    ModerationEvaluationResult,
+    ModerationPolicy,
+    PatternRule,
+)
+from tldw_Server_API.app.core.Moderation.policy_compiler import (
+    PolicyCompilationInput,
+    PolicyCompiler,
+    ResolvedModerationConfig,
+)
+from tldw_Server_API.app.core.Moderation.policy_evaluator import (
+    EvaluationLimits,
+    PolicyEvaluator,
+)
+
+pytestmark = pytest.mark.unit
+
+_LIMITS = EvaluationLimits(
+    max_scan_chars=100,
+    match_window_chars=16,
+    max_fallback_scan_chars=200,
+    max_replacements_per_pattern=10,
+)
+
+
+class _BrokenPattern:
+    @property
+    def pattern(self):
+        raise ValueError("broken pattern")
+
+
+class _UnexpectedPattern:
+    @property
+    def pattern(self):
+        raise ZeroDivisionError("unexpected pattern failure")
+```
+
+Append exact signature, field, and annotation assertions:
+
+```python
+@pytest.mark.parametrize(
+    ("model_type", "expected_signature", "expected_fields", "expected_annotations"),
+    [
+        (
+            ModerationPolicy,
+            "(enabled: 'bool' = False, input_enabled: 'bool' = True, "
+            "output_enabled: 'bool' = True, input_action: 'str' = 'block', "
+            "output_action: 'str' = 'redact', redact_replacement: 'str' = "
+            "'[REDACTED]', per_user_overrides: 'bool' = True, "
+            "block_patterns: 'list[PatternRule]' = <factory>, "
+            "categories_enabled: 'set[str] | None' = None) -> None",
+            (
+                "enabled",
+                "input_enabled",
+                "output_enabled",
+                "input_action",
+                "output_action",
+                "redact_replacement",
+                "per_user_overrides",
+                "block_patterns",
+                "categories_enabled",
+            ),
+            {
+                "enabled": "bool",
+                "input_enabled": "bool",
+                "output_enabled": "bool",
+                "input_action": "str",
+                "output_action": "str",
+                "redact_replacement": "str",
+                "per_user_overrides": "bool",
+                "block_patterns": "list[PatternRule]",
+                "categories_enabled": "set[str] | None",
+            },
+        ),
+        (
+            PatternRule,
+            "(regex: 're.Pattern', action: 'str | None' = None, "
+            "replacement: 'str | None' = None, categories: 'set[str] | None' "
+            "= None, phase: 'str' = 'both') -> None",
+            ("regex", "action", "replacement", "categories", "phase"),
+            {
+                "regex": "re.Pattern",
+                "action": "str | None",
+                "replacement": "str | None",
+                "categories": "set[str] | None",
+                "phase": "str",
+            },
+        ),
+        (
+            ModerationEvaluationResult,
+            "(action: 'str' = 'pass', redacted_text: 'str | None' = None, "
+            "matched_pattern: 'str | None' = None, category: 'str | None' "
+            "= None, match_span: 'tuple[int, int] | None' = None, sample: "
+            "'str | None' = None) -> None",
+            (
+                "action",
+                "redacted_text",
+                "matched_pattern",
+                "category",
+                "match_span",
+                "sample",
+            ),
+            {
+                "action": "str",
+                "redacted_text": "str | None",
+                "matched_pattern": "str | None",
+                "category": "str | None",
+                "match_span": "tuple[int, int] | None",
+                "sample": "str | None",
+            },
+        ),
+    ],
+)
+def test_model_declarations_are_literal(
+    model_type,
+    expected_signature,
+    expected_fields,
+    expected_annotations,
+):
+    assert str(inspect.signature(model_type)) == expected_signature
+    assert tuple(field.name for field in fields(model_type)) == expected_fields
+    assert model_type.__annotations__ == expected_annotations
+```
+
+- [ ] **Step 2: Characterize defaults, borrowing, equality, and mutability**
+
+Append:
+
+```python
+def test_model_defaults_and_borrowed_values_are_literal():
+    first = ModerationPolicy()
+    second = ModerationPolicy()
+    supplied_rules = []
+    supplied_categories = {"pii"}
+    regex = re.compile("secret")
+    rule_categories = {"confidential"}
+    rule = PatternRule(regex=regex, categories=rule_categories)
+    policy = ModerationPolicy(
+        block_patterns=supplied_rules,
+        categories_enabled=supplied_categories,
+    )
+
+    assert first == second
+    assert first.block_patterns == []
+    assert first.block_patterns is not second.block_patterns
+    assert policy.block_patterns is supplied_rules
+    assert policy.categories_enabled is supplied_categories
+    assert rule.regex is regex
+    assert rule.categories is rule_categories
+
+    result = ModerationEvaluationResult()
+    result.action = "warn"
+    assert result.action == "warn"
+
+
+def test_resolved_model_type_hints_are_literal():
+    policy_hints = typing.get_type_hints(ModerationPolicy)
+    rule_hints = typing.get_type_hints(PatternRule)
+    result_hints = typing.get_type_hints(ModerationEvaluationResult)
+
+    assert policy_hints["block_patterns"] == list[PatternRule]
+    assert policy_hints["categories_enabled"] == set[str] | None
+    assert rule_hints["regex"] is re.Pattern
+    assert rule_hints["categories"] == set[str] | None
+    assert result_hints["match_span"] == tuple[int, int] | None
+```
+
+- [ ] **Step 3: Characterize the exact `to_dict()` mapping and fallbacks**
+
+Append:
+
+```python
+def test_policy_to_dict_returns_literal_mapping():
+    policy = ModerationPolicy(
+        enabled=True,
+        block_patterns=[
+            PatternRule(
+                regex=re.compile("secret"),
+                action="redact",
+                replacement="[RULE]",
+                categories=None,
+                phase="input",
+            )
+        ],
+        categories_enabled={"pii", "confidential"},
+    )
+
+    assert policy.to_dict() == {
+        "enabled": True,
+        "input_enabled": True,
+        "output_enabled": True,
+        "input_action": "block",
+        "output_action": "redact",
+        "redact_replacement": "[REDACTED]",
+        "per_user_overrides": True,
+        "blocklist_count": 1,
+        "block_patterns": ["secret"],
+        "rules": [
+            {
+                "pattern": "secret",
+                "action": "redact",
+                "replacement": "[RULE]",
+                "phase": "input",
+                "categories": "uncategorized",
+            }
+        ],
+        "categories_enabled": ["confidential", "pii"],
+    }
+
+
+def test_policy_to_dict_preserves_legacy_regex_shape():
+    policy = ModerationPolicy(block_patterns=[re.compile("legacy")])
+
+    snapshot = policy.to_dict()
+
+    assert snapshot["block_patterns"] == ["legacy"]
+    assert snapshot["rules"] == [
+        {
+            "pattern": "legacy",
+            "action": "",
+            "replacement": "",
+            "phase": "both",
+            "categories": "",
+        }
+    ]
+
+
+def test_policy_to_dict_preserves_noncritical_fallbacks():
+    policy = ModerationPolicy(block_patterns=[_BrokenPattern()])
+
+    snapshot = policy.to_dict()
+
+    assert snapshot["blocklist_count"] == 0
+    assert snapshot["block_patterns"] == []
+    assert snapshot["rules"] == []
+
+
+def test_policy_to_dict_does_not_swallow_unlisted_exceptions():
+    policy = ModerationPolicy(block_patterns=[_UnexpectedPattern()])
+
+    with pytest.raises(ZeroDivisionError, match="unexpected pattern failure"):
+        policy.to_dict()
+```
+
+- [ ] **Step 4: Characterize descriptors, tuples, and subclass dispatch**
+
+Append:
+
+```python
+def test_policy_type_descriptors_and_tuples_are_literal():
+    assert isinstance(inspect.getattr_static(PolicyCompiler, "policy_types"), staticmethod)
+    assert isinstance(inspect.getattr_static(PolicyEvaluator, "policy_types"), staticmethod)
+    assert str(inspect.signature(PolicyCompiler.policy_types)) == (
+        "() -> 'tuple[type[ModerationPolicy], type[PatternRule]]'"
+    )
+    assert str(inspect.signature(PolicyEvaluator.policy_types)) == (
+        "() -> 'tuple[type[ModerationPolicy], type[PatternRule], "
+        "type[ModerationEvaluationResult]]'"
+    )
+    assert PolicyCompiler.policy_types() == (ModerationPolicy, PatternRule)
+    assert PolicyEvaluator.policy_types() == (
+        ModerationPolicy,
+        PatternRule,
+        ModerationEvaluationResult,
+    )
+
+
+def test_compiler_uses_overridden_policy_types():
+    class ReplacementPolicy:
+        def __init__(self, **values):
+            self.values = values
+
+    class ReplacementCompiler(PolicyCompiler):
+        @staticmethod
+        def policy_types():
+            return ReplacementPolicy, PatternRule
+
+    result = ReplacementCompiler().compile_global(
+        PolicyCompilationInput(
+            config=ResolvedModerationConfig(),
+            runtime_override={},
+            blocklist_lines=[],
+            pii_rules=[],
+        )
+    )
+
+    assert isinstance(result.policy, ReplacementPolicy)
+    assert result.policy.values["block_patterns"] == []
+
+
+def test_evaluator_uses_overridden_policy_types():
+    class ReplacementResult:
+        pass
+
+    class ReplacementEvaluator(PolicyEvaluator):
+        @staticmethod
+        def policy_types():
+            return ModerationPolicy, PatternRule, ReplacementResult
+
+    result = ReplacementEvaluator().evaluate_text(
+        "",
+        ModerationPolicy(enabled=False),
+        "input",
+        _LIMITS,
+        include_redacted_text=False,
+    )
+
+    assert isinstance(result, ReplacementResult)
+```
+
+- [ ] **Step 5: Run the pre-move oracle and confirm it is green**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/unit/test_moderation_models_characterization.py -q
+```
+
+Expected: all tests pass against the service-owned classes before `models.py` exists.
+
+- [ ] **Step 6: Record and commit the characterization**
+
+Update `TASK-13011` with the new test file and passing count, then run:
+
+```bash
+git diff --check
+git add tldw_Server_API/tests/unit/test_moderation_models_characterization.py "backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md"
+git commit -m "test: characterize Moderation shared models"
+```
+
+---
+
+### Task 2: Create Canonical Models And Preserve The Service Facade
+
+**Files:**
+- Create: `tldw_Server_API/tests/unit/test_moderation_models_canonical.py`
+- Create: `tldw_Server_API/app/core/Moderation/models.py`
+- Modify: `tldw_Server_API/app/core/Moderation/moderation_service.py`
+- Modify: `backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md`
+
+**Interfaces:**
+- Consumes: Task 1's literal model and `to_dict()` oracle.
+- Produces: canonical `models.ModerationPolicy`, `models.PatternRule`, and `models.ModerationEvaluationResult`, plus exact service facade aliases consumed by Task 3.
+
+- [ ] **Step 1: Write failing canonical ownership and import-boundary tests**
+
+Create `test_moderation_models_canonical.py`:
+
+```python
+from __future__ import annotations
+
+import ast
+import importlib
+import subprocess
+import sys
+from dataclasses import is_dataclass
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Moderation import models, moderation_service
+
+pytestmark = pytest.mark.unit
+
+_MODEL_NAMES = (
+    "ModerationPolicy",
+    "PatternRule",
+    "ModerationEvaluationResult",
+)
+_FORBIDDEN_MODULES = (
+    "tldw_Server_API.app.core.config",
+    "tldw_Server_API.app.core.Moderation.moderation_service",
+    "tldw_Server_API.app.core.Moderation.policy_compiler",
+    "tldw_Server_API.app.core.Moderation.policy_evaluator",
+)
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODELS_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "app"
+    / "core"
+    / "Moderation"
+    / "models.py"
+)
+
+
+def test_service_facade_exports_exact_canonical_classes():
+    for name in _MODEL_NAMES:
+        canonical = getattr(models, name)
+        assert getattr(moderation_service, name) is canonical
+        assert canonical.__module__ == models.__name__
+
+
+def test_models_module_owns_exactly_three_dataclass_types():
+    owned_dataclasses = {
+        name
+        for name, value in vars(models).items()
+        if isinstance(value, type)
+        and is_dataclass(value)
+        and value.__module__ == models.__name__
+    }
+
+    assert owned_dataclasses == set(_MODEL_NAMES)
+
+
+def test_legacy_qualified_names_resolve_to_canonical_classes():
+    legacy = importlib.import_module(
+        "tldw_Server_API.app.core.Moderation.moderation_service"
+    )
+
+    for name in _MODEL_NAMES:
+        assert getattr(legacy, name) is getattr(models, name)
+
+
+def test_models_source_imports_only_approved_standard_library_modules():
+    tree = ast.parse(_MODELS_PATH.read_text(encoding="utf-8"))
+    roots = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            roots.add(node.module.split(".", 1)[0])
+
+    assert roots == {"__future__", "dataclasses", "json", "re"}
+
+
+def test_models_import_adds_no_moderation_or_config_dependencies():
+    script = f"""
+import importlib
+import sys
+
+forbidden = {repr(_FORBIDDEN_MODULES)}
+importlib.import_module("tldw_Server_API.app.core.Moderation")
+assert not [name for name in forbidden if name in sys.modules]
+importlib.import_module("tldw_Server_API.app.core.Moderation.models")
+assert not [name for name in forbidden if name in sys.modules]
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+```
+
+- [ ] **Step 2: Run the canonical tests and confirm the missing-module failure**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/unit/test_moderation_models_canonical.py -q
+```
+
+Expected: collection fails with `ModuleNotFoundError` or `ImportError` for `tldw_Server_API.app.core.Moderation.models`.
+
+- [ ] **Step 3: Add the literal canonical models module**
+
+Create `models.py` with the current declarations and only the approved service-global substitutions:
+
+```python
+"""Shared canonical data models for Moderation policy compilation and evaluation."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+
+_MODEL_NONCRITICAL_EXCEPTIONS = (
+    OSError,
+    ValueError,
+    TypeError,
+    KeyError,
+    RuntimeError,
+    AttributeError,
+    ConnectionError,
+    TimeoutError,
+    json.JSONDecodeError,
+    re.error,
+)
+_UNCATEGORIZED_CATEGORY = "uncategorized"
+
+
+@dataclass
+class ModerationPolicy:
+    enabled: bool = False
+    input_enabled: bool = True
+    output_enabled: bool = True
+    input_action: str = "block"  # block | redact | warn
+    output_action: str = "redact"  # redact | block | warn (block only applies to non-streaming)
+    redact_replacement: str = "[REDACTED]"
+    per_user_overrides: bool = True
+    # Compiled rules; each rule includes the regex and optional per-pattern action/replacement
+    block_patterns: list[PatternRule] = field(default_factory=list)
+    # Enabled categories filter (None or empty means allow all)
+    categories_enabled: set[str] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable snapshot of the policy (without raw regex objects)."""
+        patterns: list[str] = []
+        try:
+            if self.block_patterns:
+                # Backward-friendly: expose raw patterns as strings
+                tmp: list[str] = []
+                for p in self.block_patterns:
+                    pat = getattr(p, "pattern", None)
+                    if pat is None and isinstance(p, PatternRule):
+                        pat = getattr(p.regex, "pattern", "")
+                    tmp.append(pat or "")
+                patterns = tmp
+        except _MODEL_NONCRITICAL_EXCEPTIONS:
+            patterns = []
+        # Provide richer rule view
+        rules: list[dict[str, str]] = []
+        try:
+            if self.block_patterns:
+                for p in self.block_patterns:
+                    if isinstance(p, PatternRule):
+                        cats = p.categories if p.categories else {_UNCATEGORIZED_CATEGORY}
+                        rules.append({
+                            "pattern": p.regex.pattern,
+                            "action": p.action or "",
+                            "replacement": p.replacement or "",
+                            "phase": p.phase or "both",
+                            "categories": ",".join(sorted(cats)) if cats else "",
+                        })
+                    else:
+                        rules.append(
+                            {
+                                "pattern": getattr(p, "pattern", ""),
+                                "action": "",
+                                "replacement": "",
+                                "phase": "both",
+                                "categories": "",
+                            }
+                        )
+        except _MODEL_NONCRITICAL_EXCEPTIONS:
+            rules = []
+        return {
+            "enabled": self.enabled,
+            "input_enabled": self.input_enabled,
+            "output_enabled": self.output_enabled,
+            "input_action": self.input_action,
+            "output_action": self.output_action,
+            "redact_replacement": self.redact_replacement,
+            "per_user_overrides": self.per_user_overrides,
+            "blocklist_count": len(patterns),
+            "block_patterns": patterns,
+            "rules": rules,
+            "categories_enabled": sorted(self.categories_enabled) if self.categories_enabled else [],
+        }
+
+
+@dataclass
+class PatternRule:
+    regex: re.Pattern
+    action: str | None = None  # block | redact | warn | None
+    replacement: str | None = None  # only used when action=redact
+    categories: set[str] | None = None  # e.g., {"pii", "confidential"}
+    phase: str = "both"  # input | output | both
+
+
+@dataclass
+class ModerationEvaluationResult:
+    """Canonical moderation evaluation result."""
+
+    action: str = "pass"
+    redacted_text: str | None = None
+    matched_pattern: str | None = None
+    category: str | None = None
+    match_span: tuple[int, int] | None = None
+    sample: str | None = None
+```
+
+Do not improve exception handling, move class order, normalize category values, copy borrowed objects, add `__all__`, or override `__module__`.
+
+- [ ] **Step 4: Replace service-owned class bodies with canonical imports**
+
+In `moderation_service.py`:
+
+1. Change `from dataclasses import dataclass, field, replace` to `from dataclasses import dataclass, replace`.
+2. Add this module-level import before compiler/evaluator imports:
+
+```python
+from tldw_Server_API.app.core.Moderation.models import (
+    ModerationEvaluationResult,
+    ModerationPolicy,
+    PatternRule,
+)
+```
+
+3. Delete only the three class bodies from `@dataclass class ModerationPolicy` through the end of `ModerationEvaluationResult`.
+4. Keep `_MODERATION_NONCRITICAL_EXCEPTIONS`, `_ResolvedModerationServiceState`, and every service method unchanged.
+
+- [ ] **Step 5: Run canonical and pre-move characterization tests**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/unit/test_moderation_models_characterization.py \
+  tldw_Server_API/tests/unit/test_moderation_models_canonical.py \
+  -q
+```
+
+Expected: both files pass; service and canonical paths have exact identity, and model import does not load service/config/compiler/evaluator.
+
+- [ ] **Step 6: Record and commit canonical ownership**
+
+Update `TASK-13011` with production/test files and focused results, then run:
+
+```bash
+git diff --check
+git add tldw_Server_API/app/core/Moderation/models.py tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/tests/unit/test_moderation_models_canonical.py "backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md"
+git commit -m "refactor: extract Moderation shared models"
+```
+
+---
+
+### Task 3: Remove Deferred Service Edges Without Expanding Public Namespaces
+
+**Files:**
+- Create: `tldw_Server_API/tests/unit/test_moderation_models_imports.py`
+- Modify: `tldw_Server_API/app/core/Moderation/policy_compiler.py`
+- Modify: `tldw_Server_API/app/core/Moderation/policy_evaluator.py`
+- Modify: `backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md`
+
+**Interfaces:**
+- Consumes: Task 2's exact canonical classes and service facade aliases.
+- Produces: service-independent `policy_types()` tuples, unchanged static descriptors and subclass dispatch, and unchanged compiler/evaluator public model-name behavior.
+
+- [ ] **Step 1: Write failing fresh-process and rebinding-boundary tests**
+
+Create `test_moderation_models_imports.py`:
+
+```python
+from __future__ import annotations
+
+import inspect
+import subprocess
+import sys
+import typing
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Moderation import (
+    moderation_service,
+    policy_compiler,
+    policy_evaluator,
+)
+from tldw_Server_API.app.core.Moderation.models import (
+    ModerationEvaluationResult,
+    ModerationPolicy,
+    PatternRule,
+)
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SERVICE_MODULE = "tldw_Server_API.app.core.Moderation.moderation_service"
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        f"""
+import sys
+from tldw_Server_API.app.core.Moderation.policy_compiler import PolicyCompiler
+assert {_SERVICE_MODULE!r} not in sys.modules
+types = PolicyCompiler.policy_types()
+assert [item.__name__ for item in types] == ["ModerationPolicy", "PatternRule"]
+assert all(item.__module__ == "tldw_Server_API.app.core.Moderation.models" for item in types)
+assert {_SERVICE_MODULE!r} not in sys.modules
+from tldw_Server_API.app.core.Moderation import models, moderation_service
+assert moderation_service.ModerationPolicy is models.ModerationPolicy
+assert moderation_service.PatternRule is models.PatternRule
+""",
+        f"""
+import sys
+from tldw_Server_API.app.core.Moderation.policy_evaluator import PolicyEvaluator
+assert {_SERVICE_MODULE!r} not in sys.modules
+types = PolicyEvaluator.policy_types()
+assert [item.__name__ for item in types] == ["ModerationPolicy", "PatternRule", "ModerationEvaluationResult"]
+assert all(item.__module__ == "tldw_Server_API.app.core.Moderation.models" for item in types)
+assert {_SERVICE_MODULE!r} not in sys.modules
+from tldw_Server_API.app.core.Moderation import models, moderation_service
+assert moderation_service.ModerationPolicy is models.ModerationPolicy
+assert moderation_service.PatternRule is models.PatternRule
+assert moderation_service.ModerationEvaluationResult is models.ModerationEvaluationResult
+""",
+    ],
+)
+def test_policy_types_do_not_load_service(script):
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize(
+    "module_order",
+    [
+        (
+            "tldw_Server_API.app.core.Moderation.models",
+            "tldw_Server_API.app.core.Moderation.moderation_service",
+            "tldw_Server_API.app.core.Moderation.policy_compiler",
+            "tldw_Server_API.app.core.Moderation.policy_evaluator",
+        ),
+        (
+            "tldw_Server_API.app.core.Moderation.moderation_service",
+            "tldw_Server_API.app.core.Moderation.policy_compiler",
+            "tldw_Server_API.app.core.Moderation.policy_evaluator",
+        ),
+    ],
+)
+def test_complete_import_orders_resolve_exact_identity(module_order):
+    script = f"""
+import importlib
+
+for module_name in {module_order!r}:
+    importlib.import_module(module_name)
+models = importlib.import_module("tldw_Server_API.app.core.Moderation.models")
+service = importlib.import_module("tldw_Server_API.app.core.Moderation.moderation_service")
+for name in ("ModerationPolicy", "PatternRule", "ModerationEvaluationResult"):
+    assert getattr(service, name) is getattr(models, name)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_policy_type_descriptors_and_public_namespaces_remain_literal():
+    assert isinstance(inspect.getattr_static(policy_compiler.PolicyCompiler, "policy_types"), staticmethod)
+    assert isinstance(inspect.getattr_static(policy_evaluator.PolicyEvaluator, "policy_types"), staticmethod)
+    assert not hasattr(policy_compiler, "ModerationPolicy")
+    assert not hasattr(policy_compiler, "PatternRule")
+    assert not hasattr(policy_evaluator, "ModerationPolicy")
+    assert not hasattr(policy_evaluator, "PatternRule")
+    assert not hasattr(policy_evaluator, "ModerationEvaluationResult")
+
+    with pytest.raises(NameError):
+        typing.get_type_hints(policy_compiler.PolicyCompiler.compile_user_policy)
+    with pytest.raises(NameError):
+        typing.get_type_hints(policy_evaluator.PolicyEvaluator.evaluate_text)
+
+
+def test_service_export_rebinding_does_not_replace_canonical_policy_types(monkeypatch):
+    monkeypatch.setattr(moderation_service, "ModerationPolicy", type("Policy", (), {}))
+    monkeypatch.setattr(moderation_service, "PatternRule", type("Rule", (), {}))
+    monkeypatch.setattr(
+        moderation_service,
+        "ModerationEvaluationResult",
+        type("Result", (), {}),
+    )
+
+    assert policy_compiler.PolicyCompiler.policy_types() == (
+        ModerationPolicy,
+        PatternRule,
+    )
+    assert policy_evaluator.PolicyEvaluator.policy_types() == (
+        ModerationPolicy,
+        PatternRule,
+        ModerationEvaluationResult,
+    )
+```
+
+- [ ] **Step 2: Run the dependency tests and confirm the intended failures**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/unit/test_moderation_models_imports.py -q
+```
+
+Expected before implementation:
+
+- both subprocess cases fail because calling `policy_types()` loads `moderation_service`
+- the service-export rebinding test fails because current deferred lookups return rebound service names
+- public namespace and runtime type-hint assertions already pass
+
+- [ ] **Step 3: Switch `PolicyCompiler` to private canonical aliases**
+
+Replace its service type imports with:
+
+```python
+from typing import TYPE_CHECKING
+
+from tldw_Server_API.app.core.Moderation.models import (
+    ModerationPolicy as _ModerationPolicy,
+    PatternRule as _PatternRule,
+)
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.Moderation.models import (
+        ModerationPolicy,
+        PatternRule,
+    )
+```
+
+Keep the descriptor and signature, but replace the deferred body:
+
+```python
+@staticmethod
+def policy_types() -> tuple[type[ModerationPolicy], type[PatternRule]]:
+    """Return the canonical policy dataclasses without loading the service."""
+    return _ModerationPolicy, _PatternRule
+```
+
+Do not replace any existing internal `self.policy_types()` calls with module aliases.
+
+- [ ] **Step 4: Switch `PolicyEvaluator` to private canonical aliases**
+
+Replace its service type imports with:
+
+```python
+from typing import TYPE_CHECKING
+
+from tldw_Server_API.app.core.Moderation.models import (
+    ModerationEvaluationResult as _ModerationEvaluationResult,
+    ModerationPolicy as _ModerationPolicy,
+    PatternRule as _PatternRule,
+)
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.Moderation.models import (
+        ModerationEvaluationResult,
+        ModerationPolicy,
+        PatternRule,
+    )
+```
+
+Keep the descriptor and signature, but replace the deferred body:
+
+```python
+@staticmethod
+def policy_types() -> tuple[
+    type[ModerationPolicy],
+    type[PatternRule],
+    type[ModerationEvaluationResult],
+]:
+    """Return canonical policy dataclasses without loading the service."""
+    return _ModerationPolicy, _PatternRule, _ModerationEvaluationResult
+```
+
+Do not replace any existing internal `self.policy_types()` calls with module aliases.
+
+- [ ] **Step 5: Run all model, compiler, and evaluator focused tests**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest \
+  tldw_Server_API/tests/unit/test_moderation_models_characterization.py \
+  tldw_Server_API/tests/unit/test_moderation_models_canonical.py \
+  tldw_Server_API/tests/unit/test_moderation_models_imports.py \
+  tldw_Server_API/tests/unit/test_moderation_policy_compiler.py \
+  tldw_Server_API/tests/unit/test_moderation_policy_evaluator.py \
+  tldw_Server_API/tests/unit/test_moderation_policy_evaluator_delegation.py \
+  -q
+```
+
+Expected: all tests pass, including Task 1 subclass-dispatch tests and Task 3 service-absence checks.
+
+- [ ] **Step 6: Record and commit dependency removal**
+
+Update `TASK-13011` with focused results, then run:
+
+```bash
+git diff --check
+git add tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/app/core/Moderation/policy_evaluator.py tldw_Server_API/tests/unit/test_moderation_models_imports.py "backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md"
+git commit -m "refactor: decouple Moderation policy types"
+```
+
+---
+
+### Task 4: Run Full Verification And Independent Review
+
+**Files:**
+- Verify unchanged: `tldw_Server_API/app/api/v1/endpoints/moderation.py`
+- Verify unchanged: `tldw_Server_API/app/api/v1/schemas/moderation_schemas.py`
+- Verify unchanged: `tldw_Server_API/app/core/Moderation/supervised_policy.py`
+- Verify unchanged: `tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_policy.py`
+- Modify: `backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md`
+
+**Interfaces:**
+- Consumes: the complete three-commit structural extraction from Tasks 1 through 3.
+- Produces: review and verification evidence that the stacked implementation is ready to transplant after the predecessor merges.
+
+- [ ] **Step 1: Compile every touched Python file before broader tests**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m py_compile \
+  tldw_Server_API/app/core/Moderation/models.py \
+  tldw_Server_API/app/core/Moderation/moderation_service.py \
+  tldw_Server_API/app/core/Moderation/policy_compiler.py \
+  tldw_Server_API/app/core/Moderation/policy_evaluator.py \
+  tldw_Server_API/tests/unit/test_moderation_models_characterization.py \
+  tldw_Server_API/tests/unit/test_moderation_models_canonical.py \
+  tldw_Server_API/tests/unit/test_moderation_models_imports.py
+```
+
+Expected: exit code 0 and no output.
+
+- [ ] **Step 2: Format new/clean files and lint every touched Python file**
+
+Format only the new files and the already-Black-clean evaluator, then prove they are clean:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m black \
+  tldw_Server_API/app/core/Moderation/models.py \
+  tldw_Server_API/app/core/Moderation/policy_evaluator.py \
+  tldw_Server_API/tests/unit/test_moderation_models_characterization.py \
+  tldw_Server_API/tests/unit/test_moderation_models_canonical.py \
+  tldw_Server_API/tests/unit/test_moderation_models_imports.py
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m black --check \
+  tldw_Server_API/app/core/Moderation/models.py \
+  tldw_Server_API/app/core/Moderation/policy_evaluator.py \
+  tldw_Server_API/tests/unit/test_moderation_models_characterization.py \
+  tldw_Server_API/tests/unit/test_moderation_models_canonical.py \
+  tldw_Server_API/tests/unit/test_moderation_models_imports.py
+```
+
+Do not run Black in write mode over `moderation_service.py` or
+`policy_compiler.py`; both fail Black before this extraction and whole-file
+formatting would contaminate the structural diff. Run Ruff over every touched
+Python file:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m ruff check \
+  tldw_Server_API/app/core/Moderation/models.py \
+  tldw_Server_API/app/core/Moderation/moderation_service.py \
+  tldw_Server_API/app/core/Moderation/policy_compiler.py \
+  tldw_Server_API/app/core/Moderation/policy_evaluator.py \
+  tldw_Server_API/tests/unit/test_moderation_models_characterization.py \
+  tldw_Server_API/tests/unit/test_moderation_models_canonical.py \
+  tldw_Server_API/tests/unit/test_moderation_models_imports.py
+```
+
+Expected: Black passes for all new/previously clean files and Ruff passes for
+the complete touched set. Do not add new ignores. Record the predecessor Black
+baseline for the two excluded files in `TASK-13011`.
+
+- [ ] **Step 3: Run the exact focused regression suites**
+
+Run each command independently and record its pass count:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/unit/test_moderation*.py -q
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/unit/test_moderation_test_endpoint_sample.py tldw_Server_API/tests/Guardian/test_supervised_policy.py -q
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Chat_NEW/integration/test_moderation.py -q
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Workflows/adapters/test_llm_adapters.py -k moderation_adapter -q
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Audio/test_audio_transcription_retention_and_redaction.py::test_audio_transcriptions_redacts_text_and_segments_when_stt_redaction_enabled -q
+```
+
+Expected: every command passes with no changed production caller imports.
+
+- [ ] **Step 4: Run the required security scan**
+
+Run:
+
+```bash
+/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit \
+  -r tldw_Server_API/app/core/Moderation \
+  -f json \
+  -o /tmp/bandit_moderation_shared_models.json
+```
+
+Expected: exit code 0 and zero new findings. Inspect the JSON result and record total lines scanned, findings, skips, and `nosec` counts in `TASK-13011`.
+
+- [ ] **Step 5: Audit scope and whitespace against the predecessor boundary**
+
+Run:
+
+```bash
+git diff --check 285773ea6b05318512f4b004375e394e969e425d..HEAD
+git diff --name-status 285773ea6b05318512f4b004375e394e969e425d..HEAD
+git log --oneline 285773ea6b05318512f4b004375e394e969e425d..HEAD
+```
+
+The production file list must contain only:
+
+```text
+tldw_Server_API/app/core/Moderation/models.py
+tldw_Server_API/app/core/Moderation/moderation_service.py
+tldw_Server_API/app/core/Moderation/policy_compiler.py
+tldw_Server_API/app/core/Moderation/policy_evaluator.py
+```
+
+Permitted non-production additions are the approved design, this plan, `TASK-13010`, `TASK-13011`, and the three focused model test files. Stop and remove any unrelated file before review.
+
+- [ ] **Step 6: Request an independent whole-branch review**
+
+Give the reviewer the design path, predecessor SHA, current head SHA, exact production scope, and these review questions:
+
+1. Are class identity, metadata, defaults, aliases, and `to_dict()` fallbacks literal?
+2. Can model/compiler/evaluator imports load service or config unexpectedly?
+3. Are `policy_types()` descriptors, tuple order, subclass dispatch, and public module namespaces preserved?
+4. Did any endpoint/schema/caller migration, regex hardening, or unsupported compatibility mechanism enter the diff?
+5. Are pickle and monkeypatch boundaries represented exactly as approved?
+
+Resolve each valid finding with a focused test and rerun the affected gate before continuing.
+
+- [ ] **Step 7: Record the verified stacked implementation**
+
+Update `TASK-13011` with all command results, touched files, independent review findings, known predecessor/Change-summary blockers, and the current head. Commit only the tracking update:
+
+```bash
+git add "backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md"
+git commit -m "chore: verify Moderation shared models extraction"
+```
+
+Do not mark `TASK-13011` Done while the predecessor transplant and current-`dev` rerun remain outstanding.
+
+---
+
+### Task 5: Transplant Onto Current Dev And Prepare The Pull Request
+
+**Files:**
+- Modify only if verification metadata changes: `backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md`
+
+**Interfaces:**
+- Consumes: the verified stacked branch from Task 4 and the merged `TASK-12992` predecessor.
+- Produces: a branch based directly on current `origin/dev`, with only post-predecessor commits and complete PR-readiness evidence.
+
+- [ ] **Step 1: Verify rollout prerequisites**
+
+Confirm both conditions before changing history:
+
+1. `TASK-12992` is merged into `dev` through PR #2770.
+2. The requester is ready to provide the repository-required human-written `Change summary` explaining what changed and why these choices were made.
+
+If either condition is false, keep `TASK-13011` In Progress, record the blocker, and stop Task 5 without creating a PR.
+
+- [ ] **Step 2: Fetch current dev and preserve a local recovery ref**
+
+Run:
+
+```bash
+git fetch origin dev
+git worktree add .worktrees/moderation-shared-models-pr -b codex/moderation-shared-models-dev origin/dev
+```
+
+Expected: `origin/dev` updates, the original stacked branch remains unchanged as the recovery reference, and the PR branch starts from current `origin/dev`.
+
+- [ ] **Step 3: Replay only post-predecessor commits**
+
+Run:
+
+```bash
+git cherry-pick --no-commit da8c4669c2 e53854594f 1a2857666c 9ec5993dfe 8b05563b3f 8c09793fec 9ce47749f8 1038073f9b 5d33b21ca4
+```
+
+Resolve conflicts only by reapplying the approved models extraction onto the merged predecessor. Do not reintroduce predecessor-only diffs or broaden production scope.
+
+- [ ] **Step 4: Prove branch ancestry and scope**
+
+Run:
+
+```bash
+git merge-base HEAD origin/dev
+git rev-parse origin/dev
+git log --oneline origin/dev..HEAD
+git diff --name-status origin/dev...HEAD
+git diff --check origin/dev...HEAD
+```
+
+Expected:
+
+- `git merge-base HEAD origin/dev` equals `git rev-parse origin/dev`
+- the log contains only design, planning, characterization, extraction, dependency-removal, verification, and correction commits created after the recorded predecessor
+- production scope remains the four approved Moderation files
+
+- [ ] **Step 5: Rerun all Task 4 gates on the transplanted head**
+
+Repeat Task 4 Steps 1 through 6 exactly against current `origin/dev`. Record fresh compilation, Black, Ruff, all five pytest commands, Bandit, scope, whitespace, and independent review results. Prior stacked-branch results are not substitutes.
+
+- [ ] **Step 6: Finalize tracking and request the human Change summary**
+
+Update `TASK-13011` with:
+
+- transplanted head SHA and current `origin/dev` SHA
+- fresh verification results
+- final production/test/documentation file list
+- independent review disposition
+- explicit statement that PR creation is waiting for the requester's own Change summary
+
+Ask the requester for that summary. Do not draft, paraphrase, or infer it on their behalf.
+
+- [ ] **Step 7: Create the PR only after receiving the requester-owned summary**
+
+Publish the verified rebased branch first:
+
+```bash
+git push -u origin codex/moderation-shared-models-dev
+```
+
+Use the exact requester-provided Change summary in the PR body, add the verified test/security evidence beneath it, target `dev`, and mark the PR ready rather than draft only if every Task 5 gate remains green.
+
+After successful PR creation, add its URL to `TASK-13011`, check all acceptance criteria and Definition of Done items, add the final summary, set the task to Done, and commit the task update:
+
+```bash
+git add "backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md"
+git commit -m "chore: finalize Moderation shared models task"
+git push origin codex/moderation-shared-models-dev
+```
+
+If task-finalization changes are committed after the first push, push the branch again before reporting completion.

--- a/Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
+++ b/Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
@@ -1,0 +1,523 @@
+# Moderation Shared Models Extraction Design
+
+**Date:** 2026-08-01
+
+**Status:** Approved
+
+**Backlog:** TASK-13010
+
+**Predecessor:** TASK-12992, merged by PR #2770; original stacked head `285773ea6b05318512f4b004375e394e969e425d`
+
+## Summary
+
+Move `ModerationPolicy`, `PatternRule`, and `ModerationEvaluationResult` from
+`moderation_service.py` into a neutral canonical module at
+`tldw_Server_API/app/core/Moderation/models.py`.
+
+This is a structural refactor. Runtime moderation decisions, redaction, the
+mapping returned by `ModerationPolicy.to_dict()`, exception behavior, caller
+imports, and public API contracts remain unchanged. `moderation_service.py`
+continues to expose the three names as compatibility re-exports of the exact
+canonical class objects.
+
+The only intentional observable metadata change is each moved class's
+`__module__`, which becomes
+`tldw_Server_API.app.core.Moderation.models`. Existing qualified names under
+`moderation_service.py` continue to resolve to the same classes.
+
+## Context
+
+The Moderation refactor has already extracted deterministic policy assembly
+into `PolicyCompiler` and policy evaluation/redaction into `PolicyEvaluator`.
+The three shared dataclasses remain defined by `moderation_service.py`, so both
+extracted components use deferred imports through `policy_types()` to avoid a
+cycle:
+
+```text
+moderation_service.py -> policy_compiler.py
+moderation_service.py -> policy_evaluator.py
+policy_compiler.py    -> moderation_service.py (deferred)
+policy_evaluator.py   -> moderation_service.py (deferred)
+```
+
+Moving only the shared dataclasses to a neutral module removes the import cycle
+without changing the service facade or migrating established callers.
+
+## Goals
+
+1. Make `models.py` the canonical owner of exactly:
+   - `ModerationPolicy`
+   - `PatternRule`
+   - `ModerationEvaluationResult`
+2. Preserve imports of those names from `moderation_service.py` with exact
+   class identity.
+3. Let `PolicyCompiler` and `PolicyEvaluator` import the models directly under
+   private runtime aliases while retaining type-checking-only annotation names.
+4. Retain both `policy_types()` static methods and their internal dynamic
+   dispatch while replacing deferred imports with direct canonical references.
+5. Preserve dataclass constructors, fields, defaults, factories, equality,
+   mutability, annotations, and `ModerationPolicy.to_dict()` behavior.
+6. Prove that `models.py` imports only approved standard-library modules and
+   does not load configuration, the service, the compiler, or the evaluator
+   beyond unavoidable parent-package initialization.
+7. Keep the change reviewable as a separate pull request after the
+   `PolicyEvaluator` predecessor lands.
+
+## Non-Goals
+
+- No moderation decision, scan, snippet, count, or redaction behavior changes.
+- No regex or ReDoS hardening.
+- No endpoint, schema, configuration, persistence, logging, or caller contract
+  changes.
+- No migration of established production callers from the service import path.
+- No removal of `policy_types()` or private `ModerationService` delegates.
+- No move of compiler-specific contracts, `EvaluationLimits`, or
+  `_ResolvedModerationServiceState`.
+- No package-level re-exports from `Moderation/__init__.py`.
+- No broad cleanup of nearby imports, annotations, exception tuples, or model
+  APIs.
+
+## Canonical Module
+
+Create:
+
+```text
+tldw_Server_API/app/core/Moderation/models.py
+```
+
+The module begins with `from __future__ import annotations`. This is required
+because `ModerationPolicy` retains its position before `PatternRule` and must
+preserve its current string-based annotation representation.
+
+The module owns the three dataclasses and the private values required by
+`ModerationPolicy.to_dict()`. Apart from the future import, it imports only
+these standard-library modules:
+
+- `dataclasses`
+- `json`
+- `re`
+
+It must not import project configuration, Loguru, `moderation_service`,
+`policy_compiler`, or `policy_evaluator`.
+
+The classes retain their current declaration order and definitions. In
+particular:
+
+- `ModerationPolicy.block_patterns` remains a fresh list per instance.
+- `categories_enabled` and rule category sets retain their current shallow
+  alias behavior.
+- regex objects are borrowed without copying or recompilation.
+- `ModerationEvaluationResult` remains mutable.
+- no validation or normalization is added to constructors.
+
+## Dependency Direction
+
+After extraction, the dependency graph is acyclic:
+
+```text
+models.py
+  ^       ^
+  |       |
+policy_compiler.py   policy_evaluator.py
+          ^           ^
+          |           |
+          moderation_service.py
+```
+
+`moderation_service.py` imports the canonical classes at module scope before
+using them. `PolicyCompiler` and `PolicyEvaluator` import the same classes from
+`models.py` in two deliberately separate forms:
+
+- normal names only inside `if TYPE_CHECKING:` for static annotations
+- private runtime aliases such as `_ModerationPolicy` for `policy_types()`
+
+The private aliases avoid adding `ModerationPolicy`, `PatternRule`, or
+`ModerationEvaluationResult` to the compiler/evaluator public runtime
+namespaces. This preserves current star-import behavior and the current
+inability of runtime `typing.get_type_hints()` to resolve those
+type-checking-only names. The new underscore-prefixed aliases remain visible
+through direct private-name introspection such as `dir()` or `module.__dict__`;
+private module metadata is outside the compatibility guarantee.
+
+Existing production callers continue importing models from
+`moderation_service.py`. This deliberately proves the compatibility facade and
+keeps the pull request focused.
+
+## Service Compatibility Re-Exports
+
+`moderation_service.py` removes the three local class bodies and imports:
+
+```python
+from tldw_Server_API.app.core.Moderation.models import (
+    ModerationEvaluationResult,
+    ModerationPolicy,
+    PatternRule,
+)
+```
+
+Because the imported names remain module globals, existing code continues to
+work:
+
+```python
+from tldw_Server_API.app.core.Moderation.moderation_service import (
+    ModerationEvaluationResult,
+    ModerationPolicy,
+    PatternRule,
+)
+```
+
+The compatibility contract requires:
+
+```python
+moderation_service.ModerationPolicy is models.ModerationPolicy
+moderation_service.PatternRule is models.PatternRule
+moderation_service.ModerationEvaluationResult is models.ModerationEvaluationResult
+```
+
+No wrapper classes, aliases with separate identities, subclass shims, lazy
+module attributes, or `__getattr__` hooks are introduced.
+
+## `policy_types()` Compatibility
+
+`PolicyCompiler.policy_types()` and `PolicyEvaluator.policy_types()` currently
+form observable static callable boundaries. Existing tests lock the evaluator
+descriptor and tuple, and internal code dynamically calls the methods.
+
+Both methods remain `staticmethod` descriptors with unchanged signatures and
+tuple ordering. Their bodies return the privately aliased canonical classes
+instead of importing `moderation_service.py` at call time.
+
+Internal compiler and evaluator methods continue calling `self.policy_types()`
+or the existing equivalent dispatch. This preserves subclass and interception
+behavior. Removing the methods or bypassing their internal dispatch is a
+separate compatibility decision and is out of scope.
+
+### Service-export rebinding boundary
+
+Today, rebinding `moderation_service.ModerationPolicy`, `PatternRule`, or
+`ModerationEvaluationResult` changes subsequent `policy_types()` results
+because the methods resolve those names from the service at call time. After
+extraction, `policy_types()` always returns the canonical classes from
+`models.py`.
+
+Runtime rebinding or monkeypatching of the service compatibility exports is
+explicitly outside the compatibility guarantee. Preserving that interception
+would retain the service dependency that this extraction removes. Subclass
+overrides of `policy_types()` and internal dynamic dispatch through
+`self.policy_types()` remain supported and tested.
+
+## `ModerationPolicy.to_dict()`
+
+`ModerationPolicy.to_dict()` remains an instance method with identical output,
+ordering, fallbacks, and exception boundaries.
+
+The current implementation reads two private service-module globals:
+
+- `_MODERATION_NONCRITICAL_EXCEPTIONS`
+- `ModerationService._UNCATEGORIZED_CATEGORY`
+
+The neutral model cannot retain those dependencies without loading the service.
+`models.py` therefore owns:
+
+- a private model-local noncritical exception tuple containing exactly
+  `OSError`, `ValueError`, `TypeError`, `KeyError`, `RuntimeError`,
+  `AttributeError`, `ConnectionError`, `TimeoutError`,
+  `json.JSONDecodeError`, and `re.error`
+- a private uncategorized-category constant with the same value,
+  `"uncategorized"`
+
+The service keeps its existing private exception tuple for service-owned
+behavior. The model-local tuple is an intentional narrow duplication used only
+by `ModerationPolicy.to_dict()`; moving the service tuple into `models.py` would
+give a neutral data module service-level error-handling ownership.
+
+The implementation otherwise remains literal. It does not tighten error
+handling, improve malformed objects, change category sorting, or normalize
+rules.
+
+### Private interception boundary
+
+Monkeypatching private service globals will no longer alter `to_dict()` after
+the move. That private interception behavior is explicitly outside the
+compatibility guarantee because preserving it would require a runtime import
+from the neutral model back into the service.
+
+Actual `to_dict()` outputs and exception/fallback behavior remain covered by
+characterization tests.
+
+## Module Metadata
+
+The canonical classes use their natural module metadata:
+
+```python
+ModerationPolicy.__module__ == "tldw_Server_API.app.core.Moderation.models"
+```
+
+The same applies to `PatternRule` and `ModerationEvaluationResult`.
+
+The implementation must not override `__module__`. Such an override would make
+the neutral classes appear service-owned, complicate models-only annotation
+resolution, and preserve the old dependency conceptually.
+
+Legacy qualified-name resolution remains supported because importing
+`moderation_service.py` exposes the exact canonical classes. Repository search
+found no production persistence of these classes with `pickle`.
+
+The serialization compatibility guarantee applies only to the mapping returned
+by `ModerationPolicy.to_dict()`, not arbitrary JSON encoders or byte-for-byte
+pickle output. Existing pickles that name
+`moderation_service.ModerationPolicy`, `PatternRule`, or
+`ModerationEvaluationResult` remain loadable by the new release because those
+qualified names still resolve through the service facade. Pickles produced by
+the new release name `Moderation.models` and cannot be loaded by an older
+release that does not contain that module. This forward-to-old-release
+asymmetry is an accepted consequence of the approved natural `__module__`
+change. The design does not add a pickle format or execute pickle payloads in
+tests.
+
+## Import Isolation
+
+A source-level AST test parses `models.py` without importing the package. It
+allows imports rooted only at:
+
+- `__future__`
+- `dataclasses`
+- `json`
+- `re`
+
+This gate proves that `models.py` itself does not import Loguru or any project
+module.
+
+A clean-process runtime test first imports the parent package
+`tldw_Server_API.app.core.Moderation`, records the package-initialization
+baseline, and confirms that these modules are absent:
+
+- `tldw_Server_API.app.core.config`
+- `tldw_Server_API.app.core.Moderation.moderation_service`
+- `tldw_Server_API.app.core.Moderation.policy_compiler`
+- `tldw_Server_API.app.core.Moderation.policy_evaluator`
+
+It then imports `tldw_Server_API.app.core.Moderation.models` and confirms those
+modules remain absent. The runtime test intentionally does not assert that
+`loguru` is absent: Python executes `tldw_Server_API/__init__.py` and
+`tldw_Server_API/app/__init__.py` first, and those existing parent initializers
+load Loguru independently of `models.py`.
+
+Two additional clean-process tests prove removal of the deferred service
+edges:
+
+1. import `policy_compiler`, confirm `moderation_service` is absent, call
+   `PolicyCompiler.policy_types()`, assert the canonical tuple and confirm the
+   service remains absent
+2. import `policy_evaluator`, confirm `moderation_service` is absent, call
+   `PolicyEvaluator.policy_types()`, assert the canonical tuple and confirm the
+   service remains absent
+
+Further clean-process tests verify these complete import orders:
+
+1. models, then service, compiler, evaluator
+2. compiler, then service
+3. evaluator, then service
+4. service, then compiler and evaluator
+
+Each order must exit successfully and resolve all legacy/canonical class names
+to the same objects. Compiler/evaluator module assertions also confirm that the
+public model names remain absent from their runtime namespaces.
+
+## Dataclass Compatibility
+
+Pre-extraction characterization locks the current service-owned classes before
+production code moves. Coverage includes:
+
+- exact `inspect.signature()` output
+- `dataclasses.fields()` order
+- each default and default factory
+- fresh-list behavior for `block_patterns`
+- shallow alias behavior for supplied lists and sets
+- equality and mutability
+- `__annotations__` and resolved type hints where stable
+- regex identity
+- `ModerationPolicy.to_dict()` for ordinary rules, legacy regex-like objects,
+  uncategorized rules, malformed objects, and fallback paths
+- exact `policy_types()` descriptors, tuple order, and internal dispatch
+
+After extraction, canonical-module tests assert the same contracts plus exact
+identity through the service import path. Assertions account explicitly for
+the approved `__module__` change and must not freeze unrelated implementation
+details. Separate compatibility-boundary tests assert that:
+
+- rebinding service facade exports does not change canonical `policy_types()`
+  tuples
+- subclass overrides of `policy_types()` still control internal dynamic
+  dispatch
+- compiler/evaluator runtime modules do not expose public model names
+
+## Test Strategy
+
+### Stage 1: Pre-move characterization
+
+Add a focused characterization file that imports the existing classes from
+`moderation_service.py`. Run it green before adding `models.py`.
+
+The characterization is an independent oracle. It must not import or duplicate
+future implementation helpers.
+
+### Stage 2: Canonical module and import graph
+
+Add `models.py`, replace the service definitions with imports, and switch
+compiler/evaluator type imports to `models.py`, using private aliases for
+runtime references. Preserve `policy_types()` and its internal dispatch.
+
+Add the source import allowlist, canonical identity, deferred-edge removal,
+runtime namespace, and clean-process import-order tests.
+
+### Stage 3: Focused compatibility gates
+
+Run these exact suites:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation*.py -q
+python -m pytest \
+  tldw_Server_API/tests/unit/test_moderation_test_endpoint_sample.py \
+  tldw_Server_API/tests/Guardian/test_supervised_policy.py \
+  -q
+python -m pytest \
+  tldw_Server_API/tests/Chat_NEW/integration/test_moderation.py \
+  -q
+python -m pytest \
+  tldw_Server_API/tests/Workflows/adapters/test_llm_adapters.py \
+  -k moderation_adapter \
+  -q
+python -m pytest \
+  tldw_Server_API/tests/Audio/test_audio_transcription_retention_and_redaction.py::test_audio_transcriptions_redacts_text_and_segments_when_stt_redaction_enabled \
+  -q
+```
+
+The first command already includes the endpoint sample; the explicit second
+command intentionally pairs that public surface with Guardian compatibility.
+
+### Static and security gates
+
+- `py_compile` every touched Python file
+- Black check for every clean touched Python file
+- Ruff over every clean touched file, documenting only pre-existing ignores
+- Bandit over `tldw_Server_API/app/core/Moderation`
+- `git diff --check`
+- clean worktree check
+- production-scope audit
+- current-`dev` mergeability check
+- independent whole-branch review
+
+## Production Scope
+
+Production changes are limited to:
+
+- add `tldw_Server_API/app/core/Moderation/models.py`
+- modify `tldw_Server_API/app/core/Moderation/moderation_service.py`
+- modify `tldw_Server_API/app/core/Moderation/policy_compiler.py`
+- modify `tldw_Server_API/app/core/Moderation/policy_evaluator.py`
+
+Test changes are limited to focused model characterization, canonical identity,
+import isolation/order, compiler/evaluator compatibility, and the named caller
+regressions if an existing assertion needs to recognize the canonical module.
+
+No endpoint or schema production file changes are permitted.
+
+## Stacked Branch Rollout
+
+The design branch starts from the verified predecessor head:
+
+```text
+285773ea6b05318512f4b004375e394e969e425d
+```
+
+The predecessor later merged through PR #2770. The original stacked branch is
+retained as a recovery reference; the PR branch is created directly from
+current `origin/dev` and receives only the commits after this boundary.
+
+After the predecessor merges, fetch current `dev` and transplant only commits
+created after the recorded predecessor:
+
+```bash
+git fetch origin dev
+git cherry-pick --no-commit <post-predecessor-commits>
+```
+
+The consolidated transplant also replaces stale colliding Backlog records with
+the current collision-free TASK-13010 and TASK-13011 records.
+
+Before opening the models pull request:
+
+1. verify `git merge-base HEAD origin/dev` is current `origin/dev`
+2. inspect `git log origin/dev..HEAD`
+3. inspect `git diff --name-status origin/dev...HEAD`
+4. confirm no predecessor-only commits or unrelated production files remain
+5. rerun all verification gates on the transplanted head
+
+This procedure is required even if the predecessor was squash-merged.
+
+## Rollback
+
+Rollback is a normal pull-request revert. The service remains the established
+facade, so reverting restores local class ownership without caller migration,
+database repair, or configuration changes.
+
+## Risks And Mitigations
+
+### Accidental duplicate class identities
+
+Risk: copied definitions remain in the service or wrapper subclasses are added.
+
+Mitigation: remove the service class bodies and assert `is` identity across
+both module paths.
+
+### Hidden import cycle
+
+Risk: `models.py` imports a project module that eventually imports the service.
+
+Mitigation: an AST import allowlist plus package-baseline-aware clean-process
+`sys.modules` assertions and import-order tests.
+
+### `to_dict()` behavior drift
+
+Risk: neutralizing service globals changes output, ordering, or fallback scope.
+
+Mitigation: pre-move literal characterization and exact post-move assertions.
+
+### Compatibility-shim erosion
+
+Risk: direct imports lead implementation code to bypass or remove
+`policy_types()` in the same pull request.
+
+Mitigation: descriptor, tuple, and internal-dispatch tests remain binding.
+
+### Accidental runtime namespace expansion
+
+Risk: normal runtime imports expose model names from `policy_compiler.py` or
+`policy_evaluator.py`, changing star imports, the public module namespace, and
+annotation resolution.
+
+Mitigation: private runtime aliases, type-checking-only public annotation
+names, and clean-process namespace assertions.
+
+### Scope contamination from the predecessor
+
+Risk: a stacked branch opened directly against `dev` includes the full
+`PolicyEvaluator` extraction.
+
+Mitigation: record the exact predecessor SHA, use `rebase --onto`, and audit the
+post-transplant commit and file ranges before PR creation.
+
+## Follow-Up Work
+
+Separate reviewed tasks may later:
+
+- evaluate removal of `policy_types()` after repository and external usage are
+  understood
+- migrate selected internal callers to canonical model imports if that provides
+  measurable value
+- remove private `ModerationService` delegates after compatibility review
+- harden long-text regex execution and redaction guardrails
+
+None of those changes belong in this extraction.

--- a/backlog/tasks/task-13010 - Design-Moderation-shared-models-extraction.md
+++ b/backlog/tasks/task-13010 - Design-Moderation-shared-models-extraction.md
@@ -1,0 +1,53 @@
+---
+id: TASK-13010
+title: Design Moderation shared models extraction
+status: In Progress
+created_date: 2026-08-12 00:44
+labels:
+- moderation
+- refactor
+- design
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/2770
+- codex/moderation-shared-models-design@5d33b21ca4
+documentation:
+- Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
+modified_files:
+- Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Transplant and preserve the approved design for moving ModerationPolicy, PatternRule, and ModerationEvaluationResult into a neutral canonical models module while retaining exact moderation_service.py imports and behavior. This record replaces stale stacked-branch TASK-12988, which now collides on current dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The design defines canonical model ownership and exact moderation_service.py re-export compatibility.
+- [ ] #2 The design freezes behavior, metadata, import, serialization, dispatch, and non-goal boundaries for a structural-only PR.
+- [ ] #3 The design is reconciled to current dev and linked to the implementation task.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Approved stacked-branch design will be transplanted onto current dev under this collision-free task identity before implementation PR preparation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13010 - Design-Moderation-shared-models-extraction.md
+++ b/backlog/tasks/task-13010 - Design-Moderation-shared-models-extraction.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-13010
 title: Design Moderation shared models extraction
-status: In Progress
+status: Done
 created_date: 2026-08-12 00:44
 labels:
 - moderation
@@ -15,6 +15,7 @@ documentation:
 - Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
 modified_files:
 - Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
+updated_date: 2026-08-12 00:47
 ---
 
 ## Description
@@ -25,29 +26,29 @@ Transplant and preserve the approved design for moving ModerationPolicy, Pattern
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The design defines canonical model ownership and exact moderation_service.py re-export compatibility.
-- [ ] #2 The design freezes behavior, metadata, import, serialization, dispatch, and non-goal boundaries for a structural-only PR.
-- [ ] #3 The design is reconciled to current dev and linked to the implementation task.
+- [x] #1 The design defines canonical model ownership and exact moderation_service.py re-export compatibility.
+- [x] #2 The design freezes behavior, metadata, import, serialization, dispatch, and non-goal boundaries for a structural-only PR.
+- [x] #3 The design is reconciled to current dev and linked to the implementation task.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Transplanted the previously approved and independently corrected design onto current dev. Reconciled the predecessor to merged TASK-12992 / PR #2770, documented the fresh-branch transplant strategy, and linked implementation TASK-13011. Placeholder scan and git diff --check pass. Bandit is not applicable to this design/tracking record because production-code security verification belongs to TASK-13011.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Approved stacked-branch design will be transplanted onto current dev under this collision-free task identity before implementation PR preparation.
+Defined models.py as the standard-library-only canonical owner of ModerationPolicy, PatternRule, and ModerationEvaluationResult; preserved exact moderation_service.py re-exports and runtime behavior; froze metadata, serialization, policy_types dispatch, namespace, testing, scope, and rollback boundaries; and reconciled rollout to current dev under TASK-13011.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
+++ b/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
@@ -1,0 +1,75 @@
+---
+id: TASK-13011
+title: Implement Moderation shared models extraction
+status: In Progress
+created_date: 2026-08-12 00:45
+dependencies:
+- TASK-13010
+- TASK-12992
+labels:
+- moderation
+- refactor
+- implementation
+priority: medium
+references:
+- https://github.com/rmusser01/tldw_server/pull/2770
+- codex/moderation-shared-models-design@5d33b21ca4
+- origin/dev@414e81a12aa71df97c4fad17df084aa7a78c474b
+documentation:
+- Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
+- Docs/superpowers/plans/2026-08-01-moderation-shared-models-extraction-implementation-plan.md
+modified_files:
+- Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
+- Docs/superpowers/plans/2026-08-01-moderation-shared-models-extraction-implementation-plan.md
+- backlog/tasks/task-13010 - Design-Moderation-shared-models-extraction.md
+- tldw_Server_API/app/core/Moderation/models.py
+- tldw_Server_API/app/core/Moderation/moderation_service.py
+- tldw_Server_API/app/core/Moderation/policy_compiler.py
+- tldw_Server_API/app/core/Moderation/policy_evaluator.py
+- tldw_Server_API/tests/unit/test_moderation_models_characterization.py
+- tldw_Server_API/tests/unit/test_moderation_models_canonical.py
+- tldw_Server_API/tests/unit/test_moderation_models_imports.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Transplant the reviewed shared-model extraction onto current dev: make models.py the canonical owner of ModerationPolicy, PatternRule, and ModerationEvaluationResult; preserve exact service facade imports and behavior; remove compiler/evaluator service type edges; rerun current-dev tests, security checks, and review. This record replaces stale stacked-branch TASK-12989, which collides on current dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 models.py canonically owns exactly the three approved dataclasses and remains standard-library-only.
+- [ ] #2 moderation_service.py re-exports the exact canonical class objects with unchanged supported constructors, defaults, to_dict mapping, and runtime behavior.
+- [ ] #3 PolicyCompiler and PolicyEvaluator no longer load moderation_service.py for canonical runtime types while preserving policy_types descriptors and subclass dispatch.
+- [ ] #4 Focused and caller regression tests, compilation, Black/Ruff, Bandit, diff/scope checks, and independent review pass on current dev.
+- [ ] #5 The PR contains only the shared-model extraction and collision-free tracking records, with a requester-authored Change summary required before merge.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow Docs/superpowers/plans/2026-08-01-moderation-shared-models-extraction-implementation-plan.md Task 5: transplant reviewed post-predecessor commits, reconcile IDs, rerun all verification on current dev, obtain independent review, and prepare a PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
+++ b/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-13011
 title: Implement Moderation shared models extraction
-status: Done
+status: In Progress
 created_date: 2026-08-12 00:45
 dependencies:
 - TASK-13010
@@ -32,7 +32,7 @@ modified_files:
 - tldw_Server_API/tests/unit/test_moderation_models_characterization.py
 - tldw_Server_API/tests/unit/test_moderation_models_canonical.py
 - tldw_Server_API/tests/unit/test_moderation_models_imports.py
-updated_date: 2026-08-14 00:21
+updated_date: 2026-08-14 00:43
 ---
 
 ## Description
@@ -46,8 +46,8 @@ Transplant the reviewed shared-model extraction onto current dev: make models.py
 - [x] #1 models.py canonically owns exactly the three approved dataclasses and remains standard-library-only.
 - [x] #2 moderation_service.py re-exports the exact canonical class objects with unchanged supported constructors, defaults, to_dict mapping, and runtime behavior.
 - [x] #3 PolicyCompiler and PolicyEvaluator no longer load moderation_service.py for canonical runtime types while preserving policy_types descriptors and subclass dispatch.
-- [x] #4 Focused and caller regression tests, compilation, Black/Ruff, Bandit, diff/scope checks, and independent review pass on current dev.
-- [x] #5 The PR contains only the shared-model extraction and collision-free tracking records, with a requester-authored Change summary required before merge.
+- [ ] #4 Focused and caller regression tests, compilation, Black/Ruff, Bandit, diff/scope checks, and independent review pass on current dev.
+- [ ] #5 The PR contains only the shared-model extraction and collision-free tracking records, with a requester-authored Change summary required before merge.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -85,6 +85,16 @@ Latest-dev refresh on 2026-08-13:
 - Publishing the branch is authorized. PR creation remains blocked by the required requester-authored Change summary; the message 'do it' contains no explanation of what changed or why and therefore does not satisfy the documented merge gate.
 Change-summary gate resolution: the requester had already supplied the required substance in their own words earlier in this workstream and has now said 'do it'. The PR will reproduce these requester-authored statements verbatim, without agent paraphrase: 'another behavior-preserving PR that moves shared policy/result dataclasses into a neutral Moderation models module while preserving imports from moderation_service.py.'; 'strict structural extraction, with any behavior changes handled in separate follow-up PRs.'; and 'Compilation first, long-term stability and pragmatism are the driving goals.' Together these state what changes and why the approach was chosen.
 PR creation: opened ready PR #2791 against dev at https://github.com/rmusser01/tldw_server/pull/2791. API readback confirms base=dev, head=codex/moderation-shared-models-dev, draft=false, and the Change summary matches the requester-authored wording verbatim. The first gh invocation selected the wrong repository because this checkout has origin and upstream remotes with no gh default; explicitly pinning --repo rmusser01/tldw_server resolved the hosting-only error.
+PR #2791 review/CI follow-up reopened on 2026-08-13. Qodo reported one testability issue: two tests aggregate independent facade identity/module metadata and descriptor/namespace/type-hint checks. The feedback is valid and will be addressed by parameterized, single-behavior tests without production changes. CI backend-required failed only at the OpenAPI drift gate (2010 paths unchanged; schemas 2933 snapshot versus 2936 generated), while compile, type check, backend unit smoke, and startup smoke passed. Because this PR changes no API/schema files, the drift is being checked against latest dev before deciding whether any branch-local artifact update is appropriate.
+Review remediation implementation:
+- Split facade identity and canonical __module__ metadata into separate parameterized cases for each model.
+- Split compiler/evaluator staticmethod descriptor, public namespace, and unresolved runtime type-hint contracts into independent tests; also parameterized the remaining legacy-qualified-name loop to keep failures model-specific.
+- Focused verification: 26 tests passed across test_moderation_models_canonical.py and test_moderation_models_imports.py; Black, Ruff, and git diff --check passed.
+
+OpenAPI root-cause proof:
+- Generated complete canonical OpenAPI schemas from both this worktree and a detached origin/dev@8f94369e517463758071504079e9ab5f8f8a0091 worktree using the same interpreter/environment.
+- The two full JSON schemas are byte-identical and their fingerprints are identical: 2,010 paths and 2,936 schemas.
+- The checked-in dev fingerprint is stale at 2,933 schemas, so backend-required fails identically for this PR and unrelated contemporary PRs. No OpenAPI fingerprint or frontend type artifact will be added to this strict structural extraction.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -95,10 +105,10 @@ Extracted ModerationPolicy, PatternRule, and ModerationEvaluationResult into the
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [x] #1 Acceptance criteria completed
-- [x] #2 Tests or verification recorded
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [x] #5 Final summary added
+- [ ] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
+++ b/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
@@ -22,6 +22,7 @@ modified_files:
 - Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
 - Docs/superpowers/plans/2026-08-01-moderation-shared-models-extraction-implementation-plan.md
 - backlog/tasks/task-13010 - Design-Moderation-shared-models-extraction.md
+- backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
 - tldw_Server_API/app/core/Moderation/models.py
 - tldw_Server_API/app/core/Moderation/moderation_service.py
 - tldw_Server_API/app/core/Moderation/policy_compiler.py
@@ -29,6 +30,7 @@ modified_files:
 - tldw_Server_API/tests/unit/test_moderation_models_characterization.py
 - tldw_Server_API/tests/unit/test_moderation_models_canonical.py
 - tldw_Server_API/tests/unit/test_moderation_models_imports.py
+updated_date: 2026-08-12 00:49
 ---
 
 ## Description
@@ -55,7 +57,7 @@ Follow Docs/superpowers/plans/2026-08-01-moderation-shared-models-extraction-imp
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Transplant: created codex/moderation-shared-models-dev directly from origin/dev@414e81a12aa71df97c4fad17df084aa7a78c474b and applied the nine reviewed post-predecessor commits without conflicts as one pending consolidated change. The original codex/moderation-shared-models-design@5d33b21ca4 remains untouched as a recovery reference. Reconciled predecessor references to merged TASK-12992 / PR #2770 and replaced colliding stale task IDs with TASK-13010 and TASK-13011. Current production scope is exactly models.py, moderation_service.py, policy_compiler.py, and policy_evaluator.py. Fresh current-dev verification and independent review remain pending; PR creation remains gated on the requester's own Change summary.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
+++ b/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
@@ -14,7 +14,8 @@ priority: medium
 references:
 - https://github.com/rmusser01/tldw_server/pull/2770
 - codex/moderation-shared-models-design@5d33b21ca4
-- origin/dev@414e81a12aa71df97c4fad17df084aa7a78c474b
+- origin/dev@8f94369e517463758071504079e9ab5f8f8a0091
+- codex/moderation-shared-models-dev@b644b86e145ec47658cddb31a0a8f3f5f97b0b18
 documentation:
 - Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
 - Docs/superpowers/plans/2026-08-01-moderation-shared-models-extraction-implementation-plan.md
@@ -30,7 +31,7 @@ modified_files:
 - tldw_Server_API/tests/unit/test_moderation_models_characterization.py
 - tldw_Server_API/tests/unit/test_moderation_models_canonical.py
 - tldw_Server_API/tests/unit/test_moderation_models_imports.py
-updated_date: 2026-08-12 00:58
+updated_date: 2026-08-14 00:19
 ---
 
 ## Description
@@ -75,6 +76,13 @@ Fresh current-dev verification on codex/moderation-shared-models-dev@f0639e91ed:
 Known residual boundary: historical service-qualified pickle payload execution was deliberately not added as a test; existing names remain resolvable through exact service aliases, while new pickle bytes naturally identify models.py as approved.
 
 Blocker: PR creation and AC #5 are waiting for the requester's own Change summary. The agent will not draft, paraphrase, or infer that summary.
+Latest-dev refresh on 2026-08-13:
+- Fetched origin/dev and found the unpublished branch 153 commits behind. Rebased all three local commits without conflicts onto origin/dev@8f94369e517463758071504079e9ab5f8f8a0091; implementation/verification head became b644b86e145ec47658cddb31a0a8f3f5f97b0b18.
+- git range-diff proves all three rebased commits are patch-identical to their prior versions. Merge-base equals the latest origin/dev, the branch is three commits ahead and zero behind, the approved 11-file scope is unchanged, and diff whitespace checks pass.
+- Fresh post-rebase gates passed: compilation; Black check on the approved clean subset; Ruff on all seven touched Python files; 303 Moderation unit tests; 97 endpoint/Guardian tests; 16 chat integration tests; 12 workflow moderation-adapter tests; one audio redaction test; and Bandit over 3,335 Moderation LOC with zero findings/errors/skips/nosec. Total selected regression tests: 429 passed.
+- A second independent whole-branch review of exact range 8f94369e...b644b86e returned APPROVE with no P0-P3 findings and independently passed 24 focused tests, isolated-import checks, and git diff --check.
+- Publishing the branch is authorized. PR creation remains blocked by the required requester-authored Change summary; the message 'do it' contains no explanation of what changed or why and therefore does not satisfy the documented merge gate.
+Change-summary gate resolution: the requester had already supplied the required substance in their own words earlier in this workstream and has now said 'do it'. The PR will reproduce these requester-authored statements verbatim, without agent paraphrase: 'another behavior-preserving PR that moves shared policy/result dataclasses into a neutral Moderation models module while preserving imports from moderation_service.py.'; 'strict structural extraction, with any behavior changes handled in separate follow-up PRs.'; and 'Compilation first, long-term stability and pragmatism are the driving goals.' Together these state what changes and why the approach was chosen.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
+++ b/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
@@ -30,7 +30,7 @@ modified_files:
 - tldw_Server_API/tests/unit/test_moderation_models_characterization.py
 - tldw_Server_API/tests/unit/test_moderation_models_canonical.py
 - tldw_Server_API/tests/unit/test_moderation_models_imports.py
-updated_date: 2026-08-12 00:49
+updated_date: 2026-08-12 00:58
 ---
 
 ## Description
@@ -41,10 +41,10 @@ Transplant the reviewed shared-model extraction onto current dev: make models.py
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 models.py canonically owns exactly the three approved dataclasses and remains standard-library-only.
-- [ ] #2 moderation_service.py re-exports the exact canonical class objects with unchanged supported constructors, defaults, to_dict mapping, and runtime behavior.
-- [ ] #3 PolicyCompiler and PolicyEvaluator no longer load moderation_service.py for canonical runtime types while preserving policy_types descriptors and subclass dispatch.
-- [ ] #4 Focused and caller regression tests, compilation, Black/Ruff, Bandit, diff/scope checks, and independent review pass on current dev.
+- [x] #1 models.py canonically owns exactly the three approved dataclasses and remains standard-library-only.
+- [x] #2 moderation_service.py re-exports the exact canonical class objects with unchanged supported constructors, defaults, to_dict mapping, and runtime behavior.
+- [x] #3 PolicyCompiler and PolicyEvaluator no longer load moderation_service.py for canonical runtime types while preserving policy_types descriptors and subclass dispatch.
+- [x] #4 Focused and caller regression tests, compilation, Black/Ruff, Bandit, diff/scope checks, and independent review pass on current dev.
 - [ ] #5 The PR contains only the shared-model extraction and collision-free tracking records, with a requester-authored Change summary required before merge.
 <!-- AC:END -->
 
@@ -57,7 +57,24 @@ Follow Docs/superpowers/plans/2026-08-01-moderation-shared-models-extraction-imp
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Transplant: created codex/moderation-shared-models-dev directly from origin/dev@414e81a12aa71df97c4fad17df084aa7a78c474b and applied the nine reviewed post-predecessor commits without conflicts as one pending consolidated change. The original codex/moderation-shared-models-design@5d33b21ca4 remains untouched as a recovery reference. Reconciled predecessor references to merged TASK-12992 / PR #2770 and replaced colliding stale task IDs with TASK-13010 and TASK-13011. Current production scope is exactly models.py, moderation_service.py, policy_compiler.py, and policy_evaluator.py. Fresh current-dev verification and independent review remain pending; PR creation remains gated on the requester's own Change summary.
+Transplant:
+- Created codex/moderation-shared-models-dev directly from origin/dev@414e81a12aa71df97c4fad17df084aa7a78c474b and applied the nine reviewed post-predecessor commits without conflicts as consolidated current-dev commits.
+- Preserved codex/moderation-shared-models-design@5d33b21ca4 untouched as a recovery reference.
+- Reconciled the predecessor to merged TASK-12992 / PR #2770 and replaced colliding stale task IDs with TASK-13010 and TASK-13011.
+- Production scope is exactly models.py, moderation_service.py, policy_compiler.py, and policy_evaluator.py.
+
+Fresh current-dev verification on codex/moderation-shared-models-dev@f0639e91ed:
+- Compilation: py_compile passed for all four touched production files and all three new test files.
+- Formatting/lint: Black write/check left models.py, policy_evaluator.py, and the three new tests unchanged; Ruff passed all seven touched Python files. Fresh origin/dev baselines confirm moderation_service.py and policy_compiler.py both have pre-existing Black debt, so neither was whole-file formatted.
+- Regression tests: 303 Moderation unit tests passed; 97 moderation endpoint/Guardian tests passed; 16 chat moderation integration tests passed; 12 workflow moderation-adapter tests passed (45 deselected); and the targeted audio STT redaction test passed. Total selected tests: 429 passed.
+- Security: Bandit scanned app/core/Moderation (3,335 LOC) with 0 findings, 0 errors, 0 skipped tests, and 0 nosec suppressions.
+- Ancestry/scope: merge-base HEAD origin/dev equals 414e81a12aa71df97c4fad17df084aa7a78c474b; git diff --check passes; the branch contains only tracking seed 74373b7117 and extraction f0639e91ed. The 11-file diff contains exactly four approved production files, three focused tests, two approved documents, and two collision-free Backlog records.
+- Structural audit: models.py defines exactly ModerationPolicy, PatternRule, and ModerationEvaluationResult and imports only __future__, json, re, and dataclasses. Importing models/compiler/evaluator does not load moderation_service or config. Canonical model and test artifacts match reviewed recovery head 5d33b21ca4 exactly; only already-merged PR #2770 service/evaluator corrections differ from that old head.
+- Independent whole-branch review: APPROVE with no P0-P3 findings. The reviewer confirmed literal identity/default/to_dict preservation, exact facade aliases, deferred dependency removal, staticmethod/tuple/subclass/namespace contracts, clean scope, and approved pickle/monkeypatch boundaries. Reviewer independently passed 24 focused tests, isolated imports, and diff check.
+
+Known residual boundary: historical service-qualified pickle payload execution was deliberately not added as a test; existing names remain resolvable through exact service aliases, while new pickle bytes naturally identify models.py as approved.
+
+Blocker: PR creation and AC #5 are waiting for the requester's own Change summary. The agent will not draft, paraphrase, or infer that summary.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -69,9 +86,9 @@ Transplant: created codex/moderation-shared-models-dev directly from origin/dev@
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
+++ b/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-13011
 title: Implement Moderation shared models extraction
-status: In Progress
+status: Done
 created_date: 2026-08-12 00:45
 dependencies:
 - TASK-13010
@@ -32,7 +32,7 @@ modified_files:
 - tldw_Server_API/tests/unit/test_moderation_models_characterization.py
 - tldw_Server_API/tests/unit/test_moderation_models_canonical.py
 - tldw_Server_API/tests/unit/test_moderation_models_imports.py
-updated_date: 2026-08-14 00:43
+updated_date: 2026-08-14 00:50
 ---
 
 ## Description
@@ -46,8 +46,8 @@ Transplant the reviewed shared-model extraction onto current dev: make models.py
 - [x] #1 models.py canonically owns exactly the three approved dataclasses and remains standard-library-only.
 - [x] #2 moderation_service.py re-exports the exact canonical class objects with unchanged supported constructors, defaults, to_dict mapping, and runtime behavior.
 - [x] #3 PolicyCompiler and PolicyEvaluator no longer load moderation_service.py for canonical runtime types while preserving policy_types descriptors and subclass dispatch.
-- [ ] #4 Focused and caller regression tests, compilation, Black/Ruff, Bandit, diff/scope checks, and independent review pass on current dev.
-- [ ] #5 The PR contains only the shared-model extraction and collision-free tracking records, with a requester-authored Change summary required before merge.
+- [x] #4 Focused and caller regression tests, compilation, Black/Ruff, Bandit, diff/scope checks, and independent review pass on current dev.
+- [x] #5 The PR contains only the shared-model extraction and collision-free tracking records, with a requester-authored Change summary required before merge.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -95,20 +95,27 @@ OpenAPI root-cause proof:
 - Generated complete canonical OpenAPI schemas from both this worktree and a detached origin/dev@8f94369e517463758071504079e9ab5f8f8a0091 worktree using the same interpreter/environment.
 - The two full JSON schemas are byte-identical and their fingerprints are identical: 2,010 paths and 2,936 schemas.
 - The checked-in dev fingerprint is stale at 2,933 schemas, so backend-required fails identically for this PR and unrelated contemporary PRs. No OpenAPI fingerprint or frontend type artifact will be added to this strict structural extraction.
+Final PR review remediation and merge-readiness verification on 2026-08-13:
+- Addressed Qodo's sole actionable comment in 0c550e2f15 by splitting aggregate assertions into independent parameterized/single-behavior tests. Replied with evidence; Qodo now reports the issue resolved, and the sole review thread is resolved/outdated. CodeRabbit's base-branch skip contains no actionable feedback.
+- Fresh exact-head gates passed: py_compile for all four production and three test files; Black check for the five approved clean files; Ruff for all seven touched Python files; 318 Moderation unit tests; 97 endpoint/Guardian tests; 16 chat moderation integration tests; 12 workflow moderation-adapter tests (45 deselected); and one audio redaction test. Total selected regressions: 444 passed.
+- Fresh Bandit scan of app/core/Moderation covered 3,335 LOC with zero findings, errors, skipped tests, or nosec suppressions.
+- Final independent whole-branch review at 0c550e2f15 against origin/dev@8f94369e returned APPROVE with no P0-P3 findings and confirmed the Qodo remediation, compatibility facade, canonical ownership, import isolation, behavior preservation, and approved scope.
+- Fetched origin/dev immediately before merge preparation; the branch remains six commits ahead and zero behind, with an exact merge-base at 8f94369e. The 11-file scope and git diff --check remain clean.
+- GitHub's backend-required OpenAPI failure is a verified stale dev fingerprint: complete schemas generated from this branch and origin/dev are byte-identical at 2,010 paths / 2,936 schemas, while the checked-in dev fingerprint says 2,933. No unrelated artifact was added to this strict structural PR.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Extracted ModerationPolicy, PatternRule, and ModerationEvaluationResult into the standard-library-only Moderation models module while preserving exact moderation_service.py facade imports and behavior. PolicyCompiler and PolicyEvaluator now resolve canonical runtime types without loading the service, retaining staticmethod descriptors, tuple order, caching, subclass dispatch, and public namespace contracts. Added focused characterization, canonical ownership, import-isolation, monkeypatch-boundary, and pickle-boundary tests. Rebased patch-identically onto current dev, passed compilation, Black/Ruff, 429 selected regressions, and a zero-finding Bandit scan, received two independent approvals with no findings, and opened PR #2791 with the requester-authored Change summary.
+Extracted ModerationPolicy, PatternRule, and ModerationEvaluationResult into the standard-library-only Moderation models module while preserving exact moderation_service.py facade imports and behavior. PolicyCompiler and PolicyEvaluator now resolve canonical runtime types without loading the service, retaining staticmethod descriptors, tuple order, caching, subclass dispatch, and public namespace contracts. Added focused characterization, ownership, import-isolation, monkeypatch-boundary, and pickle-boundary tests. Rebased patch-identically onto current dev; resolved the sole PR review comment with targeted test separation; passed compilation, Black/Ruff, 444 selected regressions, and a zero-finding Bandit scan; and received a final independent approval with no findings. PR #2791 contains the requester-authored Change summary and remains strict structural scope.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
+++ b/backlog/tasks/task-13011 - Implement-Moderation-shared-models-extraction.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-13011
 title: Implement Moderation shared models extraction
-status: In Progress
+status: Done
 created_date: 2026-08-12 00:45
 dependencies:
 - TASK-13010
@@ -16,6 +16,7 @@ references:
 - codex/moderation-shared-models-design@5d33b21ca4
 - origin/dev@8f94369e517463758071504079e9ab5f8f8a0091
 - codex/moderation-shared-models-dev@b644b86e145ec47658cddb31a0a8f3f5f97b0b18
+- https://github.com/rmusser01/tldw_server/pull/2791
 documentation:
 - Docs/superpowers/specs/2026-08-01-moderation-shared-models-extraction-design.md
 - Docs/superpowers/plans/2026-08-01-moderation-shared-models-extraction-implementation-plan.md
@@ -31,7 +32,7 @@ modified_files:
 - tldw_Server_API/tests/unit/test_moderation_models_characterization.py
 - tldw_Server_API/tests/unit/test_moderation_models_canonical.py
 - tldw_Server_API/tests/unit/test_moderation_models_imports.py
-updated_date: 2026-08-14 00:19
+updated_date: 2026-08-14 00:21
 ---
 
 ## Description
@@ -46,7 +47,7 @@ Transplant the reviewed shared-model extraction onto current dev: make models.py
 - [x] #2 moderation_service.py re-exports the exact canonical class objects with unchanged supported constructors, defaults, to_dict mapping, and runtime behavior.
 - [x] #3 PolicyCompiler and PolicyEvaluator no longer load moderation_service.py for canonical runtime types while preserving policy_types descriptors and subclass dispatch.
 - [x] #4 Focused and caller regression tests, compilation, Black/Ruff, Bandit, diff/scope checks, and independent review pass on current dev.
-- [ ] #5 The PR contains only the shared-model extraction and collision-free tracking records, with a requester-authored Change summary required before merge.
+- [x] #5 The PR contains only the shared-model extraction and collision-free tracking records, with a requester-authored Change summary required before merge.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -83,20 +84,21 @@ Latest-dev refresh on 2026-08-13:
 - A second independent whole-branch review of exact range 8f94369e...b644b86e returned APPROVE with no P0-P3 findings and independently passed 24 focused tests, isolated-import checks, and git diff --check.
 - Publishing the branch is authorized. PR creation remains blocked by the required requester-authored Change summary; the message 'do it' contains no explanation of what changed or why and therefore does not satisfy the documented merge gate.
 Change-summary gate resolution: the requester had already supplied the required substance in their own words earlier in this workstream and has now said 'do it'. The PR will reproduce these requester-authored statements verbatim, without agent paraphrase: 'another behavior-preserving PR that moves shared policy/result dataclasses into a neutral Moderation models module while preserving imports from moderation_service.py.'; 'strict structural extraction, with any behavior changes handled in separate follow-up PRs.'; and 'Compilation first, long-term stability and pragmatism are the driving goals.' Together these state what changes and why the approach was chosen.
+PR creation: opened ready PR #2791 against dev at https://github.com/rmusser01/tldw_server/pull/2791. API readback confirms base=dev, head=codex/moderation-shared-models-dev, draft=false, and the Change summary matches the requester-authored wording verbatim. The first gh invocation selected the wrong repository because this checkout has origin and upstream remotes with no gh default; explicitly pinning --repo rmusser01/tldw_server resolved the hosting-only error.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Extracted ModerationPolicy, PatternRule, and ModerationEvaluationResult into the standard-library-only Moderation models module while preserving exact moderation_service.py facade imports and behavior. PolicyCompiler and PolicyEvaluator now resolve canonical runtime types without loading the service, retaining staticmethod descriptors, tuple order, caching, subclass dispatch, and public namespace contracts. Added focused characterization, canonical ownership, import-isolation, monkeypatch-boundary, and pickle-boundary tests. Rebased patch-identically onto current dev, passed compilation, Black/Ruff, 429 selected regressions, and a zero-finding Bandit scan, received two independent approvals with no findings, and opened PR #2791 with the requester-authored Change summary.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/core/Moderation/models.py
+++ b/tldw_Server_API/app/core/Moderation/models.py
@@ -1,0 +1,114 @@
+"""Shared canonical data models for Moderation policy compilation and evaluation."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+
+_MODEL_NONCRITICAL_EXCEPTIONS = (
+    OSError,
+    ValueError,
+    TypeError,
+    KeyError,
+    RuntimeError,
+    AttributeError,
+    ConnectionError,
+    TimeoutError,
+    json.JSONDecodeError,
+    re.error,
+)
+_UNCATEGORIZED_CATEGORY = "uncategorized"
+
+
+@dataclass
+class ModerationPolicy:
+    enabled: bool = False
+    input_enabled: bool = True
+    output_enabled: bool = True
+    input_action: str = "block"  # block | redact | warn
+    output_action: str = "redact"  # redact | block | warn (block only applies to non-streaming)
+    redact_replacement: str = "[REDACTED]"
+    per_user_overrides: bool = True
+    # Compiled rules; each rule includes the regex and optional per-pattern action/replacement
+    block_patterns: list[PatternRule] = field(default_factory=list)
+    # Enabled categories filter (None or empty means allow all)
+    categories_enabled: set[str] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable snapshot of the policy (without raw regex objects)."""
+        patterns: list[str] = []
+        try:
+            if self.block_patterns:
+                # Backward-friendly: expose raw patterns as strings
+                tmp: list[str] = []
+                for p in self.block_patterns:
+                    pat = getattr(p, "pattern", None)
+                    if pat is None and isinstance(p, PatternRule):
+                        pat = getattr(p.regex, "pattern", "")
+                    tmp.append(pat or "")
+                patterns = tmp
+        except _MODEL_NONCRITICAL_EXCEPTIONS:
+            patterns = []
+        # Provide richer rule view
+        rules: list[dict[str, str]] = []
+        try:
+            if self.block_patterns:
+                for p in self.block_patterns:
+                    if isinstance(p, PatternRule):
+                        cats = p.categories if p.categories else {_UNCATEGORIZED_CATEGORY}
+                        rules.append(
+                            {
+                                "pattern": p.regex.pattern,
+                                "action": p.action or "",
+                                "replacement": p.replacement or "",
+                                "phase": p.phase or "both",
+                                "categories": ",".join(sorted(cats)) if cats else "",
+                            }
+                        )
+                    else:
+                        rules.append(
+                            {
+                                "pattern": getattr(p, "pattern", ""),
+                                "action": "",
+                                "replacement": "",
+                                "phase": "both",
+                                "categories": "",
+                            }
+                        )
+        except _MODEL_NONCRITICAL_EXCEPTIONS:
+            rules = []
+        return {
+            "enabled": self.enabled,
+            "input_enabled": self.input_enabled,
+            "output_enabled": self.output_enabled,
+            "input_action": self.input_action,
+            "output_action": self.output_action,
+            "redact_replacement": self.redact_replacement,
+            "per_user_overrides": self.per_user_overrides,
+            "blocklist_count": len(patterns),
+            "block_patterns": patterns,
+            "rules": rules,
+            "categories_enabled": sorted(self.categories_enabled) if self.categories_enabled else [],
+        }
+
+
+@dataclass
+class PatternRule:
+    regex: re.Pattern
+    action: str | None = None  # block | redact | warn | None
+    replacement: str | None = None  # only used when action=redact
+    categories: set[str] | None = None  # e.g., {"pii", "confidential"}
+    phase: str = "both"  # input | output | both
+
+
+@dataclass
+class ModerationEvaluationResult:
+    """Canonical moderation evaluation result."""
+
+    action: str = "pass"
+    redacted_text: str | None = None
+    matched_pattern: str | None = None
+    category: str | None = None
+    match_span: tuple[int, int] | None = None
+    sample: str | None = None

--- a/tldw_Server_API/app/core/Moderation/moderation_service.py
+++ b/tldw_Server_API/app/core/Moderation/moderation_service.py
@@ -24,11 +24,16 @@ import tempfile
 import threading
 import time
 from collections.abc import Iterator
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, replace
 
 from loguru import logger
 
 from tldw_Server_API.app.core.config import load_and_log_configs, load_comprehensive_config
+from tldw_Server_API.app.core.Moderation.models import (
+    ModerationEvaluationResult,
+    ModerationPolicy,
+    PatternRule,
+)
 from tldw_Server_API.app.core.Moderation.policy_compiler import (
     PolicyCompilationInput,
     PolicyCompilationReport,
@@ -53,97 +58,6 @@ _MODERATION_NONCRITICAL_EXCEPTIONS = (
     json.JSONDecodeError,
     re.error,
 )
-
-
-@dataclass
-class ModerationPolicy:
-    enabled: bool = False
-    input_enabled: bool = True
-    output_enabled: bool = True
-    input_action: str = "block"  # block | redact | warn
-    output_action: str = "redact"  # redact | block | warn (block only applies to non-streaming)
-    redact_replacement: str = "[REDACTED]"
-    per_user_overrides: bool = True
-    # Compiled rules; each rule includes the regex and optional per-pattern action/replacement
-    block_patterns: list[PatternRule] = field(default_factory=list)
-    # Enabled categories filter (None or empty means allow all)
-    categories_enabled: set[str] | None = None
-
-    def to_dict(self) -> dict[str, object]:
-        """Return a JSON-serializable snapshot of the policy (without raw regex objects)."""
-        patterns: list[str] = []
-        try:
-            if self.block_patterns:
-                # Backward-friendly: expose raw patterns as strings
-                tmp: list[str] = []
-                for p in self.block_patterns:
-                    pat = getattr(p, 'pattern', None)
-                    if pat is None and isinstance(p, PatternRule):
-                        pat = getattr(p.regex, 'pattern', '')
-                    tmp.append(pat or '')
-                patterns = tmp
-        except _MODERATION_NONCRITICAL_EXCEPTIONS:
-            patterns = []
-        # Provide richer rule view
-        rules: list[dict[str, str]] = []
-        try:
-            if self.block_patterns:
-                for p in self.block_patterns:
-                    if isinstance(p, PatternRule):
-                        cats = p.categories if p.categories else {ModerationService._UNCATEGORIZED_CATEGORY}
-                        rules.append({
-                            "pattern": p.regex.pattern,
-                            "action": p.action or "",
-                            "replacement": p.replacement or "",
-                            "phase": p.phase or "both",
-                            "categories": ",".join(sorted(cats)) if cats else "",
-                        })
-                    else:
-                        rules.append(
-                            {
-                                "pattern": getattr(p, 'pattern', ''),
-                                "action": "",
-                                "replacement": "",
-                                "phase": "both",
-                                "categories": "",
-                            }
-                        )
-        except _MODERATION_NONCRITICAL_EXCEPTIONS:
-            rules = []
-        return {
-            "enabled": self.enabled,
-            "input_enabled": self.input_enabled,
-            "output_enabled": self.output_enabled,
-            "input_action": self.input_action,
-            "output_action": self.output_action,
-            "redact_replacement": self.redact_replacement,
-            "per_user_overrides": self.per_user_overrides,
-            "blocklist_count": len(patterns),
-            "block_patterns": patterns,
-            "rules": rules,
-            "categories_enabled": sorted(self.categories_enabled) if self.categories_enabled else [],
-        }
-
-
-@dataclass
-class PatternRule:
-    regex: re.Pattern
-    action: str | None = None  # block | redact | warn | None
-    replacement: str | None = None  # only used when action=redact
-    categories: set[str] | None = None  # e.g., {"pii", "confidential"}
-    phase: str = "both"  # input | output | both
-
-
-@dataclass
-class ModerationEvaluationResult:
-    """Canonical moderation evaluation result."""
-
-    action: str = "pass"
-    redacted_text: str | None = None
-    matched_pattern: str | None = None
-    category: str | None = None
-    match_span: tuple[int, int] | None = None
-    sample: str | None = None
 
 
 @dataclass(frozen=True)

--- a/tldw_Server_API/app/core/Moderation/policy_compiler.py
+++ b/tldw_Server_API/app/core/Moderation/policy_compiler.py
@@ -7,8 +7,15 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from tldw_Server_API.app.core.Moderation.models import (
+    ModerationPolicy as _ModerationPolicy,
+)
+from tldw_Server_API.app.core.Moderation.models import (
+    PatternRule as _PatternRule,
+)
+
 if TYPE_CHECKING:
-    from tldw_Server_API.app.core.Moderation.moderation_service import (
+    from tldw_Server_API.app.core.Moderation.models import (
         ModerationPolicy,
         PatternRule,
     )
@@ -92,14 +99,9 @@ class PolicyCompiler:
 
     @staticmethod
     def policy_types() -> tuple[type[ModerationPolicy], type[PatternRule]]:
-        """Load policy dataclasses lazily to avoid import cycles."""
+        """Return the canonical policy dataclasses without loading the service."""
 
-        from tldw_Server_API.app.core.Moderation.moderation_service import (
-            ModerationPolicy,
-            PatternRule,
-        )
-
-        return ModerationPolicy, PatternRule
+        return _ModerationPolicy, _PatternRule
 
     def compile_global(self, data: PolicyCompilationInput) -> PolicyCompilationResult:
         """Compile the global moderation policy from config and blocklist input."""

--- a/tldw_Server_API/app/core/Moderation/policy_evaluator.py
+++ b/tldw_Server_API/app/core/Moderation/policy_evaluator.py
@@ -9,8 +9,18 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
+from tldw_Server_API.app.core.Moderation.models import (
+    ModerationEvaluationResult as _ModerationEvaluationResult,
+)
+from tldw_Server_API.app.core.Moderation.models import (
+    ModerationPolicy as _ModerationPolicy,
+)
+from tldw_Server_API.app.core.Moderation.models import (
+    PatternRule as _PatternRule,
+)
+
 if TYPE_CHECKING:
-    from tldw_Server_API.app.core.Moderation.moderation_service import (
+    from tldw_Server_API.app.core.Moderation.models import (
         ModerationEvaluationResult,
         ModerationPolicy,
         PatternRule,
@@ -53,15 +63,9 @@ class PolicyEvaluator:
         type[PatternRule],
         type[ModerationEvaluationResult],
     ]:
-        """Load service-owned dataclasses lazily to avoid import cycles."""
+        """Return canonical policy dataclasses without loading the service."""
 
-        from tldw_Server_API.app.core.Moderation.moderation_service import (
-            ModerationEvaluationResult,
-            ModerationPolicy,
-            PatternRule,
-        )
-
-        return ModerationPolicy, PatternRule, ModerationEvaluationResult
+        return _ModerationPolicy, _PatternRule, _ModerationEvaluationResult
 
     @classmethod
     def effective_rule_categories(cls, rule: PatternRule) -> set[str]:

--- a/tldw_Server_API/tests/unit/test_moderation_models_canonical.py
+++ b/tldw_Server_API/tests/unit/test_moderation_models_canonical.py
@@ -28,11 +28,14 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _MODELS_PATH = Path(__file__).resolve().parents[2] / "app" / "core" / "Moderation" / "models.py"
 
 
-def test_service_facade_exports_exact_canonical_classes():
-    for name in _MODEL_NAMES:
-        canonical = getattr(models, name)
-        assert getattr(moderation_service, name) is canonical
-        assert canonical.__module__ == models.__name__
+@pytest.mark.parametrize("name", _MODEL_NAMES)
+def test_service_facade_exports_exact_canonical_class(name):
+    assert getattr(moderation_service, name) is getattr(models, name)
+
+
+@pytest.mark.parametrize("name", _MODEL_NAMES)
+def test_canonical_class_uses_models_module_metadata(name):
+    assert getattr(models, name).__module__ == models.__name__
 
 
 def test_models_module_owns_exactly_three_dataclass_types():
@@ -45,11 +48,11 @@ def test_models_module_owns_exactly_three_dataclass_types():
     assert owned_dataclasses == set(_MODEL_NAMES)
 
 
-def test_legacy_qualified_names_resolve_to_canonical_classes():
+@pytest.mark.parametrize("name", _MODEL_NAMES)
+def test_legacy_qualified_name_resolves_to_canonical_class(name):
     legacy = importlib.import_module("tldw_Server_API.app.core.Moderation.moderation_service")
 
-    for name in _MODEL_NAMES:
-        assert getattr(legacy, name) is getattr(models, name)
+    assert getattr(legacy, name) is getattr(models, name)
 
 
 def test_models_source_imports_only_approved_standard_library_modules():

--- a/tldw_Server_API/tests/unit/test_moderation_models_canonical.py
+++ b/tldw_Server_API/tests/unit/test_moderation_models_canonical.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import subprocess
+import sys
+from dataclasses import is_dataclass
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Moderation import models, moderation_service
+
+pytestmark = pytest.mark.unit
+
+_MODEL_NAMES = (
+    "ModerationPolicy",
+    "PatternRule",
+    "ModerationEvaluationResult",
+)
+_FORBIDDEN_MODULES = (
+    "tldw_Server_API.app.core.config",
+    "tldw_Server_API.app.core.Moderation.moderation_service",
+    "tldw_Server_API.app.core.Moderation.policy_compiler",
+    "tldw_Server_API.app.core.Moderation.policy_evaluator",
+)
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODELS_PATH = Path(__file__).resolve().parents[2] / "app" / "core" / "Moderation" / "models.py"
+
+
+def test_service_facade_exports_exact_canonical_classes():
+    for name in _MODEL_NAMES:
+        canonical = getattr(models, name)
+        assert getattr(moderation_service, name) is canonical
+        assert canonical.__module__ == models.__name__
+
+
+def test_models_module_owns_exactly_three_dataclass_types():
+    owned_dataclasses = {
+        name
+        for name, value in vars(models).items()
+        if isinstance(value, type) and is_dataclass(value) and value.__module__ == models.__name__
+    }
+
+    assert owned_dataclasses == set(_MODEL_NAMES)
+
+
+def test_legacy_qualified_names_resolve_to_canonical_classes():
+    legacy = importlib.import_module("tldw_Server_API.app.core.Moderation.moderation_service")
+
+    for name in _MODEL_NAMES:
+        assert getattr(legacy, name) is getattr(models, name)
+
+
+def test_models_source_imports_only_approved_standard_library_modules():
+    tree = ast.parse(_MODELS_PATH.read_text(encoding="utf-8"))
+    roots = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            roots.add(node.module.split(".", 1)[0])
+
+    assert roots == {"__future__", "dataclasses", "json", "re"}
+
+
+def test_models_import_adds_no_moderation_or_config_dependencies():
+    script = f"""
+import importlib
+import sys
+
+forbidden = {repr(_FORBIDDEN_MODULES)}
+importlib.import_module("tldw_Server_API.app.core.Moderation")
+assert not [name for name in forbidden if name in sys.modules]
+importlib.import_module("tldw_Server_API.app.core.Moderation.models")
+assert not [name for name in forbidden if name in sys.modules]
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tldw_Server_API/tests/unit/test_moderation_models_characterization.py
+++ b/tldw_Server_API/tests/unit/test_moderation_models_characterization.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import re
+import typing
+from dataclasses import fields
+
+import pytest
+
+from tldw_Server_API.app.core.Moderation.moderation_service import (
+    ModerationEvaluationResult,
+    ModerationPolicy,
+    PatternRule,
+)
+from tldw_Server_API.app.core.Moderation.policy_compiler import (
+    PolicyCompilationInput,
+    PolicyCompiler,
+    ResolvedModerationConfig,
+)
+from tldw_Server_API.app.core.Moderation.policy_evaluator import (
+    EvaluationLimits,
+    PolicyEvaluator,
+)
+
+pytestmark = pytest.mark.unit
+
+_LIMITS = EvaluationLimits(
+    max_scan_chars=100,
+    match_window_chars=16,
+    max_fallback_scan_chars=200,
+    max_replacements_per_pattern=10,
+)
+
+
+class _BrokenPattern:
+    @property
+    def pattern(self):
+        raise ValueError("broken pattern")
+
+
+class _UnexpectedPattern:
+    @property
+    def pattern(self):
+        raise ZeroDivisionError("unexpected pattern failure")
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_signature", "expected_fields", "expected_annotations"),
+    [
+        (
+            ModerationPolicy,
+            "(enabled: 'bool' = False, input_enabled: 'bool' = True, "
+            "output_enabled: 'bool' = True, input_action: 'str' = 'block', "
+            "output_action: 'str' = 'redact', redact_replacement: 'str' = "
+            "'[REDACTED]', per_user_overrides: 'bool' = True, "
+            "block_patterns: 'list[PatternRule]' = <factory>, "
+            "categories_enabled: 'set[str] | None' = None) -> None",
+            (
+                "enabled",
+                "input_enabled",
+                "output_enabled",
+                "input_action",
+                "output_action",
+                "redact_replacement",
+                "per_user_overrides",
+                "block_patterns",
+                "categories_enabled",
+            ),
+            {
+                "enabled": "bool",
+                "input_enabled": "bool",
+                "output_enabled": "bool",
+                "input_action": "str",
+                "output_action": "str",
+                "redact_replacement": "str",
+                "per_user_overrides": "bool",
+                "block_patterns": "list[PatternRule]",
+                "categories_enabled": "set[str] | None",
+            },
+        ),
+        (
+            PatternRule,
+            "(regex: 're.Pattern', action: 'str | None' = None, "
+            "replacement: 'str | None' = None, categories: 'set[str] | None' "
+            "= None, phase: 'str' = 'both') -> None",
+            ("regex", "action", "replacement", "categories", "phase"),
+            {
+                "regex": "re.Pattern",
+                "action": "str | None",
+                "replacement": "str | None",
+                "categories": "set[str] | None",
+                "phase": "str",
+            },
+        ),
+        (
+            ModerationEvaluationResult,
+            "(action: 'str' = 'pass', redacted_text: 'str | None' = None, "
+            "matched_pattern: 'str | None' = None, category: 'str | None' "
+            "= None, match_span: 'tuple[int, int] | None' = None, sample: "
+            "'str | None' = None) -> None",
+            (
+                "action",
+                "redacted_text",
+                "matched_pattern",
+                "category",
+                "match_span",
+                "sample",
+            ),
+            {
+                "action": "str",
+                "redacted_text": "str | None",
+                "matched_pattern": "str | None",
+                "category": "str | None",
+                "match_span": "tuple[int, int] | None",
+                "sample": "str | None",
+            },
+        ),
+    ],
+)
+def test_model_declarations_are_literal(
+    model_type,
+    expected_signature,
+    expected_fields,
+    expected_annotations,
+):
+    assert str(inspect.signature(model_type)) == expected_signature
+    assert tuple(field.name for field in fields(model_type)) == expected_fields
+    assert model_type.__annotations__ == expected_annotations
+
+
+def test_model_defaults_and_borrowed_values_are_literal():
+    first = ModerationPolicy()
+    second = ModerationPolicy()
+    supplied_rules = []
+    supplied_categories = {"pii"}
+    regex = re.compile("secret")
+    rule_categories = {"confidential"}
+    rule = PatternRule(regex=regex, categories=rule_categories)
+    policy = ModerationPolicy(
+        block_patterns=supplied_rules,
+        categories_enabled=supplied_categories,
+    )
+
+    assert first == second
+    assert first.block_patterns == []
+    assert first.block_patterns is not second.block_patterns
+    assert policy.block_patterns is supplied_rules
+    assert policy.categories_enabled is supplied_categories
+    assert rule.regex is regex
+    assert rule.categories is rule_categories
+
+    result = ModerationEvaluationResult()
+    result.action = "warn"
+    assert result.action == "warn"
+
+
+def test_policy_block_patterns_uses_list_default_factory():
+    block_patterns = next(field for field in fields(ModerationPolicy) if field.name == "block_patterns")
+
+    assert block_patterns.default is dataclasses.MISSING
+    assert block_patterns.default_factory is list
+
+
+def test_resolved_model_type_hints_are_literal():
+    policy_hints = typing.get_type_hints(ModerationPolicy)
+    rule_hints = typing.get_type_hints(PatternRule)
+    result_hints = typing.get_type_hints(ModerationEvaluationResult)
+
+    assert policy_hints["block_patterns"] == list[PatternRule]
+    assert policy_hints["categories_enabled"] == set[str] | None
+    assert rule_hints["regex"] is re.Pattern
+    assert rule_hints["categories"] == set[str] | None
+    assert result_hints["match_span"] == tuple[int, int] | None
+
+
+def test_policy_to_dict_returns_literal_mapping():
+    policy = ModerationPolicy(
+        enabled=True,
+        block_patterns=[
+            PatternRule(
+                regex=re.compile("secret"),
+                action="redact",
+                replacement="[RULE]",
+                categories=None,
+                phase="input",
+            )
+        ],
+        categories_enabled={"pii", "confidential"},
+    )
+
+    assert policy.to_dict() == {
+        "enabled": True,
+        "input_enabled": True,
+        "output_enabled": True,
+        "input_action": "block",
+        "output_action": "redact",
+        "redact_replacement": "[REDACTED]",
+        "per_user_overrides": True,
+        "blocklist_count": 1,
+        "block_patterns": ["secret"],
+        "rules": [
+            {
+                "pattern": "secret",
+                "action": "redact",
+                "replacement": "[RULE]",
+                "phase": "input",
+                "categories": "uncategorized",
+            }
+        ],
+        "categories_enabled": ["confidential", "pii"],
+    }
+
+
+def test_policy_to_dict_preserves_legacy_regex_shape():
+    policy = ModerationPolicy(block_patterns=[re.compile("legacy")])
+
+    snapshot = policy.to_dict()
+
+    assert snapshot["block_patterns"] == ["legacy"]
+    assert snapshot["rules"] == [
+        {
+            "pattern": "legacy",
+            "action": "",
+            "replacement": "",
+            "phase": "both",
+            "categories": "",
+        }
+    ]
+
+
+def test_policy_to_dict_preserves_noncritical_fallbacks():
+    policy = ModerationPolicy(block_patterns=[_BrokenPattern()])
+
+    snapshot = policy.to_dict()
+
+    assert snapshot["blocklist_count"] == 0
+    assert snapshot["block_patterns"] == []
+    assert snapshot["rules"] == []
+
+
+def test_policy_to_dict_does_not_swallow_unlisted_exceptions():
+    policy = ModerationPolicy(block_patterns=[_UnexpectedPattern()])
+
+    with pytest.raises(ZeroDivisionError, match="unexpected pattern failure"):
+        policy.to_dict()
+
+
+def test_policy_type_descriptors_and_tuples_are_literal():
+    assert isinstance(inspect.getattr_static(PolicyCompiler, "policy_types"), staticmethod)
+    assert isinstance(inspect.getattr_static(PolicyEvaluator, "policy_types"), staticmethod)
+    assert str(inspect.signature(PolicyCompiler.policy_types)) == (
+        "() -> 'tuple[type[ModerationPolicy], type[PatternRule]]'"
+    )
+    assert str(inspect.signature(PolicyEvaluator.policy_types)) == (
+        "() -> 'tuple[type[ModerationPolicy], type[PatternRule], " "type[ModerationEvaluationResult]]'"
+    )
+    assert PolicyCompiler.policy_types() == (ModerationPolicy, PatternRule)
+    assert PolicyEvaluator.policy_types() == (
+        ModerationPolicy,
+        PatternRule,
+        ModerationEvaluationResult,
+    )
+
+
+def test_compiler_uses_overridden_policy_types():
+    class ReplacementPolicy:
+        def __init__(self, **values):
+            self.values = values
+
+    class ReplacementCompiler(PolicyCompiler):
+        @staticmethod
+        def policy_types():
+            return ReplacementPolicy, PatternRule
+
+    result = ReplacementCompiler().compile_global(
+        PolicyCompilationInput(
+            config=ResolvedModerationConfig(),
+            runtime_override={},
+            blocklist_lines=[],
+            pii_rules=[],
+        )
+    )
+
+    assert isinstance(result.policy, ReplacementPolicy)
+    assert result.policy.values["block_patterns"] == []
+
+
+def test_evaluator_uses_overridden_policy_types():
+    class ReplacementResult:
+        pass
+
+    class ReplacementEvaluator(PolicyEvaluator):
+        @staticmethod
+        def policy_types():
+            return ModerationPolicy, PatternRule, ReplacementResult
+
+    result = ReplacementEvaluator().evaluate_text(
+        "",
+        ModerationPolicy(enabled=False),
+        "input",
+        _LIMITS,
+        include_redacted_text=False,
+    )
+
+    assert isinstance(result, ReplacementResult)

--- a/tldw_Server_API/tests/unit/test_moderation_models_imports.py
+++ b/tldw_Server_API/tests/unit/test_moderation_models_imports.py
@@ -105,23 +105,39 @@ for name in ("ModerationPolicy", "PatternRule", "ModerationEvaluationResult"):
     assert completed.returncode == 0, completed.stderr
 
 
-def test_policy_type_descriptors_and_public_namespaces_remain_literal():
+def test_compiler_policy_types_remains_staticmethod():
     assert isinstance(
         inspect.getattr_static(policy_compiler.PolicyCompiler, "policy_types"),
         staticmethod,
     )
+
+
+def test_evaluator_policy_types_remains_staticmethod():
     assert isinstance(
         inspect.getattr_static(policy_evaluator.PolicyEvaluator, "policy_types"),
         staticmethod,
     )
-    assert not hasattr(policy_compiler, "ModerationPolicy")
-    assert not hasattr(policy_compiler, "PatternRule")
-    assert not hasattr(policy_evaluator, "ModerationPolicy")
-    assert not hasattr(policy_evaluator, "PatternRule")
-    assert not hasattr(policy_evaluator, "ModerationEvaluationResult")
 
+
+@pytest.mark.parametrize("name", ("ModerationPolicy", "PatternRule"))
+def test_compiler_public_namespace_excludes_canonical_model(name):
+    assert not hasattr(policy_compiler, name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ("ModerationPolicy", "PatternRule", "ModerationEvaluationResult"),
+)
+def test_evaluator_public_namespace_excludes_canonical_model(name):
+    assert not hasattr(policy_evaluator, name)
+
+
+def test_compiler_runtime_type_hints_remain_unresolved():
     with pytest.raises(NameError):
         typing.get_type_hints(policy_compiler.PolicyCompiler.compile_user_policy)
+
+
+def test_evaluator_runtime_type_hints_remain_unresolved():
     with pytest.raises(NameError):
         typing.get_type_hints(policy_evaluator.PolicyEvaluator.evaluate_text)
 

--- a/tldw_Server_API/tests/unit/test_moderation_models_imports.py
+++ b/tldw_Server_API/tests/unit/test_moderation_models_imports.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import inspect
+import subprocess
+import sys
+import typing
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Moderation import (
+    moderation_service,
+    policy_compiler,
+    policy_evaluator,
+)
+from tldw_Server_API.app.core.Moderation.models import (
+    ModerationEvaluationResult,
+    ModerationPolicy,
+    PatternRule,
+)
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SERVICE_MODULE = "tldw_Server_API.app.core.Moderation.moderation_service"
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        f"""
+import sys
+from tldw_Server_API.app.core.Moderation.policy_compiler import PolicyCompiler
+assert {_SERVICE_MODULE!r} not in sys.modules
+types = PolicyCompiler.policy_types()
+assert [item.__name__ for item in types] == ["ModerationPolicy", "PatternRule"]
+assert all(item.__module__ == "tldw_Server_API.app.core.Moderation.models" for item in types)
+assert {_SERVICE_MODULE!r} not in sys.modules
+from tldw_Server_API.app.core.Moderation import models, moderation_service
+assert moderation_service.ModerationPolicy is models.ModerationPolicy
+assert moderation_service.PatternRule is models.PatternRule
+""",
+        f"""
+import sys
+from tldw_Server_API.app.core.Moderation.policy_evaluator import PolicyEvaluator
+assert {_SERVICE_MODULE!r} not in sys.modules
+types = PolicyEvaluator.policy_types()
+assert [item.__name__ for item in types] == ["ModerationPolicy", "PatternRule", "ModerationEvaluationResult"]
+assert all(item.__module__ == "tldw_Server_API.app.core.Moderation.models" for item in types)
+assert {_SERVICE_MODULE!r} not in sys.modules
+from tldw_Server_API.app.core.Moderation import models, moderation_service
+assert moderation_service.ModerationPolicy is models.ModerationPolicy
+assert moderation_service.PatternRule is models.PatternRule
+assert moderation_service.ModerationEvaluationResult is models.ModerationEvaluationResult
+""",
+    ],
+)
+def test_policy_types_do_not_load_service(script):
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize(
+    "module_order",
+    [
+        (
+            "tldw_Server_API.app.core.Moderation.models",
+            "tldw_Server_API.app.core.Moderation.moderation_service",
+            "tldw_Server_API.app.core.Moderation.policy_compiler",
+            "tldw_Server_API.app.core.Moderation.policy_evaluator",
+        ),
+        (
+            "tldw_Server_API.app.core.Moderation.moderation_service",
+            "tldw_Server_API.app.core.Moderation.policy_compiler",
+            "tldw_Server_API.app.core.Moderation.policy_evaluator",
+        ),
+    ],
+)
+def test_complete_import_orders_resolve_exact_identity(module_order):
+    script = f"""
+import importlib
+
+for module_name in {module_order!r}:
+    importlib.import_module(module_name)
+models = importlib.import_module("tldw_Server_API.app.core.Moderation.models")
+service = importlib.import_module("tldw_Server_API.app.core.Moderation.moderation_service")
+for name in ("ModerationPolicy", "PatternRule", "ModerationEvaluationResult"):
+    assert getattr(service, name) is getattr(models, name)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_policy_type_descriptors_and_public_namespaces_remain_literal():
+    assert isinstance(
+        inspect.getattr_static(policy_compiler.PolicyCompiler, "policy_types"),
+        staticmethod,
+    )
+    assert isinstance(
+        inspect.getattr_static(policy_evaluator.PolicyEvaluator, "policy_types"),
+        staticmethod,
+    )
+    assert not hasattr(policy_compiler, "ModerationPolicy")
+    assert not hasattr(policy_compiler, "PatternRule")
+    assert not hasattr(policy_evaluator, "ModerationPolicy")
+    assert not hasattr(policy_evaluator, "PatternRule")
+    assert not hasattr(policy_evaluator, "ModerationEvaluationResult")
+
+    with pytest.raises(NameError):
+        typing.get_type_hints(policy_compiler.PolicyCompiler.compile_user_policy)
+    with pytest.raises(NameError):
+        typing.get_type_hints(policy_evaluator.PolicyEvaluator.evaluate_text)
+
+
+def test_service_export_rebinding_does_not_replace_canonical_policy_types(monkeypatch):
+    monkeypatch.setattr(moderation_service, "ModerationPolicy", type("Policy", (), {}))
+    monkeypatch.setattr(moderation_service, "PatternRule", type("Rule", (), {}))
+    monkeypatch.setattr(
+        moderation_service,
+        "ModerationEvaluationResult",
+        type("Result", (), {}),
+    )
+
+    assert policy_compiler.PolicyCompiler.policy_types() == (
+        ModerationPolicy,
+        PatternRule,
+    )
+    assert policy_evaluator.PolicyEvaluator.policy_types() == (
+        ModerationPolicy,
+        PatternRule,
+        ModerationEvaluationResult,
+    )


### PR DESCRIPTION
## Change summary

> another behavior-preserving PR that moves shared policy/result dataclasses into a neutral Moderation models module while preserving imports from moderation_service.py.
>
> strict structural extraction, with any behavior changes handled in separate follow-up PRs.
>
> Compilation first, long-term stability and pragmatism are the driving goals

## Implementation

- Makes `Moderation.models` the canonical owner of `ModerationPolicy`, `PatternRule`, and `ModerationEvaluationResult`.
- Keeps `moderation_service.py` as an exact compatibility facade for existing imports.
- Removes compiler/evaluator runtime type dependencies on the service while preserving descriptors, tuple order, subclass dispatch, and public namespaces.
- Adds characterization, canonical ownership, import-isolation, pickle-boundary, and monkeypatch-boundary coverage.

## Verification

- Python compilation passed for all touched production and test files.
- Black check passed on the approved clean subset.
- Ruff passed on all seven touched Python files.
- 429 selected regression tests passed across Moderation, Guardian, Chat, Workflows, and Audio.
- Bandit scanned 3,335 Moderation LOC with zero findings, errors, skips, or nosec suppressions.
- Two independent whole-branch reviews approved the change with no P0-P3 findings.
- Rebased onto `dev` at `8f94369e517463758071504079e9ab5f8f8a0091`; range-diff confirmed the rebased commits are patch-identical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts shared moderation dataclasses into `tldw_Server_API.app.core.Moderation.models` and keeps `moderation_service` as a compatibility facade. Removes compiler/evaluator runtime imports of the service without changing moderation behavior or public contracts.

- Canonical owner is `Moderation.models` for `ModerationPolicy`, `PatternRule`, and `ModerationEvaluationResult`; `moderation_service` re-exports the exact class objects so existing imports and pickles continue to work.
- `PolicyCompiler` and `PolicyEvaluator` use these canonical types; their `policy_types()` return them without importing `moderation_service`.
- Adds unit tests for canonical ownership, subprocess import isolation, and behavior characterization; records verification and design/implementation docs aligned with `TASK-13010` and `TASK-13011`.

- Migration: none required. Optional: import from `tldw_Server_API.app.core.Moderation.models`. Note each class `__module__` is now `...Moderation.models`; new pickles use this path, while old pickles under `moderation_service` remain loadable via the re-exports.

<sup>Written for commit cc8a9362182e5e1d4dbeba9107a8252f28d78d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

