### PR TITLE
feat(service-prompts): expose Notes title prompt

### DIFF
--- a/apps/packages/ui/src/assets/locale/en/settings.json
+++ b/apps/packages/ui/src/assets/locale/en/settings.json
@@ -42,6 +42,10 @@
       "mediaTextTranslation": {
         "label": "Text translation",
         "description": "Controls the visible instructions used by synchronous text translation."
+      },
+      "notesTitleGenerate": {
+        "label": "Notes title",
+        "description": "Controls the wording used by LLM-backed automatic Notes titles."
       }
     },
     "workflows": {
@@ -52,7 +56,8 @@
       "mainChatWebSearch": "Main chat web search",
       "compareWebSearch": "Compare web search",
       "automaticConversationTitles": "Automatic conversation titles",
-      "textTranslation": "Text translation"
+      "textTranslation": "Text translation",
+      "automaticNotesTitles": "Automatic Notes titles"
     },
     "titleGeneration": {
       "note": "Automatic title generation is enabled or disabled in Chat settings.",
@@ -61,6 +66,7 @@
     "parts": {
       "template": "Template",
       "system": "System instructions",
+      "titleInstruction": "Title instruction",
       "userTemplate": "User template"
     },
     "scope": {

--- a/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
@@ -137,6 +137,12 @@ const KNOWN_DEFINITIONS = {
     label: "Text translation",
     description:
       "Controls the visible instructions used by synchronous text translation."
+  },
+  "notes.title.generate": {
+    key: "notesTitleGenerate",
+    label: "Notes title",
+    description:
+      "Controls the wording used by LLM-backed automatic Notes titles."
   }
 } as const
 
@@ -163,12 +169,17 @@ const KNOWN_WORKFLOWS: Record<string, { key: string; label: string }> = {
   "media.text.translation": {
     key: "textTranslation",
     label: "Text translation"
+  },
+  "notes.title.generate": {
+    key: "automaticNotesTitles",
+    label: "Automatic Notes titles"
   }
 }
 
 const KNOWN_PARTS: Record<string, { key: string; label: string }> = {
   template: { key: "template", label: "Template" },
   system: { key: "system", label: "System instructions" },
+  title_instruction: { key: "titleInstruction", label: "Title instruction" },
   user_template: { key: "userTemplate", label: "User template" }
 }
 

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
@@ -197,6 +197,28 @@ const catalog: ServicePromptCatalogItem[] = [
     affected_workflows: [
       { id: "chat.title.generation", label: "Server title workflow" }
     ]
+  },
+  {
+    id: "notes.title.generate",
+    label: "Server Notes title prompt",
+    description: "Server Notes title prompt description",
+    parts: [
+      {
+        key: "system",
+        label: "Server system label",
+        mode: "literal",
+        required_variables: []
+      },
+      {
+        key: "title_instruction",
+        label: "Server title instruction label",
+        mode: "literal",
+        required_variables: []
+      }
+    ],
+    affected_workflows: [
+      { id: "notes.title.generate", label: "Server Notes title workflow" }
+    ]
   }
 ]
 
@@ -219,6 +241,11 @@ const detailFor = (
       ? { template: "History: {chat_history}\nQuestion: {question}" }
       : definition.id === "chat.title.generation"
         ? { user_template: "Create a short title for {query}" }
+      : definition.id === "notes.title.generate"
+        ? {
+            system: "Write concise document titles.",
+            title_instruction: "Write a descriptive title"
+          }
         : { template: "At {current_date_time}:\n{search_results}" }
   const effective = options.parts ?? defaults
   const source = options.source ?? "packaged"
@@ -445,7 +472,7 @@ describe("ServicePromptsSettings", () => {
     expect(document.querySelector("h1")).toBeNull()
   })
 
-  it("renders the five localized definitions, query selection, status, workflows, and exact scope", async () => {
+  it("renders the six localized definitions, query selection, status, workflows, and exact scope", async () => {
     window.history.replaceState(
       {},
       "",
@@ -454,7 +481,7 @@ describe("ServicePromptsSettings", () => {
     renderSettings()
 
     expect(await screen.findAllByTestId("service-prompt-list-item"))
-      .toHaveLength(5)
+      .toHaveLength(6)
     expect(await screen.findByRole("heading", { name: "Text translation" }))
       .toBeInTheDocument()
     expect(screen.getByText("Server default")).toBeInTheDocument()
@@ -477,6 +504,22 @@ describe("ServicePromptsSettings", () => {
     expect(screen.getByText("Automatic conversation titles")).toBeVisible()
     expect(screen.getByRole("link", { name: "Open Chat settings" }))
       .toHaveAttribute("href", "/settings/chat")
+  })
+
+  it("localizes and edits the Notes title prompt", async () => {
+    renderSettings()
+
+    await openPrompt("Notes title")
+
+    expect(screen.getByRole("heading", { name: "Notes title" })).toBeVisible()
+    expect(screen.getByLabelText("System instructions")).toHaveValue(
+      "Write concise document titles."
+    )
+    expect(screen.getByLabelText("Title instruction")).toHaveValue(
+      "Write a descriptive title"
+    )
+    expect(screen.getByText("Automatic Notes titles")).toBeVisible()
+    expect(screen.queryByText("Server Notes title prompt")).not.toBeInTheDocument()
   })
 
   it("uses the Prompts Link and reverses dirty HashRouter Back and Forward", async () => {

--- a/apps/packages/ui/src/public/_locales/en/settings.json
+++ b/apps/packages/ui/src/public/_locales/en/settings.json
@@ -6296,8 +6296,20 @@
   "servicePrompts_definitions_chatTitleGeneration_description": {
     "message": "Controls the instruction used to generate automatic conversation titles."
   },
+  "servicePrompts_definitions_notesTitleGenerate_label": {
+    "message": "Notes title"
+  },
+  "servicePrompts_definitions_notesTitleGenerate_description": {
+    "message": "Controls the wording used by LLM-backed automatic Notes titles."
+  },
   "servicePrompts_workflows_automaticConversationTitles": {
     "message": "Automatic conversation titles"
+  },
+  "servicePrompts_workflows_automaticNotesTitles": {
+    "message": "Automatic Notes titles"
+  },
+  "servicePrompts_parts_titleInstruction": {
+    "message": "Title instruction"
   },
   "servicePrompts_titleGeneration_note": {
     "message": "Automatic title generation is enabled or disabled in Chat settings."

--- a/apps/packages/ui/src/services/__tests__/service-prompts.test.ts
+++ b/apps/packages/ui/src/services/__tests__/service-prompts.test.ts
@@ -143,6 +143,20 @@ const definitions: Record<KnownServicePromptId, ServicePromptCatalogItem> = {
       mode: "template",
       required_variables: ["target_language", "text"]
     }
+  ]),
+  "notes.title.generate": definition("notes.title.generate", [
+    {
+      key: "system",
+      label: "System instructions",
+      mode: "literal",
+      required_variables: []
+    },
+    {
+      key: "title_instruction",
+      label: "Title instruction",
+      mode: "literal",
+      required_variables: []
+    }
   ])
 }
 

--- a/apps/packages/ui/src/services/tldw/domains/service-prompts.ts
+++ b/apps/packages/ui/src/services/tldw/domains/service-prompts.ts
@@ -10,6 +10,7 @@ export type KnownServicePromptId =
   | "chat.web_search.answer"
   | "chat.title.generation"
   | "media.text.translation"
+  | "notes.title.generate"
 
 export type ServicePromptSource = "user" | "packaged"
 export type ServicePromptPartMode = "literal" | "template"

--- a/apps/packages/ui/src/utils/__fixtures__/service-prompt-rendering.json
+++ b/apps/packages/ui/src/utils/__fixtures__/service-prompt-rendering.json
@@ -15,6 +15,10 @@
     "media.text.translation": {
       "system": "You are an expert translator. Your task is to provide accurate,\nnatural-sounding translations that preserve the original meaning, tone, and formatting.\nDo not add explanations or notes - only provide the translation.",
       "user_template": "Translate the following text to {target_language}.\nPreserve the original formatting, meaning, and tone.\nOnly output the translation, no explanations, notes, or additional text.\n\nText to translate:\n{text}"
+    },
+    "notes.title.generate": {
+      "system": "You are a helpful assistant that writes concise document titles.",
+      "title_instruction": "Write a descriptive title"
     }
   },
   "render_cases": [

--- a/backlog/tasks/task-13115 - Expose-Notes-automatic-title-prompt-in-Service-Prompts.md
+++ b/backlog/tasks/task-13115 - Expose-Notes-automatic-title-prompt-in-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose Notes automatic-title prompt in Service Prompts
 status: Done
 assignee: []
 created_date: '2026-08-24 04:47'
-updated_date: '2026-08-24 05:48'
+updated_date: '2026-08-24 06:07'
 labels:
   - service-prompts
   - notes
@@ -44,6 +44,8 @@ Implement test-first in three bounded stages: register the definition and metada
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented test-first. Verification: backend Service Prompt/title matrix 86/86; complete Notes title integration 12/12; legacy Notes title regressions 3/3; shared UI Settings/domain 143/143; extension TypeScript compile; i18n duplicate/coverage/sync dry-run; focused Ruff and ESLint; Bandit zero findings; git diff --check clean. Independent final code review found no remaining actionable issues. Repo-wide tldw-frontend typecheck remains outside this task's gate because origin/dev has unrelated settings navigation and skills-certification baseline errors; the extension compile covers the touched shared UI.
+
+Post-rebase Qodo review: moved the synchronous title Service Prompt lookup off the async request loop and retired the same worker thread's SQLite connection; categorized the Notes integration module with the accepted integration marker. Added a red/green regression covering both nonblocking dispatch and worker cleanup. Verification: 100/100 focused backend Service Prompt, Notes title, and legacy compatibility tests; focused Ruff; Bandit zero findings; git diff --check clean.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13115 - Expose-Notes-automatic-title-prompt-in-Service-Prompts.md
+++ b/backlog/tasks/task-13115 - Expose-Notes-automatic-title-prompt-in-Service-Prompts.md
@@ -1,0 +1,62 @@
+---
+id: TASK-13115
+title: Expose Notes automatic-title prompt in Service Prompts
+status: Done
+assignee: []
+created_date: '2026-08-24 04:47'
+updated_date: '2026-08-24 05:45'
+labels:
+  - service-prompts
+  - notes
+  - settings
+dependencies: []
+references:
+  - Docs/Design/service-prompt-inventory.md
+  - >-
+    Docs/superpowers/specs/2026-07-12-user-customizable-service-prompts-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the existing LLM-backed Notes automatic-title prompt as one bounded Service Prompts definition while preserving current title gates, provider configuration, output constraints, normalization, and heuristic fallback behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The registry exposes notes.title.generate with editable literal system and title_instruction parts, and the packaged path preserves the existing provider payload.
+- [x] #2 Note create, title suggestion, and bulk create resolve one owner-scoped immutable prompt only when an LLM strategy is active; bulk reuses one revision and heuristic paths perform no prompt read.
+- [x] #3 Maximum length, title-only output, content shaping, provider options, normalization, and feature and strategy gates remain code-owned and unchanged.
+- [x] #4 Prompt resolution or validation failures fail closed before affected provider dispatch or persistence, while existing provider-unavailable, provider-error, and empty-output cases retain heuristic fallback.
+- [x] #5 The catalog-driven WebUI and extension Settings page exposes localized Notes title metadata and uses the existing generic save and reset path without new UI or storage infrastructure.
+- [x] #6 Focused backend, frontend Settings, locale, compile, lint, diff, and Bandit verification pass for the touched scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implement test-first in three bounded stages: register the definition and metadata; resolve and consume one immutable prompt in Notes title paths; run focused regression, security, and cross-host Settings verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented test-first. Verification: backend Service Prompt/title matrix 86/86; complete Notes title integration 12/12; legacy Notes title regressions 3/3; shared UI Settings/domain 143/143; extension TypeScript compile; i18n duplicate/coverage/sync dry-run; focused Ruff and ESLint; Bandit zero findings; git diff --check clean. Independent final code review found no remaining actionable issues. Repo-wide tldw-frontend typecheck remains outside this task's gate because origin/dev has unrelated settings navigation and skills-certification baseline errors; the extension compile covers the touched shared UI.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added notes.title.generate with editable literal system and title_instruction parts, wired lazy owner-scoped resolution into create, suggest, and bulk LLM title paths, and exposed localized metadata through the existing Service Prompts Settings UI. The implementation keeps title constraints and heuristic/provider fallback behavior code-owned, avoids Prompts DB access for explicit/heuristic/disabled/replayed work, reuses one successful bulk snapshot, and fails closed before provider dispatch or persistence on prompt failures.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13115 - Expose-Notes-automatic-title-prompt-in-Service-Prompts.md
+++ b/backlog/tasks/task-13115 - Expose-Notes-automatic-title-prompt-in-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose Notes automatic-title prompt in Service Prompts
 status: Done
 assignee: []
 created_date: '2026-08-24 04:47'
-updated_date: '2026-08-24 05:45'
+updated_date: '2026-08-24 05:48'
 labels:
   - service-prompts
   - notes
@@ -14,6 +14,7 @@ references:
   - Docs/Design/service-prompt-inventory.md
   - >-
     Docs/superpowers/specs/2026-07-12-user-customizable-service-prompts-design.md
+  - 'https://github.com/rmusser01/tldw_server/pull/2812'
 priority: medium
 ---
 

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -270,7 +270,14 @@ async def _resolve_note_title_service_prompt(
     if options.strategy not in ("llm", "llm_fallback"):
         return None
     db = await get_prompts_db_for_user(request, current_user)
-    return resolve_service_prompt(db, _NOTES_TITLE_SERVICE_PROMPT_ID)
+
+    def resolve_and_close() -> ResolvedServicePrompt:
+        try:
+            return resolve_service_prompt(db, _NOTES_TITLE_SERVICE_PROMPT_ID)
+        finally:
+            db.close_connection()
+
+    return await asyncio.to_thread(resolve_and_close)
 
 
 def _generate_note_title_with_service_prompt(

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -48,6 +48,7 @@ from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import (
     get_chacha_db_for_user,
     resolve_chacha_user_base_dir,
 )
+from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_for_user
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.endpoints.notes_sync_errors import (
     NOTES_SYNC_EXCEPTIONS,
@@ -174,6 +175,10 @@ from tldw_Server_API.app.core.Personalization import (
     record_note_restored,
     record_note_updated,
 )
+from tldw_Server_API.app.core.Prompt_Management.service_prompts import (
+    ResolvedServicePrompt,
+    resolve_service_prompt,
+)
 from tldw_Server_API.app.core.Sync.v2.errors import (
     SyncStoreError,
 )
@@ -243,6 +248,8 @@ _NOTES_NONCRITICAL_EXCEPTIONS = (
 
 router = APIRouter()
 
+_NOTES_TITLE_SERVICE_PROMPT_ID = "notes.title.generate"
+
 _NOTES_ATTACHMENT_DEFAULT_MAX_BYTES = 25 * 1024 * 1024
 _NOTES_ATTACHMENT_COMPATIBILITY_LIST_LIMIT = 1000
 _NOTES_ATTACHMENT_RANGE_RE = re.compile(r"bytes=(\d*)-(\d*)\Z")
@@ -251,6 +258,36 @@ _NOTES_ATTACHMENT_RANGE_RE = re.compile(r"bytes=(\d*)-(\d*)\Z")
 def get_notes_task_service() -> NotesTaskService:
     """Provide the stateless notes task service for note-save reconciliation."""
     return NotesTaskService()
+
+
+async def _resolve_note_title_service_prompt(
+    request: Request,
+    current_user: User,
+    options: TitleGenOptions,
+) -> ResolvedServicePrompt | None:
+    """Resolve the title prompt only for an active LLM title strategy."""
+
+    if options.strategy not in ("llm", "llm_fallback"):
+        return None
+    db = await get_prompts_db_for_user(request, current_user)
+    return resolve_service_prompt(db, _NOTES_TITLE_SERVICE_PROMPT_ID)
+
+
+def _generate_note_title_with_service_prompt(
+    content: str,
+    *,
+    options: TitleGenOptions,
+    service_prompt: ResolvedServicePrompt | None,
+) -> str:
+    """Preserve the legacy generator call shape for heuristic titles."""
+
+    if options.strategy == "heuristic" or service_prompt is None:
+        return generate_note_title(content, options=options)
+    return generate_note_title(
+        content,
+        options=options,
+        service_prompt=service_prompt,
+    )
 
 
 def _resolve_notes_attachment_max_bytes() -> int:
@@ -2132,18 +2169,18 @@ async def create_note(
         )
         if not effective_title:
             if getattr(note_in, "auto_title", False):
-                try:
-                    opts = _build_title_opts(note_in)
-                    effective_title = await asyncio.to_thread(
-                        generate_note_title,
-                        note_in.content,
-                        options=opts,
-                    )
-                except _NOTES_NONCRITICAL_EXCEPTIONS as gen_err:
-                    logger.warning(f"Auto-title generation failed, falling back: {gen_err}")
-                    effective_title = await asyncio.to_thread(
-                        generate_note_title, note_in.content
-                    )
+                opts = _build_title_opts(note_in)
+                service_prompt = await _resolve_note_title_service_prompt(
+                    request,
+                    current_user,
+                    opts,
+                )
+                effective_title = await asyncio.to_thread(
+                    _generate_note_title_with_service_prompt,
+                    note_in.content,
+                    options=opts,
+                    service_prompt=service_prompt,
+                )
             else:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -6668,6 +6705,7 @@ async def restore_note(
     tags=["notes"],
 )
 async def suggest_note_title(
+        request: Request,
         payload: TitleSuggestRequest,
         rate_limiter: RateLimiter = Depends(get_rate_limiter_dep),
         current_user: User = Depends(get_request_user),
@@ -6684,7 +6722,17 @@ async def suggest_note_title(
                                 headers={"Retry-After": str(meta.get("retry_after", 60))})
 
         opts = _build_title_opts(payload)
-        title = await asyncio.to_thread(generate_note_title, payload.content, options=opts)
+        service_prompt = await _resolve_note_title_service_prompt(
+            request,
+            current_user,
+            opts,
+        )
+        title = await asyncio.to_thread(
+            _generate_note_title_with_service_prompt,
+            payload.content,
+            options=opts,
+            service_prompt=service_prompt,
+        )
         return TitleSuggestResponse(title=title)
     except HTTPException:
         raise
@@ -6710,6 +6758,7 @@ async def bulk_create_notes(
     companion_events: list[dict[str, Any]] = []
     created = 0
     failed = 0
+    title_service_prompt: ResolvedServicePrompt | None = None
     # Enforce centralized per-request rate limit (notes.bulk_create)
     try:
         allowed, meta = await rate_limiter.check_user_rate_limit(int(current_user.id), "notes.bulk_create")
@@ -6793,21 +6842,19 @@ async def bulk_create_notes(
             )
             if not effective_title:
                 if getattr(item, "auto_title", False):
-                    try:
-                        opts = _build_title_opts(item)
-                        effective_title = await asyncio.to_thread(
-                            generate_note_title,
-                            item.content,
-                            options=opts,
+                    opts = _build_title_opts(item)
+                    if title_service_prompt is None:
+                        title_service_prompt = await _resolve_note_title_service_prompt(
+                            http_request,
+                            current_user,
+                            opts,
                         )
-                    except _NOTES_NONCRITICAL_EXCEPTIONS as gen_err:
-                        logger.warning(
-                            "[Bulk] Auto-title generation failed, falling back: {}",
-                            gen_err,
-                        )
-                        effective_title = await asyncio.to_thread(
-                            generate_note_title, item.content
-                        )
+                    effective_title = await asyncio.to_thread(
+                        _generate_note_title_with_service_prompt,
+                        item.content,
+                        options=opts,
+                        service_prompt=title_service_prompt,
+                    )
                 else:
                     raise InputError(
                         "Title is required for bulk item unless auto_title=true."

--- a/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
+++ b/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
@@ -109,6 +109,9 @@ Only output the translation, no explanations, notes, or additional text.
 Text to translate:
 {text}"""
 
+_NOTES_TITLE_SYSTEM_DEFAULT = "You are a helpful assistant that writes concise document titles."
+_NOTES_TITLE_INSTRUCTION_DEFAULT = "Write a descriptive title"
+
 _DEFINITION_SEQUENCE = (
     ServicePromptDefinition(
         id="chat.rag.answer",
@@ -214,6 +217,37 @@ _DEFINITION_SEQUENCE = (
             }
         ),
         affected_workflows=(ServicePromptWorkflow(id="media.text.translation", label="Text translation"),),
+    ),
+    ServicePromptDefinition(
+        id="notes.title.generate",
+        label="Notes title",
+        description="Controls the wording used by LLM-backed automatic Notes titles.",
+        parts=(
+            ServicePromptPart(
+                key="system",
+                label="System instructions",
+                mode="literal",
+                required_variables=(),
+            ),
+            ServicePromptPart(
+                key="title_instruction",
+                label="Title instruction",
+                mode="literal",
+                required_variables=(),
+            ),
+        ),
+        default_parts=MappingProxyType(
+            {
+                "system": _NOTES_TITLE_SYSTEM_DEFAULT,
+                "title_instruction": _NOTES_TITLE_INSTRUCTION_DEFAULT,
+            }
+        ),
+        affected_workflows=(
+            ServicePromptWorkflow(
+                id="notes.title.generate",
+                label="Automatic Notes titles",
+            ),
+        ),
     ),
 )
 

--- a/tldw_Server_API/app/core/Writing/note_title.py
+++ b/tldw_Server_API/app/core/Writing/note_title.py
@@ -1,21 +1,21 @@
 """
 note_title.py
-Heuristic and pluggable title generation for Notes.
-
-MVP: heuristic-only generation with optional language hint and max length.
-Phase 2: add LLM-backed strategy behind a flag via generate_note_title().
+Heuristic and optional LLM-backed title generation for Notes.
 """
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from tldw_Server_API.app.core.config import settings as core_settings
 from tldw_Server_API.app.core.LLM_Calls.adapter_registry import get_registry
 
-# Public strategy type for future extension (Phase 2)
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.Prompt_Management.service_prompts import ResolvedServicePrompt
+
+# Public strategy type shared with the Notes API.
 TitleStrategy = Literal["heuristic", "llm", "llm_fallback"]
 
 
@@ -110,26 +110,40 @@ def generate_note_title_heuristic(content: str, max_len: int = 250, *, language:
     return _truncate_title(base, max_len)
 
 
-def generate_note_title(content: str, *, options: TitleGenOptions | None = None) -> str:
-    """Entry point used by API code.
-
-    MVP: always uses heuristic, ignoring strategy.
-    Phase 2: respect options.strategy and use LLM where configured.
-    """
+def generate_note_title(
+    content: str,
+    *,
+    options: TitleGenOptions | None = None,
+    service_prompt: ResolvedServicePrompt | None = None,
+) -> str:
+    """Generate a title, using a resolved prompt for enabled LLM strategies."""
     if options is None:
         options = TitleGenOptions()
-    # Phase 2: LLM strategy gated by env flag, with heuristic fallback
+    # LLM strategies remain feature-gated and retain the heuristic fallback.
     try_llm = bool(core_settings.get("NOTES_TITLE_LLM_ENABLED", False))
     if try_llm and options.strategy in ("llm", "llm_fallback"):
-        llm_title = _try_generate_title_llm(content, options)
+        if service_prompt is None:
+            raise RuntimeError("Service Prompt resolution is required for LLM note titles.")
+        llm_title = _try_generate_title_llm(
+            content,
+            options,
+            system_message=service_prompt.parts["system"],
+            title_instruction=service_prompt.parts["title_instruction"],
+        )
         if llm_title:
             return _truncate_title(llm_title, options.max_len)
         # Fallback to heuristic on failure
-    # MVP path / default
+    # Default and fallback path.
     return generate_note_title_heuristic(content, max_len=options.max_len, language=options.language)
 
 
-def _try_generate_title_llm(content: str, options: TitleGenOptions) -> str | None:
+def _try_generate_title_llm(
+    content: str,
+    options: TitleGenOptions,
+    *,
+    system_message: str,
+    title_instruction: str,
+) -> str | None:
     """Best-effort LLM title generation. Returns None on failure.
 
     Keeps synchronous control path; relies on local/adapter-backed sync helpers.
@@ -140,13 +154,11 @@ def _try_generate_title_llm(content: str, options: TitleGenOptions) -> str | Non
         return None
 
     try:
-        # Short prompt instructing concise title; no JSON; single line
-        sys_msg = "You are a helpful assistant that writes concise document titles."
         content_snippet = (content or "").strip()
         if len(content_snippet) > 2000:
             content_snippet = content_snippet[:2000]
         user_msg = (
-            f"Write a descriptive title no longer than {options.max_len} characters for the following note.\n"
+            f"{title_instruction} no longer than {options.max_len} characters for the following note.\n"
             f"Return only the title with no quotes or extra text.\n\n{content_snippet}"
         )
         messages = [{"role": "user", "content": user_msg}]
@@ -154,7 +166,7 @@ def _try_generate_title_llm(content: str, options: TitleGenOptions) -> str | Non
         result = adapter.chat(
             {
                 "messages": messages,
-                "system_message": sys_msg,
+                "system_message": system_message,
                 "model": None,
                 "temperature": 0.2,
                 "max_tokens": 128,

--- a/tldw_Server_API/tests/Notes/test_auto_title_integration.py
+++ b/tldw_Server_API/tests/Notes/test_auto_title_integration.py
@@ -1,32 +1,417 @@
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_for_user
+from tldw_Server_API.app.core.DB_Management.Prompts_DB import PromptsDatabase
+from tldw_Server_API.app.core.Writing import note_title as note_title_module
+
+
+class _CountingPromptsDatabase(PromptsDatabase):
+    def __init__(self, db_path: Path, client_id: str) -> None:
+        super().__init__(db_path, client_id)
+        self.read_definition_ids: list[str] = []
+
+    def get_service_prompt_override(self, definition_id: str):
+        self.read_definition_ids.append(definition_id)
+        return super().get_service_prompt_override(definition_id)
+
+
+class _RecordingAdapter:
+    def __init__(self, titles: list[str]) -> None:
+        self.titles = iter(titles)
+        self.payloads: list[dict[str, object]] = []
+
+    def chat(self, payload: dict[str, object]) -> dict[str, object]:
+        self.payloads.append(payload)
+        return {"choices": [{"message": {"content": next(self.titles)}}]}
+
 
 @pytest.fixture()
-def client_user_only(monkeypatch):
+def client_user_only(monkeypatch, tmp_path: Path):
     """Use full app profile so Notes endpoints are registered."""
     # Force full app profile for these tests
     monkeypatch.setenv("MINIMAL_TEST_APP", "0")
     monkeypatch.setenv("ULTRA_MINIMAL_APP", "0")
 
     import importlib
+
     from tldw_Server_API.app import main as app_main
+    from tldw_Server_API.app.api.v1.endpoints import notes as notes_module
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 
     # Reload after env tweaks so router gating sees MINIMAL_TEST_APP=0
     importlib.reload(app_main)
     fastapi_app = app_main.app
+    prompts_db = _CountingPromptsDatabase(
+        tmp_path / "notes-title-service-prompts.sqlite",
+        "notes-title-service-prompt-test",
+    )
 
     async def override_user():
         return User(id=1, username="tester", email="t@e.com", is_active=True)
 
+    async def resolve_test_prompts_db(_request, _current_user):
+        return prompts_db
+
     fastapi_app.dependency_overrides[get_request_user] = override_user
+    fastapi_app.dependency_overrides[get_prompts_db_for_user] = lambda: prompts_db
+    monkeypatch.setattr(
+        notes_module,
+        "get_prompts_db_for_user",
+        resolve_test_prompts_db,
+    )
+    fastapi_app.state.notes_title_prompts_db = prompts_db
     with TestClient(fastapi_app) as client:
         yield client
     fastapi_app.dependency_overrides.clear()
+    prompts_db.close_connection()
 
 
-def test_create_note_with_auto_title(client_user_only: TestClient):
+def _enable_llm(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    titles: list[str],
+) -> _RecordingAdapter:
+    settings = {
+        "NOTES_TITLE_LLM_ENABLED": True,
+        "NOTES_TITLE_DEFAULT_STRATEGY": "heuristic",
+        "NOTES_TITLE_MAX_LEN": 1_000,
+    }
+    from tldw_Server_API.app.api.v1.endpoints import notes as notes_module
+
+    monkeypatch.setattr(notes_module, "core_settings", settings)
+    monkeypatch.setattr(note_title_module, "core_settings", settings)
+    adapter = _RecordingAdapter(titles)
+    monkeypatch.setattr(
+        note_title_module,
+        "get_registry",
+        lambda: SimpleNamespace(get_adapter=lambda provider: adapter if provider == "openai" else None),
+    )
+    return adapter
+
+
+def _save_title_override(client: TestClient) -> _CountingPromptsDatabase:
+    prompts_db: _CountingPromptsDatabase = client.app.state.notes_title_prompts_db
+    prompts_db.save_service_prompt_override(
+        "notes.title.generate",
+        {
+            "system": "Write titles in the saved account style.",
+            "title_instruction": "Create an account-specific title",
+        },
+        expected_revision=None,
+    )
+    return prompts_db
+
+
+def _corrupt_title_override(client: TestClient) -> _CountingPromptsDatabase:
+    prompts_db = _save_title_override(client)
+    prompts_db.get_connection().execute(
+        "UPDATE ServicePromptOverrides SET parts_json = ? WHERE definition_id = ?",
+        ("{", "notes.title.generate"),
+    )
+    prompts_db.get_connection().commit()
+    return prompts_db
+
+
+def _make_prompts_db_unavailable(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastapi import HTTPException
+
+    from tldw_Server_API.app.api.v1.endpoints import notes as notes_module
+
+    async def unavailable_direct(_request, _current_user):
+        raise HTTPException(status_code=500, detail="Prompts DB unavailable")
+
+    async def unavailable_dependency():
+        raise HTTPException(status_code=500, detail="Prompts DB unavailable")
+
+    monkeypatch.setattr(
+        notes_module,
+        "get_prompts_db_for_user",
+        unavailable_direct,
+    )
+    client.app.dependency_overrides[get_prompts_db_for_user] = unavailable_dependency
+
+
+def test_create_note_uses_one_owner_scoped_title_prompt(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts_db = _save_title_override(client_user_only)
+    adapter = _enable_llm(monkeypatch, titles=["Saved prompt title"])
+
+    response = client_user_only.post(
+        "/api/v1/notes/",
+        json={
+            "content": "Content whose heuristic title differs",
+            "auto_title": True,
+            "title_strategy": "llm",
+            "title_max_len": 80,
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["title"] == "Saved prompt title"
+    assert prompts_db.read_definition_ids == ["notes.title.generate"]
+    assert adapter.payloads[0]["system_message"] == "Write titles in the saved account style."
+
+
+def test_suggest_title_uses_one_owner_scoped_title_prompt(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts_db = _save_title_override(client_user_only)
+    adapter = _enable_llm(monkeypatch, titles=["Suggested saved title"])
+
+    response = client_user_only.post(
+        "/api/v1/notes/title/suggest",
+        json={
+            "content": "Content whose heuristic title differs",
+            "title_strategy": "llm",
+            "title_max_len": 80,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["title"] == "Suggested saved title"
+    assert prompts_db.read_definition_ids == ["notes.title.generate"]
+    assert adapter.payloads[0]["system_message"] == "Write titles in the saved account style."
+
+
+def test_bulk_create_reuses_one_owner_scoped_title_prompt(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts_db = _save_title_override(client_user_only)
+    adapter = _enable_llm(
+        monkeypatch,
+        titles=["First saved title", "Second saved title"],
+    )
+
+    response = client_user_only.post(
+        "/api/v1/notes/bulk",
+        json={
+            "notes": [
+                {
+                    "content": "First note content",
+                    "auto_title": True,
+                    "title_strategy": "llm",
+                    "title_max_len": 80,
+                },
+                {
+                    "content": "Second note content",
+                    "auto_title": True,
+                    "title_strategy": "llm",
+                    "title_max_len": 80,
+                },
+            ]
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["created_count"] == 2
+    assert [result["note"]["title"] for result in response.json()["results"]] == [
+        "First saved title",
+        "Second saved title",
+    ]
+    assert prompts_db.read_definition_ids == ["notes.title.generate"]
+    assert [payload["system_message"] for payload in adapter.payloads] == [
+        "Write titles in the saved account style.",
+        "Write titles in the saved account style.",
+    ]
+
+
+def test_bulk_llm_then_heuristic_preserves_legacy_heuristic_call_shape(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts_db = _save_title_override(client_user_only)
+    _enable_llm(monkeypatch, titles=[])
+    calls: list[tuple[str, bool]] = []
+
+    from tldw_Server_API.app.api.v1.endpoints import notes as notes_module
+
+    def generate_title(content: str, options=None, **kwargs) -> str:
+        has_service_prompt = "service_prompt" in kwargs
+        calls.append((options.strategy, has_service_prompt))
+        if options.strategy == "heuristic" and has_service_prompt:
+            raise TypeError("legacy heuristic call received service_prompt")
+        return f"{options.strategy}: {content}"
+
+    monkeypatch.setattr(notes_module, "generate_note_title", generate_title)
+
+    response = client_user_only.post(
+        "/api/v1/notes/bulk",
+        json={
+            "notes": [
+                {
+                    "content": "LLM item",
+                    "auto_title": True,
+                    "title_strategy": "llm",
+                },
+                {
+                    "content": "Heuristic item",
+                    "auto_title": True,
+                    "title_strategy": "heuristic",
+                },
+            ]
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["created_count"] == 2
+    assert prompts_db.read_definition_ids == ["notes.title.generate"]
+    assert calls == [("llm", True), ("heuristic", False)]
+
+
+def test_corrupt_owner_title_prompt_fails_before_model_or_persistence(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts_db = _corrupt_title_override(client_user_only)
+    adapter = _enable_llm(monkeypatch, titles=["Must not be used"])
+    before = client_user_only.get("/api/v1/notes/")
+    assert before.status_code == 200, before.text
+
+    response = client_user_only.post(
+        "/api/v1/notes/",
+        json={
+            "content": "This note must not be persisted",
+            "auto_title": True,
+            "title_strategy": "llm",
+            "title_max_len": 80,
+        },
+    )
+
+    assert response.status_code == 500, response.text
+    assert prompts_db.read_definition_ids == ["notes.title.generate"]
+    assert adapter.payloads == []
+    list_response = client_user_only.get("/api/v1/notes/")
+    assert list_response.status_code == 200, list_response.text
+    assert list_response.json()["notes"] == before.json()["notes"]
+
+
+def test_bulk_corrupt_owner_title_prompt_fails_each_item_before_model_or_persistence(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts_db = _corrupt_title_override(client_user_only)
+    adapter = _enable_llm(monkeypatch, titles=["Must not be used"])
+    before = client_user_only.get("/api/v1/notes/")
+    assert before.status_code == 200, before.text
+
+    response = client_user_only.post(
+        "/api/v1/notes/bulk",
+        json={
+            "notes": [
+                {
+                    "content": "First note must not be persisted",
+                    "auto_title": True,
+                    "title_strategy": "llm",
+                },
+                {
+                    "content": "Second note must not be persisted",
+                    "auto_title": True,
+                    "title_strategy": "llm",
+                },
+            ]
+        },
+    )
+
+    assert response.status_code == 207, response.text
+    assert response.json()["created_count"] == 0
+    assert response.json()["failed_count"] == 2
+    assert prompts_db.read_definition_ids == [
+        "notes.title.generate",
+        "notes.title.generate",
+    ]
+    assert adapter.payloads == []
+    after = client_user_only.get("/api/v1/notes/")
+    assert after.status_code == 200, after.text
+    assert after.json()["notes"] == before.json()["notes"]
+
+
+def test_active_llm_prompts_db_failure_stops_before_model_or_persistence(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _enable_llm(monkeypatch, titles=["Must not be used"])
+    _make_prompts_db_unavailable(client_user_only, monkeypatch)
+    before = client_user_only.get("/api/v1/notes/")
+    assert before.status_code == 200, before.text
+
+    response = client_user_only.post(
+        "/api/v1/notes/",
+        json={
+            "content": "This note must not be persisted",
+            "auto_title": True,
+            "title_strategy": "llm",
+            "title_max_len": 80,
+        },
+    )
+
+    assert response.status_code == 500, response.text
+    assert adapter.payloads == []
+    list_response = client_user_only.get("/api/v1/notes/")
+    assert list_response.status_code == 200, list_response.text
+    assert list_response.json()["notes"] == before.json()["notes"]
+
+
+def test_explicit_title_does_not_acquire_prompts_db(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _make_prompts_db_unavailable(client_user_only, monkeypatch)
+
+    response = client_user_only.post(
+        "/api/v1/notes/",
+        json={"title": "Explicit title", "content": "Explicit-title content"},
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["title"] == "Explicit title"
+
+
+def test_disabled_llm_strategy_uses_heuristic_without_loading_prompt(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import notes as notes_module
+
+    disabled_settings = {
+        "NOTES_TITLE_LLM_ENABLED": False,
+        "NOTES_TITLE_DEFAULT_STRATEGY": "heuristic",
+        "NOTES_TITLE_MAX_LEN": 1_000,
+    }
+    monkeypatch.setattr(notes_module, "core_settings", disabled_settings)
+    monkeypatch.setattr(note_title_module, "core_settings", disabled_settings)
+    _make_prompts_db_unavailable(client_user_only, monkeypatch)
+
+    response = client_user_only.post(
+        "/api/v1/notes/",
+        json={
+            "content": "Feature-disabled title content",
+            "auto_title": True,
+            "title_strategy": "llm",
+            "title_max_len": 80,
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["title"] == "Feature-disabled title content"
+    assert client_user_only.app.state.notes_title_prompts_db.read_definition_ids == []
+
+
+def test_create_note_with_auto_title(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _make_prompts_db_unavailable(client_user_only, monkeypatch)
     resp = client_user_only.post(
         "/api/v1/notes/",
         json={
@@ -41,9 +426,14 @@ def test_create_note_with_auto_title(client_user_only: TestClient):
     assert data["title"]
     assert len(data["title"]) <= 250
     assert data["content"].startswith("# Heading") or data["content"].startswith("Heading")
+    assert client_user_only.app.state.notes_title_prompts_db.read_definition_ids == []
 
 
-def test_bulk_create_with_auto_title(client_user_only: TestClient):
+def test_bulk_create_with_auto_title(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _make_prompts_db_unavailable(client_user_only, monkeypatch)
     payload = {
         "notes": [
             {
@@ -62,9 +452,14 @@ def test_bulk_create_with_auto_title(client_user_only: TestClient):
     note = data["results"][0]["note"]
     assert note["title"]
     assert len(note["title"]) <= 250
+    assert client_user_only.app.state.notes_title_prompts_db.read_definition_ids == []
 
 
-def test_suggest_title_endpoint(client_user_only: TestClient):
+def test_suggest_title_endpoint(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _make_prompts_db_unavailable(client_user_only, monkeypatch)
     resp = client_user_only.post(
         "/api/v1/notes/title/suggest",
         json={
@@ -77,3 +472,4 @@ def test_suggest_title_endpoint(client_user_only: TestClient):
     data = resp.json()
     assert data["title"]
     assert len(data["title"]) <= 50
+    assert client_user_only.app.state.notes_title_prompts_db.read_definition_ids == []

--- a/tldw_Server_API/tests/Notes/test_auto_title_integration.py
+++ b/tldw_Server_API/tests/Notes/test_auto_title_integration.py
@@ -1,3 +1,5 @@
+import asyncio
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -7,6 +9,8 @@ from fastapi.testclient import TestClient
 from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_for_user
 from tldw_Server_API.app.core.DB_Management.Prompts_DB import PromptsDatabase
 from tldw_Server_API.app.core.Writing import note_title as note_title_module
+
+pytestmark = pytest.mark.integration
 
 
 class _CountingPromptsDatabase(PromptsDatabase):
@@ -159,6 +163,48 @@ def test_create_note_uses_one_owner_scoped_title_prompt(
     assert response.json()["title"] == "Saved prompt title"
     assert prompts_db.read_definition_ids == ["notes.title.generate"]
     assert adapter.payloads[0]["system_message"] == "Write titles in the saved account style."
+
+
+def test_title_prompt_resolution_runs_off_loop_and_closes_worker_connection(
+    client_user_only: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts_db = _save_title_override(client_user_only)
+    _enable_llm(monkeypatch, titles=["Nonblocking title"])
+
+    from tldw_Server_API.app.api.v1.endpoints import notes as notes_module
+
+    real_resolve = notes_module.resolve_service_prompt
+    real_close = prompts_db.close_connection
+    resolution_threads: list[int] = []
+    closed_threads: list[int] = []
+
+    def resolve_off_event_loop(db, definition_id):
+        with pytest.raises(RuntimeError, match="no running event loop"):
+            asyncio.get_running_loop()
+        resolution_threads.append(threading.get_ident())
+        return real_resolve(db, definition_id)
+
+    def record_close() -> None:
+        closed_threads.append(threading.get_ident())
+        real_close()
+
+    monkeypatch.setattr(notes_module, "resolve_service_prompt", resolve_off_event_loop)
+    monkeypatch.setattr(prompts_db, "close_connection", record_close)
+
+    response = client_user_only.post(
+        "/api/v1/notes/",
+        json={
+            "content": "Content resolved without blocking the request loop",
+            "auto_title": True,
+            "title_strategy": "llm",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["title"] == "Nonblocking title"
+    assert len(resolution_threads) == 1
+    assert resolution_threads[0] in closed_threads
 
 
 def test_suggest_title_uses_one_owner_scoped_title_prompt(

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
@@ -74,6 +74,15 @@ EXPECTED_REGISTRY = {
         ),
         "workflows": (("media.text.translation", "Text translation"),),
     },
+    "notes.title.generate": {
+        "label": "Notes title",
+        "description": "Controls the wording used by LLM-backed automatic Notes titles.",
+        "parts": (
+            ("system", "System instructions", "literal", ()),
+            ("title_instruction", "Title instruction", "literal", ()),
+        ),
+        "workflows": (("notes.title.generate", "Automatic Notes titles"),),
+    },
 }
 
 

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
@@ -35,6 +35,12 @@ CUSTOM_PARTS = {
 TITLE_ID = "chat.title.generation"
 TITLE_PATH = f"/api/v1/service-prompts/{TITLE_ID}"
 TITLE_CUSTOM_PARTS = {"user_template": "Name this request: {query}"}
+NOTES_TITLE_ID = "notes.title.generate"
+NOTES_TITLE_PATH = f"/api/v1/service-prompts/{NOTES_TITLE_ID}"
+NOTES_TITLE_CUSTOM_PARTS = {
+    "system": "Write note titles in the account style.",
+    "title_instruction": "Create a specific note title",
+}
 
 
 def _principal(*, api_key_id: int | None = None) -> AuthPrincipal:
@@ -185,6 +191,28 @@ def test_service_prompt_catalog_returns_exact_metadata_without_prompt_bodies(
                 {"id": "media.text.translation", "label": "Text translation"}
             ],
         },
+        {
+            "id": "notes.title.generate",
+            "label": "Notes title",
+            "description": "Controls the wording used by LLM-backed automatic Notes titles.",
+            "parts": [
+                {
+                    "key": "system",
+                    "label": "System instructions",
+                    "mode": "literal",
+                    "required_variables": [],
+                },
+                {
+                    "key": "title_instruction",
+                    "label": "Title instruction",
+                    "mode": "literal",
+                    "required_variables": [],
+                },
+            ],
+            "affected_workflows": [
+                {"id": "notes.title.generate", "label": "Automatic Notes titles"}
+            ],
+        },
     ]
     assert "You are a helpful AI assistant" not in response.text
 
@@ -212,6 +240,23 @@ def test_title_prompt_can_be_saved_and_reset_through_generic_api(api_context) ->
 
     reset = api_context.client.delete(
         TITLE_PATH,
+        params={"expected_revision": saved.json()["revision"]},
+    )
+    assert reset.status_code == 200
+    assert reset.json()["source"] == "packaged"
+    assert reset.json()["effective_parts"] == reset.json()["default_parts"]
+
+
+def test_notes_title_prompt_can_be_saved_and_reset_through_generic_api(api_context) -> None:
+    saved = api_context.client.put(
+        NOTES_TITLE_PATH,
+        json={"parts": NOTES_TITLE_CUSTOM_PARTS, "expected_revision": None},
+    )
+    assert saved.status_code == 200
+    assert saved.json()["effective_parts"] == NOTES_TITLE_CUSTOM_PARTS
+
+    reset = api_context.client.delete(
+        NOTES_TITLE_PATH,
         params={"expected_revision": saved.json()["revision"]},
     )
     assert reset.status_code == 200

--- a/tldw_Server_API/tests/unit/test_note_title_service_prompts.py
+++ b/tldw_Server_API/tests/unit/test_note_title_service_prompts.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from types import MappingProxyType, SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.core.Prompt_Management.service_prompts import (
+    ResolvedServicePrompt,
+    get_service_prompt_definition,
+)
+from tldw_Server_API.app.core.Writing import note_title as note_title_module
+from tldw_Server_API.app.core.Writing.note_title import TitleGenOptions, generate_note_title
+
+pytestmark = pytest.mark.unit
+
+
+class _RecordingAdapter:
+    def __init__(self, result: object) -> None:
+        self.result = result
+        self.payloads: list[dict[str, object]] = []
+
+    def chat(self, payload: dict[str, object]) -> object:
+        self.payloads.append(payload)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+def _resolved_prompt(*, system: str, title_instruction: str) -> ResolvedServicePrompt:
+    return ResolvedServicePrompt(
+        definition=get_service_prompt_definition("notes.title.generate"),
+        parts=MappingProxyType(
+            {
+                "system": system,
+                "title_instruction": title_instruction,
+            }
+        ),
+        source="user",
+        revision="revision-notes-title",
+    )
+
+
+def _enable_llm(monkeypatch: pytest.MonkeyPatch, adapter: _RecordingAdapter) -> None:
+    monkeypatch.setattr(
+        note_title_module,
+        "core_settings",
+        {"NOTES_TITLE_LLM_ENABLED": True},
+    )
+    monkeypatch.setattr(
+        note_title_module,
+        "get_registry",
+        lambda: SimpleNamespace(get_adapter=lambda provider: adapter if provider == "openai" else None),
+    )
+
+
+def test_llm_title_uses_editable_semantics_with_locked_provider_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _RecordingAdapter({"choices": [{"message": {"content": '  "Evocative title"  '}}]})
+    _enable_llm(monkeypatch, adapter)
+    content = "A" * 2_001
+
+    title = generate_note_title(
+        content,
+        options=TitleGenOptions(strategy="llm", max_len=64),
+        service_prompt=_resolved_prompt(
+            system="System {braces} remain literal.",
+            title_instruction="Craft an evocative {literal} title",
+        ),
+    )
+
+    assert title == "Evocative title"
+    assert adapter.payloads == [
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "Craft an evocative {literal} title no longer than 64 characters for the following note.\n"
+                        "Return only the title with no quotes or extra text.\n\n" + ("A" * 2_000)
+                    ),
+                }
+            ],
+            "system_message": "System {braces} remain literal.",
+            "model": None,
+            "temperature": 0.2,
+            "max_tokens": 128,
+        }
+    ]
+
+
+def test_provider_failure_still_uses_the_existing_heuristic_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _RecordingAdapter(RuntimeError("provider unavailable"))
+    _enable_llm(monkeypatch, adapter)
+
+    title = generate_note_title(
+        "# Existing heuristic heading\nBody",
+        options=TitleGenOptions(strategy="llm_fallback", max_len=80),
+        service_prompt=_resolved_prompt(
+            system="Custom title system",
+            title_instruction="Create a custom title",
+        ),
+    )
+
+    assert title == "Existing heuristic heading"
+    assert len(adapter.payloads) == 1
+
+
+def test_empty_provider_output_still_uses_the_existing_heuristic_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _RecordingAdapter({"choices": [{"message": {"content": ""}}]})
+    _enable_llm(monkeypatch, adapter)
+
+    title = generate_note_title(
+        "Existing empty-output fallback",
+        options=TitleGenOptions(strategy="llm", max_len=80),
+        service_prompt=_resolved_prompt(
+            system="Custom title system",
+            title_instruction="Create a custom title",
+        ),
+    )
+
+    assert title == "Existing empty-output fallback"
+    assert len(adapter.payloads) == 1
+
+
+def test_unavailable_provider_still_uses_the_existing_heuristic_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        note_title_module,
+        "core_settings",
+        {"NOTES_TITLE_LLM_ENABLED": True},
+    )
+    monkeypatch.setattr(
+        note_title_module,
+        "get_registry",
+        lambda: SimpleNamespace(get_adapter=lambda _provider: None),
+    )
+
+    title = generate_note_title(
+        "Existing unavailable-provider fallback",
+        options=TitleGenOptions(strategy="llm", max_len=80),
+        service_prompt=_resolved_prompt(
+            system="Custom title system",
+            title_instruction="Create a custom title",
+        ),
+    )
+
+    assert title == "Existing unavailable-provider fallback"
+
+
+def test_active_llm_strategy_requires_an_owner_scoped_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _RecordingAdapter({"choices": [{"message": {"content": "Must not be used"}}]})
+    _enable_llm(monkeypatch, adapter)
+
+    with pytest.raises(RuntimeError, match="Service Prompt resolution is required"):
+        generate_note_title(
+            "Owner-bound note content",
+            options=TitleGenOptions(strategy="llm", max_len=80),
+        )
+
+    assert adapter.payloads == []


### PR DESCRIPTION
## Change summary

This PR makes automatic Notes title generation customizable through the existing Service Prompts settings in the WebUI and browser extension. It applies an owner-scoped prompt to Notes creation, title suggestions, and bulk imports while preserving existing title limits, provider configuration, heuristic fallbacks, and disabled-feature behavior. Reusing the current prompt storage and Settings interface avoids introducing a separate Notes-specific configuration system.

## Summary

- What changed: Added the bounded `notes.title.generate` Service Prompt, wired it into Notes create/suggest/bulk LLM title generation, and exposed localized metadata through the existing WebUI and extension Settings page.
- Why: Users can customize automatic Notes-title wording without a separate settings or storage system, while title limits, provider options, normalization, feature gates, and heuristic fallback remain code-owned.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs/task record updated where relevant
- Backend Service Prompt and title matrix: 86/86 passed
- Notes title integration: 12/12 passed
- Legacy Notes title regressions: 3/3 passed
- Shared UI Service Prompts and Settings: 143/143 passed
- Extension TypeScript compile passed
- i18n duplicate, coverage, and sync dry-run checks passed
- Focused Ruff and ESLint passed
- Bandit: zero findings or errors
- `git diff --check`: clean
- Independent final review: no remaining actionable findings

## UX Audit Checklist (v2 Stage 5)

- [x] WebUI/extension parity validated for the shared Settings change
- [x] Remaining Stage 5 items are not applicable to this bounded Settings catalog addition

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable; Watchlists UI behavior is unchanged

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable; Watchlists behavior is unchanged

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert commit `defe9af421`; packaged prompt behavior and existing generic Service Prompts storage remain otherwise unchanged.

Backlog: TASK-13115

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the `notes.title.generate` Service Prompt and uses it for LLM-backed Notes titles across create, suggest, and bulk. Previously titles used a hardcoded prompt; now we resolve an owner-scoped prompt off the request loop, reuse one snapshot per bulk request, and keep heuristic behavior, gates, limits, and fallbacks unchanged.

- Registers `notes.title.generate` with editable literal parts `system` and `title_instruction`, packaged defaults, and localized metadata in existing Settings (WebUI and extension) with no new storage or UI; adds “Title instruction” part and “Automatic Notes titles” workflow.
- Resolves the prompt lazily in a worker thread, then closes the Prompts DB connection; bulk resolves once and reuses the same revision; explicit titles, heuristic strategy, or disabled LLM do not touch the Prompts DB.
- Fails closed on prompt resolution/validation or Prompts DB errors before model dispatch or persistence; preserves existing fallbacks for provider-unavailable/error/empty-output and enforces current max length and normalization.
- Requires a resolved Service Prompt for active LLM strategies; heuristic generator remains unchanged.
- Adds backend catalog/API tests, unit tests for LLM title generation, and create/suggest/bulk integration tests; updates locales and Settings; satisfies TASK-13115.

<sup>Written for commit a693d95e850989ac33e308717990868f23693d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

