### PR TITLE
feat(sync): implement dormant notes.task lifecycle

### DIFF
--- a/backlog/tasks/task-13006.2 - Implement-dormant-notes.task-Sync-lifecycle.md
+++ b/backlog/tasks/task-13006.2 - Implement-dormant-notes.task-Sync-lifecycle.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-13006.2
 title: Implement dormant notes.task Sync lifecycle
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-14 01:54'
+updated_date: '2026-08-21 19:27'
 labels:
   - notes
   - sync-v2
@@ -27,19 +28,47 @@ Implement the complete notes.task adapter, materializer, bootstrap, capture prim
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Strict notes.task version-1 upsert/tombstone implements create, exact-base update, complete/reopen, recurrence-state mutation, delete, and explicit tombstone restore with immutable identity and parent note.
-- [ ] #2 Task product writes use canonical revision/hash independently from REST row version, enforce owner/dataset/note authorization, and remain bounded and index-backed on SQLite and PostgreSQL.
-- [ ] #3 Existing tasks bootstrap resumably with exact legacy metadata validation, count/fingerprint verification, pull, cursor, acknowledgment, and split-commit repair.
-- [ ] #4 REST and MCP task mutations have dormant canonical capture primitives, but public supported/writable capabilities and enrollment still omit both task domains.
-- [ ] #5 Focused lifecycle, replay, conflict, cross-owner, pagination, repair, legacy REST, and live PostgreSQL tests pass.
+- [x] #1 Strict notes.task version-1 upsert/tombstone implements create, exact-base update, complete/reopen, recurrence-state mutation, delete, and explicit tombstone restore with immutable identity and parent note.
+- [x] #2 Task product writes use canonical revision/hash independently from REST row version, enforce owner/dataset/note authorization, and remain bounded and index-backed on SQLite and PostgreSQL.
+- [x] #3 Existing tasks bootstrap resumably with exact legacy metadata validation, count/fingerprint verification, pull, cursor, acknowledgment, and split-commit repair.
+- [x] #4 REST and MCP task mutations have dormant canonical capture primitives, but public supported/writable capabilities and enrollment still omit both task domains.
+- [x] #5 Focused lifecycle, replay, conflict, cross-owner, pagination, repair, legacy REST, and live PostgreSQL tests pass.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Implement strict notes.task lineage.
+2. Materialize canonical tasks with split-commit repair.
+3. Bootstrap legacy tasks in bounded resumable pages.
+4. Add dormant capture without public capability.
+5. Run SQLite/live-PostgreSQL/static gates.
+Detailed plan: Docs/superpowers/plans/2026-08-13-notes-task-sync-lifecycle-implementation-plan.md
+ADR required: no; ADR-039 applies.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented strict dormant notes.task v1 lineage, canonical product materialization and repair, resumable bootstrap, and an uninjected server-origin capture seam. Product writes now preserve canonical revision/hash independently from REST row versions, normalize completion timestamps before hashing, lock PostgreSQL task rows before canonical CAS, and remain owner/dataset scoped and index-backed. Bootstrap uses bounded keyset pages with exact source count/fingerprint/cursor/ack verification and split-commit repair. Public capabilities, enrollment, REST, and MCP remain dormant: no public caller injects capture and neither task domain is advertised or writable.
+
+Verification: complete planned matrix passed in two bounded runs after the single combined runner was externally terminated without a pytest failure: 164 passed + 259 passed = 423 passed, with TLDW_TEST_POSTGRES_REQUIRED=1 and zero skips. The live PostgreSQL 18 contract ran create/update/tombstone/restore for two owners under NOSUPERUSER/NOBYPASSRLS, proved cross-owner isolation, and used the v60 primary-key page index. Ruff passed on all planned production paths and changed tests; Bandit exited 0; py_compile exited 0; git diff --check passed.
+
+ADR required: no. Existing ADR-039 defines the canonical task ownership/projection boundary and remains authoritative. No architecture deviation or new dependency was introduced. No known skips or blockers remain.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed dormant notes.task Sync lifecycle: strict adapter, canonical materializer and repair, resumable bootstrap, capture primitives, PostgreSQL RLS/CAS/index proof, and full regression/static/security verification. Public support and enrollment remain off until the later activation task.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13006.2 - Implement-dormant-notes.task-Sync-lifecycle.md
+++ b/backlog/tasks/task-13006.2 - Implement-dormant-notes.task-Sync-lifecycle.md
@@ -4,7 +4,7 @@ title: Implement dormant notes.task Sync lifecycle
 status: Done
 assignee: []
 created_date: '2026-08-14 01:54'
-updated_date: '2026-08-21 19:27'
+updated_date: '2026-08-22 16:05'
 labels:
   - notes
   - sync-v2
@@ -50,11 +50,7 @@ ADR required: no; ADR-039 applies.
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented strict dormant notes.task v1 lineage, canonical product materialization and repair, resumable bootstrap, and an uninjected server-origin capture seam. Product writes now preserve canonical revision/hash independently from REST row versions, normalize completion timestamps before hashing, lock PostgreSQL task rows before canonical CAS, and remain owner/dataset scoped and index-backed. Bootstrap uses bounded keyset pages with exact source count/fingerprint/cursor/ack verification and split-commit repair. Public capabilities, enrollment, REST, and MCP remain dormant: no public caller injects capture and neither task domain is advertised or writable.
-
-Verification: complete planned matrix passed in two bounded runs after the single combined runner was externally terminated without a pytest failure: 164 passed + 259 passed = 423 passed, with TLDW_TEST_POSTGRES_REQUIRED=1 and zero skips. The live PostgreSQL 18 contract ran create/update/tombstone/restore for two owners under NOSUPERUSER/NOBYPASSRLS, proved cross-owner isolation, and used the v60 primary-key page index. Ruff passed on all planned production paths and changed tests; Bandit exited 0; py_compile exited 0; git diff --check passed.
-
-ADR required: no. Existing ADR-039 defines the canonical task ownership/projection boundary and remains authoritative. No architecture deviation or new dependency was introduced. No known skips or blockers remain.
+Completed the dormant notes.task lifecycle and PR #2794 review follow-up. Added strict task adapter/materializer/bootstrap/capture behavior; exact SQLite/PostgreSQL authority, RLS, bind, repair, and readiness contracts; centralized the public task-bootstrap interruption exception; documented private helpers; rejected explicit nonpositive server-origin revisions; fixed idempotent replay when deterministic revision/envelope IDs are omitted; replaced dynamic PostgreSQL role SQL with psycopg identifier composition; and refreshed the stale OpenAPI fingerprint after confirming the PR schema is identical to dev. Verification: focused Sync 188 passed; live PostgreSQL contract 2 passed with 0 skips; Ruff lint passed; Bandit, py_compile, OpenAPI drift, and git diff-check passed; mypy matched the pre-review 33-error baseline exactly; Ruff-format baseline remained unchanged at 8 files. ADR required: no; ADR-039 remains authoritative. Public task capability and enrollment stay dormant.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -35,7 +35,7 @@ from tldw_Server_API.app.core.Sync.v2.models import (
     NOTES_ORGANIZATION_DOMAINS,
     SOURCE_CACHE_SYNC_DOMAINS,
     SYNC_REBASE_REQUIRED_AFTER_CONFLICT_RESOLUTION,
-    SYNC_V2_SUPPORTED_OPERATIONS,
+    SYNC_V2_INTERNAL_OPERATIONS,
     WORKSPACE_SYNC_DOMAINS,
     ConflictStatus,
     SyncApplyStatus,
@@ -2352,6 +2352,8 @@ class SyncDatabase:
     def materialization_transaction(
         self,
         keys: Sequence[tuple[str, SyncDomain, str]],
+        *,
+        trusted_notes_task_bootstrap_id: str | None = None,
     ) -> Iterator[Any]:
         """Serialize product projection and Sync bookkeeping by dataset."""
 
@@ -2374,7 +2376,20 @@ class SyncDatabase:
                         )
                     enrolled = _dataset_domains_from_row(row)
                     for domain in sorted(domains):
-                        if domain not in enrolled:
+                        trusted_task = (
+                            domain == "notes.task"
+                            and trusted_notes_task_bootstrap_id is not None
+                        )
+                        if trusted_task:
+                            metadata = decode_json(row.get("metadata_json"), default={})
+                            readiness = metadata.get("notes_task_v1")
+                            if (
+                                not isinstance(readiness, Mapping)
+                                or readiness.get("state") != "bootstrapping"
+                                or metadata.get("task_activity_capture_enabled") is not True
+                            ):
+                                raise SyncStoreError("notes_task_sync_not_ready")
+                        elif domain not in enrolled:
                             raise SyncInvalidDomainError(
                                 "Sync domain is not enrolled for dataset "
                                 f"{dataset_id}: {domain}"
@@ -3113,6 +3128,27 @@ class SyncDatabase:
             return
         raise SyncStoreError("notes_organization_sync_not_ready")
 
+    @staticmethod
+    def _require_notes_task_bootstrap_write_ready(
+        row: Mapping[str, Any],
+        *,
+        envelope: SyncEnvelope | SyncEnvelopeCreate,
+        bootstrap_id: str,
+    ) -> None:
+        """Authorize only the private source-verified dormant task bootstrap."""
+
+        metadata = decode_json(row.get("metadata_json"), default={})
+        readiness = metadata.get("notes_task_v1")
+        routing = envelope.routing_metadata
+        if (
+            not isinstance(readiness, Mapping)
+            or readiness.get("state") != "bootstrapping"
+            or metadata.get("task_activity_capture_enabled") is not True
+            or routing.get("bootstrap_capture") is not True
+            or routing.get("bootstrap_id") != bootstrap_id
+        ):
+            raise SyncStoreError("notes_task_sync_not_ready")
+
     def _get_device_row(
         self,
         user_id: str,
@@ -3199,9 +3235,9 @@ class SyncDatabase:
                 raise SyncStoreError("notes_organization_sync_not_ready")
 
     def _validate_envelope_contract(self, envelope: SyncEnvelopeCreate) -> None:
-        if envelope.domain not in SYNC_V2_SUPPORTED_OPERATIONS:
+        if envelope.domain not in SYNC_V2_INTERNAL_OPERATIONS:
             raise SyncInvalidDomainError(f"Sync v2 M1 domain is not supported: {envelope.domain}")
-        if envelope.operation not in SYNC_V2_SUPPORTED_OPERATIONS[envelope.domain]:
+        if envelope.operation not in SYNC_V2_INTERNAL_OPERATIONS[envelope.domain]:
             raise SyncStoreError(
                 f"Sync v2 M1 operation {envelope.operation} is not supported for {envelope.domain}"
             )
@@ -6297,6 +6333,7 @@ class SyncDatabase:
         envelopes: Sequence[SyncEnvelopeCreate],
         *,
         trusted_notes_organization_bootstrap_id: str | None = None,
+        trusted_notes_task_bootstrap_id: str | None = None,
     ) -> list[SyncEnvelope]:
         """Insert one complete validated group or return its exact stored replay."""
 
@@ -6317,11 +6354,29 @@ class SyncDatabase:
         try:
             with self.backend.transaction() as conn:
                 for envelope in plan:
-                    dataset_row = self._require_dataset_domain_for_update(
-                        envelope.dataset_id,
-                        envelope.domain,
-                        connection=conn,
-                    )
+                    if (
+                        envelope.domain == "notes.task"
+                        and trusted_notes_task_bootstrap_id is not None
+                    ):
+                        dataset_row = self._get_dataset_row_for_update(
+                            envelope.dataset_id,
+                            connection=conn,
+                        )
+                        if dataset_row is None:
+                            raise SyncDatasetNotFoundError(
+                                f"Sync dataset not found: {envelope.dataset_id}"
+                            )
+                        self._require_notes_task_bootstrap_write_ready(
+                            dataset_row,
+                            envelope=envelope,
+                            bootstrap_id=trusted_notes_task_bootstrap_id,
+                        )
+                    else:
+                        dataset_row = self._require_dataset_domain_for_update(
+                            envelope.dataset_id,
+                            envelope.domain,
+                            connection=conn,
+                        )
                     self._require_notes_organization_write_ready(
                         dataset_row,
                         envelope.domain,
@@ -6824,10 +6879,27 @@ class SyncDatabase:
         state: SyncObjectState,
         *,
         connection: Any | None = None,
+        trusted_notes_task_bootstrap_id: str | None = None,
     ) -> SyncObjectState:
         now = utcnow_iso()
         with self.backend.transaction(connection) as conn:
-            self._require_dataset_domain(state.dataset_id, state.domain, connection=conn)
+            if (
+                state.domain == "notes.task"
+                and trusted_notes_task_bootstrap_id is not None
+            ):
+                row = self._require_dataset(state.dataset_id, connection=conn)
+                metadata = decode_json(row.get("metadata_json"), default={})
+                readiness = metadata.get("notes_task_v1")
+                if (
+                    not isinstance(readiness, Mapping)
+                    or readiness.get("state") != "bootstrapping"
+                    or metadata.get("task_activity_capture_enabled") is not True
+                ):
+                    raise SyncStoreError("notes_task_sync_not_ready")
+            else:
+                self._require_dataset_domain(
+                    state.dataset_id, state.domain, connection=conn
+                )
             self.execute(
                 """
                 INSERT INTO sync_object_state (
@@ -6935,6 +7007,7 @@ class SyncDatabase:
         server_cursor: int,
         *,
         bootstrap_id: str,
+        notes_task_bootstrap: bool = False,
         connection: Any | None = None,
     ) -> SyncEnvelope:
         """Atomically record a source-verified bootstrap step without product replay."""
@@ -6957,6 +7030,7 @@ class SyncDatabase:
                 return self.mark_bootstrap_envelope_verified(
                     server_cursor,
                     bootstrap_id=bootstrap_id,
+                    notes_task_bootstrap=notes_task_bootstrap,
                     connection=guarded_connection,
                 )
 
@@ -6970,9 +7044,19 @@ class SyncDatabase:
             )
             if row is None:
                 raise SyncStoreError(f"Sync envelope not found for server cursor: {server_cursor}")
-            dataset_row = self._require_dataset_domain(
-                str(row["dataset_id"]), row["domain"], connection=conn
-            )
+            if row["domain"] == "notes.task" and notes_task_bootstrap:
+                dataset_row = self._require_dataset(
+                    str(row["dataset_id"]), connection=conn
+                )
+                self._require_notes_task_bootstrap_write_ready(
+                    dataset_row,
+                    envelope=_envelope_from_row(row),
+                    bootstrap_id=bootstrap_id,
+                )
+            else:
+                dataset_row = self._require_dataset_domain(
+                    str(row["dataset_id"]), row["domain"], connection=conn
+                )
             self._require_notes_organization_write_ready(
                 dataset_row,
                 row["domain"],
@@ -6990,6 +7074,9 @@ class SyncDatabase:
                     deleted=row.get("operation") == "tombstone",
                 ),
                 connection=conn,
+                trusted_notes_task_bootstrap_id=(
+                    bootstrap_id if notes_task_bootstrap else None
+                ),
             )
             self.execute(
                 "UPDATE sync_envelopes SET apply_status = 'applied', apply_error_code = NULL, "

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -17,7 +17,11 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     logger,
 )
 from tldw_Server_API.app.core.Sync.v2.models import normalize_sync_timestamp
-from tldw_Server_API.app.core.Sync.v2.notes_task_contract import NotesTaskV1Payload
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    NotesTaskV1Payload,
+    notes_task_object_hash,
+    parse_notes_task_v1,
+)
 
 if TYPE_CHECKING:
     from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
@@ -927,7 +931,7 @@ class TaskStore:
         )
         cursor = self._execute(
             conn,
-            "UPDATE note_tasks SET text = ?, status = ?, metadata_json = ?, "
+            "UPDATE note_tasks SET text = ?, status = ?, metadata_json = ?, "  # nosec B608
             "updated_at = ?, completed_at = ?, deleted = ?, version = version + 1, "
             "canonical_revision = ?, canonical_hash = ?, source_diagnostic_code = NULL, "
             "source_diagnostic_hash = NULL"
@@ -1176,6 +1180,92 @@ class TaskStore:
             conn=None,
             fn=_read_tasks,
         )
+
+    def page_tasks_for_sync_bootstrap(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        after_task_id: str | None = None,
+        limit: int = 500,
+        conn: TaskConnection | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return one canonical task keyset page for private Sync bootstrap."""
+
+        if isinstance(limit, bool) or not 1 <= limit <= 500:
+            raise ValueError("Notes task bootstrap page limit must be 1..500")
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        cursor = str(after_task_id or "")
+
+        def _page(read_conn: TaskConnection | None) -> list[dict[str, Any]]:
+            rows = self._read(
+                "SELECT * FROM note_tasks WHERE owner_user_id = ? AND dataset_id = ? "
+                "AND id > ? ORDER BY id ASC LIMIT ?",
+                (owner, dataset, cursor, limit),
+                conn=read_conn,
+            ).fetchall()
+            return [self._sync_bootstrap_task_row(row, owner) for row in rows]
+
+        return self._with_scoped_read(dataset_id=dataset, conn=conn, fn=_page)
+
+    @staticmethod
+    def _sync_bootstrap_task_row(row: Mapping[str, Any], owner: str) -> dict[str, Any]:
+        decoded = dict(row)
+        raw_metadata = decoded.get("metadata_json")
+        if isinstance(raw_metadata, str):
+            try:
+                metadata = json.loads(raw_metadata)
+            except (TypeError, ValueError) as exc:
+                raise CharactersRAGDBError("notes_task_source_invalid") from exc
+        else:
+            metadata = raw_metadata
+        if not isinstance(metadata, dict) or decoded.get("source_diagnostic_code") is not None:
+            raise CharactersRAGDBError("notes_task_source_invalid")
+        metadata_keys = set(metadata)
+        legacy_keys = {"due_date", "priority", "estimate"}
+        canonical_keys = {
+            "description",
+            "priority",
+            "due_date",
+            "estimate",
+            "recurrence",
+            "assignee_id",
+            "tags",
+            "custom",
+        }
+        legacy = metadata_keys.issubset(legacy_keys)
+        if not legacy and metadata_keys != canonical_keys:
+            raise CharactersRAGDBError("notes_task_source_invalid")
+        raw_payload: dict[str, Any] = {
+            "task_id": decoded.get("id"),
+            "note_id": decoded.get("note_id"),
+            "title": decoded.get("text"),
+            "description": None if legacy else metadata.get("description"),
+            "status": decoded.get("status"),
+            "completed_at": normalize_sync_timestamp(decoded.get("completed_at")),
+            "priority": metadata.get("priority"),
+            "due_date": metadata.get("due_date"),
+            "estimate": metadata.get("estimate"),
+            "recurrence": None if legacy else metadata.get("recurrence"),
+            "assignee_id": None if legacy else metadata.get("assignee_id"),
+            "tags": [] if legacy else metadata.get("tags"),
+            "custom": {} if legacy else metadata.get("custom"),
+        }
+        try:
+            payload = parse_notes_task_v1(raw_payload, owner_user_id=owner)
+            revision = int(decoded.get("canonical_revision") or 0)
+            expected_hash = notes_task_object_hash(
+                payload,
+                revision=revision,
+                deleted=bool(decoded.get("deleted")),
+            )
+        except (TypeError, ValueError) as exc:
+            raise CharactersRAGDBError("notes_task_source_invalid") from exc
+        if decoded.get("canonical_hash") != expected_hash:
+            raise CharactersRAGDBError("notes_task_source_invalid")
+        decoded["metadata_json"] = metadata
+        decoded["sync_payload"] = payload.model_dump(mode="json")
+        return decoded
 
     def update_unlinked_task_metadata_record_only(
         self,

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -177,6 +177,7 @@ class TaskStore:
         source = dict(task)
         if isinstance(source.get("metadata_json"), dict):
             source["metadata_json"] = self._json_dumps(source["metadata_json"], "metadata")
+        source["completed_at"] = normalize_sync_timestamp(source.get("completed_at"))
         object_hash, code, diagnostic_hash = self._db._canonicalize_legacy_task_v60(
             source,
             owner_user_id=str(source["owner_user_id"]),
@@ -349,23 +350,37 @@ class TaskStore:
         owner_user_id: str,
         dataset_id: str,
         include_deleted: bool,
+        for_update: bool = False,
         conn: TaskConnection | None = None,
     ) -> dict[str, Any] | None:
+        lock_clause = (
+            " FOR UPDATE"
+            if for_update and self._db.backend_type == BackendType.POSTGRESQL
+            else ""
+        )
         if include_deleted:
             cursor = self._read(
-                "SELECT * FROM note_tasks WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+                "SELECT * FROM note_tasks "
+                "WHERE owner_user_id = ? AND dataset_id = ? AND id = ?"
+                + lock_clause,  # nosec B608
                 (owner_user_id, dataset_id, task_id),
                 conn=conn,
             )
             return self._decode_task_row(cursor.fetchone())
-        cursor = self._read(
+        if lock_clause:
+            lock_clause = " FOR UPDATE OF t"
+        query = (
             """
             SELECT t.*
               FROM note_tasks t
               JOIN notes n ON n.id = t.note_id
              WHERE t.owner_user_id = ? AND t.dataset_id = ? AND t.id = ?
                AND n.client_id = t.owner_user_id AND t.deleted = ? AND n.deleted = ?
-            """,
+            """
+            + lock_clause  # nosec B608
+        )
+        cursor = self._read(
+            query,
             (owner_user_id, dataset_id, task_id, self._deleted_value(False), self._deleted_value(False)),
             conn=conn,
         )
@@ -884,6 +899,7 @@ class TaskStore:
             owner_user_id=owner,
             dataset_id=dataset,
             include_deleted=True,
+            for_update=True,
             conn=conn,
         )
         if (

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -16,6 +16,8 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     InputError,
     logger,
 )
+from tldw_Server_API.app.core.Sync.v2.models import normalize_sync_timestamp
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import NotesTaskV1Payload
 
 if TYPE_CHECKING:
     from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
@@ -589,6 +591,384 @@ class TaskStore:
                 entity_id=task_id,
             )  # noqa: TRY003
         return task_status, projection
+
+    @staticmethod
+    def _sync_task_materialization_checkpoint(_stage: str) -> None:
+        """No-op seam used to prove product transaction rollback."""
+
+    @staticmethod
+    def _sync_task_metadata(payload: NotesTaskV1Payload) -> dict[str, Any]:
+        recurrence = (
+            payload.recurrence.model_dump(mode="json")
+            if payload.recurrence is not None
+            else None
+        )
+        return {
+            "description": payload.description,
+            "priority": payload.priority,
+            "due_date": payload.due_date,
+            "estimate": payload.estimate,
+            "recurrence": recurrence,
+            "assignee_id": payload.assignee_id,
+            "tags": list(payload.tags),
+            "custom": dict(payload.custom),
+        }
+
+    def verify_sync_task_postcondition(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        payload: NotesTaskV1Payload,
+        canonical_revision: int,
+        canonical_hash: str,
+        deleted: bool,
+        expected_projection_status: str | None = None,
+        conn: TaskConnection | None = None,
+    ) -> bool:
+        """Return whether the exact canonical task product state is durable."""
+
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+
+        def _verify(read_conn: TaskConnection | None) -> bool:
+            row = self._fetch_task(
+                payload.task_id,
+                owner_user_id=owner,
+                dataset_id=dataset,
+                include_deleted=True,
+                conn=read_conn,
+            )
+            if row is None:
+                return False
+            projection_status = str(row["projection_status"])
+            if expected_projection_status is not None:
+                projection_matches = projection_status == expected_projection_status
+            else:
+                projection_matches = projection_status in {
+                    "live",
+                    "unlinked",
+                    "ambiguous",
+                }
+            return bool(
+                row["owner_user_id"] == owner
+                and row["dataset_id"] == dataset
+                and row["id"] == payload.task_id
+                and row["note_id"] == payload.note_id
+                and row["text"] == payload.title
+                and row["status"] == payload.status
+                and row["metadata_json"] == self._sync_task_metadata(payload)
+                and normalize_sync_timestamp(row.get("completed_at"))
+                == payload.completed_at
+                and int(row["canonical_revision"]) == canonical_revision
+                and row["canonical_hash"] == canonical_hash
+                and bool(row["deleted"]) is deleted
+                and projection_matches
+                and row.get("source_diagnostic_code") is None
+                and row.get("source_diagnostic_hash") is None
+            )
+
+        return self._with_scoped_read(
+            dataset_id=dataset,
+            conn=conn,
+            fn=_verify,
+        )
+
+    def apply_sync_task_create(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        payload: NotesTaskV1Payload,
+        canonical_revision: int,
+        canonical_hash: str,
+        conn: TaskConnection,
+    ) -> dict[str, Any]:
+        """Create one canonical unlinked task without recording activity."""
+
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        if canonical_revision != 1:
+            raise ConflictError(
+                "Sync task create revision is invalid.",
+                entity="tasks",
+                entity_id=payload.task_id,
+            )  # noqa: TRY003
+        self._require_authorized_write_scope(
+            conn,
+            owner_user_id=owner,
+            dataset_id=dataset,
+        )
+        if self._fetch_task(
+            payload.task_id,
+            owner_user_id=owner,
+            dataset_id=dataset,
+            include_deleted=True,
+            conn=conn,
+        ) is not None:
+            raise ConflictError(
+                "Sync task identity already exists.",
+                entity="tasks",
+                entity_id=payload.task_id,
+            )  # noqa: TRY003
+        self._require_active_note(
+            payload.note_id,
+            payload.task_id,
+            owner_user_id=owner,
+            conn=conn,
+        )
+        now = self._db._get_current_utc_timestamp_iso()
+        self._execute(
+            conn,
+            """
+            INSERT INTO note_tasks (
+                owner_user_id, dataset_id, id, note_id, text, status,
+                metadata_json, projection_status, deleted, created_at, updated_at,
+                completed_at, client_id, version, canonical_revision, canonical_hash,
+                source_diagnostic_code, source_diagnostic_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+            """,
+            (
+                owner,
+                dataset,
+                payload.task_id,
+                payload.note_id,
+                payload.title,
+                payload.status,
+                self._json_dumps(self._sync_task_metadata(payload), "metadata"),
+                "unlinked",
+                self._deleted_value(False),
+                now,
+                now,
+                payload.completed_at,
+                self._db.client_id,
+                1,
+                canonical_revision,
+                canonical_hash,
+            ),
+        )
+        self._sync_task_materialization_checkpoint("create")
+        if not self.verify_sync_task_postcondition(
+            owner_user_id=owner,
+            dataset_id=dataset,
+            payload=payload,
+            canonical_revision=canonical_revision,
+            canonical_hash=canonical_hash,
+            deleted=False,
+            expected_projection_status="unlinked",
+            conn=conn,
+        ):
+            raise CharactersRAGDBError("Sync task create postcondition failed.")  # noqa: TRY003
+        created = self._fetch_task(
+            payload.task_id,
+            owner_user_id=owner,
+            dataset_id=dataset,
+            include_deleted=True,
+            conn=conn,
+        )
+        if created is None:
+            raise CharactersRAGDBError("Sync task create readback failed.")  # noqa: TRY003
+        return created
+
+    def apply_sync_task_upsert(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        payload: NotesTaskV1Payload,
+        base_revision: int,
+        base_hash: str,
+        canonical_revision: int,
+        canonical_hash: str,
+        conn: TaskConnection,
+    ) -> dict[str, Any]:
+        """Update one live canonical task without recording activity."""
+
+        return self._apply_sync_task_transition(
+            owner_user_id=owner_user_id,
+            dataset_id=dataset_id,
+            payload=payload,
+            base_revision=base_revision,
+            base_hash=base_hash,
+            canonical_revision=canonical_revision,
+            canonical_hash=canonical_hash,
+            deleted=False,
+            restore=False,
+            conn=conn,
+        )
+
+    def apply_sync_task_tombstone(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        payload: NotesTaskV1Payload,
+        base_revision: int,
+        base_hash: str,
+        canonical_revision: int,
+        canonical_hash: str,
+        conn: TaskConnection,
+    ) -> dict[str, Any]:
+        """Soft-delete one live canonical task without recording activity."""
+
+        return self._apply_sync_task_transition(
+            owner_user_id=owner_user_id,
+            dataset_id=dataset_id,
+            payload=payload,
+            base_revision=base_revision,
+            base_hash=base_hash,
+            canonical_revision=canonical_revision,
+            canonical_hash=canonical_hash,
+            deleted=True,
+            restore=False,
+            conn=conn,
+        )
+
+    def apply_sync_task_restore(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        payload: NotesTaskV1Payload,
+        base_revision: int,
+        base_hash: str,
+        canonical_revision: int,
+        canonical_hash: str,
+        conn: TaskConnection,
+    ) -> dict[str, Any]:
+        """Restore one exact task tombstone as an unlinked live task."""
+
+        return self._apply_sync_task_transition(
+            owner_user_id=owner_user_id,
+            dataset_id=dataset_id,
+            payload=payload,
+            base_revision=base_revision,
+            base_hash=base_hash,
+            canonical_revision=canonical_revision,
+            canonical_hash=canonical_hash,
+            deleted=False,
+            restore=True,
+            conn=conn,
+        )
+
+    def _apply_sync_task_transition(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        payload: NotesTaskV1Payload,
+        base_revision: int,
+        base_hash: str,
+        canonical_revision: int,
+        canonical_hash: str,
+        deleted: bool,
+        restore: bool,
+        conn: TaskConnection,
+    ) -> dict[str, Any]:
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        if canonical_revision != base_revision + 1:
+            raise ConflictError(
+                "Sync task canonical revision is stale.",
+                entity="tasks",
+                entity_id=payload.task_id,
+            )  # noqa: TRY003
+        self._require_authorized_write_scope(
+            conn,
+            owner_user_id=owner,
+            dataset_id=dataset,
+        )
+        current = self._fetch_task(
+            payload.task_id,
+            owner_user_id=owner,
+            dataset_id=dataset,
+            include_deleted=True,
+            conn=conn,
+        )
+        if (
+            current is None
+            or current["note_id"] != payload.note_id
+            or int(current["canonical_revision"]) != base_revision
+            or current["canonical_hash"] != base_hash
+            or bool(current["deleted"]) is not restore
+        ):
+            raise ConflictError(
+                "Sync task product state does not match its canonical base.",
+                entity="tasks",
+                entity_id=payload.task_id,
+            )  # noqa: TRY003
+        self._require_active_note(
+            payload.note_id,
+            payload.task_id,
+            owner_user_id=owner,
+            conn=conn,
+        )
+        now = self._db._get_current_utc_timestamp_iso()
+        projection_status = "deleted" if deleted else "unlinked" if restore else None
+        projection_sql = (
+            ", projection_status = ?" if projection_status is not None else ""
+        )
+        params: tuple[Any, ...] = (
+            payload.title,
+            payload.status,
+            self._json_dumps(self._sync_task_metadata(payload), "metadata"),
+            now,
+            payload.completed_at,
+            self._deleted_value(deleted),
+            canonical_revision,
+            canonical_hash,
+        )
+        if projection_status is not None:
+            params += (projection_status,)
+        params += (
+            owner,
+            dataset,
+            payload.task_id,
+            base_revision,
+            base_hash,
+            self._deleted_value(restore),
+        )
+        cursor = self._execute(
+            conn,
+            "UPDATE note_tasks SET text = ?, status = ?, metadata_json = ?, "
+            "updated_at = ?, completed_at = ?, deleted = ?, version = version + 1, "
+            "canonical_revision = ?, canonical_hash = ?, source_diagnostic_code = NULL, "
+            "source_diagnostic_hash = NULL"
+            + projection_sql
+            + " WHERE owner_user_id = ? AND dataset_id = ? AND id = ? "
+            "AND canonical_revision = ? AND canonical_hash = ? AND deleted = ?",  # nosec B608
+            params,
+        )
+        if getattr(cursor, "rowcount", None) == 0:
+            raise ConflictError(
+                "Sync task product state changed concurrently.",
+                entity="tasks",
+                entity_id=payload.task_id,
+            )  # noqa: TRY003
+        self._sync_task_materialization_checkpoint(
+            "restore" if restore else "tombstone" if deleted else "upsert"
+        )
+        expected_projection = (
+            "deleted" if deleted else "unlinked" if restore else None
+        )
+        if not self.verify_sync_task_postcondition(
+            owner_user_id=owner,
+            dataset_id=dataset,
+            payload=payload,
+            canonical_revision=canonical_revision,
+            canonical_hash=canonical_hash,
+            deleted=deleted,
+            expected_projection_status=expected_projection,
+            conn=conn,
+        ):
+            raise CharactersRAGDBError("Sync task transition postcondition failed.")  # noqa: TRY003
+        updated = self._fetch_task(
+            payload.task_id,
+            owner_user_id=owner,
+            dataset_id=dataset,
+            include_deleted=True,
+            conn=conn,
+        )
+        if updated is None:
+            raise CharactersRAGDBError("Sync task transition readback failed.")  # noqa: TRY003
+        return updated
 
     def create_task(
         self,

--- a/tldw_Server_API/app/core/Notes_Tasks/service.py
+++ b/tldw_Server_API/app/core/Notes_Tasks/service.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import date
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import ConflictError, InputError
 from tldw_Server_API.app.core.Notes.organization_capture import (
@@ -15,6 +17,8 @@ from tldw_Server_API.app.core.Notes.organization_capture import (
 from tldw_Server_API.app.core.Notes_Tasks.markdown_parser import parse_note_checklists
 from tldw_Server_API.app.core.Notes_Tasks.models import ParsedChecklistItem, ReconciliationResult, TaskActor
 from tldw_Server_API.app.core.Notes_Tasks.reconciler import NotesTaskReconciler
+from tldw_Server_API.app.core.Sync.v2.models import SyncOperation
+from tldw_Server_API.app.core.Sync.v2.server_origin_batch import ServerOriginMutationStep
 
 if TYPE_CHECKING:
     from tldw_Server_API.app.core.DB_Management.chacha.task_store import TaskConnection
@@ -173,6 +177,133 @@ class TaskStoreScope:
     dataset_id: str
 
 
+@dataclass(frozen=True, slots=True)
+class NotesTaskCaptureMutation:
+    """Canonical dormant capture input for one committed product task mutation."""
+
+    owner_user_id: str
+    dataset_id: str
+    actor: TaskActor
+    operation: SyncOperation
+    before: dict[str, Any] | None
+    after: dict[str, Any]
+    base_revision: int | None
+    base_hash: str | None
+    restore_intent: bool
+    idempotency_key: str
+    step: ServerOriginMutationStep
+
+
+class NotesTaskCaptureCallback(Protocol):
+    """Receive one canonical mutation while its product transaction is open."""
+
+    def __call__(
+        self,
+        mutation: NotesTaskCaptureMutation,
+        *,
+        conn: TaskConnection | None,
+    ) -> None: ...
+
+
+def build_task_capture_mutation(
+    *,
+    db: CharactersRAGDB,
+    owner_user_id: str,
+    dataset_id: str,
+    actor: TaskActor,
+    before: dict[str, Any] | None,
+    after: dict[str, Any],
+) -> NotesTaskCaptureMutation:
+    """Build one exact, stable task capture input from canonical product rows."""
+
+    owner = str(owner_user_id)
+    dataset = str(dataset_id)
+    after_row = db.task_store._sync_bootstrap_task_row(after, owner)
+    before_row = (
+        db.task_store._sync_bootstrap_task_row(before, owner)
+        if before is not None
+        else None
+    )
+    if (
+        after_row.get("owner_user_id") != owner
+        or after_row.get("dataset_id") != dataset
+    ):
+        raise ConflictError(
+            "Task capture scope is invalid.",
+            entity="tasks",
+            entity_id=str(after_row.get("id") or ""),
+        )
+    task_id = str(after_row["id"])
+    note_id = str(after_row["note_id"])
+    revision = int(after_row["canonical_revision"])
+    object_hash = str(after_row["canonical_hash"])
+    base_revision = None
+    base_hash = None
+    if before_row is None:
+        if revision != 1:
+            raise ConflictError(
+                "Task capture create revision is invalid.",
+                entity="tasks",
+                entity_id=task_id,
+            )
+    else:
+        if (
+            before_row.get("owner_user_id") != owner
+            or before_row.get("dataset_id") != dataset
+            or str(before_row.get("id")) != task_id
+            or str(before_row.get("note_id")) != note_id
+        ):
+            raise ConflictError(
+                "Task capture identity is invalid.",
+                entity="tasks",
+                entity_id=task_id,
+            )
+        base_revision = int(before_row["canonical_revision"])
+        base_hash = str(before_row["canonical_hash"])
+        if revision != base_revision + 1:
+            raise ConflictError(
+                "Task capture revision is invalid.",
+                entity="tasks",
+                entity_id=task_id,
+            )
+    deleted = bool(after_row.get("deleted"))
+    restore_intent = bool(
+        before_row is not None
+        and before_row.get("deleted")
+        and not deleted
+    )
+    operation: SyncOperation = "tombstone" if deleted else "upsert"
+    identity_hash = hashlib.sha256(
+        json.dumps(
+            [owner, dataset, task_id, revision, object_hash, operation, restore_intent],
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    step = ServerOriginMutationStep(
+        domain="notes.task",
+        operation=operation,
+        object_id=task_id,
+        parent_id=note_id,
+        payload=dict(after_row["sync_payload"]),
+        routing_metadata={"restore_intent": True} if restore_intent else {},
+        client_envelope_id=f"notes-task-server-{identity_hash[:32]}",
+        object_revision=revision,
+    )
+    return NotesTaskCaptureMutation(
+        owner_user_id=owner,
+        dataset_id=dataset,
+        actor=actor,
+        operation=operation,
+        before=dict(before_row) if before_row is not None else None,
+        after=dict(after_row),
+        base_revision=base_revision,
+        base_hash=base_hash,
+        restore_intent=restore_intent,
+        idempotency_key=f"notes-task-capture-{identity_hash}",
+        step=step,
+    )
+
+
 def resolve_task_compatibility_scope(
     db: CharactersRAGDB,
     *,
@@ -191,8 +322,38 @@ def resolve_task_compatibility_scope(
 class NotesTaskService:
     """Coordinate task-backed checklist reconciliation for saved notes."""
 
-    def __init__(self, reconciler: NotesTaskReconciler | None = None) -> None:
+    def __init__(
+        self,
+        reconciler: NotesTaskReconciler | None = None,
+        *,
+        task_capture_callback: NotesTaskCaptureCallback | None = None,
+    ) -> None:
         self._reconciler = reconciler or NotesTaskReconciler()
+        self._task_capture_callback = task_capture_callback
+
+    def _capture_task_mutation(
+        self,
+        *,
+        db: CharactersRAGDB,
+        scope: TaskStoreScope,
+        actor: TaskActor,
+        before: dict[str, Any] | None,
+        after: dict[str, Any],
+        conn: TaskConnection | None,
+    ) -> None:
+        if self._task_capture_callback is None:
+            return
+        self._task_capture_callback(
+            build_task_capture_mutation(
+                db=db,
+                owner_user_id=scope.owner_user_id,
+                dataset_id=scope.dataset_id,
+                actor=actor,
+                before=before,
+                after=after,
+            ),
+            conn=conn,
+        )
 
     @staticmethod
     def _internal_reconciliation_actor(actor: TaskActor) -> TaskActor:
@@ -345,7 +506,7 @@ class NotesTaskService:
 
         coordinator = active_coordinator(db, user_id=actor.actor_id)
         transaction = db.transaction() if coordinator is None else nullcontext(None)
-        with transaction:
+        with transaction as conn:
             note = self._require_note_version(db, note_id=note_id, expected_note_version=expected_note_version)
             self.reconcile_note(
                 db=db,
@@ -362,6 +523,7 @@ class NotesTaskService:
                 note=note,
                 content=new_content,
                 expected_version=expected_note_version,
+                conn=conn,
             )
             updated_note = self._require_note(db, note_id)
             result = self.reconcile_note(
@@ -381,6 +543,14 @@ class NotesTaskService:
             )
             if task is None:
                 raise ConflictError("Created task was not found.", entity="tasks", entity_id=note_id)
+            self._capture_task_mutation(
+                db=db,
+                scope=scope,
+                actor=actor,
+                before=None,
+                after=task,
+                conn=conn,
+            )
             return task
 
     def update_task(
@@ -435,7 +605,7 @@ class NotesTaskService:
                     )
                 if metadata is None:
                     return task
-                return self._update_record_only_metadata(
+                updated = self._update_record_only_metadata(
                     db=db,
                     conn=conn,
                     task=task,
@@ -444,6 +614,15 @@ class NotesTaskService:
                     actor=actor,
                     scope=scope,
                 )
+                self._capture_task_mutation(
+                    db=db,
+                    scope=scope,
+                    actor=actor,
+                    before=task,
+                    after=updated,
+                    conn=conn,
+                )
+                return updated
             if projection_status != "live":
                 raise ConflictError(
                     f"Task projection is {projection_status} for task '{task_id}'.",
@@ -551,6 +730,14 @@ class NotesTaskService:
                 actor=self._internal_reconciliation_actor(actor),
                 owner_user_id=scope.owner_user_id,
             )
+            self._capture_task_mutation(
+                db=db,
+                scope=scope,
+                actor=actor,
+                before=task,
+                after=updated_task,
+                conn=conn,
+            )
             return updated_task
 
     def delete_task(
@@ -593,7 +780,7 @@ class NotesTaskService:
                         entity="tasks",
                         entity_id=task_id,
                     )
-                return db.soft_delete_task(
+                deleted = db.soft_delete_task(
                     owner_user_id=scope.owner_user_id,
                     dataset_id=scope.dataset_id,
                     task_id=task_id,
@@ -607,6 +794,15 @@ class NotesTaskService:
                     idempotency_key=actor.idempotency_key,
                     conn=conn,
                 )
+                self._capture_task_mutation(
+                    db=db,
+                    scope=scope,
+                    actor=actor,
+                    before=task,
+                    after=deleted,
+                    conn=conn,
+                )
+                return deleted
             if projection_status != "live":
                 raise ConflictError(
                     f"Task projection is {projection_status} for task '{task_id}'.",
@@ -674,6 +870,14 @@ class NotesTaskService:
                 content=new_content,
                 actor=self._internal_reconciliation_actor(actor),
                 owner_user_id=scope.owner_user_id,
+            )
+            self._capture_task_mutation(
+                db=db,
+                scope=scope,
+                actor=actor,
+                before=task,
+                after=deleted,
+                conn=conn,
             )
             return deleted
 

--- a/tldw_Server_API/app/core/Sync/v2/adapters.py
+++ b/tldw_Server_API/app/core/Sync/v2/adapters.py
@@ -43,6 +43,8 @@ ATTACHMENT_REF_SERVER_AVAILABILITY: frozenset[str] = frozenset({"server", "serve
 KNOWN_SYNC_DOMAINS: frozenset[str] = frozenset(
     {
         *SYNC_V2_SUPPORTED_DOMAINS,
+        "notes.task",
+        "notes.task_activity",
         "notes",
         "chat",
         "workspaces",
@@ -133,6 +135,7 @@ class SyncAdapterContext:
     organization_bootstrap_id: str | None = None
     notes_link_bootstrap_id: str | None = None
     attachment_ref_bootstrap_id: str | None = None
+    notes_task_bootstrap_id: str | None = None
     bootstrap_relationship_verifier: BootstrapRelationshipVerifier | None = None
     bootstrap_relationship_absence_verifier: BootstrapRelationshipVerifier | None = None
     supports_attachments: bool = False

--- a/tldw_Server_API/app/core/Sync/v2/adapters.py
+++ b/tldw_Server_API/app/core/Sync/v2/adapters.py
@@ -92,6 +92,7 @@ class AdapterDeferred:
 SyncAdapterOutcome = AdapterAccepted | AdapterRejected | AdapterConflict | AdapterDeferred
 SyncHead = SyncEnvelope | SyncEnvelopeCreate
 SyncHeadLookup = Callable[[SyncDomain, str], SyncHead | None]
+AuthorizedNoteLookup = Callable[[str], SyncHead | None]
 SyncDomainHeadLoader = Callable[[SyncDomain], Sequence[SyncHead]]
 BootstrapRelationshipVerifier = Callable[
     [SyncDomain, str, Mapping[str, object]], bool
@@ -125,6 +126,7 @@ class SyncAdapterContext:
 
     prior_envelopes: Sequence[SyncHead] = field(default_factory=tuple)
     get_head: SyncHeadLookup | None = None
+    get_authorized_note: AuthorizedNoteLookup | None = None
     list_heads: SyncDomainHeadLoader | None = None
     trusted_server_origin: bool = False
     organization_group_state: str | None = None

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/__init__.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/__init__.py
@@ -7,6 +7,7 @@ from .media import MediaCompatibilityAdapter, MediaMetadataAdapter, legacy_media
 from .notes import NotesDomainAdapter
 from .notes_link import NotesLinkDomainAdapter
 from .notes_organization import NotesOrganizationDomainAdapter
+from .notes_task import NotesTaskDomainAdapter
 from .source_cache import SourceCacheAdapter
 from .workspaces import WorkspacesDomainAdapter
 
@@ -16,6 +17,7 @@ __all__ = [
     "MediaMetadataAdapter",
     "NotesDomainAdapter",
     "NotesLinkDomainAdapter",
+    "NotesTaskDomainAdapter",
     "NotesOrganizationDomainAdapter",
     "SourceCacheAdapter",
     "WorkspacesDomainAdapter",

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/_lineage.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/_lineage.py
@@ -64,6 +64,22 @@ def incoming_references_head(
     return any(_dependency_references_head(dependency, head) for dependency in envelope.dependencies)
 
 
+def incoming_references_exact_head(
+    envelope: SyncEnvelopeCreate,
+    head: SyncHead,
+) -> bool:
+    """Return whether every canonical base token matches the current head."""
+
+    return bool(
+        _same_optional_token(envelope.base_server_cursor, head.server_cursor)
+        and _same_optional_token(
+            envelope.base_object_revision,
+            head.object_revision,
+        )
+        and _same_optional_token(envelope.base_object_hash, head.payload_hash)
+    )
+
+
 def delete_update_conflict(
     envelope: SyncEnvelopeCreate,
     prior: list[SyncHead],
@@ -115,9 +131,16 @@ def _same_token(left: object, right: object) -> bool:
     return str(left) == str(right)
 
 
+def _same_optional_token(left: object, right: object) -> bool:
+    if left is None or right is None:
+        return left is right
+    return str(left) == str(right)
+
+
 __all__ = [
     "current_head",
     "delete_update_conflict",
     "incoming_references_head",
+    "incoming_references_exact_head",
     "prior_envelopes",
 ]

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task.py
@@ -178,6 +178,8 @@ def _get_head(
     envelope: SyncEnvelopeCreate,
     context: SyncAdapterContext,
 ) -> SyncHead | None:
+    """Return the current object head from the context's preferred lookup."""
+
     if context.get_head is not None:
         return context.get_head(envelope.domain, envelope.object_id)
     matches = (
@@ -189,6 +191,8 @@ def _get_head(
 
 
 def _literal_replay(head: SyncHead, envelope: SyncEnvelopeCreate) -> bool:
+    """Return whether an incoming envelope exactly replays the stored head."""
+
     return all(
         getattr(head, field_name) == getattr(envelope, field_name)
         for field_name in _REPLAY_FIELDS
@@ -196,6 +200,8 @@ def _literal_replay(head: SyncHead, envelope: SyncEnvelopeCreate) -> bool:
 
 
 def _has_base(envelope: SyncEnvelopeCreate) -> bool:
+    """Return whether any optimistic lineage token was supplied."""
+
     return any(
         value is not None
         for value in (
@@ -207,6 +213,8 @@ def _has_base(envelope: SyncEnvelopeCreate) -> bool:
 
 
 def _same_identity(head: SyncHead, task_id: str, note_id: str) -> bool:
+    """Return whether head metadata and payload preserve task-note identity."""
+
     return bool(
         head.object_id == task_id
         and head.parent_id == note_id
@@ -216,6 +224,8 @@ def _same_identity(head: SyncHead, task_id: str, note_id: str) -> bool:
 
 
 def _is_deleted(head: SyncHead) -> bool:
+    """Return whether a head represents a tombstoned task."""
+
     return head.operation == "tombstone" or head.deleted
 
 
@@ -223,6 +233,8 @@ def _trusted_task_bootstrap(
     envelope: SyncEnvelopeCreate,
     context: SyncAdapterContext | None,
 ) -> bool:
+    """Return whether routing and context authorize private bootstrap capture."""
+
     bootstrap_id = envelope.routing_metadata.get("bootstrap_id")
     return bool(
         context is not None
@@ -240,6 +252,8 @@ def _rejected(
     envelope: SyncEnvelopeCreate,
     error_code: str,
 ) -> AdapterRejected:
+    """Build a bounded task validation rejection."""
+
     return AdapterRejected(
         client_envelope_id=envelope.client_envelope_id,
         error_code=error_code,
@@ -251,6 +265,8 @@ def _conflict(
     envelope: SyncEnvelopeCreate,
     conflict_type: str,
 ) -> AdapterConflict:
+    """Build a bounded task lineage conflict."""
+
     return AdapterConflict(
         client_envelope_id=envelope.client_envelope_id,
         domain=envelope.domain,

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task.py
@@ -1,0 +1,225 @@
+"""Strict dormant Sync v1 adapter for canonical Notes tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from tldw_Server_API.app.core.exceptions import NotesTaskContractError
+
+from ..adapters import (
+    AdapterAccepted,
+    AdapterConflict,
+    AdapterDeferred,
+    AdapterRejected,
+    SyncAdapterContext,
+    SyncAdapterOutcome,
+    SyncHead,
+)
+from ..models import SyncDataset, SyncEnvelopeCreate
+from ..notes_task_contract import (
+    notes_task_object_hash,
+    parse_notes_task_tombstone_v1,
+    parse_notes_task_v1,
+)
+from ._lineage import (
+    current_head,
+    incoming_references_exact_head,
+    prior_envelopes,
+)
+
+_REPLAY_FIELDS = (
+    "dataset_id",
+    "client_envelope_id",
+    "domain",
+    "operation",
+    "object_id",
+    "parent_id",
+    "device_id",
+    "base_server_cursor",
+    "base_object_revision",
+    "base_object_hash",
+    "object_revision",
+    "entity_version",
+    "adapter_version",
+    "schema_version",
+    "payload",
+    "payload_hash",
+    "created_at_client",
+    "routing_metadata",
+)
+
+
+@dataclass(slots=True)
+class NotesTaskDomainAdapter:
+    """Validate exact task lineage without activating a public Sync domain."""
+
+    domain: str = "notes.task"
+    supported_adapter_versions: set[int] = field(default_factory=lambda: {1})
+
+    def evaluate_envelope(
+        self,
+        envelope: SyncEnvelopeCreate,
+        *,
+        dataset: SyncDataset,
+        context: SyncAdapterContext | None = None,
+    ) -> SyncAdapterOutcome:
+        """Return a stable validation, dependency, conflict, or acceptance result."""
+
+        if (
+            envelope.domain != self.domain
+            or envelope.operation not in {"upsert", "tombstone"}
+            or envelope.adapter_version != 1
+            or envelope.schema_version != 1
+        ):
+            return _rejected(envelope, "notes_task_payload_invalid")
+
+        restore_intent = envelope.routing_metadata.get("restore_intent")
+        if set(envelope.routing_metadata) - {"restore_intent"} or restore_intent not in {
+            None,
+            True,
+        }:
+            return _rejected(envelope, "notes_task_payload_invalid")
+        if restore_intent is True and envelope.operation != "upsert":
+            return _rejected(envelope, "notes_task_payload_invalid")
+
+        try:
+            parser = (
+                parse_notes_task_tombstone_v1
+                if envelope.operation == "tombstone"
+                else parse_notes_task_v1
+            )
+            payload = parser(
+                envelope.payload,
+                owner_user_id=dataset.owner_user_id,
+            )
+            expected_revision = envelope.object_revision
+            if (
+                expected_revision is None
+                or envelope.entity_version != expected_revision
+                or envelope.payload_hash
+                != notes_task_object_hash(
+                    payload,
+                    revision=expected_revision,
+                    deleted=envelope.operation == "tombstone",
+                )
+            ):
+                raise NotesTaskContractError("notes.task lineage is invalid")
+        except NotesTaskContractError:
+            return _rejected(envelope, "notes_task_payload_invalid")
+
+        if envelope.object_id != payload.task_id or envelope.parent_id != payload.note_id:
+            return _conflict(envelope, "notes_task_identity_conflict")
+
+        if context is None or context.get_authorized_note is None:
+            return _rejected(envelope, "notes_task_authorization_unavailable")
+        note = context.get_authorized_note(payload.note_id)
+        if note is None or note.dataset_id != dataset.dataset_id:
+            return AdapterDeferred(
+                client_envelope_id=envelope.client_envelope_id,
+                message="The authorized parent note is not available yet",
+            )
+        if _is_deleted(note):
+            return _conflict(envelope, "notes_task_parent_conflict")
+
+        head = _get_head(envelope, context)
+        if head is not None and _literal_replay(head, envelope):
+            return AdapterAccepted(client_envelope_id=envelope.client_envelope_id)
+
+        if head is None:
+            if _has_base(envelope) or expected_revision != 1:
+                return _conflict(envelope, "notes_task_base_conflict")
+            if restore_intent is True:
+                return _conflict(envelope, "notes_task_restore_conflict")
+            return AdapterAccepted(client_envelope_id=envelope.client_envelope_id)
+
+        if not _has_base(envelope):
+            return _conflict(envelope, "notes_task_create_conflict")
+        if not _same_identity(head, payload.task_id, payload.note_id):
+            return _conflict(envelope, "notes_task_identity_conflict")
+        if not incoming_references_exact_head(envelope, head):
+            return _conflict(envelope, "notes_task_base_conflict")
+        if expected_revision != int(head.object_revision or 0) + 1:
+            return _rejected(envelope, "notes_task_payload_invalid")
+
+        head_deleted = _is_deleted(head)
+        if restore_intent is True:
+            if not head_deleted:
+                return _conflict(envelope, "notes_task_restore_conflict")
+        elif envelope.operation == "upsert" and head_deleted:
+            return _conflict(envelope, "notes_task_restore_conflict")
+        elif envelope.operation == "tombstone" and head_deleted:
+            return _conflict(envelope, "notes_task_base_conflict")
+
+        return AdapterAccepted(client_envelope_id=envelope.client_envelope_id)
+
+
+def _get_head(
+    envelope: SyncEnvelopeCreate,
+    context: SyncAdapterContext,
+) -> SyncHead | None:
+    if context.get_head is not None:
+        return context.get_head(envelope.domain, envelope.object_id)
+    matches = (
+        item
+        for item in prior_envelopes(envelope, context)
+        if item.domain == envelope.domain and item.object_id == envelope.object_id
+    )
+    return current_head(matches)
+
+
+def _literal_replay(head: SyncHead, envelope: SyncEnvelopeCreate) -> bool:
+    return all(
+        getattr(head, field_name) == getattr(envelope, field_name)
+        for field_name in _REPLAY_FIELDS
+    )
+
+
+def _has_base(envelope: SyncEnvelopeCreate) -> bool:
+    return any(
+        value is not None
+        for value in (
+            envelope.base_server_cursor,
+            envelope.base_object_revision,
+            envelope.base_object_hash,
+        )
+    )
+
+
+def _same_identity(head: SyncHead, task_id: str, note_id: str) -> bool:
+    return bool(
+        head.object_id == task_id
+        and head.parent_id == note_id
+        and head.payload.get("task_id") == task_id
+        and head.payload.get("note_id") == note_id
+    )
+
+
+def _is_deleted(head: SyncHead) -> bool:
+    return head.operation == "tombstone" or head.deleted
+
+
+def _rejected(
+    envelope: SyncEnvelopeCreate,
+    error_code: str,
+) -> AdapterRejected:
+    return AdapterRejected(
+        client_envelope_id=envelope.client_envelope_id,
+        error_code=error_code,
+        message="notes.task envelope validation failed",
+    )
+
+
+def _conflict(
+    envelope: SyncEnvelopeCreate,
+    conflict_type: str,
+) -> AdapterConflict:
+    return AdapterConflict(
+        client_envelope_id=envelope.client_envelope_id,
+        domain=envelope.domain,
+        entity_id=envelope.object_id,
+        conflict_type=conflict_type,
+        message="notes.task lineage requires a current authorized base",
+    )
+
+
+__all__ = ["NotesTaskDomainAdapter"]

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task.py
@@ -73,8 +73,21 @@ class NotesTaskDomainAdapter:
         ):
             return _rejected(envelope, "notes_task_payload_invalid")
 
+        trusted_bootstrap = _trusted_task_bootstrap(envelope, context)
         restore_intent = envelope.routing_metadata.get("restore_intent")
-        if set(envelope.routing_metadata) - {"restore_intent"} or restore_intent not in {
+        allowed_routing = (
+            {
+                "bootstrap_capture",
+                "bootstrap_id",
+                "source",
+                "origin",
+                "server_device_id",
+                "server_owner_user_id",
+            }
+            if trusted_bootstrap
+            else {"restore_intent"}
+        )
+        if set(envelope.routing_metadata) - allowed_routing or restore_intent not in {
             None,
             True,
         }:
@@ -110,22 +123,30 @@ class NotesTaskDomainAdapter:
         if envelope.object_id != payload.task_id or envelope.parent_id != payload.note_id:
             return _conflict(envelope, "notes_task_identity_conflict")
 
-        if context is None or context.get_authorized_note is None:
+        get_authorized_note = context.get_authorized_note if context is not None else None
+        if not trusted_bootstrap and get_authorized_note is None:
             return _rejected(envelope, "notes_task_authorization_unavailable")
-        note = context.get_authorized_note(payload.note_id)
-        if note is None or note.dataset_id != dataset.dataset_id:
-            return AdapterDeferred(
-                client_envelope_id=envelope.client_envelope_id,
-                message="The authorized parent note is not available yet",
-            )
-        if _is_deleted(note):
-            return _conflict(envelope, "notes_task_parent_conflict")
+        if not trusted_bootstrap:
+            if get_authorized_note is None:
+                return _rejected(envelope, "notes_task_authorization_unavailable")
+            note = get_authorized_note(payload.note_id)
+            if note is None or note.dataset_id != dataset.dataset_id:
+                return AdapterDeferred(
+                    client_envelope_id=envelope.client_envelope_id,
+                    message="The authorized parent note is not available yet",
+                )
+            if _is_deleted(note):
+                return _conflict(envelope, "notes_task_parent_conflict")
 
         head = _get_head(envelope, context)
         if head is not None and _literal_replay(head, envelope):
             return AdapterAccepted(client_envelope_id=envelope.client_envelope_id)
 
         if head is None:
+            if trusted_bootstrap:
+                if _has_base(envelope) or restore_intent is True:
+                    return _conflict(envelope, "notes_task_base_conflict")
+                return AdapterAccepted(client_envelope_id=envelope.client_envelope_id)
             if _has_base(envelope) or expected_revision != 1:
                 return _conflict(envelope, "notes_task_base_conflict")
             if restore_intent is True:
@@ -196,6 +217,23 @@ def _same_identity(head: SyncHead, task_id: str, note_id: str) -> bool:
 
 def _is_deleted(head: SyncHead) -> bool:
     return head.operation == "tombstone" or head.deleted
+
+
+def _trusted_task_bootstrap(
+    envelope: SyncEnvelopeCreate,
+    context: SyncAdapterContext | None,
+) -> bool:
+    bootstrap_id = envelope.routing_metadata.get("bootstrap_id")
+    return bool(
+        context is not None
+        and context.trusted_server_origin
+        and isinstance(bootstrap_id, str)
+        and bootstrap_id
+        and context.notes_task_bootstrap_id == bootstrap_id
+        and envelope.routing_metadata.get("bootstrap_capture") is True
+        and envelope.routing_metadata.get("source") == "notes-task-bootstrap"
+        and envelope.routing_metadata.get("origin") == "server"
+    )
 
 
 def _rejected(

--- a/tldw_Server_API/app/core/Sync/v2/factory.py
+++ b/tldw_Server_API/app/core/Sync/v2/factory.py
@@ -23,6 +23,7 @@ from .domain_adapters.media import MediaMetadataAdapter
 from .domain_adapters.notes import NotesDomainAdapter
 from .domain_adapters.notes_link import NotesLinkDomainAdapter
 from .domain_adapters.notes_organization import NotesOrganizationDomainAdapter
+from .domain_adapters.notes_task import NotesTaskDomainAdapter
 from .domain_adapters.source_cache import SourceCacheAdapter
 from .domain_adapters.workspaces import WorkspacesDomainAdapter
 from .materializers import (
@@ -33,6 +34,7 @@ from .materializers import (
     NotesLinkMaterializer,
     NotesMaterializer,
     NotesOrganizationMaterializer,
+    NotesTaskMaterializer,
     SourceCacheMaterializer,
     SyncMaterializer,
 )
@@ -47,6 +49,7 @@ from .models import (
 from .notes_attachment_bootstrap import NotesAttachmentBootstrapper
 from .notes_link_bootstrap import NotesLinkBootstrapper
 from .notes_organization_bootstrap import NotesOrganizationBootstrapper
+from .notes_task_bootstrap import NotesTaskBootstrapper
 from .security import server_trusted_encryption_status_from_env
 from .service import SyncV2Service, SyncV2Settings
 from .store import SyncV2Store
@@ -77,6 +80,7 @@ def default_sync_v2_registry() -> SyncAdapterRegistry:
         + [MediaMetadataAdapter(domain=domain) for domain in MEDIA_SYNC_DOMAINS]
         + [NotesOrganizationDomainAdapter(domain=domain) for domain in NOTES_ORGANIZATION_DOMAINS]
         + [NotesLinkDomainAdapter()]
+        + [NotesTaskDomainAdapter()]
     )
 
 
@@ -97,6 +101,7 @@ def sync_v2_service_for_user(user_id: str) -> SyncV2Service:
         "chat.message": ChatMessageMaterializer(note_db),
         "notes.note": NotesMaterializer(note_db),
         "notes.link": NotesLinkMaterializer(note_db),
+        "notes.task": NotesTaskMaterializer(note_db),
         "source_cache.entry": SourceCacheMaterializer(),
         "media.item": MediaMetadataMaterializer(domain="media.item"),
         "media.keyword": MediaMetadataMaterializer(domain="media.keyword"),
@@ -116,6 +121,10 @@ def sync_v2_service_for_user(user_id: str) -> SyncV2Service:
         materializers=materializers,
         advertised_domains=settings.supported_domains,
     )
+    _validate_notes_task_components(
+        adapters=adapters,
+        materializers=materializers,
+    )
     return SyncV2Service(
         store=store,
         adapters=adapters,
@@ -126,6 +135,7 @@ def sync_v2_service_for_user(user_id: str) -> SyncV2Service:
         dataset_bootstrapper=NotesOrganizationBootstrapper(note_db),
         notes_link_bootstrapper=NotesLinkBootstrapper(note_db),
         notes_attachment_bootstrapper=NotesAttachmentBootstrapper(note_db),
+        notes_task_bootstrapper=NotesTaskBootstrapper(note_db),
     )
 
 
@@ -166,6 +176,21 @@ def _validate_notes_link_components(
     if not isinstance(materializers.get("notes.link"), NotesLinkMaterializer):
         raise RuntimeError(
             "Advertised Sync domain has no user-bound materializer: notes.link"
+        )
+
+
+def _validate_notes_task_components(
+    *,
+    adapters: SyncAdapterRegistry,
+    materializers: Mapping[SyncDomain, SyncMaterializer],
+) -> None:
+    """Fail closed when the private dormant task lifecycle is partially wired."""
+
+    if not isinstance(adapters.get("notes.task"), NotesTaskDomainAdapter):
+        raise RuntimeError("Private Sync domain has no strict adapter: notes.task")
+    if not isinstance(materializers.get("notes.task"), NotesTaskMaterializer):
+        raise RuntimeError(
+            "Private Sync domain has no user-bound materializer: notes.task"
         )
 
 

--- a/tldw_Server_API/app/core/Sync/v2/materializers/__init__.py
+++ b/tldw_Server_API/app/core/Sync/v2/materializers/__init__.py
@@ -9,6 +9,7 @@ from .media_metadata import MediaMetadataMaterializer
 from .notes import NotesMaterializer
 from .notes_link import NotesLinkMaterializer
 from .notes_organization import NotesOrganizationMaterializer
+from .notes_task import NotesTaskMaterializer
 from .source_cache import SourceCacheMaterializer
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     "NotesMaterializer",
     "NotesLinkMaterializer",
     "NotesOrganizationMaterializer",
+    "NotesTaskMaterializer",
     "SourceCacheMaterializer",
     "SyncMaterializer",
 ]

--- a/tldw_Server_API/app/core/Sync/v2/materializers/notes_task.py
+++ b/tldw_Server_API/app/core/Sync/v2/materializers/notes_task.py
@@ -1,0 +1,294 @@
+"""Materialize canonical ``notes.task`` envelopes into the product task store."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from loguru import logger
+
+from tldw_Server_API.app.core.DB_Management.backends.base import (
+    DatabaseError as BackendDatabaseError,
+)
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    CharactersRAGDBError,
+    ConflictError,
+    InputError,
+)
+from tldw_Server_API.app.core.exceptions import NotesTaskContractError
+
+from ..models import SyncEnvelope, SyncObjectState
+from ..notes_task_contract import (
+    NotesTaskV1Payload,
+    notes_task_object_hash,
+    parse_notes_task_tombstone_v1,
+    parse_notes_task_v1,
+)
+from ..store import SyncV2Store
+from .base import MaterializationResult
+
+_ERROR_CODE = "notes_task_projection_failed"
+_CONFLICT_TYPE = "notes_task_product_conflict"
+
+
+@dataclass(slots=True)
+class NotesTaskMaterializer:
+    """Apply accepted dormant task envelopes without creating activity."""
+
+    note_db: CharactersRAGDB
+    domain: str = "notes.task"
+
+    def apply(
+        self,
+        envelope: SyncEnvelope,
+        *,
+        store: SyncV2Store,
+    ) -> MaterializationResult:
+        """Commit product state, then repair Sync projection bookkeeping."""
+
+        if envelope.domain != self.domain:
+            return MaterializationResult(status="skipped")
+        if envelope.server_cursor is None:
+            return MaterializationResult(
+                status="failed",
+                error_code=_ERROR_CODE,
+                message="Stored notes.task envelope is missing a server cursor",
+            )
+
+        try:
+            payload = _parse_envelope(envelope, owner_user_id=str(self.note_db.client_id))
+        except NotesTaskContractError:
+            return _mark_failed(
+                envelope,
+                store,
+                "notes.task envelope validation failed",
+            )
+
+        expected_projection = _expected_projection_status(envelope)
+        task_store = self.note_db.task_store
+        if task_store.verify_sync_task_postcondition(
+            owner_user_id=str(self.note_db.client_id),
+            dataset_id=envelope.dataset_id,
+            payload=payload,
+            canonical_revision=int(envelope.object_revision or 0),
+            canonical_hash=envelope.payload_hash or "",
+            deleted=envelope.operation == "tombstone",
+            expected_projection_status=expected_projection,
+        ):
+            return _record_applied(envelope, store)
+
+        current_state = store.get_object_state(
+            envelope.dataset_id,
+            envelope.domain,
+            envelope.object_id,
+        )
+        state_conflict = _state_conflict(envelope, current_state)
+        if state_conflict is not None:
+            return _mark_conflict(envelope, store, state_conflict)
+
+        try:
+            with self.note_db.transaction() as conn:
+                common = {
+                    "owner_user_id": str(self.note_db.client_id),
+                    "dataset_id": envelope.dataset_id,
+                    "payload": payload,
+                    "canonical_revision": int(envelope.object_revision or 0),
+                    "canonical_hash": envelope.payload_hash or "",
+                    "conn": conn,
+                }
+                if current_state is None:
+                    task_store.apply_sync_task_create(**common)
+                else:
+                    transition = {
+                        **common,
+                        "base_revision": current_state.object_revision,
+                        "base_hash": current_state.object_hash,
+                    }
+                    if envelope.operation == "tombstone":
+                        task_store.apply_sync_task_tombstone(**transition)
+                    elif envelope.routing_metadata.get("restore_intent") is True:
+                        task_store.apply_sync_task_restore(**transition)
+                    else:
+                        task_store.apply_sync_task_upsert(**transition)
+            return _record_applied(envelope, store)
+        except ConflictError:
+            return _mark_conflict(
+                envelope,
+                store,
+                _conflict_result("product_state_conflict"),
+            )
+        except Exception as exc:  # noqa: BLE001 - product commit must remain replayable.
+            message = _safe_error_message(exc)
+            logger.warning(
+                "Failed to materialize notes.task envelope {} for object {}: {}",
+                envelope.client_envelope_id,
+                envelope.object_id,
+                type(exc).__name__,
+            )
+            return _mark_failed(envelope, store, message)
+
+
+def _parse_envelope(
+    envelope: SyncEnvelope,
+    *,
+    owner_user_id: str,
+) -> NotesTaskV1Payload:
+    if (
+        envelope.adapter_version != 1
+        or envelope.schema_version != 1
+        or envelope.operation not in {"upsert", "tombstone"}
+        or envelope.object_revision is None
+        or envelope.entity_version != envelope.object_revision
+    ):
+        raise NotesTaskContractError("notes.task envelope lineage is invalid")
+    parser = (
+        parse_notes_task_tombstone_v1
+        if envelope.operation == "tombstone"
+        else parse_notes_task_v1
+    )
+    payload = parser(envelope.payload, owner_user_id=owner_user_id)
+    if envelope.object_id != payload.task_id or envelope.parent_id != payload.note_id:
+        raise NotesTaskContractError("notes.task envelope identity is invalid")
+    expected_hash = notes_task_object_hash(
+        payload,
+        revision=envelope.object_revision,
+        deleted=envelope.operation == "tombstone",
+    )
+    if envelope.payload_hash != expected_hash:
+        raise NotesTaskContractError("notes.task envelope hash is invalid")
+    return payload
+
+
+def _expected_projection_status(envelope: SyncEnvelope) -> str | None:
+    if envelope.operation == "tombstone":
+        return "deleted"
+    if envelope.object_revision == 1 or envelope.routing_metadata.get("restore_intent") is True:
+        return "unlinked"
+    return None
+
+
+def _state_conflict(
+    envelope: SyncEnvelope,
+    current_state: SyncObjectState | None,
+) -> MaterializationResult | None:
+    has_base = all(
+        value is not None
+        for value in (
+            envelope.base_server_cursor,
+            envelope.base_object_revision,
+            envelope.base_object_hash,
+        )
+    )
+    if current_state is None:
+        if has_base or envelope.routing_metadata.get("restore_intent") is True:
+            return _conflict_result("missing_server_object")
+        return None
+    if (
+        envelope.base_server_cursor != current_state.latest_server_cursor
+        or envelope.base_object_revision != current_state.object_revision
+        or envelope.base_object_hash != current_state.object_hash
+    ):
+        return _conflict_result("stale_base_state")
+    if current_state.deleted:
+        if envelope.routing_metadata.get("restore_intent") is not True:
+            return _conflict_result("restore_intent_required")
+    elif envelope.routing_metadata.get("restore_intent") is True:
+        return _conflict_result("restore_target_not_deleted")
+    return None
+
+
+def _record_applied(
+    envelope: SyncEnvelope,
+    store: SyncV2Store,
+) -> MaterializationResult:
+    try:
+        store.upsert_object_state(
+            SyncObjectState(
+                dataset_id=envelope.dataset_id,
+                domain=envelope.domain,
+                object_id=envelope.object_id,
+                object_revision=int(envelope.object_revision or 0),
+                object_hash=envelope.payload_hash or "",
+                latest_server_cursor=envelope.server_cursor,
+                deleted=envelope.operation == "tombstone",
+            )
+        )
+        store.mark_envelope_apply_status(
+            envelope.server_cursor,
+            apply_status="applied",
+        )
+        return MaterializationResult(status="applied")
+    except Exception as exc:  # noqa: BLE001 - split commits must remain replayable.
+        return _mark_failed(envelope, store, _safe_error_message(exc))
+
+
+def _mark_conflict(
+    envelope: SyncEnvelope,
+    store: SyncV2Store,
+    result: MaterializationResult,
+) -> MaterializationResult:
+    try:
+        store.mark_envelope_apply_status(
+            envelope.server_cursor,
+            apply_status="conflict",
+            apply_error_code=_CONFLICT_TYPE,
+            apply_error_message=result.message,
+        )
+    except Exception as exc:  # noqa: BLE001 - preserve the deterministic conflict.
+        logger.warning(
+            "Could not persist notes.task conflict status for cursor {}: {}",
+            envelope.server_cursor,
+            type(exc).__name__,
+        )
+    return result
+
+
+def _mark_failed(
+    envelope: SyncEnvelope,
+    store: SyncV2Store,
+    message: str,
+) -> MaterializationResult:
+    try:
+        store.mark_envelope_apply_status(
+            envelope.server_cursor,
+            apply_status="failed",
+            apply_error_code=_ERROR_CODE,
+            apply_error_message=message,
+        )
+    except Exception as exc:  # noqa: BLE001 - preserve a replayable failed result.
+        logger.warning(
+            "Could not persist failed notes.task status for cursor {}: {}",
+            envelope.server_cursor,
+            type(exc).__name__,
+        )
+    return MaterializationResult(
+        status="failed",
+        error_code=_ERROR_CODE,
+        message=message,
+    )
+
+
+def _conflict_result(reason: str) -> MaterializationResult:
+    return MaterializationResult(
+        status="conflict",
+        conflict_type=_CONFLICT_TYPE,
+        message="notes.task product state does not match the current canonical base",
+        metadata={"reason": reason},
+    )
+
+
+def _safe_error_message(exc: Exception) -> str:
+    if isinstance(exc, NotesTaskContractError):
+        return "notes.task envelope validation failed"
+    if isinstance(exc, InputError):
+        return "notes.task dependency validation failed"
+    if isinstance(
+        exc,
+        (CharactersRAGDBError, BackendDatabaseError, sqlite3.DatabaseError),
+    ):
+        return "notes.task product database operation failed"
+    return "notes.task projection failed"
+
+
+__all__ = ["NotesTaskMaterializer"]

--- a/tldw_Server_API/app/core/Sync/v2/materializers/notes_task.py
+++ b/tldw_Server_API/app/core/Sync/v2/materializers/notes_task.py
@@ -134,6 +134,8 @@ def _parse_envelope(
     *,
     owner_user_id: str,
 ) -> NotesTaskV1Payload:
+    """Parse and verify one canonical task envelope against its lineage hash."""
+
     if (
         envelope.adapter_version != 1
         or envelope.schema_version != 1
@@ -161,6 +163,8 @@ def _parse_envelope(
 
 
 def _expected_projection_status(envelope: SyncEnvelope) -> str | None:
+    """Return the projection status required after the envelope is applied."""
+
     if envelope.operation == "tombstone":
         return "deleted"
     if envelope.object_revision == 1 or envelope.routing_metadata.get("restore_intent") is True:
@@ -172,6 +176,8 @@ def _state_conflict(
     envelope: SyncEnvelope,
     current_state: SyncObjectState | None,
 ) -> MaterializationResult | None:
+    """Return a deterministic conflict when the Sync base is not current."""
+
     has_base = all(
         value is not None
         for value in (
@@ -202,6 +208,8 @@ def _record_applied(
     envelope: SyncEnvelope,
     store: SyncV2Store,
 ) -> MaterializationResult:
+    """Record the applied object state and envelope status."""
+
     try:
         store.upsert_object_state(
             SyncObjectState(
@@ -228,6 +236,8 @@ def _mark_conflict(
     store: SyncV2Store,
     result: MaterializationResult,
 ) -> MaterializationResult:
+    """Persist a deterministic conflict status without replacing its result."""
+
     try:
         store.mark_envelope_apply_status(
             envelope.server_cursor,
@@ -249,6 +259,8 @@ def _mark_failed(
     store: SyncV2Store,
     message: str,
 ) -> MaterializationResult:
+    """Persist and return a bounded replayable projection failure."""
+
     try:
         store.mark_envelope_apply_status(
             envelope.server_cursor,
@@ -270,6 +282,8 @@ def _mark_failed(
 
 
 def _conflict_result(reason: str) -> MaterializationResult:
+    """Build the stable product-state conflict result."""
+
     return MaterializationResult(
         status="conflict",
         conflict_type=_CONFLICT_TYPE,
@@ -279,6 +293,8 @@ def _conflict_result(reason: str) -> MaterializationResult:
 
 
 def _safe_error_message(exc: Exception) -> str:
+    """Map internal projection failures to bounded public messages."""
+
     if isinstance(exc, NotesTaskContractError):
         return "notes.task envelope validation failed"
     if isinstance(exc, InputError):

--- a/tldw_Server_API/app/core/Sync/v2/models.py
+++ b/tldw_Server_API/app/core/Sync/v2/models.py
@@ -165,6 +165,11 @@ SYNC_V2_SUPPORTED_OPERATIONS: dict[SyncDomain, list[SyncOperation]] = {
     **NOTES_ORGANIZATION_SYNC_OPERATIONS,
     **NOTES_LINK_SYNC_OPERATIONS,
 }
+SYNC_V2_INTERNAL_OPERATIONS: dict[SyncDomain, list[SyncOperation]] = {
+    **SYNC_V2_SUPPORTED_OPERATIONS,
+    "notes.task": ["upsert", "tombstone"],
+    "notes.task_activity": ["upsert", "tombstone"],
+}
 SYNC_V2_MAX_ADAPTER_VERSION_DOMAINS = 100
 SYNC_V2_MAX_ADAPTER_VERSIONS_PER_DOMAIN = 8
 DEFAULT_M1_ENCRYPTION_POLICY: EncryptionPolicy = "server_trusted_v1"

--- a/tldw_Server_API/app/core/Sync/v2/notes_task_bootstrap.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_task_bootstrap.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+"""Bounded, resumable private bootstrap for canonical Notes tasks."""
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+from .errors import SyncStoreError
+from .models import SyncDataset, SyncEnvelope
+from .server_origin_batch import (
+    ServerOriginMutationStep,
+    capture_server_origin_mutation_batch,
+)
+from .service import SyncV2Service
+
+_SOURCE = "notes-task-bootstrap"
+_EMPTY_FINGERPRINT = hashlib.sha256(b"notes.task.bootstrap.v1").hexdigest()
+
+
+class NotesTaskBootstrapInterrupted(RuntimeError):
+    """Intentional test/worker interruption after a durable Sync append."""
+
+
+class _SourceInvalid(RuntimeError):
+    pass
+
+
+class _SourceChanged(RuntimeError):
+    pass
+
+
+class NotesTaskBootstrapper:
+    """Capture at most one source-verified task page per invocation."""
+
+    PAGE_LIMIT = 500
+
+    def __init__(
+        self,
+        note_db: CharactersRAGDB,
+        *,
+        page_limit: int = PAGE_LIMIT,
+        after_page: Callable[[int], None] | None = None,
+    ) -> None:
+        if isinstance(page_limit, bool) or not 1 <= page_limit <= self.PAGE_LIMIT:
+            raise ValueError("Notes task bootstrap page limit must be 1..500")
+        self._db = note_db
+        self._tasks = note_db.task_store
+        self._page_limit = page_limit
+        self._after_page = after_page
+
+    def bootstrap(
+        self,
+        *,
+        service: SyncV2Service,
+        dataset: SyncDataset,
+    ) -> SyncDataset:
+        """Resume one bounded page and return the durable readiness state."""
+
+        owner = dataset.owner_user_id
+        current = service.store.get_dataset(
+            dataset.dataset_id,
+            owner_user_id=owner,
+        )
+        if current is None:
+            raise SyncStoreError("Sync dataset was not found or is not accessible")
+        if self._tasks.resolve_task_compatibility_dataset_id(
+            owner_user_id=owner
+        ) != current.dataset_id:
+            raise SyncStoreError("notes_task_readiness_source_scope_invalid")
+
+        current = self._ensure_bootstrapping(service, current)
+        state = _readiness(current)
+        if state["state"] == "ready":
+            return current
+        if state["state"] != "bootstrapping":
+            raise SyncStoreError("notes_task_sync_not_ready")
+
+        bootstrap_id = _bootstrap_id(owner, current.dataset_id)
+        try:
+            source = self._source_summary(owner, current.dataset_id)
+            _verify_stored_progress(state, source)
+            after_task_id = _optional_string(state.get("source_cursor"))
+            page = self._tasks.page_tasks_for_sync_bootstrap(
+                owner_user_id=owner,
+                dataset_id=current.dataset_id,
+                after_task_id=after_task_id,
+                limit=self._page_limit,
+            )
+            running_count = int(state["source_count"])
+            running_fingerprint = str(
+                state.get("source_fingerprint") or _EMPTY_FINGERPRINT
+            )
+            for row in page:
+                self._capture_row(
+                    service=service,
+                    dataset=current,
+                    bootstrap_id=bootstrap_id,
+                    row=row,
+                )
+                running_count += 1
+                running_fingerprint = _task_bootstrap_fingerprint(
+                    running_fingerprint,
+                    str(row["id"]),
+                    str(row["canonical_hash"]),
+                )
+
+            if page and self._after_page is not None:
+                self._after_page(1)
+            if page:
+                current = service.store.transition_notes_task_readiness(
+                    current.dataset_id,
+                    owner_user_id=owner,
+                    expected_state="bootstrapping",
+                    state="bootstrapping",
+                    source_dataset_id=current.dataset_id,
+                    source_cursor=str(page[-1]["id"]),
+                    source_count=running_count,
+                    source_fingerprint=running_fingerprint,
+                )
+            if running_count < source.count:
+                return current
+            verified = self._source_summary(owner, current.dataset_id)
+            if verified != source:
+                raise _SourceChanged
+            if (
+                running_count != source.count
+                or running_fingerprint != source.fingerprint
+                or not _sync_bootstrap_matches_source(
+                    service,
+                    current.dataset_id,
+                    bootstrap_id=bootstrap_id,
+                    source=source,
+                )
+            ):
+                raise _SourceChanged
+            current = service.store.transition_notes_task_readiness(
+                current.dataset_id,
+                owner_user_id=owner,
+                expected_state="bootstrapping",
+                state="verifying",
+                source_dataset_id=current.dataset_id,
+                source_cursor=source.cursor,
+                source_count=source.count,
+                source_fingerprint=source.fingerprint,
+            )
+            return service.store.transition_notes_task_readiness(
+                current.dataset_id,
+                owner_user_id=owner,
+                expected_state="verifying",
+                state="ready",
+                source_dataset_id=current.dataset_id,
+                source_cursor=source.cursor,
+                source_count=source.count,
+                source_fingerprint=source.fingerprint,
+            )
+        except NotesTaskBootstrapInterrupted:
+            raise
+        except _SourceChanged:
+            return _block(service, current, reason="notes_task_source_changed")
+        except Exception as exc:  # noqa: BLE001 - source errors become bounded state.
+            if isinstance(exc, SyncStoreError) and str(exc) not in {
+                "notes_task_source_invalid",
+                "notes_task_source_changed",
+            }:
+                raise
+            return _block(service, current, reason="notes_task_source_invalid")
+
+    def _ensure_bootstrapping(
+        self,
+        service: SyncV2Service,
+        dataset: SyncDataset,
+    ) -> SyncDataset:
+        state = dataset.metadata.get("notes_task_v1")
+        if isinstance(state, Mapping) and state.get("state") in {
+            "bootstrapping",
+            "ready",
+        }:
+            return dataset
+        if (
+            isinstance(state, Mapping)
+            and state.get("state") == "blocked"
+            and state.get("resume_phase") == "bootstrapping"
+        ):
+            return service.store.transition_notes_task_readiness(
+                dataset.dataset_id,
+                owner_user_id=dataset.owner_user_id,
+                expected_state="blocked",
+                state="bootstrapping",
+                source_dataset_id=dataset.dataset_id,
+                source_cursor=_optional_string(state.get("source_cursor")),
+                source_count=int(state["source_count"]),
+                source_fingerprint=(
+                    str(state["source_fingerprint"])
+                    if state.get("source_fingerprint") is not None
+                    else None
+                ),
+            )
+        if state is not None:
+            raise SyncStoreError("notes_task_sync_not_ready")
+        dataset = service.store.transition_notes_task_readiness(
+            dataset.dataset_id,
+            owner_user_id=dataset.owner_user_id,
+            expected_state="not_enrolled",
+            state="enrolling",
+            source_dataset_id=dataset.dataset_id,
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=None,
+        )
+        dataset = service.store.transition_notes_task_activity_readiness(
+            dataset.dataset_id,
+            owner_user_id=dataset.owner_user_id,
+            expected_state="not_enrolled",
+            state="enrolling",
+            source_dataset_id=dataset.dataset_id,
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=None,
+            task_activity_capture_enabled=True,
+        )
+        return service.store.transition_notes_task_readiness(
+            dataset.dataset_id,
+            owner_user_id=dataset.owner_user_id,
+            expected_state="enrolling",
+            state="bootstrapping",
+            source_dataset_id=dataset.dataset_id,
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=_EMPTY_FINGERPRINT,
+        )
+
+    def _source_summary(self, owner: str, dataset_id: str) -> _SourceSummary:
+        rows: list[tuple[str, str, int, str, str]] = []
+        cursor: str | None = None
+        fingerprint = _EMPTY_FINGERPRINT
+        try:
+            while True:
+                page = self._tasks.page_tasks_for_sync_bootstrap(
+                    owner_user_id=owner,
+                    dataset_id=dataset_id,
+                    after_task_id=cursor,
+                    limit=self.PAGE_LIMIT,
+                )
+                for row in page:
+                    task_id = str(row["id"])
+                    canonical_hash = str(row["canonical_hash"])
+                    rows.append(
+                        (
+                            task_id,
+                            canonical_hash,
+                            int(row["canonical_revision"]),
+                            "tombstone" if bool(row.get("deleted")) else "upsert",
+                            str(row["note_id"]),
+                        )
+                    )
+                    fingerprint = _task_bootstrap_fingerprint(
+                        fingerprint,
+                        task_id,
+                        canonical_hash,
+                    )
+                    cursor = task_id
+                if len(page) < self.PAGE_LIMIT:
+                    break
+        except Exception as exc:  # noqa: BLE001 - product details stay private.
+            raise _SourceInvalid from exc
+        return _SourceSummary(tuple(rows), cursor, len(rows), fingerprint)
+
+    def _capture_row(
+        self,
+        *,
+        service: SyncV2Service,
+        dataset: SyncDataset,
+        bootstrap_id: str,
+        row: Mapping[str, object],
+    ) -> None:
+        task_id = str(row["id"])
+        canonical_hash = str(row["canonical_hash"])
+        payload = row.get("sync_payload")
+        if not isinstance(payload, Mapping):
+            raise _SourceInvalid
+        operation = "tombstone" if bool(row.get("deleted")) else "upsert"
+        step = ServerOriginMutationStep(
+            domain="notes.task",
+            operation=operation,
+            object_id=task_id,
+            parent_id=str(row["note_id"]),
+            payload=dict(payload),
+            routing_metadata=_task_bootstrap_routing(bootstrap_id),
+            client_envelope_id=_task_bootstrap_envelope_id(
+                bootstrap_id,
+                task_id,
+                canonical_hash,
+            ),
+            object_revision=int(row["canonical_revision"]),
+        )
+
+        def source_matches(envelope: SyncEnvelope) -> bool:
+            try:
+                current = self._tasks.get_task(
+                    owner_user_id=dataset.owner_user_id,
+                    dataset_id=dataset.dataset_id,
+                    task_id=task_id,
+                    include_deleted=True,
+                )
+                if current is None:
+                    return False
+                verified = self._tasks._sync_bootstrap_task_row(
+                    current,
+                    dataset.owner_user_id,
+                )
+            except Exception:  # noqa: BLE001 - verifier returns only a boolean.
+                return False
+            return bool(
+                envelope.client_envelope_id == step.client_envelope_id
+                and envelope.object_id == task_id
+                and envelope.parent_id == row["note_id"]
+                and envelope.operation == operation
+                and envelope.object_revision == row["canonical_revision"]
+                and envelope.payload_hash == canonical_hash
+                and dict(envelope.payload) == dict(verified["sync_payload"])
+            )
+
+        capture_server_origin_mutation_batch(
+            service=service,
+            user_id=dataset.owner_user_id,
+            steps=[step],
+            source=_SOURCE,
+            idempotency_key=f"{bootstrap_id}:{task_id}:{canonical_hash}",
+            trusted_notes_task_bootstrap_id=bootstrap_id,
+            bootstrap_step_verifier=source_matches,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceSummary:
+    """Immutable source identity with prefix lookup."""
+
+    rows: tuple[tuple[str, str, int, str, str], ...]
+    cursor: str | None
+    count: int
+    fingerprint: str
+
+
+def _verify_stored_progress(
+    state: Mapping[str, object],
+    source: _SourceSummary,
+) -> None:
+    count = int(state["source_count"])
+    cursor = _optional_string(state.get("source_cursor"))
+    fingerprint = str(state.get("source_fingerprint") or _EMPTY_FINGERPRINT)
+    if count == 0:
+        if cursor is not None or fingerprint != _EMPTY_FINGERPRINT:
+            raise _SourceChanged
+        return
+    if count > len(source.rows) or source.rows[count - 1][0] != cursor:
+        raise _SourceChanged
+    expected = _EMPTY_FINGERPRINT
+    for task_id, canonical_hash, *_ in source.rows[:count]:
+        expected = _task_bootstrap_fingerprint(expected, task_id, canonical_hash)
+    if expected != fingerprint:
+        raise _SourceChanged
+
+
+def _sync_bootstrap_matches_source(
+    service: SyncV2Service,
+    dataset_id: str,
+    *,
+    bootstrap_id: str,
+    source: _SourceSummary,
+) -> bool:
+    found: dict[str, tuple[str, int, str, str | None, str | None]] = {}
+    cursor = 0
+    while True:
+        page = service.store.list_envelopes_after(
+            dataset_id,
+            cursor,
+            limit=500,
+            domains=["notes.task"],
+            status="accepted",
+        )
+        for envelope in page:
+            if envelope.server_cursor is None:
+                return False
+            cursor = envelope.server_cursor
+            if envelope.routing_metadata.get("bootstrap_id") != bootstrap_id:
+                return False
+            if envelope.apply_status != "applied" or envelope.object_revision is None:
+                return False
+            if envelope.object_id in found:
+                return False
+            found[envelope.object_id] = (
+                envelope.payload_hash or "",
+                envelope.object_revision,
+                envelope.operation,
+                envelope.parent_id,
+                envelope.client_envelope_id,
+            )
+        if len(page) < 500:
+            break
+    if len(found) != source.count:
+        return False
+    return all(
+        found.get(task_id)
+        == (
+            canonical_hash,
+            canonical_revision,
+            operation,
+            note_id,
+            _task_bootstrap_envelope_id(
+                bootstrap_id,
+                task_id,
+                canonical_hash,
+            ),
+        )
+        for task_id, canonical_hash, canonical_revision, operation, note_id in source.rows
+    )
+
+
+def _block(
+    service: SyncV2Service,
+    dataset: SyncDataset,
+    *,
+    reason: str,
+) -> SyncDataset:
+    state = _readiness(dataset)
+    return service.store.transition_notes_task_readiness(
+        dataset.dataset_id,
+        owner_user_id=dataset.owner_user_id,
+        expected_state="bootstrapping",
+        state="blocked",
+        source_dataset_id=dataset.dataset_id,
+        source_cursor=_optional_string(state.get("source_cursor")),
+        source_count=int(state["source_count"]),
+        source_fingerprint=(
+            str(state["source_fingerprint"])
+            if state.get("source_fingerprint") is not None
+            else None
+        ),
+        reason_code=reason,
+    )
+
+
+def _readiness(dataset: SyncDataset) -> Mapping[str, object]:
+    state = dataset.metadata.get("notes_task_v1")
+    if not isinstance(state, Mapping):
+        raise SyncStoreError("notes_task_readiness_state_invalid")
+    return state
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _bootstrap_id(owner_user_id: str, dataset_id: str) -> str:
+    digest = hashlib.sha256(
+        f"notes.task.bootstrap.v1:{owner_user_id}:{dataset_id}".encode()
+    ).hexdigest()
+    return f"notes-task-bootstrap-{digest[:32]}"
+
+
+def _task_bootstrap_envelope_id(
+    bootstrap_id: str,
+    task_id: str,
+    canonical_hash: str,
+) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            [bootstrap_id, task_id, canonical_hash],
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    return f"notes-task-bootstrap-{digest[:32]}"
+
+
+def _task_bootstrap_routing(bootstrap_id: str) -> dict[str, object]:
+    return {"bootstrap_capture": True, "bootstrap_id": bootstrap_id}
+
+
+def _task_bootstrap_fingerprint(
+    previous_fingerprint: str | None,
+    task_id: str,
+    canonical_hash: str,
+) -> str:
+    seed = previous_fingerprint or _EMPTY_FINGERPRINT
+    return hashlib.sha256(
+        json.dumps(
+            [seed, task_id, canonical_hash],
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+
+
+__all__ = ["NotesTaskBootstrapInterrupted", "NotesTaskBootstrapper"]

--- a/tldw_Server_API/app/core/Sync/v2/notes_task_bootstrap.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_task_bootstrap.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Bounded, resumable private bootstrap for canonical Notes tasks."""
+
+from __future__ import annotations
 
 import hashlib
 import json
@@ -8,6 +8,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.exceptions import NotesTaskBootstrapInterrupted
 
 from .errors import SyncStoreError
 from .models import SyncDataset, SyncEnvelope
@@ -21,16 +22,12 @@ _SOURCE = "notes-task-bootstrap"
 _EMPTY_FINGERPRINT = hashlib.sha256(b"notes.task.bootstrap.v1").hexdigest()
 
 
-class NotesTaskBootstrapInterrupted(RuntimeError):
-    """Intentional test/worker interruption after a durable Sync append."""
-
-
 class _SourceInvalid(RuntimeError):
-    pass
+    """Internal marker for an unreadable or noncanonical task source."""
 
 
 class _SourceChanged(RuntimeError):
-    pass
+    """Internal marker for source progress that no longer matches its digest."""
 
 
 class NotesTaskBootstrapper:
@@ -45,6 +42,8 @@ class NotesTaskBootstrapper:
         page_limit: int = PAGE_LIMIT,
         after_page: Callable[[int], None] | None = None,
     ) -> None:
+        """Configure one bounded bootstrap worker over a canonical task store."""
+
         if isinstance(page_limit, bool) or not 1 <= page_limit <= self.PAGE_LIMIT:
             raise ValueError("Notes task bootstrap page limit must be 1..500")
         self._db = note_db
@@ -174,6 +173,8 @@ class NotesTaskBootstrapper:
         service: SyncV2Service,
         dataset: SyncDataset,
     ) -> SyncDataset:
+        """Enter or resume the task bootstrapping phase for one dataset."""
+
         state = dataset.metadata.get("notes_task_v1")
         if isinstance(state, Mapping) and state.get("state") in {
             "bootstrapping",
@@ -234,6 +235,8 @@ class NotesTaskBootstrapper:
         )
 
     def _source_summary(self, owner: str, dataset_id: str) -> _SourceSummary:
+        """Read the full canonical source identity using bounded keyset pages."""
+
         rows: list[tuple[str, str, int, str, str]] = []
         cursor: str | None = None
         fingerprint = _EMPTY_FINGERPRINT
@@ -277,6 +280,8 @@ class NotesTaskBootstrapper:
         bootstrap_id: str,
         row: Mapping[str, object],
     ) -> None:
+        """Capture one source-verified task row through the server-origin path."""
+
         task_id = str(row["id"])
         canonical_hash = str(row["canonical_hash"])
         payload = row.get("sync_payload")
@@ -299,6 +304,8 @@ class NotesTaskBootstrapper:
         )
 
         def source_matches(envelope: SyncEnvelope) -> bool:
+            """Return whether the product row still matches the planned envelope."""
+
             try:
                 current = self._tasks.get_task(
                     owner_user_id=dataset.owner_user_id,
@@ -349,6 +356,8 @@ def _verify_stored_progress(
     state: Mapping[str, object],
     source: _SourceSummary,
 ) -> None:
+    """Reject stored progress that is not an exact prefix of the source."""
+
     count = int(state["source_count"])
     cursor = _optional_string(state.get("source_cursor"))
     fingerprint = str(state.get("source_fingerprint") or _EMPTY_FINGERPRINT)
@@ -372,6 +381,8 @@ def _sync_bootstrap_matches_source(
     bootstrap_id: str,
     source: _SourceSummary,
 ) -> bool:
+    """Return whether accepted applied envelopes exactly cover the source."""
+
     found: dict[str, tuple[str, int, str, str | None, str | None]] = {}
     cursor = 0
     while True:
@@ -426,6 +437,8 @@ def _block(
     *,
     reason: str,
 ) -> SyncDataset:
+    """Persist a bounded blocked state while retaining verified progress."""
+
     state = _readiness(dataset)
     return service.store.transition_notes_task_readiness(
         dataset.dataset_id,
@@ -445,6 +458,8 @@ def _block(
 
 
 def _readiness(dataset: SyncDataset) -> Mapping[str, object]:
+    """Return the strict task readiness record for a dataset."""
+
     state = dataset.metadata.get("notes_task_v1")
     if not isinstance(state, Mapping):
         raise SyncStoreError("notes_task_readiness_state_invalid")
@@ -452,10 +467,14 @@ def _readiness(dataset: SyncDataset) -> Mapping[str, object]:
 
 
 def _optional_string(value: object) -> str | None:
+    """Return a string value or ``None`` without coercion."""
+
     return value if isinstance(value, str) else None
 
 
 def _bootstrap_id(owner_user_id: str, dataset_id: str) -> str:
+    """Derive the stable private bootstrap identity for one owner dataset."""
+
     digest = hashlib.sha256(
         f"notes.task.bootstrap.v1:{owner_user_id}:{dataset_id}".encode()
     ).hexdigest()
@@ -467,6 +486,8 @@ def _task_bootstrap_envelope_id(
     task_id: str,
     canonical_hash: str,
 ) -> str:
+    """Derive the stable envelope identity for one canonical task version."""
+
     digest = hashlib.sha256(
         json.dumps(
             [bootstrap_id, task_id, canonical_hash],
@@ -477,6 +498,8 @@ def _task_bootstrap_envelope_id(
 
 
 def _task_bootstrap_routing(bootstrap_id: str) -> dict[str, object]:
+    """Build the minimal trusted routing metadata for task bootstrap."""
+
     return {"bootstrap_capture": True, "bootstrap_id": bootstrap_id}
 
 
@@ -485,6 +508,8 @@ def _task_bootstrap_fingerprint(
     task_id: str,
     canonical_hash: str,
 ) -> str:
+    """Extend the ordered source fingerprint with one canonical task row."""
+
     seed = previous_fingerprint or _EMPTY_FINGERPRINT
     return hashlib.sha256(
         json.dumps(

--- a/tldw_Server_API/app/core/Sync/v2/server_origin_batch.py
+++ b/tldw_Server_API/app/core/Sync/v2/server_origin_batch.py
@@ -37,6 +37,7 @@ from .mutation_group_validation import (
     mutation_group_plan_hash,
     validate_stored_mutation_group,
 )
+from .notes_task_contract import notes_task_object_hash, parse_notes_task_v1
 from .server_origin import (
     SERVER_ORIGIN_DEVICE_ID,
     SyncServerOriginMutationNotSupportedError,
@@ -60,6 +61,8 @@ class ServerOriginMutationStep:
     created_at_client: str | None = None
     schema_version: int = 1
     adapter_version: int = 1
+    client_envelope_id: str | None = None
+    object_revision: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,6 +115,7 @@ def capture_server_origin_mutation_batch(
     trusted_notes_organization_bootstrap_id: str | None = None,
     trusted_notes_link_bootstrap_id: str | None = None,
     trusted_notes_attachment_bootstrap_id: str | None = None,
+    trusted_notes_task_bootstrap_id: str | None = None,
     bootstrap_relationship_verifier: Callable[[SyncDomain, str, Mapping[str, object]], bool]
     | None = None,
     bootstrap_relationship_absence_verifier: Callable[
@@ -134,6 +138,7 @@ def capture_server_origin_mutation_batch(
             trusted_notes_organization_bootstrap_id,
             trusted_notes_link_bootstrap_id,
             trusted_notes_attachment_bootstrap_id,
+            trusted_notes_task_bootstrap_id,
         )
         if item is not None
     )
@@ -143,6 +148,7 @@ def capture_server_origin_mutation_batch(
         trusted_notes_organization_bootstrap_id
         or trusted_notes_link_bootstrap_id
         or trusted_notes_attachment_bootstrap_id
+        or trusted_notes_task_bootstrap_id
     )
     if trusted_bootstrap_id is not None and bootstrap_step_verifier is None:
         raise SyncStoreError("Sync bootstrap capture requires a source-step verifier")
@@ -152,6 +158,7 @@ def capture_server_origin_mutation_batch(
         dataset,
         {step.domain for step in plan},
         trusted_bootstrap_id=trusted_bootstrap_id,
+        notes_task_bootstrap=trusted_notes_task_bootstrap_id is not None,
     )
     if not server_frontend_mutation_enabled_for_policy(dataset.encryption_policy):
         raise SyncServerOriginMutationNotSupportedError(dataset, plan[0].domain)
@@ -186,6 +193,7 @@ def capture_server_origin_mutation_batch(
             materialize_verified_bootstrap=(
                 trusted_notes_attachment_bootstrap_id is not None
             ),
+            notes_task_bootstrap=trusted_notes_task_bootstrap_id is not None,
         )
 
     envelopes = _evaluate_plan(
@@ -199,6 +207,7 @@ def capture_server_origin_mutation_batch(
         notes_attachment_bootstrap=(
             trusted_notes_attachment_bootstrap_id is not None
         ),
+        notes_task_bootstrap=trusted_notes_task_bootstrap_id is not None,
         bootstrap_relationship_verifier=bootstrap_relationship_verifier,
         bootstrap_relationship_absence_verifier=(
             bootstrap_relationship_absence_verifier
@@ -211,6 +220,7 @@ def capture_server_origin_mutation_batch(
             inserted = service.store.insert_envelopes_atomic(
                 envelopes,
                 trusted_notes_organization_bootstrap_id=trusted_bootstrap_id,
+                trusted_notes_task_bootstrap_id=trusted_notes_task_bootstrap_id,
             )
     except SyncIdempotencyConflictError as exc:
         raise SyncServerOriginBatchIdempotencyConflictError(mutation_group_id) from exc
@@ -225,6 +235,7 @@ def capture_server_origin_mutation_batch(
         materialize_verified_bootstrap=(
             trusted_notes_attachment_bootstrap_id is not None
         ),
+        notes_task_bootstrap=trusted_notes_task_bootstrap_id is not None,
     )
 
 
@@ -307,6 +318,7 @@ def _evaluate_plan(
     bootstrap_id: str | None = None,
     notes_link_bootstrap: bool = False,
     notes_attachment_bootstrap: bool = False,
+    notes_task_bootstrap: bool = False,
     bootstrap_relationship_verifier: Callable[[SyncDomain, str, Mapping[str, object]], bool]
     | None = None,
     bootstrap_relationship_absence_verifier: Callable[
@@ -346,13 +358,23 @@ def _evaluate_plan(
     step_count = len(canonical_steps)
     for index, step in enumerate(canonical_steps):
         prior_head = get_head(step.domain, step.object_id)
-        object_revision = _next_object_revision(prior_head)
+        object_revision = step.object_revision or _next_object_revision(prior_head)
         payload_hash, payload_size = canonical_payload_hash(dict(step.payload))
         if notes_attachment_bootstrap and step.domain == "attachment.ref":
             payload_hash = attachment_ref_v2_object_hash(
                 step.operation,
                 step.payload,
                 object_revision=object_revision,
+            )
+        if notes_task_bootstrap and step.domain == "notes.task":
+            task_payload = parse_notes_task_v1(
+                step.payload,
+                owner_user_id=dataset.owner_user_id,
+            )
+            payload_hash = notes_task_object_hash(
+                task_payload,
+                revision=object_revision,
+                deleted=step.operation == "tombstone",
             )
         base_server_cursor = prior_head.server_cursor if prior_head is not None else None
         if isinstance(prior_head, SyncEnvelopeCreate) and base_server_cursor is None:
@@ -361,7 +383,9 @@ def _evaluate_plan(
             base_server_cursor = 0
         envelope = SyncEnvelopeCreate(
             dataset_id=dataset.dataset_id,
-            client_envelope_id=_envelope_id(mutation_group_id, index),
+            client_envelope_id=(
+                step.client_envelope_id or _envelope_id(mutation_group_id, index)
+            ),
             domain=step.domain,
             operation=step.operation,
             object_id=step.object_id,
@@ -381,7 +405,11 @@ def _evaluate_plan(
                 else None
             ),
             object_revision=object_revision,
-            entity_version=(object_revision if step.domain == "notes.link" else None),
+            entity_version=(
+                object_revision
+                if step.domain in {"notes.link", "notes.task"}
+                else None
+            ),
             parent_id=step.parent_id,
             schema_version=step.schema_version,
             adapter_version=step.adapter_version,
@@ -423,6 +451,7 @@ def _evaluate_plan(
             attachment_ref_bootstrap_id=(
                 bootstrap_id if notes_attachment_bootstrap else None
             ),
+            notes_task_bootstrap_id=(bootstrap_id if notes_task_bootstrap else None),
             bootstrap_relationship_verifier=bootstrap_relationship_verifier,
             bootstrap_relationship_absence_verifier=(
                 bootstrap_relationship_absence_verifier
@@ -449,6 +478,7 @@ def _materialize_group(
     bootstrap_id: str | None = None,
     bootstrap_step_verifier: Callable[[SyncEnvelope], bool] | None = None,
     materialize_verified_bootstrap: bool = False,
+    notes_task_bootstrap: bool = False,
 ) -> ServerOriginBatchResult:
     group = list(envelopes)
     _validate_stored_group(
@@ -460,6 +490,9 @@ def _materialize_group(
         with service.store.materialization_guard(
             group,
             require_predecessors=bootstrap_id is None,
+            trusted_notes_task_bootstrap_id=(
+                bootstrap_id if notes_task_bootstrap else None
+            ),
         ) as guarded_store:
             group = guarded_store.list_mutation_group(
                 dataset.dataset_id,
@@ -474,6 +507,7 @@ def _materialize_group(
                 bootstrap_id=bootstrap_id,
                 bootstrap_step_verifier=bootstrap_step_verifier,
                 materialize_verified_bootstrap=materialize_verified_bootstrap,
+                notes_task_bootstrap=notes_task_bootstrap,
             )
     except SyncIdempotencyConflictError:
         raise
@@ -495,6 +529,7 @@ def _materialize_group_guarded(
     bootstrap_id: str | None,
     bootstrap_step_verifier: Callable[[SyncEnvelope], bool] | None,
     materialize_verified_bootstrap: bool,
+    notes_task_bootstrap: bool,
 ) -> tuple[ServerOriginBatchResult, bool | None]:
     """Project a complete group while the caller retains all object locks."""
 
@@ -521,6 +556,7 @@ def _materialize_group_guarded(
                 store.mark_bootstrap_envelope_verified(
                     envelope.server_cursor,
                     bootstrap_id=bootstrap_id,
+                    notes_task_bootstrap=notes_task_bootstrap,
                 )
             group = store.list_mutation_group(
                 dataset.dataset_id,
@@ -670,6 +706,8 @@ def _canonical_step(
         created_at_client=step.created_at_client,
         schema_version=step.schema_version,
         adapter_version=step.adapter_version,
+        client_envelope_id=step.client_envelope_id,
+        object_revision=step.object_revision,
     )
 
 
@@ -685,6 +723,8 @@ def _canonical_step_from_envelope(envelope: SyncEnvelope) -> ServerOriginMutatio
         created_at_client=envelope.created_at_client,
         schema_version=envelope.schema_version,
         adapter_version=envelope.adapter_version,
+        client_envelope_id=envelope.client_envelope_id,
+        object_revision=envelope.object_revision,
     )
 
 
@@ -703,6 +743,10 @@ def _mutation_plan_hash(steps: Sequence[ServerOriginMutationStep]) -> str:
         if step.schema_version != 1 or step.adapter_version != 1:
             encoded_step["schema_version"] = step.schema_version
             encoded_step["adapter_version"] = step.adapter_version
+        if step.client_envelope_id is not None:
+            encoded_step["client_envelope_id"] = step.client_envelope_id
+        if step.object_revision is not None:
+            encoded_step["object_revision"] = step.object_revision
         plan.append(encoded_step)
     encoded = json.dumps(
         plan,
@@ -758,12 +802,21 @@ def _require_batch_write_ready(
     domains: set[SyncDomain],
     *,
     trusted_bootstrap_id: str | None = None,
+    notes_task_bootstrap: bool = False,
 ) -> None:
-    missing = sorted(domains.difference(dataset.domains))
+    missing_domains = domains.difference(dataset.domains)
+    if notes_task_bootstrap:
+        missing_domains = missing_domains.difference({"notes.task"})
+    missing = sorted(missing_domains)
     if missing:
         raise SyncStoreError(
             "Sync domains are not enrolled for this dataset: " + ", ".join(missing)
         )
+    if "notes.task" in domains:
+        metadata = dataset.metadata.get("notes_task_v1")
+        state = metadata.get("state") if isinstance(metadata, Mapping) else None
+        if not notes_task_bootstrap or trusted_bootstrap_id is None or state != "bootstrapping":
+            raise SyncStoreError("notes_task_sync_not_ready")
     if "notes.link" in domains:
         metadata = dataset.metadata.get("notes_link_v1")
         state = metadata.get("state") if isinstance(metadata, Mapping) else None

--- a/tldw_Server_API/app/core/Sync/v2/server_origin_batch.py
+++ b/tldw_Server_API/app/core/Sync/v2/server_origin_batch.py
@@ -358,7 +358,11 @@ def _evaluate_plan(
     step_count = len(canonical_steps)
     for index, step in enumerate(canonical_steps):
         prior_head = get_head(step.domain, step.object_id)
-        object_revision = step.object_revision or _next_object_revision(prior_head)
+        object_revision = (
+            _next_object_revision(prior_head)
+            if step.object_revision is None
+            else step.object_revision
+        )
         payload_hash, payload_size = canonical_payload_hash(dict(step.payload))
         if notes_attachment_bootstrap and step.domain == "attachment.ref":
             payload_hash = attachment_ref_v2_object_hash(
@@ -670,9 +674,30 @@ def _validate_stored_group(
         raise SyncIdempotencyConflictError(
             "Sync stored mutation group shape is invalid"
         ) from exc
-    expected_plan_matches = expected_steps is None or _mutation_plan_hash(
-        tuple(_canonical_step_from_envelope(envelope) for envelope in envelopes)
-    ) == _mutation_plan_hash(expected_steps)
+    stored_steps = tuple(
+        _canonical_step_from_envelope(envelope) for envelope in envelopes
+    )
+    if expected_steps is not None and len(stored_steps) == len(expected_steps):
+        stored_steps = tuple(
+            replace(
+                stored,
+                client_envelope_id=(
+                    stored.client_envelope_id
+                    if expected.client_envelope_id is not None
+                    else None
+                ),
+                object_revision=(
+                    stored.object_revision
+                    if expected.object_revision is not None
+                    else None
+                ),
+            )
+            for stored, expected in zip(stored_steps, expected_steps, strict=True)
+        )
+    expected_plan_matches = expected_steps is None or (
+        len(stored_steps) == len(expected_steps)
+        and _mutation_plan_hash(stored_steps) == _mutation_plan_hash(expected_steps)
+    )
     if not expected_plan_matches:
         raise SyncIdempotencyConflictError(
             "Sync stored mutation group fingerprint does not match its plan hash"
@@ -685,6 +710,10 @@ def _canonical_step(
     source: str,
     user_id: str,
 ) -> ServerOriginMutationStep:
+    if step.object_revision is not None and (
+        type(step.object_revision) is not int or step.object_revision < 1
+    ):
+        raise SyncStoreError("Sync server-origin object revision must be positive")
     routing_metadata = dict(step.routing_metadata)
     if not (step.domain == "attachment.ref" and step.adapter_version == 2):
         routing_metadata.update(

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -895,6 +895,7 @@ class SyncV2Service:
         dataset_bootstrapper: object | None = None,
         notes_link_bootstrapper: object | None = None,
         notes_attachment_bootstrapper: object | None = None,
+        notes_task_bootstrapper: object | None = None,
     ) -> None:
         self.store = store
         self.adapters = adapters
@@ -907,6 +908,7 @@ class SyncV2Service:
         self.dataset_bootstrapper = dataset_bootstrapper
         self.notes_link_bootstrapper = notes_link_bootstrapper
         self.notes_attachment_bootstrapper = notes_attachment_bootstrapper
+        self.notes_task_bootstrapper = notes_task_bootstrapper
 
     def capabilities(
         self,

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -73,6 +73,7 @@ class SyncV2Store:
         envelopes: Sequence[SyncEnvelope | SyncEnvelopeCreate],
         *,
         require_predecessors: bool = True,
+        trusted_notes_task_bootstrap_id: str | None = None,
     ) -> Iterator[SyncV2Store]:
         """Hold the durable dataset lock and one Sync transaction for projection."""
 
@@ -80,7 +81,10 @@ class SyncV2Store:
             (envelope.dataset_id, envelope.domain, envelope.object_id)
             for envelope in envelopes
         ]
-        with self.db.materialization_transaction(keys) as connection:
+        with self.db.materialization_transaction(
+            keys,
+            trusted_notes_task_bootstrap_id=trusted_notes_task_bootstrap_id,
+        ) as connection:
             guarded = copy(self)
             guarded._connection = connection
             if require_predecessors:
@@ -623,12 +627,14 @@ class SyncV2Store:
         envelopes: Sequence[SyncEnvelopeCreate],
         *,
         trusted_notes_organization_bootstrap_id: str | None = None,
+        trusted_notes_task_bootstrap_id: str | None = None,
     ) -> list[SyncEnvelope]:
         """Insert one complete validated group or return its exact stored replay."""
 
         return self.db.insert_envelopes_atomic(
             envelopes,
             trusted_notes_organization_bootstrap_id=trusted_notes_organization_bootstrap_id,
+            trusted_notes_task_bootstrap_id=trusted_notes_task_bootstrap_id,
         )
 
     def list_mutation_group(
@@ -790,12 +796,14 @@ class SyncV2Store:
         server_cursor: int,
         *,
         bootstrap_id: str,
+        notes_task_bootstrap: bool = False,
     ) -> SyncEnvelope:
         """Record a verified bootstrap step as applied without product replay."""
 
         return self.db.mark_bootstrap_envelope_verified(
             server_cursor,
             bootstrap_id=bootstrap_id,
+            notes_task_bootstrap=notes_task_bootstrap,
             connection=self._connection,
         )
 

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -76,6 +76,10 @@ class NotesAttachmentBootstrapInterrupted(RuntimeError):
     """Testable interruption that deliberately leaves durable progress resumable."""
 
 
+class NotesTaskBootstrapInterrupted(RuntimeError):
+    """Testable interruption that leaves durable task bootstrap progress resumable."""
+
+
 class NotesAttachmentMutationError(RuntimeError):
     """Stable failure for a coordinated Notes attachment mutation."""
 

--- a/tldw_Server_API/tests/Sync/test_sync_v2_factory.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_factory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from tldw_Server_API.app.core.Sync.v2 import factory
@@ -65,7 +67,7 @@ def test_sync_v2_factory_rejects_invalid_positive_integer_env(monkeypatch, name:
 def test_sync_v2_factory_registers_each_notes_organization_domain_as_a_complete_pair(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    note_db = object()
+    note_db = SimpleNamespace(task_store=object())
     monkeypatch.setattr(factory, "_sync_v2_store_for_user", lambda *args: object())
     monkeypatch.setattr(factory, "_chacha_notes_db_for_user", lambda user_id: note_db)
     monkeypatch.setattr(factory, "_sync_v2_blob_store_for_user", lambda user_id: None)
@@ -110,7 +112,7 @@ def test_sync_v2_factory_fails_closed_when_an_advertised_notes_organization_pair
 def test_sync_v2_factory_registers_and_validates_notes_link_pair(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    note_db = object()
+    note_db = SimpleNamespace(task_store=object())
     monkeypatch.setattr(factory, "_sync_v2_store_for_user", lambda *args: object())
     monkeypatch.setattr(factory, "_chacha_notes_db_for_user", lambda user_id: note_db)
     monkeypatch.setattr(factory, "_sync_v2_blob_store_for_user", lambda user_id: None)

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_adapter.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_adapter.py
@@ -1,3 +1,5 @@
+"""Contracts for strict dormant ``notes.task`` adapter lineage."""
+
 from __future__ import annotations
 
 from dataclasses import replace
@@ -34,7 +36,7 @@ DEVICE_ID = "44444444-4444-4444-8444-444444444444"
 NOW = "2026-08-13T10:00:00+00:00"
 
 
-def _adapter():
+def _adapter() -> domain_adapters.NotesTaskDomainAdapter:
     adapter_type = getattr(domain_adapters, "NotesTaskDomainAdapter", None)
     assert adapter_type is not None, "NotesTaskDomainAdapter is not implemented"
     return adapter_type()

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_adapter.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_adapter.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from tldw_Server_API.app.core.Sync.v2 import domain_adapters
+from tldw_Server_API.app.core.Sync.v2.adapters import (
+    AdapterAccepted,
+    AdapterConflict,
+    AdapterDeferred,
+    AdapterRejected,
+    SyncAdapterContext,
+)
+from tldw_Server_API.app.core.Sync.v2.models import (
+    DEFAULT_M1_ENCRYPTION_POLICY,
+    SyncDataset,
+    SyncEnvelope,
+    SyncEnvelopeCreate,
+)
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    notes_task_object_hash,
+    parse_notes_task_v1,
+)
+
+pytestmark = pytest.mark.unit
+
+OWNER_ID = "owner-user-1"
+DATASET_ID = "dataset-1"
+TASK_ID = "11111111-1111-4111-8111-111111111111"
+NOTE_ID = "22222222-2222-4222-8222-222222222222"
+OTHER_NOTE_ID = "33333333-3333-4333-8333-333333333333"
+DEVICE_ID = "44444444-4444-4444-8444-444444444444"
+NOW = "2026-08-13T10:00:00+00:00"
+
+
+def _adapter():
+    adapter_type = getattr(domain_adapters, "NotesTaskDomainAdapter", None)
+    assert adapter_type is not None, "NotesTaskDomainAdapter is not implemented"
+    return adapter_type()
+
+
+def _dataset() -> SyncDataset:
+    return SyncDataset(
+        dataset_id=DATASET_ID,
+        owner_user_id=OWNER_ID,
+        scope_type="personal",
+        encryption_policy=DEFAULT_M1_ENCRYPTION_POLICY,
+        domains=["notes.note"],
+        workspace_id=None,
+        metadata={},
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "task_id": TASK_ID,
+        "note_id": NOTE_ID,
+        "title": "Prepare launch notes",
+        "description": "Confirm the final release checklist.",
+        "status": "open",
+        "completed_at": None,
+        "priority": "high",
+        "due_date": "2026-08-31",
+        "estimate": "90m",
+        "recurrence": {
+            "frequency": "weekly",
+            "interval": 2,
+            "by_weekday": ["mo", "we", "fr"],
+            "until": "2026-12-31",
+            "state": "active",
+            "occurrence_index": 7,
+        },
+        "assignee_id": OWNER_ID,
+        "tags": ["alpha", "Zulu"],
+        "custom": {"board.column": "Next"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _incoming(
+    *,
+    operation: str = "upsert",
+    payload: dict[str, object] | None = None,
+    base: SyncEnvelope | None = None,
+    restore: object | None = None,
+    suffix: str = "incoming",
+    object_id: str = TASK_ID,
+    parent_id: str | None = NOTE_ID,
+    adapter_version: int = 1,
+    schema_version: int = 1,
+) -> SyncEnvelopeCreate:
+    raw_payload = _payload() if payload is None else payload
+    revision = 1 if base is None else int(base.object_revision or 0) + 1
+    parsed = parse_notes_task_v1(raw_payload, owner_user_id=OWNER_ID)
+    routing = {} if restore is None else {"restore_intent": restore}
+    return SyncEnvelopeCreate(
+        dataset_id=DATASET_ID,
+        client_envelope_id=f"env-{suffix}",
+        domain="notes.task",
+        operation=operation,
+        object_id=object_id,
+        parent_id=parent_id,
+        device_id=DEVICE_ID,
+        base_server_cursor=base.server_cursor if base is not None else None,
+        base_object_revision=base.object_revision if base is not None else None,
+        base_object_hash=base.payload_hash if base is not None else None,
+        object_revision=revision,
+        entity_version=revision,
+        adapter_version=adapter_version,
+        schema_version=schema_version,
+        payload=parsed.model_dump(mode="json"),
+        payload_hash=notes_task_object_hash(
+            parsed,
+            revision=revision,
+            deleted=operation == "tombstone",
+        ),
+        created_at_client=NOW,
+        routing_metadata=routing,
+    )
+
+
+def _stored(incoming: SyncEnvelopeCreate, *, cursor: int = 10) -> SyncEnvelope:
+    excluded = {"server_cursor", "server_sequence"}
+    return SyncEnvelope(
+        **{
+            field_name: getattr(incoming, field_name)
+            for field_name in incoming.__dataclass_fields__
+            if field_name not in excluded
+        },
+        server_cursor=cursor,
+    )
+
+
+def _note_head(
+    note_id: str = NOTE_ID,
+    *,
+    dataset_id: str = DATASET_ID,
+    deleted: bool = False,
+) -> SyncEnvelope:
+    return SyncEnvelope(
+        dataset_id=dataset_id,
+        client_envelope_id=f"note-{note_id}",
+        domain="notes.note",
+        operation="tombstone" if deleted else "upsert",
+        server_cursor=1,
+        object_id=note_id,
+        object_revision=1,
+        entity_version=1,
+        payload={"title": "Parent", "content": "body"},
+        payload_hash="sha256:" + "1" * 64,
+        created_at_client=NOW,
+        deleted=deleted,
+    )
+
+
+def _context(
+    task_head: SyncEnvelope | None = None,
+    *,
+    note_head: SyncEnvelope | None = None,
+    note_available: bool = True,
+) -> SyncAdapterContext:
+    note = _note_head() if note_head is None else note_head
+
+    def get_head(domain: str, object_id: str):
+        if domain == "notes.task" and task_head is not None:
+            return task_head if object_id == task_head.object_id else None
+        return None
+
+    def get_authorized_note(note_id: str):
+        if not note_available or note_id != note.object_id:
+            return None
+        return note
+
+    return SyncAdapterContext(
+        get_head=get_head,
+        get_authorized_note=get_authorized_note,
+    )
+
+
+def test_notes_task_adapter_accepts_create_exact_update_and_completion_reopen() -> None:
+    adapter = _adapter()
+    create = _incoming()
+    assert adapter.evaluate_envelope(
+        create, dataset=_dataset(), context=_context()
+    ) == AdapterAccepted(client_envelope_id=create.client_envelope_id)
+
+    live = _stored(create)
+    completion = _incoming(
+        payload=_payload(status="done", completed_at="2026-08-13T11:00:00+00:00"),
+        base=live,
+        suffix="complete",
+    )
+    assert isinstance(
+        adapter.evaluate_envelope(
+            completion, dataset=_dataset(), context=_context(live)
+        ),
+        AdapterAccepted,
+    )
+
+    done = _stored(completion, cursor=11)
+    reopen = _incoming(
+        payload=_payload(status="open", completed_at=None),
+        base=done,
+        suffix="reopen",
+    )
+    assert isinstance(
+        adapter.evaluate_envelope(reopen, dataset=_dataset(), context=_context(done)),
+        AdapterAccepted,
+    )
+
+
+def test_notes_task_adapter_accepts_recurrence_state_mutation() -> None:
+    live = _stored(_incoming())
+    recurrence = dict(_payload()["recurrence"])
+    recurrence["state"] = "paused"
+    recurrence["occurrence_index"] = 8
+    incoming = _incoming(
+        payload=_payload(recurrence=recurrence),
+        base=live,
+        suffix="recurrence",
+    )
+
+    assert isinstance(
+        _adapter().evaluate_envelope(
+            incoming, dataset=_dataset(), context=_context(live)
+        ),
+        AdapterAccepted,
+    )
+
+
+def test_notes_task_adapter_accepts_exact_replay_without_new_lineage() -> None:
+    incoming = _incoming()
+    stored = _stored(incoming)
+
+    assert _adapter().evaluate_envelope(
+        incoming, dataset=_dataset(), context=_context(stored)
+    ) == AdapterAccepted(client_envelope_id=incoming.client_envelope_id)
+
+
+@pytest.mark.parametrize("operation", ["upsert", "tombstone"])
+def test_notes_task_adapter_conflicts_stale_update_and_delete(operation: str) -> None:
+    live = _stored(_incoming())
+    stale = replace(live, server_cursor=9, payload_hash="sha256:" + "9" * 64)
+    incoming = _incoming(operation=operation, base=stale, suffix=f"stale-{operation}")
+
+    outcome = _adapter().evaluate_envelope(
+        incoming, dataset=_dataset(), context=_context(live)
+    )
+    assert isinstance(outcome, AdapterConflict)
+    assert outcome.conflict_type == "notes_task_base_conflict"
+
+
+def test_notes_task_adapter_requires_empty_head_for_create() -> None:
+    live = _stored(_incoming())
+    second_create = _incoming(suffix="duplicate-create")
+
+    outcome = _adapter().evaluate_envelope(
+        second_create, dataset=_dataset(), context=_context(live)
+    )
+    assert isinstance(outcome, AdapterConflict)
+    assert outcome.conflict_type == "notes_task_create_conflict"
+
+
+def test_notes_task_adapter_requires_exact_live_base_for_tombstone() -> None:
+    live = _stored(_incoming())
+    tombstone = _incoming(operation="tombstone", base=live, suffix="delete")
+
+    assert isinstance(
+        _adapter().evaluate_envelope(
+            tombstone, dataset=_dataset(), context=_context(live)
+        ),
+        AdapterAccepted,
+    )
+
+
+def test_notes_task_adapter_requires_explicit_exact_restore() -> None:
+    live = _stored(_incoming())
+    tombstone = _stored(
+        _incoming(operation="tombstone", base=live, suffix="delete"),
+        cursor=11,
+    )
+
+    ordinary = _incoming(base=tombstone, suffix="ordinary-upsert")
+    outcome = _adapter().evaluate_envelope(
+        ordinary, dataset=_dataset(), context=_context(tombstone)
+    )
+    assert isinstance(outcome, AdapterConflict)
+    assert outcome.conflict_type == "notes_task_restore_conflict"
+
+    restore = _incoming(base=tombstone, restore=True, suffix="restore")
+    assert isinstance(
+        _adapter().evaluate_envelope(
+            restore, dataset=_dataset(), context=_context(tombstone)
+        ),
+        AdapterAccepted,
+    )
+
+    restore_live = _incoming(base=live, restore=True, suffix="restore-live")
+    outcome = _adapter().evaluate_envelope(
+        restore_live, dataset=_dataset(), context=_context(live)
+    )
+    assert isinstance(outcome, AdapterConflict)
+    assert outcome.conflict_type == "notes_task_restore_conflict"
+
+
+def test_notes_task_adapter_rejects_changed_task_or_parent_identity() -> None:
+    live = _stored(_incoming())
+    changed_parent = _incoming(
+        payload=_payload(note_id=OTHER_NOTE_ID),
+        base=live,
+        parent_id=OTHER_NOTE_ID,
+        suffix="changed-parent",
+    )
+    outcome = _adapter().evaluate_envelope(
+        changed_parent,
+        dataset=_dataset(),
+        context=_context(live, note_head=_note_head(OTHER_NOTE_ID)),
+    )
+    assert isinstance(outcome, AdapterConflict)
+    assert outcome.conflict_type == "notes_task_identity_conflict"
+
+    changed_object = _incoming(object_id=OTHER_NOTE_ID, suffix="changed-object")
+    outcome = _adapter().evaluate_envelope(
+        changed_object, dataset=_dataset(), context=_context()
+    )
+    assert isinstance(outcome, AdapterConflict)
+    assert outcome.conflict_type == "notes_task_identity_conflict"
+
+
+def test_notes_task_adapter_defers_missing_or_foreign_parent_without_disclosure() -> None:
+    missing = _adapter().evaluate_envelope(
+        _incoming(), dataset=_dataset(), context=_context(note_available=False)
+    )
+    foreign = _adapter().evaluate_envelope(
+        _incoming(),
+        dataset=_dataset(),
+        context=_context(note_head=_note_head(dataset_id="other-dataset")),
+    )
+
+    assert isinstance(missing, AdapterDeferred)
+    assert isinstance(foreign, AdapterDeferred)
+    assert missing.message == foreign.message
+    assert TASK_ID not in missing.message
+    assert NOTE_ID not in missing.message
+
+
+def test_notes_task_adapter_conflicts_deleted_parent_and_requires_authorization_context() -> None:
+    deleted = _adapter().evaluate_envelope(
+        _incoming(),
+        dataset=_dataset(),
+        context=_context(note_head=_note_head(deleted=True)),
+    )
+    assert isinstance(deleted, AdapterConflict)
+    assert deleted.conflict_type == "notes_task_parent_conflict"
+
+    unavailable = _adapter().evaluate_envelope(
+        _incoming(), dataset=_dataset(), context=None
+    )
+    assert isinstance(unavailable, AdapterRejected)
+    assert unavailable.error_code == "notes_task_authorization_unavailable"
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_code"),
+    [
+        ({"operation": "append"}, "notes_task_payload_invalid"),
+        ({"adapter_version": 2}, "notes_task_payload_invalid"),
+        ({"schema_version": 2}, "notes_task_payload_invalid"),
+        ({"parent_id": OTHER_NOTE_ID}, "notes_task_identity_conflict"),
+        ({"restore": False}, "notes_task_payload_invalid"),
+    ],
+)
+def test_notes_task_adapter_rejects_invalid_envelope_and_routing_shapes(
+    mutation: dict[str, object], expected_code: str
+) -> None:
+    incoming = _incoming(**mutation)
+    outcome = _adapter().evaluate_envelope(
+        incoming, dataset=_dataset(), context=_context()
+    )
+
+    if isinstance(outcome, AdapterRejected):
+        assert outcome.error_code == expected_code
+    else:
+        assert isinstance(outcome, AdapterConflict)
+        assert outcome.conflict_type == expected_code
+
+
+def test_notes_task_adapter_rejects_wrong_hash_revision_and_noncanonical_payload() -> None:
+    wrong_hash = replace(_incoming(), payload_hash="sha256:" + "0" * 64)
+    wrong_revision = replace(_incoming(), object_revision=2, entity_version=2)
+    malformed = replace(_incoming(), payload={**_payload(), "title": " spaced "})
+
+    for incoming in (wrong_hash, wrong_revision, malformed):
+        outcome = _adapter().evaluate_envelope(
+            incoming, dataset=_dataset(), context=_context()
+        )
+        assert isinstance(outcome, AdapterRejected)
+        assert outcome.error_code == "notes_task_payload_invalid"

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_bootstrap.py
@@ -1,0 +1,619 @@
+from __future__ import annotations
+
+import importlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Sync.v2.adapters import SyncAdapterRegistry
+from tldw_Server_API.app.core.Sync.v2.domain_adapters import NotesTaskDomainAdapter
+from tldw_Server_API.app.core.Sync.v2.errors import SyncStoreError
+from tldw_Server_API.app.core.Sync.v2.models import (
+    SYNC_V2_SUPPORTED_DOMAINS,
+    SyncDeviceCursor,
+    SyncDeviceDomainAckCreate,
+    SyncDeviceUpsert,
+)
+from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
+
+pytestmark = pytest.mark.unit
+
+OWNER_ID = "owner-user-1"
+NOTE_ID = "20000000-0000-4000-8000-000000000001"
+TASK_IDS = (
+    "10000000-0000-4000-8000-000000000001",
+    "10000000-0000-4000-8000-000000000002",
+    "10000000-0000-4000-8000-000000000003",
+)
+
+
+def _bootstrap_module():
+    return importlib.import_module(
+        "tldw_Server_API.app.core.Sync.v2.notes_task_bootstrap"
+    )
+
+
+@pytest.fixture()
+def bootstrap_stack(tmp_path: Path):
+    note_db = CharactersRAGDB(tmp_path / "tasks.db", client_id=OWNER_ID)
+    sync_store = SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "sync.db"))
+    dataset = sync_store.get_or_create_default_personal_dataset(OWNER_ID)
+    note_db.note_store.add_note(NOTE_ID, "Task source", note_id=NOTE_ID)
+    note_db.bind_local_task_graph_to_dataset(
+        owner_user_id=OWNER_ID,
+        target_dataset_id=dataset.dataset_id,
+    )
+    service = SyncV2Service(
+        store=sync_store,
+        adapters=SyncAdapterRegistry([NotesTaskDomainAdapter()]),
+    )
+    try:
+        yield note_db, sync_store, service, dataset
+    finally:
+        note_db.close_connection()
+
+
+def _create_tasks(
+    note_db: CharactersRAGDB,
+    dataset_id: str,
+    task_ids: tuple[str, ...] = TASK_IDS,
+) -> None:
+    for index, task_id in enumerate(reversed(task_ids), start=1):
+        note_db.task_store.create_task(
+            owner_user_id=OWNER_ID,
+            dataset_id=dataset_id,
+            note_id=NOTE_ID,
+            text=f"Task {index}",
+            metadata={"priority": "high" if index == 1 else None},
+            task_id=task_id,
+        )
+
+
+def test_task_bootstrap_helpers_are_stable_and_domain_bound() -> None:
+    module = _bootstrap_module()
+
+    first = module._task_bootstrap_envelope_id(
+        "bootstrap-1", TASK_IDS[0], "sha256:" + "a" * 64
+    )
+    assert first == module._task_bootstrap_envelope_id(
+        "bootstrap-1", TASK_IDS[0], "sha256:" + "a" * 64
+    )
+    assert first != module._task_bootstrap_envelope_id(
+        "bootstrap-1", TASK_IDS[1], "sha256:" + "a" * 64
+    )
+    assert module._task_bootstrap_routing("bootstrap-1") == {
+        "bootstrap_capture": True,
+        "bootstrap_id": "bootstrap-1",
+    }
+    assert module._task_bootstrap_fingerprint(
+        None, TASK_IDS[0], "sha256:" + "a" * 64
+    ) == module._task_bootstrap_fingerprint(
+        None, TASK_IDS[0], "sha256:" + "a" * 64
+    )
+
+
+def test_task_store_bootstrap_page_is_bounded_keyset_ordered(
+    bootstrap_stack,
+) -> None:
+    note_db, _sync_store, _service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id)
+
+    first = note_db.task_store.page_tasks_for_sync_bootstrap(
+        owner_user_id=OWNER_ID,
+        dataset_id=dataset.dataset_id,
+        after_task_id=None,
+        limit=2,
+    )
+    second = note_db.task_store.page_tasks_for_sync_bootstrap(
+        owner_user_id=OWNER_ID,
+        dataset_id=dataset.dataset_id,
+        after_task_id=first[-1]["id"],
+        limit=500,
+    )
+
+    assert [row["id"] for row in first] == list(TASK_IDS[:2])
+    assert [row["id"] for row in second] == [TASK_IDS[2]]
+    with pytest.raises(ValueError, match="1..500"):
+        note_db.task_store.page_tasks_for_sync_bootstrap(
+            owner_user_id=OWNER_ID,
+            dataset_id=dataset.dataset_id,
+            limit=501,
+        )
+
+
+def test_bootstrap_rejects_local_unbound_product_graph(tmp_path: Path) -> None:
+    note_db = CharactersRAGDB(tmp_path / "unbound.db", client_id=OWNER_ID)
+    sync_store = SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "sync.db"))
+    dataset = sync_store.get_or_create_default_personal_dataset(OWNER_ID)
+    service = SyncV2Service(
+        store=sync_store,
+        adapters=SyncAdapterRegistry([NotesTaskDomainAdapter()]),
+    )
+    try:
+        with pytest.raises(SyncStoreError, match="source_scope_invalid"):
+            _bootstrap_module().NotesTaskBootstrapper(note_db).bootstrap(
+                service=service,
+                dataset=dataset,
+            )
+    finally:
+        note_db.close_connection()
+
+
+def test_bootstrap_captures_one_page_then_finishes_task_only_readiness(
+    bootstrap_stack,
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id)
+    bootstrapper = _bootstrap_module().NotesTaskBootstrapper(note_db, page_limit=2)
+
+    partial = bootstrapper.bootstrap(service=service, dataset=dataset)
+    task_state = partial.metadata["notes_task_v1"]
+    assert task_state["state"] == "bootstrapping"
+    assert task_state["source_count"] == 2
+    assert task_state["source_cursor"] == TASK_IDS[1]
+
+    ready = bootstrapper.bootstrap(service=service, dataset=partial)
+    assert ready.metadata["notes_task_v1"]["state"] == "ready"
+    assert ready.metadata["notes_task_v1"]["source_count"] == 3
+    assert ready.metadata["notes_task_activity_v1"]["state"] == "enrolling"
+    assert ready.metadata["task_activity_capture_enabled"] is True
+    assert "notes.task" not in ready.domains
+    assert "notes.task_activity" not in ready.domains
+    assert "notes.task" not in SYNC_V2_SUPPORTED_DOMAINS
+
+    envelopes = sync_store.list_envelopes_after(
+        dataset.dataset_id,
+        0,
+        limit=10,
+    )
+    tasks = [item for item in envelopes if item.domain == "notes.task"]
+    assert [item.object_id for item in tasks] == list(TASK_IDS)
+    assert all(item.apply_status == "applied" for item in tasks)
+    bootstrap_id = _bootstrap_module()._bootstrap_id(OWNER_ID, dataset.dataset_id)
+    assert [item.client_envelope_id for item in tasks] == [
+        _bootstrap_module()._task_bootstrap_envelope_id(
+            bootstrap_id,
+            str(item.object_id),
+            str(item.payload_hash),
+        )
+        for item in tasks
+    ]
+
+
+def test_bootstrap_history_supports_internal_pull_cursor_and_acknowledgment(
+    bootstrap_stack,
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id, TASK_IDS[:2])
+    ready = _bootstrap_module().NotesTaskBootstrapper(note_db).bootstrap(
+        service=service,
+        dataset=dataset,
+    )
+    assert ready.metadata["notes_task_v1"]["state"] == "ready"
+    sync_store.upsert_device(
+        SyncDeviceUpsert(
+            device_id="device-task-bootstrap",
+            user_id=OWNER_ID,
+            display_name="Bootstrap test device",
+            client_type="test",
+            capabilities={"requested_domains": ["notes.note"]},
+        )
+    )
+
+    first = sync_store.list_envelopes_after(
+        dataset.dataset_id,
+        0,
+        limit=1,
+        domains=["notes.task"],
+    )
+    assert len(first) == 1 and first[0].server_cursor is not None
+    second = sync_store.list_envelopes_after(
+        dataset.dataset_id,
+        first[0].server_cursor,
+        limit=1,
+        domains=["notes.task"],
+    )
+    assert len(second) == 1 and second[0].server_cursor is not None
+    assert sync_store.list_envelopes_after(
+        dataset.dataset_id,
+        second[0].server_cursor,
+        limit=1,
+        domains=["notes.task"],
+    ) == []
+
+    # Exercise the generic cursor/ack path under the future trusted activation
+    # condition without adding a public task-domain enrollment seam in this PR.
+    sync_store.db.execute(
+        "UPDATE sync_datasets SET domain_set_json = ? WHERE dataset_id = ?",
+        (json.dumps([*dataset.domains, "notes.task"]), dataset.dataset_id),
+    )
+    sync_store.update_device_cursor(
+        SyncDeviceCursor(
+            dataset_id=dataset.dataset_id,
+            device_id="device-task-bootstrap",
+            domain="notes.task",
+            last_pulled_sequence=second[0].server_cursor,
+            max_delivered_sequence=second[0].server_cursor,
+        )
+    )
+    summary = sync_store.acknowledge_device_state_atomic(
+        dataset.dataset_id,
+        "device-task-bootstrap",
+        domain_acks=[
+            SyncDeviceDomainAckCreate(
+                dataset_id=dataset.dataset_id,
+                device_id="device-task-bootstrap",
+                domain="notes.task",
+                through_server_sequence=second[0].server_cursor,
+                applied_at=datetime.now(timezone.utc).isoformat(),
+            )
+        ],
+    )
+    cursor = sync_store.get_device_cursor(
+        dataset.dataset_id,
+        "device-task-bootstrap",
+        "notes.task",
+    )
+    assert cursor is not None
+    assert cursor.last_pulled_sequence == second[0].server_cursor
+    assert summary.domain_acks["notes.task"].through_server_sequence == second[0].server_cursor
+
+
+def test_bootstrap_empty_bound_graph_becomes_task_ready_only(bootstrap_stack) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+
+    ready = _bootstrap_module().NotesTaskBootstrapper(note_db).bootstrap(
+        service=service,
+        dataset=dataset,
+    )
+
+    assert ready.metadata["notes_task_v1"]["state"] == "ready"
+    assert ready.metadata["notes_task_v1"]["source_count"] == 0
+    assert ready.metadata["notes_task_v1"]["source_cursor"] is None
+    assert ready.metadata["notes_task_activity_v1"]["state"] == "enrolling"
+    assert not sync_store.list_envelopes_after(dataset.dataset_id, 0, limit=10)
+
+
+def test_bootstrap_preserves_tombstone_revision_and_hash(bootstrap_stack) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id, TASK_IDS[:1])
+    updated = note_db.task_store.update_task_record(
+        owner_user_id=OWNER_ID,
+        dataset_id=dataset.dataset_id,
+        task_id=TASK_IDS[0],
+        expected_version=1,
+        text="Updated before bootstrap",
+    )
+    deleted = note_db.task_store.soft_delete_task(
+        owner_user_id=OWNER_ID,
+        dataset_id=dataset.dataset_id,
+        task_id=TASK_IDS[0],
+        expected_version=int(updated["version"]),
+        allow_record_only=True,
+    )
+
+    ready = _bootstrap_module().NotesTaskBootstrapper(note_db).bootstrap(
+        service=service,
+        dataset=dataset,
+    )
+    envelopes = sync_store.list_envelopes_after(dataset.dataset_id, 0, limit=10)
+    tasks = [item for item in envelopes if item.domain == "notes.task"]
+
+    assert ready.metadata["notes_task_v1"]["state"] == "ready"
+    assert len(tasks) == 1
+    assert tasks[0].operation == "tombstone"
+    assert tasks[0].object_revision == deleted["canonical_revision"]
+    assert tasks[0].payload_hash == deleted["canonical_hash"]
+
+
+def test_bootstrap_resumes_exactly_after_append_before_progress_split(
+    bootstrap_stack,
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id, TASK_IDS[:2])
+    module = _bootstrap_module()
+
+    def interrupt(_page_number: int) -> None:
+        raise module.NotesTaskBootstrapInterrupted
+
+    with pytest.raises(module.NotesTaskBootstrapInterrupted):
+        module.NotesTaskBootstrapper(
+            note_db,
+            page_limit=2,
+            after_page=interrupt,
+        ).bootstrap(service=service, dataset=dataset)
+
+    interrupted = sync_store.get_dataset(
+        dataset.dataset_id,
+        owner_user_id=OWNER_ID,
+    )
+    assert interrupted is not None
+    assert interrupted.metadata["notes_task_v1"]["source_count"] == 0
+    before = sync_store.list_envelopes_after(
+        dataset.dataset_id,
+        0,
+        limit=10,
+    )
+
+    resumed = module.NotesTaskBootstrapper(note_db, page_limit=2).bootstrap(
+        service=service,
+        dataset=interrupted,
+    )
+    after = sync_store.list_envelopes_after(
+        dataset.dataset_id,
+        0,
+        limit=10,
+    )
+    assert resumed.metadata["notes_task_v1"]["source_count"] == 2
+    assert [item.client_envelope_id for item in after] == [
+        item.client_envelope_id for item in before
+    ]
+
+
+def test_bootstrap_source_drift_blocks_without_exposing_payload(
+    bootstrap_stack,
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id)
+    bootstrapper = _bootstrap_module().NotesTaskBootstrapper(note_db, page_limit=2)
+    partial = bootstrapper.bootstrap(service=service, dataset=dataset)
+
+    note_db.task_store.update_task_record(
+        owner_user_id=OWNER_ID,
+        dataset_id=dataset.dataset_id,
+        task_id=TASK_IDS[0],
+        text="Changed during bootstrap",
+        expected_version=1,
+    )
+    blocked = bootstrapper.bootstrap(service=service, dataset=partial)
+
+    state = blocked.metadata["notes_task_v1"]
+    assert state["state"] == "blocked"
+    assert state["reason_code"] == "notes_task_source_changed"
+    assert "Changed during bootstrap" not in str(state)
+    assert len(
+        [
+            item
+            for item in sync_store.list_envelopes_after(
+                dataset.dataset_id,
+                0,
+                limit=10,
+            )
+            if item.domain == "notes.task"
+        ]
+    ) == 2
+
+
+def test_bootstrap_concurrent_source_change_after_append_blocks(bootstrap_stack) -> None:
+    note_db, _sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id, TASK_IDS[:1])
+
+    def mutate_source(_page_number: int) -> None:
+        note_db.task_store.update_task_record(
+            owner_user_id=OWNER_ID,
+            dataset_id=dataset.dataset_id,
+            task_id=TASK_IDS[0],
+            expected_version=1,
+            text="Concurrent source change",
+        )
+
+    blocked = _bootstrap_module().NotesTaskBootstrapper(
+        note_db,
+        after_page=mutate_source,
+    ).bootstrap(service=service, dataset=dataset)
+
+    assert blocked.metadata["notes_task_v1"]["state"] == "blocked"
+    assert (
+        blocked.metadata["notes_task_v1"]["reason_code"]
+        == "notes_task_source_changed"
+    )
+
+
+@pytest.mark.parametrize("field", ["source_count", "source_fingerprint"])
+def test_bootstrap_stored_progress_mismatch_blocks(
+    bootstrap_stack,
+    field: str,
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id, TASK_IDS[:2])
+    partial = _bootstrap_module().NotesTaskBootstrapper(
+        note_db,
+        page_limit=1,
+    ).bootstrap(service=service, dataset=dataset)
+    metadata = dict(partial.metadata)
+    readiness = dict(metadata["notes_task_v1"])
+    readiness[field] = (
+        int(readiness["source_count"]) + 1
+        if field == "source_count"
+        else "f" * 64
+    )
+    metadata["notes_task_v1"] = readiness
+    sync_store.db.execute(
+        "UPDATE sync_datasets SET metadata_json = ? WHERE dataset_id = ?",
+        (json.dumps(metadata, sort_keys=True), dataset.dataset_id),
+    )
+    tampered = sync_store.get_dataset(
+        dataset.dataset_id,
+        owner_user_id=OWNER_ID,
+    )
+    assert tampered is not None
+
+    blocked = _bootstrap_module().NotesTaskBootstrapper(note_db).bootstrap(
+        service=service,
+        dataset=tampered,
+    )
+
+    assert blocked.metadata["notes_task_v1"]["state"] == "blocked"
+    assert (
+        blocked.metadata["notes_task_v1"]["reason_code"]
+        == "notes_task_source_changed"
+    )
+
+
+def test_bootstrap_final_verification_rejects_wrong_operation_and_revision(
+    bootstrap_stack,
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id, TASK_IDS[:2])
+    bootstrapper = _bootstrap_module().NotesTaskBootstrapper(note_db, page_limit=1)
+    partial = bootstrapper.bootstrap(service=service, dataset=dataset)
+    sync_store.db.execute(
+        "UPDATE sync_envelopes SET operation = ?, object_revision = ? "
+        "WHERE dataset_id = ? AND domain = ? AND entity_id = ?",
+        ("tombstone", 99, dataset.dataset_id, "notes.task", TASK_IDS[0]),
+    )
+
+    blocked = bootstrapper.bootstrap(service=service, dataset=partial)
+
+    assert blocked.metadata["notes_task_v1"]["state"] == "blocked"
+    assert (
+        blocked.metadata["notes_task_v1"]["reason_code"]
+        == "notes_task_source_changed"
+    )
+
+
+def test_bootstrap_invalid_legacy_task_blocks_before_append(bootstrap_stack) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id, TASK_IDS[:1])
+    note_db.execute_query(
+        "UPDATE note_tasks SET source_diagnostic_code = ?, source_diagnostic_hash = ? "
+        "WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+        (
+            "legacy_task_payload_invalid",
+            "sha256:" + "b" * 64,
+            OWNER_ID,
+            dataset.dataset_id,
+            TASK_IDS[0],
+        ),
+        commit=True,
+    )
+
+    blocked = _bootstrap_module().NotesTaskBootstrapper(note_db).bootstrap(
+        service=service,
+        dataset=dataset,
+    )
+
+    assert blocked.metadata["notes_task_v1"]["state"] == "blocked"
+    assert blocked.metadata["notes_task_v1"]["reason_code"] == "notes_task_source_invalid"
+    assert not [
+        item
+        for item in sync_store.list_envelopes_after(
+            dataset.dataset_id,
+            0,
+            limit=10,
+        )
+        if item.domain == "notes.task"
+    ]
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {
+            "description": None,
+            "priority": "high",
+            "due_date": None,
+            "estimate": None,
+            "recurrence": None,
+            "assignee_id": None,
+            "tags": [],
+            "custom": {},
+            "unknown": "ignored",
+        },
+        {"description": None, "priority": "high"},
+    ],
+)
+def test_bootstrap_rejects_noncanonical_legacy_metadata_shape(
+    bootstrap_stack,
+    metadata: dict[str, object],
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id, TASK_IDS[:1])
+    note_db.execute_query(
+        "UPDATE note_tasks SET metadata_json = ? "
+        "WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+        (
+            json.dumps(metadata, sort_keys=True),
+            OWNER_ID,
+            dataset.dataset_id,
+            TASK_IDS[0],
+        ),
+        commit=True,
+    )
+
+    blocked = _bootstrap_module().NotesTaskBootstrapper(note_db).bootstrap(
+        service=service,
+        dataset=dataset,
+    )
+
+    assert blocked.metadata["notes_task_v1"]["state"] == "blocked"
+    assert blocked.metadata["notes_task_v1"]["reason_code"] == "notes_task_source_invalid"
+    assert not [
+        item
+        for item in sync_store.list_envelopes_after(dataset.dataset_id, 0, limit=10)
+        if item.domain == "notes.task"
+    ]
+
+
+def test_bootstrap_resumes_blocked_source_after_operator_repairs_row(
+    bootstrap_stack,
+) -> None:
+    note_db, _sync_store, service, dataset = bootstrap_stack
+    _create_tasks(note_db, dataset.dataset_id, TASK_IDS[:1])
+    invalid_metadata = {
+        "description": None,
+        "priority": "high",
+        "due_date": None,
+        "estimate": None,
+        "recurrence": None,
+        "assignee_id": None,
+        "tags": [],
+        "custom": {},
+        "unknown": "ignored",
+    }
+    note_db.execute_query(
+        "UPDATE note_tasks SET metadata_json = ? "
+        "WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+        (
+            json.dumps(invalid_metadata, sort_keys=True),
+            OWNER_ID,
+            dataset.dataset_id,
+            TASK_IDS[0],
+        ),
+        commit=True,
+    )
+    bootstrapper = _bootstrap_module().NotesTaskBootstrapper(note_db)
+    blocked = bootstrapper.bootstrap(service=service, dataset=dataset)
+    assert blocked.metadata["notes_task_v1"]["state"] == "blocked"
+
+    note_db.execute_query(
+        "UPDATE note_tasks SET metadata_json = ? "
+        "WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+        (
+            json.dumps({"priority": "high"}, sort_keys=True),
+            OWNER_ID,
+            dataset.dataset_id,
+            TASK_IDS[0],
+        ),
+        commit=True,
+    )
+    ready = bootstrapper.bootstrap(service=service, dataset=blocked)
+
+    assert ready.metadata["notes_task_v1"]["state"] == "ready"
+    assert ready.metadata["notes_task_v1"]["source_count"] == 1
+
+
+def test_factory_registers_task_components_without_advertising_domain() -> None:
+    from tldw_Server_API.app.core.Sync.v2 import factory
+    from tldw_Server_API.app.core.Sync.v2.materializers import NotesTaskMaterializer
+
+    registry = factory.default_sync_v2_registry()
+    assert isinstance(registry.get("notes.task"), NotesTaskDomainAdapter)
+    assert "notes.task" not in factory._sync_v2_settings_from_env().supported_domains
+    assert hasattr(factory, "_validate_notes_task_components")
+    assert NotesTaskMaterializer is not None

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_capture.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_capture.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.Notes_Tasks.models import TaskActor
+from tldw_Server_API.app.core.Notes_Tasks.service import (
+    NotesTaskCaptureMutation,
+    NotesTaskService,
+    build_task_capture_mutation,
+)
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    notes_task_object_hash,
+    parse_notes_task_v1,
+)
+
+pytestmark = pytest.mark.unit
+
+OWNER_ID = "capture-owner"
+DATASET_ID = "local-unbound"
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CharactersRAGDB:
+    database = CharactersRAGDB(tmp_path / "capture.db", client_id=OWNER_ID)
+    try:
+        yield database
+    finally:
+        database.close_connection()
+
+
+def _actor() -> TaskActor:
+    return TaskActor(
+        actor_type="user",
+        actor_id=OWNER_ID,
+        tool_name="notes.tasks.test",
+        idempotency_key="request-task-capture",
+    )
+
+
+def _add_note(db: CharactersRAGDB, content: str = "Intro\n") -> dict[str, Any]:
+    note_id = db.add_note(title="Capture tasks", content=content)
+    note = db.get_note_by_id(str(note_id))
+    assert note is not None
+    return note
+
+
+def test_task_capture_callback_receives_exact_create_status_and_delete_steps(
+    db: CharactersRAGDB,
+) -> None:
+    captured: list[NotesTaskCaptureMutation] = []
+
+    def capture(mutation: NotesTaskCaptureMutation, *, conn: object) -> None:
+        assert conn is not None
+        captured.append(mutation)
+
+    service = NotesTaskService(task_capture_callback=capture)
+    note = _add_note(db)
+    created = service.create_task_for_note(
+        db=db,
+        note_id=str(note["id"]),
+        text="Ship capture seam",
+        status="open",
+        metadata={"priority": "high"},
+        expected_note_version=int(note["version"]),
+        actor=_actor(),
+    )
+    after_create_note = db.get_note_by_id(str(note["id"]))
+    assert after_create_note is not None
+    updated = service.update_task(
+        db=db,
+        task_id=str(created["id"]),
+        expected_task_version=int(created["version"]),
+        expected_note_version=int(after_create_note["version"]),
+        actor=_actor(),
+        status="done",
+    )
+    after_update_note = db.get_note_by_id(str(note["id"]))
+    assert after_update_note is not None
+    deleted = service.delete_task(
+        db=db,
+        task_id=str(created["id"]),
+        expected_task_version=int(updated["version"]),
+        expected_note_version=int(after_update_note["version"]),
+        record_only=False,
+        actor=_actor(),
+    )
+
+    assert [item.operation for item in captured] == ["upsert", "upsert", "tombstone"]
+    assert captured[0].before is None
+    assert captured[1].base_revision == int(created["canonical_revision"])
+    assert captured[1].base_hash == created["canonical_hash"]
+    assert captured[1].after["status"] == "done"
+    assert bool(captured[2].after["deleted"]) is True
+    assert captured[2].step.object_revision == deleted["canonical_revision"]
+    assert captured[2].step.payload == captured[2].after["sync_payload"]
+    assert captured[2].step.parent_id == note["id"]
+    assert captured[2].step.client_envelope_id
+    assert captured[2].idempotency_key
+
+
+def test_task_capture_builder_is_stable_and_marks_restore_intent(
+    db: CharactersRAGDB,
+) -> None:
+    note = _add_note(db)
+    task = db.task_store.create_task(
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        note_id=str(note["id"]),
+        text="Restore capture",
+        projection_status="unlinked",
+    )
+    deleted = db.task_store.soft_delete_task(
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        task_id=str(task["id"]),
+        expected_version=int(task["version"]),
+        allow_record_only=True,
+    )
+    deleted_source = db.task_store._sync_bootstrap_task_row(deleted, OWNER_ID)
+    payload = parse_notes_task_v1(
+        deleted_source["sync_payload"],
+        owner_user_id=OWNER_ID,
+    )
+    next_revision = int(deleted["canonical_revision"]) + 1
+    next_hash = notes_task_object_hash(
+        payload,
+        revision=next_revision,
+        deleted=False,
+    )
+    with db.transaction() as conn:
+        restored = db.task_store.apply_sync_task_restore(
+            owner_user_id=OWNER_ID,
+            dataset_id=DATASET_ID,
+            payload=payload,
+            base_revision=int(deleted["canonical_revision"]),
+            base_hash=str(deleted["canonical_hash"]),
+            canonical_revision=next_revision,
+            canonical_hash=next_hash,
+            conn=conn,
+        )
+
+    first = build_task_capture_mutation(
+        db=db,
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        actor=_actor(),
+        before=deleted,
+        after=restored,
+    )
+    second = build_task_capture_mutation(
+        db=db,
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        actor=_actor(),
+        before=deleted,
+        after=restored,
+    )
+
+    assert first == second
+    assert first.operation == "upsert"
+    assert first.restore_intent is True
+    assert first.step.routing_metadata == {"restore_intent": True}
+    assert first.base_revision == deleted["canonical_revision"]
+    assert first.base_hash == deleted["canonical_hash"]
+    assert first.step.object_revision == next_revision
+    assert first.step.client_envelope_id == second.step.client_envelope_id
+
+
+def test_task_capture_failure_rolls_back_projected_product_mutation(
+    db: CharactersRAGDB,
+) -> None:
+    note = _add_note(db, "- [ ] Preserve me\n")
+    setup = NotesTaskService()
+    setup.reconcile_note_current(db=db, note_id=str(note["id"]), actor=_actor())
+    task = db.list_tasks(
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        note_id=str(note["id"]),
+    )[0]
+    before_note = db.get_note_by_id(str(note["id"]))
+    assert before_note is not None
+
+    def fail_capture(_mutation: NotesTaskCaptureMutation, *, conn: object) -> None:
+        assert conn is not None
+        raise RuntimeError("injected task capture failure")
+
+    with pytest.raises(RuntimeError, match="injected task capture failure"):
+        NotesTaskService(task_capture_callback=fail_capture).update_task(
+            db=db,
+            task_id=str(task["id"]),
+            expected_task_version=int(task["version"]),
+            expected_note_version=int(before_note["version"]),
+            actor=_actor(),
+            status="done",
+        )
+
+    after_note = db.get_note_by_id(str(note["id"]))
+    after_task = db.get_task(
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        task_id=str(task["id"]),
+    )
+    assert after_note == before_note
+    assert after_task == task
+
+
+def test_legacy_service_without_task_capture_remains_unchanged(
+    db: CharactersRAGDB,
+) -> None:
+    note = _add_note(db)
+
+    created = NotesTaskService().create_task_for_note(
+        db=db,
+        note_id=str(note["id"]),
+        text="Legacy task",
+        status="open",
+        metadata={},
+        expected_note_version=int(note["version"]),
+        actor=_actor(),
+    )
+
+    assert created["text"] == "Legacy task"
+    assert created["canonical_revision"] == 1
+
+
+def test_task_capture_remains_unwired_from_public_factories() -> None:
+    api_root = Path(__file__).resolve().parents[2]
+    endpoint_source = (api_root / "app/api/v1/endpoints/notes_tasks.py").read_text()
+    mcp_source = (
+        api_root / "app/core/MCP_unified/modules/implementations/notes_module.py"
+    ).read_text()
+    assert "task_capture_callback=" not in endpoint_source
+    assert "task_capture_callback=" not in mcp_source

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_materializer.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_materializer.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    ConflictError,
+)
+from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Sync.v2 import materializers
+from tldw_Server_API.app.core.Sync.v2.models import (
+    SyncDatasetCreate,
+    SyncEnvelope,
+    SyncEnvelopeCreate,
+)
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    NotesTaskV1Payload,
+    notes_task_object_hash,
+    parse_notes_task_v1,
+)
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
+
+pytestmark = pytest.mark.unit
+
+OWNER_ID = "owner-user-1"
+DATASET_ID = "dataset-1"
+TASK_ID = "11111111-1111-4111-8111-111111111111"
+NOTE_ID = "22222222-2222-4222-8222-222222222222"
+MISSING_NOTE_ID = "33333333-3333-4333-8333-333333333333"
+DEVICE_ID = "44444444-4444-4444-8444-444444444444"
+NOW = "2026-08-13T10:00:00+00:00"
+
+
+def _materializer(note_db: CharactersRAGDB):
+    materializer_type = getattr(materializers, "NotesTaskMaterializer", None)
+    assert materializer_type is not None, "NotesTaskMaterializer is not implemented"
+    return materializer_type(note_db)
+
+
+def _payload(**overrides: object) -> NotesTaskV1Payload:
+    raw: dict[str, object] = {
+        "task_id": TASK_ID,
+        "note_id": NOTE_ID,
+        "title": "Prepare launch notes",
+        "description": "Confirm the final release checklist.",
+        "status": "open",
+        "completed_at": None,
+        "priority": "high",
+        "due_date": "2026-08-31",
+        "estimate": "90m",
+        "recurrence": {
+            "frequency": "weekly",
+            "interval": 2,
+            "by_weekday": ["mo", "we", "fr"],
+            "until": "2026-12-31",
+            "state": "active",
+            "occurrence_index": 7,
+        },
+        "assignee_id": OWNER_ID,
+        "tags": ["alpha", "Zulu"],
+        "custom": {"board.column": "Next"},
+    }
+    raw.update(overrides)
+    return parse_notes_task_v1(raw, owner_user_id=OWNER_ID)
+
+
+def _create(
+    *,
+    payload: NotesTaskV1Payload | None = None,
+    operation: str = "upsert",
+    base: SyncEnvelope | None = None,
+    restore: bool = False,
+    suffix: str,
+) -> SyncEnvelopeCreate:
+    canonical = payload or _payload()
+    revision = 1 if base is None else int(base.object_revision or 0) + 1
+    return SyncEnvelopeCreate(
+        dataset_id=DATASET_ID,
+        client_envelope_id=f"task-{suffix}",
+        domain="notes.task",
+        operation=operation,
+        object_id=canonical.task_id,
+        parent_id=canonical.note_id,
+        device_id=DEVICE_ID,
+        base_server_cursor=base.server_cursor if base is not None else None,
+        base_object_revision=base.object_revision if base is not None else None,
+        base_object_hash=base.payload_hash if base is not None else None,
+        object_revision=revision,
+        entity_version=revision,
+        adapter_version=1,
+        schema_version=1,
+        payload=canonical.model_dump(mode="json"),
+        payload_hash=notes_task_object_hash(
+            canonical,
+            revision=revision,
+            deleted=operation == "tombstone",
+        ),
+        created_at_client=NOW,
+        routing_metadata={"restore_intent": True} if restore else {},
+        status="accepted",
+    )
+
+
+def _insert_internal(store: SyncV2Store, create: SyncEnvelopeCreate) -> SyncEnvelope:
+    with store.db.backend.transaction() as conn:
+        return store.db._insert_envelope_in_transaction(create, connection=conn)
+
+
+@pytest.fixture()
+def materialization_stack(tmp_path: Path):
+    note_db = CharactersRAGDB(tmp_path / "notes-task-product.db", client_id=OWNER_ID)
+    note_db.note_store.add_note(NOTE_ID, "body", note_id=NOTE_ID)
+    note_db.bind_local_task_graph_to_dataset(
+        owner_user_id=OWNER_ID,
+        target_dataset_id=DATASET_ID,
+    )
+    sync_store = SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "notes-task-sync.db"))
+    sync_store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id=DATASET_ID,
+            owner_user_id=OWNER_ID,
+            domains=["notes.note"],
+        )
+    )
+    sync_store.db.execute(
+        "UPDATE sync_datasets SET domain_set_json = ? WHERE dataset_id = ?",
+        (json.dumps(["notes.note", "notes.task"]), DATASET_ID),
+    )
+    try:
+        yield note_db, sync_store
+    finally:
+        note_db.close_connection()
+
+
+def _task(note_db: CharactersRAGDB) -> dict[str, object] | None:
+    return note_db.task_store.get_task(
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        task_id=TASK_ID,
+        include_deleted=True,
+    )
+
+
+def _event_count(note_db: CharactersRAGDB) -> int:
+    return int(
+        note_db.execute_query(
+            "SELECT COUNT(*) AS count FROM task_events "
+            "WHERE owner_user_id = ? AND dataset_id = ?",
+            (OWNER_ID, DATASET_ID),
+        ).fetchone()["count"]
+    )
+
+
+def test_materializer_applies_full_task_lifecycle_without_activity(
+    materialization_stack,
+) -> None:
+    note_db, sync_store = materialization_stack
+    materializer = _materializer(note_db)
+
+    created = _insert_internal(sync_store, _create(suffix="create"))
+    assert materializer.apply(created, store=sync_store).status == "applied"
+    task = _task(note_db)
+    assert task is not None
+    assert task["text"] == "Prepare launch notes"
+    assert task["status"] == "open"
+    assert task["projection_status"] == "unlinked"
+    assert task["canonical_revision"] == 1
+    assert task["canonical_hash"] == created.payload_hash
+    assert task["metadata_json"] == {
+        "assignee_id": OWNER_ID,
+        "custom": {"board.column": "Next"},
+        "description": "Confirm the final release checklist.",
+        "due_date": "2026-08-31",
+        "estimate": "90m",
+        "priority": "high",
+        "recurrence": {
+            "by_weekday": ["mo", "we", "fr"],
+            "frequency": "weekly",
+            "interval": 2,
+            "occurrence_index": 7,
+            "state": "active",
+            "until": "2026-12-31",
+        },
+        "tags": ["alpha", "Zulu"],
+    }
+
+    completed_payload = _payload(
+        status="done",
+        completed_at="2026-08-13T11:00:00+00:00",
+    )
+    completed = _insert_internal(
+        sync_store,
+        _create(payload=completed_payload, base=created, suffix="complete"),
+    )
+    assert materializer.apply(completed, store=sync_store).status == "applied"
+    task = _task(note_db)
+    assert task is not None
+    assert task["status"] == "done"
+    assert str(task["completed_at"]) == "2026-08-13T11:00:00+00:00"
+    assert task["canonical_revision"] == 2
+
+    reopened = _insert_internal(
+        sync_store,
+        _create(payload=_payload(), base=completed, suffix="reopen"),
+    )
+    assert materializer.apply(reopened, store=sync_store).status == "applied"
+    assert _task(note_db)["completed_at"] is None
+
+    tombstone = _insert_internal(
+        sync_store,
+        _create(operation="tombstone", base=reopened, suffix="delete"),
+    )
+    assert materializer.apply(tombstone, store=sync_store).status == "applied"
+    task = _task(note_db)
+    assert task is not None and bool(task["deleted"])
+    assert task["projection_status"] == "deleted"
+
+    restored_payload = _payload(title="Restored launch notes")
+    restored = _insert_internal(
+        sync_store,
+        _create(
+            payload=restored_payload,
+            base=tombstone,
+            restore=True,
+            suffix="restore",
+        ),
+    )
+    assert materializer.apply(restored, store=sync_store).status == "applied"
+    task = _task(note_db)
+    assert task is not None and not bool(task["deleted"])
+    assert task["text"] == "Restored launch notes"
+    assert task["projection_status"] == "unlinked"
+    assert task["canonical_revision"] == 5
+    assert _event_count(note_db) == 0
+
+
+def test_materializer_preserves_separate_rest_version(
+    materialization_stack,
+) -> None:
+    note_db, sync_store = materialization_stack
+    materializer = _materializer(note_db)
+    created = _insert_internal(sync_store, _create(suffix="version-create"))
+    assert materializer.apply(created, store=sync_store).status == "applied"
+    note_db.execute_query(
+        "UPDATE note_tasks SET version = 9 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+        (OWNER_ID, DATASET_ID, TASK_ID),
+        commit=True,
+    )
+
+    updated = _insert_internal(
+        sync_store,
+        _create(
+            payload=_payload(title="Canonical update"),
+            base=created,
+            suffix="version-update",
+        ),
+    )
+    assert materializer.apply(updated, store=sync_store).status == "applied"
+    task = _task(note_db)
+    assert task is not None
+    assert task["version"] == 10
+    assert task["canonical_revision"] == 2
+
+
+def test_split_commit_replay_repairs_sync_state_without_rewriting_product(
+    materialization_stack,
+) -> None:
+    note_db, sync_store = materialization_stack
+    materializer = _materializer(note_db)
+    created = _insert_internal(sync_store, _create(suffix="split-create"))
+
+    class _FailObjectStateOnce:
+        def __init__(self, wrapped: SyncV2Store) -> None:
+            self.wrapped = wrapped
+            self.failed = False
+
+        def upsert_object_state(self, *_args, **_kwargs) -> None:
+            if not self.failed:
+                self.failed = True
+                raise RuntimeError("injected Sync status failure")
+            self.wrapped.upsert_object_state(*_args, **_kwargs)
+
+        def __getattr__(self, name: str):
+            return getattr(self.wrapped, name)
+
+    failed = materializer.apply(created, store=_FailObjectStateOnce(sync_store))
+    assert failed.status == "failed"
+    product_after_failure = _task(note_db)
+    assert product_after_failure is not None
+    assert product_after_failure["version"] == 1
+
+    replay = materializer.apply(created, store=sync_store)
+    assert replay.status == "applied"
+    assert _task(note_db)["version"] == 1
+    state = sync_store.get_object_state(DATASET_ID, "notes.task", TASK_ID)
+    assert state is not None
+    assert state.latest_server_cursor == created.server_cursor
+    assert state.object_hash == created.payload_hash
+
+
+def test_materializer_conflicts_lower_cursor_and_divergent_product_state(
+    materialization_stack,
+) -> None:
+    note_db, sync_store = materialization_stack
+    materializer = _materializer(note_db)
+    created = _insert_internal(sync_store, _create(suffix="conflict-create"))
+    assert materializer.apply(created, store=sync_store).status == "applied"
+    updated = _insert_internal(
+        sync_store,
+        _create(
+            payload=_payload(title="Current title"),
+            base=created,
+            suffix="conflict-update",
+        ),
+    )
+    assert materializer.apply(updated, store=sync_store).status == "applied"
+
+    assert materializer.apply(created, store=sync_store).status == "conflict"
+
+    note_db.execute_query(
+        "UPDATE note_tasks SET canonical_hash = ? "
+        "WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+        ("sha256:" + "f" * 64, OWNER_ID, DATASET_ID, TASK_ID),
+        commit=True,
+    )
+    next_envelope = _insert_internal(
+        sync_store,
+        _create(
+            payload=_payload(title="Rejected divergence"),
+            base=updated,
+            suffix="conflict-divergent",
+        ),
+    )
+    result = materializer.apply(next_envelope, store=sync_store)
+    assert result.status == "conflict"
+    assert result.conflict_type == "notes_task_product_conflict"
+    assert "title" not in (result.message or "")
+
+
+def test_materializer_product_failure_rolls_back_without_activity(
+    materialization_stack,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    note_db, sync_store = materialization_stack
+    materializer = _materializer(note_db)
+    incoming = _insert_internal(sync_store, _create(suffix="rollback"))
+
+    task_store_type = type(note_db.task_store)
+
+    def fail_after_write(_stage: str) -> None:
+        raise RuntimeError("injected product failure")
+
+    monkeypatch.setattr(
+        task_store_type,
+        "_sync_task_materialization_checkpoint",
+        staticmethod(fail_after_write),
+    )
+
+    result = materializer.apply(incoming, store=sync_store)
+
+    assert result.status == "failed"
+    assert _task(note_db) is None
+    assert _event_count(note_db) == 0
+
+
+def test_task_store_sync_create_rejects_missing_parent_and_wrong_scope(
+    materialization_stack,
+) -> None:
+    note_db, _sync_store = materialization_stack
+    payload = _payload(note_id=MISSING_NOTE_ID)
+
+    with pytest.raises(ConflictError):
+        with note_db.transaction() as conn:
+            note_db.task_store.apply_sync_task_create(
+                owner_user_id=OWNER_ID,
+                dataset_id=DATASET_ID,
+                payload=payload,
+                canonical_revision=1,
+                canonical_hash=notes_task_object_hash(
+                    payload,
+                    revision=1,
+                    deleted=False,
+                ),
+                conn=conn,
+            )
+
+    with pytest.raises(ConflictError):
+        with note_db.transaction() as conn:
+            note_db.task_store.apply_sync_task_create(
+                owner_user_id=OWNER_ID,
+                dataset_id="other-dataset",
+                payload=_payload(),
+                canonical_revision=1,
+                canonical_hash="sha256:" + "1" * 64,
+                conn=conn,
+            )
+
+    assert _task(note_db) is None
+
+
+def test_materializer_reports_existing_product_identity_as_conflict(
+    materialization_stack,
+) -> None:
+    note_db, sync_store = materialization_stack
+    note_db.task_store.create_task(
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        note_id=NOTE_ID,
+        text="Existing local task",
+        task_id=TASK_ID,
+        projection_status="unlinked",
+    )
+    incoming = _insert_internal(sync_store, _create(suffix="identity-collision"))
+
+    result = _materializer(note_db).apply(incoming, store=sync_store)
+
+    assert result.status == "conflict"
+    assert result.conflict_type == "notes_task_product_conflict"
+    assert _task(note_db)["text"] == "Existing local task"
+    assert _event_count(note_db) == 0

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_postgres_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_postgres_contract.py
@@ -1,0 +1,300 @@
+"""PostgreSQL contracts for dormant ``notes.task`` product materialization."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig
+from tldw_Server_API.app.core.DB_Management.backends.factory import (
+    DatabaseBackendFactory,
+)
+from tldw_Server_API.app.core.DB_Management.chacha.task_store import TaskStore
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.Sync.v2.materializers.notes_task import (
+    NotesTaskMaterializer,
+)
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    NotesTaskV1Payload,
+    notes_task_object_hash,
+    parse_notes_task_v1,
+)
+
+pytestmark = pytest.mark.integration
+
+_DATASET_ID = "local-unbound"
+
+
+def _payload(
+    *,
+    owner: str,
+    task_id: str,
+    note_id: str,
+    title: str,
+    status: str = "open",
+    completed_at: str | None = None,
+) -> NotesTaskV1Payload:
+    return parse_notes_task_v1(
+        {
+            "task_id": task_id,
+            "note_id": note_id,
+            "title": title,
+            "description": None,
+            "status": status,
+            "completed_at": completed_at,
+            "priority": "high",
+            "due_date": None,
+            "estimate": "30m",
+            "recurrence": None,
+            "assignee_id": None,
+            "tags": [],
+            "custom": {},
+        },
+        owner_user_id=owner,
+    )
+
+
+def _apply_lifecycle(
+    db: CharactersRAGDB,
+    *,
+    owner: str,
+    role_identifier: str,
+) -> dict[str, Any]:
+    note_id = str(uuid4())
+    task_id = str(uuid4())
+    db.add_note("PostgreSQL task lifecycle", "Body\n", note_id=note_id)
+
+    created_payload = _payload(
+        owner=owner,
+        task_id=task_id,
+        note_id=note_id,
+        title="Create on PostgreSQL",
+    )
+    created_hash = notes_task_object_hash(
+        created_payload,
+        revision=1,
+        deleted=False,
+    )
+    with db.transaction() as conn:
+        conn.execute(f"SET LOCAL ROLE {role_identifier}")  # nosec B608
+        conn.execute(
+            "SELECT set_config('app.current_user_id', ?, true)",
+            (owner,),
+        )
+        created = db.task_store.apply_sync_task_create(
+            owner_user_id=owner,
+            dataset_id=_DATASET_ID,
+            payload=created_payload,
+            canonical_revision=1,
+            canonical_hash=created_hash,
+            conn=conn,
+        )
+
+    updated_payload = _payload(
+        owner=owner,
+        task_id=task_id,
+        note_id=note_id,
+        title="Updated on PostgreSQL",
+        status="done",
+        completed_at="2026-08-21T12:00:00+00:00",
+    )
+    updated_hash = notes_task_object_hash(
+        updated_payload,
+        revision=2,
+        deleted=False,
+    )
+    with db.transaction() as conn:
+        conn.execute(f"SET LOCAL ROLE {role_identifier}")  # nosec B608
+        conn.execute(
+            "SELECT set_config('app.current_user_id', ?, true)",
+            (owner,),
+        )
+        updated = db.task_store.apply_sync_task_upsert(
+            owner_user_id=owner,
+            dataset_id=_DATASET_ID,
+            payload=updated_payload,
+            base_revision=1,
+            base_hash=created_hash,
+            canonical_revision=2,
+            canonical_hash=updated_hash,
+            conn=conn,
+        )
+
+    tombstone_hash = notes_task_object_hash(
+        updated_payload,
+        revision=3,
+        deleted=True,
+    )
+    with db.transaction() as conn:
+        conn.execute(f"SET LOCAL ROLE {role_identifier}")  # nosec B608
+        conn.execute(
+            "SELECT set_config('app.current_user_id', ?, true)",
+            (owner,),
+        )
+        tombstone = db.task_store.apply_sync_task_tombstone(
+            owner_user_id=owner,
+            dataset_id=_DATASET_ID,
+            payload=updated_payload,
+            base_revision=2,
+            base_hash=updated_hash,
+            canonical_revision=3,
+            canonical_hash=tombstone_hash,
+            conn=conn,
+        )
+
+    restored_hash = notes_task_object_hash(
+        updated_payload,
+        revision=4,
+        deleted=False,
+    )
+    with db.transaction() as conn:
+        conn.execute(f"SET LOCAL ROLE {role_identifier}")  # nosec B608
+        conn.execute(
+            "SELECT set_config('app.current_user_id', ?, true)",
+            (owner,),
+        )
+        restored = db.task_store.apply_sync_task_restore(
+            owner_user_id=owner,
+            dataset_id=_DATASET_ID,
+            payload=updated_payload,
+            base_revision=3,
+            base_hash=tombstone_hash,
+            canonical_revision=4,
+            canonical_hash=restored_hash,
+            conn=conn,
+        )
+
+    assert created["canonical_revision"] == 1
+    assert updated["canonical_revision"] == 2
+    assert bool(tombstone["deleted"]) is True
+    assert bool(restored["deleted"]) is False
+    assert restored["projection_status"] == "unlinked"
+    assert restored["canonical_hash"] == restored_hash
+    return restored
+
+
+def test_postgres_task_sources_bind_scope_lock_cas_and_page_by_primary_key() -> None:
+    fetch_source = inspect.getsource(TaskStore._fetch_task)
+    transition_source = inspect.getsource(TaskStore._apply_sync_task_transition)
+    page_source = inspect.getsource(TaskStore.page_tasks_for_sync_bootstrap)
+    materializer_source = inspect.getsource(NotesTaskMaterializer.apply)
+    ddl = " ".join(CharactersRAGDB._note_task_v60_postgres_ddl())
+
+    assert "WHERE owner_user_id = ? AND dataset_id = ? AND id = ?" in fetch_source
+    assert "for_update=True" in transition_source
+    assert "FOR UPDATE" in fetch_source
+    assert "WHERE owner_user_id = ? AND dataset_id = ?" in page_source
+    assert "AND id > ? ORDER BY id ASC LIMIT ?" in page_source
+    assert "PRIMARY KEY(owner_user_id,dataset_id,id)" in ddl
+    assert '"owner_user_id": str(self.note_db.client_id)' in materializer_source
+    assert '"dataset_id": envelope.dataset_id' in materializer_source
+
+
+def test_postgres_task_lifecycle_is_rls_isolated_and_index_backed_for_two_owners(
+    pg_database_config: DatabaseConfig,
+) -> None:
+    owner_a = "970001"
+    owner_b = "970002"
+    backend_a = DatabaseBackendFactory.create_backend(pg_database_config)
+    backend_b = DatabaseBackendFactory.create_backend(pg_database_config)
+    db_a = CharactersRAGDB(":memory:", client_id=owner_a, backend=backend_a)
+    db_b = CharactersRAGDB(":memory:", client_id=owner_b, backend=backend_b)
+    ident = backend_a.escape_identifier  # type: ignore[attr-defined]
+    role_name = f"notes_task_lifecycle_{uuid4().hex[:8]}"
+    role_identifier = ident(role_name)
+    role_created = False
+
+    try:
+        with backend_a.transaction() as conn:
+            backend_a.execute(
+                f"CREATE ROLE {role_identifier} NOLOGIN NOSUPERUSER NOBYPASSRLS",
+                connection=conn,
+            )
+            backend_a.execute(
+                f"GRANT USAGE ON SCHEMA public TO {role_identifier}",
+                connection=conn,
+            )
+            backend_a.execute(
+                f"GRANT SELECT ON notes TO {role_identifier}",
+                connection=conn,
+            )
+            backend_a.execute(
+                f"GRANT SELECT, INSERT, UPDATE ON note_tasks TO {role_identifier}",
+                connection=conn,
+            )
+            backend_a.execute(
+                f"GRANT SELECT, UPDATE ON note_task_scope_authority TO {role_identifier}",
+                connection=conn,
+            )
+            backend_a.execute(
+                f"GRANT {role_identifier} TO CURRENT_USER",
+                connection=conn,
+            )
+        role_created = True
+
+        with db_a.transaction() as conn:
+            conn.execute(f"SET LOCAL ROLE {role_identifier}")  # nosec B608
+            role = conn.execute(
+                "SELECT rolsuper,rolbypassrls FROM pg_roles WHERE rolname=current_user"
+            ).fetchone()
+            assert role is not None
+            assert bool(role["rolsuper"]) is False
+            assert bool(role["rolbypassrls"]) is False
+
+        task_a = _apply_lifecycle(
+            db_a,
+            owner=owner_a,
+            role_identifier=role_identifier,
+        )
+        task_b = _apply_lifecycle(
+            db_b,
+            owner=owner_b,
+            role_identifier=role_identifier,
+        )
+
+        assert db_a.get_task(
+            owner_user_id=owner_a,
+            dataset_id=_DATASET_ID,
+            task_id=str(task_b["id"]),
+            include_deleted=True,
+        ) is None
+        assert db_b.get_task(
+            owner_user_id=owner_b,
+            dataset_id=_DATASET_ID,
+            task_id=str(task_a["id"]),
+            include_deleted=True,
+        ) is None
+
+        with db_a.transaction() as conn:
+            conn.execute("ANALYZE note_tasks")
+            conn.execute("SET LOCAL enable_seqscan=off")
+            plan_rows = conn.execute(
+                "EXPLAIN SELECT id FROM note_tasks "
+                "WHERE owner_user_id=? AND dataset_id=? AND id>? "
+                "ORDER BY id ASC LIMIT ?",
+                (owner_a, _DATASET_ID, "", 50),
+            ).fetchall()
+        plan = " ".join(str(next(iter(dict(row).values()))) for row in plan_rows)
+        assert "note_tasks_pkey" in plan
+    finally:
+        if role_created:
+            with backend_a.transaction() as conn:
+                backend_a.execute(
+                    f"REVOKE {role_identifier} FROM CURRENT_USER",
+                    connection=conn,
+                )
+                backend_a.execute(
+                    f"DROP OWNED BY {role_identifier}",
+                    connection=conn,
+                )
+                backend_a.execute(
+                    f"DROP ROLE {role_identifier}",
+                    connection=conn,
+                )
+        db_b.close_all_connections()
+        db_a.close_all_connections()
+        backend_b.get_pool().close_all()
+        backend_a.get_pool().close_all()

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_postgres_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_postgres_contract.py
@@ -7,6 +7,7 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+from psycopg import sql as psycopg_sql
 
 from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig
 from tldw_Server_API.app.core.DB_Management.backends.factory import (
@@ -26,6 +27,19 @@ from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
 pytestmark = pytest.mark.integration
 
 _DATASET_ID = "local-unbound"
+
+
+def _execute_role_statement(
+    connection: Any,
+    statement: str,
+    role_name: str,
+) -> None:
+    """Execute a fixed PostgreSQL role statement with a quoted identifier."""
+    raw_connection = getattr(connection, "_connection", connection)
+    with raw_connection.cursor() as cursor:
+        cursor.execute(
+            psycopg_sql.SQL(statement).format(psycopg_sql.Identifier(role_name))
+        )
 
 
 def _payload(
@@ -61,7 +75,7 @@ def _apply_lifecycle(
     db: CharactersRAGDB,
     *,
     owner: str,
-    role_identifier: str,
+    role_name: str,
 ) -> dict[str, Any]:
     note_id = str(uuid4())
     task_id = str(uuid4())
@@ -79,7 +93,7 @@ def _apply_lifecycle(
         deleted=False,
     )
     with db.transaction() as conn:
-        conn.execute(f"SET LOCAL ROLE {role_identifier}")  # nosec B608
+        _execute_role_statement(conn, "SET LOCAL ROLE {}", role_name)
         conn.execute(
             "SELECT set_config('app.current_user_id', ?, true)",
             (owner,),
@@ -107,7 +121,7 @@ def _apply_lifecycle(
         deleted=False,
     )
     with db.transaction() as conn:
-        conn.execute(f"SET LOCAL ROLE {role_identifier}")  # nosec B608
+        _execute_role_statement(conn, "SET LOCAL ROLE {}", role_name)
         conn.execute(
             "SELECT set_config('app.current_user_id', ?, true)",
             (owner,),
@@ -129,7 +143,7 @@ def _apply_lifecycle(
         deleted=True,
     )
     with db.transaction() as conn:
-        conn.execute(f"SET LOCAL ROLE {role_identifier}")  # nosec B608
+        _execute_role_statement(conn, "SET LOCAL ROLE {}", role_name)
         conn.execute(
             "SELECT set_config('app.current_user_id', ?, true)",
             (owner,),
@@ -151,7 +165,7 @@ def _apply_lifecycle(
         deleted=False,
     )
     with db.transaction() as conn:
-        conn.execute(f"SET LOCAL ROLE {role_identifier}")  # nosec B608
+        _execute_role_statement(conn, "SET LOCAL ROLE {}", role_name)
         conn.execute(
             "SELECT set_config('app.current_user_id', ?, true)",
             (owner,),
@@ -202,41 +216,45 @@ def test_postgres_task_lifecycle_is_rls_isolated_and_index_backed_for_two_owners
     backend_b = DatabaseBackendFactory.create_backend(pg_database_config)
     db_a = CharactersRAGDB(":memory:", client_id=owner_a, backend=backend_a)
     db_b = CharactersRAGDB(":memory:", client_id=owner_b, backend=backend_b)
-    ident = backend_a.escape_identifier  # type: ignore[attr-defined]
     role_name = f"notes_task_lifecycle_{uuid4().hex[:8]}"
-    role_identifier = ident(role_name)
     role_created = False
 
     try:
         with backend_a.transaction() as conn:
-            backend_a.execute(
-                f"CREATE ROLE {role_identifier} NOLOGIN NOSUPERUSER NOBYPASSRLS",
-                connection=conn,
+            _execute_role_statement(
+                conn,
+                "CREATE ROLE {} NOLOGIN NOSUPERUSER NOBYPASSRLS",
+                role_name,
             )
-            backend_a.execute(
-                f"GRANT USAGE ON SCHEMA public TO {role_identifier}",
-                connection=conn,
+            _execute_role_statement(
+                conn,
+                "GRANT USAGE ON SCHEMA public TO {}",
+                role_name,
             )
-            backend_a.execute(
-                f"GRANT SELECT ON notes TO {role_identifier}",
-                connection=conn,
+            _execute_role_statement(
+                conn,
+                "GRANT SELECT ON notes TO {}",
+                role_name,
             )
-            backend_a.execute(
-                f"GRANT SELECT, INSERT, UPDATE ON note_tasks TO {role_identifier}",
-                connection=conn,
+            _execute_role_statement(
+                conn,
+                "GRANT SELECT, INSERT, UPDATE ON note_tasks TO {}",
+                role_name,
             )
-            backend_a.execute(
-                f"GRANT SELECT, UPDATE ON note_task_scope_authority TO {role_identifier}",
-                connection=conn,
+            _execute_role_statement(
+                conn,
+                "GRANT SELECT, UPDATE ON note_task_scope_authority TO {}",
+                role_name,
             )
-            backend_a.execute(
-                f"GRANT {role_identifier} TO CURRENT_USER",
-                connection=conn,
+            _execute_role_statement(
+                conn,
+                "GRANT {} TO CURRENT_USER",
+                role_name,
             )
         role_created = True
 
         with db_a.transaction() as conn:
-            conn.execute(f"SET LOCAL ROLE {role_identifier}")  # nosec B608
+            _execute_role_statement(conn, "SET LOCAL ROLE {}", role_name)
             role = conn.execute(
                 "SELECT rolsuper,rolbypassrls FROM pg_roles WHERE rolname=current_user"
             ).fetchone()
@@ -247,12 +265,12 @@ def test_postgres_task_lifecycle_is_rls_isolated_and_index_backed_for_two_owners
         task_a = _apply_lifecycle(
             db_a,
             owner=owner_a,
-            role_identifier=role_identifier,
+            role_name=role_name,
         )
         task_b = _apply_lifecycle(
             db_b,
             owner=owner_b,
-            role_identifier=role_identifier,
+            role_name=role_name,
         )
 
         assert db_a.get_task(
@@ -282,17 +300,20 @@ def test_postgres_task_lifecycle_is_rls_isolated_and_index_backed_for_two_owners
     finally:
         if role_created:
             with backend_a.transaction() as conn:
-                backend_a.execute(
-                    f"REVOKE {role_identifier} FROM CURRENT_USER",
-                    connection=conn,
+                _execute_role_statement(
+                    conn,
+                    "REVOKE {} FROM CURRENT_USER",
+                    role_name,
                 )
-                backend_a.execute(
-                    f"DROP OWNED BY {role_identifier}",
-                    connection=conn,
+                _execute_role_statement(
+                    conn,
+                    "DROP OWNED BY {}",
+                    role_name,
                 )
-                backend_a.execute(
-                    f"DROP ROLE {role_identifier}",
-                    connection=conn,
+                _execute_role_statement(
+                    conn,
+                    "DROP ROLE {}",
+                    role_name,
                 )
         db_b.close_all_connections()
         db_a.close_all_connections()

--- a/tldw_Server_API/tests/Sync/test_sync_v2_server_origin_batch.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_server_origin_batch.py
@@ -234,6 +234,22 @@ def test_trusted_bootstrap_id_requires_source_step_verifier(
     assert service.store.list_envelopes_after("dataset-1", 0) == []
 
 
+def test_batch_rejects_explicit_nonpositive_object_revision(
+    batch_service: tuple[SyncV2Service, _RecordingMaterializer],
+) -> None:
+    service, materializer = batch_service
+
+    with pytest.raises(SyncStoreError, match="object revision must be positive"):
+        _capture(
+            service,
+            [replace(_step("invalid-revision"), object_revision=0)],
+            key="invalid-revision",
+        )
+
+    assert materializer.calls == []
+    assert service.store.list_envelopes_after("dataset-1", 0) == []
+
+
 def test_batch_evaluates_updates_parents_and_relationships_against_planned_heads(
     batch_service: tuple[SyncV2Service, _RecordingMaterializer],
 ) -> None:


### PR DESCRIPTION
## Change summary

This PR lays the groundwork for securely syncing note tasks and task activity across SQLite and PostgreSQL. It adds tenant-scoped storage, migrations, RLS enforcement, dataset binding, readiness tracking, bootstrap/materialization, and transactional capture while keeping the new sync domains disabled from public capabilities until they are ready for activation. It also hardens catalog validation, rollback behavior, compatibility APIs, and malformed-state handling with extensive SQLite and live PostgreSQL coverage.

## Summary
- add the strict internal `notes.task` v1 adapter and canonical task materializer with exact-base conflict handling and split-commit repair
- add bounded resumable bootstrap with count/fingerprint/cursor/ack verification
- add an optional, uninjected Notes task capture seam while keeping both task domains absent from public capabilities and enrollment
- enforce owner/dataset scoping, canonical CAS row locking, and live PostgreSQL RLS/index behavior

## Verification
- `TLDW_TEST_POSTGRES_REQUIRED=1 ... pytest` planned matrix: 423 passed, 0 skipped (164 + 259 bounded runs)
- live PostgreSQL 18: two-owner create/update/tombstone/restore under `NOSUPERUSER NOBYPASSRLS`, cross-owner isolation, indexed paging
- Ruff: all planned production paths and changed tests passed
- Bandit: exit 0
- `py_compile`: exit 0
- `git diff --check`: exit 0

## Architecture
- ADR required: no; existing ADR-039 remains authoritative
- public task/task-activity capability and enrollment activation remains deferred to later child tasks

Backlog: TASK-13006.2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the dormant Sync v1 lifecycle for `notes.task` (adapter, materializer, bootstrap, optional capture) under strict exact-base rules. Previously unsupported, `notes.task` is now handled internally with owner/dataset scoping and CAS row locking, while staying out of public capabilities and enrollment.

- Adapter enforces exact-base updates, validates parent note authorization, and computes canonical object hashes; it rejects mismatched base tokens and defers on incomplete lineage.
- Materializer projects upsert/tombstone into the task store, normalizes timestamps, and surfaces product conflicts as errors without changing delivery.
- Bootstrap is bounded and resumable with count/fingerprint/cursor/ack verification and split-commit repair; DB/store accept a trusted `notes.task` bootstrap ID to bypass enrollment only for this domain.
- Server-origin batching records `client_envelope_id` and `object_revision` (must be positive) and evaluates relationships against planned heads.
- Adds `SYNC_V2_INTERNAL_OPERATIONS`; `KNOWN_SYNC_DOMAINS` includes `notes.task` and `notes.task_activity`, with capability exposure deferred per ADR-039 and TASK-13006.2.
- PostgreSQL RLS/index behavior validated; comprehensive unit and integration tests cover adapter, materializer, bootstrap, capture, and store contracts.

**Rollout**
- No user-facing changes and no migrations.
- Do not expose `notes.task` in capabilities or enrollment; follow-up enablement will track TASK-13006.2.

<sup>Written for commit f703b78cb3842f1d3051701b50dda70df9853966. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
