### PR TITLE
docs(backlog): server-offload execution seam tasks (13020-13022, tldw_chatbook ADR-077)

### DIFF
--- a/backlog/tasks/task-13020 - Automation-definition-scheduler-feed-into-the-Jobs-pipeline.md
+++ b/backlog/tasks/task-13020 - Automation-definition-scheduler-feed-into-the-Jobs-pipeline.md
@@ -1,0 +1,44 @@
+---
+id: TASK-13020
+title: 'Automation definition scheduler feed into the Jobs pipeline'
+status: To Do
+assignee: []
+created_date: '2026-08-21 14:10'
+updated_date: '2026-08-21 14:10'
+labels:
+  - scheduled-tasks
+  - automation
+  - jobs
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+First server-side piece of the server-offload execution seam, implementing the client-side contract ADR (tldw_chatbook `backlog/decisions/077-server-offloaded-scheduled-agent-tasks.md`, ACCEPTED 2026-08-21; cross-repo task tldw_chatbook TASK-18940). Today automation definitions are fully modeled, validated, redaction-policy'd, and audited (`scheduled_task_automation_service.py`), but nothing dispatches them: `DEFAULT_DEFINITION_HEALTH = "execution_unavailable"` is permanent because no scheduler feed exists. Reminders already have the exact pattern to mirror: `app/services/reminders_scheduler.py` (APScheduler, env-gated) feeds due reminders into the Jobs pipeline.
+
+Build the definition feed: an APScheduler service (env-gated, e.g. `SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED`) that loads `lifecycle="configured"` definitions from `ScheduledTasksDatabase`, computes the next occurrence from the definition's `schedule` dict (the service already validates kinds `one_time`, `interval`, `daily`, `weekly`, `cron`), and enqueues Jobs — a new domain/type pairing (e.g. domain `scheduled_tasks`, type `agent_task_run`) with payload carrying definition id + owner + the run slot. Next-run bookkeeping persists per the reminders pattern; paused/archived/disabled definitions are never armed; definition `health` transitions to `ready` when armed (and back on pause/archive), replacing the permanent `execution_unavailable` lie for server owners.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 An env-gated scheduler service arms only `configured` definitions and enqueues one Job per due occurrence with a payload carrying definition id, owner, and run slot (timestamps UTC, mirroring reminders' payload shape)
+- [ ] #2 All five validated schedule kinds compute next occurrences correctly (property/parameterized tests per kind, incl. timezone handling consistent with the reminders scheduler)
+- [ ] #3 Paused/archived/disabled definitions are never armed; resume/pause transitions re-arm/disarm without restart
+- [ ] #4 Definition `health` reflects armed reality (`ready` when armed; `execution_unavailable` only when execution genuinely cannot run), visible through the existing control-plane endpoints
+- [ ] #5 Next-run bookkeeping is durable and idempotent against duplicate scheduler passes (no double-enqueue of the same run slot)
+- [ ] #6 Tests cover arming, kind computation, lifecycle transitions, and idempotency against the real ScheduledTasksDatabase + JobManager shapes (no reimplementation)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: check — the governing contract ADR lives in the client repo (tldw_chatbook ADR-077); if this repo's conventions require a local ADR for a new execution subsystem, draft one that imports ADR-077 rather than restating it, and link it here before implementation.
+
+1. Read `reminders_scheduler.py` end-to-end; extract its env-gate/rescan/enqueue/next-run discipline as the template
+2. Definition loader: configured-lifecycle definitions + schedule-dict next-occurrence computation (five kinds)
+3. JobManager enqueue with the new domain/type + run-slot payload; durable next-run bookkeeping
+4. Health transitions (`ready`/`execution_unavailable`) wired through the existing definitions surface
+5. Tests per the AC matrix; env-gated startup registration mirroring reminders
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-13021 - Agent-task-Jobs-consumer-with-durable-runs-and-notification-pass-back.md
+++ b/backlog/tasks/task-13021 - Agent-task-Jobs-consumer-with-durable-runs-and-notification-pass-back.md
@@ -1,0 +1,50 @@
+---
+id: TASK-13021
+title: 'Agent-task Jobs consumer: durable runs, timeout status, notification pass-back'
+status: To Do
+assignee: []
+created_date: '2026-08-21 14:10'
+updated_date: '2026-08-21 14:10'
+labels:
+  - scheduled-tasks
+  - automation
+  - jobs
+  - notifications
+dependencies:
+  - task-13020
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Second server-side piece of the server-offload seam (tldw_chatbook ADR-077, accepted; cross-repo TASK-18940). The consumer that executes the Jobs the feed (TASK-13020) enqueues, mirroring `app/core/Reminders/reminder_jobs.py`: durable run rows with `run_slot_key` dedupe, terminal statuses, and delivery as user notifications.
+
+Phase-1 execution is **side-effect-free only** (ADR-077 decision 4, owner-accepted): `recurring_question` runs generate their answer via the server's LLM plumbing; `agent_task` runs execute in generation-only mode. Tool-using configurations are NOT executed in this phase — they resolve to an explicit skipped status with an actionable reason until the follow-up approval-escalation design exists. The definition's `notification_policy` governs delivery; the `metadata_only` redaction already applied to agent_task input messages is honored end-to-end; the result notification carries the definition name, outcome, a bounded result summary, and the durable run reference (full result stays server-side unless requested).
+
+Timeout semantics (ADR-077 decision 5): a run cancelled at its execution deadline records a `timed_out` run status — aligned with the client's `timed_out` vocabulary (tldw_chatbook TASK-18939) so the client displays what the server reports rather than re-deriving. Missed-fire/reconnect reconciliation is the run-slot dedupe plus the notification feed (ADR-077 decision 6): occurrences the server ran while a client was away arrive once, never re-announced.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The consumer handles `agent_task_run` Jobs with durable run rows and `run_slot_key` dedupe — a redelivered Job for an already-succeeded run slot is a recorded no-op, mirroring reminders
+- [ ] #2 Lifecycle is re-checked at execution time: paused/archived/disabled definitions skip with recorded reason, never execute
+- [ ] #3 `recurring_question` executions produce the generated answer through the server's LLM plumbing; `agent_task` executions run generation-only; tool-using configurations skip with an actionable reason (phase-1 boundary is enforced by the consumer, not assumed)
+- [ ] #4 Completed/failed/timed-out runs deliver a user notification (kind for agent-task results) carrying definition name, outcome, bounded summary, and run reference — governed by the definition's `notification_policy`; `metadata_only` redaction holds end-to-end
+- [ ] #5 A run cancelled at its deadline records `timed_out` (not failed, not skipped); the run-status vocabulary matches the client's so no translation layer is needed
+- [ ] #6 Definition health/last-run update after each execution; audit events recorded through the existing automation audit trail
+- [ ] #7 Tests cover dedupe, lifecycle skips, phase-1 boundary enforcement, notification construction (bounded + redacted), timeout status, and health/audit updates against the real DB/Jobs/notification shapes
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no (new consumer subsystem is covered by the cross-repo contract ADR — tldw_chatbook ADR-077; timeout and redaction semantics are its decisions 4/5, already owner-accepted). Link ADR-077 from the implementation notes.
+
+1. Read `core/Reminders/reminder_jobs.py` end-to-end (run rows, dedupe, skip paths, notification creation) as the template
+2. Run-row + dedupe skeleton for `agent_task_run`; lifecycle re-check
+3. Phase-1 executors: recurring_question generation; agent_task generation-only; tool-config skip enforcement
+4. Result notification construction (bounded summary, run reference, `notification_policy`, redaction)
+5. `timed_out` status at the execution-deadline seam (align with the Jobs pipeline's existing lifecycle events)
+6. Health/last-run/audit updates; test matrix per the ACs
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-13022 - Definition-run-now-endpoint-and-capabilities-honesty.md
+++ b/backlog/tasks/task-13022 - Definition-run-now-endpoint-and-capabilities-honesty.md
@@ -1,0 +1,45 @@
+---
+id: TASK-13022
+title: 'Definition run-now endpoint and capabilities honesty'
+status: To Do
+assignee: []
+created_date: '2026-08-21 14:10'
+updated_date: '2026-08-21 14:10'
+labels:
+  - scheduled-tasks
+  - automation
+  - api
+dependencies:
+  - task-13021
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Third server-side piece of the server-offload seam (tldw_chatbook ADR-077, accepted; cross-repo TASK-18940). Two surfaces close the loop with the client:
+
+**Run-now endpoint** (ADR-077 decision 7): `POST` on the definitions resource (e.g. `/scheduled-tasks/definitions/{definition_id}/run`) that enqueues an immediate execution through the same Jobs path TASK-13020/13021 use — a real dispatch with the same run-slot dedupe, NOT a bypass — for manual triggering from chatbook's Run-now action (tldw_chatbook TASK-18938 parity: until this endpoint exists, the client honestly refuses Run-now on server-scoped definitions). Honors lifecycle (paused/archived/disabled refuse with the existing error codes), idempotency key, and the control plane's permission model (`TASKS_CONTROL`).
+
+**Capabilities honesty**: the capabilities endpoint (`GET /capabilities` and per-family availability) reflects real execution availability per family — `recurring_question` executable, `agent_task` generation-only executable with tools explicitly not-yet-executable — instead of a blanket unavailable. This is what lets the client stop rendering permanent `execution_unavailable` for server owners.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `POST .../definitions/{id}/run` enqueues an immediate execution through the standard Jobs path with run-slot dedupe (a manual run colliding with a scheduled run of the same slot dedupes exactly like a redelivered Job)
+- [ ] #2 Paused/archived/disabled definitions refuse with the existing lifecycle error codes; permissions follow the control plane's `TASKS_CONTROL` model; idempotency keys behave like the other mutating definition endpoints
+- [ ] #3 The capabilities surface reports per-family execution truth: recurring_question executable; agent_task generation-only; tools not executable (with the phase-1 reason string), consistent with the consumer's enforcement
+- [ ] #4 Response shape carries the created run reference so a manual trigger can be correlated with its result notification
+- [ ] #5 Tests cover endpoint authorization, lifecycle refusals, dedupe behavior, and capability truth against the real service shapes
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no — API surface addition within the existing control plane; the contract (manual run = real dispatch, dedupe, refusal semantics) is ADR-077 decision 7, already owner-accepted.
+
+1. Endpoint + schema on the existing scheduled-tasks router group, following the pause/resume handler shapes
+2. Enqueue-through-the-standard-path implementation (no consumer bypass)
+3. Capabilities service truth update (per-family, phase-1 reason strings)
+4. Tests per the AC matrix
+<!-- SECTION:PLAN:END -->


### PR DESCRIPTION
## Summary

Files the server-side task breakdown for the server-offloaded scheduled-agent-tasks seam, implementing the client-repo contract ADR **tldw_chatbook ADR-077** (accepted 2026-08-21; cross-repo task tldw_chatbook TASK-18940):

- **TASK-13020 — definition scheduler feed into the Jobs pipeline**: mirrors `reminders_scheduler.py`'s env-gated APScheduler pattern for `configured` automation definitions; five schedule kinds; durable idempotent next-run bookkeeping; definition `health` becomes honest (`ready` when armed).
- **TASK-13021 — agent-task Jobs consumer**: mirrors `core/Reminders/reminder_jobs.py` — durable runs with run-slot dedupe, lifecycle re-check, **phase-1 side-effect-free execution only** (recurring_question generation; agent_task generation-only; tool configs skip with reason), `timed_out` run status aligned with the client's vocabulary, result notifications (bounded summary, run reference, `notification_policy`-governed, `metadata_only` redaction honored), health/audit updates.
- **TASK-13022 — run-now endpoint + capabilities honesty**: manual trigger through the standard Jobs path with the same dedupe; per-family capability truth.

Survey basis: automation surfaces on current dev are unchanged since the ADR's survey — definitions remain permanently `execution_unavailable` with nothing dispatching them; every ingredient (Jobs pipeline, control plane, audit, notifications) already exists.

Docs/backlog-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backlogs the server-offloaded scheduled-agent-tasks execution seam per tldw_chatbook ADR-077/TASK-18940 so implementation can proceed. No runtime changes; this adds three tasks with acceptance criteria and tests.

- TASK-13020 — Scheduler feed: env-gated APScheduler-style service for `configured` definitions, five schedule kinds, durable idempotent next-run bookkeeping, and `health` set to `ready` when armed.
- TASK-13021 — Jobs consumer: durable runs with run-slot dedupe and lifecycle re-check; phase-1 side-effect-free execution (`recurring_question` generation; `agent_task` generation-only); tool configs skip with reason; `timed_out` status; result notifications (bounded summary, run reference) honoring `notification_policy` and `metadata_only`; health/audit updates.
- TASK-13022 — Run-now endpoint and capabilities: `POST .../definitions/{id}/run` enqueues through the standard `Jobs` path with the same dedupe; enforces lifecycle, permissions, and idempotency; capabilities report per family (execute `recurring_question`, generation-only `agent_task`, tools not executable); response returns the run reference.
- Aligns with ADR-077 decisions 4–7 and tldw_chatbook `TASK-18938`, `TASK-18939`, `TASK-18940`.
- Docs/backlog only; no runtime behavior change.

<sup>Written for commit f04de820cf7e339265fd45daa12d2b0b7178e8e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

