### PR TITLE
feat(notes): define task sync contract and tenancy storage

### DIFF
--- a/Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+++ b/Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
@@ -18,7 +18,9 @@ state, and reconciliation bookkeeping as derived local state.
 The canonical product authorities remain the existing ChaChaNotes task tables:
 
 - `note_tasks` owns each task's stable identity, parent note, mutable fields,
-  optimistic version, and soft-delete lifecycle;
+  canonical Sync revision/hash, and soft-delete lifecycle. Its existing `version`
+  remains the REST row version because projection-only operations already advance
+  it; a new canonical revision/hash advances only for portable task mutations;
 - `task_events` owns immutable user-visible task history; and
 - `task_event_read_state`, `task_note_projections`, and
   `note_task_reconciliation_state` remain local projections or UI state and are
@@ -50,15 +52,20 @@ fingerprint replay is idempotent, while reuse of the ID with different content i
 a conflict. Activity tombstone is one-way and cannot rewrite or restore event
 content.
 
-An activity must resolve to at least one authorized parent. When both task and note
-identities are supplied, the task must belong to that note. PostgreSQL RLS and all
-service queries enforce owner, dataset, and parent-note authority. Migrations are
-transactional and fail closed on catalog drift. Existing data and REST behavior are
-preserved before a dataset explicitly enrolls in the new domains.
+Every activity has a required authorized note and an optional task. When a task is
+present, it must belong to that note. All five existing task-side tables, plus the
+new drift table, gain collision-safe owner/dataset identity, forced PostgreSQL RLS,
+and owner-scoped service predicates. Migrations are transactional and fail closed
+on catalog drift. Existing data and REST behavior are preserved before a dataset
+explicitly enrolls in the new domains.
 
 Markdown checklist text is a deterministic projection, not a competing authority.
-Reconciliation compares the last common projection with the current canonical task
-and current Markdown:
+Each managed checklist line carries a hidden versioned marker containing its task
+ID and exact last-projected task revision/hash. The marker reconstructs identity
+after projection-cache loss; the immutable Sync envelope named by that tuple
+reconstructs the last-common projected field snapshot. If that base is unavailable,
+reconciliation fails safe to review rather than guessing by text. Reconciliation
+compares that base with the current canonical task and current Markdown:
 
 - Markdown-only changes become canonical task mutations plus activity;
 - task-only changes rebuild the Markdown projection;
@@ -73,18 +80,18 @@ product materialization. Product and Sync databases do not share a distributed
 transaction; idempotent repair closes a product-commit/status-commit split.
 
 Rollout uses existing per-dataset enrollment and readiness. It adds no new global
-environment flag. A domain may be supported by the server without being advertised
-as dataset-writable. `notes.task` becomes writable only after its parent-note and
-task bootstrap is complete. `notes.task_activity` additionally requires activity
-bootstrap. Existing datasets are never silently enrolled.
+environment flag. Neither domain is publicly advertised as supported or writable
+until the fourth PR supplies deterministic task/activity group expansion,
+projection convergence, bootstrap verification, and repair. Existing datasets are
+never silently enrolled.
 
 TASK-13006 is delivered as four atomic pull requests:
 
 1. contract, storage, migration, RLS, catalog verification, and dormant readiness;
-2. the complete `notes.task` lifecycle and server-origin capture;
-3. immutable `notes.task_activity` capture and bootstrap; and
-4. Markdown projection convergence, compound mutation groups, end-to-end testing,
-   and public documentation.
+2. a complete but dormant `notes.task` lifecycle and bootstrap;
+3. complete but dormant immutable `notes.task_activity` capture and bootstrap; and
+4. deterministic compound mutation groups, Markdown projection convergence,
+   capability activation, end-to-end testing, and public documentation.
 
 ## Context
 

--- a/Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+++ b/Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
@@ -59,6 +59,15 @@ and owner-scoped service predicates. Migrations are transactional and fail close
 on catalog drift. Existing data and REST behavior are preserved before a dataset
 explicitly enrolls in the new domains.
 
+Schema v60 also owns one private `note_task_scope_authority` relation. It records at
+most one immutable real dataset for each owner and uses owner-only forced PostgreSQL
+RLS. Absence of a row means the owner's task graph remains in the private
+`local-unbound` scope. Binding inserts the authority row atomically with the graph
+rekey, including when the graph is empty; replay to the same dataset is idempotent
+and a different target is rejected. Compatibility callers resolve this indexed
+product-owned row, never accept a client dataset selector, and all shared task-store
+writes must match the recorded authority.
+
 Because the product migration cannot read the separate Sync database, preserved
 inactive rows use a private owner-scoped local-unbound dataset sentinel. Explicit
 enrollment source-verifies and atomically rekeys the complete task graph to the

--- a/Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+++ b/Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
@@ -85,6 +85,11 @@ until the fourth PR supplies deterministic task/activity group expansion,
 projection convergence, bootstrap verification, and repair. Existing datasets are
 never silently enrolled.
 
+Because every portable task mutation emits immutable activity, task writability is
+coupled to both domains: task and activity capture are enabled atomically, both
+bootstraps and both repair paths must be ready, and neither domain is writable when
+that invariant is incomplete.
+
 TASK-13006 is delivered as four atomic pull requests:
 
 1. contract, storage, migration, RLS, catalog verification, and dormant readiness;

--- a/Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+++ b/Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
@@ -59,6 +59,12 @@ and owner-scoped service predicates. Migrations are transactional and fail close
 on catalog drift. Existing data and REST behavior are preserved before a dataset
 explicitly enrolls in the new domains.
 
+Because the product migration cannot read the separate Sync database, preserved
+inactive rows use a private owner-scoped local-unbound dataset sentinel. Explicit
+enrollment source-verifies and atomically rekeys the complete task graph to the
+real dataset; the sentinel is never client-selectable, writable through Sync, or
+capability-ready.
+
 Markdown checklist text is a deterministic projection, not a competing authority.
 Each managed checklist line carries a hidden versioned marker containing its task
 ID and exact last-projected task revision/hash. The marker reconstructs identity

--- a/Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+++ b/Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
@@ -1,0 +1,148 @@
+# ADR-039: Canonical Notes task Sync and derived checklist projections
+
+**Status:** Accepted
+**Date:** 2026-08-13
+**Backfilled from:** not backfilled
+**Decision owner:** TASK-13006 requester and design review
+**Related task:** TASK-13006
+**Related spec/plan:** `Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md`
+**Depends on:** ADR-031, ADR-034, ADR-037, and ADR-038
+
+## Decision
+
+Synchronize Notes tasks and their immutable history as two independent versioned
+Sync v2 domains: mutable `notes.task` objects and append-only
+`notes.task_activity` objects. Keep Markdown checklists, projection cursors, read
+state, and reconciliation bookkeeping as derived local state.
+
+The canonical product authorities remain the existing ChaChaNotes task tables:
+
+- `note_tasks` owns each task's stable identity, parent note, mutable fields,
+  optimistic version, and soft-delete lifecycle;
+- `task_events` owns immutable user-visible task history; and
+- `task_event_read_state`, `task_note_projections`, and
+  `note_task_reconciliation_state` remain local projections or UI state and are
+  never synchronized.
+
+`notes.task` version 1 supports whole-object `upsert` and `tombstone`. Create
+requires an empty Sync head. Update, completion, reopen, delete, and restore require
+the exact current base cursor, object revision, and object hash. Restore is an
+explicit upsert against the current tombstone. Task identity and parent-note
+identity are immutable.
+
+The version-1 task payload exposes stable task ID, parent note ID, title,
+description, status, priority, due date, completion state, recurrence state,
+assignee, tags, estimate, and bounded custom metadata. Existing product columns
+remain authoritative where present. Existing `note_tasks.text` backs the wire
+`title`; existing REST APIs retain their `text` compatibility field. Extended
+fields remain in strictly validated `metadata_json` rather than creating parallel
+columns. Custom metadata may not duplicate reserved fields.
+
+Recurrence synchronization preserves only a validated recurrence rule and its
+state. Version 1 does not schedule work or generate future task instances.
+
+`notes.task_activity` version 1 creates one immutable event with a stable opaque
+event ID, parent task and note identities, actor, client timestamp, transition,
+source, and bounded metadata. Authenticated principal and source-device provenance
+are server-bound, not client-selectable. Server cursor plus event ID defines
+deterministic ordering; client timestamps never do. Exact ID and canonical
+fingerprint replay is idempotent, while reuse of the ID with different content is
+a conflict. Activity tombstone is one-way and cannot rewrite or restore event
+content.
+
+An activity must resolve to at least one authorized parent. When both task and note
+identities are supplied, the task must belong to that note. PostgreSQL RLS and all
+service queries enforce owner, dataset, and parent-note authority. Migrations are
+transactional and fail closed on catalog drift. Existing data and REST behavior are
+preserved before a dataset explicitly enrolls in the new domains.
+
+Markdown checklist text is a deterministic projection, not a competing authority.
+Reconciliation compares the last common projection with the current canonical task
+and current Markdown:
+
+- Markdown-only changes become canonical task mutations plus activity;
+- task-only changes rebuild the Markdown projection;
+- compatible changes converge deterministically; and
+- incompatible concurrent changes create a bounded, privacy-safe drift record for
+  review instead of silently overwriting either side.
+
+Server-origin REST, MCP, and reconciliation mutations use ADR-034 durable mutation
+groups when they affect task, activity, and note projection together. The complete
+ordered canonical envelope plan is appended atomically in the Sync store before
+product materialization. Product and Sync databases do not share a distributed
+transaction; idempotent repair closes a product-commit/status-commit split.
+
+Rollout uses existing per-dataset enrollment and readiness. It adds no new global
+environment flag. A domain may be supported by the server without being advertised
+as dataset-writable. `notes.task` becomes writable only after its parent-note and
+task bootstrap is complete. `notes.task_activity` additionally requires activity
+bootstrap. Existing datasets are never silently enrolled.
+
+TASK-13006 is delivered as four atomic pull requests:
+
+1. contract, storage, migration, RLS, catalog verification, and dormant readiness;
+2. the complete `notes.task` lifecycle and server-origin capture;
+3. immutable `notes.task_activity` capture and bootstrap; and
+4. Markdown projection convergence, compound mutation groups, end-to-end testing,
+   and public documentation.
+
+## Context
+
+The server already stores Notes tasks, events, projection state, and read state,
+but neither task authority nor task history is a Sync v2 domain. Existing task rows
+have a stable identifier, parent note, text, open/done state, metadata, optimistic
+version, and soft deletion. Existing events are append-only, while Markdown
+checklists are reconciled through local projection tables.
+
+Without an explicit ownership decision, synchronizing all of these tables would
+create competing authorities. A Markdown edit could overwrite an explicit task, a
+read marker could leak device-local UI state, and mutable event replication could
+rewrite history. Conversely, treating Markdown as the only authority would lose
+first-class task identity, recurrence state, structured metadata, and reliable
+multi-device conflict handling.
+
+ADR-031 requires independently mutable Notes resources to use independent Sync
+domains. ADR-034 provides the durable ordered group required when one user action
+changes a task, emits history, and rebuilds a note projection. ADR-037 establishes
+the corresponding rule that deterministic projections are rebuilt rather than
+synchronized.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Synchronize Markdown checklists as the task authority | Markdown lacks stable structured identity and would silently overwrite explicit task fields during concurrent edits. |
+| Synchronize projection and read-state tables | They are deterministic or device-local state, not portable user authority. |
+| Put task state and all activity inside one `notes.task` envelope | Append-only history would become a mutable whole-object conflict surface and grow without bound. |
+| Permit mutable activity events | It would rewrite audit history and make exact replay unverifiable. Corrections are new events or one-way tombstones. |
+| Generate future task instances from recurrence rules | It adds scheduler ownership, clock, deduplication, and offline-generation policy without an approved product requirement. |
+| Add dedicated columns for every extended task field in the first slice | Existing bounded metadata can carry the validated fields without a disruptive compatibility migration or duplicate authority. |
+| Make product and Sync writes one distributed transaction | The repositories already use ADR-034 durable plans and repair; a distributed transaction would add backend coupling without removing recovery requirements. |
+| Advertise domains as soon as schema exists | Existing rows would be missing from initial pulls and server-origin mutations could bypass canonical capture before bootstrap completes. |
+
+## Consequences
+
+- Tasks gain exact multi-device lifecycle semantics while existing REST `text` and
+  product storage remain compatible.
+- Task history is portable, ordered, and immutable; device-local read state stays
+  private.
+- Recurring tasks synchronize their rule and state but require a later, separately
+  approved scheduler if automatic instance creation is ever needed.
+- A single user action may leave repairable cross-database work after a crash, but
+  never an incomplete canonical mutation plan.
+- Existing datasets require resumable source-verified bootstrap before either new
+  domain is writable.
+- Explicit task edits are never silently replaced by Markdown. Some concurrent
+  edits therefore require user review.
+- PostgreSQL upgrades and bootstrap verification can temporarily block affected
+  writes and require live-backend verification before rollout.
+- The four-PR split delays end-to-end checklist convergence until the final PR, but
+  each earlier PR remains independently safe because incomplete domains are not
+  advertised writable.
+
+## Follow-up
+
+- Implement the four TASK-13006 child PRs defined in the related design spec.
+- Update public Sync capability documentation when each domain becomes writable.
+- Keep automatic recurrence scheduling out of scope until a separate task and ADR
+  define scheduler ownership and generation idempotency.

--- a/Docs/ADR/README.md
+++ b/Docs/ADR/README.md
@@ -70,3 +70,4 @@ Small bug fixes, local implementation details, product copy, temporary experimen
 | [ADR-036](036-web-clipper-external-identity-mapping.md) | Accepted | Map owner-scoped public Web Clipper IDs to separate canonical Notes UUIDs and migrate legacy mappings safely. |
 | [ADR-037](037-canonical-notes-link-sync-and-derived-graph-projections.md) | Accepted | Synchronize explicit manual note links while keeping wikilinks, backlinks, orphan state, and graph summaries deterministic local projections. |
 | [ADR-038](038-canonical-notes-attachment-registry-and-blob-lifecycle.md) | Accepted | Give Notes attachments stable product identity while reusing the shared Sync blob lifecycle. |
+| [ADR-039](039-canonical-notes-task-sync-and-derived-checklist-projections.md) | Accepted | Synchronize mutable Notes tasks and immutable activity while keeping Markdown checklists and read state derived. |

--- a/Docs/Published/ADR/038-canonical-notes-attachment-registry-and-blob-lifecycle.md
+++ b/Docs/Published/ADR/038-canonical-notes-attachment-registry-and-blob-lifecycle.md
@@ -81,6 +81,34 @@ deletion authority would make crash recovery unsafe.
 12. TASK-13005 is implemented as four atomic PRs: persistence contract, mutation
     lifecycle, legacy bootstrap, then restore/retention/diagnostics and rollout.
 
+## Operational completion and failure semantics
+
+The completed implementation applies the decisions above as one fail-closed
+lifecycle:
+
+- version-2 capability advertisement is dataset-bound and writable only when
+  blob transfer, the dedicated default-off rollout gate, encryption, enrollment,
+  and `notes_attachment_v2: ready` all agree;
+- canonical create, rename, replace, delete, and restore are idempotent,
+  optimistic mutations. Product projection and accepted-envelope history share
+  the materialization fence; injected projection or binding failures roll back
+  the accepted envelope rather than publishing partial authority;
+- restore ordering requires the owning Note before a live attachment ref, and
+  completeness is derived from immutable revision bindings and verified bytes;
+- legacy bootstrap is resumable and source-verified, publishes readiness only
+  after count/postcondition verification, retains source files for rollback,
+  and exposes only bounded hashed diagnostics;
+- historical binding release is monotonic and auditable. Physical collection
+  revalidates all blockers under the dataset fence, uses
+  `available -> deleting -> deleted`, and leaves retryable `deleting` state when
+  byte removal cannot be proven complete; and
+- diagnostics are read-only hints. Stable public errors and logs omit filenames,
+  source paths, storage keys, blob bytes, payloads, and secret metadata.
+
+No additional ADR is required for these operational details: they directly
+implement Decisions 2, 3, 6, 8, 9, and 10 without changing the ownership,
+storage, migration, or retention architecture selected here.
+
 ## Consequences
 
 - Users can rename, replace, delete, restore, and synchronize an attachment without

--- a/Docs/Published/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+++ b/Docs/Published/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
@@ -1,0 +1,175 @@
+# ADR-039: Canonical Notes task Sync and derived checklist projections
+
+**Status:** Accepted
+**Date:** 2026-08-13
+**Backfilled from:** not backfilled
+**Decision owner:** TASK-13006 requester and design review
+**Related task:** TASK-13006
+**Related spec/plan:** `Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md`
+**Depends on:** ADR-031, ADR-034, ADR-037, and ADR-038
+
+## Decision
+
+Synchronize Notes tasks and their immutable history as two independent versioned
+Sync v2 domains: mutable `notes.task` objects and append-only
+`notes.task_activity` objects. Keep Markdown checklists, projection cursors, read
+state, and reconciliation bookkeeping as derived local state.
+
+The canonical product authorities remain the existing ChaChaNotes task tables:
+
+- `note_tasks` owns each task's stable identity, parent note, mutable fields,
+  canonical Sync revision/hash, and soft-delete lifecycle. Its existing `version`
+  remains the REST row version because projection-only operations already advance
+  it; a new canonical revision/hash advances only for portable task mutations;
+- `task_events` owns immutable user-visible task history; and
+- `task_event_read_state`, `task_note_projections`, and
+  `note_task_reconciliation_state` remain local projections or UI state and are
+  never synchronized.
+
+`notes.task` version 1 supports whole-object `upsert` and `tombstone`. Create
+requires an empty Sync head. Update, completion, reopen, delete, and restore require
+the exact current base cursor, object revision, and object hash. Restore is an
+explicit upsert against the current tombstone. Task identity and parent-note
+identity are immutable.
+
+The version-1 task payload exposes stable task ID, parent note ID, title,
+description, status, priority, due date, completion state, recurrence state,
+assignee, tags, estimate, and bounded custom metadata. Existing product columns
+remain authoritative where present. Existing `note_tasks.text` backs the wire
+`title`; existing REST APIs retain their `text` compatibility field. Extended
+fields remain in strictly validated `metadata_json` rather than creating parallel
+columns. Custom metadata may not duplicate reserved fields.
+
+Recurrence synchronization preserves only a validated recurrence rule and its
+state. Version 1 does not schedule work or generate future task instances.
+
+`notes.task_activity` version 1 creates one immutable event with a stable opaque
+event ID, parent task and note identities, actor, client timestamp, transition,
+source, and bounded metadata. Authenticated principal and source-device provenance
+are server-bound, not client-selectable. Server cursor plus event ID defines
+deterministic ordering; client timestamps never do. Exact ID and canonical
+fingerprint replay is idempotent, while reuse of the ID with different content is
+a conflict. Activity tombstone is one-way and cannot rewrite or restore event
+content.
+
+Every activity has a required authorized note and an optional task. When a task is
+present, it must belong to that note. All five existing task-side tables, plus the
+new drift table, gain collision-safe owner/dataset identity, forced PostgreSQL RLS,
+and owner-scoped service predicates. Migrations are transactional and fail closed
+on catalog drift. Existing data and REST behavior are preserved before a dataset
+explicitly enrolls in the new domains.
+
+Schema v60 also owns one private `note_task_scope_authority` relation. It records at
+most one immutable real dataset for each owner and uses owner-only forced PostgreSQL
+RLS. Absence of a row means the owner's task graph remains in the private
+`local-unbound` scope. Binding inserts the authority row atomically with the graph
+rekey, including when the graph is empty; replay to the same dataset is idempotent
+and a different target is rejected. Compatibility callers resolve this indexed
+product-owned row, never accept a client dataset selector, and all shared task-store
+writes must match the recorded authority.
+
+Because the product migration cannot read the separate Sync database, preserved
+inactive rows use a private owner-scoped local-unbound dataset sentinel. Explicit
+enrollment source-verifies and atomically rekeys the complete task graph to the
+real dataset; the sentinel is never client-selectable, writable through Sync, or
+capability-ready.
+
+Markdown checklist text is a deterministic projection, not a competing authority.
+Each managed checklist line carries a hidden versioned marker containing its task
+ID and exact last-projected task revision/hash. The marker reconstructs identity
+after projection-cache loss; the immutable Sync envelope named by that tuple
+reconstructs the last-common projected field snapshot. If that base is unavailable,
+reconciliation fails safe to review rather than guessing by text. Reconciliation
+compares that base with the current canonical task and current Markdown:
+
+- Markdown-only changes become canonical task mutations plus activity;
+- task-only changes rebuild the Markdown projection;
+- compatible changes converge deterministically; and
+- incompatible concurrent changes create a bounded, privacy-safe drift record for
+  review instead of silently overwriting either side.
+
+Server-origin REST, MCP, and reconciliation mutations use ADR-034 durable mutation
+groups when they affect task, activity, and note projection together. The complete
+ordered canonical envelope plan is appended atomically in the Sync store before
+product materialization. Product and Sync databases do not share a distributed
+transaction; idempotent repair closes a product-commit/status-commit split.
+
+Rollout uses existing per-dataset enrollment and readiness. It adds no new global
+environment flag. Neither domain is publicly advertised as supported or writable
+until the fourth PR supplies deterministic task/activity group expansion,
+projection convergence, bootstrap verification, and repair. Existing datasets are
+never silently enrolled.
+
+Because every portable task mutation emits immutable activity, task writability is
+coupled to both domains: task and activity capture are enabled atomically, both
+bootstraps and both repair paths must be ready, and neither domain is writable when
+that invariant is incomplete.
+
+TASK-13006 is delivered as four atomic pull requests:
+
+1. contract, storage, migration, RLS, catalog verification, and dormant readiness;
+2. a complete but dormant `notes.task` lifecycle and bootstrap;
+3. complete but dormant immutable `notes.task_activity` capture and bootstrap; and
+4. deterministic compound mutation groups, Markdown projection convergence,
+   capability activation, end-to-end testing, and public documentation.
+
+## Context
+
+The server already stores Notes tasks, events, projection state, and read state,
+but neither task authority nor task history is a Sync v2 domain. Existing task rows
+have a stable identifier, parent note, text, open/done state, metadata, optimistic
+version, and soft deletion. Existing events are append-only, while Markdown
+checklists are reconciled through local projection tables.
+
+Without an explicit ownership decision, synchronizing all of these tables would
+create competing authorities. A Markdown edit could overwrite an explicit task, a
+read marker could leak device-local UI state, and mutable event replication could
+rewrite history. Conversely, treating Markdown as the only authority would lose
+first-class task identity, recurrence state, structured metadata, and reliable
+multi-device conflict handling.
+
+ADR-031 requires independently mutable Notes resources to use independent Sync
+domains. ADR-034 provides the durable ordered group required when one user action
+changes a task, emits history, and rebuilds a note projection. ADR-037 establishes
+the corresponding rule that deterministic projections are rebuilt rather than
+synchronized.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Synchronize Markdown checklists as the task authority | Markdown lacks stable structured identity and would silently overwrite explicit task fields during concurrent edits. |
+| Synchronize projection and read-state tables | They are deterministic or device-local state, not portable user authority. |
+| Put task state and all activity inside one `notes.task` envelope | Append-only history would become a mutable whole-object conflict surface and grow without bound. |
+| Permit mutable activity events | It would rewrite audit history and make exact replay unverifiable. Corrections are new events or one-way tombstones. |
+| Generate future task instances from recurrence rules | It adds scheduler ownership, clock, deduplication, and offline-generation policy without an approved product requirement. |
+| Add dedicated columns for every extended task field in the first slice | Existing bounded metadata can carry the validated fields without a disruptive compatibility migration or duplicate authority. |
+| Make product and Sync writes one distributed transaction | The repositories already use ADR-034 durable plans and repair; a distributed transaction would add backend coupling without removing recovery requirements. |
+| Advertise domains as soon as schema exists | Existing rows would be missing from initial pulls and server-origin mutations could bypass canonical capture before bootstrap completes. |
+
+## Consequences
+
+- Tasks gain exact multi-device lifecycle semantics while existing REST `text` and
+  product storage remain compatible.
+- Task history is portable, ordered, and immutable; device-local read state stays
+  private.
+- Recurring tasks synchronize their rule and state but require a later, separately
+  approved scheduler if automatic instance creation is ever needed.
+- A single user action may leave repairable cross-database work after a crash, but
+  never an incomplete canonical mutation plan.
+- Existing datasets require resumable source-verified bootstrap before either new
+  domain is writable.
+- Explicit task edits are never silently replaced by Markdown. Some concurrent
+  edits therefore require user review.
+- PostgreSQL upgrades and bootstrap verification can temporarily block affected
+  writes and require live-backend verification before rollout.
+- The four-PR split delays end-to-end checklist convergence until the final PR, but
+  each earlier PR remains independently safe because incomplete domains are not
+  advertised writable.
+
+## Follow-up
+
+- Implement the four TASK-13006 child PRs defined in the related design spec.
+- Update public Sync capability documentation when each domain becomes writable.
+- Keep automatic recurrence scheduling out of scope until a separate task and ADR
+  define scheduler ownership and generation idempotency.

--- a/Docs/Published/ADR/README.md
+++ b/Docs/Published/ADR/README.md
@@ -70,3 +70,4 @@ Small bug fixes, local implementation details, product copy, temporary experimen
 | [ADR-036](036-web-clipper-external-identity-mapping.md) | Accepted | Map owner-scoped public Web Clipper IDs to separate canonical Notes UUIDs and migrate legacy mappings safely. |
 | [ADR-037](037-canonical-notes-link-sync-and-derived-graph-projections.md) | Accepted | Synchronize explicit manual note links while keeping wikilinks, backlinks, orphan state, and graph summaries deterministic local projections. |
 | [ADR-038](038-canonical-notes-attachment-registry-and-blob-lifecycle.md) | Accepted | Give Notes attachments stable product identity while reusing the shared Sync blob lifecycle. |
+| [ADR-039](039-canonical-notes-task-sync-and-derived-checklist-projections.md) | Accepted | Synchronize mutable Notes tasks and immutable activity while keeping Markdown checklists and read state derived. |

--- a/Docs/superpowers/plans/2026-08-13-notes-task-activity-sync-lifecycle-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-13-notes-task-activity-sync-lifecycle-implementation-plan.md
@@ -1,0 +1,342 @@
+# Dormant Notes Task Activity Sync Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement immutable `notes.task_activity` v1 evaluation, product materialization, exact legacy-event bootstrap, and dormant task-transition capture without advertising or enrolling either task domain.
+
+**Architecture:** Activity is an immutable audit stream, not a mutable task projection. The adapter accepts create revision 1 and one-way tombstone revision 2 only; corrections are new stable event IDs. Bootstrap transforms the five legacy event families exactly and pages by `(created_at, id)`. Capture derives stable activity IDs from the accepted task transition, but remains private until TASK-13006.4 can atomically append the full task/activity/note plan.
+
+**Tech Stack:** Python 3.11, Pydantic contracts from TASK-13006.1, Sync v2 adapters/materializers, SQLite, PostgreSQL, pytest, Ruff, Bandit.
+
+**Design:** `Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md`
+
+**Backlog task:** `TASK-13006.3`
+
+**ADR required:** no
+**ADR path:** `Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md`
+**Reason:** This plan directly implements ADR-039's approved immutable activity lifecycle and dormant activation boundary.
+
+---
+
+## File map
+
+**Create**
+
+- `tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task_activity.py` — immutable lifecycle and stable conflict decisions.
+- `tldw_Server_API/app/core/Sync/v2/materializers/notes_task_activity.py` — idempotent owner/dataset-scoped event projection.
+- `tldw_Server_API/app/core/Sync/v2/notes_task_activity_bootstrap.py` — exact legacy conversion and resumable capture.
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_adapter.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_materializer.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_capture.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_postgres_contract.py`
+
+**Modify**
+
+- `tldw_Server_API/app/core/Sync/v2/domain_adapters/__init__.py`
+- `tldw_Server_API/app/core/Sync/v2/materializers/__init__.py`
+- `tldw_Server_API/app/core/Sync/v2/adapters.py` — bounded activity-head and note/task authorization context.
+- `tldw_Server_API/app/core/Sync/v2/factory.py` — private adapter/materializer/bootstrap wiring only.
+- `tldw_Server_API/app/core/Sync/v2/service.py` — private bootstrap and capture repair seam.
+- `tldw_Server_API/app/core/Sync/v2/profile.py` — private readiness invocation without capability exposure.
+- `tldw_Server_API/app/core/DB_Management/chacha/task_store.py` — exact event identity, cursor ordering, and postcondition helpers.
+- `tldw_Server_API/app/core/Notes_Tasks/service.py` — optional dormant transition-capture callback.
+- `tldw_Server_API/tests/Sync/test_sync_v2_factory.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_service.py`
+- `tldw_Server_API/tests/Notes_Tasks/unit/test_service.py`
+
+### Task 0: Start the child and attach this plan
+
+- [ ] **Step 1: Move TASK-13006.3 In Progress**
+
+```bash
+backlog task edit 13006.3 -s "In Progress" --plan $'1. Enforce immutable notes.task_activity lineage.\n2. Materialize activity by Sync cursor and stable ID.\n3. Bootstrap exact legacy events resumably.\n4. Add complete dormant transition capture and repair.\n5. Run SQLite/live-PostgreSQL/static gates.\nDetailed plan: Docs/superpowers/plans/2026-08-13-notes-task-activity-sync-lifecycle-implementation-plan.md\nADR required: no; ADR-039 applies.'
+backlog task 13006.3 --plain
+```
+
+Expected: TASK-13006.2 is Done, TASK-13006.3 is In Progress, and its plan/ADR are
+linked before production work.
+
+### Task 1: Enforce immutable activity lineage
+
+- [ ] **Step 1: Write adapter RED tests**
+
+Cover create revision 1, exact replay, changed stable-ID reuse, task-less note event,
+same-note task event, missing/foreign note or task, canonical old/new values,
+server-bound provenance, exact tombstone revision 2, repeated tombstone, attempted
+update/restore, and correction as a new event ID. Under untrusted client origin,
+reject lifecycle events (`created`, `updated`, `completed`, `reopened`, `deleted`,
+`restored`, projection events) and accept only `corrected` with an existing authorized
+same-owner/dataset/note/task `corrects_activity_id`. Trusted coordinator/bootstrap
+origins may create the closed lifecycle event set.
+
+```python
+def test_activity_rejects_changed_stable_id_reuse() -> None:
+    result = adapter.evaluate(
+        activity_envelope(event_id=EVENT_ID, new_value={"status": "done"}),
+        dataset,
+        context_with_activity_head(activity_head(event_id=EVENT_ID)),
+    )
+    assert result.status == "conflict"
+    assert result.error_code == "notes_task_activity_identity_reused"
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_adapter.py
+```
+
+Expected: collection or behavior failures because the activity adapter is absent.
+
+- [ ] **Step 3: Implement one strict adapter**
+
+Parse only through `notes_task_contract.py`. Bind object ID to activity ID and parent
+ID to note ID. Require the optional task to be in the same owner/dataset/note. Accept
+only `upsert` at revision 1 against an empty head and `tombstone` at revision 2 against
+the exact live revision. Use the authenticated adapter context origin: direct clients
+may create only `corrected`, and its target activity must resolve in the identical
+scope; trusted coordinator/bootstrap origins may create lifecycle events. Actor and
+source provenance remain server-bound. Do not create an activity-update or restore
+path.
+
+```python
+if head is None:
+    return accept_create(envelope, required_revision=1)
+if exact_replay(head, envelope):
+    return accept_replay(head)
+if envelope.operation == "tombstone" and exact_live_base(head, envelope):
+    return accept_tombstone(envelope, required_revision=2)
+return conflict("notes_task_activity_immutable")
+```
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_adapter.py
+git add tldw_Server_API/app/core/Sync/v2/domain_adapters \
+  tldw_Server_API/app/core/Sync/v2/adapters.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_adapter.py
+git commit -m "feat(sync): add immutable task activity adapter"
+```
+
+### Task 2: Materialize activity with exact ordering and scope
+
+- [ ] **Step 1: Write materializer RED tests**
+
+Cover revision-1 insert, exact replay, changed replay rejection, revision-2 tombstone,
+postcondition verification, owner/dataset/note/task scope, cursor ordering by
+`(sync_server_cursor, activity_id)`, and rollback on an injected product-write
+failure. Creation time is used only by the legacy bootstrap source scan.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_materializer.py
+```
+
+- [ ] **Step 3: Add exact product pages and lifecycle CAS helpers**
+
+Add connection-aware create/tombstone/get/page methods. Every predicate includes
+`owner_user_id` and `dataset_id`; task-bearing rows join the task and note scope. Use
+keyset pagination by `(sync_server_cursor, activity_id)` with the TASK-13006.1
+indexes and cap requested pages at 1,000.
+Implementation targets: `TaskStore.create_sync_task_activity(...)`,
+`TaskStore.tombstone_sync_task_activity(...)`,
+`TaskStore.get_sync_task_activity(...)`, and
+`TaskStore.page_sync_task_activity(...)`.
+
+- [ ] **Step 4: Implement the materializer**
+
+Use the accepted Sync transaction and product connection. Insert the canonical event
+only once, verify its immutable semantic row, and tombstone by exact lifecycle CAS.
+Do not project read/dismiss state into Sync. Product and Sync commits remain split:
+after a product commit/Sync-status failure, exact replay verifies the immutable row
+and advances apply status without inserting a second event.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_materializer.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+git add tldw_Server_API/app/core/Sync/v2/materializers \
+  tldw_Server_API/app/core/DB_Management/chacha/task_store.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_materializer.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+git commit -m "feat(sync): materialize immutable task activity"
+```
+
+### Task 3: Bootstrap legacy events exactly and resumably
+
+- [ ] **Step 1: Write legacy transform RED vectors**
+
+Pin the spec's exact mappings for `created`, `updated`, `status_changed`, `unlinked`,
+and `deleted`, including old/new normalization, source/provenance sentinel, optional
+task identity, and the rule that read/dismiss rows never become activity envelopes.
+
+- [ ] **Step 2: Write bootstrap RED tests**
+
+Cover deterministic `(created_at, id)` pages, equal timestamps, page boundary replay,
+stable envelope/activity IDs, count/fingerprint verification, split-commit repair,
+source drift, malformed legacy rows, empty source, and cross-owner isolation.
+
+- [ ] **Step 3: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py
+```
+
+- [ ] **Step 4: Add the exact legacy converter and source page**
+
+Reuse the contract converter from TASK-13006.1 and add an owner/dataset-scoped source
+page ordered by `(created_at, id)`, hard-capped at 1,000. Turn every five-family
+mapping/rejection vector and equal-timestamp page boundary GREEN before appending.
+Implementation targets: `TaskStore.page_legacy_events_for_sync_bootstrap(...)`,
+`legacy_task_event_to_activity(...)`, and `_activity_bootstrap_envelope_id(...)`.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py \
+  -k 'legacy_mapping or rejects_legacy or source_page or equal_timestamp'
+```
+
+- [ ] **Step 5: Implement one resumable bootstrap page**
+
+Read only through keyset pages of at most 1,000. Transform through the strict contract
+module, derive IDs from the immutable legacy event identity, use the source row's
+canonical timestamp, and persist transition progress/count/fingerprint through the
+shared readiness records. Fail closed on a changed source fingerprint.
+
+```python
+for row in task_store.page_legacy_events(after=cursor, limit=page_size):
+    payload = legacy_task_event_to_activity(row)
+    batch.append(build_bootstrap_activity(payload, provenance=LEGACY_SENTINEL))
+```
+
+- [ ] **Step 6: Reconcile count/fingerprint and readiness**
+
+After the last page, compare source count and aggregate fingerprint with applied
+activity envelopes. Persist only activity readiness. An injected split after Sync
+append resumes by exact replay; source drift fails closed without deleting history.
+
+- [ ] **Step 7: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_service.py
+git add tldw_Server_API/app/core/Sync/v2/notes_task_activity_bootstrap.py \
+  tldw_Server_API/app/core/Sync/v2/factory.py \
+  tldw_Server_API/app/core/Sync/v2/profile.py \
+  tldw_Server_API/app/core/Sync/v2/service.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_service.py
+git commit -m "feat(sync): bootstrap legacy task activity"
+```
+
+### Task 4: Add dormant transition capture and repair
+
+- [ ] **Step 1: Write capture RED tests**
+
+Cover create, title/description update, recurrence/metadata-only update, completion,
+reopen, projection unlink, delete, and restore→`restored`. Prove every portable task
+mutation derives the exact canonical event/value shape and stable activity ID;
+retries do not duplicate, a failed second write is repairable, and public
+capabilities/enrollment still omit both task domains.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_capture.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+```
+
+- [ ] **Step 3: Implement a private capture primitive**
+
+Expose a disabled-by-default callback from the task service. Given an accepted task
+transition, return the strict activity payload plus stable object/envelope IDs. Do not
+append separately from the task; TASK-13006.4 will make the full mutation plan atomic.
+
+```python
+capture = task_activity_capture
+if capture is not None:
+    capture.record_dormant_transition(before=before, after=after, operation=operation)
+```
+
+- [ ] **Step 4: Prove PostgreSQL ordering and RLS**
+
+Add server-free SQL/catalog tests and live PostgreSQL tests for owner isolation,
+same-note task references, cursor-plus-ID paging, exact replay, and rollback. Run with
+PostgreSQL required; a skip is a failure for this child PR.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_capture.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_postgres_contract.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+git add tldw_Server_API/app/core/Notes_Tasks/service.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_capture.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_postgres_contract.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+git commit -m "feat(sync): add dormant task activity capture"
+```
+
+### Task 5: Run the PR gate and close TASK-13006.3
+
+- [ ] **Step 1: Run focused and regression tests**
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_adapter.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_materializer.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_capture.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_postgres_contract.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_adapter.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_materializer.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_service.py \
+  tldw_Server_API/tests/Notes_Tasks
+```
+
+Expected: all pass; live PostgreSQL tests do not skip.
+
+- [ ] **Step 2: Run static/security checks**
+
+```bash
+PRODUCTION_PATHS=(
+  tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task_activity.py
+  tldw_Server_API/app/core/Sync/v2/domain_adapters/__init__.py
+  tldw_Server_API/app/core/Sync/v2/materializers/notes_task_activity.py
+  tldw_Server_API/app/core/Sync/v2/materializers/__init__.py
+  tldw_Server_API/app/core/Sync/v2/notes_task_activity_bootstrap.py
+  tldw_Server_API/app/core/Sync/v2/adapters.py
+  tldw_Server_API/app/core/Sync/v2/factory.py
+  tldw_Server_API/app/core/Sync/v2/service.py
+  tldw_Server_API/app/core/Sync/v2/profile.py
+  tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+  tldw_Server_API/app/core/Notes_Tasks/service.py
+)
+../../.venv/bin/ruff check --no-cache "${PRODUCTION_PATHS[@]}"
+../../.venv/bin/bandit -q "${PRODUCTION_PATHS[@]}"
+PYTHONPYCACHEPREFIX=/tmp/task13006-pycache ../../.venv/bin/python -m py_compile "${PRODUCTION_PATHS[@]}"
+git diff --check
+```
+
+- [ ] **Step 3: Self-review the dormant boundary**
+
+Confirm no public request schema, endpoint, supported/writable capability, enrollment,
+or automatic product mutation advertises either domain. Confirm read/dismiss state is
+absent and corrections always create new activity identities.
+
+- [ ] **Step 4: Complete Backlog notes and status**
+
+Check TASK-13006.3 AC/DoD, record exact commands and live PostgreSQL evidence, document
+plan deviations, add implementation notes, and set the task Done.

--- a/Docs/superpowers/plans/2026-08-13-notes-task-checklist-convergence-activation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-13-notes-task-checklist-convergence-activation-implementation-plan.md
@@ -1,0 +1,477 @@
+# Notes Task Checklist Convergence and Sync Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Atomically couple task, activity, and optional note mutations; converge managed Markdown checklists through durable anchors and explicit drift; then expose `notes.task` and `notes.task_activity` together only when enrollment and both bootstraps are ready.
+
+**Architecture:** A single coordinator builds the complete deterministic mutation plan before any append; server-origin plans use the existing ADR-034 batch and authenticated client task pushes are expanded through the same planner before append. Managed Markdown markers carry stable task identity plus the last-common canonical revision/hash; immutable Sync envelopes and group metadata are durable projection authority, while product cache/drift rows are rebuildable. The two domains share one activation predicate and are never advertised independently. The 1,000-envelope mutation-group ceiling permits at most 499 managed task transitions in one note reconciliation (`2N + 1`).
+
+**Tech Stack:** Python 3.11, Textual server API, Sync v2 mutation groups, ChaChaNotes SQLite/PostgreSQL, Pydantic, pytest, Ruff, Bandit.
+
+**Design:** `Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md`
+
+**Backlog task:** `TASK-13006.4`
+
+**ADR required:** no
+**ADR path:** `Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md`
+**Reason:** This plan activates the coupled boundary and convergence algorithm already approved by ADR-039; it introduces no additional architecture decision.
+
+---
+
+## File map
+
+**Create**
+
+- `tldw_Server_API/app/core/Sync/v2/notes_task_coordinator.py` — deterministic compound planning and one-batch append.
+- `tldw_Server_API/app/core/Notes_Tasks/projection_markers.py` — pure hidden-marker parse/render and canonical line identity.
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_coordinator.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_projection.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activation.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_end_to_end.py`
+
+**Modify**
+
+- `tldw_Server_API/app/core/Notes_Tasks/markdown_parser.py` — recognize managed checklist markers without changing ordinary Markdown parsing.
+- `tldw_Server_API/app/core/Notes_Tasks/reconciler.py` — exact three-way classification and explicit drift handling.
+- `tldw_Server_API/app/core/Notes_Tasks/service.py` — route REST/MCP task mutations through the coordinator.
+- `tldw_Server_API/app/core/Notes_Tasks/models.py` — bounded projection/drift response types only where public APIs require them.
+- `tldw_Server_API/app/core/DB_Management/chacha/task_store.py` — rebuildable projection cache, drift, product rekey, and retention-blocker methods; never durable anchor authority.
+- `tldw_Server_API/app/core/DB_Management/Sync_DB.py` — historical immutable task-envelope lookup and mutation-group anchor metadata.
+- `tldw_Server_API/app/core/Sync/v2/store.py` — owner/dataset-scoped historical envelope and group-anchor facade.
+- `tldw_Server_API/app/core/Sync/v2/service.py` — coordinator entry, coupled enrollment/readiness, retention and repair.
+- `tldw_Server_API/app/core/Sync/v2/factory.py` — coupled supported/writable activation.
+- `tldw_Server_API/app/core/Sync/v2/models.py` — domain constants and bounded internal plan types.
+- `tldw_Server_API/app/core/Sync/v2/profile.py` — coupled bootstrap/enrollment response.
+- `tldw_Server_API/app/core/Sync/v2/replay.py` — repair full mutation groups without partial projection.
+- `tldw_Server_API/app/core/Sync/v2/restore.py` — linked task/projection restore coordination.
+- `tldw_Server_API/app/api/v1/endpoints/notes_tasks.py` — expose stable drift/conflict outcomes.
+- `tldw_Server_API/app/api/v1/endpoints/sync.py` — coupled enrollment/capability behavior.
+- `tldw_Server_API/app/api/v1/schemas/sync_v2_models.py` — public capability schemas for the two domains.
+- `Docs/API/Sync_V2_M1.md` — document versions, enrollment, grouping, markers, and failure semantics.
+- `tldw_Server_API/tests/Notes_Tasks/unit/test_markdown_parser.py`
+- `tldw_Server_API/tests/Notes_Tasks/unit/test_reconciler.py`
+- `tldw_Server_API/tests/Notes_Tasks/unit/test_service.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_service.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_retention.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py`
+
+### Task 0: Start the child and attach this plan
+
+- [ ] **Step 1: Move TASK-13006.4 In Progress**
+
+```bash
+backlog task edit 13006.4 -s "In Progress" --plan $'1. Add immutable-envelope projection anchors and rebuildable caches.\n2. Expand server/client task mutations into deterministic groups.\n3. Implement exact three-way convergence and drift claims.\n4. Fence retention/delete/restore/relink.\n5. Rekey product state and activate both domains together.\n6. Run end-to-end SQLite/live-PostgreSQL/static gates.\nDetailed plan: Docs/superpowers/plans/2026-08-13-notes-task-checklist-convergence-activation-implementation-plan.md\nADR required: no; ADR-039 applies.'
+backlog task 13006.4 --plain
+```
+
+Expected: TASK-13006.3 is Done, TASK-13006.4 is In Progress, and the plan/ADR are
+linked before production work.
+
+### Task 1: Parse managed markers and persist projection authority
+
+- [ ] **Step 1: Write marker RED tests**
+
+Cover render/parse round trips, stable task UUID, canonical revision/hash, NFKC/control
+characters, duplicate markers, forged markers, ordinary checklist lines, reordered
+lines, and malformed hidden comments. Keep the marker syntax private to the helper.
+
+```python
+def test_managed_marker_round_trip() -> None:
+    marker = render_task_marker(TASK_ID, revision=7, object_hash=HASH)
+    assert parse_task_marker(marker) == TaskMarker(TASK_ID, 7, HASH)
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_markdown_parser.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_projection.py
+```
+
+- [ ] **Step 3: Implement one pure marker module**
+
+Use standard-library parsing. Return a typed result or a stable validation error; do
+not embed DB or Sync calls. The Markdown parser may call this helper but ordinary
+unmarked checklist behavior must remain unchanged.
+
+- [ ] **Step 4: Persist authoritative anchors in Sync group metadata**
+
+Extend the existing mutation-group metadata with the historical task envelope ID,
+canonical task revision/hash, note envelope ID/hash, and projection version. Add an
+owner/dataset-scoped Sync-store lookup that resolves that immutable historical task
+envelope exactly; a marker that cannot resolve its named envelope is drift.
+Implementation targets: `SyncDatabase.get_historical_task_envelope(...)`,
+`SyncV2Store.get_historical_task_envelope(...)`, and
+`_validate_task_projection_group_metadata(...)`.
+
+- [ ] **Step 5: Add rebuildable product cache and drift methods**
+
+Add owner/dataset/note/task-scoped create/get/CAS/page methods to `task_store.py`.
+These rows cache the authoritative Sync group/envelope references and are rebuildable;
+they do not become last-common authority. Drift stores privacy-safe reason codes and
+lifecycle, not raw note/task content. Rebuild missing caches only from a valid marker,
+its exact Sync group metadata, and the immutable historical task envelope named by
+that metadata—never from current task heads or checklist text.
+
+- [ ] **Step 6: Run cache-loss/retention GREEN and commit**
+
+Before committing, prove cache deletion rebuilds from the marker's immutable envelope,
+marker removal creates drift without losing the historical reference, task/note
+tombstones retain the named anchor envelope, and open drift keeps every referenced
+group member ineligible for compaction.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_markdown_parser.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_projection.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+git add tldw_Server_API/app/core/Notes_Tasks/projection_markers.py \
+  tldw_Server_API/app/core/Notes_Tasks/markdown_parser.py \
+  tldw_Server_API/app/core/DB_Management/Sync_DB.py \
+  tldw_Server_API/app/core/Sync/v2/store.py \
+  tldw_Server_API/app/core/DB_Management/chacha/task_store.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_markdown_parser.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_projection.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+git commit -m "feat(notes): add managed task projection authority"
+```
+
+### Task 2: Build one deterministic compound mutation coordinator
+
+- [ ] **Step 1: Write coordinator RED tests**
+
+Cover task-only metadata changes (`task + activity`), projection-affecting changes
+(`task + activity + note`), note-origin checklist changes, REST/MCP origins, Sync
+client task pushes, stable IDs under retry, exact parent/base tuples, full preflight
+before append, injected second/third-step failure, acceptance of exactly 499 managed
+task changes (`2N + 1 = 999`), and pre-append rejection of 500 (`1,001`).
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_coordinator.py
+```
+
+- [ ] **Step 3: Implement pure deterministic plan construction**
+
+Build all envelopes in memory before calling `server_origin_batch`. Derive activity,
+note, envelope, and idempotency IDs from the mutation identity and canonical payloads.
+Reject a plan over 1,000 steps before any append; note reconciliation therefore caps
+managed task transitions at 499.
+
+Implementation targets: `NotesTaskCoordinator.plan_task_mutation(...)`,
+`NotesTaskCoordinator.plan_note_reconciliation(...)`, `_task_activity_id(...)`, and
+`_validate_task_mutation_plan(...)`.
+
+```python
+plan = [task_envelope, activity_envelope]
+if note_projection_changed:
+    plan.append(note_envelope)
+validate_mutation_group(plan, max_steps=1000)
+return server_origin_batch.append_atomic(plan)
+```
+
+- [ ] **Step 4: Append server-origin plans and repair split commits**
+
+Replace the dormant callback in task service with one injected coordinator. Keep one
+mutation authority: append the complete compound Sync batch, then materialize product
+state. Sync and product commits are separate; injected splits replay the same accepted
+group and verify product postconditions. Repair never appends only the missing
+activity or note step and never promises cross-database rollback.
+
+- [ ] **Step 5: Expand authenticated client task pushes before append**
+
+In the Sync service, after device/dataset/domain/version authorization and strict task
+validation but before any append, expand an incoming `notes.task` envelope into the
+same compound plan. Derive activity/group IDs from the authenticated task envelope ID
+and canonical payload; add the optional note projection from the exact base/head.
+Append all steps atomically in Sync. Exact client replay must resolve the identical
+group; changed envelope-ID reuse conflicts before activation.
+Implementation targets: `SyncV2Service._expand_task_client_push(...)` and the existing
+batch append transaction; do not add a second append engine.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_coordinator.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_service.py \
+  -k 'client_push or client_replay or client_group or changed_identity'
+```
+
+- [ ] **Step 6: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_coordinator.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_service.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+git add tldw_Server_API/app/core/Sync/v2/notes_task_coordinator.py \
+  tldw_Server_API/app/core/Sync/v2/service.py \
+  tldw_Server_API/app/core/Notes_Tasks/service.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_coordinator.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_service.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+git commit -m "feat(sync): coordinate task activity and note mutations"
+```
+
+### Task 3: Implement explicit three-way checklist convergence
+
+- [ ] **Step 1: Write the reconciliation matrix as RED tests**
+
+For each managed task compare `(anchor, current task, current note line)` and cover:
+unchanged, task-only, note-only, equal concurrent result, incompatible concurrent
+change, completion/reopen, description edit, reorder, unlink, missing marker, duplicate
+marker, cache loss, explicit REST task vs unmarked checklist, and unrelated note edits.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_reconciler.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_projection.py
+```
+
+- [ ] **Step 3: Implement the minimal three-way classifier**
+
+Return one of `no_change`, `task_to_note`, `note_to_task`, `same_result`, or `drift`.
+Only a marker plus matching anchor grants managed authority. Unmarked checklists stay
+ordinary Markdown. On incompatible edits, preserve both product states and write one
+privacy-safe drift row; never silently overwrite an explicit task.
+
+- [ ] **Step 4: Route reconciliation through the coordinator**
+
+Translate non-drift decisions into deterministic compound plans. Advance anchors only
+after the full mutation group materializes and postconditions pass. A crash between
+append and projection must replay the same plan and converge without duplicate events.
+
+- [ ] **Step 5: Implement exact drift claims and outcomes**
+
+Require owner/dataset, drift ID, expected drift lifecycle revision, current task head,
+current note head, and authoritative anchor group. Test `keep_task`,
+`accept_markdown`, `unlink`, and `dismiss`; stale or changed claims conflict without
+mutation. Resolution appends its complete deterministic group first, then CAS-updates
+the rebuildable drift row. Dismissal changes only drift lifecycle and never task/note
+content.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_projection.py \
+  -k 'resolve_drift or stale_claim or dismiss_drift or keep_task or accept_markdown or unlink'
+```
+
+- [ ] **Step 6: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_reconciler.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_projection.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_coordinator.py
+git add tldw_Server_API/app/core/Notes_Tasks/reconciler.py \
+  tldw_Server_API/app/core/Sync/v2/notes_task_coordinator.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_reconciler.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_projection.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_coordinator.py
+git commit -m "feat(notes): converge managed task checklists"
+```
+
+### Task 4: Fence retention, delete, restore, and relink
+
+- [ ] **Step 1: Write lifecycle/retention RED tests**
+
+Cover linked task tombstone retaining required task/activity/note envelopes, open drift
+blocking compaction, resolved drift releasing blockers, note delete, task unlink,
+explicit restore/relink, note restore with missing task, repeated restore, cache loss,
+and stale candidate revalidation under the dataset materialization fence.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_retention.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py \
+  -k 'notes_task or task_activity or checklist_projection'
+```
+
+- [ ] **Step 3: Add exact blocker and resolution reads**
+
+Use owner/dataset-scoped, capped, index-backed pages. Revalidate task bindings, current
+heads, immutable Sync group/envelope anchor references, open drift, devices, exact
+version acks, and restore windows on the same guarded connection before retention CAS.
+Product projection caches are never retention authority. Do not introduce physical GC
+or a recurrence scheduler.
+
+- [ ] **Step 4: Implement delete/restore/relink coordination**
+
+Produce complete deterministic plans, require exact tombstone bases for restore, and
+recreate/advance projection anchors only after all referenced product state is valid.
+Unlink preserves task identity; relink requires authorized destination note scope.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Sync/test_sync_v2_retention.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_projection.py
+git add tldw_Server_API/app/core/Sync/v2/service.py \
+  tldw_Server_API/app/core/Sync/v2/replay.py \
+  tldw_Server_API/app/core/Sync/v2/restore.py \
+  tldw_Server_API/app/core/DB_Management/chacha/task_store.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_retention.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py
+git commit -m "feat(sync): fence task projection lifecycle"
+```
+
+### Task 5: Activate coupled enrollment and capabilities
+
+- [ ] **Step 1: Write activation RED tests**
+
+Cover default omission, gate off, unbound/local sentinel dataset, one bootstrap ready,
+both bootstraps ready, source diagnostic failure, explicit enrollment rekey, product-
+commit/Sync-readiness split and idempotent resume, active re-enrollment, device version
+negotiation, selected-dataset authorization, and the invariant that support/writability
+always includes both domains or neither. Inject concurrent REST and MCP mutations
+before each source scan, between task/activity scans, and after each scan; every
+transition must appear exactly once after resume. Add direct-client authorization
+vectors: lifecycle activity creates are rejected, a `corrected` event with an exact
+authorized same-scope target is accepted, and missing/foreign/cross-task targets fail
+without revealing existence.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activation.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+```
+
+- [ ] **Step 3: Implement one coupled readiness predicate**
+
+Require rollout gate, dataset authorization/enrollment, task readiness, activity
+readiness, projection repair readiness, and supported adapter version 1 for both
+domains. Reuse it from adapter enforcement, service capabilities, profile/bootstrap,
+and public endpoint responses.
+
+- [ ] **Step 4: Rekey local-unbound rows atomically at enrollment**
+
+Under the dataset fence, validate collision-free ownership, rekey all six task-side
+product tables (including rebuildable cache/drift rows) from the private sentinel to
+the enrolled dataset, verify exact counts/fingerprints, and commit that product
+transaction. Sync readiness and capture activation are a later Sync-DB transition
+under the same fence: if it fails, remain non-writable and resume idempotently from
+the verified product state. Never claim cross-database rollback or rewrite historical
+Sync envelopes.
+
+- [ ] **Step 5: Enable coupled capture, run both bootstraps, then become ready**
+
+With external task-domain Sync writes still disabled, commit one Sync readiness
+transition that enables both REST/MCP task and activity capture together. Only then
+run the task source scan and activity source scan resumably. Capture closes the race
+for mutations concurrent with either scan; exact event/envelope IDs deduplicate source
+rows and captured transitions. After both count/fingerprint verifications pass, commit
+one coupled readiness transition. Until that last commit, supported/writable maps omit
+both domains. Add split-resume tests after product rekey, capture enable, every task
+page, every activity page, and final readiness.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activation.py \
+  -k 'capture_before_scan or concurrent_rest or concurrent_mcp or split_resume or coupled_ready'
+```
+
+- [ ] **Step 6: Wire public schemas/endpoints and docs**
+
+Advertise `notes.task: [1]` and `notes.task_activity: [1]` together. Add stable,
+sanitized activation/drift errors and document payload versions, group limits,
+enrollment, marker authority, conflict behavior, client activity limited to exact
+same-scope `corrected` events, and no recurrence scheduler. Keep the service preflight
+that rejects direct client lifecycle events even if adapter/factory wiring changes.
+
+- [ ] **Step 7: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activation.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_service.py
+git add tldw_Server_API/app/core/Sync/v2/factory.py \
+  tldw_Server_API/app/core/Sync/v2/models.py \
+  tldw_Server_API/app/core/Sync/v2/profile.py \
+  tldw_Server_API/app/core/Sync/v2/service.py \
+  tldw_Server_API/app/api/v1/endpoints/sync.py \
+  tldw_Server_API/app/api/v1/schemas/sync_v2_models.py \
+  Docs/API/Sync_V2_M1.md \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activation.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+git commit -m "feat(sync): activate coupled task domains"
+```
+
+### Task 6: Prove end-to-end convergence and close TASK-13006
+
+- [ ] **Step 1: Run end-to-end SQLite and required PostgreSQL tests**
+
+Cover two devices plus server-origin REST/MCP, create/edit/complete/reopen, recurrence
+metadata propagation without scheduling, note-origin checklist edits, concurrent equal
+and incompatible edits, deletion, restoration, relink, pagination, pull/ack, crash at
+each mutation-group boundary, split-commit repair, and retention revalidation.
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 PYTHONPATH=. ../../.venv/bin/python -m pytest -q \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_end_to_end.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_coordinator.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_projection.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activation.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_postgres_contract.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_postgres_contract.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_service.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_retention.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_restore_preview.py \
+  tldw_Server_API/tests/Notes_Tasks
+```
+
+Expected: all pass; live PostgreSQL tests do not skip.
+
+- [ ] **Step 2: Run static/security checks**
+
+```bash
+PRODUCTION_PATHS=(
+  tldw_Server_API/app/core/Sync/v2/notes_task_coordinator.py
+  tldw_Server_API/app/core/Sync/v2/service.py
+  tldw_Server_API/app/core/Sync/v2/store.py
+  tldw_Server_API/app/core/Sync/v2/factory.py
+  tldw_Server_API/app/core/Sync/v2/models.py
+  tldw_Server_API/app/core/Sync/v2/profile.py
+  tldw_Server_API/app/core/Sync/v2/replay.py
+  tldw_Server_API/app/core/Sync/v2/restore.py
+  tldw_Server_API/app/core/DB_Management/Sync_DB.py
+  tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+  tldw_Server_API/app/core/Notes_Tasks/projection_markers.py
+  tldw_Server_API/app/core/Notes_Tasks/markdown_parser.py
+  tldw_Server_API/app/core/Notes_Tasks/reconciler.py
+  tldw_Server_API/app/core/Notes_Tasks/service.py
+  tldw_Server_API/app/core/Notes_Tasks/models.py
+  tldw_Server_API/app/api/v1/endpoints/notes_tasks.py
+  tldw_Server_API/app/api/v1/endpoints/sync.py
+  tldw_Server_API/app/api/v1/schemas/sync_v2_models.py
+)
+../../.venv/bin/ruff check --no-cache "${PRODUCTION_PATHS[@]}"
+../../.venv/bin/bandit -q "${PRODUCTION_PATHS[@]}"
+PYTHONPYCACHEPREFIX=/tmp/task13006-pycache ../../.venv/bin/python -m py_compile "${PRODUCTION_PATHS[@]}"
+git diff --check
+```
+
+- [ ] **Step 3: Self-review scope and security**
+
+Confirm every public mutation uses the coordinator, neither domain can activate alone,
+all task-side predicates bind owner and dataset, no raw drift content leaks, group/page
+caps are enforced before work, and no scheduler, physical GC, or unrelated Notes API
+change entered the diff.
+
+- [ ] **Step 4: Complete Backlog and final documentation**
+
+Check TASK-13006.4 and parent TASK-13006 AC/DoD, record exact SQLite/live PostgreSQL and
+static evidence, add concise implementation notes and any real lesson learned, set both
+tasks Done, and commit the closeout documentation.

--- a/Docs/superpowers/plans/2026-08-13-notes-task-sync-contract-storage-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-13-notes-task-sync-contract-storage-implementation-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Establish strict dormant `notes.task`/`notes.task_activity` contracts, schema-v60 collision-safe task storage, forced PostgreSQL tenancy, separate canonical task revisions, and resumable readiness state without advertising either domain.
 
-**Architecture:** ChaChaNotes remains the product authority. Schema v60 transactionally rebuilds the existing task graph into owner/dataset-scoped tables, initially using a private local-unbound sentinel for legacy REST rows; explicit enrollment later rekeys the graph under the dataset fence. A shared contract module owns parsing and hashing, while public supported/writable capability lists remain unchanged.
+**Architecture:** ChaChaNotes remains the product authority. Schema v60 transactionally rebuilds the existing task graph into six owner/dataset-scoped graph tables plus one private owner-to-dataset authority relation, initially using a private local-unbound sentinel for legacy REST rows; explicit enrollment later records the immutable authority and rekeys the graph under the dataset fence. A shared contract module owns parsing and hashing, while public supported/writable capability lists remain unchanged.
 
 **Tech Stack:** Python 3.11, Pydantic, SQLite, PostgreSQL, FastAPI Sync models, pytest, Ruff, Bandit.
 
@@ -31,12 +31,12 @@
 
 - `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py` — schema v60 migration, exact current-catalog verification, store wiring.
 - `tldw_Server_API/app/core/DB_Management/chacha/task_store.py` — owner/dataset predicates, canonical revision/hash, local-unbound binding/rekey helpers.
-- `tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py` — forced RLS for all six task-side tables.
+- `tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py` — six owner/dataset graph policies plus one owner-only scope-authority policy.
 - `tldw_Server_API/app/core/DB_Management/Sync_DB.py` — independent dormant readiness records and atomic state transitions.
 - `tldw_Server_API/app/core/Sync/v2/models.py` — known-but-dormant domain types and discoverable private schemas; do not add to supported lists.
 - `tldw_Server_API/app/core/Sync/v2/store.py` — readiness facade methods.
 - `tldw_Server_API/app/core/Sync/v2/profile.py` — sanitized internal readiness status only; no writable advertisement.
-- `tldw_Server_API/app/core/Notes_Tasks/service.py` — trusted local-unbound compatibility scope and enrolled scope forwarding.
+- `tldw_Server_API/app/core/Notes_Tasks/service.py` — trusted indexed scope-authority lookup and scope forwarding.
 - `tldw_Server_API/app/core/Notes_Tasks/reconciler.py` — trusted scope forwarding for legacy reconciliation.
 - `tldw_Server_API/app/api/v1/endpoints/notes_tasks.py` — authenticated owner scope forwarding without wire changes.
 - `tldw_Server_API/app/core/MCP_unified/modules/implementations/notes_module.py` — authenticated MCP owner scope forwarding without tool-schema changes.
@@ -192,7 +192,8 @@ git commit -m "feat(sync): define dormant Notes task contracts"
 
 - [ ] **Step 1: Write migration RED tests**
 
-Assert current version 60, fresh/59→60 parity, exact six table schemas, composite
+Assert current version 60, fresh/59→60 parity, exact six graph schemas plus the
+private scope-authority relation, composite
 owner/dataset identities and FKs, `ON UPDATE CASCADE`, task canonical revision/hash,
 event lifecycle columns, drift table, bounded indexes, integer storage classes,
 post-DDL rollback, collision failure, and version-last behavior.
@@ -218,8 +219,9 @@ Expected: current schema is 59 and v60 structures are absent.
 
 - [ ] **Step 3: Add fixed SQLite v60 DDL and conversion helpers**
 
-Define the six exact replacement table/index statements and pure row converters in
-`ChaChaNotes_DB.py`. Add unit tests for canonical column/check/index SQL, source-row
+Define the six exact graph replacement table/index statements, the private
+scope-authority relation, and pure row converters in `ChaChaNotes_DB.py`. Add unit
+tests for canonical column/check/index SQL, source-row
 conversion, local-unbound scope, and malformed-metadata diagnostics before invoking
 the initializer.
 
@@ -237,7 +239,7 @@ Under the existing initializer lock/transaction:
 
 1. require exact v59 authority and required source tables;
 2. reject any v60 target-table collision;
-3. create replacement tables with composite scope and exact checks;
+3. create six replacement graph tables plus the empty scope-authority relation with exact checks;
 4. map each source row to its proven owner and private local-unbound sentinel;
 5. compute canonical task hashes with the shared contract;
 6. source-count/hash verify every table;
@@ -264,8 +266,12 @@ service resolves either the enrolled dataset or the private local-unbound sentin
 Do not make endpoints or MCP tools accept a client-selected dataset. Update the REST,
 MCP, and reconciler call sites in this step and prove their public schemas unchanged.
 Add `bind_local_task_graph_to_dataset()` which verifies the complete source set,
-rejects target collisions, and updates the sentinel scope in one product transaction
-through cascading composite FKs.
+rejects target collisions, updates the sentinel scope, and records the immutable
+owner authority in one product transaction through cascading composite FKs. Empty
+graphs still record the target; same-target replay is idempotent, different-target
+rebind fails closed, and every shared task-store write must match the authority.
+Normal compatibility resolution is one indexed owner lookup and performs no table
+locks, catalog verification, RLS toggles, or graph scans.
 
 ```python
 def get_task(
@@ -358,13 +364,15 @@ Implement `_migrate_from_v59_to_v60_postgres(conn)` and
 initializer branches. Follow the reviewed v59 ordering: schema-version row lock first, fixed relation
 locks, catalog-owner/RLS verification, exact temporary FORCE handling only when
 needed, validate before DDL, transactional rebuild/copy/swap, restore FORCE, install
-all six canonical policies, exact verify, then version bump last. Current-v60
+the six graph policies plus the owner-only scope-authority policy, exact verify,
+then version bump last. Current-v60
 startup locks and verifies the full catalog; it never repairs drift silently.
 
-- [ ] **Step 5: Add all six forced-RLS policies**
+- [ ] **Step 5: Add all graph and scope-authority forced-RLS policies**
 
 Use owner/dataset predicates plus owned-note/task/event EXISTS checks in both USING
-and WITH CHECK. Enumerate all policies and reject extra permissive policies.
+and WITH CHECK for the six graph relations. Use an owner-only predicate for the
+private scope-authority relation. Enumerate all policies and reject extra permissive policies.
 
 - [ ] **Step 6: Run live GREEN and commit**
 

--- a/Docs/superpowers/plans/2026-08-13-notes-task-sync-contract-storage-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-13-notes-task-sync-contract-storage-implementation-plan.md
@@ -1,0 +1,487 @@
+# Notes Task Sync Contract And Storage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish strict dormant `notes.task`/`notes.task_activity` contracts, schema-v60 collision-safe task storage, forced PostgreSQL tenancy, separate canonical task revisions, and resumable readiness state without advertising either domain.
+
+**Architecture:** ChaChaNotes remains the product authority. Schema v60 transactionally rebuilds the existing task graph into owner/dataset-scoped tables, initially using a private local-unbound sentinel for legacy REST rows; explicit enrollment later rekeys the graph under the dataset fence. A shared contract module owns parsing and hashing, while public supported/writable capability lists remain unchanged.
+
+**Tech Stack:** Python 3.11, Pydantic, SQLite, PostgreSQL, FastAPI Sync models, pytest, Ruff, Bandit.
+
+**Design:** `Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md`
+
+**Backlog task:** `TASK-13006.1`
+
+**ADR required:** no
+**ADR path:** `Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md`
+**Reason:** ADR-039 already approves this slice's product schema, tenant identity, RLS, canonical revision ownership, and readiness contracts.
+
+---
+
+## File map
+
+**Create**
+
+- `tldw_Server_API/app/core/Sync/v2/notes_task_contract.py` — sole task/activity v1 parser, canonical JSON, legacy-event conversion, and hashes.
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py` — exact task/activity/legacy vectors and dormant-capability assertions.
+- `tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py` — SQLite fresh/upgrade/rollback/collision/rekey storage contracts.
+- `tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py` — live PostgreSQL two-owner RLS/catalog/plan proof.
+
+**Modify**
+
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py` — schema v60 migration, exact current-catalog verification, store wiring.
+- `tldw_Server_API/app/core/DB_Management/chacha/task_store.py` — owner/dataset predicates, canonical revision/hash, local-unbound binding/rekey helpers.
+- `tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py` — forced RLS for all six task-side tables.
+- `tldw_Server_API/app/core/DB_Management/Sync_DB.py` — independent dormant readiness records and atomic state transitions.
+- `tldw_Server_API/app/core/Sync/v2/models.py` — known-but-dormant domain types and discoverable private schemas; do not add to supported lists.
+- `tldw_Server_API/app/core/Sync/v2/store.py` — readiness facade methods.
+- `tldw_Server_API/app/core/Sync/v2/profile.py` — sanitized internal readiness status only; no writable advertisement.
+- `tldw_Server_API/app/core/Notes_Tasks/service.py` — trusted local-unbound compatibility scope and enrolled scope forwarding.
+- `tldw_Server_API/app/core/Notes_Tasks/reconciler.py` — trusted scope forwarding for legacy reconciliation.
+- `tldw_Server_API/app/api/v1/endpoints/notes_tasks.py` — authenticated owner scope forwarding without wire changes.
+- `tldw_Server_API/app/core/MCP_unified/modules/implementations/notes_module.py` — authenticated MCP owner scope forwarding without tool-schema changes.
+- `tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py` — scoped CRUD and revision separation.
+- `tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py` — exact policy-source contract.
+- `tldw_Server_API/tests/Sync/test_sync_v2_models.py` — dormant domain/capability boundary.
+- `tldw_Server_API/tests/Sync/test_sync_v2_store.py` — readiness state transitions and rollback.
+- `tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_api.py` — REST compatibility through the scoped store.
+- `tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py` — MCP compatibility through the scoped store.
+- `tldw_Server_API/tests/DB_Management/test_chacha_migration_v48_tasks.py` — v48 compatibility fixture removes v60-only tables when synthesizing old state.
+
+### Task 0: Start the child and attach this plan
+
+- [ ] **Step 1: Verify Backlog state and ADR link**
+
+```bash
+backlog task edit 13006.1 -s "In Progress"
+backlog task 13006.1 --plain
+```
+
+Expected: TASK-13006.1 is In Progress and links ADR-039 plus this plan before any
+production change.
+
+### Task 1: Lock the exact v1 task/activity contract
+
+- [ ] **Step 1: Write task payload RED tests**
+
+Add exact valid vectors plus one rejection per boundary: lowercase UUIDv4, all
+required nullable fields, title/description bounds, status/completed invariant,
+real due dates, estimate syntax, recurrence combinations, owner-only assignee,
+NFKC/casefold tags, reserved custom keys, JSON size/depth, extra fields, and
+canonical hash stability.
+
+```python
+def test_task_v1_rejects_open_with_completed_at() -> None:
+    payload = valid_task_payload(status="open", completed_at="2026-08-13T10:00:00Z")
+    with pytest.raises(NotesTaskContractError, match="completion"):
+        parse_notes_task_v1(payload, owner_user_id=OWNER_ID)
+
+
+def test_task_hash_ignores_projection_row_version() -> None:
+    parsed = parse_notes_task_v1(valid_task_payload(), owner_user_id=OWNER_ID)
+    assert task_object_hash(parsed, revision=7, deleted=False) == EXPECTED_VECTOR
+```
+
+- [ ] **Step 2: Write activity and legacy conversion RED tests**
+
+Cover exact event enums/old-new shapes, provenance binding inputs, revision-1 create,
+revision-2 tombstone, `created_at_client` equality, changed stable-ID fingerprints,
+idempotency-key hashing/removal, every legacy event mapping, and fail-closed unknown
+legacy data.
+
+```python
+def test_legacy_status_changed_maps_to_completed() -> None:
+    converted = convert_legacy_task_event(
+        legacy_event(event_type="status_changed", old={"status": "open"}, new={"status": "done"})
+    )
+    assert converted.event_type == "completed"
+    assert converted.old_value == {"status": "open"}
+    assert converted.new_value == {"status": "done"}
+```
+
+- [ ] **Step 3: Run the focused RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
+```
+
+Expected: collection/import failure because `notes_task_contract.py` is absent.
+
+- [ ] **Step 4: Implement strict task parsing and task hashes**
+
+Use frozen Pydantic models and one canonical JSON serializer. Do not duplicate
+validation in adapters or stores.
+
+```python
+class NotesTaskV1Payload(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    task_id: UUID4
+    note_id: UUID4
+    title: str
+    description: str | None
+    status: Literal["open", "done"]
+    completed_at: str | None
+    priority: Literal["low", "medium", "high"] | None
+    due_date: str | None
+    estimate: str | None
+    recurrence: NotesTaskRecurrenceV1 | None
+    assignee_id: str | None
+    tags: tuple[str, ...]
+    custom: dict[str, JsonValue]
+
+
+class NotesTaskActivityTombstoneV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    note_id: UUID4
+    task_id: UUID4 | None
+    deleted_at: str
+    delete_reason: Literal["user_request", "correction", "policy"]
+```
+
+Implement `parse_notes_task_v1(...)`, `parse_notes_task_tombstone_v1(...)`, and
+`notes_task_object_hash(...)`. Return typed immutable values; hash adapter version,
+revision, lifecycle, identity, and exact payload through canonical UTF-8 JSON. Never
+include projection cache, REST row version, server cursor, or read state.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py \
+  -k 'task_v1 and not activity and not legacy'
+```
+
+- [ ] **Step 5: Implement strict activity parsing and legacy conversion**
+
+Implement `parse_notes_task_activity_v1(...)`,
+`parse_notes_task_activity_tombstone_v1(...)`,
+`notes_task_activity_object_hash(...)`, and `convert_legacy_task_event(...)`. Use the
+spec's exact old/new schemas for all five legacy source families, remove only a
+validated raw idempotency key, and bind tombstone `deleted_at` to normalized
+`SyncEnvelopeCreate.created_at_client`.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py \
+  -k 'activity or legacy or deleted_at or idempotency'
+```
+
+- [ ] **Step 6: Add known-but-dormant domain types**
+
+Extend `SyncDomain` and private schema discovery so internal tests/bootstrap can
+name `notes.task` and `notes.task_activity`. Keep both absent from
+`SYNC_V2_SUPPORTED_DOMAINS`, `SYNC_V2_SUPPORTED_OPERATIONS`, public version maps,
+factory advertisement checks, and selected-dataset writable maps.
+
+- [ ] **Step 7: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_models.py \
+  -k 'notes_task or notes_task_activity or supported_domain'
+git add tldw_Server_API/app/core/Sync/v2/notes_task_contract.py \
+  tldw_Server_API/app/core/Sync/v2/models.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_models.py
+git commit -m "feat(sync): define dormant Notes task contracts"
+```
+
+### Task 2: Migrate the SQLite task graph to schema v60
+
+- [ ] **Step 1: Write migration RED tests**
+
+Assert current version 60, fresh/59→60 parity, exact six table schemas, composite
+owner/dataset identities and FKs, `ON UPDATE CASCADE`, task canonical revision/hash,
+event lifecycle columns, drift table, bounded indexes, integer storage classes,
+post-DDL rollback, collision failure, and version-last behavior.
+
+```python
+def test_v59_to_v60_preserves_rows_as_local_unbound(tmp_path: Path) -> None:
+    db = v59_database_with_task_graph(tmp_path)
+    upgraded = CharactersRAGDB(db_path=db)
+    task = upgraded.get_task_scoped(OWNER_ID, LOCAL_UNBOUND, TASK_ID)
+    assert task["id"] == TASK_ID
+    assert task["canonical_revision"] == task["version"]
+    assert task["canonical_hash"].startswith("sha256:")
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
+```
+
+Expected: current schema is 59 and v60 structures are absent.
+
+- [ ] **Step 3: Add fixed SQLite v60 DDL and conversion helpers**
+
+Define the six exact replacement table/index statements and pure row converters in
+`ChaChaNotes_DB.py`. Add unit tests for canonical column/check/index SQL, source-row
+conversion, local-unbound scope, and malformed-metadata diagnostics before invoking
+the initializer.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py \
+  -k 'sqlite_ddl or converts_source or source_diagnostic'
+```
+
+- [ ] **Step 4: Implement transactional SQLite v60 migration**
+
+Implement `_migrate_from_v59_to_v60_sqlite(conn)` and
+`_verify_note_task_schema_sqlite(conn)`, then add the exact 59→60 initializer branch.
+Under the existing initializer lock/transaction:
+
+1. require exact v59 authority and required source tables;
+2. reject any v60 target-table collision;
+3. create replacement tables with composite scope and exact checks;
+4. map each source row to its proven owner and private local-unbound sentinel;
+5. compute canonical task hashes with the shared contract;
+6. source-count/hash verify every table;
+7. swap tables and recreate bounded indexes; and
+8. compare-and-set schema version 59→60 last.
+
+Do not consult Sync DB from this migration. Do not rewrite malformed metadata into
+custom data; preserve product rows and mark readiness-blocking source diagnostics.
+Add injected failures after create, copy, index creation, and verification; every
+case must leave schema version 59 and the original tables intact.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py \
+  -k 'sqlite_upgrade or sqlite_rollback or sqlite_current_catalog or sqlite_concurrent'
+```
+
+- [ ] **Step 5: Add exact owner/dataset task-store methods and compatibility scope**
+
+All canonical task/event/projection/read/reconciliation methods take owner and
+dataset scope before IDs. Preserve existing REST/MCP behavior through one trusted
+service compatibility adapter: authenticated callers pass owner explicitly and the
+service resolves either the enrolled dataset or the private local-unbound sentinel.
+Do not make endpoints or MCP tools accept a client-selected dataset. Update the REST,
+MCP, and reconciler call sites in this step and prove their public schemas unchanged.
+Add `bind_local_task_graph_to_dataset()` which verifies the complete source set,
+rejects target collisions, and updates the sentinel scope in one product transaction
+through cascading composite FKs.
+
+```python
+def get_task(
+    self, *, owner_user_id: str, dataset_id: str, task_id: str,
+    include_deleted: bool = False, conn: TaskConnection | None = None,
+) -> dict[str, Any] | None:
+    ...
+```
+
+- [ ] **Step 6: Run scoped-store compatibility RED/GREEN**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_api.py \
+  tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py \
+  -k 'task or checklist or reconcile'
+```
+
+Expected: legacy REST and MCP behavior is unchanged, cross-owner direct store access
+fails, and no caller can select the local-unbound sentinel.
+
+- [ ] **Step 7: Prove canonical revision separation**
+
+Add tests where `set_task_projection()` and `mark_task_unlinked()` retain their REST
+row-version compatibility but do not change `canonical_revision/hash`; canonical
+task mutation advances both once.
+
+- [ ] **Step 8: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py \
+  tldw_Server_API/tests/DB_Management/test_chacha_migration_v48_tasks.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_api.py \
+  tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py
+git add tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/app/core/DB_Management/chacha/task_store.py \
+  tldw_Server_API/app/core/Notes_Tasks/service.py \
+  tldw_Server_API/app/core/Notes_Tasks/reconciler.py \
+  tldw_Server_API/app/api/v1/endpoints/notes_tasks.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/notes_module.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py \
+  tldw_Server_API/tests/DB_Management/test_chacha_migration_v48_tasks.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_api.py \
+  tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py
+git commit -m "feat(notes): add scoped task schema v60"
+```
+
+### Task 3: Enforce and verify PostgreSQL tenancy
+
+- [ ] **Step 1: Write server-free catalog and live RLS RED tests**
+
+Cover schema-version lock order, fixed relation locks, exact columns/defaults/types,
+validated PK/FKs/checks, index definitions/predicates, table/schema owner, ENABLE +
+FORCE RLS, sole exact policies, rollback/no-version-bump, two-owner same-ID
+coexistence, cross-owner get/list/update/read-state denial, and index-backed pages.
+
+- [ ] **Step 2: Run RED with PostgreSQL required**
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py \
+  tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py \
+  -k 'note_task or task_event or task_projection'
+```
+
+Expected: fail, never skip; v60 PostgreSQL DDL/RLS is absent.
+
+- [ ] **Step 3: Add PostgreSQL v60 fixed DDL and server-free catalog verifier**
+
+Add bounded, fixed catalog queries and exact expected column/default/type/constraint/
+index/policy sets. First turn the server-free catalog drift matrix GREEN; include
+extra-policy, OR-true check, weakened partial predicate, wrong FK scope, and PG18
+NOT-NULL catalog rows.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py \
+  tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py \
+  -k 'postgres_catalog or postgres_sql or rls_policy'
+```
+
+- [ ] **Step 4: Implement PostgreSQL v60 migration ordering**
+
+Implement `_migrate_from_v59_to_v60_postgres(conn)` and
+`_verify_note_task_schema_postgres(conn)`, then add the exact 59→60/current-60
+initializer branches. Follow the reviewed v59 ordering: schema-version row lock first, fixed relation
+locks, catalog-owner/RLS verification, exact temporary FORCE handling only when
+needed, validate before DDL, transactional rebuild/copy/swap, restore FORCE, install
+all six canonical policies, exact verify, then version bump last. Current-v60
+startup locks and verifies the full catalog; it never repairs drift silently.
+
+- [ ] **Step 5: Add all six forced-RLS policies**
+
+Use owner/dataset predicates plus owned-note/task/event EXISTS checks in both USING
+and WITH CHECK. Enumerate all policies and reject extra permissive policies.
+
+- [ ] **Step 6: Run live GREEN and commit**
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py \
+  tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py
+git add tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py \
+  tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py
+git commit -m "feat(notes): enforce task graph PostgreSQL tenancy"
+```
+
+### Task 4: Add dormant readiness state and source diagnostics
+
+- [ ] **Step 1: Write readiness RED tests**
+
+Test independent `notes_task_v1` and `notes_task_activity_v1` rows through
+`not_enrolled`, `enrolling`, `bootstrapping`, `verifying`, `ready`, and `blocked`;
+monotonic cursor/count/fingerprint; atomic coupled-capture flag; rollback; malformed
+state; local-unbound rejection; and sanitized diagnostics. Assert capabilities omit
+both domains in every state, including forged ready metadata.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_store.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py \
+  -k 'notes_task_readiness or notes_task_activity_readiness or dormant_task_domain'
+```
+
+- [ ] **Step 3: Implement one bounded transition helper**
+
+Store readiness in dataset metadata through one transaction-held resolver. Validate
+state transitions, cursor monotonicity, fixed reason codes, count/hash shapes, and
+atomic `task_activity_capture_enabled` changes. Facade methods delegate; they do not
+mutate raw metadata independently.
+
+- [ ] **Step 4: Expose sanitized internal status without capability support**
+
+Profile/bootstrap diagnostics may report state, counts, hashed cursor, and reason
+code to an authorized owner. They must not return task text, event values, raw
+Markdown, actor data, or local-unbound identifiers.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_store.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_models.py \
+  -k 'notes_task or notes_task_activity or capability'
+git add tldw_Server_API/app/core/DB_Management/Sync_DB.py \
+  tldw_Server_API/app/core/Sync/v2/store.py \
+  tldw_Server_API/app/core/Sync/v2/profile.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_store.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
+git commit -m "feat(sync): persist dormant task readiness"
+```
+
+### Task 5: Run the PR gate and close TASK-13006.1
+
+- [ ] **Step 1: Run the required test matrix**
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_models.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_store.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_reconciler.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_service.py \
+  tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py
+```
+
+Expected: all selected tests pass and live PostgreSQL tests report no skip.
+
+- [ ] **Step 2: Run static/security checks**
+
+```bash
+PRODUCTION_PATHS=(
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+  tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+  tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py
+  tldw_Server_API/app/core/DB_Management/Sync_DB.py
+  tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
+  tldw_Server_API/app/core/Sync/v2/models.py
+  tldw_Server_API/app/core/Sync/v2/store.py
+  tldw_Server_API/app/core/Sync/v2/profile.py
+  tldw_Server_API/app/core/Notes_Tasks/service.py
+  tldw_Server_API/app/core/Notes_Tasks/reconciler.py
+  tldw_Server_API/app/api/v1/endpoints/notes_tasks.py
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/notes_module.py
+)
+../../.venv/bin/ruff check --no-cache "${PRODUCTION_PATHS[@]}"
+../../.venv/bin/bandit -q "${PRODUCTION_PATHS[@]}"
+PYTHONPYCACHEPREFIX=/tmp/task13006-pycache ../../.venv/bin/python -m py_compile "${PRODUCTION_PATHS[@]}"
+git diff --check
+```
+
+If a legacy whole-file Ruff baseline is encountered, record the exact pre-existing
+codes and run the established file-specific ignore only for that file; Bandit and
+`py_compile` still cover every production path above.
+
+- [ ] **Step 3: Verify capability omission and self-review**
+
+Inspect the full diff for accidental additions to public supported/writable maps,
+unscoped ID predicates, raw diagnostics, schema repair, or later-PR adapter logic.
+
+- [ ] **Step 4: Update Backlog and commit closeout docs**
+
+Check every TASK-13006.1 AC/DoD item, record commands/results and the live PostgreSQL
+server identity, add concise implementation notes, set Done, then commit only the
+task file and any directly relevant documentation.

--- a/Docs/superpowers/plans/2026-08-13-notes-task-sync-lifecycle-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-13-notes-task-sync-lifecycle-implementation-plan.md
@@ -1,0 +1,361 @@
+# Dormant Notes Task Sync Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the complete strict `notes.task` v1 adapter, product materializer, resumable task bootstrap, and dormant server-origin capture primitives without exposing either task domain.
+
+**Architecture:** The adapter owns exact lineage/conflict decisions; the materializer writes owner/dataset-scoped ChaChaNotes rows and canonical revision/hash under the shared dataset fence. Bootstrap uses trusted source verification and stable task IDs. Factory wiring exists for internal bootstrap/tests only; public support, enrollment, and writable capabilities remain absent until TASK-13006.4.
+
+**Tech Stack:** Python 3.11, Pydantic contracts from TASK-13006.1, Sync v2 adapters/materializers, SQLite, PostgreSQL, pytest, Ruff, Bandit.
+
+**Design:** `Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md`
+
+**Backlog task:** `TASK-13006.2`
+
+**ADR required:** no
+**ADR path:** `Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md`
+**Reason:** This plan directly implements ADR-039's already-approved task-domain lifecycle without changing its boundary.
+
+---
+
+## File map
+
+**Create**
+
+- `tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task.py` — task lineage, authorization context, restore, and stable conflicts.
+- `tldw_Server_API/app/core/Sync/v2/materializers/notes_task.py` — idempotent scoped product projection and postcondition verification.
+- `tldw_Server_API/app/core/Sync/v2/notes_task_bootstrap.py` — resumable trusted task capture/count/fingerprint verification.
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_adapter.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_materializer.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_bootstrap.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_capture.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_notes_task_postgres_contract.py`
+
+**Modify**
+
+- `tldw_Server_API/app/core/Sync/v2/domain_adapters/__init__.py`
+- `tldw_Server_API/app/core/Sync/v2/materializers/__init__.py`
+- `tldw_Server_API/app/core/Sync/v2/adapters.py` — context callbacks for authorized note/task heads.
+- `tldw_Server_API/app/core/Sync/v2/factory.py` — internal adapter/materializer/bootstrap wiring with public-support guard unchanged.
+- `tldw_Server_API/app/core/Sync/v2/service.py` — bounded context reads and dormant bootstrap acceptance.
+- `tldw_Server_API/app/core/Sync/v2/profile.py` — invoke task bootstrap only through private readiness path.
+- `tldw_Server_API/app/core/DB_Management/chacha/task_store.py` — exact canonical task CAS/postcondition helpers.
+- `tldw_Server_API/app/core/Notes_Tasks/service.py` — optional, uninjected canonical task capture seam.
+- `tldw_Server_API/tests/Sync/test_sync_v2_factory.py`
+- `tldw_Server_API/tests/Sync/test_sync_v2_service.py`
+- `tldw_Server_API/tests/Notes_Tasks/unit/test_service.py`
+
+### Task 0: Start the child and attach this plan
+
+- [ ] **Step 1: Move TASK-13006.2 In Progress**
+
+```bash
+backlog task edit 13006.2 -s "In Progress" --plan $'1. Implement strict notes.task lineage.\n2. Materialize canonical tasks with split-commit repair.\n3. Bootstrap legacy tasks in bounded resumable pages.\n4. Add dormant capture without public capability.\n5. Run SQLite/live-PostgreSQL/static gates.\nDetailed plan: Docs/superpowers/plans/2026-08-13-notes-task-sync-lifecycle-implementation-plan.md\nADR required: no; ADR-039 applies.'
+backlog task 13006.2 --plain
+```
+
+Expected: TASK-13006.1 is Done, TASK-13006.2 is In Progress, and the approved plan
+and ADR are linked before production work.
+
+### Task 1: Implement strict task adapter lineage
+
+- [ ] **Step 1: Write adapter RED tests**
+
+Cover create-empty-head, exact-base update, completion/reopen, metadata and
+recurrence-state changes, tombstone, explicit restore, ordinary upsert against
+tombstone, stale base, changed task/note identity, deleted/missing/foreign note,
+malformed routing metadata, and exact replay.
+
+```python
+def test_task_restore_requires_exact_tombstone_base() -> None:
+    result = adapter.evaluate(
+        task_envelope(operation="upsert", restore_intent=True, base_hash=WRONG_HASH),
+        dataset,
+        context_with_task_head(tombstone_head()),
+    )
+    assert result.status == "conflict"
+    assert result.error_code == "notes_task_restore_base_mismatch"
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_adapter.py
+```
+
+- [ ] **Step 3: Implement `NotesTaskDomainAdapter`**
+
+Parse only through `notes_task_contract.py`. Require adapter version 1 and
+`upsert|tombstone`. Bind object ID to payload task ID and parent ID to note ID.
+Reuse `tldw_Server_API/app/core/Sync/v2/domain_adapters/_lineage.py` base comparison
+helpers; do not add a parallel lineage algorithm.
+
+```python
+class NotesTaskDomainAdapter:
+    domain = "notes.task"
+
+    def evaluate(
+        self, envelope: SyncEnvelopeCreate, dataset: SyncDataset, context: AdapterContext
+    ) -> AdapterResult:
+        payload = parse_notes_task_envelope(envelope, owner_user_id=context.owner_user_id)
+        note = context.get_authorized_note(payload.note_id)
+        head = context.get_head("notes.task", str(payload.task_id))
+        return evaluate_task_lineage(envelope, payload, note=note, head=head)
+```
+
+Return stable sanitized conflict/error codes; never include title, metadata, note
+existence, or another owner's identity.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_adapter.py
+git add tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task.py \
+  tldw_Server_API/app/core/Sync/v2/domain_adapters/__init__.py \
+  tldw_Server_API/app/core/Sync/v2/adapters.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_adapter.py
+git commit -m "feat(sync): add strict Notes task adapter"
+```
+
+### Task 2: Project task envelopes idempotently
+
+- [ ] **Step 1: Write materializer RED tests**
+
+Test create/update/complete/reopen/tombstone/restore; canonical vs REST revisions;
+same-cursor replay; lower/divergent cursor; exact product postcondition repair;
+owner/dataset/note predicates; task ID collision across datasets; transaction
+split after product commit but before Sync apply-status commit; idempotent replay
+repairs that split without duplicating product state; and no activity side effect.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_materializer.py
+```
+
+- [ ] **Step 3: Add focused task-store CAS helpers and turn store tests GREEN**
+
+Implement `apply_sync_task_create`, `apply_sync_task_upsert`,
+`apply_sync_task_tombstone`, `apply_sync_task_restore`, and
+`verify_sync_task_postcondition`. Each receives the existing product transaction,
+owner, dataset, exact base/head, canonical revision/hash, and payload. It never
+records an event; TASK-13006.4 coordinates the task/activity group.
+
+- [ ] **Step 4: Implement product commit then Sync-status repair**
+
+Follow `notes_link.py` materializer transaction/error mapping. Acquire no process
+mutex; use the service's dataset materialization transaction and bound product
+connection. The product DB and Sync DB do not share a transaction: commit the product
+row, then mark Sync apply status. On replay after a split, verify the exact product
+postcondition and advance Sync status without rewriting or duplicating the task.
+
+- [ ] **Step 5: Run the injected split-commit matrix**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_materializer.py \
+  -k 'split_commit or postcondition or replay or rollback_product_failure'
+```
+
+- [ ] **Step 6: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_materializer.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py \
+  -k 'sync_task or canonical_revision or projection_revision'
+git add tldw_Server_API/app/core/DB_Management/chacha/task_store.py \
+  tldw_Server_API/app/core/Sync/v2/materializers/notes_task.py \
+  tldw_Server_API/app/core/Sync/v2/materializers/__init__.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_materializer.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+git commit -m "feat(notes): materialize canonical task envelopes"
+```
+
+### Task 3: Bootstrap existing tasks resumably
+
+- [ ] **Step 1: Write bootstrap RED tests**
+
+Cover rejection of local-unbound/unbound input, an already-bound authorized dataset,
+stable IDs, keyset pages, trusted bootstrap routing, legacy metadata validation,
+concurrent capture supplied by a test harness,
+resume after each injected failure, source drift, count/fingerprint mismatch,
+blocked diagnostics, exact replay, and final task-ready while activity remains not
+ready. Public capability maps must still omit both domains.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_bootstrap.py
+```
+
+- [ ] **Step 3: Add bounded source paging and stable-ID helpers**
+
+Add an owner/dataset-scoped product page ordered by stable task ID with a hard limit
+of 500. Add pure helpers for bootstrap envelope ID, trusted routing metadata, and
+aggregate fingerprint. Turn page-boundary and stable-replay vectors GREEN before
+service wiring.
+
+Implementation targets: `TaskStore.page_tasks_for_sync_bootstrap(...)`,
+`_task_bootstrap_envelope_id(...)`, `_task_bootstrap_routing(...)`, and
+`_task_bootstrap_fingerprint(...)`.
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_bootstrap.py \
+  -k 'page or stable_id or fingerprint or routing'
+```
+
+- [ ] **Step 4: Implement one bounded bootstrap page**
+
+Use a maximum page of 500 and require that the product graph is already bound to the
+authorized real dataset. Reject the local-unbound sentinel; this dormant child neither
+enrolls nor rekeys production data. TASK-13006.4 owns product rekey and capture-before-
+scan orchestration. For each task, build one stable trusted bootstrap envelope whose
+ID derives from bootstrap ID + task ID + canonical hash. Capture with the existing
+batch primitive and a source verifier; never directly insert accepted envelopes.
+
+```python
+class NotesTaskBootstrapper:
+    PAGE_LIMIT = 500
+
+    def bootstrap(self, *, service: SyncV2Service, dataset: SyncDataset) -> SyncDataset:
+        ...
+```
+
+Each call source-verifies, appends at most one page through the existing batch
+primitive, and persists the next key plus running count/fingerprint. An injected
+split after Sync append resumes by exact replay; it never deletes accepted history.
+
+- [ ] **Step 5: Reconcile final count and fingerprint**
+
+Compare owner/dataset product count and aggregate fingerprint with applied
+`notes.task` bootstrap envelopes under the dataset fence. Set only the task readiness
+row to ready; coupled writable readiness remains false. Source drift or mismatch is
+fail-closed and records only bounded row IDs/reason codes.
+
+- [ ] **Step 6: Wire private bootstrap/factory paths**
+
+Register the strict adapter/materializer internally and validate their presence in
+the factory, but keep public supported-domain constants unchanged. Profile may call
+the bootstrapper only through the private task readiness operation; the public
+domain request validator still rejects `notes.task`.
+
+- [ ] **Step 7: Run GREEN and commit**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_bootstrap.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_factory.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
+git add tldw_Server_API/app/core/Sync/v2/notes_task_bootstrap.py \
+  tldw_Server_API/app/core/Sync/v2/factory.py \
+  tldw_Server_API/app/core/Sync/v2/profile.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_bootstrap.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_factory.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
+git commit -m "feat(sync): bootstrap dormant Notes tasks"
+```
+
+### Task 4: Add dormant server-origin task capture primitives
+
+- [ ] **Step 1: Write capture RED tests**
+
+Inject a capture callback into `NotesTaskService` and prove create/update/status/
+delete/restore inputs produce exact canonical task steps with stable IDs and bases.
+Prove no callback preserves legacy behavior, a callback failure rolls back the
+product transaction where the seam is used, and no endpoint/factory injects it yet.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_capture.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_service.py \
+  -k 'task_capture or legacy_without_sync'
+```
+
+- [ ] **Step 3: Add the smallest capture seam**
+
+Define one protocol/callback that accepts the canonical before/after task mutation,
+actor context, operation, and stable idempotency key and returns a product mutation
+result. Do not build activity/note groups here; TASK-13006.4 owns expansion. Keep the
+default `None`, so shipped REST/MCP behavior is unchanged.
+
+- [ ] **Step 4: Add PostgreSQL source/plan proof**
+
+In the server-free PostgreSQL contract tests, assert every materializer/store query
+binds owner+dataset before task ID, task rows are locked before CAS, and task pages
+use the v60 index. In the live test, execute create/update/delete/restore under a
+non-superuser, non-BYPASSRLS role for two owners.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_capture.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_postgres_contract.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+git add tldw_Server_API/app/core/Notes_Tasks/service.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_capture.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_postgres_contract.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+git commit -m "feat(notes): add dormant task capture seam"
+```
+
+### Task 5: Run the PR gate and close TASK-13006.2
+
+- [ ] **Step 1: Run focused and regression tests**
+
+```bash
+TLDW_TEST_POSTGRES_REQUIRED=1 PYTHONPATH=. ../../.venv/bin/python -m pytest -q --tb=short \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_adapter.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_materializer.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_bootstrap.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_capture.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_notes_task_postgres_contract.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_service.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_factory.py \
+  tldw_Server_API/tests/Notes_Tasks/unit/test_service.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+```
+
+Expected: all pass; live PostgreSQL tests do not skip.
+
+- [ ] **Step 2: Run static/security checks**
+
+```bash
+PRODUCTION_PATHS=(
+  tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task.py
+  tldw_Server_API/app/core/Sync/v2/domain_adapters/__init__.py
+  tldw_Server_API/app/core/Sync/v2/materializers/notes_task.py
+  tldw_Server_API/app/core/Sync/v2/materializers/__init__.py
+  tldw_Server_API/app/core/Sync/v2/notes_task_bootstrap.py
+  tldw_Server_API/app/core/Sync/v2/adapters.py
+  tldw_Server_API/app/core/Sync/v2/factory.py
+  tldw_Server_API/app/core/Sync/v2/service.py
+  tldw_Server_API/app/core/Sync/v2/profile.py
+  tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+  tldw_Server_API/app/core/Notes_Tasks/service.py
+)
+../../.venv/bin/ruff check --no-cache "${PRODUCTION_PATHS[@]}"
+../../.venv/bin/bandit -q "${PRODUCTION_PATHS[@]}"
+PYTHONPYCACHEPREFIX=/tmp/task13006-pycache ../../.venv/bin/python -m py_compile "${PRODUCTION_PATHS[@]}"
+git diff --check
+```
+
+- [ ] **Step 3: Self-review the dormant boundary**
+
+Prove public models/endpoints/capabilities/enrollment still reject or omit both
+domains. Reject any change that records activity directly or rewrites projections;
+those belong to later child tasks.
+
+- [ ] **Step 4: Complete Backlog notes and status**
+
+Check TASK-13006.2 AC/DoD, record exact commands/live PG evidence, document any plan
+deviation, add implementation notes, and set Done.

--- a/Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
+++ b/Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
@@ -255,6 +255,15 @@ result. A second create after tombstone, a distinct second tombstone, or any reu
 with changed fingerprint conflicts. Tombstones retain the immutable event content
 for audit but exclude it from ordinary activity surfaces.
 
+Create always has activity revision 1. Its payload is the complete immutable field
+set above and its object hash is the canonical fingerprint. Tombstone always has
+revision 2 and the exact payload `{note_id, task_id, deleted_at, delete_reason}`:
+parent IDs must equal the create, `deleted_at` is the canonical envelope timestamp,
+and `delete_reason` is `user_request`, `correction`, or `policy`. The tombstone hash
+binds adapter version, revision/lifecycle, original create fingerprint, parent IDs,
+deleted timestamp, and reason. The product row retains create fields and stores the
+same deleted-at/reason/hash/cursor. No revision greater than 2 is valid.
+
 Task transitions that require user-visible history create exactly one canonical
 activity. A retry or crash repair cannot duplicate it because the event ID and
 mutation-group step are stable.
@@ -370,6 +379,16 @@ client activity create is permitted only for `corrected` and must reference an
 authorized existing event. Server-origin REST/MCP/reconciliation supplies the same
 fields through trusted bindings, never caller-selectable provenance.
 
+ADR-034's 1,000-envelope mutation-group cap is authoritative. Reconciliation
+preflight parses and validates the complete note edit before appending any envelope
+or mutating product state. One changed task consumes a task step plus one activity
+step, and the note consumes at most one step, so a single request may change at
+most 499 managed tasks (`2 * 499 + 1 = 999`). Any computed plan above 1,000 steps,
+including future fixed coordinator steps, fails with the stable sanitized
+`sync_task_projection_group_too_large` error before the `notes.note` envelope is
+appended. The request is not split into sequential groups, because that would make
+an accepted prefix durable without the user's complete intent.
+
 ## Bootstrap, capability advertisement, and rollout
 
 No global environment flag is added. Existing dataset enrollment and readiness are
@@ -389,8 +408,9 @@ after PR 4 exposes them, but no profile silently opts in. Adding a domain to an
 already-ready default-personal dataset creates its independent readiness row in one
 Sync transaction without changing earlier domain readiness.
 
-Before the source scan, enrollment enables fail-closed canonical capture for the
-new domain while external device writes remain disabled. Each bootstrap page holds
+Before either source scan, enrollment atomically enables fail-closed canonical
+capture for both task and activity while external device writes remain disabled.
+It cannot enable task capture alone. Each bootstrap page holds
 the dataset materialization fence, reads an owner/dataset keyset page, appends
 trusted source-verified envelopes, and records its cursor/count/fingerprint.
 Concurrent REST changes therefore append after or before that page under the same
@@ -398,16 +418,20 @@ ordering authority rather than escaping capture.
 
 `notes.task` becomes dataset-writable in PR 4 only when:
 
-- `notes.note` and `notes.task` are enrolled at supported adapter versions;
+- `notes.note`, `notes.task`, and `notes.task_activity` are enrolled at supported
+  adapter versions;
 - source task bootstrap is complete, count/fingerprint verified, and resumable
   cursor state is `ready`;
-- server-origin task capture and repair are enabled; and
+- source activity bootstrap is complete and verified;
+- atomic task/activity capture, deterministic group expansion, and both repair
+  paths are enabled and healthy; and
 - no reconciliation blocker or unresolved bootstrap drift exists.
 
-`notes.task_activity` additionally requires activity enrollment, complete immutable
-event bootstrap, and transition capture readiness. PR 4 may then list both adapter
-versions in server-supported capabilities. The selected dataset's writable map
-still omits either domain until that domain's exact predicate is true.
+`notes.task_activity` has the same coupled readiness predicate because ordinary
+activity depends on an authorized task/note view and task mutations cannot succeed
+without activity. PR 4 may then list both adapter versions in server-supported
+capabilities. The selected dataset's writable map advertises both together or
+neither; a later adapter version may relax that coupling only through a new ADR.
 
 Bootstrap is non-destructive and keyset-paged. Stable existing task/event IDs are
 preserved. Each page records its source count, cursor, and privacy-safe fingerprint.
@@ -421,6 +445,35 @@ preserves the stored actor/tool/policy fields after validation, uses stored
 `created_at` as `client_occurred_at`, and records a null source device with a
 `legacy_source_verified` marker. Bootstrap never fabricates a client device or
 claims that a legacy timestamp ordered Sync history.
+
+Legacy event conversion is exact:
+
+| Existing `event_type` and values | Canonical event |
+| --- | --- |
+| `created` | `created`; old must be null and new must validate as the bounded task snapshot subset |
+| `updated` | `updated`; old/new must be bounded objects and differ in at least one canonical task field |
+| `status_changed`, `open -> done` | `completed` |
+| `status_changed`, `done -> open` | `reopened` |
+| `unlinked` | `projection_unlinked` |
+| `deleted` | `deleted` |
+| any other type, status transition, parent mismatch, malformed value, or invalid ID | block activity readiness; do not rewrite or drop the row |
+
+A nullable legacy `note_id` is derived only from its same-scope authorized task;
+both missing or inconsistent parents block readiness. `actor_type` must map to the
+closed actor enum and actor ID must meet its bound. `tool_name`, `policy_mode`, and
+`approval_id` become an optional `legacy_context` metadata object of separately
+bounded strings (128 code points each). Stored old/new JSON is canonicalized under
+the event-specific schema. A stored `idempotency_key` is not synchronized in raw
+form; after type/length validation it becomes a SHA-256 request fingerprint in
+metadata. Oversized, nested, or unknown values block readiness with a reason code
+and row hash.
+
+The source scan is keyset-ordered by `(created_at, id)` while holding the dataset
+fence. Trusted bootstrap envelopes receive monotonic server cursors in that order;
+after materialization all activity pages use `(sync_server_cursor, activity_id)`
+with a maximum page size of 1,000. A concurrent new event is captured normally
+under the same fence and therefore cannot be omitted between scan and final
+count/fingerprint verification.
 
 Legacy devices receive only versions they negotiated. Per-domain adapter-version
 cursors and acknowledgments prevent a version change from skipping or
@@ -448,6 +501,16 @@ task or note is overwritten.
 An applied task envelope referenced by a live marker is retention-protected until
 the marker advances or unlinks. Sync maintenance may compact unrelated history but
 must not remove the only last-common snapshot for a live projection.
+
+When a group advances or removes a marker, its privacy-safe group metadata records
+a projection anchor: task ID, linked/unlinked state, prior note envelope
+cursor/hash, prior task revision/hash, and marker hash. It contains no Markdown or
+task text. The anchor is durable Sync evidence, not the disposable locator cache,
+and lets repair reconstruct whether a task was linked before deletion. A linked
+task tombstone retains that anchor and both named envelopes until restore installs
+a new verified marker, an exact explicit unlink resolution commits, or an
+authorized hard-purge/restore-window workflow permanently releases the task. An
+unlinked task records that state and needs no former-marker retention.
 
 Only `title`, checkbox-derived `status`/`completed_at`, `due_date`, `priority`, and
 `estimate` are Markdown-projectable in version 1. Description, recurrence,
@@ -485,6 +548,12 @@ Markdown. Resolution requires an exact opaque drift ID plus current note/task he
 claims and chooses `keep_task`, `accept_markdown`, or `unlink`; changed claims create
 a new review rather than applying stale intent. Resolved/dismissed rows remain
 bounded audit metadata and are excluded from Sync.
+
+Every open drift installs retention blockers for its referenced current/prior note
+and task envelopes, including malformed or removed-marker cases that use the last
+durable projection anchor. The blockers release only when an exact drift resolution
+or dismissal commits and no live marker, linked tombstone, newer open drift, or
+pending repair still references the envelope. Cache deletion never releases them.
 
 Projection cache and drift bookkeeping never become Sync domains. After cache loss,
 restore, migration, parser change, or detected corruption, association and the
@@ -595,6 +664,8 @@ evidence afterward.
 
 - event immutability, ID/fingerprint replay, provenance, ordering, correction, and
   irreversible tombstone;
+- exact legacy event mapping/rejection, `(created_at, id)` bootstrap ordering,
+  deleted-at/reason hashes, revision-1/create and revision-2/tombstone pages;
 - transition-to-single-event behavior under retry and crash repair;
 - task/note parent mismatch and cross-owner denial;
 - resumable existing-event bootstrap and exclusion of read state; and
@@ -611,7 +682,10 @@ evidence afterward.
 - projection-cache loss/rebuild from markers plus immutable envelope bases,
   retention protection, malformed/duplicate markers, line removal/unlink, task
   delete, restore, and explicit relink;
+- linked-tombstone and open-drift compaction blockers/release, including cache loss;
 - note/task/activity mutation-group crash windows and repair;
+- 499-change boundary acceptance and pre-append rejection of 500 changes or any
+  computed plan over ADR-034's 1,000-step cap;
 - multi-device concurrent completion, recurrence-state, deletion, restore, and
   checklist edits;
 - bounded pagination and plan assertions; and

--- a/Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
+++ b/Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
@@ -298,6 +298,16 @@ reconciliation rows may contain raw Markdown or state that reveals task existenc
 so they receive the same boundary despite not being Sync domains. Every public
 predicate begins with owner and dataset before resource identity or limit.
 
+ChaChaNotes schema migration cannot consult the separate Sync database to discover
+a dataset ID. It therefore assigns preserved inactive rows the server-only
+owner-scoped `local-unbound` dataset sentinel and uses composite foreign keys with
+`ON UPDATE CASCADE`. The sentinel is never accepted from a client, never appears in
+capabilities, and can never satisfy readiness. Explicit enrollment holds the
+dataset/product fence, proves the owner and parent-note source set, rejects any
+collision, and atomically rekeys the complete task-side graph from that sentinel to
+the selected dataset before bootstrap. New inactive legacy REST rows use the same
+sentinel until binding; once bound, all writes require the real dataset scope.
+
 PostgreSQL uses forced RLS on all six tables. Task policies require authenticated
 owner/dataset and an owned parent note in `USING` and `WITH CHECK`. Activity,
 projection, read-state, reconciliation, and drift policies join through the same

--- a/Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
+++ b/Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
@@ -258,8 +258,9 @@ for audit but exclude it from ordinary activity surfaces.
 Create always has activity revision 1. Its payload is the complete immutable field
 set above and its object hash is the canonical fingerprint. Tombstone always has
 revision 2 and the exact payload `{note_id, task_id, deleted_at, delete_reason}`:
-parent IDs must equal the create, `deleted_at` is the canonical envelope timestamp,
-and `delete_reason` is `user_request`, `correction`, or `policy`. The tombstone hash
+parent IDs must equal the create, `deleted_at` must equal
+`SyncEnvelopeCreate.created_at_client` after `normalize_sync_timestamp()`, and
+`delete_reason` is `user_request`, `correction`, or `policy`. The tombstone hash
 binds adapter version, revision/lifecycle, original create fingerprint, parent IDs,
 deleted timestamp, and reason. The product row retains create fields and stores the
 same deleted-at/reason/hash/cursor. No revision greater than 2 is valid.
@@ -446,27 +447,71 @@ preserves the stored actor/tool/policy fields after validation, uses stored
 `legacy_source_verified` marker. Bootstrap never fabricates a client device or
 claims that a legacy timestamp ordered Sync history.
 
-Legacy event conversion is exact:
+Legacy event conversion is exact. First, an optional `idempotency_key` is removed
+from legacy `new_value` after validating it as a string of 1–256 characters; its
+lowercase SHA-256 becomes activity metadata `origin_request_fingerprint`. It never
+remains in old/new.
 
-| Existing `event_type` and values | Canonical event |
+A legacy metadata object must contain only `due_date`, `priority`, and `estimate`
+and expands to this complete canonical object:
+
+```json
+{
+  "description": null,
+  "priority": null,
+  "due_date": null,
+  "estimate": null,
+  "recurrence": null,
+  "assignee_id": null,
+  "tags": [],
+  "custom": {}
+}
+```
+
+The three legacy values replace their matching nulls after exact task-field
+validation. Missing legacy metadata means the object above; unknown keys block
+readiness.
+
+The canonical old/new schemas are fixed for every event:
+
+| Canonical event | Canonical `old_value` | Canonical `new_value` |
+| --- | --- | --- |
+| `created` | null | complete `{title, status, completed_at, metadata}` snapshot; a legacy done-at-create event uses normalized event `created_at` for `completed_at` |
+| `updated` | same non-empty key set as new, exactly `metadata` or `title` plus `metadata` | changed values for that exact key set; metadata is always the complete expanded object above |
+| `completed` | `{"status":"open"}` | `{"status":"done"}` |
+| `reopened` | `{"status":"done"}` | `{"status":"open"}` |
+| `deleted` | `{"deleted":false,"projection_status":<live|unlinked|ambiguous>}` | `{"deleted":true,"projection_status":"deleted"}` |
+| `restored` | `{"deleted":true,"projection_status":"deleted"}` | `{"deleted":false,"projection_status":<live|unlinked>}` |
+| `projection_linked` | `{"projection_status":<unlinked|ambiguous>}` | `{"projection_status":"live"}` |
+| `projection_unlinked` | `{"projection_status":"live"}` | `{"projection_status":"unlinked"}` |
+| `projection_drift` | null | `{"reason_code":<closed privacy-safe drift reason>}` |
+| `corrected` | same non-empty subset of one target event schema | changed values for that exact subset; `corrects_activity_id` identifies the target |
+
+No additional keys, implicit nulls, or numerically/string-coerced values are
+accepted. The closed drift reasons are `missing_marker_base`, `malformed_marker`,
+`duplicate_marker`, `marker_scope_mismatch`, `base_unavailable`, `both_changed`,
+`ambiguous_legacy_match`, and `unsupported_markdown`. A coordinator-generated
+version-1 event uses these same shapes.
+
+Legacy rows transform as follows:
+
+| Existing `event_type` and source values after idempotency removal | Canonical event and values |
 | --- | --- |
-| `created` | `created`; old must be null and new must validate as the bounded task snapshot subset |
-| `updated` | `updated`; old/new must be bounded objects and differ in at least one canonical task field |
-| `status_changed`, `open -> done` | `completed` |
-| `status_changed`, `done -> open` | `reopened` |
-| `unlinked` | `projection_unlinked` |
-| `deleted` | `deleted` |
+| `created`; old null; new exactly `{text,status,metadata}` | `created`; rename `text` to `title`, expand metadata, and derive `completed_at` as above |
+| `updated`; old/new both exactly `{metadata}` | `updated` with complete expanded metadata objects |
+| `updated`; old/new both exactly `{text,metadata}` | `updated`; rename `text` to `title` and expand metadata |
+| `status_changed`; old exactly `{"status":"open"}`, new exactly `{"status":"done"}` | `completed` with the canonical status objects above |
+| `status_changed`; old exactly `{"status":"done"}`, new exactly `{"status":"open"}` | `reopened` with the canonical status objects above |
+| `unlinked`; old exactly `{"projection_status":"live"}`, new exactly `{"projection_status":"unlinked"}` | `projection_unlinked` unchanged |
+| `deleted`; old/new exact canonical deleted shapes | `deleted` unchanged |
 | any other type, status transition, parent mismatch, malformed value, or invalid ID | block activity readiness; do not rewrite or drop the row |
 
 A nullable legacy `note_id` is derived only from its same-scope authorized task;
 both missing or inconsistent parents block readiness. `actor_type` must map to the
 closed actor enum and actor ID must meet its bound. `tool_name`, `policy_mode`, and
 `approval_id` become an optional `legacy_context` metadata object of separately
-bounded strings (128 code points each). Stored old/new JSON is canonicalized under
-the event-specific schema. A stored `idempotency_key` is not synchronized in raw
-form; after type/length validation it becomes a SHA-256 request fingerprint in
-metadata. Oversized, nested, or unknown values block readiness with a reason code
-and row hash.
+bounded strings (128 code points each). Oversized, nested, or unknown values block
+readiness with a reason code and row hash.
 
 The source scan is keyset-ordered by `(created_at, id)` while holding the dataset
 fence. Trusted bootstrap envelopes receive monotonic server cursors in that order;

--- a/Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
+++ b/Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
@@ -34,7 +34,8 @@ The reviewed server already provides:
 
 The current task payload is narrower than the required wire contract. `note_tasks`
 stores a stable ID, parent note, `text`, open/done status, metadata, projection
-status, soft delete, timestamps, client ID, and optimistic version. The existing
+status, soft delete, timestamps, client ID, and a projection-influenced REST row
+version. The existing
 metadata supports due date, priority, and estimate. There is no `notes.task` or
 `notes.task_activity` adapter, activity tombstone, or explicit task-table
 PostgreSQL RLS contract.
@@ -84,9 +85,10 @@ weakening production, then the full task baseline passed:
 | --- | --- | --- |
 | Current task | `note_tasks` | `notes.task` v1 whole-object upsert/tombstone |
 | User-visible task history | `task_events` | `notes.task_activity` v1 immutable create/one-way tombstone |
-| Checklist text and projection cursor | `task_note_projections` plus note Markdown | Derived; rebuild/reconcile locally |
+| Checklist text and projection cursor | managed marker in note Markdown plus `task_note_projections` cache | Derived; rebuild/reconcile locally |
 | Reconciliation bookkeeping | `note_task_reconciliation_state` | Local only |
 | Activity read/dismiss state | `task_event_read_state` | Device/user UI state; never synchronized |
+| Projection drift review | `task_projection_drifts` | Local review state; never synchronized |
 
 Each task and activity uses a stable opaque UUID identity. The client may submit
 the resource ID but cannot select owner, authenticated actor, or trusted source
@@ -99,20 +101,59 @@ immutable.
 continue to expose and accept `text`; adapters translate at the boundary without
 changing stored meaning.
 
-The version-1 task payload contains:
+The version-1 task payload is exact; every field is required even when nullable:
 
-- `task_id` and `note_id`;
-- `title` and nullable `description`;
-- `status` and explicit completion state;
-- nullable `priority`, due date/time, recurrence rule/state, assignee, and estimate;
-- bounded normalized tags; and
-- bounded custom metadata.
+| Field | Canonical type and constraint |
+| --- | --- |
+| `task_id`, `note_id` | lowercase canonical UUIDv4 strings; immutable and equal to the envelope object/parent identity |
+| `title` | 1–2,000 Unicode code points, no CR/LF/control characters, already stripped; REST keeps its existing strip behavior before capture |
+| `description` | null or 0–16,000 Unicode code points with no disallowed controls; content is otherwise preserved |
+| `status` | exactly `open` or `done` |
+| `completed_at` | null RFC 3339 UTC timestamp for `open`; required RFC 3339 UTC timestamp for `done` |
+| `priority` | null or `low`, `medium`, `high` |
+| `due_date` | null or a real calendar date in canonical `YYYY-MM-DD` form |
+| `estimate` | null or `[0-9]{1,6}[mhd]`, preserving the existing accepted syntax |
+| `recurrence` | null or `{frequency, interval, by_weekday, until, state, occurrence_index}` using the bounded rules below |
+| `assignee_id` | null or the authenticated personal-dataset owner; shared assignment needs a later adapter version |
+| `tags` | at most 32 already-trimmed NFKC strings of 1–64 code points, no controls, unique under casefold, stored/hash-sorted by `(casefold, value)` |
+| `custom` | JSON object with at most 32 non-reserved keys, keys 1–64 safe characters, depth at most 4, and canonical UTF-8 JSON at most 16 KiB |
+
+Recurrence is data, not a scheduler. `frequency` is `daily`, `weekly`, `monthly`,
+or `yearly`; `interval` is 1–365; `by_weekday` is an ordered unique subset of
+`mo` through `su` and is allowed only for weekly recurrence; `until` is null or a
+canonical real date; `state` is `active`, `paused`, or `completed`; and
+`occurrence_index` is an integer from 0 through 2,147,483,647. Contradictory or
+unknown keys are rejected.
 
 Existing core fields stay in existing columns. Extended fields remain in
 `metadata_json`, but they are first-class validated wire fields rather than an
 untyped pass-through. Reserved wire keys cannot appear again in custom metadata.
 Unknown fields, noncanonical values, duplicate tags, invalid recurrence data, and
 out-of-bound strings/collections are rejected before hashing or persistence.
+
+The product mapping is fixed:
+
+| Wire state | Product state |
+| --- | --- |
+| `title` | `note_tasks.text` |
+| `status` | `note_tasks.status` |
+| `completed_at` | `note_tasks.completed_at` |
+| `description`, `priority`, `due_date`, `estimate`, `recurrence`, `assignee_id`, `tags`, `custom` | reserved canonical keys in `metadata_json` |
+| portable revision/hash | new `canonical_revision`, `canonical_hash` columns |
+| REST/projection optimistic row version | existing `version` column |
+
+Canonical task mutation increments both `version` and `canonical_revision` and
+recomputes `canonical_hash`. Projection-only locator/status changes may preserve
+their current REST `version` behavior but never change `canonical_revision` or
+`canonical_hash`. Bootstrap initializes `canonical_revision` to the existing
+positive `version` and hashes the current canonical row, so no REST version moves
+backward. Sync envelope `object_revision` always equals canonical revision, never
+the projection-influenced REST version.
+
+Legacy `due_date`, `priority`, and `estimate` keys map directly after exact
+validation. A legacy reserved key with the wrong type/value, an unknown top-level
+legacy key, or an oversized value blocks readiness and reports only row ID plus a
+reason code/hash; migration does not guess or silently relocate it into `custom`.
 
 The recurrence contract stores a validated rule and recurrence state only. It does
 not interpret wall-clock time to create another task. A future scheduler requires a
@@ -123,20 +164,54 @@ separate task and architecture decision.
 An activity payload contains:
 
 - stable `activity_id`;
-- `task_id` and `note_id` parent identities;
+- required `note_id` and nullable `task_id` parent identities;
 - actor identity and source device as server-bound provenance;
 - client event timestamp preserved as submitted metadata;
 - transition/event type, source, and bounded structured metadata; and
 - optional task revision/result references needed to verify the transition.
+
+The exact value contract is:
+
+| Field | Canonical type and constraint |
+| --- | --- |
+| `activity_id`, `note_id` | required lowercase UUIDv4 strings |
+| `task_id` | null or lowercase UUIDv4; when present it belongs to `note_id` |
+| `event_type` | one closed value listed below |
+| `actor_type` | server-bound `user`, `agent`, `tool`, `system`, or `legacy` |
+| `actor_id` | null or an authorized opaque ID of 1–128 safe characters; user actors equal the authenticated owner |
+| `source_device_id` | registered canonical device UUID for client origin; null only for trusted server/bootstrap sources |
+| `client_occurred_at` | canonical RFC 3339 UTC timestamp; preserved but not ordering authority |
+| `source_kind` | `client`, `rest`, `mcp`, `markdown_reconciliation`, `repair`, or `trusted_bootstrap_v1` |
+| `corrects_activity_id` | required same-scope UUID only for `corrected`; otherwise null |
+| `old_value`, `new_value` | null or event-schema-validated canonical JSON objects, each at most 16 KiB and depth 4 |
+| `metadata` | canonical JSON object at most 8 KiB, 16 keys, and depth 3; credentials and raw Markdown are forbidden |
 
 The stable ID is opaque, not a digest. A canonical fingerprint over the validated
 immutable content protects exact replay. Server cursor and activity ID define
 deterministic order. Client timestamps may be displayed but never resolve ordering
 or conflict.
 
-An activity must resolve to at least one authorized parent. If both task and note
-are present, the task must belong to that note. A task identity from another owner
-or dataset is indistinguishable from missing at public boundaries.
+The note is always present and authorized. If the task is present, it must belong
+to that note. A task identity from another owner or dataset is indistinguishable
+from missing at public boundaries.
+
+The product mapping adds owner/dataset, `sync_revision`, `sync_object_hash`,
+`sync_server_cursor`, `source_device_id`, `client_occurred_at`, `source_kind`,
+`corrects_activity_id`, and one-way deleted/deleted-at/delete-reason columns to
+`task_events`. Existing `created_at` remains the server-created time. Existing
+actor/tool/policy/approval and old/new JSON fields remain source data for the
+canonical event metadata. Activity pages keyset-order by
+`(sync_server_cursor, activity_id)`; `created_at` and `client_occurred_at` never
+order Sync history.
+
+Version 1 event types are the closed set `created`, `updated`, `completed`,
+`reopened`, `deleted`, `restored`, `projection_linked`, `projection_unlinked`,
+`projection_drift`, and `corrected`. A `corrected` event requires a
+`corrects_activity_id` in the same owner/dataset/note and, when present, task.
+Other event types require that field to be null. The fingerprint binds adapter
+version, lifecycle, activity ID, parent IDs, event type, correction target, actor,
+source device, client timestamp, source kind, transition values, and bounded
+metadata; it excludes server cursor, server-created time, and read state.
 
 ## Domain contracts
 
@@ -164,14 +239,21 @@ part of portable state. It excludes server cursor and local projection data.
 Activity creation uses an `upsert` envelope only as the common wire verb; product
 semantics are immutable create.
 
-- A missing stable ID creates one event.
+- A previously unseen envelope object/activity ID creates one event; the ID is
+  always required.
 - Exact stable ID plus canonical fingerprint replay is idempotent.
 - Reusing an ID with changed content is a stable idempotency conflict.
 - An existing event cannot be updated.
-- Tombstone requires exact identity/fingerprint lineage and is irreversible.
+- Tombstone requires the exact current cursor/revision/hash base, advances the
+  immutable activity lifecycle revision by one, and is irreversible.
 - Tombstoned activity cannot be restored or recreated under the same ID.
 - Corrections are represented as a new activity that references the earlier event
   where the event taxonomy permits it.
+
+Exact replay of the original accepted create or tombstone returns its existing
+result. A second create after tombstone, a distinct second tombstone, or any reuse
+with changed fingerprint conflicts. Tombstones retain the immutable event content
+for audit but exclude it from ordinary activity surfaces.
 
 Task transitions that require user-visible history create exactly one canonical
 activity. A retry or crash repair cannot duplicate it because the event ID and
@@ -180,9 +262,13 @@ mutation-group step are stable.
 ## Storage, migration, and RLS
 
 The first pull request extends the existing task schema rather than creating a
-parallel product authority. Migration changes are additive except where an
-explicit lifecycle field or constraint is required for immutable activity
-tombstones and exact Sync bootstrap.
+parallel product authority. Because client-chosen IDs are dataset-scoped, migration
+rebuilds the five existing task-side tables under the schema lock with composite
+`(owner_user_id, dataset_id, id)` authority and matching composite foreign keys;
+an internal surrogate may be used only if it preserves the same collision-safe
+contract. It also adds `task_projection_drifts` with the same scope. Legacy rows are
+mapped only after their owning note and dataset are proven. The swap is
+transactional, source-count/hash verified, and version-last.
 
 Both backends must enforce:
 
@@ -194,12 +280,20 @@ Both backends must enforce:
 - owner and parent-note authorization in every read/write predicate; and
 - exact current catalog verification before advertising readiness.
 
-PostgreSQL uses forced RLS. Task policies require authenticated owner/dataset and an
-owned parent note in `USING` and `WITH CHECK`. Activity policies additionally
-require the referenced task, when present, to belong to the same owner, dataset,
-and note. The current-version verifier enumerates every required column,
-constraint, index, policy, role, command, and canonical expression and rejects
-additional permissive policy drift.
+These rules apply to `note_tasks`, `task_events`, `task_note_projections`,
+`task_event_read_state`, `note_task_reconciliation_state`, and
+`task_projection_drifts`. Read-state requires the authenticated `user_id` to equal
+the owner and joins an authorized event before any insert/update. Projection and
+reconciliation rows may contain raw Markdown or state that reveals task existence,
+so they receive the same boundary despite not being Sync domains. Every public
+predicate begins with owner and dataset before resource identity or limit.
+
+PostgreSQL uses forced RLS on all six tables. Task policies require authenticated
+owner/dataset and an owned parent note in `USING` and `WITH CHECK`. Activity,
+projection, read-state, reconciliation, and drift policies join through the same
+owned note/task/event boundary. The current-version verifier enumerates every
+required column, constraint, composite key/FK, index, policy, role, command, and
+canonical expression and rejects additional permissive policy drift.
 
 Migration is transactional and authority-locked before inspection. It never
 guesses at malformed legacy rows, rewrites existing task meaning, or deletes
@@ -233,11 +327,15 @@ stable ID. Tags and metadata limits are enforced before allocation or hashing.
 1. Validate envelope version, domain, operation, payload, and size.
 2. Authorize device, dataset, parent note, task/activity identity, and enrollment.
 3. Compare the complete optimistic base with the durable current head.
-4. Append under dataset authority and project under the ADR-034 materialization
-   fence.
-5. Persist task/activity product state, object state, and apply result
+4. Deterministically expand any task mutation into its required activity and note
+   projection steps before append. The activity ID and group ID derive from the
+   authenticated input envelope ID plus transition kind, so retry produces the
+   identical plan. Clients do not separately invent the transition event.
+5. Validate and append the complete group under dataset authority, then project
+   under the ADR-034 materialization fence.
+6. Persist task/activity product state, object state, and apply result
    idempotently.
-6. Return success only for an applied or exact terminal replay.
+7. Return success only for an applied or exact terminal replay.
 
 ### Server origin
 
@@ -259,15 +357,46 @@ Client-origin compound groups use the same append authority and materialization
 ordering. A conflict in one step blocks later projection rather than publishing a
 partial accepted intent as success.
 
+All portable task mutations emit one canonical activity, including metadata-only
+updates. A task tombstone retains history and emits `deleted`; restore emits
+`restored`. A Markdown projection change adds a `notes.note` step only when the
+canonical note bytes change. Group synthesis, validation, append, repair, and
+postcondition verification are complete before either domain is advertised.
+
+Normal lifecycle activity is coordinator-derived, not separately submitted by the
+client: actor/device/timestamp come from the authenticated task envelope and
+`old_value`/`new_value` come from its exact base and accepted payload. A direct
+client activity create is permitted only for `corrected` and must reference an
+authorized existing event. Server-origin REST/MCP/reconciliation supplies the same
+fields through trusted bindings, never caller-selectable provenance.
+
 ## Bootstrap, capability advertisement, and rollout
 
 No global environment flag is added. Existing dataset enrollment and readiness are
-the rollout boundary.
+the rollout boundary. Public supported and writable capability maps omit both
+domains through PRs 1–3; dormant adapters are not a compatibility promise.
 
-Schema presence alone advertises neither domain as writable. Existing datasets are
-not silently enrolled.
+Each domain has an independent readiness row and the state machine
+`not_enrolled -> enrolling -> bootstrapping -> verifying -> ready`, with
+`blocked` retaining its last verified keyset cursor and reason code. Retry resumes
+`bootstrapping` or `verifying`; disabling enrollment returns to `not_enrolled` only
+before a domain has published canonical history. Existing ready Notes groups are
+not reopened.
 
-`notes.task` becomes dataset-writable only when:
+Existing datasets require an explicit owner/admin enrollment action. New datasets
+begin `not_enrolled`; a creation request may atomically request these domains only
+after PR 4 exposes them, but no profile silently opts in. Adding a domain to an
+already-ready default-personal dataset creates its independent readiness row in one
+Sync transaction without changing earlier domain readiness.
+
+Before the source scan, enrollment enables fail-closed canonical capture for the
+new domain while external device writes remain disabled. Each bootstrap page holds
+the dataset materialization fence, reads an owner/dataset keyset page, appends
+trusted source-verified envelopes, and records its cursor/count/fingerprint.
+Concurrent REST changes therefore append after or before that page under the same
+ordering authority rather than escaping capture.
+
+`notes.task` becomes dataset-writable in PR 4 only when:
 
 - `notes.note` and `notes.task` are enrolled at supported adapter versions;
 - source task bootstrap is complete, count/fingerprint verified, and resumable
@@ -276,9 +405,9 @@ not silently enrolled.
 - no reconciliation blocker or unresolved bootstrap drift exists.
 
 `notes.task_activity` additionally requires activity enrollment, complete immutable
-event bootstrap, and transition capture readiness. A server may list a completed
-adapter version in supported capabilities while omitting it from the selected
-dataset's writable map until these conditions hold.
+event bootstrap, and transition capture readiness. PR 4 may then list both adapter
+versions in server-supported capabilities. The selected dataset's writable map
+still omits either domain until that domain's exact predicate is true.
 
 Bootstrap is non-destructive and keyset-paged. Stable existing task/event IDs are
 preserved. Each page records its source count, cursor, and privacy-safe fingerprint.
@@ -287,21 +416,52 @@ last verified page. Source drift either captures a verified correction under the
 dataset fence or leaves the dataset not ready; it never marks stale source data
 ready.
 
+Legacy event provenance uses the explicit `trusted_bootstrap_v1` source kind,
+preserves the stored actor/tool/policy fields after validation, uses stored
+`created_at` as `client_occurred_at`, and records a null source device with a
+`legacy_source_verified` marker. Bootstrap never fabricates a client device or
+claims that a legacy timestamp ordered Sync history.
+
 Legacy devices receive only versions they negotiated. Per-domain adapter-version
 cursors and acknowledgments prevent a version change from skipping or
 acknowledging incompatible envelopes.
 
 ## Markdown projection convergence
 
-Markdown checklists are a deterministic view over explicit task authority, with a
-recorded last-common projection used for three-way reconciliation.
+Markdown checklists are a deterministic view over explicit task authority. A
+managed line ends with the protected marker
+`<!-- tldw-task:v1:<task-uuid>:<canonical-revision>:<canonical-hash> -->`.
+The marker is not user-visible when rendered, is included in the canonical note
+bytes, and is updated only by the projection coordinator. Duplicate or malformed
+markers are drift, never identity claims. Unmarked legacy checklist lines enter the
+bounded bootstrap matcher once; after an unambiguous source-verified match or new
+task creation, the coordinator rewrites the line with its marker.
+
+The marker is the durable association and exact last-common task base tuple. The
+named immutable `notes.task` envelope supplies the base snapshot after
+`task_note_projections` loss. Projection cache rebuild parses markers, authorizes
+their owner/dataset/note/task relation, verifies the referenced envelope
+revision/hash, and regenerates offsets and hashes. If the historical envelope is
+missing, superseded, unauthorized, or inconsistent, the line becomes drift and no
+task or note is overwritten.
+
+An applied task envelope referenced by a live marker is retention-protected until
+the marker advances or unlinks. Sync maintenance may compact unrelated history but
+must not remove the only last-common snapshot for a live projection.
+
+Only `title`, checkbox-derived `status`/`completed_at`, `due_date`, `priority`, and
+`estimate` are Markdown-projectable in version 1. Description, recurrence,
+assignee, tags, and custom metadata remain explicit-task-only fields and therefore
+cannot be erased by Markdown. The last-common envelope provides the projected
+field snapshot needed to distinguish task-only, Markdown-only, and compatible
+changes.
 
 For each bounded reconciliation unit:
 
 | Markdown since base | Task since base | Result |
 | --- | --- | --- |
 | unchanged | unchanged | no-op |
-| changed | unchanged | validate Markdown edit, create/update/tombstone task, emit activity, then record new projection |
+| changed | unchanged | validate Markdown edit, create/update or unlink task projection, emit activity, then record new marker/base |
 | unchanged | changed | rebuild Markdown from canonical task and record new projection |
 | changed compatibly | changed compatibly | converge to one canonical task/projection and record the complete durable group |
 | changed incompatibly | changed incompatibly | retain both authorities, create a privacy-safe review drift record, and do not overwrite |
@@ -311,10 +471,26 @@ claim an explicit task by text coincidence alone; it must carry or resolve the
 stable projection identity. Unsupported or ambiguous Markdown remains visible and
 creates reviewable drift rather than disappearing.
 
-Projection records and drift bookkeeping never become Sync domains. After restore,
-migration, parser change, or detected corruption, they can be rebuilt from canonical
-notes, tasks, and activity. Read endpoints do not perform unbounded maintenance
-writes.
+Removing a managed line unlinks its projection and emits `projection_unlinked`; it
+does not tombstone the explicit task. Task deletion is an explicit task operation,
+removes the managed line in the same durable group when linked, and leaves the
+activity history. Restore reprojects the line only when the stored linkage is live
+and the parent note is live; an unlinked task remains unlinked until explicit
+relink. Note trash hides projections without changing task lifecycle.
+
+`task_projection_drifts` stores only owner/dataset/note/task IDs, marker base tuple,
+bounded reason code, note/task head cursors and hashes, status
+`open|resolved|dismissed`, and timestamps. It stores no raw title, description, or
+Markdown. Resolution requires an exact opaque drift ID plus current note/task head
+claims and chooses `keep_task`, `accept_markdown`, or `unlink`; changed claims create
+a new review rather than applying stale intent. Resolved/dismissed rows remain
+bounded audit metadata and are excluded from Sync.
+
+Projection cache and drift bookkeeping never become Sync domains. After cache loss,
+restore, migration, parser change, or detected corruption, association and the
+last-common snapshot are reconstructed from the marker plus immutable Sync history.
+When that proof is unavailable, rebuild stops at review. Read endpoints do not
+perform maintenance writes.
 
 ## Conflict and failure semantics
 
@@ -348,18 +524,20 @@ note before a live task and the task before task-scoped activity visibility.
 
 - add ADR-039, canonical validators/hashes, lifecycle fields, migrations, RLS,
   exact catalog verification, and bounded indexes;
+- separate portable canonical revision/hash from the projection-influenced REST
+  row version and add marker/drift storage contracts;
 - preserve current REST/data behavior;
 - add fail-closed source-reconciliation and readiness state; and
-- advertise neither new domain writable.
+- advertise neither new domain as supported or writable.
 
 ### TASK-13006.2 — `notes.task`
 
 - implement strict upsert/tombstone adapter and idempotent materializer;
 - enforce dataset, note, identity, exact base, completion/reopen, restore, and
   recurrence-state rules;
-- capture REST/MCP server-origin task mutations and repair split commits;
+- implement dormant REST/MCP task capture primitives and split-commit repair;
 - bootstrap existing tasks and prove pull/ack behavior; and
-- advertise only `notes.task` when its full readiness predicate is true.
+- keep both domains absent from public supported/writable capabilities.
 
 ### TASK-13006.3 — `notes.task_activity`
 
@@ -367,19 +545,25 @@ note before a live task and the task before task-scoped activity visibility.
 - bind actor/device provenance and deterministic ordering;
 - capture canonical events for task transitions with exact replay deduplication;
 - bootstrap existing stable event IDs and exclude read state; and
-- advertise activity only when bootstrap, capture, pull, and materialization are
-  complete.
+- keep both domains absent from public supported/writable capabilities.
 
 ### TASK-13006.4 — Projection convergence
 
 - implement the three-way task/Markdown matrix and privacy-safe drift records;
-- use durable multi-object mutation groups across note, task, and activity;
+- implement deterministic task-to-activity expansion and durable multi-object
+  mutation groups across note, task, and activity before any product mutation;
+- activate public supported capabilities, explicit enrollment, bootstrap state
+  transitions, and per-dataset writable advertisement only after all predicates
+  pass;
 - prove concurrency, pagination, repair, and two-client end-to-end convergence on
   SQLite and PostgreSQL; and
 - publish final capability/API documentation and close TASK-13006.
 
-Each PR must be independently mergeable. Dormant schema or code may land before a
-domain, but capability advertisement cannot cross a later PR's boundary.
+Each PR must be independently mergeable. PRs 1–3 are compatibility-preserving
+dormant foundations: no public capability map or enrollment API exposes either
+domain. PR 4 is the first writable state and cannot merge until task/activity/note
+group append, projection, bootstrap, repair, and live-PostgreSQL evidence are all
+complete.
 
 ## Verification strategy
 
@@ -401,9 +585,11 @@ evidence afterward.
 - create/update/complete/reopen/delete/restore and stale-base matrices;
 - exact replay, changed replay, concurrent edit, recurrence-state, and parent-note
   authorization;
-- server-origin REST/MCP capture, product/Sync split repair, bootstrap, pull,
-  cursor, acknowledgment, and capability readiness; and
-- bounded query plans on both backends.
+- dormant server-origin REST/MCP capture, product/Sync split repair, bootstrap,
+  pull, cursor, and acknowledgment; proof that public capabilities still omit both
+  domains; and
+- bounded query plans plus lifecycle/RLS/cross-owner/repair tests on SQLite and
+  live PostgreSQL.
 
 ### PR 3
 
@@ -412,19 +598,31 @@ evidence afterward.
 - transition-to-single-event behavior under retry and crash repair;
 - task/note parent mismatch and cross-owner denial;
 - resumable existing-event bootstrap and exclusion of read state; and
-- batch ordering, pull/ack, restore visibility, and capability readiness.
+- batch ordering, pull/ack, restore visibility, and proof that public capabilities
+  still omit both domains; and
+- activity lifecycle/RLS/cross-owner/index/capture/repair tests on SQLite and live
+  PostgreSQL.
 
 ### PR 4
 
 - the complete three-way reconciliation matrix;
 - explicit-task protection, stable checklist identity, ambiguous parser input, and
-  privacy-safe drift;
+  privacy-safe drift lifecycle;
+- projection-cache loss/rebuild from markers plus immutable envelope bases,
+  retention protection, malformed/duplicate markers, line removal/unlink, task
+  delete, restore, and explicit relink;
 - note/task/activity mutation-group crash windows and repair;
 - multi-device concurrent completion, recurrence-state, deletion, restore, and
   checklist edits;
 - bounded pagination and plan assertions; and
 - end-to-end SQLite and live PostgreSQL capability, bootstrap, pull, apply, replay,
   and repair.
+
+Live PostgreSQL is a required gate in every PR: PR 1 proves migration/catalog/RLS;
+PR 2 proves dormant task lifecycle, authorization, pagination, capture, and repair;
+PR 3 proves dormant activity immutability, ordering, bootstrap, capture, and repair;
+and PR 4 proves activation and end-to-end convergence. An unavailable suitable
+server blocks the PR rather than converting the evidence to an accepted skip.
 
 Every PR runs affected Notes/Sync regression tests, Ruff, Bandit on changed
 production paths, `py_compile`, and `git diff --check`. The final PR runs the broad

--- a/Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
+++ b/Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
@@ -1,0 +1,452 @@
+# Notes task and activity Sync v2 design
+
+- **Date:** 2026-08-13
+- **Task:** TASK-13006
+- **Status:** Approved design; implementation planning and execution remain separate gates
+- **Depends on:** TASK-13005, ADR-031, ADR-034, ADR-037, and ADR-038
+- **Architecture decision:** `Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md`
+- **Reviewed server baseline:** `dev` at `8f94369e51`
+
+## Purpose
+
+Make first-class Notes tasks and their immutable activity history converge across
+devices without making Markdown checklist projections or local read state competing
+authorities. Preserve existing REST behavior and data while adding strict Sync v2
+contracts, exact optimistic lifecycle semantics, resumable bootstrap, and
+reviewable reconciliation drift.
+
+The work is deliberately split into four atomic pull requests. No partially
+implemented domain is advertised writable.
+
+## Current server reference
+
+The reviewed server already provides:
+
+- schema-v48 `note_tasks`, `task_events`, `task_event_read_state`,
+  `task_note_projections`, and `note_task_reconciliation_state` tables;
+- bounded task/event stores and REST endpoints;
+- an existing Notes task reconciler for Markdown checklist projections;
+- strict `notes.note` Sync lifecycle, durable server-origin mutation groups,
+  materialization ordering, bootstrap/readiness, restore, repair, and per-version
+  cursor/ack infrastructure; and
+- SQLite and PostgreSQL backends with established exact-catalog and forced-RLS
+  migration patterns.
+
+The current task payload is narrower than the required wire contract. `note_tasks`
+stores a stable ID, parent note, `text`, open/done status, metadata, projection
+status, soft delete, timestamps, client ID, and optimistic version. The existing
+metadata supports due date, priority, and estimate. There is no `notes.task` or
+`notes.task_activity` adapter, activity tombstone, or explicit task-table
+PostgreSQL RLS contract.
+
+Focused baseline verification found one stale migration fixture that simulated
+schema v47 without removing the later v59 attachment table. The production v59
+collision guard correctly failed closed. The fixture was repaired without
+weakening production, then the full task baseline passed:
+
+```text
+74 passed, 2 warnings in 45.20s
+```
+
+## Goals
+
+1. Define strict version-1 `notes.task` and `notes.task_activity` Sync domains.
+2. Preserve stable task identity, structured task fields, exact lifecycle lineage,
+   immutable activity history, and existing REST compatibility.
+3. Enforce owner, dataset, parent-note, and task-note authority on SQLite and
+   PostgreSQL with bounded indexed queries and forced RLS.
+4. Capture normal server-origin REST, MCP, and reconciliation mutations as the same
+   canonical envelopes clients produce.
+5. Bootstrap existing tasks and events resumably before capability advertisement.
+6. Converge explicit tasks and Markdown checklists deterministically without silent
+   overwrite.
+7. Make concurrent changes, replay, restore, completion, recurrence-state edits,
+   and delete races idempotent or reviewable.
+
+## Non-goals
+
+- Automatically generating future task instances or adding a recurrence scheduler.
+- Synchronizing Markdown text as an independent task authority.
+- Synchronizing projection cursors, reconciliation state, event read state, FTS,
+  counters, cache rows, or other derived/device-local data.
+- Replacing the existing REST `text` field or integer/internal identifiers exposed
+  by compatibility routes.
+- Mutable task-history edits or activity restore.
+- Distributed transactions between the Sync and ChaChaNotes databases.
+- A global feature environment flag in addition to dataset enrollment/readiness.
+- Broad task assignment, notification, calendar, or reminder workflows.
+
+## Authority and identity
+
+### Canonical product authorities
+
+| State | Authority | Sync treatment |
+| --- | --- | --- |
+| Current task | `note_tasks` | `notes.task` v1 whole-object upsert/tombstone |
+| User-visible task history | `task_events` | `notes.task_activity` v1 immutable create/one-way tombstone |
+| Checklist text and projection cursor | `task_note_projections` plus note Markdown | Derived; rebuild/reconcile locally |
+| Reconciliation bookkeeping | `note_task_reconciliation_state` | Local only |
+| Activity read/dismiss state | `task_event_read_state` | Device/user UI state; never synchronized |
+
+Each task and activity uses a stable opaque UUID identity. The client may submit
+the resource ID but cannot select owner, authenticated actor, or trusted source
+device. Task parent-note identity is immutable. Activity parent identities are
+immutable.
+
+### Canonical task fields
+
+`note_tasks.text` is the storage authority for wire `title`. Existing REST routes
+continue to expose and accept `text`; adapters translate at the boundary without
+changing stored meaning.
+
+The version-1 task payload contains:
+
+- `task_id` and `note_id`;
+- `title` and nullable `description`;
+- `status` and explicit completion state;
+- nullable `priority`, due date/time, recurrence rule/state, assignee, and estimate;
+- bounded normalized tags; and
+- bounded custom metadata.
+
+Existing core fields stay in existing columns. Extended fields remain in
+`metadata_json`, but they are first-class validated wire fields rather than an
+untyped pass-through. Reserved wire keys cannot appear again in custom metadata.
+Unknown fields, noncanonical values, duplicate tags, invalid recurrence data, and
+out-of-bound strings/collections are rejected before hashing or persistence.
+
+The recurrence contract stores a validated rule and recurrence state only. It does
+not interpret wall-clock time to create another task. A future scheduler requires a
+separate task and architecture decision.
+
+### Canonical activity fields
+
+An activity payload contains:
+
+- stable `activity_id`;
+- `task_id` and `note_id` parent identities;
+- actor identity and source device as server-bound provenance;
+- client event timestamp preserved as submitted metadata;
+- transition/event type, source, and bounded structured metadata; and
+- optional task revision/result references needed to verify the transition.
+
+The stable ID is opaque, not a digest. A canonical fingerprint over the validated
+immutable content protects exact replay. Server cursor and activity ID define
+deterministic order. Client timestamps may be displayed but never resolve ordering
+or conflict.
+
+An activity must resolve to at least one authorized parent. If both task and note
+are present, the task must belong to that note. A task identity from another owner
+or dataset is indistinguishable from missing at public boundaries.
+
+## Domain contracts
+
+### `notes.task` version 1
+
+Supported operations are `upsert` and `tombstone`.
+
+- Create requires an empty current head and the complete canonical payload.
+- Update, completion, reopen, recurrence-state change, and any other mutation require
+  the exact current base cursor, object revision, and object hash.
+- Tombstone requires the exact live current base.
+- Restore is an upsert with explicit restore intent, exact current tombstone base,
+  and the complete canonical payload.
+- Ordinary upsert against a tombstone, restore against a live task, stale base,
+  changed identity, or changed parent note is a reviewable whole-object conflict.
+- Exact accepted replay returns the existing result and never creates a second
+  task mutation or activity.
+
+The canonical object hash binds adapter version, operation/lifecycle state,
+identity, immutable parent, all mutable fields, and provenance fields that are
+part of portable state. It excludes server cursor and local projection data.
+
+### `notes.task_activity` version 1
+
+Activity creation uses an `upsert` envelope only as the common wire verb; product
+semantics are immutable create.
+
+- A missing stable ID creates one event.
+- Exact stable ID plus canonical fingerprint replay is idempotent.
+- Reusing an ID with changed content is a stable idempotency conflict.
+- An existing event cannot be updated.
+- Tombstone requires exact identity/fingerprint lineage and is irreversible.
+- Tombstoned activity cannot be restored or recreated under the same ID.
+- Corrections are represented as a new activity that references the earlier event
+  where the event taxonomy permits it.
+
+Task transitions that require user-visible history create exactly one canonical
+activity. A retry or crash repair cannot duplicate it because the event ID and
+mutation-group step are stable.
+
+## Storage, migration, and RLS
+
+The first pull request extends the existing task schema rather than creating a
+parallel product authority. Migration changes are additive except where an
+explicit lifecycle field or constraint is required for immutable activity
+tombstones and exact Sync bootstrap.
+
+Both backends must enforce:
+
+- stable UUID identities, lifecycle and version checks, bounded metadata, and
+  immutable parent references;
+- owner/dataset/note/task indexes for point lookup, current task pages, activity
+  pages, bootstrap, and reconciliation;
+- count and cursor/fingerprint queries that remain bounded and index-backed;
+- owner and parent-note authorization in every read/write predicate; and
+- exact current catalog verification before advertising readiness.
+
+PostgreSQL uses forced RLS. Task policies require authenticated owner/dataset and an
+owned parent note in `USING` and `WITH CHECK`. Activity policies additionally
+require the referenced task, when present, to belong to the same owner, dataset,
+and note. The current-version verifier enumerates every required column,
+constraint, index, policy, role, command, and canonical expression and rejects
+additional permissive policy drift.
+
+Migration is transactional and authority-locked before inspection. It never
+guesses at malformed legacy rows, rewrites existing task meaning, or deletes
+history. A schema collision or incompatible catalog aborts without advancing the
+version. Live PostgreSQL migration/RLS verification is mandatory for the storage
+PR; an unavailable suitable server is a blocker, not a silent pass.
+
+Before any new domain is writable, runtime reconciliation proves that legacy REST
+reads and writes remain compatible and that all existing rows can be represented
+canonically. Unrepresentable source data fails readiness with bounded diagnostics.
+
+## Authorization and privacy
+
+Every operation binds the authenticated principal, device, dataset, parent note,
+and resource identity before revealing whether the resource exists. Public errors
+are stable and sanitized. They do not expose another owner's note/task/event,
+payload, Markdown, actor details, metadata, or projection drift.
+
+Diagnostics may include bounded counts, opaque identifiers already authorized to
+the caller, and hashes. Mutation-group metadata contains only opaque identities,
+ordering, operation names, and plan hashes; it never contains title, description,
+checklist text, credentials, or custom metadata.
+
+Queries are owner-scoped and capped. Activity ordering uses server cursor and
+stable ID. Tags and metadata limits are enforced before allocation or hashing.
+
+## Server-origin and client-origin mutation flow
+
+### Client origin
+
+1. Validate envelope version, domain, operation, payload, and size.
+2. Authorize device, dataset, parent note, task/activity identity, and enrollment.
+3. Compare the complete optimistic base with the durable current head.
+4. Append under dataset authority and project under the ADR-034 materialization
+   fence.
+5. Persist task/activity product state, object state, and apply result
+   idempotently.
+6. Return success only for an applied or exact terminal replay.
+
+### Server origin
+
+REST, MCP, and Markdown reconciliation call the same canonical adapter path when
+Sync owns the domain. A compound action creates one stable ordered mutation plan,
+for example:
+
+1. update `notes.task`;
+2. append `notes.task_activity`; and
+3. update `notes.note` when the Markdown projection changes.
+
+The complete plan is inserted atomically in the Sync store before product
+materialization. The product write and Sync status commit cannot be globally
+atomic. A product commit followed by a Sync status failure is repaired by replaying
+the same stable plan and verifying the already-applied product postcondition.
+Request success requires every step to be durably applied.
+
+Client-origin compound groups use the same append authority and materialization
+ordering. A conflict in one step blocks later projection rather than publishing a
+partial accepted intent as success.
+
+## Bootstrap, capability advertisement, and rollout
+
+No global environment flag is added. Existing dataset enrollment and readiness are
+the rollout boundary.
+
+Schema presence alone advertises neither domain as writable. Existing datasets are
+not silently enrolled.
+
+`notes.task` becomes dataset-writable only when:
+
+- `notes.note` and `notes.task` are enrolled at supported adapter versions;
+- source task bootstrap is complete, count/fingerprint verified, and resumable
+  cursor state is `ready`;
+- server-origin task capture and repair are enabled; and
+- no reconciliation blocker or unresolved bootstrap drift exists.
+
+`notes.task_activity` additionally requires activity enrollment, complete immutable
+event bootstrap, and transition capture readiness. A server may list a completed
+adapter version in supported capabilities while omitting it from the selected
+dataset's writable map until these conditions hold.
+
+Bootstrap is non-destructive and keyset-paged. Stable existing task/event IDs are
+preserved. Each page records its source count, cursor, and privacy-safe fingerprint.
+Final readiness rechecks the complete bounded aggregate. Restart resumes from the
+last verified page. Source drift either captures a verified correction under the
+dataset fence or leaves the dataset not ready; it never marks stale source data
+ready.
+
+Legacy devices receive only versions they negotiated. Per-domain adapter-version
+cursors and acknowledgments prevent a version change from skipping or
+acknowledging incompatible envelopes.
+
+## Markdown projection convergence
+
+Markdown checklists are a deterministic view over explicit task authority, with a
+recorded last-common projection used for three-way reconciliation.
+
+For each bounded reconciliation unit:
+
+| Markdown since base | Task since base | Result |
+| --- | --- | --- |
+| unchanged | unchanged | no-op |
+| changed | unchanged | validate Markdown edit, create/update/tombstone task, emit activity, then record new projection |
+| unchanged | changed | rebuild Markdown from canonical task and record new projection |
+| changed compatibly | changed compatibly | converge to one canonical task/projection and record the complete durable group |
+| changed incompatibly | changed incompatibly | retain both authorities, create a privacy-safe review drift record, and do not overwrite |
+
+Checklist reordering alone does not change stable task identity. A parser cannot
+claim an explicit task by text coincidence alone; it must carry or resolve the
+stable projection identity. Unsupported or ambiguous Markdown remains visible and
+creates reviewable drift rather than disappearing.
+
+Projection records and drift bookkeeping never become Sync domains. After restore,
+migration, parser change, or detected corruption, they can be rebuilt from canonical
+notes, tasks, and activity. Read endpoints do not perform unbounded maintenance
+writes.
+
+## Conflict and failure semantics
+
+The following produce stable reviewable conflicts or fail-closed readiness:
+
+- stale task base, create-against-head, update-against-tombstone, or restore-against-live;
+- changed task or activity identity/parent;
+- activity stable-ID reuse with a different fingerprint;
+- activity update or restore;
+- task and note parent mismatch;
+- duplicate recurrence transition or completion event with incompatible content;
+- concurrent explicit task and Markdown edits that cannot be merged without data
+  loss;
+- unresolved earlier materialization conflict or incomplete mutation group;
+- bootstrap source drift or unrepresentable legacy metadata; and
+- missing, malformed, or unauthorized parent state.
+
+Exact replay is idempotent. A retry after product commit but before Sync status
+commit verifies the canonical product postcondition, repairs bookkeeping, and does
+not create another event. Conflicts block later dependent projection according to
+ADR-034 ordering.
+
+Task deletion does not delete its activity history. Task restore restores only the
+task; activity tombstones remain tombstoned. Parent-note trash controls visibility
+but does not invent task or activity tombstones. Restore order requires the parent
+note before a live task and the task before task-scoped activity visibility.
+
+## Four atomic pull requests
+
+### TASK-13006.1 — Contract and storage
+
+- add ADR-039, canonical validators/hashes, lifecycle fields, migrations, RLS,
+  exact catalog verification, and bounded indexes;
+- preserve current REST/data behavior;
+- add fail-closed source-reconciliation and readiness state; and
+- advertise neither new domain writable.
+
+### TASK-13006.2 — `notes.task`
+
+- implement strict upsert/tombstone adapter and idempotent materializer;
+- enforce dataset, note, identity, exact base, completion/reopen, restore, and
+  recurrence-state rules;
+- capture REST/MCP server-origin task mutations and repair split commits;
+- bootstrap existing tasks and prove pull/ack behavior; and
+- advertise only `notes.task` when its full readiness predicate is true.
+
+### TASK-13006.3 — `notes.task_activity`
+
+- implement immutable create and one-way tombstone;
+- bind actor/device provenance and deterministic ordering;
+- capture canonical events for task transitions with exact replay deduplication;
+- bootstrap existing stable event IDs and exclude read state; and
+- advertise activity only when bootstrap, capture, pull, and materialization are
+  complete.
+
+### TASK-13006.4 — Projection convergence
+
+- implement the three-way task/Markdown matrix and privacy-safe drift records;
+- use durable multi-object mutation groups across note, task, and activity;
+- prove concurrency, pagination, repair, and two-client end-to-end convergence on
+  SQLite and PostgreSQL; and
+- publish final capability/API documentation and close TASK-13006.
+
+Each PR must be independently mergeable. Dormant schema or code may land before a
+domain, but capability advertisement cannot cross a later PR's boundary.
+
+## Verification strategy
+
+All implementation PRs use focused RED before production edits and fresh GREEN
+evidence afterward.
+
+### PR 1
+
+- fresh and upgrade migration on SQLite and live PostgreSQL;
+- exact columns, constraints, indexes, owner/parent RLS, policy drift, rollback,
+  lock order, and schema-version authority;
+- malformed legacy metadata and bounded readiness diagnostics;
+- legacy REST/task-store/reconciler regression; and
+- proof that neither domain is writable.
+
+### PR 2
+
+- strict task payload, canonical hashes, unknown/reserved metadata rejection;
+- create/update/complete/reopen/delete/restore and stale-base matrices;
+- exact replay, changed replay, concurrent edit, recurrence-state, and parent-note
+  authorization;
+- server-origin REST/MCP capture, product/Sync split repair, bootstrap, pull,
+  cursor, acknowledgment, and capability readiness; and
+- bounded query plans on both backends.
+
+### PR 3
+
+- event immutability, ID/fingerprint replay, provenance, ordering, correction, and
+  irreversible tombstone;
+- transition-to-single-event behavior under retry and crash repair;
+- task/note parent mismatch and cross-owner denial;
+- resumable existing-event bootstrap and exclusion of read state; and
+- batch ordering, pull/ack, restore visibility, and capability readiness.
+
+### PR 4
+
+- the complete three-way reconciliation matrix;
+- explicit-task protection, stable checklist identity, ambiguous parser input, and
+  privacy-safe drift;
+- note/task/activity mutation-group crash windows and repair;
+- multi-device concurrent completion, recurrence-state, deletion, restore, and
+  checklist edits;
+- bounded pagination and plan assertions; and
+- end-to-end SQLite and live PostgreSQL capability, bootstrap, pull, apply, replay,
+  and repair.
+
+Every PR runs affected Notes/Sync regression tests, Ruff, Bandit on changed
+production paths, `py_compile`, and `git diff --check`. The final PR runs the broad
+Notes and Sync suites plus public capability/documentation checks.
+
+## Acceptance mapping
+
+| TASK-13006 criterion | Design coverage |
+| --- | --- |
+| Versioned task/activity domains; upsert/tombstone; immutable new activity IDs | Domain contracts; authority and identity |
+| Stable task identity, complete fields, optimistic base, SQLite/PostgreSQL | Canonical task fields; storage/migration; task lifecycle |
+| Ordered immutable activity with actor/time/transition/source | Canonical activity fields; activity contract |
+| Deterministic rebuildable Markdown with review drift | Markdown projection convergence |
+| Server-origin canonical envelopes while Sync active | Server-origin/client-origin flow; durable groups |
+| Concurrency, recurrence, completion, delete, restore, checklist edits are idempotent or reviewable and bounded | Conflict semantics; rollout; verification strategy |
+
+## ADR check
+
+ADR required: yes
+
+ADR path: `Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md`
+
+Reason: TASK-13006 establishes two public Sync domains, product/storage authority,
+immutable history semantics, projection ownership, PostgreSQL tenancy rules,
+cross-database recovery behavior, and a long-lived recurrence boundary.

--- a/backlog/tasks/task-13006 - Synchronize-Notes-tasks-checklists-and-activity.md
+++ b/backlog/tasks/task-13006 - Synchronize-Notes-tasks-checklists-and-activity.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-13006
 title: Synchronize Notes tasks checklists and activity
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-08 20:25'
+updated_date: '2026-08-14 02:22'
 labels:
   - notes
   - sync-v2
@@ -14,9 +15,11 @@ dependencies:
 references:
   - >-
     https://github.com/rmusser01/tldw_chatbook/blob/dev/backlog/decisions/046-synchronized-database-notes-parity.md
+  - Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
 documentation:
   - >-
     https://github.com/rmusser01/tldw_chatbook/blob/dev/Docs/Parity/2026-08-08-notes-server-capability-matrix.md
+  - Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
 priority: high
 ---
 
@@ -35,6 +38,20 @@ Give explicit Notes tasks, checklist state, and task activity a synchronized lif
 - [ ] #5 Server-origin task checklist reconciliation and activity mutations capture canonical envelopes when Sync v2 is active.
 - [ ] #6 Concurrent transitions recurrence completion delete restore and checklist edits yield idempotent results or reviewable conflicts with authorized bounded queries.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+Reason: ADR-039 already governs canonical task/activity authority, tenancy, compound mutation, checklist projection, and coupled activation.
+
+1. Deliver TASK-13006.1 contract, schema v60, tenancy, and dormant readiness using Docs/superpowers/plans/2026-08-13-notes-task-sync-contract-storage-implementation-plan.md.
+2. Deliver TASK-13006.2 dormant notes.task lifecycle using Docs/superpowers/plans/2026-08-13-notes-task-sync-lifecycle-implementation-plan.md.
+3. Deliver TASK-13006.3 dormant notes.task_activity lifecycle using Docs/superpowers/plans/2026-08-13-notes-task-activity-sync-lifecycle-implementation-plan.md.
+4. Deliver TASK-13006.4 immutable-envelope projection authority, client/server compound mutation, checklist convergence, coupled activation, and end-to-end proof using Docs/superpowers/plans/2026-08-13-notes-task-checklist-convergence-activation-implementation-plan.md.
+5. Keep every child independently testable, require live PostgreSQL evidence, and expose neither task domain until the final child.
+<!-- SECTION:PLAN:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-13006.1 - Define-Notes-task-Sync-contract-and-tenancy-storage.md
+++ b/backlog/tasks/task-13006.1 - Define-Notes-task-Sync-contract-and-tenancy-storage.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13006.1
 title: Define Notes task Sync contract and tenancy storage
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-14 01:53'
-updated_date: '2026-08-14 02:06'
+updated_date: '2026-08-20 15:39'
 labels:
   - notes
   - sync-v2
@@ -28,11 +28,11 @@ Establish the fail-closed storage and validation foundation for synchronized Not
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Canonical version-1 task and activity payload validators, hashes, lifecycle fields, and strict legacy mappings are defined while existing REST behavior remains compatible.
-- [ ] #2 SQLite and PostgreSQL migrations create collision-safe owner/dataset authority, composite references, bounded indexes, and separate canonical task revision/hash without projection-only revision drift.
-- [ ] #3 Forced PostgreSQL RLS and exact current-catalog verification cover tasks, activity, projections, read state, reconciliation state, and projection drift state.
-- [ ] #4 Independent resumable readiness records and fail-closed source diagnostics exist, but public supported and writable capabilities omit both new domains.
-- [ ] #5 Fresh/upgrade/rollback/concurrency/catalog/RLS and legacy task REST/store/reconciler tests pass on SQLite and live PostgreSQL.
+- [x] #1 Canonical version-1 task and activity payload validators, hashes, lifecycle fields, and strict legacy mappings are defined while existing REST behavior remains compatible.
+- [x] #2 SQLite and PostgreSQL migrations create collision-safe owner/dataset authority, composite references, bounded indexes, and separate canonical task revision/hash without projection-only revision drift.
+- [x] #3 Forced PostgreSQL RLS and exact current-catalog verification cover tasks, activity, projections, read state, reconciliation state, and projection drift state.
+- [x] #4 Independent resumable readiness records and fail-closed source diagnostics exist, but public supported and writable capabilities omit both new domains.
+- [x] #5 Fresh/upgrade/rollback/concurrency/catalog/RLS and legacy task REST/store/reconciler tests pass on SQLite and live PostgreSQL.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -47,12 +47,24 @@ Detailed plan: Docs/superpowers/plans/2026-08-13-notes-task-sync-contract-storag
 ADR required: no; ADR-039 already governs the approved contract, storage, tenancy, and activation boundary.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented strict task/activity v1 contracts, transactional SQLite and PostgreSQL schema v60 with exact fail-closed catalog verification, forced tenant RLS, immutable private owner-to-dataset scope authority, atomic bind, dormant readiness state, and compatibility REST/MCP paths without a client dataset selector. Amended ADR-039 and the implementation plan. Verified 963 changed-scope tests with required PostgreSQL 18 and zero skips; Ruff passes with only documented legacy-file baselines excluded, py_compile and Bandit pass, and mypy remains at the exact 158-error legacy baseline. Independent final and quality reviews report no Critical or Important findings. Deferred before any future production bind exposure: coordinate active-Sync mutations with bind and close conn-less PostgreSQL read transactions.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Delivered the dormant Notes task/activity Sync contract and tenancy-storage foundation across SQLite and PostgreSQL. Public capabilities remain off, compatibility APIs remain dataset-selector-free, exact migrations/catalog/RLS/readiness tests pass, and the final required matrix is 963 passed with live PostgreSQL and zero skips.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13006.1 - Define-Notes-task-Sync-contract-and-tenancy-storage.md
+++ b/backlog/tasks/task-13006.1 - Define-Notes-task-Sync-contract-and-tenancy-storage.md
@@ -1,0 +1,58 @@
+---
+id: TASK-13006.1
+title: Define Notes task Sync contract and tenancy storage
+status: In Progress
+assignee: []
+created_date: '2026-08-14 01:53'
+updated_date: '2026-08-14 02:06'
+labels:
+  - notes
+  - sync-v2
+  - parity
+  - tasks
+dependencies:
+  - TASK-13005
+references:
+  - Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+documentation:
+  - Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
+parent_task_id: TASK-13006
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Establish the fail-closed storage and validation foundation for synchronized Notes tasks and immutable task activity without exposing an incomplete capability.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Canonical version-1 task and activity payload validators, hashes, lifecycle fields, and strict legacy mappings are defined while existing REST behavior remains compatible.
+- [ ] #2 SQLite and PostgreSQL migrations create collision-safe owner/dataset authority, composite references, bounded indexes, and separate canonical task revision/hash without projection-only revision drift.
+- [ ] #3 Forced PostgreSQL RLS and exact current-catalog verification cover tasks, activity, projections, read state, reconciliation state, and projection drift state.
+- [ ] #4 Independent resumable readiness records and fail-closed source diagnostics exist, but public supported and writable capabilities omit both new domains.
+- [ ] #5 Fresh/upgrade/rollback/concurrency/catalog/RLS and legacy task REST/store/reconciler tests pass on SQLite and live PostgreSQL.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Lock strict version-1 task/activity validators, hashes, lifecycle fields, and exact legacy transforms.
+2. Add transactional SQLite schema v60 and owner/dataset-scoped task storage with canonical revision/hash separated from projection row versions.
+3. Add PostgreSQL schema v60, forced RLS, exact current-catalog verification, and required live tenancy evidence.
+4. Add independent dormant readiness/source diagnostics while keeping both public capabilities absent.
+5. Run the complete contract/storage/legacy regression and static/security gates, then close the child task.
+Detailed plan: Docs/superpowers/plans/2026-08-13-notes-task-sync-contract-storage-implementation-plan.md
+ADR required: no; ADR-039 already governs the approved contract, storage, tenancy, and activation boundary.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13006.2 - Implement-dormant-notes.task-Sync-lifecycle.md
+++ b/backlog/tasks/task-13006.2 - Implement-dormant-notes.task-Sync-lifecycle.md
@@ -1,0 +1,45 @@
+---
+id: TASK-13006.2
+title: Implement dormant notes.task Sync lifecycle
+status: To Do
+assignee: []
+created_date: '2026-08-14 01:54'
+labels:
+  - notes
+  - sync-v2
+  - parity
+  - tasks
+dependencies:
+  - TASK-13006.1
+references:
+  - Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+documentation:
+  - Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
+parent_task_id: TASK-13006
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the complete notes.task adapter, materializer, bootstrap, capture primitives, and repair behavior as a dormant foundation that cannot yet be enrolled or advertised.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Strict notes.task version-1 upsert/tombstone implements create, exact-base update, complete/reopen, recurrence-state mutation, delete, and explicit tombstone restore with immutable identity and parent note.
+- [ ] #2 Task product writes use canonical revision/hash independently from REST row version, enforce owner/dataset/note authorization, and remain bounded and index-backed on SQLite and PostgreSQL.
+- [ ] #3 Existing tasks bootstrap resumably with exact legacy metadata validation, count/fingerprint verification, pull, cursor, acknowledgment, and split-commit repair.
+- [ ] #4 REST and MCP task mutations have dormant canonical capture primitives, but public supported/writable capabilities and enrollment still omit both task domains.
+- [ ] #5 Focused lifecycle, replay, conflict, cross-owner, pagination, repair, legacy REST, and live PostgreSQL tests pass.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13006.3 - Implement-dormant-notes.task_activity-Sync-lifecycle.md
+++ b/backlog/tasks/task-13006.3 - Implement-dormant-notes.task_activity-Sync-lifecycle.md
@@ -1,0 +1,45 @@
+---
+id: TASK-13006.3
+title: Implement dormant notes.task_activity Sync lifecycle
+status: To Do
+assignee: []
+created_date: '2026-08-14 01:54'
+labels:
+  - notes
+  - sync-v2
+  - parity
+  - tasks
+dependencies:
+  - TASK-13006.2
+references:
+  - Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+documentation:
+  - Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
+parent_task_id: TASK-13006
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement immutable Notes task activity synchronization, exact legacy event bootstrap, and transition capture as a dormant foundation that remains unavailable until compound task capture is complete.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 notes.task_activity version 1 supports immutable create and exact one-way tombstone with required note, optional same-note task, server-bound provenance, canonical old/new schemas, and cursor-plus-ID ordering.
+- [ ] #2 Exact replay is idempotent, changed stable-ID reuse conflicts, activity cannot be updated/restored, corrections are new same-scope events, and lifecycle revisions are limited to create revision 1 and tombstone revision 2.
+- [ ] #3 Existing events bootstrap in deterministic created_at/ID order with exact legacy type/value transforms, provenance sentinels, bounded pages, count/fingerprint verification, and read/dismiss state excluded.
+- [ ] #4 Task transition capture produces stable nonduplicating activity primitives and split-commit repair, while public supported/writable capabilities still omit both domains.
+- [ ] #5 Immutability, ordering, tombstone, correction, bootstrap, cross-owner, RLS, pagination, repair, and live PostgreSQL tests pass.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13006.4 - Activate-Notes-task-Sync-and-checklist-convergence.md
+++ b/backlog/tasks/task-13006.4 - Activate-Notes-task-Sync-and-checklist-convergence.md
@@ -1,0 +1,45 @@
+---
+id: TASK-13006.4
+title: Activate Notes task Sync and checklist convergence
+status: To Do
+assignee: []
+created_date: '2026-08-14 01:55'
+labels:
+  - notes
+  - sync-v2
+  - parity
+  - tasks
+dependencies:
+  - TASK-13006.3
+references:
+  - Docs/ADR/039-canonical-notes-task-sync-and-derived-checklist-projections.md
+documentation:
+  - Docs/superpowers/specs/2026-08-13-notes-task-activity-sync-design.md
+parent_task_id: TASK-13006
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Complete deterministic task/activity/note mutation grouping and three-way Markdown checklist convergence, then activate the two coupled Sync domains only after bootstrap and repair are proven ready.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every portable task mutation deterministically expands to one immutable activity and optional note-projection step, and the complete plan appends atomically before product materialization under ADR-034.
+- [ ] #2 Managed Markdown markers preserve stable task identity and exact last-common bases; cache loss rebuilds safely, incompatible edits create privacy-safe drift, and explicit tasks are never silently overwritten.
+- [ ] #3 Linked tombstone and open-drift envelope retention, unlink/delete/restore/relink behavior, exact drift resolution, and 1,000-step preflight limits are enforced and repairable.
+- [ ] #4 Explicit enrollment atomically enables coupled task/activity capture and bootstrap; supported/writable capabilities expose both domains together only after all readiness predicates pass.
+- [ ] #5 SQLite and live PostgreSQL end-to-end multi-device, concurrency, pagination, crash repair, pull/ack, projection, recurrence, completion, delete, restore, capability, and public documentation tests pass.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/notes_tasks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes_tasks.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from loguru import logger
+from starlette.concurrency import run_in_threadpool
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     RateLimiter,
@@ -149,6 +150,7 @@ def _task_response(
     scope: TaskStoreScope,
     include_projection: bool = True,
 ) -> TaskResponse:
+    """Build one backend-neutral task response within an authenticated scope."""
     projection = db.get_task_projection(
         owner_user_id=scope.owner_user_id,
         dataset_id=scope.dataset_id,
@@ -453,6 +455,31 @@ async def delete_task(
     raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Task delete failed")
 
 
+def _list_note_tasks_response(
+    db: CharactersRAGDB,
+    *,
+    owner_user_id: str,
+    note_id: str,
+    limit: int,
+) -> TaskListResponse:
+    """Build a note-scoped task list without blocking the async request loop."""
+    scope = resolve_task_compatibility_scope(
+        db, authenticated_owner_user_id=owner_user_id
+    )
+    if db.get_note_by_id(note_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Note not found")
+    tasks = db.list_tasks(
+        owner_user_id=scope.owner_user_id,
+        dataset_id=scope.dataset_id,
+        note_id=note_id,
+        limit=limit,
+    )
+    return TaskListResponse(
+        tasks=[_task_response(db, task, scope=scope) for task in tasks],
+        reconciliation=_stale_reconciliation_response(db, scope=scope, note_id=note_id),
+    )
+
+
 @router.get("/{note_id}/tasks", response_model=TaskListResponse, tags=["notes"])
 async def list_note_tasks(
     note_id: str,
@@ -464,20 +491,12 @@ async def list_note_tasks(
 ) -> TaskListResponse:
     await _check_rate_limit(rate_limiter, current_user, "notes.read")
     try:
-        scope = resolve_task_compatibility_scope(
-            db, authenticated_owner_user_id=str(current_user.id)
-        )
-        if db.get_note_by_id(note_id) is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Note not found")
-        tasks = db.list_tasks(
-            owner_user_id=scope.owner_user_id,
-            dataset_id=scope.dataset_id,
+        return await run_in_threadpool(
+            _list_note_tasks_response,
+            db,
+            owner_user_id=str(current_user.id),
             note_id=note_id,
             limit=limit,
-        )
-        return TaskListResponse(
-            tasks=[_task_response(db, task, scope=scope) for task in tasks],
-            reconciliation=_stale_reconciliation_response(db, scope=scope, note_id=note_id),
         )
     except Exception as exc:
         _handle_task_error(exc)

--- a/tldw_Server_API/app/api/v1/endpoints/notes_tasks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes_tasks.py
@@ -142,9 +142,9 @@ def _task_response(
     include_projection: bool = True,
 ) -> TaskResponse:
     projection = db.get_task_projection(
-        str(task["id"]),
         owner_user_id=scope.owner_user_id,
         dataset_id=scope.dataset_id,
+        task_id=str(task["id"]),
     ) if include_projection else None
     return TaskResponse(
         id=str(task["id"]),
@@ -218,9 +218,9 @@ def _stale_reconciliation_response(
         )
     if note_id is not None:
         state_row = db.get_reconciliation_state(
-            note_id,
             owner_user_id=scope.owner_user_id,
             dataset_id=scope.dataset_id,
+            note_id=note_id,
         )
         return _reconciliation_response(None, fallback_state=state_row)
     return TaskReconciliationSummaryResponse(status="clean", processed_notes=0, remaining_stale_notes=0)
@@ -335,16 +335,16 @@ async def update_task_activity_state(
         scope = resolve_task_compatibility_scope(db, authenticated_owner_user_id=user_id)
         state_row = (
             db.mark_task_activity_dismissed(
-                event_id,
                 owner_user_id=scope.owner_user_id,
                 dataset_id=scope.dataset_id,
+                event_id=event_id,
                 user_id=user_id,
             )
             if request.dismissed
             else db.mark_task_activity_read(
-                event_id,
                 owner_user_id=scope.owner_user_id,
                 dataset_id=scope.dataset_id,
+                event_id=event_id,
                 user_id=user_id,
             )
         )
@@ -371,7 +371,7 @@ async def get_task(
     scope = resolve_task_compatibility_scope(
         db, authenticated_owner_user_id=str(current_user.id)
     )
-    task = db.get_task_scoped(
+    task = db.get_task(
         owner_user_id=scope.owner_user_id,
         dataset_id=scope.dataset_id,
         task_id=task_id,

--- a/tldw_Server_API/app/api/v1/endpoints/notes_tasks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes_tasks.py
@@ -134,6 +134,14 @@ def _note_summary(db: CharactersRAGDB, note_id: str) -> TaskNoteSummaryResponse 
     )
 
 
+def _timestamp_response(value: Any) -> str | None:
+    """Normalize backend timestamp values at the existing string response boundary."""
+    if value is None:
+        return None
+    isoformat = getattr(value, "isoformat", None)
+    return str(isoformat() if callable(isoformat) else value)
+
+
 def _task_response(
     db: CharactersRAGDB,
     task: dict[str, Any],
@@ -154,9 +162,9 @@ def _task_response(
         metadata=dict(task.get("metadata_json") or {}),
         projection_status=task["projection_status"],
         version=int(task["version"]),
-        created_at=task.get("created_at"),
-        updated_at=task.get("updated_at"),
-        completed_at=task.get("completed_at"),
+        created_at=_timestamp_response(task.get("created_at")),
+        updated_at=_timestamp_response(task.get("updated_at")),
+        completed_at=_timestamp_response(task.get("completed_at")),
         note=_note_summary(db, str(task["note_id"])),
         projection=_projection_response(projection),
     )
@@ -351,8 +359,8 @@ async def update_task_activity_state(
         return TaskActivityStateResponse(
             event_id=str(state_row["event_id"]),
             user_id=str(state_row["user_id"]),
-            read_at=state_row.get("read_at"),
-            dismissed_at=state_row.get("dismissed_at"),
+            read_at=_timestamp_response(state_row.get("read_at")),
+            dismissed_at=_timestamp_response(state_row.get("dismissed_at")),
         )
     except Exception as exc:
         _handle_task_error(exc)
@@ -531,6 +539,9 @@ async def reconcile_note_tasks(
 
 
 def _activity_response(event: dict[str, Any], state_row: dict[str, Any] | None) -> TaskActivityResponse:
+    created_at = _timestamp_response(event.get("created_at"))
+    if created_at is None:
+        raise ValueError("Task activity created_at is required.")
     return TaskActivityResponse(
         id=str(event["id"]),
         task_id=event.get("task_id"),
@@ -543,7 +554,7 @@ def _activity_response(event: dict[str, Any], state_row: dict[str, Any] | None) 
         approval_id=event.get("approval_id"),
         old_value=event.get("old_value_json"),
         new_value=event.get("new_value_json"),
-        created_at=str(event["created_at"]),
-        read_at=state_row.get("read_at") if state_row else None,
-        dismissed_at=state_row.get("dismissed_at") if state_row else None,
+        created_at=created_at,
+        read_at=_timestamp_response(state_row.get("read_at")) if state_row else None,
+        dismissed_at=_timestamp_response(state_row.get("dismissed_at")) if state_row else None,
     )

--- a/tldw_Server_API/app/api/v1/endpoints/notes_tasks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes_tasks.py
@@ -43,7 +43,11 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     InputError,
 )
 from tldw_Server_API.app.core.Notes_Tasks import NotesTaskService, ReconciliationResult, TaskActor
-from tldw_Server_API.app.core.Notes_Tasks.service import ReconciliationBatchResult
+from tldw_Server_API.app.core.Notes_Tasks.service import (
+    ReconciliationBatchResult,
+    TaskStoreScope,
+    resolve_task_compatibility_scope,
+)
 
 router = APIRouter()
 
@@ -130,8 +134,18 @@ def _note_summary(db: CharactersRAGDB, note_id: str) -> TaskNoteSummaryResponse 
     )
 
 
-def _task_response(db: CharactersRAGDB, task: dict[str, Any], *, include_projection: bool = True) -> TaskResponse:
-    projection = db.get_task_projection(str(task["id"])) if include_projection else None
+def _task_response(
+    db: CharactersRAGDB,
+    task: dict[str, Any],
+    *,
+    scope: TaskStoreScope,
+    include_projection: bool = True,
+) -> TaskResponse:
+    projection = db.get_task_projection(
+        str(task["id"]),
+        owner_user_id=scope.owner_user_id,
+        dataset_id=scope.dataset_id,
+    ) if include_projection else None
     return TaskResponse(
         id=str(task["id"]),
         note_id=str(task["note_id"]),
@@ -182,8 +196,17 @@ def _reconciliation_response(
     return TaskReconciliationSummaryResponse(status="clean")
 
 
-def _stale_reconciliation_response(db: CharactersRAGDB, *, note_id: str | None = None) -> TaskReconciliationSummaryResponse:
-    remaining = db.count_candidate_notes_for_task_discovery(note_id=note_id)
+def _stale_reconciliation_response(
+    db: CharactersRAGDB,
+    *,
+    scope: TaskStoreScope,
+    note_id: str | None = None,
+) -> TaskReconciliationSummaryResponse:
+    remaining = db.count_candidate_notes_for_task_discovery(
+        owner_user_id=scope.owner_user_id,
+        dataset_id=scope.dataset_id,
+        note_id=note_id,
+    )
     if remaining:
         note = db.get_note_by_id(note_id) if note_id is not None else None
         return TaskReconciliationSummaryResponse(
@@ -194,7 +217,11 @@ def _stale_reconciliation_response(db: CharactersRAGDB, *, note_id: str | None =
             remaining_stale_notes=remaining,
         )
     if note_id is not None:
-        state_row = db.get_reconciliation_state(note_id)
+        state_row = db.get_reconciliation_state(
+            note_id,
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+        )
         return _reconciliation_response(None, fallback_state=state_row)
     return TaskReconciliationSummaryResponse(status="clean", processed_notes=0, remaining_stale_notes=0)
 
@@ -212,14 +239,19 @@ async def list_tasks(
 ) -> TaskListResponse:
     await _check_rate_limit(rate_limiter, current_user, "notes.read")
     try:
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=str(current_user.id)
+        )
         tasks = db.list_tasks(
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
             status=status_filter,
             projection_status=projection_status,
             limit=limit,
         )
         return TaskListResponse(
-            tasks=[_task_response(db, task) for task in tasks],
-            reconciliation=_stale_reconciliation_response(db),
+            tasks=[_task_response(db, task, scope=scope) for task in tasks],
+            reconciliation=_stale_reconciliation_response(db, scope=scope),
         )
     except Exception as exc:
         _handle_task_error(exc)
@@ -243,6 +275,7 @@ async def set_task_status(
                 tasks.append(
                     task_service.update_task(
                         db=db,
+                        owner_user_id=str(current_user.id),
                         task_id=item.task_id,
                         expected_task_version=item.expected_task_version,
                         expected_note_version=item.expected_note_version,
@@ -251,7 +284,10 @@ async def set_task_status(
                         record_only=item.record_only,
                     )
                 )
-        return TaskStatusBatchResponse(tasks=[_task_response(db, task) for task in tasks])
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=str(current_user.id)
+        )
+        return TaskStatusBatchResponse(tasks=[_task_response(db, task, scope=scope) for task in tasks])
     except Exception as exc:
         _handle_task_error(exc)
     raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Task status update failed")
@@ -269,7 +305,15 @@ async def list_task_activity(
     await _check_rate_limit(rate_limiter, current_user, "notes.read")
     try:
         user_id = str(current_user.id)
-        events = db.list_recent_unread_task_activity(user_id=user_id, note_id=note_id, actor_type="agent", limit=limit)
+        scope = resolve_task_compatibility_scope(db, authenticated_owner_user_id=user_id)
+        events = db.list_recent_unread_task_activity(
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+            user_id=user_id,
+            note_id=note_id,
+            actor_type="agent",
+            limit=limit,
+        )
         return TaskActivityListResponse(events=[_activity_response(event, None) for event in events])
     except Exception as exc:
         _handle_task_error(exc)
@@ -288,10 +332,21 @@ async def update_task_activity_state(
     await _check_rate_limit(rate_limiter, current_user, "notes.update")
     try:
         user_id = str(current_user.id)
+        scope = resolve_task_compatibility_scope(db, authenticated_owner_user_id=user_id)
         state_row = (
-            db.mark_task_activity_dismissed(event_id, user_id=user_id)
+            db.mark_task_activity_dismissed(
+                event_id,
+                owner_user_id=scope.owner_user_id,
+                dataset_id=scope.dataset_id,
+                user_id=user_id,
+            )
             if request.dismissed
-            else db.mark_task_activity_read(event_id, user_id=user_id)
+            else db.mark_task_activity_read(
+                event_id,
+                owner_user_id=scope.owner_user_id,
+                dataset_id=scope.dataset_id,
+                user_id=user_id,
+            )
         )
         return TaskActivityStateResponse(
             event_id=str(state_row["event_id"]),
@@ -313,10 +368,17 @@ async def get_task(
     _: None = Depends(rbac_rate_limit("notes.read")),
 ) -> TaskResponse:
     await _check_rate_limit(rate_limiter, current_user, "notes.read")
-    task = db.get_task(task_id)
+    scope = resolve_task_compatibility_scope(
+        db, authenticated_owner_user_id=str(current_user.id)
+    )
+    task = db.get_task_scoped(
+        owner_user_id=scope.owner_user_id,
+        dataset_id=scope.dataset_id,
+        task_id=task_id,
+    )
     if task is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
-    return _task_response(db, task)
+    return _task_response(db, task, scope=scope)
 
 
 @router.patch("/tasks/{task_id}", response_model=TaskResponse, tags=["notes"])
@@ -333,6 +395,7 @@ async def update_task(
     try:
         task = task_service.update_task(
             db=db,
+            owner_user_id=str(current_user.id),
             task_id=task_id,
             expected_task_version=request.expected_task_version,
             expected_note_version=request.expected_note_version,
@@ -341,7 +404,10 @@ async def update_task(
             actor=_actor(current_user),
             record_only=request.record_only,
         )
-        return _task_response(db, task)
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=str(current_user.id)
+        )
+        return _task_response(db, task, scope=scope)
     except Exception as exc:
         _handle_task_error(exc)
     raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Task update failed")
@@ -363,13 +429,17 @@ async def delete_task(
     try:
         task = task_service.delete_task(
             db=db,
+            owner_user_id=str(current_user.id),
             task_id=task_id,
             expected_task_version=expected_task_version,
             expected_note_version=expected_note_version,
             record_only=record_only,
             actor=_actor(current_user),
         )
-        return _task_response(db, task)
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=str(current_user.id)
+        )
+        return _task_response(db, task, scope=scope)
     except Exception as exc:
         _handle_task_error(exc)
     raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Task delete failed")
@@ -386,12 +456,20 @@ async def list_note_tasks(
 ) -> TaskListResponse:
     await _check_rate_limit(rate_limiter, current_user, "notes.read")
     try:
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=str(current_user.id)
+        )
         if db.get_note_by_id(note_id) is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Note not found")
-        tasks = db.list_tasks(note_id=note_id, limit=limit)
+        tasks = db.list_tasks(
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+            note_id=note_id,
+            limit=limit,
+        )
         return TaskListResponse(
-            tasks=[_task_response(db, task) for task in tasks],
-            reconciliation=_stale_reconciliation_response(db, note_id=note_id),
+            tasks=[_task_response(db, task, scope=scope) for task in tasks],
+            reconciliation=_stale_reconciliation_response(db, scope=scope, note_id=note_id),
         )
     except Exception as exc:
         _handle_task_error(exc)
@@ -412,6 +490,7 @@ async def create_note_task(
     try:
         task = task_service.create_task_for_note(
             db=db,
+            owner_user_id=str(current_user.id),
             note_id=note_id,
             text=request.text,
             status=request.status,
@@ -419,7 +498,10 @@ async def create_note_task(
             expected_note_version=request.expected_note_version,
             actor=_actor(current_user),
         )
-        return _task_response(db, task)
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=str(current_user.id)
+        )
+        return _task_response(db, task, scope=scope)
     except Exception as exc:
         _handle_task_error(exc)
     raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Task create failed")
@@ -436,7 +518,12 @@ async def reconcile_note_tasks(
 ) -> TaskReconciliationSummaryResponse:
     await _check_rate_limit(rate_limiter, current_user, "notes.update")
     try:
-        result = task_service.reconcile_note_current(db=db, note_id=note_id, actor=_actor(current_user))
+        result = task_service.reconcile_note_current(
+            db=db,
+            owner_user_id=str(current_user.id),
+            note_id=note_id,
+            actor=_actor(current_user),
+        )
         return _reconciliation_response(result)
     except Exception as exc:
         _handle_task_error(exc)

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -130,6 +130,7 @@ from tldw_Server_API.app.core.Flashcards.scheduler_fsrs import (  # noqa: E402
     simulate_fsrs_review_transition,
 )
 from tldw_Server_API.app.core.Persona.buddy import resolve_persona_buddy_profile  # noqa: E402
+from tldw_Server_API.app.core.exceptions import NotesTaskContractError  # noqa: E402
 from tldw_Server_API.app.core.Sync.v2.notes_link import (  # noqa: E402
     NOTES_LINK_LABEL_MAX_CHARS,
     NOTES_LINK_WEIGHT_MAX,
@@ -138,7 +139,6 @@ from tldw_Server_API.app.core.Sync.v2.notes_link import (  # noqa: E402
     validate_notes_link_properties,
 )
 from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (  # noqa: E402
-    NotesTaskContractError,
     canonical_json_bytes,
     notes_task_object_hash,
     parse_notes_task_v1,

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -11163,6 +11163,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "CREATE INDEX idx_task_projections_scope_status ON task_note_projections(owner_user_id,dataset_id,projection_status,updated_at,task_id)",
             "CREATE INDEX idx_task_events_scope_task_page ON task_events(owner_user_id,dataset_id,task_id,sync_server_cursor,id)",
             "CREATE INDEX idx_task_events_scope_note_page ON task_events(owner_user_id,dataset_id,note_id,sync_server_cursor,id)",
+            "CREATE INDEX idx_task_events_scope_cursor ON task_events(owner_user_id,dataset_id,sync_server_cursor,id)",
             "CREATE INDEX idx_task_events_scope_task_created ON task_events(owner_user_id,dataset_id,task_id,created_at,id)",
             "CREATE INDEX idx_task_events_scope_note_created ON task_events(owner_user_id,dataset_id,note_id,created_at,id)",
             "CREATE INDEX idx_task_events_scope_created ON task_events(owner_user_id,dataset_id,created_at,id)",
@@ -11502,6 +11503,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "CREATE INDEX idx_task_projections_scope_status ON task_note_projections(owner_user_id,dataset_id,projection_status,updated_at,task_id)",
             "CREATE INDEX idx_task_events_scope_task_page ON task_events(owner_user_id,dataset_id,task_id,sync_server_cursor,id)",
             "CREATE INDEX idx_task_events_scope_note_page ON task_events(owner_user_id,dataset_id,note_id,sync_server_cursor,id)",
+            "CREATE INDEX idx_task_events_scope_cursor ON task_events(owner_user_id,dataset_id,sync_server_cursor,id)",
             "CREATE INDEX idx_task_events_scope_task_created ON task_events(owner_user_id,dataset_id,task_id,created_at)",
             "CREATE INDEX idx_task_events_scope_note_created ON task_events(owner_user_id,dataset_id,note_id,created_at)",
             "CREATE INDEX idx_task_events_scope_created ON task_events(owner_user_id,dataset_id,created_at,id)",
@@ -12199,6 +12201,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def _verify_note_task_schema_postgres(self, conn: Any) -> None:
         """Verify the complete PostgreSQL v60 task graph without repairing drift."""
         backend = self.backend
+        authority_relations = ("notes", *self._NOTE_TASK_V60_TABLES)
         backend.execute(
             "LOCK TABLE notes, note_tasks, task_note_projections, task_events, "
             "task_event_read_state, note_task_reconciliation_state, task_projection_drifts "
@@ -12220,10 +12223,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                AND table_row.relname = ANY(%s)
              ORDER BY table_row.relname
             """,
-            (list(self._NOTE_TASK_V60_TABLES),),
+            (list(authority_relations),),
             connection=conn,
         ).rows
-        if {str(row.get("table_name")) for row in table_rows} != set(self._NOTE_TASK_V60_TABLES):
+        if {str(row.get("table_name")) for row in table_rows} != set(authority_relations):
             raise SchemaError("Notes task v60 PostgreSQL relation catalog drifted.")  # noqa: TRY003
         if any(
             not bool(row.get("is_table_owner"))
@@ -12564,10 +12567,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
              WHERE schemaname=current_schema() AND tablename = ANY(%s)
              ORDER BY tablename,policyname
             """,
-            (list(self._NOTE_TASK_V60_TABLES),),
+            (list(authority_relations),),
             connection=conn,
         ).rows
-        expected_policies = self._note_task_v60_policy_predicates()
+        expected_policies = {
+            "notes": "client_id = current_setting('app.current_user_id', true)",
+            **self._note_task_v60_policy_predicates(),
+        }
         if len(policy_rows) != len(expected_policies):
             raise SchemaError("Notes task v60 PostgreSQL RLS policy catalog drifted.")  # noqa: TRY003
         policies = {str(row.get("table_name")): row for row in policy_rows}

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -12461,80 +12461,99 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             ):
                 raise SchemaError("Notes task v60 PostgreSQL foreign-key catalog drifted.")  # noqa: TRY003
 
-        expected_indexes: dict[str, tuple[str, bool, str]] = {}
+        expected_indexes: dict[str, tuple[str, bool, tuple[str, ...]]] = {}
         for statement in self._note_task_v60_postgres_indexes():
             match = re.fullmatch(r"CREATE (UNIQUE )?INDEX (\w+) ON (\w+)\(([^)]+)\)", statement)
             if match is None:
                 raise SchemaError("Notes task v60 PostgreSQL index definition is not fixed.")  # noqa: TRY003
             expected_indexes[match.group(2)] = (
-                match.group(3), bool(match.group(1)), match.group(4).replace(" ", ""),
+                match.group(3), bool(match.group(1)),
+                tuple(column.strip() for column in match.group(4).split(",")),
             )
+        expected_indexes["uq_notes_owner_id"] = ("notes", True, ("client_id", "id"))
         index_rows = backend.execute(
             """
             SELECT table_row.relname AS table_name, index_table.relname AS index_name,
                    index_row.indisunique AS is_unique, index_row.indisvalid AS is_valid,
-                   index_row.indisready AS is_ready,
-                   string_agg(column_row.attname,',' ORDER BY index_key.ordinality) AS column_names,
-                   pg_get_expr(index_row.indpred,index_row.indrelid,false) AS predicate
+                   index_row.indisready AS is_ready, index_row.indisprimary AS is_primary,
+                   index_row.indisexclusion AS is_exclusion,
+                   index_row.indnatts AS num_attributes,
+                   index_row.indnkeyatts AS num_key_attributes,
+                   access_method.amname AS access_method,
+                   pg_get_indexdef(index_row.indexrelid,0,true) AS index_definition,
+                   pg_get_expr(index_row.indpred,index_row.indrelid,false) AS predicate,
+                   index_key.ordinality AS key_ordinality, index_key.attnum,
+                   column_row.attname AS column_name,
+                   opclass_row.opcdefault AS is_default_opclass,
+                   index_row.indcollation[index_key.ordinality - 1]
+                     = column_row.attcollation AS collation_matches_column,
+                   index_row.indoption[index_key.ordinality - 1] AS key_options,
+                   collation_row.collname AS collation_name,
+                   opclass_row.opcname AS opclass_name
               FROM pg_index AS index_row
               JOIN pg_class AS table_row ON table_row.oid=index_row.indrelid
               JOIN pg_namespace AS namespace_row ON namespace_row.oid=table_row.relnamespace
               JOIN pg_class AS index_table ON index_table.oid=index_row.indexrelid
+              JOIN pg_am AS access_method ON access_method.oid=index_table.relam
               CROSS JOIN LATERAL unnest(index_row.indkey) WITH ORDINALITY index_key(attnum,ordinality)
-              JOIN pg_attribute AS column_row
+              LEFT JOIN pg_attribute AS column_row
                 ON column_row.attrelid=table_row.oid AND column_row.attnum=index_key.attnum
+              LEFT JOIN pg_opclass AS opclass_row
+                ON opclass_row.oid=index_row.indclass[index_key.ordinality - 1]
+              LEFT JOIN pg_collation AS collation_row
+                ON collation_row.oid=index_row.indcollation[index_key.ordinality - 1]
              WHERE namespace_row.nspname=current_schema()
-               AND table_row.relname = ANY(%s)
-               AND index_key.ordinality<=index_row.indnkeyatts
-               AND NOT EXISTS(SELECT 1 FROM pg_constraint c WHERE c.conindid=index_row.indexrelid)
-             GROUP BY table_row.relname,index_table.relname,index_row.indisunique,
-                      index_row.indisvalid,index_row.indisready,index_row.indpred,index_row.indrelid
+               AND (
+                 (table_row.relname = ANY(%s)
+                  AND NOT EXISTS(
+                    SELECT 1 FROM pg_constraint c WHERE c.conindid=index_row.indexrelid
+                  ))
+                 OR (table_row.relname='notes' AND index_table.relname='uq_notes_owner_id')
+               )
+             ORDER BY index_table.relname,index_key.ordinality
             """,
             (list(self._NOTE_TASK_V60_TABLES),),
             connection=conn,
         ).rows
-        indexes = {str(row.get("index_name")): row for row in index_rows}
+        indexes: dict[str, dict[str, Any]] = {}
+        for row in index_rows:
+            name = str(row.get("index_name"))
+            index = indexes.setdefault(name, {**dict(row), "keys": []})
+            index["keys"].append(
+                (
+                    int(row.get("key_ordinality") or 0), int(row.get("attnum") or 0),
+                    str(row.get("column_name") or ""), bool(row.get("is_default_opclass")),
+                    bool(row.get("collation_matches_column")), int(row.get("key_options") or 0),
+                )
+            )
         if set(indexes) != set(expected_indexes):
             raise SchemaError("Notes task v60 PostgreSQL index catalog drifted.")  # noqa: TRY003
         for name, (table, unique, columns) in expected_indexes.items():
             row = indexes[name]
+            actual_keys = tuple(row.get("keys") or ())
+            keys_match = all(key[1] > 0 for key in actual_keys) and tuple(
+                (key[0], key[2], key[3], key[4], key[5]) for key in actual_keys
+            ) == tuple(
+                (ordinality, column, True, True, 0)
+                for ordinality, column in enumerate(columns, start=1)
+            )
+            expected_definition = (
+                f"CREATE {'UNIQUE ' if unique else ''}INDEX {name} ON {table} USING btree "
+                f"({', '.join(columns)})"
+            )
             if (
                 str(row.get("table_name")) != table
                 or bool(row.get("is_unique")) is not unique
                 or not bool(row.get("is_valid")) or not bool(row.get("is_ready"))
-                or str(row.get("column_names")) != columns
+                or bool(row.get("is_primary")) or bool(row.get("is_exclusion"))
+                or int(row.get("num_attributes") or 0) != len(columns)
+                or int(row.get("num_key_attributes") or 0) != len(columns)
+                or str(row.get("access_method")) != "btree"
+                or str(row.get("index_definition")) != expected_definition
                 or row.get("predicate") is not None
+                or not keys_match
             ):
                 raise SchemaError("Notes task v60 PostgreSQL index catalog drifted.")  # noqa: TRY003
-        notes_index = backend.execute(
-            """
-            SELECT index_row.indisunique AS is_unique, index_row.indisvalid AS is_valid,
-                   index_row.indisready AS is_ready,
-                   string_agg(column_row.attname,',' ORDER BY index_key.ordinality) AS column_names,
-                   pg_get_expr(index_row.indpred,index_row.indrelid,false) AS predicate
-              FROM pg_index AS index_row
-              JOIN pg_class AS table_row ON table_row.oid=index_row.indrelid
-              JOIN pg_namespace AS namespace_row ON namespace_row.oid=table_row.relnamespace
-              JOIN pg_class AS index_table ON index_table.oid=index_row.indexrelid
-              CROSS JOIN LATERAL unnest(index_row.indkey) WITH ORDINALITY index_key(attnum,ordinality)
-              JOIN pg_attribute column_row
-                ON column_row.attrelid=table_row.oid AND column_row.attnum=index_key.attnum
-             WHERE namespace_row.nspname=current_schema() AND table_row.relname='notes'
-               AND index_table.relname='uq_notes_owner_id'
-               AND index_key.ordinality<=index_row.indnkeyatts
-             GROUP BY index_row.indisunique,index_row.indisvalid,index_row.indisready,
-                      index_row.indpred,index_row.indrelid
-            """,
-            connection=conn,
-        ).rows
-        if len(notes_index) != 1 or (
-            not bool(notes_index[0].get("is_unique"))
-            or not bool(notes_index[0].get("is_valid"))
-            or not bool(notes_index[0].get("is_ready"))
-            or str(notes_index[0].get("column_names")) != "client_id,id"
-            or notes_index[0].get("predicate") is not None
-        ):
-            raise SchemaError("Notes task v60 PostgreSQL notes-owner index drifted.")  # noqa: TRY003
 
         policy_rows = backend.execute(
             """
@@ -12621,17 +12640,72 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
         if notes_rls_forced:
             backend.execute("ALTER TABLE notes FORCE ROW LEVEL SECURITY", connection=conn)
+        chacha_rls = build_chacha_rls_sql()
+        notes_rls = [
+            statement
+            for statement in chacha_rls
+            if "ALTER TABLE IF EXISTS notes " in statement
+            or "DROP POLICY IF EXISTS notes_tenant_isolation ON notes" in statement
+            or "CREATE POLICY notes_tenant_isolation ON notes" in statement
+        ]
         attachment_rls = [
             statement
-            for statement in build_chacha_rls_sql()
+            for statement in chacha_rls
             if "note_attachments" in statement
         ]
-        if len(attachment_rls) != 4:
+        if len(notes_rls) != 4 or len(attachment_rls) != 4:
             raise SchemaError("Notes attachment v59 RLS definition is not canonical.")  # noqa: TRY003
-        for statement in attachment_rls:
+        for statement in (*notes_rls, *attachment_rls):
             backend.execute(statement, connection=conn)
         self._verify_note_attachment_schema_postgres(conn)
         self._set_schema_version_postgres(conn, 59)
+
+    @classmethod
+    def _verify_note_task_v59_authority_catalog(
+        cls,
+        relation_rows: list[Mapping[str, Any]],
+        policy_rows: list[Mapping[str, Any]],
+    ) -> tuple[str, ...]:
+        """Verify the sole reviewed v59 authority/RLS state before migration DDL."""
+        expected_relations = ("notes", *cls._NOTE_TASK_V60_TABLES[:-1])
+        states = {str(row.get("table_name")): row for row in relation_rows}
+        if (
+            len(relation_rows) != len(expected_relations)
+            or set(states) != set(expected_relations)
+            or any(
+                not bool(row.get("is_table_owner"))
+                or not bool(row.get("is_schema_owner"))
+                for row in states.values()
+            )
+            or not bool(states["notes"].get("rls_enabled"))
+            or not bool(states["notes"].get("rls_forced"))
+            or any(
+                bool(states[table].get("rls_enabled"))
+                or bool(states[table].get("rls_forced"))
+                for table in cls._NOTE_TASK_V60_TABLES[:-1]
+            )
+        ):
+            raise SchemaError("Notes task v59 PostgreSQL source authority catalog drifted.")  # noqa: TRY003
+
+        expected_expression = cls._normalize_postgres_catalog_expression(
+            "client_id = current_setting('app.current_user_id', true)"
+        )
+        if len(policy_rows) != 1:
+            raise SchemaError("Notes task v59 PostgreSQL source authority catalog drifted.")  # noqa: TRY003
+        policy = policy_rows[0]
+        if (
+            str(policy.get("table_name")) != "notes"
+            or str(policy.get("policy_name")) != "notes_tenant_isolation"
+            or str(policy.get("permissive")) != "PERMISSIVE"
+            or str(policy.get("roles")) != "{public}"
+            or str(policy.get("command")) != "ALL"
+            or cls._normalize_postgres_catalog_expression(policy.get("using_expression"))
+            != expected_expression
+            or cls._normalize_postgres_catalog_expression(policy.get("check_expression"))
+            != expected_expression
+        ):
+            raise SchemaError("Notes task v59 PostgreSQL source authority catalog drifted.")  # noqa: TRY003
+        return ("notes",)
 
     def _validate_note_task_source_postgres(self, conn: Any) -> dict[str, Any]:
         """Read and owner-prove the complete locked v59 source before any v60 DDL."""
@@ -12731,15 +12805,20 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             (list(source_relations),),
             connection=conn,
         ).rows
-        states = {str(row.get("table_name")): row for row in relation_rows}
-        if set(states) != set(source_relations) or any(
-            not bool(row.get("is_table_owner")) or not bool(row.get("is_schema_owner"))
-            or (bool(row.get("rls_forced")) and not bool(row.get("rls_enabled")))
-            for row in states.values()
-        ):
-            raise SchemaError("Notes task v60 requires the verified PostgreSQL schema-owner path.")  # noqa: TRY003
-        forced_relations = tuple(
-            table for table in source_relations if bool(states[table].get("rls_forced"))
+        policy_rows = backend.execute(
+            """
+            SELECT tablename AS table_name, policyname AS policy_name, permissive,
+                   roles::text AS roles, cmd AS command, qual AS using_expression,
+                   with_check AS check_expression
+              FROM pg_policies
+             WHERE schemaname=current_schema() AND tablename = ANY(%s)
+             ORDER BY tablename,policyname
+            """,
+            (list(source_relations),),
+            connection=conn,
+        ).rows
+        forced_relations = self._verify_note_task_v59_authority_catalog(
+            relation_rows, policy_rows
         )
         collision_names = ("task_projection_drifts", *(f"{table}_v60" for table in self._NOTE_TASK_V60_TABLES))
         collisions = backend.execute(

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -137,6 +137,12 @@ from tldw_Server_API.app.core.Sync.v2.notes_link import (  # noqa: E402
     validate_notes_link_object_id,
     validate_notes_link_properties,
 )
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (  # noqa: E402
+    NotesTaskContractError,
+    canonical_json_bytes,
+    notes_task_object_hash,
+    parse_notes_task_v1,
+)
 from tldw_Server_API.app.core.Workspaces.file_inventory_models import (  # noqa: E402
     bounded_inventory_diagnostics,
     decode_inventory_cursor,
@@ -658,8 +664,17 @@ class CharactersRAGDB:
         is_memory_db (bool): True if the database is in-memory.
         db_path_str (str): String representation of the database path for SQLite connection.
     """
-    _CURRENT_SCHEMA_VERSION = 59  # Schema v59 adds the canonical Notes attachment registry
+    _CURRENT_SCHEMA_VERSION = 60  # Schema v60 scopes the Notes task graph by owner and dataset
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
+    _LOCAL_UNBOUND_TASK_DATASET_ID = "local-unbound"
+    _NOTE_TASK_V60_TABLES = (
+        "note_tasks",
+        "task_note_projections",
+        "task_events",
+        "task_event_read_state",
+        "note_task_reconciliation_state",
+        "task_projection_drifts",
+    )
     _SQLITE_SCHEMA_INIT_LOCKS_GUARD: ClassVar[threading.RLock] = threading.RLock()
     _SQLITE_SCHEMA_INIT_LOCKS: ClassVar[dict[str, threading.RLock]] = {}
     _SQLITE_CORE_SCHEMA_TABLES = frozenset(
@@ -7468,6 +7483,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             (56, "_migrate_from_v56_to_v57"),
             (57, "_migrate_from_v57_to_v58"),
             (58, "_migrate_from_v58_to_v59"),
+            (59, "_migrate_from_v59_to_v60_sqlite"),
         ):
             method = getattr(self, method_name, None)
             if method is not None:
@@ -10942,6 +10958,397 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if cursor.rowcount != 1 or self._get_db_version(conn) != 59:
             raise SchemaError("Notes attachment v59 migration failed version verification.")  # noqa: TRY003
 
+    @staticmethod
+    def _note_task_v60_migration_checkpoint(_stage: str) -> None:
+        """No-op seam used to prove rollback at each migration boundary."""
+
+    @staticmethod
+    def _note_task_v60_hash(value: object) -> str:
+        return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+    def _canonicalize_legacy_task_v60(
+        self, row: Mapping[str, Any], *, owner_user_id: str
+    ) -> tuple[str, str | None, str | None]:
+        """Hash representable task data canonically and retain bounded diagnostics otherwise."""
+        source = dict(row)
+        try:
+            metadata = json.loads(str(source.get("metadata_json") or "{}"))
+            if not isinstance(metadata, dict) or set(metadata) - {"due_date", "priority", "estimate"}:
+                raise NotesTaskContractError("legacy task metadata is not canonical")
+            parsed = parse_notes_task_v1(
+                {
+                    "task_id": source["id"], "note_id": source["note_id"],
+                    "title": source["text"], "description": None, "status": source["status"],
+                    "completed_at": source.get("completed_at"), "priority": metadata.get("priority"),
+                    "due_date": metadata.get("due_date"), "estimate": metadata.get("estimate"),
+                    "recurrence": None, "assignee_id": None, "tags": [], "custom": {},
+                },
+                owner_user_id=owner_user_id,
+            )
+            return (
+                notes_task_object_hash(
+                    parsed,
+                    revision=int(source.get("canonical_revision") or source["version"]),
+                    deleted=bool(source["deleted"]),
+                ),
+                None,
+                None,
+            )
+        except (NotesTaskContractError, TypeError, ValueError, json.JSONDecodeError):
+            source_hash = self._note_task_v60_hash({"source": source, "version": 1})
+            return source_hash, "legacy_task_payload_invalid", source_hash
+
+    @staticmethod
+    def _note_task_v60_sqlite_ddl() -> tuple[str, ...]:
+        """Return the fixed six-table v60 SQLite replacement schema."""
+        return (
+            "CREATE UNIQUE INDEX uq_notes_owner_id ON notes(client_id,id)",
+            """
+            CREATE TABLE note_tasks_v60(
+              owner_user_id TEXT NOT NULL CHECK(length(trim(owner_user_id)) > 0),
+              dataset_id TEXT NOT NULL CHECK(length(trim(dataset_id)) > 0),
+              id TEXT NOT NULL CHECK(length(trim(id)) > 0),
+              note_id TEXT NOT NULL CHECK(length(trim(note_id)) > 0),
+              text TEXT NOT NULL CHECK(length(text) > 0),
+              status TEXT NOT NULL CHECK(status IN ('open','done')),
+              metadata_json TEXT NOT NULL DEFAULT '{}',
+              projection_status TEXT NOT NULL DEFAULT 'live'
+                CHECK(projection_status IN ('live','unlinked','ambiguous','deleted')),
+              deleted INTEGER NOT NULL DEFAULT 0 CHECK(typeof(deleted)='integer' AND deleted IN (0,1)),
+              created_at TEXT NOT NULL, updated_at TEXT NOT NULL, completed_at TEXT,
+              client_id TEXT NOT NULL,
+              version INTEGER NOT NULL DEFAULT 1 CHECK(typeof(version)='integer' AND version>=1),
+              canonical_revision INTEGER NOT NULL DEFAULT 1
+                CHECK(typeof(canonical_revision)='integer' AND canonical_revision>=1),
+              canonical_hash TEXT NOT NULL CHECK(
+                length(canonical_hash)=71 AND substr(canonical_hash,1,7)='sha256:'
+                AND substr(canonical_hash,8) NOT GLOB '*[^0-9a-f]*'),
+              source_diagnostic_code TEXT CHECK(
+                source_diagnostic_code IS NULL OR source_diagnostic_code='legacy_task_payload_invalid'),
+              source_diagnostic_hash TEXT CHECK(source_diagnostic_hash IS NULL OR (
+                length(source_diagnostic_hash)=71 AND substr(source_diagnostic_hash,1,7)='sha256:'
+                AND substr(source_diagnostic_hash,8) NOT GLOB '*[^0-9a-f]*')),
+              PRIMARY KEY(owner_user_id,dataset_id,id),
+              FOREIGN KEY(owner_user_id,note_id) REFERENCES notes(client_id,id)
+                ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE task_note_projections_v60(
+              owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL,
+              task_id TEXT NOT NULL, note_id TEXT NOT NULL,
+              note_version INTEGER NOT NULL CHECK(typeof(note_version)='integer' AND note_version>=1),
+              line_number INTEGER NOT NULL CHECK(typeof(line_number)='integer' AND line_number>=1),
+              start_offset INTEGER NOT NULL CHECK(typeof(start_offset)='integer' AND start_offset>=0),
+              end_offset INTEGER NOT NULL CHECK(typeof(end_offset)='integer' AND end_offset>=start_offset),
+              normalized_text_hash TEXT NOT NULL,
+              occurrence_index INTEGER NOT NULL CHECK(typeof(occurrence_index)='integer' AND occurrence_index>=0),
+              block_fingerprint TEXT NOT NULL, raw_line TEXT NOT NULL,
+              has_child_content INTEGER NOT NULL DEFAULT 0
+                CHECK(typeof(has_child_content)='integer' AND has_child_content IN (0,1)),
+              projection_status TEXT NOT NULL DEFAULT 'live'
+                CHECK(projection_status IN ('live','unlinked','ambiguous','deleted')),
+              updated_at TEXT NOT NULL,
+              PRIMARY KEY(owner_user_id,dataset_id,task_id),
+              FOREIGN KEY(owner_user_id,dataset_id,task_id)
+                REFERENCES note_tasks_v60(owner_user_id,dataset_id,id)
+                ON UPDATE CASCADE ON DELETE CASCADE,
+              FOREIGN KEY(owner_user_id,note_id) REFERENCES notes(client_id,id)
+                ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE task_events_v60(
+              owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL, id TEXT NOT NULL,
+              task_id TEXT, note_id TEXT, event_type TEXT NOT NULL, actor_type TEXT NOT NULL,
+              actor_id TEXT, tool_name TEXT, policy_mode TEXT, approval_id TEXT,
+              old_value_json TEXT, new_value_json TEXT, created_at TEXT NOT NULL, client_id TEXT NOT NULL,
+              sync_revision INTEGER NOT NULL DEFAULT 1
+                CHECK(typeof(sync_revision)='integer' AND sync_revision IN (1,2)),
+              sync_object_hash TEXT NOT NULL CHECK(
+                length(sync_object_hash)=71 AND substr(sync_object_hash,1,7)='sha256:'
+                AND substr(sync_object_hash,8) NOT GLOB '*[^0-9a-f]*'),
+              sync_server_cursor INTEGER CHECK(sync_server_cursor IS NULL OR
+                (typeof(sync_server_cursor)='integer' AND sync_server_cursor>=1)),
+              source_device_id TEXT, client_occurred_at TEXT NOT NULL,
+              source_kind TEXT NOT NULL DEFAULT 'trusted_bootstrap_v1' CHECK(source_kind IN
+                ('client','rest','mcp','markdown_reconciliation','repair','trusted_bootstrap_v1')),
+              corrects_activity_id TEXT,
+              deleted INTEGER NOT NULL DEFAULT 0 CHECK(typeof(deleted)='integer' AND deleted IN (0,1)),
+              deleted_at TEXT,
+              delete_reason TEXT CHECK(delete_reason IS NULL OR delete_reason IN
+                ('user_request','correction','policy')),
+              source_diagnostic_code TEXT,
+              source_diagnostic_hash TEXT CHECK(source_diagnostic_hash IS NULL OR (
+                length(source_diagnostic_hash)=71 AND substr(source_diagnostic_hash,1,7)='sha256:'
+                AND substr(source_diagnostic_hash,8) NOT GLOB '*[^0-9a-f]*')),
+              CHECK((deleted=0 AND deleted_at IS NULL AND delete_reason IS NULL) OR
+                    (deleted=1 AND deleted_at IS NOT NULL AND delete_reason IS NOT NULL)),
+              PRIMARY KEY(owner_user_id,dataset_id,id),
+              FOREIGN KEY(owner_user_id,dataset_id,task_id)
+                REFERENCES note_tasks_v60(owner_user_id,dataset_id,id)
+                ON UPDATE CASCADE ON DELETE RESTRICT,
+              FOREIGN KEY(owner_user_id,note_id) REFERENCES notes(client_id,id)
+                ON UPDATE CASCADE ON DELETE RESTRICT,
+              FOREIGN KEY(owner_user_id,dataset_id,corrects_activity_id)
+                REFERENCES task_events_v60(owner_user_id,dataset_id,id)
+                ON UPDATE CASCADE ON DELETE RESTRICT
+            )
+            """,
+            """
+            CREATE TABLE task_event_read_state_v60(
+              owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL, event_id TEXT NOT NULL,
+              user_id TEXT NOT NULL CHECK(user_id=owner_user_id), read_at TEXT, dismissed_at TEXT,
+              PRIMARY KEY(owner_user_id,dataset_id,event_id,user_id),
+              FOREIGN KEY(owner_user_id,dataset_id,event_id)
+                REFERENCES task_events_v60(owner_user_id,dataset_id,id)
+                ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE note_task_reconciliation_state_v60(
+              owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL, note_id TEXT NOT NULL,
+              note_version INTEGER NOT NULL CHECK(typeof(note_version)='integer' AND note_version>=1),
+              status TEXT NOT NULL, reconciled_at TEXT NOT NULL,
+              item_count INTEGER NOT NULL DEFAULT 0 CHECK(typeof(item_count)='integer' AND item_count>=0),
+              warning_count INTEGER NOT NULL DEFAULT 0
+                CHECK(typeof(warning_count)='integer' AND warning_count>=0),
+              cursor TEXT, PRIMARY KEY(owner_user_id,dataset_id,note_id),
+              FOREIGN KEY(owner_user_id,note_id) REFERENCES notes(client_id,id)
+                ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE task_projection_drifts_v60(
+              owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL, id TEXT NOT NULL,
+              note_id TEXT NOT NULL, task_id TEXT NOT NULL,
+              marker_base_revision INTEGER NOT NULL
+                CHECK(typeof(marker_base_revision)='integer' AND marker_base_revision>=1),
+              marker_base_hash TEXT NOT NULL, note_head_cursor INTEGER, note_head_hash TEXT,
+              task_head_cursor INTEGER, task_head_hash TEXT,
+              reason_code TEXT NOT NULL CHECK(reason_code IN
+                ('missing_marker_base','malformed_marker','duplicate_marker','marker_scope_mismatch',
+                 'base_unavailable','both_changed','ambiguous_legacy_match','unsupported_markdown')),
+              status TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open','resolved','dismissed')),
+              created_at TEXT NOT NULL, updated_at TEXT NOT NULL, resolved_at TEXT,
+              PRIMARY KEY(owner_user_id,dataset_id,id),
+              FOREIGN KEY(owner_user_id,dataset_id,task_id)
+                REFERENCES note_tasks_v60(owner_user_id,dataset_id,id)
+                ON UPDATE CASCADE ON DELETE CASCADE,
+              FOREIGN KEY(owner_user_id,note_id) REFERENCES notes(client_id,id)
+                ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+        )
+
+    def _create_note_task_schema_v60_sqlite(self, conn: sqlite3.Connection) -> None:
+        for statement in self._note_task_v60_sqlite_ddl():
+            conn.execute(statement)
+
+    @staticmethod
+    def _create_note_task_indexes_v60_sqlite(conn: sqlite3.Connection) -> None:
+        statements = (
+            "CREATE INDEX idx_note_tasks_scope_note_page ON note_tasks(owner_user_id,dataset_id,note_id,deleted,created_at,id)",
+            "CREATE INDEX idx_note_tasks_scope_status_page ON note_tasks(owner_user_id,dataset_id,deleted,status,updated_at,id)",
+            "CREATE INDEX idx_note_tasks_scope_projection ON note_tasks(owner_user_id,dataset_id,projection_status,deleted,id)",
+            "CREATE INDEX idx_task_projections_scope_note ON task_note_projections(owner_user_id,dataset_id,note_id,note_version,task_id)",
+            "CREATE INDEX idx_task_projections_scope_status ON task_note_projections(owner_user_id,dataset_id,projection_status,updated_at,task_id)",
+            "CREATE INDEX idx_task_events_scope_task_page ON task_events(owner_user_id,dataset_id,task_id,sync_server_cursor,id)",
+            "CREATE INDEX idx_task_events_scope_note_page ON task_events(owner_user_id,dataset_id,note_id,sync_server_cursor,id)",
+            "CREATE INDEX idx_task_events_scope_created ON task_events(owner_user_id,dataset_id,created_at,id)",
+            "CREATE INDEX idx_task_event_read_scope_user ON task_event_read_state(owner_user_id,dataset_id,user_id,read_at,dismissed_at,event_id)",
+            "CREATE INDEX idx_task_reconciliation_scope_status ON note_task_reconciliation_state(owner_user_id,dataset_id,status,reconciled_at,note_id)",
+            "CREATE INDEX idx_task_projection_drifts_scope_status ON task_projection_drifts(owner_user_id,dataset_id,status,updated_at,id)",
+            "CREATE INDEX idx_task_projection_drifts_scope_task ON task_projection_drifts(owner_user_id,dataset_id,task_id,status,id)",
+        )
+        for statement in statements:
+            conn.execute(statement)
+
+    def _copy_note_task_graph_v60_sqlite(self, conn: sqlite3.Connection) -> None:
+        """Copy every v59 row into an owner-proven local-unbound scope."""
+        dataset_id = self._LOCAL_UNBOUND_TASK_DATASET_ID
+        task_rows = [dict(row) for row in conn.execute("SELECT * FROM note_tasks ORDER BY id")]
+        task_owners: dict[str, tuple[str, str]] = {}
+        for row in task_rows:
+            note = conn.execute("SELECT client_id FROM notes WHERE id=?", (row["note_id"],)).fetchone()
+            owner = str(note[0]).strip() if note is not None else ""
+            if not owner:
+                raise SchemaError("Notes task v60 migration could not prove a task owner.")  # noqa: TRY003
+            canonical_hash, diagnostic_code, diagnostic_hash = self._canonicalize_legacy_task_v60(
+                row, owner_user_id=owner
+            )
+            task_owners[str(row["id"])] = (owner, str(row["note_id"]))
+            conn.execute(
+                """
+                INSERT INTO note_tasks_v60(
+                  owner_user_id,dataset_id,id,note_id,text,status,metadata_json,projection_status,
+                  deleted,created_at,updated_at,completed_at,client_id,version,canonical_revision,
+                  canonical_hash,source_diagnostic_code,source_diagnostic_hash
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    owner, dataset_id, row["id"], row["note_id"], row["text"], row["status"],
+                    row["metadata_json"], row["projection_status"], row["deleted"], row["created_at"],
+                    row["updated_at"], row["completed_at"], row["client_id"], row["version"],
+                    row["version"], canonical_hash, diagnostic_code, diagnostic_hash,
+                ),
+            )
+
+        projection_rows = [dict(row) for row in conn.execute(
+            "SELECT * FROM task_note_projections ORDER BY task_id"
+        )]
+        for row in projection_rows:
+            scope = task_owners.get(str(row["task_id"]))
+            if scope is None or scope[1] != str(row["note_id"]):
+                raise SchemaError("Notes task v60 migration could not prove projection parents.")  # noqa: TRY003
+            conn.execute(
+                "INSERT INTO task_note_projections_v60 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (scope[0], dataset_id, *tuple(row.values())),
+            )
+
+        event_rows = [dict(row) for row in conn.execute("SELECT * FROM task_events ORDER BY id")]
+        event_owners: dict[str, str] = {}
+        for row in event_rows:
+            task_scope = task_owners.get(str(row["task_id"])) if row["task_id"] is not None else None
+            note_row = (
+                conn.execute("SELECT client_id FROM notes WHERE id=?", (row["note_id"],)).fetchone()
+                if row["note_id"] is not None else None
+            )
+            note_owner = str(note_row[0]).strip() if note_row is not None else None
+            event_owner = task_scope[0] if task_scope is not None else note_owner
+            if not event_owner or (note_owner is not None and event_owner != note_owner):
+                raise SchemaError("Notes task v60 migration could not prove event parents.")  # noqa: TRY003
+            if task_scope is not None and row["note_id"] is not None and task_scope[1] != str(row["note_id"]):
+                raise SchemaError("Notes task v60 migration found mismatched event parents.")  # noqa: TRY003
+            source_hash = self._note_task_v60_hash({"source": row, "version": 1})
+            event_owners[str(row["id"])] = event_owner
+            conn.execute(
+                "INSERT INTO task_events_v60 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    event_owner, dataset_id, *tuple(row.values()), 1, source_hash, None, None,
+                    row["created_at"], "trusted_bootstrap_v1", None, 0, None, None,
+                    "legacy_task_activity_unverified", source_hash,
+                ),
+            )
+
+        read_rows = [dict(row) for row in conn.execute(
+            "SELECT * FROM task_event_read_state ORDER BY event_id,user_id"
+        )]
+        for row in read_rows:
+            read_owner = event_owners.get(str(row["event_id"]))
+            if read_owner is None or str(row["user_id"]) != read_owner:
+                raise SchemaError("Notes task v60 migration could not prove read-state ownership.")  # noqa: TRY003
+            conn.execute(
+                "INSERT INTO task_event_read_state_v60 VALUES (?,?,?,?,?,?)",
+                (read_owner, dataset_id, *tuple(row.values())),
+            )
+
+        reconciliation_rows = [dict(row) for row in conn.execute(
+            "SELECT * FROM note_task_reconciliation_state ORDER BY note_id"
+        )]
+        for row in reconciliation_rows:
+            note = conn.execute("SELECT client_id FROM notes WHERE id=?", (row["note_id"],)).fetchone()
+            reconciliation_owner = str(note[0]).strip() if note is not None else ""
+            if not reconciliation_owner:
+                raise SchemaError("Notes task v60 migration could not prove reconciliation ownership.")  # noqa: TRY003
+            conn.execute(
+                "INSERT INTO note_task_reconciliation_state_v60 VALUES (?,?,?,?,?,?,?,?,?)",
+                (reconciliation_owner, dataset_id, *tuple(row.values())),
+            )
+
+        source_sets = {
+            "note_tasks": task_rows, "task_note_projections": projection_rows,
+            "task_events": event_rows, "task_event_read_state": read_rows,
+            "note_task_reconciliation_state": reconciliation_rows,
+        }
+        ordering = {
+            "note_tasks": "id", "task_note_projections": "task_id", "task_events": "id",
+            "task_event_read_state": "event_id,user_id", "note_task_reconciliation_state": "note_id",
+        }
+        for table, source_rows in source_sets.items():
+            columns = tuple(source_rows[0]) if source_rows else tuple(
+                str(column[1]) for column in conn.execute(f"PRAGMA table_info({table})")
+            )
+            target_rows = [dict(row) for row in conn.execute(
+                f"SELECT {','.join(columns)} FROM {table}_v60 ORDER BY {ordering[table]}"  # nosec B608
+            )]
+            if len(source_rows) != len(target_rows) or self._note_task_v60_hash(source_rows) != self._note_task_v60_hash(target_rows):
+                raise SchemaError(f"Notes task v60 source verification failed for {table}.")  # noqa: TRY003
+
+    def _verify_note_task_schema_sqlite(self, conn: sqlite3.Connection) -> None:
+        """Reject current-v60 SQLite task catalog drift instead of repairing it."""
+        expected_columns = {
+            "note_tasks": {"owner_user_id","dataset_id","id","note_id","text","status","metadata_json",
+                "projection_status","deleted","created_at","updated_at","completed_at","client_id","version",
+                "canonical_revision","canonical_hash","source_diagnostic_code","source_diagnostic_hash"},
+            "task_note_projections": {"owner_user_id","dataset_id","task_id","note_id","note_version",
+                "line_number","start_offset","end_offset","normalized_text_hash","occurrence_index",
+                "block_fingerprint","raw_line","has_child_content","projection_status","updated_at"},
+            "task_events": {"owner_user_id","dataset_id","id","task_id","note_id","event_type","actor_type",
+                "actor_id","tool_name","policy_mode","approval_id","old_value_json","new_value_json","created_at",
+                "client_id","sync_revision","sync_object_hash","sync_server_cursor","source_device_id",
+                "client_occurred_at","source_kind","corrects_activity_id","deleted","deleted_at","delete_reason",
+                "source_diagnostic_code","source_diagnostic_hash"},
+            "task_event_read_state": {"owner_user_id","dataset_id","event_id","user_id","read_at","dismissed_at"},
+            "note_task_reconciliation_state": {"owner_user_id","dataset_id","note_id","note_version","status",
+                "reconciled_at","item_count","warning_count","cursor"},
+            "task_projection_drifts": {"owner_user_id","dataset_id","id","note_id","task_id",
+                "marker_base_revision","marker_base_hash","note_head_cursor","note_head_hash","task_head_cursor",
+                "task_head_hash","reason_code","status","created_at","updated_at","resolved_at"},
+        }
+        if not set(expected_columns).issubset(self._sqlite_table_names(conn)):
+            raise SchemaError("Notes task v60 SQLite table catalog drifted.")  # noqa: TRY003
+        for table, columns in expected_columns.items():
+            actual = {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}  # nosec B608
+            if actual != columns:
+                raise SchemaError(f"Notes task v60 SQLite column catalog drifted for {table}.")  # noqa: TRY003
+        if conn.execute("PRAGMA foreign_key_check").fetchall():
+            raise SchemaError("Notes task v60 SQLite foreign-key catalog is invalid.")  # noqa: TRY003
+        expected_indexes = {
+            "idx_note_tasks_scope_note_page","idx_note_tasks_scope_status_page","idx_note_tasks_scope_projection",
+            "idx_task_projections_scope_note","idx_task_projections_scope_status","idx_task_events_scope_task_page",
+            "idx_task_events_scope_note_page","idx_task_events_scope_created","idx_task_event_read_scope_user",
+            "idx_task_reconciliation_scope_status","idx_task_projection_drifts_scope_status",
+            "idx_task_projection_drifts_scope_task",
+        }
+        actual_indexes = {str(row[0]) for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND sql IS NOT NULL AND tbl_name IN (?,?,?,?,?,?)",
+            self._NOTE_TASK_V60_TABLES,
+        )}
+        if actual_indexes != expected_indexes:
+            raise SchemaError("Notes task v60 SQLite index catalog drifted.")  # noqa: TRY003
+
+    def _migrate_from_v59_to_v60_sqlite(self, conn: sqlite3.Connection) -> None:
+        """Transactionally replace the legacy task graph with scoped v60 tables."""
+        if self._get_db_version(conn) != 59:
+            raise SchemaError("Notes task v60 migration requires exact schema version 59.")  # noqa: TRY003
+        source_tables = set(self._NOTE_TASK_V60_TABLES[:-1])
+        tables = self._sqlite_table_names(conn)
+        if not source_tables.issubset(tables):
+            raise SchemaError("Notes task v60 migration source catalog is incomplete.")  # noqa: TRY003
+        targets = {f"{table}_v60" for table in self._NOTE_TASK_V60_TABLES}
+        if "task_projection_drifts" in tables or tables.intersection(targets):
+            raise SchemaError("Notes task v60 target-table collision requires explicit repair.")  # noqa: TRY003
+        self._create_note_task_schema_v60_sqlite(conn)
+        self._note_task_v60_migration_checkpoint("create")
+        self._copy_note_task_graph_v60_sqlite(conn)
+        self._note_task_v60_migration_checkpoint("copy")
+        for table in ("task_event_read_state","task_note_projections","note_task_reconciliation_state",
+                      "task_events","note_tasks"):
+            conn.execute(f"DROP TABLE {table}")  # nosec B608 - fixed relation names.
+        for table in self._NOTE_TASK_V60_TABLES:
+            conn.execute(f"ALTER TABLE {table}_v60 RENAME TO {table}")  # nosec B608
+        self._create_note_task_indexes_v60_sqlite(conn)
+        self._note_task_v60_migration_checkpoint("index")
+        self._verify_note_task_schema_sqlite(conn)
+        self._note_task_v60_migration_checkpoint("verify")
+        cursor = conn.execute(
+            "UPDATE db_schema_version SET version=60 WHERE schema_name=? AND version=59",
+            (self._SCHEMA_NAME,),
+        )
+        if cursor.rowcount != 1 or self._get_db_version(conn) != 60:
+            raise SchemaError("Notes task v60 migration failed version verification.")  # noqa: TRY003
+
     def _create_note_attachment_schema_postgres(self, conn: Any) -> None:
         """Create the PostgreSQL v59 registry with fixed constraint and index SQL."""
 
@@ -14050,6 +14457,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         current_db_version = 0
                         current_initial_version = 0
                     else:
+                        if target_version == 60:
+                            self._verify_note_task_schema_sqlite(conn)
                         logger.debug(f"Database schema '{self._SCHEMA_NAME}' is up to date (Version {target_version}).")
                         # Ensure helpful indexes that may have been introduced post-creation
                         try:
@@ -14292,6 +14701,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         current_db_version = self._get_db_version(conn)
                     if target_version >= 59 and current_db_version == 58:
                         self._migrate_from_v58_to_v59(conn)
+                        current_db_version = self._get_db_version(conn)
+                    if target_version >= 60 and current_db_version == 59:
+                        self._migrate_from_v59_to_v60_sqlite(conn)
                         current_db_version = self._get_db_version(conn)
                 # Ensure helpful indexes that may have been introduced post-creation
                 try:
@@ -14719,6 +15131,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 if target_version >= 59 and current_db_version == 58:
                     self._migrate_from_v58_to_v59(conn)
                     current_db_version = self._get_db_version(conn)
+                if target_version >= 60 and current_db_version == 59:
+                    self._migrate_from_v59_to_v60_sqlite(conn)
+                    current_db_version = self._get_db_version(conn)
 
                 self._ensure_recent_persona_schema_sqlite(conn)
                 self._ensure_recent_voice_command_schema_sqlite(conn)
@@ -14736,6 +15151,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 if final_version_check != target_version:
                     raise SchemaError(  # noqa: TRY003, TRY301
                         f"Schema migration process completed, but final DB version is {final_version_check}, expected {target_version}. Manual check required.")
+                if final_version_check == 60:
+                    self._verify_note_task_schema_sqlite(conn)
                 # Verify core FTS tables after migrations complete
                 self._verify_required_fts_tables_sqlite(conn)
                 self._ensure_workspace_subresource_schema_sqlite(conn)
@@ -35459,6 +35876,8 @@ for _note_store_method in (
 for _task_store_method in (
     "create_task",
     "get_task",
+    "get_task_scoped",
+    "resolve_task_compatibility_scope",
     "get_task_projection",
     "list_tasks",
     "update_unlinked_task_metadata_record_only",
@@ -35477,6 +35896,7 @@ for _task_store_method in (
     "set_reconciliation_state",
     "candidate_notes_for_task_discovery",
     "count_candidate_notes_for_task_discovery",
+    "bind_local_task_graph_to_dataset",
 ):
     setattr(
         CharactersRAGDB,

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -676,6 +676,8 @@ class CharactersRAGDB:
         "note_task_reconciliation_state",
         "task_projection_drifts",
     )
+    _NOTE_TASK_SCOPE_AUTHORITY_TABLE = "note_task_scope_authority"
+    _NOTE_TASK_V60_RELATIONS = (*_NOTE_TASK_V60_TABLES, _NOTE_TASK_SCOPE_AUTHORITY_TABLE)
     _SQLITE_SCHEMA_INIT_LOCKS_GUARD: ClassVar[threading.RLock] = threading.RLock()
     _SQLITE_SCHEMA_INIT_LOCKS: ClassVar[dict[str, threading.RLock]] = {}
     _SQLITE_CORE_SCHEMA_TABLES = frozenset(
@@ -11001,7 +11003,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
     @staticmethod
     def _note_task_v60_postgres_ddl() -> tuple[str, ...]:
-        """Return the fixed six-table PostgreSQL v60 replacement schema."""
+        """Return the fixed task graph plus private scope-authority schema."""
         return (
             "CREATE UNIQUE INDEX uq_notes_owner_id ON notes(client_id,id)",
             """
@@ -11151,6 +11153,19 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 REFERENCES notes(client_id,id) ON UPDATE CASCADE ON DELETE CASCADE
             )
             """,
+            """
+            CREATE TABLE note_task_scope_authority_v60(
+              owner_user_id TEXT NOT NULL
+                CONSTRAINT note_task_scope_authority_owner_check
+                CHECK(char_length(btrim(owner_user_id)) > 0),
+              dataset_id TEXT NOT NULL
+                CONSTRAINT note_task_scope_authority_dataset_check
+                CHECK(char_length(btrim(dataset_id)) > 0
+                  AND dataset_id=btrim(dataset_id)
+                  AND dataset_id<>'local-unbound'),
+              CONSTRAINT note_task_scope_authority_pkey PRIMARY KEY(owner_user_id)
+            )
+            """,
         )
 
     @staticmethod
@@ -11294,6 +11309,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 ("created_at", ts, True, None), ("updated_at", ts, True, None),
                 ("resolved_at", ts, False, None),
             ),
+            "note_task_scope_authority": (
+                ("owner_user_id", "text", True, None),
+                ("dataset_id", "text", True, None),
+            ),
         }
 
     @staticmethod
@@ -11343,11 +11362,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 AND EXISTS(SELECT 1 FROM notes AS note WHERE note.id=task_projection_drifts.note_id
                 AND note.client_id=current_setting('app.current_user_id',true)
                 AND note.client_id=task_projection_drifts.owner_user_id)""",
+            "note_task_scope_authority": """note_task_scope_authority.owner_user_id=
+                current_setting('app.current_user_id',true)""",
         }
 
     @staticmethod
     def _note_task_v60_sqlite_ddl() -> tuple[str, ...]:
-        """Return the fixed six-table v60 SQLite replacement schema."""
+        """Return the fixed task graph plus private scope-authority schema."""
         return (
             "CREATE UNIQUE INDEX uq_notes_owner_id ON notes(client_id,id)",
             """
@@ -11485,6 +11506,16 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 ON UPDATE CASCADE ON DELETE CASCADE,
               FOREIGN KEY(owner_user_id,note_id) REFERENCES notes(client_id,id)
                 ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE note_task_scope_authority_v60(
+              owner_user_id TEXT NOT NULL CHECK(length(trim(owner_user_id)) > 0),
+              dataset_id TEXT NOT NULL CHECK(
+                length(trim(dataset_id)) > 0
+                AND dataset_id=trim(dataset_id)
+                AND dataset_id<>'local-unbound'),
+              PRIMARY KEY(owner_user_id)
             )
             """,
         )
@@ -11637,7 +11668,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         return " ".join(sql.split()).lower() if sql is not None else None
 
     def _note_task_catalog_snapshot_sqlite(self, conn: sqlite3.Connection) -> dict[str, Any]:
-        tables = self._NOTE_TASK_V60_TABLES
+        tables = self._NOTE_TASK_V60_RELATIONS
         placeholders = ",".join("?" for _ in tables)
         table_sql = {
             str(row[0]): self._normalize_sqlite_catalog_sql(row[1])
@@ -11705,12 +11736,109 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             expected.execute("PRAGMA foreign_keys=ON")
             expected.execute("CREATE TABLE notes(id TEXT PRIMARY KEY, client_id TEXT NOT NULL)")
             self._create_note_task_schema_v60_sqlite(expected)
-            for table in self._NOTE_TASK_V60_TABLES:
+            for table in self._NOTE_TASK_V60_RELATIONS:
                 expected.execute(f"ALTER TABLE {table}_v60 RENAME TO {table}")  # nosec B608
             self._create_note_task_indexes_v60_sqlite(expected)
             return self._note_task_catalog_snapshot_sqlite(expected)
         finally:
             expected.close()
+
+    def _note_task_v59_catalog_snapshot_sqlite(
+        self, conn: sqlite3.Connection
+    ) -> dict[str, Any]:
+        """Return the exact legacy task catalog consumed by the v60 migration."""
+        tables = self._NOTE_TASK_V60_TABLES[:-1]
+        placeholders = ",".join("?" for _ in tables)
+        table_sql = {
+            str(row[0]): self._normalize_sqlite_catalog_sql(row[1])
+            for row in conn.execute(
+                f"SELECT name,sql FROM sqlite_master WHERE type='table' "  # nosec B608
+                f"AND name IN ({placeholders}) ORDER BY name",
+                tables,
+            )
+        }
+        explicit_index_sql = {
+            str(row[0]): (str(row[1]), self._normalize_sqlite_catalog_sql(row[2]))
+            for row in conn.execute(
+                f"SELECT name,tbl_name,sql FROM sqlite_master WHERE type='index' "  # nosec B608
+                f"AND tbl_name IN ({placeholders}) AND sql IS NOT NULL ORDER BY name",
+                tables,
+            )
+        }
+        table_details: dict[str, Any] = {}
+        for table in tables:
+            index_rows = [
+                tuple(row) for row in conn.execute(f"PRAGMA index_list({table})")  # nosec B608
+            ]
+            table_details[table] = {
+                "xinfo": [
+                    tuple(row) for row in conn.execute(f"PRAGMA table_xinfo({table})")  # nosec B608
+                ],
+                "foreign_keys": [
+                    tuple(row) for row in conn.execute(f"PRAGMA foreign_key_list({table})")  # nosec B608
+                ],
+                "indexes": [
+                    (
+                        index_row,
+                        [
+                            tuple(row)
+                            for row in conn.execute(
+                                f"PRAGMA index_xinfo({index_row[1]})"  # nosec B608
+                            )
+                        ],
+                    )
+                    for index_row in index_rows
+                ],
+            }
+        related_objects = {
+            str(row[1]): (
+                str(row[0]),
+                str(row[2]),
+                self._normalize_sqlite_catalog_sql(row[3]),
+            )
+            for row in conn.execute(
+                "SELECT type,name,tbl_name,sql FROM sqlite_master "
+                "WHERE type IN ('table','trigger','view') ORDER BY type,name"
+            )
+            if not (str(row[0]) == "table" and str(row[1]) in tables)
+            and (
+                str(row[2]) in tables
+                or any(
+                    re.search(rf"\b{re.escape(table)}\b", str(row[3]), re.IGNORECASE)
+                    for table in tables
+                )
+            )
+        }
+        return {
+            "table_sql": table_sql,
+            "explicit_index_sql": explicit_index_sql,
+            "table_details": table_details,
+            "related_objects": related_objects,
+        }
+
+    def _expected_note_task_v59_catalog_sqlite(self) -> dict[str, Any]:
+        expected = sqlite3.connect(":memory:")
+        try:
+            expected.execute("PRAGMA foreign_keys=ON")
+            expected.execute("CREATE TABLE notes(id TEXT PRIMARY KEY)")
+            expected.execute(
+                "CREATE TABLE db_schema_version(schema_name TEXT PRIMARY KEY, version INTEGER)"
+            )
+            expected.execute(
+                "INSERT INTO db_schema_version(schema_name,version) VALUES (?,47)",
+                (self._SCHEMA_NAME,),
+            )
+            expected.executescript(self._MIGRATION_SQL_V47_TO_V48)
+            return self._note_task_v59_catalog_snapshot_sqlite(expected)
+        finally:
+            expected.close()
+
+    def _verify_note_task_v59_catalog_sqlite(self, conn: sqlite3.Connection) -> None:
+        """Reject legacy task catalog drift before creating any v60 relation."""
+        if self._note_task_v59_catalog_snapshot_sqlite(
+            conn
+        ) != self._expected_note_task_v59_catalog_sqlite():
+            raise SchemaError("Notes task v59 SQLite source catalog drifted.")  # noqa: TRY003
 
     def _verify_note_task_schema_sqlite(self, conn: sqlite3.Connection) -> None:
         """Reject any current-v60 SQLite task catalog drift instead of repairing it."""
@@ -11721,7 +11849,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             or set(actual["table_details"]) != set(expected["table_details"])
             or any(
                 actual["table_details"][table][key] != expected["table_details"][table][key]
-                for table in self._NOTE_TASK_V60_TABLES
+                for table in self._NOTE_TASK_V60_RELATIONS
                 for key in ("xinfo", "foreign_keys")
             )
         ):
@@ -11732,7 +11860,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             or any(
                 actual["table_details"][table]["indexes"]
                 != expected["table_details"][table]["indexes"]
-                for table in self._NOTE_TASK_V60_TABLES
+                for table in self._NOTE_TASK_V60_RELATIONS
             )
         ):
             raise SchemaError("Notes task v60 SQLite index catalog drifted.")  # noqa: TRY003
@@ -11749,8 +11877,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         tables = self._sqlite_table_names(conn)
         if not source_tables.issubset(tables):
             raise SchemaError("Notes task v60 migration source catalog is incomplete.")  # noqa: TRY003
-        targets = {f"{table}_v60" for table in self._NOTE_TASK_V60_TABLES}
-        if "task_projection_drifts" in tables or tables.intersection(targets):
+        self._verify_note_task_v59_catalog_sqlite(conn)
+        targets = {f"{table}_v60" for table in self._NOTE_TASK_V60_RELATIONS}
+        if (
+            "task_projection_drifts" in tables
+            or self._NOTE_TASK_SCOPE_AUTHORITY_TABLE in tables
+            or tables.intersection(targets)
+        ):
             raise SchemaError("Notes task v60 target-table collision requires explicit repair.")  # noqa: TRY003
         self._create_note_task_schema_v60_sqlite(conn)
         self._note_task_v60_migration_checkpoint("create")
@@ -11759,7 +11892,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         for table in ("task_event_read_state","task_note_projections","note_task_reconciliation_state",
                       "task_events","note_tasks"):
             conn.execute(f"DROP TABLE {table}")  # nosec B608 - fixed relation names.
-        for table in self._NOTE_TASK_V60_TABLES:
+        for table in self._NOTE_TASK_V60_RELATIONS:
             conn.execute(f"ALTER TABLE {table}_v60 RENAME TO {table}")  # nosec B608
         self._create_note_task_indexes_v60_sqlite(conn)
         self._note_task_v60_migration_checkpoint("index")
@@ -12201,9 +12334,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def _verify_note_task_schema_postgres(self, conn: Any) -> None:
         """Verify the complete PostgreSQL v60 task graph without repairing drift."""
         backend = self.backend
-        authority_relations = ("notes", *self._NOTE_TASK_V60_TABLES)
+        authority_relations = ("notes", *self._NOTE_TASK_V60_RELATIONS)
         backend.execute(
-            "LOCK TABLE notes, note_tasks, task_note_projections, task_events, "
+            "LOCK TABLE note_task_scope_authority, notes, note_tasks, "
+            "task_note_projections, task_events, "
             "task_event_read_state, note_task_reconciliation_state, task_projection_drifts "
             "IN SHARE MODE",
             connection=conn,
@@ -12255,11 +12389,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                AND column_row.attnum>0 AND NOT column_row.attisdropped
              ORDER BY table_row.relname,column_row.attnum
             """,
-            (list(self._NOTE_TASK_V60_TABLES),),
+            (list(self._NOTE_TASK_V60_RELATIONS),),
             connection=conn,
         ).rows
         actual_columns: dict[str, list[tuple[str, str, bool, str | None]]] = {
-            table: [] for table in self._NOTE_TASK_V60_TABLES
+            table: [] for table in self._NOTE_TASK_V60_RELATIONS
         }
         for row in column_rows:
             default = row.get("default_expression")
@@ -12270,7 +12404,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     None if default is None else "".join(str(default).lower().split()),
                 )
             )
-        if any(tuple(actual_columns[table]) != expected_columns[table] for table in self._NOTE_TASK_V60_TABLES):
+        if any(
+            tuple(actual_columns[table]) != expected_columns[table]
+            for table in self._NOTE_TASK_V60_RELATIONS
+        ):
             raise SchemaError("Notes task v60 PostgreSQL column catalog drifted.")  # noqa: TRY003
 
         constraint_rows = backend.execute(
@@ -12306,7 +12443,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                AND table_row.relname = ANY(%s)
                AND constraint_row.contype <> 'n'
             """,
-            (list(self._NOTE_TASK_V60_TABLES),),
+            (list(self._NOTE_TASK_V60_RELATIONS),),
             connection=conn,
         ).rows
 
@@ -12370,6 +12507,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 "'unsupported_markdown'])"
             ),
             "task_projection_drifts_status_check": "status=any(array['open','resolved','dismissed'])",
+            "note_task_scope_authority_owner_check": "char_length(btrim(owner_user_id))>0",
+            "note_task_scope_authority_dataset_check": (
+                "char_length(btrim(dataset_id))>0anddataset_id=btrim(dataset_id)and"
+                "dataset_id<>'local-unbound'"
+            ),
         }
         expected_primary = {
             "note_tasks_pkey": ("note_tasks", ("owner_user_id", "dataset_id", "id")),
@@ -12385,6 +12527,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             ),
             "task_projection_drifts_pkey": (
                 "task_projection_drifts", ("owner_user_id", "dataset_id", "id"),
+            ),
+            "note_task_scope_authority_pkey": (
+                "note_task_scope_authority", ("owner_user_id",),
             ),
         }
         expected_foreign = {
@@ -12515,7 +12660,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                )
              ORDER BY index_table.relname,index_key.ordinality
             """,
-            (list(self._NOTE_TASK_V60_TABLES),),
+            (list(self._NOTE_TASK_V60_RELATIONS),),
             connection=conn,
         ).rows
         indexes: dict[str, dict[str, Any]] = {}
@@ -12826,7 +12971,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         forced_relations = self._verify_note_task_v59_authority_catalog(
             relation_rows, policy_rows
         )
-        collision_names = ("task_projection_drifts", *(f"{table}_v60" for table in self._NOTE_TASK_V60_TABLES))
+        collision_names = (
+            "task_projection_drifts",
+            self._NOTE_TASK_SCOPE_AUTHORITY_TABLE,
+            *(f"{table}_v60" for table in self._NOTE_TASK_V60_RELATIONS),
+        )
         collisions = backend.execute(
             """
             SELECT table_row.relname AS relation_name
@@ -12959,7 +13108,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "task_events", "note_tasks",
         ):
             backend.execute(f"DROP TABLE {table}", connection=conn)  # nosec B608
-        for table in self._NOTE_TASK_V60_TABLES:
+        for table in self._NOTE_TASK_V60_RELATIONS:
             backend.execute(f"ALTER TABLE {table}_v60 RENAME TO {table}", connection=conn)  # nosec B608
         for statement in self._note_task_v60_postgres_indexes():
             backend.execute(statement, connection=conn)
@@ -12973,10 +13122,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 f"ALTER TABLE IF EXISTS {table} " in statement
                 or f"DROP POLICY IF EXISTS {table}_tenant_isolation ON {table}" in statement
                 or f"CREATE POLICY {table}_tenant_isolation ON {table}" in statement
-                for table in self._NOTE_TASK_V60_TABLES
+                for table in self._NOTE_TASK_V60_RELATIONS
             ):
                 task_rls.append(statement)
-        if len(task_rls) != 4 * len(self._NOTE_TASK_V60_TABLES):
+        if len(task_rls) != 4 * len(self._NOTE_TASK_V60_RELATIONS):
             raise SchemaError("Notes task v60 RLS definition is not canonical.")  # noqa: TRY003
         for statement in task_rls:
             backend.execute(statement, connection=conn)
@@ -37058,6 +37207,7 @@ for _task_store_method in (
     "set_reconciliation_state",
     "candidate_notes_for_task_discovery",
     "count_candidate_notes_for_task_discovery",
+    "resolve_task_compatibility_dataset_id",
     "bind_local_task_graph_to_dataset",
 ):
     setattr(

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -665,6 +665,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
     _CURRENT_SCHEMA_VERSION = 60  # Schema v60 scopes the Notes task graph by owner and dataset
+    _POSTGRES_SCHEMA_VERSION = 59  # PostgreSQL v60 lands atomically in plan Task 3.
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _LOCAL_UNBOUND_TASK_DATASET_ID = "local-unbound"
     _NOTE_TASK_V60_TABLES = (
@@ -11060,7 +11061,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             """
             CREATE TABLE task_events_v60(
               owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL, id TEXT NOT NULL,
-              task_id TEXT, note_id TEXT, event_type TEXT NOT NULL, actor_type TEXT NOT NULL,
+              task_id TEXT, note_id TEXT NOT NULL CHECK(length(trim(note_id)) > 0),
+              event_type TEXT NOT NULL, actor_type TEXT NOT NULL,
               actor_id TEXT, tool_name TEXT, policy_mode TEXT, approval_id TEXT,
               old_value_json TEXT, new_value_json TEXT, created_at TEXT NOT NULL, client_id TEXT NOT NULL,
               sync_revision INTEGER NOT NULL DEFAULT 1
@@ -11207,25 +11209,31 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
 
         event_rows = [dict(row) for row in conn.execute("SELECT * FROM task_events ORDER BY id")]
+        migrated_event_rows: list[dict[str, Any]] = []
         event_owners: dict[str, str] = {}
         for row in event_rows:
             task_scope = task_owners.get(str(row["task_id"])) if row["task_id"] is not None else None
+            derived_note_id = str(row["note_id"]) if row["note_id"] is not None else (
+                task_scope[1] if task_scope is not None else None
+            )
             note_row = (
-                conn.execute("SELECT client_id FROM notes WHERE id=?", (row["note_id"],)).fetchone()
-                if row["note_id"] is not None else None
+                conn.execute("SELECT client_id FROM notes WHERE id=?", (derived_note_id,)).fetchone()
+                if derived_note_id is not None else None
             )
             note_owner = str(note_row[0]).strip() if note_row is not None else None
             event_owner = task_scope[0] if task_scope is not None else note_owner
-            if not event_owner or (note_owner is not None and event_owner != note_owner):
+            if not event_owner or not derived_note_id or note_owner != event_owner:
                 raise SchemaError("Notes task v60 migration could not prove event parents.")  # noqa: TRY003
-            if task_scope is not None and row["note_id"] is not None and task_scope[1] != str(row["note_id"]):
+            if task_scope is not None and task_scope[1] != derived_note_id:
                 raise SchemaError("Notes task v60 migration found mismatched event parents.")  # noqa: TRY003
             source_hash = self._note_task_v60_hash({"source": row, "version": 1})
             event_owners[str(row["id"])] = event_owner
+            migrated_row = {**row, "note_id": derived_note_id}
+            migrated_event_rows.append(migrated_row)
             conn.execute(
                 "INSERT INTO task_events_v60 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
-                    event_owner, dataset_id, *tuple(row.values()), 1, source_hash, None, None,
+                    event_owner, dataset_id, *tuple(migrated_row.values()), 1, source_hash, None, None,
                     row["created_at"], "trusted_bootstrap_v1", None, 0, None, None,
                     "legacy_task_activity_unverified", source_hash,
                 ),
@@ -11258,7 +11266,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
         source_sets = {
             "note_tasks": task_rows, "task_note_projections": projection_rows,
-            "task_events": event_rows, "task_event_read_state": read_rows,
+            "task_events": migrated_event_rows, "task_event_read_state": read_rows,
             "note_task_reconciliation_state": reconciliation_rows,
         }
         ordering = {
@@ -11275,48 +11283,95 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             if len(source_rows) != len(target_rows) or self._note_task_v60_hash(source_rows) != self._note_task_v60_hash(target_rows):
                 raise SchemaError(f"Notes task v60 source verification failed for {table}.")  # noqa: TRY003
 
-    def _verify_note_task_schema_sqlite(self, conn: sqlite3.Connection) -> None:
-        """Reject current-v60 SQLite task catalog drift instead of repairing it."""
-        expected_columns = {
-            "note_tasks": {"owner_user_id","dataset_id","id","note_id","text","status","metadata_json",
-                "projection_status","deleted","created_at","updated_at","completed_at","client_id","version",
-                "canonical_revision","canonical_hash","source_diagnostic_code","source_diagnostic_hash"},
-            "task_note_projections": {"owner_user_id","dataset_id","task_id","note_id","note_version",
-                "line_number","start_offset","end_offset","normalized_text_hash","occurrence_index",
-                "block_fingerprint","raw_line","has_child_content","projection_status","updated_at"},
-            "task_events": {"owner_user_id","dataset_id","id","task_id","note_id","event_type","actor_type",
-                "actor_id","tool_name","policy_mode","approval_id","old_value_json","new_value_json","created_at",
-                "client_id","sync_revision","sync_object_hash","sync_server_cursor","source_device_id",
-                "client_occurred_at","source_kind","corrects_activity_id","deleted","deleted_at","delete_reason",
-                "source_diagnostic_code","source_diagnostic_hash"},
-            "task_event_read_state": {"owner_user_id","dataset_id","event_id","user_id","read_at","dismissed_at"},
-            "note_task_reconciliation_state": {"owner_user_id","dataset_id","note_id","note_version","status",
-                "reconciled_at","item_count","warning_count","cursor"},
-            "task_projection_drifts": {"owner_user_id","dataset_id","id","note_id","task_id",
-                "marker_base_revision","marker_base_hash","note_head_cursor","note_head_hash","task_head_cursor",
-                "task_head_hash","reason_code","status","created_at","updated_at","resolved_at"},
+    @staticmethod
+    def _normalize_sqlite_catalog_sql(sql: str | None) -> str | None:
+        return " ".join(sql.split()).lower() if sql is not None else None
+
+    def _note_task_catalog_snapshot_sqlite(self, conn: sqlite3.Connection) -> dict[str, Any]:
+        tables = self._NOTE_TASK_V60_TABLES
+        placeholders = ",".join("?" for _ in tables)
+        table_sql = {
+            str(row[0]): self._normalize_sqlite_catalog_sql(row[1])
+            for row in conn.execute(
+                f"SELECT name,sql FROM sqlite_master WHERE type='table' "  # nosec B608
+                f"AND name IN ({placeholders}) ORDER BY name",
+                tables,
+            )
         }
-        if not set(expected_columns).issubset(self._sqlite_table_names(conn)):
+        explicit_index_sql = {
+            str(row[0]): (str(row[1]), self._normalize_sqlite_catalog_sql(row[2]))
+            for row in conn.execute(
+                f"SELECT name,tbl_name,sql FROM sqlite_master WHERE type='index' "  # nosec B608
+                f"AND tbl_name IN ({placeholders}) AND sql IS NOT NULL ORDER BY name",
+                tables,
+            )
+        }
+        table_details: dict[str, Any] = {}
+        for table in tables:
+            index_rows = [tuple(row) for row in conn.execute(f"PRAGMA index_list({table})")]  # nosec B608
+            table_details[table] = {
+                "xinfo": [tuple(row) for row in conn.execute(f"PRAGMA table_xinfo({table})")],  # nosec B608
+                "foreign_keys": [tuple(row) for row in conn.execute(f"PRAGMA foreign_key_list({table})")],  # nosec B608
+                "indexes": [
+                    (index_row, [tuple(row) for row in conn.execute(
+                        f"PRAGMA index_xinfo({index_row[1]})"  # nosec B608
+                    )])
+                    for index_row in index_rows
+                ],
+            }
+        note_index = conn.execute(
+            "SELECT tbl_name,sql FROM sqlite_master WHERE type='index' AND name='uq_notes_owner_id'"
+        ).fetchone()
+        return {
+            "table_sql": table_sql,
+            "explicit_index_sql": explicit_index_sql,
+            "table_details": table_details,
+            "note_index": None if note_index is None else (
+                str(note_index[0]),
+                self._normalize_sqlite_catalog_sql(note_index[1]),
+                [str(row[2]) for row in conn.execute("PRAGMA index_info(uq_notes_owner_id)")],
+            ),
+        }
+
+    def _expected_note_task_catalog_sqlite(self) -> dict[str, Any]:
+        expected = sqlite3.connect(":memory:")
+        try:
+            expected.execute("PRAGMA foreign_keys=ON")
+            expected.execute("CREATE TABLE notes(id TEXT PRIMARY KEY, client_id TEXT NOT NULL)")
+            self._create_note_task_schema_v60_sqlite(expected)
+            for table in self._NOTE_TASK_V60_TABLES:
+                expected.execute(f"ALTER TABLE {table}_v60 RENAME TO {table}")  # nosec B608
+            self._create_note_task_indexes_v60_sqlite(expected)
+            return self._note_task_catalog_snapshot_sqlite(expected)
+        finally:
+            expected.close()
+
+    def _verify_note_task_schema_sqlite(self, conn: sqlite3.Connection) -> None:
+        """Reject any current-v60 SQLite task catalog drift instead of repairing it."""
+        expected = self._expected_note_task_catalog_sqlite()
+        actual = self._note_task_catalog_snapshot_sqlite(conn)
+        if (
+            actual["table_sql"] != expected["table_sql"]
+            or set(actual["table_details"]) != set(expected["table_details"])
+            or any(
+                actual["table_details"][table][key] != expected["table_details"][table][key]
+                for table in self._NOTE_TASK_V60_TABLES
+                for key in ("xinfo", "foreign_keys")
+            )
+        ):
             raise SchemaError("Notes task v60 SQLite table catalog drifted.")  # noqa: TRY003
-        for table, columns in expected_columns.items():
-            actual = {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}  # nosec B608
-            if actual != columns:
-                raise SchemaError(f"Notes task v60 SQLite column catalog drifted for {table}.")  # noqa: TRY003
+        if (
+            actual["explicit_index_sql"] != expected["explicit_index_sql"]
+            or actual["note_index"] != expected["note_index"]
+            or any(
+                actual["table_details"][table]["indexes"]
+                != expected["table_details"][table]["indexes"]
+                for table in self._NOTE_TASK_V60_TABLES
+            )
+        ):
+            raise SchemaError("Notes task v60 SQLite index catalog drifted.")  # noqa: TRY003
         if conn.execute("PRAGMA foreign_key_check").fetchall():
             raise SchemaError("Notes task v60 SQLite foreign-key catalog is invalid.")  # noqa: TRY003
-        expected_indexes = {
-            "idx_note_tasks_scope_note_page","idx_note_tasks_scope_status_page","idx_note_tasks_scope_projection",
-            "idx_task_projections_scope_note","idx_task_projections_scope_status","idx_task_events_scope_task_page",
-            "idx_task_events_scope_note_page","idx_task_events_scope_created","idx_task_event_read_scope_user",
-            "idx_task_reconciliation_scope_status","idx_task_projection_drifts_scope_status",
-            "idx_task_projection_drifts_scope_task",
-        }
-        actual_indexes = {str(row[0]) for row in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='index' AND sql IS NOT NULL AND tbl_name IN (?,?,?,?,?,?)",
-            self._NOTE_TASK_V60_TABLES,
-        )}
-        if actual_indexes != expected_indexes:
-            raise SchemaError("Notes task v60 SQLite index catalog drifted.")  # noqa: TRY003
 
     def _migrate_from_v59_to_v60_sqlite(self, conn: sqlite3.Connection) -> None:
         """Transactionally replace the legacy task graph with scoped v60 tables."""
@@ -18867,7 +18922,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         """Bootstrap or migrate the ChaCha schema on PostgreSQL."""
 
         backend = self.backend
-        target_version = self._CURRENT_SCHEMA_VERSION
+        target_version = self._POSTGRES_SCHEMA_VERSION
 
         with backend.transaction() as conn:
             schema_exists = backend.table_exists('db_schema_version', connection=conn)
@@ -35876,8 +35931,6 @@ for _note_store_method in (
 for _task_store_method in (
     "create_task",
     "get_task",
-    "get_task_scoped",
-    "resolve_task_compatibility_scope",
     "get_task_projection",
     "list_tasks",
     "update_unlinked_task_metadata_record_only",

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -665,7 +665,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
     _CURRENT_SCHEMA_VERSION = 60  # Schema v60 scopes the Notes task graph by owner and dataset
-    _POSTGRES_SCHEMA_VERSION = 59  # PostgreSQL v60 lands atomically in plan Task 3.
+    _POSTGRES_SCHEMA_VERSION = 60
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _LOCAL_UNBOUND_TASK_DATASET_ID = "local-unbound"
     _NOTE_TASK_V60_TABLES = (
@@ -11000,6 +11000,351 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             return source_hash, "legacy_task_payload_invalid", source_hash
 
     @staticmethod
+    def _note_task_v60_postgres_ddl() -> tuple[str, ...]:
+        """Return the fixed six-table PostgreSQL v60 replacement schema."""
+        return (
+            "CREATE UNIQUE INDEX uq_notes_owner_id ON notes(client_id,id)",
+            """
+            CREATE TABLE note_tasks_v60(
+              owner_user_id TEXT NOT NULL CONSTRAINT note_tasks_owner_user_id_check
+                CHECK(char_length(btrim(owner_user_id)) > 0),
+              dataset_id TEXT NOT NULL CONSTRAINT note_tasks_dataset_id_check
+                CHECK(char_length(btrim(dataset_id)) > 0),
+              id TEXT NOT NULL CONSTRAINT note_tasks_id_check CHECK(char_length(btrim(id)) > 0),
+              note_id TEXT NOT NULL CONSTRAINT note_tasks_note_id_check
+                CHECK(char_length(btrim(note_id)) > 0),
+              text TEXT NOT NULL CONSTRAINT note_tasks_text_check CHECK(char_length(text) > 0),
+              status TEXT NOT NULL CONSTRAINT note_tasks_status_check CHECK(status IN ('open','done')),
+              metadata_json TEXT NOT NULL DEFAULT '{}',
+              projection_status TEXT NOT NULL DEFAULT 'live'
+                CONSTRAINT note_tasks_projection_status_check
+                CHECK(projection_status IN ('live','unlinked','ambiguous','deleted')),
+              deleted BOOLEAN NOT NULL DEFAULT FALSE,
+              created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL,
+              completed_at TIMESTAMPTZ, client_id TEXT NOT NULL,
+              version BIGINT NOT NULL DEFAULT 1 CONSTRAINT note_tasks_version_check CHECK(version >= 1),
+              canonical_revision BIGINT NOT NULL DEFAULT 1
+                CONSTRAINT note_tasks_canonical_revision_check CHECK(canonical_revision >= 1),
+              canonical_hash TEXT NOT NULL CONSTRAINT note_tasks_canonical_hash_check
+                CHECK(canonical_hash ~ '^sha256:[0-9a-f]{64}$'),
+              source_diagnostic_code TEXT CONSTRAINT note_tasks_source_diagnostic_code_check
+                CHECK(source_diagnostic_code IS NULL OR source_diagnostic_code='legacy_task_payload_invalid'),
+              source_diagnostic_hash TEXT CONSTRAINT note_tasks_source_diagnostic_hash_check
+                CHECK(source_diagnostic_hash IS NULL OR source_diagnostic_hash ~ '^sha256:[0-9a-f]{64}$'),
+              CONSTRAINT note_tasks_pkey PRIMARY KEY(owner_user_id,dataset_id,id),
+              CONSTRAINT note_tasks_note_owner_fkey FOREIGN KEY(owner_user_id,note_id)
+                REFERENCES notes(client_id,id) ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE task_note_projections_v60(
+              owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL,
+              task_id TEXT NOT NULL, note_id TEXT NOT NULL,
+              note_version BIGINT NOT NULL CONSTRAINT task_note_projections_note_version_check CHECK(note_version>=1),
+              line_number BIGINT NOT NULL CONSTRAINT task_note_projections_line_number_check CHECK(line_number>=1),
+              start_offset BIGINT NOT NULL CONSTRAINT task_note_projections_start_offset_check CHECK(start_offset>=0),
+              end_offset BIGINT NOT NULL CONSTRAINT task_note_projections_end_offset_check CHECK(end_offset>=start_offset),
+              normalized_text_hash TEXT NOT NULL,
+              occurrence_index BIGINT NOT NULL CONSTRAINT task_note_projections_occurrence_index_check
+                CHECK(occurrence_index>=0),
+              block_fingerprint TEXT NOT NULL, raw_line TEXT NOT NULL,
+              has_child_content BOOLEAN NOT NULL DEFAULT FALSE,
+              projection_status TEXT NOT NULL DEFAULT 'live'
+                CONSTRAINT task_note_projections_projection_status_check
+                CHECK(projection_status IN ('live','unlinked','ambiguous','deleted')),
+              updated_at TIMESTAMPTZ NOT NULL,
+              CONSTRAINT task_note_projections_pkey PRIMARY KEY(owner_user_id,dataset_id,task_id),
+              CONSTRAINT task_note_projections_task_fkey FOREIGN KEY(owner_user_id,dataset_id,task_id)
+                REFERENCES note_tasks_v60(owner_user_id,dataset_id,id)
+                ON UPDATE CASCADE ON DELETE CASCADE,
+              CONSTRAINT task_note_projections_note_owner_fkey FOREIGN KEY(owner_user_id,note_id)
+                REFERENCES notes(client_id,id) ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE task_events_v60(
+              owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL, id TEXT NOT NULL,
+              task_id TEXT, note_id TEXT NOT NULL CONSTRAINT task_events_note_id_check
+                CHECK(char_length(btrim(note_id)) > 0),
+              event_type TEXT NOT NULL, actor_type TEXT NOT NULL,
+              actor_id TEXT, tool_name TEXT, policy_mode TEXT, approval_id TEXT,
+              old_value_json TEXT, new_value_json TEXT, created_at TIMESTAMPTZ NOT NULL,
+              client_id TEXT NOT NULL,
+              sync_revision BIGINT NOT NULL DEFAULT 1 CONSTRAINT task_events_sync_revision_check
+                CHECK(sync_revision IN (1,2)),
+              sync_object_hash TEXT NOT NULL CONSTRAINT task_events_sync_object_hash_check
+                CHECK(sync_object_hash ~ '^sha256:[0-9a-f]{64}$'),
+              sync_server_cursor BIGINT CONSTRAINT task_events_sync_server_cursor_check
+                CHECK(sync_server_cursor IS NULL OR sync_server_cursor>=1),
+              source_device_id TEXT, client_occurred_at TIMESTAMPTZ NOT NULL,
+              source_kind TEXT NOT NULL DEFAULT 'trusted_bootstrap_v1'
+                CONSTRAINT task_events_source_kind_check CHECK(source_kind IN
+                  ('client','rest','mcp','markdown_reconciliation','repair','trusted_bootstrap_v1')),
+              corrects_activity_id TEXT,
+              deleted BOOLEAN NOT NULL DEFAULT FALSE, deleted_at TIMESTAMPTZ,
+              delete_reason TEXT CONSTRAINT task_events_delete_reason_check
+                CHECK(delete_reason IS NULL OR delete_reason IN ('user_request','correction','policy')),
+              source_diagnostic_code TEXT,
+              source_diagnostic_hash TEXT CONSTRAINT task_events_source_diagnostic_hash_check
+                CHECK(source_diagnostic_hash IS NULL OR source_diagnostic_hash ~ '^sha256:[0-9a-f]{64}$'),
+              CONSTRAINT task_events_deleted_lifecycle_check CHECK(
+                (deleted=FALSE AND deleted_at IS NULL AND delete_reason IS NULL) OR
+                (deleted=TRUE AND deleted_at IS NOT NULL AND delete_reason IS NOT NULL)),
+              CONSTRAINT task_events_pkey PRIMARY KEY(owner_user_id,dataset_id,id),
+              CONSTRAINT task_events_task_fkey FOREIGN KEY(owner_user_id,dataset_id,task_id)
+                REFERENCES note_tasks_v60(owner_user_id,dataset_id,id)
+                ON UPDATE CASCADE ON DELETE RESTRICT,
+              CONSTRAINT task_events_note_owner_fkey FOREIGN KEY(owner_user_id,note_id)
+                REFERENCES notes(client_id,id) ON UPDATE CASCADE ON DELETE RESTRICT,
+              CONSTRAINT task_events_correction_fkey FOREIGN KEY(owner_user_id,dataset_id,corrects_activity_id)
+                REFERENCES task_events_v60(owner_user_id,dataset_id,id)
+                ON UPDATE CASCADE ON DELETE RESTRICT
+            )
+            """,
+            """
+            CREATE TABLE task_event_read_state_v60(
+              owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL, event_id TEXT NOT NULL,
+              user_id TEXT NOT NULL CONSTRAINT task_event_read_state_user_check CHECK(user_id=owner_user_id),
+              read_at TIMESTAMPTZ, dismissed_at TIMESTAMPTZ,
+              CONSTRAINT task_event_read_state_pkey PRIMARY KEY(owner_user_id,dataset_id,event_id,user_id),
+              CONSTRAINT task_event_read_state_event_fkey FOREIGN KEY(owner_user_id,dataset_id,event_id)
+                REFERENCES task_events_v60(owner_user_id,dataset_id,id)
+                ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE note_task_reconciliation_state_v60(
+              owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL, note_id TEXT NOT NULL,
+              note_version BIGINT NOT NULL CONSTRAINT note_task_reconciliation_note_version_check
+                CHECK(note_version>=1),
+              status TEXT NOT NULL, reconciled_at TIMESTAMPTZ NOT NULL,
+              item_count BIGINT NOT NULL DEFAULT 0 CONSTRAINT note_task_reconciliation_item_count_check
+                CHECK(item_count>=0),
+              warning_count BIGINT NOT NULL DEFAULT 0 CONSTRAINT note_task_reconciliation_warning_count_check
+                CHECK(warning_count>=0),
+              cursor TEXT,
+              CONSTRAINT note_task_reconciliation_state_pkey PRIMARY KEY(owner_user_id,dataset_id,note_id),
+              CONSTRAINT note_task_reconciliation_note_owner_fkey FOREIGN KEY(owner_user_id,note_id)
+                REFERENCES notes(client_id,id) ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE task_projection_drifts_v60(
+              owner_user_id TEXT NOT NULL, dataset_id TEXT NOT NULL, id TEXT NOT NULL,
+              note_id TEXT NOT NULL, task_id TEXT NOT NULL,
+              marker_base_revision BIGINT NOT NULL CONSTRAINT task_projection_drifts_revision_check
+                CHECK(marker_base_revision>=1),
+              marker_base_hash TEXT NOT NULL, note_head_cursor BIGINT, note_head_hash TEXT,
+              task_head_cursor BIGINT, task_head_hash TEXT,
+              reason_code TEXT NOT NULL CONSTRAINT task_projection_drifts_reason_check CHECK(reason_code IN
+                ('missing_marker_base','malformed_marker','duplicate_marker','marker_scope_mismatch',
+                 'base_unavailable','both_changed','ambiguous_legacy_match','unsupported_markdown')),
+              status TEXT NOT NULL DEFAULT 'open' CONSTRAINT task_projection_drifts_status_check
+                CHECK(status IN ('open','resolved','dismissed')),
+              created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL,
+              resolved_at TIMESTAMPTZ,
+              CONSTRAINT task_projection_drifts_pkey PRIMARY KEY(owner_user_id,dataset_id,id),
+              CONSTRAINT task_projection_drifts_task_fkey FOREIGN KEY(owner_user_id,dataset_id,task_id)
+                REFERENCES note_tasks_v60(owner_user_id,dataset_id,id)
+                ON UPDATE CASCADE ON DELETE CASCADE,
+              CONSTRAINT task_projection_drifts_note_owner_fkey FOREIGN KEY(owner_user_id,note_id)
+                REFERENCES notes(client_id,id) ON UPDATE CASCADE ON DELETE CASCADE
+            )
+            """,
+        )
+
+    @staticmethod
+    def _note_task_v60_postgres_indexes() -> tuple[str, ...]:
+        return (
+            "CREATE INDEX idx_note_tasks_scope_note_page ON note_tasks(owner_user_id,dataset_id,note_id,deleted,created_at,id)",
+            "CREATE INDEX idx_note_tasks_scope_status_page ON note_tasks(owner_user_id,dataset_id,deleted,status,updated_at,id)",
+            "CREATE INDEX idx_note_tasks_scope_projection ON note_tasks(owner_user_id,dataset_id,projection_status,deleted,id)",
+            "CREATE INDEX idx_task_projections_scope_note ON task_note_projections(owner_user_id,dataset_id,note_id,note_version,task_id)",
+            "CREATE INDEX idx_task_projections_scope_status ON task_note_projections(owner_user_id,dataset_id,projection_status,updated_at,task_id)",
+            "CREATE INDEX idx_task_events_scope_task_page ON task_events(owner_user_id,dataset_id,task_id,sync_server_cursor,id)",
+            "CREATE INDEX idx_task_events_scope_note_page ON task_events(owner_user_id,dataset_id,note_id,sync_server_cursor,id)",
+            "CREATE INDEX idx_task_events_scope_task_created ON task_events(owner_user_id,dataset_id,task_id,created_at,id)",
+            "CREATE INDEX idx_task_events_scope_note_created ON task_events(owner_user_id,dataset_id,note_id,created_at,id)",
+            "CREATE INDEX idx_task_events_scope_created ON task_events(owner_user_id,dataset_id,created_at,id)",
+            "CREATE INDEX idx_task_event_read_scope_user ON task_event_read_state(owner_user_id,dataset_id,user_id,read_at,dismissed_at,event_id)",
+            "CREATE INDEX idx_task_reconciliation_scope_status ON note_task_reconciliation_state(owner_user_id,dataset_id,status,reconciled_at,note_id)",
+            "CREATE INDEX idx_task_projection_drifts_scope_status ON task_projection_drifts(owner_user_id,dataset_id,status,updated_at,id)",
+            "CREATE INDEX idx_task_projection_drifts_scope_task ON task_projection_drifts(owner_user_id,dataset_id,task_id,status,id)",
+        )
+
+    @staticmethod
+    def _note_task_v59_postgres_constraint_collisions() -> tuple[tuple[str, str], ...]:
+        """Return the fixed v59 names that would collide with v60 constraints."""
+        return (
+            ("note_tasks", "note_tasks_pkey"),
+            ("note_tasks", "note_tasks_projection_status_check"),
+            ("note_tasks", "note_tasks_status_check"),
+            ("task_note_projections", "task_note_projections_pkey"),
+            ("task_note_projections", "task_note_projections_projection_status_check"),
+            ("task_events", "task_events_pkey"),
+            ("task_event_read_state", "task_event_read_state_pkey"),
+            ("note_task_reconciliation_state", "note_task_reconciliation_state_pkey"),
+        )
+
+    def _rename_note_task_v59_postgres_constraints(self, conn: Any) -> None:
+        """Free canonical constraint names only after v59 rows are validated."""
+        for table_name, constraint_name in self._note_task_v59_postgres_constraint_collisions():
+            self.backend.execute(
+                f"ALTER TABLE {table_name} RENAME CONSTRAINT {constraint_name} "
+                f"TO {constraint_name}_v59",
+                connection=conn,
+            )  # nosec B608 - identifiers are fixed migration constants.
+
+    def _create_note_task_schema_v60_postgres(self, conn: Any) -> None:
+        for statement in self._note_task_v60_postgres_ddl():
+            self.backend.execute(statement, connection=conn)
+
+    @staticmethod
+    def _normalize_postgres_catalog_expression(value: Any) -> str:
+        normalized = str(value or "").lower()
+        normalized = re.sub(r"::(?:pg_catalog\.)?(?:text|character varying|bigint|boolean)", "", normalized)
+        normalized = re.sub(r"\bas\b", "", normalized)
+        return re.sub(r'[\s()"]+', "", normalized)
+
+    @classmethod
+    def _note_task_v60_json_safe(cls, value: Any) -> Any:
+        if isinstance(value, datetime):
+            normalized = value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+            return normalized.astimezone(timezone.utc).isoformat()
+        if isinstance(value, Mapping):
+            return {str(key): cls._note_task_v60_json_safe(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [cls._note_task_v60_json_safe(item) for item in value]
+        return value
+
+    @staticmethod
+    def _note_task_v60_postgres_columns() -> dict[str, tuple[tuple[str, str, bool, str | None], ...]]:
+        ts = "timestamp with time zone"
+        return {
+            "note_tasks": (
+                ("owner_user_id", "text", True, None), ("dataset_id", "text", True, None),
+                ("id", "text", True, None), ("note_id", "text", True, None),
+                ("text", "text", True, None), ("status", "text", True, None),
+                ("metadata_json", "text", True, "'{}'::text"),
+                ("projection_status", "text", True, "'live'::text"),
+                ("deleted", "boolean", True, "false"), ("created_at", ts, True, None),
+                ("updated_at", ts, True, None), ("completed_at", ts, False, None),
+                ("client_id", "text", True, None), ("version", "bigint", True, "1"),
+                ("canonical_revision", "bigint", True, "1"),
+                ("canonical_hash", "text", True, None),
+                ("source_diagnostic_code", "text", False, None),
+                ("source_diagnostic_hash", "text", False, None),
+            ),
+            "task_note_projections": (
+                ("owner_user_id", "text", True, None), ("dataset_id", "text", True, None),
+                ("task_id", "text", True, None), ("note_id", "text", True, None),
+                ("note_version", "bigint", True, None), ("line_number", "bigint", True, None),
+                ("start_offset", "bigint", True, None), ("end_offset", "bigint", True, None),
+                ("normalized_text_hash", "text", True, None),
+                ("occurrence_index", "bigint", True, None),
+                ("block_fingerprint", "text", True, None), ("raw_line", "text", True, None),
+                ("has_child_content", "boolean", True, "false"),
+                ("projection_status", "text", True, "'live'::text"),
+                ("updated_at", ts, True, None),
+            ),
+            "task_events": (
+                ("owner_user_id", "text", True, None), ("dataset_id", "text", True, None),
+                ("id", "text", True, None), ("task_id", "text", False, None),
+                ("note_id", "text", True, None), ("event_type", "text", True, None),
+                ("actor_type", "text", True, None), ("actor_id", "text", False, None),
+                ("tool_name", "text", False, None), ("policy_mode", "text", False, None),
+                ("approval_id", "text", False, None), ("old_value_json", "text", False, None),
+                ("new_value_json", "text", False, None), ("created_at", ts, True, None),
+                ("client_id", "text", True, None), ("sync_revision", "bigint", True, "1"),
+                ("sync_object_hash", "text", True, None),
+                ("sync_server_cursor", "bigint", False, None),
+                ("source_device_id", "text", False, None),
+                ("client_occurred_at", ts, True, None),
+                ("source_kind", "text", True, "'trusted_bootstrap_v1'::text"),
+                ("corrects_activity_id", "text", False, None),
+                ("deleted", "boolean", True, "false"), ("deleted_at", ts, False, None),
+                ("delete_reason", "text", False, None),
+                ("source_diagnostic_code", "text", False, None),
+                ("source_diagnostic_hash", "text", False, None),
+            ),
+            "task_event_read_state": (
+                ("owner_user_id", "text", True, None), ("dataset_id", "text", True, None),
+                ("event_id", "text", True, None), ("user_id", "text", True, None),
+                ("read_at", ts, False, None), ("dismissed_at", ts, False, None),
+            ),
+            "note_task_reconciliation_state": (
+                ("owner_user_id", "text", True, None), ("dataset_id", "text", True, None),
+                ("note_id", "text", True, None), ("note_version", "bigint", True, None),
+                ("status", "text", True, None), ("reconciled_at", ts, True, None),
+                ("item_count", "bigint", True, "0"), ("warning_count", "bigint", True, "0"),
+                ("cursor", "text", False, None),
+            ),
+            "task_projection_drifts": (
+                ("owner_user_id", "text", True, None), ("dataset_id", "text", True, None),
+                ("id", "text", True, None), ("note_id", "text", True, None),
+                ("task_id", "text", True, None), ("marker_base_revision", "bigint", True, None),
+                ("marker_base_hash", "text", True, None),
+                ("note_head_cursor", "bigint", False, None),
+                ("note_head_hash", "text", False, None),
+                ("task_head_cursor", "bigint", False, None),
+                ("task_head_hash", "text", False, None),
+                ("reason_code", "text", True, None),
+                ("status", "text", True, "'open'::text"),
+                ("created_at", ts, True, None), ("updated_at", ts, True, None),
+                ("resolved_at", ts, False, None),
+            ),
+        }
+
+    @staticmethod
+    def _note_task_v60_policy_predicates() -> dict[str, str]:
+        return {
+            "note_tasks": """note_tasks.owner_user_id=current_setting('app.current_user_id',true)
+                AND note_tasks.dataset_id=current_setting('app.current_dataset_id',true)
+                AND EXISTS(SELECT 1 FROM notes AS note WHERE note.id=note_tasks.note_id
+                AND note.client_id=current_setting('app.current_user_id',true)
+                AND note.client_id=note_tasks.owner_user_id)""",
+            "task_note_projections": """task_note_projections.owner_user_id=current_setting('app.current_user_id',true)
+                AND task_note_projections.dataset_id=current_setting('app.current_dataset_id',true)
+                AND EXISTS(SELECT 1 FROM note_tasks AS task
+                WHERE task.owner_user_id=task_note_projections.owner_user_id
+                AND task.dataset_id=task_note_projections.dataset_id
+                AND task.id=task_note_projections.task_id AND task.note_id=task_note_projections.note_id)
+                AND EXISTS(SELECT 1 FROM notes AS note WHERE note.id=task_note_projections.note_id
+                AND note.client_id=current_setting('app.current_user_id',true)
+                AND note.client_id=task_note_projections.owner_user_id)""",
+            "task_events": """task_events.owner_user_id=current_setting('app.current_user_id',true)
+                AND task_events.dataset_id=current_setting('app.current_dataset_id',true)
+                AND EXISTS(SELECT 1 FROM notes AS note WHERE note.id=task_events.note_id
+                AND note.client_id=current_setting('app.current_user_id',true)
+                AND note.client_id=task_events.owner_user_id)
+                AND (task_events.task_id IS NULL OR EXISTS(SELECT 1 FROM note_tasks AS task
+                WHERE task.owner_user_id=task_events.owner_user_id
+                AND task.dataset_id=task_events.dataset_id AND task.id=task_events.task_id
+                AND task.note_id=task_events.note_id))""",
+            "task_event_read_state": """task_event_read_state.owner_user_id=current_setting('app.current_user_id',true)
+                AND task_event_read_state.dataset_id=current_setting('app.current_dataset_id',true)
+                AND task_event_read_state.user_id=task_event_read_state.owner_user_id
+                AND EXISTS(SELECT 1 FROM task_events AS event
+                WHERE event.owner_user_id=task_event_read_state.owner_user_id
+                AND event.dataset_id=task_event_read_state.dataset_id
+                AND event.id=task_event_read_state.event_id)""",
+            "note_task_reconciliation_state": """note_task_reconciliation_state.owner_user_id=current_setting('app.current_user_id',true)
+                AND note_task_reconciliation_state.dataset_id=current_setting('app.current_dataset_id',true)
+                AND EXISTS(SELECT 1 FROM notes AS note WHERE note.id=note_task_reconciliation_state.note_id
+                AND note.client_id=current_setting('app.current_user_id',true)
+                AND note.client_id=note_task_reconciliation_state.owner_user_id)""",
+            "task_projection_drifts": """task_projection_drifts.owner_user_id=current_setting('app.current_user_id',true)
+                AND task_projection_drifts.dataset_id=current_setting('app.current_dataset_id',true)
+                AND EXISTS(SELECT 1 FROM note_tasks AS task
+                WHERE task.owner_user_id=task_projection_drifts.owner_user_id
+                AND task.dataset_id=task_projection_drifts.dataset_id
+                AND task.id=task_projection_drifts.task_id AND task.note_id=task_projection_drifts.note_id)
+                AND EXISTS(SELECT 1 FROM notes AS note WHERE note.id=task_projection_drifts.note_id
+                AND note.client_id=current_setting('app.current_user_id',true)
+                AND note.client_id=task_projection_drifts.owner_user_id)""",
+        }
+
+    @staticmethod
     def _note_task_v60_sqlite_ddl() -> tuple[str, ...]:
         """Return the fixed six-table v60 SQLite replacement schema."""
         return (
@@ -11851,6 +12196,386 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 "Notes attachment v59 PostgreSQL registry RLS policy catalog drifted."
             )
 
+    def _verify_note_task_schema_postgres(self, conn: Any) -> None:
+        """Verify the complete PostgreSQL v60 task graph without repairing drift."""
+        backend = self.backend
+        backend.execute(
+            "LOCK TABLE notes, note_tasks, task_note_projections, task_events, "
+            "task_event_read_state, note_task_reconciliation_state, task_projection_drifts "
+            "IN SHARE MODE",
+            connection=conn,
+        )
+        table_rows = backend.execute(
+            """
+            SELECT table_row.relname AS table_name,
+                   table_row.relrowsecurity AS rls_enabled,
+                   table_row.relforcerowsecurity AS rls_forced,
+                   table_row.relowner = current_user::regrole AS is_table_owner,
+                   pg_has_role(current_user, namespace_row.nspowner, 'USAGE')
+                     AS is_schema_owner
+              FROM pg_class AS table_row
+              JOIN pg_namespace AS namespace_row ON namespace_row.oid=table_row.relnamespace
+             WHERE namespace_row.nspname=current_schema()
+               AND table_row.relkind IN ('r','p')
+               AND table_row.relname = ANY(%s)
+             ORDER BY table_row.relname
+            """,
+            (list(self._NOTE_TASK_V60_TABLES),),
+            connection=conn,
+        ).rows
+        if {str(row.get("table_name")) for row in table_rows} != set(self._NOTE_TASK_V60_TABLES):
+            raise SchemaError("Notes task v60 PostgreSQL relation catalog drifted.")  # noqa: TRY003
+        if any(
+            not bool(row.get("is_table_owner"))
+            or not bool(row.get("is_schema_owner"))
+            or not bool(row.get("rls_enabled"))
+            or not bool(row.get("rls_forced"))
+            for row in table_rows
+        ):
+            raise SchemaError("Notes task v60 PostgreSQL ownership or RLS catalog drifted.")  # noqa: TRY003
+
+        expected_columns = self._note_task_v60_postgres_columns()
+        column_rows = backend.execute(
+            """
+            SELECT table_row.relname AS table_name, column_row.attnum,
+                   column_row.attname AS column_name,
+                   format_type(column_row.atttypid,column_row.atttypmod) AS data_type,
+                   column_row.attnotnull AS is_not_null,
+                   pg_get_expr(default_row.adbin,default_row.adrelid,false) AS default_expression
+              FROM pg_attribute AS column_row
+              JOIN pg_class AS table_row ON table_row.oid=column_row.attrelid
+              JOIN pg_namespace AS namespace_row ON namespace_row.oid=table_row.relnamespace
+              LEFT JOIN pg_attrdef AS default_row
+                ON default_row.adrelid=table_row.oid AND default_row.adnum=column_row.attnum
+             WHERE namespace_row.nspname=current_schema()
+               AND table_row.relname = ANY(%s)
+               AND column_row.attnum>0 AND NOT column_row.attisdropped
+             ORDER BY table_row.relname,column_row.attnum
+            """,
+            (list(self._NOTE_TASK_V60_TABLES),),
+            connection=conn,
+        ).rows
+        actual_columns: dict[str, list[tuple[str, str, bool, str | None]]] = {
+            table: [] for table in self._NOTE_TASK_V60_TABLES
+        }
+        for row in column_rows:
+            default = row.get("default_expression")
+            actual_columns[str(row.get("table_name"))].append(
+                (
+                    str(row.get("column_name")), str(row.get("data_type")),
+                    bool(row.get("is_not_null")),
+                    None if default is None else "".join(str(default).lower().split()),
+                )
+            )
+        if any(tuple(actual_columns[table]) != expected_columns[table] for table in self._NOTE_TASK_V60_TABLES):
+            raise SchemaError("Notes task v60 PostgreSQL column catalog drifted.")  # noqa: TRY003
+
+        constraint_rows = backend.execute(
+            """
+            SELECT table_row.relname AS table_name, constraint_row.conname AS constraint_name,
+                   constraint_row.contype AS constraint_type,
+                   pg_get_expr(constraint_row.conbin,constraint_row.conrelid,false) AS check_expression,
+                   referenced_table.relname AS referenced_table,
+                   referenced_namespace.nspname AS referenced_schema,
+                   referenced_namespace.nspname=current_schema() AS referenced_in_current_schema,
+                   ARRAY(SELECT local_column.attname
+                           FROM unnest(constraint_row.conkey) WITH ORDINALITY key_row(attnum,ordinality)
+                           JOIN pg_attribute local_column
+                             ON local_column.attrelid=table_row.oid AND local_column.attnum=key_row.attnum
+                          ORDER BY key_row.ordinality) AS local_columns,
+                   CASE WHEN constraint_row.confrelid=0 THEN NULL ELSE
+                     ARRAY(SELECT referenced_column.attname
+                             FROM unnest(constraint_row.confkey) WITH ORDINALITY key_row(attnum,ordinality)
+                             JOIN pg_attribute referenced_column
+                               ON referenced_column.attrelid=referenced_table.oid
+                              AND referenced_column.attnum=key_row.attnum
+                            ORDER BY key_row.ordinality) END AS referenced_columns,
+                   constraint_row.convalidated AS constraint_validated,
+                   constraint_row.confdeltype AS delete_action,
+                   constraint_row.confupdtype AS update_action
+              FROM pg_constraint AS constraint_row
+              JOIN pg_class AS table_row ON table_row.oid=constraint_row.conrelid
+              JOIN pg_namespace AS namespace_row ON namespace_row.oid=table_row.relnamespace
+              LEFT JOIN pg_class AS referenced_table ON referenced_table.oid=constraint_row.confrelid
+              LEFT JOIN pg_namespace AS referenced_namespace
+                ON referenced_namespace.oid=referenced_table.relnamespace
+             WHERE namespace_row.nspname=current_schema()
+               AND table_row.relname = ANY(%s)
+               AND constraint_row.contype <> 'n'
+            """,
+            (list(self._NOTE_TASK_V60_TABLES),),
+            connection=conn,
+        ).rows
+
+        def _catalog_names(value: Any) -> tuple[str, ...]:
+            if value is None:
+                return ()
+            if isinstance(value, str):
+                return tuple(part for part in value.strip("{}").split(",") if part)
+            return tuple(str(part) for part in value)
+
+        expected_checks = {
+            "note_tasks_owner_user_id_check": "char_length(btrim(owner_user_id))>0",
+            "note_tasks_dataset_id_check": "char_length(btrim(dataset_id))>0",
+            "note_tasks_id_check": "char_length(btrim(id))>0",
+            "note_tasks_note_id_check": "char_length(btrim(note_id))>0",
+            "note_tasks_text_check": "char_length(text)>0",
+            "note_tasks_status_check": "status=any(array['open','done'])",
+            "note_tasks_projection_status_check": "projection_status=any(array['live','unlinked','ambiguous','deleted'])",
+            "note_tasks_version_check": "version>=1",
+            "note_tasks_canonical_revision_check": "canonical_revision>=1",
+            "note_tasks_canonical_hash_check": "canonical_hash~'^sha256:[0-9a-f]{64}$'",
+            "note_tasks_source_diagnostic_code_check": (
+                "source_diagnostic_codeisnullorsource_diagnostic_code='legacy_task_payload_invalid'"
+            ),
+            "note_tasks_source_diagnostic_hash_check": (
+                "source_diagnostic_hashisnullorsource_diagnostic_hash~'^sha256:[0-9a-f]{64}$'"
+            ),
+            "task_note_projections_note_version_check": "note_version>=1",
+            "task_note_projections_line_number_check": "line_number>=1",
+            "task_note_projections_start_offset_check": "start_offset>=0",
+            "task_note_projections_end_offset_check": "end_offset>=start_offset",
+            "task_note_projections_occurrence_index_check": "occurrence_index>=0",
+            "task_note_projections_projection_status_check": (
+                "projection_status=any(array['live','unlinked','ambiguous','deleted'])"
+            ),
+            "task_events_note_id_check": "char_length(btrim(note_id))>0",
+            "task_events_sync_revision_check": "sync_revision=any(array[1,2])",
+            "task_events_sync_object_hash_check": "sync_object_hash~'^sha256:[0-9a-f]{64}$'",
+            "task_events_sync_server_cursor_check": "sync_server_cursorisnullorsync_server_cursor>=1",
+            "task_events_source_kind_check": (
+                "source_kind=any(array['client','rest','mcp','markdown_reconciliation','repair','trusted_bootstrap_v1'])"
+            ),
+            "task_events_delete_reason_check": (
+                "delete_reasonisnullordelete_reason=any(array['user_request','correction','policy'])"
+            ),
+            "task_events_source_diagnostic_hash_check": (
+                "source_diagnostic_hashisnullorsource_diagnostic_hash~'^sha256:[0-9a-f]{64}$'"
+            ),
+            "task_events_deleted_lifecycle_check": (
+                "deleted=falseanddeleted_atisnullanddelete_reasonisnullor"
+                "deleted=trueanddeleted_atisnotnullanddelete_reasonisnotnull"
+            ),
+            "task_event_read_state_user_check": "user_id=owner_user_id",
+            "note_task_reconciliation_note_version_check": "note_version>=1",
+            "note_task_reconciliation_item_count_check": "item_count>=0",
+            "note_task_reconciliation_warning_count_check": "warning_count>=0",
+            "task_projection_drifts_revision_check": "marker_base_revision>=1",
+            "task_projection_drifts_reason_check": (
+                "reason_code=any(array['missing_marker_base','malformed_marker','duplicate_marker',"
+                "'marker_scope_mismatch','base_unavailable','both_changed','ambiguous_legacy_match',"
+                "'unsupported_markdown'])"
+            ),
+            "task_projection_drifts_status_check": "status=any(array['open','resolved','dismissed'])",
+        }
+        expected_primary = {
+            "note_tasks_pkey": ("note_tasks", ("owner_user_id", "dataset_id", "id")),
+            "task_note_projections_pkey": (
+                "task_note_projections", ("owner_user_id", "dataset_id", "task_id"),
+            ),
+            "task_events_pkey": ("task_events", ("owner_user_id", "dataset_id", "id")),
+            "task_event_read_state_pkey": (
+                "task_event_read_state", ("owner_user_id", "dataset_id", "event_id", "user_id"),
+            ),
+            "note_task_reconciliation_state_pkey": (
+                "note_task_reconciliation_state", ("owner_user_id", "dataset_id", "note_id"),
+            ),
+            "task_projection_drifts_pkey": (
+                "task_projection_drifts", ("owner_user_id", "dataset_id", "id"),
+            ),
+        }
+        expected_foreign = {
+            "note_tasks_note_owner_fkey": (
+                "note_tasks", ("owner_user_id", "note_id"), "notes", ("client_id", "id"), "c", "c",
+            ),
+            "task_note_projections_task_fkey": (
+                "task_note_projections", ("owner_user_id", "dataset_id", "task_id"), "note_tasks",
+                ("owner_user_id", "dataset_id", "id"), "c", "c",
+            ),
+            "task_note_projections_note_owner_fkey": (
+                "task_note_projections", ("owner_user_id", "note_id"), "notes", ("client_id", "id"), "c", "c",
+            ),
+            "task_events_task_fkey": (
+                "task_events", ("owner_user_id", "dataset_id", "task_id"), "note_tasks",
+                ("owner_user_id", "dataset_id", "id"), "r", "c",
+            ),
+            "task_events_note_owner_fkey": (
+                "task_events", ("owner_user_id", "note_id"), "notes", ("client_id", "id"), "r", "c",
+            ),
+            "task_events_correction_fkey": (
+                "task_events", ("owner_user_id", "dataset_id", "corrects_activity_id"), "task_events",
+                ("owner_user_id", "dataset_id", "id"), "r", "c",
+            ),
+            "task_event_read_state_event_fkey": (
+                "task_event_read_state", ("owner_user_id", "dataset_id", "event_id"), "task_events",
+                ("owner_user_id", "dataset_id", "id"), "c", "c",
+            ),
+            "note_task_reconciliation_note_owner_fkey": (
+                "note_task_reconciliation_state", ("owner_user_id", "note_id"), "notes",
+                ("client_id", "id"), "c", "c",
+            ),
+            "task_projection_drifts_task_fkey": (
+                "task_projection_drifts", ("owner_user_id", "dataset_id", "task_id"), "note_tasks",
+                ("owner_user_id", "dataset_id", "id"), "c", "c",
+            ),
+            "task_projection_drifts_note_owner_fkey": (
+                "task_projection_drifts", ("owner_user_id", "note_id"), "notes",
+                ("client_id", "id"), "c", "c",
+            ),
+        }
+        expected_constraint_names = set(expected_checks) | set(expected_primary) | set(expected_foreign)
+        constraints = {str(row.get("constraint_name")): row for row in constraint_rows}
+        if set(constraints) != expected_constraint_names or any(
+            not bool(row.get("constraint_validated")) for row in constraints.values()
+        ):
+            raise SchemaError("Notes task v60 PostgreSQL constraint catalog drifted.")  # noqa: TRY003
+        for name, expression in expected_checks.items():
+            row = constraints[name]
+            if (
+                str(row.get("constraint_type")) != "c"
+                or self._normalize_postgres_catalog_expression(row.get("check_expression"))
+                != self._normalize_postgres_catalog_expression(expression)
+            ):
+                raise SchemaError("Notes task v60 PostgreSQL check catalog drifted.")  # noqa: TRY003
+        for name, (table, columns) in expected_primary.items():
+            row = constraints[name]
+            if (
+                str(row.get("constraint_type")) != "p"
+                or str(row.get("table_name")) != table
+                or _catalog_names(row.get("local_columns")) != columns
+            ):
+                raise SchemaError("Notes task v60 PostgreSQL primary-key catalog drifted.")  # noqa: TRY003
+        for name, expected in expected_foreign.items():
+            table, local_columns, referenced_table, referenced_columns, delete_action, update_action = expected
+            row = constraints[name]
+            if (
+                str(row.get("constraint_type")) != "f"
+                or str(row.get("table_name")) != table
+                or _catalog_names(row.get("local_columns")) != local_columns
+                or str(row.get("referenced_table")) != referenced_table
+                or not bool(row.get("referenced_in_current_schema"))
+                or not str(row.get("referenced_schema") or "")
+                or _catalog_names(row.get("referenced_columns")) != referenced_columns
+                or str(row.get("delete_action")) != delete_action
+                or str(row.get("update_action")) != update_action
+            ):
+                raise SchemaError("Notes task v60 PostgreSQL foreign-key catalog drifted.")  # noqa: TRY003
+
+        expected_indexes: dict[str, tuple[str, bool, str]] = {}
+        for statement in self._note_task_v60_postgres_indexes():
+            match = re.fullmatch(r"CREATE (UNIQUE )?INDEX (\w+) ON (\w+)\(([^)]+)\)", statement)
+            if match is None:
+                raise SchemaError("Notes task v60 PostgreSQL index definition is not fixed.")  # noqa: TRY003
+            expected_indexes[match.group(2)] = (
+                match.group(3), bool(match.group(1)), match.group(4).replace(" ", ""),
+            )
+        index_rows = backend.execute(
+            """
+            SELECT table_row.relname AS table_name, index_table.relname AS index_name,
+                   index_row.indisunique AS is_unique, index_row.indisvalid AS is_valid,
+                   index_row.indisready AS is_ready,
+                   string_agg(column_row.attname,',' ORDER BY index_key.ordinality) AS column_names,
+                   pg_get_expr(index_row.indpred,index_row.indrelid,false) AS predicate
+              FROM pg_index AS index_row
+              JOIN pg_class AS table_row ON table_row.oid=index_row.indrelid
+              JOIN pg_namespace AS namespace_row ON namespace_row.oid=table_row.relnamespace
+              JOIN pg_class AS index_table ON index_table.oid=index_row.indexrelid
+              CROSS JOIN LATERAL unnest(index_row.indkey) WITH ORDINALITY index_key(attnum,ordinality)
+              JOIN pg_attribute AS column_row
+                ON column_row.attrelid=table_row.oid AND column_row.attnum=index_key.attnum
+             WHERE namespace_row.nspname=current_schema()
+               AND table_row.relname = ANY(%s)
+               AND index_key.ordinality<=index_row.indnkeyatts
+               AND NOT EXISTS(SELECT 1 FROM pg_constraint c WHERE c.conindid=index_row.indexrelid)
+             GROUP BY table_row.relname,index_table.relname,index_row.indisunique,
+                      index_row.indisvalid,index_row.indisready,index_row.indpred,index_row.indrelid
+            """,
+            (list(self._NOTE_TASK_V60_TABLES),),
+            connection=conn,
+        ).rows
+        indexes = {str(row.get("index_name")): row for row in index_rows}
+        if set(indexes) != set(expected_indexes):
+            raise SchemaError("Notes task v60 PostgreSQL index catalog drifted.")  # noqa: TRY003
+        for name, (table, unique, columns) in expected_indexes.items():
+            row = indexes[name]
+            if (
+                str(row.get("table_name")) != table
+                or bool(row.get("is_unique")) is not unique
+                or not bool(row.get("is_valid")) or not bool(row.get("is_ready"))
+                or str(row.get("column_names")) != columns
+                or row.get("predicate") is not None
+            ):
+                raise SchemaError("Notes task v60 PostgreSQL index catalog drifted.")  # noqa: TRY003
+        notes_index = backend.execute(
+            """
+            SELECT index_row.indisunique AS is_unique, index_row.indisvalid AS is_valid,
+                   index_row.indisready AS is_ready,
+                   string_agg(column_row.attname,',' ORDER BY index_key.ordinality) AS column_names,
+                   pg_get_expr(index_row.indpred,index_row.indrelid,false) AS predicate
+              FROM pg_index AS index_row
+              JOIN pg_class AS table_row ON table_row.oid=index_row.indrelid
+              JOIN pg_namespace AS namespace_row ON namespace_row.oid=table_row.relnamespace
+              JOIN pg_class AS index_table ON index_table.oid=index_row.indexrelid
+              CROSS JOIN LATERAL unnest(index_row.indkey) WITH ORDINALITY index_key(attnum,ordinality)
+              JOIN pg_attribute column_row
+                ON column_row.attrelid=table_row.oid AND column_row.attnum=index_key.attnum
+             WHERE namespace_row.nspname=current_schema() AND table_row.relname='notes'
+               AND index_table.relname='uq_notes_owner_id'
+               AND index_key.ordinality<=index_row.indnkeyatts
+             GROUP BY index_row.indisunique,index_row.indisvalid,index_row.indisready,
+                      index_row.indpred,index_row.indrelid
+            """,
+            connection=conn,
+        ).rows
+        if len(notes_index) != 1 or (
+            not bool(notes_index[0].get("is_unique"))
+            or not bool(notes_index[0].get("is_valid"))
+            or not bool(notes_index[0].get("is_ready"))
+            or str(notes_index[0].get("column_names")) != "client_id,id"
+            or notes_index[0].get("predicate") is not None
+        ):
+            raise SchemaError("Notes task v60 PostgreSQL notes-owner index drifted.")  # noqa: TRY003
+
+        policy_rows = backend.execute(
+            """
+            SELECT tablename AS table_name, policyname AS policy_name, permissive,
+                   roles::text AS roles, cmd AS command, qual AS using_expression,
+                   with_check AS check_expression
+              FROM pg_policies
+             WHERE schemaname=current_schema() AND tablename = ANY(%s)
+             ORDER BY tablename,policyname
+            """,
+            (list(self._NOTE_TASK_V60_TABLES),),
+            connection=conn,
+        ).rows
+        expected_policies = self._note_task_v60_policy_predicates()
+        if len(policy_rows) != len(expected_policies):
+            raise SchemaError("Notes task v60 PostgreSQL RLS policy catalog drifted.")  # noqa: TRY003
+        policies = {str(row.get("table_name")): row for row in policy_rows}
+        if set(policies) != set(expected_policies):
+            raise SchemaError("Notes task v60 PostgreSQL RLS policy catalog drifted.")  # noqa: TRY003
+        for table, expression in expected_policies.items():
+            row = policies[table]
+            table_prefix = f"{table}."
+            normalized_expected = self._normalize_postgres_catalog_expression(expression).replace(
+                table_prefix, ""
+            )
+            normalized_using = self._normalize_postgres_catalog_expression(
+                row.get("using_expression")
+            ).replace(table_prefix, "")
+            normalized_check = self._normalize_postgres_catalog_expression(
+                row.get("check_expression")
+            ).replace(table_prefix, "")
+            if (
+                str(row.get("policy_name")) != f"{table}_tenant_isolation"
+                or str(row.get("permissive")) != "PERMISSIVE"
+                or str(row.get("roles")) != "{public}"
+                or str(row.get("command")) != "ALL"
+                or normalized_using != normalized_expected
+                or normalized_check != normalized_expected
+            ):
+                raise SchemaError("Notes task v60 PostgreSQL RLS policy catalog drifted.")  # noqa: TRY003
+
     def _migrate_from_v58_to_v59_postgres(self, conn: Any) -> None:
         """Install the empty registry under verified PostgreSQL schema authority."""
 
@@ -11907,6 +12632,278 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             backend.execute(statement, connection=conn)
         self._verify_note_attachment_schema_postgres(conn)
         self._set_schema_version_postgres(conn, 59)
+
+    def _validate_note_task_source_postgres(self, conn: Any) -> dict[str, Any]:
+        """Read and owner-prove the complete locked v59 source before any v60 DDL."""
+        backend = self.backend
+        notes = {
+            str(row.get("id")): str(row.get("client_id") or "").strip()
+            for row in backend.execute("SELECT id,client_id FROM notes", connection=conn).rows
+        }
+        tasks = [
+            self._note_task_v60_json_safe(dict(row))
+            for row in backend.execute("SELECT * FROM note_tasks ORDER BY id", connection=conn).rows
+        ]
+        task_scopes: dict[str, tuple[str, str]] = {}
+        for row in tasks:
+            note_id = str(row.get("note_id") or "")
+            owner = notes.get(note_id, "")
+            if not owner:
+                raise SchemaError("Notes task v60 migration could not prove a task owner.")  # noqa: TRY003
+            task_scopes[str(row.get("id"))] = (owner, note_id)
+
+        projections = [
+            self._note_task_v60_json_safe(dict(row))
+            for row in backend.execute("SELECT * FROM task_note_projections ORDER BY task_id", connection=conn).rows
+        ]
+        for row in projections:
+            scope = task_scopes.get(str(row.get("task_id")))
+            if scope is None or scope[1] != str(row.get("note_id") or ""):
+                raise SchemaError("Notes task v60 migration could not prove projection parents.")  # noqa: TRY003
+
+        source_events = [
+            self._note_task_v60_json_safe(dict(row))
+            for row in backend.execute("SELECT * FROM task_events ORDER BY id", connection=conn).rows
+        ]
+        events: list[tuple[dict[str, Any], str, str, str]] = []
+        event_owners: dict[str, str] = {}
+        for row in source_events:
+            task_scope = task_scopes.get(str(row.get("task_id"))) if row.get("task_id") is not None else None
+            note_id = str(row.get("note_id") or (task_scope[1] if task_scope else ""))
+            note_owner = notes.get(note_id, "")
+            owner = task_scope[0] if task_scope else note_owner
+            if not owner or note_owner != owner or (task_scope is not None and task_scope[1] != note_id):
+                raise SchemaError("Notes task v60 migration could not prove event parents.")  # noqa: TRY003
+            normalized_row = {**row, "note_id": note_id}
+            source_hash = self._note_task_v60_hash(
+                {"source": self._note_task_v60_json_safe(row), "version": 1}
+            )
+            events.append((normalized_row, owner, note_id, source_hash))
+            event_owners[str(row.get("id"))] = owner
+
+        read_states = [
+            self._note_task_v60_json_safe(dict(row))
+            for row in backend.execute(
+                "SELECT * FROM task_event_read_state ORDER BY event_id,user_id", connection=conn
+            ).rows
+        ]
+        for row in read_states:
+            owner = event_owners.get(str(row.get("event_id")))
+            if owner is None or owner != str(row.get("user_id") or ""):
+                raise SchemaError("Notes task v60 migration could not prove read-state ownership.")  # noqa: TRY003
+
+        reconciliation = [
+            self._note_task_v60_json_safe(dict(row))
+            for row in backend.execute(
+                "SELECT * FROM note_task_reconciliation_state ORDER BY note_id", connection=conn
+            ).rows
+        ]
+        for row in reconciliation:
+            if not notes.get(str(row.get("note_id") or ""), ""):
+                raise SchemaError("Notes task v60 migration could not prove reconciliation ownership.")  # noqa: TRY003
+        return {
+            "notes": notes, "tasks": tasks, "task_scopes": task_scopes,
+            "projections": projections, "events": events, "read_states": read_states,
+            "reconciliation": reconciliation,
+        }
+
+    def _migrate_from_v59_to_v60_postgres(self, conn: Any) -> None:
+        """Atomically rebuild the PostgreSQL task graph under owner/dataset tenancy."""
+        backend = self.backend
+        backend.execute(
+            "LOCK TABLE notes, note_tasks, task_note_projections, task_events, "
+            "task_event_read_state, note_task_reconciliation_state IN ACCESS EXCLUSIVE MODE",
+            connection=conn,
+        )
+        source_relations = ("notes", *self._NOTE_TASK_V60_TABLES[:-1])
+        relation_rows = backend.execute(
+            """
+            SELECT table_row.relname AS table_name, table_row.relrowsecurity AS rls_enabled,
+                   table_row.relforcerowsecurity AS rls_forced,
+                   table_row.relowner=current_user::regrole AS is_table_owner,
+                   pg_has_role(current_user, namespace_row.nspowner, 'USAGE')
+                     AS is_schema_owner
+              FROM pg_class AS table_row
+              JOIN pg_namespace AS namespace_row ON namespace_row.oid=table_row.relnamespace
+             WHERE namespace_row.nspname=current_schema() AND table_row.relkind IN ('r','p')
+               AND table_row.relname = ANY(%s)
+            """,
+            (list(source_relations),),
+            connection=conn,
+        ).rows
+        states = {str(row.get("table_name")): row for row in relation_rows}
+        if set(states) != set(source_relations) or any(
+            not bool(row.get("is_table_owner")) or not bool(row.get("is_schema_owner"))
+            or (bool(row.get("rls_forced")) and not bool(row.get("rls_enabled")))
+            for row in states.values()
+        ):
+            raise SchemaError("Notes task v60 requires the verified PostgreSQL schema-owner path.")  # noqa: TRY003
+        forced_relations = tuple(
+            table for table in source_relations if bool(states[table].get("rls_forced"))
+        )
+        collision_names = ("task_projection_drifts", *(f"{table}_v60" for table in self._NOTE_TASK_V60_TABLES))
+        collisions = backend.execute(
+            """
+            SELECT table_row.relname AS relation_name
+              FROM pg_class AS table_row
+              JOIN pg_namespace AS namespace_row ON namespace_row.oid=table_row.relnamespace
+             WHERE namespace_row.nspname=current_schema() AND table_row.relname = ANY(%s)
+            """,
+            (list(collision_names),),
+            connection=conn,
+        ).rows
+        if collisions:
+            raise SchemaError("Notes task v60 target collision requires explicit repair.")  # noqa: TRY003
+        note_index_collision = backend.execute(
+            "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace "
+            "WHERE n.nspname=current_schema() AND c.relname='uq_notes_owner_id'",
+            connection=conn,
+        ).rows
+        if note_index_collision:
+            raise SchemaError("Notes task v60 notes-owner index collision requires explicit repair.")  # noqa: TRY003
+
+        for table in forced_relations:
+            backend.execute(f"ALTER TABLE {table} NO FORCE ROW LEVEL SECURITY", connection=conn)  # nosec B608
+        source = self._validate_note_task_source_postgres(conn)
+        self._note_task_v60_migration_checkpoint("validate")
+
+        self._rename_note_task_v59_postgres_constraints(conn)
+        self._create_note_task_schema_v60_postgres(conn)
+        self._note_task_v60_migration_checkpoint("create")
+
+        dataset = self._LOCAL_UNBOUND_TASK_DATASET_ID
+        for row in source["tasks"]:
+            owner, _note_id = source["task_scopes"][str(row["id"])]
+            canonical_source = self._note_task_v60_json_safe(row)
+            canonical_hash, diagnostic_code, diagnostic_hash = self._canonicalize_legacy_task_v60(
+                canonical_source, owner_user_id=owner
+            )
+            backend.execute(
+                """
+                INSERT INTO note_tasks_v60(
+                  owner_user_id,dataset_id,id,note_id,text,status,metadata_json,projection_status,
+                  deleted,created_at,updated_at,completed_at,client_id,version,canonical_revision,
+                  canonical_hash,source_diagnostic_code,source_diagnostic_hash
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                """,
+                (
+                    owner, dataset, row["id"], row["note_id"], row["text"], row["status"],
+                    row["metadata_json"], row["projection_status"], row["deleted"], row["created_at"],
+                    row["updated_at"], row["completed_at"], row["client_id"], row["version"],
+                    row["version"], canonical_hash, diagnostic_code, diagnostic_hash,
+                ),
+                connection=conn,
+            )
+        for row in source["projections"]:
+            owner, _note_id = source["task_scopes"][str(row["task_id"])]
+            backend.execute(
+                """
+                INSERT INTO task_note_projections_v60(
+                  owner_user_id,dataset_id,task_id,note_id,note_version,line_number,start_offset,
+                  end_offset,normalized_text_hash,occurrence_index,block_fingerprint,raw_line,
+                  has_child_content,projection_status,updated_at
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                """,
+                (owner, dataset, *tuple(row.values())),
+                connection=conn,
+            )
+        for row, owner, note_id, source_hash in source["events"]:
+            backend.execute(
+                """
+                INSERT INTO task_events_v60(
+                  owner_user_id,dataset_id,id,task_id,note_id,event_type,actor_type,actor_id,tool_name,
+                  policy_mode,approval_id,old_value_json,new_value_json,created_at,client_id,sync_revision,
+                  sync_object_hash,sync_server_cursor,source_device_id,client_occurred_at,source_kind,
+                  corrects_activity_id,deleted,deleted_at,delete_reason,source_diagnostic_code,
+                  source_diagnostic_hash
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                """,
+                (
+                    owner, dataset, row["id"], row["task_id"], note_id, row["event_type"],
+                    row["actor_type"], row["actor_id"], row["tool_name"], row["policy_mode"],
+                    row["approval_id"], row["old_value_json"], row["new_value_json"],
+                    row["created_at"], row["client_id"], 1, source_hash, None, None,
+                    row["created_at"], "trusted_bootstrap_v1", None, False, None, None,
+                    "legacy_task_activity_unverified", source_hash,
+                ),
+                connection=conn,
+            )
+        event_owners = {str(row[0]["id"]): row[1] for row in source["events"]}
+        for row in source["read_states"]:
+            backend.execute(
+                "INSERT INTO task_event_read_state_v60 VALUES (%s,%s,%s,%s,%s,%s)",
+                (event_owners[str(row["event_id"])], dataset, *tuple(row.values())),
+                connection=conn,
+            )
+        for row in source["reconciliation"]:
+            backend.execute(
+                "INSERT INTO note_task_reconciliation_state_v60 VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+                (source["notes"][str(row["note_id"])], dataset, *tuple(row.values())),
+                connection=conn,
+            )
+        self._note_task_v60_migration_checkpoint("copy")
+
+        verification_queries = {
+            "note_tasks": (source["tasks"], "id"),
+            "task_note_projections": (source["projections"], "task_id"),
+            "task_events": ([row[0] for row in source["events"]], "id"),
+            "task_event_read_state": (source["read_states"], "event_id,user_id"),
+            "note_task_reconciliation_state": (source["reconciliation"], "note_id"),
+        }
+        for table, (source_rows, ordering) in verification_queries.items():
+            source_columns = tuple(source_rows[0]) if source_rows else {
+                "note_tasks": ("id","note_id","text","status","metadata_json","projection_status","deleted","created_at","updated_at","completed_at","client_id","version"),
+                "task_note_projections": ("task_id","note_id","note_version","line_number","start_offset","end_offset","normalized_text_hash","occurrence_index","block_fingerprint","raw_line","has_child_content","projection_status","updated_at"),
+                "task_events": ("id","task_id","note_id","event_type","actor_type","actor_id","tool_name","policy_mode","approval_id","old_value_json","new_value_json","created_at","client_id"),
+                "task_event_read_state": ("event_id","user_id","read_at","dismissed_at"),
+                "note_task_reconciliation_state": ("note_id","note_version","status","reconciled_at","item_count","warning_count","cursor"),
+            }[table]
+            target_rows = [
+                dict(row) for row in backend.execute(
+                    f"SELECT {','.join(source_columns)} FROM {table}_v60 ORDER BY {ordering}",  # nosec B608
+                    connection=conn,
+                ).rows
+            ]
+            if len(source_rows) != len(target_rows) or self._note_task_v60_hash(
+                self._note_task_v60_json_safe(source_rows)
+            ) != self._note_task_v60_hash(self._note_task_v60_json_safe(target_rows)):
+                raise SchemaError(f"Notes task v60 source verification failed for {table}.")  # noqa: TRY003
+
+        for table in (
+            "task_event_read_state", "task_note_projections", "note_task_reconciliation_state",
+            "task_events", "note_tasks",
+        ):
+            backend.execute(f"DROP TABLE {table}", connection=conn)  # nosec B608
+        for table in self._NOTE_TASK_V60_TABLES:
+            backend.execute(f"ALTER TABLE {table}_v60 RENAME TO {table}", connection=conn)  # nosec B608
+        for statement in self._note_task_v60_postgres_indexes():
+            backend.execute(statement, connection=conn)
+        self._note_task_v60_migration_checkpoint("index")
+
+        for table in forced_relations:
+            backend.execute(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY", connection=conn)  # nosec B608
+        task_rls: list[str] = []
+        for statement in build_chacha_rls_sql():
+            if any(
+                f"ALTER TABLE IF EXISTS {table} " in statement
+                or f"DROP POLICY IF EXISTS {table}_tenant_isolation ON {table}" in statement
+                or f"CREATE POLICY {table}_tenant_isolation ON {table}" in statement
+                for table in self._NOTE_TASK_V60_TABLES
+            ):
+                task_rls.append(statement)
+        if len(task_rls) != 4 * len(self._NOTE_TASK_V60_TABLES):
+            raise SchemaError("Notes task v60 RLS definition is not canonical.")  # noqa: TRY003
+        for statement in task_rls:
+            backend.execute(statement, connection=conn)
+        self._verify_note_task_schema_postgres(conn)
+        self._note_task_v60_migration_checkpoint("verify")
+        version_cursor = backend.execute(
+            "UPDATE db_schema_version SET version=60 WHERE schema_name=%s AND version=59",
+            (self._SCHEMA_NAME,),
+            connection=conn,
+        )
+        if version_cursor.rowcount != 1 or self._get_schema_version_postgres(conn) != 60:
+            raise SchemaError("Notes task v60 PostgreSQL migration failed version verification.")  # noqa: TRY003
 
     def _notes_graph_schema_postgres(self, conn: Any) -> None:
         """Create owner-scoped graph projections and direct-write invalidation."""
@@ -18958,6 +19955,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 )
             if current_version == 59:
                 self._verify_note_attachment_schema_postgres(conn)
+            elif current_version == 60:
+                self._verify_note_attachment_schema_postgres(conn)
+                self._verify_note_task_schema_postgres(conn)
 
             if current_version < 36:
                 self._ensure_postgres_workspaces_table_base(conn)
@@ -19159,6 +20159,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             if current_version < 59:
                 self._migrate_from_v58_to_v59_postgres(conn)
                 current_version = 59
+            if current_version < 60:
+                self._migrate_from_v59_to_v60_postgres(conn)
+                current_version = 60
 
             if current_version > target_version:
                 raise SchemaError(  # noqa: TRY003

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -11157,6 +11157,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "CREATE INDEX idx_task_projections_scope_status ON task_note_projections(owner_user_id,dataset_id,projection_status,updated_at,task_id)",
             "CREATE INDEX idx_task_events_scope_task_page ON task_events(owner_user_id,dataset_id,task_id,sync_server_cursor,id)",
             "CREATE INDEX idx_task_events_scope_note_page ON task_events(owner_user_id,dataset_id,note_id,sync_server_cursor,id)",
+            "CREATE INDEX idx_task_events_scope_task_created ON task_events(owner_user_id,dataset_id,task_id,created_at)",
+            "CREATE INDEX idx_task_events_scope_note_created ON task_events(owner_user_id,dataset_id,note_id,created_at)",
             "CREATE INDEX idx_task_events_scope_created ON task_events(owner_user_id,dataset_id,created_at,id)",
             "CREATE INDEX idx_task_event_read_scope_user ON task_event_read_state(owner_user_id,dataset_id,user_id,read_at,dismissed_at,event_id)",
             "CREATE INDEX idx_task_reconciliation_scope_status ON note_task_reconciliation_state(owner_user_id,dataset_id,status,reconciled_at,note_id)",
@@ -11322,10 +11324,27 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         note_index = conn.execute(
             "SELECT tbl_name,sql FROM sqlite_master WHERE type='index' AND name='uq_notes_owner_id'"
         ).fetchone()
+        related_objects = {
+            str(row[1]): (
+                str(row[0]),
+                str(row[2]),
+                self._normalize_sqlite_catalog_sql(row[3]),
+            )
+            for row in conn.execute(
+                "SELECT type,name,tbl_name,sql FROM sqlite_master "
+                "WHERE type IN ('trigger','view') ORDER BY type,name"
+            )
+            if str(row[2]) in tables
+            or any(
+                re.search(rf"\b{re.escape(table)}\b", str(row[3]), re.IGNORECASE)
+                for table in tables
+            )
+        }
         return {
             "table_sql": table_sql,
             "explicit_index_sql": explicit_index_sql,
             "table_details": table_details,
+            "related_objects": related_objects,
             "note_index": None if note_index is None else (
                 str(note_index[0]),
                 self._normalize_sqlite_catalog_sql(note_index[1]),
@@ -11370,6 +11389,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
         ):
             raise SchemaError("Notes task v60 SQLite index catalog drifted.")  # noqa: TRY003
+        if actual["related_objects"] != expected["related_objects"]:
+            raise SchemaError("Notes task v60 SQLite related catalog drifted.")  # noqa: TRY003
         if conn.execute("PRAGMA foreign_key_check").fetchall():
             raise SchemaError("Notes task v60 SQLite foreign-key catalog is invalid.")  # noqa: TRY003
 

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.parse import urlparse
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Sync.v2.errors import (
@@ -89,6 +89,14 @@ from tldw_Server_API.app.core.Sync.v2.models import (
 from tldw_Server_API.app.core.Sync.v2.mutation_group_validation import (
     SYNC_MUTATION_GROUP_MAX_SIZE,
 )
+from tldw_Server_API.app.core.Sync.v2.notes_task_readiness import (
+    NOTES_TASK_READINESS_REASON_CODES_BY_KEY,
+    NOTES_TASK_READINESS_STATES,
+    NOTES_TASK_SERVER_METADATA_KEYS,
+    NotesTaskReadinessRecord,
+    default_notes_task_readiness_record,
+    parse_notes_task_readiness_record,
+)
 from tldw_Server_API.app.core.Utils.path_utils import safe_join
 
 from .backends.base import (
@@ -118,25 +126,6 @@ _ATTACHMENT_REF_REQUIRED_PAYLOAD_KEYS = {
     "payload_hash",
     "availability",
 }
-_NOTES_TASK_READINESS_KEYS = frozenset(
-    {
-        "state",
-        "source_cursor",
-        "source_count",
-        "source_fingerprint",
-        "reason_code",
-    }
-)
-_NOTES_TASK_READINESS_STATES = frozenset(
-    {
-        "not_enrolled",
-        "enrolling",
-        "bootstrapping",
-        "verifying",
-        "ready",
-        "blocked",
-    }
-)
 _NOTES_TASK_READINESS_TRANSITIONS = {
     "not_enrolled": frozenset({"not_enrolled", "enrolling"}),
     "enrolling": frozenset(
@@ -151,43 +140,7 @@ _NOTES_TASK_READINESS_TRANSITIONS = {
     ),
     "ready": frozenset({"ready"}),
 }
-_NOTES_TASK_READINESS_REASON_CODES_BY_KEY = {
-    "notes_task_v1": frozenset(
-        {
-            "notes_task_source_invalid",
-            "notes_task_source_changed",
-            "notes_task_source_scope_invalid",
-            "notes_task_source_catalog_invalid",
-            "notes_task_verification_failed",
-        }
-    ),
-    "notes_task_activity_v1": frozenset(
-        {
-            "notes_task_activity_source_invalid",
-            "notes_task_activity_source_changed",
-            "notes_task_activity_source_scope_invalid",
-            "notes_task_activity_source_catalog_invalid",
-            "notes_task_activity_verification_failed",
-        }
-    ),
-}
-_NOTES_TASK_READINESS_REASON_CODES = frozenset(
-    reason_code
-    for reason_codes in _NOTES_TASK_READINESS_REASON_CODES_BY_KEY.values()
-    for reason_code in reason_codes
-)
 _NOTES_TASK_LOCAL_UNBOUND_DATASET_ID = "local-unbound"
-_NOTES_TASK_READINESS_CURSOR_MAX_BYTES = 4_096
-_NOTES_TASK_READINESS_COUNT_MAX = 9_223_372_036_854_775_807
-
-
-def _is_valid_notes_task_readiness_cursor(value: object) -> bool:
-    if not isinstance(value, str) or not value or value != value.strip():
-        return False
-    try:
-        return len(value.encode("utf-8")) <= _NOTES_TASK_READINESS_CURSOR_MAX_BYTES
-    except UnicodeEncodeError:
-        return False
 
 
 def _is_rebase_required_conflict_source(
@@ -3447,11 +3400,14 @@ class SyncDatabase:
         self._validate_dataset_contract(dataset)
         now = utcnow_iso()
         domains_json = encode_json(dataset.domains, default=[])
-        metadata_json = encode_json(dataset.metadata, default={})
         with self.backend.transaction() as conn:
+            lock_suffix = (
+                " FOR UPDATE" if self.backend_type == BackendType.POSTGRESQL else ""
+            )
             existing = _first(
                 self.execute(
-                    "SELECT * FROM sync_datasets WHERE dataset_id = ?",
+                    "SELECT * FROM sync_datasets WHERE dataset_id = ?"
+                    + lock_suffix,  # nosec B608 - backend-controlled row lock suffix.
                     (dataset.dataset_id,),
                     connection=conn,
                 )
@@ -3461,6 +3417,27 @@ class SyncDatabase:
                     raise SyncStoreError(
                         f"Sync dataset already belongs to another user: {dataset.dataset_id}"
                     )
+                raw_existing_metadata = existing.get("metadata_json")
+                if not isinstance(raw_existing_metadata, str):
+                    raise SyncStoreError("sync_dataset_metadata_invalid")
+                try:
+                    existing_metadata = json.loads(raw_existing_metadata)
+                except ValueError as exc:
+                    raise SyncStoreError("sync_dataset_metadata_invalid") from exc
+                if not isinstance(existing_metadata, dict):
+                    raise SyncStoreError("sync_dataset_metadata_invalid")
+                metadata = {
+                    key: value
+                    for key, value in dataset.metadata.items()
+                    if key not in NOTES_TASK_SERVER_METADATA_KEYS
+                }
+                metadata.update(
+                    {
+                        key: existing_metadata[key]
+                        for key in NOTES_TASK_SERVER_METADATA_KEYS
+                        if key in existing_metadata
+                    }
+                )
                 self.execute(
                     """
                     UPDATE sync_datasets
@@ -3480,7 +3457,7 @@ class SyncDatabase:
                         dataset.scope_type,
                         dataset.encryption_policy,
                         domains_json,
-                        metadata_json,
+                        encode_json(metadata, default={}),
                         now,
                         dataset.archived_at,
                         dataset.dataset_id,
@@ -3504,7 +3481,7 @@ class SyncDatabase:
                         dataset.scope_type,
                         dataset.encryption_policy,
                         domains_json,
-                        metadata_json,
+                        encode_json(dataset.metadata, default={}),
                         now,
                         now,
                         dataset.archived_at,
@@ -4728,100 +4705,19 @@ class SyncDatabase:
         )
 
     @staticmethod
-    def _validate_notes_task_readiness_input(
-        *,
-        expected_state: str,
-        state: str,
-        source_cursor: str | None,
-        source_count: object,
-        source_fingerprint: str | None,
-        reason_code: str | None,
-    ) -> dict[str, Any]:
-        if (
-            expected_state not in _NOTES_TASK_READINESS_STATES
-            or state not in _NOTES_TASK_READINESS_STATES
-        ):
-            raise SyncStoreError("notes_task_readiness_transition_invalid")
-        if (
-            isinstance(source_count, bool)
-            or not isinstance(source_count, int)
-            or not 0 <= source_count <= _NOTES_TASK_READINESS_COUNT_MAX
-        ):
-            raise SyncStoreError("notes_task_readiness_progress_invalid")
-        if source_cursor is not None and not _is_valid_notes_task_readiness_cursor(
-            source_cursor
-        ):
-            raise SyncStoreError("notes_task_readiness_cursor_invalid")
-        if source_fingerprint is not None and re.fullmatch(
-            r"[0-9a-f]{64}", source_fingerprint
-        ) is None:
-            raise SyncStoreError("notes_task_readiness_fingerprint_invalid")
-        if reason_code is not None and (
-            not isinstance(reason_code, str)
-            or reason_code not in _NOTES_TASK_READINESS_REASON_CODES
-        ):
-            raise SyncStoreError("notes_task_readiness_reason_invalid")
-        if state == "blocked":
-            if reason_code is None:
-                raise SyncStoreError("notes_task_readiness_reason_invalid")
-        elif reason_code is not None:
-            raise SyncStoreError("notes_task_readiness_reason_invalid")
-        if state in {"not_enrolled", "enrolling"} and (
-            source_cursor is not None
-            or source_count != 0
-            or source_fingerprint is not None
-        ):
-            raise SyncStoreError("notes_task_readiness_progress_invalid")
-        if source_count > 0 and (
-            source_cursor is None or source_fingerprint is None
-        ):
-            raise SyncStoreError("notes_task_readiness_progress_invalid")
-        if source_cursor is not None and source_fingerprint is None:
-            raise SyncStoreError("notes_task_readiness_progress_invalid")
-        if state in {"verifying", "ready"} and source_fingerprint is None:
-            raise SyncStoreError("notes_task_readiness_fingerprint_invalid")
-        return {
-            "state": state,
-            "source_cursor": source_cursor,
-            "source_count": source_count,
-            "source_fingerprint": source_fingerprint,
-            "reason_code": reason_code,
-        }
-
-    @classmethod
     def _notes_task_readiness_record(
-        cls,
         metadata: Mapping[str, Any],
         readiness_key: str,
-    ) -> dict[str, Any]:
+    ) -> NotesTaskReadinessRecord:
         if readiness_key not in metadata:
-            return {
-                "state": "not_enrolled",
-                "source_cursor": None,
-                "source_count": 0,
-                "source_fingerprint": None,
-                "reason_code": None,
-            }
-        raw = metadata[readiness_key]
-        if not isinstance(raw, Mapping) or set(raw) != _NOTES_TASK_READINESS_KEYS:
+            return default_notes_task_readiness_record()
+        result = parse_notes_task_readiness_record(
+            metadata[readiness_key],
+            readiness_key=readiness_key,
+        )
+        if result.record is None:
             raise SyncStoreError("notes_task_readiness_state_invalid")
-        try:
-            record = cls._validate_notes_task_readiness_input(
-                expected_state=str(raw.get("state")),
-                state=str(raw.get("state")),
-                source_cursor=raw.get("source_cursor"),
-                source_count=raw.get("source_count"),
-                source_fingerprint=raw.get("source_fingerprint"),
-                reason_code=raw.get("reason_code"),
-            )
-        except SyncStoreError as exc:
-            raise SyncStoreError("notes_task_readiness_state_invalid") from exc
-        reason_code = record["reason_code"]
-        if reason_code is not None and reason_code not in (
-            _NOTES_TASK_READINESS_REASON_CODES_BY_KEY[readiness_key]
-        ):
-            raise SyncStoreError("notes_task_readiness_state_invalid")
-        return record
+        return result.record
 
     def transition_notes_task_domain_readiness(
         self,
@@ -4840,8 +4736,13 @@ class SyncDatabase:
     ) -> SyncDataset:
         """Atomically persist one bounded dormant task-domain readiness transition."""
 
-        if readiness_key not in {"notes_task_v1", "notes_task_activity_v1"}:
+        if readiness_key not in NOTES_TASK_READINESS_REASON_CODES_BY_KEY:
             raise SyncStoreError("notes_task_readiness_domain_invalid")
+        if (
+            expected_state not in NOTES_TASK_READINESS_STATES
+            or state not in NOTES_TASK_READINESS_STATES
+        ):
+            raise SyncStoreError("notes_task_readiness_transition_invalid")
         if (
             not isinstance(source_dataset_id, str)
             or source_dataset_id != dataset_id
@@ -4852,19 +4753,6 @@ class SyncDatabase:
             task_activity_capture_enabled, bool
         ):
             raise SyncStoreError("notes_task_readiness_capture_invalid")
-        requested = self._validate_notes_task_readiness_input(
-            expected_state=expected_state,
-            state=state,
-            source_cursor=source_cursor,
-            source_count=source_count,
-            source_fingerprint=source_fingerprint,
-            reason_code=reason_code,
-        )
-        if reason_code is not None and reason_code not in (
-            _NOTES_TASK_READINESS_REASON_CODES_BY_KEY[readiness_key]
-        ):
-            raise SyncStoreError("notes_task_readiness_reason_invalid")
-
         with self.backend.transaction() as conn:
             row = self._require_dataset_owner_for_update(
                 dataset_id,
@@ -4883,14 +4771,46 @@ class SyncDatabase:
             if not isinstance(metadata, dict):
                 raise SyncStoreError("notes_task_readiness_state_invalid")
             current = self._notes_task_readiness_record(metadata, readiness_key)
-            if current["state"] != expected_state:
+            if current.state != expected_state:
                 raise SyncStoreError("notes_task_readiness_compare_and_set_failed")
             if state not in _NOTES_TASK_READINESS_TRANSITIONS[expected_state]:
                 raise SyncStoreError("notes_task_readiness_transition_invalid")
+            if (
+                isinstance(source_count, int)
+                and not isinstance(source_count, bool)
+                and source_count < current.source_count
+            ):
+                raise SyncStoreError("notes_task_readiness_progress_regressed")
 
-            current_count = int(current["source_count"])
-            current_cursor = current["source_cursor"]
-            current_fingerprint = current["source_fingerprint"]
+            resume_phase: str | None = None
+            if state == "blocked":
+                if expected_state == "blocked":
+                    resume_phase = current.resume_phase
+                elif expected_state == "verifying":
+                    resume_phase = "verifying"
+                else:
+                    resume_phase = "bootstrapping"
+            parsed = parse_notes_task_readiness_record(
+                {
+                    "state": state,
+                    "source_cursor": source_cursor,
+                    "source_count": source_count,
+                    "source_fingerprint": source_fingerprint,
+                    "reason_code": reason_code,
+                    "resume_phase": resume_phase,
+                },
+                readiness_key=readiness_key,
+            )
+            if parsed.record is None:
+                raise SyncStoreError(
+                    parsed.error_code or "notes_task_readiness_state_invalid"
+                )
+            requested = parsed.record
+
+            current_count = current.source_count
+            current_cursor = current.source_cursor
+            current_cursor_key = current.source_cursor_key
+            current_fingerprint = current.source_fingerprint
             resetting_empty = state == "not_enrolled" and current_count == 0
             if state == "blocked" and any(
                 (
@@ -4900,16 +4820,68 @@ class SyncDatabase:
                 )
             ):
                 raise SyncStoreError("notes_task_readiness_source_changed")
-            if expected_state == "ready" and requested != current:
+            if (
+                expected_state == "blocked"
+                and state not in {"blocked", "not_enrolled"}
+            ):
+                if state != current.resume_phase:
+                    raise SyncStoreError("notes_task_readiness_transition_invalid")
+                if any(
+                    (
+                        source_cursor != current_cursor,
+                        source_count != current_count,
+                        source_fingerprint != current_fingerprint,
+                    )
+                ):
+                    raise SyncStoreError("notes_task_readiness_source_changed")
+            if (
+                expected_state == "ready"
+                and requested.as_metadata() != current.as_metadata()
+            ):
                 raise SyncStoreError("notes_task_readiness_source_changed")
             if not resetting_empty:
                 if source_count < current_count:
                     raise SyncStoreError("notes_task_readiness_progress_regressed")
-                if current_cursor is not None and (
-                    source_cursor is None or source_cursor < current_cursor
-                ):
-                    raise SyncStoreError("notes_task_readiness_progress_regressed")
-                cursor_advanced = source_cursor != current_cursor
+                requested_cursor_key = requested.source_cursor_key
+                if current_cursor_key is not None:
+                    if requested_cursor_key is None:
+                        raise SyncStoreError(
+                            "notes_task_readiness_progress_regressed"
+                        )
+                    if readiness_key == "notes_task_v1":
+                        if not isinstance(current_cursor_key, UUID) or not isinstance(
+                            requested_cursor_key, UUID
+                        ):
+                            raise SyncStoreError(
+                                "notes_task_readiness_cursor_invalid"
+                            )
+                        cursor_regressed = (
+                            requested_cursor_key.int < current_cursor_key.int
+                        )
+                    else:
+                        if not isinstance(current_cursor_key, tuple) or not isinstance(
+                            requested_cursor_key, tuple
+                        ):
+                            raise SyncStoreError(
+                                "notes_task_readiness_cursor_invalid"
+                            )
+                        current_created_at, current_activity_id = current_cursor_key
+                        requested_created_at, requested_activity_id = (
+                            requested_cursor_key
+                        )
+                        cursor_regressed = (
+                            requested_created_at < current_created_at
+                            or (
+                                requested_created_at == current_created_at
+                                and requested_activity_id.int
+                                < current_activity_id.int
+                            )
+                        )
+                    if cursor_regressed:
+                        raise SyncStoreError(
+                            "notes_task_readiness_progress_regressed"
+                        )
+                cursor_advanced = requested.source_cursor_key != current_cursor_key
                 count_advanced = source_count != current_count
                 if cursor_advanced != count_advanced:
                     raise SyncStoreError("notes_task_readiness_progress_regressed")
@@ -4935,7 +4907,7 @@ class SyncDatabase:
                 if task_activity_capture_enabled is None
                 else task_activity_capture_enabled
             )
-            metadata[readiness_key] = requested
+            metadata[readiness_key] = requested.as_metadata()
             task = self._notes_task_readiness_record(metadata, "notes_task_v1")
             activity = self._notes_task_readiness_record(
                 metadata,
@@ -4943,16 +4915,16 @@ class SyncDatabase:
             )
             readiness_records = (task, activity)
             if capture_enabled and any(
-                item["state"] == "not_enrolled" for item in readiness_records
+                item.state == "not_enrolled" for item in readiness_records
             ):
                 raise SyncStoreError("notes_task_readiness_capture_incomplete")
             if not capture_enabled and any(
-                item["state"] in {"bootstrapping", "verifying", "ready"}
+                item.state in {"bootstrapping", "verifying", "ready"}
                 for item in readiness_records
             ):
                 raise SyncStoreError("notes_task_readiness_capture_required")
             if raw_capture and not capture_enabled and any(
-                item["source_count"] != 0 or item["state"] == "ready"
+                item.source_count != 0 or item.state == "ready"
                 for item in readiness_records
             ):
                 raise SyncStoreError("notes_task_readiness_capture_disable_forbidden")
@@ -11819,6 +11791,7 @@ class SyncDatabase:
                     'idx_sync_attachment_bindings_unresolved',
                     'idx_sync_attachment_bindings_blob',
                     'idx_sync_attachment_bindings_blob_retention',
+                    'idx_sync_attachment_bindings_retention_release',
                     'idx_sync_attachment_bindings_pending_digest',
                     'uq_sync_dataset_storage_namespace_id',
                     'idx_sync_dataset_storage_namespaces_owner'

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -118,6 +118,76 @@ _ATTACHMENT_REF_REQUIRED_PAYLOAD_KEYS = {
     "payload_hash",
     "availability",
 }
+_NOTES_TASK_READINESS_KEYS = frozenset(
+    {
+        "state",
+        "source_cursor",
+        "source_count",
+        "source_fingerprint",
+        "reason_code",
+    }
+)
+_NOTES_TASK_READINESS_STATES = frozenset(
+    {
+        "not_enrolled",
+        "enrolling",
+        "bootstrapping",
+        "verifying",
+        "ready",
+        "blocked",
+    }
+)
+_NOTES_TASK_READINESS_TRANSITIONS = {
+    "not_enrolled": frozenset({"not_enrolled", "enrolling"}),
+    "enrolling": frozenset(
+        {"enrolling", "bootstrapping", "blocked", "not_enrolled"}
+    ),
+    "bootstrapping": frozenset(
+        {"bootstrapping", "verifying", "blocked", "not_enrolled"}
+    ),
+    "verifying": frozenset({"verifying", "ready", "blocked", "not_enrolled"}),
+    "blocked": frozenset(
+        {"blocked", "bootstrapping", "verifying", "not_enrolled"}
+    ),
+    "ready": frozenset({"ready"}),
+}
+_NOTES_TASK_READINESS_REASON_CODES_BY_KEY = {
+    "notes_task_v1": frozenset(
+        {
+            "notes_task_source_invalid",
+            "notes_task_source_changed",
+            "notes_task_source_scope_invalid",
+            "notes_task_source_catalog_invalid",
+            "notes_task_verification_failed",
+        }
+    ),
+    "notes_task_activity_v1": frozenset(
+        {
+            "notes_task_activity_source_invalid",
+            "notes_task_activity_source_changed",
+            "notes_task_activity_source_scope_invalid",
+            "notes_task_activity_source_catalog_invalid",
+            "notes_task_activity_verification_failed",
+        }
+    ),
+}
+_NOTES_TASK_READINESS_REASON_CODES = frozenset(
+    reason_code
+    for reason_codes in _NOTES_TASK_READINESS_REASON_CODES_BY_KEY.values()
+    for reason_code in reason_codes
+)
+_NOTES_TASK_LOCAL_UNBOUND_DATASET_ID = "local-unbound"
+_NOTES_TASK_READINESS_CURSOR_MAX_BYTES = 4_096
+_NOTES_TASK_READINESS_COUNT_MAX = 9_223_372_036_854_775_807
+
+
+def _is_valid_notes_task_readiness_cursor(value: object) -> bool:
+    if not isinstance(value, str) or not value or value != value.strip():
+        return False
+    try:
+        return len(value.encode("utf-8")) <= _NOTES_TASK_READINESS_CURSOR_MAX_BYTES
+    except UnicodeEncodeError:
+        return False
 
 
 def _is_rebase_required_conflict_source(
@@ -4656,6 +4726,253 @@ class SyncDatabase:
                 metadata={"default_personal": True, "client_family": "chatbook"},
             )
         )
+
+    @staticmethod
+    def _validate_notes_task_readiness_input(
+        *,
+        expected_state: str,
+        state: str,
+        source_cursor: str | None,
+        source_count: object,
+        source_fingerprint: str | None,
+        reason_code: str | None,
+    ) -> dict[str, Any]:
+        if (
+            expected_state not in _NOTES_TASK_READINESS_STATES
+            or state not in _NOTES_TASK_READINESS_STATES
+        ):
+            raise SyncStoreError("notes_task_readiness_transition_invalid")
+        if (
+            isinstance(source_count, bool)
+            or not isinstance(source_count, int)
+            or not 0 <= source_count <= _NOTES_TASK_READINESS_COUNT_MAX
+        ):
+            raise SyncStoreError("notes_task_readiness_progress_invalid")
+        if source_cursor is not None and not _is_valid_notes_task_readiness_cursor(
+            source_cursor
+        ):
+            raise SyncStoreError("notes_task_readiness_cursor_invalid")
+        if source_fingerprint is not None and re.fullmatch(
+            r"[0-9a-f]{64}", source_fingerprint
+        ) is None:
+            raise SyncStoreError("notes_task_readiness_fingerprint_invalid")
+        if reason_code is not None and (
+            not isinstance(reason_code, str)
+            or reason_code not in _NOTES_TASK_READINESS_REASON_CODES
+        ):
+            raise SyncStoreError("notes_task_readiness_reason_invalid")
+        if state == "blocked":
+            if reason_code is None:
+                raise SyncStoreError("notes_task_readiness_reason_invalid")
+        elif reason_code is not None:
+            raise SyncStoreError("notes_task_readiness_reason_invalid")
+        if state in {"not_enrolled", "enrolling"} and (
+            source_cursor is not None
+            or source_count != 0
+            or source_fingerprint is not None
+        ):
+            raise SyncStoreError("notes_task_readiness_progress_invalid")
+        if source_count > 0 and (
+            source_cursor is None or source_fingerprint is None
+        ):
+            raise SyncStoreError("notes_task_readiness_progress_invalid")
+        if source_cursor is not None and source_fingerprint is None:
+            raise SyncStoreError("notes_task_readiness_progress_invalid")
+        if state in {"verifying", "ready"} and source_fingerprint is None:
+            raise SyncStoreError("notes_task_readiness_fingerprint_invalid")
+        return {
+            "state": state,
+            "source_cursor": source_cursor,
+            "source_count": source_count,
+            "source_fingerprint": source_fingerprint,
+            "reason_code": reason_code,
+        }
+
+    @classmethod
+    def _notes_task_readiness_record(
+        cls,
+        metadata: Mapping[str, Any],
+        readiness_key: str,
+    ) -> dict[str, Any]:
+        if readiness_key not in metadata:
+            return {
+                "state": "not_enrolled",
+                "source_cursor": None,
+                "source_count": 0,
+                "source_fingerprint": None,
+                "reason_code": None,
+            }
+        raw = metadata[readiness_key]
+        if not isinstance(raw, Mapping) or set(raw) != _NOTES_TASK_READINESS_KEYS:
+            raise SyncStoreError("notes_task_readiness_state_invalid")
+        try:
+            record = cls._validate_notes_task_readiness_input(
+                expected_state=str(raw.get("state")),
+                state=str(raw.get("state")),
+                source_cursor=raw.get("source_cursor"),
+                source_count=raw.get("source_count"),
+                source_fingerprint=raw.get("source_fingerprint"),
+                reason_code=raw.get("reason_code"),
+            )
+        except SyncStoreError as exc:
+            raise SyncStoreError("notes_task_readiness_state_invalid") from exc
+        reason_code = record["reason_code"]
+        if reason_code is not None and reason_code not in (
+            _NOTES_TASK_READINESS_REASON_CODES_BY_KEY[readiness_key]
+        ):
+            raise SyncStoreError("notes_task_readiness_state_invalid")
+        return record
+
+    def transition_notes_task_domain_readiness(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        readiness_key: str,
+        expected_state: str,
+        state: str,
+        source_dataset_id: str,
+        source_cursor: str | None,
+        source_count: int,
+        source_fingerprint: str | None,
+        reason_code: str | None = None,
+        task_activity_capture_enabled: bool | None = None,
+    ) -> SyncDataset:
+        """Atomically persist one bounded dormant task-domain readiness transition."""
+
+        if readiness_key not in {"notes_task_v1", "notes_task_activity_v1"}:
+            raise SyncStoreError("notes_task_readiness_domain_invalid")
+        if (
+            not isinstance(source_dataset_id, str)
+            or source_dataset_id != dataset_id
+            or source_dataset_id == _NOTES_TASK_LOCAL_UNBOUND_DATASET_ID
+        ):
+            raise SyncStoreError("notes_task_readiness_source_scope_invalid")
+        if task_activity_capture_enabled is not None and not isinstance(
+            task_activity_capture_enabled, bool
+        ):
+            raise SyncStoreError("notes_task_readiness_capture_invalid")
+        requested = self._validate_notes_task_readiness_input(
+            expected_state=expected_state,
+            state=state,
+            source_cursor=source_cursor,
+            source_count=source_count,
+            source_fingerprint=source_fingerprint,
+            reason_code=reason_code,
+        )
+        if reason_code is not None and reason_code not in (
+            _NOTES_TASK_READINESS_REASON_CODES_BY_KEY[readiness_key]
+        ):
+            raise SyncStoreError("notes_task_readiness_reason_invalid")
+
+        with self.backend.transaction() as conn:
+            row = self._require_dataset_owner_for_update(
+                dataset_id,
+                owner_user_id,
+                connection=conn,
+            )
+            if row.get("scope_type") != "personal":
+                raise SyncStoreError("Sync dataset was not found or is not accessible")
+            raw_metadata = row.get("metadata_json")
+            if not isinstance(raw_metadata, str) or not raw_metadata:
+                raise SyncStoreError("notes_task_readiness_state_invalid")
+            try:
+                metadata = json.loads(raw_metadata)
+            except ValueError as exc:
+                raise SyncStoreError("notes_task_readiness_state_invalid") from exc
+            if not isinstance(metadata, dict):
+                raise SyncStoreError("notes_task_readiness_state_invalid")
+            current = self._notes_task_readiness_record(metadata, readiness_key)
+            if current["state"] != expected_state:
+                raise SyncStoreError("notes_task_readiness_compare_and_set_failed")
+            if state not in _NOTES_TASK_READINESS_TRANSITIONS[expected_state]:
+                raise SyncStoreError("notes_task_readiness_transition_invalid")
+
+            current_count = int(current["source_count"])
+            current_cursor = current["source_cursor"]
+            current_fingerprint = current["source_fingerprint"]
+            resetting_empty = state == "not_enrolled" and current_count == 0
+            if state == "blocked" and any(
+                (
+                    source_cursor != current_cursor,
+                    source_count != current_count,
+                    source_fingerprint != current_fingerprint,
+                )
+            ):
+                raise SyncStoreError("notes_task_readiness_source_changed")
+            if expected_state == "ready" and requested != current:
+                raise SyncStoreError("notes_task_readiness_source_changed")
+            if not resetting_empty:
+                if source_count < current_count:
+                    raise SyncStoreError("notes_task_readiness_progress_regressed")
+                if current_cursor is not None and (
+                    source_cursor is None or source_cursor < current_cursor
+                ):
+                    raise SyncStoreError("notes_task_readiness_progress_regressed")
+                cursor_advanced = source_cursor != current_cursor
+                count_advanced = source_count != current_count
+                if cursor_advanced != count_advanced:
+                    raise SyncStoreError("notes_task_readiness_progress_regressed")
+                if cursor_advanced and source_fingerprint == current_fingerprint:
+                    raise SyncStoreError("notes_task_readiness_source_changed")
+                if current_fingerprint is not None and source_fingerprint is None:
+                    raise SyncStoreError("notes_task_readiness_progress_regressed")
+                if (
+                    not cursor_advanced
+                    and not count_advanced
+                    and current_fingerprint is not None
+                    and source_fingerprint != current_fingerprint
+                ):
+                    raise SyncStoreError("notes_task_readiness_source_changed")
+            if state == "not_enrolled" and not resetting_empty:
+                raise SyncStoreError("notes_task_readiness_disable_forbidden")
+
+            raw_capture = metadata.get("task_activity_capture_enabled", False)
+            if not isinstance(raw_capture, bool):
+                raise SyncStoreError("notes_task_readiness_state_invalid")
+            capture_enabled = (
+                raw_capture
+                if task_activity_capture_enabled is None
+                else task_activity_capture_enabled
+            )
+            metadata[readiness_key] = requested
+            task = self._notes_task_readiness_record(metadata, "notes_task_v1")
+            activity = self._notes_task_readiness_record(
+                metadata,
+                "notes_task_activity_v1",
+            )
+            readiness_records = (task, activity)
+            if capture_enabled and any(
+                item["state"] == "not_enrolled" for item in readiness_records
+            ):
+                raise SyncStoreError("notes_task_readiness_capture_incomplete")
+            if not capture_enabled and any(
+                item["state"] in {"bootstrapping", "verifying", "ready"}
+                for item in readiness_records
+            ):
+                raise SyncStoreError("notes_task_readiness_capture_required")
+            if raw_capture and not capture_enabled and any(
+                item["source_count"] != 0 or item["state"] == "ready"
+                for item in readiness_records
+            ):
+                raise SyncStoreError("notes_task_readiness_capture_disable_forbidden")
+            metadata["task_activity_capture_enabled"] = capture_enabled
+
+            self.execute(
+                "UPDATE sync_datasets SET metadata_json = ?, updated_at = ? "
+                "WHERE dataset_id = ? AND owner_user_id = ?",
+                (
+                    encode_json(metadata, default={}),
+                    utcnow_iso(),
+                    dataset_id,
+                    owner_user_id,
+                ),
+                connection=conn,
+            )
+            updated = self._get_dataset_row(dataset_id, connection=conn)
+            if updated is None:
+                raise SyncStoreError("Sync dataset readiness transition was not persisted")
+            return _dataset_from_row(updated)
 
     def begin_notes_organization_bootstrap(
         self,

--- a/tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py
+++ b/tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py
@@ -363,6 +363,103 @@ def build_chacha_rls_sql() -> list[str]:
     """.strip()
     add_tenant_policy("note_attachments", note_attachment_owner)
 
+    task_scope = """
+    note_tasks.owner_user_id = current_setting('app.current_user_id', true)
+    AND note_tasks.dataset_id = current_setting('app.current_dataset_id', true)
+    AND EXISTS (
+      SELECT 1 FROM notes AS note
+      WHERE note.id = note_tasks.note_id
+        AND note.client_id = current_setting('app.current_user_id', true)
+        AND note.client_id = note_tasks.owner_user_id
+    )
+    """.strip()
+    add_tenant_policy("note_tasks", task_scope)
+
+    projection_scope = """
+    task_note_projections.owner_user_id = current_setting('app.current_user_id', true)
+    AND task_note_projections.dataset_id = current_setting('app.current_dataset_id', true)
+    AND EXISTS (
+      SELECT 1 FROM note_tasks AS task
+      WHERE task.owner_user_id = task_note_projections.owner_user_id
+        AND task.dataset_id = task_note_projections.dataset_id
+        AND task.id = task_note_projections.task_id
+        AND task.note_id = task_note_projections.note_id
+    )
+    AND EXISTS (
+      SELECT 1 FROM notes AS note
+      WHERE note.id = task_note_projections.note_id
+        AND note.client_id = current_setting('app.current_user_id', true)
+        AND note.client_id = task_note_projections.owner_user_id
+    )
+    """.strip()
+    add_tenant_policy("task_note_projections", projection_scope)
+
+    event_scope = """
+    task_events.owner_user_id = current_setting('app.current_user_id', true)
+    AND task_events.dataset_id = current_setting('app.current_dataset_id', true)
+    AND EXISTS (
+      SELECT 1 FROM notes AS note
+      WHERE note.id = task_events.note_id
+        AND note.client_id = current_setting('app.current_user_id', true)
+        AND note.client_id = task_events.owner_user_id
+    )
+    AND (
+      task_events.task_id IS NULL
+      OR EXISTS (
+        SELECT 1 FROM note_tasks AS task
+        WHERE task.owner_user_id = task_events.owner_user_id
+          AND task.dataset_id = task_events.dataset_id
+          AND task.id = task_events.task_id
+          AND task.note_id = task_events.note_id
+      )
+    )
+    """.strip()
+    add_tenant_policy("task_events", event_scope)
+
+    read_state_scope = """
+    task_event_read_state.owner_user_id = current_setting('app.current_user_id', true)
+    AND task_event_read_state.dataset_id = current_setting('app.current_dataset_id', true)
+    AND task_event_read_state.user_id = task_event_read_state.owner_user_id
+    AND EXISTS (
+      SELECT 1 FROM task_events AS event
+      WHERE event.owner_user_id = task_event_read_state.owner_user_id
+        AND event.dataset_id = task_event_read_state.dataset_id
+        AND event.id = task_event_read_state.event_id
+    )
+    """.strip()
+    add_tenant_policy("task_event_read_state", read_state_scope)
+
+    reconciliation_scope = """
+    note_task_reconciliation_state.owner_user_id = current_setting('app.current_user_id', true)
+    AND note_task_reconciliation_state.dataset_id = current_setting('app.current_dataset_id', true)
+    AND EXISTS (
+      SELECT 1 FROM notes AS note
+      WHERE note.id = note_task_reconciliation_state.note_id
+        AND note.client_id = current_setting('app.current_user_id', true)
+        AND note.client_id = note_task_reconciliation_state.owner_user_id
+    )
+    """.strip()
+    add_tenant_policy("note_task_reconciliation_state", reconciliation_scope)
+
+    drift_scope = """
+    task_projection_drifts.owner_user_id = current_setting('app.current_user_id', true)
+    AND task_projection_drifts.dataset_id = current_setting('app.current_dataset_id', true)
+    AND EXISTS (
+      SELECT 1 FROM note_tasks AS task
+      WHERE task.owner_user_id = task_projection_drifts.owner_user_id
+        AND task.dataset_id = task_projection_drifts.dataset_id
+        AND task.id = task_projection_drifts.task_id
+        AND task.note_id = task_projection_drifts.note_id
+    )
+    AND EXISTS (
+      SELECT 1 FROM notes AS note
+      WHERE note.id = task_projection_drifts.note_id
+        AND note.client_id = current_setting('app.current_user_id', true)
+        AND note.client_id = task_projection_drifts.owner_user_id
+    )
+    """.strip()
+    add_tenant_policy("task_projection_drifts", drift_scope)
+
     note_edge_owner = """
     note_edges.user_id = current_setting('app.current_user_id', true)
     AND EXISTS (

--- a/tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py
+++ b/tldw_Server_API/app/core/DB_Management/backends/pg_rls_policies.py
@@ -460,6 +460,12 @@ def build_chacha_rls_sql() -> list[str]:
     """.strip()
     add_tenant_policy("task_projection_drifts", drift_scope)
 
+    scope_authority_owner = """
+    note_task_scope_authority.owner_user_id =
+      current_setting('app.current_user_id', true)
+    """.strip()
+    add_tenant_policy("note_task_scope_authority", scope_authority_owner)
+
     note_edge_owner = """
     note_edges.user_id = current_setting('app.current_user_id', true)
     AND EXISTS (

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -50,32 +50,19 @@ class TaskStore:
         dataset = str(dataset_id).strip()
         if not owner or not dataset:
             raise InputError("Task owner and dataset scope cannot be empty.")  # noqa: TRY003
+        if self._db.backend_type == BackendType.POSTGRESQL and (
+            owner != str(self._db.client_id) or dataset != self._LOCAL_UNBOUND
+        ):
+            raise ConflictError(
+                "Task scope is unavailable on PostgreSQL schema v59.",
+                entity="tasks",
+                entity_id=owner,
+            )  # noqa: TRY003
         return owner, dataset
 
-    def resolve_task_compatibility_scope(self, *, owner_user_id: str) -> tuple[str, str]:
-        """Resolve the sole product-owned task dataset, or the local sentinel when empty."""
-        owner = str(owner_user_id).strip()
-        if not owner:
-            raise InputError("Task owner cannot be empty.")  # noqa: TRY003
-        datasets: set[str] = set()
-        for table in (
-            "note_tasks",
-            "task_events",
-            "note_task_reconciliation_state",
-            "task_projection_drifts",
-        ):
-            cursor = self._read(
-                f"SELECT DISTINCT dataset_id FROM {table} WHERE owner_user_id = ?",  # nosec B608
-                (owner,),
-            )
-            datasets.update(str(row["dataset_id"]) for row in cursor.fetchall())
-        if not datasets:
-            return owner, self._LOCAL_UNBOUND
-        if len(datasets) != 1:
-            raise ConflictError(
-                "Task compatibility scope is ambiguous.", entity="tasks", entity_id=owner
-            )  # noqa: TRY003
-        return owner, datasets.pop()
+    @property
+    def _uses_postgres_v59_schema(self) -> bool:
+        return self._db.backend_type == BackendType.POSTGRESQL
 
     def _canonical_task_values(self, task: Mapping[str, Any]) -> tuple[int, str, str | None, str | None]:
         revision = int(task.get("canonical_revision") or task.get("version") or 1)
@@ -256,6 +243,25 @@ class TaskStore:
         include_deleted: bool,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
+        if self._uses_postgres_v59_schema:
+            if include_deleted:
+                cursor = self._read(
+                    "SELECT * FROM note_tasks WHERE client_id = ? AND id = ?",
+                    (owner_user_id, task_id),
+                    conn=conn,
+                )
+                return self._decode_task_row(cursor.fetchone())
+            cursor = self._read(
+                """
+                SELECT t.*
+                  FROM note_tasks t
+                  JOIN notes n ON n.id = t.note_id AND n.client_id = t.client_id
+                 WHERE t.client_id = ? AND t.id = ? AND t.deleted = ? AND n.deleted = ?
+                """,
+                (owner_user_id, task_id, self._deleted_value(False), self._deleted_value(False)),
+                conn=conn,
+            )
+            return self._decode_task_row(cursor.fetchone())
         if include_deleted:
             cursor = self._read(
                 "SELECT * FROM note_tasks WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
@@ -284,20 +290,32 @@ class TaskStore:
         dataset_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
-        cursor = self._read(
-            "SELECT * FROM task_note_projections WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?",
-            (owner_user_id, dataset_id, task_id),
-            conn=conn,
-        )
+        if self._uses_postgres_v59_schema:
+            cursor = self._read(
+                """
+                SELECT p.*
+                  FROM task_note_projections p
+                  JOIN note_tasks t ON t.id = p.task_id
+                 WHERE t.client_id = ? AND p.task_id = ?
+                """,
+                (owner_user_id, task_id),
+                conn=conn,
+            )
+        else:
+            cursor = self._read(
+                "SELECT * FROM task_note_projections WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?",
+                (owner_user_id, dataset_id, task_id),
+                conn=conn,
+            )
         row = cursor.fetchone()
         return dict(row) if row else None
 
     def get_task_projection(
         self,
-        task_id: str,
         *,
         owner_user_id: str,
         dataset_id: str,
+        task_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
         """Return the markdown projection row for one task."""
@@ -307,9 +325,9 @@ class TaskStore:
     def get_note_reconciliation_snapshot(
         self,
         *,
-        note_id: str,
         owner_user_id: str,
         dataset_id: str,
+        note_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
         """Return note fields needed to validate task reconciliation input."""
@@ -325,9 +343,9 @@ class TaskStore:
     def list_live_projected_tasks(
         self,
         *,
-        note_id: str,
         owner_user_id: str,
         dataset_id: str,
+        note_id: str,
         conn: TaskConnection | None = None,
     ) -> list[dict[str, dict[str, Any]]]:
         """Return live tasks for a note together with their projection rows.
@@ -337,18 +355,29 @@ class TaskStore:
         case rather than creating a replacement task beside an orphaned live row.
         """
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        cursor = self._read(
-            """
-            SELECT *
-              FROM note_tasks
-             WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?
-               AND deleted = ?
-               AND projection_status = ?
-             ORDER BY created_at ASC, id ASC
-            """,
-            (owner, dataset, note_id, self._deleted_value(False), "live"),
-            conn=conn,
-        )
+        if self._uses_postgres_v59_schema:
+            cursor = self._read(
+                """
+                SELECT *
+                  FROM note_tasks
+                 WHERE client_id = ? AND note_id = ? AND deleted = ? AND projection_status = ?
+                 ORDER BY created_at ASC, id ASC
+                """,
+                (owner, note_id, self._deleted_value(False), "live"),
+                conn=conn,
+            )
+        else:
+            cursor = self._read(
+                """
+                SELECT *
+                  FROM note_tasks
+                 WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?
+                   AND deleted = ? AND projection_status = ?
+                 ORDER BY created_at ASC, id ASC
+                """,
+                (owner, dataset, note_id, self._deleted_value(False), "live"),
+                conn=conn,
+            )
         projected_tasks: list[dict[str, dict[str, Any]]] = []
         for row in cursor.fetchall():
             task = self._decode_task_row(row)
@@ -505,59 +534,73 @@ class TaskStore:
         now = self._db._get_current_utc_timestamp_iso()
         completed_at = now if normalized_status == "done" else None
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
-            {
-                "owner_user_id": owner,
-                "id": final_task_id,
-                "note_id": note_id,
-                "text": normalized_text,
-                "status": normalized_status,
-                "metadata_json": metadata_json,
-                "projection_status": normalized_projection_status,
-                "deleted": 0,
-                "created_at": now,
-                "updated_at": now,
-                "completed_at": completed_at,
-                "client_id": self._db.client_id,
-                "version": 1,
-                "canonical_revision": 1,
-            }
-        )
+        canonical_values = None
+        if not self._uses_postgres_v59_schema:
+            canonical_values = self._canonical_task_values(
+                {
+                    "owner_user_id": owner,
+                    "id": final_task_id,
+                    "note_id": note_id,
+                    "text": normalized_text,
+                    "status": normalized_status,
+                    "metadata_json": metadata_json,
+                    "projection_status": normalized_projection_status,
+                    "deleted": 0,
+                    "created_at": now,
+                    "updated_at": now,
+                    "completed_at": completed_at,
+                    "client_id": self._db.client_id,
+                    "version": 1,
+                    "canonical_revision": 1,
+                }
+            )
 
         def _execute_create(transaction_conn: TaskConnection) -> dict[str, Any]:
             self._require_active_note(note_id, final_task_id, owner_user_id=owner, conn=transaction_conn)
-            self._execute(
-                transaction_conn,
-                """
-                INSERT INTO note_tasks (
-                    owner_user_id, dataset_id, id, note_id, text, status, metadata_json,
-                    projection_status, deleted, created_at, updated_at, completed_at, client_id,
-                    version, canonical_revision, canonical_hash, source_diagnostic_code,
-                    source_diagnostic_hash
+            if self._uses_postgres_v59_schema:
+                self._execute(
+                    transaction_conn,
+                    """
+                    INSERT INTO note_tasks (
+                        id, note_id, text, status, metadata_json, projection_status,
+                        deleted, created_at, updated_at, completed_at, client_id, version
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        final_task_id,
+                        note_id,
+                        normalized_text,
+                        normalized_status,
+                        metadata_json,
+                        normalized_projection_status,
+                        self._deleted_value(False),
+                        now,
+                        now,
+                        completed_at,
+                        owner,
+                        1,
+                    ),
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    owner,
-                    dataset,
-                    final_task_id,
-                    note_id,
-                    normalized_text,
-                    normalized_status,
-                    metadata_json,
-                    normalized_projection_status,
-                    self._deleted_value(False),
-                    now,
-                    now,
-                    completed_at,
-                    self._db.client_id,
-                    1,
-                    canonical_revision,
-                    canonical_hash,
-                    diagnostic_code,
-                    diagnostic_hash,
-                ),
-            )
+            else:
+                assert canonical_values is not None  # nosec B101
+                canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = canonical_values
+                self._execute(
+                    transaction_conn,
+                    """
+                    INSERT INTO note_tasks (
+                        owner_user_id, dataset_id, id, note_id, text, status, metadata_json,
+                        projection_status, deleted, created_at, updated_at, completed_at, client_id,
+                        version, canonical_revision, canonical_hash, source_diagnostic_code,
+                        source_diagnostic_hash
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        owner, dataset, final_task_id, note_id, normalized_text, normalized_status,
+                        metadata_json, normalized_projection_status, self._deleted_value(False),
+                        now, now, completed_at, self._db.client_id, 1, canonical_revision,
+                        canonical_hash, diagnostic_code, diagnostic_hash,
+                    ),
+                )
             if actor_type:
                 self.record_task_event(
                     task_id=final_task_id,
@@ -600,23 +643,6 @@ class TaskStore:
 
     def get_task(
         self,
-        task_id: str,
-        include_deleted: bool = False,
-        *,
-        owner_user_id: str,
-        dataset_id: str,
-    ) -> dict[str, Any] | None:
-        """Return one task by ID."""
-        owner, dataset = self._scope(owner_user_id, dataset_id)
-        return self._fetch_task(
-            task_id,
-            owner_user_id=owner,
-            dataset_id=dataset,
-            include_deleted=include_deleted,
-        )
-
-    def get_task_scoped(
-        self,
         *,
         owner_user_id: str,
         dataset_id: str,
@@ -624,7 +650,7 @@ class TaskStore:
         include_deleted: bool = False,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
-        """Return one task only inside the exact canonical owner/dataset scope."""
+        """Return one task by ID."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
         return self._fetch_task(
             task_id,
@@ -651,8 +677,12 @@ class TaskStore:
     ) -> list[dict[str, Any]]:
         """List tasks with optional note/status filters."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        clauses: list[str] = ["t.owner_user_id = ?", "t.dataset_id = ?"]
-        params: list[Any] = [owner, dataset]
+        if self._uses_postgres_v59_schema:
+            clauses: list[str] = ["t.client_id = ?"]
+            params: list[Any] = [owner]
+        else:
+            clauses = ["t.owner_user_id = ?", "t.dataset_id = ?"]
+            params = [owner, dataset]
         if note_id is not None:
             clauses.append("t.note_id = ?")
             params.append(note_id)
@@ -688,7 +718,10 @@ class TaskStore:
             params.append(self._deleted_value(False))
         sql_query = "SELECT t.* FROM note_tasks t"
         if not include_deleted:
-            sql_query += " JOIN notes n ON n.id = t.note_id AND n.client_id = t.owner_user_id"
+            if self._uses_postgres_v59_schema:
+                sql_query += " JOIN notes n ON n.id = t.note_id AND n.client_id = t.client_id"
+            else:
+                sql_query += " JOIN notes n ON n.id = t.note_id AND n.client_id = t.owner_user_id"
         if clauses:
             sql_query += " WHERE " + " AND ".join(clauses)
         sql_query += " ORDER BY t.created_at ASC, t.id ASC LIMIT ? OFFSET ?"
@@ -737,42 +770,46 @@ class TaskStore:
                 )  # noqa: TRY003
             self._require_active_note(old["note_id"], task_id, owner_user_id=owner, conn=transaction_conn)
             now = self._db._get_current_utc_timestamp_iso()
-            canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
-                {
-                    **old,
-                    "metadata_json": metadata_json,
-                    "updated_at": now,
-                    "version": int(old["version"]) + 1,
-                    "canonical_revision": int(old["canonical_revision"]) + 1,
-                }
-            )
-            cursor = self._execute(
-                transaction_conn,
-                """
-                UPDATE note_tasks
-                   SET metadata_json = ?,
-                       updated_at = ?,
-                       version = version + 1,
-                       canonical_revision = ?, canonical_hash = ?,
-                       source_diagnostic_code = ?, source_diagnostic_hash = ?
-                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
-                   AND version = ? AND deleted = ? AND projection_status = ?
-                """,
-                (
-                    metadata_json,
-                    now,
-                    canonical_revision,
-                    canonical_hash,
-                    diagnostic_code,
-                    diagnostic_hash,
-                    owner,
-                    dataset,
-                    task_id,
-                    expected_version,
-                    self._deleted_value(False),
-                    "unlinked",
-                ),
-            )
+            if self._uses_postgres_v59_schema:
+                cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE note_tasks
+                       SET metadata_json = ?, updated_at = ?, version = version + 1
+                     WHERE client_id = ? AND id = ? AND version = ?
+                       AND deleted = ? AND projection_status = ?
+                    """,
+                    (
+                        metadata_json, now, owner, task_id, expected_version,
+                        self._deleted_value(False), "unlinked",
+                    ),
+                )
+            else:
+                canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+                    {
+                        **old,
+                        "metadata_json": metadata_json,
+                        "updated_at": now,
+                        "version": int(old["version"]) + 1,
+                        "canonical_revision": int(old["canonical_revision"]) + 1,
+                    }
+                )
+                cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE note_tasks
+                       SET metadata_json = ?, updated_at = ?, version = version + 1,
+                           canonical_revision = ?, canonical_hash = ?,
+                           source_diagnostic_code = ?, source_diagnostic_hash = ?
+                     WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                       AND version = ? AND deleted = ? AND projection_status = ?
+                    """,
+                    (
+                        metadata_json, now, canonical_revision, canonical_hash,
+                        diagnostic_code, diagnostic_hash, owner, dataset, task_id,
+                        expected_version, self._deleted_value(False), "unlinked",
+                    ),
+                )
             if getattr(cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task version mismatch for ID '{task_id}'. Expected {expected_version}.",
@@ -866,49 +903,55 @@ class TaskStore:
                 completed_at = now
             elif new_status == "open":
                 completed_at = None
-            canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
-                {
-                    **old,
-                    "text": new_text,
-                    "status": new_status,
-                    "metadata_json": new_metadata_json,
-                    "updated_at": now,
-                    "completed_at": completed_at,
-                    "version": int(old["version"]) + 1,
-                    "canonical_revision": int(old["canonical_revision"]) + 1,
-                }
-            )
-
-            update_cursor = self._execute(
-                transaction_conn,
-                """
-                UPDATE note_tasks
-                   SET text = ?,
-                       status = ?,
-                       metadata_json = ?,
-                       updated_at = ?,
-                       completed_at = ?,
-                       version = version + 1,
-                       canonical_revision = ?, canonical_hash = ?,
-                       source_diagnostic_code = ?, source_diagnostic_hash = ?
-                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ? AND version = ?
-                """,
-                (
-                    new_text,
-                    new_status,
-                    new_metadata_json,
-                    now,
-                    completed_at,
-                    canonical_revision,
-                    canonical_hash,
-                    diagnostic_code,
-                    diagnostic_hash,
-                    owner,
-                    dataset,
-                    task_id,
-                    expected_version,
-                ),
-            )
+            if self._uses_postgres_v59_schema:
+                update_cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE note_tasks
+                       SET text = ?, status = ?, metadata_json = ?, updated_at = ?,
+                           completed_at = ?, version = version + 1
+                     WHERE client_id = ? AND id = ? AND version = ?
+                    """,
+                    (
+                        new_text,
+                        new_status,
+                        new_metadata_json,
+                        now,
+                        completed_at,
+                        owner,
+                        task_id,
+                        expected_version,
+                    ),
+                )
+            else:
+                canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+                    {
+                        **old,
+                        "text": new_text,
+                        "status": new_status,
+                        "metadata_json": new_metadata_json,
+                        "updated_at": now,
+                        "completed_at": completed_at,
+                        "version": int(old["version"]) + 1,
+                        "canonical_revision": int(old["canonical_revision"]) + 1,
+                    }
+                )
+                update_cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE note_tasks
+                       SET text = ?, status = ?, metadata_json = ?, updated_at = ?,
+                           completed_at = ?, version = version + 1,
+                           canonical_revision = ?, canonical_hash = ?,
+                           source_diagnostic_code = ?, source_diagnostic_hash = ?
+                     WHERE owner_user_id = ? AND dataset_id = ? AND id = ? AND version = ?
+                    """,
+                    (
+                        new_text, new_status, new_metadata_json, now, completed_at,
+                        canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash,
+                        owner, dataset, task_id, expected_version,
+                    ),
+                )
             if getattr(update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task version mismatch for ID '{task_id}'. Expected {expected_version}.",
@@ -1006,78 +1049,87 @@ class TaskStore:
                     entity="tasks",
                     entity_id=task_id,
                 )  # noqa: TRY003
-            update_cursor = self._execute(
-                transaction_conn,
-                """
-                UPDATE note_tasks
-                   SET projection_status = ?,
-                       updated_at = ?,
-                       version = CASE
-                           WHEN projection_status != ? THEN version + 1
-                           ELSE version
-                       END
-                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
-                   AND note_id = ? AND deleted = ? AND projection_status = ?
-                """,
-                (
-                    normalized_projection_status,
-                    now,
-                    normalized_projection_status,
-                    owner,
-                    dataset,
-                    task_id,
-                    note_id,
-                    self._deleted_value(False),
-                    projection_state,
-                ),
-            )
+            if self._uses_postgres_v59_schema:
+                update_cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE note_tasks
+                       SET projection_status = ?, updated_at = ?,
+                           version = CASE WHEN projection_status != ? THEN version + 1 ELSE version END
+                     WHERE client_id = ? AND id = ? AND note_id = ?
+                       AND deleted = ? AND projection_status = ?
+                    """,
+                    (
+                        normalized_projection_status, now, normalized_projection_status,
+                        owner, task_id, note_id, self._deleted_value(False), projection_state,
+                    ),
+                )
+            else:
+                update_cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE note_tasks
+                       SET projection_status = ?, updated_at = ?,
+                           version = CASE WHEN projection_status != ? THEN version + 1 ELSE version END
+                     WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                       AND note_id = ? AND deleted = ? AND projection_status = ?
+                    """,
+                    (
+                        normalized_projection_status, now, normalized_projection_status,
+                        owner, dataset, task_id, note_id, self._deleted_value(False), projection_state,
+                    ),
+                )
             if getattr(update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task projection changed concurrently for task '{task_id}'.",
                     entity="tasks",
                     entity_id=task_id,
                 )  # noqa: TRY003
-            self._execute(
-                transaction_conn,
-                """
-                INSERT INTO task_note_projections (
-                    owner_user_id, dataset_id, task_id, note_id, note_version, line_number, start_offset, end_offset,
-                    normalized_text_hash, occurrence_index, block_fingerprint, raw_line,
-                    has_child_content, projection_status, updated_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(owner_user_id, dataset_id, task_id) DO UPDATE SET
-                    note_id = excluded.note_id,
-                    note_version = excluded.note_version,
-                    line_number = excluded.line_number,
-                    start_offset = excluded.start_offset,
-                    end_offset = excluded.end_offset,
-                    normalized_text_hash = excluded.normalized_text_hash,
-                    occurrence_index = excluded.occurrence_index,
-                    block_fingerprint = excluded.block_fingerprint,
-                    raw_line = excluded.raw_line,
-                    has_child_content = excluded.has_child_content,
-                    projection_status = excluded.projection_status,
-                    updated_at = excluded.updated_at
-                """,
-                (
-                    owner,
-                    dataset,
-                    task_id,
-                    note_id,
-                    int(note_version),
-                    int(line_number),
-                    int(start_offset),
-                    int(end_offset),
-                    normalized_text_hash,
-                    int(occurrence_index),
-                    block_fingerprint,
-                    raw_line,
-                    self._deleted_value(bool(has_child_content)),
-                    normalized_projection_status,
-                    now,
-                ),
+            projection_values = (
+                task_id, note_id, int(note_version), int(line_number), int(start_offset), int(end_offset),
+                normalized_text_hash, int(occurrence_index), block_fingerprint, raw_line,
+                self._deleted_value(bool(has_child_content)), normalized_projection_status, now,
             )
+            if self._uses_postgres_v59_schema:
+                self._execute(
+                    transaction_conn,
+                    """
+                    INSERT INTO task_note_projections (
+                        task_id, note_id, note_version, line_number, start_offset, end_offset,
+                        normalized_text_hash, occurrence_index, block_fingerprint, raw_line,
+                        has_child_content, projection_status, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(task_id) DO UPDATE SET
+                        note_id = excluded.note_id, note_version = excluded.note_version,
+                        line_number = excluded.line_number, start_offset = excluded.start_offset,
+                        end_offset = excluded.end_offset, normalized_text_hash = excluded.normalized_text_hash,
+                        occurrence_index = excluded.occurrence_index,
+                        block_fingerprint = excluded.block_fingerprint, raw_line = excluded.raw_line,
+                        has_child_content = excluded.has_child_content,
+                        projection_status = excluded.projection_status, updated_at = excluded.updated_at
+                    """,
+                    projection_values,
+                )
+            else:
+                self._execute(
+                    transaction_conn,
+                    """
+                    INSERT INTO task_note_projections (
+                        owner_user_id, dataset_id, task_id, note_id, note_version, line_number,
+                        start_offset, end_offset, normalized_text_hash, occurrence_index,
+                        block_fingerprint, raw_line, has_child_content, projection_status, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(owner_user_id, dataset_id, task_id) DO UPDATE SET
+                        note_id = excluded.note_id, note_version = excluded.note_version,
+                        line_number = excluded.line_number, start_offset = excluded.start_offset,
+                        end_offset = excluded.end_offset, normalized_text_hash = excluded.normalized_text_hash,
+                        occurrence_index = excluded.occurrence_index,
+                        block_fingerprint = excluded.block_fingerprint, raw_line = excluded.raw_line,
+                        has_child_content = excluded.has_child_content,
+                        projection_status = excluded.projection_status, updated_at = excluded.updated_at
+                    """,
+                    (owner, dataset, *projection_values),
+                )
             projection = self._fetch_projection(
                 task_id, owner_user_id=owner, dataset_id=dataset, conn=transaction_conn
             )
@@ -1130,54 +1182,67 @@ class TaskStore:
                 )  # noqa: TRY003
             self._require_live_projection_row(task_id, projection)
             now = self._db._get_current_utc_timestamp_iso()
-            update_cursor = self._execute(
-                transaction_conn,
-                """
-                UPDATE note_tasks
-                   SET projection_status = ?,
-                       updated_at = ?,
-                       version = version + 1
-                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
-                   AND version = ? AND projection_status = ?
-                """,
-                ("unlinked", now, owner, dataset, task_id, expected_version, projection_state),
-            )
+            if self._uses_postgres_v59_schema:
+                update_cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE note_tasks
+                       SET projection_status = ?, updated_at = ?, version = version + 1
+                     WHERE client_id = ? AND id = ? AND version = ? AND projection_status = ?
+                    """,
+                    ("unlinked", now, owner, task_id, expected_version, projection_state),
+                )
+            else:
+                update_cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE note_tasks
+                       SET projection_status = ?, updated_at = ?, version = version + 1
+                     WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                       AND version = ? AND projection_status = ?
+                    """,
+                    ("unlinked", now, owner, dataset, task_id, expected_version, projection_state),
+                )
             if getattr(update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task version mismatch for ID '{task_id}'. Expected {expected_version}.",
                     entity="tasks",
                     entity_id=task_id,
                 )  # noqa: TRY003
-            projection_update_cursor = self._execute(
-                transaction_conn,
-                """
-                UPDATE task_note_projections
-                   SET projection_status = ?,
-                       updated_at = ?
-                 WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?
-                   AND projection_status = ?
-                   AND note_id = ?
-                   AND note_version = ?
-                   AND line_number = ?
-                   AND normalized_text_hash = ?
-                   AND occurrence_index = ?
-                   AND block_fingerprint = ?
-                """,
-                (
-                    "unlinked",
-                    now,
-                    owner,
-                    dataset,
-                    task_id,
-                    projection_state,
-                    projection["note_id"],
-                    projection["note_version"],
-                    projection["line_number"],
-                    projection["normalized_text_hash"],
-                    projection["occurrence_index"],
-                    projection["block_fingerprint"],
-                ),
+            projection_locator = (
+                projection_state, projection["note_id"], projection["note_version"],
+                projection["line_number"], projection["normalized_text_hash"],
+                projection["occurrence_index"], projection["block_fingerprint"],
             )
+            if self._uses_postgres_v59_schema:
+                projection_update_cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE task_note_projections
+                       SET projection_status = ?, updated_at = ?
+                     WHERE task_id = ? AND projection_status = ? AND note_id = ?
+                       AND note_version = ? AND line_number = ? AND normalized_text_hash = ?
+                       AND occurrence_index = ? AND block_fingerprint = ?
+                       AND EXISTS (
+                           SELECT 1 FROM note_tasks task
+                            WHERE task.id = task_note_projections.task_id AND task.client_id = ?
+                       )
+                    """,
+                    ("unlinked", now, task_id, *projection_locator, owner),
+                )
+            else:
+                projection_update_cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE task_note_projections
+                       SET projection_status = ?, updated_at = ?
+                     WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?
+                       AND projection_status = ? AND note_id = ? AND note_version = ?
+                       AND line_number = ? AND normalized_text_hash = ?
+                       AND occurrence_index = ? AND block_fingerprint = ?
+                    """,
+                    ("unlinked", now, owner, dataset, task_id, *projection_locator),
+                )
             if getattr(projection_update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task projection changed concurrently for task '{task_id}'.",
@@ -1278,92 +1343,89 @@ class TaskStore:
                         "Task projection deletion is ambiguous without a matching projection locator."
                     )  # noqa: TRY003
             now = self._db._get_current_utc_timestamp_iso()
-            canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
-                {
-                    **old,
-                    "deleted": 1,
-                    "projection_status": "deleted",
-                    "updated_at": now,
-                    "version": int(old["version"]) + 1,
-                    "canonical_revision": int(old["canonical_revision"]) + 1,
-                }
-            )
-            update_cursor = self._execute(
-                transaction_conn,
-                """
-                UPDATE note_tasks
-                   SET deleted = ?,
-                       projection_status = ?,
-                       updated_at = ?,
-                       version = version + 1,
-                       canonical_revision = ?, canonical_hash = ?,
-                       source_diagnostic_code = ?, source_diagnostic_hash = ?
-                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
-                   AND version = ? AND deleted = ? AND projection_status = ?
-                """,
-                (
-                    self._deleted_value(True),
-                    "deleted",
-                    now,
-                    canonical_revision,
-                    canonical_hash,
-                    diagnostic_code,
-                    diagnostic_hash,
-                    owner,
-                    dataset,
-                    task_id,
-                    expected_version,
-                    self._deleted_value(False),
-                    projection_status,
-                ),
-            )
+            if self._uses_postgres_v59_schema:
+                update_cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE note_tasks
+                       SET deleted = ?, projection_status = ?, updated_at = ?, version = version + 1
+                     WHERE client_id = ? AND id = ? AND version = ?
+                       AND deleted = ? AND projection_status = ?
+                    """,
+                    (
+                        self._deleted_value(True), "deleted", now, owner, task_id,
+                        expected_version, self._deleted_value(False), projection_status,
+                    ),
+                )
+            else:
+                canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+                    {
+                        **old,
+                        "deleted": 1,
+                        "projection_status": "deleted",
+                        "updated_at": now,
+                        "version": int(old["version"]) + 1,
+                        "canonical_revision": int(old["canonical_revision"]) + 1,
+                    }
+                )
+                update_cursor = self._execute(
+                    transaction_conn,
+                    """
+                    UPDATE note_tasks
+                       SET deleted = ?, projection_status = ?, updated_at = ?, version = version + 1,
+                           canonical_revision = ?, canonical_hash = ?,
+                           source_diagnostic_code = ?, source_diagnostic_hash = ?
+                     WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                       AND version = ? AND deleted = ? AND projection_status = ?
+                    """,
+                    (
+                        self._deleted_value(True), "deleted", now, canonical_revision,
+                        canonical_hash, diagnostic_code, diagnostic_hash, owner, dataset,
+                        task_id, expected_version, self._deleted_value(False), projection_status,
+                    ),
+                )
             if getattr(update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task version mismatch for ID '{task_id}'. Expected {expected_version}.",
                     entity="tasks",
                     entity_id=task_id,
                 )  # noqa: TRY003
+            locator = ()
             if projection_status == "live" and not allow_record_only:
+                locator = (
+                    projection_status, projection["note_id"], projection["note_version"],
+                    projection["line_number"], projection["normalized_text_hash"],
+                    projection["occurrence_index"], projection["block_fingerprint"],
+                )
+            if self._uses_postgres_v59_schema:
+                locator_sql = ""
+                if locator:
+                    locator_sql = (
+                        " AND projection_status = ? AND note_id = ? AND note_version = ?"
+                        " AND line_number = ? AND normalized_text_hash = ?"
+                        " AND occurrence_index = ? AND block_fingerprint = ?"
+                    )
                 projection_update_cursor = self._execute(
                     transaction_conn,
-                    """
-                    UPDATE task_note_projections
-                       SET projection_status = ?,
-                           updated_at = ?
-                     WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?
-                       AND projection_status = ?
-                       AND note_id = ?
-                       AND note_version = ?
-                       AND line_number = ?
-                       AND normalized_text_hash = ?
-                       AND occurrence_index = ?
-                       AND block_fingerprint = ?
-                    """,
-                    (
-                        "deleted",
-                        now,
-                        owner,
-                        dataset,
-                        task_id,
-                        projection_status,
-                        projection["note_id"],
-                        projection["note_version"],
-                        projection["line_number"],
-                        projection["normalized_text_hash"],
-                        projection["occurrence_index"],
-                        projection["block_fingerprint"],
-                    ),
+                    "UPDATE task_note_projections SET projection_status = ?, updated_at = ? "  # nosec B608
+                    "WHERE task_id = ?" + locator_sql +
+                    " AND EXISTS (SELECT 1 FROM note_tasks task "  # nosec B608
+                    "WHERE task.id = task_note_projections.task_id AND task.client_id = ?)",
+                    ("deleted", now, task_id, *locator, owner),
                 )
             else:
+                locator_sql = ""
+                if locator:
+                    locator_sql = (
+                        " AND projection_status = ? AND note_id = ? AND note_version = ?"
+                        " AND line_number = ? AND normalized_text_hash = ?"
+                        " AND occurrence_index = ? AND block_fingerprint = ?"
+                    )
                 projection_update_cursor = self._execute(
                     transaction_conn,
-                    """
-                    UPDATE task_note_projections
-                       SET projection_status = ?,
-                           updated_at = ?
-                     WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?
-                    """,
-                    ("deleted", now, owner, dataset, task_id),
+                    "UPDATE task_note_projections SET projection_status = ?, updated_at = ? "  # nosec B608
+                    "WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?" + locator_sql,
+                    ("deleted", now, owner, dataset, task_id, *locator),
                 )
             if projection_status == "live" and not allow_record_only:
                 if getattr(projection_update_cursor, "rowcount", None) == 0:
@@ -1406,10 +1468,10 @@ class TaskStore:
         *,
         owner_user_id: str,
         dataset_id: str,
-        event_type: str,
-        actor_type: str,
         task_id: str | None = None,
         note_id: str | None = None,
+        event_type: str,
+        actor_type: str,
         actor_id: str | None = None,
         tool_name: str | None = None,
         policy_mode: str | None = None,
@@ -1420,12 +1482,15 @@ class TaskStore:
         conn: TaskConnection | None = None,
     ) -> dict[str, Any]:
         """Append a task activity/audit event."""
+        if not isinstance(note_id, str) or not note_id.strip():
+            raise InputError("Task event note_id is required.")  # noqa: TRY003
+        note_id = note_id.strip()
         final_event_id = event_id or self._db._generate_uuid()
         now = self._db._get_current_utc_timestamp_iso()
         old_value_json = self._json_dumps(old_value, "old_value") if old_value is not None else None
         new_value_json = self._json_dumps(new_value, "new_value") if new_value is not None else None
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        event_hash = self._db._note_task_v60_hash(
+        event_hash = None if self._uses_postgres_v59_schema else self._db._note_task_v60_hash(
             {
                 "owner_user_id": owner,
                 "dataset_id": dataset,
@@ -1446,6 +1511,49 @@ class TaskStore:
         )
 
         def _execute_event(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_active_note(
+                note_id, final_event_id, owner_user_id=owner, conn=transaction_conn
+            )
+            if task_id is not None:
+                task = self._fetch_task(
+                    task_id,
+                    owner_user_id=owner,
+                    dataset_id=dataset,
+                    include_deleted=True,
+                    conn=transaction_conn,
+                )
+                if task is None:
+                    raise ConflictError("Task event task not found.", entity="tasks", entity_id=task_id)  # noqa: TRY003
+                if str(task["note_id"]) != note_id:
+                    raise ConflictError(
+                        "Task event note does not match the task's owning note.",
+                        entity="tasks",
+                        entity_id=task_id,
+                    )  # noqa: TRY003
+            if self._uses_postgres_v59_schema:
+                self._execute(
+                    transaction_conn,
+                    """
+                    INSERT INTO task_events (
+                        id, task_id, note_id, event_type, actor_type, actor_id, tool_name,
+                        policy_mode, approval_id, old_value_json, new_value_json, created_at, client_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        final_event_id, task_id, note_id, event_type, actor_type, actor_id,
+                        tool_name, policy_mode, approval_id, old_value_json, new_value_json,
+                        now, owner,
+                    ),
+                )
+                cursor = self._read(
+                    "SELECT * FROM task_events WHERE client_id = ? AND id = ?",
+                    (owner, final_event_id),
+                    conn=transaction_conn,
+                )
+                event = self._decode_event_row(cursor.fetchone())
+                if event is None:
+                    raise CharactersRAGDBError(f"Failed to read task event '{final_event_id}'.")  # noqa: TRY003
+                return event
             self._execute(
                 transaction_conn,
                 """
@@ -1527,8 +1635,12 @@ class TaskStore:
     ) -> list[dict[str, Any]]:
         """List task events by task or note scope."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        clauses: list[str] = ["owner_user_id = ?", "dataset_id = ?"]
-        params: list[Any] = [owner, dataset]
+        if self._uses_postgres_v59_schema:
+            clauses: list[str] = ["client_id = ?"]
+            params: list[Any] = [owner]
+        else:
+            clauses = ["owner_user_id = ?", "dataset_id = ?"]
+            params = [owner, dataset]
         if task_id is not None:
             clauses.append("task_id = ?")
             params.append(task_id)
@@ -1558,8 +1670,12 @@ class TaskStore:
     ) -> list[dict[str, Any]]:
         """List task events newest-first without changing the ascending default helper."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        clauses: list[str] = ["owner_user_id = ?", "dataset_id = ?"]
-        params: list[Any] = [owner, dataset]
+        if self._uses_postgres_v59_schema:
+            clauses: list[str] = ["client_id = ?"]
+            params: list[Any] = [owner]
+        else:
+            clauses = ["owner_user_id = ?", "dataset_id = ?"]
+            params = [owner, dataset]
         if task_id is not None:
             clauses.append("task_id = ?")
             params.append(task_id)
@@ -1595,34 +1711,50 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
         if user_id != owner:
             return []
-        query = """
-            SELECT events.*
-            FROM task_events AS events
-            LEFT JOIN task_event_read_state AS state
-              ON state.owner_user_id = events.owner_user_id
-             AND state.dataset_id = events.dataset_id
-             AND state.event_id = events.id AND state.user_id = ?
-            WHERE events.owner_user_id = ? AND events.dataset_id = ?
-              AND (state.event_id IS NULL OR (state.read_at IS NULL AND state.dismissed_at IS NULL))
-              AND (? IS NULL OR events.task_id = ?)
-              AND (? IS NULL OR events.note_id = ?)
-              AND (? IS NULL OR events.actor_type = ?)
-        """
+        if self._uses_postgres_v59_schema:
+            query = """
+                SELECT events.*
+                FROM task_events AS events
+                LEFT JOIN task_event_read_state AS state
+                  ON state.event_id = events.id AND state.user_id = ?
+                WHERE events.client_id = ?
+                  AND (state.event_id IS NULL OR (state.read_at IS NULL AND state.dismissed_at IS NULL))
+                  AND (? IS NULL OR events.task_id = ?)
+                  AND (? IS NULL OR events.note_id = ?)
+                  AND (? IS NULL OR events.actor_type = ?)
+            """
+        else:
+            query = """
+                SELECT events.*
+                FROM task_events AS events
+                LEFT JOIN task_event_read_state AS state
+                  ON state.owner_user_id = events.owner_user_id
+                 AND state.dataset_id = events.dataset_id
+                 AND state.event_id = events.id AND state.user_id = ?
+                WHERE events.owner_user_id = ? AND events.dataset_id = ?
+                  AND (state.event_id IS NULL OR (state.read_at IS NULL AND state.dismissed_at IS NULL))
+                  AND (? IS NULL OR events.task_id = ?)
+                  AND (? IS NULL OR events.note_id = ?)
+                  AND (? IS NULL OR events.actor_type = ?)
+            """
         if self._db.backend_type == BackendType.SQLITE:
             query += " ORDER BY events.created_at DESC, events.rowid DESC LIMIT ?"
         else:
             query += " ORDER BY events.created_at DESC, events.id DESC LIMIT ?"
-        params: list[Any] = [user_id, owner, dataset, task_id, task_id, note_id, note_id, actor_type, actor_type]
+        if self._uses_postgres_v59_schema:
+            params: list[Any] = [user_id, owner, task_id, task_id, note_id, note_id, actor_type, actor_type]
+        else:
+            params = [user_id, owner, dataset, task_id, task_id, note_id, note_id, actor_type, actor_type]
         params.append(self._clamp_limit(limit))
         cursor = self._read(query, tuple(params))
         return [self._decode_event_row(row) for row in cursor.fetchall()]
 
     def mark_task_activity_read(
         self,
-        event_id: str,
         *,
         owner_user_id: str,
         dataset_id: str,
+        event_id: str,
         user_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any]:
@@ -1633,6 +1765,34 @@ class TaskStore:
             raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
 
         def _execute_read(transaction_conn: TaskConnection) -> dict[str, Any]:
+            if self._uses_postgres_v59_schema:
+                event = self._read(
+                    "SELECT id FROM task_events WHERE client_id = ? AND id = ?",
+                    (owner, event_id),
+                    conn=transaction_conn,
+                ).fetchone()
+                if event is None:
+                    raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
+                self._execute(
+                    transaction_conn,
+                    """
+                    INSERT INTO task_event_read_state (event_id, user_id, read_at, dismissed_at)
+                    VALUES (?, ?, ?, NULL)
+                    ON CONFLICT(event_id, user_id) DO UPDATE SET
+                        read_at = COALESCE(task_event_read_state.read_at, excluded.read_at)
+                    """,
+                    (event_id, user_id, now),
+                )
+                state = self.get_task_activity_read_state(
+                    owner_user_id=owner,
+                    dataset_id=dataset,
+                    event_id=event_id,
+                    user_id=user_id,
+                    conn=transaction_conn,
+                )
+                if state is None:
+                    raise CharactersRAGDBError(f"Failed to read task event read state for '{event_id}'.")  # noqa: TRY003
+                return state
             self._execute(
                 transaction_conn,
                 """
@@ -1645,7 +1805,7 @@ class TaskStore:
                 (owner, dataset, event_id, user_id, now),
             )
             state = self.get_task_activity_read_state(
-                event_id, user_id=user_id, owner_user_id=owner, dataset_id=dataset,
+                owner_user_id=owner, dataset_id=dataset, event_id=event_id, user_id=user_id,
                 conn=transaction_conn,
             )
             if state is None:
@@ -1671,10 +1831,10 @@ class TaskStore:
 
     def mark_task_activity_dismissed(
         self,
-        event_id: str,
         *,
         owner_user_id: str,
         dataset_id: str,
+        event_id: str,
         user_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any]:
@@ -1685,6 +1845,35 @@ class TaskStore:
             raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
 
         def _execute_dismiss(transaction_conn: TaskConnection) -> dict[str, Any]:
+            if self._uses_postgres_v59_schema:
+                event = self._read(
+                    "SELECT id FROM task_events WHERE client_id = ? AND id = ?",
+                    (owner, event_id),
+                    conn=transaction_conn,
+                ).fetchone()
+                if event is None:
+                    raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
+                self._execute(
+                    transaction_conn,
+                    """
+                    INSERT INTO task_event_read_state (event_id, user_id, read_at, dismissed_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(event_id, user_id) DO UPDATE SET
+                        read_at = COALESCE(task_event_read_state.read_at, excluded.read_at),
+                        dismissed_at = excluded.dismissed_at
+                    """,
+                    (event_id, user_id, now, now),
+                )
+                state = self.get_task_activity_read_state(
+                    owner_user_id=owner,
+                    dataset_id=dataset,
+                    event_id=event_id,
+                    user_id=user_id,
+                    conn=transaction_conn,
+                )
+                if state is None:
+                    raise CharactersRAGDBError(f"Failed to read task event read state for '{event_id}'.")  # noqa: TRY003
+                return state
             self._execute(
                 transaction_conn,
                 """
@@ -1698,7 +1887,7 @@ class TaskStore:
                 (owner, dataset, event_id, user_id, now, now),
             )
             state = self.get_task_activity_read_state(
-                event_id, user_id=user_id, owner_user_id=owner, dataset_id=dataset,
+                owner_user_id=owner, dataset_id=dataset, event_id=event_id, user_id=user_id,
                 conn=transaction_conn,
             )
             if state is None:
@@ -1724,10 +1913,10 @@ class TaskStore:
 
     def get_task_activity_read_state(
         self,
-        event_id: str,
         *,
         owner_user_id: str,
         dataset_id: str,
+        event_id: str,
         user_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
@@ -1735,32 +1924,57 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
         if user_id != owner:
             return None
-        cursor = self._read(
-            """
-            SELECT * FROM task_event_read_state
-             WHERE owner_user_id = ? AND dataset_id = ? AND event_id = ? AND user_id = ?
-            """,
-            (owner, dataset, event_id, user_id),
-            conn=conn,
-        )
+        if self._uses_postgres_v59_schema:
+            cursor = self._read(
+                """
+                SELECT state.*
+                  FROM task_event_read_state state
+                  JOIN task_events event ON event.id = state.event_id
+                 WHERE event.client_id = ? AND state.event_id = ? AND state.user_id = ?
+                """,
+                (owner, event_id, user_id),
+                conn=conn,
+            )
+        else:
+            cursor = self._read(
+                """
+                SELECT * FROM task_event_read_state
+                 WHERE owner_user_id = ? AND dataset_id = ? AND event_id = ? AND user_id = ?
+                """,
+                (owner, dataset, event_id, user_id),
+                conn=conn,
+            )
         row = cursor.fetchone()
         return dict(row) if row else None
 
     def get_reconciliation_state(
         self,
-        note_id: str,
         *,
         owner_user_id: str,
         dataset_id: str,
+        note_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
         """Return the last task reconciliation state for a note."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        cursor = self._read(
-            "SELECT * FROM note_task_reconciliation_state WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
-            (owner, dataset, note_id),
-            conn=conn,
-        )
+        if self._uses_postgres_v59_schema:
+            cursor = self._read(
+                """
+                SELECT state.*
+                  FROM note_task_reconciliation_state state
+                  JOIN notes note ON note.id = state.note_id
+                 WHERE note.client_id = ? AND state.note_id = ?
+                """,
+                (owner, note_id),
+                conn=conn,
+            )
+        else:
+            cursor = self._read(
+                "SELECT * FROM note_task_reconciliation_state "
+                "WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
+                (owner, dataset, note_id),
+                conn=conn,
+            )
         row = cursor.fetchone()
         return dict(row) if row else None
 
@@ -1782,37 +1996,71 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_state(transaction_conn: TaskConnection) -> dict[str, Any]:
-            self._execute(
-                transaction_conn,
-                """
-                INSERT INTO note_task_reconciliation_state (
-                    owner_user_id, dataset_id, note_id, note_version, status,
-                    reconciled_at, item_count, warning_count, cursor
+            if self._uses_postgres_v59_schema:
+                note = self._read(
+                    "SELECT id FROM notes WHERE client_id = ? AND id = ?",
+                    (owner, note_id),
+                    conn=transaction_conn,
+                ).fetchone()
+                if note is None:
+                    raise ConflictError("Task note not found.", entity="tasks", entity_id=note_id)  # noqa: TRY003
+                self._execute(
+                    transaction_conn,
+                    """
+                    INSERT INTO note_task_reconciliation_state (
+                        note_id, note_version, status, reconciled_at,
+                        item_count, warning_count, cursor
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(note_id) DO UPDATE SET
+                        note_version = excluded.note_version,
+                        status = excluded.status,
+                        reconciled_at = excluded.reconciled_at,
+                        item_count = excluded.item_count,
+                        warning_count = excluded.warning_count,
+                        cursor = excluded.cursor
+                    """,
+                    (
+                        note_id,
+                        int(note_version),
+                        status,
+                        now,
+                        int(item_count),
+                        int(warning_count),
+                        cursor,
+                    ),
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(owner_user_id, dataset_id, note_id) DO UPDATE SET
-                    note_version = excluded.note_version,
-                    status = excluded.status,
-                    reconciled_at = excluded.reconciled_at,
-                    item_count = excluded.item_count,
-                    warning_count = excluded.warning_count,
-                    cursor = excluded.cursor
-                """,
-                (
-                    owner,
-                    dataset,
-                    note_id,
-                    int(note_version),
-                    status,
-                    now,
-                    int(item_count),
-                    int(warning_count),
-                    cursor,
-                ),
-            )
+            else:
+                self._execute(
+                    transaction_conn,
+                    """
+                    INSERT INTO note_task_reconciliation_state (
+                        owner_user_id, dataset_id, note_id, note_version, status,
+                        reconciled_at, item_count, warning_count, cursor
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(owner_user_id, dataset_id, note_id) DO UPDATE SET
+                        note_version = excluded.note_version,
+                        status = excluded.status,
+                        reconciled_at = excluded.reconciled_at,
+                        item_count = excluded.item_count,
+                        warning_count = excluded.warning_count,
+                        cursor = excluded.cursor
+                    """,
+                    (
+                        owner,
+                        dataset,
+                        note_id,
+                        int(note_version),
+                        status,
+                        now,
+                        int(item_count),
+                        int(warning_count),
+                        cursor,
+                    ),
+                )
             state = (
                 self.get_reconciliation_state(
-                    note_id, owner_user_id=owner, dataset_id=dataset
+                    owner_user_id=owner, dataset_id=dataset, note_id=note_id
                 )
                 if conn is None
                 else self._get_reconciliation_state_in_conn(
@@ -1848,11 +2096,24 @@ class TaskStore:
         dataset_id: str,
         conn: TaskConnection,
     ) -> dict[str, Any] | None:
-        cursor = self._read(
-            "SELECT * FROM note_task_reconciliation_state WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
-            (owner_user_id, dataset_id, note_id),
-            conn=conn,
-        )
+        if self._uses_postgres_v59_schema:
+            cursor = self._read(
+                """
+                SELECT state.*
+                  FROM note_task_reconciliation_state state
+                  JOIN notes note ON note.id = state.note_id
+                 WHERE note.client_id = ? AND state.note_id = ?
+                """,
+                (owner_user_id, note_id),
+                conn=conn,
+            )
+        else:
+            cursor = self._read(
+                "SELECT * FROM note_task_reconciliation_state "
+                "WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
+                (owner_user_id, dataset_id, note_id),
+                conn=conn,
+            )
         row = cursor.fetchone()
         return dict(row) if row else None
 
@@ -1865,6 +2126,28 @@ class TaskStore:
     ) -> list[dict[str, Any]]:
         """Return checklist-bearing notes whose task reconciliation is stale or missing."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
+        if self._uses_postgres_v59_schema:
+            cursor = self._read(
+                """
+                SELECT n.id, n.title, n.version, n.last_modified
+                  FROM notes n
+                  LEFT JOIN note_task_reconciliation_state r ON r.note_id = n.id
+                 WHERE n.client_id = ? AND n.deleted = ?
+                   AND (n.content LIKE ? OR n.content LIKE ? OR n.content LIKE ?)
+                   AND (n.content LIKE ? OR n.content LIKE ? OR n.content LIKE ?)
+                   AND (r.note_id IS NULL OR r.note_version < n.version)
+                 ORDER BY n.last_modified DESC, n.id ASC
+                 LIMIT ?
+                """,
+                (
+                    owner,
+                    self._deleted_value(False),
+                    *self._CHECKLIST_DISCOVERY_MARKER_PATTERNS,
+                    *self._CHECKLIST_DISCOVERY_BULLET_PATTERNS,
+                    self._clamp_limit(limit),
+                ),
+            )
+            return [dict(row) for row in cursor.fetchall()]
         cursor = self._read(
             """
             SELECT n.id, n.title, n.version, n.last_modified
@@ -1909,6 +2192,28 @@ class TaskStore:
     ) -> int:
         """Count checklist-bearing notes whose task reconciliation is stale or missing."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
+        if self._uses_postgres_v59_schema:
+            params: list[Any] = [
+                owner,
+                self._deleted_value(False),
+                *self._CHECKLIST_DISCOVERY_MARKER_PATTERNS,
+                *self._CHECKLIST_DISCOVERY_BULLET_PATTERNS,
+            ]
+            sql_query = """
+                SELECT COUNT(*) AS stale_count
+                  FROM notes n
+                  LEFT JOIN note_task_reconciliation_state r ON r.note_id = n.id
+                 WHERE n.client_id = ? AND n.deleted = ?
+                   AND (n.content LIKE ? OR n.content LIKE ? OR n.content LIKE ?)
+                   AND (n.content LIKE ? OR n.content LIKE ? OR n.content LIKE ?)
+                   AND (r.note_id IS NULL OR r.note_version < n.version)
+            """
+            if note_id is not None:
+                sql_query += " AND n.id = ?"
+                params.append(note_id)
+            cursor = self._read(sql_query, tuple(params))
+            row = cursor.fetchone()
+            return int(row["stale_count"] if row else 0)
         params: list[Any] = [
             dataset,
             owner,

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -36,6 +36,14 @@ class TaskStore:
     _MIN_LIMIT = 1
     _MAX_LIMIT = 500
     _LOCAL_UNBOUND = "local-unbound"
+    _BIND_TABLE_ORDER = (
+        ("note_tasks", "id"),
+        ("task_note_projections", "task_id"),
+        ("task_events", "id"),
+        ("task_event_read_state", "event_id,user_id"),
+        ("note_task_reconciliation_state", "note_id"),
+        ("task_projection_drifts", "id"),
+    )
 
     def __init__(self, db: CharactersRAGDB) -> None:
         self._db = db
@@ -1831,39 +1839,189 @@ class TaskStore:
         target = str(target_dataset_id).strip()
         if not owner or not target or target == self._LOCAL_UNBOUND:
             raise InputError("A non-sentinel owner and target dataset are required.")  # noqa: TRY003
-        if self._db.backend_type != BackendType.SQLITE:
-            raise InputError("Local task graph binding is only supported by SQLite storage.")  # noqa: TRY003
+        postgres = self._db.backend_type == BackendType.POSTGRESQL
+        if postgres and owner != str(self._db.client_id):
+            raise ConflictError(
+                "Task owner does not match the authenticated PostgreSQL client.",
+                entity="tasks",
+                entity_id=owner,
+            )  # noqa: TRY003
 
-        tables = (
-            "note_tasks",
-            "task_note_projections",
-            "task_events",
-            "task_event_read_state",
-            "note_task_reconciliation_state",
-            "task_projection_drifts",
-        )
-
-        def _counts(transaction_conn: TaskConnection, dataset: str) -> dict[str, int]:
-            result: dict[str, int] = {}
-            for table in tables:
-                row = self._read(
-                    f"SELECT COUNT(*) AS count FROM {table} "  # nosec B608
-                    "WHERE owner_user_id = ? AND dataset_id = ?",
+        def _snapshot(
+            transaction_conn: TaskConnection,
+            dataset: str,
+        ) -> dict[str, tuple[int, str]]:
+            snapshot: dict[str, tuple[int, str]] = {}
+            for table, ordering in self._BIND_TABLE_ORDER:
+                lock_clause = " FOR UPDATE" if postgres else ""
+                rows = self._read(
+                    f"SELECT * FROM {table} WHERE owner_user_id = ? AND dataset_id = ? "  # nosec B608
+                    f"ORDER BY {ordering}{lock_clause}",  # nosec B608
                     (owner, dataset),
                     conn=transaction_conn,
-                ).fetchone()
-                result[table] = int(row["count"])
-            return result
+                ).fetchall()
+                canonical_rows = [
+                    {
+                        key: value
+                        for key, value in dict(row).items()
+                        if key != "dataset_id"
+                    }
+                    for row in rows
+                ]
+                snapshot[table] = (
+                    len(canonical_rows),
+                    self._db._note_task_v60_hash(
+                        self._db._note_task_v60_json_safe(canonical_rows)
+                    ),
+                )
+            return snapshot
+
+        def _counts(snapshot: dict[str, tuple[int, str]]) -> dict[str, int]:
+            return {table: count for table, (count, _hash) in snapshot.items()}
+
+        def _prove_parents(transaction_conn: TaskConnection) -> None:
+            invalid = self._read(
+                """
+                SELECT 1 FROM (
+                  SELECT t.id
+                    FROM note_tasks t
+                   WHERE t.owner_user_id = ? AND t.dataset_id = ?
+                     AND NOT EXISTS(
+                       SELECT 1 FROM notes n
+                        WHERE n.client_id = t.owner_user_id AND n.id = t.note_id
+                     )
+                  UNION ALL
+                  SELECT p.task_id
+                    FROM task_note_projections p
+                   WHERE p.owner_user_id = ? AND p.dataset_id = ? AND (
+                     NOT EXISTS(
+                       SELECT 1 FROM note_tasks t
+                        WHERE t.owner_user_id = p.owner_user_id
+                          AND t.dataset_id = p.dataset_id AND t.id = p.task_id
+                          AND t.note_id = p.note_id
+                     ) OR NOT EXISTS(
+                       SELECT 1 FROM notes n
+                        WHERE n.client_id = p.owner_user_id AND n.id = p.note_id
+                     )
+                   )
+                  UNION ALL
+                  SELECT e.id
+                    FROM task_events e
+                   WHERE e.owner_user_id = ? AND e.dataset_id = ? AND (
+                     NOT EXISTS(
+                       SELECT 1 FROM notes n
+                        WHERE n.client_id = e.owner_user_id AND n.id = e.note_id
+                     ) OR (e.task_id IS NOT NULL AND NOT EXISTS(
+                       SELECT 1 FROM note_tasks t
+                        WHERE t.owner_user_id = e.owner_user_id
+                          AND t.dataset_id = e.dataset_id AND t.id = e.task_id
+                          AND t.note_id = e.note_id
+                     )) OR (e.corrects_activity_id IS NOT NULL AND NOT EXISTS(
+                       SELECT 1 FROM task_events corrected
+                        WHERE corrected.owner_user_id = e.owner_user_id
+                          AND corrected.dataset_id = e.dataset_id
+                          AND corrected.id = e.corrects_activity_id
+                     ))
+                   )
+                  UNION ALL
+                  SELECT r.event_id
+                    FROM task_event_read_state r
+                   WHERE r.owner_user_id = ? AND r.dataset_id = ? AND (
+                     r.user_id <> r.owner_user_id OR NOT EXISTS(
+                       SELECT 1 FROM task_events e
+                        WHERE e.owner_user_id = r.owner_user_id
+                          AND e.dataset_id = r.dataset_id AND e.id = r.event_id
+                     )
+                   )
+                  UNION ALL
+                  SELECT r.note_id
+                    FROM note_task_reconciliation_state r
+                   WHERE r.owner_user_id = ? AND r.dataset_id = ?
+                     AND NOT EXISTS(
+                       SELECT 1 FROM notes n
+                        WHERE n.client_id = r.owner_user_id AND n.id = r.note_id
+                     )
+                  UNION ALL
+                  SELECT d.id
+                    FROM task_projection_drifts d
+                   WHERE d.owner_user_id = ? AND d.dataset_id = ? AND (
+                     NOT EXISTS(
+                       SELECT 1 FROM note_tasks t
+                        WHERE t.owner_user_id = d.owner_user_id
+                          AND t.dataset_id = d.dataset_id AND t.id = d.task_id
+                          AND t.note_id = d.note_id
+                     ) OR NOT EXISTS(
+                       SELECT 1 FROM notes n
+                        WHERE n.client_id = d.owner_user_id AND n.id = d.note_id
+                     )
+                   )
+                ) invalid_parents
+                LIMIT 1
+                """,
+                (
+                    owner, self._LOCAL_UNBOUND,
+                    owner, self._LOCAL_UNBOUND,
+                    owner, self._LOCAL_UNBOUND,
+                    owner, self._LOCAL_UNBOUND,
+                    owner, self._LOCAL_UNBOUND,
+                    owner, self._LOCAL_UNBOUND,
+                ),
+                conn=transaction_conn,
+            ).fetchone()
+            if invalid is not None:
+                raise ConflictError(
+                    "Task dataset binding failed parent proof.",
+                    entity="tasks",
+                    entity_id=target,
+                )  # noqa: TRY003
+
+        def _prepare_postgres(transaction_conn: TaskConnection) -> None:
+            if not postgres:
+                return
+            version = self._db._get_schema_version_postgres(transaction_conn, lock=True)
+            if version != self._db._POSTGRES_SCHEMA_VERSION:
+                raise ConflictError(
+                    "Task dataset binding requires the current PostgreSQL schema.",
+                    entity="tasks",
+                    entity_id=target,
+                )  # noqa: TRY003
+            self._execute(
+                transaction_conn,
+                "LOCK TABLE notes, note_tasks, task_note_projections, task_events, "
+                "task_event_read_state, note_task_reconciliation_state, task_projection_drifts "
+                "IN ACCESS EXCLUSIVE MODE",
+            )
+            self._db._verify_note_task_schema_postgres(transaction_conn)
+            for table, _ordering in self._BIND_TABLE_ORDER:
+                self._execute(
+                    transaction_conn,
+                    f"ALTER TABLE {table} NO FORCE ROW LEVEL SECURITY",  # nosec B608
+                )
+
+        def _finish_postgres(transaction_conn: TaskConnection) -> None:
+            if not postgres:
+                return
+            for table, _ordering in self._BIND_TABLE_ORDER:
+                self._execute(
+                    transaction_conn,
+                    f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY",  # nosec B608
+                )
+            self._db._verify_note_task_schema_postgres(transaction_conn)
 
         def _execute_bind(transaction_conn: TaskConnection) -> dict[str, int]:
-            source_counts = _counts(transaction_conn, self._LOCAL_UNBOUND)
-            target_counts = _counts(transaction_conn, target)
+            _prepare_postgres(transaction_conn)
+            source_snapshot = _snapshot(transaction_conn, self._LOCAL_UNBOUND)
+            target_snapshot = _snapshot(transaction_conn, target)
+            source_counts = _counts(source_snapshot)
+            target_counts = _counts(target_snapshot)
             if any(target_counts.values()):
                 raise ConflictError(
                     "Task dataset binding target collision.", entity="tasks", entity_id=target
                 )  # noqa: TRY003
             if not any(source_counts.values()):
+                _finish_postgres(transaction_conn)
                 return source_counts
+            _prove_parents(transaction_conn)
 
             # Rekey roots only. Composite ON UPDATE CASCADE relationships carry
             # projections, task-linked events, read-state, and drift rows.
@@ -1884,15 +2042,16 @@ class TaskStore:
                 (target, owner, self._LOCAL_UNBOUND),
             )
 
-            remaining = _counts(transaction_conn, self._LOCAL_UNBOUND)
-            rebound = _counts(transaction_conn, target)
-            if any(remaining.values()) or rebound != source_counts:
+            remaining = _snapshot(transaction_conn, self._LOCAL_UNBOUND)
+            rebound = _snapshot(transaction_conn, target)
+            if any(_counts(remaining).values()) or rebound != source_snapshot:
                 raise ConflictError(
                     "Task dataset binding failed complete-set verification.",
                     entity="tasks",
                     entity_id=target,
                 )  # noqa: TRY003
-            return rebound
+            _finish_postgres(transaction_conn)
+            return _counts(rebound)
 
         return self._with_transaction(_execute_bind, conn)
 

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -50,19 +50,18 @@ class TaskStore:
         dataset = str(dataset_id).strip()
         if not owner or not dataset:
             raise InputError("Task owner and dataset scope cannot be empty.")  # noqa: TRY003
-        if self._db.backend_type == BackendType.POSTGRESQL and (
-            owner != str(self._db.client_id) or dataset != self._LOCAL_UNBOUND
-        ):
-            raise ConflictError(
-                "Task scope is unavailable on PostgreSQL schema v59.",
-                entity="tasks",
-                entity_id=owner,
-            )  # noqa: TRY003
+        if self._db.backend_type == BackendType.POSTGRESQL:
+            if owner != str(self._db.client_id):
+                raise ConflictError(
+                    "Task owner does not match the authenticated PostgreSQL client.",
+                    entity="tasks",
+                    entity_id=owner,
+                )  # noqa: TRY003
+            self._db.execute_query(
+                "SELECT set_config('app.current_dataset_id', ?, false)",
+                (dataset,),
+            )
         return owner, dataset
-
-    @property
-    def _uses_postgres_v59_schema(self) -> bool:
-        return self._db.backend_type == BackendType.POSTGRESQL
 
     def _canonical_task_values(self, task: Mapping[str, Any]) -> tuple[int, str, str | None, str | None]:
         revision = int(task.get("canonical_revision") or task.get("version") or 1)
@@ -243,25 +242,6 @@ class TaskStore:
         include_deleted: bool,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
-        if self._uses_postgres_v59_schema:
-            if include_deleted:
-                cursor = self._read(
-                    "SELECT * FROM note_tasks WHERE client_id = ? AND id = ?",
-                    (owner_user_id, task_id),
-                    conn=conn,
-                )
-                return self._decode_task_row(cursor.fetchone())
-            cursor = self._read(
-                """
-                SELECT t.*
-                  FROM note_tasks t
-                  JOIN notes n ON n.id = t.note_id AND n.client_id = t.client_id
-                 WHERE t.client_id = ? AND t.id = ? AND t.deleted = ? AND n.deleted = ?
-                """,
-                (owner_user_id, task_id, self._deleted_value(False), self._deleted_value(False)),
-                conn=conn,
-            )
-            return self._decode_task_row(cursor.fetchone())
         if include_deleted:
             cursor = self._read(
                 "SELECT * FROM note_tasks WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
@@ -290,23 +270,11 @@ class TaskStore:
         dataset_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
-        if self._uses_postgres_v59_schema:
-            cursor = self._read(
-                """
-                SELECT p.*
-                  FROM task_note_projections p
-                  JOIN note_tasks t ON t.id = p.task_id
-                 WHERE t.client_id = ? AND p.task_id = ?
-                """,
-                (owner_user_id, task_id),
-                conn=conn,
-            )
-        else:
-            cursor = self._read(
-                "SELECT * FROM task_note_projections WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?",
-                (owner_user_id, dataset_id, task_id),
-                conn=conn,
-            )
+        cursor = self._read(
+            "SELECT * FROM task_note_projections WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?",
+            (owner_user_id, dataset_id, task_id),
+            conn=conn,
+        )
         row = cursor.fetchone()
         return dict(row) if row else None
 
@@ -355,29 +323,17 @@ class TaskStore:
         case rather than creating a replacement task beside an orphaned live row.
         """
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        if self._uses_postgres_v59_schema:
-            cursor = self._read(
-                """
-                SELECT *
-                  FROM note_tasks
-                 WHERE client_id = ? AND note_id = ? AND deleted = ? AND projection_status = ?
-                 ORDER BY created_at ASC, id ASC
-                """,
-                (owner, note_id, self._deleted_value(False), "live"),
-                conn=conn,
-            )
-        else:
-            cursor = self._read(
-                """
-                SELECT *
-                  FROM note_tasks
-                 WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?
-                   AND deleted = ? AND projection_status = ?
-                 ORDER BY created_at ASC, id ASC
-                """,
-                (owner, dataset, note_id, self._deleted_value(False), "live"),
-                conn=conn,
-            )
+        cursor = self._read(
+            """
+            SELECT *
+              FROM note_tasks
+             WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?
+               AND deleted = ? AND projection_status = ?
+             ORDER BY created_at ASC, id ASC
+            """,
+            (owner, dataset, note_id, self._deleted_value(False), "live"),
+            conn=conn,
+        )
         projected_tasks: list[dict[str, dict[str, Any]]] = []
         for row in cursor.fetchall():
             task = self._decode_task_row(row)
@@ -534,73 +490,44 @@ class TaskStore:
         now = self._db._get_current_utc_timestamp_iso()
         completed_at = now if normalized_status == "done" else None
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        canonical_values = None
-        if not self._uses_postgres_v59_schema:
-            canonical_values = self._canonical_task_values(
-                {
-                    "owner_user_id": owner,
-                    "id": final_task_id,
-                    "note_id": note_id,
-                    "text": normalized_text,
-                    "status": normalized_status,
-                    "metadata_json": metadata_json,
-                    "projection_status": normalized_projection_status,
-                    "deleted": 0,
-                    "created_at": now,
-                    "updated_at": now,
-                    "completed_at": completed_at,
-                    "client_id": self._db.client_id,
-                    "version": 1,
-                    "canonical_revision": 1,
-                }
-            )
+        canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+            {
+                "owner_user_id": owner,
+                "id": final_task_id,
+                "note_id": note_id,
+                "text": normalized_text,
+                "status": normalized_status,
+                "metadata_json": metadata_json,
+                "projection_status": normalized_projection_status,
+                "deleted": 0,
+                "created_at": now,
+                "updated_at": now,
+                "completed_at": completed_at,
+                "client_id": self._db.client_id,
+                "version": 1,
+                "canonical_revision": 1,
+            }
+        )
 
         def _execute_create(transaction_conn: TaskConnection) -> dict[str, Any]:
             self._require_active_note(note_id, final_task_id, owner_user_id=owner, conn=transaction_conn)
-            if self._uses_postgres_v59_schema:
-                self._execute(
-                    transaction_conn,
-                    """
-                    INSERT INTO note_tasks (
-                        id, note_id, text, status, metadata_json, projection_status,
-                        deleted, created_at, updated_at, completed_at, client_id, version
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        final_task_id,
-                        note_id,
-                        normalized_text,
-                        normalized_status,
-                        metadata_json,
-                        normalized_projection_status,
-                        self._deleted_value(False),
-                        now,
-                        now,
-                        completed_at,
-                        owner,
-                        1,
-                    ),
-                )
-            else:
-                assert canonical_values is not None  # nosec B101
-                canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = canonical_values
-                self._execute(
-                    transaction_conn,
-                    """
-                    INSERT INTO note_tasks (
-                        owner_user_id, dataset_id, id, note_id, text, status, metadata_json,
-                        projection_status, deleted, created_at, updated_at, completed_at, client_id,
-                        version, canonical_revision, canonical_hash, source_diagnostic_code,
-                        source_diagnostic_hash
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        owner, dataset, final_task_id, note_id, normalized_text, normalized_status,
-                        metadata_json, normalized_projection_status, self._deleted_value(False),
-                        now, now, completed_at, self._db.client_id, 1, canonical_revision,
-                        canonical_hash, diagnostic_code, diagnostic_hash,
-                    ),
-                )
+            self._execute(
+                transaction_conn,
+                """
+                INSERT INTO note_tasks (
+                    owner_user_id, dataset_id, id, note_id, text, status, metadata_json,
+                    projection_status, deleted, created_at, updated_at, completed_at, client_id,
+                    version, canonical_revision, canonical_hash, source_diagnostic_code,
+                    source_diagnostic_hash
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    owner, dataset, final_task_id, note_id, normalized_text, normalized_status,
+                    metadata_json, normalized_projection_status, self._deleted_value(False),
+                    now, now, completed_at, self._db.client_id, 1, canonical_revision,
+                    canonical_hash, diagnostic_code, diagnostic_hash,
+                ),
+            )
             if actor_type:
                 self.record_task_event(
                     task_id=final_task_id,
@@ -677,12 +604,8 @@ class TaskStore:
     ) -> list[dict[str, Any]]:
         """List tasks with optional note/status filters."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        if self._uses_postgres_v59_schema:
-            clauses: list[str] = ["t.client_id = ?"]
-            params: list[Any] = [owner]
-        else:
-            clauses = ["t.owner_user_id = ?", "t.dataset_id = ?"]
-            params = [owner, dataset]
+        clauses: list[str] = ["t.owner_user_id = ?", "t.dataset_id = ?"]
+        params: list[Any] = [owner, dataset]
         if note_id is not None:
             clauses.append("t.note_id = ?")
             params.append(note_id)
@@ -718,10 +641,7 @@ class TaskStore:
             params.append(self._deleted_value(False))
         sql_query = "SELECT t.* FROM note_tasks t"
         if not include_deleted:
-            if self._uses_postgres_v59_schema:
-                sql_query += " JOIN notes n ON n.id = t.note_id AND n.client_id = t.client_id"
-            else:
-                sql_query += " JOIN notes n ON n.id = t.note_id AND n.client_id = t.owner_user_id"
+            sql_query += " JOIN notes n ON n.id = t.note_id AND n.client_id = t.owner_user_id"
         if clauses:
             sql_query += " WHERE " + " AND ".join(clauses)
         sql_query += " ORDER BY t.created_at ASC, t.id ASC LIMIT ? OFFSET ?"
@@ -767,49 +687,34 @@ class TaskStore:
                     f"Task projection is {old['projection_status']} for task '{task_id}'.",
                     entity="tasks",
                     entity_id=task_id,
-                )  # noqa: TRY003
+            )  # noqa: TRY003
             self._require_active_note(old["note_id"], task_id, owner_user_id=owner, conn=transaction_conn)
             now = self._db._get_current_utc_timestamp_iso()
-            if self._uses_postgres_v59_schema:
-                cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE note_tasks
-                       SET metadata_json = ?, updated_at = ?, version = version + 1
-                     WHERE client_id = ? AND id = ? AND version = ?
-                       AND deleted = ? AND projection_status = ?
-                    """,
-                    (
-                        metadata_json, now, owner, task_id, expected_version,
-                        self._deleted_value(False), "unlinked",
-                    ),
-                )
-            else:
-                canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
-                    {
-                        **old,
-                        "metadata_json": metadata_json,
-                        "updated_at": now,
-                        "version": int(old["version"]) + 1,
-                        "canonical_revision": int(old["canonical_revision"]) + 1,
-                    }
-                )
-                cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE note_tasks
-                       SET metadata_json = ?, updated_at = ?, version = version + 1,
-                           canonical_revision = ?, canonical_hash = ?,
-                           source_diagnostic_code = ?, source_diagnostic_hash = ?
-                     WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
-                       AND version = ? AND deleted = ? AND projection_status = ?
-                    """,
-                    (
-                        metadata_json, now, canonical_revision, canonical_hash,
-                        diagnostic_code, diagnostic_hash, owner, dataset, task_id,
-                        expected_version, self._deleted_value(False), "unlinked",
-                    ),
-                )
+            canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+                {
+                    **old,
+                    "metadata_json": metadata_json,
+                    "updated_at": now,
+                    "version": int(old["version"]) + 1,
+                    "canonical_revision": int(old["canonical_revision"]) + 1,
+                }
+            )
+            cursor = self._execute(
+                transaction_conn,
+                """
+                UPDATE note_tasks
+                   SET metadata_json = ?, updated_at = ?, version = version + 1,
+                       canonical_revision = ?, canonical_hash = ?,
+                       source_diagnostic_code = ?, source_diagnostic_hash = ?
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                   AND version = ? AND deleted = ? AND projection_status = ?
+                """,
+                (
+                    metadata_json, now, canonical_revision, canonical_hash,
+                    diagnostic_code, diagnostic_hash, owner, dataset, task_id,
+                    expected_version, self._deleted_value(False), "unlinked",
+                ),
+            )
             if getattr(cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task version mismatch for ID '{task_id}'. Expected {expected_version}.",
@@ -903,55 +808,34 @@ class TaskStore:
                 completed_at = now
             elif new_status == "open":
                 completed_at = None
-            if self._uses_postgres_v59_schema:
-                update_cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE note_tasks
-                       SET text = ?, status = ?, metadata_json = ?, updated_at = ?,
-                           completed_at = ?, version = version + 1
-                     WHERE client_id = ? AND id = ? AND version = ?
-                    """,
-                    (
-                        new_text,
-                        new_status,
-                        new_metadata_json,
-                        now,
-                        completed_at,
-                        owner,
-                        task_id,
-                        expected_version,
-                    ),
-                )
-            else:
-                canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
-                    {
-                        **old,
-                        "text": new_text,
-                        "status": new_status,
-                        "metadata_json": new_metadata_json,
-                        "updated_at": now,
-                        "completed_at": completed_at,
-                        "version": int(old["version"]) + 1,
-                        "canonical_revision": int(old["canonical_revision"]) + 1,
-                    }
-                )
-                update_cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE note_tasks
-                       SET text = ?, status = ?, metadata_json = ?, updated_at = ?,
-                           completed_at = ?, version = version + 1,
-                           canonical_revision = ?, canonical_hash = ?,
-                           source_diagnostic_code = ?, source_diagnostic_hash = ?
-                     WHERE owner_user_id = ? AND dataset_id = ? AND id = ? AND version = ?
-                    """,
-                    (
-                        new_text, new_status, new_metadata_json, now, completed_at,
-                        canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash,
-                        owner, dataset, task_id, expected_version,
-                    ),
-                )
+            canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+                {
+                    **old,
+                    "text": new_text,
+                    "status": new_status,
+                    "metadata_json": new_metadata_json,
+                    "updated_at": now,
+                    "completed_at": completed_at,
+                    "version": int(old["version"]) + 1,
+                    "canonical_revision": int(old["canonical_revision"]) + 1,
+                }
+            )
+            update_cursor = self._execute(
+                transaction_conn,
+                """
+                UPDATE note_tasks
+                   SET text = ?, status = ?, metadata_json = ?, updated_at = ?,
+                       completed_at = ?, version = version + 1,
+                       canonical_revision = ?, canonical_hash = ?,
+                       source_diagnostic_code = ?, source_diagnostic_hash = ?
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ? AND version = ?
+                """,
+                (
+                    new_text, new_status, new_metadata_json, now, completed_at,
+                    canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash,
+                    owner, dataset, task_id, expected_version,
+                ),
+            )
             if getattr(update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task version mismatch for ID '{task_id}'. Expected {expected_version}.",
@@ -1049,36 +933,20 @@ class TaskStore:
                     entity="tasks",
                     entity_id=task_id,
                 )  # noqa: TRY003
-            if self._uses_postgres_v59_schema:
-                update_cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE note_tasks
-                       SET projection_status = ?, updated_at = ?,
-                           version = CASE WHEN projection_status != ? THEN version + 1 ELSE version END
-                     WHERE client_id = ? AND id = ? AND note_id = ?
-                       AND deleted = ? AND projection_status = ?
-                    """,
-                    (
-                        normalized_projection_status, now, normalized_projection_status,
-                        owner, task_id, note_id, self._deleted_value(False), projection_state,
-                    ),
-                )
-            else:
-                update_cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE note_tasks
-                       SET projection_status = ?, updated_at = ?,
-                           version = CASE WHEN projection_status != ? THEN version + 1 ELSE version END
-                     WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
-                       AND note_id = ? AND deleted = ? AND projection_status = ?
-                    """,
-                    (
-                        normalized_projection_status, now, normalized_projection_status,
-                        owner, dataset, task_id, note_id, self._deleted_value(False), projection_state,
-                    ),
-                )
+            update_cursor = self._execute(
+                transaction_conn,
+                """
+                UPDATE note_tasks
+                   SET projection_status = ?, updated_at = ?,
+                       version = CASE WHEN projection_status != ? THEN version + 1 ELSE version END
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                   AND note_id = ? AND deleted = ? AND projection_status = ?
+                """,
+                (
+                    normalized_projection_status, now, normalized_projection_status,
+                    owner, dataset, task_id, note_id, self._deleted_value(False), projection_state,
+                ),
+            )
             if getattr(update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task projection changed concurrently for task '{task_id}'.",
@@ -1090,46 +958,25 @@ class TaskStore:
                 normalized_text_hash, int(occurrence_index), block_fingerprint, raw_line,
                 self._deleted_value(bool(has_child_content)), normalized_projection_status, now,
             )
-            if self._uses_postgres_v59_schema:
-                self._execute(
-                    transaction_conn,
-                    """
-                    INSERT INTO task_note_projections (
-                        task_id, note_id, note_version, line_number, start_offset, end_offset,
-                        normalized_text_hash, occurrence_index, block_fingerprint, raw_line,
-                        has_child_content, projection_status, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(task_id) DO UPDATE SET
-                        note_id = excluded.note_id, note_version = excluded.note_version,
-                        line_number = excluded.line_number, start_offset = excluded.start_offset,
-                        end_offset = excluded.end_offset, normalized_text_hash = excluded.normalized_text_hash,
-                        occurrence_index = excluded.occurrence_index,
-                        block_fingerprint = excluded.block_fingerprint, raw_line = excluded.raw_line,
-                        has_child_content = excluded.has_child_content,
-                        projection_status = excluded.projection_status, updated_at = excluded.updated_at
-                    """,
-                    projection_values,
-                )
-            else:
-                self._execute(
-                    transaction_conn,
-                    """
-                    INSERT INTO task_note_projections (
-                        owner_user_id, dataset_id, task_id, note_id, note_version, line_number,
-                        start_offset, end_offset, normalized_text_hash, occurrence_index,
-                        block_fingerprint, raw_line, has_child_content, projection_status, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(owner_user_id, dataset_id, task_id) DO UPDATE SET
-                        note_id = excluded.note_id, note_version = excluded.note_version,
-                        line_number = excluded.line_number, start_offset = excluded.start_offset,
-                        end_offset = excluded.end_offset, normalized_text_hash = excluded.normalized_text_hash,
-                        occurrence_index = excluded.occurrence_index,
-                        block_fingerprint = excluded.block_fingerprint, raw_line = excluded.raw_line,
-                        has_child_content = excluded.has_child_content,
-                        projection_status = excluded.projection_status, updated_at = excluded.updated_at
-                    """,
-                    (owner, dataset, *projection_values),
-                )
+            self._execute(
+                transaction_conn,
+                """
+                INSERT INTO task_note_projections (
+                    owner_user_id, dataset_id, task_id, note_id, note_version, line_number,
+                    start_offset, end_offset, normalized_text_hash, occurrence_index,
+                    block_fingerprint, raw_line, has_child_content, projection_status, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(owner_user_id, dataset_id, task_id) DO UPDATE SET
+                    note_id = excluded.note_id, note_version = excluded.note_version,
+                    line_number = excluded.line_number, start_offset = excluded.start_offset,
+                    end_offset = excluded.end_offset, normalized_text_hash = excluded.normalized_text_hash,
+                    occurrence_index = excluded.occurrence_index,
+                    block_fingerprint = excluded.block_fingerprint, raw_line = excluded.raw_line,
+                    has_child_content = excluded.has_child_content,
+                    projection_status = excluded.projection_status, updated_at = excluded.updated_at
+                """,
+                (owner, dataset, *projection_values),
+            )
             projection = self._fetch_projection(
                 task_id, owner_user_id=owner, dataset_id=dataset, conn=transaction_conn
             )
@@ -1182,27 +1029,16 @@ class TaskStore:
                 )  # noqa: TRY003
             self._require_live_projection_row(task_id, projection)
             now = self._db._get_current_utc_timestamp_iso()
-            if self._uses_postgres_v59_schema:
-                update_cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE note_tasks
-                       SET projection_status = ?, updated_at = ?, version = version + 1
-                     WHERE client_id = ? AND id = ? AND version = ? AND projection_status = ?
-                    """,
-                    ("unlinked", now, owner, task_id, expected_version, projection_state),
-                )
-            else:
-                update_cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE note_tasks
-                       SET projection_status = ?, updated_at = ?, version = version + 1
-                     WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
-                       AND version = ? AND projection_status = ?
-                    """,
-                    ("unlinked", now, owner, dataset, task_id, expected_version, projection_state),
-                )
+            update_cursor = self._execute(
+                transaction_conn,
+                """
+                UPDATE note_tasks
+                   SET projection_status = ?, updated_at = ?, version = version + 1
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                   AND version = ? AND projection_status = ?
+                """,
+                ("unlinked", now, owner, dataset, task_id, expected_version, projection_state),
+            )
             if getattr(update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task version mismatch for ID '{task_id}'. Expected {expected_version}.",
@@ -1214,35 +1050,18 @@ class TaskStore:
                 projection["line_number"], projection["normalized_text_hash"],
                 projection["occurrence_index"], projection["block_fingerprint"],
             )
-            if self._uses_postgres_v59_schema:
-                projection_update_cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE task_note_projections
-                       SET projection_status = ?, updated_at = ?
-                     WHERE task_id = ? AND projection_status = ? AND note_id = ?
-                       AND note_version = ? AND line_number = ? AND normalized_text_hash = ?
-                       AND occurrence_index = ? AND block_fingerprint = ?
-                       AND EXISTS (
-                           SELECT 1 FROM note_tasks task
-                            WHERE task.id = task_note_projections.task_id AND task.client_id = ?
-                       )
-                    """,
-                    ("unlinked", now, task_id, *projection_locator, owner),
-                )
-            else:
-                projection_update_cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE task_note_projections
-                       SET projection_status = ?, updated_at = ?
-                     WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?
-                       AND projection_status = ? AND note_id = ? AND note_version = ?
-                       AND line_number = ? AND normalized_text_hash = ?
-                       AND occurrence_index = ? AND block_fingerprint = ?
-                    """,
-                    ("unlinked", now, owner, dataset, task_id, *projection_locator),
-                )
+            projection_update_cursor = self._execute(
+                transaction_conn,
+                """
+                UPDATE task_note_projections
+                   SET projection_status = ?, updated_at = ?
+                 WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?
+                   AND projection_status = ? AND note_id = ? AND note_version = ?
+                   AND line_number = ? AND normalized_text_hash = ?
+                   AND occurrence_index = ? AND block_fingerprint = ?
+                """,
+                ("unlinked", now, owner, dataset, task_id, *projection_locator),
+            )
             if getattr(projection_update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task projection changed concurrently for task '{task_id}'.",
@@ -1343,47 +1162,32 @@ class TaskStore:
                         "Task projection deletion is ambiguous without a matching projection locator."
                     )  # noqa: TRY003
             now = self._db._get_current_utc_timestamp_iso()
-            if self._uses_postgres_v59_schema:
-                update_cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE note_tasks
-                       SET deleted = ?, projection_status = ?, updated_at = ?, version = version + 1
-                     WHERE client_id = ? AND id = ? AND version = ?
-                       AND deleted = ? AND projection_status = ?
-                    """,
-                    (
-                        self._deleted_value(True), "deleted", now, owner, task_id,
-                        expected_version, self._deleted_value(False), projection_status,
-                    ),
-                )
-            else:
-                canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
-                    {
-                        **old,
-                        "deleted": 1,
-                        "projection_status": "deleted",
-                        "updated_at": now,
-                        "version": int(old["version"]) + 1,
-                        "canonical_revision": int(old["canonical_revision"]) + 1,
-                    }
-                )
-                update_cursor = self._execute(
-                    transaction_conn,
-                    """
-                    UPDATE note_tasks
-                       SET deleted = ?, projection_status = ?, updated_at = ?, version = version + 1,
-                           canonical_revision = ?, canonical_hash = ?,
-                           source_diagnostic_code = ?, source_diagnostic_hash = ?
-                     WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
-                       AND version = ? AND deleted = ? AND projection_status = ?
-                    """,
-                    (
-                        self._deleted_value(True), "deleted", now, canonical_revision,
-                        canonical_hash, diagnostic_code, diagnostic_hash, owner, dataset,
-                        task_id, expected_version, self._deleted_value(False), projection_status,
-                    ),
-                )
+            canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+                {
+                    **old,
+                    "deleted": 1,
+                    "projection_status": "deleted",
+                    "updated_at": now,
+                    "version": int(old["version"]) + 1,
+                    "canonical_revision": int(old["canonical_revision"]) + 1,
+                }
+            )
+            update_cursor = self._execute(
+                transaction_conn,
+                """
+                UPDATE note_tasks
+                   SET deleted = ?, projection_status = ?, updated_at = ?, version = version + 1,
+                       canonical_revision = ?, canonical_hash = ?,
+                       source_diagnostic_code = ?, source_diagnostic_hash = ?
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                   AND version = ? AND deleted = ? AND projection_status = ?
+                """,
+                (
+                    self._deleted_value(True), "deleted", now, canonical_revision,
+                    canonical_hash, diagnostic_code, diagnostic_hash, owner, dataset,
+                    task_id, expected_version, self._deleted_value(False), projection_status,
+                ),
+            )
             if getattr(update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
                     f"Task version mismatch for ID '{task_id}'. Expected {expected_version}.",
@@ -1397,36 +1201,19 @@ class TaskStore:
                     projection["line_number"], projection["normalized_text_hash"],
                     projection["occurrence_index"], projection["block_fingerprint"],
                 )
-            if self._uses_postgres_v59_schema:
-                locator_sql = ""
-                if locator:
-                    locator_sql = (
-                        " AND projection_status = ? AND note_id = ? AND note_version = ?"
-                        " AND line_number = ? AND normalized_text_hash = ?"
-                        " AND occurrence_index = ? AND block_fingerprint = ?"
-                    )
-                projection_update_cursor = self._execute(
-                    transaction_conn,
-                    "UPDATE task_note_projections SET projection_status = ?, updated_at = ? "  # nosec B608
-                    "WHERE task_id = ?" + locator_sql +
-                    " AND EXISTS (SELECT 1 FROM note_tasks task "  # nosec B608
-                    "WHERE task.id = task_note_projections.task_id AND task.client_id = ?)",
-                    ("deleted", now, task_id, *locator, owner),
+            locator_sql = ""
+            if locator:
+                locator_sql = (
+                    " AND projection_status = ? AND note_id = ? AND note_version = ?"
+                    " AND line_number = ? AND normalized_text_hash = ?"
+                    " AND occurrence_index = ? AND block_fingerprint = ?"
                 )
-            else:
-                locator_sql = ""
-                if locator:
-                    locator_sql = (
-                        " AND projection_status = ? AND note_id = ? AND note_version = ?"
-                        " AND line_number = ? AND normalized_text_hash = ?"
-                        " AND occurrence_index = ? AND block_fingerprint = ?"
-                    )
-                projection_update_cursor = self._execute(
-                    transaction_conn,
-                    "UPDATE task_note_projections SET projection_status = ?, updated_at = ? "  # nosec B608
-                    "WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?" + locator_sql,
-                    ("deleted", now, owner, dataset, task_id, *locator),
-                )
+            projection_update_cursor = self._execute(
+                transaction_conn,
+                "UPDATE task_note_projections SET projection_status = ?, updated_at = ? "  # nosec B608
+                "WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?" + locator_sql,
+                ("deleted", now, owner, dataset, task_id, *locator),
+            )
             if projection_status == "live" and not allow_record_only:
                 if getattr(projection_update_cursor, "rowcount", None) == 0:
                     raise ConflictError(
@@ -1490,7 +1277,7 @@ class TaskStore:
         old_value_json = self._json_dumps(old_value, "old_value") if old_value is not None else None
         new_value_json = self._json_dumps(new_value, "new_value") if new_value is not None else None
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        event_hash = None if self._uses_postgres_v59_schema else self._db._note_task_v60_hash(
+        event_hash = self._db._note_task_v60_hash(
             {
                 "owner_user_id": owner,
                 "dataset_id": dataset,
@@ -1530,30 +1317,6 @@ class TaskStore:
                         entity="tasks",
                         entity_id=task_id,
                     )  # noqa: TRY003
-            if self._uses_postgres_v59_schema:
-                self._execute(
-                    transaction_conn,
-                    """
-                    INSERT INTO task_events (
-                        id, task_id, note_id, event_type, actor_type, actor_id, tool_name,
-                        policy_mode, approval_id, old_value_json, new_value_json, created_at, client_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        final_event_id, task_id, note_id, event_type, actor_type, actor_id,
-                        tool_name, policy_mode, approval_id, old_value_json, new_value_json,
-                        now, owner,
-                    ),
-                )
-                cursor = self._read(
-                    "SELECT * FROM task_events WHERE client_id = ? AND id = ?",
-                    (owner, final_event_id),
-                    conn=transaction_conn,
-                )
-                event = self._decode_event_row(cursor.fetchone())
-                if event is None:
-                    raise CharactersRAGDBError(f"Failed to read task event '{final_event_id}'.")  # noqa: TRY003
-                return event
             self._execute(
                 transaction_conn,
                 """
@@ -1635,12 +1398,8 @@ class TaskStore:
     ) -> list[dict[str, Any]]:
         """List task events by task or note scope."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        if self._uses_postgres_v59_schema:
-            clauses: list[str] = ["client_id = ?"]
-            params: list[Any] = [owner]
-        else:
-            clauses = ["owner_user_id = ?", "dataset_id = ?"]
-            params = [owner, dataset]
+        clauses: list[str] = ["owner_user_id = ?", "dataset_id = ?"]
+        params: list[Any] = [owner, dataset]
         if task_id is not None:
             clauses.append("task_id = ?")
             params.append(task_id)
@@ -1670,12 +1429,8 @@ class TaskStore:
     ) -> list[dict[str, Any]]:
         """List task events newest-first without changing the ascending default helper."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        if self._uses_postgres_v59_schema:
-            clauses: list[str] = ["client_id = ?"]
-            params: list[Any] = [owner]
-        else:
-            clauses = ["owner_user_id = ?", "dataset_id = ?"]
-            params = [owner, dataset]
+        clauses: list[str] = ["owner_user_id = ?", "dataset_id = ?"]
+        params: list[Any] = [owner, dataset]
         if task_id is not None:
             clauses.append("task_id = ?")
             params.append(task_id)
@@ -1711,40 +1466,26 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
         if user_id != owner:
             return []
-        if self._uses_postgres_v59_schema:
-            query = """
-                SELECT events.*
-                FROM task_events AS events
-                LEFT JOIN task_event_read_state AS state
-                  ON state.event_id = events.id AND state.user_id = ?
-                WHERE events.client_id = ?
-                  AND (state.event_id IS NULL OR (state.read_at IS NULL AND state.dismissed_at IS NULL))
-                  AND (? IS NULL OR events.task_id = ?)
-                  AND (? IS NULL OR events.note_id = ?)
-                  AND (? IS NULL OR events.actor_type = ?)
-            """
-        else:
-            query = """
-                SELECT events.*
-                FROM task_events AS events
-                LEFT JOIN task_event_read_state AS state
-                  ON state.owner_user_id = events.owner_user_id
-                 AND state.dataset_id = events.dataset_id
-                 AND state.event_id = events.id AND state.user_id = ?
-                WHERE events.owner_user_id = ? AND events.dataset_id = ?
-                  AND (state.event_id IS NULL OR (state.read_at IS NULL AND state.dismissed_at IS NULL))
-                  AND (? IS NULL OR events.task_id = ?)
-                  AND (? IS NULL OR events.note_id = ?)
-                  AND (? IS NULL OR events.actor_type = ?)
-            """
+        query = """
+            SELECT events.*
+            FROM task_events AS events
+            LEFT JOIN task_event_read_state AS state
+              ON state.owner_user_id = events.owner_user_id
+             AND state.dataset_id = events.dataset_id
+             AND state.event_id = events.id AND state.user_id = ?
+            WHERE events.owner_user_id = ? AND events.dataset_id = ?
+              AND (state.event_id IS NULL OR (state.read_at IS NULL AND state.dismissed_at IS NULL))
+              AND (? IS NULL OR events.task_id = ?)
+              AND (? IS NULL OR events.note_id = ?)
+              AND (? IS NULL OR events.actor_type = ?)
+        """
         if self._db.backend_type == BackendType.SQLITE:
             query += " ORDER BY events.created_at DESC, events.rowid DESC LIMIT ?"
         else:
             query += " ORDER BY events.created_at DESC, events.id DESC LIMIT ?"
-        if self._uses_postgres_v59_schema:
-            params: list[Any] = [user_id, owner, task_id, task_id, note_id, note_id, actor_type, actor_type]
-        else:
-            params = [user_id, owner, dataset, task_id, task_id, note_id, note_id, actor_type, actor_type]
+        params: list[Any] = [
+            user_id, owner, dataset, task_id, task_id, note_id, note_id, actor_type, actor_type
+        ]
         params.append(self._clamp_limit(limit))
         cursor = self._read(query, tuple(params))
         return [self._decode_event_row(row) for row in cursor.fetchall()]
@@ -1765,34 +1506,6 @@ class TaskStore:
             raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
 
         def _execute_read(transaction_conn: TaskConnection) -> dict[str, Any]:
-            if self._uses_postgres_v59_schema:
-                event = self._read(
-                    "SELECT id FROM task_events WHERE client_id = ? AND id = ?",
-                    (owner, event_id),
-                    conn=transaction_conn,
-                ).fetchone()
-                if event is None:
-                    raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
-                self._execute(
-                    transaction_conn,
-                    """
-                    INSERT INTO task_event_read_state (event_id, user_id, read_at, dismissed_at)
-                    VALUES (?, ?, ?, NULL)
-                    ON CONFLICT(event_id, user_id) DO UPDATE SET
-                        read_at = COALESCE(task_event_read_state.read_at, excluded.read_at)
-                    """,
-                    (event_id, user_id, now),
-                )
-                state = self.get_task_activity_read_state(
-                    owner_user_id=owner,
-                    dataset_id=dataset,
-                    event_id=event_id,
-                    user_id=user_id,
-                    conn=transaction_conn,
-                )
-                if state is None:
-                    raise CharactersRAGDBError(f"Failed to read task event read state for '{event_id}'.")  # noqa: TRY003
-                return state
             self._execute(
                 transaction_conn,
                 """
@@ -1845,35 +1558,6 @@ class TaskStore:
             raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
 
         def _execute_dismiss(transaction_conn: TaskConnection) -> dict[str, Any]:
-            if self._uses_postgres_v59_schema:
-                event = self._read(
-                    "SELECT id FROM task_events WHERE client_id = ? AND id = ?",
-                    (owner, event_id),
-                    conn=transaction_conn,
-                ).fetchone()
-                if event is None:
-                    raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
-                self._execute(
-                    transaction_conn,
-                    """
-                    INSERT INTO task_event_read_state (event_id, user_id, read_at, dismissed_at)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT(event_id, user_id) DO UPDATE SET
-                        read_at = COALESCE(task_event_read_state.read_at, excluded.read_at),
-                        dismissed_at = excluded.dismissed_at
-                    """,
-                    (event_id, user_id, now, now),
-                )
-                state = self.get_task_activity_read_state(
-                    owner_user_id=owner,
-                    dataset_id=dataset,
-                    event_id=event_id,
-                    user_id=user_id,
-                    conn=transaction_conn,
-                )
-                if state is None:
-                    raise CharactersRAGDBError(f"Failed to read task event read state for '{event_id}'.")  # noqa: TRY003
-                return state
             self._execute(
                 transaction_conn,
                 """
@@ -1924,26 +1608,14 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
         if user_id != owner:
             return None
-        if self._uses_postgres_v59_schema:
-            cursor = self._read(
-                """
-                SELECT state.*
-                  FROM task_event_read_state state
-                  JOIN task_events event ON event.id = state.event_id
-                 WHERE event.client_id = ? AND state.event_id = ? AND state.user_id = ?
-                """,
-                (owner, event_id, user_id),
-                conn=conn,
-            )
-        else:
-            cursor = self._read(
-                """
-                SELECT * FROM task_event_read_state
-                 WHERE owner_user_id = ? AND dataset_id = ? AND event_id = ? AND user_id = ?
-                """,
-                (owner, dataset, event_id, user_id),
-                conn=conn,
-            )
+        cursor = self._read(
+            """
+            SELECT * FROM task_event_read_state
+             WHERE owner_user_id = ? AND dataset_id = ? AND event_id = ? AND user_id = ?
+            """,
+            (owner, dataset, event_id, user_id),
+            conn=conn,
+        )
         row = cursor.fetchone()
         return dict(row) if row else None
 
@@ -1957,24 +1629,12 @@ class TaskStore:
     ) -> dict[str, Any] | None:
         """Return the last task reconciliation state for a note."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        if self._uses_postgres_v59_schema:
-            cursor = self._read(
-                """
-                SELECT state.*
-                  FROM note_task_reconciliation_state state
-                  JOIN notes note ON note.id = state.note_id
-                 WHERE note.client_id = ? AND state.note_id = ?
-                """,
-                (owner, note_id),
-                conn=conn,
-            )
-        else:
-            cursor = self._read(
-                "SELECT * FROM note_task_reconciliation_state "
-                "WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
-                (owner, dataset, note_id),
-                conn=conn,
-            )
+        cursor = self._read(
+            "SELECT * FROM note_task_reconciliation_state "
+            "WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
+            (owner, dataset, note_id),
+            conn=conn,
+        )
         row = cursor.fetchone()
         return dict(row) if row else None
 
@@ -1996,68 +1656,34 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_state(transaction_conn: TaskConnection) -> dict[str, Any]:
-            if self._uses_postgres_v59_schema:
-                note = self._read(
-                    "SELECT id FROM notes WHERE client_id = ? AND id = ?",
-                    (owner, note_id),
-                    conn=transaction_conn,
-                ).fetchone()
-                if note is None:
-                    raise ConflictError("Task note not found.", entity="tasks", entity_id=note_id)  # noqa: TRY003
-                self._execute(
-                    transaction_conn,
-                    """
-                    INSERT INTO note_task_reconciliation_state (
-                        note_id, note_version, status, reconciled_at,
-                        item_count, warning_count, cursor
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(note_id) DO UPDATE SET
-                        note_version = excluded.note_version,
-                        status = excluded.status,
-                        reconciled_at = excluded.reconciled_at,
-                        item_count = excluded.item_count,
-                        warning_count = excluded.warning_count,
-                        cursor = excluded.cursor
-                    """,
-                    (
-                        note_id,
-                        int(note_version),
-                        status,
-                        now,
-                        int(item_count),
-                        int(warning_count),
-                        cursor,
-                    ),
+            self._execute(
+                transaction_conn,
+                """
+                INSERT INTO note_task_reconciliation_state (
+                    owner_user_id, dataset_id, note_id, note_version, status,
+                    reconciled_at, item_count, warning_count, cursor
                 )
-            else:
-                self._execute(
-                    transaction_conn,
-                    """
-                    INSERT INTO note_task_reconciliation_state (
-                        owner_user_id, dataset_id, note_id, note_version, status,
-                        reconciled_at, item_count, warning_count, cursor
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(owner_user_id, dataset_id, note_id) DO UPDATE SET
-                        note_version = excluded.note_version,
-                        status = excluded.status,
-                        reconciled_at = excluded.reconciled_at,
-                        item_count = excluded.item_count,
-                        warning_count = excluded.warning_count,
-                        cursor = excluded.cursor
-                    """,
-                    (
-                        owner,
-                        dataset,
-                        note_id,
-                        int(note_version),
-                        status,
-                        now,
-                        int(item_count),
-                        int(warning_count),
-                        cursor,
-                    ),
-                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(owner_user_id, dataset_id, note_id) DO UPDATE SET
+                    note_version = excluded.note_version,
+                    status = excluded.status,
+                    reconciled_at = excluded.reconciled_at,
+                    item_count = excluded.item_count,
+                    warning_count = excluded.warning_count,
+                    cursor = excluded.cursor
+                """,
+                (
+                    owner,
+                    dataset,
+                    note_id,
+                    int(note_version),
+                    status,
+                    now,
+                    int(item_count),
+                    int(warning_count),
+                    cursor,
+                ),
+            )
             state = (
                 self.get_reconciliation_state(
                     owner_user_id=owner, dataset_id=dataset, note_id=note_id
@@ -2096,24 +1722,12 @@ class TaskStore:
         dataset_id: str,
         conn: TaskConnection,
     ) -> dict[str, Any] | None:
-        if self._uses_postgres_v59_schema:
-            cursor = self._read(
-                """
-                SELECT state.*
-                  FROM note_task_reconciliation_state state
-                  JOIN notes note ON note.id = state.note_id
-                 WHERE note.client_id = ? AND state.note_id = ?
-                """,
-                (owner_user_id, note_id),
-                conn=conn,
-            )
-        else:
-            cursor = self._read(
-                "SELECT * FROM note_task_reconciliation_state "
-                "WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
-                (owner_user_id, dataset_id, note_id),
-                conn=conn,
-            )
+        cursor = self._read(
+            "SELECT * FROM note_task_reconciliation_state "
+            "WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
+            (owner_user_id, dataset_id, note_id),
+            conn=conn,
+        )
         row = cursor.fetchone()
         return dict(row) if row else None
 
@@ -2126,28 +1740,6 @@ class TaskStore:
     ) -> list[dict[str, Any]]:
         """Return checklist-bearing notes whose task reconciliation is stale or missing."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        if self._uses_postgres_v59_schema:
-            cursor = self._read(
-                """
-                SELECT n.id, n.title, n.version, n.last_modified
-                  FROM notes n
-                  LEFT JOIN note_task_reconciliation_state r ON r.note_id = n.id
-                 WHERE n.client_id = ? AND n.deleted = ?
-                   AND (n.content LIKE ? OR n.content LIKE ? OR n.content LIKE ?)
-                   AND (n.content LIKE ? OR n.content LIKE ? OR n.content LIKE ?)
-                   AND (r.note_id IS NULL OR r.note_version < n.version)
-                 ORDER BY n.last_modified DESC, n.id ASC
-                 LIMIT ?
-                """,
-                (
-                    owner,
-                    self._deleted_value(False),
-                    *self._CHECKLIST_DISCOVERY_MARKER_PATTERNS,
-                    *self._CHECKLIST_DISCOVERY_BULLET_PATTERNS,
-                    self._clamp_limit(limit),
-                ),
-            )
-            return [dict(row) for row in cursor.fetchall()]
         cursor = self._read(
             """
             SELECT n.id, n.title, n.version, n.last_modified
@@ -2192,28 +1784,6 @@ class TaskStore:
     ) -> int:
         """Count checklist-bearing notes whose task reconciliation is stale or missing."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        if self._uses_postgres_v59_schema:
-            params: list[Any] = [
-                owner,
-                self._deleted_value(False),
-                *self._CHECKLIST_DISCOVERY_MARKER_PATTERNS,
-                *self._CHECKLIST_DISCOVERY_BULLET_PATTERNS,
-            ]
-            sql_query = """
-                SELECT COUNT(*) AS stale_count
-                  FROM notes n
-                  LEFT JOIN note_task_reconciliation_state r ON r.note_id = n.id
-                 WHERE n.client_id = ? AND n.deleted = ?
-                   AND (n.content LIKE ? OR n.content LIKE ? OR n.content LIKE ?)
-                   AND (n.content LIKE ? OR n.content LIKE ? OR n.content LIKE ?)
-                   AND (r.note_id IS NULL OR r.note_version < n.version)
-            """
-            if note_id is not None:
-                sql_query += " AND n.id = ?"
-                params.append(note_id)
-            cursor = self._read(sql_query, tuple(params))
-            row = cursor.fetchone()
-            return int(row["stale_count"] if row else 0)
         params: list[Any] = [
             dataset,
             owner,

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, TypeAlias, TypeVar
 
 from tldw_Server_API.app.core.DB_Management.backends.base import (
     DatabaseError as BackendDatabaseError,
@@ -21,7 +21,8 @@ if TYPE_CHECKING:
     from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 
 
-TaskConnection = sqlite3.Connection | BackendConnectionWrapper
+TaskConnection: TypeAlias = sqlite3.Connection | BackendConnectionWrapper
+ScopedReadT = TypeVar("ScopedReadT")
 
 
 class TaskStore:
@@ -65,11 +66,37 @@ class TaskStore:
                     entity="tasks",
                     entity_id=owner,
                 )  # noqa: TRY003
-            self._db.execute_query(
-                "SELECT set_config('app.current_dataset_id', ?, false)",
-                (dataset,),
-            )
         return owner, dataset
+
+    def _set_postgres_dataset_scope(
+        self,
+        conn: TaskConnection,
+        dataset_id: str,
+    ) -> None:
+        """Set transaction-local PostgreSQL task RLS scope on one connection."""
+        if self._db.backend_type == BackendType.POSTGRESQL:
+            self._execute(
+                conn,
+                "SELECT set_config('app.current_dataset_id', ?, true)",
+                (dataset_id,),
+            )
+
+    def _with_scoped_read(
+        self,
+        *,
+        dataset_id: str,
+        conn: TaskConnection | None,
+        fn: Callable[[TaskConnection | None], ScopedReadT],
+    ) -> ScopedReadT:
+        """Run a read with transaction-local PostgreSQL dataset scope."""
+        if self._db.backend_type != BackendType.POSTGRESQL:
+            return fn(conn)
+        if conn is not None:
+            self._set_postgres_dataset_scope(conn, dataset_id)
+            return fn(conn)
+        with self._db.transaction() as transaction_conn:
+            self._set_postgres_dataset_scope(transaction_conn, dataset_id)
+            return fn(transaction_conn)
 
     def _require_authorized_write_scope(
         self,
@@ -92,6 +119,7 @@ class TaskStore:
         ).fetchall()
         if not rows:
             if dataset_id == self._LOCAL_UNBOUND:
+                self._set_postgres_dataset_scope(conn, dataset_id)
                 return
             raise ConflictError(
                 "Task write scope is not bound.",
@@ -112,6 +140,7 @@ class TaskStore:
                 entity="tasks",
                 entity_id=owner_user_id,
             )  # noqa: TRY003
+        self._set_postgres_dataset_scope(conn, dataset_id)
 
     def lock_authorized_write_scope(
         self,
@@ -362,7 +391,16 @@ class TaskStore:
     ) -> dict[str, Any] | None:
         """Return the markdown projection row for one task."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        return self._fetch_projection(task_id, owner_user_id=owner, dataset_id=dataset, conn=conn)
+        return self._with_scoped_read(
+            dataset_id=dataset,
+            conn=conn,
+            fn=lambda read_conn: self._fetch_projection(
+                task_id,
+                owner_user_id=owner,
+                dataset_id=dataset,
+                conn=read_conn,
+            ),
+        )
 
     def get_note_reconciliation_snapshot(
         self,
@@ -373,14 +411,22 @@ class TaskStore:
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
         """Return note fields needed to validate task reconciliation input."""
-        owner, _dataset = self._scope(owner_user_id, dataset_id)
-        cursor = self._read(
-            "SELECT id, version, content, deleted FROM notes WHERE client_id = ? AND id = ?",
-            (owner, note_id),
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+
+        def _read_snapshot(read_conn: TaskConnection | None) -> dict[str, Any] | None:
+            cursor = self._read(
+                "SELECT id, version, content, deleted FROM notes WHERE client_id = ? AND id = ?",
+                (owner, note_id),
+                conn=read_conn,
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
             conn=conn,
+            fn=_read_snapshot,
         )
-        row = cursor.fetchone()
-        return dict(row) if row else None
 
     def list_live_projected_tasks(
         self,
@@ -397,42 +443,54 @@ class TaskStore:
         case rather than creating a replacement task beside an orphaned live row.
         """
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        cursor = self._read(
-            """
-            SELECT *
-              FROM note_tasks
-             WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?
-               AND deleted = ? AND projection_status = ?
-             ORDER BY created_at ASC, id ASC
-            """,
-            (owner, dataset, note_id, self._deleted_value(False), "live"),
+
+        def _read_projected_tasks(
+            read_conn: TaskConnection | None,
+        ) -> list[dict[str, dict[str, Any]]]:
+            cursor = self._read(
+                """
+                SELECT *
+                  FROM note_tasks
+                 WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?
+                   AND deleted = ? AND projection_status = ?
+                 ORDER BY created_at ASC, id ASC
+                """,
+                (owner, dataset, note_id, self._deleted_value(False), "live"),
+                conn=read_conn,
+            )
+            projected_tasks: list[dict[str, dict[str, Any]]] = []
+            for row in cursor.fetchall():
+                task = self._decode_task_row(row)
+                if task is None:
+                    continue
+                projection_state, projection = self._resolve_projection_state(
+                    task,
+                    task["id"],
+                    owner_user_id=owner,
+                    dataset_id=dataset,
+                    conn=read_conn,
+                )
+                if projection_state != "live":
+                    raise ConflictError(
+                        f"Task projection is {projection_state} for live task '{task['id']}'.",
+                        entity="tasks",
+                        entity_id=task["id"],
+                    )  # noqa: TRY003
+                projected_tasks.append(
+                    {
+                        "task": task,
+                        "projection": self._require_live_projection_row(
+                            task["id"], projection
+                        ),
+                    }
+                )
+            return projected_tasks
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
             conn=conn,
+            fn=_read_projected_tasks,
         )
-        projected_tasks: list[dict[str, dict[str, Any]]] = []
-        for row in cursor.fetchall():
-            task = self._decode_task_row(row)
-            if task is None:
-                continue
-            projection_state, projection = self._resolve_projection_state(
-                task,
-                task["id"],
-                owner_user_id=owner,
-                dataset_id=dataset,
-                conn=conn,
-            )
-            if projection_state != "live":
-                raise ConflictError(
-                    f"Task projection is {projection_state} for live task '{task['id']}'.",
-                    entity="tasks",
-                    entity_id=task["id"],
-                )  # noqa: TRY003
-            projected_tasks.append(
-                {
-                    "task": task,
-                    "projection": self._require_live_projection_row(task["id"], projection),
-                }
-            )
-        return projected_tasks
 
     @staticmethod
     def _validate_status(status: str) -> str:
@@ -656,12 +714,16 @@ class TaskStore:
     ) -> dict[str, Any] | None:
         """Return one task by ID."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        return self._fetch_task(
-            task_id,
-            owner_user_id=owner,
+        return self._with_scoped_read(
             dataset_id=dataset,
-            include_deleted=include_deleted,
             conn=conn,
+            fn=lambda read_conn: self._fetch_task(
+                task_id,
+                owner_user_id=owner,
+                dataset_id=dataset,
+                include_deleted=include_deleted,
+                conn=read_conn,
+            ),
         )
 
     def list_tasks(
@@ -724,8 +786,16 @@ class TaskStore:
         sql_query += " ORDER BY t.created_at ASC, t.id ASC LIMIT ? OFFSET ?"
         params.append(self._clamp_limit(limit))
         params.append(self._normalize_offset(offset))
-        cursor = self._read(sql_query, tuple(params))
-        return [self._decode_task_row(row) for row in cursor.fetchall()]
+
+        def _read_tasks(read_conn: TaskConnection | None) -> list[dict[str, Any]]:
+            cursor = self._read(sql_query, tuple(params), conn=read_conn)
+            return [self._decode_task_row(row) for row in cursor.fetchall()]
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
+            conn=None,
+            fn=_read_tasks,
+        )
 
     def update_unlinked_task_metadata_record_only(
         self,
@@ -1509,8 +1579,16 @@ class TaskStore:
         else:
             query += " ORDER BY created_at ASC, id ASC LIMIT ?"
         params.append(self._clamp_limit(limit))
-        cursor = self._read(query, tuple(params))
-        return [self._decode_event_row(row) for row in cursor.fetchall()]
+
+        def _read_activity(read_conn: TaskConnection | None) -> list[dict[str, Any]]:
+            cursor = self._read(query, tuple(params), conn=read_conn)
+            return [self._decode_event_row(row) for row in cursor.fetchall()]
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
+            conn=None,
+            fn=_read_activity,
+        )
 
     def list_recent_task_activity(
         self,
@@ -1543,8 +1621,16 @@ class TaskStore:
         else:
             query += " ORDER BY created_at DESC, id DESC LIMIT ?"
         params.append(self._clamp_limit(limit))
-        cursor = self._read(query, tuple(params))
-        return [self._decode_event_row(row) for row in cursor.fetchall()]
+
+        def _read_activity(read_conn: TaskConnection | None) -> list[dict[str, Any]]:
+            cursor = self._read(query, tuple(params), conn=read_conn)
+            return [self._decode_event_row(row) for row in cursor.fetchall()]
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
+            conn=None,
+            fn=_read_activity,
+        )
 
     def list_recent_unread_task_activity(
         self,
@@ -1586,8 +1672,16 @@ class TaskStore:
         else:
             query += " ORDER BY events.created_at DESC, events.id DESC LIMIT ?"
         params.append(self._clamp_limit(limit))
-        cursor = self._read(query, tuple(params))
-        return [self._decode_event_row(row) for row in cursor.fetchall()]
+
+        def _read_activity(read_conn: TaskConnection | None) -> list[dict[str, Any]]:
+            cursor = self._read(query, tuple(params), conn=read_conn)
+            return [self._decode_event_row(row) for row in cursor.fetchall()]
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
+            conn=None,
+            fn=_read_activity,
+        )
 
     def mark_task_activity_read(
         self,
@@ -1713,16 +1807,24 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
         if user_id != owner:
             return None
-        cursor = self._read(
-            """
-            SELECT * FROM task_event_read_state
-             WHERE owner_user_id = ? AND dataset_id = ? AND event_id = ? AND user_id = ?
-            """,
-            (owner, dataset, event_id, user_id),
+
+        def _read_state(read_conn: TaskConnection | None) -> dict[str, Any] | None:
+            cursor = self._read(
+                """
+                SELECT * FROM task_event_read_state
+                 WHERE owner_user_id = ? AND dataset_id = ? AND event_id = ? AND user_id = ?
+                """,
+                (owner, dataset, event_id, user_id),
+                conn=read_conn,
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
             conn=conn,
+            fn=_read_state,
         )
-        row = cursor.fetchone()
-        return dict(row) if row else None
 
     def get_reconciliation_state(
         self,
@@ -1734,14 +1836,22 @@ class TaskStore:
     ) -> dict[str, Any] | None:
         """Return the last task reconciliation state for a note."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        cursor = self._read(
-            "SELECT * FROM note_task_reconciliation_state "
-            "WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
-            (owner, dataset, note_id),
+
+        def _read_state(read_conn: TaskConnection | None) -> dict[str, Any] | None:
+            cursor = self._read(
+                "SELECT * FROM note_task_reconciliation_state "
+                "WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
+                (owner, dataset, note_id),
+                conn=read_conn,
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
             conn=conn,
+            fn=_read_state,
         )
-        row = cursor.fetchone()
-        return dict(row) if row else None
 
     def set_reconciliation_state(
         self,
@@ -1848,40 +1958,49 @@ class TaskStore:
     ) -> list[dict[str, Any]]:
         """Return checklist-bearing notes whose task reconciliation is stale or missing."""
         owner, dataset = self._scope(owner_user_id, dataset_id)
-        cursor = self._read(
-            """
-            SELECT n.id, n.title, n.version, n.last_modified
-              FROM notes n
-              LEFT JOIN note_task_reconciliation_state r
-                ON r.owner_user_id = n.client_id AND r.dataset_id = ? AND r.note_id = n.id
-             WHERE n.client_id = ? AND n.deleted = ?
-               AND (
-                    n.content LIKE ?
-                 OR n.content LIKE ?
-                 OR n.content LIKE ?
-               )
-               AND (
-                    n.content LIKE ?
-                 OR n.content LIKE ?
-                 OR n.content LIKE ?
-               )
-               AND (
-                    r.note_id IS NULL
-                 OR r.note_version < n.version
-               )
-             ORDER BY n.last_modified DESC, n.id ASC
-             LIMIT ?
-            """,
-            (
-                dataset,
-                owner,
-                self._deleted_value(False),
-                *self._CHECKLIST_DISCOVERY_MARKER_PATTERNS,
-                *self._CHECKLIST_DISCOVERY_BULLET_PATTERNS,
-                self._clamp_limit(limit),
-            ),
+
+        def _read_candidates(read_conn: TaskConnection | None) -> list[dict[str, Any]]:
+            cursor = self._read(
+                """
+                SELECT n.id, n.title, n.version, n.last_modified
+                  FROM notes n
+                  LEFT JOIN note_task_reconciliation_state r
+                    ON r.owner_user_id = n.client_id AND r.dataset_id = ? AND r.note_id = n.id
+                 WHERE n.client_id = ? AND n.deleted = ?
+                   AND (
+                        n.content LIKE ?
+                     OR n.content LIKE ?
+                     OR n.content LIKE ?
+                   )
+                   AND (
+                        n.content LIKE ?
+                     OR n.content LIKE ?
+                     OR n.content LIKE ?
+                   )
+                   AND (
+                        r.note_id IS NULL
+                     OR r.note_version < n.version
+                   )
+                 ORDER BY n.last_modified DESC, n.id ASC
+                 LIMIT ?
+                """,
+                (
+                    dataset,
+                    owner,
+                    self._deleted_value(False),
+                    *self._CHECKLIST_DISCOVERY_MARKER_PATTERNS,
+                    *self._CHECKLIST_DISCOVERY_BULLET_PATTERNS,
+                    self._clamp_limit(limit),
+                ),
+                conn=read_conn,
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
+            conn=None,
+            fn=_read_candidates,
         )
-        return [dict(row) for row in cursor.fetchall()]
 
     def count_candidate_notes_for_task_discovery(
         self,
@@ -1923,9 +2042,16 @@ class TaskStore:
         if note_id is not None:
             sql_query += " AND n.id = ?"
             params.append(note_id)
-        cursor = self._read(sql_query, tuple(params))
-        row = cursor.fetchone()
-        return int(row["stale_count"] if row else 0)
+        def _read_count(read_conn: TaskConnection | None) -> int:
+            cursor = self._read(sql_query, tuple(params), conn=read_conn)
+            row = cursor.fetchone()
+            return int(row["stale_count"] if row else 0)
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
+            conn=None,
+            fn=_read_count,
+        )
 
     def resolve_task_compatibility_dataset_id(
         self,
@@ -1952,12 +2078,6 @@ class TaskStore:
             conn=conn,
         ).fetchall()
         if not rows:
-            if postgres:
-                self._read(
-                    "SELECT set_config('app.current_dataset_id', ?, false)",
-                    (self._LOCAL_UNBOUND,),
-                    conn=conn,
-                )
             return self._LOCAL_UNBOUND
         if len(rows) != 1:
             raise ConflictError(
@@ -1973,12 +2093,6 @@ class TaskStore:
                 entity="tasks",
                 entity_id=owner,
             )  # noqa: TRY003
-        if postgres:
-            self._read(
-                "SELECT set_config('app.current_dataset_id', ?, false)",
-                (dataset,),
-                conn=conn,
-            )
         return dataset
 
     def bind_local_task_graph_to_dataset(

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -71,6 +71,72 @@ class TaskStore:
             )
         return owner, dataset
 
+    def _require_authorized_write_scope(
+        self,
+        conn: TaskConnection,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+    ) -> None:
+        """Serialize with binding and reject writes outside the private authority scope."""
+        if self._db.backend_type == BackendType.POSTGRESQL:
+            self._execute(
+                conn,
+                "LOCK TABLE note_task_scope_authority IN SHARE MODE",
+            )
+        rows = self._read(
+            "SELECT owner_user_id,dataset_id FROM note_task_scope_authority "
+            "WHERE owner_user_id = ? LIMIT 2",
+            (owner_user_id,),
+            conn=conn,
+        ).fetchall()
+        if not rows:
+            if dataset_id == self._LOCAL_UNBOUND:
+                return
+            raise ConflictError(
+                "Task write scope is not bound.",
+                entity="tasks",
+                entity_id=owner_user_id,
+            )  # noqa: TRY003
+        row_owner = str(rows[0]["owner_user_id"]).strip()
+        authority_dataset = str(rows[0]["dataset_id"]).strip()
+        if (
+            len(rows) != 1
+            or row_owner != owner_user_id
+            or not authority_dataset
+            or authority_dataset == self._LOCAL_UNBOUND
+            or dataset_id != authority_dataset
+        ):
+            raise ConflictError(
+                "Task write scope conflicts with bound authority.",
+                entity="tasks",
+                entity_id=owner_user_id,
+            )  # noqa: TRY003
+
+    def lock_authorized_write_scope(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        conn: TaskConnection,
+    ) -> None:
+        """Fence a wider note/task transaction before it reads or mutates graph rows."""
+        owner = str(owner_user_id).strip()
+        dataset = str(dataset_id).strip()
+        if not owner or not dataset:
+            raise InputError("Task owner and dataset scope cannot be empty.")  # noqa: TRY003
+        if self._db.backend_type == BackendType.POSTGRESQL and owner != str(self._db.client_id):
+            raise ConflictError(
+                "Task owner does not match the authenticated PostgreSQL client.",
+                entity="tasks",
+                entity_id=owner,
+            )  # noqa: TRY003
+        self._require_authorized_write_scope(
+            conn,
+            owner_user_id=owner,
+            dataset_id=dataset,
+        )
+
     def _canonical_task_values(self, task: Mapping[str, Any]) -> tuple[int, str, str | None, str | None]:
         revision = int(task.get("canonical_revision") or task.get("version") or 1)
         source = dict(task)
@@ -518,6 +584,9 @@ class TaskStore:
         )
 
         def _execute_create(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_authorized_write_scope(
+                transaction_conn, owner_user_id=owner, dataset_id=dataset
+            )
             self._require_active_note(note_id, final_task_id, owner_user_id=owner, conn=transaction_conn)
             self._execute(
                 transaction_conn,
@@ -679,6 +748,9 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_metadata_update(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_authorized_write_scope(
+                transaction_conn, owner_user_id=owner, dataset_id=dataset
+            )
             old = self._require_active_task(
                 self._require_expected_version(
                     self._fetch_task(
@@ -788,6 +860,9 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_update(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_authorized_write_scope(
+                transaction_conn, owner_user_id=owner, dataset_id=dataset
+            )
             old = self._require_active_task(
                 self._require_expected_version(
                     self._fetch_task(
@@ -924,6 +999,9 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_projection(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_authorized_write_scope(
+                transaction_conn, owner_user_id=owner, dataset_id=dataset
+            )
             task = self._require_active_task(
                 self._fetch_task(
                     task_id, owner_user_id=owner, dataset_id=dataset,
@@ -1014,6 +1092,9 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_unlink(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_authorized_write_scope(
+                transaction_conn, owner_user_id=owner, dataset_id=dataset
+            )
             old = self._require_active_task(
                 self._require_expected_version(
                     self._fetch_task(
@@ -1129,6 +1210,9 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_delete(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_authorized_write_scope(
+                transaction_conn, owner_user_id=owner, dataset_id=dataset
+            )
             old = self._require_active_task(
                 self._require_expected_version(
                     self._fetch_task(
@@ -1306,6 +1390,9 @@ class TaskStore:
         )
 
         def _execute_event(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_authorized_write_scope(
+                transaction_conn, owner_user_id=owner, dataset_id=dataset
+            )
             self._require_active_note(
                 note_id, final_event_id, owner_user_id=owner, conn=transaction_conn
             )
@@ -1483,17 +1570,21 @@ class TaskStore:
              AND state.event_id = events.id AND state.user_id = ?
             WHERE events.owner_user_id = ? AND events.dataset_id = ?
               AND (state.event_id IS NULL OR (state.read_at IS NULL AND state.dismissed_at IS NULL))
-              AND (? IS NULL OR events.task_id = ?)
-              AND (? IS NULL OR events.note_id = ?)
-              AND (? IS NULL OR events.actor_type = ?)
         """
+        params: list[Any] = [user_id, owner, dataset]
+        for column, value in (
+            ("task_id", task_id),
+            ("note_id", note_id),
+            ("actor_type", actor_type),
+        ):
+            if value is not None:
+                # Column names are fixed above; values remain parameterized.
+                query += f" AND events.{column} = ?"  # nosec B608
+                params.append(value)
         if self._db.backend_type == BackendType.SQLITE:
             query += " ORDER BY events.created_at DESC, events.rowid DESC LIMIT ?"
         else:
             query += " ORDER BY events.created_at DESC, events.id DESC LIMIT ?"
-        params: list[Any] = [
-            user_id, owner, dataset, task_id, task_id, note_id, note_id, actor_type, actor_type
-        ]
         params.append(self._clamp_limit(limit))
         cursor = self._read(query, tuple(params))
         return [self._decode_event_row(row) for row in cursor.fetchall()]
@@ -1514,6 +1605,9 @@ class TaskStore:
             raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
 
         def _execute_read(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_authorized_write_scope(
+                transaction_conn, owner_user_id=owner, dataset_id=dataset
+            )
             self._execute(
                 transaction_conn,
                 """
@@ -1566,6 +1660,9 @@ class TaskStore:
             raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
 
         def _execute_dismiss(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_authorized_write_scope(
+                transaction_conn, owner_user_id=owner, dataset_id=dataset
+            )
             self._execute(
                 transaction_conn,
                 """
@@ -1664,6 +1761,9 @@ class TaskStore:
         owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_state(transaction_conn: TaskConnection) -> dict[str, Any]:
+            self._require_authorized_write_scope(
+                transaction_conn, owner_user_id=owner, dataset_id=dataset
+            )
             self._execute(
                 transaction_conn,
                 """
@@ -1827,6 +1927,60 @@ class TaskStore:
         row = cursor.fetchone()
         return int(row["stale_count"] if row else 0)
 
+    def resolve_task_compatibility_dataset_id(
+        self,
+        *,
+        owner_user_id: str,
+        conn: TaskConnection | None = None,
+    ) -> str:
+        """Resolve the private immutable owner-to-dataset binding, or the sentinel."""
+        owner = str(owner_user_id).strip()
+        if not owner:
+            raise InputError("Task owner cannot be empty.")  # noqa: TRY003
+        postgres = self._db.backend_type == BackendType.POSTGRESQL
+        if postgres and owner != str(self._db.client_id):
+            raise ConflictError(
+                "Task compatibility scope is unavailable.",
+                entity="tasks",
+                entity_id=owner,
+            )  # noqa: TRY003
+
+        rows = self._read(
+            "SELECT owner_user_id,dataset_id FROM note_task_scope_authority "
+            "WHERE owner_user_id = ? LIMIT 2",
+            (owner,),
+            conn=conn,
+        ).fetchall()
+        if not rows:
+            if postgres:
+                self._read(
+                    "SELECT set_config('app.current_dataset_id', ?, false)",
+                    (self._LOCAL_UNBOUND,),
+                    conn=conn,
+                )
+            return self._LOCAL_UNBOUND
+        if len(rows) != 1:
+            raise ConflictError(
+                "Task compatibility scope is inconsistent.",
+                entity="tasks",
+                entity_id=owner,
+            )  # noqa: TRY003
+        row_owner = str(rows[0]["owner_user_id"]).strip()
+        dataset = str(rows[0]["dataset_id"]).strip()
+        if row_owner != owner or not dataset or dataset == self._LOCAL_UNBOUND:
+            raise ConflictError(
+                "Task compatibility scope is inconsistent.",
+                entity="tasks",
+                entity_id=owner,
+            )  # noqa: TRY003
+        if postgres:
+            self._read(
+                "SELECT set_config('app.current_dataset_id', ?, false)",
+                (dataset,),
+                conn=conn,
+            )
+        return dataset
+
     def bind_local_task_graph_to_dataset(
         self,
         *,
@@ -1878,6 +2032,25 @@ class TaskStore:
 
         def _counts(snapshot: dict[str, tuple[int, str]]) -> dict[str, int]:
             return {table: count for table, (count, _hash) in snapshot.items()}
+
+        def _graph_datasets(transaction_conn: TaskConnection) -> set[str]:
+            datasets: set[str] = set()
+            for table, _ordering in self._BIND_TABLE_ORDER:
+                rows = self._read(
+                    f"SELECT DISTINCT dataset_id FROM {table} WHERE owner_user_id = ?",  # nosec B608
+                    (owner,),
+                    conn=transaction_conn,
+                ).fetchall()
+                for row in rows:
+                    dataset = str(row["dataset_id"]).strip()
+                    if not dataset:
+                        raise ConflictError(
+                            "Task dataset binding found malformed graph scope.",
+                            entity="tasks",
+                            entity_id=target,
+                        )  # noqa: TRY003
+                    datasets.add(dataset)
+            return datasets
 
         def _prove_parents(transaction_conn: TaskConnection) -> None:
             invalid = self._read(
@@ -1987,7 +2160,8 @@ class TaskStore:
                 )  # noqa: TRY003
             self._execute(
                 transaction_conn,
-                "LOCK TABLE notes, note_tasks, task_note_projections, task_events, "
+                "LOCK TABLE note_task_scope_authority, notes, note_tasks, "
+                "task_note_projections, task_events, "
                 "task_event_read_state, note_task_reconciliation_state, task_projection_drifts "
                 "IN ACCESS EXCLUSIVE MODE",
             )
@@ -2010,15 +2184,71 @@ class TaskStore:
 
         def _execute_bind_body(transaction_conn: TaskConnection) -> dict[str, int]:
             _prepare_postgres(transaction_conn)
+            authority_lock = " FOR UPDATE" if postgres else ""
+            authority_rows = self._read(
+                # authority_lock is a fixed backend suffix, never caller input.
+                "SELECT owner_user_id,dataset_id FROM note_task_scope_authority "
+                f"WHERE owner_user_id = ?{authority_lock}",  # nosec B608
+                (owner,),
+                conn=transaction_conn,
+            ).fetchall()
+            if len(authority_rows) > 1:
+                raise ConflictError(
+                    "Task dataset binding authority is inconsistent.",
+                    entity="tasks",
+                    entity_id=target,
+                )  # noqa: TRY003
+            authority_dataset = None
+            if authority_rows:
+                authority_owner = str(authority_rows[0]["owner_user_id"]).strip()
+                authority_dataset = str(authority_rows[0]["dataset_id"]).strip()
+                if (
+                    authority_owner != owner
+                    or not authority_dataset
+                    or authority_dataset == self._LOCAL_UNBOUND
+                ):
+                    raise ConflictError(
+                        "Task dataset binding authority is inconsistent.",
+                        entity="tasks",
+                        entity_id=target,
+                    )  # noqa: TRY003
+                if authority_dataset != target:
+                    raise ConflictError(
+                        "Task dataset binding is immutable.",
+                        entity="tasks",
+                        entity_id=target,
+                    )  # noqa: TRY003
+
+            graph_datasets = _graph_datasets(transaction_conn)
             source_snapshot = _snapshot(transaction_conn, self._LOCAL_UNBOUND)
             target_snapshot = _snapshot(transaction_conn, target)
             source_counts = _counts(source_snapshot)
             target_counts = _counts(target_snapshot)
+            if authority_dataset == target:
+                if graph_datasets - {target} or any(source_counts.values()):
+                    raise ConflictError(
+                        "Task dataset binding authority conflicts with graph scope.",
+                        entity="tasks",
+                        entity_id=target,
+                    )  # noqa: TRY003
+                _finish_postgres(transaction_conn)
+                return target_counts
+            if graph_datasets - {self._LOCAL_UNBOUND, target}:
+                raise ConflictError(
+                    "Task dataset binding found an unowned graph scope.",
+                    entity="tasks",
+                    entity_id=target,
+                )  # noqa: TRY003
             if any(target_counts.values()):
                 raise ConflictError(
                     "Task dataset binding target collision.", entity="tasks", entity_id=target
                 )  # noqa: TRY003
             if not any(source_counts.values()):
+                self._execute(
+                    transaction_conn,
+                    "INSERT INTO note_task_scope_authority(owner_user_id,dataset_id) VALUES (?,?)",
+                    (owner, target),
+                )
                 _finish_postgres(transaction_conn)
                 return source_counts
             _prove_parents(transaction_conn)
@@ -2050,6 +2280,11 @@ class TaskStore:
                     entity="tasks",
                     entity_id=target,
                 )  # noqa: TRY003
+            self._execute(
+                transaction_conn,
+                "INSERT INTO note_task_scope_authority(owner_user_id,dataset_id) VALUES (?,?)",
+                (owner, target),
+            )
             _finish_postgres(transaction_conn)
             return _counts(rebound)
 
@@ -2062,6 +2297,7 @@ class TaskStore:
             except Exception:  # noqa: BLE001 - rollback must cover every failed bind
                 self._execute(transaction_conn, "ROLLBACK TO SAVEPOINT bind_local_task_graph")
                 self._execute(transaction_conn, "RELEASE SAVEPOINT bind_local_task_graph")
+                self._db._verify_note_task_schema_postgres(transaction_conn)
                 raise
             self._execute(transaction_conn, "RELEASE SAVEPOINT bind_local_task_graph")
             return result

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Callable
 
+from tldw_Server_API.app.core.DB_Management.backends.base import (
+    DatabaseError as BackendDatabaseError,
+)
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     BackendConnectionWrapper,
     BackendType,
@@ -11,9 +15,6 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     ConflictError,
     InputError,
     logger,
-)
-from tldw_Server_API.app.core.DB_Management.backends.base import (
-    DatabaseError as BackendDatabaseError,
 )
 
 if TYPE_CHECKING:
@@ -34,9 +35,58 @@ class TaskStore:
     _PROJECTION_STATUSES = {"live", "unlinked", "deleted", "ambiguous"}
     _MIN_LIMIT = 1
     _MAX_LIMIT = 500
+    _LOCAL_UNBOUND = "local-unbound"
 
     def __init__(self, db: CharactersRAGDB) -> None:
         self._db = db
+
+    def _scope(
+        self,
+        owner_user_id: str,
+        dataset_id: str,
+    ) -> tuple[str, str]:
+        """Validate one exact canonical owner/dataset scope."""
+        owner = str(owner_user_id).strip()
+        dataset = str(dataset_id).strip()
+        if not owner or not dataset:
+            raise InputError("Task owner and dataset scope cannot be empty.")  # noqa: TRY003
+        return owner, dataset
+
+    def resolve_task_compatibility_scope(self, *, owner_user_id: str) -> tuple[str, str]:
+        """Resolve the sole product-owned task dataset, or the local sentinel when empty."""
+        owner = str(owner_user_id).strip()
+        if not owner:
+            raise InputError("Task owner cannot be empty.")  # noqa: TRY003
+        datasets: set[str] = set()
+        for table in (
+            "note_tasks",
+            "task_events",
+            "note_task_reconciliation_state",
+            "task_projection_drifts",
+        ):
+            cursor = self._read(
+                f"SELECT DISTINCT dataset_id FROM {table} WHERE owner_user_id = ?",  # nosec B608
+                (owner,),
+            )
+            datasets.update(str(row["dataset_id"]) for row in cursor.fetchall())
+        if not datasets:
+            return owner, self._LOCAL_UNBOUND
+        if len(datasets) != 1:
+            raise ConflictError(
+                "Task compatibility scope is ambiguous.", entity="tasks", entity_id=owner
+            )  # noqa: TRY003
+        return owner, datasets.pop()
+
+    def _canonical_task_values(self, task: Mapping[str, Any]) -> tuple[int, str, str | None, str | None]:
+        revision = int(task.get("canonical_revision") or task.get("version") or 1)
+        source = dict(task)
+        if isinstance(source.get("metadata_json"), dict):
+            source["metadata_json"] = self._json_dumps(source["metadata_json"], "metadata")
+        object_hash, code, diagnostic_hash = self._db._canonicalize_legacy_task_v60(
+            source,
+            owner_user_id=str(source["owner_user_id"]),
+        )
+        return revision, object_hash, code, diagnostic_hash
 
     def _deleted_value(self, deleted: bool) -> bool | int:
         """Return the backend-native value for a soft-delete flag."""
@@ -146,12 +196,13 @@ class TaskStore:
         note_id: str,
         task_id: str,
         *,
+        owner_user_id: str,
         conn: TaskConnection,
     ) -> None:
         """Require a task's owning note to exist and not be soft-deleted."""
         cursor = self._read(
-            "SELECT deleted FROM notes WHERE id = ?",
-            (note_id,),
+            "SELECT deleted FROM notes WHERE client_id = ? AND id = ?",
+            (owner_user_id, note_id),
             conn=conn,
         )
         row = cursor.fetchone()
@@ -200,20 +251,27 @@ class TaskStore:
         self,
         task_id: str,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         include_deleted: bool,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
         if include_deleted:
-            cursor = self._read("SELECT * FROM note_tasks WHERE id = ?", (task_id,), conn=conn)
+            cursor = self._read(
+                "SELECT * FROM note_tasks WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+                (owner_user_id, dataset_id, task_id),
+                conn=conn,
+            )
             return self._decode_task_row(cursor.fetchone())
         cursor = self._read(
             """
             SELECT t.*
               FROM note_tasks t
               JOIN notes n ON n.id = t.note_id
-             WHERE t.id = ? AND t.deleted = ? AND n.deleted = ?
+             WHERE t.owner_user_id = ? AND t.dataset_id = ? AND t.id = ?
+               AND n.client_id = t.owner_user_id AND t.deleted = ? AND n.deleted = ?
             """,
-            (task_id, self._deleted_value(False), self._deleted_value(False)),
+            (owner_user_id, dataset_id, task_id, self._deleted_value(False), self._deleted_value(False)),
             conn=conn,
         )
         return self._decode_task_row(cursor.fetchone())
@@ -222,30 +280,43 @@ class TaskStore:
         self,
         task_id: str,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
         cursor = self._read(
-            "SELECT * FROM task_note_projections WHERE task_id = ?",
-            (task_id,),
+            "SELECT * FROM task_note_projections WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?",
+            (owner_user_id, dataset_id, task_id),
             conn=conn,
         )
         row = cursor.fetchone()
         return dict(row) if row else None
 
-    def get_task_projection(self, task_id: str, *, conn: TaskConnection | None = None) -> dict[str, Any] | None:
+    def get_task_projection(
+        self,
+        task_id: str,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        conn: TaskConnection | None = None,
+    ) -> dict[str, Any] | None:
         """Return the markdown projection row for one task."""
-        return self._fetch_projection(task_id, conn=conn)
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        return self._fetch_projection(task_id, owner_user_id=owner, dataset_id=dataset, conn=conn)
 
     def get_note_reconciliation_snapshot(
         self,
         *,
         note_id: str,
+        owner_user_id: str,
+        dataset_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
         """Return note fields needed to validate task reconciliation input."""
+        owner, _dataset = self._scope(owner_user_id, dataset_id)
         cursor = self._read(
-            "SELECT id, version, content, deleted FROM notes WHERE id = ?",
-            (note_id,),
+            "SELECT id, version, content, deleted FROM notes WHERE client_id = ? AND id = ?",
+            (owner, note_id),
             conn=conn,
         )
         row = cursor.fetchone()
@@ -255,6 +326,8 @@ class TaskStore:
         self,
         *,
         note_id: str,
+        owner_user_id: str,
+        dataset_id: str,
         conn: TaskConnection | None = None,
     ) -> list[dict[str, dict[str, Any]]]:
         """Return live tasks for a note together with their projection rows.
@@ -263,16 +336,17 @@ class TaskStore:
         inconsistent projection state. Reconciliation must fail closed in that
         case rather than creating a replacement task beside an orphaned live row.
         """
+        owner, dataset = self._scope(owner_user_id, dataset_id)
         cursor = self._read(
             """
             SELECT *
               FROM note_tasks
-             WHERE note_id = ?
+             WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?
                AND deleted = ?
                AND projection_status = ?
              ORDER BY created_at ASC, id ASC
             """,
-            (note_id, self._deleted_value(False), "live"),
+            (owner, dataset, note_id, self._deleted_value(False), "live"),
             conn=conn,
         )
         projected_tasks: list[dict[str, dict[str, Any]]] = []
@@ -280,7 +354,13 @@ class TaskStore:
             task = self._decode_task_row(row)
             if task is None:
                 continue
-            projection_state, projection = self._resolve_projection_state(task, task["id"], conn=conn)
+            projection_state, projection = self._resolve_projection_state(
+                task,
+                task["id"],
+                owner_user_id=owner,
+                dataset_id=dataset,
+                conn=conn,
+            )
             if projection_state != "live":
                 raise ConflictError(
                     f"Task projection is {projection_state} for live task '{task['id']}'.",
@@ -359,9 +439,16 @@ class TaskStore:
         task: dict[str, Any],
         task_id: str,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         conn: TaskConnection,
     ) -> tuple[str, dict[str, Any] | None]:
-        projection = self._fetch_projection(task_id, conn=conn)
+        projection = self._fetch_projection(
+            task_id,
+            owner_user_id=owner_user_id,
+            dataset_id=dataset_id,
+            conn=conn,
+        )
         task_status = task["projection_status"]
         if projection is None:
             return task_status, None
@@ -389,6 +476,8 @@ class TaskStore:
     def create_task(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         note_id: str,
         text: str,
         status: str = "open",
@@ -415,19 +504,42 @@ class TaskStore:
         metadata_json = self._json_dumps(metadata, "metadata")
         now = self._db._get_current_utc_timestamp_iso()
         completed_at = now if normalized_status == "done" else None
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+            {
+                "owner_user_id": owner,
+                "id": final_task_id,
+                "note_id": note_id,
+                "text": normalized_text,
+                "status": normalized_status,
+                "metadata_json": metadata_json,
+                "projection_status": normalized_projection_status,
+                "deleted": 0,
+                "created_at": now,
+                "updated_at": now,
+                "completed_at": completed_at,
+                "client_id": self._db.client_id,
+                "version": 1,
+                "canonical_revision": 1,
+            }
+        )
 
         def _execute_create(transaction_conn: TaskConnection) -> dict[str, Any]:
-            self._require_active_note(note_id, final_task_id, conn=transaction_conn)
+            self._require_active_note(note_id, final_task_id, owner_user_id=owner, conn=transaction_conn)
             self._execute(
                 transaction_conn,
                 """
                 INSERT INTO note_tasks (
-                    id, note_id, text, status, metadata_json, projection_status, deleted,
-                    created_at, updated_at, completed_at, client_id, version
+                    owner_user_id, dataset_id, id, note_id, text, status, metadata_json,
+                    projection_status, deleted, created_at, updated_at, completed_at, client_id,
+                    version, canonical_revision, canonical_hash, source_diagnostic_code,
+                    source_diagnostic_hash
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
+                    owner,
+                    dataset,
                     final_task_id,
                     note_id,
                     normalized_text,
@@ -440,12 +552,18 @@ class TaskStore:
                     completed_at,
                     self._db.client_id,
                     1,
+                    canonical_revision,
+                    canonical_hash,
+                    diagnostic_code,
+                    diagnostic_hash,
                 ),
             )
             if actor_type:
                 self.record_task_event(
                     task_id=final_task_id,
                     note_id=note_id,
+                    owner_user_id=owner,
+                    dataset_id=dataset,
                     event_type="created",
                     actor_type=actor_type,
                     actor_id=actor_id,
@@ -462,7 +580,13 @@ class TaskStore:
                     ),
                     conn=transaction_conn,
                 )
-            task = self._fetch_task(final_task_id, include_deleted=True, conn=transaction_conn)
+            task = self._fetch_task(
+                final_task_id,
+                owner_user_id=owner,
+                dataset_id=dataset,
+                include_deleted=True,
+                conn=transaction_conn,
+            )
             if task is None:
                 raise CharactersRAGDBError(f"Failed to read created task '{final_task_id}'.")  # noqa: TRY003
             return task
@@ -474,13 +598,47 @@ class TaskStore:
         except BackendDatabaseError as exc:
             self._raise_backend_error(exc, final_task_id)
 
-    def get_task(self, task_id: str, include_deleted: bool = False) -> dict[str, Any] | None:
+    def get_task(
+        self,
+        task_id: str,
+        include_deleted: bool = False,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+    ) -> dict[str, Any] | None:
         """Return one task by ID."""
-        return self._fetch_task(task_id, include_deleted=include_deleted)
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        return self._fetch_task(
+            task_id,
+            owner_user_id=owner,
+            dataset_id=dataset,
+            include_deleted=include_deleted,
+        )
+
+    def get_task_scoped(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        task_id: str,
+        include_deleted: bool = False,
+        conn: TaskConnection | None = None,
+    ) -> dict[str, Any] | None:
+        """Return one task only inside the exact canonical owner/dataset scope."""
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        return self._fetch_task(
+            task_id,
+            owner_user_id=owner,
+            dataset_id=dataset,
+            include_deleted=include_deleted,
+            conn=conn,
+        )
 
     def list_tasks(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         note_id: str | None = None,
         status: str | None = None,
         projection_status: str | None = None,
@@ -492,8 +650,9 @@ class TaskStore:
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         """List tasks with optional note/status filters."""
-        clauses: list[str] = []
-        params: list[Any] = []
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        clauses: list[str] = ["t.owner_user_id = ?", "t.dataset_id = ?"]
+        params: list[Any] = [owner, dataset]
         if note_id is not None:
             clauses.append("t.note_id = ?")
             params.append(note_id)
@@ -529,7 +688,7 @@ class TaskStore:
             params.append(self._deleted_value(False))
         sql_query = "SELECT t.* FROM note_tasks t"
         if not include_deleted:
-            sql_query += " JOIN notes n ON n.id = t.note_id"
+            sql_query += " JOIN notes n ON n.id = t.note_id AND n.client_id = t.owner_user_id"
         if clauses:
             sql_query += " WHERE " + " AND ".join(clauses)
         sql_query += " ORDER BY t.created_at ASC, t.id ASC LIMIT ? OFFSET ?"
@@ -541,6 +700,8 @@ class TaskStore:
     def update_unlinked_task_metadata_record_only(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         task_id: str,
         expected_version: int,
         metadata: dict[str, Any],
@@ -554,11 +715,15 @@ class TaskStore:
     ) -> dict[str, Any]:
         """Update metadata for an unlinked task without modifying note content."""
         metadata_json = self._json_dumps(metadata, "metadata")
+        owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_metadata_update(transaction_conn: TaskConnection) -> dict[str, Any]:
             old = self._require_active_task(
                 self._require_expected_version(
-                    self._fetch_task(task_id, include_deleted=True, conn=transaction_conn),
+                    self._fetch_task(
+                        task_id, owner_user_id=owner, dataset_id=dataset,
+                        include_deleted=True, conn=transaction_conn,
+                    ),
                     expected_version,
                     task_id,
                 ),
@@ -570,20 +735,38 @@ class TaskStore:
                     entity="tasks",
                     entity_id=task_id,
                 )  # noqa: TRY003
-            self._require_active_note(old["note_id"], task_id, conn=transaction_conn)
+            self._require_active_note(old["note_id"], task_id, owner_user_id=owner, conn=transaction_conn)
             now = self._db._get_current_utc_timestamp_iso()
+            canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+                {
+                    **old,
+                    "metadata_json": metadata_json,
+                    "updated_at": now,
+                    "version": int(old["version"]) + 1,
+                    "canonical_revision": int(old["canonical_revision"]) + 1,
+                }
+            )
             cursor = self._execute(
                 transaction_conn,
                 """
                 UPDATE note_tasks
                    SET metadata_json = ?,
                        updated_at = ?,
-                       version = version + 1
-                 WHERE id = ? AND version = ? AND deleted = ? AND projection_status = ?
+                       version = version + 1,
+                       canonical_revision = ?, canonical_hash = ?,
+                       source_diagnostic_code = ?, source_diagnostic_hash = ?
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                   AND version = ? AND deleted = ? AND projection_status = ?
                 """,
                 (
                     metadata_json,
                     now,
+                    canonical_revision,
+                    canonical_hash,
+                    diagnostic_code,
+                    diagnostic_hash,
+                    owner,
+                    dataset,
                     task_id,
                     expected_version,
                     self._deleted_value(False),
@@ -596,12 +779,17 @@ class TaskStore:
                     entity="tasks",
                     entity_id=task_id,
                 )  # noqa: TRY003
-            updated = self._fetch_task(task_id, include_deleted=True, conn=transaction_conn)
+            updated = self._fetch_task(
+                task_id, owner_user_id=owner, dataset_id=dataset,
+                include_deleted=True, conn=transaction_conn,
+            )
             if updated is None:
                 raise ConflictError(f"Task with ID '{task_id}' not found.", entity="tasks", entity_id=task_id)  # noqa: TRY003
             self.record_task_event(
                 task_id=task_id,
                 note_id=str(updated["note_id"]),
+                owner_user_id=owner,
+                dataset_id=dataset,
                 event_type="updated",
                 actor_type=actor_type,
                 actor_id=actor_id,
@@ -622,6 +810,8 @@ class TaskStore:
     def update_task_record(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         task_id: str,
         expected_version: int,
         text: str | None = None,
@@ -645,18 +835,24 @@ class TaskStore:
             )  # noqa: TRY003
         normalized_status = self._validate_status(status) if status is not None else None
         metadata_json = self._json_dumps(metadata, "metadata") if metadata is not None else None
+        owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_update(transaction_conn: TaskConnection) -> dict[str, Any]:
             old = self._require_active_task(
                 self._require_expected_version(
-                    self._fetch_task(task_id, include_deleted=True, conn=transaction_conn),
+                    self._fetch_task(
+                        task_id, owner_user_id=owner, dataset_id=dataset,
+                        include_deleted=True, conn=transaction_conn,
+                    ),
                     expected_version,
                     task_id,
                 ),
                 task_id,
             )
-            self._require_active_note(old["note_id"], task_id, conn=transaction_conn)
-            projection_state, _ = self._resolve_projection_state(old, task_id, conn=transaction_conn)
+            self._require_active_note(old["note_id"], task_id, owner_user_id=owner, conn=transaction_conn)
+            projection_state, _ = self._resolve_projection_state(
+                old, task_id, owner_user_id=owner, dataset_id=dataset, conn=transaction_conn
+            )
             old["projection_status"] = projection_state
             self._require_record_update_allowed(old, task_id)
             now = self._db._get_current_utc_timestamp_iso()
@@ -670,6 +866,18 @@ class TaskStore:
                 completed_at = now
             elif new_status == "open":
                 completed_at = None
+            canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+                {
+                    **old,
+                    "text": new_text,
+                    "status": new_status,
+                    "metadata_json": new_metadata_json,
+                    "updated_at": now,
+                    "completed_at": completed_at,
+                    "version": int(old["version"]) + 1,
+                    "canonical_revision": int(old["canonical_revision"]) + 1,
+                }
+            )
 
             update_cursor = self._execute(
                 transaction_conn,
@@ -680,8 +888,10 @@ class TaskStore:
                        metadata_json = ?,
                        updated_at = ?,
                        completed_at = ?,
-                       version = version + 1
-                 WHERE id = ? AND version = ?
+                       version = version + 1,
+                       canonical_revision = ?, canonical_hash = ?,
+                       source_diagnostic_code = ?, source_diagnostic_hash = ?
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ? AND version = ?
                 """,
                 (
                     new_text,
@@ -689,6 +899,12 @@ class TaskStore:
                     new_metadata_json,
                     now,
                     completed_at,
+                    canonical_revision,
+                    canonical_hash,
+                    diagnostic_code,
+                    diagnostic_hash,
+                    owner,
+                    dataset,
                     task_id,
                     expected_version,
                 ),
@@ -699,7 +915,10 @@ class TaskStore:
                     entity="tasks",
                     entity_id=task_id,
                 )  # noqa: TRY003
-            updated = self._fetch_task(task_id, include_deleted=True, conn=transaction_conn)
+            updated = self._fetch_task(
+                task_id, owner_user_id=owner, dataset_id=dataset,
+                include_deleted=True, conn=transaction_conn,
+            )
             if updated is None:
                 raise ConflictError(
                     f"Task with ID '{task_id}' not found.", entity="tasks", entity_id=task_id
@@ -708,6 +927,8 @@ class TaskStore:
                 self.record_task_event(
                     task_id=task_id,
                     note_id=updated["note_id"],
+                    owner_user_id=owner,
+                    dataset_id=dataset,
                     event_type="status_changed",
                     actor_type=actor_type,
                     actor_id=actor_id,
@@ -722,6 +943,8 @@ class TaskStore:
                 self.record_task_event(
                     task_id=task_id,
                     note_id=updated["note_id"],
+                    owner_user_id=owner,
+                    dataset_id=dataset,
                     event_type="updated",
                     actor_type=actor_type,
                     actor_id=actor_id,
@@ -742,6 +965,8 @@ class TaskStore:
     def set_task_projection(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         task_id: str,
         note_id: str,
         note_version: int,
@@ -761,14 +986,20 @@ class TaskStore:
         if normalized_projection_status == "deleted":
             raise InputError("projection_status 'deleted' is reserved for soft_delete_task.")  # noqa: TRY003
         now = self._db._get_current_utc_timestamp_iso()
+        owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_projection(transaction_conn: TaskConnection) -> dict[str, Any]:
             task = self._require_active_task(
-                self._fetch_task(task_id, include_deleted=True, conn=transaction_conn),
+                self._fetch_task(
+                    task_id, owner_user_id=owner, dataset_id=dataset,
+                    include_deleted=True, conn=transaction_conn,
+                ),
                 task_id,
             )
-            self._require_active_note(task["note_id"], task_id, conn=transaction_conn)
-            projection_state, _ = self._resolve_projection_state(task, task_id, conn=transaction_conn)
+            self._require_active_note(task["note_id"], task_id, owner_user_id=owner, conn=transaction_conn)
+            projection_state, _ = self._resolve_projection_state(
+                task, task_id, owner_user_id=owner, dataset_id=dataset, conn=transaction_conn
+            )
             if task["note_id"] != note_id:
                 raise ConflictError(
                     f"Task projection note does not match owning note for task '{task_id}'.",
@@ -785,12 +1016,15 @@ class TaskStore:
                            WHEN projection_status != ? THEN version + 1
                            ELSE version
                        END
-                 WHERE id = ? AND note_id = ? AND deleted = ? AND projection_status = ?
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                   AND note_id = ? AND deleted = ? AND projection_status = ?
                 """,
                 (
                     normalized_projection_status,
                     now,
                     normalized_projection_status,
+                    owner,
+                    dataset,
                     task_id,
                     note_id,
                     self._deleted_value(False),
@@ -807,12 +1041,12 @@ class TaskStore:
                 transaction_conn,
                 """
                 INSERT INTO task_note_projections (
-                    task_id, note_id, note_version, line_number, start_offset, end_offset,
+                    owner_user_id, dataset_id, task_id, note_id, note_version, line_number, start_offset, end_offset,
                     normalized_text_hash, occurrence_index, block_fingerprint, raw_line,
                     has_child_content, projection_status, updated_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(task_id) DO UPDATE SET
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(owner_user_id, dataset_id, task_id) DO UPDATE SET
                     note_id = excluded.note_id,
                     note_version = excluded.note_version,
                     line_number = excluded.line_number,
@@ -827,6 +1061,8 @@ class TaskStore:
                     updated_at = excluded.updated_at
                 """,
                 (
+                    owner,
+                    dataset,
                     task_id,
                     note_id,
                     int(note_version),
@@ -842,7 +1078,9 @@ class TaskStore:
                     now,
                 ),
             )
-            projection = self._fetch_projection(task_id, conn=transaction_conn)
+            projection = self._fetch_projection(
+                task_id, owner_user_id=owner, dataset_id=dataset, conn=transaction_conn
+            )
             if projection is None:
                 raise CharactersRAGDBError(f"Failed to read projection for task '{task_id}'.")  # noqa: TRY003
             return projection
@@ -852,6 +1090,8 @@ class TaskStore:
     def mark_task_unlinked(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         task_id: str,
         expected_version: int,
         actor_type: str | None = None,
@@ -864,17 +1104,24 @@ class TaskStore:
     ) -> dict[str, Any]:
         """Mark a task's projection as unlinked after reconciliation."""
 
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+
         def _execute_unlink(transaction_conn: TaskConnection) -> dict[str, Any]:
             old = self._require_active_task(
                 self._require_expected_version(
-                    self._fetch_task(task_id, include_deleted=True, conn=transaction_conn),
+                    self._fetch_task(
+                        task_id, owner_user_id=owner, dataset_id=dataset,
+                        include_deleted=True, conn=transaction_conn,
+                    ),
                     expected_version,
                     task_id,
                 ),
                 task_id,
             )
-            self._require_active_note(old["note_id"], task_id, conn=transaction_conn)
-            projection_state, projection = self._resolve_projection_state(old, task_id, conn=transaction_conn)
+            self._require_active_note(old["note_id"], task_id, owner_user_id=owner, conn=transaction_conn)
+            projection_state, projection = self._resolve_projection_state(
+                old, task_id, owner_user_id=owner, dataset_id=dataset, conn=transaction_conn
+            )
             if projection_state != "live":
                 raise ConflictError(
                     f"Task projection is {projection_state} for task '{task_id}'.",
@@ -890,9 +1137,10 @@ class TaskStore:
                    SET projection_status = ?,
                        updated_at = ?,
                        version = version + 1
-                 WHERE id = ? AND version = ? AND projection_status = ?
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                   AND version = ? AND projection_status = ?
                 """,
-                ("unlinked", now, task_id, expected_version, projection_state),
+                ("unlinked", now, owner, dataset, task_id, expected_version, projection_state),
             )
             if getattr(update_cursor, "rowcount", None) == 0:
                 raise ConflictError(
@@ -906,7 +1154,7 @@ class TaskStore:
                 UPDATE task_note_projections
                    SET projection_status = ?,
                        updated_at = ?
-                 WHERE task_id = ?
+                 WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?
                    AND projection_status = ?
                    AND note_id = ?
                    AND note_version = ?
@@ -918,6 +1166,8 @@ class TaskStore:
                 (
                     "unlinked",
                     now,
+                    owner,
+                    dataset,
                     task_id,
                     projection_state,
                     projection["note_id"],
@@ -934,11 +1184,16 @@ class TaskStore:
                     entity="tasks",
                     entity_id=task_id,
                 )  # noqa: TRY003
-            updated = self._fetch_task(task_id, include_deleted=True, conn=transaction_conn)
+            updated = self._fetch_task(
+                task_id, owner_user_id=owner, dataset_id=dataset,
+                include_deleted=True, conn=transaction_conn,
+            )
             if actor_type:
                 self.record_task_event(
                     task_id=task_id,
                     note_id=old["note_id"],
+                    owner_user_id=owner,
+                    dataset_id=dataset,
                     event_type="unlinked",
                     actor_type=actor_type,
                     actor_id=actor_id,
@@ -961,6 +1216,8 @@ class TaskStore:
     def soft_delete_task(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         task_id: str,
         expected_version: int,
         projection_note_id: str | None = None,
@@ -977,17 +1234,24 @@ class TaskStore:
     ) -> dict[str, Any]:
         """Soft-delete a task, requiring projection context for live projected rows."""
 
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+
         def _execute_delete(transaction_conn: TaskConnection) -> dict[str, Any]:
             old = self._require_active_task(
                 self._require_expected_version(
-                    self._fetch_task(task_id, include_deleted=True, conn=transaction_conn),
+                    self._fetch_task(
+                        task_id, owner_user_id=owner, dataset_id=dataset,
+                        include_deleted=True, conn=transaction_conn,
+                    ),
                     expected_version,
                     task_id,
                 ),
                 task_id,
             )
-            self._require_active_note(old["note_id"], task_id, conn=transaction_conn)
-            projection_status, projection = self._resolve_projection_state(old, task_id, conn=transaction_conn)
+            self._require_active_note(old["note_id"], task_id, owner_user_id=owner, conn=transaction_conn)
+            projection_status, projection = self._resolve_projection_state(
+                old, task_id, owner_user_id=owner, dataset_id=dataset, conn=transaction_conn
+            )
             if projection_status == "ambiguous":
                 raise ConflictError(
                     f"Task projection is ambiguous for task '{task_id}'.", entity="tasks", entity_id=task_id
@@ -1014,6 +1278,16 @@ class TaskStore:
                         "Task projection deletion is ambiguous without a matching projection locator."
                     )  # noqa: TRY003
             now = self._db._get_current_utc_timestamp_iso()
+            canonical_revision, canonical_hash, diagnostic_code, diagnostic_hash = self._canonical_task_values(
+                {
+                    **old,
+                    "deleted": 1,
+                    "projection_status": "deleted",
+                    "updated_at": now,
+                    "version": int(old["version"]) + 1,
+                    "canonical_revision": int(old["canonical_revision"]) + 1,
+                }
+            )
             update_cursor = self._execute(
                 transaction_conn,
                 """
@@ -1021,13 +1295,22 @@ class TaskStore:
                    SET deleted = ?,
                        projection_status = ?,
                        updated_at = ?,
-                       version = version + 1
-                 WHERE id = ? AND version = ? AND deleted = ? AND projection_status = ?
+                       version = version + 1,
+                       canonical_revision = ?, canonical_hash = ?,
+                       source_diagnostic_code = ?, source_diagnostic_hash = ?
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                   AND version = ? AND deleted = ? AND projection_status = ?
                 """,
                 (
                     self._deleted_value(True),
                     "deleted",
                     now,
+                    canonical_revision,
+                    canonical_hash,
+                    diagnostic_code,
+                    diagnostic_hash,
+                    owner,
+                    dataset,
                     task_id,
                     expected_version,
                     self._deleted_value(False),
@@ -1047,7 +1330,7 @@ class TaskStore:
                     UPDATE task_note_projections
                        SET projection_status = ?,
                            updated_at = ?
-                     WHERE task_id = ?
+                     WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?
                        AND projection_status = ?
                        AND note_id = ?
                        AND note_version = ?
@@ -1059,6 +1342,8 @@ class TaskStore:
                     (
                         "deleted",
                         now,
+                        owner,
+                        dataset,
                         task_id,
                         projection_status,
                         projection["note_id"],
@@ -1076,9 +1361,9 @@ class TaskStore:
                     UPDATE task_note_projections
                        SET projection_status = ?,
                            updated_at = ?
-                     WHERE task_id = ?
+                     WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?
                     """,
-                    ("deleted", now, task_id),
+                    ("deleted", now, owner, dataset, task_id),
                 )
             if projection_status == "live" and not allow_record_only:
                 if getattr(projection_update_cursor, "rowcount", None) == 0:
@@ -1087,11 +1372,16 @@ class TaskStore:
                         entity="tasks",
                         entity_id=task_id,
                     )  # noqa: TRY003
-            updated = self._fetch_task(task_id, include_deleted=True, conn=transaction_conn)
+            updated = self._fetch_task(
+                task_id, owner_user_id=owner, dataset_id=dataset,
+                include_deleted=True, conn=transaction_conn,
+            )
             if actor_type:
                 self.record_task_event(
                     task_id=task_id,
                     note_id=old["note_id"],
+                    owner_user_id=owner,
+                    dataset_id=dataset,
                     event_type="deleted",
                     actor_type=actor_type,
                     actor_id=actor_id,
@@ -1114,6 +1404,8 @@ class TaskStore:
     def record_task_event(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         event_type: str,
         actor_type: str,
         task_id: str | None = None,
@@ -1132,18 +1424,44 @@ class TaskStore:
         now = self._db._get_current_utc_timestamp_iso()
         old_value_json = self._json_dumps(old_value, "old_value") if old_value is not None else None
         new_value_json = self._json_dumps(new_value, "new_value") if new_value is not None else None
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        event_hash = self._db._note_task_v60_hash(
+            {
+                "owner_user_id": owner,
+                "dataset_id": dataset,
+                "id": final_event_id,
+                "task_id": task_id,
+                "note_id": note_id,
+                "event_type": event_type,
+                "actor_type": actor_type,
+                "actor_id": actor_id,
+                "tool_name": tool_name,
+                "policy_mode": policy_mode,
+                "approval_id": approval_id,
+                "old_value_json": old_value_json,
+                "new_value_json": new_value_json,
+                "created_at": now,
+                "client_id": self._db.client_id,
+            }
+        )
 
         def _execute_event(transaction_conn: TaskConnection) -> dict[str, Any]:
             self._execute(
                 transaction_conn,
                 """
                 INSERT INTO task_events (
-                    id, task_id, note_id, event_type, actor_type, actor_id, tool_name,
-                    policy_mode, approval_id, old_value_json, new_value_json, created_at, client_id
+                    owner_user_id, dataset_id, id, task_id, note_id, event_type, actor_type,
+                    actor_id, tool_name, policy_mode, approval_id, old_value_json, new_value_json,
+                    created_at, client_id, sync_revision, sync_object_hash, sync_server_cursor,
+                    source_device_id, client_occurred_at, source_kind, corrects_activity_id,
+                    deleted, deleted_at, delete_reason, source_diagnostic_code,
+                    source_diagnostic_hash
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
+                    owner,
+                    dataset,
                     final_event_id,
                     task_id,
                     note_id,
@@ -1157,9 +1475,25 @@ class TaskStore:
                     new_value_json,
                     now,
                     self._db.client_id,
+                    1,
+                    event_hash,
+                    None,
+                    None,
+                    now,
+                    "rest",
+                    None,
+                    self._deleted_value(False),
+                    None,
+                    None,
+                    "legacy_task_activity_unverified",
+                    event_hash,
                 ),
             )
-            cursor = self._read("SELECT * FROM task_events WHERE id = ?", (final_event_id,), conn=transaction_conn)
+            cursor = self._read(
+                "SELECT * FROM task_events WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+                (owner, dataset, final_event_id),
+                conn=transaction_conn,
+            )
             event = self._decode_event_row(cursor.fetchone())
             if event is None:
                 raise CharactersRAGDBError(f"Failed to read task event '{final_event_id}'.")  # noqa: TRY003
@@ -1185,13 +1519,16 @@ class TaskStore:
     def list_task_activity(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         task_id: str | None = None,
         note_id: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         """List task events by task or note scope."""
-        clauses: list[str] = []
-        params: list[Any] = []
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        clauses: list[str] = ["owner_user_id = ?", "dataset_id = ?"]
+        params: list[Any] = [owner, dataset]
         if task_id is not None:
             clauses.append("task_id = ?")
             params.append(task_id)
@@ -1212,14 +1549,17 @@ class TaskStore:
     def list_recent_task_activity(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         task_id: str | None = None,
         note_id: str | None = None,
         actor_type: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         """List task events newest-first without changing the ascending default helper."""
-        clauses: list[str] = []
-        params: list[Any] = []
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        clauses: list[str] = ["owner_user_id = ?", "dataset_id = ?"]
+        params: list[Any] = [owner, dataset]
         if task_id is not None:
             clauses.append("task_id = ?")
             params.append(task_id)
@@ -1243,6 +1583,8 @@ class TaskStore:
     def list_recent_unread_task_activity(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         user_id: str,
         task_id: str | None = None,
         note_id: str | None = None,
@@ -1250,13 +1592,18 @@ class TaskStore:
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         """List newest unread task events for a user, applying visibility before limit."""
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        if user_id != owner:
+            return []
         query = """
             SELECT events.*
             FROM task_events AS events
             LEFT JOIN task_event_read_state AS state
-              ON state.event_id = events.id
-             AND state.user_id = ?
-            WHERE (state.event_id IS NULL OR (state.read_at IS NULL AND state.dismissed_at IS NULL))
+              ON state.owner_user_id = events.owner_user_id
+             AND state.dataset_id = events.dataset_id
+             AND state.event_id = events.id AND state.user_id = ?
+            WHERE events.owner_user_id = ? AND events.dataset_id = ?
+              AND (state.event_id IS NULL OR (state.read_at IS NULL AND state.dismissed_at IS NULL))
               AND (? IS NULL OR events.task_id = ?)
               AND (? IS NULL OR events.note_id = ?)
               AND (? IS NULL OR events.actor_type = ?)
@@ -1265,7 +1612,7 @@ class TaskStore:
             query += " ORDER BY events.created_at DESC, events.rowid DESC LIMIT ?"
         else:
             query += " ORDER BY events.created_at DESC, events.id DESC LIMIT ?"
-        params: list[Any] = [user_id, task_id, task_id, note_id, note_id, actor_type, actor_type]
+        params: list[Any] = [user_id, owner, dataset, task_id, task_id, note_id, note_id, actor_type, actor_type]
         params.append(self._clamp_limit(limit))
         cursor = self._read(query, tuple(params))
         return [self._decode_event_row(row) for row in cursor.fetchall()]
@@ -1274,24 +1621,33 @@ class TaskStore:
         self,
         event_id: str,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         user_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any]:
         """Mark an activity event read for one user."""
         now = self._db._get_current_utc_timestamp_iso()
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        if user_id != owner:
+            raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
 
         def _execute_read(transaction_conn: TaskConnection) -> dict[str, Any]:
             self._execute(
                 transaction_conn,
                 """
-                INSERT INTO task_event_read_state (event_id, user_id, read_at, dismissed_at)
-                VALUES (?, ?, ?, NULL)
-                ON CONFLICT(event_id, user_id) DO UPDATE SET
+                INSERT INTO task_event_read_state (
+                    owner_user_id, dataset_id, event_id, user_id, read_at, dismissed_at
+                ) VALUES (?, ?, ?, ?, ?, NULL)
+                ON CONFLICT(owner_user_id, dataset_id, event_id, user_id) DO UPDATE SET
                     read_at = COALESCE(task_event_read_state.read_at, excluded.read_at)
                 """,
-                (event_id, user_id, now),
+                (owner, dataset, event_id, user_id, now),
             )
-            state = self.get_task_activity_read_state(event_id, user_id=user_id, conn=transaction_conn)
+            state = self.get_task_activity_read_state(
+                event_id, user_id=user_id, owner_user_id=owner, dataset_id=dataset,
+                conn=transaction_conn,
+            )
             if state is None:
                 raise CharactersRAGDBError(f"Failed to read task event read state for '{event_id}'.")  # noqa: TRY003
             return state
@@ -1317,25 +1673,34 @@ class TaskStore:
         self,
         event_id: str,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         user_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any]:
         """Mark an activity event dismissed for one user."""
         now = self._db._get_current_utc_timestamp_iso()
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        if user_id != owner:
+            raise ConflictError("Task event not found.", entity="tasks", entity_id=event_id)  # noqa: TRY003
 
         def _execute_dismiss(transaction_conn: TaskConnection) -> dict[str, Any]:
             self._execute(
                 transaction_conn,
                 """
-                INSERT INTO task_event_read_state (event_id, user_id, read_at, dismissed_at)
-                VALUES (?, ?, ?, ?)
-                ON CONFLICT(event_id, user_id) DO UPDATE SET
+                INSERT INTO task_event_read_state (
+                    owner_user_id, dataset_id, event_id, user_id, read_at, dismissed_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(owner_user_id, dataset_id, event_id, user_id) DO UPDATE SET
                     read_at = COALESCE(task_event_read_state.read_at, excluded.read_at),
                     dismissed_at = excluded.dismissed_at
                 """,
-                (event_id, user_id, now, now),
+                (owner, dataset, event_id, user_id, now, now),
             )
-            state = self.get_task_activity_read_state(event_id, user_id=user_id, conn=transaction_conn)
+            state = self.get_task_activity_read_state(
+                event_id, user_id=user_id, owner_user_id=owner, dataset_id=dataset,
+                conn=transaction_conn,
+            )
             if state is None:
                 raise CharactersRAGDBError(f"Failed to read task event read state for '{event_id}'.")  # noqa: TRY003
             return state
@@ -1361,26 +1726,40 @@ class TaskStore:
         self,
         event_id: str,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         user_id: str,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
         """Return read/dismiss state for one event and user."""
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        if user_id != owner:
+            return None
         cursor = self._read(
             """
             SELECT * FROM task_event_read_state
-             WHERE event_id = ? AND user_id = ?
+             WHERE owner_user_id = ? AND dataset_id = ? AND event_id = ? AND user_id = ?
             """,
-            (event_id, user_id),
+            (owner, dataset, event_id, user_id),
             conn=conn,
         )
         row = cursor.fetchone()
         return dict(row) if row else None
 
-    def get_reconciliation_state(self, note_id: str) -> dict[str, Any] | None:
+    def get_reconciliation_state(
+        self,
+        note_id: str,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        conn: TaskConnection | None = None,
+    ) -> dict[str, Any] | None:
         """Return the last task reconciliation state for a note."""
+        owner, dataset = self._scope(owner_user_id, dataset_id)
         cursor = self._read(
-            "SELECT * FROM note_task_reconciliation_state WHERE note_id = ?",
-            (note_id,),
+            "SELECT * FROM note_task_reconciliation_state WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
+            (owner, dataset, note_id),
+            conn=conn,
         )
         row = cursor.fetchone()
         return dict(row) if row else None
@@ -1388,6 +1767,8 @@ class TaskStore:
     def set_reconciliation_state(
         self,
         *,
+        owner_user_id: str,
+        dataset_id: str,
         note_id: str,
         note_version: int,
         status: str,
@@ -1398,16 +1779,18 @@ class TaskStore:
     ) -> dict[str, Any]:
         """Upsert task reconciliation progress for a note/version."""
         now = self._db._get_current_utc_timestamp_iso()
+        owner, dataset = self._scope(owner_user_id, dataset_id)
 
         def _execute_state(transaction_conn: TaskConnection) -> dict[str, Any]:
             self._execute(
                 transaction_conn,
                 """
                 INSERT INTO note_task_reconciliation_state (
-                    note_id, note_version, status, reconciled_at, item_count, warning_count, cursor
+                    owner_user_id, dataset_id, note_id, note_version, status,
+                    reconciled_at, item_count, warning_count, cursor
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(note_id) DO UPDATE SET
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(owner_user_id, dataset_id, note_id) DO UPDATE SET
                     note_version = excluded.note_version,
                     status = excluded.status,
                     reconciled_at = excluded.reconciled_at,
@@ -1416,6 +1799,8 @@ class TaskStore:
                     cursor = excluded.cursor
                 """,
                 (
+                    owner,
+                    dataset,
                     note_id,
                     int(note_version),
                     status,
@@ -1426,9 +1811,13 @@ class TaskStore:
                 ),
             )
             state = (
-                self.get_reconciliation_state(note_id)
+                self.get_reconciliation_state(
+                    note_id, owner_user_id=owner, dataset_id=dataset
+                )
                 if conn is None
-                else self._get_reconciliation_state_in_conn(note_id, transaction_conn)
+                else self._get_reconciliation_state_in_conn(
+                    note_id, owner_user_id=owner, dataset_id=dataset, conn=transaction_conn
+                )
             )
             if state is None:
                 raise CharactersRAGDBError(f"Failed to read reconciliation state for note '{note_id}'.")  # noqa: TRY003
@@ -1451,23 +1840,38 @@ class TaskStore:
                 reference="note",
             )
 
-    def _get_reconciliation_state_in_conn(self, note_id: str, conn: TaskConnection) -> dict[str, Any] | None:
+    def _get_reconciliation_state_in_conn(
+        self,
+        note_id: str,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        conn: TaskConnection,
+    ) -> dict[str, Any] | None:
         cursor = self._read(
-            "SELECT * FROM note_task_reconciliation_state WHERE note_id = ?",
-            (note_id,),
+            "SELECT * FROM note_task_reconciliation_state WHERE owner_user_id = ? AND dataset_id = ? AND note_id = ?",
+            (owner_user_id, dataset_id, note_id),
             conn=conn,
         )
         row = cursor.fetchone()
         return dict(row) if row else None
 
-    def candidate_notes_for_task_discovery(self, *, limit: int = 100) -> list[dict[str, Any]]:
+    def candidate_notes_for_task_discovery(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
         """Return checklist-bearing notes whose task reconciliation is stale or missing."""
+        owner, dataset = self._scope(owner_user_id, dataset_id)
         cursor = self._read(
             """
             SELECT n.id, n.title, n.version, n.last_modified
               FROM notes n
-              LEFT JOIN note_task_reconciliation_state r ON r.note_id = n.id
-             WHERE n.deleted = ?
+              LEFT JOIN note_task_reconciliation_state r
+                ON r.owner_user_id = n.client_id AND r.dataset_id = ? AND r.note_id = n.id
+             WHERE n.client_id = ? AND n.deleted = ?
                AND (
                     n.content LIKE ?
                  OR n.content LIKE ?
@@ -1486,6 +1890,8 @@ class TaskStore:
              LIMIT ?
             """,
             (
+                dataset,
+                owner,
                 self._deleted_value(False),
                 *self._CHECKLIST_DISCOVERY_MARKER_PATTERNS,
                 *self._CHECKLIST_DISCOVERY_BULLET_PATTERNS,
@@ -1494,9 +1900,18 @@ class TaskStore:
         )
         return [dict(row) for row in cursor.fetchall()]
 
-    def count_candidate_notes_for_task_discovery(self, *, note_id: str | None = None) -> int:
+    def count_candidate_notes_for_task_discovery(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        note_id: str | None = None,
+    ) -> int:
         """Count checklist-bearing notes whose task reconciliation is stale or missing."""
+        owner, dataset = self._scope(owner_user_id, dataset_id)
         params: list[Any] = [
+            dataset,
+            owner,
             self._deleted_value(False),
             *self._CHECKLIST_DISCOVERY_MARKER_PATTERNS,
             *self._CHECKLIST_DISCOVERY_BULLET_PATTERNS,
@@ -1504,8 +1919,9 @@ class TaskStore:
         sql_query = """
             SELECT COUNT(*) AS stale_count
               FROM notes n
-              LEFT JOIN note_task_reconciliation_state r ON r.note_id = n.id
-             WHERE n.deleted = ?
+              LEFT JOIN note_task_reconciliation_state r
+                ON r.owner_user_id = n.client_id AND r.dataset_id = ? AND r.note_id = n.id
+             WHERE n.client_id = ? AND n.deleted = ?
                AND (
                     n.content LIKE ?
                  OR n.content LIKE ?
@@ -1527,6 +1943,83 @@ class TaskStore:
         cursor = self._read(sql_query, tuple(params))
         row = cursor.fetchone()
         return int(row["stale_count"] if row else 0)
+
+    def bind_local_task_graph_to_dataset(
+        self,
+        *,
+        owner_user_id: str,
+        target_dataset_id: str,
+        conn: TaskConnection | None = None,
+    ) -> dict[str, int]:
+        """Atomically rekey one owner's complete local task graph to an enrolled dataset."""
+        owner = str(owner_user_id).strip()
+        target = str(target_dataset_id).strip()
+        if not owner or not target or target == self._LOCAL_UNBOUND:
+            raise InputError("A non-sentinel owner and target dataset are required.")  # noqa: TRY003
+        if self._db.backend_type != BackendType.SQLITE:
+            raise InputError("Local task graph binding is only supported by SQLite storage.")  # noqa: TRY003
+
+        tables = (
+            "note_tasks",
+            "task_note_projections",
+            "task_events",
+            "task_event_read_state",
+            "note_task_reconciliation_state",
+            "task_projection_drifts",
+        )
+
+        def _counts(transaction_conn: TaskConnection, dataset: str) -> dict[str, int]:
+            result: dict[str, int] = {}
+            for table in tables:
+                row = self._read(
+                    f"SELECT COUNT(*) AS count FROM {table} "  # nosec B608
+                    "WHERE owner_user_id = ? AND dataset_id = ?",
+                    (owner, dataset),
+                    conn=transaction_conn,
+                ).fetchone()
+                result[table] = int(row["count"])
+            return result
+
+        def _execute_bind(transaction_conn: TaskConnection) -> dict[str, int]:
+            source_counts = _counts(transaction_conn, self._LOCAL_UNBOUND)
+            target_counts = _counts(transaction_conn, target)
+            if any(target_counts.values()):
+                raise ConflictError(
+                    "Task dataset binding target collision.", entity="tasks", entity_id=target
+                )  # noqa: TRY003
+            if not any(source_counts.values()):
+                return source_counts
+
+            # Rekey roots only. Composite ON UPDATE CASCADE relationships carry
+            # projections, task-linked events, read-state, and drift rows.
+            self._execute(
+                transaction_conn,
+                "UPDATE note_tasks SET dataset_id = ? WHERE owner_user_id = ? AND dataset_id = ?",
+                (target, owner, self._LOCAL_UNBOUND),
+            )
+            self._execute(
+                transaction_conn,
+                "UPDATE task_events SET dataset_id = ? WHERE owner_user_id = ? AND dataset_id = ?",
+                (target, owner, self._LOCAL_UNBOUND),
+            )
+            self._execute(
+                transaction_conn,
+                "UPDATE note_task_reconciliation_state SET dataset_id = ? "
+                "WHERE owner_user_id = ? AND dataset_id = ?",
+                (target, owner, self._LOCAL_UNBOUND),
+            )
+
+            remaining = _counts(transaction_conn, self._LOCAL_UNBOUND)
+            rebound = _counts(transaction_conn, target)
+            if any(remaining.values()) or rebound != source_counts:
+                raise ConflictError(
+                    "Task dataset binding failed complete-set verification.",
+                    entity="tasks",
+                    entity_id=target,
+                )  # noqa: TRY003
+            return rebound
+
+        return self._with_transaction(_execute_bind, conn)
 
     def _raise_integrity_error(self, exc: sqlite3.IntegrityError, task_id: str) -> None:
         msg = str(exc).lower()

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -2008,7 +2008,7 @@ class TaskStore:
                 )
             self._db._verify_note_task_schema_postgres(transaction_conn)
 
-        def _execute_bind(transaction_conn: TaskConnection) -> dict[str, int]:
+        def _execute_bind_body(transaction_conn: TaskConnection) -> dict[str, int]:
             _prepare_postgres(transaction_conn)
             source_snapshot = _snapshot(transaction_conn, self._LOCAL_UNBOUND)
             target_snapshot = _snapshot(transaction_conn, target)
@@ -2052,6 +2052,19 @@ class TaskStore:
                 )  # noqa: TRY003
             _finish_postgres(transaction_conn)
             return _counts(rebound)
+
+        def _execute_bind(transaction_conn: TaskConnection) -> dict[str, int]:
+            if not postgres:
+                return _execute_bind_body(transaction_conn)
+            self._execute(transaction_conn, "SAVEPOINT bind_local_task_graph")
+            try:
+                result = _execute_bind_body(transaction_conn)
+            except Exception:  # noqa: BLE001 - rollback must cover every failed bind
+                self._execute(transaction_conn, "ROLLBACK TO SAVEPOINT bind_local_task_graph")
+                self._execute(transaction_conn, "RELEASE SAVEPOINT bind_local_task_graph")
+                raise
+            self._execute(transaction_conn, "RELEASE SAVEPOINT bind_local_task_graph")
+            return result
 
         return self._with_transaction(_execute_bind, conn)
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/notes_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/notes_module.py
@@ -1253,9 +1253,9 @@ class NotesModule(BaseModule):
         if task.get("projection_status") != "live":
             return
         projection = db.get_task_projection(
-            task_id,
             owner_user_id=scope.owner_user_id,
             dataset_id=scope.dataset_id,
+            task_id=task_id,
         )
         if projection is None:
             raise ConflictError(
@@ -1360,7 +1360,7 @@ class NotesModule(BaseModule):
 
     def _require_scoped_task(self, db: CharactersRAGDB, context: Any | None, task_id: str) -> dict[str, Any]:
         scope = self._task_scope(db, context)
-        task = db.get_task_scoped(
+        task = db.get_task(
             owner_user_id=scope.owner_user_id,
             dataset_id=scope.dataset_id,
             task_id=task_id,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/notes_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/notes_module.py
@@ -25,6 +25,7 @@ from ....Notes.organization_capture import (
     stable_note_id,
 )
 from ....Notes_Tasks import NotesTaskService, TaskActor
+from ....Notes_Tasks.service import TaskStoreScope, resolve_task_compatibility_scope
 from ...persona_scope import assert_identifier_in_scope, get_explicit_scope_ids, merge_requested_ids_with_scope
 from ..base import BaseModule, create_tool_definition
 from ..disk_space import get_free_disk_space_gb
@@ -982,6 +983,7 @@ class NotesModule(BaseModule):
 
         db = self._open_db(context)
         try:
+            scope = self._task_scope(db, context)
             if note_id is not None:
                 assert_identifier_in_scope(context, "note_id", note_id, label="Note")
                 if reconcile_limit > 0:
@@ -989,10 +991,13 @@ class NotesModule(BaseModule):
                         db=db,
                         note_id=str(note_id),
                         actor=actor,
+                        owner_user_id=str(getattr(context, "user_id", "")),
                     )
                 else:
                     reconciliation = {"status": "clean", "processed_notes": 0, "remaining_stale_notes": 0}
                 tasks = db.list_tasks(
+                    owner_user_id=scope.owner_user_id,
+                    dataset_id=scope.dataset_id,
                     note_id=str(note_id),
                     status=status,
                     projection_status=projection_status,
@@ -1010,10 +1015,13 @@ class NotesModule(BaseModule):
                             db=db,
                             limit=reconcile_limit,
                             actor=actor,
+                            owner_user_id=str(getattr(context, "user_id", "")),
                         )
                     else:
                         reconciliation = {"status": "clean", "processed_notes": 0, "remaining_stale_notes": 0}
                     tasks = db.list_tasks(
+                        owner_user_id=scope.owner_user_id,
+                        dataset_id=scope.dataset_id,
                         status=status,
                         projection_status=projection_status,
                         query=query,
@@ -1036,6 +1044,7 @@ class NotesModule(BaseModule):
                                     db=db,
                                     note_id=str(scoped_note_id),
                                     actor=actor,
+                                    owner_user_id=str(getattr(context, "user_id", "")),
                                 )
                                 processed += 1
                             else:
@@ -1044,6 +1053,8 @@ class NotesModule(BaseModule):
                         while len(fetched_tasks) < target_fetch:
                             page_limit = min(500, target_fetch - len(fetched_tasks))
                             batch = db.list_tasks(
+                                owner_user_id=scope.owner_user_id,
+                                dataset_id=scope.dataset_id,
                                 note_id=str(scoped_note_id),
                                 status=status,
                                 projection_status=projection_status,
@@ -1117,6 +1128,7 @@ class NotesModule(BaseModule):
             self._require_scoped_note(db, context, note_id)
             task = self._task_service.create_task_for_note(
                 db=db,
+                owner_user_id=str(getattr(context, "user_id", "")),
                 note_id=note_id,
                 text=text,
                 status=status,
@@ -1142,6 +1154,7 @@ class NotesModule(BaseModule):
             self._require_scoped_task(db, context, task_id)
             task = self._task_service.update_task(
                 db=db,
+                owner_user_id=str(getattr(context, "user_id", "")),
                 task_id=task_id,
                 expected_task_version=int(args.get("expected_task_version")),
                 expected_note_version=int(args["expected_note_version"]),
@@ -1183,6 +1196,7 @@ class NotesModule(BaseModule):
                     self._require_task_expected_versions(
                         db,
                         current,
+                        scope=self._task_scope(db, context),
                         expected_task_version=int(item.get("expected_task_version")),
                         expected_note_version=int(item["expected_note_version"]),
                     )
@@ -1195,6 +1209,7 @@ class NotesModule(BaseModule):
                         continue
                     task = self._task_service.update_task(
                         db=db,
+                        owner_user_id=str(getattr(context, "user_id", "")),
                         task_id=task_id,
                         expected_task_version=int(item.get("expected_task_version")),
                         expected_note_version=int(item["expected_note_version"]),
@@ -1222,6 +1237,7 @@ class NotesModule(BaseModule):
         db: CharactersRAGDB,
         task: dict[str, Any],
         *,
+        scope: TaskStoreScope,
         expected_task_version: int,
         expected_note_version: int,
     ) -> None:
@@ -1236,8 +1252,11 @@ class NotesModule(BaseModule):
             )
         if task.get("projection_status") != "live":
             return
-        task_store = getattr(db, "task_store", None)
-        projection = task_store._fetch_projection(task_id) if task_store is not None else None
+        projection = db.get_task_projection(
+            task_id,
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+        )
         if projection is None:
             raise ConflictError(
                 f"Task projection is missing for task '{task_id}'.",
@@ -1276,6 +1295,7 @@ class NotesModule(BaseModule):
             self._require_scoped_task(db, context, task_id)
             task = self._task_service.delete_task(
                 db=db,
+                owner_user_id=str(getattr(context, "user_id", "")),
                 task_id=task_id,
                 expected_task_version=int(args.get("expected_task_version")),
                 expected_note_version=int(args["expected_note_version"]),
@@ -1305,6 +1325,7 @@ class NotesModule(BaseModule):
                     )
             result = self._task_service.reconcile_note_current(
                 db=db,
+                owner_user_id=str(getattr(context, "user_id", "")),
                 note_id=note_id,
                 actor=self._task_actor(context, tool_name=tool_name),
             )
@@ -1319,6 +1340,17 @@ class NotesModule(BaseModule):
         if context is None or not str(getattr(context, "user_id", "") or "").strip():
             raise ValueError("Missing user context for Notes task write")
 
+    @staticmethod
+    def _task_scope(db: CharactersRAGDB, context: Any | None) -> TaskStoreScope:
+        """Resolve task scope from authenticated MCP context only."""
+        owner_user_id = str(getattr(context, "user_id", "") or "").strip()
+        if not owner_user_id:
+            raise ValueError("Missing user context for Notes task access")
+        return resolve_task_compatibility_scope(
+            db,
+            authenticated_owner_user_id=owner_user_id,
+        )
+
     def _require_scoped_note(self, db: CharactersRAGDB, context: Any | None, note_id: str) -> dict[str, Any]:
         assert_identifier_in_scope(context, "note_id", note_id, label="Note")
         note = db.get_note_by_id(note_id)
@@ -1327,7 +1359,12 @@ class NotesModule(BaseModule):
         return dict(note)
 
     def _require_scoped_task(self, db: CharactersRAGDB, context: Any | None, task_id: str) -> dict[str, Any]:
-        task = db.get_task(task_id)
+        scope = self._task_scope(db, context)
+        task = db.get_task_scoped(
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+            task_id=task_id,
+        )
         if task is None:
             raise ValueError(f"Task not found: {task_id}")
         note_id = str(task.get("note_id") or "")
@@ -1344,7 +1381,11 @@ class NotesModule(BaseModule):
         try:
             task_store = getattr(db, "task_store", None)
             if task_store is not None:
-                projection = task_store._fetch_projection(task_id)
+                projection = task_store._fetch_projection(
+                    task_id,
+                    owner_user_id=str(task["owner_user_id"]),
+                    dataset_id=str(task["dataset_id"]),
+                )
         except _NOTES_MODULE_NONCRITICAL_EXCEPTIONS:
             projection = None
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/notes_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/notes_module.py
@@ -1078,7 +1078,7 @@ class NotesModule(BaseModule):
                     }
 
             return {
-                "tasks": [self._task_response(db, task) for task in tasks],
+                "tasks": [self._task_response(db, task, scope=scope) for task in tasks],
                 "reconciliation": self._task_reconciliation_response(reconciliation),
                 "pagination": {
                     "limit": limit,
@@ -1111,8 +1111,9 @@ class NotesModule(BaseModule):
         task_id = str(args.get("task_id"))
         db = self._open_db(context)
         try:
+            scope = self._task_scope(db, context)
             task = self._require_scoped_task(db, context, task_id)
-            return self._task_response(db, task)
+            return self._task_response(db, task, scope=scope)
         finally:
             self._close_task_db(db, "task fetch")
 
@@ -1125,6 +1126,7 @@ class NotesModule(BaseModule):
         expected_note_version = int(args.get("expected_note_version"))
         db = self._open_db(context)
         try:
+            scope = self._task_scope(db, context)
             self._require_scoped_note(db, context, note_id)
             task = self._task_service.create_task_for_note(
                 db=db,
@@ -1140,7 +1142,7 @@ class NotesModule(BaseModule):
                     idempotency_key=self._get_idempotency_key(args),
                 ),
             )
-            response = self._task_response(db, task)
+            response = self._task_response(db, task, scope=scope)
             response["insertion"] = {"mode": "append"}
             return response
         finally:
@@ -1151,6 +1153,7 @@ class NotesModule(BaseModule):
         task_id = str(args.get("task_id"))
         db = self._open_db(context)
         try:
+            scope = self._task_scope(db, context)
             self._require_scoped_task(db, context, task_id)
             task = self._task_service.update_task(
                 db=db,
@@ -1167,7 +1170,7 @@ class NotesModule(BaseModule):
                 ),
                 record_only=bool(args.get("record_only", False)),
             )
-            return self._task_response(db, task)
+            return self._task_response(db, task, scope=scope)
         finally:
             self._close_task_db(db, "task update")
 
@@ -1184,6 +1187,7 @@ class NotesModule(BaseModule):
             idempotency_key=self._get_idempotency_key(args),
         )
         try:
+            scope = self._task_scope(db, context)
             for item in self._task_status_updates(args) or []:
                 task_id = str(item.get("task_id") or "")
                 if task_id in seen_task_ids:
@@ -1196,7 +1200,7 @@ class NotesModule(BaseModule):
                     self._require_task_expected_versions(
                         db,
                         current,
-                        scope=self._task_scope(db, context),
+                        scope=scope,
                         expected_task_version=int(item.get("expected_task_version")),
                         expected_note_version=int(item["expected_note_version"]),
                     )
@@ -1204,7 +1208,7 @@ class NotesModule(BaseModule):
                         skipped.append({
                             "task_id": task_id,
                             "reason": f"already_{requested_status}",
-                            "task": self._task_response(db, current),
+                            "task": self._task_response(db, current, scope=scope),
                         })
                         continue
                     task = self._task_service.update_task(
@@ -1217,7 +1221,10 @@ class NotesModule(BaseModule):
                         actor=actor,
                         record_only=bool(item.get("record_only", False)),
                     )
-                    succeeded.append({"task_id": task_id, "task": self._task_response(db, task)})
+                    succeeded.append({
+                        "task_id": task_id,
+                        "task": self._task_response(db, task, scope=scope),
+                    })
                 except Exception as exc:
                     failed.append({
                         "task_id": task_id,
@@ -1292,6 +1299,7 @@ class NotesModule(BaseModule):
         task_id = str(args.get("task_id"))
         db = self._open_db(context)
         try:
+            scope = self._task_scope(db, context)
             self._require_scoped_task(db, context, task_id)
             task = self._task_service.delete_task(
                 db=db,
@@ -1306,7 +1314,7 @@ class NotesModule(BaseModule):
                     idempotency_key=self._get_idempotency_key(args),
                 ),
             )
-            return self._task_response(db, task)
+            return self._task_response(db, task, scope=scope)
         finally:
             self._close_task_db(db, "task delete")
 
@@ -1373,21 +1381,21 @@ class NotesModule(BaseModule):
             raise ValueError(f"Task note not found: {note_id}")
         return dict(task)
 
-    def _task_response(self, db: CharactersRAGDB, task: dict[str, Any]) -> dict[str, Any]:
+    def _task_response(
+        self,
+        db: CharactersRAGDB,
+        task: dict[str, Any],
+        *,
+        scope: TaskStoreScope,
+    ) -> dict[str, Any]:
         task_id = str(task.get("id"))
         note_id = str(task.get("note_id"))
         note = db.get_note_by_id(note_id)
-        projection = None
-        try:
-            task_store = getattr(db, "task_store", None)
-            if task_store is not None:
-                projection = task_store._fetch_projection(
-                    task_id,
-                    owner_user_id=str(task["owner_user_id"]),
-                    dataset_id=str(task["dataset_id"]),
-                )
-        except _NOTES_MODULE_NONCRITICAL_EXCEPTIONS:
-            projection = None
+        projection = db.get_task_projection(
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+            task_id=task_id,
+        )
 
         return {
             "id": task_id,

--- a/tldw_Server_API/app/core/Notes_Tasks/reconciler.py
+++ b/tldw_Server_API/app/core/Notes_Tasks/reconciler.py
@@ -15,8 +15,8 @@ from tldw_Server_API.app.core.Notes_Tasks.models import (
 )
 
 if TYPE_CHECKING:
-    from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
     from tldw_Server_API.app.core.DB_Management.chacha.task_store import TaskConnection
+    from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 
 
 @dataclass(frozen=True)
@@ -36,6 +36,8 @@ class NotesTaskReconciler:
         note_version: int,
         content: str,
         actor: TaskActor,
+        owner_user_id: str,
+        dataset_id: str,
     ) -> ReconciliationResult:
         parsed = parse_note_checklists(note_id=note_id, note_version=note_version, content=content)
 
@@ -46,8 +48,16 @@ class NotesTaskReconciler:
                 note_id=note_id,
                 note_version=note_version,
                 content=content,
+                owner_user_id=owner_user_id,
+                dataset_id=dataset_id,
             )
-            live_tasks = self._load_live_projected_tasks(db=db, conn=conn, note_id=note_id)
+            live_tasks = self._load_live_projected_tasks(
+                db=db,
+                conn=conn,
+                note_id=note_id,
+                owner_user_id=owner_user_id,
+                dataset_id=dataset_id,
+            )
             parsed_hash_counts = Counter(item.locator.normalized_text_hash for item in parsed.items)
             live_hash_counts = Counter(
                 projected.projection["normalized_text_hash"]
@@ -80,6 +90,8 @@ class NotesTaskReconciler:
                     if self._is_ambiguous_hash(item, parsed_hash_counts, live_hash_counts):
                         ambiguous_count += 1
                     task = db.create_task(
+                        owner_user_id=owner_user_id,
+                        dataset_id=dataset_id,
                         note_id=note_id,
                         text=item.text,
                         status=self._status_for_item(item),
@@ -93,6 +105,8 @@ class NotesTaskReconciler:
                         conn=conn,
                     )
                     db.set_task_projection(
+                        owner_user_id=owner_user_id,
+                        dataset_id=dataset_id,
                         task_id=task["id"],
                         note_id=note_id,
                         note_version=note_version,
@@ -116,6 +130,8 @@ class NotesTaskReconciler:
                 changed_task = self._task_record_differs(task, item)
                 if changed_task:
                     task = db.update_task_record(
+                        owner_user_id=owner_user_id,
+                        dataset_id=dataset_id,
                         task_id=task["id"],
                         expected_version=int(task["version"]),
                         text=item.text,
@@ -131,6 +147,8 @@ class NotesTaskReconciler:
                     )
                     updated_count += 1
                 db.set_task_projection(
+                    owner_user_id=owner_user_id,
+                    dataset_id=dataset_id,
                     task_id=task["id"],
                     note_id=note_id,
                     note_version=note_version,
@@ -151,6 +169,8 @@ class NotesTaskReconciler:
                     continue
                 task = projected.task
                 unlinked = db.mark_task_unlinked(
+                    owner_user_id=owner_user_id,
+                    dataset_id=dataset_id,
                     task_id=task["id"],
                     expected_version=int(task["version"]),
                     actor_type=actor.actor_type,
@@ -166,6 +186,8 @@ class NotesTaskReconciler:
             parser_warning_count = sum(len(item.warnings) for item in parsed.items)
             warning_count = parser_warning_count + ambiguous_count + placeholder_warning_count
             db.set_reconciliation_state(
+                owner_user_id=owner_user_id,
+                dataset_id=dataset_id,
                 note_id=note_id,
                 note_version=note_version,
                 status="clean" if warning_count == 0 else "warnings",
@@ -208,9 +230,13 @@ class NotesTaskReconciler:
         note_id: str,
         note_version: int,
         content: str,
+        owner_user_id: str,
+        dataset_id: str,
     ) -> None:
         note = db.task_store.get_note_reconciliation_snapshot(
             note_id=note_id,
+            owner_user_id=owner_user_id,
+            dataset_id=dataset_id,
             conn=conn,
         )
         if note is None or bool(note["deleted"]):
@@ -237,9 +263,13 @@ class NotesTaskReconciler:
         db: CharactersRAGDB,
         conn: TaskConnection,
         note_id: str,
+        owner_user_id: str,
+        dataset_id: str,
     ) -> list[_ProjectedTask]:
         projected_pairs = db.task_store.list_live_projected_tasks(
             note_id=note_id,
+            owner_user_id=owner_user_id,
+            dataset_id=dataset_id,
             conn=conn,
         )
         return [

--- a/tldw_Server_API/app/core/Notes_Tasks/service.py
+++ b/tldw_Server_API/app/core/Notes_Tasks/service.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import BackendType, ConflictError, InputError
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import ConflictError, InputError
 from tldw_Server_API.app.core.Notes.organization_capture import (
     active_coordinator,
     capture_note_upsert,
@@ -184,27 +184,8 @@ def resolve_task_compatibility_scope(
         raise InputError("Task owner cannot be empty.")  # noqa: TRY003
     if owner != str(db.client_id):
         raise ConflictError("Task scope is unavailable.", entity="tasks", entity_id=owner)  # noqa: TRY003
-    if db.backend_type == BackendType.POSTGRESQL:
-        return TaskStoreScope(owner_user_id=owner, dataset_id="local-unbound")
-    datasets: set[str] = set()
-    for table in (
-        "note_tasks",
-        "task_events",
-        "note_task_reconciliation_state",
-        "task_projection_drifts",
-    ):
-        cursor = db.execute_query(
-            f"SELECT DISTINCT dataset_id FROM {table} WHERE owner_user_id = ?",  # nosec B608
-            (owner,),
-        )
-        datasets.update(str(row["dataset_id"]) for row in cursor.fetchall())
-    if not datasets:
-        return TaskStoreScope(owner_user_id=owner, dataset_id="local-unbound")
-    if len(datasets) != 1:
-        raise ConflictError(
-            "Task compatibility scope is ambiguous.", entity="tasks", entity_id=owner
-        )  # noqa: TRY003
-    return TaskStoreScope(owner_user_id=owner, dataset_id=datasets.pop())
+    dataset = db.resolve_task_compatibility_dataset_id(owner_user_id=owner)  # type: ignore[attr-defined]
+    return TaskStoreScope(owner_user_id=owner, dataset_id=dataset)
 
 
 class NotesTaskService:
@@ -429,6 +410,12 @@ class NotesTaskService:
         coordinator = active_coordinator(db, user_id=actor.actor_id)
         transaction = db.transaction() if coordinator is None else nullcontext(None)
         with transaction as conn:
+            if conn is not None:
+                db.task_store.lock_authorized_write_scope(
+                    owner_user_id=scope.owner_user_id,
+                    dataset_id=scope.dataset_id,
+                    conn=conn,
+                )
             task = self._require_task_version(
                 db,
                 task_id=task_id,
@@ -583,6 +570,12 @@ class NotesTaskService:
         coordinator = active_coordinator(db, user_id=actor.actor_id)
         transaction = db.transaction() if coordinator is None else nullcontext(None)
         with transaction as conn:
+            if conn is not None:
+                db.task_store.lock_authorized_write_scope(
+                    owner_user_id=scope.owner_user_id,
+                    dataset_id=scope.dataset_id,
+                    conn=conn,
+                )
             task = self._require_task_version(
                 db,
                 task_id=task_id,

--- a/tldw_Server_API/app/core/Notes_Tasks/service.py
+++ b/tldw_Server_API/app/core/Notes_Tasks/service.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import ConflictError, InputError
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import BackendType, ConflictError, InputError
 from tldw_Server_API.app.core.Notes.organization_capture import (
     active_coordinator,
     capture_note_upsert,
@@ -179,10 +179,32 @@ def resolve_task_compatibility_scope(
     authenticated_owner_user_id: str,
 ) -> TaskStoreScope:
     """Resolve product-owned task scope without accepting a client dataset selector."""
-    owner, dataset = db.resolve_task_compatibility_scope(
-        owner_user_id=str(authenticated_owner_user_id)
-    )
-    return TaskStoreScope(owner_user_id=owner, dataset_id=dataset)
+    owner = str(authenticated_owner_user_id).strip()
+    if not owner:
+        raise InputError("Task owner cannot be empty.")  # noqa: TRY003
+    if owner != str(db.client_id):
+        raise ConflictError("Task scope is unavailable.", entity="tasks", entity_id=owner)  # noqa: TRY003
+    if db.backend_type == BackendType.POSTGRESQL:
+        return TaskStoreScope(owner_user_id=owner, dataset_id="local-unbound")
+    datasets: set[str] = set()
+    for table in (
+        "note_tasks",
+        "task_events",
+        "note_task_reconciliation_state",
+        "task_projection_drifts",
+    ):
+        cursor = db.execute_query(
+            f"SELECT DISTINCT dataset_id FROM {table} WHERE owner_user_id = ?",  # nosec B608
+            (owner,),
+        )
+        datasets.update(str(row["dataset_id"]) for row in cursor.fetchall())
+    if not datasets:
+        return TaskStoreScope(owner_user_id=owner, dataset_id="local-unbound")
+    if len(datasets) != 1:
+        raise ConflictError(
+            "Task compatibility scope is ambiguous.", entity="tasks", entity_id=owner
+        )  # noqa: TRY003
+    return TaskStoreScope(owner_user_id=owner, dataset_id=datasets.pop())
 
 
 class NotesTaskService:
@@ -297,9 +319,9 @@ class NotesTaskService:
         )
         note = self._require_note(db, note_id)
         state = db.get_reconciliation_state(
-            note_id,
             owner_user_id=scope.owner_user_id,
             dataset_id=scope.dataset_id,
+            note_id=note_id,
         )
         if state is not None and int(state["note_version"]) == int(note["version"]):
             if state["status"] == "clean":
@@ -371,7 +393,7 @@ class NotesTaskService:
             )
             if not result.created_task_ids:
                 raise ConflictError("Task creation did not create a task record.", entity="tasks", entity_id=note_id)
-            task = db.get_task_scoped(
+            task = db.get_task(
                 owner_user_id=scope.owner_user_id,
                 dataset_id=scope.dataset_id,
                 task_id=result.created_task_ids[-1],
@@ -720,9 +742,9 @@ class NotesTaskService:
         conn: TaskConnection,
     ) -> dict[str, Any]:
         projection = db.get_task_projection(
-            task_id,
             owner_user_id=scope.owner_user_id,
             dataset_id=scope.dataset_id,
+            task_id=task_id,
             conn=conn,
         )
         if projection is None:

--- a/tldw_Server_API/app/core/Notes_Tasks/service.py
+++ b/tldw_Server_API/app/core/Notes_Tasks/service.py
@@ -165,6 +165,26 @@ class ReconciliationBatchResult:
     results: list[ReconciliationResult]
 
 
+@dataclass(frozen=True)
+class TaskStoreScope:
+    """Trusted product scope used by compatibility REST and MCP callers."""
+
+    owner_user_id: str
+    dataset_id: str
+
+
+def resolve_task_compatibility_scope(
+    db: CharactersRAGDB,
+    *,
+    authenticated_owner_user_id: str,
+) -> TaskStoreScope:
+    """Resolve product-owned task scope without accepting a client dataset selector."""
+    owner, dataset = db.resolve_task_compatibility_scope(
+        owner_user_id=str(authenticated_owner_user_id)
+    )
+    return TaskStoreScope(owner_user_id=owner, dataset_id=dataset)
+
+
 class NotesTaskService:
     """Coordinate task-backed checklist reconciliation for saved notes."""
 
@@ -187,13 +207,20 @@ class NotesTaskService:
         note_version: int,
         content: str,
         actor: TaskActor,
+        owner_user_id: str | None = None,
     ) -> ReconciliationResult:
+        scope = resolve_task_compatibility_scope(
+            db,
+            authenticated_owner_user_id=owner_user_id or db.client_id,
+        )
         return self._reconciler.reconcile_note(
             db=db,
             note_id=note_id,
             note_version=note_version,
             content=content,
             actor=actor,
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
         )
 
     def reconcile_stale_notes(
@@ -202,9 +229,17 @@ class NotesTaskService:
         db: CharactersRAGDB,
         limit: int,
         actor: TaskActor,
+        owner_user_id: str | None = None,
     ) -> ReconciliationBatchResult:
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=owner_user_id or db.client_id
+        )
         work_limit = max(0, int(limit))
-        to_process = db.candidate_notes_for_task_discovery(limit=work_limit) if work_limit else []
+        to_process = db.candidate_notes_for_task_discovery(
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+            limit=work_limit,
+        ) if work_limit else []
         results: list[ReconciliationResult] = []
         for candidate in to_process:
             note = db.get_note_by_id(str(candidate["id"]))
@@ -217,9 +252,13 @@ class NotesTaskService:
                     note_version=int(note["version"]),
                     content=str(note.get("content") or ""),
                     actor=actor,
+                    owner_user_id=scope.owner_user_id,
                 )
             )
-        remaining = db.count_candidate_notes_for_task_discovery()
+        remaining = db.count_candidate_notes_for_task_discovery(
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+        )
         return ReconciliationBatchResult(
             status="incomplete" if remaining else "clean",
             processed_notes=len(results),
@@ -233,6 +272,7 @@ class NotesTaskService:
         db: CharactersRAGDB,
         note_id: str,
         actor: TaskActor,
+        owner_user_id: str | None = None,
     ) -> ReconciliationResult:
         note = self._require_note(db, note_id)
         return self.reconcile_note(
@@ -241,6 +281,7 @@ class NotesTaskService:
             note_version=int(note["version"]),
             content=str(note.get("content") or ""),
             actor=actor,
+            owner_user_id=owner_user_id,
         )
 
     def ensure_note_reconciled(
@@ -249,9 +290,17 @@ class NotesTaskService:
         db: CharactersRAGDB,
         note_id: str,
         actor: TaskActor,
+        owner_user_id: str | None = None,
     ) -> ReconciliationResult | None:
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=owner_user_id or db.client_id
+        )
         note = self._require_note(db, note_id)
-        state = db.get_reconciliation_state(note_id)
+        state = db.get_reconciliation_state(
+            note_id,
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+        )
         if state is not None and int(state["note_version"]) == int(note["version"]):
             if state["status"] == "clean":
                 return None
@@ -267,6 +316,7 @@ class NotesTaskService:
             note_version=int(note["version"]),
             content=str(note.get("content") or ""),
             actor=actor,
+            owner_user_id=scope.owner_user_id,
         )
 
     def create_task_for_note(
@@ -279,7 +329,11 @@ class NotesTaskService:
         metadata: dict[str, Any],
         expected_note_version: int,
         actor: TaskActor,
+        owner_user_id: str | None = None,
     ) -> dict[str, Any]:
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=owner_user_id or db.client_id
+        )
         self._validate_task_text(text)
         self._validate_task_status(status)
         self._validate_metadata(metadata)
@@ -296,6 +350,7 @@ class NotesTaskService:
                 note_version=expected_note_version,
                 content=str(note.get("content") or ""),
                 actor=self._internal_reconciliation_actor(actor),
+                owner_user_id=scope.owner_user_id,
             )
             new_content = self._append_checklist_line(str(note.get("content") or ""), line)
             _write_note_content(
@@ -312,10 +367,15 @@ class NotesTaskService:
                 note_version=int(updated_note["version"]),
                 content=str(updated_note.get("content") or ""),
                 actor=actor,
+                owner_user_id=scope.owner_user_id,
             )
             if not result.created_task_ids:
                 raise ConflictError("Task creation did not create a task record.", entity="tasks", entity_id=note_id)
-            task = db.get_task(result.created_task_ids[-1])
+            task = db.get_task_scoped(
+                owner_user_id=scope.owner_user_id,
+                dataset_id=scope.dataset_id,
+                task_id=result.created_task_ids[-1],
+            )
             if task is None:
                 raise ConflictError("Created task was not found.", entity="tasks", entity_id=note_id)
             return task
@@ -332,7 +392,11 @@ class NotesTaskService:
         status: str | None = None,
         metadata: dict[str, Any] | None = None,
         record_only: bool = False,
+        owner_user_id: str | None = None,
     ) -> dict[str, Any]:
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=owner_user_id or db.client_id
+        )
         if text is not None:
             self._validate_task_text(text)
         if status is not None:
@@ -347,6 +411,7 @@ class NotesTaskService:
                 db,
                 task_id=task_id,
                 expected_task_version=expected_task_version,
+                scope=scope,
                 conn=conn,
             )
             projection_status = str(task["projection_status"])
@@ -368,6 +433,7 @@ class NotesTaskService:
                     expected_task_version=expected_task_version,
                     metadata=metadata,
                     actor=actor,
+                    scope=scope,
                 )
             if projection_status != "live":
                 raise ConflictError(
@@ -384,7 +450,7 @@ class NotesTaskService:
             if expected_note_version is None:
                 raise InputError("expected_note_version is required for projected task updates.")
 
-            projection = self._require_projection(db, task_id=task_id, conn=conn)
+            projection = self._require_projection(db, task_id=task_id, scope=scope, conn=conn)
             note = self._require_note_version(
                 db,
                 note_id=str(task["note_id"]),
@@ -429,6 +495,8 @@ class NotesTaskService:
             )
             updated_note_version = expected_note_version + 1
             updated_task = db.update_task_record(
+                owner_user_id=scope.owner_user_id,
+                dataset_id=scope.dataset_id,
                 task_id=task_id,
                 expected_version=expected_task_version,
                 text=new_text,
@@ -451,6 +519,8 @@ class NotesTaskService:
                 line_number=int(projection["line_number"]),
             )
             db.set_task_projection(
+                owner_user_id=scope.owner_user_id,
+                dataset_id=scope.dataset_id,
                 task_id=task_id,
                 note_id=str(note["id"]),
                 note_version=updated_note_version,
@@ -470,6 +540,7 @@ class NotesTaskService:
                 note_version=updated_note_version,
                 content=new_content,
                 actor=self._internal_reconciliation_actor(actor),
+                owner_user_id=scope.owner_user_id,
             )
             return updated_task
 
@@ -482,7 +553,11 @@ class NotesTaskService:
         expected_note_version: int | None,
         record_only: bool,
         actor: TaskActor,
+        owner_user_id: str | None = None,
     ) -> dict[str, Any]:
+        scope = resolve_task_compatibility_scope(
+            db, authenticated_owner_user_id=owner_user_id or db.client_id
+        )
         coordinator = active_coordinator(db, user_id=actor.actor_id)
         transaction = db.transaction() if coordinator is None else nullcontext(None)
         with transaction as conn:
@@ -490,6 +565,7 @@ class NotesTaskService:
                 db,
                 task_id=task_id,
                 expected_task_version=expected_task_version,
+                scope=scope,
                 conn=conn,
             )
             projection_status = str(task["projection_status"])
@@ -503,6 +579,8 @@ class NotesTaskService:
                         entity_id=task_id,
                     )
                 return db.soft_delete_task(
+                    owner_user_id=scope.owner_user_id,
+                    dataset_id=scope.dataset_id,
                     task_id=task_id,
                     expected_version=expected_task_version,
                     allow_record_only=True,
@@ -529,7 +607,7 @@ class NotesTaskService:
             if expected_note_version is None:
                 raise InputError("expected_note_version is required for projected task deletion.")
 
-            projection = self._require_projection(db, task_id=task_id, conn=conn)
+            projection = self._require_projection(db, task_id=task_id, scope=scope, conn=conn)
             note = self._require_note_version(
                 db,
                 note_id=str(task["note_id"]),
@@ -559,6 +637,8 @@ class NotesTaskService:
                 conn=conn,
             )
             deleted = db.soft_delete_task(
+                owner_user_id=scope.owner_user_id,
+                dataset_id=scope.dataset_id,
                 task_id=task_id,
                 expected_version=expected_task_version,
                 projection_note_id=str(projection["note_id"]),
@@ -578,6 +658,7 @@ class NotesTaskService:
                 note_version=expected_note_version + 1,
                 content=new_content,
                 actor=self._internal_reconciliation_actor(actor),
+                owner_user_id=scope.owner_user_id,
             )
             return deleted
 
@@ -610,9 +691,16 @@ class NotesTaskService:
         *,
         task_id: str,
         expected_task_version: int,
+        scope: TaskStoreScope,
         conn: TaskConnection,
     ) -> dict[str, Any]:
-        task = db.task_store._fetch_task(task_id, include_deleted=False, conn=conn)
+        task = db.task_store._fetch_task(
+            task_id,
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+            include_deleted=False,
+            conn=conn,
+        )
         if task is None:
             raise ConflictError(f"Task with ID '{task_id}' not found.", entity="tasks", entity_id=task_id)
         if int(task["version"]) != int(expected_task_version):
@@ -624,8 +712,19 @@ class NotesTaskService:
         return task
 
     @staticmethod
-    def _require_projection(db: CharactersRAGDB, *, task_id: str, conn: TaskConnection) -> dict[str, Any]:
-        projection = db.get_task_projection(task_id, conn=conn)
+    def _require_projection(
+        db: CharactersRAGDB,
+        *,
+        task_id: str,
+        scope: TaskStoreScope,
+        conn: TaskConnection,
+    ) -> dict[str, Any]:
+        projection = db.get_task_projection(
+            task_id,
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
+            conn=conn,
+        )
         if projection is None:
             raise ConflictError(f"Task projection is missing for task '{task_id}'.", entity="tasks", entity_id=task_id)
         return projection
@@ -786,8 +885,11 @@ class NotesTaskService:
         expected_task_version: int,
         metadata: dict[str, Any],
         actor: TaskActor,
+        scope: TaskStoreScope,
     ) -> dict[str, Any]:
         return db.update_unlinked_task_metadata_record_only(
+            owner_user_id=scope.owner_user_id,
+            dataset_id=scope.dataset_id,
             task_id=str(task["id"]),
             expected_version=expected_task_version,
             metadata=metadata,

--- a/tldw_Server_API/app/core/Sync/v2/models.py
+++ b/tldw_Server_API/app/core/Sync/v2/models.py
@@ -560,7 +560,7 @@ def normalize_supported_adapter_versions(
 
     requested = normalize_sync_v2_requested_domains(requested_domains)
     if value is None:
-        return {cast(SyncDomain, domain): [1] for domain in requested}
+        return {domain: [1] for domain in requested}
     if not isinstance(value, Mapping):
         raise ValueError("supported_adapter_versions must be an object")
     if len(value) > SYNC_V2_MAX_ADAPTER_VERSION_DOMAINS:
@@ -572,7 +572,7 @@ def normalize_supported_adapter_versions(
     known = set(SYNC_V2_SUPPORTED_DOMAINS)
     requested_set = set(requested)
     normalized: dict[SyncDomain, list[int]] = {
-        cast(SyncDomain, domain): [1] for domain in requested
+        domain: [1] for domain in requested
     }
     for raw_domain, raw_versions in value.items():
         if not isinstance(raw_domain, str) or raw_domain not in known:
@@ -605,7 +605,7 @@ def normalize_supported_adapter_versions(
             )
         if len(set(versions)) != len(versions):
             raise ValueError("supported_adapter_versions contains duplicate adapter versions")
-        normalized[cast(SyncDomain, raw_domain)] = sorted(versions)
+        normalized[raw_domain] = sorted(versions)
     return normalized
 
 

--- a/tldw_Server_API/app/core/Sync/v2/models.py
+++ b/tldw_Server_API/app/core/Sync/v2/models.py
@@ -36,6 +36,8 @@ SyncDomain = Literal[
     "notes.folder",
     "notes.folder_link",
     "notes.link",
+    "notes.task",
+    "notes.task_activity",
 ]
 SyncOperation = Literal["upsert", "append", "tombstone"]
 DatasetScopeType = Literal["personal", "workspace"]
@@ -435,6 +437,38 @@ def sync_v2_domain_schemas() -> dict[SyncDomain, dict[str, object]]:
             },
         },
     }
+
+
+def _sync_v2_internal_domain_schemas() -> dict[SyncDomain, dict[str, object]]:
+    """Return private known-domain contracts without advertising dormant domains."""
+
+    from .notes_task_contract import (
+        NotesTaskActivityTombstoneV1,
+        NotesTaskActivityV1,
+        NotesTaskV1Payload,
+    )
+
+    schemas = sync_v2_domain_schemas()
+    task_schema = NotesTaskV1Payload.model_json_schema()
+    activity_schema = NotesTaskActivityV1.model_json_schema()
+    activity_tombstone_schema = NotesTaskActivityTombstoneV1.model_json_schema()
+    schemas.update(
+        {
+            "notes.task": {
+                "schema_version": 1,
+                "operations": ["upsert", "tombstone"],
+                "upsert": task_schema,
+                "tombstone": task_schema,
+            },
+            "notes.task_activity": {
+                "schema_version": 1,
+                "operations": ["upsert", "tombstone"],
+                "upsert": activity_schema,
+                "tombstone": activity_tombstone_schema,
+            },
+        }
+    )
+    return schemas
 
 
 def sync_v2_server_supported_adapter_versions() -> dict[SyncDomain, list[int]]:

--- a/tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
@@ -1,0 +1,1104 @@
+"""Strict dormant Sync v1 contracts for Notes tasks and task activity."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime
+from typing import Any, Literal, TypeVar, cast
+from uuid import RFC_4122, UUID
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from .models import normalize_sync_timestamp
+
+_UUID4_MESSAGE = "IDs must be canonical lowercase UUIDv4 strings"
+_SAFE_KEY_RE = re.compile(r"[A-Za-z0-9_.-]{1,64}")
+_SAFE_ACTOR_ID_RE = re.compile(r"[A-Za-z0-9._:@/+-]{1,128}")
+_ESTIMATE_RE = re.compile(r"[0-9]{1,6}[mhd]")
+_SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}")
+_WEEKDAYS = ("mo", "tu", "we", "th", "fr", "sa", "su")
+_TASK_RESERVED_KEYS = frozenset(
+    {
+        "task_id",
+        "note_id",
+        "title",
+        "description",
+        "status",
+        "completed_at",
+        "priority",
+        "due_date",
+        "estimate",
+        "recurrence",
+        "assignee_id",
+        "tags",
+        "custom",
+    }
+)
+_TASK_METADATA_KEYS = frozenset(
+    {
+        "description",
+        "priority",
+        "due_date",
+        "estimate",
+        "recurrence",
+        "assignee_id",
+        "tags",
+        "custom",
+    }
+)
+_ACTIVITY_METADATA_FORBIDDEN_KEYS = frozenset(
+    {
+        "api_key",
+        "authorization",
+        "credential",
+        "credentials",
+        "markdown",
+        "password",
+        "raw_markdown",
+        "secret",
+        "token",
+    }
+)
+_DRIFT_REASONS = frozenset(
+    {
+        "missing_marker_base",
+        "malformed_marker",
+        "duplicate_marker",
+        "marker_scope_mismatch",
+        "base_unavailable",
+        "both_changed",
+        "ambiguous_legacy_match",
+        "unsupported_markdown",
+    }
+)
+_PROJECTION_STATUSES = frozenset({"live", "unlinked", "ambiguous", "deleted"})
+_ACTOR_TYPES = frozenset({"user", "agent", "tool", "system", "legacy"})
+_LEGACY_FIELDS = frozenset(
+    {
+        "id",
+        "task_id",
+        "note_id",
+        "event_type",
+        "actor_type",
+        "actor_id",
+        "tool_name",
+        "policy_mode",
+        "approval_id",
+        "old_value",
+        "new_value",
+        "created_at",
+        "client_id",
+    }
+)
+
+TaskStatus = Literal["open", "done"]
+TaskPriority = Literal["low", "medium", "high"]
+TaskFrequency = Literal["daily", "weekly", "monthly", "yearly"]
+TaskRecurrenceState = Literal["active", "paused", "completed"]
+TaskEventType = Literal[
+    "created",
+    "updated",
+    "completed",
+    "reopened",
+    "deleted",
+    "restored",
+    "projection_linked",
+    "projection_unlinked",
+    "projection_drift",
+    "corrected",
+]
+TaskActorType = Literal["user", "agent", "tool", "system", "legacy"]
+TaskActivitySource = Literal[
+    "client",
+    "rest",
+    "mcp",
+    "markdown_reconciliation",
+    "repair",
+    "trusted_bootstrap_v1",
+]
+DeleteReason = Literal["user_request", "correction", "policy"]
+
+
+class NotesTaskContractError(ValueError):
+    """Stable fail-closed error for Notes task Sync contract violations."""
+
+
+class NotesTaskRecurrenceV1(BaseModel):
+    """Validated recurrence rule and state; this contract does not schedule work."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    frequency: TaskFrequency
+    interval: StrictInt = Field(ge=1, le=365)
+    by_weekday: tuple[StrictStr, ...]
+    until: StrictStr | None
+    state: TaskRecurrenceState
+    occurrence_index: StrictInt = Field(ge=0, le=2_147_483_647)
+
+    @field_validator("by_weekday", mode="before")
+    @classmethod
+    def _tuple_weekdays(cls, value: object) -> tuple[object, ...]:
+        if not isinstance(value, Sequence) or isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            raise ValueError("recurrence by_weekday must be an array")
+        return tuple(value)
+
+    @model_validator(mode="after")
+    def _validate_rule(self) -> NotesTaskRecurrenceV1:
+        if len(set(self.by_weekday)) != len(self.by_weekday):
+            raise ValueError("recurrence by_weekday values must be unique")
+        if any(day not in _WEEKDAYS for day in self.by_weekday):
+            raise ValueError("recurrence by_weekday contains an unknown weekday")
+        if tuple(sorted(self.by_weekday, key=_WEEKDAYS.index)) != self.by_weekday:
+            raise ValueError("recurrence by_weekday must be in Monday-to-Sunday order")
+        if self.frequency != "weekly" and self.by_weekday:
+            raise ValueError("recurrence by_weekday is allowed only for weekly rules")
+        if self.until is not None:
+            _validate_date(self.until, "recurrence until")
+        return self
+
+
+class NotesTaskV1Payload(BaseModel):
+    """Complete canonical whole-object payload for ``notes.task`` version 1."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    task_id: StrictStr
+    note_id: StrictStr
+    title: StrictStr = Field(min_length=1, max_length=2_000)
+    description: StrictStr | None = Field(max_length=16_000)
+    status: TaskStatus
+    completed_at: StrictStr | None
+    priority: TaskPriority | None
+    due_date: StrictStr | None
+    estimate: StrictStr | None
+    recurrence: NotesTaskRecurrenceV1 | None
+    assignee_id: StrictStr | None
+    tags: tuple[StrictStr, ...]
+    custom: dict[str, Any]
+
+    @field_validator("task_id", "note_id")
+    @classmethod
+    def _validate_ids(cls, value: str) -> str:
+        return _canonical_uuid4(value)
+
+    @field_validator("title")
+    @classmethod
+    def _validate_title(cls, value: str) -> str:
+        if value.strip() != value:
+            raise ValueError("task title must already be stripped")
+        if _has_control(value):
+            raise ValueError("task title cannot contain CR, LF, or control characters")
+        return value
+
+    @field_validator("description")
+    @classmethod
+    def _validate_description(cls, value: str | None) -> str | None:
+        if value is not None and _has_control(value, allowed="\n\t"):
+            raise ValueError("task description contains a disallowed control character")
+        return value
+
+    @field_validator("completed_at")
+    @classmethod
+    def _validate_completed_at(cls, value: str | None) -> str | None:
+        return None if value is None else _canonical_timestamp(value, "completed_at")
+
+    @field_validator("due_date")
+    @classmethod
+    def _validate_due_date(cls, value: str | None) -> str | None:
+        return None if value is None else _validate_date(value, "due_date")
+
+    @field_validator("estimate")
+    @classmethod
+    def _validate_estimate(cls, value: str | None) -> str | None:
+        if value is not None and _ESTIMATE_RE.fullmatch(value) is None:
+            raise ValueError("task estimate must match [0-9]{1,6}[mhd]")
+        return value
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def _validate_tags(cls, value: object) -> tuple[str, ...]:
+        if not isinstance(value, Sequence) or isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            raise ValueError("task tags must be an array")
+        tags = tuple(value)
+        if len(tags) > 32:
+            raise ValueError("task tags may contain at most 32 values")
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for tag in tags:
+            if not isinstance(tag, str):
+                raise ValueError("task tags must be strings")
+            if not 1 <= len(tag) <= 64:
+                raise ValueError("task tags must contain 1 to 64 code points")
+            if tag.strip() != tag:
+                raise ValueError("task tags must already be trimmed")
+            if unicodedata.normalize("NFKC", tag) != tag:
+                raise ValueError("task tags must already be NFKC normalized")
+            if _has_control(tag):
+                raise ValueError("task tags cannot contain control characters")
+            folded = tag.casefold()
+            if folded in seen:
+                raise ValueError("task tags must be unique under casefold")
+            seen.add(folded)
+            normalized.append(tag)
+        return tuple(sorted(normalized, key=lambda item: (item.casefold(), item)))
+
+    @field_validator("custom")
+    @classmethod
+    def _validate_custom(cls, value: dict[str, Any]) -> dict[str, Any]:
+        if len(value) > 32:
+            raise ValueError("task custom may contain at most 32 keys")
+        for key in value:
+            if not isinstance(key, str) or _SAFE_KEY_RE.fullmatch(key) is None:
+                raise ValueError("task custom keys must use 1 to 64 safe characters")
+            if key in _TASK_RESERVED_KEYS:
+                raise ValueError("task custom cannot contain reserved wire keys")
+        _validate_json_object(value, label="task custom", max_depth=4, max_bytes=16 * 1_024)
+        return value
+
+    @model_validator(mode="after")
+    def _validate_completion(self) -> NotesTaskV1Payload:
+        if (self.status == "open" and self.completed_at is not None) or (
+            self.status == "done" and self.completed_at is None
+        ):
+            raise ValueError("task completion requires open/null or done/timestamp")
+        return self
+
+
+class NotesTaskActivityV1(BaseModel):
+    """Complete immutable create payload for ``notes.task_activity`` version 1."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    activity_id: StrictStr
+    note_id: StrictStr
+    task_id: StrictStr | None
+    event_type: TaskEventType
+    actor_type: TaskActorType
+    actor_id: StrictStr | None = Field(max_length=128)
+    source_device_id: StrictStr | None
+    client_occurred_at: StrictStr
+    source_kind: TaskActivitySource
+    corrects_activity_id: StrictStr | None
+    old_value: dict[str, Any] | None
+    new_value: dict[str, Any] | None
+    metadata: dict[str, Any]
+
+    @field_validator("activity_id", "note_id")
+    @classmethod
+    def _validate_required_ids(cls, value: str) -> str:
+        return _canonical_uuid4(value)
+
+    @field_validator("task_id", "source_device_id", "corrects_activity_id")
+    @classmethod
+    def _validate_optional_ids(cls, value: str | None) -> str | None:
+        return None if value is None else _canonical_uuid4(value)
+
+    @field_validator("actor_id")
+    @classmethod
+    def _validate_actor_id(cls, value: str | None) -> str | None:
+        if value is not None and _SAFE_ACTOR_ID_RE.fullmatch(value) is None:
+            raise ValueError("activity actor_id must use 1 to 128 safe characters")
+        return value
+
+    @field_validator("client_occurred_at")
+    @classmethod
+    def _validate_client_occurred_at(cls, value: str) -> str:
+        return _canonical_timestamp(value, "client_occurred_at")
+
+    @field_validator("old_value", "new_value")
+    @classmethod
+    def _validate_transition_json(
+        cls, value: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        if value is not None:
+            _validate_json_object(
+                value, label="activity transition value", max_depth=4, max_bytes=16 * 1_024
+            )
+        return value
+
+    @field_validator("metadata")
+    @classmethod
+    def _validate_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
+        if len(value) > 16:
+            raise ValueError("activity metadata may contain at most 16 keys")
+        _validate_json_object(
+            value, label="activity metadata", max_depth=3, max_bytes=8 * 1_024
+        )
+        if any(key.casefold() in _ACTIVITY_METADATA_FORBIDDEN_KEYS for key in _walk_keys(value)):
+            raise ValueError("activity metadata cannot contain credentials or raw Markdown")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_correction_target(self) -> NotesTaskActivityV1:
+        if (self.event_type == "corrected") != (self.corrects_activity_id is not None):
+            raise ValueError("corrected activity must have exactly one correction target")
+        return self
+
+
+class NotesTaskActivityTombstoneV1(BaseModel):
+    """Exact one-way tombstone payload for one immutable activity."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    note_id: StrictStr
+    task_id: StrictStr | None
+    deleted_at: StrictStr
+    delete_reason: DeleteReason
+
+    @field_validator("note_id")
+    @classmethod
+    def _validate_note_id(cls, value: str) -> str:
+        return _canonical_uuid4(value)
+
+    @field_validator("task_id")
+    @classmethod
+    def _validate_task_id(cls, value: str | None) -> str | None:
+        return None if value is None else _canonical_uuid4(value)
+
+    @field_validator("deleted_at")
+    @classmethod
+    def _validate_deleted_at(cls, value: str) -> str:
+        return _canonical_timestamp(value, "deleted_at")
+
+
+ContractModel = TypeVar("ContractModel", bound=BaseModel)
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    """Serialize one validated value as canonical UTF-8 JSON."""
+
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeEncodeError) as exc:
+        raise NotesTaskContractError("value is not canonical UTF-8 JSON") from exc
+
+
+def parse_notes_task_v1(
+    payload: Mapping[str, object] | NotesTaskV1Payload,
+    *,
+    owner_user_id: str,
+) -> NotesTaskV1Payload:
+    """Parse and owner-bind one complete live task payload."""
+
+    parsed = _parse_model(NotesTaskV1Payload, payload, "notes.task v1 payload")
+    if parsed.assignee_id is not None and parsed.assignee_id != owner_user_id:
+        raise NotesTaskContractError(
+            "notes.task v1 assignee must be the authenticated personal-dataset owner"
+        )
+    return parsed
+
+
+def parse_notes_task_tombstone_v1(
+    payload: Mapping[str, object] | NotesTaskV1Payload,
+    *,
+    owner_user_id: str,
+) -> NotesTaskV1Payload:
+    """Parse a task tombstone using the same complete whole-object payload."""
+
+    return parse_notes_task_v1(payload, owner_user_id=owner_user_id)
+
+
+def notes_task_object_hash(
+    payload: NotesTaskV1Payload,
+    *,
+    revision: int,
+    deleted: bool,
+) -> str:
+    """Hash exact task payload, identity, revision, adapter, and lifecycle."""
+
+    _positive_revision(revision, "notes.task")
+    if not isinstance(payload, NotesTaskV1Payload):
+        raise NotesTaskContractError("notes.task hash requires a parsed v1 payload")
+    semantic = {
+        "adapter_version": 1,
+        "domain": "notes.task",
+        "identity": {"note_id": payload.note_id, "task_id": payload.task_id},
+        "lifecycle": "tombstone" if deleted else "live",
+        "payload": payload.model_dump(mode="json"),
+        "revision": revision,
+    }
+    return _sha256(semantic)
+
+
+def parse_notes_task_activity_v1(
+    payload: Mapping[str, object] | NotesTaskActivityV1,
+    *,
+    owner_user_id: str,
+    bound_actor_type: str,
+    bound_actor_id: object,
+    authenticated_device_id: str | None,
+    trusted_server_origin: bool,
+) -> NotesTaskActivityV1:
+    """Parse an immutable activity create and verify server-bound provenance."""
+
+    parsed = _parse_model(
+        NotesTaskActivityV1, payload, "notes.task_activity v1 payload"
+    )
+    if parsed.actor_type != bound_actor_type or parsed.actor_id != bound_actor_id:
+        raise NotesTaskContractError(
+            "notes.task_activity actor provenance does not match the server binding"
+        )
+    if parsed.actor_type == "user" and parsed.actor_id != owner_user_id:
+        raise NotesTaskContractError(
+            "notes.task_activity user actor must equal the authenticated owner"
+        )
+    if parsed.source_kind == "client":
+        if trusted_server_origin:
+            raise NotesTaskContractError("client activity cannot use trusted server provenance")
+        if authenticated_device_id is None or parsed.source_device_id != authenticated_device_id:
+            raise NotesTaskContractError(
+                "notes.task_activity source device does not match the authenticated device"
+            )
+    elif not trusted_server_origin or parsed.source_device_id is not None:
+        raise NotesTaskContractError(
+            "trusted server activity provenance requires a null source device"
+        )
+    _validate_event_values(
+        parsed.event_type,
+        parsed.old_value,
+        parsed.new_value,
+        owner_user_id=owner_user_id,
+    )
+    return parsed
+
+
+def parse_notes_task_activity_tombstone_v1(
+    payload: Mapping[str, object] | NotesTaskActivityTombstoneV1,
+    *,
+    envelope_created_at_client: str,
+    original_activity: NotesTaskActivityV1,
+) -> NotesTaskActivityTombstoneV1:
+    """Parse the exact revision-2 tombstone and bind its parent and timestamp."""
+
+    parsed = _parse_model(
+        NotesTaskActivityTombstoneV1,
+        payload,
+        "notes.task_activity v1 tombstone",
+    )
+    expected_deleted_at = _normalized_envelope_timestamp(envelope_created_at_client)
+    if parsed.deleted_at != expected_deleted_at:
+        raise NotesTaskContractError(
+            "activity tombstone deleted_at must equal normalized created_at_client"
+        )
+    if (
+        parsed.note_id != original_activity.note_id
+        or parsed.task_id != original_activity.task_id
+    ):
+        raise NotesTaskContractError(
+            "activity tombstone parent identities must equal the original create"
+        )
+    return parsed
+
+
+def notes_task_activity_object_hash(
+    payload: NotesTaskActivityV1 | NotesTaskActivityTombstoneV1,
+    *,
+    revision: int,
+    deleted: bool,
+    activity_id: str | None = None,
+    original_create_hash: str | None = None,
+) -> str:
+    """Hash the exact immutable activity create or its one-way tombstone."""
+
+    if deleted:
+        if revision != 2:
+            raise NotesTaskContractError("activity tombstone must use revision 2")
+        if not isinstance(payload, NotesTaskActivityTombstoneV1):
+            raise NotesTaskContractError("activity tombstone hash requires a parsed tombstone")
+        if activity_id is None:
+            raise NotesTaskContractError("activity tombstone hash requires activity_id")
+        canonical_activity_id = _canonical_uuid4(activity_id)
+        if original_create_hash is None or _SHA256_RE.fullmatch(original_create_hash) is None:
+            raise NotesTaskContractError(
+                "activity tombstone hash requires the original create fingerprint"
+            )
+        identity = {
+            "activity_id": canonical_activity_id,
+            "note_id": payload.note_id,
+            "task_id": payload.task_id,
+        }
+    else:
+        if revision != 1:
+            raise NotesTaskContractError("activity create must use revision 1")
+        if not isinstance(payload, NotesTaskActivityV1):
+            raise NotesTaskContractError("activity create hash requires a parsed create")
+        if activity_id is not None or original_create_hash is not None:
+            raise NotesTaskContractError("activity create hash has no tombstone binding inputs")
+        identity = {
+            "activity_id": payload.activity_id,
+            "note_id": payload.note_id,
+            "task_id": payload.task_id,
+        }
+    semantic = {
+        "adapter_version": 1,
+        "domain": "notes.task_activity",
+        "identity": identity,
+        "lifecycle": "tombstone" if deleted else "live",
+        "original_create_hash": original_create_hash if deleted else None,
+        "payload": payload.model_dump(mode="json"),
+        "revision": revision,
+    }
+    return _sha256(semantic)
+
+
+def convert_legacy_task_event(
+    legacy_event: Mapping[str, object],
+    *,
+    owner_user_id: str,
+    resolved_task_note_id: str | None,
+) -> NotesTaskActivityV1:
+    """Convert one source-verified legacy task event or fail closed."""
+
+    if not isinstance(legacy_event, Mapping):
+        raise NotesTaskContractError("legacy task event must be an object")
+    raw = dict(legacy_event)
+    unknown = set(raw).difference(_LEGACY_FIELDS)
+    required = _LEGACY_FIELDS.difference({"client_id"})
+    if unknown or not required.issubset(raw):
+        raise NotesTaskContractError("legacy task event has unknown or missing fields")
+
+    activity_id = _canonical_uuid4(raw["id"])
+    task_id = _optional_uuid4(raw["task_id"])
+    note_id = _optional_uuid4(raw["note_id"])
+    if task_id is not None:
+        if resolved_task_note_id is None:
+            raise NotesTaskContractError("legacy task event parent task is not verified")
+        resolved_note = _canonical_uuid4(resolved_task_note_id)
+        if note_id is None:
+            note_id = resolved_note
+        elif note_id != resolved_note:
+            raise NotesTaskContractError("legacy task event parent identities do not match")
+    elif note_id is None:
+        raise NotesTaskContractError("legacy task event must have a verified parent")
+
+    occurred_at = _normalized_envelope_timestamp(raw["created_at"])
+    old_value = _copy_json_object(raw["old_value"], "legacy old_value")
+    new_value = _copy_json_object(raw["new_value"], "legacy new_value")
+    idempotency_key = None
+    if new_value is not None and "idempotency_key" in new_value:
+        idempotency_key = new_value.pop("idempotency_key")
+        if not isinstance(idempotency_key, str) or not 1 <= len(idempotency_key) <= 256:
+            raise NotesTaskContractError(
+                "legacy idempotency_key must be a string of 1 to 256 characters"
+            )
+
+    event_type = raw["event_type"]
+    canonical_type: str
+    canonical_old: dict[str, Any] | None
+    canonical_new: dict[str, Any] | None
+    if event_type == "created" and old_value is None and set(new_value or {}) == {
+        "text",
+        "status",
+        "metadata",
+    }:
+        if new_value is None:
+            raise NotesTaskContractError("legacy created payload is missing new_value")
+        title = _validate_standalone_title(new_value["text"])
+        status = new_value["status"]
+        if status not in {"open", "done"}:
+            raise NotesTaskContractError("legacy created status is invalid")
+        canonical_type = "created"
+        canonical_old = None
+        canonical_new = {
+            "title": title,
+            "status": status,
+            "completed_at": occurred_at if status == "done" else None,
+            "metadata": _expand_legacy_metadata(new_value["metadata"]),
+        }
+    elif event_type == "updated" and old_value is not None and new_value is not None:
+        key_set = set(old_value)
+        if key_set != set(new_value) or key_set not in (
+            {"metadata"},
+            {"text", "metadata"},
+        ):
+            raise NotesTaskContractError("legacy updated event has a noncanonical shape")
+        canonical_type = "updated"
+        canonical_old = {"metadata": _expand_legacy_metadata(old_value["metadata"])}
+        canonical_new = {"metadata": _expand_legacy_metadata(new_value["metadata"])}
+        if "text" in key_set:
+            canonical_old = {
+                "title": _validate_standalone_title(old_value["text"]),
+                **canonical_old,
+            }
+            canonical_new = {
+                "title": _validate_standalone_title(new_value["text"]),
+                **canonical_new,
+            }
+    elif event_type == "status_changed" and old_value == {"status": "open"} and new_value == {
+        "status": "done"
+    }:
+        canonical_type, canonical_old, canonical_new = "completed", old_value, new_value
+    elif event_type == "status_changed" and old_value == {"status": "done"} and new_value == {
+        "status": "open"
+    }:
+        canonical_type, canonical_old, canonical_new = "reopened", old_value, new_value
+    elif event_type == "unlinked" and old_value == {
+        "projection_status": "live"
+    } and new_value == {"projection_status": "unlinked"}:
+        canonical_type, canonical_old, canonical_new = (
+            "projection_unlinked",
+            old_value,
+            new_value,
+        )
+    elif event_type == "deleted":
+        canonical_type, canonical_old, canonical_new = "deleted", old_value, new_value
+    else:
+        raise NotesTaskContractError("legacy task event does not match an approved mapping")
+
+    actor_type = raw["actor_type"]
+    if not isinstance(actor_type, str) or actor_type not in _ACTOR_TYPES:
+        raise NotesTaskContractError("legacy task event actor_type is invalid")
+    actor_id = raw["actor_id"]
+    if actor_id is not None and (
+        not isinstance(actor_id, str) or _SAFE_ACTOR_ID_RE.fullmatch(actor_id) is None
+    ):
+        raise NotesTaskContractError("legacy task event actor_id is invalid")
+    metadata: dict[str, Any] = {"legacy_source_verified": True}
+    if idempotency_key is not None:
+        metadata["origin_request_fingerprint"] = (
+            "sha256:" + hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()
+        )
+    legacy_context: dict[str, str] = {}
+    for field_name in ("tool_name", "policy_mode", "approval_id"):
+        value = raw[field_name]
+        if value is None:
+            continue
+        if not isinstance(value, str) or not 1 <= len(value) <= 128:
+            raise NotesTaskContractError(
+                f"legacy task event {field_name} must contain 1 to 128 characters"
+            )
+        legacy_context[field_name] = value
+    if legacy_context:
+        metadata["legacy_context"] = legacy_context
+    client_id = raw.get("client_id")
+    if client_id is not None and (
+        not isinstance(client_id, str) or not 1 <= len(client_id) <= 128
+    ):
+        raise NotesTaskContractError("legacy task event client_id is invalid")
+
+    return parse_notes_task_activity_v1(
+        {
+            "activity_id": activity_id,
+            "note_id": cast(str, note_id),
+            "task_id": task_id,
+            "event_type": canonical_type,
+            "actor_type": actor_type,
+            "actor_id": actor_id,
+            "source_device_id": None,
+            "client_occurred_at": occurred_at,
+            "source_kind": "trusted_bootstrap_v1",
+            "corrects_activity_id": None,
+            "old_value": canonical_old,
+            "new_value": canonical_new,
+            "metadata": metadata,
+        },
+        owner_user_id=owner_user_id,
+        bound_actor_type=actor_type,
+        bound_actor_id=actor_id,
+        authenticated_device_id=None,
+        trusted_server_origin=True,
+    )
+
+
+def _parse_model(
+    model: type[ContractModel],
+    payload: Mapping[str, object] | ContractModel,
+    label: str,
+) -> ContractModel:
+    if isinstance(payload, model):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise NotesTaskContractError(f"{label} must be an object")
+    try:
+        return model.model_validate(dict(payload))
+    except ValidationError as exc:
+        message = str(exc).replace(
+            "Extra inputs are not permitted", "extra inputs are not permitted"
+        )
+        raise NotesTaskContractError(f"{label}: {message}") from exc
+
+
+def _canonical_uuid4(value: object) -> str:
+    if not isinstance(value, str):
+        raise NotesTaskContractError(_UUID4_MESSAGE)
+    try:
+        parsed = UUID(value)
+    except ValueError as exc:
+        raise NotesTaskContractError(_UUID4_MESSAGE) from exc
+    if parsed.version != 4 or parsed.variant != RFC_4122 or str(parsed) != value:
+        raise NotesTaskContractError(_UUID4_MESSAGE)
+    return value
+
+
+def _optional_uuid4(value: object) -> str | None:
+    return None if value is None else _canonical_uuid4(value)
+
+
+def _canonical_timestamp(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a canonical RFC 3339 UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must be a canonical RFC 3339 UTC timestamp"
+        ) from exc
+    normalized = normalize_sync_timestamp(parsed)
+    if parsed.tzinfo is None or parsed.utcoffset() is None or normalized != value:
+        raise ValueError(f"{field_name} must be a canonical RFC 3339 UTC timestamp")
+    return value
+
+
+def _normalized_envelope_timestamp(value: object) -> str:
+    if not isinstance(value, (str, datetime)):
+        raise NotesTaskContractError("created_at_client must be an RFC 3339 timestamp")
+    try:
+        parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise NotesTaskContractError("created_at_client must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise NotesTaskContractError("created_at_client must include a timezone")
+    normalized = normalize_sync_timestamp(parsed)
+    if normalized is None:
+        raise NotesTaskContractError("created_at_client is required")
+    return normalized
+
+
+def _validate_date(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a real canonical date")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be a real canonical date") from exc
+    if parsed.isoformat() != value:
+        raise ValueError(f"{field_name} must be a real canonical date")
+    return value
+
+
+def _has_control(value: str, *, allowed: str = "") -> bool:
+    return any(char not in allowed and unicodedata.category(char) == "Cc" for char in value)
+
+
+def _validate_json_object(
+    value: object,
+    *,
+    label: str,
+    max_depth: int,
+    max_bytes: int,
+) -> None:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    _validate_json_value(value, label)
+    if _json_depth(value) > max_depth:
+        raise ValueError(f"{label} exceeds maximum depth {max_depth}")
+    if len(canonical_json_bytes(value)) > max_bytes:
+        raise ValueError(f"{label} exceeds {max_bytes // 1_024} KiB")
+
+
+def _validate_json_value(value: object, label: str) -> None:
+    if value is None or isinstance(value, (str, bool)):
+        return
+    if isinstance(value, int) and not isinstance(value, bool):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{label} must contain finite JSON numbers")
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate_json_value(item, label)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"{label} JSON object keys must be strings")
+            _validate_json_value(item, label)
+        return
+    raise ValueError(f"{label} must contain only JSON values")
+
+
+def _json_depth(value: object) -> int:
+    if isinstance(value, dict):
+        return 1 + max((_json_depth(item) for item in value.values()), default=0)
+    if isinstance(value, list):
+        return 1 + max((_json_depth(item) for item in value), default=0)
+    return 0
+
+
+def _walk_keys(value: object):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            yield key
+            yield from _walk_keys(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_keys(item)
+
+
+def _positive_revision(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise NotesTaskContractError(f"{label} revision must be a positive integer")
+    return value
+
+
+def _sha256(value: object) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _task_metadata_from_payload(parsed: NotesTaskV1Payload) -> dict[str, object]:
+    dumped = parsed.model_dump(mode="json")
+    return {key: dumped[key] for key in _TASK_METADATA_KEYS}
+
+
+def _validate_task_metadata(
+    value: object, *, owner_user_id: str
+) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != _TASK_METADATA_KEYS:
+        raise NotesTaskContractError("activity task metadata must be the complete exact object")
+    parsed = parse_notes_task_v1(
+        {
+            "task_id": "00000000-0000-4000-8000-000000000001",
+            "note_id": "00000000-0000-4000-8000-000000000002",
+            "title": "metadata validation",
+            "status": "open",
+            "completed_at": None,
+            **value,
+        },
+        owner_user_id=owner_user_id,
+    )
+    canonical = _task_metadata_from_payload(parsed)
+    if canonical != value:
+        raise NotesTaskContractError("activity task metadata is not canonical")
+    return canonical
+
+
+def _validate_standalone_title(value: object) -> str:
+    if not isinstance(value, str):
+        raise NotesTaskContractError("legacy task title must be a string")
+    try:
+        parsed = NotesTaskV1Payload.model_validate(
+            {
+                "task_id": "00000000-0000-4000-8000-000000000001",
+                "note_id": "00000000-0000-4000-8000-000000000002",
+                "title": value,
+                "description": None,
+                "status": "open",
+                "completed_at": None,
+                "priority": None,
+                "due_date": None,
+                "estimate": None,
+                "recurrence": None,
+                "assignee_id": None,
+                "tags": [],
+                "custom": {},
+            }
+        )
+    except ValidationError as exc:
+        raise NotesTaskContractError("legacy task title is invalid") from exc
+    return parsed.title
+
+
+def _validate_event_values(
+    event_type: str,
+    old_value: dict[str, Any] | None,
+    new_value: dict[str, Any] | None,
+    *,
+    owner_user_id: str,
+) -> None:
+    if event_type == "created":
+        if old_value is not None or set(new_value or {}) != {
+            "title",
+            "status",
+            "completed_at",
+            "metadata",
+        }:
+            raise NotesTaskContractError("created activity requires the exact snapshot shape")
+        if new_value is None:
+            raise NotesTaskContractError("created activity is missing new_value")
+        _validate_standalone_title(new_value["title"])
+        status = new_value["status"]
+        completed_at = new_value["completed_at"]
+        if status not in {"open", "done"} or (
+            status == "open" and completed_at is not None
+        ) or (status == "done" and completed_at is None):
+            raise NotesTaskContractError("created activity has an invalid completion snapshot")
+        if completed_at is not None:
+            _canonical_timestamp(completed_at, "completed_at")
+        _validate_task_metadata(new_value["metadata"], owner_user_id=owner_user_id)
+        return
+    if event_type == "updated":
+        if old_value is None or new_value is None or set(old_value) != set(new_value):
+            raise NotesTaskContractError("updated activity requires matching old/new keys")
+        if set(old_value) not in ({"metadata"}, {"title", "metadata"}) or old_value == new_value:
+            raise NotesTaskContractError("updated activity has a noncanonical change shape")
+        _validate_task_metadata(old_value["metadata"], owner_user_id=owner_user_id)
+        _validate_task_metadata(new_value["metadata"], owner_user_id=owner_user_id)
+        if "title" in old_value:
+            _validate_standalone_title(old_value["title"])
+            _validate_standalone_title(new_value["title"])
+        return
+    exact = {
+        "completed": ({"status": "open"}, {"status": "done"}),
+        "reopened": ({"status": "done"}, {"status": "open"}),
+        "projection_unlinked": (
+            {"projection_status": "live"},
+            {"projection_status": "unlinked"},
+        ),
+    }
+    if event_type in exact:
+        if (old_value, new_value) != exact[event_type]:
+            raise NotesTaskContractError(f"{event_type} activity has a noncanonical shape")
+        return
+    if event_type == "deleted":
+        if (
+            set(old_value or {}) != {"deleted", "projection_status"}
+            or old_value["deleted"] is not False
+            or old_value["projection_status"] not in {"live", "unlinked", "ambiguous"}
+            or new_value != {"deleted": True, "projection_status": "deleted"}
+        ):
+            raise NotesTaskContractError("deleted activity has a noncanonical shape")
+        return
+    if event_type == "restored":
+        if (
+            old_value != {"deleted": True, "projection_status": "deleted"}
+            or set(new_value or {}) != {"deleted", "projection_status"}
+            or new_value["deleted"] is not False
+            or new_value["projection_status"] not in {"live", "unlinked"}
+        ):
+            raise NotesTaskContractError("restored activity has a noncanonical shape")
+        return
+    if event_type == "projection_linked":
+        if (
+            set(old_value or {}) != {"projection_status"}
+            or old_value["projection_status"] not in {"unlinked", "ambiguous"}
+            or new_value != {"projection_status": "live"}
+        ):
+            raise NotesTaskContractError("projection_linked activity has a noncanonical shape")
+        return
+    if event_type == "projection_drift":
+        if (
+            old_value is not None
+            or set(new_value or {}) != {"reason_code"}
+            or new_value["reason_code"] not in _DRIFT_REASONS
+        ):
+            raise NotesTaskContractError("projection_drift activity has a noncanonical shape")
+        return
+    if event_type == "corrected":
+        _validate_corrected_values(old_value, new_value, owner_user_id=owner_user_id)
+        return
+    raise NotesTaskContractError("activity event_type is not supported")
+
+
+def _validate_corrected_values(
+    old_value: dict[str, Any] | None,
+    new_value: dict[str, Any] | None,
+    *,
+    owner_user_id: str,
+) -> None:
+    if not old_value or not new_value or set(old_value) != set(new_value) or old_value == new_value:
+        raise NotesTaskContractError("corrected activity requires a changed non-empty key subset")
+    keys = set(old_value)
+    allowed_subsets = (
+        {"title", "status", "completed_at", "metadata"},
+        {"title", "metadata"},
+        {"metadata"},
+        {"status"},
+        {"deleted", "projection_status"},
+        {"projection_status"},
+        {"reason_code"},
+    )
+    if not any(keys.issubset(schema) for schema in allowed_subsets):
+        raise NotesTaskContractError("corrected activity does not match a target event schema")
+    for value in (old_value, new_value):
+        if "title" in value:
+            _validate_standalone_title(value["title"])
+        if "metadata" in value:
+            _validate_task_metadata(value["metadata"], owner_user_id=owner_user_id)
+        if "status" in value and value["status"] not in {"open", "done"}:
+            raise NotesTaskContractError("corrected activity status is invalid")
+        if "completed_at" in value and value["completed_at"] is not None:
+            _canonical_timestamp(value["completed_at"], "completed_at")
+        if "deleted" in value and type(value["deleted"]) is not bool:
+            raise NotesTaskContractError("corrected activity deleted flag is invalid")
+        if "projection_status" in value and value["projection_status"] not in _PROJECTION_STATUSES:
+            raise NotesTaskContractError("corrected activity projection status is invalid")
+        if "reason_code" in value and value["reason_code"] not in _DRIFT_REASONS:
+            raise NotesTaskContractError("corrected activity drift reason is invalid")
+
+
+def _copy_json_object(value: object, label: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise NotesTaskContractError(f"{label} must be an object or null")
+    copied = dict(value)
+    try:
+        _validate_json_value(copied, label)
+    except ValueError as exc:
+        raise NotesTaskContractError(str(exc)) from exc
+    return copied
+
+
+def _expand_legacy_metadata(value: object) -> dict[str, object]:
+    if value is None:
+        metadata: dict[str, object] = {}
+    elif isinstance(value, Mapping):
+        metadata = dict(value)
+    else:
+        raise NotesTaskContractError("legacy task metadata must be an object")
+    if set(metadata).difference({"due_date", "priority", "estimate"}):
+        raise NotesTaskContractError("legacy task metadata contains unknown keys")
+    expanded: dict[str, object] = {
+        "description": None,
+        "priority": None,
+        "due_date": None,
+        "estimate": None,
+        "recurrence": None,
+        "assignee_id": None,
+        "tags": [],
+        "custom": {},
+    }
+    expanded.update(metadata)
+    return _validate_task_metadata(expanded, owner_user_id="__legacy_owner__")
+
+
+__all__ = [
+    "NotesTaskActivityTombstoneV1",
+    "NotesTaskActivityV1",
+    "NotesTaskContractError",
+    "NotesTaskRecurrenceV1",
+    "NotesTaskV1Payload",
+    "canonical_json_bytes",
+    "convert_legacy_task_event",
+    "notes_task_activity_object_hash",
+    "notes_task_object_hash",
+    "parse_notes_task_activity_tombstone_v1",
+    "parse_notes_task_activity_v1",
+    "parse_notes_task_tombstone_v1",
+    "parse_notes_task_v1",
+]

--- a/tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
@@ -137,6 +137,42 @@ class NotesTaskContractError(ValueError):
     """Stable fail-closed error for Notes task Sync contract violations."""
 
 
+class _FrozenJsonDict(dict[str, Any]):
+    """JSON object that retains normal dict serialization without mutation."""
+
+    def _reject_mutation(self, *_args: object, **_kwargs: object) -> None:
+        raise TypeError("canonical JSON values are immutable")
+
+    __setitem__ = _reject_mutation
+    __delitem__ = _reject_mutation
+    __ior__ = _reject_mutation
+    clear = _reject_mutation
+    pop = _reject_mutation
+    popitem = _reject_mutation
+    setdefault = _reject_mutation
+    update = _reject_mutation
+
+
+class _FrozenJsonList(list[Any]):
+    """JSON array that retains normal list serialization without mutation."""
+
+    def _reject_mutation(self, *_args: object, **_kwargs: object) -> None:
+        raise TypeError("canonical JSON values are immutable")
+
+    __setitem__ = _reject_mutation
+    __delitem__ = _reject_mutation
+    __iadd__ = _reject_mutation
+    __imul__ = _reject_mutation
+    append = _reject_mutation
+    clear = _reject_mutation
+    extend = _reject_mutation
+    insert = _reject_mutation
+    pop = _reject_mutation
+    remove = _reject_mutation
+    reverse = _reject_mutation
+    sort = _reject_mutation
+
+
 class NotesTaskRecurrenceV1(BaseModel):
     """Validated recurrence rule and state; this contract does not schedule work."""
 
@@ -271,7 +307,7 @@ class NotesTaskV1Payload(BaseModel):
             if key in _TASK_RESERVED_KEYS:
                 raise ValueError("task custom cannot contain reserved wire keys")
         _validate_json_object(value, label="task custom", max_depth=4, max_bytes=16 * 1_024)
-        return value
+        return cast(dict[str, Any], _freeze_json(value))
 
     @model_validator(mode="after")
     def _validate_completion(self) -> NotesTaskV1Payload:
@@ -332,7 +368,7 @@ class NotesTaskActivityV1(BaseModel):
             _validate_json_object(
                 value, label="activity transition value", max_depth=4, max_bytes=16 * 1_024
             )
-        return value
+        return cast(dict[str, Any], _freeze_json(value)) if value is not None else None
 
     @field_validator("metadata")
     @classmethod
@@ -344,7 +380,7 @@ class NotesTaskActivityV1(BaseModel):
         )
         if any(key.casefold() in _ACTIVITY_METADATA_FORBIDDEN_KEYS for key in _walk_keys(value)):
             raise ValueError("activity metadata cannot contain credentials or raw Markdown")
-        return value
+        return cast(dict[str, Any], _freeze_json(value))
 
     @model_validator(mode="after")
     def _validate_correction_target(self) -> NotesTaskActivityV1:
@@ -820,6 +856,16 @@ def _validate_json_object(
         raise ValueError(f"{label} exceeds {max_bytes // 1_024} KiB")
 
 
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return _FrozenJsonDict(
+            {key: _freeze_json(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return _FrozenJsonList(_freeze_json(item) for item in value)
+    return value
+
+
 def _validate_json_value(value: object, label: str) -> None:
     if value is None or isinstance(value, (str, bool)):
         return
@@ -880,6 +926,7 @@ def _validate_task_metadata(
 ) -> dict[str, object]:
     if not isinstance(value, dict) or set(value) != _TASK_METADATA_KEYS:
         raise NotesTaskContractError("activity task metadata must be the complete exact object")
+    wire_value = cast(dict[str, object], json.loads(canonical_json_bytes(value)))
     parsed = parse_notes_task_v1(
         {
             "task_id": "00000000-0000-4000-8000-000000000001",
@@ -887,12 +934,12 @@ def _validate_task_metadata(
             "title": "metadata validation",
             "status": "open",
             "completed_at": None,
-            **value,
+            **wire_value,
         },
         owner_user_id=owner_user_id,
     )
     canonical = _task_metadata_from_payload(parsed)
-    if canonical != value:
+    if canonical != wire_value:
         raise NotesTaskContractError("activity task metadata is not canonical")
     return canonical
 
@@ -1049,6 +1096,20 @@ def _validate_corrected_values(
             raise NotesTaskContractError("corrected activity projection status is invalid")
         if "reason_code" in value and value["reason_code"] not in _DRIFT_REASONS:
             raise NotesTaskContractError("corrected activity drift reason is invalid")
+        if {"status", "completed_at"}.issubset(value) and (
+            (value["status"] == "open" and value["completed_at"] is not None)
+            or (value["status"] == "done" and value["completed_at"] is None)
+        ):
+            raise NotesTaskContractError(
+                "corrected activity completion snapshot is invalid"
+            )
+        if {"deleted", "projection_status"}.issubset(value) and (
+            (value["deleted"] is True)
+            != (value["projection_status"] == "deleted")
+        ):
+            raise NotesTaskContractError(
+                "corrected activity lifecycle snapshot is invalid"
+            )
 
 
 def _copy_json_object(value: object, label: str) -> dict[str, Any] | None:

--- a/tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
-import math
 import re
 import unicodedata
 from collections.abc import Mapping, Sequence
 from datetime import date, datetime
-from typing import Any, Literal, TypeVar, cast
+from typing import Any, Literal, NoReturn, TypeVar, cast
 from uuid import RFC_4122, UUID
 
 from pydantic import (
@@ -30,6 +29,7 @@ _SAFE_KEY_RE = re.compile(r"[A-Za-z0-9_.-]{1,64}")
 _SAFE_ACTOR_ID_RE = re.compile(r"[A-Za-z0-9._:@/+-]{1,128}")
 _ESTIMATE_RE = re.compile(r"[0-9]{1,6}[mhd]")
 _SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}")
+_JS_SAFE_INTEGER = 9_007_199_254_740_991
 _WEEKDAYS = ("mo", "tu", "we", "th", "fr", "sa", "su")
 _TASK_RESERVED_KEYS = frozenset(
     {
@@ -140,8 +140,14 @@ class NotesTaskContractError(ValueError):
 class _FrozenJsonDict(dict[str, Any]):
     """JSON object that retains normal dict serialization without mutation."""
 
-    def _reject_mutation(self, *_args: object, **_kwargs: object) -> None:
+    def _reject_mutation(self, *_args: object, **_kwargs: object) -> NoReturn:
         raise TypeError("canonical JSON values are immutable")
+
+    def __copy__(self) -> _FrozenJsonDict:
+        return self
+
+    def __deepcopy__(self, _memo: dict[int, object]) -> _FrozenJsonDict:
+        return self
 
     __setitem__ = _reject_mutation
     __delitem__ = _reject_mutation
@@ -156,8 +162,14 @@ class _FrozenJsonDict(dict[str, Any]):
 class _FrozenJsonList(list[Any]):
     """JSON array that retains normal list serialization without mutation."""
 
-    def _reject_mutation(self, *_args: object, **_kwargs: object) -> None:
+    def _reject_mutation(self, *_args: object, **_kwargs: object) -> NoReturn:
         raise TypeError("canonical JSON values are immutable")
+
+    def __copy__(self) -> _FrozenJsonList:
+        return self
+
+    def __deepcopy__(self, _memo: dict[int, object]) -> _FrozenJsonList:
+        return self
 
     __setitem__ = _reject_mutation
     __delitem__ = _reject_mutation
@@ -422,6 +434,7 @@ def canonical_json_bytes(value: object) -> bytes:
     """Serialize one validated value as canonical UTF-8 JSON."""
 
     try:
+        _validate_json_value(value, "value")
         return json.dumps(
             value,
             sort_keys=True,
@@ -429,7 +442,7 @@ def canonical_json_bytes(value: object) -> bytes:
             ensure_ascii=False,
             allow_nan=False,
         ).encode("utf-8")
-    except (TypeError, ValueError, UnicodeEncodeError) as exc:
+    except (TypeError, ValueError, UnicodeEncodeError, RecursionError) as exc:
         raise NotesTaskContractError("value is not canonical UTF-8 JSON") from exc
 
 
@@ -739,7 +752,7 @@ def convert_legacy_task_event(
     return parse_notes_task_activity_v1(
         {
             "activity_id": activity_id,
-            "note_id": cast(str, note_id),
+            "note_id": note_id,
             "task_id": task_id,
             "event_type": canonical_type,
             "actor_type": actor_type,
@@ -849,9 +862,7 @@ def _validate_json_object(
 ) -> None:
     if not isinstance(value, dict):
         raise ValueError(f"{label} must be a JSON object")
-    _validate_json_value(value, label)
-    if _json_depth(value) > max_depth:
-        raise ValueError(f"{label} exceeds maximum depth {max_depth}")
+    _validate_json_value(value, label, max_depth=max_depth)
     if len(canonical_json_bytes(value)) > max_bytes:
         raise ValueError(f"{label} exceeds {max_bytes // 1_024} KiB")
 
@@ -866,34 +877,44 @@ def _freeze_json(value: Any) -> Any:
     return value
 
 
-def _validate_json_value(value: object, label: str) -> None:
-    if value is None or isinstance(value, (str, bool)):
-        return
-    if isinstance(value, int) and not isinstance(value, bool):
-        return
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise ValueError(f"{label} must contain finite JSON numbers")
-        return
-    if isinstance(value, list):
-        for item in value:
-            _validate_json_value(item, label)
-        return
-    if isinstance(value, dict):
-        for key, item in value.items():
-            if not isinstance(key, str):
-                raise ValueError(f"{label} JSON object keys must be strings")
-            _validate_json_value(item, label)
-        return
-    raise ValueError(f"{label} must contain only JSON values")
-
-
-def _json_depth(value: object) -> int:
-    if isinstance(value, dict):
-        return 1 + max((_json_depth(item) for item in value.values()), default=0)
-    if isinstance(value, list):
-        return 1 + max((_json_depth(item) for item in value), default=0)
-    return 0
+def _validate_json_value(
+    value: object,
+    label: str,
+    *,
+    max_depth: int | None = None,
+) -> None:
+    active_containers: set[int] = set()
+    stack: list[tuple[object, int, bool]] = [(value, 0, False)]
+    while stack:
+        current, parent_depth, leaving = stack.pop()
+        if leaving:
+            active_containers.remove(id(current))
+            continue
+        if current is None or isinstance(current, (str, bool)):
+            continue
+        if isinstance(current, int):
+            if not -_JS_SAFE_INTEGER <= current <= _JS_SAFE_INTEGER:
+                raise ValueError(f"{label} integers must be within the JS safe range")
+            continue
+        if isinstance(current, float):
+            raise ValueError(f"{label} cannot contain floating-point values")
+        if not isinstance(current, (dict, list)):
+            raise ValueError(f"{label} must contain only JSON values")
+        depth = parent_depth + 1
+        if max_depth is not None and depth > max_depth:
+            raise ValueError(f"{label} exceeds maximum depth {max_depth}")
+        container_id = id(current)
+        if container_id in active_containers:
+            raise ValueError(f"{label} cannot contain circular values")
+        active_containers.add(container_id)
+        stack.append((current, parent_depth, True))
+        if isinstance(current, dict):
+            for key, item in current.items():
+                if not isinstance(key, str):
+                    raise ValueError(f"{label} JSON object keys must be strings")
+                stack.append((item, depth, False))
+        else:
+            stack.extend((item, depth, False) for item in current)
 
 
 def _walk_keys(value: object):
@@ -1023,17 +1044,25 @@ def _validate_event_values(
         return
     if event_type == "deleted":
         if (
-            set(old_value or {}) != {"deleted", "projection_status"}
+            old_value is None
+            or new_value is None
+            or set(old_value) != {"deleted", "projection_status"}
             or old_value["deleted"] is not False
             or old_value["projection_status"] not in {"live", "unlinked", "ambiguous"}
-            or new_value != {"deleted": True, "projection_status": "deleted"}
+            or set(new_value) != {"deleted", "projection_status"}
+            or new_value["deleted"] is not True
+            or new_value["projection_status"] != "deleted"
         ):
             raise NotesTaskContractError("deleted activity has a noncanonical shape")
         return
     if event_type == "restored":
         if (
-            old_value != {"deleted": True, "projection_status": "deleted"}
-            or set(new_value or {}) != {"deleted", "projection_status"}
+            old_value is None
+            or new_value is None
+            or set(old_value) != {"deleted", "projection_status"}
+            or old_value["deleted"] is not True
+            or old_value["projection_status"] != "deleted"
+            or set(new_value) != {"deleted", "projection_status"}
             or new_value["deleted"] is not False
             or new_value["projection_status"] not in {"live", "unlinked"}
         ):
@@ -1041,7 +1070,9 @@ def _validate_event_values(
         return
     if event_type == "projection_linked":
         if (
-            set(old_value or {}) != {"projection_status"}
+            old_value is None
+            or new_value is None
+            or set(old_value) != {"projection_status"}
             or old_value["projection_status"] not in {"unlinked", "ambiguous"}
             or new_value != {"projection_status": "live"}
         ):
@@ -1050,7 +1081,8 @@ def _validate_event_values(
     if event_type == "projection_drift":
         if (
             old_value is not None
-            or set(new_value or {}) != {"reason_code"}
+            or new_value is None
+            or set(new_value) != {"reason_code"}
             or new_value["reason_code"] not in _DRIFT_REASONS
         ):
             raise NotesTaskContractError("projection_drift activity has a noncanonical shape")
@@ -1119,7 +1151,12 @@ def _copy_json_object(value: object, label: str) -> dict[str, Any] | None:
         raise NotesTaskContractError(f"{label} must be an object or null")
     copied = dict(value)
     try:
-        _validate_json_value(copied, label)
+        _validate_json_object(
+            copied,
+            label=label,
+            max_depth=4,
+            max_bytes=16 * 1_024,
+        )
     except ValueError as exc:
         raise NotesTaskContractError(str(exc)) from exc
     return copied

--- a/tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
@@ -910,8 +910,10 @@ def _validate_json_value(
         stack.append((current, parent_depth, True))
         if isinstance(current, dict):
             for key, item in current.items():
-                if not isinstance(key, str):
-                    raise ValueError(f"{label} JSON object keys must be strings")
+                if not isinstance(key, str) or _SAFE_KEY_RE.fullmatch(key) is None:
+                    raise ValueError(
+                        f"{label} JSON object keys must use 1 to 64 safe ASCII characters"
+                    )
                 stack.append((item, depth, False))
         else:
             stack.extend((item, depth, False) for item in current)

--- a/tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_task_contract.py
@@ -22,6 +22,8 @@ from pydantic import (
     model_validator,
 )
 
+from tldw_Server_API.app.core.exceptions import NotesTaskContractError
+
 from .models import normalize_sync_timestamp
 
 _UUID4_MESSAGE = "IDs must be canonical lowercase UUIDv4 strings"
@@ -131,10 +133,6 @@ TaskActivitySource = Literal[
     "trusted_bootstrap_v1",
 ]
 DeleteReason = Literal["user_request", "correction", "policy"]
-
-
-class NotesTaskContractError(ValueError):
-    """Stable fail-closed error for Notes task Sync contract violations."""
 
 
 class _FrozenJsonDict(dict[str, Any]):

--- a/tldw_Server_API/app/core/Sync/v2/notes_task_readiness.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_task_readiness.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+"""Pure validation helpers for dormant notes task readiness metadata."""
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TypeAlias
+from uuid import RFC_4122, UUID
+
+NOTES_TASK_READINESS_KEYS = frozenset(
+    {
+        "state",
+        "source_cursor",
+        "source_count",
+        "source_fingerprint",
+        "reason_code",
+        "resume_phase",
+    }
+)
+NOTES_TASK_READINESS_STATES = frozenset(
+    {
+        "not_enrolled",
+        "enrolling",
+        "bootstrapping",
+        "verifying",
+        "ready",
+        "blocked",
+    }
+)
+NOTES_TASK_READINESS_REASON_CODES_BY_KEY = {
+    "notes_task_v1": frozenset(
+        {
+            "notes_task_source_invalid",
+            "notes_task_source_changed",
+            "notes_task_source_scope_invalid",
+            "notes_task_source_catalog_invalid",
+            "notes_task_verification_failed",
+        }
+    ),
+    "notes_task_activity_v1": frozenset(
+        {
+            "notes_task_activity_source_invalid",
+            "notes_task_activity_source_changed",
+            "notes_task_activity_source_scope_invalid",
+            "notes_task_activity_source_catalog_invalid",
+            "notes_task_activity_verification_failed",
+        }
+    ),
+}
+NOTES_TASK_SERVER_METADATA_KEYS = frozenset(
+    {
+        *NOTES_TASK_READINESS_REASON_CODES_BY_KEY,
+        "task_activity_capture_enabled",
+    }
+)
+NOTES_TASK_READINESS_COUNT_MAX = 9_223_372_036_854_775_807
+_RESUME_PHASES = frozenset({"bootstrapping", "verifying"})
+_FINGERPRINT = re.compile(r"[0-9a-f]{64}")
+
+CursorOrderKey: TypeAlias = UUID | tuple[datetime, UUID]
+
+
+@dataclass(frozen=True, slots=True)
+class NotesTaskReadinessRecord:
+    """Validated readiness record plus its domain-specific cursor order key."""
+
+    state: str
+    source_cursor: str | None
+    source_count: int
+    source_fingerprint: str | None
+    reason_code: str | None
+    resume_phase: str | None
+    source_cursor_key: CursorOrderKey | None
+
+    def as_metadata(self) -> dict[str, object]:
+        """Return the exact persisted metadata representation."""
+
+        return {
+            "state": self.state,
+            "source_cursor": self.source_cursor,
+            "source_count": self.source_count,
+            "source_fingerprint": self.source_fingerprint,
+            "reason_code": self.reason_code,
+            "resume_phase": self.resume_phase,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class NotesTaskReadinessParseResult:
+    """Total parser outcome with a stable, non-sensitive error code."""
+
+    record: NotesTaskReadinessRecord | None = None
+    error_code: str | None = None
+
+
+def default_notes_task_readiness_record() -> NotesTaskReadinessRecord:
+    """Return the implicit readiness record for an absent domain key."""
+
+    return NotesTaskReadinessRecord(
+        state="not_enrolled",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        reason_code=None,
+        resume_phase=None,
+        source_cursor_key=None,
+    )
+
+
+def redact_notes_task_server_metadata(
+    metadata: Mapping[str, object],
+) -> dict[str, object]:
+    """Return public dataset metadata without internal readiness state."""
+
+    return {
+        key: value
+        for key, value in metadata.items()
+        if key not in NOTES_TASK_SERVER_METADATA_KEYS
+    }
+
+
+def parse_notes_task_readiness_record(
+    raw: object,
+    *,
+    readiness_key: str,
+) -> NotesTaskReadinessParseResult:
+    """Parse one exact dormant-task readiness record without raising."""
+
+    if not isinstance(raw, dict) or set(raw) != NOTES_TASK_READINESS_KEYS:
+        return _error("notes_task_readiness_state_invalid")
+    reason_codes = NOTES_TASK_READINESS_REASON_CODES_BY_KEY.get(readiness_key)
+    if reason_codes is None:
+        return _error("notes_task_readiness_state_invalid")
+
+    state = raw.get("state")
+    source_cursor = raw.get("source_cursor")
+    source_count = raw.get("source_count")
+    source_fingerprint = raw.get("source_fingerprint")
+    reason_code = raw.get("reason_code")
+    resume_phase = raw.get("resume_phase")
+
+    if not isinstance(state, str) or state not in NOTES_TASK_READINESS_STATES:
+        return _error("notes_task_readiness_state_invalid")
+    if (
+        isinstance(source_count, bool)
+        or not isinstance(source_count, int)
+        or not 0 <= source_count <= NOTES_TASK_READINESS_COUNT_MAX
+    ):
+        return _error("notes_task_readiness_progress_invalid")
+    if source_fingerprint is not None and (
+        not isinstance(source_fingerprint, str)
+        or _FINGERPRINT.fullmatch(source_fingerprint) is None
+    ):
+        return _error("notes_task_readiness_fingerprint_invalid")
+    if reason_code is not None and (
+        not isinstance(reason_code, str) or reason_code not in reason_codes
+    ):
+        return _error("notes_task_readiness_reason_invalid")
+    if state == "blocked":
+        if reason_code is None:
+            return _error("notes_task_readiness_reason_invalid")
+        if not isinstance(resume_phase, str) or resume_phase not in _RESUME_PHASES:
+            return _error("notes_task_readiness_state_invalid")
+        if resume_phase == "verifying" and source_fingerprint is None:
+            return _error("notes_task_readiness_state_invalid")
+    elif reason_code is not None:
+        return _error("notes_task_readiness_reason_invalid")
+    elif resume_phase is not None:
+        return _error("notes_task_readiness_state_invalid")
+
+    cursor_key = _parse_cursor(source_cursor, readiness_key)
+    if source_cursor is not None and cursor_key is None:
+        return _error("notes_task_readiness_cursor_invalid")
+    if state in {"not_enrolled", "enrolling"} and (
+        source_cursor is not None
+        or source_count != 0
+        or source_fingerprint is not None
+    ):
+        return _error("notes_task_readiness_progress_invalid")
+    if (source_cursor is None) != (source_count == 0):
+        return _error("notes_task_readiness_progress_invalid")
+    if state in {"verifying", "ready"} and source_fingerprint is None:
+        return _error("notes_task_readiness_fingerprint_invalid")
+    if source_cursor is not None and source_fingerprint is None:
+        return _error("notes_task_readiness_progress_invalid")
+
+    return NotesTaskReadinessParseResult(
+        record=NotesTaskReadinessRecord(
+            state=state,
+            source_cursor=source_cursor,
+            source_count=source_count,
+            source_fingerprint=source_fingerprint,
+            reason_code=reason_code,
+            resume_phase=resume_phase,
+            source_cursor_key=cursor_key,
+        )
+    )
+
+
+def _parse_cursor(value: object, readiness_key: str) -> CursorOrderKey | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    if readiness_key == "notes_task_v1":
+        return _parse_uuid(value)
+    if readiness_key != "notes_task_activity_v1":
+        return None
+    try:
+        created_at_text, activity_id_text = value.rsplit("|", 1)
+        created_at = datetime.fromisoformat(created_at_text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if created_at.tzinfo is None:
+        return None
+    try:
+        created_at = created_at.astimezone(timezone.utc)
+    except OverflowError:
+        return None
+    activity_id = _parse_uuid(activity_id_text)
+    if created_at.isoformat() != created_at_text or activity_id is None:
+        return None
+    return created_at, activity_id
+
+
+def _parse_uuid(value: str) -> UUID | None:
+    try:
+        parsed = UUID(value)
+    except (AttributeError, ValueError):
+        return None
+    if parsed.version != 4 or parsed.variant != RFC_4122 or str(parsed) != value:
+        return None
+    return parsed
+
+
+def _error(error_code: str) -> NotesTaskReadinessParseResult:
+    return NotesTaskReadinessParseResult(error_code=error_code)

--- a/tldw_Server_API/app/core/Sync/v2/profile.py
+++ b/tldw_Server_API/app/core/Sync/v2/profile.py
@@ -23,53 +23,13 @@ from .models import (
     server_frontend_mutation_blockers_for_policy,
     server_frontend_mutation_enabled_for_policy,
 )
+from .notes_task_readiness import parse_notes_task_readiness_record
 from .store import SyncV2Store
 
 SYNC_V2_M1_PROTOCOL_VERSION = "sync-v2-m1"
 BOOTSTRAP_MODES = frozenset({"server_frontend", "offline_sync"})
 DEFAULT_CLIENT_FAMILY = "chatbook"
-_DORMANT_TASK_READINESS_STATES = frozenset(
-    {
-        "not_enrolled",
-        "enrolling",
-        "bootstrapping",
-        "verifying",
-        "ready",
-        "blocked",
-    }
-)
-_DORMANT_TASK_READINESS_REASON_CODES_BY_DOMAIN = {
-    "notes_task": frozenset(
-        {
-            "notes_task_source_invalid",
-            "notes_task_source_changed",
-            "notes_task_source_scope_invalid",
-            "notes_task_source_catalog_invalid",
-            "notes_task_verification_failed",
-        }
-    ),
-    "notes_task_activity": frozenset(
-        {
-            "notes_task_activity_source_invalid",
-            "notes_task_activity_source_changed",
-            "notes_task_activity_source_scope_invalid",
-            "notes_task_activity_source_catalog_invalid",
-            "notes_task_activity_verification_failed",
-        }
-    ),
-}
-_DORMANT_TASK_READINESS_CURSOR_MAX_BYTES = 4_096
-_DORMANT_TASK_READINESS_COUNT_MAX = 9_223_372_036_854_775_807
 _DORMANT_TASK_READINESS_MISSING = object()
-
-
-def _is_valid_dormant_task_cursor(value: object) -> bool:
-    if not isinstance(value, str) or not value or value != value.strip():
-        return False
-    try:
-        return len(value.encode("utf-8")) <= _DORMANT_TASK_READINESS_CURSOR_MAX_BYTES
-    except UnicodeEncodeError:
-        return False
 
 
 @dataclass(frozen=True, slots=True)
@@ -765,70 +725,30 @@ def _safe_dormant_task_readiness(
         state="blocked",
         reason_code=f"{domain}_readiness_state_invalid",
     )
-    if not isinstance(metadata, Mapping):
+    readiness_key = (
+        "notes_task_v1"
+        if domain == "notes_task"
+        else "notes_task_activity_v1"
+    )
+    result = parse_notes_task_readiness_record(
+        metadata,
+        readiness_key=readiness_key,
+    )
+    if result.record is None:
         return invalid
-    required = {
-        "state",
-        "source_cursor",
-        "source_count",
-        "source_fingerprint",
-        "reason_code",
-    }
-    if not required.issubset(metadata):
-        return invalid
-    state = metadata.get("state")
-    source_cursor = metadata.get("source_cursor")
-    source_count = metadata.get("source_count")
-    source_fingerprint = metadata.get("source_fingerprint")
-    reason_code = metadata.get("reason_code")
-    if state not in _DORMANT_TASK_READINESS_STATES:
-        return invalid
-    if (
-        isinstance(source_count, bool)
-        or not isinstance(source_count, int)
-        or source_count < 0
-        or source_count > _DORMANT_TASK_READINESS_COUNT_MAX
-    ):
-        return invalid
-    if source_cursor is not None and not _is_valid_dormant_task_cursor(source_cursor):
-        return invalid
-    if source_fingerprint is not None and (
-        not isinstance(source_fingerprint, str)
-        or len(source_fingerprint) != 64
-        or any(character not in "0123456789abcdef" for character in source_fingerprint)
-    ):
-        return invalid
-    if reason_code is not None and reason_code not in (
-        _DORMANT_TASK_READINESS_REASON_CODES_BY_DOMAIN[domain]
-    ):
-        return invalid
-    if (state == "blocked") != (reason_code is not None):
-        return invalid
-    if state in {"not_enrolled", "enrolling"} and (
-        source_cursor is not None
-        or source_count != 0
-        or source_fingerprint is not None
-    ):
-        return invalid
-    if source_count > 0 and (
-        source_cursor is None or source_fingerprint is None
-    ):
-        return invalid
-    if source_cursor is not None and source_fingerprint is None:
-        return invalid
-    if state in {"verifying", "ready"} and source_fingerprint is None:
-        return invalid
+    record = result.record
     cursor_hash = (
-        "sha256:" + hashlib.sha256(source_cursor.encode("utf-8")).hexdigest()
-        if source_cursor is not None
+        "sha256:"
+        + hashlib.sha256(record.source_cursor.encode("utf-8")).hexdigest()
+        if record.source_cursor is not None
         else None
     )
     return SyncDormantTaskDomainReadiness(
-        state=str(state),
-        source_count=source_count,
+        state=record.state,
+        source_count=record.source_count,
         cursor=cursor_hash,
-        source_fingerprint=source_fingerprint,
-        reason_code=reason_code if isinstance(reason_code, str) else None,
+        source_fingerprint=record.source_fingerprint,
+        reason_code=record.reason_code,
     )
 
 

--- a/tldw_Server_API/app/core/Sync/v2/profile.py
+++ b/tldw_Server_API/app/core/Sync/v2/profile.py
@@ -28,6 +28,48 @@ from .store import SyncV2Store
 SYNC_V2_M1_PROTOCOL_VERSION = "sync-v2-m1"
 BOOTSTRAP_MODES = frozenset({"server_frontend", "offline_sync"})
 DEFAULT_CLIENT_FAMILY = "chatbook"
+_DORMANT_TASK_READINESS_STATES = frozenset(
+    {
+        "not_enrolled",
+        "enrolling",
+        "bootstrapping",
+        "verifying",
+        "ready",
+        "blocked",
+    }
+)
+_DORMANT_TASK_READINESS_REASON_CODES_BY_DOMAIN = {
+    "notes_task": frozenset(
+        {
+            "notes_task_source_invalid",
+            "notes_task_source_changed",
+            "notes_task_source_scope_invalid",
+            "notes_task_source_catalog_invalid",
+            "notes_task_verification_failed",
+        }
+    ),
+    "notes_task_activity": frozenset(
+        {
+            "notes_task_activity_source_invalid",
+            "notes_task_activity_source_changed",
+            "notes_task_activity_source_scope_invalid",
+            "notes_task_activity_source_catalog_invalid",
+            "notes_task_activity_verification_failed",
+        }
+    ),
+}
+_DORMANT_TASK_READINESS_CURSOR_MAX_BYTES = 4_096
+_DORMANT_TASK_READINESS_COUNT_MAX = 9_223_372_036_854_775_807
+_DORMANT_TASK_READINESS_MISSING = object()
+
+
+def _is_valid_dormant_task_cursor(value: object) -> bool:
+    if not isinstance(value, str) or not value or value != value.strip():
+        return False
+    try:
+        return len(value.encode("utf-8")) <= _DORMANT_TASK_READINESS_CURSOR_MAX_BYTES
+    except UnicodeEncodeError:
+        return False
 
 
 @dataclass(frozen=True, slots=True)
@@ -100,6 +142,26 @@ class SyncNotesAttachmentBootstrapDiagnostics:
         default_factory=list
     )
     recovery_actions: list[SyncRecoveryActionDescriptor] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class SyncDormantTaskDomainReadiness:
+    """Privacy-safe internal readiness for one dormant task domain."""
+
+    state: str = "not_enrolled"
+    source_count: int = 0
+    cursor: str | None = None
+    source_fingerprint: str | None = None
+    reason_code: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SyncDormantTaskReadinessDiagnostics:
+    """Owner-scoped dormant task readiness without source payload values."""
+
+    task: SyncDormantTaskDomainReadiness
+    task_activity: SyncDormantTaskDomainReadiness
+    task_activity_capture_enabled: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -312,6 +374,37 @@ class SyncV2ProfileManager:
             dataset=dataset,
             device_id=device_id,
             created=None,
+        )
+
+    def notes_task_readiness_diagnostics(
+        self,
+        *,
+        user_id: str,
+        dataset_id: str,
+    ) -> SyncDormantTaskReadinessDiagnostics:
+        """Return owner-only, payload-free readiness for dormant task domains."""
+
+        dataset = self.store.get_dataset(dataset_id, owner_user_id=user_id)
+        if dataset is None:
+            raise SyncStoreError("Sync dataset was not found or is not accessible")
+        return SyncDormantTaskReadinessDiagnostics(
+            task=_safe_dormant_task_readiness(
+                dataset.metadata.get(
+                    "notes_task_v1",
+                    _DORMANT_TASK_READINESS_MISSING,
+                ),
+                domain="notes_task",
+            ),
+            task_activity=_safe_dormant_task_readiness(
+                dataset.metadata.get(
+                    "notes_task_activity_v1",
+                    _DORMANT_TASK_READINESS_MISSING,
+                ),
+                domain="notes_task_activity",
+            ),
+            task_activity_capture_enabled=(
+                dataset.metadata.get("task_activity_capture_enabled") is True
+            ),
         )
 
     def notes_attachment_bootstrap_diagnostics(
@@ -660,6 +753,85 @@ def _safe_notes_attachment_status(
     }
 
 
+def _safe_dormant_task_readiness(
+    metadata: object,
+    *,
+    domain: str,
+) -> SyncDormantTaskDomainReadiness:
+    if metadata is _DORMANT_TASK_READINESS_MISSING:
+        return SyncDormantTaskDomainReadiness()
+
+    invalid = SyncDormantTaskDomainReadiness(
+        state="blocked",
+        reason_code=f"{domain}_readiness_state_invalid",
+    )
+    if not isinstance(metadata, Mapping):
+        return invalid
+    required = {
+        "state",
+        "source_cursor",
+        "source_count",
+        "source_fingerprint",
+        "reason_code",
+    }
+    if not required.issubset(metadata):
+        return invalid
+    state = metadata.get("state")
+    source_cursor = metadata.get("source_cursor")
+    source_count = metadata.get("source_count")
+    source_fingerprint = metadata.get("source_fingerprint")
+    reason_code = metadata.get("reason_code")
+    if state not in _DORMANT_TASK_READINESS_STATES:
+        return invalid
+    if (
+        isinstance(source_count, bool)
+        or not isinstance(source_count, int)
+        or source_count < 0
+        or source_count > _DORMANT_TASK_READINESS_COUNT_MAX
+    ):
+        return invalid
+    if source_cursor is not None and not _is_valid_dormant_task_cursor(source_cursor):
+        return invalid
+    if source_fingerprint is not None and (
+        not isinstance(source_fingerprint, str)
+        or len(source_fingerprint) != 64
+        or any(character not in "0123456789abcdef" for character in source_fingerprint)
+    ):
+        return invalid
+    if reason_code is not None and reason_code not in (
+        _DORMANT_TASK_READINESS_REASON_CODES_BY_DOMAIN[domain]
+    ):
+        return invalid
+    if (state == "blocked") != (reason_code is not None):
+        return invalid
+    if state in {"not_enrolled", "enrolling"} and (
+        source_cursor is not None
+        or source_count != 0
+        or source_fingerprint is not None
+    ):
+        return invalid
+    if source_count > 0 and (
+        source_cursor is None or source_fingerprint is None
+    ):
+        return invalid
+    if source_cursor is not None and source_fingerprint is None:
+        return invalid
+    if state in {"verifying", "ready"} and source_fingerprint is None:
+        return invalid
+    cursor_hash = (
+        "sha256:" + hashlib.sha256(source_cursor.encode("utf-8")).hexdigest()
+        if source_cursor is not None
+        else None
+    )
+    return SyncDormantTaskDomainReadiness(
+        state=str(state),
+        source_count=source_count,
+        cursor=cursor_hash,
+        source_fingerprint=source_fingerprint,
+        reason_code=reason_code if isinstance(reason_code, str) else None,
+    )
+
+
 def _safe_non_negative_int(value: object) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
 
@@ -726,6 +898,8 @@ __all__ = [
     "BOOTSTRAP_MODES",
     "DEFAULT_CLIENT_FAMILY",
     "SYNC_V2_M1_PROTOCOL_VERSION",
+    "SyncDormantTaskDomainReadiness",
+    "SyncDormantTaskReadinessDiagnostics",
     "SyncNotesAttachmentBootstrapDiagnostics",
     "SyncNotesAttachmentCleanupSample",
     "SyncProfileDatasetStatus",

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -111,6 +111,10 @@ from .mutation_group_validation import (
     StoredMutationGroupValidationError,
     validate_stored_mutation_group,
 )
+from .notes_task_readiness import (
+    NOTES_TASK_SERVER_METADATA_KEYS,
+    redact_notes_task_server_metadata,
+)
 from .profile import (
     SyncNotesAttachmentBootstrapDiagnostics,
     SyncProfileStatus,
@@ -1772,6 +1776,7 @@ class SyncV2Service:
             "notes_attachment_v2",
             "default_personal",
             "client_family",
+            *NOTES_TASK_SERVER_METADATA_KEYS,
         }
         if (
             requested_domains.intersection(
@@ -1798,7 +1803,10 @@ class SyncV2Service:
             )
         )
         return SyncDatasetEnrollment(
-            dataset=dataset,
+            dataset=replace(
+                dataset,
+                metadata=redact_notes_task_server_metadata(dataset.metadata),
+            ),
             cursors=dict.fromkeys(dataset.domains, "0"),
             key_setup_required=False,
         )
@@ -6978,7 +6986,11 @@ class SyncV2Service:
         last_updated_at = stats.last_updated_at or dataset.updated_at
         if last_updated_at < dataset.updated_at:
             last_updated_at = dataset.updated_at
-        metadata: dict[str, object] = {} if dataset.encryption_policy == "client_private_v1" else dict(dataset.metadata)
+        metadata = (
+            {}
+            if dataset.encryption_policy == "client_private_v1"
+            else redact_notes_task_server_metadata(dataset.metadata)
+        )
         return SyncRestoreManifestDataset(
             dataset_id=dataset.dataset_id,
             scope_type=dataset.scope_type,

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -315,6 +315,66 @@ class SyncV2Store:
     def get_or_create_default_personal_dataset(self, user_id: str) -> SyncDataset:
         return self.db.get_or_create_default_personal_dataset(user_id)
 
+    def transition_notes_task_readiness(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        expected_state: str,
+        state: str,
+        source_dataset_id: str,
+        source_cursor: str | None,
+        source_count: int,
+        source_fingerprint: str | None,
+        reason_code: str | None = None,
+        task_activity_capture_enabled: bool | None = None,
+    ) -> SyncDataset:
+        """Delegate one dormant notes.task readiness transition."""
+
+        return self.db.transition_notes_task_domain_readiness(
+            dataset_id,
+            owner_user_id=owner_user_id,
+            readiness_key="notes_task_v1",
+            expected_state=expected_state,
+            state=state,
+            source_dataset_id=source_dataset_id,
+            source_cursor=source_cursor,
+            source_count=source_count,
+            source_fingerprint=source_fingerprint,
+            reason_code=reason_code,
+            task_activity_capture_enabled=task_activity_capture_enabled,
+        )
+
+    def transition_notes_task_activity_readiness(
+        self,
+        dataset_id: str,
+        *,
+        owner_user_id: str,
+        expected_state: str,
+        state: str,
+        source_dataset_id: str,
+        source_cursor: str | None,
+        source_count: int,
+        source_fingerprint: str | None,
+        reason_code: str | None = None,
+        task_activity_capture_enabled: bool | None = None,
+    ) -> SyncDataset:
+        """Delegate one dormant notes.task_activity readiness transition."""
+
+        return self.db.transition_notes_task_domain_readiness(
+            dataset_id,
+            owner_user_id=owner_user_id,
+            readiness_key="notes_task_activity_v1",
+            expected_state=expected_state,
+            state=state,
+            source_dataset_id=source_dataset_id,
+            source_cursor=source_cursor,
+            source_count=source_count,
+            source_fingerprint=source_fingerprint,
+            reason_code=reason_code,
+            task_activity_capture_enabled=task_activity_capture_enabled,
+        )
+
     def begin_notes_organization_bootstrap(
         self,
         dataset_id: str,

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -59,6 +59,10 @@ class NoteAttachmentPolicyError(ValueError):
     """Raised when attachment metadata is outside the canonical Notes policy."""
 
 
+class NotesTaskContractError(ValueError):
+    """Stable fail-closed error for Notes task Sync contract violations."""
+
+
 class LegacyAttachmentSourceError(RuntimeError):
     """Sanitized failure while reading a legacy Notes attachment source."""
 

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
@@ -43,6 +43,22 @@ def test_task_store_has_no_postgres_v59_sql_bridge() -> None:
         assert legacy_sql not in source
 
 
+def test_bind_local_task_graph_has_one_strict_postgres_and_sqlite_contract() -> None:
+    source = inspect.getsource(TaskStore)
+    bind_source = inspect.getsource(TaskStore.bind_local_task_graph_to_dataset)
+
+    assert "only supported by SQLite" not in bind_source
+    assert "LOCK TABLE notes, note_tasks, task_note_projections, task_events" in source
+    assert "IN ACCESS EXCLUSIVE MODE" in source
+    assert "_get_schema_version_postgres" in source
+    assert "_verify_note_task_schema_postgres" in source
+    assert "FOR UPDATE" in source
+    assert "NO FORCE ROW LEVEL SECURITY" in source
+    assert "FORCE ROW LEVEL SECURITY" in source
+    assert "_note_task_v60_hash" in source
+    assert "complete-set verification" in source
+
+
 def test_canonical_task_store_methods_are_keyword_only_scope_first() -> None:
     methods = (
         "get_task_projection",

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
@@ -74,6 +74,20 @@ def test_compatibility_resolver_is_one_indexed_authority_lookup() -> None:
         assert forbidden not in source
 
 
+def test_postgres_task_scope_uses_transaction_local_settings() -> None:
+    scope_source = inspect.getsource(TaskStore._scope)
+    setter_source = inspect.getsource(TaskStore._set_postgres_dataset_scope)
+    guard_source = inspect.getsource(TaskStore._require_authorized_write_scope)
+    resolver_source = inspect.getsource(
+        TaskStore.resolve_task_compatibility_dataset_id
+    )
+
+    assert "set_config('app.current_dataset_id', ?, false)" not in scope_source
+    assert "set_config('app.current_dataset_id', ?, true)" in setter_source
+    assert "_set_postgres_dataset_scope" in guard_source
+    assert "set_config('app.current_dataset_id'" not in resolver_source
+
+
 def test_every_task_graph_write_checks_the_private_scope_authority() -> None:
     for method_name in (
         "create_task",

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import inspect
+from contextlib import contextmanager
+from typing import Any
+
 import pytest
 
+from tldw_Server_API.app.core.DB_Management.chacha.task_store import TaskStore
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    BackendType,
     CharactersRAGDB,
     ConflictError,
     InputError,
@@ -15,6 +21,162 @@ pytestmark = pytest.mark.unit
 LOCAL_UNBOUND = "local-unbound"
 
 
+class _PostgresV59Cursor:
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.rows = rows or []
+        self.rowcount = 1
+
+    def fetchone(self):
+        return self.rows[0] if self.rows else None
+
+    def fetchall(self):
+        return self.rows
+
+
+class _PostgresV59Connection:
+    _FORBIDDEN = (
+        "owner_user_id",
+        "dataset_id",
+        "canonical_revision",
+        "canonical_hash",
+        "sync_revision",
+        "sync_object_hash",
+        "sync_server_cursor",
+        "source_device_id",
+        "client_occurred_at",
+        "source_kind",
+        "corrects_activity_id",
+        "source_diagnostic_code",
+        "source_diagnostic_hash",
+        "task_projection_drifts",
+    )
+
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+        self.task = {
+            "id": "pg-task",
+            "note_id": "pg-note",
+            "text": "Review source",
+            "status": "open",
+            "metadata_json": "{}",
+            "projection_status": "live",
+            "deleted": False,
+            "created_at": "2026-08-13T00:00:00+00:00",
+            "updated_at": "2026-08-13T00:00:00+00:00",
+            "completed_at": None,
+            "client_id": "pg-owner",
+            "version": 1,
+        }
+        self.projection = {
+            "task_id": "pg-task",
+            "note_id": "pg-note",
+            "note_version": 1,
+            "line_number": 1,
+            "start_offset": 0,
+            "end_offset": 10,
+            "normalized_text_hash": "sha256:review",
+            "occurrence_index": 0,
+            "block_fingerprint": "block",
+            "raw_line": "- [ ] Review source",
+            "has_child_content": False,
+            "projection_status": "live",
+            "updated_at": "2026-08-13T00:00:00+00:00",
+        }
+        self.event = {
+            "id": "pg-event",
+            "task_id": "pg-task",
+            "note_id": "pg-note",
+            "event_type": "updated",
+            "actor_type": "user",
+            "actor_id": "pg-owner",
+            "tool_name": None,
+            "policy_mode": None,
+            "approval_id": None,
+            "old_value_json": None,
+            "new_value_json": None,
+            "created_at": "2026-08-13T00:00:00+00:00",
+            "client_id": "pg-owner",
+        }
+
+    def execute(self, query: str, _params=()) -> _PostgresV59Cursor:
+        normalized = " ".join(query.lower().split())
+        self.statements.append(normalized)
+        leaked = [token for token in self._FORBIDDEN if token in normalized]
+        assert leaked == [], f"PostgreSQL v59 received v60-only SQL: {leaked}: {normalized}"
+        if "select count(*) as stale_count" in normalized:
+            return _PostgresV59Cursor([{"stale_count": 1}])
+        if "select id from notes" in normalized:
+            return _PostgresV59Cursor([{"id": "pg-note"}])
+        if "select deleted from notes" in normalized:
+            return _PostgresV59Cursor([{"deleted": False}])
+        if "select id, version, content, deleted from notes" in normalized:
+            return _PostgresV59Cursor([
+                {"id": "pg-note", "version": 1, "content": "- [ ] Review source\n", "deleted": False}
+            ])
+        if "from task_note_projections" in normalized:
+            return _PostgresV59Cursor([self.projection])
+        if "from task_events" in normalized:
+            return _PostgresV59Cursor([self.event])
+        if "from task_event_read_state" in normalized:
+            return _PostgresV59Cursor([
+                {"event_id": "pg-event", "user_id": "pg-owner", "read_at": "now", "dismissed_at": None}
+            ])
+        if "from note_task_reconciliation_state" in normalized:
+            return _PostgresV59Cursor([
+                {
+                    "note_id": "pg-note",
+                    "note_version": 1,
+                    "status": "clean",
+                    "reconciled_at": "now",
+                    "item_count": 1,
+                    "warning_count": 0,
+                    "cursor": None,
+                }
+            ])
+        if "from note_tasks" in normalized:
+            return _PostgresV59Cursor([self.task])
+        if "from notes n" in normalized:
+            return _PostgresV59Cursor([
+                {"id": "pg-note", "version": 1, "content": "- [ ] Review source\n"}
+            ])
+        return _PostgresV59Cursor()
+
+
+class _PostgresV59DB:
+    backend_type = BackendType.POSTGRESQL
+    client_id = "pg-owner"
+
+    def __init__(self) -> None:
+        self.connection = _PostgresV59Connection()
+
+    def execute_query(self, query: str, params=None):
+        return self.connection.execute(query, params)
+
+    @contextmanager
+    def transaction(self):
+        yield self.connection
+
+    @staticmethod
+    def _prepare_backend_statement(query: str, params=None):
+        return query, params
+
+    @staticmethod
+    def _generate_uuid() -> str:
+        return "pg-event"
+
+    @staticmethod
+    def _get_current_utc_timestamp_iso() -> str:
+        return "2026-08-13T00:00:00+00:00"
+
+    @staticmethod
+    def _canonicalize_legacy_task_v60(*_args, **_kwargs):
+        raise AssertionError("PostgreSQL v59 task writes must not compute v60 canonical fields")
+
+    @staticmethod
+    def _note_task_v60_hash(*_args, **_kwargs):
+        raise AssertionError("PostgreSQL v59 events must not compute v60 sync fields")
+
+
 @pytest.fixture()
 def db(tmp_path) -> CharactersRAGDB:
     database = CharactersRAGDB(
@@ -23,6 +185,155 @@ def db(tmp_path) -> CharactersRAGDB:
     )
     yield database
     database.close_connection()
+
+
+def test_postgres_v59_task_operations_never_issue_v60_sql() -> None:
+    legacy_db = _PostgresV59DB()
+    store = TaskStore(legacy_db)
+    scope = {"owner_user_id": legacy_db.client_id, "dataset_id": LOCAL_UNBOUND}
+
+    assert store.create_task(
+        **scope,
+        task_id="pg-task",
+        note_id="pg-note",
+        text="Review source",
+        actor_type=None,
+    ) is not None
+    assert store.get_task(**scope, task_id="pg-task") is not None
+    assert store.list_tasks(**scope, note_id="pg-note")
+    assert store.update_task_record(
+        **scope,
+        task_id="pg-task",
+        expected_version=1,
+        text="Review source",
+        actor_type=None,
+    ) is not None
+    assert store.set_task_projection(
+        **scope,
+        task_id="pg-task",
+        note_id="pg-note",
+        note_version=1,
+        line_number=1,
+        start_offset=0,
+        end_offset=10,
+        normalized_text_hash="sha256:review",
+        occurrence_index=0,
+        block_fingerprint="block",
+        raw_line="- [ ] Review source",
+        has_child_content=False,
+    ) is not None
+    legacy_db.connection.task["projection_status"] = "unlinked"
+    legacy_db.connection.projection["projection_status"] = "unlinked"
+    assert store.update_unlinked_task_metadata_record_only(
+        **scope,
+        task_id="pg-task",
+        expected_version=1,
+        metadata={"priority": "high"},
+        actor_type="user",
+    ) is not None
+    legacy_db.connection.task["projection_status"] = "live"
+    legacy_db.connection.projection["projection_status"] = "live"
+    assert store.mark_task_unlinked(
+        **scope,
+        task_id="pg-task",
+        expected_version=1,
+        actor_type=None,
+    ) is not None
+    assert store.soft_delete_task(
+        **scope,
+        task_id="pg-task",
+        expected_version=1,
+        allow_record_only=True,
+        actor_type=None,
+    ) is not None
+    assert store.get_task_projection(**scope, task_id="pg-task") is not None
+    assert store.get_note_reconciliation_snapshot(**scope, note_id="pg-note") is not None
+    assert store.list_live_projected_tasks(**scope, note_id="pg-note")
+    assert store.record_task_event(
+        **scope,
+        event_id="pg-event",
+        task_id="pg-task",
+        note_id="pg-note",
+        event_type="updated",
+        actor_type="user",
+    ) is not None
+    assert store.list_task_activity(**scope, task_id="pg-task")
+    assert store.list_recent_task_activity(**scope, task_id="pg-task")
+    assert store.list_recent_unread_task_activity(
+        **scope,
+        user_id=legacy_db.client_id,
+        task_id="pg-task",
+    )
+    assert store.mark_task_activity_read(
+        **scope,
+        event_id="pg-event",
+        user_id=legacy_db.client_id,
+    ) is not None
+    assert store.mark_task_activity_dismissed(
+        **scope,
+        event_id="pg-event",
+        user_id=legacy_db.client_id,
+    ) is not None
+    assert store.get_task_activity_read_state(
+        **scope,
+        event_id="pg-event",
+        user_id=legacy_db.client_id,
+    ) is not None
+    assert store.get_reconciliation_state(**scope, note_id="pg-note") is not None
+    assert store.set_reconciliation_state(
+        **scope,
+        note_id="pg-note",
+        note_version=1,
+        status="clean",
+        item_count=1,
+        warning_count=0,
+    ) is not None
+    assert store.candidate_notes_for_task_discovery(**scope)
+    assert store.count_candidate_notes_for_task_discovery(**scope) == 1
+
+    assert legacy_db.connection.statements
+
+
+def test_canonical_task_store_methods_are_keyword_only_scope_first() -> None:
+    methods = (
+        "get_task_projection",
+        "get_note_reconciliation_snapshot",
+        "list_live_projected_tasks",
+        "create_task",
+        "get_task",
+        "list_tasks",
+        "update_unlinked_task_metadata_record_only",
+        "update_task_record",
+        "set_task_projection",
+        "mark_task_unlinked",
+        "soft_delete_task",
+        "record_task_event",
+        "list_task_activity",
+        "list_recent_task_activity",
+        "list_recent_unread_task_activity",
+        "mark_task_activity_read",
+        "mark_task_activity_dismissed",
+        "get_task_activity_read_state",
+        "get_reconciliation_state",
+        "set_reconciliation_state",
+        "candidate_notes_for_task_discovery",
+        "count_candidate_notes_for_task_discovery",
+    )
+    for method_name in methods:
+        parameters = tuple(inspect.signature(getattr(TaskStore, method_name)).parameters.values())
+        assert tuple(parameter.name for parameter in parameters[:3]) == (  # nosec B101
+            "self",
+            "owner_user_id",
+            "dataset_id",
+        ), method_name
+        assert all(  # nosec B101
+            parameter.kind is inspect.Parameter.KEYWORD_ONLY for parameter in parameters[1:]
+        ), method_name
+
+    assert not hasattr(TaskStore, "get_task_scoped")  # nosec B101
+    assert not hasattr(TaskStore, "resolve_task_compatibility_scope")  # nosec B101
+    with pytest.raises(TypeError):
+        TaskStore.get_task(object())
 
 
 def _create_note(db: CharactersRAGDB, content: str = "- [ ] Review source\n") -> str:
@@ -45,6 +356,40 @@ def _create_task(db: CharactersRAGDB, note_id: str, *, task_id: str = "task-1") 
     )
     assert created["id"] == task_id  # nosec B101
     return created
+
+
+def test_record_task_event_requires_note_and_task_note_consistency(db: CharactersRAGDB) -> None:
+    note_id = _create_note(db)
+    other_note_id = db.add_note(title="Other", content="Body")
+    _create_task(db, note_id)
+
+    with pytest.raises(InputError, match="note_id"):
+        db.record_task_event(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
+            task_id="task-1",
+            note_id=None,
+            event_type="updated",
+            actor_type="user",
+        )
+    with pytest.raises(ConflictError, match="does not match"):
+        db.record_task_event(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
+            task_id="task-1",
+            note_id=other_note_id,
+            event_type="updated",
+            actor_type="user",
+        )
+    with pytest.raises(ConflictError, match="note not found"):
+        db.record_task_event(
+            owner_user_id="other-owner",
+            dataset_id=LOCAL_UNBOUND,
+            task_id="task-1",
+            note_id=note_id,
+            event_type="updated",
+            actor_type="user",
+        )
 
 
 def _create_named_task(
@@ -1595,10 +1940,12 @@ def test_set_reconciliation_state_maps_missing_note_fk_to_conflict(db: Character
 
 
 def test_record_task_event_maps_duplicate_event_id_to_conflict(db: CharactersRAGDB) -> None:
+    note_id = _create_note(db)
     db.record_task_event(
         owner_user_id=db.client_id,
         dataset_id=LOCAL_UNBOUND,
         event_id="event-1",
+        note_id=note_id,
         event_type="created",
         actor_type="user",
         actor_id="user-1",
@@ -1609,6 +1956,7 @@ def test_record_task_event_maps_duplicate_event_id_to_conflict(db: CharactersRAG
             owner_user_id=db.client_id,
             dataset_id=LOCAL_UNBOUND,
             event_id="event-1",
+            note_id=note_id,
             event_type="created",
             actor_type="user",
             actor_id="user-1",
@@ -1616,11 +1964,13 @@ def test_record_task_event_maps_duplicate_event_id_to_conflict(db: CharactersRAG
 
 
 def test_record_task_event_maps_missing_task_fk_to_conflict(db: CharactersRAGDB) -> None:
-    with pytest.raises(ConflictError, match="event.*reference"):
+    note_id = _create_note(db)
+    with pytest.raises(ConflictError, match="task not found"):
         db.record_task_event(
             owner_user_id=db.client_id,
             dataset_id=LOCAL_UNBOUND,
             task_id="missing-task",
+            note_id=note_id,
             event_type="updated",
             actor_type="user",
             actor_id="user-1",
@@ -1798,7 +2148,7 @@ def test_scoped_task_lookup_requires_exact_owner_and_dataset(db: CharactersRAGDB
     _create_task(db, note_id)
 
     assert (
-        db.get_task_scoped(  # nosec B101
+        db.get_task(  # nosec B101
             owner_user_id=db.client_id,
             dataset_id="local-unbound",
             task_id="task-1",
@@ -1806,7 +2156,7 @@ def test_scoped_task_lookup_requires_exact_owner_and_dataset(db: CharactersRAGDB
         == "task-1"
     )
     assert (
-        db.get_task_scoped(  # nosec B101
+        db.get_task(  # nosec B101
             owner_user_id="other-owner",
             dataset_id="local-unbound",
             task_id="task-1",
@@ -1814,7 +2164,7 @@ def test_scoped_task_lookup_requires_exact_owner_and_dataset(db: CharactersRAGDB
         is None
     )
     assert (
-        db.get_task_scoped(  # nosec B101
+        db.get_task(  # nosec B101
             owner_user_id=db.client_id,
             dataset_id="other-dataset",
             task_id="task-1",
@@ -1824,8 +2174,8 @@ def test_scoped_task_lookup_requires_exact_owner_and_dataset(db: CharactersRAGDB
 
 
 def test_canonical_task_store_rejects_omitted_scope(db: CharactersRAGDB) -> None:
-    with pytest.raises(TypeError, match="owner_user_id"):
-        db.get_task("missing-task")
+    with pytest.raises(TypeError):
+        db.get_task(task_id="missing-task")
 
 
 def test_projection_and_unlink_versions_do_not_change_canonical_identity(db: CharactersRAGDB) -> None:
@@ -1920,13 +2270,13 @@ def test_bind_local_task_graph_rekeys_complete_scope_atomically(db: CharactersRA
         "task_projection_drifts": 1,
     }
     assert (
-        db.get_task_scoped(  # nosec B101
+        db.get_task(  # nosec B101
             owner_user_id=db.client_id, dataset_id="local-unbound", task_id=task["id"]
         )
         is None
     )
     assert (
-        db.get_task_scoped(  # nosec B101
+        db.get_task(  # nosec B101
             owner_user_id=db.client_id, dataset_id="dataset-a", task_id=task["id"]
         )["id"]
         == task["id"]
@@ -1951,7 +2301,7 @@ def test_bind_local_task_graph_rejects_target_collision_without_partial_rekey(db
         )
 
     assert (
-        db.get_task_scoped(  # nosec B101
+        db.get_task(  # nosec B101
             owner_user_id=db.client_id, dataset_id="local-unbound", task_id=local_task["id"]
         )["id"]
         == local_task["id"]

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
@@ -10,8 +10,9 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     InputError,
 )
 
-
 pytestmark = pytest.mark.unit
+
+LOCAL_UNBOUND = "local-unbound"
 
 
 @pytest.fixture()
@@ -32,6 +33,8 @@ def _create_note(db: CharactersRAGDB, content: str = "- [ ] Review source\n") ->
 
 def _create_task(db: CharactersRAGDB, note_id: str, *, task_id: str = "task-1") -> dict:
     created = db.create_task(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=task_id,
         note_id=note_id,
         text="Review source",
@@ -53,6 +56,8 @@ def _create_named_task(
     metadata: dict | None = None,
 ) -> dict:
     created = db.create_task(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=task_id,
         note_id=note_id,
         text=text,
@@ -74,6 +79,8 @@ def _set_projection(
     projection_status: str = "live",
 ) -> dict:
     return db.set_task_projection(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=task_id,
         note_id=note_id,
         note_version=note_version,
@@ -154,7 +161,7 @@ def _delete_projection(db: CharactersRAGDB, task_id: str) -> None:
 
 
 def _event_count(db: CharactersRAGDB, task_id: str, event_type: str) -> int:
-    events = db.list_task_activity(task_id=task_id)
+    events = db.list_task_activity(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task_id)
     return sum(1 for event in events if event["event_type"] == event_type)
 
 
@@ -171,9 +178,9 @@ def test_create_task_record_and_list_by_note(db: CharactersRAGDB) -> None:
     assert task["deleted"] in (0, False)  # nosec B101
     assert task["version"] == 1  # nosec B101
     assert task["client_id"] == "task-store-user"  # nosec B101
-    fetched = db.get_task("task-1")
+    fetched = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1")
     assert fetched == task  # nosec B101
-    listed = db.list_tasks(note_id=note_id)
+    listed = db.list_tasks(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, note_id=note_id)
     assert [row["id"] for row in listed] == ["task-1"]  # nosec B101
 
 
@@ -183,10 +190,19 @@ def test_active_task_reads_exclude_tasks_for_soft_deleted_notes(db: CharactersRA
 
     assert db.soft_delete_note(note_id, expected_version=1) is True  # nosec B101
 
-    assert db.get_task("task-1") is None  # nosec B101
-    assert db.get_task("task-1", include_deleted=True)["id"] == task["id"]  # nosec B101
-    assert db.list_tasks() == []  # nosec B101
-    assert db.list_tasks(note_id=note_id) == []  # nosec B101
+    assert db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1") is None  # nosec B101
+    assert (
+        db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)["id"]
+        == task["id"]
+    )  # nosec B101
+    assert (
+        db.list_tasks(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
+        )
+        == []
+    )  # nosec B101
+    assert db.list_tasks(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, note_id=note_id) == []  # nosec B101
 
 
 def test_create_task_rejects_soft_deleted_notes(db: CharactersRAGDB) -> None:
@@ -195,13 +211,15 @@ def test_create_task_rejects_soft_deleted_notes(db: CharactersRAGDB) -> None:
 
     with pytest.raises(ConflictError, match="note.*deleted"):
         db.create_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-soft-deleted-note",
             note_id=note_id,
             text="Review source",
             actor_type="user",
             actor_id="user-1",
         )
-    assert db.list_tasks(include_deleted=True) == []  # nosec B101
+    assert db.list_tasks(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, include_deleted=True) == []  # nosec B101
 
 
 def test_create_task_rejects_deleted_projection_status(db: CharactersRAGDB) -> None:
@@ -209,6 +227,8 @@ def test_create_task_rejects_deleted_projection_status(db: CharactersRAGDB) -> N
 
     with pytest.raises(InputError, match="deleted"):
         db.create_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-deleted-projection",
             note_id=note_id,
             text="Review source",
@@ -216,7 +236,7 @@ def test_create_task_rejects_deleted_projection_status(db: CharactersRAGDB) -> N
             actor_type="user",
             actor_id="user-1",
         )
-    assert db.list_tasks(include_deleted=True) == []  # nosec B101
+    assert db.list_tasks(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, include_deleted=True) == []  # nosec B101
 
 
 def test_list_helpers_clamp_negative_limits(db: CharactersRAGDB) -> None:
@@ -224,8 +244,8 @@ def test_list_helpers_clamp_negative_limits(db: CharactersRAGDB) -> None:
     for index in range(3):
         _create_task(db, note_id, task_id=f"task-{index}")
 
-    assert len(db.list_tasks(limit=-10)) == 1  # nosec B101
-    assert len(db.list_task_activity(limit=-10)) == 1  # nosec B101
+    assert len(db.list_tasks(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, limit=-10)) == 1  # nosec B101
+    assert len(db.list_task_activity(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, limit=-10)) == 1  # nosec B101
 
 
 def test_list_tasks_filters_query_and_metadata_before_limit_and_offset(db: CharactersRAGDB) -> None:
@@ -235,9 +255,20 @@ def test_list_tasks_filters_query_and_metadata_before_limit_and_offset(db: Chara
     _create_named_task(db, note_id, task_id="task-c", text="Needle first", metadata={"priority": "high"})
     _create_named_task(db, note_id, task_id="task-d", text="Needle second", metadata={"priority": "high"})
 
-    queried = db.list_tasks(note_id=note_id, query="needle", limit=1)
-    second_high = db.list_tasks(note_id=note_id, metadata_filters={"priority": "high"}, offset=1, limit=1)
+    queried = db.list_tasks(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, note_id=note_id, query="needle", limit=1
+    )
+    second_high = db.list_tasks(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
+        note_id=note_id,
+        metadata_filters={"priority": "high"},
+        offset=1,
+        limit=1,
+    )
     combined = db.list_tasks(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         note_id=note_id,
         query="needle",
         metadata_filters={"priority": "high"},
@@ -252,12 +283,37 @@ def test_list_tasks_filters_query_and_metadata_before_limit_and_offset(db: Chara
 def test_list_recent_task_activity_returns_newest_without_changing_default_order(db: CharactersRAGDB) -> None:
     note_id = _create_note(db)
     task = _create_task(db, note_id)
-    first = db.record_task_event(task_id=task["id"], note_id=note_id, event_type="updated", actor_type="user")
-    second = db.record_task_event(task_id=task["id"], note_id=note_id, event_type="updated", actor_type="agent")
-    third = db.record_task_event(task_id=task["id"], note_id=note_id, event_type="updated", actor_type="agent")
+    first = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
+        task_id=task["id"],
+        note_id=note_id,
+        event_type="updated",
+        actor_type="user",
+    )
+    second = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
+        task_id=task["id"],
+        note_id=note_id,
+        event_type="updated",
+        actor_type="agent",
+    )
+    third = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
+        task_id=task["id"],
+        note_id=note_id,
+        event_type="updated",
+        actor_type="agent",
+    )
 
-    ascending_events = db.list_task_activity(task_id=task["id"], limit=10)
-    recent_events = db.list_recent_task_activity(task_id=task["id"], limit=2)
+    ascending_events = db.list_task_activity(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task["id"], limit=10
+    )
+    recent_events = db.list_recent_task_activity(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task["id"], limit=2
+    )
 
     assert [event["id"] for event in ascending_events[-3:]] == [first["id"], second["id"], third["id"]]  # nosec B101
     assert [event["id"] for event in recent_events] == [third["id"], second["id"]]  # nosec B101
@@ -267,24 +323,34 @@ def test_list_recent_unread_task_activity_filters_read_state_before_limit(db: Ch
     note_id = _create_note(db)
     task = _create_task(db, note_id)
     older_unread_event = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=task["id"],
         note_id=note_id,
         event_type="updated",
         actor_type="agent",
     )
     newer_dismissed_event = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=task["id"],
         note_id=note_id,
         event_type="updated",
         actor_type="agent",
     )
-    db.mark_task_activity_dismissed(newer_dismissed_event["id"], user_id="user-1")
+    db.mark_task_activity_dismissed(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, event_id=newer_dismissed_event["id"], user_id=db.client_id
+    )
 
-    user_one_events = db.list_recent_unread_task_activity(user_id="user-1", actor_type="agent", limit=1)
-    user_two_events = db.list_recent_unread_task_activity(user_id="user-2", actor_type="agent", limit=1)
+    user_one_events = db.list_recent_unread_task_activity(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, user_id=db.client_id, actor_type="agent", limit=1
+    )
+    user_two_events = db.list_recent_unread_task_activity(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, user_id="user-2", actor_type="agent", limit=1
+    )
 
     assert [event["id"] for event in user_one_events] == [older_unread_event["id"]]  # nosec B101
-    assert [event["id"] for event in user_two_events] == [newer_dismissed_event["id"]]  # nosec B101
+    assert user_two_events == []  # nosec B101
 
 
 def test_list_helpers_reject_nonnumeric_limits(db: CharactersRAGDB) -> None:
@@ -292,7 +358,7 @@ def test_list_helpers_reject_nonnumeric_limits(db: CharactersRAGDB) -> None:
     _create_task(db, note_id)
 
     with pytest.raises(InputError, match="limit"):
-        db.list_tasks(limit="many")
+        db.list_tasks(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, limit="many")
 
 
 def test_candidate_notes_for_task_discovery_clamps_oversized_limits(
@@ -303,7 +369,9 @@ def test_candidate_notes_for_task_discovery_clamps_oversized_limits(
         _create_note(db, content=f"- [ ] Review source {index}\n")
     monkeypatch.setattr(db.task_store, "_MAX_LIMIT", 2, raising=False)
 
-    candidates = db.candidate_notes_for_task_discovery(limit=10_000)
+    candidates = db.candidate_notes_for_task_discovery(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, limit=10_000
+    )
 
     assert len(candidates) == 2  # nosec B101
 
@@ -313,6 +381,8 @@ def test_update_status_uses_optimistic_locking(db: CharactersRAGDB) -> None:
     _create_task(db, note_id)
 
     updated = db.update_task_record(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         status="done",
@@ -325,6 +395,8 @@ def test_update_status_uses_optimistic_locking(db: CharactersRAGDB) -> None:
     assert updated["completed_at"] is not None  # nosec B101
     with pytest.raises(ConflictError, match="version mismatch"):
         db.update_task_record(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             status="open",
@@ -353,6 +425,8 @@ def test_update_task_record_rejects_zero_rowcount_update(
 
     with pytest.raises(ConflictError, match="version mismatch"):
         db.update_task_record(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             status="done",
@@ -366,6 +440,8 @@ def test_reopen_clears_completed_at_and_records_event_history(db: CharactersRAGD
     _create_task(db, note_id)
 
     db.update_task_record(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         status="done",
@@ -373,6 +449,8 @@ def test_reopen_clears_completed_at_and_records_event_history(db: CharactersRAGD
         actor_id="user-1",
     )
     reopened = db.update_task_record(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=2,
         status="open",
@@ -382,7 +460,7 @@ def test_reopen_clears_completed_at_and_records_event_history(db: CharactersRAGD
 
     assert reopened["status"] == "open"  # nosec B101
     assert reopened["completed_at"] is None  # nosec B101
-    events = db.list_task_activity(task_id="task-1")
+    events = db.list_task_activity(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1")
     status_events = [event for event in events if event["event_type"] == "status_changed"]
     assert [event["old_value_json"]["status"] for event in status_events] == ["open", "done"]  # nosec B101
     assert [event["new_value_json"]["status"] for event in status_events] == ["done", "open"]  # nosec B101
@@ -392,6 +470,8 @@ def test_update_task_record_rejects_deleted_tasks(db: CharactersRAGDB) -> None:
     note_id = _create_note(db)
     _create_task(db, note_id)
     deleted = db.soft_delete_task(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         allow_record_only=True,
@@ -401,13 +481,15 @@ def test_update_task_record_rejects_deleted_tasks(db: CharactersRAGDB) -> None:
 
     with pytest.raises(ConflictError, match="deleted"):
         db.update_task_record(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=deleted["version"],
             status="open",
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["version"] == deleted["version"]  # nosec B101
     assert task["deleted"] in (1, True)  # nosec B101
 
@@ -419,13 +501,15 @@ def test_update_task_record_rejects_soft_deleted_parent_note(db: CharactersRAGDB
 
     with pytest.raises(ConflictError, match="note.*deleted"):
         db.update_task_record(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             status="done",
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["status"] == "open"  # nosec B101
     assert task["version"] == 1  # nosec B101
 
@@ -437,13 +521,15 @@ def test_update_task_record_rejects_projection_status_updates(db: CharactersRAGD
 
     with pytest.raises(InputError, match="projection_status"):
         db.update_task_record(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             projection_status="unlinked",
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
 
@@ -455,13 +541,15 @@ def test_update_task_record_rejects_ambiguous_projected_tasks(db: CharactersRAGD
 
     with pytest.raises(ConflictError, match="ambiguous"):
         db.update_task_record(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=2,
             status="done",
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["status"] == "open"  # nosec B101
     assert task["version"] == 2  # nosec B101
 
@@ -479,13 +567,15 @@ def test_update_task_record_rejects_drifted_ambiguous_projection_status(db: Char
 
     with pytest.raises(ConflictError, match="projection status mismatch"):
         db.update_task_record(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             status="done",
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["status"] == "open"  # nosec B101
     assert task["version"] == 1  # nosec B101
 
@@ -499,14 +589,16 @@ def test_update_task_record_rejects_drifted_projection_note_ownership(db: Charac
 
     with pytest.raises(ConflictError, match="projection ownership mismatch"):
         db.update_task_record(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             status="done",
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
-    events = db.list_task_activity(task_id="task-1")
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
+    events = db.list_task_activity(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1")
     assert task["status"] == "open"  # nosec B101
     assert task["version"] == 1  # nosec B101
     assert [event["event_type"] for event in events] == ["created"]  # nosec B101
@@ -517,6 +609,8 @@ def test_update_task_record_rejects_unlinked_projected_tasks_by_default(db: Char
     _create_task(db, note_id)
     _set_projection(db, "task-1", note_id)
     unlinked = db.mark_task_unlinked(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         actor_type="system",
@@ -525,13 +619,15 @@ def test_update_task_record_rejects_unlinked_projected_tasks_by_default(db: Char
 
     with pytest.raises(ConflictError, match="unlinked"):
         db.update_task_record(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=unlinked["version"],
             text="Review source again",
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["text"] == "Review source"  # nosec B101
     assert task["version"] == unlinked["version"]  # nosec B101
 
@@ -549,12 +645,14 @@ def test_mark_task_unlinked_rejects_drifted_unlinked_projection_status(db: Chara
 
     with pytest.raises(ConflictError, match="projection status mismatch"):
         db.mark_task_unlinked(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             actor_type="system",
             actor_id="reconciler",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
 
@@ -584,6 +682,8 @@ def test_mark_task_unlinked_rejects_zero_rowcount_update(
 
     with pytest.raises(ConflictError, match="version mismatch"):
         db.mark_task_unlinked(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             actor_type="system",
@@ -597,6 +697,8 @@ def test_mark_task_unlinked_rejects_deleted_tasks(db: CharactersRAGDB) -> None:
     _create_task(db, note_id)
     _set_projection(db, "task-1", note_id)
     deleted = db.soft_delete_task(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         projection_note_id=note_id,
@@ -608,12 +710,14 @@ def test_mark_task_unlinked_rejects_deleted_tasks(db: CharactersRAGDB) -> None:
 
     with pytest.raises(ConflictError, match="deleted"):
         db.mark_task_unlinked(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=deleted["version"],
             actor_type="system",
             actor_id="reconciler",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "deleted"  # nosec B101
     assert task["version"] == deleted["version"]  # nosec B101
 
@@ -626,12 +730,14 @@ def test_mark_task_unlinked_rejects_soft_deleted_parent_note(db: CharactersRAGDB
 
     with pytest.raises(ConflictError, match="note.*deleted"):
         db.mark_task_unlinked(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             actor_type="system",
             actor_id="reconciler",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
 
@@ -644,12 +750,14 @@ def test_mark_task_unlinked_rejects_missing_live_projection_row(db: CharactersRA
 
     with pytest.raises(ConflictError, match="projection.*missing"):
         db.mark_task_unlinked(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             actor_type="system",
             actor_id="reconciler",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
     assert _event_count(db, "task-1", "unlinked") == 0  # nosec B101
@@ -676,12 +784,14 @@ def test_mark_task_unlinked_rejects_projection_update_zero_rowcount(
 
     with pytest.raises(ConflictError, match="projection.*changed"):
         db.mark_task_unlinked(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             actor_type="system",
             actor_id="reconciler",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
     assert _projection_count(db, "task-1") == 1  # nosec B101
@@ -725,12 +835,14 @@ def test_mark_task_unlinked_rejects_projection_locator_refresh_race(
 
     with pytest.raises(ConflictError, match="projection.*changed"):
         db.mark_task_unlinked(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             actor_type="system",
             actor_id="reconciler",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
     assert _projection_row(db, "task-1") == original_projection  # nosec B101
@@ -749,6 +861,8 @@ def test_soft_delete_projected_task_transactionally(db: CharactersRAGDB, monkeyp
             lambda: pytest.fail("task helper should use the explicit transaction connection"),
         )
         deleted = db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             projection_note_id=note_id,
@@ -762,9 +876,9 @@ def test_soft_delete_projected_task_transactionally(db: CharactersRAGDB, monkeyp
     assert deleted["deleted"] in (1, True)  # nosec B101
     assert deleted["projection_status"] == "deleted"  # nosec B101
     assert deleted["version"] == 2  # nosec B101
-    fetched = db.get_task("task-1")
+    fetched = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1")
     assert fetched is None  # nosec B101
-    included = db.get_task("task-1", include_deleted=True)
+    included = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert included is not None  # nosec B101
     assert included["deleted"] in (1, True)  # nosec B101
 
@@ -777,6 +891,8 @@ def test_soft_delete_task_rejects_soft_deleted_parent_note(db: CharactersRAGDB) 
 
     with pytest.raises(ConflictError, match="note.*deleted"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             projection_note_id=note_id,
@@ -785,8 +901,12 @@ def test_soft_delete_task_rejects_soft_deleted_parent_note(db: CharactersRAGDB) 
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
-    delete_events = [event for event in db.list_task_activity(task_id="task-1") if event["event_type"] == "deleted"]
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
+    delete_events = [
+        event
+        for event in db.list_task_activity(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1")
+        if event["event_type"] == "deleted"
+    ]
     assert task["deleted"] in (0, False)  # nosec B101
     assert task["version"] == 1  # nosec B101
     assert delete_events == []  # nosec B101
@@ -797,6 +917,8 @@ def test_soft_delete_task_rejects_repeat_delete_without_new_version_or_event(db:
     _create_task(db, note_id)
     _set_projection(db, "task-1", note_id)
     deleted = db.soft_delete_task(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         projection_note_id=note_id,
@@ -808,14 +930,20 @@ def test_soft_delete_task_rejects_repeat_delete_without_new_version_or_event(db:
 
     with pytest.raises(ConflictError, match="deleted"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=deleted["version"],
             allow_record_only=True,
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
-    delete_events = [event for event in db.list_task_activity(task_id="task-1") if event["event_type"] == "deleted"]
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
+    delete_events = [
+        event
+        for event in db.list_task_activity(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1")
+        if event["event_type"] == "deleted"
+    ]
     assert task["version"] == deleted["version"]  # nosec B101
     assert len(delete_events) == 1  # nosec B101
 
@@ -825,6 +953,8 @@ def test_set_task_projection_rejects_deleted_tasks(db: CharactersRAGDB) -> None:
     _create_task(db, note_id)
     _set_projection(db, "task-1", note_id)
     deleted = db.soft_delete_task(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         projection_note_id=note_id,
@@ -836,6 +966,8 @@ def test_set_task_projection_rejects_deleted_tasks(db: CharactersRAGDB) -> None:
 
     with pytest.raises(ConflictError, match="deleted"):
         db.set_task_projection(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             note_id=note_id,
             note_version=2,
@@ -849,7 +981,7 @@ def test_set_task_projection_rejects_deleted_tasks(db: CharactersRAGDB) -> None:
             has_child_content=False,
             projection_status="live",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "deleted"  # nosec B101
     assert task["version"] == deleted["version"]  # nosec B101
 
@@ -861,6 +993,8 @@ def test_set_task_projection_rejects_soft_deleted_parent_note(db: CharactersRAGD
 
     with pytest.raises(ConflictError, match="note.*deleted"):
         db.set_task_projection(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             note_id=note_id,
             note_version=2,
@@ -902,6 +1036,8 @@ def test_set_task_projection_rejects_projection_status_race(
 
     with pytest.raises(ConflictError, match="projection.*changed"):
         db.set_task_projection(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             note_id=note_id,
             note_version=2,
@@ -915,7 +1051,7 @@ def test_set_task_projection_rejects_projection_status_race(
             has_child_content=False,
             projection_status="live",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
 
@@ -926,6 +1062,8 @@ def test_set_task_projection_bumps_version_when_projection_status_changes(db: Ch
     _set_projection(db, "task-1", note_id)
 
     db.set_task_projection(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         note_id=note_id,
         note_version=2,
@@ -940,7 +1078,7 @@ def test_set_task_projection_bumps_version_when_projection_status_changes(db: Ch
         projection_status="ambiguous",
     )
 
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "ambiguous"  # nosec B101
     assert task["version"] == 2  # nosec B101
 
@@ -951,6 +1089,8 @@ def test_set_task_projection_refresh_does_not_bump_live_task_version(db: Charact
     _set_projection(db, "task-1", note_id)
 
     db.set_task_projection(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         note_id=note_id,
         note_version=2,
@@ -965,7 +1105,7 @@ def test_set_task_projection_refresh_does_not_bump_live_task_version(db: Charact
         projection_status="live",
     )
 
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
 
@@ -977,6 +1117,8 @@ def test_soft_delete_task_rejects_ambiguous_projection_without_mutation(db: Char
 
     with pytest.raises(ConflictError, match="ambiguous"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=2,
             projection_note_id=note_id,
@@ -985,8 +1127,12 @@ def test_soft_delete_task_rejects_ambiguous_projection_without_mutation(db: Char
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
-    delete_events = [event for event in db.list_task_activity(task_id="task-1") if event["event_type"] == "deleted"]
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
+    delete_events = [
+        event
+        for event in db.list_task_activity(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1")
+        if event["event_type"] == "deleted"
+    ]
     assert task["deleted"] in (0, False)  # nosec B101
     assert task["projection_status"] == "ambiguous"  # nosec B101
     assert task["version"] == 2  # nosec B101
@@ -1006,6 +1152,8 @@ def test_soft_delete_task_rejects_drifted_unlinked_projection_status(db: Charact
 
     with pytest.raises(ConflictError, match="projection status mismatch"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             projection_note_id=note_id,
@@ -1014,8 +1162,12 @@ def test_soft_delete_task_rejects_drifted_unlinked_projection_status(db: Charact
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
-    delete_events = [event for event in db.list_task_activity(task_id="task-1") if event["event_type"] == "deleted"]
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
+    delete_events = [
+        event
+        for event in db.list_task_activity(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1")
+        if event["event_type"] == "deleted"
+    ]
     assert task["deleted"] in (0, False)  # nosec B101
     assert task["version"] == 1  # nosec B101
     assert delete_events == []  # nosec B101
@@ -1028,6 +1180,8 @@ def test_set_task_projection_rejects_deleted_projection_status_for_active_task(d
 
     with pytest.raises(InputError, match="deleted"):
         db.set_task_projection(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             note_id=note_id,
             note_version=2,
@@ -1041,7 +1195,7 @@ def test_set_task_projection_rejects_deleted_projection_status_for_active_task(d
             has_child_content=False,
             projection_status="deleted",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["deleted"] in (0, False)  # nosec B101
     assert task["projection_status"] == "live"  # nosec B101
 
@@ -1053,6 +1207,8 @@ def test_set_task_projection_requires_task_note_ownership(db: CharactersRAGDB) -
 
     with pytest.raises(ConflictError, match="owning note"):
         db.set_task_projection(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             note_id=other_note_id,
             note_version=1,
@@ -1066,6 +1222,8 @@ def test_set_task_projection_requires_task_note_ownership(db: CharactersRAGDB) -
             has_child_content=False,
         )
     deleted = db.soft_delete_task(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         allow_record_only=True,
@@ -1084,6 +1242,8 @@ def test_set_task_projection_rejects_drifted_projection_note_ownership(db: Chara
 
     with pytest.raises(ConflictError, match="projection ownership mismatch"):
         db.set_task_projection(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             note_id=owning_note_id,
             note_version=2,
@@ -1097,7 +1257,7 @@ def test_set_task_projection_rejects_drifted_projection_note_ownership(db: Chara
             has_child_content=False,
             projection_status="live",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
 
@@ -1111,6 +1271,8 @@ def test_soft_delete_task_rejects_drifted_projection_note_ownership(db: Characte
 
     with pytest.raises(ConflictError, match="projection ownership mismatch"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             projection_note_id=owning_note_id,
@@ -1119,8 +1281,12 @@ def test_soft_delete_task_rejects_drifted_projection_note_ownership(db: Characte
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
-    delete_events = [event for event in db.list_task_activity(task_id="task-1") if event["event_type"] == "deleted"]
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
+    delete_events = [
+        event
+        for event in db.list_task_activity(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1")
+        if event["event_type"] == "deleted"
+    ]
     assert task["deleted"] in (0, False)  # nosec B101
     assert task["version"] == 1  # nosec B101
     assert delete_events == []  # nosec B101
@@ -1134,6 +1300,8 @@ def test_soft_delete_task_rejects_missing_live_projection_row(db: CharactersRAGD
 
     with pytest.raises(ConflictError, match="projection.*missing"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             projection_note_id=note_id,
@@ -1142,7 +1310,7 @@ def test_soft_delete_task_rejects_missing_live_projection_row(db: CharactersRAGD
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["deleted"] in (0, False)  # nosec B101
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
@@ -1156,6 +1324,8 @@ def test_record_only_soft_delete_allows_missing_live_projection_row(db: Characte
     _delete_projection(db, "task-1")
 
     deleted = db.soft_delete_task(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         allow_record_only=True,
@@ -1190,6 +1360,8 @@ def test_soft_delete_task_rejects_projection_update_zero_rowcount(
 
     with pytest.raises(ConflictError, match="projection.*changed"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             projection_note_id=note_id,
@@ -1198,7 +1370,7 @@ def test_soft_delete_task_rejects_projection_update_zero_rowcount(
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["deleted"] in (0, False)  # nosec B101
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
@@ -1243,6 +1415,8 @@ def test_soft_delete_task_rejects_projection_locator_refresh_race(
 
     with pytest.raises(ConflictError, match="projection.*changed"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             projection_note_id=note_id,
@@ -1251,7 +1425,7 @@ def test_soft_delete_task_rejects_projection_locator_refresh_race(
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
     assert task["deleted"] in (0, False)  # nosec B101
     assert task["projection_status"] == "live"  # nosec B101
     assert task["version"] == 1  # nosec B101
@@ -1284,6 +1458,8 @@ def test_soft_delete_task_rejects_zero_rowcount_update(
 
     with pytest.raises(ConflictError, match="version mismatch"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             projection_note_id=note_id,
@@ -1301,6 +1477,8 @@ def test_record_only_soft_delete_is_allowed_for_unlinked_task(db: CharactersRAGD
     _set_projection(db, "task-1", note_id)
 
     unlinked = db.mark_task_unlinked(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         actor_type="system",
@@ -1309,6 +1487,8 @@ def test_record_only_soft_delete_is_allowed_for_unlinked_task(db: CharactersRAGD
     assert unlinked["projection_status"] == "unlinked"  # nosec B101
     assert unlinked["version"] == 2  # nosec B101
     deleted = db.soft_delete_task(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=2,
         allow_record_only=True,
@@ -1326,6 +1506,8 @@ def test_soft_delete_task_rejects_unlinked_without_record_only(db: CharactersRAG
     _create_task(db, note_id)
     _set_projection(db, "task-1", note_id)
     unlinked = db.mark_task_unlinked(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         expected_version=1,
         actor_type="system",
@@ -1334,13 +1516,19 @@ def test_soft_delete_task_rejects_unlinked_without_record_only(db: CharactersRAG
 
     with pytest.raises(ConflictError, match="unlinked"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=unlinked["version"],
             actor_type="user",
             actor_id="user-1",
         )
-    task = db.get_task("task-1", include_deleted=True)
-    delete_events = [event for event in db.list_task_activity(task_id="task-1") if event["event_type"] == "deleted"]
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1", include_deleted=True)
+    delete_events = [
+        event
+        for event in db.list_task_activity(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id="task-1")
+        if event["event_type"] == "deleted"
+    ]
     assert task["deleted"] in (0, False)  # nosec B101
     assert task["version"] == unlinked["version"]  # nosec B101
     assert delete_events == []  # nosec B101
@@ -1353,6 +1541,8 @@ def test_rejects_ambiguous_projection_deletion(db: CharactersRAGDB) -> None:
 
     with pytest.raises(InputError, match="projection deletion is ambiguous"):
         db.soft_delete_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="task-1",
             expected_version=1,
             actor_type="user",
@@ -1364,6 +1554,8 @@ def test_reconciliation_state_is_recorded_per_note_version(db: CharactersRAGDB) 
     note_id = _create_note(db)
 
     first = db.set_reconciliation_state(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         note_id=note_id,
         note_version=1,
         status="clean",
@@ -1374,6 +1566,8 @@ def test_reconciliation_state_is_recorded_per_note_version(db: CharactersRAGDB) 
     assert first["note_version"] == 1  # nosec B101
     assert first["status"] == "clean"  # nosec B101
     second = db.set_reconciliation_state(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         note_id=note_id,
         note_version=2,
         status="warnings",
@@ -1383,13 +1577,15 @@ def test_reconciliation_state_is_recorded_per_note_version(db: CharactersRAGDB) 
     )
     assert second["note_version"] == 2  # nosec B101
     assert second["status"] == "warnings"  # nosec B101
-    fetched = db.get_reconciliation_state(note_id)
+    fetched = db.get_reconciliation_state(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, note_id=note_id)
     assert fetched == second  # nosec B101
 
 
 def test_set_reconciliation_state_maps_missing_note_fk_to_conflict(db: CharactersRAGDB) -> None:
     with pytest.raises(ConflictError, match="note"):
         db.set_reconciliation_state(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             note_id="missing-note",
             note_version=1,
             status="clean",
@@ -1400,6 +1596,8 @@ def test_set_reconciliation_state_maps_missing_note_fk_to_conflict(db: Character
 
 def test_record_task_event_maps_duplicate_event_id_to_conflict(db: CharactersRAGDB) -> None:
     db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         event_id="event-1",
         event_type="created",
         actor_type="user",
@@ -1408,6 +1606,8 @@ def test_record_task_event_maps_duplicate_event_id_to_conflict(db: CharactersRAG
 
     with pytest.raises(ConflictError, match="event.*already exists"):
         db.record_task_event(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             event_id="event-1",
             event_type="created",
             actor_type="user",
@@ -1418,6 +1618,8 @@ def test_record_task_event_maps_duplicate_event_id_to_conflict(db: CharactersRAG
 def test_record_task_event_maps_missing_task_fk_to_conflict(db: CharactersRAGDB) -> None:
     with pytest.raises(ConflictError, match="event.*reference"):
         db.record_task_event(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id="missing-task",
             event_type="updated",
             actor_type="user",
@@ -1427,18 +1629,24 @@ def test_record_task_event_maps_missing_task_fk_to_conflict(db: CharactersRAGDB)
 
 def test_mark_task_activity_read_maps_missing_event_fk_to_conflict(db: CharactersRAGDB) -> None:
     with pytest.raises(ConflictError, match="event"):
-        db.mark_task_activity_read("missing-event", user_id="user-1")
+        db.mark_task_activity_read(
+            owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, event_id="missing-event", user_id=db.client_id
+        )
 
 
 def test_mark_task_activity_dismissed_maps_missing_event_fk_to_conflict(db: CharactersRAGDB) -> None:
     with pytest.raises(ConflictError, match="event"):
-        db.mark_task_activity_dismissed("missing-event", user_id="user-1")
+        db.mark_task_activity_dismissed(
+            owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, event_id="missing-event", user_id=db.client_id
+        )
 
 
 def test_activity_read_and_dismiss_state_is_per_user(db: CharactersRAGDB) -> None:
     note_id = _create_note(db)
     _create_task(db, note_id)
     event = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         note_id=note_id,
         event_type="status_changed",
@@ -1450,16 +1658,30 @@ def test_activity_read_and_dismiss_state_is_per_user(db: CharactersRAGDB) -> Non
         policy_mode="autonomous",
     )
 
-    assert db.get_task_activity_read_state(event["id"], user_id="user-1") is None  # nosec B101
-    read = db.mark_task_activity_read(event["id"], user_id="user-1")
+    assert (
+        db.get_task_activity_read_state(
+            owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, event_id=event["id"], user_id=db.client_id
+        )
+        is None
+    )  # nosec B101
+    read = db.mark_task_activity_read(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, event_id=event["id"], user_id=db.client_id
+    )
     assert read["event_id"] == event["id"]  # nosec B101
-    assert read["user_id"] == "user-1"  # nosec B101
+    assert read["user_id"] == db.client_id  # nosec B101
     assert read["read_at"] is not None  # nosec B101
     assert read["dismissed_at"] is None  # nosec B101
-    dismissed = db.mark_task_activity_dismissed(event["id"], user_id="user-1")
+    dismissed = db.mark_task_activity_dismissed(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, event_id=event["id"], user_id=db.client_id
+    )
     assert dismissed["read_at"] == read["read_at"]  # nosec B101
     assert dismissed["dismissed_at"] is not None  # nosec B101
-    assert db.get_task_activity_read_state(event["id"], user_id="user-2") is None  # nosec B101
+    assert (
+        db.get_task_activity_read_state(
+            owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, event_id=event["id"], user_id="user-2"
+        )
+        is None
+    )  # nosec B101
 
 
 def test_activity_read_and_dismiss_helpers_accept_explicit_transaction_connection(
@@ -1469,6 +1691,8 @@ def test_activity_read_and_dismiss_helpers_accept_explicit_transaction_connectio
     note_id = _create_note(db)
     _create_task(db, note_id)
     event = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id="task-1",
         note_id=note_id,
         event_type="status_changed",
@@ -1484,8 +1708,12 @@ def test_activity_read_and_dismiss_helpers_accept_explicit_transaction_connectio
             "transaction",
             lambda: pytest.fail("task activity helpers should use the explicit transaction connection"),
         )
-        read = db.mark_task_activity_read(event["id"], user_id="user-1", conn=conn)
-        dismissed = db.mark_task_activity_dismissed(event["id"], user_id="user-1", conn=conn)
+        read = db.mark_task_activity_read(
+            owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, event_id=event["id"], user_id=db.client_id, conn=conn
+        )
+        dismissed = db.mark_task_activity_dismissed(
+            owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, event_id=event["id"], user_id=db.client_id, conn=conn
+        )
 
     assert read["read_at"] is not None  # nosec B101
     assert dismissed["dismissed_at"] is not None  # nosec B101
@@ -1495,9 +1723,11 @@ def test_candidate_notes_for_task_discovery_excludes_currently_reconciled_notes(
     note_id = _create_note(db, content="Intro\n- [ ] Review source\n")
     plain_note_id = _create_note(db, content="No checklist here")
 
-    candidates = db.candidate_notes_for_task_discovery(limit=10)
+    candidates = db.candidate_notes_for_task_discovery(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, limit=10)
     assert [row["id"] for row in candidates] == [note_id]  # nosec B101
     db.set_reconciliation_state(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         note_id=note_id,
         note_version=1,
         status="clean",
@@ -1505,7 +1735,7 @@ def test_candidate_notes_for_task_discovery_excludes_currently_reconciled_notes(
         warning_count=0,
     )
 
-    assert db.candidate_notes_for_task_discovery(limit=10) == []  # nosec B101
+    assert db.candidate_notes_for_task_discovery(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, limit=10) == []  # nosec B101
     assert plain_note_id not in {row["id"] for row in candidates}  # nosec B101
 
 
@@ -1516,7 +1746,7 @@ def test_candidate_notes_for_task_discovery_matches_parser_checkbox_bullets_and_
     tab_note_id = _create_note(db, content="-\t[ ] Tab task\n")
     spaced_note_id = _create_note(db, content="*   [x] Spaced task\n")
 
-    candidates = db.candidate_notes_for_task_discovery(limit=10)
+    candidates = db.candidate_notes_for_task_discovery(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, limit=10)
 
     assert {row["id"] for row in candidates} == {  # nosec B101
         dash_note_id,
@@ -1532,6 +1762,8 @@ def test_candidate_notes_for_task_discovery_excludes_current_warning_state_until
 ) -> None:
     note_id = _create_note(db, content="- [ ] Review @due(not-a-date)\n")
     db.set_reconciliation_state(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         note_id=note_id,
         note_version=1,
         status="warnings",
@@ -1539,8 +1771,13 @@ def test_candidate_notes_for_task_discovery_excludes_current_warning_state_until
         warning_count=1,
     )
 
-    assert db.candidate_notes_for_task_discovery(limit=10) == []  # nosec B101
-    assert db.count_candidate_notes_for_task_discovery(note_id=note_id) == 0  # nosec B101
+    assert db.candidate_notes_for_task_discovery(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, limit=10) == []  # nosec B101
+    assert (
+        db.count_candidate_notes_for_task_discovery(
+            owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, note_id=note_id
+        )
+        == 0
+    )  # nosec B101
 
     db.update_note(
         note_id=note_id,
@@ -1548,4 +1785,174 @@ def test_candidate_notes_for_task_discovery_excludes_current_warning_state_until
         expected_version=1,
     )
 
-    assert db.count_candidate_notes_for_task_discovery(note_id=note_id) == 1  # nosec B101
+    assert (
+        db.count_candidate_notes_for_task_discovery(
+            owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, note_id=note_id
+        )
+        == 1
+    )  # nosec B101
+
+
+def test_scoped_task_lookup_requires_exact_owner_and_dataset(db: CharactersRAGDB) -> None:
+    note_id = _create_note(db)
+    _create_task(db, note_id)
+
+    assert (
+        db.get_task_scoped(  # nosec B101
+            owner_user_id=db.client_id,
+            dataset_id="local-unbound",
+            task_id="task-1",
+        )["id"]
+        == "task-1"
+    )
+    assert (
+        db.get_task_scoped(  # nosec B101
+            owner_user_id="other-owner",
+            dataset_id="local-unbound",
+            task_id="task-1",
+        )
+        is None
+    )
+    assert (
+        db.get_task_scoped(  # nosec B101
+            owner_user_id=db.client_id,
+            dataset_id="other-dataset",
+            task_id="task-1",
+        )
+        is None
+    )
+
+
+def test_canonical_task_store_rejects_omitted_scope(db: CharactersRAGDB) -> None:
+    with pytest.raises(TypeError, match="owner_user_id"):
+        db.get_task("missing-task")
+
+
+def test_projection_and_unlink_versions_do_not_change_canonical_identity(db: CharactersRAGDB) -> None:
+    note_id = _create_note(db)
+    created = _create_task(db, note_id)
+    _set_projection(db, created["id"], note_id)
+
+    unlinked = db.mark_task_unlinked(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=created["id"], expected_version=created["version"]
+    )
+
+    assert unlinked["version"] == created["version"] + 1  # nosec B101
+    assert unlinked["canonical_revision"] == created["canonical_revision"]  # nosec B101
+    assert unlinked["canonical_hash"] == created["canonical_hash"]  # nosec B101
+
+
+def test_canonical_task_mutation_advances_revision_and_hash_once(db: CharactersRAGDB) -> None:
+    note_id = _create_note(db)
+    created = _create_task(db, note_id)
+
+    updated = db.update_task_record(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
+        task_id=created["id"],
+        expected_version=created["version"],
+        text="Review canonical source",
+    )
+
+    assert updated["version"] == created["version"] + 1  # nosec B101
+    assert updated["canonical_revision"] == created["canonical_revision"] + 1  # nosec B101
+    assert updated["canonical_hash"] != created["canonical_hash"]  # nosec B101
+
+
+def test_bind_local_task_graph_rekeys_complete_scope_atomically(db: CharactersRAGDB) -> None:
+    note_id = _create_note(db)
+    task = _create_task(db, note_id)
+    _set_projection(db, task["id"], note_id)
+    event = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
+        task_id=task["id"],
+        note_id=note_id,
+        event_type="updated",
+        actor_type="user",
+    )
+    db.mark_task_activity_read(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, event_id=event["id"], user_id=db.client_id
+    )
+    db.set_reconciliation_state(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
+        note_id=note_id,
+        note_version=1,
+        status="clean",
+        item_count=1,
+        warning_count=0,
+    )
+    with db.transaction() as conn:
+        conn.execute(
+            """
+            INSERT INTO task_projection_drifts (
+                owner_user_id,dataset_id,id,note_id,task_id,marker_base_revision,
+                marker_base_hash,reason_code,status,created_at,updated_at
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                db.client_id,
+                "local-unbound",
+                "drift-1",
+                note_id,
+                task["id"],
+                1,
+                task["canonical_hash"],
+                "both_changed",
+                "open",
+                task["created_at"],
+                task["updated_at"],
+            ),
+        )
+
+    result = db.bind_local_task_graph_to_dataset(
+        owner_user_id=db.client_id,
+        target_dataset_id="dataset-a",
+    )
+
+    assert result == {  # nosec B101
+        "note_tasks": 1,
+        "task_note_projections": 1,
+        "task_events": 2,
+        "task_event_read_state": 1,
+        "note_task_reconciliation_state": 1,
+        "task_projection_drifts": 1,
+    }
+    assert (
+        db.get_task_scoped(  # nosec B101
+            owner_user_id=db.client_id, dataset_id="local-unbound", task_id=task["id"]
+        )
+        is None
+    )
+    assert (
+        db.get_task_scoped(  # nosec B101
+            owner_user_id=db.client_id, dataset_id="dataset-a", task_id=task["id"]
+        )["id"]
+        == task["id"]
+    )
+
+
+def test_bind_local_task_graph_rejects_target_collision_without_partial_rekey(db: CharactersRAGDB) -> None:
+    note_id = _create_note(db)
+    local_task = _create_task(db, note_id, task_id="collision-task")
+    db.create_task(
+        owner_user_id=db.client_id,
+        dataset_id="dataset-a",
+        task_id=local_task["id"],
+        note_id=note_id,
+        text="Existing target task",
+    )
+
+    with pytest.raises(ConflictError, match="collision"):
+        db.bind_local_task_graph_to_dataset(
+            owner_user_id=db.client_id,
+            target_dataset_id="dataset-a",
+        )
+
+    assert (
+        db.get_task_scoped(  # nosec B101
+            owner_user_id=db.client_id, dataset_id="local-unbound", task_id=local_task["id"]
+        )["id"]
+        == local_task["id"]
+    )

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
@@ -48,7 +48,7 @@ def test_bind_local_task_graph_has_one_strict_postgres_and_sqlite_contract() -> 
     bind_source = inspect.getsource(TaskStore.bind_local_task_graph_to_dataset)
 
     assert "only supported by SQLite" not in bind_source
-    assert "LOCK TABLE notes, note_tasks, task_note_projections, task_events" in source
+    assert "LOCK TABLE note_task_scope_authority, notes, note_tasks" in source
     assert "IN ACCESS EXCLUSIVE MODE" in source
     assert "_get_schema_version_postgres" in source
     assert "_verify_note_task_schema_postgres" in source
@@ -57,6 +57,111 @@ def test_bind_local_task_graph_has_one_strict_postgres_and_sqlite_contract() -> 
     assert "FORCE ROW LEVEL SECURITY" in source
     assert "_note_task_v60_hash" in source
     assert "complete-set verification" in source
+
+
+def test_compatibility_resolver_is_one_indexed_authority_lookup() -> None:
+    source = inspect.getsource(TaskStore.resolve_task_compatibility_dataset_id)
+
+    assert "note_task_scope_authority" in source
+    assert "SELECT owner_user_id,dataset_id" in source
+    for forbidden in (
+        "ACCESS EXCLUSIVE",
+        "ROW LEVEL SECURITY",
+        "SELECT DISTINCT",
+        "_BIND_TABLE_ORDER",
+        "_verify_note_task_schema_postgres",
+    ):
+        assert forbidden not in source
+
+
+def test_every_task_graph_write_checks_the_private_scope_authority() -> None:
+    for method_name in (
+        "create_task",
+        "update_unlinked_task_metadata_record_only",
+        "update_task_record",
+        "set_task_projection",
+        "mark_task_unlinked",
+        "soft_delete_task",
+        "record_task_event",
+        "mark_task_activity_read",
+        "mark_task_activity_dismissed",
+        "set_reconciliation_state",
+    ):
+        source = inspect.getsource(getattr(TaskStore, method_name))
+        assert "_require_authorized_write_scope" in source, method_name
+
+
+def test_empty_bind_persists_immutable_authority_and_guards_writes(
+    db: CharactersRAGDB,
+) -> None:
+    zero_counts = {
+        table: 0 for table, _ordering in db.task_store._BIND_TABLE_ORDER
+    }
+
+    assert db.bind_local_task_graph_to_dataset(
+        owner_user_id=db.client_id,
+        target_dataset_id="dataset-a",
+    ) == zero_counts
+    assert db.resolve_task_compatibility_dataset_id(
+        owner_user_id=db.client_id
+    ) == "dataset-a"
+    assert db.bind_local_task_graph_to_dataset(
+        owner_user_id=db.client_id,
+        target_dataset_id="dataset-a",
+    ) == zero_counts
+    with pytest.raises(ConflictError, match="immutable"):
+        db.bind_local_task_graph_to_dataset(
+            owner_user_id=db.client_id,
+            target_dataset_id="dataset-b",
+        )
+
+    note_id = _create_note(db)
+    with pytest.raises(ConflictError, match="scope conflicts"):
+        db.create_task(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
+            note_id=note_id,
+            text="Wrong scope",
+        )
+    task = db.create_task(
+        owner_user_id=db.client_id,
+        dataset_id="dataset-a",
+        note_id=note_id,
+        text="Bound scope",
+    )
+    rebound = db.bind_local_task_graph_to_dataset(
+        owner_user_id=db.client_id,
+        target_dataset_id="dataset-a",
+    )
+    assert rebound["note_tasks"] == 1
+    assert db.get_task(
+        owner_user_id=db.client_id,
+        dataset_id="dataset-a",
+        task_id=task["id"],
+    )["id"] == task["id"]
+
+
+def test_idempotent_bind_rejects_authority_sentinel_inconsistency(
+    db: CharactersRAGDB,
+) -> None:
+    db.bind_local_task_graph_to_dataset(
+        owner_user_id=db.client_id,
+        target_dataset_id="dataset-a",
+    )
+    note_id = _create_note(db)
+    now = db._get_current_utc_timestamp_iso()
+    db.execute_query(
+        "INSERT INTO note_task_reconciliation_state("
+        "owner_user_id,dataset_id,note_id,note_version,status,reconciled_at,"
+        "item_count,warning_count,cursor) VALUES (?,?,?,?,?,?,?,?,?)",
+        (db.client_id, LOCAL_UNBOUND, note_id, 1, "complete", now, 0, 0, None),
+    )
+
+    with pytest.raises(ConflictError, match="authority conflicts"):
+        db.bind_local_task_graph_to_dataset(
+            owner_user_id=db.client_id,
+            target_dataset_id="dataset-a",
+        )
 
 
 def test_canonical_task_store_methods_are_keyword_only_scope_first() -> None:
@@ -2051,12 +2156,20 @@ def test_bind_local_task_graph_rekeys_complete_scope_atomically(db: CharactersRA
 def test_bind_local_task_graph_rejects_target_collision_without_partial_rekey(db: CharactersRAGDB) -> None:
     note_id = _create_note(db)
     local_task = _create_task(db, note_id, task_id="collision-task")
+    db.execute_query(
+        "INSERT INTO note_task_scope_authority(owner_user_id,dataset_id) VALUES (?,?)",
+        (db.client_id, "dataset-a"),
+    )
     db.create_task(
         owner_user_id=db.client_id,
         dataset_id="dataset-a",
         task_id=local_task["id"],
         note_id=note_id,
         text="Existing target task",
+    )
+    db.execute_query(
+        "DELETE FROM note_task_scope_authority WHERE owner_user_id=?",
+        (db.client_id,),
     )
 
     with pytest.raises(ConflictError, match="collision"):

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 import inspect
-from contextlib import contextmanager
-from typing import Any
 
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.chacha.task_store import TaskStore
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
-    BackendType,
     CharactersRAGDB,
     ConflictError,
     InputError,
@@ -19,162 +16,6 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
 pytestmark = pytest.mark.unit
 
 LOCAL_UNBOUND = "local-unbound"
-
-
-class _PostgresV59Cursor:
-    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
-        self.rows = rows or []
-        self.rowcount = 1
-
-    def fetchone(self):
-        return self.rows[0] if self.rows else None
-
-    def fetchall(self):
-        return self.rows
-
-
-class _PostgresV59Connection:
-    _FORBIDDEN = (
-        "owner_user_id",
-        "dataset_id",
-        "canonical_revision",
-        "canonical_hash",
-        "sync_revision",
-        "sync_object_hash",
-        "sync_server_cursor",
-        "source_device_id",
-        "client_occurred_at",
-        "source_kind",
-        "corrects_activity_id",
-        "source_diagnostic_code",
-        "source_diagnostic_hash",
-        "task_projection_drifts",
-    )
-
-    def __init__(self) -> None:
-        self.statements: list[str] = []
-        self.task = {
-            "id": "pg-task",
-            "note_id": "pg-note",
-            "text": "Review source",
-            "status": "open",
-            "metadata_json": "{}",
-            "projection_status": "live",
-            "deleted": False,
-            "created_at": "2026-08-13T00:00:00+00:00",
-            "updated_at": "2026-08-13T00:00:00+00:00",
-            "completed_at": None,
-            "client_id": "pg-owner",
-            "version": 1,
-        }
-        self.projection = {
-            "task_id": "pg-task",
-            "note_id": "pg-note",
-            "note_version": 1,
-            "line_number": 1,
-            "start_offset": 0,
-            "end_offset": 10,
-            "normalized_text_hash": "sha256:review",
-            "occurrence_index": 0,
-            "block_fingerprint": "block",
-            "raw_line": "- [ ] Review source",
-            "has_child_content": False,
-            "projection_status": "live",
-            "updated_at": "2026-08-13T00:00:00+00:00",
-        }
-        self.event = {
-            "id": "pg-event",
-            "task_id": "pg-task",
-            "note_id": "pg-note",
-            "event_type": "updated",
-            "actor_type": "user",
-            "actor_id": "pg-owner",
-            "tool_name": None,
-            "policy_mode": None,
-            "approval_id": None,
-            "old_value_json": None,
-            "new_value_json": None,
-            "created_at": "2026-08-13T00:00:00+00:00",
-            "client_id": "pg-owner",
-        }
-
-    def execute(self, query: str, _params=()) -> _PostgresV59Cursor:
-        normalized = " ".join(query.lower().split())
-        self.statements.append(normalized)
-        leaked = [token for token in self._FORBIDDEN if token in normalized]
-        assert leaked == [], f"PostgreSQL v59 received v60-only SQL: {leaked}: {normalized}"
-        if "select count(*) as stale_count" in normalized:
-            return _PostgresV59Cursor([{"stale_count": 1}])
-        if "select id from notes" in normalized:
-            return _PostgresV59Cursor([{"id": "pg-note"}])
-        if "select deleted from notes" in normalized:
-            return _PostgresV59Cursor([{"deleted": False}])
-        if "select id, version, content, deleted from notes" in normalized:
-            return _PostgresV59Cursor([
-                {"id": "pg-note", "version": 1, "content": "- [ ] Review source\n", "deleted": False}
-            ])
-        if "from task_note_projections" in normalized:
-            return _PostgresV59Cursor([self.projection])
-        if "from task_events" in normalized:
-            return _PostgresV59Cursor([self.event])
-        if "from task_event_read_state" in normalized:
-            return _PostgresV59Cursor([
-                {"event_id": "pg-event", "user_id": "pg-owner", "read_at": "now", "dismissed_at": None}
-            ])
-        if "from note_task_reconciliation_state" in normalized:
-            return _PostgresV59Cursor([
-                {
-                    "note_id": "pg-note",
-                    "note_version": 1,
-                    "status": "clean",
-                    "reconciled_at": "now",
-                    "item_count": 1,
-                    "warning_count": 0,
-                    "cursor": None,
-                }
-            ])
-        if "from note_tasks" in normalized:
-            return _PostgresV59Cursor([self.task])
-        if "from notes n" in normalized:
-            return _PostgresV59Cursor([
-                {"id": "pg-note", "version": 1, "content": "- [ ] Review source\n"}
-            ])
-        return _PostgresV59Cursor()
-
-
-class _PostgresV59DB:
-    backend_type = BackendType.POSTGRESQL
-    client_id = "pg-owner"
-
-    def __init__(self) -> None:
-        self.connection = _PostgresV59Connection()
-
-    def execute_query(self, query: str, params=None):
-        return self.connection.execute(query, params)
-
-    @contextmanager
-    def transaction(self):
-        yield self.connection
-
-    @staticmethod
-    def _prepare_backend_statement(query: str, params=None):
-        return query, params
-
-    @staticmethod
-    def _generate_uuid() -> str:
-        return "pg-event"
-
-    @staticmethod
-    def _get_current_utc_timestamp_iso() -> str:
-        return "2026-08-13T00:00:00+00:00"
-
-    @staticmethod
-    def _canonicalize_legacy_task_v60(*_args, **_kwargs):
-        raise AssertionError("PostgreSQL v59 task writes must not compute v60 canonical fields")
-
-    @staticmethod
-    def _note_task_v60_hash(*_args, **_kwargs):
-        raise AssertionError("PostgreSQL v59 events must not compute v60 sync fields")
 
 
 @pytest.fixture()
@@ -187,111 +28,19 @@ def db(tmp_path) -> CharactersRAGDB:
     database.close_connection()
 
 
-def test_postgres_v59_task_operations_never_issue_v60_sql() -> None:
-    legacy_db = _PostgresV59DB()
-    store = TaskStore(legacy_db)
-    scope = {"owner_user_id": legacy_db.client_id, "dataset_id": LOCAL_UNBOUND}
+def test_task_store_has_no_postgres_v59_sql_bridge() -> None:
+    source = inspect.getsource(TaskStore)
 
-    assert store.create_task(
-        **scope,
-        task_id="pg-task",
-        note_id="pg-note",
-        text="Review source",
-        actor_type=None,
-    ) is not None
-    assert store.get_task(**scope, task_id="pg-task") is not None
-    assert store.list_tasks(**scope, note_id="pg-note")
-    assert store.update_task_record(
-        **scope,
-        task_id="pg-task",
-        expected_version=1,
-        text="Review source",
-        actor_type=None,
-    ) is not None
-    assert store.set_task_projection(
-        **scope,
-        task_id="pg-task",
-        note_id="pg-note",
-        note_version=1,
-        line_number=1,
-        start_offset=0,
-        end_offset=10,
-        normalized_text_hash="sha256:review",
-        occurrence_index=0,
-        block_fingerprint="block",
-        raw_line="- [ ] Review source",
-        has_child_content=False,
-    ) is not None
-    legacy_db.connection.task["projection_status"] = "unlinked"
-    legacy_db.connection.projection["projection_status"] = "unlinked"
-    assert store.update_unlinked_task_metadata_record_only(
-        **scope,
-        task_id="pg-task",
-        expected_version=1,
-        metadata={"priority": "high"},
-        actor_type="user",
-    ) is not None
-    legacy_db.connection.task["projection_status"] = "live"
-    legacy_db.connection.projection["projection_status"] = "live"
-    assert store.mark_task_unlinked(
-        **scope,
-        task_id="pg-task",
-        expected_version=1,
-        actor_type=None,
-    ) is not None
-    assert store.soft_delete_task(
-        **scope,
-        task_id="pg-task",
-        expected_version=1,
-        allow_record_only=True,
-        actor_type=None,
-    ) is not None
-    assert store.get_task_projection(**scope, task_id="pg-task") is not None
-    assert store.get_note_reconciliation_snapshot(**scope, note_id="pg-note") is not None
-    assert store.list_live_projected_tasks(**scope, note_id="pg-note")
-    assert store.record_task_event(
-        **scope,
-        event_id="pg-event",
-        task_id="pg-task",
-        note_id="pg-note",
-        event_type="updated",
-        actor_type="user",
-    ) is not None
-    assert store.list_task_activity(**scope, task_id="pg-task")
-    assert store.list_recent_task_activity(**scope, task_id="pg-task")
-    assert store.list_recent_unread_task_activity(
-        **scope,
-        user_id=legacy_db.client_id,
-        task_id="pg-task",
-    )
-    assert store.mark_task_activity_read(
-        **scope,
-        event_id="pg-event",
-        user_id=legacy_db.client_id,
-    ) is not None
-    assert store.mark_task_activity_dismissed(
-        **scope,
-        event_id="pg-event",
-        user_id=legacy_db.client_id,
-    ) is not None
-    assert store.get_task_activity_read_state(
-        **scope,
-        event_id="pg-event",
-        user_id=legacy_db.client_id,
-    ) is not None
-    assert store.get_reconciliation_state(**scope, note_id="pg-note") is not None
-    assert store.set_reconciliation_state(
-        **scope,
-        note_id="pg-note",
-        note_version=1,
-        status="clean",
-        item_count=1,
-        warning_count=0,
-    ) is not None
-    assert store.candidate_notes_for_task_discovery(**scope)
-    assert store.count_candidate_notes_for_task_discovery(**scope) == 1
-
-    assert legacy_db.connection.statements
+    assert "_uses_postgres_v59_schema" not in source
+    assert "PostgreSQL schema v59" not in source
+    assert "FROM note_tasks WHERE client_id = ?" not in source
+    for legacy_sql in (
+        "t.client_id",
+        "events.client_id",
+        "task.client_id",
+        "WHERE client_id = ? AND id = ? AND version",
+    ):
+        assert legacy_sql not in source
 
 
 def test_canonical_task_store_methods_are_keyword_only_scope_first() -> None:

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
@@ -25,10 +25,128 @@ TASK_ID = "22222222-2222-4222-8222-222222222222"
 EVENT_ID = "33333333-3333-4333-8333-333333333333"
 
 
-def test_postgres_initializer_authority_remains_v59_until_postgres_v60_lands() -> None:
-    assert CharactersRAGDB._POSTGRES_SCHEMA_VERSION == 59
+def test_postgres_initializer_authority_is_schema_v60() -> None:
+    assert CharactersRAGDB._POSTGRES_SCHEMA_VERSION == 60
     source = inspect.getsource(CharactersRAGDB._initialize_schema_postgres)
     assert "target_version = self._POSTGRES_SCHEMA_VERSION" in source
+    assert "_migrate_from_v59_to_v60_postgres" in source
+    assert "_verify_note_task_schema_postgres" in source
+
+
+def test_postgres_v60_ddl_is_fixed_and_scopes_all_six_relations() -> None:
+    statements = CharactersRAGDB._note_task_v60_postgres_ddl()
+    sql = " ".join("\n".join(statements).split()).lower()
+
+    assert len(statements) == 7
+    assert "create unique index uq_notes_owner_id on notes(client_id,id)" in sql
+    for table in CharactersRAGDB._NOTE_TASK_V60_TABLES:
+        assert f"create table {table}_v60" in sql
+        assert "owner_user_id text not null" in sql.split(
+            f"create table {table}_v60", 1
+        )[1].split("create table", 1)[0]
+        assert "dataset_id text not null" in sql.split(
+            f"create table {table}_v60", 1
+        )[1].split("create table", 1)[0]
+    assert "primary key(owner_user_id,dataset_id,id)" in sql
+    assert "references note_tasks_v60(owner_user_id,dataset_id,id)" in sql
+    assert "references task_events_v60(owner_user_id,dataset_id,id)" in sql
+    assert "on update cascade" in sql
+    assert "boolean not null default false" in sql
+    assert "bigint not null default 1" in sql
+    assert "timestamptz not null" in sql
+
+    indexes = CharactersRAGDB._note_task_v60_postgres_indexes()
+    assert (
+        "CREATE INDEX idx_task_events_scope_task_created ON "
+        "task_events(owner_user_id,dataset_id,task_id,created_at,id)"
+    ) in indexes
+    assert (
+        "CREATE INDEX idx_task_events_scope_note_created ON "
+        "task_events(owner_user_id,dataset_id,note_id,created_at,id)"
+    ) in indexes
+
+
+def test_postgres_v60_migration_uses_fixed_lock_and_version_last_order() -> None:
+    source = inspect.getsource(CharactersRAGDB._migrate_from_v59_to_v60_postgres)
+
+    assert "LOCK TABLE notes, note_tasks, task_note_projections, task_events" in source
+    assert "task_event_read_state, note_task_reconciliation_state IN ACCESS EXCLUSIVE MODE" in source
+    assert source.index("LOCK TABLE") < source.index("_validate_note_task_source_postgres")
+    assert source.index("_validate_note_task_source_postgres") < source.index(
+        "_create_note_task_schema_v60_postgres"
+    )
+    verify_pos = source.index("_verify_note_task_schema_postgres")
+    version_pos = source.index("UPDATE db_schema_version SET version=60")
+    assert verify_pos < version_pos
+    assert source.index("_validate_note_task_source_postgres") < source.index(
+        "_rename_note_task_v59_postgres_constraints"
+    ) < source.index("_create_note_task_schema_v60_postgres")
+    assert "WHERE schema_name=%s AND version=59" in source
+
+
+def test_postgres_v60_frees_only_fixed_v59_constraint_collisions() -> None:
+    assert CharactersRAGDB._note_task_v59_postgres_constraint_collisions() == (
+        ("note_tasks", "note_tasks_pkey"),
+        ("note_tasks", "note_tasks_projection_status_check"),
+        ("note_tasks", "note_tasks_status_check"),
+        ("task_note_projections", "task_note_projections_pkey"),
+        ("task_note_projections", "task_note_projections_projection_status_check"),
+        ("task_events", "task_events_pkey"),
+        ("task_event_read_state", "task_event_read_state_pkey"),
+        ("note_task_reconciliation_state", "note_task_reconciliation_state_pkey"),
+    )
+    source = inspect.getsource(CharactersRAGDB._rename_note_task_v59_postgres_constraints)
+    assert "ALTER TABLE {table_name} RENAME CONSTRAINT {constraint_name}" in source
+    assert "TO {constraint_name}_v59" in source
+
+
+def test_postgres_v60_uses_effective_schema_owner_and_exact_table_owner() -> None:
+    for method in (
+        CharactersRAGDB._migrate_from_v59_to_v60_postgres,
+        CharactersRAGDB._verify_note_task_schema_postgres,
+    ):
+        source = inspect.getsource(method).replace(" ", "")
+        assert (
+            "pg_has_role(current_user,namespace_row.nspowner,'USAGE')"
+            in source
+        )
+        assert "table_row.relowner=current_user::regroleASis_table_owner" in source
+
+
+def test_postgres_v60_verifier_enumerates_full_catalog_and_pg18_not_null_rows() -> None:
+    source = inspect.getsource(CharactersRAGDB._verify_note_task_schema_postgres)
+
+    for catalog in ("pg_class", "pg_attribute", "pg_constraint", "pg_index", "pg_policies"):
+        assert catalog in source
+    assert "constraint_row.contype <> 'n'" in source
+    assert "constraint_row.convalidated" in source
+    assert "referenced_namespace.nspname=current_schema()" in source.replace(" ", "")
+    assert "index_row.indisvalid" in source
+    assert "index_row.indisready" in source
+    assert "relrowsecurity" in source
+    assert "relforcerowsecurity" in source
+    assert "permissive" in source
+    assert "with_check" in source
+
+
+def test_postgres_v60_catalog_comparisons_fail_closed_on_security_drift() -> None:
+    source = inspect.getsource(CharactersRAGDB._verify_note_task_schema_postgres)
+
+    assert "set(constraints) != expected_constraint_names" in source
+    assert "not bool(row.get(\"constraint_validated\"))" in source
+    assert "_catalog_names(row.get(\"local_columns\")) != local_columns" in source
+    assert "_catalog_names(row.get(\"referenced_columns\")) != referenced_columns" in source
+    assert "str(row.get(\"delete_action\")) != delete_action" in source
+    assert "str(row.get(\"update_action\")) != update_action" in source
+    assert "set(indexes) != set(expected_indexes)" in source
+    assert "row.get(\"predicate\") is not None" in source
+    assert "len(policy_rows) != len(expected_policies)" in source
+    assert "normalized_using != normalized_expected" in source
+    assert "normalized_check != normalized_expected" in source
+
+    normalize = CharactersRAGDB._normalize_postgres_catalog_expression
+    canonical = "owner_user_id=current_setting('app.current_user_id',true)"
+    assert normalize(canonical) != normalize(f"({canonical}) OR TRUE")
 
 
 def _prepare_v59_database(db_path: Path) -> None:

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
@@ -65,6 +65,10 @@ def test_postgres_v60_ddl_is_fixed_and_scopes_all_six_relations() -> None:
         "CREATE INDEX idx_task_events_scope_note_created ON "
         "task_events(owner_user_id,dataset_id,note_id,created_at,id)"
     ) in indexes
+    assert (
+        "CREATE INDEX idx_task_events_scope_cursor ON "
+        "task_events(owner_user_id,dataset_id,sync_server_cursor,id)"
+    ) in indexes
 
 
 def test_postgres_v60_migration_uses_fixed_lock_and_version_last_order() -> None:
@@ -593,6 +597,62 @@ def test_sqlite_v60_activity_pages_use_scoped_created_indexes(
                 )
             ]
         assert any(expected_index in detail for detail in plan), plan  # nosec B101
+        assert not any("TEMP B-TREE" in detail.upper() for detail in plan), plan  # nosec B101
+    finally:
+        db.close_all_connections()
+
+
+@pytest.mark.parametrize("migrated", [False, True], ids=("fresh", "migrated"))
+def test_sqlite_v60_dataset_cursor_page_uses_exact_index(
+    tmp_path: Path,
+    migrated: bool,
+) -> None:
+    db_path = tmp_path / f"dataset-cursor-plan-{migrated}.sqlite"
+    if migrated:
+        _prepare_v59_database(db_path)
+    db = CharactersRAGDB(str(db_path), client_id=OWNER)
+    note_id = NOTE_ID if migrated else db.add_note("Cursor parent", "Body")
+
+    try:
+        with db.transaction() as conn:
+            for cursor in range(1, 65):
+                target_event = db.record_task_event(
+                    owner_user_id=OWNER,
+                    dataset_id=LOCAL_UNBOUND,
+                    note_id=note_id,
+                    event_type="updated",
+                    actor_type="user",
+                    conn=conn,
+                )
+                conn.execute(
+                    "UPDATE task_events SET sync_server_cursor=? "
+                    "WHERE owner_user_id=? AND dataset_id=? AND id=?",
+                    (cursor, OWNER, LOCAL_UNBOUND, target_event["id"]),
+                )
+                other_event = db.record_task_event(
+                    owner_user_id=OWNER,
+                    dataset_id="other-dataset",
+                    note_id=note_id,
+                    event_type="updated",
+                    actor_type="user",
+                    conn=conn,
+                )
+                conn.execute(
+                    "UPDATE task_events SET sync_server_cursor=? "
+                    "WHERE owner_user_id=? AND dataset_id=? AND id=?",
+                    (cursor, OWNER, "other-dataset", other_event["id"]),
+                )
+            conn.execute("ANALYZE task_events")
+            plan = [
+                str(row[3])
+                for row in conn.execute(
+                    "EXPLAIN QUERY PLAN SELECT id FROM task_events "
+                    "WHERE owner_user_id=? AND dataset_id=? AND sync_server_cursor>? "
+                    "ORDER BY sync_server_cursor,id LIMIT ?",
+                    (OWNER, LOCAL_UNBOUND, 0, 10),
+                )
+            ]
+        assert any("idx_task_events_scope_cursor" in detail for detail in plan), plan  # nosec B101
         assert not any("TEMP B-TREE" in detail.upper() for detail in plan), plan  # nosec B101
     finally:
         db.close_all_connections()

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
@@ -34,11 +34,11 @@ def test_postgres_initializer_authority_is_schema_v60() -> None:
     assert "_verify_note_task_schema_postgres" in source
 
 
-def test_postgres_v60_ddl_is_fixed_and_scopes_all_six_relations() -> None:
+def test_postgres_v60_ddl_is_fixed_and_scopes_graph_plus_authority() -> None:
     statements = CharactersRAGDB._note_task_v60_postgres_ddl()
     sql = " ".join("\n".join(statements).split()).lower()
 
-    assert len(statements) == 7
+    assert len(statements) == 8
     assert "create unique index uq_notes_owner_id on notes(client_id,id)" in sql
     for table in CharactersRAGDB._NOTE_TASK_V60_TABLES:
         assert f"create table {table}_v60" in sql
@@ -48,6 +48,9 @@ def test_postgres_v60_ddl_is_fixed_and_scopes_all_six_relations() -> None:
         assert "dataset_id text not null" in sql.split(
             f"create table {table}_v60", 1
         )[1].split("create table", 1)[0]
+    assert "create table note_task_scope_authority_v60" in sql
+    assert "note_task_scope_authority_pkey primary key(owner_user_id)" in sql
+    assert "dataset_id<>'local-unbound'" in sql
     assert "primary key(owner_user_id,dataset_id,id)" in sql
     assert "references note_tasks_v60(owner_user_id,dataset_id,id)" in sql
     assert "references task_events_v60(owner_user_id,dataset_id,id)" in sql
@@ -383,6 +386,75 @@ def _rewrite_sqlite_catalog(db_path: Path, *, object_name: str, old: str, new: s
         conn.execute("PRAGMA writable_schema=OFF")
 
 
+@pytest.mark.parametrize(
+    "drift",
+    ("weakened_constraint", "extra_index", "extra_trigger", "extra_view", "extra_table"),
+)
+def test_sqlite_v60_upgrade_rejects_exact_v59_source_catalog_drift_before_ddl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    drift: str,
+) -> None:
+    db_path = tmp_path / f"v59-source-{drift}.sqlite"
+    _prepare_v59_database(db_path)
+    drift_object = "note_tasks"
+    if drift == "weakened_constraint":
+        _rewrite_sqlite_catalog(
+            db_path,
+            object_name=drift_object,
+            old="CHECK(status IN ('open','done'))",
+            new="CHECK(status IN ('open','done','paused'))",
+        )
+    else:
+        statements = {
+            "extra_index": (
+                "CREATE INDEX unexpected_task_index ON note_tasks(text)",
+                "unexpected_task_index",
+            ),
+            "extra_trigger": (
+                "CREATE TRIGGER unexpected_task_trigger AFTER UPDATE ON note_tasks "
+                "BEGIN SELECT NEW.id; END",
+                "unexpected_task_trigger",
+            ),
+            "extra_view": (
+                "CREATE VIEW unexpected_task_view AS SELECT id FROM note_tasks",
+                "unexpected_task_view",
+            ),
+            "extra_table": (
+                "CREATE TABLE unexpected_task_table("
+                "id TEXT PRIMARY KEY, task_id TEXT REFERENCES note_tasks(id))",
+                "unexpected_task_table",
+            ),
+        }
+        statement, drift_object = statements[drift]
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(statement)
+
+    checkpoints: list[str] = []
+    monkeypatch.setattr(
+        CharactersRAGDB,
+        "_note_task_v60_migration_checkpoint",
+        lambda _db, stage: checkpoints.append(stage),
+    )
+    with pytest.raises(CharactersRAGDBError, match="v59 SQLite source catalog drifted"):
+        CharactersRAGDB(str(db_path), client_id=OWNER)
+
+    assert checkpoints == []  # nosec B101 - validation must precede v60 DDL.
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(  # nosec B101
+            "SELECT version FROM db_schema_version WHERE schema_name=?",
+            (CharactersRAGDB._SCHEMA_NAME,),
+        ).fetchone()[0] == 59
+        assert conn.execute("SELECT id FROM note_tasks").fetchone()[0] == TASK_ID  # nosec B101
+        assert conn.execute("SELECT id FROM task_events").fetchone()[0] == EVENT_ID  # nosec B101
+        catalog_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name=?", (drift_object,)
+        ).fetchone()[0]
+        assert catalog_sql is not None  # nosec B101
+        if drift == "weakened_constraint":
+            assert "'paused'" in catalog_sql  # nosec B101
+
+
 def test_sqlite_v60_upgrade_preserves_graph_under_local_unbound_scope(tmp_path: Path) -> None:
     db_path = tmp_path / "task-v59.sqlite"
     _prepare_v59_database(db_path)
@@ -401,6 +473,7 @@ def test_sqlite_v60_upgrade_preserves_graph_under_local_unbound_scope(tmp_path: 
                     "task_event_read_state",
                     "note_task_reconciliation_state",
                     "task_projection_drifts",
+                    "note_task_scope_authority",
                 )
             }
             assert counts == {  # nosec B101
@@ -410,6 +483,7 @@ def test_sqlite_v60_upgrade_preserves_graph_under_local_unbound_scope(tmp_path: 
                 "task_event_read_state": 1,
                 "note_task_reconciliation_state": 1,
                 "task_projection_drifts": 0,
+                "note_task_scope_authority": 0,
             }
         task = upgraded.get_task(
             owner_user_id=OWNER,
@@ -497,6 +571,13 @@ def test_sqlite_v60_has_exact_scoped_task_graph_columns(tmp_path: Path) -> None:
                 "task_projection_drifts",
             ):
                 assert {"owner_user_id", "dataset_id"} <= _table_columns(conn, table)  # nosec B101
+            assert _table_columns(conn, "note_task_scope_authority") == {  # nosec B101
+                "owner_user_id",
+                "dataset_id",
+            }
+            assert conn.execute(  # nosec B101
+                "SELECT COUNT(*) FROM note_task_scope_authority"
+            ).fetchone()[0] == 0
             foreign_keys = conn.execute("PRAGMA foreign_key_list(task_note_projections)").fetchall()
             assert any(str(row[5]).upper() == "CASCADE" for row in foreign_keys)  # nosec B101
     finally:
@@ -629,6 +710,11 @@ def test_sqlite_v60_dataset_cursor_page_uses_exact_index(
                     "WHERE owner_user_id=? AND dataset_id=? AND id=?",
                     (cursor, OWNER, LOCAL_UNBOUND, target_event["id"]),
                 )
+            conn.execute(
+                "INSERT INTO note_task_scope_authority(owner_user_id,dataset_id) VALUES (?,?)",
+                (OWNER, "other-dataset"),
+            )
+            for cursor in range(1, 65):
                 other_event = db.record_task_event(
                     owner_user_id=OWNER,
                     dataset_id="other-dataset",
@@ -642,6 +728,10 @@ def test_sqlite_v60_dataset_cursor_page_uses_exact_index(
                     "WHERE owner_user_id=? AND dataset_id=? AND id=?",
                     (cursor, OWNER, "other-dataset", other_event["id"]),
                 )
+            conn.execute(
+                "DELETE FROM note_task_scope_authority WHERE owner_user_id=?",
+                (OWNER,),
+            )
             conn.execute("ANALYZE task_events")
             plan = [
                 str(row[3])

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
@@ -1,0 +1,295 @@
+"""SQLite schema-v60 contracts for owner/dataset-scoped Notes tasks."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    CharactersRAGDBError,
+    SchemaError,
+)
+
+pytestmark = pytest.mark.unit
+
+OWNER = "task-v60-owner"
+LOCAL_UNBOUND = "local-unbound"
+NOTE_ID = "11111111-1111-4111-8111-111111111111"
+TASK_ID = "22222222-2222-4222-8222-222222222222"
+EVENT_ID = "33333333-3333-4333-8333-333333333333"
+
+
+def _prepare_v59_database(db_path: Path) -> None:
+    """Create the preceding real schema and one complete legacy task graph."""
+
+    original_version = CharactersRAGDB._CURRENT_SCHEMA_VERSION
+    CharactersRAGDB._CURRENT_SCHEMA_VERSION = 59
+    try:
+        db = CharactersRAGDB(str(db_path), client_id=OWNER)
+        note_id = db.add_note("Task parent", "- [ ] Review source\n", note_id=NOTE_ID)
+        assert note_id == NOTE_ID  # nosec B101
+        now = "2026-08-13T00:00:00+00:00"
+        with db.transaction() as conn:
+            conn.execute(
+                """
+                INSERT INTO note_tasks(
+                    id, note_id, text, status, metadata_json, projection_status, deleted,
+                    created_at, updated_at, completed_at, client_id, version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    TASK_ID,
+                    NOTE_ID,
+                    "Review source",
+                    "open",
+                    '{"due_date":"2026-08-15","estimate":"30m","priority":"high"}',
+                    "live",
+                    0,
+                    now,
+                    now,
+                    None,
+                    OWNER,
+                    1,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO task_note_projections(
+                    task_id, note_id, note_version, line_number, start_offset, end_offset,
+                    normalized_text_hash, occurrence_index, block_fingerprint, raw_line,
+                    has_child_content, projection_status, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    TASK_ID,
+                    NOTE_ID,
+                    1,
+                    1,
+                    0,
+                    19,
+                    "sha256:" + "a" * 64,
+                    0,
+                    "sha256:" + "b" * 64,
+                    "- [ ] Review source",
+                    0,
+                    "live",
+                    now,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO task_events(
+                    id, task_id, note_id, event_type, actor_type, actor_id, tool_name,
+                    policy_mode, approval_id, old_value_json, new_value_json, created_at,
+                    client_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    EVENT_ID,
+                    TASK_ID,
+                    NOTE_ID,
+                    "created",
+                    "user",
+                    OWNER,
+                    None,
+                    None,
+                    None,
+                    None,
+                    '{"status":"open","text":"Review source"}',
+                    now,
+                    OWNER,
+                ),
+            )
+            conn.execute(
+                "INSERT INTO task_event_read_state(event_id, user_id, read_at) VALUES (?, ?, ?)",
+                (EVENT_ID, OWNER, now),
+            )
+            conn.execute(
+                """
+                INSERT INTO note_task_reconciliation_state(
+                    note_id, note_version, status, reconciled_at, item_count, warning_count,
+                    cursor
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (NOTE_ID, 1, "clean", now, 1, 0, None),
+            )
+        db.close_all_connections()
+    finally:
+        CharactersRAGDB._CURRENT_SCHEMA_VERSION = original_version
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}  # nosec B608
+
+
+def test_sqlite_v60_upgrade_preserves_graph_under_local_unbound_scope(tmp_path: Path) -> None:
+    db_path = tmp_path / "task-v59.sqlite"
+    _prepare_v59_database(db_path)
+
+    upgraded = CharactersRAGDB(str(db_path), client_id=OWNER)
+    try:
+        with upgraded.transaction() as conn:
+            assert upgraded._get_db_version(conn) == 60  # nosec B101
+            assert conn.execute("PRAGMA foreign_key_check").fetchall() == []  # nosec B101
+            counts = {
+                table: int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])  # nosec B608
+                for table in (
+                    "note_tasks",
+                    "task_note_projections",
+                    "task_events",
+                    "task_event_read_state",
+                    "note_task_reconciliation_state",
+                    "task_projection_drifts",
+                )
+            }
+            assert counts == {  # nosec B101
+                "note_tasks": 1,
+                "task_note_projections": 1,
+                "task_events": 1,
+                "task_event_read_state": 1,
+                "note_task_reconciliation_state": 1,
+                "task_projection_drifts": 0,
+            }
+        task = upgraded.get_task_scoped(
+            owner_user_id=OWNER,
+            dataset_id=LOCAL_UNBOUND,
+            task_id=TASK_ID,
+            include_deleted=True,
+        )
+        assert task is not None  # nosec B101
+        assert task["id"] == TASK_ID  # nosec B101
+        assert task["canonical_revision"] == task["version"] == 1  # nosec B101
+        assert task["canonical_hash"].startswith("sha256:")  # nosec B101
+    finally:
+        upgraded.close_all_connections()
+
+
+def test_sqlite_v60_has_exact_scoped_task_graph_columns(tmp_path: Path) -> None:
+    db = CharactersRAGDB(str(tmp_path / "fresh.sqlite"), client_id=OWNER)
+    try:
+        with db.transaction() as conn:
+            assert {"owner_user_id", "dataset_id", "canonical_revision", "canonical_hash"} <= _table_columns(  # nosec B101
+                conn, "note_tasks"
+            )
+            assert {
+                "owner_user_id",
+                "dataset_id",
+                "sync_revision",
+                "sync_object_hash",
+                "sync_server_cursor",
+                "source_device_id",
+                "client_occurred_at",
+                "source_kind",
+                "corrects_activity_id",
+                "deleted",
+                "deleted_at",
+                "delete_reason",
+            } <= _table_columns(conn, "task_events")  # nosec B101
+            for table in (
+                "task_note_projections",
+                "task_event_read_state",
+                "note_task_reconciliation_state",
+                "task_projection_drifts",
+            ):
+                assert {"owner_user_id", "dataset_id"} <= _table_columns(conn, table)  # nosec B101
+            foreign_keys = conn.execute("PRAGMA foreign_key_list(task_note_projections)").fetchall()
+            assert any(str(row[5]).upper() == "CASCADE" for row in foreign_keys)  # nosec B101
+    finally:
+        db.close_all_connections()
+
+
+@pytest.mark.parametrize("stage", ["create", "copy", "index", "verify"])
+def test_sqlite_v60_injected_failure_rolls_back_original_graph_and_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stage: str,
+) -> None:
+    db_path = tmp_path / f"rollback-{stage}.sqlite"
+    _prepare_v59_database(db_path)
+
+    def fail_at_stage(self: CharactersRAGDB, current_stage: str) -> None:
+        if current_stage == stage:
+            raise SchemaError(f"injected v60 {stage} failure")
+
+    monkeypatch.setattr(
+        CharactersRAGDB,
+        "_note_task_v60_migration_checkpoint",
+        fail_at_stage,
+        raising=False,
+    )
+    with pytest.raises(CharactersRAGDBError, match=f"injected v60 {stage} failure"):
+        CharactersRAGDB(str(db_path), client_id=OWNER)
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(  # nosec B101
+            "SELECT version FROM db_schema_version WHERE schema_name = ?",
+            (CharactersRAGDB._SCHEMA_NAME,),
+        ).fetchone()[0] == 59
+        assert "owner_user_id" not in _table_columns(conn, "note_tasks")  # nosec B101
+        assert conn.execute("SELECT id FROM note_tasks").fetchone()[0] == TASK_ID  # nosec B101
+        assert conn.execute("SELECT id FROM task_events").fetchone()[0] == EVENT_ID  # nosec B101
+
+
+def test_sqlite_v60_rejects_target_table_collision_without_version_change(tmp_path: Path) -> None:
+    db_path = tmp_path / "collision.sqlite"
+    _prepare_v59_database(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE task_projection_drifts(id TEXT PRIMARY KEY)")
+
+    with pytest.raises(CharactersRAGDBError, match="collision"):
+        CharactersRAGDB(str(db_path), client_id=OWNER)
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(  # nosec B101
+            "SELECT version FROM db_schema_version WHERE schema_name = ?",
+            (CharactersRAGDB._SCHEMA_NAME,),
+        ).fetchone()[0] == 59
+        assert "owner_user_id" not in _table_columns(conn, "note_tasks")  # nosec B101
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [("canonical_revision", 1.5), ("version", 1.5), ("deleted", 1.5)],
+)
+def test_sqlite_v60_rejects_noninteger_task_storage_classes(
+    tmp_path: Path,
+    column: str,
+    value: object,
+) -> None:
+    db = CharactersRAGDB(str(tmp_path / f"integer-{column}.sqlite"), client_id=OWNER)
+    try:
+        note_id = db.add_note("Task parent", "Body", note_id=NOTE_ID)
+        assert note_id == NOTE_ID  # nosec B101
+        with pytest.raises(sqlite3.IntegrityError), db.transaction() as conn:
+            conn.execute(
+                """
+                INSERT INTO note_tasks(
+                    owner_user_id, dataset_id, id, note_id, text, status, metadata_json,
+                    projection_status, deleted, created_at, updated_at, completed_at,
+                    client_id, version, canonical_revision, canonical_hash
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,  # nosec B608 - column is test-parametrized from a fixed set.
+                (
+                    OWNER,
+                    LOCAL_UNBOUND,
+                    TASK_ID,
+                    NOTE_ID,
+                    "Review source",
+                    "open",
+                    "{}",
+                    "live",
+                    value if column == "deleted" else 0,
+                    "2026-08-13T00:00:00+00:00",
+                    "2026-08-13T00:00:00+00:00",
+                    None,
+                    OWNER,
+                    value if column == "version" else 1,
+                    value if column == "canonical_revision" else 1,
+                    "sha256:" + "a" * 64,
+                ),
+            )
+    finally:
+        db.close_all_connections()

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import sqlite3
 from pathlib import Path
 
@@ -20,6 +21,12 @@ LOCAL_UNBOUND = "local-unbound"
 NOTE_ID = "11111111-1111-4111-8111-111111111111"
 TASK_ID = "22222222-2222-4222-8222-222222222222"
 EVENT_ID = "33333333-3333-4333-8333-333333333333"
+
+
+def test_postgres_initializer_authority_remains_v59_until_postgres_v60_lands() -> None:
+    assert CharactersRAGDB._POSTGRES_SCHEMA_VERSION == 59
+    source = inspect.getsource(CharactersRAGDB._initialize_schema_postgres)
+    assert "target_version = self._POSTGRES_SCHEMA_VERSION" in source
 
 
 def _prepare_v59_database(db_path: Path) -> None:
@@ -125,6 +132,22 @@ def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
     return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}  # nosec B608
 
 
+def _rewrite_sqlite_catalog(db_path: Path, *, object_name: str, old: str, new: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        current = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name=?", (object_name,)
+        ).fetchone()[0]
+        assert old in current  # nosec B101 - proves the adversarial mutation was applied.
+        conn.execute("PRAGMA writable_schema=ON")
+        conn.execute(
+            "UPDATE sqlite_master SET sql=? WHERE name=?",
+            (current.replace(old, new, 1), object_name),
+        )
+        schema_version = int(conn.execute("PRAGMA schema_version").fetchone()[0])
+        conn.execute(f"PRAGMA schema_version={schema_version + 1}")  # nosec B608
+        conn.execute("PRAGMA writable_schema=OFF")
+
+
 def test_sqlite_v60_upgrade_preserves_graph_under_local_unbound_scope(tmp_path: Path) -> None:
     db_path = tmp_path / "task-v59.sqlite"
     _prepare_v59_database(db_path)
@@ -153,7 +176,7 @@ def test_sqlite_v60_upgrade_preserves_graph_under_local_unbound_scope(tmp_path: 
                 "note_task_reconciliation_state": 1,
                 "task_projection_drifts": 0,
             }
-        task = upgraded.get_task_scoped(
+        task = upgraded.get_task(
             owner_user_id=OWNER,
             dataset_id=LOCAL_UNBOUND,
             task_id=TASK_ID,
@@ -165,6 +188,50 @@ def test_sqlite_v60_upgrade_preserves_graph_under_local_unbound_scope(tmp_path: 
         assert task["canonical_hash"].startswith("sha256:")  # nosec B101
     finally:
         upgraded.close_all_connections()
+
+
+def test_sqlite_v60_upgrade_derives_missing_event_note_from_task(tmp_path: Path) -> None:
+    db_path = tmp_path / "task-v59-null-event-note.sqlite"
+    _prepare_v59_database(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE task_events SET note_id=NULL WHERE id=?", (EVENT_ID,))
+
+    upgraded = CharactersRAGDB(str(db_path), client_id=OWNER)
+    try:
+        with upgraded.transaction() as conn:
+            row = conn.execute("SELECT note_id FROM task_events WHERE id=?", (EVENT_ID,)).fetchone()
+            assert row[0] == NOTE_ID  # nosec B101
+            note_column = next(
+                column for column in conn.execute("PRAGMA table_xinfo(task_events)")
+                if column[1] == "note_id"
+            )
+            assert note_column[3] == 1  # nosec B101 - NOT NULL is catalog authority.
+    finally:
+        upgraded.close_all_connections()
+
+
+def test_sqlite_v60_upgrade_rejects_mismatched_event_task_and_note(tmp_path: Path) -> None:
+    db_path = tmp_path / "task-v59-mismatched-event-note.sqlite"
+    _prepare_v59_database(db_path)
+    other_note_id = "44444444-4444-4444-8444-444444444444"
+    original_version = CharactersRAGDB._CURRENT_SCHEMA_VERSION
+    CharactersRAGDB._CURRENT_SCHEMA_VERSION = 59
+    try:
+        legacy = CharactersRAGDB(str(db_path), client_id=OWNER)
+        assert legacy.add_note("Other", "Body", note_id=other_note_id) == other_note_id  # nosec B101
+        with legacy.transaction() as conn:
+            conn.execute("UPDATE task_events SET note_id=? WHERE id=?", (other_note_id, EVENT_ID))
+        legacy.close_all_connections()
+    finally:
+        CharactersRAGDB._CURRENT_SCHEMA_VERSION = original_version
+
+    with pytest.raises(CharactersRAGDBError, match="mismatched event parents"):
+        CharactersRAGDB(str(db_path), client_id=OWNER)
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(  # nosec B101
+            "SELECT version FROM db_schema_version WHERE schema_name=?",
+            (CharactersRAGDB._SCHEMA_NAME,),
+        ).fetchone()[0] == 59
 
 
 def test_sqlite_v60_has_exact_scoped_task_graph_columns(tmp_path: Path) -> None:
@@ -199,6 +266,43 @@ def test_sqlite_v60_has_exact_scoped_task_graph_columns(tmp_path: Path) -> None:
             assert any(str(row[5]).upper() == "CASCADE" for row in foreign_keys)  # nosec B101
     finally:
         db.close_all_connections()
+
+
+def test_sqlite_v60_verifier_rejects_same_name_weak_index(tmp_path: Path) -> None:
+    db_path = tmp_path / "weak-index.sqlite"
+    db = CharactersRAGDB(str(db_path), client_id=OWNER)
+    db.close_all_connections()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP INDEX idx_task_events_scope_task_page")
+        conn.execute(
+            "CREATE INDEX idx_task_events_scope_task_page ON task_events(owner_user_id)"
+        )
+
+    with pytest.raises(CharactersRAGDBError, match="index catalog drifted"):
+        CharactersRAGDB(str(db_path), client_id=OWNER)
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    [
+        ("note_id TEXT NOT NULL", "note_id BLOB NOT NULL"),
+        ("CHECK(length(trim(note_id)) > 0)", "CHECK(1)"),
+        ("ON UPDATE CASCADE ON DELETE RESTRICT", "ON UPDATE NO ACTION ON DELETE RESTRICT"),
+    ],
+    ids=("type", "check", "foreign-key-action"),
+)
+def test_sqlite_v60_verifier_rejects_table_catalog_drift(
+    tmp_path: Path,
+    old: str,
+    new: str,
+) -> None:
+    db_path = tmp_path / f"table-drift-{old[:4]}.sqlite"
+    db = CharactersRAGDB(str(db_path), client_id=OWNER)
+    db.close_all_connections()
+    _rewrite_sqlite_catalog(db_path, object_name="task_events", old=old, new=new)
+
+    with pytest.raises(CharactersRAGDBError, match="table catalog drifted"):
+        CharactersRAGDB(str(db_path), client_id=OWNER)
 
 
 @pytest.mark.parametrize("stage", ["create", "copy", "index", "verify"])

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
@@ -6,6 +6,7 @@ import inspect
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -113,11 +114,121 @@ def test_postgres_v60_uses_effective_schema_owner_and_exact_table_owner() -> Non
         assert "table_row.relowner=current_user::regroleASis_table_owner" in source
 
 
+def _canonical_postgres_v59_source_authority() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    relation_rows = [
+        {
+            "table_name": table,
+            "rls_enabled": table == "notes",
+            "rls_forced": table == "notes",
+            "is_table_owner": True,
+            "is_schema_owner": True,
+        }
+        for table in ("notes", *CharactersRAGDB._NOTE_TASK_V60_TABLES[:-1])
+    ]
+    policy_rows = [
+        {
+            "table_name": "notes",
+            "policy_name": "notes_tenant_isolation",
+            "permissive": "PERMISSIVE",
+            "roles": "{public}",
+            "command": "ALL",
+            "using_expression": "(client_id = current_setting('app.current_user_id'::text, true))",
+            "check_expression": "(client_id = current_setting('app.current_user_id'::text, true))",
+        }
+    ]
+    return relation_rows, policy_rows
+
+
+def test_postgres_v59_source_authority_accepts_only_reviewed_catalog() -> None:
+    relation_rows, policy_rows = _canonical_postgres_v59_source_authority()
+
+    assert CharactersRAGDB._verify_note_task_v59_authority_catalog(
+        relation_rows, policy_rows
+    ) == ("notes",)
+
+    source = inspect.getsource(CharactersRAGDB._migrate_from_v59_to_v60_postgres)
+    authority_pos = source.index("_verify_note_task_v59_authority_catalog")
+    assert authority_pos < source.index("collision_names")
+    assert source.index("for table in forced_relations") < source.index(
+        "_validate_note_task_source_postgres"
+    )
+
+
+@pytest.mark.parametrize(
+    "drift",
+    (
+        "missing_relation",
+        "extra_relation",
+        "table_owner",
+        "schema_owner",
+        "notes_rls_disabled",
+        "notes_unforced",
+        "task_rls_enabled",
+        "task_forced",
+        "missing_policy",
+        "extra_task_policy",
+        "policy_name",
+        "policy_permissiveness",
+        "policy_roles",
+        "policy_command",
+        "policy_using",
+        "policy_check",
+    ),
+)
+def test_postgres_v59_source_authority_drift_matrix_fails_closed(drift: str) -> None:
+    relation_rows, policy_rows = _canonical_postgres_v59_source_authority()
+    relation_rows = deepcopy(relation_rows)
+    policy_rows = deepcopy(policy_rows)
+    relations = {str(row["table_name"]): row for row in relation_rows}
+
+    if drift == "missing_relation":
+        relation_rows.pop()
+    elif drift == "extra_relation":
+        relation_rows.append({**relation_rows[-1], "table_name": "unexpected_tasks"})
+    elif drift == "table_owner":
+        relations["note_tasks"]["is_table_owner"] = False
+    elif drift == "schema_owner":
+        relations["notes"]["is_schema_owner"] = False
+    elif drift == "notes_rls_disabled":
+        relations["notes"]["rls_enabled"] = False
+    elif drift == "notes_unforced":
+        relations["notes"]["rls_forced"] = False
+    elif drift == "task_rls_enabled":
+        relations["note_tasks"]["rls_enabled"] = True
+    elif drift == "task_forced":
+        relations["note_tasks"]["rls_forced"] = True
+    elif drift == "missing_policy":
+        policy_rows.clear()
+    elif drift == "extra_task_policy":
+        policy_rows.append({**policy_rows[0], "table_name": "note_tasks"})
+    elif drift == "policy_name":
+        policy_rows[0]["policy_name"] = "notes_open"
+    elif drift == "policy_permissiveness":
+        policy_rows[0]["permissive"] = "RESTRICTIVE"
+    elif drift == "policy_roles":
+        policy_rows[0]["roles"] = "{postgres}"
+    elif drift == "policy_command":
+        policy_rows[0]["command"] = "SELECT"
+    elif drift == "policy_using":
+        policy_rows[0]["using_expression"] = "true"
+    elif drift == "policy_check":
+        policy_rows[0]["check_expression"] = "true"
+
+    with pytest.raises(SchemaError, match="v59 PostgreSQL source authority"):
+        CharactersRAGDB._verify_note_task_v59_authority_catalog(relation_rows, policy_rows)
+
+
 def test_postgres_v60_verifier_enumerates_full_catalog_and_pg18_not_null_rows() -> None:
     source = inspect.getsource(CharactersRAGDB._verify_note_task_schema_postgres)
 
     for catalog in ("pg_class", "pg_attribute", "pg_constraint", "pg_index", "pg_policies"):
         assert catalog in source
+    for exact_index_field in (
+        "indnatts", "indnkeyatts", "indclass", "indcollation", "indoption", "attnum",
+    ):
+        assert exact_index_field in source
+    for exact_index_catalog in ("pg_am", "pg_opclass", "pg_collation", "pg_get_indexdef"):
+        assert exact_index_catalog in source
     assert "constraint_row.contype <> 'n'" in source
     assert "constraint_row.convalidated" in source
     assert "referenced_namespace.nspname=current_schema()" in source.replace(" ", "")

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_migration_v60.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import inspect
 import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -305,6 +307,68 @@ def test_sqlite_v60_verifier_rejects_table_catalog_drift(
         CharactersRAGDB(str(db_path), client_id=OWNER)
 
 
+@pytest.mark.parametrize(
+    "ddl",
+    [
+        (
+            "CREATE TRIGGER unexpected_task_delete AFTER INSERT ON note_tasks "
+            "BEGIN DELETE FROM note_tasks WHERE id = NEW.id; END"
+        ),
+        "CREATE VIEW unexpected_task_view AS SELECT id,note_id FROM note_tasks",
+    ],
+    ids=("trigger", "view"),
+)
+def test_sqlite_v60_verifier_rejects_related_trigger_or_view(
+    tmp_path: Path,
+    ddl: str,
+) -> None:
+    db_path = tmp_path / "related-catalog-drift.sqlite"
+    db = CharactersRAGDB(str(db_path), client_id=OWNER)
+    db.close_all_connections()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(ddl)
+
+    with pytest.raises(CharactersRAGDBError, match="related catalog drifted"):
+        CharactersRAGDB(str(db_path), client_id=OWNER)
+
+
+@pytest.mark.parametrize("migrated", [False, True], ids=("fresh", "migrated"))
+@pytest.mark.parametrize(
+    ("filter_column", "filter_value", "expected_index"),
+    [
+        ("task_id", TASK_ID, "idx_task_events_scope_task_created"),
+        ("note_id", NOTE_ID, "idx_task_events_scope_note_created"),
+    ],
+    ids=("task-page", "note-page"),
+)
+def test_sqlite_v60_activity_pages_use_scoped_created_indexes(
+    tmp_path: Path,
+    migrated: bool,
+    filter_column: str,
+    filter_value: str,
+    expected_index: str,
+) -> None:
+    db_path = tmp_path / f"activity-plan-{migrated}-{filter_column}.sqlite"
+    if migrated:
+        _prepare_v59_database(db_path)
+    db = CharactersRAGDB(str(db_path), client_id=OWNER)
+    try:
+        with db.transaction() as conn:
+            plan = [
+                str(row[3])
+                for row in conn.execute(
+                    "EXPLAIN QUERY PLAN SELECT * FROM task_events "
+                    f"WHERE owner_user_id=? AND dataset_id=? AND {filter_column}=? "  # nosec B608
+                    "ORDER BY created_at ASC,rowid ASC LIMIT ?",
+                    (OWNER, LOCAL_UNBOUND, filter_value, 100),
+                )
+            ]
+        assert any(expected_index in detail for detail in plan), plan  # nosec B101
+        assert not any("TEMP B-TREE" in detail.upper() for detail in plan), plan  # nosec B101
+    finally:
+        db.close_all_connections()
+
+
 @pytest.mark.parametrize("stage", ["create", "copy", "index", "verify"])
 def test_sqlite_v60_injected_failure_rolls_back_original_graph_and_version(
     tmp_path: Path,
@@ -335,6 +399,54 @@ def test_sqlite_v60_injected_failure_rolls_back_original_graph_and_version(
         assert "owner_user_id" not in _table_columns(conn, "note_tasks")  # nosec B101
         assert conn.execute("SELECT id FROM note_tasks").fetchone()[0] == TASK_ID  # nosec B101
         assert conn.execute("SELECT id FROM task_events").fetchone()[0] == EVENT_ID  # nosec B101
+
+
+def test_sqlite_v60_same_path_concurrent_openers_complete_one_migration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "concurrent-openers.sqlite"
+    _prepare_v59_database(db_path)
+    start = threading.Barrier(2)
+    checkpoint_lock = threading.Lock()
+    checkpoints: list[str] = []
+    original_checkpoint = CharactersRAGDB._note_task_v60_migration_checkpoint
+
+    def track_checkpoint(_db: CharactersRAGDB, stage: str) -> None:
+        with checkpoint_lock:
+            checkpoints.append(stage)
+        original_checkpoint(stage)
+
+    monkeypatch.setattr(
+        CharactersRAGDB,
+        "_note_task_v60_migration_checkpoint",
+        track_checkpoint,
+    )
+
+    def open_same_path() -> int:
+        start.wait(timeout=10)
+        db = CharactersRAGDB(str(db_path), client_id=OWNER)
+        try:
+            with db.transaction() as conn:
+                return db._get_db_version(conn)
+        finally:
+            db.close_all_connections()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        versions = list(executor.map(lambda _index: open_same_path(), range(2)))
+
+    assert versions == [60, 60]  # nosec B101
+    assert checkpoints == ["create", "copy", "index", "verify"]  # nosec B101
+    with sqlite3.connect(db_path) as conn:
+        tables = {str(row[0]) for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+        assert conn.execute(  # nosec B101
+            "SELECT version FROM db_schema_version WHERE schema_name=?",
+            (CharactersRAGDB._SCHEMA_NAME,),
+        ).fetchone()[0] == 60
+        assert not any(name.endswith("_v60") for name in tables)  # nosec B101
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []  # nosec B101
 
 
 def test_sqlite_v60_rejects_target_table_collision_without_version_change(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
@@ -21,6 +21,44 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
 pytestmark = pytest.mark.integration
 
 
+def _postgres_session_dataset_scope(db: CharactersRAGDB) -> str | None:
+    """Read and end the current connection's session-level dataset setting."""
+    conn = db.get_connection()
+    row = conn.execute(
+        "SELECT current_setting('app.current_dataset_id', true) AS dataset_id"
+    ).fetchone()
+    conn.rollback()
+    return row["dataset_id"] if row else None
+
+
+def test_postgres_task_operations_do_not_leak_dataset_scope_to_the_session(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "950000"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+
+    try:
+        note_id = db.add_note("Transaction-local task scope", "Body")
+        task = db.create_task(
+            owner_user_id=owner,
+            dataset_id="local-unbound",
+            note_id=note_id,
+            text="Do not leak RLS scope",
+        )
+        assert _postgres_session_dataset_scope(db) in (None, "")
+
+        assert db.get_task(
+            owner_user_id=owner,
+            dataset_id="local-unbound",
+            task_id=str(task["id"]),
+        )["id"] == task["id"]
+        assert _postgres_session_dataset_scope(db) in (None, "")
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
 def _restore_reviewed_postgres_v59_task_source(db: CharactersRAGDB) -> None:
     """Replace the fresh v60 task graph with the exact reviewed empty v59 source."""
     with db.transaction() as conn:

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
@@ -25,6 +25,7 @@ def _restore_reviewed_postgres_v59_task_source(db: CharactersRAGDB) -> None:
     """Replace the fresh v60 task graph with the exact reviewed empty v59 source."""
     with db.transaction() as conn:
         for table in (
+            "note_task_scope_authority",
             "task_projection_drifts",
             "task_event_read_state",
             "task_note_projections",
@@ -151,29 +152,63 @@ def _create_complete_postgres_local_task_graph(
     }
 
 
+def _seed_occupied_target_without_authority(
+    db: CharactersRAGDB,
+    *,
+    owner: str,
+    target: str,
+    note_id: str,
+) -> None:
+    """Create a deliberate split-scope fixture outside the guarded product path."""
+    db.execute_query(
+        "INSERT INTO note_task_scope_authority(owner_user_id,dataset_id) VALUES (?,?)",
+        (owner, target),
+    )
+    try:
+        db.create_task(
+            owner_user_id=owner,
+            dataset_id=target,
+            task_id=str(uuid4()),
+            note_id=note_id,
+            text="Occupied target",
+            actor_type=None,
+        )
+    finally:
+        db.execute_query(
+            "DELETE FROM note_task_scope_authority WHERE owner_user_id=?",
+            (owner,),
+        )
+
+
 def _postgres_task_force_flags(conn: Any) -> dict[str, bool]:
     rows = conn.execute(
         "SELECT relname,relforcerowsecurity FROM pg_class c "
         "JOIN pg_namespace n ON n.oid=c.relnamespace "
         "WHERE n.nspname=current_schema() AND c.relname=ANY(?)",
-        (list(CharactersRAGDB._NOTE_TASK_V60_TABLES),),
+        (list(CharactersRAGDB._NOTE_TASK_V60_RELATIONS),),
     ).fetchall()
     return {str(row["relname"]): bool(row["relforcerowsecurity"]) for row in rows}
 
 
-def _postgres_notes_authority_snapshot(backend: Any) -> tuple[tuple[object, ...], ...]:
+def _postgres_rls_authority_snapshot(
+    backend: Any,
+    *,
+    table: str,
+) -> tuple[tuple[object, ...], ...]:
     with backend.transaction() as conn:
         relation = backend.execute(
             "SELECT relrowsecurity,relforcerowsecurity,relowner=current_user::regrole "
             "AS is_table_owner,pg_has_role(current_user,n.nspowner,'USAGE') "
             "AS is_schema_owner FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace "
-            "WHERE n.nspname=current_schema() AND c.relname='notes'",
+            "WHERE n.nspname=current_schema() AND c.relname=?",
+            (table,),
             connection=conn,
         ).rows
         policies = backend.execute(
             "SELECT policyname,permissive,roles::text AS roles,cmd,qual,with_check "
-            "FROM pg_policies WHERE schemaname=current_schema() AND tablename='notes' "
+            "FROM pg_policies WHERE schemaname=current_schema() AND tablename=? "
             "ORDER BY policyname",
+            (table,),
             connection=conn,
         ).rows
     return (
@@ -221,13 +256,8 @@ def test_postgres_bind_local_task_graph_rejects_cross_owner_and_occupied_target(
             db.bind_local_task_graph_to_dataset(
                 owner_user_id="950022", target_dataset_id=target
             )
-        db.create_task(
-            owner_user_id=owner,
-            dataset_id=target,
-            task_id=str(uuid4()),
-            note_id=note_id,
-            text="Occupied target",
-            actor_type=None,
+        _seed_occupied_target_without_authority(
+            db, owner=owner, target=target, note_id=note_id
         )
         with pytest.raises(ConflictError, match="target collision"):
             db.bind_local_task_graph_to_dataset(
@@ -284,13 +314,8 @@ def test_postgres_bind_caught_collision_restores_force_in_caller_transaction(
 
     try:
         note_id, task_id, _counts = _create_complete_postgres_local_task_graph(db)
-        db.create_task(
-            owner_user_id=owner,
-            dataset_id=target,
-            task_id=str(uuid4()),
-            note_id=note_id,
-            text="Occupied target",
-            actor_type=None,
+        _seed_occupied_target_without_authority(
+            db, owner=owner, target=target, note_id=note_id
         )
         with db.transaction() as conn:
             with pytest.raises(ConflictError, match="target collision"):
@@ -300,7 +325,7 @@ def test_postgres_bind_caught_collision_restores_force_in_caller_transaction(
                     conn=conn,
                 )
             assert _postgres_task_force_flags(conn) == dict.fromkeys(
-                CharactersRAGDB._NOTE_TASK_V60_TABLES, True
+                CharactersRAGDB._NOTE_TASK_V60_RELATIONS, True
             )
 
         assert db.get_task(
@@ -341,7 +366,7 @@ def test_postgres_bind_caught_hash_failure_rolls_back_rekey_and_restores_force(
                     conn=conn,
                 )
             assert _postgres_task_force_flags(conn) == dict.fromkeys(
-                CharactersRAGDB._NOTE_TASK_V60_TABLES, True
+                CharactersRAGDB._NOTE_TASK_V60_RELATIONS, True
             )
 
         assert db.get_task(
@@ -372,12 +397,12 @@ def test_postgres_note_task_schema_v60_is_authoritative(
                 "SELECT tablename, policyname FROM pg_policies "
                 "WHERE schemaname = current_schema() AND tablename = ANY(?) "
                 "ORDER BY tablename, policyname",
-                (list(CharactersRAGDB._NOTE_TASK_V60_TABLES),),
+                (list(CharactersRAGDB._NOTE_TASK_V60_RELATIONS),),
             ).fetchall()
         assert version == 60
         assert [(row["tablename"], row["policyname"]) for row in policy_rows] == [
             (table, f"{table}_tenant_isolation")
-            for table in sorted(CharactersRAGDB._NOTE_TASK_V60_TABLES)
+            for table in sorted(CharactersRAGDB._NOTE_TASK_V60_RELATIONS)
         ]
     finally:
         db.close_all_connections()
@@ -412,13 +437,65 @@ def test_postgres_current_v60_rejects_notes_authority_drift_without_repair(
         with db.transaction() as conn:
             for statement in drift_statements:
                 conn.execute(statement)
-        drifted = _postgres_notes_authority_snapshot(backend)
+        drifted = _postgres_rls_authority_snapshot(backend, table="notes")
         db.close_all_connections()
         drift_backend = DatabaseBackendFactory.create_backend(pg_database_config)
         with pytest.raises(CharactersRAGDBError, match="ownership or RLS|policy catalog"):
             startup_db = CharactersRAGDB(":memory:", client_id=owner, backend=drift_backend)
         observer_backend = DatabaseBackendFactory.create_backend(pg_database_config)
-        assert _postgres_notes_authority_snapshot(observer_backend) == drifted
+        assert _postgres_rls_authority_snapshot(observer_backend, table="notes") == drifted
+    finally:
+        if startup_db is not None:
+            startup_db.close_all_connections()
+        db.close_all_connections()
+        backend.get_pool().close_all()
+        if drift_backend is not None:
+            drift_backend.get_pool().close_all()
+        if observer_backend is not None:
+            observer_backend.get_pool().close_all()
+
+
+@pytest.mark.parametrize(
+    "drift_statements",
+    (
+        ("ALTER TABLE note_task_scope_authority NO FORCE ROW LEVEL SECURITY",),
+        ("DROP POLICY note_task_scope_authority_tenant_isolation ON note_task_scope_authority",),
+        (
+            "CREATE POLICY note_task_scope_authority_open ON note_task_scope_authority "
+            "USING (true) WITH CHECK (true)",
+        ),
+        (
+            "DROP POLICY note_task_scope_authority_tenant_isolation "
+            "ON note_task_scope_authority",
+            "CREATE POLICY note_task_scope_authority_tenant_isolation "
+            "ON note_task_scope_authority USING (true) WITH CHECK (true)",
+        ),
+    ),
+    ids=("no-force", "missing-policy", "extra-policy", "weakened-policy"),
+)
+def test_postgres_current_v60_rejects_scope_authority_drift_without_repair(
+    pg_database_config: DatabaseConfig,
+    drift_statements: tuple[str, ...],
+) -> None:
+    owner = "950028"
+    table = "note_task_scope_authority"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+    drift_backend = None
+    observer_backend = None
+    startup_db = None
+
+    try:
+        with db.transaction() as conn:
+            for statement in drift_statements:
+                conn.execute(statement)
+        drifted = _postgres_rls_authority_snapshot(backend, table=table)
+        db.close_all_connections()
+        drift_backend = DatabaseBackendFactory.create_backend(pg_database_config)
+        with pytest.raises(CharactersRAGDBError, match="ownership or RLS|policy catalog"):
+            startup_db = CharactersRAGDB(":memory:", client_id=owner, backend=drift_backend)
+        observer_backend = DatabaseBackendFactory.create_backend(pg_database_config)
+        assert _postgres_rls_authority_snapshot(observer_backend, table=table) == drifted
     finally:
         if startup_db is not None:
             startup_db.close_all_connections()
@@ -441,6 +518,10 @@ def test_postgres_dataset_cursor_page_uses_exact_index(
     note_id = db.add_note("Cursor parent", "Body")
 
     try:
+        db.bind_local_task_graph_to_dataset(
+            owner_user_id=owner,
+            target_dataset_id=dataset_id,
+        )
         with db.transaction() as conn:
             for cursor in range(1, 65):
                 target_event = db.record_task_event(
@@ -456,6 +537,15 @@ def test_postgres_dataset_cursor_page_uses_exact_index(
                     "WHERE owner_user_id=? AND dataset_id=? AND id=?",
                     (cursor, owner, dataset_id, target_event["id"]),
                 )
+            conn.execute(
+                "UPDATE note_task_scope_authority SET dataset_id=? WHERE owner_user_id=?",
+                (other_dataset_id, owner),
+            )
+            conn.execute(
+                "SELECT set_config('app.current_dataset_id', ?, true)",
+                (other_dataset_id,),
+            )
+            for cursor in range(1, 65):
                 other_event = db.record_task_event(
                     owner_user_id=owner,
                     dataset_id=other_dataset_id,
@@ -469,6 +559,10 @@ def test_postgres_dataset_cursor_page_uses_exact_index(
                     "WHERE owner_user_id=? AND dataset_id=? AND id=?",
                     (cursor, owner, other_dataset_id, other_event["id"]),
                 )
+            conn.execute(
+                "UPDATE note_task_scope_authority SET dataset_id=? WHERE owner_user_id=?",
+                (dataset_id, owner),
+            )
             conn.execute("ANALYZE task_events")
             conn.execute("SELECT set_config('app.current_dataset_id', ?, true)", (dataset_id,))
             conn.execute("SET LOCAL enable_seqscan=off")
@@ -520,6 +614,14 @@ def test_postgres_note_tasks_allow_same_id_for_two_owners(
     try:
         db_a.add_note("Owner A", "Body", note_id=note_a)
         db_b.add_note("Owner B", "Body", note_id=note_b)
+        db_a.bind_local_task_graph_to_dataset(
+            owner_user_id=owner_a,
+            target_dataset_id=dataset_id,
+        )
+        db_b.bind_local_task_graph_to_dataset(
+            owner_user_id=owner_b,
+            target_dataset_id=dataset_id,
+        )
         first = db_a.create_task(
             owner_user_id=owner_a,
             dataset_id=dataset_id,
@@ -536,14 +638,15 @@ def test_postgres_note_tasks_allow_same_id_for_two_owners(
             text="Same ID",
             actor_type=None,
         )
-        third = db_a.create_task(
-            owner_user_id=owner_a,
-            dataset_id=other_dataset_id,
-            task_id=task_id,
-            note_id=note_a,
-            text="Same ID, other dataset",
-            actor_type=None,
-        )
+        with pytest.raises(ConflictError, match="bound authority"):
+            db_a.create_task(
+                owner_user_id=owner_a,
+                dataset_id=other_dataset_id,
+                task_id=task_id,
+                note_id=note_a,
+                text="Same ID, other dataset",
+                actor_type=None,
+            )
         event_a = db_a.record_task_event(
             owner_user_id=owner_a,
             dataset_id=dataset_id,
@@ -575,7 +678,6 @@ def test_postgres_note_tasks_allow_same_id_for_two_owners(
 
         assert first["owner_user_id"] == owner_a
         assert second["owner_user_id"] == owner_b
-        assert third["dataset_id"] == other_dataset_id
         assert db_a.get_task(
             owner_user_id=owner_a,
             dataset_id=dataset_id,
@@ -599,6 +701,10 @@ def test_postgres_note_tasks_allow_same_id_for_two_owners(
                     f"GRANT SELECT, INSERT, UPDATE ON {ident(table)} TO {ident(role_name)}",
                     connection=conn,
                 )
+            backend_a.execute(
+                f"GRANT SELECT ON note_task_scope_authority TO {ident(role_name)}",
+                connection=conn,
+            )
             backend_a.execute(f"GRANT {ident(role_name)} TO CURRENT_USER", connection=conn)
         role_created = True
 
@@ -615,6 +721,13 @@ def test_postgres_note_tasks_allow_same_id_for_two_owners(
                 connection=conn,
             ).rows[0]
             assert principal == {"rolsuper": False, "rolbypassrls": False}
+            visible_authority = backend_a.execute(
+                "SELECT owner_user_id,dataset_id FROM note_task_scope_authority",
+                connection=conn,
+            ).rows
+            assert visible_authority == [
+                {"owner_user_id": owner_a, "dataset_id": dataset_id}
+            ]
             visible_tasks = backend_a.execute(
                 "SELECT owner_user_id,note_id FROM note_tasks WHERE id=?", (task_id,), connection=conn
             ).rows
@@ -831,7 +944,7 @@ def _populate_reviewed_postgres_v59_source(
 
 
 def _postgres_v60_task_catalog_snapshot(db: CharactersRAGDB) -> dict[str, object]:
-    tables = list(CharactersRAGDB._NOTE_TASK_V60_TABLES)
+    tables = list(CharactersRAGDB._NOTE_TASK_V60_RELATIONS)
     with db.transaction() as conn:
         relation_rows = conn.execute(
             "SELECT relname,relrowsecurity,relforcerowsecurity FROM pg_class c "
@@ -895,8 +1008,9 @@ def _postgres_v59_source_snapshot(db: CharactersRAGDB) -> dict[str, object]:
     }
     collision_names = (
         "task_projection_drifts",
+        "note_task_scope_authority",
         "uq_notes_owner_id",
-        *(f"{table}_v60" for table in CharactersRAGDB._NOTE_TASK_V60_TABLES),
+        *(f"{table}_v60" for table in CharactersRAGDB._NOTE_TASK_V60_RELATIONS),
     )
     with db.transaction() as conn:
         version = conn.execute(

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -150,6 +151,16 @@ def _create_complete_postgres_local_task_graph(
     }
 
 
+def _postgres_task_force_flags(conn: Any) -> dict[str, bool]:
+    rows = conn.execute(
+        "SELECT relname,relforcerowsecurity FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid=c.relnamespace "
+        "WHERE n.nspname=current_schema() AND c.relname=ANY(?)",
+        (list(CharactersRAGDB._NOTE_TASK_V60_TABLES),),
+    ).fetchall()
+    return {str(row["relname"]): bool(row["relforcerowsecurity"]) for row in rows}
+
+
 def test_postgres_bind_local_task_graph_rekeys_complete_six_table_scope(
     pg_database_config: DatabaseConfig,
 ) -> None:
@@ -237,6 +248,87 @@ def test_postgres_bind_local_task_graph_rejects_inconsistent_parent_scope(
         assert db.get_task(
             owner_user_id=owner, dataset_id="local-unbound", task_id=task_id
         )["id"] == task_id
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_bind_caught_collision_restores_force_in_caller_transaction(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "950024"
+    target = f"dataset-{uuid4()}"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+
+    try:
+        note_id, task_id, _counts = _create_complete_postgres_local_task_graph(db)
+        db.create_task(
+            owner_user_id=owner,
+            dataset_id=target,
+            task_id=str(uuid4()),
+            note_id=note_id,
+            text="Occupied target",
+            actor_type=None,
+        )
+        with db.transaction() as conn:
+            with pytest.raises(ConflictError, match="target collision"):
+                db.bind_local_task_graph_to_dataset(
+                    owner_user_id=owner,
+                    target_dataset_id=target,
+                    conn=conn,
+                )
+            assert _postgres_task_force_flags(conn) == dict.fromkeys(
+                CharactersRAGDB._NOTE_TASK_V60_TABLES, True
+            )
+
+        assert db.get_task(
+            owner_user_id=owner, dataset_id="local-unbound", task_id=task_id
+        )["id"] == task_id
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_bind_caught_hash_failure_rolls_back_rekey_and_restores_force(
+    pg_database_config: DatabaseConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = "950025"
+    target = f"dataset-{uuid4()}"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+
+    try:
+        _note_id, task_id, _counts = _create_complete_postgres_local_task_graph(db)
+        original_hash = db._note_task_v60_hash
+        hash_calls = 0
+
+        def drift_rebound_hash(value: object) -> str:
+            nonlocal hash_calls
+            hash_calls += 1
+            digest = original_hash(value)
+            rebound_start = 3 * len(CharactersRAGDB._NOTE_TASK_V60_TABLES)
+            return f"{digest}-drift" if hash_calls > rebound_start else digest
+
+        monkeypatch.setattr(db, "_note_task_v60_hash", drift_rebound_hash)
+        with db.transaction() as conn:
+            with pytest.raises(ConflictError, match="complete-set verification"):
+                db.bind_local_task_graph_to_dataset(
+                    owner_user_id=owner,
+                    target_dataset_id=target,
+                    conn=conn,
+                )
+            assert _postgres_task_force_flags(conn) == dict.fromkeys(
+                CharactersRAGDB._NOTE_TASK_V60_TABLES, True
+            )
+
+        assert db.get_task(
+            owner_user_id=owner, dataset_id="local-unbound", task_id=task_id
+        )["id"] == task_id
+        assert db.get_task(
+            owner_user_id=owner, dataset_id=target, task_id=task_id
+        ) is None
     finally:
         db.close_all_connections()
         backend.get_pool().close_all()

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
@@ -2,15 +2,244 @@
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
 
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig, DatabaseError
 from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    CharactersRAGDBError,
+    ConflictError,
+    SchemaError,
+)
 
 pytestmark = pytest.mark.integration
+
+
+def _restore_reviewed_postgres_v59_task_source(db: CharactersRAGDB) -> None:
+    """Replace the fresh v60 task graph with the exact reviewed empty v59 source."""
+    with db.transaction() as conn:
+        for table in (
+            "task_projection_drifts",
+            "task_event_read_state",
+            "task_note_projections",
+            "note_task_reconciliation_state",
+            "task_events",
+            "note_tasks",
+        ):
+            db.backend.execute(f"DROP TABLE {table}", connection=conn)  # nosec B608
+        db.backend.execute("DROP INDEX uq_notes_owner_id", connection=conn)
+        statements = db._convert_sqlite_schema_to_postgres_statements(
+            db._MIGRATION_SQL_V47_TO_V48_POSTGRES
+        )
+        for statement in statements:
+            if not statement.lstrip().upper().startswith("UPDATE DB_SCHEMA_VERSION"):
+                db.backend.execute(statement, connection=conn)
+        db._set_schema_version_postgres(conn, 59)
+
+
+@pytest.mark.parametrize(
+    "drift_sql",
+    (
+        "ALTER TABLE notes NO FORCE ROW LEVEL SECURITY",
+        "ALTER TABLE note_tasks ENABLE ROW LEVEL SECURITY",
+        "DROP POLICY notes_tenant_isolation ON notes",
+        "CREATE POLICY note_tasks_open ON note_tasks USING (true) WITH CHECK (true)",
+        "CREATE POLICY notes_open ON notes USING (true) WITH CHECK (true)",
+    ),
+)
+def test_postgres_v59_source_authority_drift_fails_before_migration_ddl(
+    pg_database_config: DatabaseConfig,
+    drift_sql: str,
+) -> None:
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id="950000", backend=backend)
+
+    try:
+        _restore_reviewed_postgres_v59_task_source(db)
+        with db.transaction() as conn:
+            backend.execute(drift_sql, connection=conn)
+
+        with pytest.raises(SchemaError, match="v59 PostgreSQL source authority"):
+            with db.transaction() as conn:
+                db._migrate_from_v59_to_v60_postgres(conn)
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def _create_complete_postgres_local_task_graph(
+    db: CharactersRAGDB,
+) -> tuple[str, str, dict[str, int]]:
+    owner = str(db.client_id)
+    note_id = str(uuid4())
+    task_id = str(uuid4())
+    db.add_note("Bound task", "- [ ] Bind this task\n", note_id=note_id)
+    task = db.create_task(
+        owner_user_id=owner,
+        dataset_id="local-unbound",
+        task_id=task_id,
+        note_id=note_id,
+        text="Bind this task",
+        actor_type="user",
+    )
+    db.set_task_projection(
+        owner_user_id=owner,
+        dataset_id="local-unbound",
+        task_id=task_id,
+        note_id=note_id,
+        note_version=1,
+        line_number=1,
+        start_offset=0,
+        end_offset=20,
+        normalized_text_hash="sha256:bind",
+        occurrence_index=0,
+        block_fingerprint="bind-block",
+        raw_line="- [ ] Bind this task",
+        has_child_content=False,
+    )
+    event = db.record_task_event(
+        owner_user_id=owner,
+        dataset_id="local-unbound",
+        task_id=task_id,
+        note_id=note_id,
+        event_type="updated",
+        actor_type="user",
+    )
+    db.mark_task_activity_read(
+        owner_user_id=owner,
+        dataset_id="local-unbound",
+        event_id=event["id"],
+        user_id=owner,
+    )
+    db.set_reconciliation_state(
+        owner_user_id=owner,
+        dataset_id="local-unbound",
+        note_id=note_id,
+        note_version=1,
+        status="clean",
+        item_count=1,
+        warning_count=0,
+    )
+    with db.transaction() as conn:
+        conn.execute("SELECT set_config('app.current_dataset_id', ?, true)", ("local-unbound",))
+        conn.execute(
+            """
+            INSERT INTO task_projection_drifts(
+                owner_user_id,dataset_id,id,note_id,task_id,marker_base_revision,
+                marker_base_hash,reason_code,status,created_at,updated_at
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                owner, "local-unbound", str(uuid4()), note_id, task_id, 1,
+                task["canonical_hash"], "both_changed", "open",
+                task["created_at"], task["updated_at"],
+            ),
+        )
+    return note_id, task_id, {
+        "note_tasks": 1,
+        "task_note_projections": 1,
+        "task_events": 2,
+        "task_event_read_state": 1,
+        "note_task_reconciliation_state": 1,
+        "task_projection_drifts": 1,
+    }
+
+
+def test_postgres_bind_local_task_graph_rekeys_complete_six_table_scope(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "950020"
+    target = f"dataset-{uuid4()}"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+
+    try:
+        _note_id, task_id, expected_counts = _create_complete_postgres_local_task_graph(db)
+
+        assert db.bind_local_task_graph_to_dataset(
+            owner_user_id=owner, target_dataset_id=target
+        ) == expected_counts
+        assert db.get_task(
+            owner_user_id=owner, dataset_id="local-unbound", task_id=task_id
+        ) is None
+        assert db.get_task(
+            owner_user_id=owner, dataset_id=target, task_id=task_id
+        )["id"] == task_id
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_bind_local_task_graph_rejects_cross_owner_and_occupied_target(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "950021"
+    target = f"dataset-{uuid4()}"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+
+    try:
+        note_id, task_id, _counts = _create_complete_postgres_local_task_graph(db)
+        with pytest.raises(ConflictError, match="authenticated PostgreSQL client"):
+            db.bind_local_task_graph_to_dataset(
+                owner_user_id="950022", target_dataset_id=target
+            )
+        db.create_task(
+            owner_user_id=owner,
+            dataset_id=target,
+            task_id=str(uuid4()),
+            note_id=note_id,
+            text="Occupied target",
+            actor_type=None,
+        )
+        with pytest.raises(ConflictError, match="target collision"):
+            db.bind_local_task_graph_to_dataset(
+                owner_user_id=owner, target_dataset_id=target
+            )
+        assert db.get_task(
+            owner_user_id=owner, dataset_id="local-unbound", task_id=task_id
+        )["id"] == task_id
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_bind_local_task_graph_rejects_inconsistent_parent_scope(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "950023"
+    target = f"dataset-{uuid4()}"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+
+    try:
+        _note_id, task_id, _counts = _create_complete_postgres_local_task_graph(db)
+        other_note_id = str(uuid4())
+        db.add_note("Wrong parent", "Body", note_id=other_note_id)
+        with db.transaction() as conn:
+            conn.execute("ALTER TABLE task_note_projections NO FORCE ROW LEVEL SECURITY")
+            conn.execute(
+                "UPDATE task_note_projections SET note_id = ? "
+                "WHERE owner_user_id = ? AND dataset_id = ? AND task_id = ?",
+                (other_note_id, owner, "local-unbound", task_id),
+            )
+            conn.execute("ALTER TABLE task_note_projections FORCE ROW LEVEL SECURITY")
+
+        with pytest.raises(ConflictError, match="parent proof"):
+            db.bind_local_task_graph_to_dataset(
+                owner_user_id=owner, target_dataset_id=target
+            )
+        assert db.get_task(
+            owner_user_id=owner, dataset_id="local-unbound", task_id=task_id
+        )["id"] == task_id
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
 
 
 def test_postgres_note_task_schema_v60_is_authoritative(
@@ -259,3 +488,390 @@ def test_postgres_note_tasks_allow_same_id_for_two_owners(
         db_b.close_all_connections()
         backend_a.get_pool().close_all()
         backend_b.get_pool().close_all()
+
+
+@pytest.mark.parametrize(
+    "replacement_sql",
+    [
+        "CREATE INDEX idx_note_tasks_scope_projection ON note_tasks("
+        "owner_user_id,dataset_id,projection_status,deleted,id) INCLUDE(text)",
+        "CREATE INDEX idx_note_tasks_scope_projection ON note_tasks("
+        "owner_user_id,dataset_id,projection_status,deleted,id DESC NULLS FIRST)",
+        "CREATE INDEX idx_note_tasks_scope_projection ON note_tasks("
+        "owner_user_id text_pattern_ops,dataset_id,projection_status,deleted,id)",
+        "CREATE INDEX idx_note_tasks_scope_projection ON note_tasks("
+        "owner_user_id COLLATE \"C\",dataset_id,projection_status,deleted,id)",
+        "CREATE INDEX idx_note_tasks_scope_projection ON note_tasks("
+        "(lower(owner_user_id)),dataset_id,projection_status,deleted,id)",
+    ],
+    ids=("include", "descending-nulls", "opclass", "collation", "expression"),
+)
+def test_postgres_note_task_current_v60_rejects_full_index_shape_drift(
+    pg_database_config: DatabaseConfig,
+    replacement_sql: str,
+) -> None:
+    owner = "950021"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+
+    try:
+        with db.transaction() as conn:
+            canonical = conn.execute(
+                "SELECT pg_get_indexdef(indexrelid,0,true) AS definition "
+                "FROM pg_index WHERE indexrelid='idx_note_tasks_scope_projection'::regclass"
+            ).fetchone()["definition"]
+            assert canonical == (
+                "CREATE INDEX idx_note_tasks_scope_projection ON note_tasks USING btree "
+                "(owner_user_id, dataset_id, projection_status, deleted, id)"
+            )
+            conn.execute("DROP INDEX idx_note_tasks_scope_projection")
+            conn.execute(replacement_sql)
+        db.close_all_connections()
+        drift_backend = DatabaseBackendFactory.create_backend(pg_database_config)
+
+        try:
+            with pytest.raises(CharactersRAGDBError, match="index catalog drifted"):
+                CharactersRAGDB(":memory:", client_id=owner, backend=drift_backend)
+        finally:
+            drift_backend.get_pool().close_all()
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def _populate_reviewed_postgres_v59_source(
+    db: CharactersRAGDB,
+) -> tuple[str, str, str]:
+    owner = str(db.client_id)
+    note_id = str(uuid4())
+    task_id = str(uuid4())
+    event_id = str(uuid4())
+    timestamp = "2026-08-14T00:00:00+00:00"
+    db.add_note("Legacy task", "- [ ] Migrate this task\n", note_id=note_id)
+    with db.transaction() as conn:
+        conn.execute(
+            """
+            INSERT INTO note_tasks(
+                id,note_id,text,status,metadata_json,projection_status,deleted,
+                created_at,updated_at,completed_at,client_id,version
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                task_id, note_id, "Migrate this task", "open", "{}", "live", False,
+                timestamp, timestamp, None, owner, 1,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO task_note_projections(
+                task_id,note_id,note_version,line_number,start_offset,end_offset,
+                normalized_text_hash,occurrence_index,block_fingerprint,raw_line,
+                has_child_content,projection_status,updated_at
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                task_id, note_id, 1, 1, 0, 23, "sha256:legacy", 0,
+                "legacy-block", "- [ ] Migrate this task", False, "live", timestamp,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO task_events(
+                id,task_id,note_id,event_type,actor_type,actor_id,tool_name,policy_mode,
+                approval_id,old_value_json,new_value_json,created_at,client_id
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                event_id, task_id, note_id, "created", "user", owner, None, None,
+                None, None, "{}", timestamp, owner,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_event_read_state(event_id,user_id,read_at,dismissed_at) "
+            "VALUES (?,?,?,?)",
+            (event_id, owner, timestamp, None),
+        )
+        conn.execute(
+            """
+            INSERT INTO note_task_reconciliation_state(
+                note_id,note_version,status,reconciled_at,item_count,warning_count,cursor
+            ) VALUES (?,?,?,?,?,?,?)
+            """,
+            (note_id, 1, "clean", timestamp, 1, 0, "legacy-cursor"),
+        )
+    return note_id, task_id, event_id
+
+
+def _postgres_v60_task_catalog_snapshot(db: CharactersRAGDB) -> dict[str, object]:
+    tables = list(CharactersRAGDB._NOTE_TASK_V60_TABLES)
+    with db.transaction() as conn:
+        relation_rows = conn.execute(
+            "SELECT relname,relrowsecurity,relforcerowsecurity FROM pg_class c "
+            "JOIN pg_namespace n ON n.oid=c.relnamespace "
+            "WHERE n.nspname=current_schema() AND c.relname=ANY(?) ORDER BY relname",
+            (tables,),
+        ).fetchall()
+        column_rows = conn.execute(
+            "SELECT c.relname,a.attnum,a.attname,format_type(a.atttypid,a.atttypmod) AS type,"
+            "a.attnotnull,pg_get_expr(d.adbin,d.adrelid,false) AS default_expression "
+            "FROM pg_attribute a JOIN pg_class c ON c.oid=a.attrelid "
+            "JOIN pg_namespace n ON n.oid=c.relnamespace "
+            "LEFT JOIN pg_attrdef d ON d.adrelid=c.oid AND d.adnum=a.attnum "
+            "WHERE n.nspname=current_schema() AND c.relname=ANY(?) "
+            "AND a.attnum>0 AND NOT a.attisdropped ORDER BY c.relname,a.attnum",
+            (tables,),
+        ).fetchall()
+        constraint_rows = conn.execute(
+            "SELECT c.relname,k.conname,k.contype,k.convalidated,"
+            "pg_get_constraintdef(k.oid,false) AS definition "
+            "FROM pg_constraint k JOIN pg_class c ON c.oid=k.conrelid "
+            "JOIN pg_namespace n ON n.oid=c.relnamespace "
+            "WHERE n.nspname=current_schema() AND c.relname=ANY(?) AND k.contype<>'n' "
+            "ORDER BY c.relname,k.conname",
+            (tables,),
+        ).fetchall()
+        index_rows = conn.execute(
+            "SELECT table_row.relname,index_row.relname AS index_name,"
+            "pg_get_indexdef(i.indexrelid,0,true) AS definition "
+            "FROM pg_index i JOIN pg_class table_row ON table_row.oid=i.indrelid "
+            "JOIN pg_class index_row ON index_row.oid=i.indexrelid "
+            "JOIN pg_namespace n ON n.oid=table_row.relnamespace "
+            "WHERE n.nspname=current_schema() AND (table_row.relname=ANY(?) OR "
+            "index_row.relname='uq_notes_owner_id') ORDER BY table_row.relname,index_row.relname",
+            (tables,),
+        ).fetchall()
+        policy_rows = conn.execute(
+            "SELECT tablename,policyname,permissive,roles::text,cmd,qual,with_check "
+            "FROM pg_policies WHERE schemaname=current_schema() AND tablename=ANY(?) "
+            "ORDER BY tablename,policyname",
+            (tables,),
+        ).fetchall()
+    return {
+        "relations": [dict(row) for row in relation_rows],
+        "columns": [dict(row) for row in column_rows],
+        "constraints": [dict(row) for row in constraint_rows],
+        "indexes": [dict(row) for row in index_rows],
+        "policies": [dict(row) for row in policy_rows],
+    }
+
+
+def _postgres_v59_source_snapshot(db: CharactersRAGDB) -> dict[str, object]:
+    source_tables = ("notes", *CharactersRAGDB._NOTE_TASK_V60_TABLES[:-1])
+    legacy_tables = CharactersRAGDB._NOTE_TASK_V60_TABLES[:-1]
+    data_order = {
+        "note_tasks": "id",
+        "task_note_projections": "task_id",
+        "task_events": "id",
+        "task_event_read_state": "event_id,user_id",
+        "note_task_reconciliation_state": "note_id",
+    }
+    collision_names = (
+        "task_projection_drifts",
+        "uq_notes_owner_id",
+        *(f"{table}_v60" for table in CharactersRAGDB._NOTE_TASK_V60_TABLES),
+    )
+    with db.transaction() as conn:
+        version = conn.execute(
+            "SELECT version FROM db_schema_version WHERE schema_name=?",
+            (CharactersRAGDB._SCHEMA_NAME,),
+        ).fetchone()["version"]
+        relations = conn.execute(
+            "SELECT c.relname,c.relrowsecurity,c.relforcerowsecurity "
+            "FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace "
+            "WHERE n.nspname=current_schema() AND c.relname=ANY(?) ORDER BY c.relname",
+            (list(source_tables),),
+        ).fetchall()
+        policies = conn.execute(
+            "SELECT tablename,policyname,permissive,roles::text,cmd,qual,with_check "
+            "FROM pg_policies WHERE schemaname=current_schema() AND tablename=ANY(?) "
+            "ORDER BY tablename,policyname",
+            (list(source_tables),),
+        ).fetchall()
+        constraints = conn.execute(
+            "SELECT c.relname,k.conname,pg_get_constraintdef(k.oid,false) AS definition "
+            "FROM pg_constraint k JOIN pg_class c ON c.oid=k.conrelid "
+            "JOIN pg_namespace n ON n.oid=c.relnamespace "
+            "WHERE n.nspname=current_schema() AND c.relname=ANY(?) AND k.contype<>'n' "
+            "ORDER BY c.relname,k.conname",
+            (list(legacy_tables),),
+        ).fetchall()
+        data = {
+            table: [dict(row) for row in conn.execute(
+                f"SELECT * FROM {table} ORDER BY {ordering}"  # nosec B608
+            ).fetchall()]
+            for table, ordering in data_order.items()
+        }
+        notes = conn.execute("SELECT id,client_id FROM notes ORDER BY id").fetchall()
+        remnants = conn.execute(
+            "SELECT c.relname FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace "
+            "WHERE n.nspname=current_schema() AND c.relname=ANY(?) ORDER BY c.relname",
+            (list(collision_names),),
+        ).fetchall()
+    return db._note_task_v60_json_safe(
+        {
+            "version": version,
+            "relations": [dict(row) for row in relations],
+            "policies": [dict(row) for row in policies],
+            "constraints": [dict(row) for row in constraints],
+            "data": data,
+            "notes": [dict(row) for row in notes],
+            "target_remnants": [dict(row) for row in remnants],
+        }
+    )
+
+
+def test_postgres_populated_v59_upgrade_matches_fresh_v60_catalog(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "950030"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+
+    try:
+        fresh_catalog = _postgres_v60_task_catalog_snapshot(db)
+        _restore_reviewed_postgres_v59_task_source(db)
+        note_id, task_id, event_id = _populate_reviewed_postgres_v59_source(db)
+        with db.transaction() as conn:
+            db._migrate_from_v59_to_v60_postgres(conn)
+
+        assert _postgres_v60_task_catalog_snapshot(db) == fresh_catalog
+        with db.transaction() as conn:
+            db._verify_note_task_schema_postgres(conn)
+            task = conn.execute(
+                "SELECT owner_user_id,dataset_id,id,note_id FROM note_tasks WHERE id=?",
+                (task_id,),
+            ).fetchone()
+            event = conn.execute(
+                "SELECT owner_user_id,dataset_id,id,note_id FROM task_events WHERE id=?",
+                (event_id,),
+            ).fetchone()
+        assert dict(task) == {
+            "owner_user_id": owner,
+            "dataset_id": "local-unbound",
+            "id": task_id,
+            "note_id": note_id,
+        }
+        assert dict(event) == {
+            "owner_user_id": owner,
+            "dataset_id": "local-unbound",
+            "id": event_id,
+            "note_id": note_id,
+        }
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+@pytest.mark.parametrize("stage", ("validate", "create", "copy", "index", "verify"))
+def test_postgres_v60_checkpoint_failure_restores_exact_populated_v59_state(
+    pg_database_config: DatabaseConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    stage: str,
+) -> None:
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id="950031", backend=backend)
+
+    try:
+        _restore_reviewed_postgres_v59_task_source(db)
+        _populate_reviewed_postgres_v59_source(db)
+        before = _postgres_v59_source_snapshot(db)
+        assert before["version"] == 59
+        assert before["target_remnants"] == []
+
+        def fail_at_stage(_db: CharactersRAGDB, current_stage: str) -> None:
+            if current_stage == stage:
+                raise SchemaError(f"injected PostgreSQL v60 {stage} failure")
+
+        monkeypatch.setattr(
+            CharactersRAGDB,
+            "_note_task_v60_migration_checkpoint",
+            fail_at_stage,
+        )
+        with pytest.raises(SchemaError, match=f"injected PostgreSQL v60 {stage} failure"):
+            with db.transaction() as conn:
+                db._migrate_from_v59_to_v60_postgres(conn)
+
+        assert _postgres_v59_source_snapshot(db) == before
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_concurrent_v59_initializers_serialize_one_migration(
+    pg_database_config: DatabaseConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = "950032"
+    setup_backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    setup_db = CharactersRAGDB(":memory:", client_id=owner, backend=setup_backend)
+    _restore_reviewed_postgres_v59_task_source(setup_db)
+    _populate_reviewed_postgres_v59_source(setup_db)
+    setup_db.close_all_connections()
+    setup_backend.get_pool().close_all()
+
+    barrier = threading.Barrier(2)
+    record_lock = threading.Lock()
+    checkpoints: list[str] = []
+    verify_threads: list[int] = []
+    original_checkpoint = CharactersRAGDB._note_task_v60_migration_checkpoint
+    original_verify = CharactersRAGDB._verify_note_task_schema_postgres
+
+    def track_checkpoint(_db: CharactersRAGDB, stage: str) -> None:
+        with record_lock:
+            checkpoints.append(stage)
+        original_checkpoint(stage)
+
+    def track_verify(db: CharactersRAGDB, conn: object) -> None:
+        with record_lock:
+            verify_threads.append(threading.get_ident())
+        original_verify(db, conn)
+
+    monkeypatch.setattr(
+        CharactersRAGDB,
+        "_note_task_v60_migration_checkpoint",
+        track_checkpoint,
+    )
+    monkeypatch.setattr(
+        CharactersRAGDB,
+        "_verify_note_task_schema_postgres",
+        track_verify,
+    )
+
+    def initialize() -> int:
+        backend = DatabaseBackendFactory.create_backend(pg_database_config)
+        barrier.wait(timeout=30)
+        db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+        try:
+            with db.transaction() as conn:
+                return db._get_schema_version_postgres(conn)
+        finally:
+            db.close_all_connections()
+            backend.get_pool().close_all()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(initialize) for _index in range(2)]
+        versions = [future.result(timeout=120) for future in futures]
+
+    assert versions == [60, 60]
+    assert checkpoints == ["validate", "create", "copy", "index", "verify"]
+    assert len(verify_threads) == 2
+    assert len(set(verify_threads)) == 2
+
+    check_backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    try:
+        with check_backend.transaction() as conn:
+            version = check_backend.execute(
+                "SELECT version FROM db_schema_version WHERE schema_name=%s",
+                (CharactersRAGDB._SCHEMA_NAME,),
+                connection=conn,
+            ).scalar
+            remnants = check_backend.execute(
+                "SELECT relname FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace "
+                "WHERE n.nspname=current_schema() AND relname LIKE %s",
+                ("%_v60",),
+                connection=conn,
+            ).rows
+        assert version == 60
+        assert remnants == []
+    finally:
+        check_backend.get_pool().close_all()

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
@@ -161,6 +161,27 @@ def _postgres_task_force_flags(conn: Any) -> dict[str, bool]:
     return {str(row["relname"]): bool(row["relforcerowsecurity"]) for row in rows}
 
 
+def _postgres_notes_authority_snapshot(backend: Any) -> tuple[tuple[object, ...], ...]:
+    with backend.transaction() as conn:
+        relation = backend.execute(
+            "SELECT relrowsecurity,relforcerowsecurity,relowner=current_user::regrole "
+            "AS is_table_owner,pg_has_role(current_user,n.nspowner,'USAGE') "
+            "AS is_schema_owner FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace "
+            "WHERE n.nspname=current_schema() AND c.relname='notes'",
+            connection=conn,
+        ).rows
+        policies = backend.execute(
+            "SELECT policyname,permissive,roles::text AS roles,cmd,qual,with_check "
+            "FROM pg_policies WHERE schemaname=current_schema() AND tablename='notes' "
+            "ORDER BY policyname",
+            connection=conn,
+        ).rows
+    return (
+        tuple(relation[0].values()),
+        *(tuple(row.values()) for row in policies),
+    )
+
+
 def test_postgres_bind_local_task_graph_rekeys_complete_six_table_scope(
     pg_database_config: DatabaseConfig,
 ) -> None:
@@ -358,6 +379,121 @@ def test_postgres_note_task_schema_v60_is_authoritative(
             (table, f"{table}_tenant_isolation")
             for table in sorted(CharactersRAGDB._NOTE_TASK_V60_TABLES)
         ]
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+@pytest.mark.parametrize(
+    "drift_statements",
+    (
+        ("ALTER TABLE notes NO FORCE ROW LEVEL SECURITY",),
+        ("DROP POLICY notes_tenant_isolation ON notes",),
+        ("CREATE POLICY notes_open ON notes USING (true) WITH CHECK (true)",),
+        (
+            "DROP POLICY notes_tenant_isolation ON notes",
+            "CREATE POLICY notes_tenant_isolation ON notes USING (true) WITH CHECK (true)",
+        ),
+    ),
+    ids=("no-force", "missing-policy", "extra-policy", "weakened-policy"),
+)
+def test_postgres_current_v60_rejects_notes_authority_drift_without_repair(
+    pg_database_config: DatabaseConfig,
+    drift_statements: tuple[str, ...],
+) -> None:
+    owner = "950026"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+    drift_backend = None
+    observer_backend = None
+    startup_db = None
+
+    try:
+        with db.transaction() as conn:
+            for statement in drift_statements:
+                conn.execute(statement)
+        drifted = _postgres_notes_authority_snapshot(backend)
+        db.close_all_connections()
+        drift_backend = DatabaseBackendFactory.create_backend(pg_database_config)
+        with pytest.raises(CharactersRAGDBError, match="ownership or RLS|policy catalog"):
+            startup_db = CharactersRAGDB(":memory:", client_id=owner, backend=drift_backend)
+        observer_backend = DatabaseBackendFactory.create_backend(pg_database_config)
+        assert _postgres_notes_authority_snapshot(observer_backend) == drifted
+    finally:
+        if startup_db is not None:
+            startup_db.close_all_connections()
+        db.close_all_connections()
+        backend.get_pool().close_all()
+        if drift_backend is not None:
+            drift_backend.get_pool().close_all()
+        if observer_backend is not None:
+            observer_backend.get_pool().close_all()
+
+
+def test_postgres_dataset_cursor_page_uses_exact_index(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "950027"
+    dataset_id = "cursor-dataset"
+    other_dataset_id = "cursor-other"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+    note_id = db.add_note("Cursor parent", "Body")
+
+    try:
+        with db.transaction() as conn:
+            for cursor in range(1, 65):
+                target_event = db.record_task_event(
+                    owner_user_id=owner,
+                    dataset_id=dataset_id,
+                    note_id=note_id,
+                    event_type="updated",
+                    actor_type="user",
+                    conn=conn,
+                )
+                conn.execute(
+                    "UPDATE task_events SET sync_server_cursor=? "
+                    "WHERE owner_user_id=? AND dataset_id=? AND id=?",
+                    (cursor, owner, dataset_id, target_event["id"]),
+                )
+                other_event = db.record_task_event(
+                    owner_user_id=owner,
+                    dataset_id=other_dataset_id,
+                    note_id=note_id,
+                    event_type="updated",
+                    actor_type="user",
+                    conn=conn,
+                )
+                conn.execute(
+                    "UPDATE task_events SET sync_server_cursor=? "
+                    "WHERE owner_user_id=? AND dataset_id=? AND id=?",
+                    (cursor, owner, other_dataset_id, other_event["id"]),
+                )
+            conn.execute("ANALYZE task_events")
+            conn.execute("SELECT set_config('app.current_dataset_id', ?, true)", (dataset_id,))
+            conn.execute("SET LOCAL enable_seqscan=off")
+            index_definition = conn.execute(
+                "SELECT pg_get_indexdef('idx_task_events_scope_cursor'::regclass,0,true)"
+            ).fetchone()["pg_get_indexdef"]
+            assert index_definition == (
+                "CREATE INDEX idx_task_events_scope_cursor ON task_events USING btree "
+                "(owner_user_id, dataset_id, sync_server_cursor, id)"
+            )
+            plan_rows = conn.execute(
+                "EXPLAIN SELECT id FROM task_events "
+                "WHERE owner_user_id=? AND dataset_id=? AND sync_server_cursor>? "
+                "ORDER BY sync_server_cursor,id LIMIT ?",
+                (owner, dataset_id, 0, 10),
+            ).fetchall()
+        plan = [str(next(iter(dict(row).values()))) for row in plan_rows]
+        relevant_plan = [
+            line.strip()
+            for line in plan
+            if "Sort" in line or "Index" in line or "Filter:" in line
+        ]
+        assert any("idx_task_events_scope_cursor" in line for line in plan), relevant_plan
+        assert not any("Sort" in line for line in plan), relevant_plan
+        assert not any("Filter: (sync_server_cursor" in line for line in plan), relevant_plan
     finally:
         db.close_all_connections()
         backend.get_pool().close_all()

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_task_sync_postgres_tenancy.py
@@ -1,0 +1,261 @@
+"""Live PostgreSQL tenancy proof for the schema-v60 Notes task graph."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig, DatabaseError
+from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+pytestmark = pytest.mark.integration
+
+
+def test_postgres_note_task_schema_v60_is_authoritative(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "950001"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+
+    try:
+        with db.transaction() as conn:
+            version = conn.execute(
+                "SELECT version FROM db_schema_version WHERE schema_name = ?",
+                (CharactersRAGDB._SCHEMA_NAME,),
+            ).fetchone()["version"]
+            policy_rows = conn.execute(
+                "SELECT tablename, policyname FROM pg_policies "
+                "WHERE schemaname = current_schema() AND tablename = ANY(?) "
+                "ORDER BY tablename, policyname",
+                (list(CharactersRAGDB._NOTE_TASK_V60_TABLES),),
+            ).fetchall()
+        assert version == 60
+        assert [(row["tablename"], row["policyname"]) for row in policy_rows] == [
+            (table, f"{table}_tenant_isolation")
+            for table in sorted(CharactersRAGDB._NOTE_TASK_V60_TABLES)
+        ]
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_note_tasks_allow_same_id_for_two_owners(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner_a = "950011"
+    owner_b = "950012"
+    dataset_id = f"dataset-{uuid4()}"
+    other_dataset_id = f"dataset-{uuid4()}"
+    note_a = str(uuid4())
+    note_b = str(uuid4())
+    task_id = str(uuid4())
+    backend_a = DatabaseBackendFactory.create_backend(pg_database_config)
+    backend_b = DatabaseBackendFactory.create_backend(pg_database_config)
+    db_a = CharactersRAGDB(":memory:", client_id=owner_a, backend=backend_a)
+    db_b = CharactersRAGDB(":memory:", client_id=owner_b, backend=backend_b)
+    ident = backend_a.escape_identifier  # type: ignore[attr-defined]
+    role_name = f"note_task_rls_{uuid4().hex[:8]}"
+    role_created = False
+
+    try:
+        db_a.add_note("Owner A", "Body", note_id=note_a)
+        db_b.add_note("Owner B", "Body", note_id=note_b)
+        first = db_a.create_task(
+            owner_user_id=owner_a,
+            dataset_id=dataset_id,
+            task_id=task_id,
+            note_id=note_a,
+            text="Same ID",
+            actor_type=None,
+        )
+        second = db_b.create_task(
+            owner_user_id=owner_b,
+            dataset_id=dataset_id,
+            task_id=task_id,
+            note_id=note_b,
+            text="Same ID",
+            actor_type=None,
+        )
+        third = db_a.create_task(
+            owner_user_id=owner_a,
+            dataset_id=other_dataset_id,
+            task_id=task_id,
+            note_id=note_a,
+            text="Same ID, other dataset",
+            actor_type=None,
+        )
+        event_a = db_a.record_task_event(
+            owner_user_id=owner_a,
+            dataset_id=dataset_id,
+            task_id=task_id,
+            note_id=note_a,
+            event_type="updated",
+            actor_type="user",
+        )
+        event_b = db_b.record_task_event(
+            owner_user_id=owner_b,
+            dataset_id=dataset_id,
+            task_id=task_id,
+            note_id=note_b,
+            event_type="updated",
+            actor_type="user",
+        )
+        db_a.mark_task_activity_read(
+            owner_user_id=owner_a,
+            dataset_id=dataset_id,
+            event_id=event_a["id"],
+            user_id=owner_a,
+        )
+        db_b.mark_task_activity_read(
+            owner_user_id=owner_b,
+            dataset_id=dataset_id,
+            event_id=event_b["id"],
+            user_id=owner_b,
+        )
+
+        assert first["owner_user_id"] == owner_a
+        assert second["owner_user_id"] == owner_b
+        assert third["dataset_id"] == other_dataset_id
+        assert db_a.get_task(
+            owner_user_id=owner_a,
+            dataset_id=dataset_id,
+            task_id=task_id,
+        )["note_id"] == note_a
+        assert db_b.get_task(
+            owner_user_id=owner_b,
+            dataset_id=dataset_id,
+            task_id=task_id,
+        )["note_id"] == note_b
+
+        with backend_a.transaction() as conn:
+            backend_a.execute(
+                f"CREATE ROLE {ident(role_name)} NOLOGIN NOSUPERUSER NOBYPASSRLS",
+                connection=conn,
+            )
+            backend_a.execute(f"GRANT USAGE ON SCHEMA public TO {ident(role_name)}", connection=conn)
+            backend_a.execute(f"GRANT SELECT ON notes TO {ident(role_name)}", connection=conn)
+            for table in CharactersRAGDB._NOTE_TASK_V60_TABLES:
+                backend_a.execute(
+                    f"GRANT SELECT, INSERT, UPDATE ON {ident(table)} TO {ident(role_name)}",
+                    connection=conn,
+                )
+            backend_a.execute(f"GRANT {ident(role_name)} TO CURRENT_USER", connection=conn)
+        role_created = True
+
+        with backend_a.transaction() as conn:
+            backend_a.execute(f"SET LOCAL ROLE {ident(role_name)}", connection=conn)
+            backend_a.execute(
+                "SELECT set_config('app.current_user_id', ?, true)", (owner_a,), connection=conn
+            )
+            backend_a.execute(
+                "SELECT set_config('app.current_dataset_id', ?, true)", (dataset_id,), connection=conn
+            )
+            principal = backend_a.execute(
+                "SELECT rolsuper,rolbypassrls FROM pg_roles WHERE rolname=current_user",
+                connection=conn,
+            ).rows[0]
+            assert principal == {"rolsuper": False, "rolbypassrls": False}
+            visible_tasks = backend_a.execute(
+                "SELECT owner_user_id,note_id FROM note_tasks WHERE id=?", (task_id,), connection=conn
+            ).rows
+            assert visible_tasks == [{"owner_user_id": owner_a, "note_id": note_a}]
+            visible_events = backend_a.execute(
+                "SELECT owner_user_id,id FROM task_events WHERE task_id=? ORDER BY id",
+                (task_id,),
+                connection=conn,
+            ).rows
+            assert {row["id"] for row in visible_events} == {event_a["id"]}
+            visible_read_state = backend_a.execute(
+                "SELECT owner_user_id,event_id FROM task_event_read_state ORDER BY event_id",
+                connection=conn,
+            ).rows
+            assert visible_read_state == [{"owner_user_id": owner_a, "event_id": event_a["id"]}]
+            hidden_update = backend_a.execute(
+                "UPDATE note_tasks SET text=? WHERE owner_user_id=? AND dataset_id=? AND id=?",
+                ("cross-owner overwrite", owner_b, dataset_id, task_id),
+                connection=conn,
+            )
+            assert hidden_update.rowcount == 0
+            hidden_dataset_update = backend_a.execute(
+                "UPDATE note_tasks SET text=? WHERE owner_user_id=? AND dataset_id=? AND id=?",
+                ("cross-dataset overwrite", owner_a, other_dataset_id, task_id),
+                connection=conn,
+            )
+            assert hidden_dataset_update.rowcount == 0
+
+        with pytest.raises(DatabaseError):
+            with backend_a.transaction() as conn:
+                backend_a.execute(f"SET LOCAL ROLE {ident(role_name)}", connection=conn)
+                backend_a.execute(
+                    "SELECT set_config('app.current_user_id', ?, true)", (owner_a,), connection=conn
+                )
+                backend_a.execute(
+                    "SELECT set_config('app.current_dataset_id', ?, true)", (dataset_id,), connection=conn
+                )
+                backend_a.execute(
+                    """
+                    INSERT INTO note_tasks(
+                      owner_user_id,dataset_id,id,note_id,text,status,metadata_json,
+                      projection_status,deleted,created_at,updated_at,client_id,version,
+                      canonical_revision,canonical_hash
+                    ) VALUES (?,?,?,?,?,'open','{}','live',FALSE,CURRENT_TIMESTAMP,
+                              CURRENT_TIMESTAMP,?,1,1,?)
+                    """,
+                    (owner_a, dataset_id, str(uuid4()), note_b, "cross-owner parent", owner_a,
+                     "sha256:" + "a" * 64),
+                    connection=conn,
+                )
+
+        # Exercise a real task page amid same-scope activity so the ordered task
+        # index is both selective and useful for satisfying the LIMIT.
+        with db_a.transaction() as conn:
+            for _ in range(64):
+                db_a.record_task_event(
+                    owner_user_id=owner_a,
+                    dataset_id=dataset_id,
+                    task_id=task_id,
+                    note_id=note_a,
+                    event_type="updated",
+                    actor_type="user",
+                    conn=conn,
+                )
+                db_a.record_task_event(
+                    owner_user_id=owner_a,
+                    dataset_id=dataset_id,
+                    note_id=note_a,
+                    event_type="updated",
+                    actor_type="user",
+                    conn=conn,
+                )
+
+        db_a.get_task(owner_user_id=owner_a, dataset_id=dataset_id, task_id=task_id)
+        with db_a.transaction() as conn:
+            conn.execute("ANALYZE task_events")
+            conn.execute("SET LOCAL enable_seqscan=off")
+            task_plan_rows = conn.execute(
+                "EXPLAIN SELECT id FROM note_tasks WHERE owner_user_id=? AND dataset_id=? "
+                "AND note_id=? AND deleted=FALSE ORDER BY created_at,id LIMIT ?",
+                (owner_a, dataset_id, note_a, 50),
+            ).fetchall()
+            event_plan_rows = conn.execute(
+                "EXPLAIN SELECT id FROM task_events WHERE owner_user_id=? AND dataset_id=? "
+                "AND task_id=? ORDER BY created_at,id LIMIT ?",
+                (owner_a, dataset_id, task_id, 50),
+            ).fetchall()
+        task_plan = " ".join(str(next(iter(dict(row).values()))) for row in task_plan_rows)
+        event_plan = " ".join(str(next(iter(dict(row).values()))) for row in event_plan_rows)
+        assert "idx_note_tasks_scope_note_page" in task_plan
+        assert "idx_task_events_scope_task_created" in event_plan
+    finally:
+        if role_created:
+            with backend_a.transaction() as conn:
+                backend_a.execute(f"REVOKE {ident(role_name)} FROM CURRENT_USER", connection=conn)
+                backend_a.execute(f"DROP OWNED BY {ident(role_name)}", connection=conn)
+                backend_a.execute(f"DROP ROLE {ident(role_name)}", connection=conn)
+        db_a.close_all_connections()
+        db_b.close_all_connections()
+        backend_a.get_pool().close_all()
+        backend_b.get_pool().close_all()

--- a/tldw_Server_API/tests/DB_Management/test_chacha_migration_v48_tasks.py
+++ b/tldw_Server_API/tests/DB_Management/test_chacha_migration_v48_tasks.py
@@ -15,6 +15,7 @@ def test_sqlite_migration_adds_task_tables(tmp_path) -> None:
     with sqlite3.connect(db_path) as conn:
         for table in (
             "note_attachments",
+            "task_projection_drifts",
             "task_event_read_state",
             "task_note_projections",
             "task_events",
@@ -23,6 +24,7 @@ def test_sqlite_migration_adds_task_tables(tmp_path) -> None:
             "tasks",
         ):
             conn.execute(f"DROP TABLE IF EXISTS {table}")  # nosec B608 - test-only fixed table list
+        conn.execute("DROP INDEX IF EXISTS uq_notes_owner_id")
         conn.execute(
             "UPDATE db_schema_version SET version = ? WHERE schema_name = ?",
             (47, CharactersRAGDB._SCHEMA_NAME),

--- a/tldw_Server_API/tests/DB_Management/test_chacha_migration_v48_tasks.py
+++ b/tldw_Server_API/tests/DB_Management/test_chacha_migration_v48_tasks.py
@@ -15,6 +15,7 @@ def test_sqlite_migration_adds_task_tables(tmp_path) -> None:
     with sqlite3.connect(db_path) as conn:
         for table in (
             "note_attachments",
+            "note_task_scope_authority",
             "task_projection_drifts",
             "task_event_read_state",
             "task_note_projections",
@@ -52,6 +53,7 @@ def test_sqlite_migration_adds_task_tables(tmp_path) -> None:
         "task_event_read_state",
         "task_note_projections",
         "note_task_reconciliation_state",
+        "note_task_scope_authority",
     } <= tables
     assert "tasks" not in tables  # nosec B101
     assert final_version == CharactersRAGDB._CURRENT_SCHEMA_VERSION  # nosec B101

--- a/tldw_Server_API/tests/DB_Management/test_chacha_migration_v48_tasks.py
+++ b/tldw_Server_API/tests/DB_Management/test_chacha_migration_v48_tasks.py
@@ -4,7 +4,6 @@ import pytest
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -15,6 +14,7 @@ def test_sqlite_migration_adds_task_tables(tmp_path) -> None:
 
     with sqlite3.connect(db_path) as conn:
         for table in (
+            "note_attachments",
             "task_event_read_state",
             "task_note_projections",
             "task_events",

--- a/tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py
+++ b/tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py
@@ -275,6 +275,51 @@ def test_chacha_note_attachment_rls_checks_registry_and_note_owner_for_reads_and
         assert policy.count(clause) == 2
 
 
+def test_chacha_note_task_graph_rls_checks_scope_and_owned_parents_for_reads_and_writes() -> None:
+    sql = " ".join("\n".join(build_chacha_rls_sql()).split())
+    owner = "current_setting('app.current_user_id', true)"
+    dataset = "current_setting('app.current_dataset_id', true)"
+
+    for table in (
+        "note_tasks",
+        "task_note_projections",
+        "task_events",
+        "task_event_read_state",
+        "note_task_reconciliation_state",
+        "task_projection_drifts",
+    ):
+        assert f"ALTER TABLE IF EXISTS {table} ENABLE ROW LEVEL SECURITY" in sql
+        assert f"ALTER TABLE IF EXISTS {table} FORCE ROW LEVEL SECURITY" in sql
+        policy = sql.split(
+            f"CREATE POLICY {table}_tenant_isolation ON {table}", 1
+        )[1].split(";", 1)[0]
+        assert "USING (" in policy
+        assert "WITH CHECK (" in policy
+        assert policy.count(f"{table}.owner_user_id = {owner}") == 2
+        assert policy.count(f"{table}.dataset_id = {dataset}") == 2
+
+    task_policy = sql.split(
+        "CREATE POLICY note_tasks_tenant_isolation ON note_tasks", 1
+    )[1].split(";", 1)[0]
+    for clause in (
+        "note.id = note_tasks.note_id",
+        "note.client_id = note_tasks.owner_user_id",
+        f"note.client_id = {owner}",
+    ):
+        assert task_policy.count(clause) == 2
+
+    read_state_policy = sql.split(
+        "CREATE POLICY task_event_read_state_tenant_isolation ON task_event_read_state", 1
+    )[1].split(";", 1)[0]
+    for clause in (
+        "task_event_read_state.user_id = task_event_read_state.owner_user_id",
+        "event.id = task_event_read_state.event_id",
+        "event.owner_user_id = task_event_read_state.owner_user_id",
+        "event.dataset_id = task_event_read_state.dataset_id",
+    ):
+        assert read_state_policy.count(clause) == 2
+
+
 def test_chacha_rls_includes_source_review_read_and_write_policies():
     sql = "\n".join(build_chacha_rls_sql())
 

--- a/tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py
+++ b/tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py
@@ -298,6 +298,16 @@ def test_chacha_note_task_graph_rls_checks_scope_and_owned_parents_for_reads_and
         assert policy.count(f"{table}.owner_user_id = {owner}") == 2
         assert policy.count(f"{table}.dataset_id = {dataset}") == 2
 
+    authority_policy = sql.split(
+        "CREATE POLICY note_task_scope_authority_tenant_isolation "
+        "ON note_task_scope_authority",
+        1,
+    )[1].split(";", 1)[0]
+    assert authority_policy.count(
+        f"note_task_scope_authority.owner_user_id = {owner}"
+    ) == 2
+    assert "current_dataset_id" not in authority_policy
+
     task_policy = sql.split(
         "CREATE POLICY note_tasks_tenant_isolation ON note_tasks", 1
     )[1].split(";", 1)[0]

--- a/tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py
+++ b/tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py
@@ -18,12 +18,16 @@ class _FakeTaskStore:
     def __init__(self, db: _FakeTaskDB) -> None:
         self._db = db
 
-    def _fetch_projection(self, task_id: str, **_scope: Any) -> dict[str, Any] | None:
+    def get_task_projection(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        task_id: str,
+    ) -> dict[str, Any] | None:
+        self._db.projection_requests.append((owner_user_id, dataset_id, task_id))
         projection = self._db.projections.get(task_id)
         return dict(projection) if projection else None
-
-    def get_task_projection(self, task_id: str, **_scope: Any) -> dict[str, Any] | None:
-        return self._fetch_projection(task_id)
 
 
 class _FakeTaskDB:
@@ -75,14 +79,28 @@ class _FakeTaskDB:
             for task_id, task in self.tasks.items()
         }
         self.task_store = _FakeTaskStore(self)
+        self.projection_requests: list[tuple[str, str, str]] = []
+        self.projection_error: Exception | None = None
         self.closed = False
 
     @staticmethod
     def execute_query(_query: str, _params: Any = None) -> Any:
         return SimpleNamespace(fetchall=lambda: [])
 
-    def get_task_projection(self, *, task_id: str, **scope: Any) -> dict[str, Any] | None:
-        return self.task_store.get_task_projection(task_id, **scope)
+    def get_task_projection(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        task_id: str,
+    ) -> dict[str, Any] | None:
+        if self.projection_error is not None:
+            raise self.projection_error
+        return self.task_store.get_task_projection(
+            owner_user_id=owner_user_id,
+            dataset_id=dataset_id,
+            task_id=task_id,
+        )
 
     def _task(
         self,
@@ -519,6 +537,35 @@ async def test_notes_tasks_list_and_get_execute_read_only_with_reconciliation_su
         context=_ctx(),
     )
     assert [task["id"] for task in metadata_filtered["tasks"]] == ["task-filter"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_notes_tasks_get_preserves_pg_v59_projection_using_authenticated_scope() -> None:
+    module, db, _service = _module_with_fakes()
+    db.backend_type = BackendType.POSTGRESQL
+    db.tasks["task-1"].pop("owner_user_id")
+    db.tasks["task-1"].pop("dataset_id")
+
+    fetched = await module.execute_tool(
+        "notes.tasks.get",
+        {"task_id": "task-1"},
+        context=_ctx(),
+    )
+
+    assert fetched["projection"]["projection_status"] == "live"  # nosec B101
+    assert db.projection_requests == [("7", LOCAL_UNBOUND, "task-1")]  # nosec B101
+
+    db.projection_error = ConflictError(
+        "projection scope failure",
+        entity="tasks",
+        entity_id="task-1",
+    )
+    with pytest.raises(ConflictError, match="projection scope failure"):
+        await module.execute_tool(
+            "notes.tasks.get",
+            {"task_id": "task-1"},
+            context=_ctx(),
+        )
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py
+++ b/tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py
@@ -87,6 +87,10 @@ class _FakeTaskDB:
     def execute_query(_query: str, _params: Any = None) -> Any:
         return SimpleNamespace(fetchall=lambda: [])
 
+    def resolve_task_compatibility_dataset_id(self, *, owner_user_id: str) -> str:
+        assert owner_user_id == self.client_id  # nosec B101
+        return LOCAL_UNBOUND
+
     def get_task_projection(
         self,
         *,

--- a/tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py
+++ b/tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import BackendType, CharactersRAGDB, ConflictError
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.notes_module import NotesModule
 
@@ -27,6 +27,8 @@ class _FakeTaskStore:
 
 
 class _FakeTaskDB:
+    backend_type = BackendType.SQLITE
+
     def __init__(self) -> None:
         self.client_id = "7"
         self.notes: dict[str, dict[str, Any]] = {
@@ -75,10 +77,11 @@ class _FakeTaskDB:
         self.task_store = _FakeTaskStore(self)
         self.closed = False
 
-    def resolve_task_compatibility_scope(self, *, owner_user_id: str) -> tuple[str, str]:
-        return owner_user_id, "local-unbound"
+    @staticmethod
+    def execute_query(_query: str, _params: Any = None) -> Any:
+        return SimpleNamespace(fetchall=lambda: [])
 
-    def get_task_projection(self, task_id: str, **scope: Any) -> dict[str, Any] | None:
+    def get_task_projection(self, *, task_id: str, **scope: Any) -> dict[str, Any] | None:
         return self.task_store.get_task_projection(task_id, **scope)
 
     def _task(
@@ -111,12 +114,17 @@ class _FakeTaskDB:
         note = self.notes.get(note_id)
         return dict(note) if note else None
 
-    def get_task(self, task_id: str, include_deleted: bool = False) -> dict[str, Any] | None:  # noqa: ARG002
+    def get_task(
+        self,
+        *,
+        task_id: str,
+        owner_user_id: str,  # noqa: ARG002
+        dataset_id: str,  # noqa: ARG002
+        include_deleted: bool = False,  # noqa: ARG002
+        conn: Any = None,  # noqa: ARG002
+    ) -> dict[str, Any] | None:
         task = self.tasks.get(task_id)
         return dict(task) if task else None
-
-    def get_task_scoped(self, *, task_id: str, **_scope: Any) -> dict[str, Any] | None:
-        return self.get_task(task_id)
 
     def list_tasks(
         self,

--- a/tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py
+++ b/tldw_Server_API/tests/MCP_unified/test_notes_task_tools.py
@@ -11,21 +11,24 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGD
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.notes_module import NotesModule
 
+LOCAL_UNBOUND = "local-unbound"
+
 
 class _FakeTaskStore:
-    def __init__(self, db: "_FakeTaskDB") -> None:
+    def __init__(self, db: _FakeTaskDB) -> None:
         self._db = db
 
-    def _fetch_projection(self, task_id: str) -> dict[str, Any] | None:
+    def _fetch_projection(self, task_id: str, **_scope: Any) -> dict[str, Any] | None:
         projection = self._db.projections.get(task_id)
         return dict(projection) if projection else None
 
-    def get_task_projection(self, task_id: str) -> dict[str, Any] | None:
+    def get_task_projection(self, task_id: str, **_scope: Any) -> dict[str, Any] | None:
         return self._fetch_projection(task_id)
 
 
 class _FakeTaskDB:
     def __init__(self) -> None:
+        self.client_id = "7"
         self.notes: dict[str, dict[str, Any]] = {
             "note-1": {"id": "note-1", "title": "Inbox", "version": 1, "content": "- [ ] Seed\n"},
             "note-2": {"id": "note-2", "title": "Later", "version": 3, "content": ""},
@@ -72,8 +75,11 @@ class _FakeTaskDB:
         self.task_store = _FakeTaskStore(self)
         self.closed = False
 
-    def get_task_projection(self, task_id: str) -> dict[str, Any] | None:
-        return self.task_store.get_task_projection(task_id)
+    def resolve_task_compatibility_scope(self, *, owner_user_id: str) -> tuple[str, str]:
+        return owner_user_id, "local-unbound"
+
+    def get_task_projection(self, task_id: str, **scope: Any) -> dict[str, Any] | None:
+        return self.task_store.get_task_projection(task_id, **scope)
 
     def _task(
         self,
@@ -87,6 +93,8 @@ class _FakeTaskDB:
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         return {
+            "owner_user_id": "7",
+            "dataset_id": "local-unbound",
             "id": task_id,
             "note_id": note_id,
             "text": text,
@@ -107,9 +115,14 @@ class _FakeTaskDB:
         task = self.tasks.get(task_id)
         return dict(task) if task else None
 
+    def get_task_scoped(self, *, task_id: str, **_scope: Any) -> dict[str, Any] | None:
+        return self.get_task(task_id)
+
     def list_tasks(
         self,
         *,
+        owner_user_id: str | None = None,  # noqa: ARG002
+        dataset_id: str | None = None,  # noqa: ARG002
         note_id: str | None = None,
         status: str | None = None,
         projection_status: str | None = None,
@@ -155,11 +168,15 @@ class _FakeTaskService:
         self.delete_calls: list[dict[str, Any]] = []
         self.reconcile_note_calls: list[str] = []
 
-    def reconcile_stale_notes(self, *, db: _FakeTaskDB, limit: int, actor: Any) -> Any:  # noqa: ARG002
+    def reconcile_stale_notes(
+        self, *, db: _FakeTaskDB, limit: int, actor: Any, owner_user_id: str | None = None
+    ) -> Any:  # noqa: ARG002
         self.reconcile_stale_calls += 1
         return SimpleNamespace(status="clean", processed_notes=1, remaining_stale_notes=0)
 
-    def ensure_note_reconciled(self, *, db: _FakeTaskDB, note_id: str, actor: Any) -> Any:  # noqa: ARG002
+    def ensure_note_reconciled(
+        self, *, db: _FakeTaskDB, note_id: str, actor: Any, owner_user_id: str | None = None
+    ) -> Any:  # noqa: ARG002
         self.ensure_note_calls.append(note_id)
         return SimpleNamespace(
             note_id=note_id,
@@ -172,7 +189,9 @@ class _FakeTaskService:
             warning_count=0,
         )
 
-    def reconcile_note_current(self, *, db: _FakeTaskDB, note_id: str, actor: Any) -> Any:  # noqa: ARG002
+    def reconcile_note_current(
+        self, *, db: _FakeTaskDB, note_id: str, actor: Any, owner_user_id: str | None = None
+    ) -> Any:  # noqa: ARG002
         self.reconcile_note_calls.append(note_id)
         return SimpleNamespace(
             note_id=note_id,
@@ -195,6 +214,7 @@ class _FakeTaskService:
         metadata: dict[str, Any],
         expected_note_version: int,
         actor: Any,  # noqa: ARG002
+        owner_user_id: str | None = None,  # noqa: ARG002
     ) -> dict[str, Any]:
         self.create_calls += 1
         task_id = f"task-created-{self.create_calls}"
@@ -224,6 +244,7 @@ class _FakeTaskService:
         status: str | None = None,
         metadata: dict[str, Any] | None = None,
         record_only: bool = False,
+        owner_user_id: str | None = None,  # noqa: ARG002
     ) -> dict[str, Any]:
         self.update_calls.append(
             {
@@ -780,7 +801,7 @@ async def test_set_status_already_matching_status_checks_current_note_version() 
 @pytest.mark.asyncio
 async def test_mcp_task_writes_record_runtime_policy_and_idempotency_metadata(tmp_path: Path) -> None:
     db_path = tmp_path / "notes_task_mcp_events.db"
-    db = CharactersRAGDB(str(db_path), client_id="mcp_task_events_test")
+    db = CharactersRAGDB(str(db_path), client_id="7")
     try:
         note_id = str(db.add_note(title="Inbox", content=""))
         note = db.get_note_by_id(note_id)
@@ -791,7 +812,7 @@ async def test_mcp_task_writes_record_runtime_policy_and_idempotency_metadata(tm
     opened_dbs: list[CharactersRAGDB] = []
 
     def _open_db(_ctx: Any) -> CharactersRAGDB:
-        handle = CharactersRAGDB(str(db_path), client_id="mcp_task_events_test")
+        handle = CharactersRAGDB(str(db_path), client_id="7")
         opened_dbs.append(handle)
         return handle
 
@@ -851,9 +872,11 @@ async def test_mcp_task_writes_record_runtime_policy_and_idempotency_metadata(tm
             context=context,
         )
 
-        event_db = CharactersRAGDB(str(db_path), client_id="mcp_task_events_test")
+        event_db = CharactersRAGDB(str(db_path), client_id="7")
         opened_dbs.append(event_db)
-        events = event_db.list_task_activity(task_id=created["id"], limit=20)
+        events = event_db.list_task_activity(
+            owner_user_id="7", dataset_id=LOCAL_UNBOUND, task_id=created["id"], limit=20
+        )
 
         def _event_for(event_type: str, idempotency_key: str) -> dict[str, Any]:
             for event in events:
@@ -887,7 +910,7 @@ async def test_mcp_task_writes_record_runtime_policy_and_idempotency_metadata(tm
 @pytest.mark.asyncio
 async def test_autonomous_mcp_task_write_records_policy_metadata_and_unread_activity(tmp_path: Path) -> None:
     db_path = tmp_path / "notes_task_mcp_autonomous_events.db"
-    db = CharactersRAGDB(str(db_path), client_id="mcp_task_autonomous_events_test")
+    db = CharactersRAGDB(str(db_path), client_id="7")
     try:
         note_id = str(db.add_note(title="Inbox", content=""))
         note = db.get_note_by_id(note_id)
@@ -898,7 +921,7 @@ async def test_autonomous_mcp_task_write_records_policy_metadata_and_unread_acti
     opened_dbs: list[CharactersRAGDB] = []
 
     def _open_db(_ctx: Any) -> CharactersRAGDB:
-        handle = CharactersRAGDB(str(db_path), client_id="mcp_task_autonomous_events_test")
+        handle = CharactersRAGDB(str(db_path), client_id="7")
         opened_dbs.append(handle)
         return handle
 
@@ -927,9 +950,11 @@ async def test_autonomous_mcp_task_write_records_policy_metadata_and_unread_acti
             context=context,
         )
 
-        event_db = CharactersRAGDB(str(db_path), client_id="mcp_task_autonomous_events_test")
+        event_db = CharactersRAGDB(str(db_path), client_id="7")
         opened_dbs.append(event_db)
-        events = event_db.list_task_activity(task_id=created["id"], limit=20)
+        events = event_db.list_task_activity(
+            owner_user_id="7", dataset_id=LOCAL_UNBOUND, task_id=created["id"], limit=20
+        )
         created_events = [
             event
             for event in events
@@ -944,7 +969,13 @@ async def test_autonomous_mcp_task_write_records_policy_metadata_and_unread_acti
         assert event["policy_mode"] == "autonomous"  # nosec B101
         assert event["approval_id"] is None  # nosec B101
 
-        unread = event_db.list_recent_unread_task_activity(user_id="7", actor_type="agent", limit=20)
+        unread = event_db.list_recent_unread_task_activity(
+            owner_user_id="7",
+            dataset_id=LOCAL_UNBOUND,
+            user_id="7",
+            actor_type="agent",
+            limit=20,
+        )
         assert [row["id"] for row in unread] == [event["id"]]  # nosec B101
     finally:
         for handle in opened_dbs:
@@ -954,7 +985,7 @@ async def test_autonomous_mcp_task_write_records_policy_metadata_and_unread_acti
 @pytest.mark.asyncio
 async def test_follow_up_reconciliation_events_do_not_inherit_direct_tool_idempotency_metadata(tmp_path: Path) -> None:
     db_path = tmp_path / "notes_task_mcp_internal_events.db"
-    db = CharactersRAGDB(str(db_path), client_id="mcp_task_internal_events_test")
+    db = CharactersRAGDB(str(db_path), client_id="7")
     try:
         note_id = str(db.add_note(title="Inbox", content="- [ ] Existing sibling\n"))
         note = db.get_note_by_id(note_id)
@@ -965,7 +996,7 @@ async def test_follow_up_reconciliation_events_do_not_inherit_direct_tool_idempo
     opened_dbs: list[CharactersRAGDB] = []
 
     def _open_db(_ctx: Any) -> CharactersRAGDB:
-        handle = CharactersRAGDB(str(db_path), client_id="mcp_task_internal_events_test")
+        handle = CharactersRAGDB(str(db_path), client_id="7")
         opened_dbs.append(handle)
         return handle
 
@@ -988,9 +1019,11 @@ async def test_follow_up_reconciliation_events_do_not_inherit_direct_tool_idempo
             context=context,
         )
 
-        event_db = CharactersRAGDB(str(db_path), client_id="mcp_task_internal_events_test")
+        event_db = CharactersRAGDB(str(db_path), client_id="7")
         opened_dbs.append(event_db)
-        events = event_db.list_task_activity(note_id=note_id, limit=20)
+        events = event_db.list_task_activity(
+            owner_user_id="7", dataset_id=LOCAL_UNBOUND, note_id=note_id, limit=20
+        )
         sibling_events = [event for event in events if event["event_type"] == "created" and event["task_id"]]
         assert len(sibling_events) == 2  # nosec B101
         direct_events = [

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_api.py
@@ -19,6 +19,8 @@ from tldw_Server_API.app.core.Notes_Tasks.service import NotesTaskService
 
 pytestmark = pytest.mark.integration
 
+LOCAL_UNBOUND = "local-unbound"
+
 
 class _NoopRateLimiter:
     async def check_user_rate_limit(self, *_args: Any, **_kwargs: Any) -> tuple[bool, dict[str, Any]]:
@@ -32,7 +34,7 @@ class _FailingRateLimiter:
 
 @pytest.fixture()
 def notes_tasks_api_client(tmp_path: Path) -> Generator[tuple[TestClient, CharactersRAGDB], None, None]:
-    db = CharactersRAGDB(str(tmp_path / "notes_tasks_rest_api.db"), client_id="notes_tasks_rest_user")
+    db = CharactersRAGDB(str(tmp_path / "notes_tasks_rest_api.db"), client_id="1")
 
     async def override_user() -> User:
         return User(id=1, username="tester", email="t@e.com", is_active=True, is_admin=True)
@@ -65,16 +67,18 @@ def _create_note(client: TestClient, *, content: str, title: str = "Tasks") -> d
 
 
 def _task_by_text(db: CharactersRAGDB, note_id: str, text: str) -> dict[str, Any]:
-    tasks = db.list_tasks(note_id=note_id, include_deleted=True, limit=100)
+    tasks = db.list_tasks(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, note_id=note_id, include_deleted=True, limit=100
+    )
     matches = [task for task in tasks if task["text"] == text]
     assert len(matches) == 1
     return matches[0]
 
 
 def _task_with_projection(db: CharactersRAGDB, task_id: str) -> dict[str, Any]:
-    task = db.get_task(task_id)
+    task = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task_id)
     assert task is not None
-    projection = db.get_task_projection(task_id)
+    projection = db.get_task_projection(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task_id)
     assert projection is not None
     return {"task": task, "projection": projection}
 
@@ -216,7 +220,12 @@ def test_set_status_on_clean_note_rewrites_marker_and_records_event(
     assert saved["content"] == "- [x] Alpha\n"
     assert updated["status"] == "done"
     assert updated["version"] == task["version"] + 1
-    events = db.list_task_activity(task_id=task["id"], limit=20)
+    events = db.list_task_activity(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
+        task_id=task["id"],
+        limit=20,
+    )
     assert any(event["event_type"] == "status_changed" for event in events)
 
 
@@ -323,9 +332,9 @@ def test_update_projected_task_refreshes_sibling_projection(
     assert alpha_response.status_code == 200, alpha_response.text
     saved = db.get_note_by_id(note["id"])
     assert saved is not None
-    beta_after_alpha = db.get_task(beta["id"])
+    beta_after_alpha = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=beta["id"])
     assert beta_after_alpha is not None
-    beta_projection = db.get_task_projection(beta["id"])
+    beta_projection = db.get_task_projection(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=beta["id"])
     assert beta_projection is not None
     assert beta_projection["note_version"] == saved["version"]
 
@@ -342,7 +351,14 @@ def test_update_projected_task_refreshes_sibling_projection(
     saved_after_beta = db.get_note_by_id(note["id"])
     assert saved_after_beta is not None
     assert saved_after_beta["content"] == "- [ ] Alpha updated\n- [ ] Beta updated\n"
-    assert len(db.list_tasks(note_id=note["id"], include_deleted=True, limit=20)) == 2
+    assert (
+        len(
+            db.list_tasks(
+                owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, note_id=note["id"], include_deleted=True, limit=20
+            )
+        )
+        == 2
+    )
 
 
 def test_delete_projected_task_refreshes_sibling_projection(
@@ -361,9 +377,9 @@ def test_delete_projected_task_refreshes_sibling_projection(
     assert delete_response.status_code == 200, delete_response.text
     saved = db.get_note_by_id(note["id"])
     assert saved is not None
-    beta_after_delete = db.get_task(beta["id"])
+    beta_after_delete = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=beta["id"])
     assert beta_after_delete is not None
-    beta_projection = db.get_task_projection(beta["id"])
+    beta_projection = db.get_task_projection(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=beta["id"])
     assert beta_projection is not None
     assert beta_projection["note_version"] == saved["version"]
 
@@ -521,7 +537,9 @@ def test_delete_projected_task_removes_line_transactionally(
     saved = db.get_note_by_id(note["id"])
     assert saved is not None
     assert saved["content"] == "Before\nAfter\n"
-    deleted = db.get_task(task["id"], include_deleted=True)
+    deleted = db.get_task(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task["id"], include_deleted=True
+    )
     assert deleted is not None
     assert bool(deleted["deleted"])
 
@@ -543,7 +561,7 @@ def test_delete_with_nested_child_content_conflicts(
     saved = db.get_note_by_id(note["id"])
     assert saved is not None
     assert saved["content"] == "- [ ] Parent\n  child detail\n"
-    assert db.get_task(task["id"]) is not None
+    assert db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task["id"]) is not None
 
 
 def test_unlinked_task_record_only_delete_succeeds(
@@ -558,7 +576,7 @@ def test_unlinked_task_record_only_delete_succeeds(
         headers={"expected-version": str(note["version"])},
     )
     assert patched.status_code == 200, patched.text
-    unlinked = db.get_task(task["id"])
+    unlinked = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task["id"])
     assert unlinked is not None
     assert unlinked["projection_status"] == "unlinked"
 
@@ -569,7 +587,9 @@ def test_unlinked_task_record_only_delete_succeeds(
     )
 
     assert response.status_code == 200, response.text
-    deleted = db.get_task(task["id"], include_deleted=True)
+    deleted = db.get_task(
+        owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task["id"], include_deleted=True
+    )
     assert deleted is not None
     assert bool(deleted["deleted"])
 
@@ -586,7 +606,7 @@ def test_unlinked_task_projection_updates_conflict_unless_record_only_metadata(
         headers={"expected-version": str(note["version"])},
     )
     assert patched.status_code == 200, patched.text
-    unlinked = db.get_task(task["id"])
+    unlinked = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task["id"])
     assert unlinked is not None
 
     status_response = _status_update(client, task=unlinked, status="done", record_only=True)
@@ -622,7 +642,7 @@ def test_ambiguous_projected_mutations_conflict(
             "UPDATE task_note_projections SET projection_status = ? WHERE task_id = ?",
             ("ambiguous", task["id"]),
         )
-    ambiguous = db.get_task(task["id"])
+    ambiguous = db.get_task(owner_user_id=db.client_id, dataset_id=LOCAL_UNBOUND, task_id=task["id"])
     assert ambiguous is not None
 
     status_response = _status_update(client, task=ambiguous, status="done", expected_note_version=note["version"])
@@ -659,6 +679,8 @@ def test_recent_activity_returns_unread_agent_events_and_supports_dismissal(
     note = _create_note(client, content="- [ ] Alpha\n")
     task = _task_by_text(db, note["id"], "Alpha")
     db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=task["id"],
         note_id=note["id"],
         event_type="updated",
@@ -670,6 +692,8 @@ def test_recent_activity_returns_unread_agent_events_and_supports_dismissal(
         new_value={"text": "Agent proposal"},
     )
     db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=task["id"],
         note_id=note["id"],
         event_type="updated",
@@ -712,6 +736,8 @@ def test_recent_activity_includes_latest_agent_event_after_many_older_user_event
     task = _task_by_text(db, note["id"], "Alpha")
     for index in range(201):
         db.record_task_event(
+            owner_user_id=db.client_id,
+            dataset_id=LOCAL_UNBOUND,
             task_id=task["id"],
             note_id=note["id"],
             event_type="updated",
@@ -720,6 +746,8 @@ def test_recent_activity_includes_latest_agent_event_after_many_older_user_event
             new_value={"index": index},
         )
     latest_agent_event = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=task["id"],
         note_id=note["id"],
         event_type="updated",
@@ -742,6 +770,8 @@ def test_recent_activity_limit_skips_newer_dismissed_agent_event(
     note = _create_note(client, content="- [ ] Alpha\n")
     task = _task_by_text(db, note["id"], "Alpha")
     older_unread_event = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=task["id"],
         note_id=note["id"],
         event_type="updated",
@@ -750,6 +780,8 @@ def test_recent_activity_limit_skips_newer_dismissed_agent_event(
         new_value={"text": "older unread event"},
     )
     newer_dismissed_event = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=task["id"],
         note_id=note["id"],
         event_type="updated",
@@ -778,6 +810,8 @@ def test_recent_activity_can_be_scoped_to_note_before_limit(
     first_task = _task_by_text(db, first_note["id"], "Alpha")
     second_task = _task_by_text(db, second_note["id"], "Beta")
     scoped_event = db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=first_task["id"],
         note_id=first_note["id"],
         event_type="updated",
@@ -786,6 +820,8 @@ def test_recent_activity_can_be_scoped_to_note_before_limit(
         new_value={"text": "scoped"},
     )
     db.record_task_event(
+        owner_user_id=db.client_id,
+        dataset_id=LOCAL_UNBOUND,
         task_id=second_task["id"],
         note_id=second_note["id"],
         event_type="updated",

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_postgres_compatibility.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_postgres_compatibility.py
@@ -1,0 +1,500 @@
+"""Live PostgreSQL continuity for product-owned Notes task compatibility scope."""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig
+from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.notes_module import NotesModule
+from tldw_Server_API.app.core.Notes_Tasks import service as notes_task_service_module
+from tldw_Server_API.app.core.Notes_Tasks.models import TaskActor
+from tldw_Server_API.app.core.Notes_Tasks.service import (
+    NotesTaskService,
+    resolve_task_compatibility_scope,
+)
+
+pytestmark = pytest.mark.integration
+
+LOCAL_UNBOUND = "local-unbound"
+
+
+class _NoopRateLimiter:
+    async def check_user_rate_limit(self, *_args: Any, **_kwargs: Any) -> tuple[bool, dict[str, Any]]:
+        return True, {}
+
+
+def _bound_task_graph(
+    pg_database_config: DatabaseConfig,
+    *,
+    owner: str,
+) -> tuple[Any, CharactersRAGDB, NotesTaskService, str, dict[str, Any], str]:
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+    service = NotesTaskService()
+    note_id = str(uuid4())
+    db.add_note("Bound task", "- [ ] Preserve continuity\n", note_id=note_id)
+    service.reconcile_note_current(
+        db=db,
+        note_id=note_id,
+        owner_user_id=owner,
+        actor=TaskActor(actor_type="user", actor_id=owner),
+    )
+    tasks = db.list_tasks(
+        owner_user_id=owner,
+        dataset_id=LOCAL_UNBOUND,
+        note_id=note_id,
+        limit=10,
+    )
+    assert len(tasks) == 1
+    target = f"dataset-{uuid4()}"
+    db.bind_local_task_graph_to_dataset(
+        owner_user_id=owner,
+        target_dataset_id=target,
+    )
+    return backend, db, service, note_id, tasks[0], target
+
+
+def _assert_only_target_task(
+    db: CharactersRAGDB,
+    *,
+    owner: str,
+    target: str,
+    task_id: str,
+) -> dict[str, Any]:
+    assert (
+        db.list_tasks(
+            owner_user_id=owner,
+            dataset_id=LOCAL_UNBOUND,
+            include_deleted=True,
+            limit=10,
+        )
+        == []
+    )
+    for table, _ordering in db.task_store._BIND_TABLE_ORDER:
+        # Table names come only from the fixed class-level task graph list.
+        row = db.execute_query(
+            f"SELECT COUNT(*) AS row_count FROM {table} "  # nosec B608
+            "WHERE owner_user_id = ? AND dataset_id = ?",
+            (owner, LOCAL_UNBOUND),
+        ).fetchone()
+        assert int(row["row_count"]) == 0, table
+    rows = db.list_tasks(
+        owner_user_id=owner,
+        dataset_id=target,
+        include_deleted=True,
+        limit=10,
+    )
+    assert [row["id"] for row in rows] == [task_id]
+    return rows[0]
+
+
+def test_postgres_empty_bind_persists_authority_before_first_task(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "960000"
+    backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    db = CharactersRAGDB(":memory:", client_id=owner, backend=backend)
+    service = NotesTaskService()
+    try:
+        assert (
+            resolve_task_compatibility_scope(
+                db,
+                authenticated_owner_user_id=owner,
+            ).dataset_id
+            == LOCAL_UNBOUND
+        )
+
+        target = f"dataset-{uuid4()}"
+        zero_counts = {
+            table: 0 for table, _ordering in db.task_store._BIND_TABLE_ORDER
+        }
+        assert db.bind_local_task_graph_to_dataset(
+            owner_user_id=owner,
+            target_dataset_id=target,
+        ) == zero_counts
+        assert db.bind_local_task_graph_to_dataset(
+            owner_user_id=owner,
+            target_dataset_id=target,
+        ) == zero_counts
+        with pytest.raises(ConflictError, match="immutable"):
+            db.bind_local_task_graph_to_dataset(
+                owner_user_id=owner,
+                target_dataset_id=f"dataset-{uuid4()}",
+            )
+
+        note_id = str(uuid4())
+        db.add_note("Bound-first task", "- [ ] Stay bound\n", note_id=note_id)
+        service.reconcile_note_current(
+            db=db,
+            note_id=note_id,
+            owner_user_id=owner,
+            actor=TaskActor(actor_type="user", actor_id=owner),
+        )
+        assert (
+            resolve_task_compatibility_scope(
+                db,
+                authenticated_owner_user_id=owner,
+            ).dataset_id
+            == target
+        )
+        assert len(db.list_tasks(
+            owner_user_id=owner,
+            dataset_id=target,
+            note_id=note_id,
+            limit=10,
+        )) == 1
+        assert db.list_tasks(
+            owner_user_id=owner,
+            dataset_id=LOCAL_UNBOUND,
+            note_id=note_id,
+            limit=10,
+        ) == []
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_service_updates_bound_task_without_recreating_sentinel_rows(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "960001"
+    backend, db, service, note_id, task, target = _bound_task_graph(
+        pg_database_config,
+        owner=owner,
+    )
+    try:
+        scope = resolve_task_compatibility_scope(
+            db,
+            authenticated_owner_user_id=owner,
+        )
+        assert scope.dataset_id == target
+
+        updated = service.update_task(
+            db=db,
+            owner_user_id=owner,
+            task_id=str(task["id"]),
+            expected_task_version=int(task["version"]),
+            expected_note_version=1,
+            text="Continuity preserved",
+            actor=TaskActor(actor_type="user", actor_id=owner),
+        )
+
+        assert updated["text"] == "Continuity preserved"
+        assert db.get_note_by_id(note_id)["content"] == "- [ ] Continuity preserved\n"
+        assert (
+            _assert_only_target_task(
+                db,
+                owner=owner,
+                target=target,
+                task_id=str(task["id"]),
+            )["text"]
+            == "Continuity preserved"
+        )
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_projected_update_serializes_before_same_target_bind(
+    pg_database_config: DatabaseConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = "960007"
+    backend, db, service, _note_id, task, target = _bound_task_graph(
+        pg_database_config,
+        owner=owner,
+    )
+    bind_backend = DatabaseBackendFactory.create_backend(pg_database_config)
+    bind_db = CharactersRAGDB(":memory:", client_id=owner, backend=bind_backend)
+    write_entered = threading.Event()
+    allow_write = threading.Event()
+    original_write = notes_task_service_module._write_note_content
+
+    def paused_write(*args: Any, **kwargs: Any) -> None:
+        write_entered.set()
+        assert allow_write.wait(30), "projected update was not released"
+        original_write(*args, **kwargs)
+
+    monkeypatch.setattr(notes_task_service_module, "_write_note_content", paused_write)
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            update_future = executor.submit(
+                service.update_task,
+                db=db,
+                owner_user_id=owner,
+                task_id=str(task["id"]),
+                expected_task_version=int(task["version"]),
+                expected_note_version=1,
+                text="Serialized update",
+                actor=TaskActor(actor_type="user", actor_id=owner),
+            )
+            assert write_entered.wait(30), "projected update did not reach the note write"
+            bind_future = executor.submit(
+                bind_db.bind_local_task_graph_to_dataset,
+                owner_user_id=owner,
+                target_dataset_id=target,
+            )
+            try:
+                with pytest.raises(FutureTimeoutError):
+                    bind_future.result(timeout=0.25)
+            finally:
+                allow_write.set()
+
+            assert update_future.result(timeout=30)["text"] == "Serialized update"
+            counts = bind_future.result(timeout=30)
+            assert counts["note_tasks"] == 1
+    finally:
+        allow_write.set()
+        bind_db.close_all_connections()
+        bind_backend.get_pool().close_all()
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_rest_reads_and_updates_bound_task_without_dataset_selector(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "960002"
+    backend, db, _service, note_id, task, target = _bound_task_graph(
+        pg_database_config,
+        owner=owner,
+    )
+
+    async def override_user() -> User:
+        return User(
+            id=int(owner),
+            username="pg-task-owner",
+            email="pg-task-owner@example.com",
+            is_active=True,
+            is_admin=True,
+        )
+
+    from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import (
+        get_chacha_db_for_user,
+    )
+
+    app = FastAPI()
+    endpoint = importlib.import_module("tldw_Server_API.app.api.v1.endpoints.notes_tasks")
+    app.include_router(endpoint.router, prefix="/api/v1/notes")
+    app.dependency_overrides[get_request_user] = override_user
+    app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    app.dependency_overrides[get_rate_limiter_dep] = lambda: _NoopRateLimiter()
+
+    try:
+        with TestClient(app) as client:
+            fetched = client.get(f"/api/v1/notes/tasks/{task['id']}")
+            assert fetched.status_code == 200, fetched.text
+            assert fetched.json()["text"] == "Preserve continuity"
+            assert fetched.json()["created_at"] == task["created_at"].isoformat()
+
+            updated = client.patch(
+                f"/api/v1/notes/tasks/{task['id']}",
+                json={
+                    "text": "REST continuity",
+                    "expected_task_version": task["version"],
+                    "expected_note_version": 1,
+                },
+            )
+            assert updated.status_code == 200, updated.text
+            assert updated.json()["text"] == "REST continuity"
+
+        assert db.get_note_by_id(note_id)["content"] == "- [ ] REST continuity\n"
+        assert (
+            _assert_only_target_task(
+                db,
+                owner=owner,
+                target=target,
+                task_id=str(task["id"]),
+            )["text"]
+            == "REST continuity"
+        )
+    finally:
+        app.dependency_overrides.clear()
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_rest_activity_after_bind_serializes_read_and_dismiss_timestamps(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "960006"
+    backend, db, _service, note_id, task, target = _bound_task_graph(
+        pg_database_config,
+        owner=owner,
+    )
+    event = db.record_task_event(
+        owner_user_id=owner,
+        dataset_id=target,
+        task_id=str(task["id"]),
+        note_id=note_id,
+        event_type="updated",
+        actor_type="agent",
+        actor_id="assistant",
+    )
+
+    async def override_user() -> User:
+        return User(
+            id=int(owner),
+            username="pg-task-activity-owner",
+            email="pg-task-activity-owner@example.com",
+            is_active=True,
+            is_admin=True,
+        )
+
+    from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import (
+        get_chacha_db_for_user,
+    )
+
+    app = FastAPI()
+    endpoint = importlib.import_module("tldw_Server_API.app.api.v1.endpoints.notes_tasks")
+    app.include_router(endpoint.router, prefix="/api/v1/notes")
+    app.dependency_overrides[get_request_user] = override_user
+    app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    app.dependency_overrides[get_rate_limiter_dep] = lambda: _NoopRateLimiter()
+
+    try:
+        with TestClient(app) as client:
+            activity = client.get("/api/v1/notes/tasks/activity")
+            assert activity.status_code == 200, activity.text
+            assert activity.json()["events"][0]["id"] == event["id"]
+            assert activity.json()["events"][0]["created_at"] == event["created_at"].isoformat()
+
+            read = client.patch(
+                f"/api/v1/notes/tasks/activity/{event['id']}",
+                json={"read": True},
+            )
+            assert read.status_code == 200, read.text
+            read_state = db.get_task_activity_read_state(
+                owner_user_id=owner,
+                dataset_id=target,
+                event_id=str(event["id"]),
+                user_id=owner,
+            )
+            assert read_state is not None
+            assert read.json()["read_at"] == read_state["read_at"].isoformat()
+            assert read.json()["dismissed_at"] is None
+
+            dismissed = client.patch(
+                f"/api/v1/notes/tasks/activity/{event['id']}",
+                json={"dismissed": True},
+            )
+            assert dismissed.status_code == 200, dismissed.text
+            dismissed_state = db.get_task_activity_read_state(
+                owner_user_id=owner,
+                dataset_id=target,
+                event_id=str(event["id"]),
+                user_id=owner,
+            )
+            assert dismissed_state is not None
+            assert dismissed.json()["read_at"] == dismissed_state["read_at"].isoformat()
+            assert dismissed.json()["dismissed_at"] == dismissed_state["dismissed_at"].isoformat()
+    finally:
+        app.dependency_overrides.clear()
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+@pytest.mark.asyncio
+async def test_postgres_mcp_reads_and_updates_bound_task_without_dataset_selector(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner = "960003"
+    backend, db, _service, note_id, task, target = _bound_task_graph(
+        pg_database_config,
+        owner=owner,
+    )
+    module = NotesModule(ModuleConfig(name="notes"))
+    module._open_db = lambda _context: db  # type: ignore[method-assign]
+    module._close_task_db = lambda _db, _operation: None  # type: ignore[method-assign]
+    context = SimpleNamespace(
+        request_id="req-pg-task",
+        user_id=owner,
+        client_id="pg-task-client",
+        session_id="pg-task-session",
+        metadata={},
+    )
+
+    try:
+        fetched = await module.execute_tool(
+            "notes.tasks.get",
+            {"task_id": task["id"]},
+            context=context,
+        )
+        assert fetched["text"] == "Preserve continuity"
+
+        updated = await module.execute_tool(
+            "notes.tasks.update",
+            {
+                "task_id": task["id"],
+                "text": "MCP continuity",
+                "expected_task_version": task["version"],
+                "expected_note_version": 1,
+            },
+            context=context,
+        )
+        assert updated["text"] == "MCP continuity"
+        assert db.get_note_by_id(note_id)["content"] == "- [ ] MCP continuity\n"
+        assert (
+            _assert_only_target_task(
+                db,
+                owner=owner,
+                target=target,
+                task_id=str(task["id"]),
+            )["text"]
+            == "MCP continuity"
+        )
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()
+
+
+def test_postgres_compatibility_resolver_performs_no_graph_lock_or_ddl(
+    pg_database_config: DatabaseConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = "960005"
+    backend, db, _service, _note_id, _task, _target = _bound_task_graph(
+        pg_database_config,
+        owner=owner,
+    )
+    queries: list[str] = []
+    original_read = db.task_store._read
+
+    def record_read(query: str, *args: Any, **kwargs: Any) -> Any:
+        queries.append(query)
+        return original_read(query, *args, **kwargs)
+
+    monkeypatch.setattr(db.task_store, "_read", record_read)
+    monkeypatch.setattr(
+        db.task_store,
+        "_execute",
+        lambda *_args, **_kwargs: pytest.fail("resolver must not execute DDL or locks"),
+    )
+    try:
+        assert resolve_task_compatibility_scope(
+            db,
+            authenticated_owner_user_id=owner,
+        ).dataset_id == _target
+        rendered = " ".join(queries).upper()
+        assert "NOTE_TASK_SCOPE_AUTHORITY" in rendered
+        assert "LOCK TABLE" not in rendered
+        assert "ALTER TABLE" not in rendered
+        assert "SELECT DISTINCT" not in rendered
+    finally:
+        db.close_all_connections()
+        backend.get_pool().close_all()

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_reconciliation_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_reconciliation_api.py
@@ -16,6 +16,9 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGD
 
 pytestmark = pytest.mark.integration
 
+TASK_OWNER_USER_ID = "notes_tasks_api_user"
+TASK_DATASET_ID = "local-unbound"
+
 
 class _NoopRateLimiter:
     async def check_user_rate_limit(self, *_args, **_kwargs):
@@ -29,7 +32,7 @@ class _FailingNotesTaskService:
 
 @pytest.fixture()
 def notes_tasks_client(tmp_path: Path) -> Generator[tuple[TestClient, CharactersRAGDB], None, None]:
-    db = CharactersRAGDB(str(tmp_path / "notes_tasks_api.db"), client_id="notes_tasks_api_user")
+    db = CharactersRAGDB(str(tmp_path / "notes_tasks_api.db"), client_id=TASK_OWNER_USER_ID)
 
     async def override_user():
         return User(id=1, username="tester", email="t@e.com", is_active=True, is_admin=True)
@@ -54,7 +57,16 @@ def notes_tasks_client(tmp_path: Path) -> Generator[tuple[TestClient, Characters
 
 
 def _tasks_by_text(db: CharactersRAGDB, note_id: str) -> dict[str, dict]:
-    return {task["text"]: task for task in db.list_tasks(note_id=note_id, include_deleted=True, limit=100)}
+    return {
+        task["text"]: task
+        for task in db.list_tasks(
+            note_id=note_id,
+            include_deleted=True,
+            limit=100,
+            owner_user_id=TASK_OWNER_USER_ID,
+            dataset_id=TASK_DATASET_ID,
+        )
+    }
 
 
 def _single_note_by_title(db: CharactersRAGDB, title: str) -> dict:
@@ -79,8 +91,18 @@ def test_note_create_returns_saved_note_when_reconciliation_raises(
     saved_note = db.get_note_by_id(created["id"])
     assert saved_note is not None
     assert saved_note["content"] == "- [ ] Alpha\n"
-    assert db.get_reconciliation_state(created["id"]) is None
-    assert db.list_tasks(note_id=created["id"], include_deleted=True, limit=100) == []
+    assert db.get_reconciliation_state(
+        created["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    ) is None
+    assert db.list_tasks(
+        note_id=created["id"],
+        include_deleted=True,
+        limit=100,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    ) == []
 
 
 def test_note_patch_returns_saved_note_when_reconciliation_raises(
@@ -94,7 +116,11 @@ def test_note_patch_returns_saved_note_when_reconciliation_raises(
     )
     assert create_response.status_code == 201, create_response.text
     created = create_response.json()
-    original_state = db.get_reconciliation_state(created["id"])
+    original_state = db.get_reconciliation_state(
+        created["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     assert original_state is not None
     client.app.dependency_overrides[notes_endpoint.get_notes_task_service] = lambda: _FailingNotesTaskService()
 
@@ -110,7 +136,11 @@ def test_note_patch_returns_saved_note_when_reconciliation_raises(
     assert patched["content"] == "- [x] Alpha\n"
     assert saved_note is not None
     assert saved_note["content"] == "- [x] Alpha\n"
-    assert db.get_reconciliation_state(created["id"]) == original_state
+    assert db.get_reconciliation_state(
+        created["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    ) == original_state
 
 
 def test_note_create_ignores_empty_checklist_placeholder_with_warning_state(
@@ -125,8 +155,18 @@ def test_note_create_ignores_empty_checklist_placeholder_with_warning_state(
 
     assert create_response.status_code == 201, create_response.text
     created = create_response.json()
-    state = db.get_reconciliation_state(created["id"])
-    tasks = db.list_tasks(note_id=created["id"], include_deleted=True, limit=100)
+    state = db.get_reconciliation_state(
+        created["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
+    tasks = db.list_tasks(
+        note_id=created["id"],
+        include_deleted=True,
+        limit=100,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     assert [task["text"] for task in tasks] == ["Alpha"]
     assert state is not None
     assert state["status"] == "warnings"
@@ -155,7 +195,11 @@ def test_title_only_put_advances_reconciliation_state_without_changing_tasks(
 
     assert update_response.status_code == 200, update_response.text
     updated = update_response.json()
-    updated_state = db.get_reconciliation_state(note_id)
+    updated_state = db.get_reconciliation_state(
+        note_id,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     updated_tasks = _tasks_by_text(db, note_id)
     assert updated["version"] == created["version"] + 1
     assert updated_state is not None
@@ -188,7 +232,11 @@ def test_title_only_patch_advances_reconciliation_state_without_changing_tasks(
 
     assert patch_response.status_code == 200, patch_response.text
     patched = patch_response.json()
-    patched_state = db.get_reconciliation_state(note_id)
+    patched_state = db.get_reconciliation_state(
+        note_id,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     patched_tasks = _tasks_by_text(db, note_id)
     assert patched["version"] == created["version"] + 1
     assert patched_state is not None
@@ -222,7 +270,11 @@ def test_bulk_create_reconciles_checklist_tasks_for_created_note(
     assert payload["failed_count"] == 0
     created_note = payload["results"][0]["note"]
     note_id = created_note["id"]
-    state = db.get_reconciliation_state(note_id)
+    state = db.get_reconciliation_state(
+        note_id,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     tasks = _tasks_by_text(db, note_id)
 
     assert state is not None
@@ -259,7 +311,11 @@ def test_markdown_import_reconciles_checklist_tasks_for_created_note(
     assert payload["created_count"] == 1
     assert payload["failed_count"] == 0
     imported_note = _single_note_by_title(db, "Import Tasks")
-    state = db.get_reconciliation_state(imported_note["id"])
+    state = db.get_reconciliation_state(
+        imported_note["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     tasks = _tasks_by_text(db, imported_note["id"])
 
     assert state is not None
@@ -284,7 +340,11 @@ def test_note_create_update_and_conflict_reconcile_tasks_after_successful_saves(
     created = create_response.json()
     note_id = created["id"]
 
-    created_state = db.get_reconciliation_state(note_id)
+    created_state = db.get_reconciliation_state(
+        note_id,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     created_tasks = _tasks_by_text(db, note_id)
     assert created_state is not None
     assert created_state["note_version"] == created["version"]
@@ -302,7 +362,11 @@ def test_note_create_update_and_conflict_reconcile_tasks_after_successful_saves(
     assert update_response.status_code == 200, update_response.text
     updated = update_response.json()
     updated_tasks = _tasks_by_text(db, note_id)
-    updated_state = db.get_reconciliation_state(note_id)
+    updated_state = db.get_reconciliation_state(
+        note_id,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
 
     assert updated["version"] == created["version"] + 1
     assert updated_state is not None
@@ -318,7 +382,11 @@ def test_note_create_update_and_conflict_reconcile_tasks_after_successful_saves(
     )
     assert conflict_response.status_code == 409, conflict_response.text
 
-    assert db.get_reconciliation_state(note_id) == updated_state
+    assert db.get_reconciliation_state(
+        note_id,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    ) == updated_state
     tasks_after_conflict = _tasks_by_text(db, note_id)
     assert tasks_after_conflict["Alpha"]["status"] == "done"
     assert tasks_after_conflict["Beta"]["status"] == "open"

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_reconciliation_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_reconciliation_api.py
@@ -92,9 +92,9 @@ def test_note_create_returns_saved_note_when_reconciliation_raises(
     assert saved_note is not None
     assert saved_note["content"] == "- [ ] Alpha\n"
     assert db.get_reconciliation_state(
-        created["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=created["id"],
     ) is None
     assert db.list_tasks(
         note_id=created["id"],
@@ -117,9 +117,9 @@ def test_note_patch_returns_saved_note_when_reconciliation_raises(
     assert create_response.status_code == 201, create_response.text
     created = create_response.json()
     original_state = db.get_reconciliation_state(
-        created["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=created["id"],
     )
     assert original_state is not None
     client.app.dependency_overrides[notes_endpoint.get_notes_task_service] = lambda: _FailingNotesTaskService()
@@ -137,9 +137,9 @@ def test_note_patch_returns_saved_note_when_reconciliation_raises(
     assert saved_note is not None
     assert saved_note["content"] == "- [x] Alpha\n"
     assert db.get_reconciliation_state(
-        created["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=created["id"],
     ) == original_state
 
 
@@ -156,9 +156,9 @@ def test_note_create_ignores_empty_checklist_placeholder_with_warning_state(
     assert create_response.status_code == 201, create_response.text
     created = create_response.json()
     state = db.get_reconciliation_state(
-        created["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=created["id"],
     )
     tasks = db.list_tasks(
         note_id=created["id"],
@@ -196,9 +196,9 @@ def test_title_only_put_advances_reconciliation_state_without_changing_tasks(
     assert update_response.status_code == 200, update_response.text
     updated = update_response.json()
     updated_state = db.get_reconciliation_state(
-        note_id,
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note_id,
     )
     updated_tasks = _tasks_by_text(db, note_id)
     assert updated["version"] == created["version"] + 1
@@ -233,9 +233,9 @@ def test_title_only_patch_advances_reconciliation_state_without_changing_tasks(
     assert patch_response.status_code == 200, patch_response.text
     patched = patch_response.json()
     patched_state = db.get_reconciliation_state(
-        note_id,
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note_id,
     )
     patched_tasks = _tasks_by_text(db, note_id)
     assert patched["version"] == created["version"] + 1
@@ -271,9 +271,9 @@ def test_bulk_create_reconciles_checklist_tasks_for_created_note(
     created_note = payload["results"][0]["note"]
     note_id = created_note["id"]
     state = db.get_reconciliation_state(
-        note_id,
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note_id,
     )
     tasks = _tasks_by_text(db, note_id)
 
@@ -312,9 +312,9 @@ def test_markdown_import_reconciles_checklist_tasks_for_created_note(
     assert payload["failed_count"] == 0
     imported_note = _single_note_by_title(db, "Import Tasks")
     state = db.get_reconciliation_state(
-        imported_note["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=imported_note["id"],
     )
     tasks = _tasks_by_text(db, imported_note["id"])
 
@@ -341,9 +341,9 @@ def test_note_create_update_and_conflict_reconcile_tasks_after_successful_saves(
     note_id = created["id"]
 
     created_state = db.get_reconciliation_state(
-        note_id,
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note_id,
     )
     created_tasks = _tasks_by_text(db, note_id)
     assert created_state is not None
@@ -363,9 +363,9 @@ def test_note_create_update_and_conflict_reconcile_tasks_after_successful_saves(
     updated = update_response.json()
     updated_tasks = _tasks_by_text(db, note_id)
     updated_state = db.get_reconciliation_state(
-        note_id,
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note_id,
     )
 
     assert updated["version"] == created["version"] + 1
@@ -383,9 +383,9 @@ def test_note_create_update_and_conflict_reconcile_tasks_after_successful_saves(
     assert conflict_response.status_code == 409, conflict_response.text
 
     assert db.get_reconciliation_state(
-        note_id,
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note_id,
     ) == updated_state
     tasks_after_conflict = _tasks_by_text(db, note_id)
     assert tasks_after_conflict["Alpha"]["status"] == "done"

--- a/tldw_Server_API/tests/Notes_Tasks/unit/test_reconciler.py
+++ b/tldw_Server_API/tests/Notes_Tasks/unit/test_reconciler.py
@@ -13,10 +13,13 @@ from tldw_Server_API.app.core.Notes_Tasks.service import NotesTaskService
 
 pytestmark = pytest.mark.unit
 
+TASK_OWNER_USER_ID = "task_reconciler_test"
+TASK_DATASET_ID = "local-unbound"
+
 
 @pytest.fixture()
 def notes_db(tmp_path: Path) -> Generator[CharactersRAGDB, None, None]:
-    db = CharactersRAGDB(str(tmp_path / "notes_tasks_reconciler.db"), client_id="task_reconciler_test")
+    db = CharactersRAGDB(str(tmp_path / "notes_tasks_reconciler.db"), client_id=TASK_OWNER_USER_ID)
     try:
         yield db
     finally:
@@ -58,16 +61,30 @@ def _reconcile(service: NotesTaskService, db: CharactersRAGDB, note: dict):
         note_version=int(note["version"]),
         content=str(note["content"]),
         actor=_actor(),
+        owner_user_id=TASK_OWNER_USER_ID,
     )
 
 
 def _task_by_text(db: CharactersRAGDB, note_id: str) -> dict[str, dict]:
-    return {task["text"]: task for task in db.list_tasks(note_id=note_id, include_deleted=True, limit=100)}
+    return {
+        task["text"]: task
+        for task in db.list_tasks(
+            note_id=note_id,
+            include_deleted=True,
+            limit=100,
+            owner_user_id=TASK_OWNER_USER_ID,
+            dataset_id=TASK_DATASET_ID,
+        )
+    }
 
 
 def _live_tasks_by_line(db: CharactersRAGDB, note_id: str) -> dict[int, dict]:
     tasks_by_line: dict[int, dict] = {}
-    for pair in db.task_store.list_live_projected_tasks(note_id=note_id):
+    for pair in db.task_store.list_live_projected_tasks(
+        note_id=note_id,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    ):
         tasks_by_line[int(pair["projection"]["line_number"])] = pair["task"]
     return tasks_by_line
 
@@ -75,7 +92,13 @@ def _live_tasks_by_line(db: CharactersRAGDB, note_id: str) -> dict[int, dict]:
 def _tasks_for_text(db: CharactersRAGDB, note_id: str, text: str) -> list[dict]:
     return [
         task
-        for task in db.list_tasks(note_id=note_id, include_deleted=True, limit=100)
+        for task in db.list_tasks(
+            note_id=note_id,
+            include_deleted=True,
+            limit=100,
+            owner_user_id=TASK_OWNER_USER_ID,
+            dataset_id=TASK_DATASET_ID,
+        )
         if task["text"] == text
     ]
 
@@ -87,18 +110,34 @@ def test_unchanged_content_is_idempotent(
     note = _create_note(notes_db, "- [ ] Alpha\n- [x] Beta\n")
 
     first = _reconcile(service, notes_db, note)
-    tasks_after_first = notes_db.list_tasks(note_id=note["id"], include_deleted=True, limit=100)
+    tasks_after_first = notes_db.list_tasks(
+        note_id=note["id"],
+        include_deleted=True,
+        limit=100,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     versions_after_first = {task["id"]: task["version"] for task in tasks_after_first}
 
     second = _reconcile(service, notes_db, note)
-    tasks_after_second = notes_db.list_tasks(note_id=note["id"], include_deleted=True, limit=100)
+    tasks_after_second = notes_db.list_tasks(
+        note_id=note["id"],
+        include_deleted=True,
+        limit=100,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
 
     assert first.created_count == 2
     assert second.created_count == 0
     assert second.updated_count == 0
     assert [task["id"] for task in tasks_after_second] == [task["id"] for task in tasks_after_first]
     assert {task["id"]: task["version"] for task in tasks_after_second} == versions_after_first
-    assert notes_db.get_reconciliation_state(note["id"])["note_version"] == note["version"]
+    assert notes_db.get_reconciliation_state(
+        note["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )["note_version"] == note["version"]
 
 
 def test_same_locator_and_hash_preserves_task_id(
@@ -129,7 +168,11 @@ def test_child_detail_only_edit_preserves_task_id(
     updated_note = _update_note(notes_db, note["id"], int(note["version"]), "- [ ] Task\n  detail B\n")
     result = _reconcile(service, notes_db, updated_note)
     updated_task = _task_by_text(notes_db, note["id"])["Task"]
-    state = notes_db.get_reconciliation_state(note["id"])
+    state = notes_db.get_reconciliation_state(
+        note["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
 
     assert result.created_count == 0
     assert result.updated_count == 0
@@ -165,18 +208,36 @@ def test_duplicate_text_reorder_becomes_ambiguous_or_distinct(
     _reconcile(service, notes_db, note)
     original_live_ids = {
         task["id"]
-        for task in notes_db.list_tasks(note_id=note["id"], include_deleted=True, limit=100)
+        for task in notes_db.list_tasks(
+            note_id=note["id"],
+            include_deleted=True,
+            limit=100,
+            owner_user_id=TASK_OWNER_USER_ID,
+            dataset_id=TASK_DATASET_ID,
+        )
         if task["projection_status"] == "live"
     }
     original_same_ids = {
         task["id"]
-        for task in notes_db.list_tasks(note_id=note["id"], include_deleted=True, limit=100)
+        for task in notes_db.list_tasks(
+            note_id=note["id"],
+            include_deleted=True,
+            limit=100,
+            owner_user_id=TASK_OWNER_USER_ID,
+            dataset_id=TASK_DATASET_ID,
+        )
         if task["projection_status"] == "live" and task["text"] == "Same"
     }
 
     updated_note = _update_note(notes_db, note["id"], int(note["version"]), "- [ ] Same\n- [ ] Solo\n- [ ] Same\n")
     result = _reconcile(service, notes_db, updated_note)
-    tasks = notes_db.list_tasks(note_id=note["id"], include_deleted=True, limit=100)
+    tasks = notes_db.list_tasks(
+        note_id=note["id"],
+        include_deleted=True,
+        limit=100,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     live_ids = {task["id"] for task in tasks if task["projection_status"] == "live"}
     live_same_ids = {task["id"] for task in tasks if task["projection_status"] == "live" and task["text"] == "Same"}
     unlinked_same_ids = {
@@ -238,7 +299,12 @@ def test_unique_hash_fallback_requires_same_block_fingerprint(
     _reconcile(service, notes_db, updated_note)
     move_tasks = _tasks_for_text(notes_db, note["id"], "Move me")
     live_move_tasks = [task for task in move_tasks if task["projection_status"] == "live"]
-    original_after = notes_db.get_task(original_move_task["id"], include_deleted=True)
+    original_after = notes_db.get_task(
+        original_move_task["id"],
+        include_deleted=True,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
 
     assert len(live_move_tasks) == 1
     assert live_move_tasks[0]["id"] != original_move_task["id"]
@@ -253,7 +319,11 @@ def test_missing_live_projection_row_fails_closed_without_duplicate_task(
     note = _create_note(notes_db, "- [ ] Alpha\n")
     _reconcile(service, notes_db, note)
     original_alpha = _task_by_text(notes_db, note["id"])["Alpha"]
-    original_state = notes_db.get_reconciliation_state(note["id"])
+    original_state = notes_db.get_reconciliation_state(
+        note["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     assert original_state is not None
     notes_db.execute_query(
         "DELETE FROM task_note_projections WHERE task_id = ?",
@@ -264,9 +334,19 @@ def test_missing_live_projection_row_fails_closed_without_duplicate_task(
     with pytest.raises(ConflictError):
         _reconcile(service, notes_db, updated_note)
 
-    tasks = notes_db.list_tasks(note_id=note["id"], include_deleted=True, limit=100)
+    tasks = notes_db.list_tasks(
+        note_id=note["id"],
+        include_deleted=True,
+        limit=100,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     assert [task["text"] for task in tasks] == ["Alpha"]
-    assert notes_db.get_reconciliation_state(note["id"]) == original_state
+    assert notes_db.get_reconciliation_state(
+        note["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    ) == original_state
 
 
 def test_empty_checklist_placeholder_is_warning_not_task(
@@ -276,8 +356,18 @@ def test_empty_checklist_placeholder_is_warning_not_task(
     note = _create_note(notes_db, "- [ ]\n- [ ] Alpha\n")
 
     result = _reconcile(service, notes_db, note)
-    tasks = notes_db.list_tasks(note_id=note["id"], include_deleted=True, limit=100)
-    state = notes_db.get_reconciliation_state(note["id"])
+    tasks = notes_db.list_tasks(
+        note_id=note["id"],
+        include_deleted=True,
+        limit=100,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
+    state = notes_db.get_reconciliation_state(
+        note["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
 
     assert result.created_count == 1
     assert result.warning_count == 1
@@ -297,7 +387,12 @@ def test_missing_line_marks_previous_task_unlinked(
 
     updated_note = _update_note(notes_db, note["id"], int(note["version"]), "- [ ] Alpha\n")
     result = _reconcile(service, notes_db, updated_note)
-    beta = notes_db.get_task(beta_id, include_deleted=True)
+    beta = notes_db.get_task(
+        beta_id,
+        include_deleted=True,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
 
     assert result.unlinked_count == 1
     assert beta is not None
@@ -314,8 +409,18 @@ def test_manual_line_removal_does_not_hard_delete_task_history(
 
     updated_note = _update_note(notes_db, note["id"], int(note["version"]), "- [ ] Keep\n")
     _reconcile(service, notes_db, updated_note)
-    removed_task = notes_db.get_task(removed_id, include_deleted=True)
-    events = notes_db.list_task_activity(task_id=removed_id, limit=20)
+    removed_task = notes_db.get_task(
+        removed_id,
+        include_deleted=True,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
+    events = notes_db.list_task_activity(
+        task_id=removed_id,
+        limit=20,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
 
     assert removed_task is not None
     assert not bool(removed_task["deleted"])
@@ -329,7 +434,11 @@ def test_stale_note_version_does_not_update_reconciliation_state(
 ) -> None:
     note = _create_note(notes_db, "- [ ] Alpha\n")
     _reconcile(service, notes_db, note)
-    original_state = notes_db.get_reconciliation_state(note["id"])
+    original_state = notes_db.get_reconciliation_state(
+        note["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    )
     assert original_state is not None
 
     _update_note(notes_db, note["id"], int(note["version"]), "- [x] Alpha\n")
@@ -341,9 +450,14 @@ def test_stale_note_version_does_not_update_reconciliation_state(
             note_version=int(note["version"]),
             content="- [x] Alpha\n",
             actor=_actor(),
+            owner_user_id=TASK_OWNER_USER_ID,
         )
 
-    assert notes_db.get_reconciliation_state(note["id"]) == original_state
+    assert notes_db.get_reconciliation_state(
+        note["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    ) == original_state
 
 
 def test_current_note_validation_uses_public_task_store_snapshot(
@@ -353,7 +467,14 @@ def test_current_note_validation_uses_public_task_store_snapshot(
 ) -> None:
     note = _create_note(notes_db, "- [ ] Alpha\n")
 
-    def stale_snapshot(self, *, note_id: str, conn=None):
+    def stale_snapshot(
+        self,
+        *,
+        note_id: str,
+        owner_user_id: str,
+        dataset_id: str,
+        conn=None,
+    ):
         return {
             "id": note_id,
             "version": int(note["version"]) + 1,
@@ -371,5 +492,15 @@ def test_current_note_validation_uses_public_task_store_snapshot(
     with pytest.raises(ConflictError):
         _reconcile(service, notes_db, note)
 
-    assert notes_db.list_tasks(note_id=note["id"], include_deleted=True, limit=100) == []
-    assert notes_db.get_reconciliation_state(note["id"]) is None
+    assert notes_db.list_tasks(
+        note_id=note["id"],
+        include_deleted=True,
+        limit=100,
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    ) == []
+    assert notes_db.get_reconciliation_state(
+        note["id"],
+        owner_user_id=TASK_OWNER_USER_ID,
+        dataset_id=TASK_DATASET_ID,
+    ) is None

--- a/tldw_Server_API/tests/Notes_Tasks/unit/test_reconciler.py
+++ b/tldw_Server_API/tests/Notes_Tasks/unit/test_reconciler.py
@@ -134,9 +134,9 @@ def test_unchanged_content_is_idempotent(
     assert [task["id"] for task in tasks_after_second] == [task["id"] for task in tasks_after_first]
     assert {task["id"]: task["version"] for task in tasks_after_second} == versions_after_first
     assert notes_db.get_reconciliation_state(
-        note["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note["id"],
     )["note_version"] == note["version"]
 
 
@@ -169,9 +169,9 @@ def test_child_detail_only_edit_preserves_task_id(
     result = _reconcile(service, notes_db, updated_note)
     updated_task = _task_by_text(notes_db, note["id"])["Task"]
     state = notes_db.get_reconciliation_state(
-        note["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note["id"],
     )
 
     assert result.created_count == 0
@@ -300,10 +300,10 @@ def test_unique_hash_fallback_requires_same_block_fingerprint(
     move_tasks = _tasks_for_text(notes_db, note["id"], "Move me")
     live_move_tasks = [task for task in move_tasks if task["projection_status"] == "live"]
     original_after = notes_db.get_task(
-        original_move_task["id"],
-        include_deleted=True,
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        task_id=original_move_task["id"],
+        include_deleted=True,
     )
 
     assert len(live_move_tasks) == 1
@@ -320,9 +320,9 @@ def test_missing_live_projection_row_fails_closed_without_duplicate_task(
     _reconcile(service, notes_db, note)
     original_alpha = _task_by_text(notes_db, note["id"])["Alpha"]
     original_state = notes_db.get_reconciliation_state(
-        note["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note["id"],
     )
     assert original_state is not None
     notes_db.execute_query(
@@ -343,9 +343,9 @@ def test_missing_live_projection_row_fails_closed_without_duplicate_task(
     )
     assert [task["text"] for task in tasks] == ["Alpha"]
     assert notes_db.get_reconciliation_state(
-        note["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note["id"],
     ) == original_state
 
 
@@ -364,9 +364,9 @@ def test_empty_checklist_placeholder_is_warning_not_task(
         dataset_id=TASK_DATASET_ID,
     )
     state = notes_db.get_reconciliation_state(
-        note["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note["id"],
     )
 
     assert result.created_count == 1
@@ -388,10 +388,10 @@ def test_missing_line_marks_previous_task_unlinked(
     updated_note = _update_note(notes_db, note["id"], int(note["version"]), "- [ ] Alpha\n")
     result = _reconcile(service, notes_db, updated_note)
     beta = notes_db.get_task(
-        beta_id,
-        include_deleted=True,
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        task_id=beta_id,
+        include_deleted=True,
     )
 
     assert result.unlinked_count == 1
@@ -410,10 +410,10 @@ def test_manual_line_removal_does_not_hard_delete_task_history(
     updated_note = _update_note(notes_db, note["id"], int(note["version"]), "- [ ] Keep\n")
     _reconcile(service, notes_db, updated_note)
     removed_task = notes_db.get_task(
-        removed_id,
-        include_deleted=True,
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        task_id=removed_id,
+        include_deleted=True,
     )
     events = notes_db.list_task_activity(
         task_id=removed_id,
@@ -435,9 +435,9 @@ def test_stale_note_version_does_not_update_reconciliation_state(
     note = _create_note(notes_db, "- [ ] Alpha\n")
     _reconcile(service, notes_db, note)
     original_state = notes_db.get_reconciliation_state(
-        note["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note["id"],
     )
     assert original_state is not None
 
@@ -454,9 +454,9 @@ def test_stale_note_version_does_not_update_reconciliation_state(
         )
 
     assert notes_db.get_reconciliation_state(
-        note["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note["id"],
     ) == original_state
 
 
@@ -500,7 +500,7 @@ def test_current_note_validation_uses_public_task_store_snapshot(
         dataset_id=TASK_DATASET_ID,
     ) == []
     assert notes_db.get_reconciliation_state(
-        note["id"],
         owner_user_id=TASK_OWNER_USER_ID,
         dataset_id=TASK_DATASET_ID,
+        note_id=note["id"],
     ) is None

--- a/tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+++ b/tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
@@ -53,7 +53,11 @@ def test_create_task_for_note_rejects_invalid_status_without_rewriting_note(db: 
     saved = db.get_note_by_id(str(note["id"]))
     assert saved is not None
     assert saved["content"] == "Intro\n"
-    assert db.list_tasks(note_id=str(note["id"])) == []
+    assert db.list_tasks(
+        note_id=str(note["id"]),
+        owner_user_id=db.client_id,
+        dataset_id="local-unbound",
+    ) == []
 
 
 @pytest.mark.parametrize(

--- a/tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+++ b/tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +11,6 @@ import pytest
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
 from tldw_Server_API.app.core.Notes_Tasks.models import TaskActor
 from tldw_Server_API.app.core.Notes_Tasks.service import NotesTaskService, _parse_checklist_line
-
 
 pytestmark = pytest.mark.unit
 
@@ -33,6 +33,15 @@ def _add_note(db: CharactersRAGDB, *, title: str, content: str) -> dict[str, Any
     note = db.get_note_by_id(str(note_id))
     assert note is not None
     return note
+
+
+def test_projected_mutations_lock_task_scope_before_reading_task_or_note_rows() -> None:
+    """Keep projected note writes in the same authority-first order as dataset bind."""
+    for method in (NotesTaskService.update_task, NotesTaskService.delete_task):
+        source = inspect.getsource(method)
+        fence = source.index("lock_authorized_write_scope")
+        assert fence < source.index("_require_task_version")
+        assert fence < source.index("_write_note_content")
 
 
 def test_create_task_for_note_rejects_invalid_status_without_rewriting_note(db: CharactersRAGDB) -> None:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py
@@ -2037,6 +2037,128 @@ def test_dataset_enroll_endpoint_rejects_forged_attachment_readiness(
     assert sync_service.store.list_datasets_for_user("user-1") == []
 
 
+@pytest.mark.parametrize(
+    ("metadata_key", "value", "private_marker"),
+    [
+        (
+            "notes_task_v1",
+            {
+                "state": "ready",
+                "source_cursor": "00000000-0000-4000-8000-000000000001",
+            },
+            "00000000-0000-4000-8000-000000000001",
+        ),
+        (
+            "notes_task_activity_v1",
+            {
+                "state": "ready",
+                "source_cursor": (
+                    "2026-08-13T00:00:00+00:00|"
+                    "00000000-0000-4000-8000-000000000011"
+                ),
+            },
+            "00000000-0000-4000-8000-000000000011",
+        ),
+        ("task_activity_capture_enabled", True, "task_activity_capture_enabled"),
+    ],
+)
+def test_dataset_enroll_endpoint_rejects_forged_task_readiness(
+    client: TestClient,
+    sync_service: SyncV2Service,
+    metadata_key: str,
+    value: object,
+    private_marker: str,
+) -> None:
+    response = client.post(
+        "/api/v1/sync/datasets/enroll",
+        json={
+            "dataset_id": f"forged-{metadata_key}",
+            "scope_type": "personal",
+            "domains": list(M1_SYNC_DOMAINS),
+            "encryption_policy": "server_trusted_v1",
+            "metadata": {metadata_key: value},
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == {
+        "error_code": "sync_reserved_dataset_enrollment",
+        "message": "Reserved Sync dataset capabilities require profile bootstrap.",
+    }
+    assert private_marker not in response.text
+    assert sync_service.store.list_datasets_for_user("user-1") == []
+
+
+def test_dataset_enrollment_and_manifest_never_disclose_task_readiness_metadata(
+    client: TestClient,
+    sync_service: SyncV2Service,
+) -> None:
+    server_metadata = {
+        "notes_task_v1": {
+            "state": "ready",
+            "source_cursor": "00000000-0000-4000-8000-000000000001",
+            "source_count": 1,
+            "source_fingerprint": "a" * 64,
+            "reason_code": None,
+            "resume_phase": None,
+        },
+        "notes_task_activity_v1": {
+            "state": "ready",
+            "source_cursor": (
+                "2026-08-13T00:00:00+00:00|"
+                "00000000-0000-4000-8000-000000000011"
+            ),
+            "source_count": 1,
+            "source_fingerprint": "b" * 64,
+            "reason_code": None,
+            "resume_phase": None,
+        },
+        "task_activity_capture_enabled": True,
+    }
+    sync_service.store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-task-readiness-private",
+            owner_user_id="user-1",
+            domains=list(M1_SYNC_DOMAINS),
+            metadata={"label": "before", **server_metadata},
+        )
+    )
+
+    enrolled = client.post(
+        "/api/v1/sync/datasets/enroll",
+        json={
+            "dataset_id": "dataset-task-readiness-private",
+            "scope_type": "personal",
+            "domains": list(M1_SYNC_DOMAINS),
+            "encryption_policy": "server_trusted_v1",
+            "metadata": {"label": "after"},
+        },
+    )
+    manifest = client.get(
+        "/api/v1/sync/restore-manifest",
+        params={"dataset_id": "dataset-task-readiness-private"},
+    )
+    stored = sync_service.store.get_dataset(
+        "dataset-task-readiness-private",
+        owner_user_id="user-1",
+    )
+
+    assert enrolled.status_code == 200
+    assert enrolled.json()["metadata"] == {"label": "after"}
+    assert manifest.status_code == 200
+    assert manifest.json()["datasets"][0]["metadata"] == {"label": "after"}
+    assert stored is not None
+    assert stored.metadata == {"label": "after", **server_metadata}
+    for private_marker in (
+        "notes_task_v1",
+        "notes_task_activity_v1",
+        "task_activity_capture_enabled",
+        "00000000-0000-4000-8000-000000000011",
+    ):
+        assert private_marker not in enrolled.text
+        assert private_marker not in manifest.text
+
+
 def test_key_recovery_bundle_validation_error_does_not_expose_wrapped_material(
     client: TestClient,
     sync_service: SyncV2Service,

--- a/tldw_Server_API/tests/Sync/test_sync_v2_models.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_models.py
@@ -194,6 +194,27 @@ def test_notes_link_schema_is_server_trusted_v1_and_separate_from_organization()
     assert SyncCapabilitiesResponse().domain_schemas["notes.link"] == schema
 
 
+def test_notes_task_domains_are_known_internally_but_not_supported_or_public() -> None:
+    dormant = {"notes.task", "notes.task_activity"}
+
+    assert dormant.issubset(set(core_sync_models.SyncDomain.__args__))
+    assert dormant.isdisjoint(core_sync_models.SYNC_V2_SUPPORTED_DOMAINS)
+    assert dormant.isdisjoint(core_sync_models.SYNC_V2_SUPPORTED_OPERATIONS)
+    assert dormant.isdisjoint(core_sync_models.sync_v2_domain_schemas())
+    assert dormant.isdisjoint(core_sync_models.sync_v2_server_supported_adapter_versions())
+    assert dormant.isdisjoint(core_sync_models.sync_v2_dataset_writable_adapter_versions())
+
+    private_schemas = core_sync_models._sync_v2_internal_domain_schemas()
+    assert set(private_schemas) >= dormant
+    assert private_schemas["notes.task"]["schema_version"] == 1
+    assert private_schemas["notes.task"]["operations"] == ["upsert", "tombstone"]
+    assert private_schemas["notes.task_activity"]["schema_version"] == 1
+    assert private_schemas["notes.task_activity"]["operations"] == [
+        "upsert",
+        "tombstone",
+    ]
+
+
 @pytest.mark.parametrize(
     ("domain", "payload"),
     [

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_postgres_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_postgres_contract.py
@@ -340,14 +340,74 @@ def test_postgres_attachment_binding_lookup_and_unresolved_page_use_declared_ind
         with backend.transaction() as conn:
             db._create_attachment_revision_binding(
                 SyncAttachmentRevisionBindingCreate(
-                dataset_id="dataset-binding-pg",
+                    dataset_id="dataset-binding-pg",
                 attachment_id="11111111-1111-4111-8111-111111111111",
                 attachment_revision=1,
-                blob_hash="sha256:" + "a" * 64,
+                blob_hash="sha256:" + "c" * 64,
                 size_bytes=1,
                 establishing_server_cursor=1,
                 availability_at_acceptance="metadata_only",
                 ),
+                connection=conn,
+            )
+            for index in range(2, 130):
+                attachment_id = (
+                    f"{index:08x}-0000-4000-8000-{index:012x}"
+                )
+                db._create_attachment_revision_binding(
+                    SyncAttachmentRevisionBindingCreate(
+                        dataset_id="dataset-binding-pg",
+                        attachment_id=attachment_id,
+                        attachment_revision=1,
+                        blob_hash="sha256:" + "a" * 64,
+                        size_bytes=1,
+                        establishing_server_cursor=index,
+                        availability_at_acceptance="metadata_only",
+                    ),
+                    connection=conn,
+                )
+                db.execute(
+                    "UPDATE sync_attachment_revision_bindings "
+                    "SET resolved_blob_id = ? WHERE dataset_id = ? "
+                    "AND attachment_id = ? AND attachment_revision = ?",
+                    (
+                        f"resolved-blob-{index}",
+                        "dataset-binding-pg",
+                        attachment_id,
+                        1,
+                    ),
+                    connection=conn,
+                )
+            for index in range(130, 258):
+                attachment_id = (
+                    f"{index:08x}-0000-4000-8000-{index:012x}"
+                )
+                db._create_attachment_revision_binding(
+                    SyncAttachmentRevisionBindingCreate(
+                        dataset_id="dataset-binding-pg",
+                        attachment_id=attachment_id,
+                        attachment_revision=1,
+                        blob_hash="sha256:" + "a" * 64,
+                        size_bytes=1,
+                        establishing_server_cursor=index,
+                        availability_at_acceptance="metadata_only",
+                    ),
+                    connection=conn,
+                )
+                db.execute(
+                    "UPDATE sync_attachment_revision_bindings "
+                    "SET retention_released_at = ? WHERE dataset_id = ? "
+                    "AND attachment_id = ? AND attachment_revision = ?",
+                    (
+                        "2026-08-11T21:00:00+00:00",
+                        "dataset-binding-pg",
+                        attachment_id,
+                        1,
+                    ),
+                    connection=conn,
+                )
+            db.execute(
+                "ANALYZE sync_attachment_revision_bindings",
                 connection=conn,
             )
         with pytest.raises(SyncDatasetNotFoundError):
@@ -380,6 +440,7 @@ def test_postgres_attachment_binding_lookup_and_unresolved_page_use_declared_ind
             )
         with backend.transaction() as conn:
             db.execute("SET LOCAL enable_seqscan = off", connection=conn)
+            db.execute("SET LOCAL enable_bitmapscan = off", connection=conn)
             lookup_rows = db.execute(
                 "EXPLAIN SELECT attachment_id FROM sync_attachment_revision_bindings "
                 "WHERE dataset_id = ? AND attachment_id = ? AND attachment_revision = ?",
@@ -405,13 +466,32 @@ def test_postgres_attachment_binding_lookup_and_unresolved_page_use_declared_ind
                 ("owner-binding-pg", "dataset-binding-pg"),
                 connection=conn,
             ).rows
+            for index in range(258, 386):
+                db._create_attachment_revision_binding(
+                    SyncAttachmentRevisionBindingCreate(
+                        dataset_id="dataset-binding-pg",
+                        attachment_id=(
+                            f"{index:08x}-0000-4000-8000-{index:012x}"
+                        ),
+                        attachment_revision=1,
+                        blob_hash="sha256:" + "b" * 64,
+                        size_bytes=2,
+                        establishing_server_cursor=index,
+                        availability_at_acceptance="metadata_only",
+                    ),
+                    connection=conn,
+                )
+            db.execute(
+                "ANALYZE sync_attachment_revision_bindings",
+                connection=conn,
+            )
             digest_rows = db.execute(
                 "EXPLAIN SELECT attachment_id FROM sync_attachment_revision_bindings "
                 "WHERE dataset_id = ? AND blob_hash = ? AND size_bytes = ? "
                 "AND resolved_blob_id IS NULL AND retention_released_at IS NULL "
                 "ORDER BY establishing_server_cursor, attachment_id, attachment_revision "
                 "LIMIT 1000",
-                ("dataset-binding-pg", "sha256:" + "a" * 64, 1),
+                ("dataset-binding-pg", "sha256:" + "c" * 64, 1),
                 connection=conn,
             ).rows
             release_rows = db.execute(
@@ -442,6 +522,7 @@ def test_postgres_attachment_binding_lookup_and_unresolved_page_use_declared_ind
         release_plan = " ".join(str(next(iter(row.values()))) for row in release_rows)
         assert "sync_attachment_revision_bindings_pkey" in lookup_plan
         assert "idx_sync_attachment_bindings_unresolved" in page_plan
+        assert "Filter: (resolved_blob_id IS NULL)" not in page_plan
         assert "idx_sync_dataset_storage_namespaces_owner" in namespace_plan
         assert "idx_sync_attachment_bindings_pending_digest" in digest_plan
         assert "idx_sync_attachment_bindings_retention_release" in release_plan

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
@@ -241,6 +241,39 @@ def test_arbitrary_json_accepts_js_safe_integer_endpoints() -> None:
     ).metadata == {"minimum": minimum, "maximum": maximum}
 
 
+def test_canonical_json_rejects_bmp_and_non_bmp_object_keys() -> None:
+    with pytest.raises(NotesTaskContractError):
+        canonical_json_bytes({"\ue000": 1, "\U00010000": 2})
+
+
+def test_canonical_json_safe_ascii_key_order_is_stable() -> None:
+    assert canonical_json_bytes(
+        {"z": 3, "a.b": {"Z-9_": 2}, "A": 1}
+    ) == b'{"A":1,"a.b":{"Z-9_":2},"z":3}'
+
+
+def test_task_and_activity_reject_nested_non_safe_json_keys() -> None:
+    with pytest.raises(NotesTaskContractError, match="safe ASCII"):
+        parse_notes_task_v1(
+            valid_task_payload(custom={"nested": {"unsafe key": 1}}),
+            owner_user_id=OWNER_ID,
+        )
+    with pytest.raises(NotesTaskContractError, match="safe ASCII"):
+        parse_activity(
+            valid_activity_payload(metadata={"nested": {"\U00010000": 1}})
+        )
+
+
+def test_legacy_conversion_rejects_non_safe_json_keys_before_mapping() -> None:
+    with pytest.raises(NotesTaskContractError, match="safe ASCII"):
+        convert_legacy(
+            legacy_event(
+                old_value={"status": "open", "\ue000": 1},
+                new_value={"status": "done"},
+            )
+        )
+
+
 @pytest.mark.parametrize(
     "recurrence",
     [

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
@@ -292,6 +292,24 @@ def test_notes_task_hash_has_exact_stable_vector_and_excludes_projection_version
     assert notes_task_object_hash(parsed, revision=7, deleted=True) != before
 
 
+def test_notes_task_nested_custom_is_immutable_and_hash_stable() -> None:
+    raw = valid_task_payload(
+        custom={"nested": {"items": [{"value": 1}]}},
+    )
+    parsed = parse_notes_task_v1(raw, owner_user_id=OWNER_ID)
+    before = notes_task_object_hash(parsed, revision=1, deleted=False)
+
+    with pytest.raises(TypeError):
+        parsed.custom["nested"]["items"][0]["value"] = 2
+    with pytest.raises(TypeError):
+        parsed.custom["nested"]["items"].append({"value": 2})
+
+    raw_custom = raw["custom"]
+    assert isinstance(raw_custom, dict)
+    raw_custom["nested"]["items"].append({"value": 3})
+    assert notes_task_object_hash(parsed, revision=1, deleted=False) == before
+
+
 @pytest.mark.parametrize(
     ("event_type", "old_value", "new_value", "corrects_activity_id"),
     [
@@ -400,6 +418,76 @@ def test_notes_task_activity_v1_rejects_noncanonical_event_shapes(
         )
 
 
+@pytest.mark.parametrize(
+    ("old_value", "new_value"),
+    [
+        (
+            {"status": "open", "completed_at": OCCURRED_AT},
+            {"status": "done", "completed_at": OCCURRED_AT},
+        ),
+        (
+            {"status": "open", "completed_at": None},
+            {"status": "done", "completed_at": None},
+        ),
+        (
+            {"deleted": False, "projection_status": "deleted"},
+            {"deleted": True, "projection_status": "deleted"},
+        ),
+        (
+            {"deleted": True, "projection_status": "deleted"},
+            {"deleted": False, "projection_status": "deleted"},
+        ),
+    ],
+)
+def test_corrected_activity_rejects_incompatible_coupled_states(
+    old_value: dict[str, object],
+    new_value: dict[str, object],
+) -> None:
+    with pytest.raises(NotesTaskContractError):
+        parse_activity(
+            valid_activity_payload(
+                event_type="corrected",
+                old_value=old_value,
+                new_value=new_value,
+                corrects_activity_id=CORRECTED_ID,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("old_value", "new_value"),
+    [
+        (
+            {"status": "open", "completed_at": None},
+            {"status": "done", "completed_at": OCCURRED_AT},
+        ),
+        (
+            {"deleted": True, "projection_status": "deleted"},
+            {"deleted": False, "projection_status": "live"},
+        ),
+        (
+            {"projection_status": "ambiguous"},
+            {"projection_status": "live"},
+        ),
+    ],
+)
+def test_corrected_activity_accepts_compatible_target_event_subsets(
+    old_value: dict[str, object],
+    new_value: dict[str, object],
+) -> None:
+    parsed = parse_activity(
+        valid_activity_payload(
+            event_type="corrected",
+            old_value=old_value,
+            new_value=new_value,
+            corrects_activity_id=CORRECTED_ID,
+        )
+    )
+
+    assert parsed.old_value == old_value
+    assert parsed.new_value == new_value
+
+
 def test_notes_task_activity_v1_binds_actor_and_device_provenance() -> None:
     payload = valid_activity_payload()
 
@@ -497,6 +585,40 @@ def test_notes_task_activity_create_hash_is_revision_one_and_stable_id_bound() -
     )
     with pytest.raises(NotesTaskContractError, match="revision 1"):
         notes_task_activity_object_hash(parsed, revision=2, deleted=False)
+
+
+def test_notes_task_activity_nested_json_is_immutable_and_hash_stable() -> None:
+    raw = valid_activity_payload(
+        old_value={
+            "metadata": canonical_task_metadata(
+                priority="low",
+                custom={"nested": {"value": 1}},
+            )
+        },
+        new_value={
+            "metadata": canonical_task_metadata(
+                priority="high",
+                custom={"nested": {"value": 2}},
+            )
+        },
+        metadata={"nested": {"items": [3]}},
+    )
+    parsed = parse_activity(raw)
+    before = notes_task_activity_object_hash(parsed, revision=1, deleted=False)
+    assert parsed.old_value is not None
+    assert parsed.new_value is not None
+
+    with pytest.raises(TypeError):
+        parsed.old_value["metadata"]["custom"]["nested"]["value"] = 4
+    with pytest.raises(TypeError):
+        parsed.new_value["metadata"]["custom"]["nested"]["value"] = 4
+    with pytest.raises(TypeError):
+        parsed.metadata["nested"]["items"].append(4)
+
+    raw_metadata = raw["metadata"]
+    assert isinstance(raw_metadata, dict)
+    raw_metadata["nested"]["items"].append(5)
+    assert notes_task_activity_object_hash(parsed, revision=1, deleted=False) == before
 
 
 def test_notes_task_activity_tombstone_binds_parents_timestamp_and_revision_two() -> None:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
@@ -1,0 +1,785 @@
+from __future__ import annotations
+
+import hashlib
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    NotesTaskActivityTombstoneV1,
+    NotesTaskContractError,
+    NotesTaskV1Payload,
+    convert_legacy_task_event,
+    notes_task_activity_object_hash,
+    notes_task_object_hash,
+    parse_notes_task_activity_tombstone_v1,
+    parse_notes_task_activity_v1,
+    parse_notes_task_tombstone_v1,
+    parse_notes_task_v1,
+)
+
+OWNER_ID = "owner-user-1"
+TASK_ID = "11111111-1111-4111-8111-111111111111"
+NOTE_ID = "22222222-2222-4222-8222-222222222222"
+ACTIVITY_ID = "33333333-3333-4333-8333-333333333333"
+DEVICE_ID = "44444444-4444-4444-8444-444444444444"
+CORRECTED_ID = "55555555-5555-4555-8555-555555555555"
+OCCURRED_AT = "2026-08-13T10:00:00+00:00"
+
+
+def valid_task_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "task_id": TASK_ID,
+        "note_id": NOTE_ID,
+        "title": "Prepare launch notes",
+        "description": "Confirm the final release checklist.\nOwner approved.",
+        "status": "open",
+        "completed_at": None,
+        "priority": "high",
+        "due_date": "2026-08-31",
+        "estimate": "90m",
+        "recurrence": {
+            "frequency": "weekly",
+            "interval": 2,
+            "by_weekday": ["mo", "we", "fr"],
+            "until": "2026-12-31",
+            "state": "active",
+            "occurrence_index": 7,
+        },
+        "assignee_id": OWNER_ID,
+        "tags": ["Zulu", "alpha", "Résumé"],
+        "custom": {"board.column": "Next", "score": 1, "nested": {"ok": True}},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def canonical_task_metadata(**overrides: object) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "description": None,
+        "priority": None,
+        "due_date": None,
+        "estimate": None,
+        "recurrence": None,
+        "assignee_id": None,
+        "tags": [],
+        "custom": {},
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+def valid_activity_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "activity_id": ACTIVITY_ID,
+        "note_id": NOTE_ID,
+        "task_id": TASK_ID,
+        "event_type": "updated",
+        "actor_type": "user",
+        "actor_id": OWNER_ID,
+        "source_device_id": DEVICE_ID,
+        "client_occurred_at": OCCURRED_AT,
+        "source_kind": "client",
+        "corrects_activity_id": None,
+        "old_value": {"metadata": canonical_task_metadata(priority="low")},
+        "new_value": {"metadata": canonical_task_metadata(priority="high")},
+        "metadata": {"mutation_group_step": 2},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def parse_activity(payload: dict[str, object]):
+    return parse_notes_task_activity_v1(
+        payload,
+        owner_user_id=OWNER_ID,
+        bound_actor_type=str(payload["actor_type"]),
+        bound_actor_id=payload["actor_id"],
+        authenticated_device_id=DEVICE_ID,
+        trusted_server_origin=False,
+    )
+
+
+def legacy_event(**overrides: object) -> dict[str, object]:
+    event: dict[str, object] = {
+        "id": ACTIVITY_ID,
+        "task_id": TASK_ID,
+        "note_id": NOTE_ID,
+        "event_type": "status_changed",
+        "actor_type": "user",
+        "actor_id": OWNER_ID,
+        "tool_name": None,
+        "policy_mode": None,
+        "approval_id": None,
+        "old_value": {"status": "open"},
+        "new_value": {"status": "done"},
+        "created_at": "2026-08-13T10:00:00Z",
+        "client_id": "legacy-client",
+    }
+    event.update(overrides)
+    return event
+
+
+def convert_legacy(event: dict[str, object]):
+    return convert_legacy_task_event(
+        event,
+        owner_user_id=OWNER_ID,
+        resolved_task_note_id=NOTE_ID,
+    )
+
+
+def test_notes_task_v1_exact_valid_vector_is_typed_sorted_and_frozen() -> None:
+    parsed = parse_notes_task_v1(valid_task_payload(), owner_user_id=OWNER_ID)
+
+    assert isinstance(parsed, NotesTaskV1Payload)
+    assert parsed.model_dump(mode="json") == {
+        **valid_task_payload(),
+        "tags": ["alpha", "Résumé", "Zulu"],
+    }
+    with pytest.raises(ValidationError):
+        parsed.title = "changed"  # type: ignore[misc]
+
+
+def test_notes_task_tombstone_v1_is_the_same_complete_payload_contract() -> None:
+    parsed = parse_notes_task_tombstone_v1(
+        valid_task_payload(), owner_user_id=OWNER_ID
+    )
+
+    assert isinstance(parsed, NotesTaskV1Payload)
+    assert parsed == parse_notes_task_v1(valid_task_payload(), owner_user_id=OWNER_ID)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "description",
+        "completed_at",
+        "priority",
+        "due_date",
+        "estimate",
+        "recurrence",
+        "assignee_id",
+    ],
+)
+def test_notes_task_v1_requires_every_nullable_field(field: str) -> None:
+    payload = valid_task_payload()
+    payload.pop(field)
+
+    with pytest.raises(NotesTaskContractError):
+        parse_notes_task_v1(payload, owner_user_id=OWNER_ID)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"task_id": "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"}, "UUIDv4"),
+        ({"note_id": "00000000-0000-1000-8000-000000000000"}, "UUIDv4"),
+        ({"title": ""}, "title"),
+        ({"title": " leading"}, "stripped"),
+        ({"title": "line\nbreak"}, "control"),
+        ({"title": "x" * 2_001}, "title"),
+        ({"description": "x" * 16_001}, "description"),
+        ({"description": "bad\x00control"}, "control"),
+        ({"status": "open", "completed_at": OCCURRED_AT}, "completion"),
+        ({"status": "done", "completed_at": None}, "completion"),
+        ({"status": "done", "completed_at": "2026-08-13T10:00:00Z"}, "canonical"),
+        ({"due_date": "2026-02-29"}, "date"),
+        ({"due_date": "2026-8-3"}, "date"),
+        ({"estimate": "1.5h"}, "estimate"),
+        ({"estimate": "1000000m"}, "estimate"),
+        ({"assignee_id": "another-owner"}, "assignee"),
+        ({"tags": ["Tag", "tag"]}, "casefold"),
+        ({"tags": ["e\u0301"]}, "NFKC"),
+        ({"tags": [" trailing "]}, "trimmed"),
+        ({"tags": [str(index) for index in range(33)]}, "32"),
+        ({"custom": {"title": "shadow"}}, "reserved"),
+        ({"custom": {"unsafe key": True}}, "safe"),
+        ({"custom": {f"k{index}": index for index in range(33)}}, "32"),
+        ({"custom": {"a": {"b": {"c": {"d": {"e": 1}}}}}}, "depth"),
+        ({"custom": {"large": "x" * (16 * 1_024)}}, "16 KiB"),
+        ({"custom": {"bad": {1, 2}}}, "JSON"),
+    ],
+)
+def test_notes_task_v1_rejects_each_payload_boundary(
+    overrides: dict[str, object], message: str
+) -> None:
+    with pytest.raises(NotesTaskContractError, match=message):
+        parse_notes_task_v1(valid_task_payload(**overrides), owner_user_id=OWNER_ID)
+
+
+@pytest.mark.parametrize(
+    "recurrence",
+    [
+        {
+            "frequency": "weekly",
+            "interval": 0,
+            "by_weekday": [],
+            "until": None,
+            "state": "active",
+            "occurrence_index": 0,
+        },
+        {
+            "frequency": "daily",
+            "interval": 1,
+            "by_weekday": ["mo"],
+            "until": None,
+            "state": "active",
+            "occurrence_index": 0,
+        },
+        {
+            "frequency": "weekly",
+            "interval": 1,
+            "by_weekday": ["we", "mo"],
+            "until": None,
+            "state": "active",
+            "occurrence_index": 0,
+        },
+        {
+            "frequency": "weekly",
+            "interval": 1,
+            "by_weekday": ["mo", "mo"],
+            "until": None,
+            "state": "active",
+            "occurrence_index": 0,
+        },
+        {
+            "frequency": "weekly",
+            "interval": 1,
+            "by_weekday": [],
+            "until": "2026-02-29",
+            "state": "active",
+            "occurrence_index": 0,
+        },
+        {
+            "frequency": "weekly",
+            "interval": 1,
+            "by_weekday": [],
+            "until": None,
+            "state": "active",
+            "occurrence_index": 0,
+            "timezone": "UTC",
+        },
+    ],
+)
+def test_notes_task_v1_rejects_invalid_recurrence_combinations(
+    recurrence: dict[str, object],
+) -> None:
+    with pytest.raises(NotesTaskContractError, match="recurrence"):
+        parse_notes_task_v1(
+            valid_task_payload(recurrence=recurrence), owner_user_id=OWNER_ID
+        )
+
+
+def test_notes_task_v1_rejects_extra_top_level_fields() -> None:
+    with pytest.raises(NotesTaskContractError, match="extra"):
+        parse_notes_task_v1(
+            valid_task_payload(projection_row_version=99), owner_user_id=OWNER_ID
+        )
+
+
+def test_notes_task_hash_has_exact_stable_vector_and_excludes_projection_version() -> None:
+    parsed = parse_notes_task_v1(valid_task_payload(), owner_user_id=OWNER_ID)
+    projection_row_version_before = 8
+    projection_row_version_after = 9
+
+    before = notes_task_object_hash(parsed, revision=7, deleted=False)
+    after = notes_task_object_hash(parsed, revision=7, deleted=False)
+
+    assert projection_row_version_before != projection_row_version_after
+    assert before == after == "sha256:8b0692a0287e324c733176bb8199e073f1f526bc4fbd153151e8c09e4e73352b"
+    assert notes_task_object_hash(parsed, revision=8, deleted=False) != before
+    assert notes_task_object_hash(parsed, revision=7, deleted=True) != before
+
+
+@pytest.mark.parametrize(
+    ("event_type", "old_value", "new_value", "corrects_activity_id"),
+    [
+        (
+            "created",
+            None,
+            {
+                "title": "Created task",
+                "status": "open",
+                "completed_at": None,
+                "metadata": canonical_task_metadata(),
+            },
+            None,
+        ),
+        (
+            "updated",
+            {"metadata": canonical_task_metadata(priority="low")},
+            {"metadata": canonical_task_metadata(priority="high")},
+            None,
+        ),
+        ("completed", {"status": "open"}, {"status": "done"}, None),
+        ("reopened", {"status": "done"}, {"status": "open"}, None),
+        (
+            "deleted",
+            {"deleted": False, "projection_status": "ambiguous"},
+            {"deleted": True, "projection_status": "deleted"},
+            None,
+        ),
+        (
+            "restored",
+            {"deleted": True, "projection_status": "deleted"},
+            {"deleted": False, "projection_status": "live"},
+            None,
+        ),
+        (
+            "projection_linked",
+            {"projection_status": "unlinked"},
+            {"projection_status": "live"},
+            None,
+        ),
+        (
+            "projection_unlinked",
+            {"projection_status": "live"},
+            {"projection_status": "unlinked"},
+            None,
+        ),
+        (
+            "projection_drift",
+            None,
+            {"reason_code": "both_changed"},
+            None,
+        ),
+        (
+            "corrected",
+            {"title": "Old", "metadata": canonical_task_metadata()},
+            {"title": "New", "metadata": canonical_task_metadata()},
+            CORRECTED_ID,
+        ),
+    ],
+)
+def test_notes_task_activity_v1_accepts_every_exact_event_schema(
+    event_type: str,
+    old_value: dict[str, object] | None,
+    new_value: dict[str, object] | None,
+    corrects_activity_id: str | None,
+) -> None:
+    parsed = parse_activity(
+        valid_activity_payload(
+            event_type=event_type,
+            old_value=old_value,
+            new_value=new_value,
+            corrects_activity_id=corrects_activity_id,
+        )
+    )
+
+    assert parsed.event_type == event_type
+
+
+@pytest.mark.parametrize(
+    ("event_type", "old_value", "new_value", "corrects_activity_id"),
+    [
+        ("unknown", None, None, None),
+        ("completed", {"status": "open", "extra": True}, {"status": "done"}, None),
+        ("reopened", {"status": "done"}, {"status": "done"}, None),
+        ("updated", {"title": "Old"}, {"title": "New"}, None),
+        ("projection_drift", None, {"reason_code": "raw_markdown"}, None),
+        ("created", None, {"title": "missing snapshot"}, None),
+        ("corrected", {"status": "open"}, {"status": "done"}, None),
+        ("completed", {"status": "open"}, {"status": "done"}, CORRECTED_ID),
+    ],
+)
+def test_notes_task_activity_v1_rejects_noncanonical_event_shapes(
+    event_type: str,
+    old_value: dict[str, object] | None,
+    new_value: dict[str, object] | None,
+    corrects_activity_id: str | None,
+) -> None:
+    with pytest.raises(NotesTaskContractError):
+        parse_activity(
+            valid_activity_payload(
+                event_type=event_type,
+                old_value=old_value,
+                new_value=new_value,
+                corrects_activity_id=corrects_activity_id,
+            )
+        )
+
+
+def test_notes_task_activity_v1_binds_actor_and_device_provenance() -> None:
+    payload = valid_activity_payload()
+
+    with pytest.raises(NotesTaskContractError, match="actor"):
+        parse_notes_task_activity_v1(
+            payload,
+            owner_user_id=OWNER_ID,
+            bound_actor_type="agent",
+            bound_actor_id=OWNER_ID,
+            authenticated_device_id=DEVICE_ID,
+            trusted_server_origin=False,
+        )
+    with pytest.raises(NotesTaskContractError, match="device"):
+        parse_notes_task_activity_v1(
+            payload,
+            owner_user_id=OWNER_ID,
+            bound_actor_type="user",
+            bound_actor_id=OWNER_ID,
+            authenticated_device_id=CORRECTED_ID,
+            trusted_server_origin=False,
+        )
+    with pytest.raises(NotesTaskContractError, match="owner"):
+        parse_notes_task_activity_v1(
+            valid_activity_payload(actor_id="another-owner"),
+            owner_user_id=OWNER_ID,
+            bound_actor_type="user",
+            bound_actor_id="another-owner",
+            authenticated_device_id=DEVICE_ID,
+            trusted_server_origin=False,
+        )
+
+
+def test_notes_task_activity_v1_trusted_server_provenance_has_no_device() -> None:
+    payload = valid_activity_payload(
+        actor_type="system",
+        actor_id=None,
+        source_device_id=None,
+        source_kind="repair",
+    )
+    parsed = parse_notes_task_activity_v1(
+        payload,
+        owner_user_id=OWNER_ID,
+        bound_actor_type="system",
+        bound_actor_id=None,
+        authenticated_device_id=None,
+        trusted_server_origin=True,
+    )
+
+    assert parsed.source_device_id is None
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {f"k{index}": index for index in range(17)},
+        {"a": {"b": {"c": {"d": 1}}}},
+        {"large": "x" * (8 * 1_024)},
+        {"api_key": "secret"},
+        {"raw_markdown": "- [ ] secret"},
+    ],
+)
+def test_notes_task_activity_v1_rejects_metadata_boundaries(
+    metadata: dict[str, object],
+) -> None:
+    with pytest.raises(NotesTaskContractError, match="metadata"):
+        parse_activity(valid_activity_payload(metadata=metadata))
+
+
+def test_notes_task_activity_v1_rejects_extra_fields_and_noncanonical_ids() -> None:
+    with pytest.raises(NotesTaskContractError, match="extra"):
+        parse_activity(valid_activity_payload(server_cursor=1))
+    with pytest.raises(NotesTaskContractError, match="UUIDv4"):
+        parse_activity(
+            valid_activity_payload(
+                activity_id="AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"
+            )
+        )
+
+
+def test_notes_task_activity_create_hash_is_revision_one_and_stable_id_bound() -> None:
+    parsed = parse_activity(valid_activity_payload())
+    digest = notes_task_activity_object_hash(parsed, revision=1, deleted=False)
+    changed_id = parse_activity(valid_activity_payload(activity_id=CORRECTED_ID))
+    changed_content = parse_activity(
+        valid_activity_payload(metadata={"mutation_group_step": 3})
+    )
+
+    assert digest == "sha256:163c01a2ec395d36c3769b2f3c91f9579576afc15483f84cd2a4e3cabe3f4c83"
+    assert notes_task_activity_object_hash(changed_id, revision=1, deleted=False) != digest
+    assert (
+        notes_task_activity_object_hash(
+            changed_content, revision=1, deleted=False
+        )
+        != digest
+    )
+    with pytest.raises(NotesTaskContractError, match="revision 1"):
+        notes_task_activity_object_hash(parsed, revision=2, deleted=False)
+
+
+def test_notes_task_activity_tombstone_binds_parents_timestamp_and_revision_two() -> None:
+    original = parse_activity(valid_activity_payload())
+    original_hash = notes_task_activity_object_hash(
+        original, revision=1, deleted=False
+    )
+    tombstone = parse_notes_task_activity_tombstone_v1(
+        {
+            "note_id": NOTE_ID,
+            "task_id": TASK_ID,
+            "deleted_at": OCCURRED_AT,
+            "delete_reason": "user_request",
+        },
+        envelope_created_at_client="2026-08-13T10:00:00Z",
+        original_activity=original,
+    )
+
+    assert isinstance(tombstone, NotesTaskActivityTombstoneV1)
+    assert notes_task_activity_object_hash(
+        tombstone,
+        revision=2,
+        deleted=True,
+        activity_id=ACTIVITY_ID,
+        original_create_hash=original_hash,
+    ) == "sha256:0f6af02bfdeee072cac6e8c902b082d2ff2d27ce0586b2de5027858f29e17519"
+
+    for changed in (
+        {"deleted_at": "2026-08-13T10:00:01+00:00"},
+        {"note_id": CORRECTED_ID},
+        {"task_id": None},
+    ):
+        payload = tombstone.model_dump(mode="json")
+        payload.update(changed)
+        with pytest.raises(NotesTaskContractError):
+            parse_notes_task_activity_tombstone_v1(
+                payload,
+                envelope_created_at_client="2026-08-13T10:00:00Z",
+                original_activity=original,
+            )
+
+    with pytest.raises(NotesTaskContractError, match="revision 2"):
+        notes_task_activity_object_hash(
+            tombstone,
+            revision=1,
+            deleted=True,
+            activity_id=ACTIVITY_ID,
+            original_create_hash=original_hash,
+        )
+
+
+@pytest.mark.parametrize(
+    ("event", "canonical_type", "old_value", "new_value"),
+    [
+        (
+            legacy_event(
+                event_type="created",
+                old_value=None,
+                new_value={"text": "New", "status": "open", "metadata": {}},
+            ),
+            "created",
+            None,
+            {
+                "title": "New",
+                "status": "open",
+                "completed_at": None,
+                "metadata": canonical_task_metadata(),
+            },
+        ),
+        (
+            legacy_event(
+                event_type="updated",
+                old_value={"metadata": {"priority": "low"}},
+                new_value={"metadata": {"priority": "high"}},
+            ),
+            "updated",
+            {"metadata": canonical_task_metadata(priority="low")},
+            {"metadata": canonical_task_metadata(priority="high")},
+        ),
+        (
+            legacy_event(
+                event_type="updated",
+                old_value={"text": "Old", "metadata": {}},
+                new_value={"text": "New", "metadata": {"estimate": "2h"}},
+            ),
+            "updated",
+            {"title": "Old", "metadata": canonical_task_metadata()},
+            {
+                "title": "New",
+                "metadata": canonical_task_metadata(estimate="2h"),
+            },
+        ),
+        (
+            legacy_event(),
+            "completed",
+            {"status": "open"},
+            {"status": "done"},
+        ),
+        (
+            legacy_event(
+                old_value={"status": "done"}, new_value={"status": "open"}
+            ),
+            "reopened",
+            {"status": "done"},
+            {"status": "open"},
+        ),
+        (
+            legacy_event(
+                event_type="unlinked",
+                old_value={"projection_status": "live"},
+                new_value={"projection_status": "unlinked"},
+            ),
+            "projection_unlinked",
+            {"projection_status": "live"},
+            {"projection_status": "unlinked"},
+        ),
+        (
+            legacy_event(
+                event_type="deleted",
+                old_value={"deleted": False, "projection_status": "ambiguous"},
+                new_value={"deleted": True, "projection_status": "deleted"},
+            ),
+            "deleted",
+            {"deleted": False, "projection_status": "ambiguous"},
+            {"deleted": True, "projection_status": "deleted"},
+        ),
+    ],
+)
+def test_convert_legacy_task_event_maps_every_approved_source_family(
+    event: dict[str, object],
+    canonical_type: str,
+    old_value: dict[str, object] | None,
+    new_value: dict[str, object] | None,
+) -> None:
+    converted = convert_legacy(event)
+
+    assert converted.event_type == canonical_type
+    assert converted.old_value == old_value
+    assert converted.new_value == new_value
+    assert converted.source_kind == "trusted_bootstrap_v1"
+    assert converted.source_device_id is None
+    assert converted.client_occurred_at == OCCURRED_AT
+    assert converted.metadata["legacy_source_verified"] is True
+
+
+def test_convert_legacy_created_done_uses_event_time_and_removes_idempotency_key() -> None:
+    event = legacy_event(
+        event_type="created",
+        old_value=None,
+        new_value={
+            "text": "Done",
+            "status": "done",
+            "metadata": {"due_date": "2026-08-31"},
+            "idempotency_key": "Request-Key-1",
+        },
+        tool_name="notes-tool",
+        policy_mode="review",
+        approval_id="approval-1",
+    )
+
+    converted = convert_legacy(event)
+
+    assert converted.new_value == {
+        "title": "Done",
+        "status": "done",
+        "completed_at": OCCURRED_AT,
+        "metadata": canonical_task_metadata(due_date="2026-08-31"),
+    }
+    assert converted.metadata == {
+        "legacy_source_verified": True,
+        "origin_request_fingerprint": "sha256:"
+        + hashlib.sha256(b"Request-Key-1").hexdigest(),
+        "legacy_context": {
+            "tool_name": "notes-tool",
+            "policy_mode": "review",
+            "approval_id": "approval-1",
+        },
+    }
+
+
+def test_convert_legacy_created_expands_missing_metadata() -> None:
+    converted = convert_legacy(
+        legacy_event(
+            event_type="created",
+            old_value=None,
+            new_value={"text": "New", "status": "open", "metadata": None},
+        )
+    )
+
+    assert converted.new_value == {
+        "title": "New",
+        "status": "open",
+        "completed_at": None,
+        "metadata": canonical_task_metadata(),
+    }
+    assert converted.metadata == {"legacy_source_verified": True}
+
+
+def test_convert_legacy_task_event_derives_only_a_verified_missing_note_parent() -> None:
+    converted = convert_legacy(legacy_event(note_id=None))
+    assert str(converted.note_id) == NOTE_ID
+
+    with pytest.raises(NotesTaskContractError, match="parent"):
+        convert_legacy_task_event(
+            legacy_event(note_id=None),
+            owner_user_id=OWNER_ID,
+            resolved_task_note_id=None,
+        )
+    with pytest.raises(NotesTaskContractError, match="parent"):
+        convert_legacy_task_event(
+            legacy_event(),
+            owner_user_id=OWNER_ID,
+            resolved_task_note_id=CORRECTED_ID,
+        )
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        legacy_event(event_type="renamed"),
+        legacy_event(old_value={"status": "open"}, new_value={"status": "paused"}),
+        legacy_event(
+            event_type="updated",
+            old_value={"metadata": {"unknown": 1}},
+            new_value={"metadata": {}},
+        ),
+        legacy_event(new_value={"status": "done", "idempotency_key": ""}),
+        legacy_event(new_value={"status": "done", "idempotency_key": 7}),
+        legacy_event(unexpected="data"),
+    ],
+)
+def test_convert_legacy_task_event_fails_closed_on_unknown_or_malformed_data(
+    event: dict[str, object],
+) -> None:
+    with pytest.raises(NotesTaskContractError):
+        convert_legacy(event)
+
+
+def test_convert_legacy_task_event_wraps_invalid_ids_as_contract_errors() -> None:
+    with pytest.raises(NotesTaskContractError, match="UUIDv4"):
+        convert_legacy(
+            legacy_event(id="AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA")
+        )
+
+
+def test_convert_legacy_idempotency_fingerprint_changes_activity_hash() -> None:
+    first = convert_legacy(
+        legacy_event(new_value={"status": "done", "idempotency_key": "first"})
+    )
+    second = convert_legacy(
+        legacy_event(new_value={"status": "done", "idempotency_key": "second"})
+    )
+
+    assert first.new_value == second.new_value == {"status": "done"}
+    assert notes_task_activity_object_hash(
+        first, revision=1, deleted=False
+    ) != notes_task_activity_object_hash(second, revision=1, deleted=False)
+
+
+def test_hash_inputs_do_not_accept_server_cursor_read_state_or_projection_cache() -> None:
+    task = parse_notes_task_v1(valid_task_payload(), owner_user_id=OWNER_ID)
+    activity = parse_activity(valid_activity_payload())
+    task_before = notes_task_object_hash(task, revision=3, deleted=False)
+    activity_before = notes_task_activity_object_hash(
+        activity, revision=1, deleted=False
+    )
+    excluded_local_state = deepcopy(
+        {
+            "projection_row_version": 99,
+            "server_cursor": 321,
+            "read_at": OCCURRED_AT,
+            "dismissed_at": None,
+        }
+    )
+    excluded_local_state.update(
+        projection_row_version=100,
+        server_cursor=322,
+        read_at=None,
+        dismissed_at=OCCURRED_AT,
+    )
+
+    assert notes_task_object_hash(task, revision=3, deleted=False) == task_before
+    assert (
+        notes_task_activity_object_hash(activity, revision=1, deleted=False)
+        == activity_before
+    )

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
@@ -6,9 +6,10 @@ from copy import deepcopy
 import pytest
 from pydantic import ValidationError
 
+from tldw_Server_API.app.core.exceptions import NotesTaskContractError
 from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
     NotesTaskActivityTombstoneV1,
-    NotesTaskContractError,
+    NotesTaskActivityV1,
     NotesTaskV1Payload,
     canonical_json_bytes,
     convert_legacy_task_event,
@@ -19,6 +20,8 @@ from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
     parse_notes_task_tombstone_v1,
     parse_notes_task_v1,
 )
+
+pytestmark = pytest.mark.unit
 
 OWNER_ID = "owner-user-1"
 TASK_ID = "11111111-1111-4111-8111-111111111111"
@@ -122,7 +125,7 @@ def legacy_event(**overrides: object) -> dict[str, object]:
     return event
 
 
-def convert_legacy(event: dict[str, object]):
+def convert_legacy(event: dict[str, object]) -> NotesTaskActivityV1:
     return convert_legacy_task_event(
         event,
         owner_user_id=OWNER_ID,

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_contract.py
@@ -10,6 +10,7 @@ from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
     NotesTaskActivityTombstoneV1,
     NotesTaskContractError,
     NotesTaskV1Payload,
+    canonical_json_bytes,
     convert_legacy_task_event,
     notes_task_activity_object_hash,
     notes_task_object_hash,
@@ -209,6 +210,38 @@ def test_notes_task_v1_rejects_each_payload_boundary(
 
 
 @pytest.mark.parametrize(
+    "value",
+    [1.0, 1e-7, -0.0, 9_007_199_254_740_992, -9_007_199_254_740_992],
+)
+def test_arbitrary_json_rejects_cross_runtime_numeric_values(value: object) -> None:
+    with pytest.raises(NotesTaskContractError):
+        canonical_json_bytes({"value": value})
+    with pytest.raises(NotesTaskContractError):
+        parse_notes_task_v1(
+            valid_task_payload(custom={"value": value}),
+            owner_user_id=OWNER_ID,
+        )
+    with pytest.raises(NotesTaskContractError):
+        parse_activity(valid_activity_payload(metadata={"value": value}))
+
+
+def test_arbitrary_json_accepts_js_safe_integer_endpoints() -> None:
+    minimum = -9_007_199_254_740_991
+    maximum = 9_007_199_254_740_991
+
+    assert canonical_json_bytes({"minimum": minimum, "maximum": maximum}) == (
+        b'{"maximum":9007199254740991,"minimum":-9007199254740991}'
+    )
+    assert parse_notes_task_v1(
+        valid_task_payload(custom={"minimum": minimum, "maximum": maximum}),
+        owner_user_id=OWNER_ID,
+    ).custom == {"minimum": minimum, "maximum": maximum}
+    assert parse_activity(
+        valid_activity_payload(metadata={"minimum": minimum, "maximum": maximum})
+    ).metadata == {"minimum": minimum, "maximum": maximum}
+
+
+@pytest.mark.parametrize(
     "recurrence",
     [
         {
@@ -308,6 +341,23 @@ def test_notes_task_nested_custom_is_immutable_and_hash_stable() -> None:
     assert isinstance(raw_custom, dict)
     raw_custom["nested"]["items"].append({"value": 3})
     assert notes_task_object_hash(parsed, revision=1, deleted=False) == before
+
+
+def test_deepcopy_preserves_parsed_model_values_and_hashes() -> None:
+    task = parse_notes_task_v1(valid_task_payload(), owner_user_id=OWNER_ID)
+    activity = parse_activity(valid_activity_payload())
+
+    task_copy = deepcopy(task)
+    activity_copy = deepcopy(activity)
+
+    assert task_copy == task
+    assert activity_copy == activity
+    assert notes_task_object_hash(
+        task_copy, revision=1, deleted=False
+    ) == notes_task_object_hash(task, revision=1, deleted=False)
+    assert notes_task_activity_object_hash(
+        activity_copy, revision=1, deleted=False
+    ) == notes_task_activity_object_hash(activity, revision=1, deleted=False)
 
 
 @pytest.mark.parametrize(
@@ -414,6 +464,46 @@ def test_notes_task_activity_v1_rejects_noncanonical_event_shapes(
                 old_value=old_value,
                 new_value=new_value,
                 corrects_activity_id=corrects_activity_id,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("event_type", "old_value", "new_value"),
+    [
+        (
+            "deleted",
+            {"deleted": 0, "projection_status": "live"},
+            {"deleted": True, "projection_status": "deleted"},
+        ),
+        (
+            "deleted",
+            {"deleted": False, "projection_status": "live"},
+            {"deleted": 1, "projection_status": "deleted"},
+        ),
+        (
+            "restored",
+            {"deleted": 1, "projection_status": "deleted"},
+            {"deleted": False, "projection_status": "live"},
+        ),
+        (
+            "restored",
+            {"deleted": True, "projection_status": "deleted"},
+            {"deleted": 0, "projection_status": "live"},
+        ),
+    ],
+)
+def test_lifecycle_activity_rejects_integer_deleted_flags(
+    event_type: str,
+    old_value: dict[str, object],
+    new_value: dict[str, object],
+) -> None:
+    with pytest.raises(NotesTaskContractError):
+        parse_activity(
+            valid_activity_payload(
+                event_type=event_type,
+                old_value=old_value,
+                new_value=new_value,
             )
         )
 
@@ -855,6 +945,21 @@ def test_convert_legacy_task_event_fails_closed_on_unknown_or_malformed_data(
 ) -> None:
     with pytest.raises(NotesTaskContractError):
         convert_legacy(event)
+
+
+def test_convert_legacy_task_event_bounds_deep_json_before_schema_matching() -> None:
+    deep: dict[str, object] = {}
+    for _ in range(1_500):
+        deep = {"nested": deep}
+
+    with pytest.raises(NotesTaskContractError, match="depth"):
+        convert_legacy(
+            legacy_event(
+                event_type="updated",
+                old_value=deep,
+                new_value=deep,
+            )
+        )
 
 
 def test_convert_legacy_task_event_wraps_invalid_ids_as_contract_errors() -> None:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_readiness_postgres_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_readiness_postgres_contract.py
@@ -1,0 +1,166 @@
+"""Live PostgreSQL transaction contracts for dormant Notes task readiness."""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig
+from tldw_Server_API.app.core.DB_Management.backends.factory import (
+    DatabaseBackendFactory,
+)
+from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
+from tldw_Server_API.app.core.Sync.v2.models import SyncDatasetCreate
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
+
+pytestmark = pytest.mark.integration
+
+_TASK_CURSOR_1 = "00000000-0000-4000-8000-000000000001"
+_TASK_CURSOR_2 = "00000000-0000-4000-8000-000000000002"
+
+
+def _postgres_store(config: DatabaseConfig) -> SyncV2Store:
+    return SyncV2Store(
+        SyncDatabase(backend=DatabaseBackendFactory.create_backend(config))
+    )
+
+
+def _close_postgres_store(store: SyncV2Store) -> None:
+    store.db.backend.get_pool().close_all()
+
+
+def _enroll_both_domains(
+    store: SyncV2Store,
+    dataset_id: str,
+    *,
+    capture_enabled: bool,
+) -> None:
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id=dataset_id,
+            owner_user_id="user-1",
+            domains=[
+                "notes.note",
+                "chat.conversation",
+                "chat.message",
+                "attachment.ref",
+            ],
+        )
+    )
+    store.transition_notes_task_readiness(
+        dataset_id,
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id=dataset_id,
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    store.transition_notes_task_activity_readiness(
+        dataset_id,
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id=dataset_id,
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        task_activity_capture_enabled=True if capture_enabled else None,
+    )
+
+
+def test_postgres_readiness_row_lock_serializes_competing_compare_and_set(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    setup = _postgres_store(pg_database_config)
+    contender_a = _postgres_store(pg_database_config)
+    contender_b = _postgres_store(pg_database_config)
+    dataset_id = "dataset-readiness-cas"
+    _enroll_both_domains(setup, dataset_id, capture_enabled=True)
+    barrier = threading.Barrier(2)
+
+    def transition(
+        store: SyncV2Store,
+        cursor: str,
+        fingerprint: str,
+    ) -> tuple[str, str]:
+        barrier.wait(timeout=30)
+        try:
+            updated = store.transition_notes_task_readiness(
+                dataset_id,
+                owner_user_id="user-1",
+                expected_state="enrolling",
+                state="bootstrapping",
+                source_dataset_id=dataset_id,
+                source_cursor=cursor,
+                source_count=1,
+                source_fingerprint=fingerprint,
+            )
+        except SyncStoreError as exc:
+            return "error", str(exc)
+        return "ok", str(updated.metadata["notes_task_v1"]["source_cursor"])
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(transition, contender_a, _TASK_CURSOR_1, "a" * 64),
+                executor.submit(transition, contender_b, _TASK_CURSOR_2, "b" * 64),
+            ]
+            results = [future.result(timeout=60) for future in futures]
+
+        winners = [detail for status, detail in results if status == "ok"]
+        losers = [detail for status, detail in results if status == "error"]
+        stored = setup.get_dataset(dataset_id, owner_user_id="user-1")
+
+        assert len(winners) == 1
+        assert losers == ["notes_task_readiness_compare_and_set_failed"]
+        assert stored is not None
+        assert stored.metadata["notes_task_v1"]["source_cursor"] == winners[0]
+        assert stored.metadata["notes_task_activity_v1"]["state"] == "enrolling"
+        assert stored.metadata["task_activity_capture_enabled"] is True
+    finally:
+        _close_postgres_store(contender_b)
+        _close_postgres_store(contender_a)
+        _close_postgres_store(setup)
+
+
+def test_postgres_readiness_and_capture_update_roll_back_atomically(
+    pg_database_config: DatabaseConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mutator = _postgres_store(pg_database_config)
+    observer = _postgres_store(pg_database_config)
+    dataset_id = "dataset-readiness-rollback"
+    _enroll_both_domains(mutator, dataset_id, capture_enabled=False)
+
+    def fail_after_update(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise RuntimeError("forced PostgreSQL post-update failure")
+
+    try:
+        monkeypatch.setattr(mutator.db, "_get_dataset_row", fail_after_update)
+        with pytest.raises(RuntimeError, match="forced PostgreSQL post-update failure"):
+            mutator.transition_notes_task_activity_readiness(
+                dataset_id,
+                owner_user_id="user-1",
+                expected_state="enrolling",
+                state="bootstrapping",
+                source_dataset_id=dataset_id,
+                source_cursor=None,
+                source_count=0,
+                source_fingerprint=None,
+                task_activity_capture_enabled=True,
+            )
+
+        stored = observer.get_dataset(dataset_id, owner_user_id="user-1")
+        assert stored is not None
+        assert stored.metadata["notes_task_v1"]["state"] == "enrolling"
+        assert stored.metadata["notes_task_activity_v1"]["state"] == "enrolling"
+        assert stored.metadata.get("task_activity_capture_enabled") is not True
+    finally:
+        _close_postgres_store(observer)
+        _close_postgres_store(mutator)

--- a/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
@@ -963,7 +963,10 @@ def test_dormant_task_domain_readiness_diagnostics_are_owner_scoped_and_sanitize
     tmp_path: Path,
 ) -> None:
     service, store = _service(tmp_path)
-    private_cursor = "local-unbound|private task title|actor@example.test"
+    private_cursor = "00000000-0000-4000-8000-000000000001"
+    private_activity_cursor = (
+        "2026-08-13T00:00:00+00:00|00000000-0000-4000-8000-000000000011"
+    )
     store.enroll_dataset(
         SyncDatasetCreate(
             dataset_id="dataset-task-readiness",
@@ -979,17 +982,15 @@ def test_dormant_task_domain_readiness_diagnostics_are_owner_scoped_and_sanitize
                     "source_count": 3,
                     "source_fingerprint": "a" * 64,
                     "reason_code": "notes_task_source_invalid",
-                    "title": "must not escape",
-                    "markdown": "- [ ] private",
+                    "resume_phase": "bootstrapping",
                 },
                 "notes_task_activity_v1": {
                     "state": "ready",
-                    "source_cursor": "activity-3",
+                    "source_cursor": private_activity_cursor,
                     "source_count": 5,
                     "source_fingerprint": "b" * 64,
                     "reason_code": None,
-                    "actor_id": "private-actor",
-                    "event_value": {"private": True},
+                    "resume_phase": None,
                 },
                 "task_activity_capture_enabled": True,
             },
@@ -1011,18 +1012,13 @@ def test_dormant_task_domain_readiness_diagnostics_are_owner_scoped_and_sanitize
     assert diagnostics.task_activity.state == "ready"
     assert diagnostics.task_activity.source_count == 5
     assert diagnostics.task_activity.cursor == "sha256:" + hashlib.sha256(
-        b"activity-3"
+        private_activity_cursor.encode("utf-8")
     ).hexdigest()
     assert diagnostics.task_activity_capture_enabled is True
     serialized = repr(diagnostics)
     for secret in (
         private_cursor,
-        "private task title",
-        "actor@example.test",
-        "must not escape",
-        "private-actor",
-        "event_value",
-        "local-unbound",
+        private_activity_cursor,
     ):
         assert secret not in serialized
 
@@ -1053,6 +1049,7 @@ def test_dormant_task_domain_malformed_readiness_fails_closed(
                     "source_count": True,
                     "source_fingerprint": "not-a-hash",
                     "reason_code": "private detail",
+                    "resume_phase": None,
                 },
                 "notes_task_activity_v1": None,
                 "task_activity_capture_enabled": "yes",
@@ -1078,6 +1075,107 @@ def test_dormant_task_domain_malformed_readiness_fails_closed(
     assert "private detail" not in repr(diagnostics)
 
 
+@pytest.mark.parametrize(
+    ("readiness_key", "raw", "reason_code"),
+    [
+        ("notes_task_v1", None, "notes_task_readiness_state_invalid"),
+        ("notes_task_v1", [], "notes_task_readiness_state_invalid"),
+        ("notes_task_v1", {}, "notes_task_readiness_state_invalid"),
+        (
+            "notes_task_v1",
+            {
+                "state": "not_enrolled",
+                "source_cursor": None,
+                "source_count": 0,
+                "source_fingerprint": None,
+                "reason_code": None,
+                "resume_phase": None,
+                "private_extra": "must not escape",
+            },
+            "notes_task_readiness_state_invalid",
+        ),
+        (
+            "notes_task_v1",
+            {
+                "state": "bootstrapping",
+                "source_cursor": "00000000-0000-4000-8000-000000000001",
+                "source_count": 1,
+                "source_fingerprint": {"private": "must not escape"},
+                "reason_code": None,
+                "resume_phase": None,
+            },
+            "notes_task_readiness_state_invalid",
+        ),
+        (
+            "notes_task_activity_v1",
+            {
+                "state": "bootstrapping",
+                "source_cursor": "00000000-0000-4000-8000-000000000001",
+                "source_count": 1,
+                "source_fingerprint": "a" * 64,
+                "reason_code": None,
+                "resume_phase": None,
+            },
+            "notes_task_activity_readiness_state_invalid",
+        ),
+        (
+            "notes_task_v1",
+            {
+                "state": "blocked",
+                "source_cursor": None,
+                "source_count": 0,
+                "source_fingerprint": "a" * 64,
+                "reason_code": "notes_task_source_invalid",
+                "resume_phase": [],
+            },
+            "notes_task_readiness_state_invalid",
+        ),
+        (
+            "notes_task_activity_v1",
+            {
+                "state": "blocked",
+                "source_cursor": None,
+                "source_count": 0,
+                "source_fingerprint": "a" * 64,
+                "reason_code": "notes_task_activity_source_invalid",
+                "resume_phase": {},
+            },
+            "notes_task_activity_readiness_state_invalid",
+        ),
+    ],
+)
+def test_dormant_task_domain_shared_parser_failures_are_sanitized(
+    tmp_path: Path,
+    readiness_key: str,
+    raw: object,
+    reason_code: str,
+) -> None:
+    service, store = _service(tmp_path)
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-total-parser",
+            owner_user_id="user-1",
+            scope_type="personal",
+            domains=list(M1_SYNC_DOMAINS),
+            metadata={readiness_key: raw},
+        )
+    )
+
+    diagnostics = service._profile_manager().notes_task_readiness_diagnostics(
+        user_id="user-1",
+        dataset_id="dataset-total-parser",
+    )
+    domain = (
+        diagnostics.task
+        if readiness_key == "notes_task_v1"
+        else diagnostics.task_activity
+    )
+
+    assert domain.state == "blocked"
+    assert domain.reason_code == reason_code
+    assert "must not escape" not in repr(diagnostics)
+
+
 def test_dormant_task_domain_other_domain_reason_fails_closed(
     tmp_path: Path,
 ) -> None:
@@ -1091,10 +1189,11 @@ def test_dormant_task_domain_other_domain_reason_fails_closed(
             metadata={
                 "notes_task_v1": {
                     "state": "blocked",
-                    "source_cursor": "cursor-1",
+                    "source_cursor": "00000000-0000-4000-8000-000000000001",
                     "source_count": 1,
                     "source_fingerprint": "a" * 64,
                     "reason_code": "notes_task_activity_source_invalid",
+                    "resume_phase": "bootstrapping",
                 }
             },
         )
@@ -1121,10 +1220,11 @@ def test_dormant_task_domain_oversized_count_fails_closed(tmp_path: Path) -> Non
             metadata={
                 "notes_task_v1": {
                     "state": "bootstrapping",
-                    "source_cursor": "cursor-1",
+                    "source_cursor": "00000000-0000-4000-8000-000000000001",
                     "source_count": 9_223_372_036_854_775_808,
                     "source_fingerprint": "a" * 64,
                     "reason_code": None,
+                    "resume_phase": None,
                 }
             },
         )
@@ -1157,6 +1257,7 @@ def test_dormant_task_domain_unpaired_surrogate_cursor_fails_closed(
                     "source_count": 1,
                     "source_fingerprint": "a" * 64,
                     "reason_code": None,
+                    "resume_phase": None,
                 }
             },
         )
@@ -1176,12 +1277,24 @@ def test_dormant_task_domain_forged_ready_never_changes_capabilities(
     tmp_path: Path,
 ) -> None:
     service, store = _service(tmp_path)
-    ready = {
+    task_ready = {
         "state": "ready",
-        "source_cursor": "cursor-1",
+        "source_cursor": "00000000-0000-4000-8000-000000000001",
         "source_count": 1,
         "source_fingerprint": "a" * 64,
         "reason_code": None,
+        "resume_phase": None,
+    }
+    activity_ready = {
+        "state": "ready",
+        "source_cursor": (
+            "2026-08-13T00:00:00+00:00|"
+            "00000000-0000-4000-8000-000000000011"
+        ),
+        "source_count": 1,
+        "source_fingerprint": "a" * 64,
+        "reason_code": None,
+        "resume_phase": None,
     }
     store.enroll_dataset(
         SyncDatasetCreate(
@@ -1192,8 +1305,8 @@ def test_dormant_task_domain_forged_ready_never_changes_capabilities(
             metadata={
                 "default_personal": True,
                 "client_family": "chatbook",
-                "notes_task_v1": dict(ready),
-                "notes_task_activity_v1": dict(ready),
+                "notes_task_v1": task_ready,
+                "notes_task_activity_v1": activity_ready,
                 "task_activity_capture_enabled": True,
             },
         )

--- a/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_profile_bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from dataclasses import replace
 from pathlib import Path
 
@@ -956,3 +957,260 @@ def test_notes_organization_failed_profile_exposes_only_safe_summary(
         "error_code": "notes_organization_bootstrap_source_invalid",
     }
     assert "bootstrap_id" not in failed.dataset.notes_organization
+
+
+def test_dormant_task_domain_readiness_diagnostics_are_owner_scoped_and_sanitized(
+    tmp_path: Path,
+) -> None:
+    service, store = _service(tmp_path)
+    private_cursor = "local-unbound|private task title|actor@example.test"
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-task-readiness",
+            owner_user_id="user-1",
+            scope_type="personal",
+            domains=list(M1_SYNC_DOMAINS),
+            metadata={
+                "default_personal": True,
+                "client_family": "chatbook",
+                "notes_task_v1": {
+                    "state": "blocked",
+                    "source_cursor": private_cursor,
+                    "source_count": 3,
+                    "source_fingerprint": "a" * 64,
+                    "reason_code": "notes_task_source_invalid",
+                    "title": "must not escape",
+                    "markdown": "- [ ] private",
+                },
+                "notes_task_activity_v1": {
+                    "state": "ready",
+                    "source_cursor": "activity-3",
+                    "source_count": 5,
+                    "source_fingerprint": "b" * 64,
+                    "reason_code": None,
+                    "actor_id": "private-actor",
+                    "event_value": {"private": True},
+                },
+                "task_activity_capture_enabled": True,
+            },
+        )
+    )
+
+    diagnostics = service._profile_manager().notes_task_readiness_diagnostics(
+        user_id="user-1",
+        dataset_id="dataset-task-readiness",
+    )
+
+    assert diagnostics.task.state == "blocked"
+    assert diagnostics.task.source_count == 3
+    assert diagnostics.task.cursor == "sha256:" + hashlib.sha256(
+        private_cursor.encode("utf-8")
+    ).hexdigest()
+    assert diagnostics.task.source_fingerprint == "a" * 64
+    assert diagnostics.task.reason_code == "notes_task_source_invalid"
+    assert diagnostics.task_activity.state == "ready"
+    assert diagnostics.task_activity.source_count == 5
+    assert diagnostics.task_activity.cursor == "sha256:" + hashlib.sha256(
+        b"activity-3"
+    ).hexdigest()
+    assert diagnostics.task_activity_capture_enabled is True
+    serialized = repr(diagnostics)
+    for secret in (
+        private_cursor,
+        "private task title",
+        "actor@example.test",
+        "must not escape",
+        "private-actor",
+        "event_value",
+        "local-unbound",
+    ):
+        assert secret not in serialized
+
+    with pytest.raises(
+        SyncStoreError,
+        match="Sync dataset was not found or is not accessible",
+    ):
+        service._profile_manager().notes_task_readiness_diagnostics(
+            user_id="other-user",
+            dataset_id="dataset-task-readiness",
+        )
+
+
+def test_dormant_task_domain_malformed_readiness_fails_closed(
+    tmp_path: Path,
+) -> None:
+    service, store = _service(tmp_path)
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-malformed-readiness",
+            owner_user_id="user-1",
+            scope_type="personal",
+            domains=list(M1_SYNC_DOMAINS),
+            metadata={
+                "notes_task_v1": {
+                    "state": "ready",
+                    "source_cursor": ["private", "cursor"],
+                    "source_count": True,
+                    "source_fingerprint": "not-a-hash",
+                    "reason_code": "private detail",
+                },
+                "notes_task_activity_v1": None,
+                "task_activity_capture_enabled": "yes",
+            },
+        )
+    )
+
+    diagnostics = service._profile_manager().notes_task_readiness_diagnostics(
+        user_id="user-1",
+        dataset_id="dataset-malformed-readiness",
+    )
+
+    assert diagnostics.task.state == "blocked"
+    assert diagnostics.task.source_count == 0
+    assert diagnostics.task.cursor is None
+    assert diagnostics.task.source_fingerprint is None
+    assert diagnostics.task.reason_code == "notes_task_readiness_state_invalid"
+    assert diagnostics.task_activity.state == "blocked"
+    assert diagnostics.task_activity.reason_code == (
+        "notes_task_activity_readiness_state_invalid"
+    )
+    assert diagnostics.task_activity_capture_enabled is False
+    assert "private detail" not in repr(diagnostics)
+
+
+def test_dormant_task_domain_other_domain_reason_fails_closed(
+    tmp_path: Path,
+) -> None:
+    service, store = _service(tmp_path)
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-cross-domain-reason",
+            owner_user_id="user-1",
+            scope_type="personal",
+            domains=list(M1_SYNC_DOMAINS),
+            metadata={
+                "notes_task_v1": {
+                    "state": "blocked",
+                    "source_cursor": "cursor-1",
+                    "source_count": 1,
+                    "source_fingerprint": "a" * 64,
+                    "reason_code": "notes_task_activity_source_invalid",
+                }
+            },
+        )
+    )
+
+    diagnostics = service._profile_manager().notes_task_readiness_diagnostics(
+        user_id="user-1",
+        dataset_id="dataset-cross-domain-reason",
+    )
+
+    assert diagnostics.task.state == "blocked"
+    assert diagnostics.task.source_count == 0
+    assert diagnostics.task.reason_code == "notes_task_readiness_state_invalid"
+
+
+def test_dormant_task_domain_oversized_count_fails_closed(tmp_path: Path) -> None:
+    service, store = _service(tmp_path)
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-oversized-count",
+            owner_user_id="user-1",
+            scope_type="personal",
+            domains=list(M1_SYNC_DOMAINS),
+            metadata={
+                "notes_task_v1": {
+                    "state": "bootstrapping",
+                    "source_cursor": "cursor-1",
+                    "source_count": 9_223_372_036_854_775_808,
+                    "source_fingerprint": "a" * 64,
+                    "reason_code": None,
+                }
+            },
+        )
+    )
+
+    diagnostics = service._profile_manager().notes_task_readiness_diagnostics(
+        user_id="user-1",
+        dataset_id="dataset-oversized-count",
+    )
+
+    assert diagnostics.task.state == "blocked"
+    assert diagnostics.task.source_count == 0
+    assert diagnostics.task.reason_code == "notes_task_readiness_state_invalid"
+
+
+def test_dormant_task_domain_unpaired_surrogate_cursor_fails_closed(
+    tmp_path: Path,
+) -> None:
+    service, store = _service(tmp_path)
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-surrogate-cursor",
+            owner_user_id="user-1",
+            scope_type="personal",
+            domains=list(M1_SYNC_DOMAINS),
+            metadata={
+                "notes_task_v1": {
+                    "state": "bootstrapping",
+                    "source_cursor": "\ud800",
+                    "source_count": 1,
+                    "source_fingerprint": "a" * 64,
+                    "reason_code": None,
+                }
+            },
+        )
+    )
+
+    diagnostics = service._profile_manager().notes_task_readiness_diagnostics(
+        user_id="user-1",
+        dataset_id="dataset-surrogate-cursor",
+    )
+
+    assert diagnostics.task.state == "blocked"
+    assert diagnostics.task.source_count == 0
+    assert diagnostics.task.reason_code == "notes_task_readiness_state_invalid"
+
+
+def test_dormant_task_domain_forged_ready_never_changes_capabilities(
+    tmp_path: Path,
+) -> None:
+    service, store = _service(tmp_path)
+    ready = {
+        "state": "ready",
+        "source_cursor": "cursor-1",
+        "source_count": 1,
+        "source_fingerprint": "a" * 64,
+        "reason_code": None,
+    }
+    store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-forged-ready",
+            owner_user_id="user-1",
+            scope_type="personal",
+            domains=list(M1_SYNC_DOMAINS),
+            metadata={
+                "default_personal": True,
+                "client_family": "chatbook",
+                "notes_task_v1": dict(ready),
+                "notes_task_activity_v1": dict(ready),
+                "task_activity_capture_enabled": True,
+            },
+        )
+    )
+
+    profile = service.profile(user_id="user-1")
+
+    assert "notes.task" not in profile.capabilities.supported_domains
+    assert "notes.task_activity" not in profile.capabilities.supported_domains
+    assert "notes.task" not in profile.capabilities.operations
+    assert "notes.task_activity" not in profile.capabilities.operations
+    assert "notes.task" not in profile.capabilities.domain_schemas
+    assert "notes.task_activity" not in profile.capabilities.domain_schemas
+    assert "notes.task" not in profile.capabilities.supported_adapter_versions
+    assert "notes.task_activity" not in profile.capabilities.supported_adapter_versions
+    assert "notes.task" not in profile.capabilities.writable_adapter_versions
+    assert "notes.task_activity" not in profile.capabilities.writable_adapter_versions
+    assert profile.dataset is not None
+    assert "notes.task" not in profile.dataset.domains
+    assert "notes.task_activity" not in profile.dataset.domains

--- a/tldw_Server_API/tests/Sync/test_sync_v2_service.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_service.py
@@ -1662,6 +1662,103 @@ def test_public_dataset_enrollment_rejects_notes_organization_and_reserved_metad
     assert sync_service.store.list_datasets_for_user("user-1") == []
 
 
+@pytest.mark.parametrize(
+    ("metadata_key", "value"),
+    [
+        (
+            "notes_task_v1",
+            {
+                "state": "ready",
+                "source_cursor": "00000000-0000-4000-8000-000000000001",
+                "source_count": 1,
+                "source_fingerprint": "a" * 64,
+                "reason_code": None,
+                "resume_phase": None,
+            },
+        ),
+        (
+            "notes_task_activity_v1",
+            {
+                "state": "ready",
+                "source_cursor": (
+                    "2026-08-13T00:00:00+00:00|"
+                    "00000000-0000-4000-8000-000000000011"
+                ),
+                "source_count": 1,
+                "source_fingerprint": "b" * 64,
+                "reason_code": None,
+                "resume_phase": None,
+            },
+        ),
+        ("task_activity_capture_enabled", True),
+    ],
+)
+def test_public_dataset_enrollment_rejects_forged_task_readiness_metadata(
+    sync_service: SyncV2Service,
+    metadata_key: str,
+    value: object,
+) -> None:
+    with pytest.raises(SyncStoreError, match="sync_reserved_dataset_enrollment"):
+        sync_service.enroll_dataset(
+            user_id="user-1",
+            dataset_id=f"forged-{metadata_key}",
+            metadata={metadata_key: value},
+        )
+
+    assert sync_service.store.list_datasets_for_user("user-1") == []
+
+
+def test_public_enrollment_and_manifest_redact_internal_task_readiness(
+    sync_service: SyncV2Service,
+) -> None:
+    internal_metadata = {
+        "notes_task_v1": {
+            "state": "ready",
+            "source_cursor": "00000000-0000-4000-8000-000000000001",
+            "source_count": 1,
+            "source_fingerprint": "a" * 64,
+            "reason_code": None,
+            "resume_phase": None,
+        },
+        "notes_task_activity_v1": {
+            "state": "blocked",
+            "source_cursor": (
+                "2026-08-13T00:00:00+00:00|"
+                "00000000-0000-4000-8000-000000000011"
+            ),
+            "source_count": 1,
+            "source_fingerprint": "b" * 64,
+            "reason_code": "notes_task_activity_source_invalid",
+            "resume_phase": "bootstrapping",
+        },
+        "task_activity_capture_enabled": True,
+    }
+    sync_service.store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id="dataset-internal-task-readiness",
+            owner_user_id="user-1",
+            domains=list(M1_SYNC_DOMAINS),
+            metadata={"label": "before", **internal_metadata},
+        )
+    )
+
+    enrollment = sync_service.enroll_dataset(
+        user_id="user-1",
+        dataset_id="dataset-internal-task-readiness",
+        metadata={"label": "after"},
+    )
+    manifest = sync_service.restore_manifest(user_id="user-1")
+    stored = sync_service.store.get_dataset(
+        "dataset-internal-task-readiness",
+        owner_user_id="user-1",
+    )
+
+    assert enrollment.dataset.metadata == {"label": "after"}
+    assert manifest.datasets[0].metadata == {"label": "after"}
+    assert stored is not None
+    assert stored.metadata == {"label": "after", **internal_metadata}
+
+
 def test_adapter_registry_accepts_known_domains_and_rejects_unknown_domains(
     registry: SyncAdapterRegistry,
 ):

--- a/tldw_Server_API/tests/Sync/test_sync_v2_store.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_store.py
@@ -2957,6 +2957,660 @@ def test_get_or_create_default_personal_dataset_is_idempotent(sync_store: SyncV2
     assert sync_store.list_datasets_for_user("user-1") == [second]
 
 
+def _task_readiness_at_first_bootstrap_page(sync_store: SyncV2Store) -> None:
+    sync_store.enroll_dataset(_dataset())
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        task_activity_capture_enabled=True,
+    )
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="enrolling",
+        state="bootstrapping",
+        source_dataset_id="dataset-1",
+        source_cursor="00000001",
+        source_count=1,
+        source_fingerprint="a" * 64,
+    )
+
+
+def test_notes_task_readiness_blocked_retains_last_verified_progress(
+    sync_store: SyncV2Store,
+) -> None:
+    _task_readiness_at_first_bootstrap_page(sync_store)
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_source_changed"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="bootstrapping",
+            state="blocked",
+            source_dataset_id="dataset-1",
+            source_cursor="00000002",
+            source_count=2,
+            source_fingerprint="b" * 64,
+            reason_code="notes_task_source_invalid",
+        )
+
+
+def test_notes_task_readiness_progress_requires_new_aggregate_fingerprint(
+    sync_store: SyncV2Store,
+) -> None:
+    _task_readiness_at_first_bootstrap_page(sync_store)
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_source_changed"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="bootstrapping",
+            state="bootstrapping",
+            source_dataset_id="dataset-1",
+            source_cursor="00000002",
+            source_count=2,
+            source_fingerprint="a" * 64,
+        )
+
+
+def test_notes_task_readiness_rejects_corrupt_dataset_metadata_json(
+    sync_store: SyncV2Store,
+) -> None:
+    sync_store.enroll_dataset(_dataset())
+    sync_store.db.execute(
+        "UPDATE sync_datasets SET metadata_json = ? WHERE dataset_id = ?",
+        ("{not-json", "dataset-1"),
+    )
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_state_invalid"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="not_enrolled",
+            state="enrolling",
+            source_dataset_id="dataset-1",
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=None,
+        )
+
+    stored = sync_store.db.execute(
+        "SELECT metadata_json FROM sync_datasets WHERE dataset_id = ?",
+        ("dataset-1",),
+    ).rows[0]
+    assert stored["metadata_json"] == "{not-json"
+
+
+def test_notes_task_readiness_sanitizes_oversized_json_integer(
+    sync_store: SyncV2Store,
+) -> None:
+    sync_store.enroll_dataset(_dataset())
+    sync_store.db.execute(
+        "UPDATE sync_datasets SET metadata_json = ? WHERE dataset_id = ?",
+        ('{"oversized":' + "1" * 4_301 + "}", "dataset-1"),
+    )
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_state_invalid"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="not_enrolled",
+            state="enrolling",
+            source_dataset_id="dataset-1",
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=None,
+        )
+
+
+def test_notes_task_readiness_rejects_unpaired_surrogate_cursor(
+    sync_store: SyncV2Store,
+) -> None:
+    _task_readiness_at_first_bootstrap_page(sync_store)
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_cursor_invalid"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="bootstrapping",
+            state="bootstrapping",
+            source_dataset_id="dataset-1",
+            source_cursor="\ud800",
+            source_count=2,
+            source_fingerprint="b" * 64,
+        )
+
+
+def test_notes_task_readiness_rejects_other_domain_reason_code(
+    sync_store: SyncV2Store,
+) -> None:
+    _task_readiness_at_first_bootstrap_page(sync_store)
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_reason_invalid"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="bootstrapping",
+            state="blocked",
+            source_dataset_id="dataset-1",
+            source_cursor="00000001",
+            source_count=1,
+            source_fingerprint="a" * 64,
+            reason_code="notes_task_activity_source_invalid",
+        )
+
+
+def test_notes_task_readiness_rejects_explicit_null_stored_state(
+    sync_store: SyncV2Store,
+) -> None:
+    sync_store.enroll_dataset(_dataset(metadata={"notes_task_v1": None}))
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_state_invalid"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="not_enrolled",
+            state="enrolling",
+            source_dataset_id="dataset-1",
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=None,
+        )
+
+
+def test_notes_task_readiness_rejects_other_domain_reason_in_stored_state(
+    sync_store: SyncV2Store,
+) -> None:
+    sync_store.enroll_dataset(
+        _dataset(
+            metadata={
+                "notes_task_v1": {
+                    "state": "blocked",
+                    "source_cursor": "00000001",
+                    "source_count": 1,
+                    "source_fingerprint": "a" * 64,
+                    "reason_code": "notes_task_activity_source_invalid",
+                },
+                "notes_task_activity_v1": {
+                    "state": "enrolling",
+                    "source_cursor": None,
+                    "source_count": 0,
+                    "source_fingerprint": None,
+                    "reason_code": None,
+                },
+                "task_activity_capture_enabled": True,
+            }
+        )
+    )
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_state_invalid"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="blocked",
+            state="verifying",
+            source_dataset_id="dataset-1",
+            source_cursor="00000001",
+            source_count=1,
+            source_fingerprint="a" * 64,
+        )
+
+
+def test_notes_task_readiness_domains_advance_independently(sync_store: SyncV2Store):
+    sync_store.enroll_dataset(_dataset())
+
+    task = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    activity = sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        task_activity_capture_enabled=True,
+    )
+
+    assert task.metadata["notes_task_v1"]["state"] == "enrolling"
+    assert "notes_task_activity_v1" not in task.metadata
+    assert activity.metadata["notes_task_v1"]["state"] == "enrolling"
+    assert activity.metadata["notes_task_activity_v1"]["state"] == "enrolling"
+    assert activity.metadata["task_activity_capture_enabled"] is True
+    assert "notes.task" not in activity.domains
+    assert "notes.task_activity" not in activity.domains
+
+    task = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="enrolling",
+        state="bootstrapping",
+        source_dataset_id="dataset-1",
+        source_cursor="00000001",
+        source_count=1,
+        source_fingerprint="a" * 64,
+    )
+    task = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="bootstrapping",
+        state="verifying",
+        source_dataset_id="dataset-1",
+        source_cursor="00000002",
+        source_count=2,
+        source_fingerprint="b" * 64,
+    )
+    task = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="verifying",
+        state="ready",
+        source_dataset_id="dataset-1",
+        source_cursor="00000002",
+        source_count=2,
+        source_fingerprint="b" * 64,
+    )
+
+    assert task.metadata["notes_task_v1"] == {
+        "state": "ready",
+        "source_cursor": "00000002",
+        "source_count": 2,
+        "source_fingerprint": "b" * 64,
+        "reason_code": None,
+    }
+    assert task.metadata["notes_task_activity_v1"]["state"] == "enrolling"
+
+    activity = sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="enrolling",
+        state="bootstrapping",
+        source_dataset_id="dataset-1",
+        source_cursor="2026-08-13T00:00:00+00:00|activity-1",
+        source_count=1,
+        source_fingerprint="c" * 64,
+    )
+    blocked = sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="bootstrapping",
+        state="blocked",
+        source_dataset_id="dataset-1",
+        source_cursor="2026-08-13T00:00:00+00:00|activity-1",
+        source_count=1,
+        source_fingerprint="c" * 64,
+        reason_code="notes_task_activity_source_invalid",
+    )
+    resumed = sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="blocked",
+        state="verifying",
+        source_dataset_id="dataset-1",
+        source_cursor="2026-08-13T00:00:00+00:00|activity-1",
+        source_count=1,
+        source_fingerprint="c" * 64,
+    )
+
+    assert activity.metadata["notes_task_activity_v1"]["state"] == "bootstrapping"
+    assert blocked.metadata["notes_task_activity_v1"]["reason_code"] == (
+        "notes_task_activity_source_invalid"
+    )
+    assert resumed.metadata["notes_task_activity_v1"]["state"] == "verifying"
+    assert resumed.metadata["notes_task_activity_v1"]["reason_code"] is None
+
+
+@pytest.mark.parametrize(
+    ("changes", "error_code"),
+    [
+        ({"source_count": 0}, "notes_task_readiness_progress_regressed"),
+        ({"source_cursor": "00000000"}, "notes_task_readiness_progress_regressed"),
+        ({"source_fingerprint": "b" * 64}, "notes_task_readiness_source_changed"),
+        ({"source_fingerprint": "not-a-hash"}, "notes_task_readiness_fingerprint_invalid"),
+        ({"reason_code": "raw private task text"}, "notes_task_readiness_reason_invalid"),
+    ],
+)
+def test_notes_task_readiness_rejects_regression_and_malformed_progress(
+    sync_store: SyncV2Store,
+    changes: dict[str, object],
+    error_code: str,
+) -> None:
+    sync_store.enroll_dataset(_dataset())
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        task_activity_capture_enabled=True,
+    )
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="enrolling",
+        state="bootstrapping",
+        source_dataset_id="dataset-1",
+        source_cursor="00000001",
+        source_count=1,
+        source_fingerprint="a" * 64,
+    )
+    arguments: dict[str, object] = {
+        "owner_user_id": "user-1",
+        "expected_state": "bootstrapping",
+        "state": "bootstrapping",
+        "source_dataset_id": "dataset-1",
+        "source_cursor": "00000001",
+        "source_count": 1,
+        "source_fingerprint": "a" * 64,
+        "reason_code": None,
+    }
+    arguments.update(changes)
+
+    with pytest.raises(SyncStoreError, match=error_code):
+        sync_store.transition_notes_task_readiness("dataset-1", **arguments)
+
+
+def test_notes_task_readiness_capture_change_is_atomic_and_rolls_back(
+    sync_store: SyncV2Store,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sync_store.enroll_dataset(_dataset())
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    original = sync_store.db._get_dataset_row
+
+    def fail_after_update(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise RuntimeError("forced post-update failure")
+
+    monkeypatch.setattr(sync_store.db, "_get_dataset_row", fail_after_update)
+    with pytest.raises(RuntimeError, match="forced post-update failure"):
+        sync_store.transition_notes_task_activity_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="enrolling",
+            state="bootstrapping",
+            source_dataset_id="dataset-1",
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=None,
+            task_activity_capture_enabled=True,
+        )
+    monkeypatch.setattr(sync_store.db, "_get_dataset_row", original)
+
+    stored = sync_store.get_dataset("dataset-1", owner_user_id="user-1")
+    assert stored is not None
+    assert stored.metadata["notes_task_activity_v1"]["state"] == "enrolling"
+    assert stored.metadata.get("task_activity_capture_enabled") is not True
+
+
+def test_notes_task_readiness_capture_requires_both_domains_and_empty_reset_is_safe(
+    sync_store: SyncV2Store,
+) -> None:
+    sync_store.enroll_dataset(_dataset())
+    initial = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="not_enrolled",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    assert initial.metadata["notes_task_v1"]["state"] == "not_enrolled"
+
+    with pytest.raises(
+        SyncStoreError,
+        match="notes_task_readiness_capture_incomplete",
+    ):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="not_enrolled",
+            state="enrolling",
+            source_dataset_id="dataset-1",
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=None,
+            task_activity_capture_enabled=True,
+        )
+
+    sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        task_activity_capture_enabled=True,
+    )
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="enrolling",
+        state="bootstrapping",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    with pytest.raises(
+        SyncStoreError,
+        match="notes_task_readiness_capture_required",
+    ):
+        sync_store.transition_notes_task_activity_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="enrolling",
+            state="enrolling",
+            source_dataset_id="dataset-1",
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=None,
+            task_activity_capture_enabled=False,
+        )
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="bootstrapping",
+        state="verifying",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=hashlib.sha256(b"").hexdigest(),
+    )
+
+    reset = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="verifying",
+        state="not_enrolled",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        task_activity_capture_enabled=False,
+    )
+
+    assert reset.metadata["notes_task_v1"] == {
+        "state": "not_enrolled",
+        "source_cursor": None,
+        "source_count": 0,
+        "source_fingerprint": None,
+        "reason_code": None,
+    }
+    assert reset.metadata["notes_task_activity_v1"]["state"] == "enrolling"
+    assert reset.metadata["task_activity_capture_enabled"] is False
+
+
+def test_notes_task_readiness_ready_state_is_terminal(sync_store: SyncV2Store) -> None:
+    sync_store.enroll_dataset(_dataset())
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        task_activity_capture_enabled=True,
+    )
+    for expected_state, state in (
+        ("enrolling", "bootstrapping"),
+        ("bootstrapping", "verifying"),
+        ("verifying", "ready"),
+    ):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state=expected_state,
+            state=state,
+            source_dataset_id="dataset-1",
+            source_cursor="00000001",
+            source_count=1,
+            source_fingerprint="a" * 64,
+        )
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_source_changed"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="ready",
+            state="ready",
+            source_dataset_id="dataset-1",
+            source_cursor="00000002",
+            source_count=2,
+            source_fingerprint="b" * 64,
+        )
+
+
+def test_notes_task_readiness_rejects_wrong_owner_local_unbound_and_malformed_state(
+    sync_store: SyncV2Store,
+) -> None:
+    sync_store.enroll_dataset(_dataset())
+
+    for owner_user_id, source_dataset_id in (
+        ("other-user", "dataset-1"),
+        ("user-1", "local-unbound"),
+    ):
+        with pytest.raises(SyncStoreError):
+            sync_store.transition_notes_task_readiness(
+                "dataset-1",
+                owner_user_id=owner_user_id,
+                expected_state="not_enrolled",
+                state="enrolling",
+                source_dataset_id=source_dataset_id,
+                source_cursor=None,
+                source_count=0,
+                source_fingerprint=None,
+            )
+
+    sync_store.enroll_dataset(
+        _dataset(
+            metadata={
+                "notes_task_v1": {
+                    "state": "ready",
+                    "source_cursor": "private task title",
+                    "source_count": "many",
+                    "source_fingerprint": "not-a-hash",
+                    "reason_code": "private failure detail",
+                }
+            }
+        )
+    )
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_state_invalid"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="ready",
+            state="ready",
+            source_dataset_id="dataset-1",
+            source_cursor="private task title",
+            source_count=1,
+            source_fingerprint="a" * 64,
+        )
+
+
 def test_insert_envelope_is_idempotent_by_dataset_and_client_envelope(sync_store: SyncV2Store):
     sync_store.enroll_dataset(_dataset())
     envelope = _envelope(client_envelope_id="env-1")

--- a/tldw_Server_API/tests/Sync/test_sync_v2_store.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_store.py
@@ -109,6 +109,36 @@ def _dataset(**overrides) -> SyncDatasetCreate:
     return SyncDatasetCreate(**payload)
 
 
+_TASK_CURSOR_1 = "00000000-0000-4000-8000-000000000001"
+_TASK_CURSOR_2 = "00000000-0000-4000-8000-000000000002"
+_TASK_CURSOR_3 = "00000000-0000-4000-8000-000000000003"
+_ACTIVITY_CURSOR_1 = (
+    "2026-08-13T00:00:00+00:00|00000000-0000-4000-8000-000000000011"
+)
+_ACTIVITY_CURSOR_2 = (
+    "2026-08-13T00:00:01+00:00|00000000-0000-4000-8000-000000000012"
+)
+
+
+def _readiness_record(
+    *,
+    state: str,
+    source_cursor: str | None = None,
+    source_count: int = 0,
+    source_fingerprint: str | None = None,
+    reason_code: str | None = None,
+    resume_phase: str | None = None,
+) -> dict[str, object]:
+    return {
+        "state": state,
+        "source_cursor": source_cursor,
+        "source_count": source_count,
+        "source_fingerprint": source_fingerprint,
+        "reason_code": reason_code,
+        "resume_phase": resume_phase,
+    }
+
+
 def _envelope(**overrides) -> SyncEnvelopeCreate:
     payload = {
         "dataset_id": "dataset-1",
@@ -2986,7 +3016,7 @@ def _task_readiness_at_first_bootstrap_page(sync_store: SyncV2Store) -> None:
         expected_state="enrolling",
         state="bootstrapping",
         source_dataset_id="dataset-1",
-        source_cursor="00000001",
+        source_cursor=_TASK_CURSOR_1,
         source_count=1,
         source_fingerprint="a" * 64,
     )
@@ -3004,7 +3034,7 @@ def test_notes_task_readiness_blocked_retains_last_verified_progress(
             expected_state="bootstrapping",
             state="blocked",
             source_dataset_id="dataset-1",
-            source_cursor="00000002",
+            source_cursor=_TASK_CURSOR_2,
             source_count=2,
             source_fingerprint="b" * 64,
             reason_code="notes_task_source_invalid",
@@ -3023,7 +3053,7 @@ def test_notes_task_readiness_progress_requires_new_aggregate_fingerprint(
             expected_state="bootstrapping",
             state="bootstrapping",
             source_dataset_id="dataset-1",
-            source_cursor="00000002",
+            source_cursor=_TASK_CURSOR_2,
             source_count=2,
             source_fingerprint="a" * 64,
         )
@@ -3109,7 +3139,7 @@ def test_notes_task_readiness_rejects_other_domain_reason_code(
             expected_state="bootstrapping",
             state="blocked",
             source_dataset_id="dataset-1",
-            source_cursor="00000001",
+            source_cursor=_TASK_CURSOR_1,
             source_count=1,
             source_fingerprint="a" * 64,
             reason_code="notes_task_activity_source_invalid",
@@ -3142,7 +3172,7 @@ def test_notes_task_readiness_rejects_other_domain_reason_in_stored_state(
             metadata={
                 "notes_task_v1": {
                     "state": "blocked",
-                    "source_cursor": "00000001",
+                    "source_cursor": _TASK_CURSOR_1,
                     "source_count": 1,
                     "source_fingerprint": "a" * 64,
                     "reason_code": "notes_task_activity_source_invalid",
@@ -3166,7 +3196,7 @@ def test_notes_task_readiness_rejects_other_domain_reason_in_stored_state(
             expected_state="blocked",
             state="verifying",
             source_dataset_id="dataset-1",
-            source_cursor="00000001",
+            source_cursor=_TASK_CURSOR_1,
             source_count=1,
             source_fingerprint="a" * 64,
         )
@@ -3211,7 +3241,7 @@ def test_notes_task_readiness_domains_advance_independently(sync_store: SyncV2St
         expected_state="enrolling",
         state="bootstrapping",
         source_dataset_id="dataset-1",
-        source_cursor="00000001",
+        source_cursor=_TASK_CURSOR_1,
         source_count=1,
         source_fingerprint="a" * 64,
     )
@@ -3221,7 +3251,7 @@ def test_notes_task_readiness_domains_advance_independently(sync_store: SyncV2St
         expected_state="bootstrapping",
         state="verifying",
         source_dataset_id="dataset-1",
-        source_cursor="00000002",
+        source_cursor=_TASK_CURSOR_2,
         source_count=2,
         source_fingerprint="b" * 64,
     )
@@ -3231,17 +3261,18 @@ def test_notes_task_readiness_domains_advance_independently(sync_store: SyncV2St
         expected_state="verifying",
         state="ready",
         source_dataset_id="dataset-1",
-        source_cursor="00000002",
+        source_cursor=_TASK_CURSOR_2,
         source_count=2,
         source_fingerprint="b" * 64,
     )
 
     assert task.metadata["notes_task_v1"] == {
         "state": "ready",
-        "source_cursor": "00000002",
+        "source_cursor": _TASK_CURSOR_2,
         "source_count": 2,
         "source_fingerprint": "b" * 64,
         "reason_code": None,
+        "resume_phase": None,
     }
     assert task.metadata["notes_task_activity_v1"]["state"] == "enrolling"
 
@@ -3251,7 +3282,7 @@ def test_notes_task_readiness_domains_advance_independently(sync_store: SyncV2St
         expected_state="enrolling",
         state="bootstrapping",
         source_dataset_id="dataset-1",
-        source_cursor="2026-08-13T00:00:00+00:00|activity-1",
+        source_cursor=_ACTIVITY_CURSOR_1,
         source_count=1,
         source_fingerprint="c" * 64,
     )
@@ -3261,7 +3292,7 @@ def test_notes_task_readiness_domains_advance_independently(sync_store: SyncV2St
         expected_state="bootstrapping",
         state="blocked",
         source_dataset_id="dataset-1",
-        source_cursor="2026-08-13T00:00:00+00:00|activity-1",
+        source_cursor=_ACTIVITY_CURSOR_1,
         source_count=1,
         source_fingerprint="c" * 64,
         reason_code="notes_task_activity_source_invalid",
@@ -3270,9 +3301,19 @@ def test_notes_task_readiness_domains_advance_independently(sync_store: SyncV2St
         "dataset-1",
         owner_user_id="user-1",
         expected_state="blocked",
+        state="bootstrapping",
+        source_dataset_id="dataset-1",
+        source_cursor=_ACTIVITY_CURSOR_1,
+        source_count=1,
+        source_fingerprint="c" * 64,
+    )
+    verifying = sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="bootstrapping",
         state="verifying",
         source_dataset_id="dataset-1",
-        source_cursor="2026-08-13T00:00:00+00:00|activity-1",
+        source_cursor=_ACTIVITY_CURSOR_1,
         source_count=1,
         source_fingerprint="c" * 64,
     )
@@ -3281,15 +3322,16 @@ def test_notes_task_readiness_domains_advance_independently(sync_store: SyncV2St
     assert blocked.metadata["notes_task_activity_v1"]["reason_code"] == (
         "notes_task_activity_source_invalid"
     )
-    assert resumed.metadata["notes_task_activity_v1"]["state"] == "verifying"
+    assert resumed.metadata["notes_task_activity_v1"]["state"] == "bootstrapping"
     assert resumed.metadata["notes_task_activity_v1"]["reason_code"] is None
+    assert verifying.metadata["notes_task_activity_v1"]["state"] == "verifying"
 
 
 @pytest.mark.parametrize(
     ("changes", "error_code"),
     [
         ({"source_count": 0}, "notes_task_readiness_progress_regressed"),
-        ({"source_cursor": "00000000"}, "notes_task_readiness_progress_regressed"),
+        ({"source_cursor": _TASK_CURSOR_1}, "notes_task_readiness_progress_regressed"),
         ({"source_fingerprint": "b" * 64}, "notes_task_readiness_source_changed"),
         ({"source_fingerprint": "not-a-hash"}, "notes_task_readiness_fingerprint_invalid"),
         ({"reason_code": "raw private task text"}, "notes_task_readiness_reason_invalid"),
@@ -3328,7 +3370,7 @@ def test_notes_task_readiness_rejects_regression_and_malformed_progress(
         expected_state="enrolling",
         state="bootstrapping",
         source_dataset_id="dataset-1",
-        source_cursor="00000001",
+        source_cursor=_TASK_CURSOR_2,
         source_count=1,
         source_fingerprint="a" * 64,
     )
@@ -3337,7 +3379,7 @@ def test_notes_task_readiness_rejects_regression_and_malformed_progress(
         "expected_state": "bootstrapping",
         "state": "bootstrapping",
         "source_dataset_id": "dataset-1",
-        "source_cursor": "00000001",
+        "source_cursor": _TASK_CURSOR_2,
         "source_count": 1,
         "source_fingerprint": "a" * 64,
         "reason_code": None,
@@ -3507,6 +3549,7 @@ def test_notes_task_readiness_capture_requires_both_domains_and_empty_reset_is_s
         "source_count": 0,
         "source_fingerprint": None,
         "reason_code": None,
+        "resume_phase": None,
     }
     assert reset.metadata["notes_task_activity_v1"]["state"] == "enrolling"
     assert reset.metadata["task_activity_capture_enabled"] is False
@@ -3546,7 +3589,7 @@ def test_notes_task_readiness_ready_state_is_terminal(sync_store: SyncV2Store) -
             expected_state=expected_state,
             state=state,
             source_dataset_id="dataset-1",
-            source_cursor="00000001",
+            source_cursor=_TASK_CURSOR_1,
             source_count=1,
             source_fingerprint="a" * 64,
         )
@@ -3558,7 +3601,7 @@ def test_notes_task_readiness_ready_state_is_terminal(sync_store: SyncV2Store) -
             expected_state="ready",
             state="ready",
             source_dataset_id="dataset-1",
-            source_cursor="00000002",
+            source_cursor=_TASK_CURSOR_2,
             source_count=2,
             source_fingerprint="b" * 64,
         )
@@ -3585,18 +3628,15 @@ def test_notes_task_readiness_rejects_wrong_owner_local_unbound_and_malformed_st
                 source_fingerprint=None,
             )
 
-    sync_store.enroll_dataset(
-        _dataset(
-            metadata={
-                "notes_task_v1": {
-                    "state": "ready",
-                    "source_cursor": "private task title",
-                    "source_count": "many",
-                    "source_fingerprint": "not-a-hash",
-                    "reason_code": "private failure detail",
-                }
-            }
-        )
+    sync_store.db.execute(
+        "UPDATE sync_datasets SET metadata_json = ? WHERE dataset_id = ?",
+        (
+            '{"notes_task_v1":{"state":"ready",'
+            '"source_cursor":"private task title","source_count":"many",'
+            '"source_fingerprint":"not-a-hash",'
+            '"reason_code":"private failure detail"}}',
+            "dataset-1",
+        ),
     )
     with pytest.raises(SyncStoreError, match="notes_task_readiness_state_invalid"):
         sync_store.transition_notes_task_readiness(
@@ -3609,6 +3649,559 @@ def test_notes_task_readiness_rejects_wrong_owner_local_unbound_and_malformed_st
             source_count=1,
             source_fingerprint="a" * 64,
         )
+
+
+def test_dataset_reenrollment_preserves_server_owned_task_readiness_metadata(
+    sync_store: SyncV2Store,
+) -> None:
+    server_metadata = {
+        "notes_task_v1": _readiness_record(
+            state="ready",
+            source_cursor=_TASK_CURSOR_2,
+            source_count=2,
+            source_fingerprint="a" * 64,
+        ),
+        "notes_task_activity_v1": _readiness_record(
+            state="blocked",
+            source_cursor=_ACTIVITY_CURSOR_1,
+            source_count=1,
+            source_fingerprint="b" * 64,
+            reason_code="notes_task_activity_source_invalid",
+            resume_phase="bootstrapping",
+        ),
+        "task_activity_capture_enabled": True,
+    }
+    sync_store.enroll_dataset(
+        _dataset(metadata={"label": "before", **server_metadata})
+    )
+
+    overwritten = sync_store.enroll_dataset(
+        _dataset(
+            metadata={
+                "label": "after",
+                "notes_task_v1": _readiness_record(state="not_enrolled"),
+                "notes_task_activity_v1": _readiness_record(state="not_enrolled"),
+                "task_activity_capture_enabled": False,
+            }
+        )
+    )
+    erased = sync_store.enroll_dataset(_dataset(metadata={}))
+
+    assert overwritten.metadata == {"label": "after", **server_metadata}
+    assert erased.metadata == server_metadata
+
+
+@pytest.mark.parametrize(
+    ("readiness_key", "raw", "error_code"),
+    [
+        ("notes_task_v1", None, "notes_task_readiness_state_invalid"),
+        ("notes_task_v1", [], "notes_task_readiness_state_invalid"),
+        ("notes_task_v1", {}, "notes_task_readiness_state_invalid"),
+        (
+            "notes_task_v1",
+            {**_readiness_record(state="not_enrolled"), "extra": "private"},
+            "notes_task_readiness_state_invalid",
+        ),
+        (
+            "notes_task_v1",
+            _readiness_record(
+                state="ready",
+                source_cursor=_TASK_CURSOR_1,
+                source_count=1,
+                source_fingerprint=None,
+            ),
+            "notes_task_readiness_fingerprint_invalid",
+        ),
+        (
+            "notes_task_v1",
+            _readiness_record(
+                state="bootstrapping",
+                source_cursor=_TASK_CURSOR_1,
+                source_count=1,
+                source_fingerprint=[],  # type: ignore[arg-type]
+            ),
+            "notes_task_readiness_fingerprint_invalid",
+        ),
+        (
+            "notes_task_v1",
+            _readiness_record(
+                state="bootstrapping",
+                source_cursor=_TASK_CURSOR_1,
+                source_count=9_223_372_036_854_775_808,
+                source_fingerprint="a" * 64,
+            ),
+            "notes_task_readiness_progress_invalid",
+        ),
+        (
+            "notes_task_v1",
+            _readiness_record(
+                state="bootstrapping",
+                source_cursor="not-a-uuid",
+                source_count=1,
+                source_fingerprint="a" * 64,
+            ),
+            "notes_task_readiness_cursor_invalid",
+        ),
+        (
+            "notes_task_activity_v1",
+            _readiness_record(
+                state="bootstrapping",
+                source_cursor=_TASK_CURSOR_1,
+                source_count=1,
+                source_fingerprint="a" * 64,
+            ),
+            "notes_task_readiness_cursor_invalid",
+        ),
+        (
+            "notes_task_activity_v1",
+            _readiness_record(
+                state="bootstrapping",
+                source_cursor=(
+                    "0001-01-01T00:00:00+14:00|"
+                    "00000000-0000-4000-8000-000000000011"
+                ),
+                source_count=1,
+                source_fingerprint="a" * 64,
+            ),
+            "notes_task_readiness_cursor_invalid",
+        ),
+        (
+            "notes_task_activity_v1",
+            _readiness_record(
+                state="bootstrapping",
+                source_cursor=(
+                    "9999-12-31T23:59:59-14:00|"
+                    "00000000-0000-4000-8000-000000000011"
+                ),
+                source_count=1,
+                source_fingerprint="a" * 64,
+            ),
+            "notes_task_readiness_cursor_invalid",
+        ),
+        (
+            "notes_task_v1",
+            {
+                **_readiness_record(
+                    state="blocked",
+                    source_fingerprint="a" * 64,
+                    reason_code="notes_task_source_invalid",
+                ),
+                "resume_phase": [],
+            },
+            "notes_task_readiness_state_invalid",
+        ),
+        (
+            "notes_task_activity_v1",
+            {
+                **_readiness_record(
+                    state="blocked",
+                    source_fingerprint="a" * 64,
+                    reason_code="notes_task_activity_source_invalid",
+                ),
+                "resume_phase": {},
+            },
+            "notes_task_readiness_state_invalid",
+        ),
+        (
+            "notes_task_v1",
+            _readiness_record(
+                state="blocked",
+                reason_code="notes_task_verification_failed",
+                resume_phase="verifying",
+            ),
+            "notes_task_readiness_state_invalid",
+        ),
+        (
+            "notes_task_activity_v1",
+            _readiness_record(
+                state="blocked",
+                reason_code="notes_task_activity_verification_failed",
+                resume_phase="verifying",
+            ),
+            "notes_task_readiness_state_invalid",
+        ),
+    ],
+)
+def test_notes_task_readiness_shared_parser_is_total_and_exact(
+    readiness_key: str,
+    raw: object,
+    error_code: str,
+) -> None:
+    from tldw_Server_API.app.core.Sync.v2.notes_task_readiness import (
+        parse_notes_task_readiness_record,
+    )
+
+    result = parse_notes_task_readiness_record(raw, readiness_key=readiness_key)
+
+    assert result.record is None
+    assert result.error_code == error_code
+
+
+def test_notes_task_readiness_shared_parser_accepts_signed_int64_boundary() -> None:
+    from tldw_Server_API.app.core.Sync.v2.notes_task_readiness import (
+        parse_notes_task_readiness_record,
+    )
+
+    result = parse_notes_task_readiness_record(
+        _readiness_record(
+            state="bootstrapping",
+            source_cursor=_TASK_CURSOR_3,
+            source_count=9_223_372_036_854_775_807,
+            source_fingerprint="f" * 64,
+        ),
+        readiness_key="notes_task_v1",
+    )
+
+    assert result.error_code is None
+    assert result.record is not None
+    assert result.record.source_count == 9_223_372_036_854_775_807
+
+
+@pytest.mark.parametrize(
+    ("readiness_key", "resume_phase"),
+    [
+        ("notes_task_v1", []),
+        ("notes_task_activity_v1", {}),
+    ],
+)
+def test_notes_task_readiness_transition_rejects_unhashable_resume_phase(
+    sync_store: SyncV2Store,
+    readiness_key: str,
+    resume_phase: object,
+) -> None:
+    reason_code = (
+        "notes_task_source_invalid"
+        if readiness_key == "notes_task_v1"
+        else "notes_task_activity_source_invalid"
+    )
+    sync_store.enroll_dataset(
+        _dataset(
+            metadata={
+                readiness_key: {
+                    **_readiness_record(
+                        state="blocked",
+                        source_fingerprint="a" * 64,
+                        reason_code=reason_code,
+                    ),
+                    "resume_phase": resume_phase,
+                }
+            }
+        )
+    )
+    method = (
+        sync_store.transition_notes_task_readiness
+        if readiness_key == "notes_task_v1"
+        else sync_store.transition_notes_task_activity_readiness
+    )
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_state_invalid"):
+        method(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="blocked",
+            state="bootstrapping",
+            source_dataset_id="dataset-1",
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint="a" * 64,
+        )
+
+
+def test_notes_task_readiness_shared_parser_exposes_domain_order_keys() -> None:
+    from datetime import datetime
+    from uuid import UUID
+
+    from tldw_Server_API.app.core.Sync.v2.notes_task_readiness import (
+        parse_notes_task_readiness_record,
+    )
+
+    task = parse_notes_task_readiness_record(
+        _readiness_record(
+            state="bootstrapping",
+            source_cursor=_TASK_CURSOR_1,
+            source_count=1,
+            source_fingerprint="a" * 64,
+        ),
+        readiness_key="notes_task_v1",
+    )
+    activity = parse_notes_task_readiness_record(
+        _readiness_record(
+            state="bootstrapping",
+            source_cursor=_ACTIVITY_CURSOR_1,
+            source_count=1,
+            source_fingerprint="b" * 64,
+        ),
+        readiness_key="notes_task_activity_v1",
+    )
+
+    assert task.record is not None
+    assert task.record.source_cursor_key == UUID(_TASK_CURSOR_1)
+    assert activity.record is not None
+    assert activity.record.source_cursor_key == (
+        datetime.fromisoformat("2026-08-13T00:00:00+00:00"),
+        UUID("00000000-0000-4000-8000-000000000011"),
+    )
+
+
+@pytest.mark.parametrize("source_fingerprint", [[], {}])
+def test_notes_task_readiness_non_string_fingerprint_is_bounded_error(
+    sync_store: SyncV2Store,
+    source_fingerprint: object,
+) -> None:
+    _task_readiness_at_first_bootstrap_page(sync_store)
+
+    with pytest.raises(
+        SyncStoreError,
+        match="notes_task_readiness_fingerprint_invalid",
+    ):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="bootstrapping",
+            state="bootstrapping",
+            source_dataset_id="dataset-1",
+            source_cursor=_TASK_CURSOR_2,
+            source_count=2,
+            source_fingerprint=source_fingerprint,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    ("transition", "source_cursor"),
+    [
+        ("task", "not-a-uuid"),
+        ("task", _ACTIVITY_CURSOR_1),
+        ("activity", _TASK_CURSOR_1),
+        (
+            "activity",
+            "2026-08-13T00:00:00-07:00|00000000-0000-4000-8000-000000000011",
+        ),
+    ],
+)
+def test_notes_task_readiness_rejects_noncanonical_domain_cursor(
+    sync_store: SyncV2Store,
+    transition: str,
+    source_cursor: str,
+) -> None:
+    sync_store.enroll_dataset(_dataset())
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        task_activity_capture_enabled=True,
+    )
+    method = (
+        sync_store.transition_notes_task_readiness
+        if transition == "task"
+        else sync_store.transition_notes_task_activity_readiness
+    )
+
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_cursor_invalid"):
+        method(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="enrolling",
+            state="bootstrapping",
+            source_dataset_id="dataset-1",
+            source_cursor=source_cursor,
+            source_count=1,
+            source_fingerprint="a" * 64,
+        )
+
+
+def _enroll_both_dormant_task_readiness_domains(sync_store: SyncV2Store) -> None:
+    sync_store.enroll_dataset(_dataset())
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    sync_store.transition_notes_task_activity_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="not_enrolled",
+        state="enrolling",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        task_activity_capture_enabled=True,
+    )
+
+
+def test_notes_task_readiness_blocked_from_enrolling_requires_bootstrap_resume(
+    sync_store: SyncV2Store,
+) -> None:
+    _enroll_both_dormant_task_readiness_domains(sync_store)
+    blocked = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="enrolling",
+        state="blocked",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+        reason_code="notes_task_source_invalid",
+    )
+
+    assert blocked.metadata["notes_task_v1"]["resume_phase"] == "bootstrapping"
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_transition_invalid"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="blocked",
+            state="verifying",
+            source_dataset_id="dataset-1",
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=hashlib.sha256(b"").hexdigest(),
+        )
+    resumed = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="blocked",
+        state="bootstrapping",
+        source_dataset_id="dataset-1",
+        source_cursor=None,
+        source_count=0,
+        source_fingerprint=None,
+    )
+    assert resumed.metadata["notes_task_v1"]["resume_phase"] is None
+
+
+def test_notes_task_readiness_blocked_from_bootstrap_resumes_without_advancing(
+    sync_store: SyncV2Store,
+) -> None:
+    _task_readiness_at_first_bootstrap_page(sync_store)
+    blocked = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="bootstrapping",
+        state="blocked",
+        source_dataset_id="dataset-1",
+        source_cursor=_TASK_CURSOR_1,
+        source_count=1,
+        source_fingerprint="a" * 64,
+        reason_code="notes_task_source_invalid",
+    )
+
+    assert blocked.metadata["notes_task_v1"]["resume_phase"] == "bootstrapping"
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_transition_invalid"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="blocked",
+            state="verifying",
+            source_dataset_id="dataset-1",
+            source_cursor=_TASK_CURSOR_1,
+            source_count=1,
+            source_fingerprint="a" * 64,
+        )
+    resumed = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="blocked",
+        state="bootstrapping",
+        source_dataset_id="dataset-1",
+        source_cursor=_TASK_CURSOR_1,
+        source_count=1,
+        source_fingerprint="a" * 64,
+    )
+    advanced = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="bootstrapping",
+        state="verifying",
+        source_dataset_id="dataset-1",
+        source_cursor=_TASK_CURSOR_1,
+        source_count=1,
+        source_fingerprint="a" * 64,
+    )
+    assert resumed.metadata["notes_task_v1"]["state"] == "bootstrapping"
+    assert advanced.metadata["notes_task_v1"]["state"] == "verifying"
+
+
+def test_notes_task_readiness_blocked_from_verifying_preserves_resume_progress(
+    sync_store: SyncV2Store,
+) -> None:
+    _task_readiness_at_first_bootstrap_page(sync_store)
+    sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="bootstrapping",
+        state="verifying",
+        source_dataset_id="dataset-1",
+        source_cursor=_TASK_CURSOR_1,
+        source_count=1,
+        source_fingerprint="a" * 64,
+    )
+    blocked = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="verifying",
+        state="blocked",
+        source_dataset_id="dataset-1",
+        source_cursor=_TASK_CURSOR_1,
+        source_count=1,
+        source_fingerprint="a" * 64,
+        reason_code="notes_task_verification_failed",
+    )
+
+    assert blocked.metadata["notes_task_v1"]["resume_phase"] == "verifying"
+    with pytest.raises(SyncStoreError, match="notes_task_readiness_source_changed"):
+        sync_store.transition_notes_task_readiness(
+            "dataset-1",
+            owner_user_id="user-1",
+            expected_state="blocked",
+            state="verifying",
+            source_dataset_id="dataset-1",
+            source_cursor=_TASK_CURSOR_2,
+            source_count=2,
+            source_fingerprint="b" * 64,
+        )
+    resumed = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="blocked",
+        state="verifying",
+        source_dataset_id="dataset-1",
+        source_cursor=_TASK_CURSOR_1,
+        source_count=1,
+        source_fingerprint="a" * 64,
+    )
+    ready = sync_store.transition_notes_task_readiness(
+        "dataset-1",
+        owner_user_id="user-1",
+        expected_state="verifying",
+        state="ready",
+        source_dataset_id="dataset-1",
+        source_cursor=_TASK_CURSOR_1,
+        source_count=1,
+        source_fingerprint="a" * 64,
+    )
+    assert resumed.metadata["notes_task_v1"]["state"] == "verifying"
+    assert ready.metadata["notes_task_v1"]["state"] == "ready"
 
 
 def test_insert_envelope_is_idempotent_by_dataset_and_client_envelope(sync_store: SyncV2Store):


### PR DESCRIPTION
## Summary
- Define strict Notes task/activity v1 contracts, canonical hashes, legacy transforms, and dormant readiness diagnostics while keeping both public capabilities disabled.
- Add authoritative SQLite and PostgreSQL schema v60 storage with exact fail-closed catalog verification, forced tenant RLS, immutable private owner-to-dataset authority, and atomic dataset binding.
- Preserve dataset-selector-free REST/MCP compatibility, bounded activity queries, PostgreSQL timestamp parity, and document the architecture in ADR-039 and TASK-13006.1.

## Test plan
- [x] Required 19-file SQLite and PostgreSQL 18 matrix: 963 passed, 0 skipped.
- [x] Ruff passes on changed files with only documented legacy-file baseline codes excluded.
- [x] Production py_compile passes.
- [x] Bandit exits 0 on all touched production files.
- [x] Independent final and quality reviews report no Critical or Important findings.

## Notes
- Focused mypy remains at the exact pre-existing 158-error legacy baseline; this change adds no new diagnostics.
- Before exposing dataset bind through a production caller, coordinate it with active-Sync mutations and close conn-less PostgreSQL read transactions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines strict v1 Sync contracts for Notes tasks/activity and owner/dataset-scoped schema v60 with enforced PostgreSQL RLS and private readiness metadata. Public behavior stays the same: `notes.task` and `notes.task_activity` remain dormant; REST/MCP continue using product-owned scope without a dataset selector.

- Contracts and hashing: adds validators, canonical JSON/hashes, tombstone formats, and exact legacy transforms for `notes.task` and `notes.task_activity`; introduces `NotesTaskContractError`; internal schemas are known but not advertised or writable.
- Storage and tenancy: introduces SQLite/PostgreSQL schema v60 with fail-closed catalog verification, immutable owner→dataset authority (initial `local-unbound` sentinel), atomic dataset binding, and forced RLS across all task tables; removes the legacy PostgreSQL v59 TaskStore bridge.
- Readiness state: persists dormant task/activity readiness with guarded transitions; enrollment rejects forged readiness keys and redacts private server-only metadata; profile exposes only sanitized per-owner diagnostics.
- REST/MCP compatibility: resolves a trusted owner/dataset scope via `resolve_task_compatibility_scope`; projected note writes lock the authorized scope first; timestamp responses are normalized for parity; existing endpoints and tools are unchanged.
- Tests and docs: adds ADR-039, design/spec/plan docs, and comprehensive SQLite/PostgreSQL tests for migration, tenancy/RLS, readiness, contract validation, and internal-domain non-advertisement. Satisfies TASK-13006.1.

- Rollout/migration
  - Apply DB migration to schema v60 and ensure PostgreSQL RLS context (`app.current_user_id`, `app.current_dataset_id`) is set by the application.
  - Do not enroll or advertise `notes.task`/`notes.task_activity`, and do not expose dataset bind to production callers until TASK-13006.4 couples activation with lifecycle capture. No client changes required.

<sup>Written for commit 9328e1dc047f5109c486e1c62ecf4695b4b69dbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

