### PR TITLE
fix(research): close PR 2800 review gaps (TASK-12968.10)

### DIFF
--- a/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
+++ b/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
@@ -26,7 +26,7 @@ modified_files:
 - tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
 - tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
 - tldw_Server_API/tests/Research/test_research_discovery_planner.py
-updated_date: 2026-08-22 18:52
+updated_date: 2026-08-22 19:03
 ---
 
 ## Description
@@ -85,6 +85,7 @@ Draft follow-up PR #2802 opened from exact reviewed/rebased branch. Human-author
 Original PR #2800 review closure verified through GitHub GraphQL: all six target threads are isResolved=true and isOutdated=false after evidence-backed replies. Reply comment IDs: 3836632602, 3836632643, 3836632666, 3836632703, 3836632738, 3836632767. Remaining external gate: PR #2802 checks/reviews and the repository-required human-authored Change summary before normal merge.
 PR #2802 review-fix cycle started for Qodo threads r3836707902, r3836707906, and r3836707910. Scope under technical validation: new test docstrings/annotations and fail-closed detection of malformed-policy routes carrying any PubMed overlay marker. Latest origin/dev remains 7ed3f03577; branch is current before edits.
 Task 2 PR #2802 Qodo review-fix evidence: added mutation-sensitive planner RED coverage for malformed Semantic Scholar policy carrying every sealed PubMed identity marker; initial RED was 8 failed/1 passed (raw AttributeError end-to-end). Implemented the single fail-closed classifier branch, then GREEN was 9 passed. Refreshed only the witnessed planner semantic AST digest (f47af4f735688f3f8eca0a6c5e9620fca2a1ddabadc3ec1aef4324ac12afa39f). Final required five-file discovery suite: 1523 passed, 4 existing warnings. Ruff, Black --check, Python 3.11 compileall, Python 3.10 py_compile, Bandit on planner (0 findings), and git diff --check passed. Full task report: .superpowers/sdd/TASK-12968.10-review-plan/task-2-report.md. No remote delivery actions taken.
+PR #2802 Qodo review closure at commit 74b893f55b: the three post-push threads r3836707902, r3836707906, and r3836707910 received evidence-backed replies and were resolved through GitHub. GraphQL verification shows all three threads isResolved=true; Qodo's refreshed report on exact head 74b893f55b reports 0 bugs and 0 rule violations. Independent Task 2 review found no Critical, Important, or Minor issues. Latest origin/dev remains 7ed3f03577 and branch divergence is 0 behind/9 ahead. Fresh controller verification: 1523 focused discovery tests passed with 4 existing warnings; Ruff, Black, Python 3.11/3.10 compilation, Bandit (0 findings), and git diff --check passed. Remaining merge gates are repository CI, any new exact-head review comments, the mandatory human-authored Change summary, final task summary, and normal merge.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 

--- a/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
+++ b/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
@@ -25,7 +25,7 @@ modified_files:
 - tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
 - tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
 - tldw_Server_API/tests/Research/test_research_discovery_planner.py
-updated_date: 2026-08-22 17:38
+updated_date: 2026-08-22 17:41
 ---
 
 ## Description
@@ -58,28 +58,28 @@ Stage 4: independently review the exact diff, push a focused PR, reply to and re
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Implementation completed on isolated branch codex/task-12968-10-pr2800-review-followup from PR #2800 merge commit 4ea6d97ef6.
 
-Commits:
+Committed implementation lineage before the final tracking-only commit:
 - 6325fe9db0 — implement six review fixes with focused tests and boundary-pin refreshes.
 - 2f7541acaa — make the PubMed policy predicate itself fail closed and normalize NCBI callback IndexError.
 - b9599a307e — add a direct mutation-sensitive trusted-input IndexError regression (test-only).
+- Final Fix Wave committed in its own commit atop b9599a307e; it adds exact PubMed binding scalar guards, direct ESummary IndexError coverage, the test-helper annotation/docstring, and only the witnessed gateway-adapter AST pin. This wording is intentionally hash-free because the task record is part of that commit lineage.
 
 TDD/review evidence:
 - Initial corrected RED: 12 collected, 7 failed/5 passed, 4 existing warnings; failures matched the six targeted defects.
 - Fix Round 1 RED 3 failed, GREEN 3 passed; 593 planner/gateway/boundary and 1510 focused discovery tests passed.
 - Fix Round 2 controlled mutation RED 1 failed with raw IndexError, then GREEN; gateway suite 372 passed.
+- Final Fix Wave RED: binding mutations 4 failed/7 passed; controlled ESummary catch removal 1 failed/10 passed with raw IndexError. GREEN amended set 11 passed.
 - Scoped task review is clean: no Critical or Important findings.
+- Whole-branch re-review confirms all code/test findings are fixed, with no Critical or Important regression or scope creep; its sole tracking wording correction is this hash-free note.
 
-Fresh controller verification at b9599a307e:
-- Focused discovery suite: 1510 passed, 4 existing warnings.
-- Ruff passed; Black --check left 9 files unchanged.
+Fresh exact-final-code verification:
+- Focused discovery suite: 1514 passed, 4 existing warnings.
+- Ruff passed; Black --check left all 9 branch-touched Python files unchanged.
 - Python 3.11 compileall and Python 3.10 py_compile passed.
 - Bandit on all four touched production modules passed with no findings.
 - git diff --check passed.
 
-Pending: independent whole-branch review, push/follow-up PR, evidence-backed replies and resolution of all six original PR #2800 threads, repository gates, human-authored Change summary, normal merge, and task finalization.
-Final Fix Wave from base b9599a307e. Added exact trusted PubMed binding scalar checks (binding_id/query_name exact str; max_item_chars/max_items exact int), mutation-sensitive tests for equal-valued str subclasses and 16.0/1.0, valid ESearch→ESummary IndexError callback regression, _pubmed_group docstring/PlannedDispatchGroup annotation, and only witnessed gateway AST pin 809bc6e27b6ccebeaac25108ef34823c9b2da53509cb74b7dc0c091ecb44947a. RED: binding mutations 4 failed/7 passed/4 warnings; controlled ESummary catch removal 1 failed/10 passed/4 warnings with raw IndexError. GREEN amended set 11 passed/4 warnings; five-file suite 1514 passed/4 warnings. Ruff, Black (3 unchanged), 3.11 compileall, 3.10 py_compile, Bandit gateway (0 findings; 1 existing disabled check), diff-check passed. Report appended. Final commit pending.
-Final Fix Wave committed separately as d7ced14924 (fix: harden pubmed binding contract), atop b9599a307e. Commit includes gateway exactness guards/tests, ESummary IndexError regression, _pubmed_group annotation/docstring, gateway AST pin, and the MCP task-record update. No push/PR/thread/merge actions taken.
-Lineage correction: after the final Backlog MCP note was recorded, the final fix commit was amended to include that note and is now 4c5121f1c3 (not d7ced14924). Final lineage is 2f7541acaa → b9599a307e → 4c5121f1c3. Worktree verified clean after the amendment; no push/PR/thread/merge actions taken.
+Pending remote delivery only: push/follow-up PR, evidence-backed replies and resolution of all six original PR #2800 threads, repository gates, human-authored Change summary, normal merge, and task finalization.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 

--- a/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
+++ b/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
@@ -13,6 +13,7 @@ references:
 - https://github.com/rmusser01/tldw_server/pull/2800#discussion_r3836415127
 - https://github.com/rmusser01/tldw_server/pull/2800#discussion_r3836415129
 - https://github.com/rmusser01/tldw_server/pull/2800#discussion_r3836415134
+- https://github.com/rmusser01/tldw_server/pull/2802
 documentation:
 - Docs/Design/2026-07-15-clinicaltrials-pubmed-central-shared-discovery-route-family-design.md
 modified_files:
@@ -25,7 +26,7 @@ modified_files:
 - tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
 - tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
 - tldw_Server_API/tests/Research/test_research_discovery_planner.py
-updated_date: 2026-08-22 17:44
+updated_date: 2026-08-22 17:46
 ---
 
 ## Description
@@ -80,6 +81,7 @@ Fresh post-rebase verification:
 - git diff --check against origin/dev passed.
 
 Pending remote delivery only: push/follow-up PR, evidence-backed replies and resolution of all six original PR #2800 threads, repository gates, human-authored Change summary, normal merge, and task finalization.
+Draft follow-up PR #2802 opened from exact reviewed/rebased branch. Human-authored Change summary remains the only intentional pre-merge content blocker; CI and original-thread resolution proceed while the PR stays draft.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 

--- a/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
+++ b/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
@@ -17,15 +17,15 @@ documentation:
 - Docs/Design/2026-07-15-clinicaltrials-pubmed-central-shared-discovery-route-family-design.md
 modified_files:
 - tldw_Server_API/app/core/Research/discovery/clinicaltrials_pubmed_central.py
-- tldw_Server_API/app/core/Research/discovery/planner.py
-- tldw_Server_API/app/core/Research/discovery/gateway_adapters.py
 - tldw_Server_API/app/core/Research/discovery/executor.py
+- tldw_Server_API/app/core/Research/discovery/gateway_adapters.py
+- tldw_Server_API/app/core/Research/discovery/planner.py
 - tldw_Server_API/tests/Research/test_research_discovery_clinicaltrials_pubmed_central.py
-- tldw_Server_API/tests/Research/test_research_discovery_planner.py
-- tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
 - tldw_Server_API/tests/Research/test_research_discovery_executor.py
+- tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
 - tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
-updated_date: 2026-08-22 17:22
+- tldw_Server_API/tests/Research/test_research_discovery_planner.py
+updated_date: 2026-08-22 17:38
 ---
 
 ## Description
@@ -36,11 +36,11 @@ Follow up the six Qodo review threads posted after PR #2800's final commit. Pres
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Every previously undocumented function introduced in clinicaltrials_pubmed_central.py has a concise docstring, and the test helper _module has an explicit ModuleType return annotation.
-- [ ] #2 ClinicalTrials.gov rejects nonterminal pages that make no unique NCT progress while preserving terminal identical-duplicate collapse and ceiling-token behavior.
-- [ ] #3 Malformed PubMed identity route/policy objects fail closed through typed planning errors instead of leaking AttributeError.
-- [ ] #4 NCBI trusted-input callback and malformed intent/query/binding container failures normalize to provider_payload_invalid while explicit DiscoveryAdapterError values propagate unchanged.
-- [ ] #5 Numeric and opaque pagination cursors use separate typed tracking so numeric progress checks cannot evaluate mixed cursor types.
+- [x] #1 Every previously undocumented function introduced in clinicaltrials_pubmed_central.py has a concise docstring, and the test helper _module has an explicit ModuleType return annotation.
+- [x] #2 ClinicalTrials.gov rejects nonterminal pages that make no unique NCT progress while preserving terminal identical-duplicate collapse and ceiling-token behavior.
+- [x] #3 Malformed PubMed identity route/policy objects fail closed through typed planning errors instead of leaking AttributeError.
+- [x] #4 NCBI trusted-input callback and malformed intent/query/binding container failures normalize to provider_payload_invalid while explicit DiscoveryAdapterError values propagate unchanged.
+- [x] #5 Numeric and opaque pagination cursors use separate typed tracking so numeric progress checks cannot evaluate mixed cursor types.
 - [ ] #6 All six PR #2800 review threads receive evidence-backed replies and are resolved after focused/full discovery, format, compile, diff, and Bandit gates pass.
 <!-- AC:END -->
 
@@ -56,22 +56,30 @@ Stage 4: independently review the exact diff, push a focused PR, reply to and re
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-2026-08-22 handoff verification:
-- Inherited TDD evidence (reported by first implementer): the six focused selectors collected 12 tests; RED result was 7 failed/5 passed with 4 existing warnings. The documented intended failures were missing docstrings, nonterminal duplicate acceptance, malformed PubMed policy AttributeError, trusted-input callback AttributeError, malformed intent/limits AttributeError, and mixed cursor TypeError. Two initial fixture defects were discarded before this RED run.
-- Replacement implementer read the complete scoped diff and confirmed it is limited to the four discovery modules, five relevant test modules, and stale boundary digest updates. git diff --check exits 0.
-- Fresh focused pytest verification could not start because the read-only sandbox has no writable temporary directory. The required escalated retry, and the required Black formatting write, were rejected by the platform with a usage-limit block (retry after 2026-08-28 11:34 AM). No completion, test-pass, formatting, security, report, or commit claim is made.
-- External PR/thread/push/merge work remains intentionally outside this handoff's scope.
-2026-08-22 controller verification after hosted implementer limits:
-- Applied Black mechanically; exactly two test files were reformatted and seven changed Python files were unchanged.
-- Exact six-selector GREEN: 12 passed with 4 existing repository warnings.
-- Full five-module discovery regression: 1,508 passed with the same 4 existing warnings.
-- Ruff: all checks passed. Black --check: 9 files unchanged. Python 3.11 compileall and Python 3.10 py_compile: passed. Bandit on the four changed production modules: 0 findings, 0 errors, 1 existing nosec. git diff --check: passed.
-- Controller self-review confirmed the diff remains limited to the four discovery modules, five focused test modules, boundary digests, and this task record. Independent task review and whole-branch review remain pending before delivery.
-Fix Round 1 started in codex/task-12968-10-pr2800-review-followup. Scope: direct planner predicate guard and NCBI ESearch/ESummary IndexError normalization, with strict RED/GREEN evidence and required verification.
-Fix Round 1 verification: direct RED 3 failed/4 warnings (raw planner AttributeError and NCBI parser IndexError); exact GREEN 3 passed/4 warnings. Planner+gateway-adapter+network-boundary suites 593 passed/4 warnings. Five-file focused discovery suite 1510 passed/4 warnings. Ruff passed; Black --check 5 files unchanged; Python 3.11 compileall and 3.10 py_compile passed; Bandit on planner/gateway_adapters no issues (0 findings, 1 existing disabled check); git diff --check passed. Refreshed only witnessed planner/gateway-adapter AST pins. Fix Round 1 report appended to .superpowers/sdd/TASK-12968.10-review-plan/task-1-report.md.
-Fix Round 1 committed separately as c36f207184 (fix: harden pubmed planner and ncbi callback boundaries). No push/PR/thread/merge actions taken.
-Fix Round 2 started from exact HEAD 2f7541acaa. Test-only scope: add a direct trusted_inputs callback raising IndexError to the NCBI normalization regression, witness RED under controlled removal of only IndexError from the trusted-input catch, restore production byte-exact, then GREEN and focused verification. No production or boundary-pin changes expected.
-Fix Round 2 evidence: amended focused gateway test GREEN 1 passed/4 warnings. Controlled mutation removing only IndexError from trusted-input catch produced expected raw IndexError failure (1 failed/4 warnings); restored production and git diff --exit-code HEAD on gateway_adapters.py passed. Full gateway suite 372 passed/4 warnings. Ruff passed; Black --check 1 file unchanged; Python 3.11 compileall and 3.10 py_compile passed; git diff --check passed. Bandit skipped per test-only instruction. Fix Round 2 report appended. Pending separate commit.
+Implementation completed on isolated branch codex/task-12968-10-pr2800-review-followup from PR #2800 merge commit 4ea6d97ef6.
+
+Commits:
+- 6325fe9db0 — implement six review fixes with focused tests and boundary-pin refreshes.
+- 2f7541acaa — make the PubMed policy predicate itself fail closed and normalize NCBI callback IndexError.
+- b9599a307e — add a direct mutation-sensitive trusted-input IndexError regression (test-only).
+
+TDD/review evidence:
+- Initial corrected RED: 12 collected, 7 failed/5 passed, 4 existing warnings; failures matched the six targeted defects.
+- Fix Round 1 RED 3 failed, GREEN 3 passed; 593 planner/gateway/boundary and 1510 focused discovery tests passed.
+- Fix Round 2 controlled mutation RED 1 failed with raw IndexError, then GREEN; gateway suite 372 passed.
+- Scoped task review is clean: no Critical or Important findings.
+
+Fresh controller verification at b9599a307e:
+- Focused discovery suite: 1510 passed, 4 existing warnings.
+- Ruff passed; Black --check left 9 files unchanged.
+- Python 3.11 compileall and Python 3.10 py_compile passed.
+- Bandit on all four touched production modules passed with no findings.
+- git diff --check passed.
+
+Pending: independent whole-branch review, push/follow-up PR, evidence-backed replies and resolution of all six original PR #2800 threads, repository gates, human-authored Change summary, normal merge, and task finalization.
+Final Fix Wave from base b9599a307e. Added exact trusted PubMed binding scalar checks (binding_id/query_name exact str; max_item_chars/max_items exact int), mutation-sensitive tests for equal-valued str subclasses and 16.0/1.0, valid ESearch→ESummary IndexError callback regression, _pubmed_group docstring/PlannedDispatchGroup annotation, and only witnessed gateway AST pin 809bc6e27b6ccebeaac25108ef34823c9b2da53509cb74b7dc0c091ecb44947a. RED: binding mutations 4 failed/7 passed/4 warnings; controlled ESummary catch removal 1 failed/10 passed/4 warnings with raw IndexError. GREEN amended set 11 passed/4 warnings; five-file suite 1514 passed/4 warnings. Ruff, Black (3 unchanged), 3.11 compileall, 3.10 py_compile, Bandit gateway (0 findings; 1 existing disabled check), diff-check passed. Report appended. Final commit pending.
+Final Fix Wave committed separately as d7ced14924 (fix: harden pubmed binding contract), atop b9599a307e. Commit includes gateway exactness guards/tests, ESummary IndexError regression, _pubmed_group annotation/docstring, gateway AST pin, and the MCP task-record update. No push/PR/thread/merge actions taken.
+Lineage correction: after the final Backlog MCP note was recorded, the final fix commit was amended to include that note and is now 4c5121f1c3 (not d7ced14924). Final lineage is 2f7541acaa → b9599a307e → 4c5121f1c3. Worktree verified clean after the amendment; no push/PR/thread/merge actions taken.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 
@@ -82,9 +90,9 @@ Fix Round 2 evidence: amended focused gateway test GREEN 1 passed/4 warnings. Co
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
 - [ ] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
+++ b/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
@@ -25,7 +25,7 @@ modified_files:
 - tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
 - tldw_Server_API/tests/Research/test_research_discovery_executor.py
 - tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
-updated_date: 2026-08-22 17:17
+updated_date: 2026-08-22 17:22
 ---
 
 ## Description
@@ -70,6 +70,8 @@ Stage 4: independently review the exact diff, push a focused PR, reply to and re
 Fix Round 1 started in codex/task-12968-10-pr2800-review-followup. Scope: direct planner predicate guard and NCBI ESearch/ESummary IndexError normalization, with strict RED/GREEN evidence and required verification.
 Fix Round 1 verification: direct RED 3 failed/4 warnings (raw planner AttributeError and NCBI parser IndexError); exact GREEN 3 passed/4 warnings. Planner+gateway-adapter+network-boundary suites 593 passed/4 warnings. Five-file focused discovery suite 1510 passed/4 warnings. Ruff passed; Black --check 5 files unchanged; Python 3.11 compileall and 3.10 py_compile passed; Bandit on planner/gateway_adapters no issues (0 findings, 1 existing disabled check); git diff --check passed. Refreshed only witnessed planner/gateway-adapter AST pins. Fix Round 1 report appended to .superpowers/sdd/TASK-12968.10-review-plan/task-1-report.md.
 Fix Round 1 committed separately as c36f207184 (fix: harden pubmed planner and ncbi callback boundaries). No push/PR/thread/merge actions taken.
+Fix Round 2 started from exact HEAD 2f7541acaa. Test-only scope: add a direct trusted_inputs callback raising IndexError to the NCBI normalization regression, witness RED under controlled removal of only IndexError from the trusted-input catch, restore production byte-exact, then GREEN and focused verification. No production or boundary-pin changes expected.
+Fix Round 2 evidence: amended focused gateway test GREEN 1 passed/4 warnings. Controlled mutation removing only IndexError from trusted-input catch produced expected raw IndexError failure (1 failed/4 warnings); restored production and git diff --exit-code HEAD on gateway_adapters.py passed. Full gateway suite 372 passed/4 warnings. Ruff passed; Black --check 1 file unchanged; Python 3.11 compileall and 3.10 py_compile passed; git diff --check passed. Bandit skipped per test-only instruction. Fix Round 2 report appended. Pending separate commit.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 

--- a/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
+++ b/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
@@ -26,7 +26,7 @@ modified_files:
 - tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
 - tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
 - tldw_Server_API/tests/Research/test_research_discovery_planner.py
-updated_date: 2026-08-22 17:46
+updated_date: 2026-08-22 17:48
 ---
 
 ## Description
@@ -42,7 +42,7 @@ Follow up the six Qodo review threads posted after PR #2800's final commit. Pres
 - [x] #3 Malformed PubMed identity route/policy objects fail closed through typed planning errors instead of leaking AttributeError.
 - [x] #4 NCBI trusted-input callback and malformed intent/query/binding container failures normalize to provider_payload_invalid while explicit DiscoveryAdapterError values propagate unchanged.
 - [x] #5 Numeric and opaque pagination cursors use separate typed tracking so numeric progress checks cannot evaluate mixed cursor types.
-- [ ] #6 All six PR #2800 review threads receive evidence-backed replies and are resolved after focused/full discovery, format, compile, diff, and Bandit gates pass.
+- [x] #6 All six PR #2800 review threads receive evidence-backed replies and are resolved after focused/full discovery, format, compile, diff, and Bandit gates pass.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -82,6 +82,7 @@ Fresh post-rebase verification:
 
 Pending remote delivery only: push/follow-up PR, evidence-backed replies and resolution of all six original PR #2800 threads, repository gates, human-authored Change summary, normal merge, and task finalization.
 Draft follow-up PR #2802 opened from exact reviewed/rebased branch. Human-authored Change summary remains the only intentional pre-merge content blocker; CI and original-thread resolution proceed while the PR stays draft.
+Original PR #2800 review closure verified through GitHub GraphQL: all six target threads are isResolved=true and isOutdated=false after evidence-backed replies. Reply comment IDs: 3836632602, 3836632643, 3836632666, 3836632703, 3836632738, 3836632767. Remaining external gate: PR #2802 checks/reviews and the repository-required human-authored Change summary before normal merge.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 
@@ -91,10 +92,10 @@ Draft follow-up PR #2802 opened from exact reviewed/rebased branch. Human-author
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
+++ b/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
@@ -26,7 +26,7 @@ modified_files:
 - tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
 - tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
 - tldw_Server_API/tests/Research/test_research_discovery_planner.py
-updated_date: 2026-08-22 17:48
+updated_date: 2026-08-22 18:52
 ---
 
 ## Description
@@ -83,6 +83,8 @@ Fresh post-rebase verification:
 Pending remote delivery only: push/follow-up PR, evidence-backed replies and resolution of all six original PR #2800 threads, repository gates, human-authored Change summary, normal merge, and task finalization.
 Draft follow-up PR #2802 opened from exact reviewed/rebased branch. Human-authored Change summary remains the only intentional pre-merge content blocker; CI and original-thread resolution proceed while the PR stays draft.
 Original PR #2800 review closure verified through GitHub GraphQL: all six target threads are isResolved=true and isOutdated=false after evidence-backed replies. Reply comment IDs: 3836632602, 3836632643, 3836632666, 3836632703, 3836632738, 3836632767. Remaining external gate: PR #2802 checks/reviews and the repository-required human-authored Change summary before normal merge.
+PR #2802 review-fix cycle started for Qodo threads r3836707902, r3836707906, and r3836707910. Scope under technical validation: new test docstrings/annotations and fail-closed detection of malformed-policy routes carrying any PubMed overlay marker. Latest origin/dev remains 7ed3f03577; branch is current before edits.
+Task 2 PR #2802 Qodo review-fix evidence: added mutation-sensitive planner RED coverage for malformed Semantic Scholar policy carrying every sealed PubMed identity marker; initial RED was 8 failed/1 passed (raw AttributeError end-to-end). Implemented the single fail-closed classifier branch, then GREEN was 9 passed. Refreshed only the witnessed planner semantic AST digest (f47af4f735688f3f8eca0a6c5e9620fca2a1ddabadc3ec1aef4324ac12afa39f). Final required five-file discovery suite: 1523 passed, 4 existing warnings. Ruff, Black --check, Python 3.11 compileall, Python 3.10 py_compile, Bandit on planner (0 findings), and git diff --check passed. Full task report: .superpowers/sdd/TASK-12968.10-review-plan/task-2-report.md. No remote delivery actions taken.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 

--- a/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
+++ b/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
@@ -25,7 +25,7 @@ modified_files:
 - tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
 - tldw_Server_API/tests/Research/test_research_discovery_executor.py
 - tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
-updated_date: 2026-08-22 17:03
+updated_date: 2026-08-22 17:17
 ---
 
 ## Description
@@ -67,6 +67,9 @@ Stage 4: independently review the exact diff, push a focused PR, reply to and re
 - Full five-module discovery regression: 1,508 passed with the same 4 existing warnings.
 - Ruff: all checks passed. Black --check: 9 files unchanged. Python 3.11 compileall and Python 3.10 py_compile: passed. Bandit on the four changed production modules: 0 findings, 0 errors, 1 existing nosec. git diff --check: passed.
 - Controller self-review confirmed the diff remains limited to the four discovery modules, five focused test modules, boundary digests, and this task record. Independent task review and whole-branch review remain pending before delivery.
+Fix Round 1 started in codex/task-12968-10-pr2800-review-followup. Scope: direct planner predicate guard and NCBI ESearch/ESummary IndexError normalization, with strict RED/GREEN evidence and required verification.
+Fix Round 1 verification: direct RED 3 failed/4 warnings (raw planner AttributeError and NCBI parser IndexError); exact GREEN 3 passed/4 warnings. Planner+gateway-adapter+network-boundary suites 593 passed/4 warnings. Five-file focused discovery suite 1510 passed/4 warnings. Ruff passed; Black --check 5 files unchanged; Python 3.11 compileall and 3.10 py_compile passed; Bandit on planner/gateway_adapters no issues (0 findings, 1 existing disabled check); git diff --check passed. Refreshed only witnessed planner/gateway-adapter AST pins. Fix Round 1 report appended to .superpowers/sdd/TASK-12968.10-review-plan/task-1-report.md.
+Fix Round 1 committed separately as c36f207184 (fix: harden pubmed planner and ncbi callback boundaries). No push/PR/thread/merge actions taken.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 

--- a/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
+++ b/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
@@ -25,7 +25,7 @@ modified_files:
 - tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
 - tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
 - tldw_Server_API/tests/Research/test_research_discovery_planner.py
-updated_date: 2026-08-22 17:41
+updated_date: 2026-08-22 17:44
 ---
 
 ## Description
@@ -56,28 +56,28 @@ Stage 4: independently review the exact diff, push a focused PR, reply to and re
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Implementation completed on isolated branch codex/task-12968-10-pr2800-review-followup from PR #2800 merge commit 4ea6d97ef6.
+Implementation completed on isolated branch codex/task-12968-10-pr2800-review-followup. The branch was rebased conflict-free onto latest dev commit 7ed3f03577 after the local review gates.
 
-Committed implementation lineage before the final tracking-only commit:
-- 6325fe9db0 — implement six review fixes with focused tests and boundary-pin refreshes.
-- 2f7541acaa — make the PubMed policy predicate itself fail closed and normalize NCBI callback IndexError.
-- b9599a307e — add a direct mutation-sensitive trusted-input IndexError regression (test-only).
-- Final Fix Wave committed in its own commit atop b9599a307e; it adds exact PubMed binding scalar guards, direct ESummary IndexError coverage, the test-helper annotation/docstring, and only the witnessed gateway-adapter AST pin. This wording is intentionally hash-free because the task record is part of that commit lineage.
+Rebased implementation lineage before the final tracking-only commit:
+- 071e1d689c — implement six review fixes with focused tests and boundary-pin refreshes.
+- f3c62f1c72 — make the PubMed policy predicate itself fail closed and normalize NCBI callback IndexError.
+- 39f599d641 — add a direct mutation-sensitive trusted-input IndexError regression (test-only).
+- c57606f469 — exact PubMed binding scalar guards, direct ESummary IndexError coverage, test-helper annotation/docstring, and only the witnessed gateway-adapter AST pin.
+- The final tracking-only commit is intentionally unnamed here to avoid a self-referential hash loop.
 
 TDD/review evidence:
 - Initial corrected RED: 12 collected, 7 failed/5 passed, 4 existing warnings; failures matched the six targeted defects.
 - Fix Round 1 RED 3 failed, GREEN 3 passed; 593 planner/gateway/boundary and 1510 focused discovery tests passed.
 - Fix Round 2 controlled mutation RED 1 failed with raw IndexError, then GREEN; gateway suite 372 passed.
 - Final Fix Wave RED: binding mutations 4 failed/7 passed; controlled ESummary catch removal 1 failed/10 passed with raw IndexError. GREEN amended set 11 passed.
-- Scoped task review is clean: no Critical or Important findings.
-- Whole-branch re-review confirms all code/test findings are fixed, with no Critical or Important regression or scope creep; its sole tracking wording correction is this hash-free note.
+- Scoped task review and whole-branch review are clean: no Critical, Important, or Minor findings remain.
 
-Fresh exact-final-code verification:
+Fresh post-rebase verification:
 - Focused discovery suite: 1514 passed, 4 existing warnings.
 - Ruff passed; Black --check left all 9 branch-touched Python files unchanged.
 - Python 3.11 compileall and Python 3.10 py_compile passed.
 - Bandit on all four touched production modules passed with no findings.
-- git diff --check passed.
+- git diff --check against origin/dev passed.
 
 Pending remote delivery only: push/follow-up PR, evidence-backed replies and resolution of all six original PR #2800 threads, repository gates, human-authored Change summary, normal merge, and task finalization.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
+++ b/backlog/tasks/task-12968.10 - Address-PR-2800-post-merge-review-findings.md
@@ -1,0 +1,85 @@
+---
+id: TASK-12968.10
+title: Address PR 2800 post-merge review findings
+status: In Progress
+created_date: 2026-08-22 16:41
+priority: High
+parent_task_id: TASK-12968
+references:
+- https://github.com/rmusser01/tldw_server/pull/2800
+- https://github.com/rmusser01/tldw_server/pull/2800#discussion_r3836415116
+- https://github.com/rmusser01/tldw_server/pull/2800#discussion_r3836415122
+- https://github.com/rmusser01/tldw_server/pull/2800#discussion_r3836415124
+- https://github.com/rmusser01/tldw_server/pull/2800#discussion_r3836415127
+- https://github.com/rmusser01/tldw_server/pull/2800#discussion_r3836415129
+- https://github.com/rmusser01/tldw_server/pull/2800#discussion_r3836415134
+documentation:
+- Docs/Design/2026-07-15-clinicaltrials-pubmed-central-shared-discovery-route-family-design.md
+modified_files:
+- tldw_Server_API/app/core/Research/discovery/clinicaltrials_pubmed_central.py
+- tldw_Server_API/app/core/Research/discovery/planner.py
+- tldw_Server_API/app/core/Research/discovery/gateway_adapters.py
+- tldw_Server_API/app/core/Research/discovery/executor.py
+- tldw_Server_API/tests/Research/test_research_discovery_clinicaltrials_pubmed_central.py
+- tldw_Server_API/tests/Research/test_research_discovery_planner.py
+- tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
+- tldw_Server_API/tests/Research/test_research_discovery_executor.py
+- tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
+updated_date: 2026-08-22 17:03
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow up the six Qodo review threads posted after PR #2800's final commit. Preserve the approved ClinicalTrials.gov and PubMed Central shadow-only contract while closing real fail-closed, pagination-progress, typing, and documentation gaps in a focused PR from current dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every previously undocumented function introduced in clinicaltrials_pubmed_central.py has a concise docstring, and the test helper _module has an explicit ModuleType return annotation.
+- [ ] #2 ClinicalTrials.gov rejects nonterminal pages that make no unique NCT progress while preserving terminal identical-duplicate collapse and ceiling-token behavior.
+- [ ] #3 Malformed PubMed identity route/policy objects fail closed through typed planning errors instead of leaking AttributeError.
+- [ ] #4 NCBI trusted-input callback and malformed intent/query/binding container failures normalize to provider_payload_invalid while explicit DiscoveryAdapterError values propagate unchanged.
+- [ ] #5 Numeric and opaque pagination cursors use separate typed tracking so numeric progress checks cannot evaluate mixed cursor types.
+- [ ] #6 All six PR #2800 review threads receive evidence-backed replies and are resolved after focused/full discovery, format, compile, diff, and Bandit gates pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Stage 1: add mutation-sensitive RED tests for each valid behavioral finding and static documentation/type coverage.
+Stage 2: implement the smallest fail-closed fixes and refresh only witnessed network-boundary digests.
+Stage 3: run focused and full discovery regressions plus Ruff, Black, Python 3.10/3.11 compilation, Bandit, and diff checks.
+Stage 4: independently review the exact diff, push a focused PR, reply to and resolve all six PR #2800 threads, then merge through normal repository gates.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-08-22 handoff verification:
+- Inherited TDD evidence (reported by first implementer): the six focused selectors collected 12 tests; RED result was 7 failed/5 passed with 4 existing warnings. The documented intended failures were missing docstrings, nonterminal duplicate acceptance, malformed PubMed policy AttributeError, trusted-input callback AttributeError, malformed intent/limits AttributeError, and mixed cursor TypeError. Two initial fixture defects were discarded before this RED run.
+- Replacement implementer read the complete scoped diff and confirmed it is limited to the four discovery modules, five relevant test modules, and stale boundary digest updates. git diff --check exits 0.
+- Fresh focused pytest verification could not start because the read-only sandbox has no writable temporary directory. The required escalated retry, and the required Black formatting write, were rejected by the platform with a usage-limit block (retry after 2026-08-28 11:34 AM). No completion, test-pass, formatting, security, report, or commit claim is made.
+- External PR/thread/push/merge work remains intentionally outside this handoff's scope.
+2026-08-22 controller verification after hosted implementer limits:
+- Applied Black mechanically; exactly two test files were reformatted and seven changed Python files were unchanged.
+- Exact six-selector GREEN: 12 passed with 4 existing repository warnings.
+- Full five-module discovery regression: 1,508 passed with the same 4 existing warnings.
+- Ruff: all checks passed. Black --check: 9 files unchanged. Python 3.11 compileall and Python 3.10 py_compile: passed. Bandit on the four changed production modules: 0 findings, 0 errors, 1 existing nosec. git diff --check: passed.
+- Controller self-review confirmed the diff remains limited to the four discovery modules, five focused test modules, boundary digests, and this task record. Independent task review and whole-branch review remain pending before delivery.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Research/discovery/clinicaltrials_pubmed_central.py
+++ b/tldw_Server_API/app/core/Research/discovery/clinicaltrials_pubmed_central.py
@@ -213,6 +213,7 @@ def _pubmed_identity_overlay(route: AccessRoute) -> AccessRoute:
 
 
 def _clinicaltrials_source() -> SourceDefinition:
+    """Return the sealed ClinicalTrials.gov shadow source definition."""
     return SourceDefinition(
         catalog_source_id="clinicaltrials_gov",
         display_name="ClinicalTrials.gov",
@@ -228,6 +229,7 @@ def _clinicaltrials_source() -> SourceDefinition:
 
 
 def _pubmed_central_source() -> SourceDefinition:
+    """Return the sealed PubMed Central shadow source definition."""
     return SourceDefinition(
         catalog_source_id="pubmed_central",
         display_name="PubMed Central",
@@ -243,6 +245,7 @@ def _pubmed_central_source() -> SourceDefinition:
 
 
 def _clinicaltrials_route() -> AccessRoute:
+    """Return the exact ClinicalTrials.gov search route."""
     return AccessRoute(
         route_id="clinicaltrials_gov_studies_search_direct",
         backend_id="clinicaltrials_gov_api_v2",
@@ -285,6 +288,7 @@ def _clinicaltrials_route() -> AccessRoute:
 
 
 def _pubmed_central_route() -> AccessRoute:
+    """Return the exact PubMed Central E-utilities route."""
     return AccessRoute(
         route_id="pubmed_central_esearch_summary_direct",
         backend_id="ncbi_eutils_pmc",
@@ -471,10 +475,12 @@ def _trusted_clinicaltrials_inputs(
 
 
 def _has_forbidden_text_character(value: str) -> bool:
+    """Return whether text contains forbidden control or replacement characters."""
     return any(character == "\ufffd" or unicodedata.category(character) in {"Cc", "Cf", "Cs"} for character in value)
 
 
 def _contains_residual_markup(value: str) -> bool:
+    """Return whether text still contains markup delimiters or entity forms."""
     return "<" in value or ">" in value or _RESIDUAL_ENTITY_RE.search(value) is not None
 
 
@@ -555,19 +561,23 @@ def _plain_clinical_text(
 
 class _LegacySummaryParser(HTMLParser):
     def __init__(self) -> None:
+        """Initialize inert text collection for a legacy summary fragment."""
         super().__init__(convert_charrefs=True)
         self.parts: list[str] = []
         self.ignored_depth = 0
 
     def handle_starttag(self, tag: str, _attrs: list[tuple[str, str | None]]) -> None:
+        """Suppress text nested in script and style elements."""
         if tag.casefold() in {"script", "style"}:
             self.ignored_depth += 1
 
     def handle_endtag(self, tag: str) -> None:
+        """Resume text collection after a suppressed element closes."""
         if tag.casefold() in {"script", "style"} and self.ignored_depth:
             self.ignored_depth -= 1
 
     def handle_data(self, data: str) -> None:
+        """Collect text content outside suppressed elements."""
         if not self.ignored_depth:
             self.parts.append(data)
 
@@ -621,6 +631,7 @@ def _partial_date(value: Any) -> str | None:
 
 
 def _optional_container(record: dict[str, Any], key: str) -> dict[str, Any] | None:
+    """Return one optional mapping field while rejecting malformed containers."""
     value = record.get(key, _MISSING)
     if value is _MISSING:
         return None
@@ -628,6 +639,7 @@ def _optional_container(record: dict[str, Any], key: str) -> dict[str, Any] | No
 
 
 def _optional_plain_field(container: dict[str, Any] | None, key: str, max_chars: int) -> str | None:
+    """Return one optional normalized text field from a mapping."""
     if container is None or key not in container:
         return None
     value = container[key]
@@ -642,6 +654,7 @@ def _optional_text_list(
     *,
     guard: _ParseGuard,
 ) -> tuple[str, ...] | None:
+    """Return an optional bounded tuple of normalized text values."""
     if container is None or key not in container:
         return None
     values = _require_list(container[key])
@@ -664,6 +677,7 @@ def _optional_interventions(
     *,
     guard: _ParseGuard,
 ) -> tuple[str, ...] | None:
+    """Return optional normalized intervention names from a protocol section."""
     if container is None or "interventions" not in container:
         return None
     values = _require_list(container["interventions"])
@@ -683,6 +697,7 @@ def _optional_interventions(
 
 
 def _optional_date(status: dict[str, Any] | None, key: str) -> str | None:
+    """Return one optional validated partial date from study status."""
     if status is None or key not in status:
         return None
     structure = _require_dict(status[key])
@@ -812,6 +827,7 @@ async def _execute_clinicaltrials_adapter(
     dispatch: BoundDispatch,
     clock: MonotonicClock,
 ) -> DiscoveryAdapterResult:
+    """Execute bounded ClinicalTrials.gov pages and atomically stage NCT records."""
     trusted, profile, max_input_bytes, page_size = _trusted_clinicaltrials_inputs(group)
     intent = trusted.intents[0]
     staged_by_nct: dict[str, dict[str, Any]] = {}
@@ -841,12 +857,15 @@ async def _execute_clinicaltrials_adapter(
             if token_required != (page.next_page_token is not None):
                 raise _PayloadInvalid
 
+            staged_before_page = len(staged_by_nct)
             for record in page.records:
                 nct_id = cast(str, cast(dict[str, str], record["provider_ids"])["nct_id"])
                 previous = staged_by_nct.get(nct_id)
                 if previous is not None and previous != record:
                     raise _PayloadInvalid
                 staged_by_nct.setdefault(nct_id, record)
+            if cumulative_raw < frozen_total and len(staged_by_nct) == staged_before_page:
+                raise _PayloadInvalid
             guard.checkpoint()
 
             capacity_remains = (
@@ -1246,6 +1265,7 @@ async def _execute_pubmed_central_adapter(
     dispatch: BoundDispatch,
     clock: MonotonicClock,
 ) -> DiscoveryAdapterResult:
+    """Execute the sealed PubMed Central ESearch and ESummary pair."""
     return await _execute_ncbi_esearch_summary(
         group,
         dispatch,
@@ -1280,12 +1300,14 @@ def clinicaltrials_pubmed_central_gateway_adapters(
         group: PlannedDispatchGroup,
         dispatch: BoundDispatch,
     ) -> DiscoveryAdapterResult:
+        """Bind the shared clock to the ClinicalTrials.gov adapter."""
         return await _execute_clinicaltrials_adapter(group, dispatch, monotonic_clock)
 
     async def pubmed_central_adapter(
         group: PlannedDispatchGroup,
         dispatch: BoundDispatch,
     ) -> DiscoveryAdapterResult:
+        """Bind the shared clock to the PubMed Central adapter."""
         return await _execute_pubmed_central_adapter(group, dispatch, monotonic_clock)
 
     return _compose_adapter_maps(

--- a/tldw_Server_API/app/core/Research/discovery/executor.py
+++ b/tldw_Server_API/app/core/Research/discovery/executor.py
@@ -1238,7 +1238,8 @@ class _GroupExecutionController:
         self._used: set[int] = set()
         self._completed_searches: set[int] = set()
         self._successful_searches: set[int] = set()
-        self._seen_cursors: dict[int, set[int | str]] = {}
+        self._seen_numeric_cursors: dict[int, set[int]] = {}
+        self._seen_opaque_cursors: dict[int, set[str]] = {}
         self.physical_dispatches = 0
         self.pages = 0
         self.redirects = 0
@@ -1504,7 +1505,7 @@ class _GroupExecutionController:
                 self._reject("cursor_not_allowed")
             if intent_index not in self._successful_searches:
                 self._reject("search_not_ready")
-            seen_cursors = self._seen_cursors.get(intent_index, set())
+            seen_cursors = self._seen_opaque_cursors.get(intent_index, set())
             if cursor.value in seen_cursors:
                 self._reject("pagination_cursor_repeated")
             if type(query_key) is not str or body_key is not None:
@@ -1535,7 +1536,7 @@ class _GroupExecutionController:
             self._reject("cursor_not_allowed")
         if intent_index not in self._successful_searches:
             self._reject("search_not_ready")
-        seen_cursors = self._seen_cursors.get(intent_index, set())
+        seen_cursors = self._seen_numeric_cursors.get(intent_index, set())
         if cursor.value in seen_cursors:
             self._reject("pagination_cursor_repeated")
         if path_channel and seen_cursors and cursor.value < max(cast(set[int], seen_cursors)):
@@ -1675,8 +1676,10 @@ class _GroupExecutionController:
             pending_continuation = None
             if first_hop and is_page:
                 self.pages += 1
-                if type(page_cursor) in {int, str}:
-                    self._seen_cursors.setdefault(intent_index, set()).add(page_cursor)
+                if type(page_cursor) is int:
+                    self._seen_numeric_cursors.setdefault(intent_index, set()).add(page_cursor)
+                elif type(page_cursor) is str:
+                    self._seen_opaque_cursors.setdefault(intent_index, set()).add(page_cursor)
             first_hop = False
             aggregate_timed_out = False
             try:

--- a/tldw_Server_API/app/core/Research/discovery/gateway_adapters.py
+++ b/tldw_Server_API/app/core/Research/discovery/gateway_adapters.py
@@ -1511,6 +1511,25 @@ def _trusted_pubmed_inputs(
     search, summary = group.intents
     limits = group.limits
     if (
+        type(search) is not DispatchIntent
+        or type(summary) is not DispatchIntent
+        or type(limits) is not RouteLimits
+        or type(search.query_pairs) is not tuple
+        or type(summary.query_pairs) is not tuple
+        or type(search.json_body_pairs) is not tuple
+        or type(summary.json_body_pairs) is not tuple
+        or type(search.query_bindings) is not tuple
+        or type(summary.query_bindings) is not tuple
+        or any(type(pair) is not QueryPair for pair in (*search.query_pairs, *summary.query_pairs))
+        or any(
+            type(pair.name) is not str or type(pair.value) is not str
+            for pair in (*search.query_pairs, *summary.query_pairs)
+        )
+        or len(summary.query_bindings) != 1
+        or type(summary.query_bindings[0]) is not DeferredNumericCSVQueryBinding
+    ):
+        raise DiscoveryAdapterError("provider_payload_invalid")
+    if (
         search.operation_kind is not OperationKind.SEARCH
         or summary.operation_kind is not OperationKind.CONDITIONAL_SUMMARY
         or search.method != "GET"
@@ -1688,7 +1707,12 @@ async def _execute_ncbi_esearch_summary(
     strict_rate_envelope: bool,
 ) -> DiscoveryAdapterResult:
     """Execute one sealed ESearch and conditional ESummary pair."""
-    trusted_group, profile, max_input_bytes, retstart, retmax, binding = trusted_inputs(group)
+    try:
+        trusted_group, profile, max_input_bytes, retstart, retmax, binding = trusted_inputs(group)
+    except DiscoveryAdapterError:
+        raise
+    except (AttributeError, KeyError, TypeError, ValueError, OverflowError):
+        raise DiscoveryAdapterError("provider_payload_invalid") from None
     search, summary = trusted_group.intents
     search_response = _checked_response(await dispatch(search))
     search_payload, search_guard = _strict_json(

--- a/tldw_Server_API/app/core/Research/discovery/gateway_adapters.py
+++ b/tldw_Server_API/app/core/Research/discovery/gateway_adapters.py
@@ -1711,7 +1711,7 @@ async def _execute_ncbi_esearch_summary(
         trusted_group, profile, max_input_bytes, retstart, retmax, binding = trusted_inputs(group)
     except DiscoveryAdapterError:
         raise
-    except (AttributeError, KeyError, TypeError, ValueError, OverflowError):
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError, OverflowError):
         raise DiscoveryAdapterError("provider_payload_invalid") from None
     search, summary = trusted_group.intents
     search_response = _checked_response(await dispatch(search))
@@ -1737,7 +1737,7 @@ async def _execute_ncbi_esearch_summary(
         _raise_adapter_error(error)
     except DiscoveryAdapterError:
         raise
-    except (KeyError, TypeError, ValueError, OverflowError):
+    except (IndexError, KeyError, TypeError, ValueError, OverflowError):
         raise DiscoveryAdapterError("provider_payload_invalid") from None
     if not ids:
         return DiscoveryAdapterResult(candidates=())
@@ -1780,7 +1780,7 @@ async def _execute_ncbi_esearch_summary(
         _raise_adapter_error(error)
     except DiscoveryAdapterError:
         raise
-    except (KeyError, TypeError, ValueError, OverflowError):
+    except (IndexError, KeyError, TypeError, ValueError, OverflowError):
         raise DiscoveryAdapterError("provider_payload_invalid") from None
     return DiscoveryAdapterResult(tuple(candidates))
 

--- a/tldw_Server_API/app/core/Research/discovery/gateway_adapters.py
+++ b/tldw_Server_API/app/core/Research/discovery/gateway_adapters.py
@@ -1584,9 +1584,13 @@ def _trusted_pubmed_inputs(
     binding = summary.query_bindings[0]
     if (
         type(binding) is not DeferredNumericCSVQueryBinding
+        or type(binding.binding_id) is not str
         or binding.binding_id != _PUBMED_BINDING_ID
+        or type(binding.query_name) is not str
         or binding.query_name != "id"
+        or type(binding.max_item_chars) is not int
         or binding.max_item_chars != 16
+        or type(binding.max_items) is not int
     ):
         raise DiscoveryAdapterError("provider_payload_invalid")
     try:

--- a/tldw_Server_API/app/core/Research/discovery/planner.py
+++ b/tldw_Server_API/app/core/Research/discovery/planner.py
@@ -137,8 +137,20 @@ def _has_pubmed_identity_component(route: AccessRoute) -> bool:
     """Return whether a non-foundation route claims any PubMed overlay marker."""
     if type(route) is not AccessRoute:
         return False
+    try:
+        policy_version = route.policy.policy_version
+    except Exception:  # noqa: BLE001 - malformed registry policies fail closed as identity drift.
+        policy_version = None
     if type(route.policy) is not RoutePolicy:
-        return route.route_id == _PUBMED_ROUTE_ID
+        return any(
+            (
+                route.route_id == _PUBMED_ROUTE_ID,
+                route.backend_id == _PUBMED_BACKEND_ID,
+                route.adapter_id == _PUBMED_ADAPTER_ID,
+                route.adapter_version == _PUBMED_IDENTITY_ADAPTER_VERSION,
+                policy_version == _PUBMED_IDENTITY_POLICY_VERSION,
+            )
+        )
     if _is_foundation_pubmed_policy_owner(route):
         return False
     return any(

--- a/tldw_Server_API/app/core/Research/discovery/planner.py
+++ b/tldw_Server_API/app/core/Research/discovery/planner.py
@@ -108,6 +108,8 @@ _CLINICALTRIALS_QUERY_KEYS = (
 
 def _is_identity_pubmed_route(route: AccessRoute) -> bool:
     """Return whether one route is the complete sealed NCBI identity overlay."""
+    if type(route) is not AccessRoute or type(route.policy) is not RoutePolicy:
+        return False
     return (
         route.route_id == _PUBMED_ROUTE_ID
         and route.backend_id == _PUBMED_BACKEND_ID
@@ -120,6 +122,8 @@ def _is_identity_pubmed_route(route: AccessRoute) -> bool:
 
 def _is_foundation_pubmed_policy_owner(route: AccessRoute) -> bool:
     """Exclude the exact foundation identity from overlay-specific sealing."""
+    if type(route) is not AccessRoute or type(route.policy) is not RoutePolicy:
+        return False
     return (
         route.route_id == _PUBMED_ROUTE_ID
         and route.backend_id == _PUBMED_BACKEND_ID
@@ -131,6 +135,10 @@ def _is_foundation_pubmed_policy_owner(route: AccessRoute) -> bool:
 
 def _has_pubmed_identity_component(route: AccessRoute) -> bool:
     """Return whether a non-foundation route claims any PubMed overlay marker."""
+    if type(route) is not AccessRoute:
+        return False
+    if type(route.policy) is not RoutePolicy:
+        return route.route_id == _PUBMED_ROUTE_ID
     if _is_foundation_pubmed_policy_owner(route):
         return False
     return any(

--- a/tldw_Server_API/app/core/Research/discovery/planner.py
+++ b/tldw_Server_API/app/core/Research/discovery/planner.py
@@ -365,6 +365,8 @@ def _has_exact_clinicaltrials_policy(route: AccessRoute) -> bool:
 
 def _has_exact_pubmed_identity_policy(route: AccessRoute) -> bool:
     """Anchor the PubMed identity overlay to one approved route and policy."""
+    if type(route) is not AccessRoute or type(route.policy) is not RoutePolicy:
+        return False
     policy = route.policy
     origin = policy.origin
     return (

--- a/tldw_Server_API/tests/Research/test_research_discovery_clinicaltrials_pubmed_central.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_clinicaltrials_pubmed_central.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
+import inspect
 import json
 from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
-from types import MappingProxyType
+from types import MappingProxyType, ModuleType
 from typing import Any
 
 import pytest
@@ -169,8 +171,20 @@ class _OpaqueCursorQueryValuePolicySubclass(OpaqueCursorQueryValuePolicy):
     """Equal-valued opaque-cursor policy with a non-exact type."""
 
 
-def _module():
+def _module() -> ModuleType:
     return importlib.import_module(_MODULE)
+
+
+def test_family_module_functions_are_documented_and_module_loader_is_typed() -> None:
+    module_path = (
+        Path(__file__).parents[2] / "app" / "core" / "Research" / "discovery" / "clinicaltrials_pubmed_central.py"
+    )
+    tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
+    functions = tuple(node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)))
+
+    assert functions
+    assert all(ast.get_docstring(function) for function in functions)
+    assert inspect.signature(_module).return_annotation == "ModuleType"
 
 
 def _budget() -> BudgetCeilings:
@@ -1474,6 +1488,18 @@ async def test_clinicaltrials_identical_duplicate_collapses_only_after_raw_accou
 
     assert len(result.candidates) == 1
     assert len(dispatch.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_clinicaltrials_repeated_nonterminal_page_fails_atomically_after_raw_accounting() -> None:
+    first = _fixture_payload("success_page_1")
+    repeated = {"totalCount": 3, "studies": [first["studies"][0]], "nextPageToken": "synthetic-page-three"}
+    first["totalCount"] = 3
+
+    with pytest.raises(Exception) as caught:
+        await _invoke_clinical_bodies([_payload_bytes(first), _payload_bytes(repeated)])
+
+    _assert_adapter_error(caught.value, "provider_payload_invalid")
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Research/test_research_discovery_executor.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_executor.py
@@ -33,6 +33,7 @@ from tldw_Server_API.app.core.Research.discovery.contracts import (
     PathSlot,
     PathSlotKind,
     PathTemplate,
+    PlannedDispatchGroup,
     PredicateOperator,
     QueryMode,
     ReadinessOverlay,
@@ -51,6 +52,7 @@ from tldw_Server_API.app.core.Research.discovery.contracts import (
 )
 from tldw_Server_API.app.core.Research.discovery.executor import (
     AttemptJournal,
+    BoundDispatch,
     DiscoveryAdapterResult,
     DiscoveryCandidate,
     DispatchAccounting,
@@ -58,6 +60,7 @@ from tldw_Server_API.app.core.Research.discovery.executor import (
     NumericCSVBindingValues,
     NumericCursor,
     PhysicalDispatchState,
+    PolicyActivityCheck,
     execute_discovery_plan,
 )
 from tldw_Server_API.app.core.Research.discovery.gateway import (
@@ -3440,14 +3443,25 @@ async def test_opaque_query_cursor_rejects_repeat_without_imposing_order() -> No
 
 @pytest.mark.asyncio
 async def test_numeric_path_progress_ignores_separately_tracked_opaque_history() -> None:
+    """Reject numeric cursor regression despite separately tracked opaque state."""
     registry, plan = _path_paginated_plan()
     group = plan.dispatch_groups[0]
     observed_errors = []
 
-    async def gateway(route, intent, *, is_policy_active):
+    async def gateway(
+        route: AccessRoute,
+        intent: DispatchIntent,
+        *,
+        is_policy_active: PolicyActivityCheck,
+    ) -> DiscoveryGatewayResponse:
+        """Return the deterministic response for a dispatched route intent."""
         return _gateway_response(route, intent)
 
-    async def adapter(bound_group, dispatch):
+    async def adapter(
+        bound_group: PlannedDispatchGroup,
+        dispatch: BoundDispatch,
+    ) -> DiscoveryAdapterResult:
+        """Dispatch numeric cursors after seeding isolated opaque history."""
         await dispatch(bound_group.intents[0])
         await dispatch(bound_group.intents[0], cursor=NumericCursor(10))
         controller = next(

--- a/tldw_Server_API/tests/Research/test_research_discovery_executor.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_executor.py
@@ -3439,6 +3439,48 @@ async def test_opaque_query_cursor_rejects_repeat_without_imposing_order() -> No
 
 
 @pytest.mark.asyncio
+async def test_numeric_path_progress_ignores_separately_tracked_opaque_history() -> None:
+    registry, plan = _path_paginated_plan()
+    group = plan.dispatch_groups[0]
+    observed_errors = []
+
+    async def gateway(route, intent, *, is_policy_active):
+        return _gateway_response(route, intent)
+
+    async def adapter(bound_group, dispatch):
+        await dispatch(bound_group.intents[0])
+        await dispatch(bound_group.intents[0], cursor=NumericCursor(10))
+        controller = next(
+            cell.cell_contents
+            for cell in dispatch.__closure__ or ()
+            if type(cell.cell_contents) is executor_module._GroupExecutionController
+        )
+        opaque_history = getattr(controller, "_seen_opaque_cursors", None)
+        if opaque_history is None:
+            opaque_history = controller._seen_cursors
+        opaque_history.setdefault(0, set()).add("opaque-history")
+        try:
+            await dispatch(bound_group.intents[0], cursor=NumericCursor(5))
+        except Exception as error:  # noqa: BLE001 - assert the typed execution boundary below.
+            observed_errors.append(error)
+        return DiscoveryAdapterResult(candidates=())
+
+    result = await execute_discovery_plan(
+        plan,
+        registry=registry,
+        adapters={group.adapter_id: adapter},
+        gateway=gateway,
+        policy_is_active=lambda _route_id, _digest: True,
+        dispatch_id_factory=iter(("path-initial", "path-ten", "must-not-reserve")).__next__,
+    )
+
+    assert len(observed_errors) == 1
+    assert type(observed_errors[0]) is executor_module.DiscoveryExecutionError
+    assert observed_errors[0].code == "pagination_cursor_non_progress"
+    assert result.logical_outcomes[0].code == "pagination_cursor_non_progress"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("invalid_value", ("", "control\n", "caf\u00e9", "x" * 1_025))
 async def test_opaque_query_cursor_rejects_mutated_invalid_values_before_reservation(invalid_value: str) -> None:
     registry, plan = _opaque_query_paginated_plan()

--- a/tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
@@ -23,6 +23,7 @@ from tldw_Server_API.app.core.Research.discovery.contracts import (
     BudgetCeilings,
     DiscoveryOutcomeIdentity,
     ExecutionMode,
+    PlannedDispatchGroup,
 )
 from tldw_Server_API.app.core.Research.discovery.executor import (
     DiscoveryAdapterResult,
@@ -56,6 +57,12 @@ pytestmark = pytest.mark.unit
 
 _FIXTURE_ROOT = Path(__file__).parents[1] / "fixtures" / "research_discovery_gateway_adapters"
 _ADAPTER_MODULE = "tldw_Server_API.app.core.Research.discovery.gateway_adapters"
+
+
+class _EqualStringSubclass(str):
+    """String subclass used to prove exact scalar type checks."""
+
+
 _NORMALIZED_KEYS = {
     "title",
     "authors",
@@ -322,7 +329,8 @@ def _plan_for(
     return registry, plan
 
 
-def _pubmed_group():
+def _pubmed_group() -> PlannedDispatchGroup:
+    """Build one valid foundation PubMed dispatch group for adapter tests."""
     registry = foundation_registry()
     plan = compile_discovery_plan(
         PlanningRequest(("pubmed",), "bounded discovery", (), 1),
@@ -606,9 +614,44 @@ async def test_ncbi_trusted_input_callback_attribute_error_normalizes_but_adapte
 
     _assert_typed_error(indexed.value, "provider_payload_invalid")
 
+    summary_dispatch = _RecordingDispatch(
+        [
+            _response(route, group.intents[0], b"{}"),
+            _response(route, group.intents[1], b"{}"),
+        ]
+    )
+
+    def indexed_summary_parser(*_args, **_kwargs):
+        raise IndexError("synthetic indexed summary callback failure")
+
+    with pytest.raises(_adapter_error_type()) as indexed_summary:
+        await module._execute_ncbi_esearch_summary(
+            group,
+            summary_dispatch,
+            _CountingClock(),
+            trusted_inputs=module._trusted_pubmed_inputs,
+            parse_esearch_ids=lambda *_args, **_kwargs: (("123", 1),),
+            parse_summary_records=indexed_summary_parser,
+            strict_rate_envelope=False,
+        )
+
+    _assert_typed_error(indexed_summary.value, "provider_payload_invalid")
+
 
 @pytest.mark.parametrize(
-    "mutation", ("intent", "query_container", "query_member", "binding_container", "binding_member", "limits")
+    "mutation",
+    (
+        "intent",
+        "query_container",
+        "query_member",
+        "binding_container",
+        "binding_member",
+        "binding_id_scalar_type",
+        "binding_query_name_scalar_type",
+        "binding_max_item_chars_scalar_type",
+        "binding_max_items_scalar_type",
+        "limits",
+    ),
 )
 def test_pubmed_trusted_inputs_reject_malformed_containers_before_dereference(mutation: str) -> None:
     module = _gateway_adapters_module()
@@ -624,6 +667,22 @@ def test_pubmed_trusted_inputs_reject_malformed_containers_before_dereference(mu
         object.__setattr__(summary, "query_bindings", [])
     elif mutation == "binding_member":
         object.__setattr__(summary.query_bindings[0], "binding_id", object())
+    elif mutation == "binding_id_scalar_type":
+        object.__setattr__(
+            summary.query_bindings[0],
+            "binding_id",
+            _EqualStringSubclass(summary.query_bindings[0].binding_id),
+        )
+    elif mutation == "binding_query_name_scalar_type":
+        object.__setattr__(
+            summary.query_bindings[0],
+            "query_name",
+            _EqualStringSubclass(summary.query_bindings[0].query_name),
+        )
+    elif mutation == "binding_max_item_chars_scalar_type":
+        object.__setattr__(summary.query_bindings[0], "max_item_chars", 16.0)
+    elif mutation == "binding_max_items_scalar_type":
+        object.__setattr__(summary.query_bindings[0], "max_items", 1.0)
     else:
         object.__setattr__(group, "limits", object())
 

--- a/tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
@@ -322,6 +322,17 @@ def _plan_for(
     return registry, plan
 
 
+def _pubmed_group():
+    registry = foundation_registry()
+    plan = compile_discovery_plan(
+        PlanningRequest(("pubmed",), "bounded discovery", (), 1),
+        registry=registry,
+        readiness=foundation_readiness(ExecutionMode.SYNTHETIC),
+        budget=BudgetCeilings(1, 2, 1, 0, 0, 40_000, 1),
+    )
+    return plan.dispatch_groups[0]
+
+
 def _response(
     route,
     intent,
@@ -516,6 +527,73 @@ def _assert_typed_error(error: BaseException, code: str) -> None:
     assert type(error) is error_type
     assert error.code == code
     assert str(error) == code
+
+
+@pytest.mark.asyncio
+async def test_ncbi_trusted_input_callback_attribute_error_normalizes_but_adapter_error_propagates() -> None:
+    module = _gateway_adapters_module()
+
+    def attribute_failure(_group: object):
+        raise AttributeError("synthetic structural callback failure")
+
+    async def forbidden_dispatch(*_args, **_kwargs):
+        raise AssertionError("trusted-input failure must precede dispatch")
+
+    with pytest.raises(_adapter_error_type()) as caught:
+        await module._execute_ncbi_esearch_summary(
+            object(),
+            forbidden_dispatch,
+            _CountingClock(),
+            trusted_inputs=attribute_failure,
+            parse_esearch_ids=lambda *_args, **_kwargs: (),
+            parse_summary_records=lambda *_args, **_kwargs: (),
+            strict_rate_envelope=False,
+        )
+
+    _assert_typed_error(caught.value, "provider_payload_invalid")
+    expected = _adapter_error_type()("provider_response_rejected")
+
+    def typed_failure(_group: object):
+        raise expected
+
+    with pytest.raises(_adapter_error_type()) as propagated:
+        await module._execute_ncbi_esearch_summary(
+            object(),
+            forbidden_dispatch,
+            _CountingClock(),
+            trusted_inputs=typed_failure,
+            parse_esearch_ids=lambda *_args, **_kwargs: (),
+            parse_summary_records=lambda *_args, **_kwargs: (),
+            strict_rate_envelope=False,
+        )
+
+    assert propagated.value is expected
+
+
+@pytest.mark.parametrize(
+    "mutation", ("intent", "query_container", "query_member", "binding_container", "binding_member", "limits")
+)
+def test_pubmed_trusted_inputs_reject_malformed_containers_before_dereference(mutation: str) -> None:
+    module = _gateway_adapters_module()
+    group = _pubmed_group()
+    search, summary = group.intents
+    if mutation == "intent":
+        object.__setattr__(group, "intents", (object(), summary))
+    elif mutation == "query_container":
+        object.__setattr__(search, "query_pairs", [])
+    elif mutation == "query_member":
+        object.__setattr__(search.query_pairs[0], "name", object())
+    elif mutation == "binding_container":
+        object.__setattr__(summary, "query_bindings", [])
+    elif mutation == "binding_member":
+        object.__setattr__(summary.query_bindings[0], "binding_id", object())
+    else:
+        object.__setattr__(group, "limits", object())
+
+    with pytest.raises(_adapter_error_type()) as caught:
+        module._trusted_pubmed_inputs(group)
+
+    _assert_typed_error(caught.value, "provider_payload_invalid")
 
 
 def _assert_two_completed_physical_hops(result) -> None:

--- a/tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
@@ -551,6 +551,23 @@ async def test_ncbi_trusted_input_callback_attribute_error_normalizes_but_adapte
         )
 
     _assert_typed_error(caught.value, "provider_payload_invalid")
+
+    def indexed_failure(_group: object):
+        raise IndexError("synthetic indexed trusted-input failure")
+
+    with pytest.raises(_adapter_error_type()) as indexed_trusted_input:
+        await module._execute_ncbi_esearch_summary(
+            object(),
+            forbidden_dispatch,
+            _CountingClock(),
+            trusted_inputs=indexed_failure,
+            parse_esearch_ids=lambda *_args, **_kwargs: (),
+            parse_summary_records=lambda *_args, **_kwargs: (),
+            strict_rate_envelope=False,
+        )
+
+    _assert_typed_error(indexed_trusted_input.value, "provider_payload_invalid")
+
     expected = _adapter_error_type()("provider_response_rejected")
 
     def typed_failure(_group: object):

--- a/tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_gateway_adapters.py
@@ -569,6 +569,26 @@ async def test_ncbi_trusted_input_callback_attribute_error_normalizes_but_adapte
 
     assert propagated.value is expected
 
+    group = _pubmed_group()
+    route = foundation_registry().get_route(group.route_id)
+    dispatch = _RecordingDispatch([_response(route, group.intents[0], b"{}")])
+
+    def indexed_parser(*_args, **_kwargs):
+        raise IndexError("synthetic indexed parser failure")
+
+    with pytest.raises(_adapter_error_type()) as indexed:
+        await module._execute_ncbi_esearch_summary(
+            group,
+            dispatch,
+            _CountingClock(),
+            trusted_inputs=module._trusted_pubmed_inputs,
+            parse_esearch_ids=indexed_parser,
+            parse_summary_records=lambda *_args, **_kwargs: (),
+            strict_rate_envelope=False,
+        )
+
+    _assert_typed_error(indexed.value, "provider_payload_invalid")
+
 
 @pytest.mark.parametrize(
     "mutation", ("intent", "query_container", "query_member", "binding_container", "binding_member", "limits")

--- a/tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
@@ -130,7 +130,7 @@ _EXPECTED_AST_DIGESTS = {
     "registry.py": "260df2717fcf7cdd91a926dda694bf0517611f0d6378049448581637b4a3def3",
     "planner.py": "b9e0bc18e4e523cd87e1fd2652818483e0355c7bdac30a8100f9c60e0ed65520",
     "executor.py": "9b50ab4e6b7971ec8fa371a705175ee4ee0d81030136b1a6ccb44d33f7aad87c",
-    "gateway_adapters.py": "f02ac5723e263f557a19540b5adcda659651bd20732a8ce798fcb98be1876167",
+    "gateway_adapters.py": "809bc6e27b6ccebeaac25108ef34823c9b2da53509cb74b7dc0c091ecb44947a",
     "gateway.py": "9fa3be4b099e4beb519e63bee037873d55fcd8425c7ec939520ea100cd896654",
     "identity.py": "f59640d8f793fd3ebd11df49d333f73ebee9e59efb549393116bee2a241f5f06",
     "catalog.py": "6f89e526a0cee3f934fc04da6adc5698800842e9f798ac45e35847d859e08ba6",

--- a/tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
@@ -128,9 +128,9 @@ _EXPECTED_IMPORT_DIGESTS = {
 _EXPECTED_AST_DIGESTS = {
     "contracts.py": "31006c7e537eadf401494f1356cf55d690da2af8314adb57751b59ce88d36e52",
     "registry.py": "260df2717fcf7cdd91a926dda694bf0517611f0d6378049448581637b4a3def3",
-    "planner.py": "cd86b4eec709cd193873f292c7b5e028653f13df938ca9f1ea1ba2fde7b11369",
-    "executor.py": "632a842dded5721b60966e234b63a3bb39f626bfb9ca3e53e9661844e88a9976",
-    "gateway_adapters.py": "98b8b0013e26fba491bf50e5270178b5c7d396990f601a2e63c3376b1fc8be32",
+    "planner.py": "e8bcf046ecda7122ee2d33f4b1717fd3e444a77faa7d6485a0999ad4c4cda40c",
+    "executor.py": "9b50ab4e6b7971ec8fa371a705175ee4ee0d81030136b1a6ccb44d33f7aad87c",
+    "gateway_adapters.py": "3bb6bd0edfe4fed115f4c5b177c6299bc249ced0b0883121a1729153dd36bc64",
     "gateway.py": "9fa3be4b099e4beb519e63bee037873d55fcd8425c7ec939520ea100cd896654",
     "identity.py": "f59640d8f793fd3ebd11df49d333f73ebee9e59efb549393116bee2a241f5f06",
     "catalog.py": "6f89e526a0cee3f934fc04da6adc5698800842e9f798ac45e35847d859e08ba6",
@@ -146,7 +146,7 @@ _EXPECTED_AST_DIGESTS = {
 }
 _EXPECTED_FAMILY_RAW_DIGESTS = {
     "biorxiv_medrxiv.py": "ee77fb9bc5da1cb93dc88baea86c9cd5b6a6e961d02faec97faa66cbcf383af9",
-    "clinicaltrials_pubmed_central.py": "fd95c87625e0f360cea486cf27dab159dfe66d1e58911954c13e2653f4f0032f",
+    "clinicaltrials_pubmed_central.py": "3eb3afbf50e3ddab04953e88ec33c4e1510eebfda731e36c80cb3b37f3d333df",
 }
 _EXPECTED_FAMILY_IMPORT_DIGESTS = {
     "biorxiv_medrxiv.py": "a9a057e486c28731299b0997b04862a6e81dc6454d73d4fc94d0806d6831ebf3",
@@ -154,7 +154,7 @@ _EXPECTED_FAMILY_IMPORT_DIGESTS = {
 }
 _EXPECTED_FAMILY_AST_DIGESTS = {
     "biorxiv_medrxiv.py": "21f46f0468fc0a83877d6cc4f1bb8830bdc48bbe4c10ee1c1db90d9144e67f95",
-    "clinicaltrials_pubmed_central.py": "57e7d21c5db2a4805f2ca8a87a457b9e2a0db83bca31f58b8cfb04c73f8d6289",
+    "clinicaltrials_pubmed_central.py": "b9c1e7635a6450563b7dbef0861f1bdc54db20dc571e3375512336c220e60a82",
 }
 _BIORXIV_MEDRXIV_LOCAL_IMPORTS = MappingProxyType(
     {

--- a/tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
@@ -128,9 +128,9 @@ _EXPECTED_IMPORT_DIGESTS = {
 _EXPECTED_AST_DIGESTS = {
     "contracts.py": "31006c7e537eadf401494f1356cf55d690da2af8314adb57751b59ce88d36e52",
     "registry.py": "260df2717fcf7cdd91a926dda694bf0517611f0d6378049448581637b4a3def3",
-    "planner.py": "e8bcf046ecda7122ee2d33f4b1717fd3e444a77faa7d6485a0999ad4c4cda40c",
+    "planner.py": "b9e0bc18e4e523cd87e1fd2652818483e0355c7bdac30a8100f9c60e0ed65520",
     "executor.py": "9b50ab4e6b7971ec8fa371a705175ee4ee0d81030136b1a6ccb44d33f7aad87c",
-    "gateway_adapters.py": "3bb6bd0edfe4fed115f4c5b177c6299bc249ced0b0883121a1729153dd36bc64",
+    "gateway_adapters.py": "f02ac5723e263f557a19540b5adcda659651bd20732a8ce798fcb98be1876167",
     "gateway.py": "9fa3be4b099e4beb519e63bee037873d55fcd8425c7ec939520ea100cd896654",
     "identity.py": "f59640d8f793fd3ebd11df49d333f73ebee9e59efb549393116bee2a241f5f06",
     "catalog.py": "6f89e526a0cee3f934fc04da6adc5698800842e9f798ac45e35847d859e08ba6",

--- a/tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_network_boundary.py
@@ -128,7 +128,7 @@ _EXPECTED_IMPORT_DIGESTS = {
 _EXPECTED_AST_DIGESTS = {
     "contracts.py": "31006c7e537eadf401494f1356cf55d690da2af8314adb57751b59ce88d36e52",
     "registry.py": "260df2717fcf7cdd91a926dda694bf0517611f0d6378049448581637b4a3def3",
-    "planner.py": "b9e0bc18e4e523cd87e1fd2652818483e0355c7bdac30a8100f9c60e0ed65520",
+    "planner.py": "f47af4f735688f3f8eca0a6c5e9620fca2a1ddabadc3ec1aef4324ac12afa39f",
     "executor.py": "9b50ab4e6b7971ec8fa371a705175ee4ee0d81030136b1a6ccb44d33f7aad87c",
     "gateway_adapters.py": "809bc6e27b6ccebeaac25108ef34823c9b2da53509cb74b7dc0c091ecb44947a",
     "gateway.py": "9fa3be4b099e4beb519e63bee037873d55fcd8425c7ec939520ea100cd896654",

--- a/tldw_Server_API/tests/Research/test_research_discovery_planner.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_planner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from types import SimpleNamespace
+from typing import Callable
 
 import pytest
 from hypothesis import given, settings
@@ -562,7 +563,10 @@ def test_pubmed_identity_overlay_rejects_exact_policy_or_route_semantic_drift(mu
         lambda route: object.__setattr__(route.policy, "origin", object()),
     ),
 )
-def test_pubmed_identity_overlay_rejects_malformed_policy_objects_with_typed_planning_error(mutation) -> None:
+def test_pubmed_identity_overlay_rejects_malformed_policy_objects_with_typed_planning_error(
+    mutation: Callable[[AccessRoute], None],
+) -> None:
+    """Reject malformed PubMed policies through the typed planning boundary."""
     registry = clinicaltrials_pubmed_central_shadow_registry()
     route = registry.get_route("pubmed_ncbi_eutils_pubmed_direct")
     mutation(route)
@@ -580,17 +584,82 @@ def test_pubmed_identity_overlay_rejects_malformed_policy_objects_with_typed_pla
 
 @pytest.mark.parametrize("malformed_route", (object(),))
 def test_pubmed_identity_policy_predicate_rejects_non_contract_route_without_attribute_error(
-    malformed_route,
+    malformed_route: object,
 ) -> None:
+    """Reject an object that is not an exact PubMed identity route."""
     assert planner_module._has_exact_pubmed_identity_policy(malformed_route) is False
 
 
 def test_pubmed_identity_policy_predicate_rejects_non_contract_policy_without_attribute_error() -> None:
+    """Reject a PubMed route whose policy is not the contract type."""
     registry = clinicaltrials_pubmed_central_shadow_registry()
     route = registry.get_route("pubmed_ncbi_eutils_pubmed_direct")
     object.__setattr__(route, "policy", object())
 
     assert planner_module._has_exact_pubmed_identity_policy(route) is False
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        lambda route: object.__setattr__(route, "route_id", "pubmed_ncbi_eutils_pubmed_direct"),
+        lambda route: object.__setattr__(route, "backend_id", "ncbi_eutils_pubmed"),
+        lambda route: object.__setattr__(route, "adapter_id", "pubmed_v2"),
+        lambda route: object.__setattr__(route, "adapter_version", "pubmed-v2-ncbi-identity"),
+        lambda route: object.__setattr__(
+            route,
+            "policy",
+            SimpleNamespace(
+                policy_version="research-discovery-route-policy-v2-foundation-pubmed-ncbi-identity-2026-08-21"
+            ),
+        ),
+    ),
+)
+def test_pubmed_identity_classifier_recognizes_each_marker_when_policy_is_malformed(
+    mutation: Callable[[AccessRoute], None],
+) -> None:
+    """Recognize every PubMed marker despite a malformed route policy."""
+    registry = clinicaltrials_pubmed_central_shadow_registry()
+    route = registry.get_route("semantic_scholar_semantic_scholar_graph_api_direct")
+    object.__setattr__(route, "policy", object())
+    mutation(route)
+
+    assert planner_module._has_pubmed_identity_component(route) is True
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        lambda route: object.__setattr__(route, "backend_id", "ncbi_eutils_pubmed"),
+        lambda route: object.__setattr__(route, "adapter_id", "pubmed_v2"),
+        lambda route: object.__setattr__(route, "adapter_version", "pubmed-v2-ncbi-identity"),
+        lambda route: object.__setattr__(
+            route,
+            "policy",
+            SimpleNamespace(
+                policy_version="research-discovery-route-policy-v2-foundation-pubmed-ncbi-identity-2026-08-21"
+            ),
+        ),
+    ),
+)
+def test_semantic_scholar_pubmed_markers_with_malformed_policy_fail_through_planning(
+    mutation: Callable[[AccessRoute], None],
+) -> None:
+    """Fail closed when Semantic Scholar carries one PubMed identity marker."""
+    registry = clinicaltrials_pubmed_central_shadow_registry()
+    route = registry.get_route("semantic_scholar_semantic_scholar_graph_api_direct")
+    object.__setattr__(route, "policy", object())
+    mutation(route)
+
+    with pytest.raises(PlanningError) as caught:
+        compile_discovery_plan(
+            _request(("semantic_scholar",), result_limit=7),
+            registry=registry,
+            readiness=foundation_readiness(ExecutionMode.SYNTHETIC),
+            budget=_budget(max_physical_dispatches=8, max_pages_per_route=3, max_redirects=2, max_retries=2),
+        )
+
+    assert caught.value.code == "invalid_pubmed_route_identity:semantic_scholar_semantic_scholar_graph_api_direct"
 
 
 @pytest.mark.parametrize(

--- a/tldw_Server_API/tests/Research/test_research_discovery_planner.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_planner.py
@@ -556,6 +556,29 @@ def test_pubmed_identity_overlay_rejects_exact_policy_or_route_semantic_drift(mu
 
 
 @pytest.mark.parametrize(
+    "mutation",
+    (
+        lambda route: object.__setattr__(route, "policy", object()),
+        lambda route: object.__setattr__(route.policy, "origin", object()),
+    ),
+)
+def test_pubmed_identity_overlay_rejects_malformed_policy_objects_with_typed_planning_error(mutation) -> None:
+    registry = clinicaltrials_pubmed_central_shadow_registry()
+    route = registry.get_route("pubmed_ncbi_eutils_pubmed_direct")
+    mutation(route)
+
+    with pytest.raises(PlanningError) as caught:
+        compile_discovery_plan(
+            _request(("pubmed",), result_limit=7),
+            registry=registry,
+            readiness=foundation_readiness(ExecutionMode.SYNTHETIC),
+            budget=_budget(max_physical_dispatches=8, max_pages_per_route=3, max_redirects=2, max_retries=2),
+        )
+
+    assert caught.value.code == "invalid_pubmed_route_identity:pubmed_ncbi_eutils_pubmed_direct"
+
+
+@pytest.mark.parametrize(
     ("field", "value"),
     (
         ("backend_id", "ncbi_eutils_pubmed"),

--- a/tldw_Server_API/tests/Research/test_research_discovery_planner.py
+++ b/tldw_Server_API/tests/Research/test_research_discovery_planner.py
@@ -578,6 +578,21 @@ def test_pubmed_identity_overlay_rejects_malformed_policy_objects_with_typed_pla
     assert caught.value.code == "invalid_pubmed_route_identity:pubmed_ncbi_eutils_pubmed_direct"
 
 
+@pytest.mark.parametrize("malformed_route", (object(),))
+def test_pubmed_identity_policy_predicate_rejects_non_contract_route_without_attribute_error(
+    malformed_route,
+) -> None:
+    assert planner_module._has_exact_pubmed_identity_policy(malformed_route) is False
+
+
+def test_pubmed_identity_policy_predicate_rejects_non_contract_policy_without_attribute_error() -> None:
+    registry = clinicaltrials_pubmed_central_shadow_registry()
+    route = registry.get_route("pubmed_ncbi_eutils_pubmed_direct")
+    object.__setattr__(route, "policy", object())
+
+    assert planner_module._has_exact_pubmed_identity_policy(route) is False
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     (


### PR DESCRIPTION
## Change summary (human-authored; required before merge)\n\nPending text from the human requester. This PR must remain draft and must not merge until this section explains what changed and why these implementation choices were made in the requester’s own words.\n\n## Technical scope\n\n- Adds the missing provider-family docstrings and test-helper type annotation.\n- Rejects nonterminal ClinicalTrials.gov pages that make no unique NCT progress while preserving terminal duplicate collapse and ceiling-token behavior.\n- Makes PubMed policy and NCBI callback/container validation fail closed with typed errors.\n- Separates numeric and opaque pagination histories.\n- Seals PubMed binding scalar types and adds direct ESummary IndexError coverage.\n\n## Verification\n\n- 1514 focused discovery tests passed with 4 existing warnings.\n- Ruff and Black passed; 9 Python files unchanged by Black.\n- Python 3.11 compileall and Python 3.10 py_compile passed.\n- Bandit passed on all four touched production modules with no findings.\n- Independent whole-branch and post-rebase reviews found no Critical, Important, or Minor issues.\n\n## Context\n\n- Follow-up to merged PR #2800.\n- Tracks TASK-12968.10.\n- All provider behavior remains shadow-only and credentialless.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens shadow ClinicalTrials.gov and PubMed Central discovery to fail closed and enforce real pagination progress. Before: mixed cursor histories and repeated nonterminal ClinicalTrials pages could pass; after: numeric vs opaque cursors track separately and nonterminal pages with no new NCTs fail with typed errors while preserving duplicate collapse and ceiling-token behavior. Aligns with TASK-12968.10.

- ClinicalTrials.gov: rejects nonterminal pages that add no unique NCTs; identical terminal duplicates still collapse.
- Executor: separates numeric and opaque pagination histories; numeric progress checks use only numeric history and reject regressions as pagination_cursor_non_progress.
- PubMed/NCBI: seals binding scalar types and container shapes; trusted-input and parser structural errors normalize to provider_payload_invalid; existing DiscoveryAdapterError continues to propagate.
- Planner: adds guards that reject malformed PubMed routes/policies with a PlanningError invalid_pubmed_route_identity:<route_id>; classifier recognizes PubMed markers even when the policy object is malformed, and fails closed when non-PubMed routes carry those markers.
- Tests/docs/boundary pins: adds docstrings and mutation-sensitive coverage; refreshes network-boundary digests. Behavior remains shadow-only and credentialless.

<sup>Written for commit d56da3a8cf302333cbbef19711239929db40769a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

