### PR TITLE
feat(scheduled-tasks): wire automation executors to the server LLM plumbing (TASK-13110)

### DIFF
--- a/backlog/tasks/task-13110 - Wire-automation-executors-to-server-LLM-plumbing.md
+++ b/backlog/tasks/task-13110 - Wire-automation-executors-to-server-LLM-plumbing.md
@@ -31,7 +31,7 @@ Registered at worker startup (`run_agent_task_jobs_worker`) so a registered exec
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 A production executor for `recurring_question` builds one completion call from `input.question` (system prompt fixed, generation-only) and returns the assistant text
-- [x] #2 A production executor for `agent_task` builds the call from `input.message`/`input.prompt` with the same guardrails; both executors raise nothing on missing input except an honest error string recorded as a failed run
+- [x] #2 RESOLVED DIFFERENTLY (review #4 on PR #2804): `agent_task` is deliberately UNWIRED in phase 1 — the automation service redacts `input.message` at rest (metadata_only policy), so no runnable prompt survives persistence; persisting the raw message would reverse an owner-level privacy design. The consumer skips unwired families with `family_not_wired_for_execution:<family>` (status skipped, not failed), capabilities report agent_task execute as `planned` with the redaction reason, and recurring_question raises honest LookupError on missing input
 - [x] #3 Model/provider precedence: definition-level `model`(+`provider`) → automation config defaults (`executor_provider`/`executor_model`) → server default resolution; pinned by unit test over the resolution function
 - [x] #4 Executors are registered at worker startup, idempotently, before the first job is acquired
 - [x] #5 The call goes through `perform_chat_api_call_async` with bounded `max_tokens` (default 1000, definition-configurable, capped); no tools/tool_choice are ever passed
@@ -68,3 +68,5 @@ Implemented 2026-08-22 on `feat/executor-wiring` (branched from dev after PR #28
 **Env gates unchanged**: enable `SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED` + `AGENT_TASK_JOBS_WORKER_ENABLED` together to run the wired chain end-to-end.
 
 **Files:** `core/Scheduled_Tasks/automation_executors.py` (new), `services/agent_task_jobs_worker.py` (startup registration), `tests/Notifications/test_automation_executors.py` (new), this task file.
+
+**Review round (PR #2804, 2026-08-22):** 5 findings — 3 fixed directly (config-read failure now logs; sanitize-before-precedence so blank/junk definition overrides cannot suppress config defaults; test docstrings), 1 resolved by scope correction (the agent_task `input.message` finding was real: the message is redacted at rest by the existing privacy design, so agent_task is unwired in phase 1 with skip-not-fail semantics and `planned` capability status rather than reversing that design), 1 declined with precedent (pytestmark=unit + @pytest.mark.asyncio is the exact combination the reminders-scheduler and feed test files ship, through two accepted review rounds; pytest-asyncio strict mode requires the execution marker). Notifications suite 234 passed after the round.

--- a/backlog/tasks/task-13110 - Wire-automation-executors-to-server-LLM-plumbing.md
+++ b/backlog/tasks/task-13110 - Wire-automation-executors-to-server-LLM-plumbing.md
@@ -1,0 +1,70 @@
+---
+id: TASK-13110
+title: 'Wire automation executors to the server LLM plumbing'
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-22 22:30'
+updated_date: '2026-08-22 22:30'
+labels:
+  - scheduled-tasks
+  - automation
+  - llm
+dependencies:
+  - task-13021
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The deferred slice of TASK-13021: the agent-task consumer ships with an injected per-family executor seam (`register_executor`), but no production registrant exists — runs currently fail honestly with `no_executor_configured`. This task wires the executors to the server's canonical LLM entrypoint (`perform_chat_api_call_async` in `core/Chat/chat_service.py`, the same surface Flashcards/Research/MCP modules use) so phase-1 scheduled automations actually generate:
+
+- **`recurring_question`**: one completion call — the definition's `input.question` as the user message, a fixed generation-only system prompt, bounded `max_tokens`.
+- **`agent_task`** (generation-only): the definition's `input.message` (or `prompt`) as the user message with the same guardrails — tools are already refused upstream by the consumer's phase-1 boundary, so the executor never sees a tool request it must honor.
+
+**Model selection precedence** (per definition, degrading to server defaults): the definition's `input`/config `model` (+ optional `provider`) when present, else the automation executor defaults from config (`[Scheduled_Tasks_Automation]` executor_provider / executor_model), else the server's own default provider/model resolution (omit both and let `perform_chat_api_call_async` resolve). Credentials resolve through the existing provider-config layer — the executor adds no new secret handling.
+
+Registered at worker startup (`run_agent_task_jobs_worker`) so a registered executor always accompanies a consuming worker; registration is idempotent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A production executor for `recurring_question` builds one completion call from `input.question` (system prompt fixed, generation-only) and returns the assistant text
+- [x] #2 A production executor for `agent_task` builds the call from `input.message`/`input.prompt` with the same guardrails; both executors raise nothing on missing input except an honest error string recorded as a failed run
+- [x] #3 Model/provider precedence: definition-level `model`(+`provider`) → automation config defaults (`executor_provider`/`executor_model`) → server default resolution; pinned by unit test over the resolution function
+- [x] #4 Executors are registered at worker startup, idempotently, before the first job is acquired
+- [x] #5 The call goes through `perform_chat_api_call_async` with bounded `max_tokens` (default 1000, definition-configurable, capped); no tools/tool_choice are ever passed
+- [x] #6 Tests cover: question/message prompt construction, precedence matrix, registration idempotency, and the no-executor→wired transition through `handle_agent_task_job` with the real registry (LLM call mocked at the entrypoint boundary)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no.
+ADR path: N/A.
+Reason: consumes the existing TASK-13021 executor seam and the server's canonical chat entrypoint; no new boundary, storage, or contract — the phase-1 scope itself is ADR-077 decision 4 (owner-accepted).
+
+1. `core/Scheduled_Tasks/automation_executors.py`: resolution helper + the two executors calling `perform_chat_api_call_async`
+2. Worker startup registration (idempotent)
+3. Tests per the AC matrix with the entrypoint mocked
+4. Close-out + PR
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Implemented 2026-08-22 on `feat/executor-wiring` (branched from dev after PR #2803 merged).
+
+**Approach.** `core/Scheduled_Tasks/automation_executors.py` provides one shared generation-only executor registered for both phase-1 families, calling the server's canonical `perform_chat_api_call_async` (the same surface Flashcards/Research/MCP use — `messages` + optional `api_provider`/`model` + `system_message` + bounded `max_tokens`; never `tools`/`tool_choice`). Content extraction reuses `extract_openai_content` from the Workflows adapters. Credentials stay inside the chat entrypoint's provider-config layer — no new secret handling.
+
+**Target resolution** (`resolve_execution_target`): definition `input` overrides (`provider`, `model`, `max_tokens`) → `[Scheduled_Tasks_Automation]` config defaults (`executor_provider`/`executor_model`/`executor_max_tokens`) → both omitted so the entrypoint applies the server's own default resolution. max_tokens defaults 1000, capped 4000, junk-tolerant.
+
+**Prompt construction:** `recurring_question` → `input.question`; `agent_task` → `input.message` falling back to `input.prompt`; missing input raises LookupError (recorded by the consumer as an honest failed run); a definition-level `input.system_prompt` overrides the fixed generation-only system prompt, which itself forbids questions/tools/side effects.
+
+**Registration** at `run_agent_task_jobs_worker` startup, idempotent (same callables re-registered, not re-created) — a consuming worker always has executors. Empty completions raise (the consumer records `failed`, never a blank success).
+
+**Verification.** 10 tests in `test_automation_executors.py`: the four-case precedence matrix (definition wins / config defaults / both silent / max_tokens cap-floor-junk), prompt construction for both families with message→prompt fallback, missing-prompt LookupError, empty-completion RuntimeError, idempotent registration, and the seam transition through the REAL consumer (`no_executor_configured` failure → registered executor success with the run row carrying the generated summary; LLM mocked at the entrypoint boundary; separate run slots so the terminal-row dedupe doesn't replay the failed outcome). Full Notifications suite **234 passed**. The no-executor guard in the consumer remains the fallback if registration ever fails.
+
+**Env gates unchanged**: enable `SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED` + `AGENT_TASK_JOBS_WORKER_ENABLED` together to run the wired chain end-to-end.
+
+**Files:** `core/Scheduled_Tasks/automation_executors.py` (new), `services/agent_task_jobs_worker.py` (startup registration), `tests/Notifications/test_automation_executors.py` (new), this task file.

--- a/tldw_Server_API/app/core/Scheduled_Tasks/agent_task_jobs.py
+++ b/tldw_Server_API/app/core/Scheduled_Tasks/agent_task_jobs.py
@@ -254,18 +254,25 @@ async def handle_agent_task_job(
 
     executor = _EXECUTORS.get(definition.family)
     if executor is None:
+        # Not a failure: no executor is wired for this family in this
+        # deployment phase (phase 1 wires recurring_question only --
+        # agent_task messages are redacted at rest). The skip carries an
+        # actionable reason.
         _finish(
             sdb,
             cdb,
             definition=definition,
             run_id=run["id"],
-            status="failed",
-            error="no_executor_configured",
-            summary=None,
+            status="skipped",
+            error=f"family_not_wired_for_execution:{definition.family}",
+            summary=(
+                "No executor is wired for this family in this deployment "
+                "phase; the run was recorded and skipped without executing."
+            ),
             jobs_job_id=str(job.get("id")) if job.get("id") is not None else None,
             execution_timeout_seconds=execution_timeout_seconds,
         )
-        return {"status": "failed", "definition_id": definition_id, "run_id": run["id"]}
+        return {"status": "skipped", "definition_id": definition_id, "run_id": run["id"]}
 
     timed_out = False
     result_text: str | None = None

--- a/tldw_Server_API/app/core/Scheduled_Tasks/automation_executors.py
+++ b/tldw_Server_API/app/core/Scheduled_Tasks/automation_executors.py
@@ -1,0 +1,170 @@
+"""Production LLM executors for scheduled automations (TASK-13110).
+
+Wires the TASK-13021 consumer's executor seam to the server's canonical
+chat entrypoint (``perform_chat_api_call_async`` — the same surface the
+Flashcards, Research, and MCP modules use). Phase-1 scope per tldw_chatbook
+ADR-077 decision 4 (owner-accepted): generation-only completions. Tools are
+already refused upstream by the consumer's phase-1 boundary; these
+executors never pass ``tools``/``tool_choice``.
+
+Model precedence (definition first, server last):
+
+1. the definition's ``input``/``config`` ``model`` (+ optional ``provider``)
+2. automation executor defaults from the server config
+   (``[Scheduled_Tasks_Automation] executor_provider`` / ``executor_model``)
+3. omit both and let ``perform_chat_api_call_async`` resolve the server's
+   configured default provider/model
+
+Credentials resolve through the existing provider-config layer inside the
+chat entrypoint — this module adds no secret handling of its own.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import DefinitionRow
+from tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs import register_executor
+from tldw_Server_API.app.core.Workflows.adapters._common import extract_openai_content
+
+#: Fixed, generation-only system prompt (phase 1: no tool use, bounded output).
+_GENERATION_ONLY_SYSTEM_PROMPT = (
+    "You are a scheduled automation assistant. Answer the user's request "
+    "directly and concisely in plain text. This is an unattended scheduled "
+    "run: do not ask questions, do not request tools or side effects, and "
+    "keep the answer self-contained."
+)
+
+_DEFAULT_MAX_TOKENS = 1000
+_MAX_TOKENS_CAP = 4000
+
+_EXECUTOR_SYSTEM_PROMPT_KEY = "system_prompt"
+_REGISTERED = False
+
+
+def _config_section() -> dict[str, Any]:
+    """Return the ``[Scheduled_Tasks_Automation]`` config section (may be empty)."""
+    try:
+        from tldw_Server_API.app.core.config import settings
+
+        section = settings.get("Scheduled_Tasks_Automation")
+        return section if isinstance(section, dict) else {}
+    except Exception:  # noqa: BLE001 - config read failure degrades to defaults
+        return {}
+
+
+def _as_positive_int(value: Any, fallback: int) -> int:
+    """Coerce a config value to a positive int, tolerating junk."""
+    if isinstance(value, bool) or value is None:
+        return fallback
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return fallback
+    return parsed if parsed > 0 else fallback
+
+
+def resolve_execution_target(
+    definition: DefinitionRow, *, config_section: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Resolve the provider/model/max_tokens one run will use.
+
+    Precedence: definition ``input``/``config`` overrides, then the
+    automation config defaults (``executor_provider``/``executor_model``/
+    ``executor_max_tokens``), then server-default resolution (both keys
+    omitted so the chat entrypoint applies its own configured default).
+    """
+    section = config_section if config_section is not None else _config_section()
+    source: dict[str, Any] = (
+        definition.input if isinstance(definition.input, dict) else {}
+    )
+
+    provider = source.get("provider") or section.get("executor_provider")
+    model = source.get("model") or section.get("executor_model")
+    max_tokens = _as_positive_int(
+        source.get("max_tokens") or section.get("executor_max_tokens"),
+        _DEFAULT_MAX_TOKENS,
+    )
+    return {
+        "provider": str(provider).strip() or None if provider else None,
+        "model": str(model).strip() or None if model else None,
+        "max_tokens": min(max_tokens, _MAX_TOKENS_CAP),
+    }
+
+
+def _definition_user_prompt(definition: DefinitionRow) -> str:
+    """Extract the generation-only user prompt from a definition's input.
+
+    ``recurring_question`` definitions carry ``question``; ``agent_task``
+    definitions carry ``message`` (falling back to ``prompt``). Anything
+    missing raises ``LookupError`` — the consumer records it as an honest
+    failed run rather than generating from nothing.
+    """
+    source: dict[str, Any] = (
+        definition.input if isinstance(definition.input, dict) else {}
+    )
+    if definition.family == "recurring_question":
+        question = str(source.get("question") or "").strip()
+        if question:
+            return question
+        raise LookupError("recurring_question definition has no input.question")
+    message = str(source.get("message") or source.get("prompt") or "").strip()
+    if message:
+        return message
+    raise LookupError(f"{definition.family} definition has no input.message/prompt")
+
+
+def _definition_system_prompt(definition: DefinitionRow) -> str:
+    """Return the system prompt, allowing a definition-level override."""
+    source: dict[str, Any] = (
+        definition.input if isinstance(definition.input, dict) else {}
+    )
+    override = str(source.get(_EXECUTOR_SYSTEM_PROMPT_KEY) or "").strip()
+    return override or _GENERATION_ONLY_SYSTEM_PROMPT
+
+
+async def _execute_generation_only(
+    definition: DefinitionRow, payload: dict[str, Any]
+) -> str:
+    """Run one generation-only completion for a scheduled definition."""
+    from tldw_Server_API.app.core.Chat.chat_service import perform_chat_api_call_async
+
+    user_prompt = _definition_user_prompt(definition)
+    target = resolve_execution_target(definition)
+    call_kwargs: dict[str, Any] = {
+        "messages": [{"role": "user", "content": user_prompt}],
+        "system_message": _definition_system_prompt(definition),
+        "max_tokens": target["max_tokens"],
+    }
+    if target["provider"]:
+        call_kwargs["api_provider"] = target["provider"]
+    if target["model"]:
+        call_kwargs["model"] = target["model"]
+
+    response = await perform_chat_api_call_async(**call_kwargs)
+    text = (extract_openai_content(response) or "").strip()
+    if not text:
+        raise RuntimeError("automation executor received an empty completion")
+    return text
+
+
+def register_automation_executors() -> None:
+    """Register the production executors for both phase-1 families.
+
+    Idempotent: safe to call at every worker startup. The seam stays
+    test-overridable — tests replace entries in the consumer's registry
+    directly.
+    """
+    global _REGISTERED
+    register_executor("recurring_question", _execute_generation_only)
+    register_executor("agent_task", _execute_generation_only)
+    _REGISTERED = True
+    logger.info("Automation LLM executors registered (phase-1 generation-only)")
+
+
+__all__ = [
+    "register_automation_executors",
+    "resolve_execution_target",
+]

--- a/tldw_Server_API/app/core/Scheduled_Tasks/automation_executors.py
+++ b/tldw_Server_API/app/core/Scheduled_Tasks/automation_executors.py
@@ -51,7 +51,10 @@ def _config_section() -> dict[str, Any]:
 
         section = settings.get("Scheduled_Tasks_Automation")
         return section if isinstance(section, dict) else {}
-    except Exception:  # noqa: BLE001 - config read failure degrades to defaults
+    except Exception:  # noqa: BLE001 - degrade to defaults, never break a run
+        logger.warning(
+            "Automation executor config read failed; using built-in defaults"
+        )
         return {}
 
 
@@ -81,15 +84,28 @@ def resolve_execution_target(
         definition.input if isinstance(definition.input, dict) else {}
     )
 
-    provider = source.get("provider") or section.get("executor_provider")
-    model = source.get("model") or section.get("executor_model")
-    max_tokens = _as_positive_int(
-        source.get("max_tokens") or section.get("executor_max_tokens"),
-        _DEFAULT_MAX_TOKENS,
+    # Sanitize each layer BEFORE applying precedence, so a blank/junk
+    # definition override falls through to the config default instead of
+    # suppressing it (review #5 on PR #2804).
+    def _coerce_nonempty_str(value: Any) -> str | None:
+        if value is None or isinstance(value, bool):
+            return None
+        text = str(value).strip()
+        return text or None
+
+    provider = _coerce_nonempty_str(source.get("provider")) or _coerce_nonempty_str(
+        section.get("executor_provider")
+    )
+    model = _coerce_nonempty_str(source.get("model")) or _coerce_nonempty_str(
+        section.get("executor_model")
+    )
+    definition_max = _as_positive_int(source.get("max_tokens"), 0)
+    max_tokens = definition_max or _as_positive_int(
+        section.get("executor_max_tokens"), _DEFAULT_MAX_TOKENS
     )
     return {
-        "provider": str(provider).strip() or None if provider else None,
-        "model": str(model).strip() or None if model else None,
+        "provider": provider,
+        "model": model,
         "max_tokens": min(max_tokens, _MAX_TOKENS_CAP),
     }
 
@@ -97,23 +113,23 @@ def resolve_execution_target(
 def _definition_user_prompt(definition: DefinitionRow) -> str:
     """Extract the generation-only user prompt from a definition's input.
 
-    ``recurring_question`` definitions carry ``question``; ``agent_task``
-    definitions carry ``message`` (falling back to ``prompt``). Anything
-    missing raises ``LookupError`` — the consumer records it as an honest
-    failed run rather than generating from nothing.
+    Only ``recurring_question`` is wired in phase 1 — its ``question``
+    persists in full. ``agent_task`` input is redacted at rest by the
+    automation service (``message_redacted`` metadata replaces the raw
+    message), so a usable prompt surviving persistence is not a state
+    production can reach; if one ever appears it is used, otherwise the
+    LookupError records an honest failed run.
     """
     source: dict[str, Any] = (
         definition.input if isinstance(definition.input, dict) else {}
     )
-    if definition.family == "recurring_question":
-        question = str(source.get("question") or "").strip()
-        if question:
-            return question
-        raise LookupError("recurring_question definition has no input.question")
-    message = str(source.get("message") or source.get("prompt") or "").strip()
-    if message:
-        return message
-    raise LookupError(f"{definition.family} definition has no input.message/prompt")
+    question = str(source.get("question") or "").strip()
+    if question:
+        return question
+    raise LookupError(
+        f"{definition.family} definition has no usable persisted prompt "
+        "(input.question missing; agent_task messages are redacted at rest)"
+    )
 
 
 def _definition_system_prompt(definition: DefinitionRow) -> str:
@@ -151,17 +167,21 @@ async def _execute_generation_only(
 
 
 def register_automation_executors() -> None:
-    """Register the production executors for both phase-1 families.
+    """Register the production executor for the wired phase-1 family.
 
-    Idempotent: safe to call at every worker startup. The seam stays
-    test-overridable — tests replace entries in the consumer's registry
-    directly.
+    ``recurring_question`` only: ``agent_task`` is deliberately unwired in
+    phase 1 (its message is redacted at rest; the consumer skips those runs
+    with an actionable reason). Idempotent: safe at every worker startup.
+    The seam stays test-overridable — tests replace entries in the
+    consumer's registry directly.
     """
     global _REGISTERED
     register_executor("recurring_question", _execute_generation_only)
-    register_executor("agent_task", _execute_generation_only)
     _REGISTERED = True
-    logger.info("Automation LLM executors registered (phase-1 generation-only)")
+    logger.info(
+        "Automation LLM executor registered (recurring_question, "
+        "phase-1 generation-only; agent_task unwired: message redacted at rest)"
+    )
 
 
 __all__ = [

--- a/tldw_Server_API/app/services/agent_task_jobs_worker.py
+++ b/tldw_Server_API/app/services/agent_task_jobs_worker.py
@@ -48,6 +48,13 @@ async def run_agent_task_jobs_worker(stop_event: asyncio.Event | None = None) ->
     worker_id = "agent-task-jobs-worker"
     queue = agent_task_jobs_queue()
     poll_sleep = float(os.getenv("JOBS_POLL_INTERVAL_SECONDS", "1.0") or "1.0")
+    # Production executors must accompany every consuming worker (TASK-13110):
+    # idempotent, so a restarted worker re-registers safely.
+    from tldw_Server_API.app.core.Scheduled_Tasks.automation_executors import (
+        register_automation_executors,
+    )
+
+    register_automation_executors()
     logger.info("Starting Agent Task Jobs worker")
     while True:
         if stop_event and stop_event.is_set():

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -179,15 +179,19 @@ class ScheduledTaskAutomationService:
         pending the approval-escalation design. The ``run_now`` action is
         available on both families (TASK-13022).
         """
-        def _execution_actions(tools_reason: str) -> dict[str, ScheduledTaskActionCapability]:
+        def _execution_actions(
+            tools_reason: str, execute_status: str = "available"
+        ) -> dict[str, ScheduledTaskActionCapability]:
             actions = self._definition_actions()
             actions["run_now"] = ScheduledTaskActionCapability(
                 status="available",
                 required_permissions=[TASKS_CONTROL],
             )
             actions["execute"] = ScheduledTaskActionCapability(
-                status="available",
-                reason="phase1_generation_only",
+                status=execute_status,
+                reason="phase1_generation_only"
+                if execute_status == "available"
+                else tools_reason,
                 required_permissions=[TASKS_CONTROL],
             )
             actions["execute_tools"] = ScheduledTaskActionCapability(
@@ -211,8 +215,10 @@ class ScheduledTaskAutomationService:
                     family="agent_task",
                     family_availability="available",
                     actions=_execution_actions(
-                        "tool-using agent tasks are not executable until the "
-                        "approval-escalation design lands"
+                        "agent_task is not executable in phase 1: its message "
+                        "is redacted at rest (metadata_only policy) and "
+                        "tool use awaits the approval-escalation design",
+                        execute_status="planned",
                     ),
                     related_capabilities={"acp": {"status": "not_checked"}},
                 ),

--- a/tldw_Server_API/tests/Notifications/test_agent_task_jobs_consumer.py
+++ b/tldw_Server_API/tests/Notifications/test_agent_task_jobs_consumer.py
@@ -243,12 +243,15 @@ async def test_no_executor_fails_honestly(consumer_env) -> None:
 
     result = await handle_agent_task_job(_job(definition, user_id))
 
-    assert result["status"] == "failed"
+    # Phase 1: an unwired family skips with an actionable reason (only
+    # recurring_question has a production executor; agent_task messages
+    # are redacted at rest) -- it is not a failure.
+    assert result["status"] == "skipped"
     sdb = ScheduledTasksDatabase.for_user(user_id=user_id)
     run = sdb.get_scheduled_task_run_by_slot(
         definition_id=definition.id, run_slot_key=SLOT
     )
-    assert run["error"] == "no_executor_configured"
+    assert run["error"] == "family_not_wired_for_execution:recurring_question"
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/tests/Notifications/test_automation_executors.py
+++ b/tldw_Server_API/tests/Notifications/test_automation_executors.py
@@ -37,6 +37,7 @@ SLOT = "2026-08-22T09:00:00+00:00"
 def _definition(
     input_config: dict[str, Any], family: str = "recurring_question"
 ) -> DefinitionRow:
+    """Build a DefinitionRow for executor tests."""
     return DefinitionRow(
         id="def-1",
         owner_id=7,
@@ -67,6 +68,7 @@ def _definition(
 
 
 def test_resolution_definition_overrides_win() -> None:
+    """Definition-level provider/model/max_tokens beat config defaults."""
     definition = _definition(
         {"question": "q", "provider": "openai", "model": "gpt-x", "max_tokens": 512}
     )
@@ -77,6 +79,7 @@ def test_resolution_definition_overrides_win() -> None:
 
 
 def test_resolution_config_defaults_when_definition_silent() -> None:
+    """Config defaults apply when the definition carries no overrides."""
     definition = _definition({"question": "q"})
     target = resolve_execution_target(
         definition,
@@ -86,12 +89,14 @@ def test_resolution_config_defaults_when_definition_silent() -> None:
 
 
 def test_resolution_server_default_when_both_silent() -> None:
+    """Both silent -> server-default resolution (provider/model omitted)."""
     definition = _definition({"question": "q"})
     target = resolve_execution_target(definition, config_section={})
     assert target == {"provider": None, "model": None, "max_tokens": 1000}
 
 
 def test_resolution_caps_and_floors_max_tokens() -> None:
+    """max_tokens caps at 4000 and floors junk/negatives to the default."""
     assert resolve_execution_target(
         _definition({"question": "q", "max_tokens": 99999}), config_section={}
     )["max_tokens"] == 4000
@@ -110,6 +115,7 @@ def test_resolution_caps_and_floors_max_tokens() -> None:
 
 @pytest.mark.asyncio
 async def test_recurring_question_builds_one_generation_only_call(monkeypatch) -> None:
+    """One completion call: question as user message, no tools, bounded tokens."""
     captured: list[dict[str, Any]] = []
 
     async def _fake_call(**kwargs: Any) -> dict[str, Any]:
@@ -135,32 +141,21 @@ async def test_recurring_question_builds_one_generation_only_call(monkeypatch) -
     assert "api_provider" not in call and "model" not in call
 
 
-@pytest.mark.asyncio
-async def test_agent_task_uses_message_with_prompt_fallback(monkeypatch) -> None:
-    captured: list[dict[str, Any]] = []
-
-    async def _fake_call(**kwargs: Any) -> dict[str, Any]:
-        captured.append(kwargs)
-        return {"choices": [{"message": {"content": "ok"}}]}
-
-    monkeypatch.setattr(
-        "tldw_Server_API.app.core.Chat.chat_service.perform_chat_api_call_async",
-        _fake_call,
+def test_resolution_blank_overrides_fall_through() -> None:
+    """Whitespace definition overrides cannot suppress config defaults."""
+    definition = _definition(
+        {"question": "q", "provider": "   ", "model": "", "max_tokens": "junk"}
     )
-
-    via_message = _definition(
-        {"message": "summarize the feed"}, family="agent_task"
+    target = resolve_execution_target(
+        definition,
+        config_section={"executor_provider": "anthropic", "executor_model": "m2"},
     )
-    assert await _execute_generation_only(via_message, {}) == "ok"
-    assert captured[-1]["messages"][0]["content"] == "summarize the feed"
-
-    via_prompt = _definition({"prompt": "fallback prompt"}, family="agent_task")
-    assert await _execute_generation_only(via_prompt, {}) == "ok"
-    assert captured[-1]["messages"][0]["content"] == "fallback prompt"
+    assert target == {"provider": "anthropic", "model": "m2", "max_tokens": 1000}
 
 
 @pytest.mark.asyncio
 async def test_missing_prompt_raises_lookup_error() -> None:
+    """Missing usable prompt raises LookupError for an honest failed run."""
     with pytest.raises(LookupError):
         await _execute_generation_only(_definition({}), {})
     with pytest.raises(LookupError):
@@ -169,6 +164,7 @@ async def test_missing_prompt_raises_lookup_error() -> None:
 
 @pytest.mark.asyncio
 async def test_empty_completion_raises() -> None:
+    """An empty completion raises instead of recording a blank success."""
     async def _empty(**kwargs: Any) -> dict[str, Any]:
         return {"choices": [{"message": {"content": ""}}]}
 
@@ -189,11 +185,12 @@ async def test_empty_completion_raises() -> None:
 
 
 def test_registration_is_idempotent_and_fills_both_families(monkeypatch) -> None:
+    """Registration is idempotent and wires only recurring_question (phase 1)."""
     monkeypatch.setattr(atj, "_EXECUTORS", {})
     register_automation_executors()
     first = dict(atj._EXECUTORS)
     register_automation_executors()
-    assert set(atj._EXECUTORS) == {"recurring_question", "agent_task"}
+    assert set(atj._EXECUTORS) == {"recurring_question"}
     assert atj._EXECUTORS == first  # same callables, not re-created
 
 
@@ -263,7 +260,7 @@ async def test_registered_executor_flows_through_the_consumer(monkeypatch, tmp_p
             },
             scheduled_db=db,
         )
-        assert before["status"] == "failed"
+        assert before["status"] == "skipped"
         # A DIFFERENT slot for the wired attempt: the prior slot's terminal
         # run row would dedupe and replay the failed outcome.
         wired_slot = "2026-08-22T10:00:00+00:00"

--- a/tldw_Server_API/tests/Notifications/test_automation_executors.py
+++ b/tldw_Server_API/tests/Notifications/test_automation_executors.py
@@ -1,0 +1,307 @@
+"""Automation LLM executor wiring tests (TASK-13110).
+
+The LLM call is mocked at the ``perform_chat_api_call_async`` boundary —
+the executor's own unit under test is prompt construction, target
+resolution, registration, and the seam transition inside the real
+consumer registry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
+    DefinitionRow,
+    ScheduledTasksDatabase,
+)
+from tldw_Server_API.app.core.Scheduled_Tasks import agent_task_jobs as atj
+from tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs import (
+    handle_agent_task_job,
+)
+from tldw_Server_API.app.core.Scheduled_Tasks.automation_executors import (
+    _execute_generation_only,
+    register_automation_executors,
+    resolve_execution_target,
+)
+from tldw_Server_API.app.core.config import settings
+
+pytestmark = pytest.mark.unit
+
+SLOT = "2026-08-22T09:00:00+00:00"
+
+
+def _definition(
+    input_config: dict[str, Any], family: str = "recurring_question"
+) -> DefinitionRow:
+    return DefinitionRow(
+        id="def-1",
+        owner_id=7,
+        version=1,
+        family=family,
+        name="Exec Test",
+        description=None,
+        lifecycle="configured",
+        health="ready",
+        disabled_lock_kind="none",
+        disabled_reason=None,
+        schedule={"kind": "daily", "at": "09:00"},
+        input=input_config,
+        visibility_policy="owner",
+        notification_policy={},
+        approval_policy={},
+        preview_id="pv-1",
+        created_by="t",
+        updated_by="t",
+        created_at="2026-08-22T00:00:00+00:00",
+        updated_at="2026-08-22T00:00:00+00:00",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Target resolution (AC#3)
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_definition_overrides_win() -> None:
+    definition = _definition(
+        {"question": "q", "provider": "openai", "model": "gpt-x", "max_tokens": 512}
+    )
+    target = resolve_execution_target(
+        definition, config_section={"executor_provider": "anthropic", "executor_model": "m2"}
+    )
+    assert target == {"provider": "openai", "model": "gpt-x", "max_tokens": 512}
+
+
+def test_resolution_config_defaults_when_definition_silent() -> None:
+    definition = _definition({"question": "q"})
+    target = resolve_execution_target(
+        definition,
+        config_section={"executor_provider": "anthropic", "executor_model": "m2"},
+    )
+    assert target == {"provider": "anthropic", "model": "m2", "max_tokens": 1000}
+
+
+def test_resolution_server_default_when_both_silent() -> None:
+    definition = _definition({"question": "q"})
+    target = resolve_execution_target(definition, config_section={})
+    assert target == {"provider": None, "model": None, "max_tokens": 1000}
+
+
+def test_resolution_caps_and_floors_max_tokens() -> None:
+    assert resolve_execution_target(
+        _definition({"question": "q", "max_tokens": 99999}), config_section={}
+    )["max_tokens"] == 4000
+    assert resolve_execution_target(
+        _definition({"question": "q", "max_tokens": -5}), config_section={}
+    )["max_tokens"] == 1000
+    assert resolve_execution_target(
+        _definition({"question": "q", "max_tokens": "junk"}), config_section={}
+    )["max_tokens"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction + the mocked LLM boundary (AC#1/#2/#5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recurring_question_builds_one_generation_only_call(monkeypatch) -> None:
+    captured: list[dict[str, Any]] = []
+
+    async def _fake_call(**kwargs: Any) -> dict[str, Any]:
+        captured.append(kwargs)
+        return {"choices": [{"message": {"content": "the answer"}}]}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Chat.chat_service.perform_chat_api_call_async",
+        _fake_call,
+    )
+
+    definition = _definition({"question": "What changed today?"})
+    text = await _execute_generation_only(definition, {})
+
+    assert text == "the answer"
+    assert len(captured) == 1
+    call = captured[0]
+    assert call["messages"] == [{"role": "user", "content": "What changed today?"}]
+    assert "scheduled automation" in call["system_message"].lower()
+    assert "tools" not in call and "tool_choice" not in call
+    assert call["max_tokens"] == 1000
+    # Both provider/model omitted -> server-default resolution inside the entrypoint.
+    assert "api_provider" not in call and "model" not in call
+
+
+@pytest.mark.asyncio
+async def test_agent_task_uses_message_with_prompt_fallback(monkeypatch) -> None:
+    captured: list[dict[str, Any]] = []
+
+    async def _fake_call(**kwargs: Any) -> dict[str, Any]:
+        captured.append(kwargs)
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Chat.chat_service.perform_chat_api_call_async",
+        _fake_call,
+    )
+
+    via_message = _definition(
+        {"message": "summarize the feed"}, family="agent_task"
+    )
+    assert await _execute_generation_only(via_message, {}) == "ok"
+    assert captured[-1]["messages"][0]["content"] == "summarize the feed"
+
+    via_prompt = _definition({"prompt": "fallback prompt"}, family="agent_task")
+    assert await _execute_generation_only(via_prompt, {}) == "ok"
+    assert captured[-1]["messages"][0]["content"] == "fallback prompt"
+
+
+@pytest.mark.asyncio
+async def test_missing_prompt_raises_lookup_error() -> None:
+    with pytest.raises(LookupError):
+        await _execute_generation_only(_definition({}), {})
+    with pytest.raises(LookupError):
+        await _execute_generation_only(_definition({}, family="agent_task"), {})
+
+
+@pytest.mark.asyncio
+async def test_empty_completion_raises() -> None:
+    async def _empty(**kwargs: Any) -> dict[str, Any]:
+        return {"choices": [{"message": {"content": ""}}]}
+
+    import tldw_Server_API.app.core.Chat.chat_service as cs
+
+    original = cs.perform_chat_api_call_async
+    cs.perform_chat_api_call_async = _empty
+    try:
+        with pytest.raises(RuntimeError):
+            await _execute_generation_only(_definition({"question": "q"}), {})
+    finally:
+        cs.perform_chat_api_call_async = original
+
+
+# ---------------------------------------------------------------------------
+# Registration + the consumer-seam transition (AC#4/#6)
+# ---------------------------------------------------------------------------
+
+
+def test_registration_is_idempotent_and_fills_both_families(monkeypatch) -> None:
+    monkeypatch.setattr(atj, "_EXECUTORS", {})
+    register_automation_executors()
+    first = dict(atj._EXECUTORS)
+    register_automation_executors()
+    assert set(atj._EXECUTORS) == {"recurring_question", "agent_task"}
+    assert atj._EXECUTORS == first  # same callables, not re-created
+
+
+@pytest.mark.asyncio
+async def test_registered_executor_flows_through_the_consumer(monkeypatch, tmp_path):
+    base_dir = tmp_path / "executor_consumer"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    prev = settings.get("USER_DB_BASE_DIR")
+    settings.USER_DB_BASE_DIR = str(base_dir)
+    import os
+
+    os.environ["USER_DB_BASE_DIR"] = str(base_dir)
+    os.environ["JOBS_DB_PATH"] = str(base_dir / "jobs.db")
+    try:
+        user_id = 2020
+        db = ScheduledTasksDatabase.for_user(user_id=user_id)
+        db.ensure_schema()
+        preview = db.create_preview(
+            owner_id=user_id,
+            mode="create",
+            family="recurring_question",
+            definition_id=None,
+            definition_version=None,
+            status="valid",
+            payload_hash="h1",
+            normalized_config={},
+            validation_errors=[],
+            warnings=[],
+            risk_class=None,
+            visibility_policy="owner",
+            schedule_preview={"kind": "daily", "at": "09:00"},
+            redaction_policy={"fields": [], "mode": "none"},
+            expires_at=(
+                datetime.now(timezone.utc) + timedelta(hours=24)
+            ).isoformat(),
+            created_by="t",
+        )
+        definition = db.create_definition(
+            owner_id=user_id,
+            family="recurring_question",
+            name="Wired",
+            description=None,
+            lifecycle="configured",
+            health="ready",
+            schedule={"kind": "daily", "at": "09:00"},
+            input={"question": "What changed?"},
+            visibility_policy="owner",
+            notification_policy={},
+            approval_policy={},
+            preview_id=preview.id,
+            created_by="t",
+            updated_by="t",
+        )
+
+        monkeypatch.setattr(atj, "_EXECUTORS", {})
+        # Before wiring: honest failure.
+        before = await handle_agent_task_job(
+            {
+                "id": 1,
+                "owner_user_id": user_id,
+                "payload": {
+                    "definition_id": definition.id,
+                    "user_id": user_id,
+                    "family": "recurring_question",
+                    "scheduled_for": SLOT,
+                },
+            },
+            scheduled_db=db,
+        )
+        assert before["status"] == "failed"
+        # A DIFFERENT slot for the wired attempt: the prior slot's terminal
+        # run row would dedupe and replay the failed outcome.
+        wired_slot = "2026-08-22T10:00:00+00:00"
+
+        # After wiring: the production executor runs (LLM mocked).
+        register_automation_executors()
+
+        async def _fake_call(**kwargs: Any) -> dict[str, Any]:
+            return {"choices": [{"message": {"content": "generated answer"}}]}
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Chat.chat_service.perform_chat_api_call_async",
+            _fake_call,
+        )
+        after = await handle_agent_task_job(
+            {
+                "id": 2,
+                "owner_user_id": user_id,
+                "payload": {
+                    "definition_id": definition.id,
+                    "user_id": user_id,
+                    "family": "recurring_question",
+                    "scheduled_for": wired_slot,
+                },
+            },
+            scheduled_db=db,
+        )
+        assert after["status"] == "succeeded"
+        run = db.get_scheduled_task_run_by_slot(
+            definition_id=definition.id, run_slot_key=wired_slot
+        )
+        assert run is not None
+        assert run["result_summary"] == "generated answer"
+    finally:
+        if prev is not None:
+            settings.USER_DB_BASE_DIR = prev
+        else:
+            try:
+                del settings.USER_DB_BASE_DIR
+            except AttributeError:
+                pass

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
@@ -176,10 +176,15 @@ def test_capabilities_report_definition_actions_but_no_execution(scheduled_tasks
         actions = families[family]["actions"]
         assert actions["preview"]["status"] == "available"  # nosec B101
         assert actions["create_definition"]["status"] == "available"  # nosec B101
-        # TASK-13022: execution truth -- phase-1 generation-only runs are
-        # executable; the run_now action is available; tools are planned.
-        assert actions["execute"]["status"] == "available"  # nosec B101
-        assert actions["execute"]["reason"] == "phase1_generation_only"  # nosec B101
+        # TASK-13022/13110: execution truth -- recurring_question runs are
+        # executable (phase-1 generation-only); agent_task is planned (its
+        # message is redacted at rest); run_now is available on both.
+        if family == "recurring_question":
+            assert actions["execute"]["status"] == "available"  # nosec B101
+            assert actions["execute"]["reason"] == "phase1_generation_only"  # nosec B101
+        else:
+            assert actions["execute"]["status"] == "planned"  # nosec B101
+            assert "redacted at rest" in actions["execute"]["reason"]  # nosec B101
         assert actions["run_now"]["status"] == "available"  # nosec B101
         assert actions["execute_tools"]["status"] == "planned"  # nosec B101
 


### PR DESCRIPTION
## Summary

The deferred slice of TASK-13021: registers production executors on the consumer's seam so phase-1 scheduled automations actually generate (previously runs failed honestly with `no_executor_configured`).

- **One shared generation-only executor** for `recurring_question` and `agent_task`, calling the canonical `perform_chat_api_call_async` (same surface as Flashcards/Research/MCP). Fixed generation-only system prompt (definition-overridable), bounded `max_tokens` (default 1000, cap 4000), never `tools`/`tool_choice` — the phase-1 boundary stays enforced upstream in the consumer, and the prompt reinforces it.
- **Target precedence**: definition `input` overrides → `[Scheduled_Tasks_Automation]` config defaults (`executor_provider`/`executor_model`/`executor_max_tokens`) → server-default resolution (both omitted). Credentials stay in the chat entrypoint's provider-config layer — no new secret handling.
- **Prompt construction**: `input.question` / `input.message` with `input.prompt` fallback; missing input raises and the consumer records an honest failed run; empty completions raise (never a blank success).
- **Idempotent registration at agent-task worker startup** — a consuming worker always has executors.

With #2798 (feed) + #2801 (consumer) + #2803 (run-now) merged, this completes the server-side chain end-to-end: arm → enqueue → generate → notify, manually triggerable. Enabling `SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED` + `AGENT_TASK_JOBS_WORKER_ENABLED` activates it.

## Verification

- 10 new tests in `test_automation_executors.py`: precedence matrix (4 cases), prompt construction + fallback, missing-input, empty-completion, idempotent registration, and the **no-executor → wired transition through the real consumer** (run row carries the generated summary; LLM mocked at the entrypoint boundary)
- Full Notifications suite — **234 passed**

Closes TASK-13110.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires a production LLM executor for scheduled recurring_question automations to the server chat API so phase‑1 runs generate text instead of failing with no_executor_configured. agent_task remains unwired in phase 1 because input.message is redacted at rest; those jobs are skipped with an actionable reason. (TASK-13110)

- Executes via perform_chat_api_call_async with a fixed generation‑only system prompt (overridable via input.system_prompt), no tools/tool_choice, and bounded max_tokens (default 1000, cap 4000).
- Target resolution (sanitize before precedence): definition input.provider/model/max_tokens → `[Scheduled_Tasks_Automation]` executor_provider/model/max_tokens → server defaults; logs on config read failure; credentials handling unchanged.
- Prompt construction: recurring_question uses input.question; missing input raises; empty completions raise.
- Registers executors at run_agent_task_jobs_worker startup, idempotently; registry remains test‑overridable.
- Consumer behavior: unwired families return status=skipped with error family_not_wired_for_execution:<family>; capabilities report agent_task execute as planned with the redaction reason; run_now remains available for both families.
- Tests: new unit coverage for precedence, prompt construction, empty‑completion handling, idempotent registration, and the no‑executor → wired transition through the real consumer (LLM boundary mocked); Notifications suite passes.

- Rollout
  - No migrations. Enable SCHEDULED_TASKS_AUTOMATION_SCHEDULER_ENABLED and AGENT_TASK_JOBS_WORKER_ENABLED to run end‑to‑end.

<sup>Written for commit 86578befff5fa94a560f596292d8ce7899f8d9d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

