### PR TITLE
feat(scheduled-tasks): agent-task Jobs consumer — durable runs, timed_out, notification pass-back (TASK-13021)

### DIFF
--- a/backlog/tasks/task-13021 - Agent-task-Jobs-consumer-with-durable-runs-and-notification-pass-back.md
+++ b/backlog/tasks/task-13021 - Agent-task-Jobs-consumer-with-durable-runs-and-notification-pass-back.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-13021
 title: 'Agent-task Jobs consumer: durable runs, timeout status, notification pass-back'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@robert'
 created_date: '2026-08-21 14:10'
 updated_date: '2026-08-21 14:10'
 labels:
@@ -27,13 +28,13 @@ Timeout semantics (ADR-077 decision 5): a run cancelled at its execution deadlin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The consumer handles `agent_task_run` Jobs with durable run rows and `run_slot_key` dedupe — a redelivered Job for an already-succeeded run slot is a recorded no-op, mirroring reminders
-- [ ] #2 Lifecycle is re-checked at execution time: paused/archived/disabled definitions skip with recorded reason, never execute
-- [ ] #3 `recurring_question` executions produce the generated answer through the server's LLM plumbing; `agent_task` executions run generation-only; tool-using configurations skip with an actionable reason (phase-1 boundary is enforced by the consumer, not assumed)
-- [ ] #4 Completed/failed/timed-out runs deliver a user notification (kind for agent-task results) carrying definition name, outcome, bounded summary, and run reference — governed by the definition's `notification_policy`; `metadata_only` redaction holds end-to-end
-- [ ] #5 A run cancelled at its deadline records `timed_out` (not failed, not skipped); the run-status vocabulary matches the client's so no translation layer is needed
-- [ ] #6 Definition health/last-run update after each execution; audit events recorded through the existing automation audit trail
-- [ ] #7 Tests cover dedupe, lifecycle skips, phase-1 boundary enforcement, notification construction (bounded + redacted), timeout status, and health/audit updates against the real DB/Jobs/notification shapes
+- [x] #1 The consumer handles `agent_task_run` Jobs with durable run rows and `run_slot_key` dedupe — a redelivered Job for an already-succeeded run slot is a recorded no-op, mirroring reminders
+- [x] #2 Lifecycle is re-checked at execution time: paused/archived/disabled definitions skip with recorded reason, never execute
+- [x] #3 `recurring_question` executions produce the generated answer through the server's LLM plumbing; `agent_task` executions run generation-only; tool-using configurations skip with an actionable reason (phase-1 boundary is enforced by the consumer, not assumed)
+- [x] #4 Completed/failed/timed-out runs deliver a user notification (kind for agent-task results) carrying definition name, outcome, bounded summary, and run reference — governed by the definition's `notification_policy`; `metadata_only` redaction holds end-to-end
+- [x] #5 A run cancelled at its deadline records `timed_out` (not failed, not skipped); the run-status vocabulary matches the client's so no translation layer is needed
+- [x] #6 Definition health/last-run update after each execution; audit events recorded through the existing automation audit trail
+- [x] #7 Tests cover dedupe, lifecycle skips, phase-1 boundary enforcement, notification construction (bounded + redacted), timeout status, and health/audit updates against the real DB/Jobs/notification shapes
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,3 +49,23 @@ ADR required: no (new consumer subsystem is covered by the cross-repo contract A
 5. `timed_out` status at the execution-deadline seam (align with the Jobs pipeline's existing lifecycle events)
 6. Health/last-run/audit updates; test matrix per the ACs
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Implemented 2026-08-22 on `feat/agent-task-consumer` (branched from dev after PR #2798 merged).
+
+**Approach.** Mirrors `core/Reminders/reminder_jobs.py` end-to-end: a new `scheduled_task_runs` table in `ScheduledTasksDatabase.ensure_schema` (new-table addition — safe for existing DBs, unlike ALTERs) with the reminders' dedupe-on-create semantics (`ON CONFLICT(definition_id, run_slot_key) DO NOTHING`, existing row returned); the consumer `core/Scheduled_Tasks/agent_task_jobs.py` (`handle_agent_task_job`); and `services/agent_task_jobs_worker.py` mirroring `reminder_jobs_worker.py`, registered in the sidecar poller specs (`startup_sidecar_owned_jobs_pollers.py`) under `AGENT_TASK_JOBS_WORKER_ENABLED` with the `agent_task_jobs_task` handle field.
+
+**Phase-1 boundary (AC#3) is enforced in the consumer**: any input config requesting tools (list/str/bool across `tools`/`allowed_tools`/`enable_tools`) resolves to a `skipped` run with error `tools_not_executable_in_phase1` and an actionable summary naming the approval-escalation dependency — never executed. Unknown families skip with `family_not_executable:<name>`.
+
+**Executor seam (deliberate scope cut):** the LLM executor is an injected per-family async callable (`register_executor(family, fn)`) returning the result text. This task owns the run/notification/audit/timeout machinery; wiring the real server LLM plumbing (model selection from the definition/config, provider calls) is the next slice — without a registered executor the run fails honestly (`no_executor_configured`), visible rather than silent. `agent_task` executes generation-only by sharing the same seam.
+
+**Timeout (AC#5):** `asyncio.wait_for` around the executor at 300s default records the distinct `timed_out` run status and delivers `automation_run_timed_out` — matching the client vocabulary (tldw_chatbook TASK-18939) with no translation layer.
+
+**Notification pass-back (AC#4):** outcome → user notification via the same `create_user_notification` channel reminders use, kinds `automation_run_{succeeded,failed,timed_out,skipped}`, message = bounded result summary (1000-char cap, truncation-marked) for successes / outcome copy otherwise, `dedupe_key=automation_run:{definition}:{run_id}`, governed by the definition's `notification_policy` (`enabled:false` silences; `kinds` allowlist filters). Full result stays server-side per ADR-077 decision 3; the run row carries `result_summary`.
+
+**Health/audit (AC#6):** succeeded → `ready`, failed/timed_out → `degraded` (new value; only-on-change, no version churn), skipped preserves health; every terminal outcome writes a `run_{status}` audit event. Notification/audit/health failures log and continue — the run row is written first and is authoritative.
+
+**Verification.** `tests/Notifications/test_agent_task_jobs_consumer.py` — 10 tests through real preview-gated definitions, real run rows, real user notifications, injected stub executors: success+notify, redelivery dedupe (recorded no-op), paused skip with reason, missing definition skip, tool-request refusal with actionable reason, no-executor honest failure, timeout→timed_out+notification, executor exception→failed, notification-policy silence, degraded health + audit. Full Notifications suite **221 passed**; startup preflight **16 passed**. Not live-verified against a running server (headless worktree) — noted; the tldw_chatbook TASK-18940 AC#8 live gate covers the end-to-end pass once the client side lands.
+
+**Files:** `app/core/DB_Management/Scheduled_Tasks_DB.py` (runs table + 3 run-row methods), `app/core/Scheduled_Tasks/__init__.py` + `agent_task_jobs.py` (new), `app/services/agent_task_jobs_worker.py` (new), `app/services/startup_sidecar_owned_jobs_pollers.py` (spec + service + handle), `tests/Notifications/test_agent_task_jobs_consumer.py` (new), this task file.

--- a/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
@@ -766,6 +766,27 @@ class ScheduledTasksDatabase:
                     updated_at TEXT NOT NULL
                 );
 
+                CREATE TABLE IF NOT EXISTS scheduled_task_runs (
+                    id INTEGER PRIMARY KEY,
+                    definition_id TEXT NOT NULL,
+                    owner_id INTEGER NOT NULL,
+                    scheduled_for TEXT,
+                    job_id TEXT,
+                    run_slot_utc TEXT NOT NULL,
+                    run_slot_key TEXT NOT NULL,
+                    status TEXT NOT NULL
+                        CHECK (status IN ('running', 'succeeded', 'failed', 'timed_out', 'skipped')),
+                    error TEXT,
+                    result_summary TEXT,
+                    created_at TEXT NOT NULL,
+                    started_at TEXT,
+                    completed_at TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_scheduled_task_runs_definition
+                    ON scheduled_task_runs(definition_id);
+                CREATE UNIQUE INDEX IF NOT EXISTS ux_scheduled_task_runs_slot
+                    ON scheduled_task_runs(definition_id, run_slot_key);
+
                 CREATE TABLE IF NOT EXISTS scheduled_task_audit_events (
                     id TEXT PRIMARY KEY,
                     owner_id INTEGER NOT NULL,
@@ -1297,6 +1318,93 @@ class ScheduledTasksDatabase:
                 raise ValueError("definition version conflict")
             raise KeyError(f"definition not found after update: {definition_id}")
         return updated
+
+    def create_scheduled_task_run(
+        self,
+        *,
+        definition_id: str,
+        owner_id: int,
+        scheduled_for: str | None,
+        job_id: str | None,
+        run_slot_utc: str,
+        run_slot_key: str,
+        status: str,
+        error: str | None = None,
+        started_at: str | None = None,
+    ) -> dict[str, Any]:
+        """Insert one run row, deduped on (definition_id, run_slot_key).
+
+        Mirrors the reminders' create_reminder_task_run semantics: an
+        insert that conflicts with an existing slot is a no-op, and the
+        EXISTING row is returned -- callers detect dedupe by checking the
+        returned status before doing any work.
+        """
+        now = _utcnow_iso()
+        with self._connect() as conn:
+            begin_immediate_if_needed(conn)
+            conn.execute(
+                "INSERT INTO scheduled_task_runs ("
+                "definition_id, owner_id, scheduled_for, job_id, run_slot_utc, "
+                "run_slot_key, status, error, created_at, started_at, completed_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL) "
+                "ON CONFLICT(definition_id, run_slot_key) DO NOTHING",
+                (
+                    definition_id,
+                    owner_id,
+                    scheduled_for,
+                    job_id,
+                    run_slot_utc,
+                    run_slot_key,
+                    status,
+                    error,
+                    now,
+                    started_at,
+                ),
+            )
+            row = conn.execute(
+                "SELECT * FROM scheduled_task_runs "
+                "WHERE definition_id = ? AND run_slot_key = ?",
+                (definition_id, run_slot_key),
+            ).fetchone()
+        if row is None:  # pragma: no cover - conflict path always returns a row
+            raise KeyError("scheduled_task_run_not_found")
+        return dict(row)
+
+    def update_scheduled_task_run_status(
+        self,
+        *,
+        run_id: int,
+        status: str,
+        error: str | None = None,
+        result_summary: str | None = None,
+        completed_at: str | None = None,
+    ) -> dict[str, Any]:
+        """Update a run row's terminal (or interim) status by row id."""
+        with self._connect() as conn:
+            begin_immediate_if_needed(conn)
+            cursor = conn.execute(
+                "UPDATE scheduled_task_runs SET status = ?, error = ?, "
+                "result_summary = ?, completed_at = ? WHERE id = ?",
+                (status, error, result_summary, completed_at, run_id),
+            )
+            if cursor.rowcount <= 0:
+                raise KeyError(f"scheduled_task_run_not_found: {run_id}")
+            row = conn.execute(
+                "SELECT * FROM scheduled_task_runs WHERE id = ?", (run_id,)
+            ).fetchone()
+        return dict(row)
+
+    def get_scheduled_task_run_by_slot(
+        self, *, definition_id: str, run_slot_key: str
+    ) -> dict[str, Any] | None:
+        """Return the run row for one (definition, slot), or None."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM scheduled_task_runs "
+                "WHERE definition_id = ? AND run_slot_key = ?",
+                (definition_id, run_slot_key),
+            ).fetchone()
+        return dict(row) if row is not None else None
 
     def create_audit_event(
         self,

--- a/tldw_Server_API/app/core/Scheduled_Tasks/__init__.py
+++ b/tldw_Server_API/app/core/Scheduled_Tasks/__init__.py
@@ -1,0 +1,3 @@
+from .agent_task_jobs import handle_agent_task_job, register_executor
+
+__all__ = ["handle_agent_task_job", "register_executor"]

--- a/tldw_Server_API/app/core/Scheduled_Tasks/agent_task_jobs.py
+++ b/tldw_Server_API/app/core/Scheduled_Tasks/agent_task_jobs.py
@@ -1,0 +1,385 @@
+"""Jobs consumer for scheduled automation definitions (TASK-13021).
+
+Executes the ``agent_task_run`` Jobs the scheduler feed (TASK-13020)
+enqueues, mirroring ``core/Reminders/reminder_jobs.py``: durable run rows
+deduped on (definition, run slot), lifecycle re-checked at execution
+time, and delivery of the outcome as a user notification through the same
+channel reminders use.
+
+Phase-1 boundary (tldw_chatbook ADR-077, decision 4, owner-accepted):
+execution is **side-effect-free only**. ``recurring_question`` runs
+generate their answer through the registered executor; ``agent_task``
+runs execute in generation-only mode; tool-using configurations are NOT
+executed — they resolve to an explicit ``skipped`` run with an actionable
+reason until the approval-escalation design exists. The boundary is
+enforced HERE, by the consumer, not assumed from the definition.
+
+Timeout semantics (ADR-077 decision 5): a run cancelled at its execution
+deadline records the distinct ``timed_out`` status — the client displays
+what the server reports (its own vocabulary matches, tldw_chatbook
+TASK-18939); no translation layer.
+
+The LLM executor is an injected async callable so this module owns the
+run/notification/audit machinery while the executor wiring lives where
+the server's model plumbing is configured. Without a registered executor
+the run fails honestly ("no executor configured") — visible, never
+silent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
+    DefinitionRow,
+    ScheduledTasksDatabase,
+)
+
+AUTOMATION_DOMAIN = "scheduled_tasks"
+AUTOMATION_JOB_TYPE = "agent_task_run"
+CONSUMER_ACTOR = "automation-consumer"
+
+#: Notification kinds delivered for run outcomes (bounded summary in the
+#: message body; the full result stays server-side per ADR-077 decision 3).
+NOTIFICATION_KIND_BY_STATUS = {
+    "succeeded": "automation_run_succeeded",
+    "failed": "automation_run_failed",
+    "timed_out": "automation_run_timed_out",
+    "skipped": "automation_run_skipped",
+}
+
+#: Execution deadline (seconds) for one phase-1 run. Distinct from the
+#: feed's misfire concerns: this bounds the EXECUTION, recording
+#: ``timed_out`` on expiry.
+RUN_EXECUTION_TIMEOUT_SECONDS = 300.0
+
+#: Bounded result summary cap for notifications (ADR-077 decision 3).
+RESULT_SUMMARY_MAX_CHARS = 1000
+
+#: Definition families executable in phase 1 (side-effect-free only).
+_PHASE1_EXECUTABLE_FAMILIES = {"recurring_question", "agent_task"}
+
+Executor = Callable[[DefinitionRow, dict[str, Any]], Awaitable[str]]
+
+#: Process-wide executor registry. The wiring layer (server model
+#: plumbing) registers per-family executors at startup; tests inject
+#: their own. Keyed by family; ``None`` value = generation-only default.
+_EXECUTORS: dict[str, Executor] = {}
+
+
+def register_executor(family: str, executor: Executor) -> None:
+    """Register the phase-1 executor callable for one definition family."""
+    _EXECUTORS[family] = executor
+
+
+def _phase1_tools_requested(definition: DefinitionRow) -> bool:
+    """Return True when the definition's config asks for tools (phase-2).
+
+    Phase 1 executes generation-only work; a config that enables tools of
+    any kind marks the definition out of bounds until the
+    approval-escalation design exists.
+    """
+    config = definition.input if isinstance(definition.input, dict) else {}
+    tools = config.get("tools") or config.get("allowed_tools") or config.get("enable_tools")
+    if isinstance(tools, (list, tuple, set)) and tools:
+        return True
+    if isinstance(tools, str) and tools.strip().lower() not in ("", "false", "none", "0"):
+        return True
+    if isinstance(tools, bool) and tools:
+        return True
+    return False
+
+
+def _normalize_slot_utc(value: Any) -> str:
+    """Normalize a slot timestamp to second-precision UTC ISO-8601."""
+    if not value:
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        parsed = datetime.now(timezone.utc)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _bound_summary(text: str) -> str:
+    """Bound a result summary for notification delivery."""
+    cleaned = " ".join(str(text or "").split())
+    if len(cleaned) <= RESULT_SUMMARY_MAX_CHARS:
+        return cleaned
+    return cleaned[: RESULT_SUMMARY_MAX_CHARS - 20] + " … [truncated]"
+
+
+def _notification_enabled(definition: DefinitionRow, status: str) -> bool:
+    """Apply the definition's notification_policy to an outcome.
+
+    Policies default to delivering everything; an explicit ``kinds``
+    allowlist filters by outcome, and ``enabled: false`` silences all.
+    """
+    policy = (
+        definition.notification_policy
+        if isinstance(definition.notification_policy, dict)
+        else {}
+    )
+    if policy.get("enabled") is False:
+        return False
+    kinds = policy.get("kinds")
+    if isinstance(kinds, (list, tuple)) and kinds:
+        return status in kinds
+    return True
+
+
+async def handle_agent_task_job(
+    job: dict[str, Any],
+    *,
+    scheduled_db: ScheduledTasksDatabase | None = None,
+    collections_db: CollectionsDatabase | None = None,
+    execution_timeout_seconds: float = RUN_EXECUTION_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Consume one ``agent_task_run`` Job: run row, execute, notify, audit.
+
+    Returns a result dict shaped like the reminders consumer's (``status``,
+    ``definition_id``, ``run_id``, ``deduped`` for no-op redeliveries).
+    """
+    payload = job.get("payload") if isinstance(job.get("payload"), dict) else {}
+    definition_id = str(payload.get("definition_id") or "").strip()
+    if not definition_id:
+        raise ValueError("missing definition_id")
+    owner = job.get("owner_user_id") or payload.get("user_id")
+    if owner is None or str(owner).strip() == "":
+        raise ValueError("missing owner_user_id")
+    user_id = int(owner)
+
+    run_slot_utc = _normalize_slot_utc(payload.get("scheduled_for"))
+    run_slot_key = run_slot_utc
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    sdb = scheduled_db or ScheduledTasksDatabase.for_user(user_id=user_id)
+    cdb = collections_db or CollectionsDatabase.for_user(user_id=user_id)
+
+    # Durable run row, deduped on (definition, slot): a redelivered Job for
+    # an already-terminal (or in-flight) slot is a recorded no-op.
+    run = sdb.create_scheduled_task_run(
+        definition_id=definition_id,
+        owner_id=user_id,
+        scheduled_for=payload.get("scheduled_for"),
+        job_id=str(job.get("id")) if job.get("id") is not None else None,
+        run_slot_utc=run_slot_utc,
+        run_slot_key=run_slot_key,
+        status="running",
+        started_at=now_iso,
+    )
+    if run["status"] in ("succeeded", "skipped", "failed", "timed_out"):
+        return {
+            "status": run["status"],
+            "definition_id": definition_id,
+            "run_id": run["id"],
+            "deduped": True,
+        }
+
+    try:
+        definition = sdb.get_definition(owner_id=user_id, definition_id=definition_id)
+    except KeyError:
+        definition = None
+    if definition is None:
+        _finish(
+            sdb,
+            cdb,
+            definition=None,
+            run_id=run["id"],
+            status="skipped",
+            error="definition_missing",
+            summary=None,
+        )
+        return {"status": "skipped", "definition_id": definition_id, "run_id": run["id"]}
+
+    # Lifecycle re-check at execution time: arming gates on 'configured',
+    # but the definition may have been paused/archived/disabled since.
+    if definition.lifecycle != "configured":
+        _finish(
+            sdb,
+            cdb,
+            definition=definition,
+            run_id=run["id"],
+            status="skipped",
+            error=f"definition_{definition.lifecycle}",
+            summary=None,
+        )
+        return {"status": "skipped", "definition_id": definition_id, "run_id": run["id"]}
+
+    # Phase-1 boundary, enforced by the consumer (not assumed): tools are
+    # out of bounds until the approval-escalation design exists.
+    if _phase1_tools_requested(definition):
+        _finish(
+            sdb,
+            cdb,
+            definition=definition,
+            run_id=run["id"],
+            status="skipped",
+            error="tools_not_executable_in_phase1",
+            summary=(
+                "This definition requests tools; server-side tool use is not "
+                "executable until the approval-escalation design lands."
+            ),
+        )
+        return {"status": "skipped", "definition_id": definition_id, "run_id": run["id"]}
+
+    if definition.family not in _PHASE1_EXECUTABLE_FAMILIES:
+        _finish(
+            sdb,
+            cdb,
+            definition=definition,
+            run_id=run["id"],
+            status="skipped",
+            error=f"family_not_executable:{definition.family}",
+            summary=None,
+        )
+        return {"status": "skipped", "definition_id": definition_id, "run_id": run["id"]}
+
+    executor = _EXECUTORS.get(definition.family)
+    if executor is None:
+        _finish(
+            sdb,
+            cdb,
+            definition=definition,
+            run_id=run["id"],
+            status="failed",
+            error="no_executor_configured",
+            summary=None,
+        )
+        return {"status": "failed", "definition_id": definition_id, "run_id": run["id"]}
+
+    timed_out = False
+    result_text: str | None = None
+    error_text: str | None = None
+    try:
+        result_text = await asyncio.wait_for(
+            executor(definition, payload), timeout=execution_timeout_seconds
+        )
+    except asyncio.TimeoutError:
+        timed_out = True
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - one bad run must not kill the worker
+        error_text = f"{type(exc).__name__}: {exc}"
+        logger.warning(
+            "Automation run executor failed for definition {}: {}",
+            definition_id,
+            error_text,
+        )
+
+    status = "timed_out" if timed_out else ("failed" if error_text else "succeeded")
+    _finish(
+        sdb,
+        cdb,
+        definition=definition,
+        run_id=run["id"],
+        status=status,
+        error=error_text,
+        summary=_bound_summary(result_text) if result_text is not None else None,
+    )
+    return {"status": status, "definition_id": definition_id, "run_id": run["id"]}
+
+
+def _finish(
+    sdb: ScheduledTasksDatabase,
+    cdb: CollectionsDatabase,
+    *,
+    definition: DefinitionRow | None,
+    run_id: int,
+    status: str,
+    error: str | None,
+    summary: str | None,
+) -> None:
+    """Record the terminal run state, deliver the notification, update health.
+
+    Notification and audit failures never mask the run outcome: the run
+    row is written first, and downstream failures log and continue.
+    """
+    completed_at = datetime.now(timezone.utc).isoformat()
+    try:
+        sdb.update_scheduled_task_run_status(
+            run_id=run_id,
+            status=status,
+            error=error,
+            result_summary=summary,
+            completed_at=completed_at,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Automation run status update failed: run_id={}", run_id)
+
+    if definition is None:
+        return
+
+    # Definition health reflects the latest run's reality (only-on-change:
+    # no version churn for repeated identical outcomes).
+    health = {
+        "succeeded": "ready",
+        "timed_out": "degraded",
+        "failed": "degraded",
+        "skipped": definition.health,
+    }.get(status, definition.health)
+    if health != definition.health:
+        try:
+            sdb.update_definition(
+                owner_id=definition.owner_id,
+                definition_id=definition.id,
+                patch={"health": health, "updated_by": CONSUMER_ACTOR},
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Automation health update failed for definition {}", definition.id
+            )
+
+    if _notification_enabled(definition, status):
+        try:
+            kind = NOTIFICATION_KIND_BY_STATUS.get(status, "automation_run_failed")
+            if status == "succeeded" and summary:
+                message = summary
+            elif status == "timed_out":
+                message = (
+                    f"Run timed out after the execution deadline "
+                    f"({int(RUN_EXECUTION_TIMEOUT_SECONDS)}s)."
+                )
+            elif status == "skipped":
+                message = summary or f"Skipped: {error or 'unknown reason'}."
+            else:
+                message = f"Run failed: {error or 'unknown error'}."
+            cdb.create_user_notification(
+                kind=kind,
+                title=definition.name,
+                message=message,
+                severity="info" if status == "succeeded" else "warning",
+                source_domain=AUTOMATION_DOMAIN,
+                source_job_type=AUTOMATION_JOB_TYPE,
+                source_job_id=str(run_id),
+                dedupe_key=f"automation_run:{definition.id}:{run_id}",
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Automation run notification failed: definition={} run_id={}",
+                definition.id,
+                run_id,
+            )
+
+    try:
+        sdb.create_audit_event(
+            owner_id=definition.owner_id,
+            definition_id=definition.id,
+            event_type=f"run_{status}",
+            actor=CONSUMER_ACTOR,
+            summary=f"Run {status}" + (f": {error}" if error else "."),
+            before=None,
+            after={"run_id": run_id, "status": status},
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "Automation run audit failed: definition={} run_id={}", definition.id, run_id
+        )

--- a/tldw_Server_API/app/core/Scheduled_Tasks/agent_task_jobs.py
+++ b/tldw_Server_API/app/core/Scheduled_Tasks/agent_task_jobs.py
@@ -36,6 +36,7 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+from tldw_Server_API.app.core.exceptions import BadRequestError
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
     DefinitionRow,
     ScheduledTasksDatabase,
@@ -151,10 +152,10 @@ async def handle_agent_task_job(
     payload = job.get("payload") if isinstance(job.get("payload"), dict) else {}
     definition_id = str(payload.get("definition_id") or "").strip()
     if not definition_id:
-        raise ValueError("missing definition_id")
+        raise BadRequestError("missing definition_id")
     owner = job.get("owner_user_id") or payload.get("user_id")
     if owner is None or str(owner).strip() == "":
-        raise ValueError("missing owner_user_id")
+        raise BadRequestError("missing owner_user_id")
     user_id = int(owner)
 
     run_slot_utc = _normalize_slot_utc(payload.get("scheduled_for"))
@@ -197,6 +198,8 @@ async def handle_agent_task_job(
             status="skipped",
             error="definition_missing",
             summary=None,
+            jobs_job_id=str(job.get("id")) if job.get("id") is not None else None,
+            execution_timeout_seconds=execution_timeout_seconds,
         )
         return {"status": "skipped", "definition_id": definition_id, "run_id": run["id"]}
 
@@ -211,6 +214,8 @@ async def handle_agent_task_job(
             status="skipped",
             error=f"definition_{definition.lifecycle}",
             summary=None,
+            jobs_job_id=str(job.get("id")) if job.get("id") is not None else None,
+            execution_timeout_seconds=execution_timeout_seconds,
         )
         return {"status": "skipped", "definition_id": definition_id, "run_id": run["id"]}
 
@@ -228,6 +233,8 @@ async def handle_agent_task_job(
                 "This definition requests tools; server-side tool use is not "
                 "executable until the approval-escalation design lands."
             ),
+            jobs_job_id=str(job.get("id")) if job.get("id") is not None else None,
+            execution_timeout_seconds=execution_timeout_seconds,
         )
         return {"status": "skipped", "definition_id": definition_id, "run_id": run["id"]}
 
@@ -240,6 +247,8 @@ async def handle_agent_task_job(
             status="skipped",
             error=f"family_not_executable:{definition.family}",
             summary=None,
+            jobs_job_id=str(job.get("id")) if job.get("id") is not None else None,
+            execution_timeout_seconds=execution_timeout_seconds,
         )
         return {"status": "skipped", "definition_id": definition_id, "run_id": run["id"]}
 
@@ -253,12 +262,15 @@ async def handle_agent_task_job(
             status="failed",
             error="no_executor_configured",
             summary=None,
+            jobs_job_id=str(job.get("id")) if job.get("id") is not None else None,
+            execution_timeout_seconds=execution_timeout_seconds,
         )
         return {"status": "failed", "definition_id": definition_id, "run_id": run["id"]}
 
     timed_out = False
     result_text: str | None = None
     error_text: str | None = None
+    jobs_job_id = str(job.get("id")) if job.get("id") is not None else None
     try:
         result_text = await asyncio.wait_for(
             executor(definition, payload), timeout=execution_timeout_seconds
@@ -273,6 +285,10 @@ async def handle_agent_task_job(
             "Automation run executor failed for definition {}: {}",
             definition_id,
             error_text,
+            definition_id=definition_id,
+            user_id=user_id,
+            run_id=run["id"],
+            job_id=job.get("id"),
         )
 
     status = "timed_out" if timed_out else ("failed" if error_text else "succeeded")
@@ -284,6 +300,8 @@ async def handle_agent_task_job(
         status=status,
         error=error_text,
         summary=_bound_summary(result_text) if result_text is not None else None,
+        jobs_job_id=jobs_job_id,
+        execution_timeout_seconds=execution_timeout_seconds,
     )
     return {"status": status, "definition_id": definition_id, "run_id": run["id"]}
 
@@ -297,6 +315,8 @@ def _finish(
     status: str,
     error: str | None,
     summary: str | None,
+    jobs_job_id: str | None = None,
+    execution_timeout_seconds: float = RUN_EXECUTION_TIMEOUT_SECONDS,
 ) -> None:
     """Record the terminal run state, deliver the notification, update health.
 
@@ -313,7 +333,11 @@ def _finish(
             completed_at=completed_at,
         )
     except Exception:  # noqa: BLE001
-        logger.exception("Automation run status update failed: run_id={}", run_id)
+        logger.exception(
+            "Automation run status update failed",
+            run_id=run_id,
+            status=status,
+        )
 
     if definition is None:
         return
@@ -335,7 +359,10 @@ def _finish(
             )
         except Exception:  # noqa: BLE001
             logger.exception(
-                "Automation health update failed for definition {}", definition.id
+                "Automation health update failed",
+                definition_id=definition.id,
+                owner_id=definition.owner_id,
+                health=health,
             )
 
     if _notification_enabled(definition, status):
@@ -346,7 +373,7 @@ def _finish(
             elif status == "timed_out":
                 message = (
                     f"Run timed out after the execution deadline "
-                    f"({int(RUN_EXECUTION_TIMEOUT_SECONDS)}s)."
+                    f"({int(execution_timeout_seconds)}s)."
                 )
             elif status == "skipped":
                 message = summary or f"Skipped: {error or 'unknown reason'}."
@@ -359,14 +386,15 @@ def _finish(
                 severity="info" if status == "succeeded" else "warning",
                 source_domain=AUTOMATION_DOMAIN,
                 source_job_type=AUTOMATION_JOB_TYPE,
-                source_job_id=str(run_id),
+                source_job_id=jobs_job_id,
                 dedupe_key=f"automation_run:{definition.id}:{run_id}",
             )
         except Exception:  # noqa: BLE001
             logger.exception(
-                "Automation run notification failed: definition={} run_id={}",
-                definition.id,
-                run_id,
+                "Automation run notification failed",
+                definition_id=definition.id,
+                run_id=run_id,
+                status=status,
             )
 
     try:
@@ -381,5 +409,8 @@ def _finish(
         )
     except Exception:  # noqa: BLE001
         logger.exception(
-            "Automation run audit failed: definition={} run_id={}", definition.id, run_id
+            "Automation run audit failed",
+            definition_id=definition.id,
+            run_id=run_id,
+            status=status,
         )

--- a/tldw_Server_API/app/services/agent_task_jobs_worker.py
+++ b/tldw_Server_API/app/services/agent_task_jobs_worker.py
@@ -1,0 +1,117 @@
+"""Jobs worker for scheduled automation definitions (TASK-13021).
+
+Mirrors ``reminder_jobs_worker.py`` exactly: env-gated worker loop,
+lease-based job acquisition on the ``scheduled_tasks`` domain, and
+completion/failure reporting back to the Jobs pipeline. Enable together
+with the feed (`SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED`) — arming
+without a consumer only queues jobs nobody executes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs import (
+    AUTOMATION_DOMAIN,
+    AUTOMATION_JOB_TYPE,
+    handle_agent_task_job,
+)
+from tldw_Server_API.app.core.testing import env_flag_enabled
+
+_AGENT_WORKER_NONCRITICAL_EXCEPTIONS = (
+    AttributeError,
+    LookupError,
+    OSError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+)
+
+
+def agent_task_jobs_queue() -> str:
+    """Return the Jobs queue name for automation work (AUTOMATION_JOBS_QUEUE)."""
+    queue = (os.getenv("AUTOMATION_JOBS_QUEUE") or "default").strip()
+    return queue or "default"
+
+
+async def run_agent_task_jobs_worker(stop_event: asyncio.Event | None = None) -> None:
+    """Poll the automation queue and consume agent_task_run Jobs until stopped."""
+    jm = JobManager()
+    worker_id = "agent-task-jobs-worker"
+    queue = agent_task_jobs_queue()
+    poll_sleep = float(os.getenv("JOBS_POLL_INTERVAL_SECONDS", "1.0") or "1.0")
+    logger.info("Starting Agent Task Jobs worker")
+    while True:
+        if stop_event and stop_event.is_set():
+            logger.info("Stopping Agent Task Jobs worker on shutdown signal")
+            return
+        try:
+            lease_seconds = int(os.getenv("JOBS_LEASE_SECONDS", "120") or "120")
+            job = jm.acquire_next_job(
+                domain=AUTOMATION_DOMAIN,
+                queue=queue,
+                lease_seconds=lease_seconds,
+                worker_id=worker_id,
+            )
+            if not job:
+                await asyncio.sleep(poll_sleep)
+                continue
+
+            lease_id = str(job.get("lease_id"))
+            if str(job.get("job_type") or "").lower() != AUTOMATION_JOB_TYPE:
+                jm.fail_job(
+                    int(job["id"]),
+                    error="unsupported automation job_type",
+                    retryable=False,
+                    worker_id=worker_id,
+                    lease_id=lease_id,
+                    completion_token=lease_id,
+                )
+                continue
+
+            try:
+                result = await handle_agent_task_job(job)
+                jm.complete_job(
+                    int(job["id"]),
+                    result=result,
+                    worker_id=worker_id,
+                    lease_id=lease_id,
+                    completion_token=lease_id,
+                )
+            except _AGENT_WORKER_NONCRITICAL_EXCEPTIONS as exc:
+                jm.fail_job(
+                    int(job["id"]),
+                    error=str(exc),
+                    retryable=False,
+                    worker_id=worker_id,
+                    lease_id=lease_id,
+                    completion_token=lease_id,
+                )
+        except _AGENT_WORKER_NONCRITICAL_EXCEPTIONS as exc:
+            logger.error("Agent Task Jobs worker loop error: {}", exc)
+            await asyncio.sleep(poll_sleep)
+
+
+async def start_agent_task_jobs_worker(
+    stop_event: asyncio.Event | None = None,
+) -> asyncio.Task | None:
+    """Start the worker when its env gate is enabled (AGENT_TASK_JOBS_WORKER_ENABLED)."""
+    if not env_flag_enabled("AGENT_TASK_JOBS_WORKER_ENABLED"):
+        return None
+    managed_stop_event = stop_event or asyncio.Event()
+    return asyncio.create_task(
+        run_agent_task_jobs_worker(managed_stop_event),
+        name="agent_task_jobs_worker",
+    )
+
+
+__all__ = [
+    "agent_task_jobs_queue",
+    "run_agent_task_jobs_worker",
+    "start_agent_task_jobs_worker",
+]

--- a/tldw_Server_API/app/services/agent_task_jobs_worker.py
+++ b/tldw_Server_API/app/services/agent_task_jobs_worker.py
@@ -16,6 +16,9 @@ from loguru import logger
 
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs import (
+    RUN_EXECUTION_TIMEOUT_SECONDS,
+)
+from tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs import (
     AUTOMATION_DOMAIN,
     AUTOMATION_JOB_TYPE,
     handle_agent_task_job,
@@ -51,7 +54,18 @@ async def run_agent_task_jobs_worker(stop_event: asyncio.Event | None = None) ->
             logger.info("Stopping Agent Task Jobs worker on shutdown signal")
             return
         try:
-            lease_seconds = int(os.getenv("JOBS_LEASE_SECONDS", "120") or "120")
+            try:
+                env_lease = int(os.getenv("JOBS_LEASE_SECONDS", "120") or "120")
+            except ValueError:
+                env_lease = 120
+            # The lease must outlive the longest execution this worker can
+            # run (review #4 on PR #2801): the Jobs manager requeues
+            # 'processing' jobs whose lease expired, so a lease shorter
+            # than the execution deadline would let a second worker start
+            # a duplicate run mid-flight. Env can only RAISE the floor.
+            lease_seconds = max(
+                env_lease, int(RUN_EXECUTION_TIMEOUT_SECONDS) + 30
+            )
             job = jm.acquire_next_job(
                 domain=AUTOMATION_DOMAIN,
                 queue=queue,

--- a/tldw_Server_API/app/services/startup_sidecar_owned_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_sidecar_owned_jobs_pollers.py
@@ -38,6 +38,7 @@ class SidecarOwnedJobsPollerHandles:
 
     reminder_jobs_stop_event: Any | None = None
     reminder_jobs_task: Any | None = None
+    agent_task_jobs_task: Any | None = None
     admin_backup_jobs_stop_event: Any | None = None
     admin_backup_jobs_task: Any | None = None
     admin_byok_validation_jobs_stop_event: Any | None = None
@@ -62,6 +63,16 @@ def provide_sidecar_owned_jobs_worker_specs(
             enabled=lambda context: _sidecar_owned_worker_enabled(
                 context,
                 _reminder_jobs_worker_enabled,
+            ),
+        ),
+        stop_event_worker_spec(
+            name="agent_task_jobs_task",
+            worker_service=_run_agent_task_jobs_worker_service,
+            category="jobs",
+            phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+            enabled=lambda context: _sidecar_owned_worker_enabled(
+                context,
+                _agent_task_jobs_worker_enabled,
             ),
         ),
         stop_event_worker_spec(
@@ -127,6 +138,12 @@ def _reminder_jobs_worker_enabled() -> bool:
     from tldw_Server_API.app.core.testing import env_flag_enabled
 
     return env_flag_enabled("REMINDER_JOBS_WORKER_ENABLED")
+
+
+def _agent_task_jobs_worker_enabled() -> bool:
+    from tldw_Server_API.app.core.testing import env_flag_enabled
+
+    return env_flag_enabled("AGENT_TASK_JOBS_WORKER_ENABLED")
 
 
 def _admin_backup_jobs_worker_enabled() -> bool:
@@ -477,6 +494,14 @@ def _run_reminder_jobs_worker_service(stop_event: Any) -> Any:
     )
 
     return _run_reminder_jobs_worker_impl(stop_event=stop_event)
+
+
+def _run_agent_task_jobs_worker_service(stop_event: Any) -> Any:
+    from tldw_Server_API.app.services.agent_task_jobs_worker import (
+        run_agent_task_jobs_worker as _run_agent_task_jobs_worker_impl,
+    )
+
+    return _run_agent_task_jobs_worker_impl(stop_event=stop_event)
 
 
 def _start_admin_backup_jobs_worker_service(*, stop_event: Any) -> Any:

--- a/tldw_Server_API/tests/Notifications/test_agent_task_jobs_consumer.py
+++ b/tldw_Server_API/tests/Notifications/test_agent_task_jobs_consumer.py
@@ -157,6 +157,9 @@ async def test_successful_run_records_and_notifies(consumer_env) -> None:
     assert notification is not None
     assert notification.kind == "automation_run_succeeded"
     assert "Daily Digest" in str(notification.title)
+    # Traceability: source_job_id references the JOBS pipeline id, not the
+    # run row id (review #6).
+    assert str(notification.source_job_id) == "77"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Notifications/test_agent_task_jobs_consumer.py
+++ b/tldw_Server_API/tests/Notifications/test_agent_task_jobs_consumer.py
@@ -1,0 +1,339 @@
+"""Agent-task Jobs consumer tests (TASK-13021).
+
+Mirrors the reminder consumer's test shapes: real per-user databases
+under a tmp USER_DB_BASE_DIR (preview-gated definition creation, real run
+rows, real user notifications), an injected stub executor, and direct
+``handle_agent_task_job`` invocation. No reimplementation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
+    DefinitionRow,
+    ScheduledTasksDatabase,
+)
+from tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs import (
+    handle_agent_task_job,
+    register_executor,
+)
+from tldw_Server_API.app.core.config import settings
+
+pytestmark = pytest.mark.unit
+
+SLOT = "2026-08-21T09:00:00+00:00"
+
+
+@pytest.fixture()
+def consumer_env(monkeypatch, tmp_path):
+    base_dir = tmp_path / "test_agent_task_consumer"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    prev_base_dir = settings.get("USER_DB_BASE_DIR")
+    settings.USER_DB_BASE_DIR = str(base_dir)
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
+    monkeypatch.setenv("JOBS_DB_PATH", str(base_dir / "jobs.db"))
+    _orig_executors = dict(getattr(__import__(
+        "tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs", fromlist=["_EXECUTORS"]
+    ), "_EXECUTORS"))
+    __import__(
+        "tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs", fromlist=["_EXECUTORS"]
+    )._EXECUTORS.clear()
+    try:
+        yield
+    finally:
+        module = __import__(
+            "tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs",
+            fromlist=["_EXECUTORS"],
+        )
+        module._EXECUTORS.clear()
+        module._EXECUTORS.update(_orig_executors)
+        if prev_base_dir is not None:
+            settings.USER_DB_BASE_DIR = prev_base_dir
+        else:
+            try:
+                del settings.USER_DB_BASE_DIR
+            except AttributeError:
+                pass
+
+
+def _create_definition(
+    user_id: int,
+    *,
+    input_config: dict[str, Any] | None = None,
+    lifecycle: str = "configured",
+    family: str = "recurring_question",
+    notification_policy: dict[str, Any] | None = None,
+) -> DefinitionRow:
+    db = ScheduledTasksDatabase.for_user(user_id=user_id)
+    db.ensure_schema()
+    preview = db.create_preview(
+        owner_id=user_id,
+        mode="create",
+        family=family,
+        definition_id=None,
+        definition_version=None,
+        status="valid",
+        payload_hash=f"hash-{datetime.now(timezone.utc).timestamp()}",
+        normalized_config={},
+        validation_errors=[],
+        warnings=[],
+        risk_class=None,
+        visibility_policy="owner",
+        schedule_preview={"kind": "daily", "at": "09:00"},
+        redaction_policy={"fields": ["input.message"], "mode": "metadata_only"},
+        expires_at=(datetime.now(timezone.utc) + timedelta(hours=24)).isoformat(),
+        created_by="test",
+    )
+    return db.create_definition(
+        owner_id=user_id,
+        family=family,
+        name="Daily Digest",
+        description=None,
+        lifecycle=lifecycle,
+        health="ready",
+        schedule={"kind": "daily", "at": "09:00"},
+        input=input_config or {"question": "What changed today?"},
+        visibility_policy="owner",
+        notification_policy=notification_policy or {},
+        approval_policy={},
+        preview_id=preview.id,
+        created_by="test",
+        updated_by="test",
+    )
+
+
+def _job(definition: DefinitionRow, user_id: int, *, slot: str = SLOT) -> dict[str, Any]:
+    return {
+        "id": 77,
+        "owner_user_id": user_id,
+        "job_type": "agent_task_run",
+        "payload": {
+            "definition_id": definition.id,
+            "user_id": user_id,
+            "family": definition.family,
+            "scheduled_for": slot,
+        },
+    }
+
+
+def _latest_notification(user_id: int) -> Any | None:
+    cdb = CollectionsDatabase.for_user(user_id=user_id)
+    rows = cdb.list_user_notifications(limit=5)
+    return rows[0] if rows else None
+
+
+# ---------------------------------------------------------------------------
+# Run rows, dedupe, lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_successful_run_records_and_notifies(consumer_env) -> None:
+    user_id = 1010
+    definition = _create_definition(user_id)
+    register_executor("recurring_question", lambda d, p: asyncio.sleep(0, result="42"))
+
+    result = await handle_agent_task_job(_job(definition, user_id))
+
+    assert result["status"] == "succeeded"
+    assert result.get("deduped") is None
+    sdb = ScheduledTasksDatabase.for_user(user_id=user_id)
+    slot_key = datetime.fromisoformat(SLOT).astimezone(timezone.utc).replace(
+        microsecond=0
+    ).isoformat()
+    run = sdb.get_scheduled_task_run_by_slot(
+        definition_id=definition.id, run_slot_key=slot_key
+    )
+    assert run is not None and run["status"] == "succeeded"
+    assert run["result_summary"] == "42"
+
+    notification = _latest_notification(user_id)
+    assert notification is not None
+    assert notification.kind == "automation_run_succeeded"
+    assert "Daily Digest" in str(notification.title)
+
+
+@pytest.mark.asyncio
+async def test_redelivered_job_for_terminal_slot_is_recorded_noop(consumer_env) -> None:
+    user_id = 1011
+    definition = _create_definition(user_id)
+    register_executor("recurring_question", lambda d, p: asyncio.sleep(0, result="42"))
+    job = _job(definition, user_id)
+
+    first = await handle_agent_task_job(job)
+    second = await handle_agent_task_job(job)
+
+    assert first["status"] == "succeeded"
+    assert second["status"] == "succeeded"
+    assert second.get("deduped") is True
+
+
+@pytest.mark.asyncio
+async def test_paused_definition_skips_with_reason(consumer_env) -> None:
+    user_id = 1012
+    definition = _create_definition(user_id, lifecycle="paused")
+    register_executor("recurring_question", lambda d, p: asyncio.sleep(0, result="never"))
+
+    result = await handle_agent_task_job(_job(definition, user_id))
+
+    assert result["status"] == "skipped"
+    sdb = ScheduledTasksDatabase.for_user(user_id=user_id)
+    run = sdb.get_scheduled_task_run_by_slot(
+        definition_id=definition.id, run_slot_key=SLOT
+    )
+    assert run is not None
+    assert run["status"] == "skipped"
+    assert run["error"] == "definition_paused"
+
+
+@pytest.mark.asyncio
+async def test_missing_definition_skips(consumer_env) -> None:
+    user_id = 1013
+    ghost = _create_definition(user_id)
+
+    job = {
+        "id": 78,
+        "owner_user_id": user_id,
+        "job_type": "agent_task_run",
+        # A definition id that was never created: unique to this test.
+        "payload": {"definition_id": ghost.id + "deadbeef", "user_id": user_id},
+    }
+    result = await handle_agent_task_job(job)
+
+    assert result["status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Phase-1 boundary (enforced by the consumer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_requesting_config_skips_with_actionable_reason(consumer_env) -> None:
+    user_id = 1014
+    definition = _create_definition(
+        user_id, input_config={"question": "q", "tools": ["fs_read", "http_fetch"]}
+    )
+    register_executor("recurring_question", lambda d, p: asyncio.sleep(0, result="never"))
+
+    result = await handle_agent_task_job(_job(definition, user_id))
+
+    assert result["status"] == "skipped"
+    sdb = ScheduledTasksDatabase.for_user(user_id=user_id)
+    run = sdb.get_scheduled_task_run_by_slot(
+        definition_id=definition.id, run_slot_key=SLOT
+    )
+    assert run["error"] == "tools_not_executable_in_phase1"
+    assert "approval-escalation" in (run["result_summary"] or "")
+
+
+@pytest.mark.asyncio
+async def test_no_executor_fails_honestly(consumer_env) -> None:
+    user_id = 1015
+    definition = _create_definition(user_id)
+
+    result = await handle_agent_task_job(_job(definition, user_id))
+
+    assert result["status"] == "failed"
+    sdb = ScheduledTasksDatabase.for_user(user_id=user_id)
+    run = sdb.get_scheduled_task_run_by_slot(
+        definition_id=definition.id, run_slot_key=SLOT
+    )
+    assert run["error"] == "no_executor_configured"
+
+
+# ---------------------------------------------------------------------------
+# Timeout status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execution_deadline_records_timed_out(consumer_env) -> None:
+    user_id = 1016
+    definition = _create_definition(user_id)
+
+    async def _slow(d: DefinitionRow, p: dict[str, Any]) -> str:
+        await asyncio.sleep(30)
+        return "never"
+
+    register_executor("recurring_question", _slow)
+
+    result = await handle_agent_task_job(
+        _job(definition, user_id), execution_timeout_seconds=0.05
+    )
+
+    assert result["status"] == "timed_out"
+    sdb = ScheduledTasksDatabase.for_user(user_id=user_id)
+    run = sdb.get_scheduled_task_run_by_slot(
+        definition_id=definition.id, run_slot_key=SLOT
+    )
+    assert run["status"] == "timed_out"
+    notification = _latest_notification(user_id)
+    assert notification is not None
+    assert notification.kind == "automation_run_timed_out"
+
+
+# ---------------------------------------------------------------------------
+# Executor failure, notification policy, health, audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_executor_exception_records_failed(consumer_env) -> None:
+    user_id = 1017
+    definition = _create_definition(user_id)
+
+    async def _boom(d: DefinitionRow, p: dict[str, Any]) -> str:
+        raise RuntimeError("model exploded")
+
+    register_executor("recurring_question", _boom)
+
+    result = await handle_agent_task_job(_job(definition, user_id))
+
+    assert result["status"] == "failed"
+    sdb = ScheduledTasksDatabase.for_user(user_id=user_id)
+    run = sdb.get_scheduled_task_run_by_slot(
+        definition_id=definition.id, run_slot_key=SLOT
+    )
+    assert "RuntimeError" in (run["error"] or "")
+
+
+@pytest.mark.asyncio
+async def test_notification_policy_enabled_false_silences(consumer_env) -> None:
+    user_id = 1018
+    definition = _create_definition(
+        user_id, notification_policy={"enabled": False}
+    )
+    register_executor("recurring_question", lambda d, p: asyncio.sleep(0, result="42"))
+
+    result = await handle_agent_task_job(_job(definition, user_id))
+
+    assert result["status"] == "succeeded"
+    assert _latest_notification(user_id) is None
+
+
+@pytest.mark.asyncio
+async def test_failed_run_degrades_health_and_audits(consumer_env) -> None:
+    user_id = 1019
+    definition = _create_definition(user_id)
+
+    async def _boom(d: DefinitionRow, p: dict[str, Any]) -> str:
+        raise RuntimeError("nope")
+
+    register_executor("recurring_question", _boom)
+
+    await handle_agent_task_job(_job(definition, user_id))
+
+    sdb = ScheduledTasksDatabase.for_user(user_id=user_id)
+    updated = sdb.get_definition(owner_id=user_id, definition_id=definition.id)
+    assert updated.health == "degraded"
+    audits, _total = sdb.list_audit_events(
+        owner_id=user_id, definition_id=definition.id
+    )
+    assert any(a.event_type == "run_failed" for a in audits)


### PR DESCRIPTION
## Summary

Executes **TASK-13021**, second server-side piece of the server-offload seam (tldw_chatbook ADR-077, accepted). The consumer for the `agent_task_run` Jobs the feed (TASK-13020, merged) enqueues, mirroring `core/Reminders/reminder_jobs.py` throughout:

- **Durable runs, deduped**: new `scheduled_task_runs` table (new-table `ensure_schema` addition — safe for existing DBs) with the reminders' dedupe-on-create semantics; redelivered Jobs for terminal slots are recorded no-ops.
- **Phase-1 boundary enforced by the consumer** (not assumed): tool-requesting configs skip with error `tools_not_executable_in_phase1` and an actionable summary naming the approval-escalation dependency.
- **`timed_out`** as a distinct run status at the 300s execution deadline — matches the client's vocabulary (tldw_chatbook TASK-18939) directly.
- **Notification pass-back** on the reminders channel: bounded result summary, run reference, `dedupe_key`, governed by the definition's `notification_policy` (full result stays server-side per ADR-077 decision 3).
- **Health honesty**: succeeded→`ready`, failed/timed_out→`degraded` (only-on-change); `run_{status}` audit events; downstream notification/audit failures never mask the run outcome.
- **Worker** mirroring `reminder_jobs_worker.py`, sidecar-registered under `AGENT_TASK_JOBS_WORKER_ENABLED`.

**Deliberate scope cut:** the LLM executor is an injected per-family seam (`register_executor`); wiring the real server model plumbing is the next slice. Without an executor, runs fail honestly (`no_executor_configured`).

## Verification

- `test_agent_task_jobs_consumer.py` — **10 passed** (real preview-gated definitions, run rows, user notifications; stub executors): success+notify, dedupe no-op, paused/missing skips, tool refusal, no-executor failure, timeout status+notification, executor exception, policy silence, degraded health + audit
- Notifications suite — **221 passed**; startup preflight — **16 passed**
- Not live-verified against a running server (headless); the chatbook TASK-18940 AC#8 live gate covers end-to-end once the client side lands

Closes TASK-13021.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consumes `agent_task_run` Jobs with durable `scheduled_task_runs`, lifecycle re-checks, and bounded notification pass-back; enforces phase‑1 side‑effect‑free execution. Previously there was no consumer; now runs dedupe by slot, record `succeeded|failed|timed_out|skipped`, update definition health, and notify without masking outcomes. Implements TASK-13021.

- Creates `scheduled_task_runs` via `ensure_schema`; no migration required.
- Enforces phase‑1: tool‑requesting configs skip with `tools_not_executable_in_phase1`; executors are injected per family via `register_executor`; without one, runs fail with `no_executor_configured`.
- Records `timed_out` at the execution deadline and reports the effective timeout in notifications; correlation uses `source_job_id` from the Jobs pipeline.
- Worker `agent_task_jobs_worker` is gated by `AGENT_TASK_JOBS_WORKER_ENABLED`, uses `AUTOMATION_JOBS_QUEUE`, and is registered in sidecar pollers as `agent_task_jobs_task`; its lease floor is `max(env, RUN_EXECUTION_TIMEOUT_SECONDS + 30)` to prevent duplicate in‑flight executions.
- Invalid job payloads raise `BadRequestError`; logs include structured context fields.

**Rollout**
- No DB migration.
- Enable `AGENT_TASK_JOBS_WORKER_ENABLED=true` where the scheduler feed runs.
- Set `AUTOMATION_JOBS_QUEUE` if not using the default.
- Register real executors for `recurring_question` and `agent_task` via `register_executor` before enabling in production.

<sup>Written for commit 4e44d3b542cc298302cf47d654d27067947470f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

