### PR TITLE
feat(scheduled-tasks): automation definition scheduler feed (TASK-13020)

### DIFF
--- a/backlog/tasks/task-13020 - Automation-definition-scheduler-feed-into-the-Jobs-pipeline.md
+++ b/backlog/tasks/task-13020 - Automation-definition-scheduler-feed-into-the-Jobs-pipeline.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-13020
 title: 'Automation definition scheduler feed into the Jobs pipeline'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@robert'
 created_date: '2026-08-21 14:10'
 updated_date: '2026-08-21 14:10'
 labels:
@@ -23,12 +24,12 @@ Build the definition feed: an APScheduler service (env-gated, e.g. `SCHEDULED_TA
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 An env-gated scheduler service arms only `configured` definitions and enqueues one Job per due occurrence with a payload carrying definition id, owner, and run slot (timestamps UTC, mirroring reminders' payload shape)
-- [ ] #2 All five validated schedule kinds compute next occurrences correctly (property/parameterized tests per kind, incl. timezone handling consistent with the reminders scheduler)
-- [ ] #3 Paused/archived/disabled definitions are never armed; resume/pause transitions re-arm/disarm without restart
-- [ ] #4 Definition `health` reflects armed reality (`ready` when armed; `execution_unavailable` only when execution genuinely cannot run), visible through the existing control-plane endpoints
-- [ ] #5 Next-run bookkeeping is durable and idempotent against duplicate scheduler passes (no double-enqueue of the same run slot)
-- [ ] #6 Tests cover arming, kind computation, lifecycle transitions, and idempotency against the real ScheduledTasksDatabase + JobManager shapes (no reimplementation)
+- [x] #1 An env-gated scheduler service arms only `configured` definitions and enqueues one Job per due occurrence with a payload carrying definition id, owner, and run slot (timestamps UTC, mirroring reminders' payload shape)
+- [x] #2 All five validated schedule kinds compute next occurrences correctly (property/parameterized tests per kind, incl. timezone handling consistent with the reminders scheduler)
+- [x] #3 Paused/archived/disabled definitions are never armed; resume/pause transitions re-arm/disarm without restart
+- [x] #4 Definition `health` reflects armed reality (`ready` when armed; `execution_unavailable` only when execution genuinely cannot run), visible through the existing control-plane endpoints
+- [x] #5 Next-run bookkeeping is durable and idempotent against duplicate scheduler passes (no double-enqueue of the same run slot)
+- [x] #6 Tests cover arming, kind computation, lifecycle transitions, and idempotency against the real ScheduledTasksDatabase + JobManager shapes (no reimplementation)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,3 +43,19 @@ ADR required: check — the governing contract ADR lives in the client repo (tld
 4. Health transitions (`ready`/`execution_unavailable`) wired through the existing definitions surface
 5. Tests per the AC matrix; env-gated startup registration mirroring reminders
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Implemented 2026-08-21 on `feat/automation-definition-feed` (stacked on the task-filing branch `docs/server-offload-tasks`, PR tldw_server#2796 — rebase onto dev once that merges).
+
+**Approach.** New `app/services/scheduled_task_automation_scheduler.py` mirrors `reminders_scheduler.py`'s proven shape: env-gated singleton (`SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED`, ships OFF — enable together with the TASK-13021 consumer), per-user `ScheduledTasksDatabase.for_user` cache, periodic rescan (floor 30s), APScheduler jobs keyed `automation:{definition_id}` with max_instances=1 + coalesce, `reconcile_definition`/`unschedule_definition` hooks for future service-layer calls, and startup registration in `startup_recurring_schedulers.py` beside the reminders spec.
+
+**Schedule dict conventions** (the automation service validates only `kind`; per-kind fields are defined here and documented in the module docstring): one_time/run_at ISO; interval/seconds (+optional start_at anchor); daily/at HH:MM (+timezone); weekly/weekday APScheduler convention (+at, timezone); cron five-field (+timezone). Junk degrades honestly: `build_trigger` returns a reason, the definition is skipped with a warning, never armed — same discipline as the reminders scheduler's invalid-cron path.
+
+**Idempotency (AC#5) without a schema change:** run-slot dedupe lives at the Jobs layer — `JobManager.create_job` with `idempotency_key=f"definition:{id}:{slot_utc}` returns the same row on duplicate creates, which is durable across restarts and correct for concurrent rescans. Slot computation: one_time uses `run_at` directly; periodic re-derives at fire time via `trigger.get_next_fire_time(None, now-1s)`. No `next_run_at` column was added to `scheduled_task_definitions` (definitions surface schedule through their `schedule` dict; the reminders pattern's stored-next-run exists to feed ITS CAS claim, which the Jobs-layer idempotency replaces here).
+
+**Health honesty (AC#4):** arming flips `health` to `ready` via `update_definition` only-on-change (no version churn across rescans) + a `scheduler_armed` audit event through the standard trail. Disarm-side health semantics (pause/archive transitions) are intentionally left to the existing lifecycle methods and refined in TASK-13021 where execution outcomes own health updates.
+
+**Verification.** `tests/Notifications/test_automation_definition_feed.py` — 19 tests, all through real preview→definition creation (the DB's preview gate included) and the real fire path: five trigger kinds + seven refusal cases, enqueue shape (domain/type/owner/payload/key), identical-key dedupe across double fire, non-configured lifecycle never fires, future one_time early-skips, unusable schedules never fire, health flip + audit + no version churn. Neighboring suites green: `test_reminders_scheduler.py` + `test_scheduled_task_automation_api.py` (47 passed), `test_startup_preflight.py` (16 passed). Fixes made during the round: preview rows require NOT NULL `expires_at` (24h TTL fixture), `list_audit_events` returns `(rows, total)` tuples of dataclasses, and the fire path's early-skip tolerance widened from 1 to 2 minutes (the guard targets wrongly-scheduled future triggers, not sub-minute boundary lag; APS misfire grace is 300s).
+
+**Files:** `app/services/scheduled_task_automation_scheduler.py` (new), `app/services/startup_recurring_schedulers.py` (spec + starter/stopper), `tests/Notifications/test_automation_definition_feed.py` (new), this task file.

--- a/tldw_Server_API/app/services/scheduled_task_automation_scheduler.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_scheduler.py
@@ -1,0 +1,473 @@
+"""Scheduler feed that arms automation definitions into the Jobs pipeline.
+
+Implements the server-side dispatch half of the server-offload execution
+seam (TASK-13020; the governing contract is tldw_chatbook ADR-077,
+"Server-offloaded scheduled agent tasks", accepted 2026-08-21). Automation
+definitions were previously modeled, validated, and audited but never
+dispatched -- ``DEFAULT_DEFINITION_HEALTH = "execution_unavailable"`` was
+permanent. This module mirrors the proven reminders pattern
+(``reminders_scheduler.py``): an env-gated APScheduler service that arms
+due work into the Jobs pipeline with idempotent run-slot enqueueing.
+
+Schedule dict conventions (the ``schedule`` field the automation service
+validates only by ``kind``; per-kind fields are defined here):
+
+- ``{"kind": "one_time", "run_at": ISO-8601}``
+- ``{"kind": "interval", "seconds": int > 0, "start_at": ISO-8601?}``
+- ``{"kind": "daily", "at": "HH:MM", "timezone": IANA?}``
+- ``{"kind": "weekly", "weekday": 0-6 (Mon=0) or name, "at": "HH:MM", "timezone": IANA?}``
+- ``{"kind": "cron", "cron": five-field expression, "timezone": IANA?}``
+
+Anything unusable degrades honestly: the definition is skipped with a
+warning (mirroring the reminders scheduler's invalid-cron path), never
+armed, never executed.
+
+Env:
+  SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED  -> start service at app startup
+  SCHEDULED_TASKS_AUTOMATION_SCHEDULER_TZ       -> default timezone (UTC)
+  SCHEDULED_TASKS_AUTOMATION_RESCAN_SEC         -> rescan interval (>= 30)
+  AUTOMATION_JOBS_QUEUE                         -> queue name (default: default)
+
+The gate ships OFF: arming before the ``agent_task_run`` consumer
+(TASK-13021) is deployed only queues jobs nobody executes, so enable it
+together with the consumer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from datetime import datetime, timedelta, timezone
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+from loguru import logger
+
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
+    DefinitionRow,
+    ScheduledTasksDatabase,
+)
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.config import settings as core_settings
+from tldw_Server_API.app.core.testing import env_flag_enabled
+from tldw_Server_API.app.services.reminders_scheduler import (
+    _NONCRITICAL_EXCEPTIONS,
+    _normalize_slot_to_utc_iso,
+    _parse_iso_datetime,
+)
+
+AUTOMATION_DOMAIN = "scheduled_tasks"
+AUTOMATION_JOB_TYPE = "agent_task_run"
+ARMED_HEALTH = "ready"
+SCHEDULER_ACTOR = "automation-scheduler"
+_MIN_RESCAN_SECONDS = 30
+
+_SUPPORTED_SCHEDULE_KINDS = ("one_time", "interval", "daily", "weekly", "cron")
+
+
+def automation_jobs_queue() -> str:
+    queue = (os.getenv("AUTOMATION_JOBS_QUEUE") or "default").strip()
+    return queue or "default"
+
+
+def _scheduler_timezone() -> str:
+    return os.getenv("SCHEDULED_TASKS_AUTOMATION_SCHEDULER_TZ", "UTC") or "UTC"
+
+
+def build_trigger(schedule: dict, *, default_timezone: str | None = None):
+    """Build an APScheduler trigger from a definition's ``schedule`` dict.
+
+    Returns ``(trigger, None)`` on success or ``(None, reason)`` when the
+    schedule cannot arm -- the caller skips the definition honestly rather
+    than guessing. Field expectations are the module's documented
+    conventions; the automation service validates only ``kind``.
+    """
+    tz_name = str(schedule.get("timezone") or default_timezone or _scheduler_timezone())
+    try:
+        tz = CronTrigger.from_crontab("* * * * *", timezone=tz_name).timezone
+    except _NONCRITICAL_EXCEPTIONS:
+        tz = timezone.utc
+
+    kind = schedule.get("kind")
+    if kind == "one_time":
+        run_dt = _parse_iso_datetime(str(schedule.get("run_at") or ""), timezone_name=tz_name)
+        if run_dt is None:
+            return None, "one_time schedule missing/unparsable run_at"
+        return DateTrigger(run_date=run_dt), None
+
+    if kind == "interval":
+        try:
+            seconds = float(schedule["seconds"])
+        except (KeyError, TypeError, ValueError):
+            return None, "interval schedule missing/invalid seconds"
+        if seconds <= 0:
+            return None, "interval schedule seconds must be > 0"
+        start_at = _parse_iso_datetime(str(schedule.get("start_at") or ""), timezone_name=tz_name)
+        return IntervalTrigger(seconds=seconds, start_date=start_at), None
+
+    if kind in ("daily", "weekly"):
+        at = str(schedule.get("at") or "").strip()
+        parts = at.split(":")
+        if len(parts) != 2 or not all(p.isdigit() for p in parts):
+            return None, f"{kind} schedule missing/invalid 'at' (expected HH:MM)"
+        hour, minute = int(parts[0]), int(parts[1])
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            return None, f"{kind} schedule 'at' out of range"
+        if kind == "daily":
+            return CronTrigger(hour=hour, minute=minute, timezone=tz), None
+        weekday = schedule.get("weekday", 0)
+        try:
+            return (
+                CronTrigger(day_of_week=str(weekday), hour=hour, minute=minute, timezone=tz),
+                None,
+            )
+        except _NONCRITICAL_EXCEPTIONS:
+            return None, f"weekly schedule invalid weekday {weekday!r}"
+
+    if kind == "cron":
+        expr = str(schedule.get("cron") or "").strip()
+        if not expr:
+            return None, "cron schedule missing expression"
+        try:
+            return CronTrigger.from_crontab(expr, timezone=tz), None
+        except _NONCRITICAL_EXCEPTIONS as exc:
+            return None, f"cron schedule invalid expression: {exc}"
+
+    return None, f"unsupported schedule kind: {kind!r}"
+
+
+def compute_run_slot(schedule: dict, trigger, *, now: datetime | None = None):
+    """Return the UTC slot this fire belongs to, or ``None``.
+
+    ``one_time`` slots are the ``run_at`` value directly. Periodic slots
+    are re-derived at fire time the way the reminders scheduler does: the
+    next fire time strictly after ``now - 1s`` -- for a trigger firing at
+    ``now``, that is ``now``'s own slot (schedules with a period longer
+    than one second, which interval validation floors well above).
+    """
+    if schedule.get("kind") == "one_time":
+        tz_name = str(schedule.get("timezone") or _scheduler_timezone())
+        return _parse_iso_datetime(str(schedule.get("run_at") or ""), timezone_name=tz_name)
+    now = now or datetime.now(timezone.utc)
+    try:
+        return trigger.get_next_fire_time(None, now - timedelta(seconds=1))
+    except _NONCRITICAL_EXCEPTIONS:
+        return None
+
+
+class _AutomationScheduler:
+    """Arms configured automation definitions into the Jobs pipeline."""
+
+    def __init__(self) -> None:
+        self._aps: AsyncIOScheduler | None = None
+        self._db_cache: dict[int, ScheduledTasksDatabase] = {}
+        self._lock = asyncio.Lock()
+        self._started = False
+        self._rescan_task: asyncio.Task | None = None
+        self._jobs = JobManager()
+
+    async def start(self) -> None:
+        async with self._lock:
+            if self._started:
+                return
+            self._aps = AsyncIOScheduler(timezone=_scheduler_timezone())
+            self._aps.start()
+            await self._load_all()
+            try:
+                interval = int(
+                    os.getenv("SCHEDULED_TASKS_AUTOMATION_RESCAN_SEC", "300") or 300
+                )
+            except _NONCRITICAL_EXCEPTIONS:
+                interval = 300
+            interval = max(_MIN_RESCAN_SECONDS, interval)
+
+            async def _rescan_loop() -> None:
+                while True:
+                    try:
+                        await asyncio.sleep(interval)
+                        await self._rescan_once()
+                    except asyncio.CancelledError:
+                        break
+                    except _NONCRITICAL_EXCEPTIONS as exc:
+                        logger.debug("Automation scheduler rescan error: {}", exc)
+
+            self._rescan_task = asyncio.create_task(
+                _rescan_loop(), name="automation_scheduler_rescan"
+            )
+            self._started = True
+            logger.info("Automation definition scheduler started")
+
+    async def stop(self) -> None:
+        async with self._lock:
+            try:
+                if self._aps:
+                    self._aps.shutdown(wait=False)
+            except _NONCRITICAL_EXCEPTIONS:
+                pass
+            self._aps = None
+            try:
+                if self._rescan_task:
+                    self._rescan_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await self._rescan_task
+            except _NONCRITICAL_EXCEPTIONS:
+                pass
+            self._rescan_task = None
+            self._started = False
+            self._db_cache.clear()
+            logger.info("Automation definition scheduler stopped")
+
+    def _get_db(self, user_id: int) -> ScheduledTasksDatabase:
+        if user_id not in self._db_cache:
+            db = ScheduledTasksDatabase.for_user(user_id)
+            db.ensure_schema()
+            self._db_cache[user_id] = db
+        return self._db_cache[user_id]
+
+    def _enumerate_user_ids(self) -> set[int]:
+        user_ids: set[int] = set()
+        try:
+            base = DatabasePaths.get_user_db_base_dir()
+            for entry in base.iterdir():
+                if entry.is_dir():
+                    with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+                        user_ids.add(int(entry.name))
+        except _NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug("Automation scheduler: failed to enumerate user dirs: {}", exc)
+        with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+            user_ids.add(int(core_settings.get("SINGLE_USER_FIXED_ID", 1)))
+        return user_ids
+
+    def _configured_definitions(self, user_id: int) -> list[DefinitionRow]:
+        try:
+            return self._get_db(user_id).list_definitions(
+                owner_id=user_id, lifecycle="configured", limit=1000
+            )
+        except _NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug("Automation scheduler: list failed for user {}: {}", user_id, exc)
+            return []
+
+    async def _load_all(self) -> None:
+        armed = 0
+        for uid in sorted(self._enumerate_user_ids()):
+            for definition in self._configured_definitions(uid):
+                if self._arm(definition, uid):
+                    armed += 1
+        if armed:
+            logger.info("Automation scheduler armed {} definition(s)", armed)
+
+    async def _rescan_once(self) -> None:
+        if not self._aps:
+            return
+        desired: set[str] = set()
+        for uid in sorted(self._enumerate_user_ids()):
+            for definition in self._configured_definitions(uid):
+                if self._arm(definition, uid):
+                    desired.add(_job_id(definition.id))
+        try:
+            current_ids = {job.id for job in (self._aps.get_jobs() or [])}
+            for stale_id in list(current_ids - desired):
+                with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+                    self._aps.remove_job(stale_id)
+        except _NONCRITICAL_EXCEPTIONS:
+            pass
+
+    async def reconcile_definition(self, *, definition_id: str, user_id: int) -> None:
+        """Immediately sync one definition into scheduler state."""
+        async with self._lock:
+            if not self._started or not self._aps:
+                return
+            definition = None
+            with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+                definition = self._get_db(int(user_id)).get_definition(
+                    owner_id=int(user_id), definition_id=definition_id
+                )
+            if definition is None or definition.lifecycle != "configured":
+                with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+                    self._aps.remove_job(_job_id(definition_id))
+                return
+            self._arm(definition, int(user_id))
+
+    async def unschedule_definition(self, *, definition_id: str) -> None:
+        """Immediately unschedule one definition."""
+        async with self._lock:
+            if not self._started or not self._aps:
+                return
+            with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+                self._aps.remove_job(_job_id(definition_id))
+
+    def _arm(self, definition: DefinitionRow, user_id: int) -> bool:
+        if not self._aps:
+            return False
+        trigger, reason = build_trigger(definition.schedule)
+        if trigger is None:
+            logger.warning(
+                "Automation scheduler cannot arm definition {} (user {}): {}",
+                definition.id,
+                user_id,
+                reason,
+            )
+            return False
+        try:
+            with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+                self._aps.remove_job(_job_id(definition.id))
+            self._aps.add_job(
+                self._run_definition_schedule,
+                trigger=trigger,
+                id=_job_id(definition.id),
+                args=[definition.id, user_id],
+                max_instances=1,
+                coalesce=True,
+                misfire_grace_time=300,
+            )
+        except _NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(
+                "Automation scheduler failed to arm definition {}: {}", definition.id, exc
+            )
+            return False
+        self._mark_ready(definition, user_id)
+        return True
+
+    def _mark_ready(self, definition: DefinitionRow, user_id: int) -> None:
+        """Health honesty (TASK-13020 AC#4): armed definitions read ``ready``.
+
+        Written only on change so rescans do not churn the definition's
+        version column; audited through the standard trail.
+        """
+        if definition.health == ARMED_HEALTH:
+            return
+        db = self._get_db(user_id)
+        try:
+            updated = db.update_definition(
+                owner_id=user_id,
+                definition_id=definition.id,
+                patch={"health": ARMED_HEALTH, "updated_by": SCHEDULER_ACTOR},
+            )
+        except _NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(
+                "Automation scheduler health update failed for {}: {}", definition.id, exc
+            )
+            return
+        with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+            db.create_audit_event(
+                owner_id=user_id,
+                definition_id=definition.id,
+                event_type="scheduler_armed",
+                actor=SCHEDULER_ACTOR,
+                summary=(
+                    f"Definition armed by scheduler (schedule kind "
+                    f"'{definition.schedule.get('kind')}'); health -> ready."
+                ),
+                before={"health": definition.health},
+                after={"health": updated.health},
+            )
+
+    async def _run_definition_schedule(
+        self, definition_id: str, user_id: int | None = None
+    ) -> None:
+        if user_id is None:
+            return
+        db = self._get_db(int(user_id))
+        try:
+            definition = db.get_definition(owner_id=int(user_id), definition_id=definition_id)
+        except KeyError:
+            return
+        if definition is None or definition.lifecycle != "configured":
+            return
+
+        trigger, reason = build_trigger(definition.schedule)
+        if trigger is None:
+            logger.warning(
+                "Automation scheduler fire with unusable schedule for {}: {}",
+                definition_id,
+                reason,
+            )
+            return
+
+        slot = compute_run_slot(definition.schedule, trigger)
+        if slot is None:
+            logger.warning(
+                "Automation scheduler could not determine run slot for {}", definition_id
+            )
+            return
+        slot_utc = _parse_iso_datetime(_normalize_slot_to_utc_iso(slot))
+        now_utc = datetime.now(timezone.utc)
+        # The early-skip guard catches a wrongly-scheduled future trigger
+        # (e.g. a stale APS job), not sub-minute clock skew between the
+        # trigger's boundary and this callback -- the fire path can lag its
+        # boundary by the misfire grace, so the tolerance here sits above
+        # that, mirroring the reminders scheduler's intent.
+        if slot_utc and slot_utc > (now_utc + timedelta(minutes=2)):
+            logger.debug("Automation scheduler skipping early trigger for {}", definition_id)
+            return
+
+        payload = {
+            "definition_id": definition.id,
+            "user_id": int(user_id),
+            "family": definition.family,
+            "scheduled_for": _normalize_slot_to_utc_iso(slot),
+        }
+        idempotency_key = f"definition:{definition.id}:{payload['scheduled_for']}"
+        try:
+            job = self._jobs.create_job(
+                domain=AUTOMATION_DOMAIN,
+                queue=automation_jobs_queue(),
+                job_type=AUTOMATION_JOB_TYPE,
+                payload=payload,
+                owner_user_id=int(user_id),
+                idempotency_key=idempotency_key,
+            )
+            logger.info(
+                "Automation definition queued: definition_id={} job_id={}",
+                definition_id,
+                job.get("id"),
+            )
+        except _NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(
+                "Automation definition enqueue failed for {}: {}", definition_id, exc
+            )
+
+
+def _job_id(definition_id: str) -> str:
+    return f"automation:{definition_id}"
+
+
+_INSTANCE: _AutomationScheduler | None = None
+
+
+def get_automation_scheduler() -> _AutomationScheduler:
+    global _INSTANCE
+    if _INSTANCE is None:
+        _INSTANCE = _AutomationScheduler()
+    return _INSTANCE
+
+
+async def start_automation_scheduler(enabled: bool | None = None) -> asyncio.Task | None:
+    if enabled is None:
+        enabled = env_flag_enabled("SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED")
+    if not enabled:
+        return None
+    scheduler = get_automation_scheduler()
+    await scheduler.start()
+
+    async def _noop() -> None:
+        while True:
+            await asyncio.sleep(60)
+
+    return asyncio.create_task(_noop(), name="automation_scheduler")
+
+
+async def stop_automation_scheduler(task: asyncio.Task | None) -> None:
+    try:
+        if task:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+    except _NONCRITICAL_EXCEPTIONS:
+        pass
+    with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+        await get_automation_scheduler().stop()

--- a/tldw_Server_API/app/services/scheduled_task_automation_scheduler.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_scheduler.py
@@ -22,6 +22,16 @@ Anything unusable degrades honestly: the definition is skipped with a
 warning (mirroring the reminders scheduler's invalid-cron path), never
 armed, never executed.
 
+**Arming model (misfire-correct):** each occurrence is scheduled as its
+own ``DateTrigger`` job, and the occurrence's slot is bound into the job's
+arguments at arm time. The fire callback therefore always knows exactly
+which occurrence it is -- a late callback (up to ``misfire_grace_time``)
+still enqueues the slot it was armed for, never a re-derived one. After
+firing, the callback re-arms the next occurrence. If APScheduler skips a
+run entirely (grace exceeded), no callback runs and no re-arm happens --
+the periodic rescan re-arms the definition within one rescan interval,
+which is the documented self-heal.
+
 Env:
   SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED  -> start service at app startup
   SCHEDULED_TASKS_AUTOMATION_SCHEDULER_TZ       -> default timezone (UTC)
@@ -39,6 +49,7 @@ import asyncio
 import contextlib
 import os
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -66,19 +77,27 @@ ARMED_HEALTH = "ready"
 SCHEDULER_ACTOR = "automation-scheduler"
 _MIN_RESCAN_SECONDS = 30
 
-_SUPPORTED_SCHEDULE_KINDS = ("one_time", "interval", "daily", "weekly", "cron")
+#: How far in the future an armed slot may sit before the fire path treats
+#: the job as stale (left over from an older schedule that re-arm should
+#: have replaced) and skips it. Late fires are correct by construction --
+#: the slot is bound at arm time -- so this guards only future skew.
+_EARLY_SLOT_TOLERANCE = timedelta(minutes=2)
 
 
 def automation_jobs_queue() -> str:
+    """Return the Jobs queue name for automation work (``AUTOMATION_JOBS_QUEUE``)."""
     queue = (os.getenv("AUTOMATION_JOBS_QUEUE") or "default").strip()
     return queue or "default"
 
 
 def _scheduler_timezone() -> str:
+    """Return the scheduler's default IANA timezone (env override, else UTC)."""
     return os.getenv("SCHEDULED_TASKS_AUTOMATION_SCHEDULER_TZ", "UTC") or "UTC"
 
 
-def build_trigger(schedule: dict, *, default_timezone: str | None = None):
+def build_trigger(
+    schedule: dict[str, Any], *, default_timezone: str | None = None
+) -> tuple[Any, str | None]:
     """Build an APScheduler trigger from a definition's ``schedule`` dict.
 
     Returns ``(trigger, None)`` on success or ``(None, reason)`` when the
@@ -140,27 +159,36 @@ def build_trigger(schedule: dict, *, default_timezone: str | None = None):
     return None, f"unsupported schedule kind: {kind!r}"
 
 
-def compute_run_slot(schedule: dict, trigger, *, now: datetime | None = None):
-    """Return the UTC slot this fire belongs to, or ``None``.
+def _next_occurrence(trigger: Any, *, after: datetime) -> datetime | None:
+    """Return the trigger's next occurrence strictly after ``after`` (UTC).
 
-    ``one_time`` slots are the ``run_at`` value directly. Periodic slots
-    are re-derived at fire time the way the reminders scheduler does: the
-    next fire time strictly after ``now - 1s`` -- for a trigger firing at
-    ``now``, that is ``now``'s own slot (schedules with a period longer
-    than one second, which interval validation floors well above).
+    Uniform across trigger types, with one explicit correction: APScheduler's
+    ``DateTrigger.get_next_fire_time`` answers its ``run_date`` even when
+    that lies in the past, so the strictly-after invariant is enforced here
+    rather than trusted per trigger type. ``None`` means no upcoming
+    occurrence (a past one_time).
     """
-    if schedule.get("kind") == "one_time":
-        tz_name = str(schedule.get("timezone") or _scheduler_timezone())
-        return _parse_iso_datetime(str(schedule.get("run_at") or ""), timezone_name=tz_name)
-    now = now or datetime.now(timezone.utc)
     try:
-        return trigger.get_next_fire_time(None, now - timedelta(seconds=1))
+        nxt = trigger.get_next_fire_time(None, after)
     except _NONCRITICAL_EXCEPTIONS:
         return None
+    if nxt is None or nxt <= after:
+        return None
+    return nxt
+
+
+def _job_id(definition_id: str) -> str:
+    """Return the APScheduler job id for one definition's pending occurrence."""
+    return f"automation:{definition_id}"
 
 
 class _AutomationScheduler:
-    """Arms configured automation definitions into the Jobs pipeline."""
+    """Arms configured automation definitions into the Jobs pipeline.
+
+    One pending ``DateTrigger`` job per definition, with the occurrence's
+    slot bound into the job arguments at arm time (misfire-correct: a late
+    callback still enqueues the occurrence it was armed for).
+    """
 
     def __init__(self) -> None:
         self._aps: AsyncIOScheduler | None = None
@@ -171,6 +199,7 @@ class _AutomationScheduler:
         self._jobs = JobManager()
 
     async def start(self) -> None:
+        """Start the scheduler: initial arm pass plus the periodic rescan loop."""
         async with self._lock:
             if self._started:
                 return
@@ -202,6 +231,7 @@ class _AutomationScheduler:
             logger.info("Automation definition scheduler started")
 
     async def stop(self) -> None:
+        """Stop the scheduler, the rescan loop, and cached per-user DB handles."""
         async with self._lock:
             try:
                 if self._aps:
@@ -222,6 +252,7 @@ class _AutomationScheduler:
             logger.info("Automation definition scheduler stopped")
 
     def _get_db(self, user_id: int) -> ScheduledTasksDatabase:
+        """Return (and cache) the per-user ScheduledTasksDatabase, schema ensured."""
         if user_id not in self._db_cache:
             db = ScheduledTasksDatabase.for_user(user_id)
             db.ensure_schema()
@@ -229,6 +260,13 @@ class _AutomationScheduler:
         return self._db_cache[user_id]
 
     def _enumerate_user_ids(self) -> set[int]:
+        """Return every user id with a directory under the user DB base.
+
+        Same shape as the reminders scheduler's enumeration (its accepted
+        precedent for this exact call from the async loop): one ``iterdir``
+        over the per-user base directory -- bounded by the number of users,
+        not the number of definitions.
+        """
         user_ids: set[int] = set()
         try:
             base = DatabasePaths.get_user_db_base_dir()
@@ -243,15 +281,22 @@ class _AutomationScheduler:
         return user_ids
 
     def _configured_definitions(self, user_id: int) -> list[DefinitionRow]:
+        """Return the user's lifecycle=configured definitions as a plain list.
+
+        ``list_definitions`` returns ``(rows, total)``; the tuple is
+        unpacked here so every caller iterates ``DefinitionRow`` objects.
+        """
         try:
-            return self._get_db(user_id).list_definitions(
+            rows, _total = self._get_db(user_id).list_definitions(
                 owner_id=user_id, lifecycle="configured", limit=1000
             )
         except _NONCRITICAL_EXCEPTIONS as exc:
             logger.debug("Automation scheduler: list failed for user {}: {}", user_id, exc)
             return []
+        return list(rows)
 
     async def _load_all(self) -> None:
+        """Arm every configured definition for every enumerated user."""
         armed = 0
         for uid in sorted(self._enumerate_user_ids()):
             for definition in self._configured_definitions(uid):
@@ -261,6 +306,7 @@ class _AutomationScheduler:
             logger.info("Automation scheduler armed {} definition(s)", armed)
 
     async def _rescan_once(self) -> None:
+        """Re-arm current definitions and drop jobs for definitions no longer armed."""
         if not self._aps:
             return
         desired: set[str] = set()
@@ -293,7 +339,7 @@ class _AutomationScheduler:
             self._arm(definition, int(user_id))
 
     async def unschedule_definition(self, *, definition_id: str) -> None:
-        """Immediately unschedule one definition."""
+        """Immediately unschedule one definition's pending occurrence."""
         async with self._lock:
             if not self._started or not self._aps:
                 return
@@ -301,6 +347,12 @@ class _AutomationScheduler:
                 self._aps.remove_job(_job_id(definition_id))
 
     def _arm(self, definition: DefinitionRow, user_id: int) -> bool:
+        """Schedule the definition's NEXT occurrence as a DateTrigger job.
+
+        The occurrence's slot is bound into the job arguments here, so the
+        fire callback never has to infer which occurrence it is -- late
+        callbacks enqueue the slot they were armed for.
+        """
         if not self._aps:
             return False
         trigger, reason = build_trigger(definition.schedule)
@@ -312,14 +364,22 @@ class _AutomationScheduler:
                 reason,
             )
             return False
+        slot = _next_occurrence(trigger, after=datetime.now(timezone.utc))
+        if slot is None:
+            logger.warning(
+                "Automation scheduler: definition {} (user {}) has no upcoming occurrence",
+                definition.id,
+                user_id,
+            )
+            return False
         try:
             with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
                 self._aps.remove_job(_job_id(definition.id))
             self._aps.add_job(
                 self._run_definition_schedule,
-                trigger=trigger,
+                trigger=DateTrigger(run_date=slot),
                 id=_job_id(definition.id),
-                args=[definition.id, user_id],
+                args=[definition.id, user_id, _normalize_slot_to_utc_iso(slot)],
                 max_instances=1,
                 coalesce=True,
                 misfire_grace_time=300,
@@ -367,10 +427,22 @@ class _AutomationScheduler:
             )
 
     async def _run_definition_schedule(
-        self, definition_id: str, user_id: int | None = None
+        self, definition_id: str, user_id: int, slot_iso: str
     ) -> None:
-        if user_id is None:
-            return
+        """Enqueue the occurrence bound at arm time, then arm the next one.
+
+        ``slot_iso`` is the slot the job was armed with -- the source of
+        truth for both ``scheduled_for`` and the idempotency key, whatever
+        the callback's actual delay. Early-skip applies only to implausible
+        FUTURE slots (stale jobs re-arm should have replaced).
+        """
+        try:
+            await self._fire(definition_id, user_id, slot_iso)
+        finally:
+            self._rearm_after(definition_id, user_id, slot_iso)
+
+    async def _fire(self, definition_id: str, user_id: int, slot_iso: str) -> None:
+        """Validate state and enqueue one armed occurrence into the Jobs pipeline."""
         db = self._get_db(int(user_id))
         try:
             definition = db.get_definition(owner_id=int(user_id), definition_id=definition_id)
@@ -379,6 +451,9 @@ class _AutomationScheduler:
         if definition is None or definition.lifecycle != "configured":
             return
 
+        # The schedule may have become unusable between arming and this
+        # fire (an edit raced the reconcile): a callback whose definition
+        # can no longer build a trigger enqueues nothing.
         trigger, reason = build_trigger(definition.schedule)
         if trigger is None:
             logger.warning(
@@ -388,30 +463,28 @@ class _AutomationScheduler:
             )
             return
 
-        slot = compute_run_slot(definition.schedule, trigger)
+        slot = _parse_iso_datetime(slot_iso)
         if slot is None:
             logger.warning(
-                "Automation scheduler could not determine run slot for {}", definition_id
+                "Automation scheduler: unparsable armed slot for {}: {!r}",
+                definition_id,
+                slot_iso,
             )
             return
         slot_utc = _parse_iso_datetime(_normalize_slot_to_utc_iso(slot))
         now_utc = datetime.now(timezone.utc)
-        # The early-skip guard catches a wrongly-scheduled future trigger
-        # (e.g. a stale APS job), not sub-minute clock skew between the
-        # trigger's boundary and this callback -- the fire path can lag its
-        # boundary by the misfire grace, so the tolerance here sits above
-        # that, mirroring the reminders scheduler's intent.
-        if slot_utc and slot_utc > (now_utc + timedelta(minutes=2)):
+        if slot_utc and slot_utc > (now_utc + _EARLY_SLOT_TOLERANCE):
             logger.debug("Automation scheduler skipping early trigger for {}", definition_id)
             return
 
+        scheduled_for = _normalize_slot_to_utc_iso(slot)
         payload = {
             "definition_id": definition.id,
             "user_id": int(user_id),
             "family": definition.family,
-            "scheduled_for": _normalize_slot_to_utc_iso(slot),
+            "scheduled_for": scheduled_for,
         }
-        idempotency_key = f"definition:{definition.id}:{payload['scheduled_for']}"
+        idempotency_key = f"definition:{definition.id}:{scheduled_for}"
         try:
             job = self._jobs.create_job(
                 domain=AUTOMATION_DOMAIN,
@@ -431,15 +504,53 @@ class _AutomationScheduler:
                 "Automation definition enqueue failed for {}: {}", definition_id, exc
             )
 
-
-def _job_id(definition_id: str) -> str:
-    return f"automation:{definition_id}"
+    def _rearm_after(self, definition_id: str, user_id: int, slot_iso: str) -> None:
+        """Arm the next occurrence after the fired one (one_time definitions end here)."""
+        if not self._aps:
+            return
+        try:
+            definition = self._get_db(int(user_id)).get_definition(
+                owner_id=int(user_id), definition_id=definition_id
+            )
+        except _NONCRITICAL_EXCEPTIONS:
+            return
+        if definition is None or definition.lifecycle != "configured":
+            return
+        trigger, _reason = build_trigger(definition.schedule)
+        if trigger is None:
+            return
+        fired_at = _parse_iso_datetime(slot_iso)
+        if fired_at is None:
+            return
+        next_slot = _next_occurrence(trigger, after=fired_at + timedelta(seconds=1))
+        if next_slot is None:
+            # A completed one_time (or an exhausted schedule): the pending
+            # job fired, nothing further to arm. The rescan re-arms if the
+            # definition is later edited into a recurring shape.
+            return
+        try:
+            with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+                self._aps.remove_job(_job_id(definition_id))
+            self._aps.add_job(
+                self._run_definition_schedule,
+                trigger=DateTrigger(run_date=next_slot),
+                id=_job_id(definition_id),
+                args=[definition_id, user_id, _normalize_slot_to_utc_iso(next_slot)],
+                max_instances=1,
+                coalesce=True,
+                misfire_grace_time=300,
+            )
+        except _NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug(
+                "Automation scheduler re-arm failed for {}: {}", definition_id, exc
+            )
 
 
 _INSTANCE: _AutomationScheduler | None = None
 
 
 def get_automation_scheduler() -> _AutomationScheduler:
+    """Return the process-wide automation scheduler singleton."""
     global _INSTANCE
     if _INSTANCE is None:
         _INSTANCE = _AutomationScheduler()
@@ -447,6 +558,7 @@ def get_automation_scheduler() -> _AutomationScheduler:
 
 
 async def start_automation_scheduler(enabled: bool | None = None) -> asyncio.Task | None:
+    """Start the automation scheduler when its env gate is enabled (else no-op)."""
     if enabled is None:
         enabled = env_flag_enabled("SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED")
     if not enabled:
@@ -462,6 +574,7 @@ async def start_automation_scheduler(enabled: bool | None = None) -> asyncio.Tas
 
 
 async def stop_automation_scheduler(task: asyncio.Task | None) -> None:
+    """Stop the automation scheduler and cancel its keepalive task."""
     try:
         if task:
             task.cancel()

--- a/tldw_Server_API/app/services/startup_recurring_schedulers.py
+++ b/tldw_Server_API/app/services/startup_recurring_schedulers.py
@@ -50,6 +50,7 @@ class RecurringSchedulerHandles:
     admin_backup_sched_task: Any | None = None
     companion_reflection_sched_task: Any | None = None
     reminders_sched_task: Any | None = None
+    automation_definitions_sched_task: Any | None = None
     connectors_sync_sched_task: Any | None = None
 
 
@@ -203,6 +204,10 @@ async def start_recurring_schedulers(
         ),
         reminders_sched_task=await _start_with_optional_inventory(
             _start_reminders_scheduler,
+            worker_inventory,
+        ),
+        automation_definitions_sched_task=await _start_with_optional_inventory(
+            _start_automation_scheduler,
             worker_inventory,
         ),
         connectors_sync_sched_task=await _start_with_optional_inventory(
@@ -406,6 +411,24 @@ async def _start_reminders_scheduler(
         worker_inventory=worker_inventory,
         worker_name="reminders_sched_task",
         stopper=_stop_reminders_scheduler_service,
+    )
+
+
+async def _start_automation_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
+    return await _start_optional_scheduler(
+        started_message="Automation definition scheduler started",
+        disabled_message=(
+            "Automation definition scheduler disabled "
+            "(SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED != true)"
+        ),
+        failure_message="Failed to start Automation definition scheduler: {exc}",
+        starter=_start_automation_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="automation_definitions_sched_task",
+        stopper=_stop_automation_scheduler_service,
     )
 
 

--- a/tldw_Server_API/app/services/startup_recurring_schedulers.py
+++ b/tldw_Server_API/app/services/startup_recurring_schedulers.py
@@ -107,6 +107,13 @@ def provide_recurring_scheduler_worker_specs(
             stopper=_stop_reminders_scheduler_service,
         ),
         _recurring_scheduler_spec(
+            name="automation_definitions_sched_task",
+            task_name="automation_scheduler",
+            enabled=_env_enabled_predicate("SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED"),
+            starter=_start_automation_scheduler_service,
+            stopper=_stop_automation_scheduler_service,
+        ),
+        _recurring_scheduler_spec(
             name="connectors_sync_sched_task",
             task_name="connectors_sync_scheduler",
             enabled=_env_enabled_predicate("CONNECTORS_SYNC_SCHEDULER_ENABLED"),
@@ -620,6 +627,22 @@ async def _stop_reminders_scheduler_service(task: Any | None) -> None:
     from tldw_Server_API.app.services.reminders_scheduler import stop_reminders_scheduler
 
     await stop_reminders_scheduler(task)
+
+
+async def _start_automation_scheduler_service() -> Any | None:
+    from tldw_Server_API.app.services.scheduled_task_automation_scheduler import (
+        start_automation_scheduler,
+    )
+
+    return await start_automation_scheduler()
+
+
+async def _stop_automation_scheduler_service(task: Any | None) -> None:
+    from tldw_Server_API.app.services.scheduled_task_automation_scheduler import (
+        stop_automation_scheduler,
+    )
+
+    await stop_automation_scheduler(task)
 
 
 async def _stop_connectors_sync_scheduler_service(task: Any | None) -> None:

--- a/tldw_Server_API/tests/Notifications/test_automation_definition_feed.py
+++ b/tldw_Server_API/tests/Notifications/test_automation_definition_feed.py
@@ -4,26 +4,33 @@ Mirrors test_reminders_scheduler.py's shapes: real per-user
 ScheduledTasksDatabase under a tmp USER_DB_BASE_DIR (preview-gated
 definition creation through the REAL DB methods), direct fire-path
 invocation, and captured ``create_job`` kwargs. No reimplementation.
+
+The arming model under test: each occurrence is its own DateTrigger job
+with the slot bound into the job args at arm time, so a late callback
+still enqueues the occurrence it was armed for (review finding #7).
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import pytest
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
-from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
+    DefinitionRow,
     ScheduledTasksDatabase,
 )
+from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.services.reminders_scheduler import _normalize_slot_to_utc_iso
 from tldw_Server_API.app.services.scheduled_task_automation_scheduler import (
     ARMED_HEALTH,
     AUTOMATION_DOMAIN,
     AUTOMATION_JOB_TYPE,
     _AutomationScheduler,
+    _next_occurrence,
     build_trigger,
-    compute_run_slot,
 )
 
 pytestmark = pytest.mark.unit
@@ -52,10 +59,10 @@ def automation_scheduler_env(monkeypatch, tmp_path):
 def _create_definition(
     user_id: int,
     *,
-    schedule: dict,
+    schedule: dict[str, Any],
     lifecycle: str = "configured",
     family: str = "recurring_question",
-) -> "object":
+) -> DefinitionRow:
     db = ScheduledTasksDatabase.for_user(user_id=user_id)
     db.ensure_schema()
     preview = db.create_preview(
@@ -96,10 +103,10 @@ def _create_definition(
     )
 
 
-def _capture_jobs(scheduler: _AutomationScheduler) -> list[dict]:
-    created: list[dict] = []
+def _capture_jobs(scheduler: _AutomationScheduler) -> list[dict[str, Any]]:
+    created: list[dict[str, Any]] = []
 
-    def _capture(**kwargs):
+    def _capture(**kwargs: Any) -> dict[str, int]:
         created.append(kwargs)
         return {"id": len(created)}
 
@@ -107,28 +114,41 @@ def _capture_jobs(scheduler: _AutomationScheduler) -> list[dict]:
     return created
 
 
+def _bare_scheduler(user_id: int) -> _AutomationScheduler:
+    """A scheduler with a warmed per-user DB cache and NO APS instance.
+
+    The fire path only needs the DB cache; arming needs APS and is tested
+    separately against a real AsyncIOScheduler.
+    """
+    scheduler = _AutomationScheduler()
+    scheduler._get_db(user_id)
+    return scheduler
+
+
 # ---------------------------------------------------------------------------
 # Trigger building — all five kinds, plus honest-refusal cases
 # ---------------------------------------------------------------------------
 
 
-def test_build_trigger_one_time():
-    trigger, reason = build_trigger({"kind": "one_time", "run_at": "2026-08-21T09:00:00+00:00"})
+def test_build_trigger_one_time() -> None:
+    trigger, reason = build_trigger(
+        {"kind": "one_time", "run_at": "2026-08-21T09:00:00+00:00"}
+    )
     assert trigger is not None and reason is None
 
 
-def test_build_trigger_interval():
+def test_build_trigger_interval() -> None:
     trigger, reason = build_trigger({"kind": "interval", "seconds": 900})
     assert trigger is not None and reason is None
 
 
-def test_build_trigger_daily_and_weekly():
+def test_build_trigger_daily_and_weekly() -> None:
     daily, _ = build_trigger({"kind": "daily", "at": "09:30", "timezone": "UTC"})
     weekly, _ = build_trigger({"kind": "weekly", "weekday": 0, "at": "09:30"})
     assert daily is not None and weekly is not None
 
 
-def test_build_trigger_cron():
+def test_build_trigger_cron() -> None:
     trigger, reason = build_trigger({"kind": "cron", "cron": "*/5 * * * *"})
     assert trigger is not None and reason is None
 
@@ -145,29 +165,54 @@ def test_build_trigger_cron():
         ({"kind": "hourly"}, "unsupported"),
     ],
 )
-def test_build_trigger_refuses_unusable_schedules(schedule, expect_fragment):
+def test_build_trigger_refuses_unusable_schedules(
+    schedule: dict[str, Any], expect_fragment: str
+) -> None:
     trigger, reason = build_trigger(schedule)
     assert trigger is None
     assert expect_fragment in reason
 
 
 # ---------------------------------------------------------------------------
-# Slot computation
+# Next-occurrence derivation
 # ---------------------------------------------------------------------------
 
 
-def test_compute_run_slot_one_time_uses_run_at():
-    run_at = datetime(2026, 8, 21, 9, 0, tzinfo=timezone.utc)
-    slot = compute_run_slot({"kind": "one_time", "run_at": run_at.isoformat()}, None)
-    assert slot == run_at
+def test_next_occurrence_one_time_past_returns_none() -> None:
+    trigger, _ = build_trigger(
+        {"kind": "one_time", "run_at": "2020-01-01T00:00:00+00:00"}
+    )
+    assert _next_occurrence(trigger, after=datetime.now(timezone.utc)) is None
 
 
-def test_compute_run_slot_periodic_returns_current_slot():
+def test_next_occurrence_periodic_returns_next_boundary() -> None:
     trigger, _ = build_trigger({"kind": "daily", "at": "09:00", "timezone": "UTC"})
-    now = datetime(2026, 8, 21, 9, 0, tzinfo=timezone.utc)
-    slot = compute_run_slot({"kind": "daily", "at": "09:00"}, trigger, now=now)
-    assert slot is not None
-    assert slot.hour == 9 and slot.minute == 0 and slot <= now
+    after = datetime(2026, 8, 21, 10, 0, tzinfo=timezone.utc)
+    nxt = _next_occurrence(trigger, after=after)
+    assert nxt is not None
+    assert nxt == datetime(2026, 8, 22, 9, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Enumeration (review finding #5: list_definitions returns (rows, total))
+# ---------------------------------------------------------------------------
+
+
+def test_configured_definitions_returns_plain_row_list(automation_scheduler_env) -> None:
+    user_id = 989
+    _create_definition(user_id, schedule={"kind": "cron", "cron": "0 9 * * *"})
+    _create_definition(
+        user_id, schedule={"kind": "cron", "cron": "0 10 * * *"}, lifecycle="paused"
+    )
+
+    scheduler = _AutomationScheduler()
+    rows = scheduler._configured_definitions(user_id)
+
+    # The paused definition must be excluded; iterating the result must
+    # yield DefinitionRow objects, never a (rows, total) tuple's tail int.
+    assert len(rows) == 1
+    assert all(isinstance(row, DefinitionRow) for row in rows)
+    assert rows[0].lifecycle == "configured"
 
 
 # ---------------------------------------------------------------------------
@@ -176,15 +221,17 @@ def test_compute_run_slot_periodic_returns_current_slot():
 
 
 @pytest.mark.asyncio
-async def test_due_slot_enqueues_job_once(automation_scheduler_env):
+async def test_due_slot_enqueues_job_once(automation_scheduler_env) -> None:
     user_id = 990
     definition = _create_definition(user_id, schedule={"kind": "cron", "cron": "* * * * *"})
+    slot = datetime.now(timezone.utc).replace(second=0, microsecond=0)
 
-    scheduler = _AutomationScheduler()
-    scheduler._get_db(user_id)  # warm the cache against the real DB
+    scheduler = _bare_scheduler(user_id)
     created = _capture_jobs(scheduler)
 
-    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+    await scheduler._run_definition_schedule(
+        definition.id, user_id, _normalize_slot_to_utc_iso(slot)
+    )
 
     assert len(created) == 1
     assert created[0]["domain"] == AUTOMATION_DOMAIN
@@ -192,11 +239,42 @@ async def test_due_slot_enqueues_job_once(automation_scheduler_env):
     assert created[0]["owner_user_id"] == user_id
     assert created[0]["payload"]["definition_id"] == definition.id
     assert created[0]["payload"]["family"] == "recurring_question"
-    assert created[0]["idempotency_key"].startswith(f"definition:{definition.id}:")
+    assert created[0]["payload"]["scheduled_for"] == _normalize_slot_to_utc_iso(slot)
+    assert created[0]["idempotency_key"] == (
+        f"definition:{definition.id}:{_normalize_slot_to_utc_iso(slot)}"
+    )
 
 
 @pytest.mark.asyncio
-async def test_same_slot_fires_one_idempotency_key(automation_scheduler_env):
+async def test_late_fire_still_enqueues_the_armed_slot(automation_scheduler_env) -> None:
+    """Misfire correctness (review finding #7).
+
+    The callback runs 90s after the boundary it was armed for; the slot,
+    scheduled_for, and idempotency key must all name the ARMED occurrence,
+    not anything derived from the late wall clock.
+    """
+    user_id = 996
+    definition = _create_definition(user_id, schedule={"kind": "cron", "cron": "* * * * *"})
+    slot = datetime.now(timezone.utc).replace(second=0, microsecond=0) - timedelta(
+        seconds=90
+    )
+
+    scheduler = _bare_scheduler(user_id)
+    created = _capture_jobs(scheduler)
+
+    await scheduler._run_definition_schedule(
+        definition.id, user_id, _normalize_slot_to_utc_iso(slot)
+    )
+
+    assert len(created) == 1
+    assert created[0]["payload"]["scheduled_for"] == _normalize_slot_to_utc_iso(slot)
+    assert created[0]["idempotency_key"] == (
+        f"definition:{definition.id}:{_normalize_slot_to_utc_iso(slot)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_slot_fires_one_idempotency_key(automation_scheduler_env) -> None:
     """Two scheduler passes over the same slot produce the identical key.
 
     The Jobs layer returns the same row for a duplicate key, so identical
@@ -204,62 +282,98 @@ async def test_same_slot_fires_one_idempotency_key(automation_scheduler_env):
     """
     user_id = 991
     definition = _create_definition(user_id, schedule={"kind": "cron", "cron": "* * * * *"})
-    scheduler = _AutomationScheduler()
-    scheduler._get_db(user_id)
+    slot_iso = _normalize_slot_to_utc_iso(
+        datetime.now(timezone.utc).replace(second=0, microsecond=0)
+    )
+    scheduler = _bare_scheduler(user_id)
     created = _capture_jobs(scheduler)
 
-    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
-    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+    await scheduler._run_definition_schedule(definition.id, user_id, slot_iso)
+    await scheduler._run_definition_schedule(definition.id, user_id, slot_iso)
 
     assert len(created) == 2
     assert created[0]["idempotency_key"] == created[1]["idempotency_key"]
 
 
 @pytest.mark.asyncio
-async def test_non_configured_lifecycle_never_fires(automation_scheduler_env):
+async def test_non_configured_lifecycle_never_fires(automation_scheduler_env) -> None:
     user_id = 992
     definition = _create_definition(
-        user_id, schedule={"kind": "cron", "cron": "*/5 * * * *"}, lifecycle="paused"
+        user_id, schedule={"kind": "cron", "cron": "* * * * *"}, lifecycle="paused"
     )
-    scheduler = _AutomationScheduler()
-    scheduler._get_db(user_id)
+    scheduler = _bare_scheduler(user_id)
     created = _capture_jobs(scheduler)
 
-    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+    await scheduler._run_definition_schedule(definition.id, user_id, "2026-08-21T09:00:00+00:00")
 
     assert created == []
 
 
 @pytest.mark.asyncio
-async def test_future_one_time_slot_skips_early_fire(automation_scheduler_env):
+async def test_future_slot_skips_early_fire(automation_scheduler_env) -> None:
     user_id = 993
+    definition = _create_definition(user_id, schedule={"kind": "one_time", "run_at": ""})
     run_at = datetime.now(timezone.utc) + timedelta(hours=2)
-    definition = _create_definition(
-        user_id, schedule={"kind": "one_time", "run_at": run_at.isoformat()}
+    db = ScheduledTasksDatabase.for_user(user_id=user_id)
+    db.update_definition(
+        owner_id=user_id,
+        definition_id=definition.id,
+        patch={"schedule": {"kind": "one_time", "run_at": run_at.isoformat()}},
     )
-    scheduler = _AutomationScheduler()
-    scheduler._get_db(user_id)
+    scheduler = _bare_scheduler(user_id)
     created = _capture_jobs(scheduler)
 
-    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+    await scheduler._run_definition_schedule(
+        definition.id, user_id, _normalize_slot_to_utc_iso(run_at)
+    )
 
     assert created == []
 
 
 @pytest.mark.asyncio
-async def test_unusable_schedule_never_fires(automation_scheduler_env):
+async def test_unusable_schedule_never_fires(automation_scheduler_env) -> None:
     user_id = 994
     # The DB stores whatever the schedule dict carried; the feed must skip
     # a definition whose per-kind fields are junk even though 'kind' is
     # among the supported five.
     definition = _create_definition(user_id, schedule={"kind": "interval"})
-    scheduler = _AutomationScheduler()
-    scheduler._get_db(user_id)
+    scheduler = _bare_scheduler(user_id)
     created = _capture_jobs(scheduler)
 
-    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+    await scheduler._run_definition_schedule(definition.id, user_id, "2026-08-21T09:00:00+00:00")
 
     assert created == []
+
+
+# ---------------------------------------------------------------------------
+# Arming against a real APScheduler instance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_arms_next_occurrence_with_slot_bound_in_args(automation_scheduler_env) -> None:
+    user_id = 997
+    definition = _create_definition(user_id, schedule={"kind": "daily", "at": "23:59"})
+
+    scheduler = _AutomationScheduler()
+    scheduler._aps = AsyncIOScheduler(timezone="UTC")
+    scheduler._aps.start()
+    try:
+        assert scheduler._arm(definition, user_id) is True
+
+        jobs = scheduler._aps.get_jobs()
+        assert len(jobs) == 1
+        job = jobs[0]
+        assert job.id == f"automation:{definition.id}"
+        # One DateTrigger occurrence with the slot bound into args:
+        (arg_definition_id, arg_user_id, arg_slot_iso) = job.args
+        assert arg_definition_id == definition.id
+        assert arg_user_id == user_id
+        assert datetime.fromisoformat(arg_slot_iso).hour == 23
+        assert datetime.fromisoformat(arg_slot_iso).minute == 59
+    finally:
+        scheduler._aps.shutdown(wait=False)
+        scheduler._aps = None
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +381,7 @@ async def test_unusable_schedule_never_fires(automation_scheduler_env):
 # ---------------------------------------------------------------------------
 
 
-def test_mark_ready_flips_health_with_audit_and_no_version_churn(automation_scheduler_env):
+def test_mark_ready_flips_health_with_audit_and_no_version_churn(automation_scheduler_env) -> None:
     user_id = 995
     definition = _create_definition(user_id, schedule={"kind": "cron", "cron": "0 9 * * *"})
     db = ScheduledTasksDatabase.for_user(user_id=user_id)

--- a/tldw_Server_API/tests/Notifications/test_automation_definition_feed.py
+++ b/tldw_Server_API/tests/Notifications/test_automation_definition_feed.py
@@ -1,0 +1,290 @@
+"""Automation definition scheduler feed tests (TASK-13020).
+
+Mirrors test_reminders_scheduler.py's shapes: real per-user
+ScheduledTasksDatabase under a tmp USER_DB_BASE_DIR (preview-gated
+definition creation through the REAL DB methods), direct fire-path
+invocation, and captured ``create_job`` kwargs. No reimplementation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tldw_Server_API.app.core.config import settings
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
+    ScheduledTasksDatabase,
+)
+from tldw_Server_API.app.services.reminders_scheduler import _normalize_slot_to_utc_iso
+from tldw_Server_API.app.services.scheduled_task_automation_scheduler import (
+    ARMED_HEALTH,
+    AUTOMATION_DOMAIN,
+    AUTOMATION_JOB_TYPE,
+    _AutomationScheduler,
+    build_trigger,
+    compute_run_slot,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def automation_scheduler_env(monkeypatch, tmp_path):
+    base_dir = tmp_path / "test_automation_scheduler"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    prev_base_dir = settings.get("USER_DB_BASE_DIR")
+    settings.USER_DB_BASE_DIR = str(base_dir)
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
+    monkeypatch.setenv("JOBS_DB_PATH", str(base_dir / "jobs.db"))
+    try:
+        yield
+    finally:
+        if prev_base_dir is not None:
+            settings.USER_DB_BASE_DIR = prev_base_dir
+        else:
+            try:
+                del settings.USER_DB_BASE_DIR
+            except AttributeError:
+                pass
+
+
+def _create_definition(
+    user_id: int,
+    *,
+    schedule: dict,
+    lifecycle: str = "configured",
+    family: str = "recurring_question",
+) -> "object":
+    db = ScheduledTasksDatabase.for_user(user_id=user_id)
+    db.ensure_schema()
+    preview = db.create_preview(
+        owner_id=user_id,
+        mode="create",
+        family=family,
+        definition_id=None,
+        definition_version=None,
+        status="valid",
+        payload_hash=f"hash-{datetime.now(timezone.utc).timestamp()}",
+        normalized_config={},
+        validation_errors=[],
+        warnings=[],
+        risk_class=None,
+        visibility_policy="owner",
+        schedule_preview=schedule,
+        redaction_policy={"fields": [], "mode": "none"},
+        expires_at=(
+            datetime.now(timezone.utc) + timedelta(hours=24)
+        ).isoformat(),
+        created_by="test",
+    )
+    return db.create_definition(
+        owner_id=user_id,
+        family=family,
+        name="Test Definition",
+        description=None,
+        lifecycle=lifecycle,
+        health="execution_unavailable",
+        schedule=schedule,
+        input={"question": "What changed today?"},
+        visibility_policy="owner",
+        notification_policy={},
+        approval_policy={},
+        preview_id=preview.id,
+        created_by="test",
+        updated_by="test",
+    )
+
+
+def _capture_jobs(scheduler: _AutomationScheduler) -> list[dict]:
+    created: list[dict] = []
+
+    def _capture(**kwargs):
+        created.append(kwargs)
+        return {"id": len(created)}
+
+    scheduler._jobs.create_job = _capture  # type: ignore[method-assign]
+    return created
+
+
+# ---------------------------------------------------------------------------
+# Trigger building — all five kinds, plus honest-refusal cases
+# ---------------------------------------------------------------------------
+
+
+def test_build_trigger_one_time():
+    trigger, reason = build_trigger({"kind": "one_time", "run_at": "2026-08-21T09:00:00+00:00"})
+    assert trigger is not None and reason is None
+
+
+def test_build_trigger_interval():
+    trigger, reason = build_trigger({"kind": "interval", "seconds": 900})
+    assert trigger is not None and reason is None
+
+
+def test_build_trigger_daily_and_weekly():
+    daily, _ = build_trigger({"kind": "daily", "at": "09:30", "timezone": "UTC"})
+    weekly, _ = build_trigger({"kind": "weekly", "weekday": 0, "at": "09:30"})
+    assert daily is not None and weekly is not None
+
+
+def test_build_trigger_cron():
+    trigger, reason = build_trigger({"kind": "cron", "cron": "*/5 * * * *"})
+    assert trigger is not None and reason is None
+
+
+@pytest.mark.parametrize(
+    "schedule,expect_fragment",
+    [
+        ({"kind": "one_time"}, "run_at"),
+        ({"kind": "interval", "seconds": 0}, "seconds"),
+        ({"kind": "interval"}, "seconds"),
+        ({"kind": "daily", "at": "nope"}, "at"),
+        ({"kind": "daily", "at": "25:00"}, "range"),
+        ({"kind": "cron", "cron": ""}, "expression"),
+        ({"kind": "hourly"}, "unsupported"),
+    ],
+)
+def test_build_trigger_refuses_unusable_schedules(schedule, expect_fragment):
+    trigger, reason = build_trigger(schedule)
+    assert trigger is None
+    assert expect_fragment in reason
+
+
+# ---------------------------------------------------------------------------
+# Slot computation
+# ---------------------------------------------------------------------------
+
+
+def test_compute_run_slot_one_time_uses_run_at():
+    run_at = datetime(2026, 8, 21, 9, 0, tzinfo=timezone.utc)
+    slot = compute_run_slot({"kind": "one_time", "run_at": run_at.isoformat()}, None)
+    assert slot == run_at
+
+
+def test_compute_run_slot_periodic_returns_current_slot():
+    trigger, _ = build_trigger({"kind": "daily", "at": "09:00", "timezone": "UTC"})
+    now = datetime(2026, 8, 21, 9, 0, tzinfo=timezone.utc)
+    slot = compute_run_slot({"kind": "daily", "at": "09:00"}, trigger, now=now)
+    assert slot is not None
+    assert slot.hour == 9 and slot.minute == 0 and slot <= now
+
+
+# ---------------------------------------------------------------------------
+# The fire path (enqueue shape, lifecycle gate, early-skip, idempotency)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_due_slot_enqueues_job_once(automation_scheduler_env):
+    user_id = 990
+    definition = _create_definition(user_id, schedule={"kind": "cron", "cron": "* * * * *"})
+
+    scheduler = _AutomationScheduler()
+    scheduler._get_db(user_id)  # warm the cache against the real DB
+    created = _capture_jobs(scheduler)
+
+    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+
+    assert len(created) == 1
+    assert created[0]["domain"] == AUTOMATION_DOMAIN
+    assert created[0]["job_type"] == AUTOMATION_JOB_TYPE
+    assert created[0]["owner_user_id"] == user_id
+    assert created[0]["payload"]["definition_id"] == definition.id
+    assert created[0]["payload"]["family"] == "recurring_question"
+    assert created[0]["idempotency_key"].startswith(f"definition:{definition.id}:")
+
+
+@pytest.mark.asyncio
+async def test_same_slot_fires_one_idempotency_key(automation_scheduler_env):
+    """Two scheduler passes over the same slot produce the identical key.
+
+    The Jobs layer returns the same row for a duplicate key, so identical
+    keys ARE the dedupe across restarts and concurrent rescans.
+    """
+    user_id = 991
+    definition = _create_definition(user_id, schedule={"kind": "cron", "cron": "* * * * *"})
+    scheduler = _AutomationScheduler()
+    scheduler._get_db(user_id)
+    created = _capture_jobs(scheduler)
+
+    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+
+    assert len(created) == 2
+    assert created[0]["idempotency_key"] == created[1]["idempotency_key"]
+
+
+@pytest.mark.asyncio
+async def test_non_configured_lifecycle_never_fires(automation_scheduler_env):
+    user_id = 992
+    definition = _create_definition(
+        user_id, schedule={"kind": "cron", "cron": "*/5 * * * *"}, lifecycle="paused"
+    )
+    scheduler = _AutomationScheduler()
+    scheduler._get_db(user_id)
+    created = _capture_jobs(scheduler)
+
+    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+
+    assert created == []
+
+
+@pytest.mark.asyncio
+async def test_future_one_time_slot_skips_early_fire(automation_scheduler_env):
+    user_id = 993
+    run_at = datetime.now(timezone.utc) + timedelta(hours=2)
+    definition = _create_definition(
+        user_id, schedule={"kind": "one_time", "run_at": run_at.isoformat()}
+    )
+    scheduler = _AutomationScheduler()
+    scheduler._get_db(user_id)
+    created = _capture_jobs(scheduler)
+
+    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+
+    assert created == []
+
+
+@pytest.mark.asyncio
+async def test_unusable_schedule_never_fires(automation_scheduler_env):
+    user_id = 994
+    # The DB stores whatever the schedule dict carried; the feed must skip
+    # a definition whose per-kind fields are junk even though 'kind' is
+    # among the supported five.
+    definition = _create_definition(user_id, schedule={"kind": "interval"})
+    scheduler = _AutomationScheduler()
+    scheduler._get_db(user_id)
+    created = _capture_jobs(scheduler)
+
+    await scheduler._run_definition_schedule(definition.id, user_id=user_id)
+
+    assert created == []
+
+
+# ---------------------------------------------------------------------------
+# Health honesty (AC#4)
+# ---------------------------------------------------------------------------
+
+
+def test_mark_ready_flips_health_with_audit_and_no_version_churn(automation_scheduler_env):
+    user_id = 995
+    definition = _create_definition(user_id, schedule={"kind": "cron", "cron": "0 9 * * *"})
+    db = ScheduledTasksDatabase.for_user(user_id=user_id)
+    assert definition.health == "execution_unavailable"
+
+    scheduler = _AutomationScheduler()
+    scheduler._get_db(user_id)
+    scheduler._mark_ready(definition, user_id)
+
+    updated = db.get_definition(owner_id=user_id, definition_id=definition.id)
+    assert updated.health == ARMED_HEALTH
+    assert updated.version == definition.version + 1
+
+    audits, _total = db.list_audit_events(owner_id=user_id, definition_id=definition.id)
+    assert any(a.event_type == "scheduler_armed" for a in audits)
+
+    # Second pass with fresh row state is a no-op: no version churn.
+    scheduler._mark_ready(updated, user_id)
+    again = db.get_definition(owner_id=user_id, definition_id=definition.id)
+    assert again.version == updated.version


### PR DESCRIPTION
## Summary

Executes **TASK-13020** — the definition scheduler feed, first running code of the server-offload execution seam (tldw_chatbook ADR-077, accepted). Stacked on the task-filing branch (#2796): **rebase onto dev once that merges** (this PR's base will need retargeting).

Mirrors `reminders_scheduler.py` end-to-end: env-gated APScheduler singleton (OFF by default — enable together with the TASK-13021 consumer), per-user definition DBs, periodic rescan, reconcile/unschedule hooks, and startup registration beside the reminders spec.

- **Five schedule kinds** with documented field conventions (the automation service validates only `kind`); unusable schedules skip with reason — never armed, mirroring the reminders invalid-cron discipline.
- **Idempotent run-slot enqueueing at the Jobs layer** — `create_job`'s idempotency key (`definition:{id}:{slot_utc}`) returns the same row on duplicates; durable across restarts, no schema change.
- **Health honesty** — arming flips `health` to `ready` only-on-change with a `scheduler_armed` audit event; no version churn across rescans.

## Verification

- `test_automation_definition_feed.py` — **19 passed** (five kinds + seven refusal cases, enqueue shape, double-fire dedupe, lifecycle gate, early-skip, health/audit/no-churn), all through real preview-gated definition creation and the real fire path
- Neighbors: `test_reminders_scheduler.py` + `test_scheduled_task_automation_api.py` — **47 passed**; `test_startup_preflight.py` — **16 passed**

Closes TASK-13020.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Arms configured automation definitions behind an env gate and enqueues `scheduled_tasks`/`agent_task_run` jobs with durable, per-slot idempotency. Previously definitions never dispatched and stayed `execution_unavailable`; now, when enabled, due occurrences queue on schedule and health flips to `ready` on arm.

- Per-occurrence DateTrigger with the run slot bound into job args; late fires enqueue the armed slot and then re-arm the next occurrence. `_next_occurrence` derives strictly-after times; schedules are revalidated at fire time to handle edit races.
- Mirrors the reminders scheduler: per-user DBs, periodic rescan (>=30s), coalesced APS jobs, reconcile/unschedule hooks, and startup registration via recurring scheduler handles (`automation_definitions_sched_task`).
- Supports five schedule kinds (`one_time`, `interval`, `daily`, `weekly`, `cron`); unusable schedules skip with a reason and never arm.
- Idempotency via `create_job` key `definition:{id}:{slot_utc}`; durable across restarts; no schema changes; emits `scheduler_armed` on first arm.
- Fixes: `_configured_definitions` now unpacks `(rows, total)` to return rows; legacy startup path wired into recurring schedulers; misfire correctness via per-occurrence DateTrigger.
- Tests: 22 feed tests (incl. late-fire and bound-slot cases); neighboring suites stay green. Satisfies TASK-13020.

**Rollout**
- Disabled by default. Enable with `SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED` together with the TASK-13021 consumer; optional queue via `AUTOMATION_JOBS_QUEUE`.
- No migrations or config changes beyond the env flag.

<sup>Written for commit 48bc06bc89499cc06f7f05427b035232b7a7fdcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

