### PR TITLE
fix(chat): prevent stale server history after scope changes

### DIFF
--- a/apps/packages/ui/src/hooks/__tests__/useServerChatLoader.scope.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useServerChatLoader.scope.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react"
+import type { TFunction } from "i18next"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => {
+  const store = {
+    serverChatId: "chat-a" as string | null,
+    serverChatTitle: "Chat A" as string | null,
+    serverChatCharacterId: null as string | number | null,
+    serverChatAssistantKind: "character" as "character" | "persona" | null,
+    serverChatAssistantId: null as string | null,
+    serverChatPersonaMemoryMode: null as "read_only" | "read_write" | null,
+    serverChatMetaLoaded: true,
+    temporaryChat: false,
+    setServerChatId: vi.fn(),
+    setServerChatLoadState: vi.fn(),
+    setServerChatLoadError: vi.fn(),
+    setServerChatTitle: vi.fn(),
+    setServerChatCharacterId: vi.fn(),
+    setServerChatAssistantKind: vi.fn(),
+    setServerChatAssistantId: vi.fn(),
+    setServerChatPersonaMemoryMode: vi.fn(),
+    setServerChatState: vi.fn(),
+    setServerChatVersion: vi.fn(),
+    setServerChatTopic: vi.fn(),
+    setServerChatClusterId: vi.fn(),
+    setServerChatSource: vi.fn(),
+    setServerChatExternalRef: vi.fn(),
+    setServerChatMetaLoaded: vi.fn()
+  }
+
+  return {
+    store,
+    getHistoriesWithMetadata: vi.fn(),
+    initialize: vi.fn(),
+    listChatMessages: vi.fn(),
+    saveMessage: vi.fn(),
+    setHistory: vi.fn(),
+    setIsLoading: vi.fn(),
+    setMessages: vi.fn(),
+    setSelectedAssistant: vi.fn(),
+    syncChatSettingsForServerChat: vi.fn(),
+    updatePageTitle: vi.fn()
+  }
+})
+
+vi.mock("@/hooks/chat/useChatBaseState", () => ({
+  useChatBaseState: () => ({
+    messages: [],
+    streaming: false,
+    isProcessing: false,
+    setHistory: mocks.setHistory,
+    setMessages: mocks.setMessages,
+    setIsLoading: mocks.setIsLoading
+  })
+}))
+
+vi.mock("@/store/option", () => ({
+  useStoreMessageOption: (
+    selector: (state: typeof mocks.store) => unknown
+  ) => selector(mocks.store)
+}))
+
+vi.mock("@/hooks/useSelectedAssistant", () => ({
+  useSelectedAssistant: () => [null, mocks.setSelectedAssistant]
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: mocks.initialize,
+    listChatMessages: mocks.listChatMessages
+  }
+}))
+
+vi.mock("@/db/dexie/helpers", () => ({
+  getHistoriesWithMetadata: mocks.getHistoriesWithMetadata,
+  saveMessage: mocks.saveMessage
+}))
+
+vi.mock("@/services/chat-settings", () => ({
+  syncChatSettingsForServerChat: mocks.syncChatSettingsForServerChat
+}))
+
+vi.mock("@/utils/update-page-title", () => ({
+  updatePageTitle: mocks.updatePageTitle
+}))
+
+import { useServerChatLoader } from "@/hooks/chat/useServerChatLoader"
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
+}
+
+describe("useServerChatLoader scoped local history", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    mocks.store.serverChatId = "chat-a"
+    mocks.store.serverChatTitle = "Chat A"
+    mocks.store.serverChatMetaLoaded = true
+    mocks.store.temporaryChat = false
+    mocks.initialize.mockResolvedValue(undefined)
+    mocks.listChatMessages.mockResolvedValue([])
+    mocks.getHistoriesWithMetadata.mockResolvedValue(
+      new Map([["history-a", { messageCount: 1 }]])
+    )
+    mocks.syncChatSettingsForServerChat.mockResolvedValue(null)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does not publish a superseded load after history linking is aborted", async () => {
+    const historyLink = deferred<string | null>()
+    const ensureServerChatHistoryId = vi.fn(
+      (_chatId: string, _title?: string, signal?: AbortSignal) => {
+        if (signal) {
+          signal.addEventListener(
+            "abort",
+            () => {
+              const error = Object.assign(new Error("Request scope changed"), {
+                status: 412,
+                details: {
+                  detail: { code: "request_config_scope_changed" }
+                }
+              })
+              historyLink.reject(error)
+            },
+            { once: true }
+          )
+        }
+        return historyLink.promise
+      }
+    )
+    const notification = { error: vi.fn() }
+    const { rerender } = renderHook(() =>
+      useServerChatLoader({
+        ensureServerChatHistoryId,
+        notification,
+        t: ((_key: string, options?: { defaultValue?: string }) =>
+          options?.defaultValue ?? "Error") as unknown as TFunction
+      })
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    await vi.waitFor(() =>
+      expect(ensureServerChatHistoryId).toHaveBeenCalledTimes(1)
+    )
+
+    mocks.store.serverChatId = "chat-b"
+    rerender()
+    historyLink.resolve("history-a")
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mocks.updatePageTitle).not.toHaveBeenCalled()
+    expect(mocks.store.setServerChatLoadState).not.toHaveBeenCalledWith(
+      "loaded"
+    )
+    expect(notification.error).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts
@@ -194,6 +194,20 @@ describe("shouldCommitServerChatLoadResult", () => {
       })
     ).toBe(false)
   })
+
+  it("returns false when the owned request controller has already been aborted", () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    expect(
+      shouldCommitServerChatLoadResult({
+        requestedChatId: "chat-1",
+        activeServerChatId: "chat-1",
+        requestController: controller,
+        activeController: controller
+      })
+    ).toBe(false)
+  })
 })
 
 describe("resolveServerChatAssistantIdentity", () => {

--- a/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
@@ -21,6 +21,14 @@ const createSetterBundle = () => ({
   setServerChatExternalRef: vi.fn()
 })
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 describe("ensurePersonaServerChat", () => {
   it("creates a persona-backed chat with read_only default and updates chat state", async () => {
     const setters = createSetterBundle()
@@ -84,6 +92,64 @@ describe("ensurePersonaServerChat", () => {
       historyId: "history-1",
       personaMemoryMode: "read_only"
     })
+  })
+
+  it("does not publish a newly created persona chat when scope changes during history linking", async () => {
+    const setters = createSetterBundle()
+    const historyLink = deferred<string | null>()
+    const ensureServerChatHistoryId = vi.fn(() => historyLink.promise)
+    const invalidateServerChatHistory = vi.fn()
+    const scopeController = new AbortController()
+    const pending = ensurePersonaServerChat({
+      assistant: {
+        kind: "persona",
+        id: "garden-helper",
+        name: "Garden Helper"
+      },
+      serverChatId: null,
+      serverChatTitle: null,
+      serverChatAssistantKind: null,
+      serverChatAssistantId: null,
+      serverChatPersonaMemoryMode: null,
+      serverChatMetaLoaded: false,
+      serverChatState: "in-progress",
+      serverChatTopic: null,
+      serverChatClusterId: null,
+      serverChatSource: null,
+      serverChatExternalRef: null,
+      historyId: null,
+      temporaryChat: false,
+      scopeInvalidatedSignal: scopeController.signal,
+      createChat: vi.fn().mockResolvedValue({
+        id: "persona-chat-scoped",
+        title: "Scoped persona chat",
+        assistant_kind: "persona",
+        assistant_id: "garden-helper",
+        persona_memory_mode: "read_only",
+        state: "resolved",
+        version: 4
+      }),
+      ensureServerChatHistoryId,
+      invalidateServerChatHistory,
+      ...setters
+    })
+
+    await vi.waitFor(() =>
+      expect(ensureServerChatHistoryId).toHaveBeenCalledTimes(1)
+    )
+    scopeController.abort()
+    historyLink.resolve("history-stale")
+
+    await expect(pending).rejects.toMatchObject({ status: 412 })
+    expect(ensureServerChatHistoryId).toHaveBeenCalledWith(
+      "persona-chat-scoped",
+      undefined,
+      scopeController.signal
+    )
+    for (const setter of Object.values(setters)) {
+      expect(setter).not.toHaveBeenCalled()
+    }
+    expect(invalidateServerChatHistory).not.toHaveBeenCalled()
   })
 
   it("passes workspace scope through when creating a persona-backed chat", async () => {
@@ -272,6 +338,54 @@ describe("ensurePersonaServerChat", () => {
       historyId: "history-2",
       personaMemoryMode: "read_write"
     })
+  })
+
+  it("does not publish reused persona metadata when scope changes during history linking", async () => {
+    const setters = createSetterBundle()
+    const historyLink = deferred<string | null>()
+    const ensureServerChatHistoryId = vi.fn(() => historyLink.promise)
+    const scopeController = new AbortController()
+    const pending = ensurePersonaServerChat({
+      assistant: {
+        kind: "persona",
+        id: "garden-helper",
+        name: "Garden Helper"
+      },
+      serverChatId: "persona-chat-existing",
+      serverChatTitle: "Existing persona chat",
+      serverChatAssistantKind: "persona",
+      serverChatAssistantId: "garden-helper",
+      serverChatPersonaMemoryMode: "read_write",
+      serverChatMetaLoaded: true,
+      serverChatState: "in-progress",
+      serverChatTopic: null,
+      serverChatClusterId: null,
+      serverChatSource: null,
+      serverChatExternalRef: null,
+      historyId: null,
+      temporaryChat: false,
+      scopeInvalidatedSignal: scopeController.signal,
+      createChat: vi.fn(),
+      ensureServerChatHistoryId,
+      invalidateServerChatHistory: vi.fn(),
+      ...setters
+    })
+
+    await vi.waitFor(() =>
+      expect(ensureServerChatHistoryId).toHaveBeenCalledTimes(1)
+    )
+    scopeController.abort()
+    historyLink.resolve("history-stale")
+
+    await expect(pending).rejects.toMatchObject({ status: 412 })
+    expect(ensureServerChatHistoryId).toHaveBeenCalledWith(
+      "persona-chat-existing",
+      "Existing persona chat",
+      scopeController.signal
+    )
+    for (const setter of Object.values(setters)) {
+      expect(setter).not.toHaveBeenCalled()
+    }
   })
 
   it("resets stale character-backed server chat metadata before creating persona chat", async () => {

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
@@ -298,6 +298,14 @@ const servicePromptSnapshot = {
   release: releaseServicePromptSnapshotMock
 }
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 describe("useChatActions persona integration", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -753,6 +761,80 @@ describe("useChatActions persona integration", () => {
         conversationId: "workspace-rag-chat"
       })
     )
+  })
+
+  it("does not publish workspace chat metadata when scope changes during history linking", async () => {
+    const scope = {
+      type: "workspace",
+      workspaceId: "workspace-scope-race"
+    } as const
+    const scopeController = new AbortController()
+    const scopedSnapshot = {
+      ...servicePromptSnapshot,
+      scopeSignal: new AbortController().signal,
+      scopeInvalidatedSignal: scopeController.signal
+    }
+    loadServicePromptSnapshotMock.mockResolvedValueOnce(scopedSnapshot)
+    createChatMock.mockResolvedValueOnce({
+      id: "workspace-scope-race-chat",
+      title: "Workspace scope race",
+      state: "resolved",
+      version: 5,
+      topic_label: "Race topic",
+      cluster_id: "race-cluster",
+      source: "workspace",
+      external_ref: "race-ref"
+    })
+    const historyLink = deferred<string | null>()
+    const options = {
+      ...createHookOptions(),
+      scope,
+      selectedAssistant: null,
+      ensureServerChatHistoryId: vi.fn(() => historyLink.promise)
+    }
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    let submission!: ReturnType<typeof result.current.onSubmit>
+    act(() => {
+      submission = result.current.onSubmit({
+        message: "Keep workspace state scoped",
+        image: "",
+        requestOverrides: {
+          fileRetrievalEnabled: true,
+          ragMediaIds: [101]
+        }
+      })
+    })
+    await vi.waitFor(() =>
+      expect(options.ensureServerChatHistoryId).toHaveBeenCalledTimes(1)
+    )
+    scopeController.abort()
+    historyLink.resolve("history-stale")
+
+    await act(async () => {
+      await submission
+    })
+
+    expect(options.ensureServerChatHistoryId).toHaveBeenCalledWith(
+      "workspace-scope-race-chat",
+      "Workspace scope race",
+      scopeController.signal
+    )
+    expect(options.setServerChatId).not.toHaveBeenCalled()
+    expect(options.setServerChatTitle).not.toHaveBeenCalled()
+    expect(options.setServerChatCharacterId).not.toHaveBeenCalled()
+    expect(options.setServerChatAssistantKind).not.toHaveBeenCalled()
+    expect(options.setServerChatAssistantId).not.toHaveBeenCalled()
+    expect(options.setServerChatPersonaMemoryMode).not.toHaveBeenCalled()
+    expect(options.setServerChatMetaLoaded).not.toHaveBeenCalled()
+    expect(options.setServerChatState).not.toHaveBeenCalled()
+    expect(options.setServerChatVersion).not.toHaveBeenCalled()
+    expect(options.setServerChatTopic).not.toHaveBeenCalled()
+    expect(options.setServerChatClusterId).not.toHaveBeenCalled()
+    expect(options.setServerChatSource).not.toHaveBeenCalled()
+    expect(options.setServerChatExternalRef).not.toHaveBeenCalled()
+    expect(options.invalidateServerChatHistory).not.toHaveBeenCalled()
+    expect(ragModeMock).not.toHaveBeenCalled()
   })
 
   it("keeps plain global sends out of the workspace server-chat bootstrap path", async () => {

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.service-prompts.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.service-prompts.test.tsx
@@ -1265,6 +1265,11 @@ describe("useChatActions Compare service prompt snapshot", () => {
     });
 
     expect(options.ensureServerChatHistoryId).toHaveBeenCalledTimes(1);
+    expect(options.ensureServerChatHistoryId).toHaveBeenCalledWith(
+      "server-chat-7",
+      undefined,
+      snapshot.scopeInvalidatedSignal,
+    );
     expect(events.indexOf("loadSnapshot")).toBeLessThan(
       events.indexOf("ensureHistory"),
     );

--- a/apps/packages/ui/src/hooks/chat/__tests__/useServerChatHistoryId.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useServerChatHistoryId.test.tsx
@@ -94,10 +94,6 @@ describe("useServerChatHistoryId", () => {
       }
     })
     expect(setHistoryId).not.toHaveBeenCalled()
-    expect(runChatPersistenceTransactionMock).toHaveBeenCalledWith(
-      scopeController.signal,
-      expect.any(Function)
-    )
 
     await act(async () => {
       await expect(

--- a/apps/packages/ui/src/hooks/chat/__tests__/useServerChatHistoryId.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useServerChatHistoryId.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  getHistoryByServerChatIdMock,
+  runChatPersistenceTransactionMock,
+  saveHistoryMock,
+  setHistoryServerChatIdMock,
+  updateHistoryMock
+} = vi.hoisted(() => ({
+  getHistoryByServerChatIdMock: vi.fn(),
+  runChatPersistenceTransactionMock: vi.fn(),
+  saveHistoryMock: vi.fn(),
+  setHistoryServerChatIdMock: vi.fn(),
+  updateHistoryMock: vi.fn()
+}))
+
+vi.mock("@/db/dexie/helpers", () => ({
+  getHistoryByServerChatId: getHistoryByServerChatIdMock,
+  saveHistory: saveHistoryMock,
+  setHistoryServerChatId: setHistoryServerChatIdMock,
+  updateHistory: updateHistoryMock
+}))
+
+vi.mock("@/db/dexie/chat-persistence-transaction", () => ({
+  runChatPersistenceTransaction: runChatPersistenceTransactionMock
+}))
+
+import { useServerChatHistoryId } from "../useServerChatHistoryId"
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+const abortError = () => {
+  const error = new Error("Request scope changed")
+  error.name = "AbortError"
+  return error
+}
+
+describe("useServerChatHistoryId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getHistoryByServerChatIdMock.mockResolvedValue(null)
+    saveHistoryMock.mockResolvedValue({ id: "history-default" })
+    setHistoryServerChatIdMock.mockResolvedValue(undefined)
+    updateHistoryMock.mockResolvedValue(undefined)
+    runChatPersistenceTransactionMock.mockImplementation(
+      async (signal: AbortSignal | undefined, operation: () => Promise<unknown>) => {
+        if (signal?.aborted) throw abortError()
+        const result = await operation()
+        if (signal?.aborted) throw abortError()
+        return result
+      }
+    )
+  })
+
+  it("does not publish or cache a new local history after its request scope changes", async () => {
+    const staleSave = deferred<{ id: string }>()
+    saveHistoryMock
+      .mockImplementationOnce(() => staleSave.promise)
+      .mockResolvedValueOnce({ id: "history-fresh" })
+    const setHistoryId = vi.fn()
+    const scopeController = new AbortController()
+    const { result } = renderHook(() =>
+      useServerChatHistoryId({
+        serverChatId: null,
+        historyId: null,
+        setHistoryId,
+        temporaryChat: false,
+        t: ((_key: string, options?: { defaultValue?: string }) =>
+          options?.defaultValue ?? "Untitled") as any
+      })
+    )
+
+    const staleAttempt = result.current.ensureServerChatHistoryId(
+      "server-chat-1",
+      "Scoped title",
+      scopeController.signal
+    )
+    await vi.waitFor(() => expect(saveHistoryMock).toHaveBeenCalledTimes(1))
+    scopeController.abort()
+    staleSave.resolve({ id: "history-stale" })
+
+    await expect(staleAttempt).rejects.toMatchObject({
+      status: 412,
+      details: {
+        detail: { code: "request_config_scope_changed" }
+      }
+    })
+    expect(setHistoryId).not.toHaveBeenCalled()
+    expect(runChatPersistenceTransactionMock).toHaveBeenCalledWith(
+      scopeController.signal,
+      expect.any(Function)
+    )
+
+    await act(async () => {
+      await expect(
+        result.current.ensureServerChatHistoryId(
+          "server-chat-1",
+          "Fresh title"
+        )
+      ).resolves.toBe("history-fresh")
+    })
+    expect(saveHistoryMock).toHaveBeenCalledTimes(2)
+    expect(setHistoryId).toHaveBeenCalledWith("history-fresh", {
+      preserveServerChatId: true
+    })
+  })
+
+  it("does not cache an existing local-history mapping when its scoped transaction aborts", async () => {
+    const staleMapping = deferred<void>()
+    setHistoryServerChatIdMock
+      .mockImplementationOnce(() => staleMapping.promise)
+      .mockResolvedValueOnce(undefined)
+    const scopeController = new AbortController()
+    const { result } = renderHook(() =>
+      useServerChatHistoryId({
+        serverChatId: null,
+        historyId: "history-local",
+        setHistoryId: vi.fn(),
+        temporaryChat: false,
+        t: ((_key: string, options?: { defaultValue?: string }) =>
+          options?.defaultValue ?? "Untitled") as any
+      })
+    )
+
+    const staleAttempt = result.current.ensureServerChatHistoryId(
+      "server-chat-2",
+      undefined,
+      scopeController.signal
+    )
+    await vi.waitFor(() =>
+      expect(setHistoryServerChatIdMock).toHaveBeenCalledTimes(1)
+    )
+    scopeController.abort()
+    staleMapping.resolve()
+
+    await expect(staleAttempt).rejects.toMatchObject({ status: 412 })
+
+    await act(async () => {
+      await expect(
+        result.current.ensureServerChatHistoryId("server-chat-2")
+      ).resolves.toBe("history-local")
+    })
+    expect(setHistoryServerChatIdMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/packages/ui/src/hooks/chat/personaServerChat.ts
+++ b/apps/packages/ui/src/hooks/chat/personaServerChat.ts
@@ -43,7 +43,8 @@ type EnsurePersonaServerChatArgs = {
   ) => Promise<any>
   ensureServerChatHistoryId: (
     chatId: string,
-    title?: string
+    title?: string,
+    scopeInvalidatedSignal?: AbortSignal
   ) => Promise<string | null>
   invalidateServerChatHistory: () => void
   setServerChatId: (value: string | null) => void
@@ -204,6 +205,7 @@ export const ensurePersonaServerChat = async ({
   }
 
   let chatId = shouldResetServerChat ? null : resolvedServerChatId
+  let publishServerChatState: (() => void) | null = null
   if (!chatId) {
     const created = await createChat({
       assistant_kind: "persona",
@@ -236,7 +238,6 @@ export const ensurePersonaServerChat = async ({
       throw new Error("Failed to create persona-backed chat session")
     }
     chatId = normalizedId
-    setServerChatId(normalizedId)
     const createdState =
       typeof createdMeta?.state === "string"
         ? createdMeta.state
@@ -280,27 +281,30 @@ export const ensurePersonaServerChat = async ({
         ? createdMeta.persona_memory_mode
         : personaMemoryMode
 
-    setServerChatState(
-      normalizeConversationState(createdState)
-    )
-    setServerChatVersion(createdVersion)
-    setServerChatTopic(createdTopic)
-    setServerChatClusterId(createdClusterId)
-    setServerChatSource(createdSource)
-    setServerChatExternalRef(createdExternalRef)
-    setServerChatTitle(createdTitle)
-    setServerChatCharacterId(createdCharacterId)
-    setServerChatAssistantKind(createdAssistantKind)
-    setServerChatAssistantId(createdAssistantId)
-    setServerChatPersonaMemoryMode(createdPersonaMemoryMode)
-    setServerChatMetaLoaded(true)
-    invalidateServerChatHistory()
+    publishServerChatState = () => {
+      setServerChatId(normalizedId)
+      setServerChatState(normalizeConversationState(createdState))
+      setServerChatVersion(createdVersion)
+      setServerChatTopic(createdTopic)
+      setServerChatClusterId(createdClusterId)
+      setServerChatSource(createdSource)
+      setServerChatExternalRef(createdExternalRef)
+      setServerChatTitle(createdTitle)
+      setServerChatCharacterId(createdCharacterId)
+      setServerChatAssistantKind(createdAssistantKind)
+      setServerChatAssistantId(createdAssistantId)
+      setServerChatPersonaMemoryMode(createdPersonaMemoryMode)
+      setServerChatMetaLoaded(true)
+      invalidateServerChatHistory()
+    }
   } else {
     throwIfScopeInvalidated()
-    setServerChatAssistantKind("persona")
-    setServerChatAssistantId(assistantId)
-    setServerChatPersonaMemoryMode(personaMemoryMode)
-    setServerChatCharacterId(null)
+    publishServerChatState = () => {
+      setServerChatAssistantKind("persona")
+      setServerChatAssistantId(assistantId)
+      setServerChatPersonaMemoryMode(personaMemoryMode)
+      setServerChatCharacterId(null)
+    }
   }
 
   let resolvedHistoryId = historyId
@@ -308,10 +312,13 @@ export const ensurePersonaServerChat = async ({
     throwIfScopeInvalidated()
     resolvedHistoryId = await ensureServerChatHistoryId(
       chatId,
-      serverChatTitle || undefined
+      serverChatTitle || undefined,
+      scopeInvalidatedSignal
     )
     throwIfScopeInvalidated()
   }
+  throwIfScopeInvalidated()
+  publishServerChatState?.()
 
   return {
     chatId,

--- a/apps/packages/ui/src/hooks/chat/useChatActions.ts
+++ b/apps/packages/ui/src/hooks/chat/useChatActions.ts
@@ -463,7 +463,8 @@ type UseChatActionsOptions = {
   setServerChatExternalRef: (ref: string | null) => void
   ensureServerChatHistoryId: (
     chatId: string,
-    title?: string
+    title?: string,
+    scopeInvalidatedSignal?: AbortSignal
   ) => Promise<string | null>
   contextFiles: UploadedFile[]
   setContextFiles: (files: UploadedFile[]) => void
@@ -1291,7 +1292,10 @@ export const useChatActions = ({
     return historyKey
   }
 
-  const buildChatModeParams = async (overrides: ChatModeOverrides = {}) => {
+  const buildChatModeParams = async (
+    overrides: ChatModeOverrides = {},
+    scopeInvalidatedSignal?: AbortSignal
+  ) => {
     const hasHistoryOverride = Object.prototype.hasOwnProperty.call(
       overrides,
       "historyId"
@@ -1303,7 +1307,8 @@ export const useChatActions = ({
       : resolvedServerChatId && !temporaryChat
         ? await ensureServerChatHistoryId(
             resolvedServerChatId,
-            serverChatTitle || undefined
+            serverChatTitle || undefined,
+            scopeInvalidatedSignal
           )
         : historyId
 
@@ -1522,7 +1527,8 @@ export const useChatActions = ({
           throwIfServicePromptScopeInvalidated(servicePromptSnapshot)
           const ensuredHistoryId = await ensureServerChatHistoryId(
             validatedServerChatId,
-            serverChatTitle || undefined
+            serverChatTitle || undefined,
+            servicePromptSnapshot?.scopeInvalidatedSignal
           )
           throwIfServicePromptScopeInvalidated(servicePromptSnapshot)
           return { chatId: validatedServerChatId, historyId: ensuredHistoryId }
@@ -1547,6 +1553,7 @@ export const useChatActions = ({
       throwIfServicePromptScopeInvalidated(servicePromptSnapshot)
 
       let rawId: string | number | undefined
+      let publishCreatedMetadata: (() => void) | null = null
       if (created && typeof created === "object") {
         const {
           id,
@@ -1560,14 +1567,16 @@ export const useChatActions = ({
           external_ref
         } = created
         rawId = id ?? chat_id
-        setServerChatState(
-          normalizeConversationState(state ?? conversation_state ?? null)
-        )
-        setServerChatVersion(typeof version === "number" ? version : null)
-        setServerChatTopic(topic_label ?? null)
-        setServerChatClusterId(cluster_id ?? null)
-        setServerChatSource(source ?? null)
-        setServerChatExternalRef(external_ref ?? null)
+        publishCreatedMetadata = () => {
+          setServerChatState(
+            normalizeConversationState(state ?? conversation_state ?? null)
+          )
+          setServerChatVersion(typeof version === "number" ? version : null)
+          setServerChatTopic(topic_label ?? null)
+          setServerChatClusterId(cluster_id ?? null)
+          setServerChatSource(source ?? null)
+          setServerChatExternalRef(external_ref ?? null)
+        }
       } else if (typeof created === "string" || typeof created === "number") {
         rawId = created
       }
@@ -1581,6 +1590,14 @@ export const useChatActions = ({
         created && typeof created === "object"
           ? String(created.title ?? "")
           : titleSeed
+
+      const ensuredHistoryId = await ensureServerChatHistoryId(
+        normalizedId,
+        createdTitle || titleSeed || undefined,
+        servicePromptSnapshot?.scopeInvalidatedSignal
+      )
+      throwIfServicePromptScopeInvalidated(servicePromptSnapshot)
+      publishCreatedMetadata?.()
       setServerChatId(normalizedId)
       setServerChatTitle(createdTitle)
       setServerChatCharacterId(null)
@@ -1589,12 +1606,6 @@ export const useChatActions = ({
       setServerChatPersonaMemoryMode(null)
       setServerChatMetaLoaded(true)
       invalidateServerChatHistory()
-
-      const ensuredHistoryId = await ensureServerChatHistoryId(
-        normalizedId,
-        createdTitle || titleSeed || undefined
-      )
-      throwIfServicePromptScopeInvalidated(servicePromptSnapshot)
       return { chatId: normalizedId, historyId: ensuredHistoryId }
     },
     [
@@ -3287,24 +3298,29 @@ export const useChatActions = ({
           getRequiredServicePrompt(loadedSnapshot, promptId)
         }
       }
-      const chatModeParams = await buildChatModeParams({
-        ...(requestOverrides ?? {}),
-        ragMediaIds: turnRagMediaIds,
-        fileRetrievalEnabled: turnFileRetrievalEnabled,
-        selectedKnowledge: turnSelectedKnowledge,
-        selectedModel: effectiveSelectedModel,
-        messageSteering: messageSteeringForTurn,
-        userMessageType,
-        assistantMessageType,
-        imageGenerationRequest,
-        imageGenerationRefine,
-        imageGenerationPromptMode,
-        imageGenerationSource,
-        imageEventSyncPolicy,
-        researchContext,
-        dynamicUIRequest: turnDynamicUIRequest,
-        userMetadataExtra: turnUserMetadataExtra
-      })
+      const chatModeParams = await buildChatModeParams(
+        {
+          ...(requestOverrides ?? {}),
+          ragMediaIds: turnRagMediaIds,
+          fileRetrievalEnabled: turnFileRetrievalEnabled,
+          selectedKnowledge: turnSelectedKnowledge,
+          selectedModel: effectiveSelectedModel,
+          messageSteering: messageSteeringForTurn,
+          userMessageType,
+          assistantMessageType,
+          imageGenerationRequest,
+          imageGenerationRefine,
+          imageGenerationPromptMode,
+          imageGenerationSource,
+          imageEventSyncPolicy,
+          researchContext,
+          dynamicUIRequest: turnDynamicUIRequest,
+          userMetadataExtra: turnUserMetadataExtra
+        },
+        (
+          turnServicePromptSnapshot ?? compareServicePromptSnapshot
+        )?.scopeInvalidatedSignal
+      )
       const baseMessages = chatHistory || messages
       const baseHistory = memory || history
       const replyOverrides = replyActive
@@ -3866,18 +3882,21 @@ export const useChatActions = ({
 
           setIsProcessing(true)
 
-          const compareChatModeParams = await buildChatModeParams({
-            ...(requestOverrides ?? {}),
-            historyId: activeHistoryId,
-            setHistory: () => {},
-            setStreaming: () => {},
-            setIsProcessing: () => {},
-            setAbortController: () => {},
-            // Compare owns the shared controller for the whole turn (see the
-            // single reset after Promise.all). Sub-turns must not release it.
-            releaseAbortControllerIfOwned: () => false,
-            messageSteering: messageSteeringForTurn
-          })
+          const compareChatModeParams = await buildChatModeParams(
+            {
+              ...(requestOverrides ?? {}),
+              historyId: activeHistoryId,
+              setHistory: () => {},
+              setStreaming: () => {},
+              setIsProcessing: () => {},
+              setAbortController: () => {},
+              // Compare owns the shared controller for the whole turn (see the
+              // single reset after Promise.all). Sub-turns must not release it.
+              releaseAbortControllerIfOwned: () => false,
+              messageSteering: messageSteeringForTurn
+            },
+            compareServicePromptSnapshot?.scopeInvalidatedSignal
+          )
           const compareEnhancedParams = {
             ...compareChatModeParams,
             uploadedFiles: turnUploadedFiles,
@@ -4156,9 +4175,10 @@ export const useChatActions = ({
           getRequiredServicePrompt(replyServicePromptSnapshot, promptId)
         }
       }
-      const chatModeParams = await buildChatModeParams({
-        messageSteering: messageSteeringForTurn
-      })
+      const chatModeParams = await buildChatModeParams(
+        { messageSteering: messageSteeringForTurn },
+        replyServicePromptSnapshot?.scopeInvalidatedSignal
+      )
       const enhancedChatModeParams = {
         ...chatModeParams,
         uploadedFiles: uploadedFiles,

--- a/apps/packages/ui/src/hooks/chat/useServerChatHistoryId.ts
+++ b/apps/packages/ui/src/hooks/chat/useServerChatHistoryId.ts
@@ -6,6 +6,8 @@ import {
   setHistoryServerChatId,
   updateHistory
 } from "@/db/dexie/helpers"
+import { runChatPersistenceTransaction } from "@/db/dexie/chat-persistence-transaction"
+import { createServicePromptScopeChangedError } from "@/services/tldw/service-prompt-scope-error"
 
 type UseServerChatHistoryIdOptions = {
   serverChatId: string | null
@@ -45,8 +47,18 @@ export const useServerChatHistoryId = ({
   }, [serverChatId])
 
   const ensureServerChatHistoryId = React.useCallback(
-    async (chatId: string, title?: string) => {
+    async (
+      chatId: string,
+      title?: string,
+      scopeInvalidatedSignal?: AbortSignal
+    ) => {
       if (!chatId || temporaryChat) return null
+      const throwIfScopeInvalidated = () => {
+        if (scopeInvalidatedSignal?.aborted) {
+          throw createServicePromptScopeChangedError()
+        }
+      }
+      throwIfScopeInvalidated()
       const currentHistoryId = historyIdRef.current
       if (
         serverChatHistoryIdRef.current.chatId === chatId &&
@@ -59,51 +71,71 @@ export const useServerChatHistoryId = ({
         return existingId
       }
 
-      const existing = await getHistoryByServerChatId(chatId)
-      const trimmedTitle = (title || existing?.title || "").trim()
-      const resolvedTitle =
-        trimmedTitle ||
-        t("common:untitled", { defaultValue: "Untitled" })
+      const linkHistory = async () => {
+        const existing = await getHistoryByServerChatId(chatId)
+        const trimmedTitle = (title || existing?.title || "").trim()
+        const resolvedTitle =
+          trimmedTitle ||
+          t("common:untitled", { defaultValue: "Untitled" })
 
-      if (existing) {
-        if (resolvedTitle && resolvedTitle !== existing.title) {
-          await updateHistory(existing.id, resolvedTitle)
+        if (existing) {
+          if (resolvedTitle && resolvedTitle !== existing.title) {
+            await updateHistory(existing.id, resolvedTitle)
+          }
+          return {
+            historyId: existing.id,
+            shouldSetHistoryId: currentHistoryId !== existing.id
+          }
         }
-        serverChatHistoryIdRef.current = {
-          chatId,
-          historyId: existing.id
+
+        if (currentHistoryId && currentHistoryId !== "temp") {
+          await setHistoryServerChatId(currentHistoryId, chatId)
+          if (resolvedTitle) {
+            await updateHistory(currentHistoryId, resolvedTitle)
+          }
+          return {
+            historyId: currentHistoryId,
+            shouldSetHistoryId: false
+          }
         }
-        if (currentHistoryId !== existing.id) {
-          setHistoryId(existing.id, { preserveServerChatId: true })
+
+        const newHistory = await saveHistory(
+          resolvedTitle,
+          false,
+          "server",
+          undefined,
+          chatId
+        )
+        return {
+          historyId: newHistory.id,
+          shouldSetHistoryId: true
         }
-        return existing.id
       }
 
-      if (currentHistoryId && currentHistoryId !== "temp") {
-        await setHistoryServerChatId(currentHistoryId, chatId)
-        if (resolvedTitle) {
-          await updateHistory(currentHistoryId, resolvedTitle)
+      let linkedHistory: Awaited<ReturnType<typeof linkHistory>>
+      try {
+        linkedHistory = scopeInvalidatedSignal
+          ? await runChatPersistenceTransaction(
+              scopeInvalidatedSignal,
+              linkHistory
+            )
+          : await linkHistory()
+      } catch (error) {
+        if (scopeInvalidatedSignal?.aborted) {
+          throw createServicePromptScopeChangedError()
         }
-        serverChatHistoryIdRef.current = {
-          chatId,
-          historyId: currentHistoryId
-        }
-        return currentHistoryId
+        throw error
       }
 
-      const newHistory = await saveHistory(
-        resolvedTitle,
-        false,
-        "server",
-        undefined,
-        chatId
-      )
+      throwIfScopeInvalidated()
       serverChatHistoryIdRef.current = {
         chatId,
-        historyId: newHistory.id
+        historyId: linkedHistory.historyId
       }
-      setHistoryId(newHistory.id, { preserveServerChatId: true })
-      return newHistory.id
+      if (linkedHistory.shouldSetHistoryId) {
+        setHistoryId(linkedHistory.historyId, { preserveServerChatId: true })
+      }
+      return linkedHistory.historyId
     },
     [setHistoryId, t, temporaryChat]
   )

--- a/apps/packages/ui/src/hooks/chat/useServerChatLoader.ts
+++ b/apps/packages/ui/src/hooks/chat/useServerChatLoader.ts
@@ -38,7 +38,8 @@ type NotificationApi = {
 type UseServerChatLoaderOptions = {
   ensureServerChatHistoryId: (
     chatId: string,
-    title?: string
+    title?: string,
+    scopeInvalidatedSignal?: AbortSignal
   ) => Promise<string | null>
   notification: NotificationApi
   t: TFunction
@@ -149,6 +150,7 @@ export const shouldCommitServerChatLoadResult = ({
 }): boolean => {
   if (!requestedChatId || !activeServerChatId) return false
   if (requestedChatId !== activeServerChatId) return false
+  if (requestController?.signal.aborted) return false
   return requestController != null && requestController === activeController
 }
 
@@ -1031,11 +1033,18 @@ export const useServerChatLoader = ({
               })
           }
           if (!temporaryChat && !shouldPreserveLocal && !shouldPreserveAtCommit) {
+            if (!canCommitCurrentLoad()) {
+              return
+            }
             try {
               const localHistoryId = await ensureServerChatHistoryId(
                 serverChatId,
-                chatTitle || undefined
+                chatTitle || undefined,
+                controller.signal
               )
+              if (!canCommitCurrentLoad()) {
+                return
+              }
               if (localHistoryId) {
                 try {
                   await syncChatSettingsForServerChat({
@@ -1092,8 +1101,14 @@ export const useServerChatLoader = ({
                 }
               }
             } catch {
+              if (!canCommitCurrentLoad()) {
+                return
+              }
               // Local mirror is best-effort for server chats.
             }
+          }
+          if (!canCommitCurrentLoad()) {
+            return
           }
           if (chatTitle) {
             updatePageTitle(chatTitle)

--- a/backlog/tasks/task-13023 - Prevent-stale-server-chat-history-persistence-after-request-scope-changes.md
+++ b/backlog/tasks/task-13023 - Prevent-stale-server-chat-history-persistence-after-request-scope-changes.md
@@ -1,0 +1,62 @@
+---
+id: TASK-13023
+title: Prevent stale server-chat history persistence after request scope changes
+status: Done
+assignee: []
+created_date: '2026-08-22 07:08'
+updated_date: '2026-08-22 07:26'
+labels:
+  - chat
+  - scope-isolation
+  - frontend
+dependencies: []
+references:
+  - TASK-13014
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make workspace and persona server-chat history linking fail closed when the captured server/account scope is invalidated, so stale Dexie mappings, history refs, and shared server-chat UI metadata cannot commit after a scope change.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Scoped history linking rolls back Dexie mutations when the dedicated scope-invalidated signal aborts before commit.
+- [x] #2 Workspace and persona create/reuse paths publish server-chat metadata and invalidate history only after scoped history linking succeeds.
+- [x] #3 Unscoped callers preserve existing behavior and public call compatibility.
+- [x] #4 Focused regressions cover workspace creation, persona creation/reuse, and local history ref/persistence invalidation.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Trace the existing history-linking boundary; add RED regressions; implement the minimal scoped transaction and deferred-state commit; run focused tests, typecheck, lint, extension compile, and diff verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: five focused regressions reproduced stale Dexie/ref and workspace/persona publication; an additional existing-chat preflight assertion also failed before its signal was threaded.
+
+GREEN: 81 focused/adjacent Vitest tests passed; extension compile passed; focused ESLint reported 0 errors; git diff --check passed.
+
+Known baseline: the mixed image-event suite retains four unrelated character-stream failures; package-wide UI test typecheck retains an unrelated docs fixture error at useChatActions.service-prompts.test.tsx:1030. All five image-sync tests passed. Bandit is not applicable because the touched implementation is TypeScript only; no documentation change was needed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made server-chat history linking scope-aware: scoped Dexie work now runs transactionally and publishes refs/history state only after scope validation. Workspace, persona create/reuse, existing-chat preflight, Compare, and per-model paths pass the dedicated invalidation signal and defer shared server-chat metadata until history linking succeeds. Added RED/GREEN regressions for rollback/cache isolation and deferred workspace/persona publication.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13023 - Prevent-stale-server-chat-history-persistence-after-request-scope-changes.md
+++ b/backlog/tasks/task-13023 - Prevent-stale-server-chat-history-persistence-after-request-scope-changes.md
@@ -4,7 +4,7 @@ title: Prevent stale server-chat history persistence after request scope changes
 status: Done
 assignee: []
 created_date: '2026-08-22 07:08'
-updated_date: '2026-08-22 07:26'
+updated_date: '2026-08-22 07:41'
 labels:
   - chat
   - scope-isolation
@@ -43,12 +43,18 @@ RED: five focused regressions reproduced stale Dexie/ref and workspace/persona p
 GREEN: 81 focused/adjacent Vitest tests passed; extension compile passed; focused ESLint reported 0 errors; git diff --check passed.
 
 Known baseline: the mixed image-event suite retains four unrelated character-stream failures; package-wide UI test typecheck retains an unrelated docs fixture error at useChatActions.service-prompts.test.tsx:1030. All five image-sync tests passed. Bandit is not applicable because the touched implementation is TypeScript only; no documentation change was needed.
+
+Independent pre-publication review of 8d83b6d3..ed57d8aa found no Critical, Important, or Minor issues and assessed the change ready to merge.
+
+Published as draft PR #2799: https://github.com/rmusser01/tldw_server/pull/2799. The repository-required human-authored Change summary remains the only known manual merge gate at publication time.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Made server-chat history linking scope-aware: scoped Dexie work now runs transactionally and publishes refs/history state only after scope validation. Workspace, persona create/reuse, existing-chat preflight, Compare, and per-model paths pass the dedicated invalidation signal and defer shared server-chat metadata until history linking succeeds. Added RED/GREEN regressions for rollback/cache isolation and deferred workspace/persona publication.
+
+The reviewed branch was rebased onto current dev and published as draft PR #2799.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13023 - Prevent-stale-server-chat-history-persistence-after-request-scope-changes.md
+++ b/backlog/tasks/task-13023 - Prevent-stale-server-chat-history-persistence-after-request-scope-changes.md
@@ -4,7 +4,7 @@ title: Prevent stale server-chat history persistence after request scope changes
 status: Done
 assignee: []
 created_date: '2026-08-22 07:08'
-updated_date: '2026-08-22 07:41'
+updated_date: '2026-08-22 15:19'
 labels:
   - chat
   - scope-isolation
@@ -47,6 +47,12 @@ Known baseline: the mixed image-event suite retains four unrelated character-str
 Independent pre-publication review of 8d83b6d3..ed57d8aa found no Critical, Important, or Minor issues and assessed the change ready to merge.
 
 Published as draft PR #2799: https://github.com/rmusser01/tldw_server/pull/2799. The repository-required human-authored Change summary remains the only known manual merge gate at publication time.
+
+Qodo review on PR #2799 posted two threads: remove the transaction-helper implementation assertion, and prevent an aborted/superseded useServerChatLoader load from committing local history/title/load state. Root cause: shouldCommitServerChatLoadResult does not reject an already-aborted owned controller, and the best-effort local-mirror catch can continue after cancellation.
+
+Qodo remediation RED: 2 focused failures reproduced the gap—an aborted owned loader still passed shouldCommitServerChatLoadResult, and superseded Chat A published its title after Chat B replaced it. GREEN: the loader now rejects aborted ownership, forwards its per-load signal into scoped history linking, and checks ownership before/after the link and before final publication; the brittle transaction-helper call assertion was removed while behavior coverage remains. Verification: 84/84 focused and adjacent tests passed; extension compile passed; focused ESLint reported 0 errors (pre-existing warnings only); git diff --check passed. Bandit remains not applicable because all touched implementation is TypeScript.
+
+Post-review rebase: rebased conflict-free onto origin/dev 424cb464a6225d71adbcd1fcedcb0a73853a2055, then reran the exact focused gates: 84/84 tests passed, extension compile passed, focused ESLint reported 0 errors, and branch diff check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -55,6 +61,8 @@ Published as draft PR #2799: https://github.com/rmusser01/tldw_server/pull/2799.
 Made server-chat history linking scope-aware: scoped Dexie work now runs transactionally and publishes refs/history state only after scope validation. Workspace, persona create/reuse, existing-chat preflight, Compare, and per-model paths pass the dedicated invalidation signal and defer shared server-chat metadata until history linking succeeds. Added RED/GREEN regressions for rollback/cache isolation and deferred workspace/persona publication.
 
 The reviewed branch was rebased onto current dev and published as draft PR #2799.
+
+Addressed both Qodo review findings with behavior-first coverage: removed the internal transaction-call assertion and made server-chat loading fail closed when its per-load controller is aborted, preventing superseded history linking, title publication, and loaded-state publication.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Change summary (human-authored)

PR addressing sync state mismatch in user local chat history.

This approach was chosen to prevent account or server changes during asynchronous history linking from persisting stale mappings or exposing old-scope chat state, while preserving existing behavior for unscoped callers.

## Summary

- What changed: Server-chat local-history linking now uses the dedicated captured-scope invalidation signal. Scoped Dexie work is transactional, cache/history publication waits for successful scope validation, and workspace/persona metadata is published only after history linking succeeds.
- Why: A server or account switch during asynchronous history linking could previously leave stale local mappings or old-scope server-chat UI state committed.
- Tracking: TASK-13023.

## Validation

- [x] Tests added/updated for behavior changes.
- [x] Relevant unit/integration tests pass locally: 81/81 across the history hook, transaction helper, workspace/persona/service-prompt paths, adjacent chat actions, and unscoped useMessageOption consumers.
- [x] Extension TypeScript compile passes.
- [x] Focused ESLint completes with 0 errors; existing warnings remain unchanged.
- [x] git diff --check passes.
- [x] Independent code review found no Critical, Important, or Minor issues.
- [x] Docs reviewed: no user-facing route, configuration, or UI documentation change is needed.
- [x] Bandit not applicable because all touched implementation files are TypeScript.

Known unrelated baseline: the mixed image-event-sync suite retains four character-stream failures while all five image-sync tests pass. The package-wide UI test typecheck retains the existing docs fixture error at useChatActions.service-prompts.test.tsx:1030.

## UX Audit Checklist (v2 Stage 5)

- [x] WebUI/extension parity validated through the shared focused tests and extension compile.
- [x] Remaining Stage 5 visual/a11y items are not applicable; this change has no rendered UI or copy changes.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable; no Watchlists behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable; no Watchlists behavior changed.

## Risk & Rollback

- Risk level: Low. The optional signal preserves legacy unscoped behavior, and scoped state publication is only delayed until the existing history-link boundary succeeds.
- Rollback plan: Revert commit ed57d8aab900673fbed90dca672dcb23fcc69eae.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale server-chat history, title, and load-state commits when scope or active chat changes mid-link. Old behavior: async linking could persist stale local mappings and publish old-scope metadata; new behavior: history linking runs in a scope-aware Dexie transaction, loaders abort superseded requests, and we publish metadata only after scope validation. Satisfies TASK-13023.

- Key changes:
  - `useServerChatHistoryId` links in `runChatPersistenceTransaction` and throws a scope-changed error on abort.
  - `useServerChatLoader` forwards its per-load controller.signal to linking and blocks aborted/superseded commits.
  - Persona/workspace/service-prompt paths pass the invalidation signal and defer metadata publication until history linking succeeds. Unscoped callers keep existing behavior.

- Migration:
  - `ensureServerChatHistoryId(chatId, title?, scopeInvalidatedSignal?)`: scoped callers must pass a `scopeInvalidatedSignal`. Unscoped callers require no changes.

<sup>Written for commit 32e09ac83189fef7666d89de129b752dbfc418a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



