### PR TITLE
feat(sync): add dormant notes task activity lifecycle

### DIFF
--- a/backlog/tasks/task-13006.3 - Implement-dormant-notes.task_activity-Sync-lifecycle.md
+++ b/backlog/tasks/task-13006.3 - Implement-dormant-notes.task_activity-Sync-lifecycle.md
@@ -50,10 +50,10 @@ ADR required: no; ADR-039 applies.
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented the dormant notes.task_activity v1 lifecycle defined by ADR-039. Added strict immutable adapter decisions, exact revision-1 create/revision-2 tombstone materialization, cursor-plus-ID product paging, owner/dataset/note/task scope enforcement, exact replay and split-commit repair, deterministic legacy event bootstrap with readiness count/fingerprint verification, and stable task-transition activity plans through the existing optional task-service callback. Public supported/writable capabilities, enrollment, REST, and MCP wiring remain unchanged.
+Implemented the dormant notes.task_activity v1 lifecycle defined by ADR-039. Added strict immutable adapter decisions, exact revision-1 create/revision-2 tombstone materialization, cursor-plus-ID product paging, owner/dataset/note/task scope enforcement, exact replay and split-commit repair, deterministic legacy event bootstrap with readiness count/fingerprint verification, and stable task-transition activity plans through the existing optional task-service callback. Qodo review hardening centralizes activity-bootstrap exceptions, completes helper documentation, and makes non-final resumes page-bounded while final exact source/envelope verification streams with constant memory. Public supported/writable capabilities, enrollment, REST, and MCP wiring remain unchanged.
 
 Verification:
-- Required focused/regression gate with live PostgreSQL: 281 passed, 0 skipped.
+- Required focused/regression gate with live PostgreSQL after Qodo remediation: 282 passed, 0 skipped.
 - Capture plus live PostgreSQL contract: 29 passed, 0 skipped.
 - Adjacent task/activity regressions: 30 passed.
 - Ruff passed for all touched production paths.

--- a/backlog/tasks/task-13006.3 - Implement-dormant-notes.task_activity-Sync-lifecycle.md
+++ b/backlog/tasks/task-13006.3 - Implement-dormant-notes.task_activity-Sync-lifecycle.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-13006.3
 title: Implement dormant notes.task_activity Sync lifecycle
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-14 01:54'
-updated_date: '2026-08-24 15:12'
+updated_date: '2026-08-24 16:10'
 labels:
   - notes
   - sync-v2
@@ -28,11 +28,11 @@ Implement immutable Notes task activity synchronization, exact legacy event boot
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 notes.task_activity version 1 supports immutable create and exact one-way tombstone with required note, optional same-note task, server-bound provenance, canonical old/new schemas, and cursor-plus-ID ordering.
-- [ ] #2 Exact replay is idempotent, changed stable-ID reuse conflicts, activity cannot be updated/restored, corrections are new same-scope events, and lifecycle revisions are limited to create revision 1 and tombstone revision 2.
-- [ ] #3 Existing events bootstrap in deterministic created_at/ID order with exact legacy type/value transforms, provenance sentinels, bounded pages, count/fingerprint verification, and read/dismiss state excluded.
-- [ ] #4 Task transition capture produces stable nonduplicating activity primitives and split-commit repair, while public supported/writable capabilities still omit both domains.
-- [ ] #5 Immutability, ordering, tombstone, correction, bootstrap, cross-owner, RLS, pagination, repair, and live PostgreSQL tests pass.
+- [x] #1 notes.task_activity version 1 supports immutable create and exact one-way tombstone with required note, optional same-note task, server-bound provenance, canonical old/new schemas, and cursor-plus-ID ordering.
+- [x] #2 Exact replay is idempotent, changed stable-ID reuse conflicts, activity cannot be updated/restored, corrections are new same-scope events, and lifecycle revisions are limited to create revision 1 and tombstone revision 2.
+- [x] #3 Existing events bootstrap in deterministic created_at/ID order with exact legacy type/value transforms, provenance sentinels, bounded pages, count/fingerprint verification, and read/dismiss state excluded.
+- [x] #4 Task transition capture produces stable nonduplicating activity primitives and split-commit repair, while public supported/writable capabilities still omit both domains.
+- [x] #5 Immutability, ordering, tombstone, correction, bootstrap, cross-owner, RLS, pagination, repair, and live PostgreSQL tests pass.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -47,12 +47,36 @@ Detailed plan: Docs/superpowers/plans/2026-08-13-notes-task-activity-sync-lifecy
 ADR required: no; ADR-039 applies.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the dormant notes.task_activity v1 lifecycle defined by ADR-039. Added strict immutable adapter decisions, exact revision-1 create/revision-2 tombstone materialization, cursor-plus-ID product paging, owner/dataset/note/task scope enforcement, exact replay and split-commit repair, deterministic legacy event bootstrap with readiness count/fingerprint verification, and stable task-transition activity plans through the existing optional task-service callback. Public supported/writable capabilities, enrollment, REST, and MCP wiring remain unchanged.
+
+Verification:
+- Required focused/regression gate with live PostgreSQL: 281 passed, 0 skipped.
+- Capture plus live PostgreSQL contract: 29 passed, 0 skipped.
+- Adjacent task/activity regressions: 30 passed.
+- Ruff passed for all touched production paths.
+- Bandit passed for all touched production paths; two fixed-fragment parameterized SQL queries carry targeted B608 annotations.
+- py_compile and git diff --check passed.
+
+Plan deviations: none material. Capture extends the already-approved dormant task callback into a stable ordered task/activity plan and intentionally does not append or advertise it; TASK-13006.4 owns atomic activation.
+
+ADR required: no. ADR-039 applies. No new ADR was needed. Known skips/blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Dormant notes.task_activity Sync is complete: immutable lifecycle, scoped product projection, resumable exact legacy bootstrap, stable transition capture, and live PostgreSQL RLS/order/rollback evidence are in place while both task domains remain publicly disabled.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13006.3 - Implement-dormant-notes.task_activity-Sync-lifecycle.md
+++ b/backlog/tasks/task-13006.3 - Implement-dormant-notes.task_activity-Sync-lifecycle.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-13006.3
 title: Implement dormant notes.task_activity Sync lifecycle
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-14 01:54'
+updated_date: '2026-08-24 15:12'
 labels:
   - notes
   - sync-v2
@@ -33,6 +34,18 @@ Implement immutable Notes task activity synchronization, exact legacy event boot
 - [ ] #4 Task transition capture produces stable nonduplicating activity primitives and split-commit repair, while public supported/writable capabilities still omit both domains.
 - [ ] #5 Immutability, ordering, tombstone, correction, bootstrap, cross-owner, RLS, pagination, repair, and live PostgreSQL tests pass.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Enforce immutable notes.task_activity lineage.
+2. Materialize activity by Sync cursor and stable ID.
+3. Bootstrap exact legacy events resumably.
+4. Add complete dormant transition capture and repair.
+5. Run SQLite/live-PostgreSQL/static gates.
+Detailed plan: Docs/superpowers/plans/2026-08-13-notes-task-activity-sync-lifecycle-implementation-plan.md
+ADR required: no; ADR-039 applies.
+<!-- SECTION:PLAN:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -2377,12 +2377,17 @@ class SyncDatabase:
                     enrolled = _dataset_domains_from_row(row)
                     for domain in sorted(domains):
                         trusted_task = (
-                            domain == "notes.task"
+                            domain in {"notes.task", "notes.task_activity"}
                             and trusted_notes_task_bootstrap_id is not None
                         )
                         if trusted_task:
                             metadata = decode_json(row.get("metadata_json"), default={})
-                            readiness = metadata.get("notes_task_v1")
+                            readiness_key = (
+                                "notes_task_v1"
+                                if domain == "notes.task"
+                                else "notes_task_activity_v1"
+                            )
+                            readiness = metadata.get(readiness_key)
                             if (
                                 not isinstance(readiness, Mapping)
                                 or readiness.get("state") != "bootstrapping"
@@ -3138,7 +3143,15 @@ class SyncDatabase:
         """Authorize only the private source-verified dormant task bootstrap."""
 
         metadata = decode_json(row.get("metadata_json"), default={})
-        readiness = metadata.get("notes_task_v1")
+        readiness_key = {
+            "notes.task": "notes_task_v1",
+            "notes.task_activity": "notes_task_activity_v1",
+        }.get(envelope.domain)
+        expected_source = {
+            "notes.task": "notes-task-bootstrap",
+            "notes.task_activity": "notes-task-activity-bootstrap",
+        }.get(envelope.domain)
+        readiness = metadata.get(readiness_key) if readiness_key is not None else None
         routing = envelope.routing_metadata
         if (
             not isinstance(readiness, Mapping)
@@ -3146,6 +3159,7 @@ class SyncDatabase:
             or metadata.get("task_activity_capture_enabled") is not True
             or routing.get("bootstrap_capture") is not True
             or routing.get("bootstrap_id") != bootstrap_id
+            or routing.get("source") != expected_source
         ):
             raise SyncStoreError("notes_task_sync_not_ready")
 
@@ -6355,7 +6369,7 @@ class SyncDatabase:
             with self.backend.transaction() as conn:
                 for envelope in plan:
                     if (
-                        envelope.domain == "notes.task"
+                        envelope.domain in {"notes.task", "notes.task_activity"}
                         and trusted_notes_task_bootstrap_id is not None
                     ):
                         dataset_row = self._get_dataset_row_for_update(
@@ -6884,12 +6898,16 @@ class SyncDatabase:
         now = utcnow_iso()
         with self.backend.transaction(connection) as conn:
             if (
-                state.domain == "notes.task"
+                state.domain in {"notes.task", "notes.task_activity"}
                 and trusted_notes_task_bootstrap_id is not None
             ):
                 row = self._require_dataset(state.dataset_id, connection=conn)
                 metadata = decode_json(row.get("metadata_json"), default={})
-                readiness = metadata.get("notes_task_v1")
+                readiness = metadata.get(
+                    "notes_task_v1"
+                    if state.domain == "notes.task"
+                    else "notes_task_activity_v1"
+                )
                 if (
                     not isinstance(readiness, Mapping)
                     or readiness.get("state") != "bootstrapping"

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -18,7 +18,10 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
 )
 from tldw_Server_API.app.core.Sync.v2.models import normalize_sync_timestamp
 from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    NotesTaskActivityTombstoneV1,
+    NotesTaskActivityV1,
     NotesTaskV1Payload,
+    notes_task_activity_object_hash,
     notes_task_object_hash,
     parse_notes_task_v1,
 )
@@ -614,6 +617,10 @@ class TaskStore:
     @staticmethod
     def _sync_task_materialization_checkpoint(_stage: str) -> None:
         """No-op seam used to prove product transaction rollback."""
+
+    @staticmethod
+    def _sync_task_activity_materialization_checkpoint(_stage: str) -> None:
+        """No-op seam used to prove activity transaction rollback."""
 
     @staticmethod
     def _sync_task_metadata(payload: NotesTaskV1Payload) -> dict[str, Any]:
@@ -1897,6 +1904,447 @@ class TaskStore:
             return updated
 
         return self._with_transaction(_execute_delete, conn)
+
+    @staticmethod
+    def _sync_activity_legacy_context(
+        payload: NotesTaskActivityV1,
+    ) -> tuple[str | None, str | None, str | None]:
+        """Map verified legacy context into the existing audit columns."""
+
+        context = payload.metadata.get("legacy_context")
+        if not isinstance(context, Mapping):
+            return None, None, None
+        return tuple(
+            value if isinstance((value := context.get(field)), str) else None
+            for field in ("tool_name", "policy_mode", "approval_id")
+        )
+
+    def _require_sync_activity_parents(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        payload: NotesTaskActivityV1,
+        conn: TaskConnection,
+    ) -> None:
+        """Require exact owner/dataset/note/task and correction scope."""
+
+        note = self._read(
+            "SELECT id FROM notes WHERE client_id = ? AND id = ?",
+            (owner_user_id, payload.note_id),
+            conn=conn,
+        ).fetchone()
+        if note is None:
+            raise ConflictError(
+                "Sync task activity note not found.",
+                entity="task_activity",
+                entity_id=payload.activity_id,
+            )  # noqa: TRY003
+        if payload.task_id is not None:
+            task = self._fetch_task(
+                payload.task_id,
+                owner_user_id=owner_user_id,
+                dataset_id=dataset_id,
+                include_deleted=True,
+                conn=conn,
+            )
+            if task is None or task["note_id"] != payload.note_id:
+                raise ConflictError(
+                    "Sync task activity task scope does not match its note.",
+                    entity="task_activity",
+                    entity_id=payload.activity_id,
+                )  # noqa: TRY003
+        if payload.corrects_activity_id is not None:
+            corrected = self.get_sync_task_activity(
+                owner_user_id=owner_user_id,
+                dataset_id=dataset_id,
+                activity_id=payload.corrects_activity_id,
+                conn=conn,
+            )
+            if (
+                corrected is None
+                or corrected["note_id"] != payload.note_id
+                or corrected["task_id"] != payload.task_id
+            ):
+                raise ConflictError(
+                    "Sync task activity correction scope does not match its target.",
+                    entity="task_activity",
+                    entity_id=payload.activity_id,
+                )  # noqa: TRY003
+
+    @staticmethod
+    def _sync_activity_create_row_matches(
+        row: Mapping[str, Any],
+        payload: NotesTaskActivityV1,
+    ) -> bool:
+        """Return whether immutable product columns equal a canonical create."""
+
+        tool_name, policy_mode, approval_id = TaskStore._sync_activity_legacy_context(payload)
+        return bool(
+            row["id"] == payload.activity_id
+            and row["note_id"] == payload.note_id
+            and row["task_id"] == payload.task_id
+            and row["event_type"] == payload.event_type
+            and row["actor_type"] == payload.actor_type
+            and row["actor_id"] == payload.actor_id
+            and row["tool_name"] == tool_name
+            and row["policy_mode"] == policy_mode
+            and row["approval_id"] == approval_id
+            and row["old_value_json"] == payload.old_value
+            and row["new_value_json"] == payload.new_value
+            and row["source_device_id"] == payload.source_device_id
+            and normalize_sync_timestamp(row["client_occurred_at"])
+            == payload.client_occurred_at
+            and row["source_kind"] == payload.source_kind
+            and row["corrects_activity_id"] == payload.corrects_activity_id
+            and row.get("source_diagnostic_code") is None
+            and row.get("source_diagnostic_hash") is None
+        )
+
+    def verify_sync_task_activity_postcondition(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        payload: NotesTaskActivityV1 | NotesTaskActivityTombstoneV1,
+        sync_revision: int,
+        sync_object_hash: str,
+        sync_server_cursor: int,
+        original_payload: NotesTaskActivityV1 | None = None,
+        conn: TaskConnection | None = None,
+    ) -> bool:
+        """Return whether the exact immutable activity state is durable."""
+
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        activity_id = (
+            payload.activity_id
+            if isinstance(payload, NotesTaskActivityV1)
+            else (original_payload.activity_id if original_payload is not None else "")
+        )
+
+        def _verify(read_conn: TaskConnection | None) -> bool:
+            row = self.get_sync_task_activity(
+                owner_user_id=owner,
+                dataset_id=dataset,
+                activity_id=activity_id,
+                conn=read_conn,
+            )
+            if row is None:
+                return False
+            create_payload = payload if isinstance(payload, NotesTaskActivityV1) else original_payload
+            if create_payload is None or not self._sync_activity_create_row_matches(row, create_payload):
+                return False
+            lifecycle_matches = (
+                not bool(row["deleted"])
+                and row["deleted_at"] is None
+                and row["delete_reason"] is None
+                if sync_revision == 1
+                else bool(row["deleted"])
+                and isinstance(payload, NotesTaskActivityTombstoneV1)
+                and normalize_sync_timestamp(row["deleted_at"]) == payload.deleted_at
+                and row["delete_reason"] == payload.delete_reason
+            )
+            return bool(
+                row["owner_user_id"] == owner
+                and row["dataset_id"] == dataset
+                and int(row["sync_revision"]) == sync_revision
+                and row["sync_object_hash"] == sync_object_hash
+                and int(row["sync_server_cursor"]) == sync_server_cursor
+                and lifecycle_matches
+            )
+
+        return self._with_scoped_read(dataset_id=dataset, conn=conn, fn=_verify)
+
+    def create_sync_task_activity(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        payload: NotesTaskActivityV1,
+        sync_object_hash: str,
+        sync_server_cursor: int,
+        conn: TaskConnection,
+    ) -> dict[str, Any]:
+        """Insert one canonical revision-1 activity exactly once."""
+
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        expected_hash = notes_task_activity_object_hash(payload, revision=1, deleted=False)
+        if sync_object_hash != expected_hash or isinstance(sync_server_cursor, bool) or sync_server_cursor < 1:
+            raise ConflictError(
+                "Sync task activity create lineage is invalid.",
+                entity="task_activity",
+                entity_id=payload.activity_id,
+            )  # noqa: TRY003
+        self._require_authorized_write_scope(conn, owner_user_id=owner, dataset_id=dataset)
+        if self.get_sync_task_activity(
+            owner_user_id=owner,
+            dataset_id=dataset,
+            activity_id=payload.activity_id,
+            conn=conn,
+        ) is not None:
+            raise ConflictError(
+                "Sync task activity identity already exists.",
+                entity="task_activity",
+                entity_id=payload.activity_id,
+            )  # noqa: TRY003
+        self._require_sync_activity_parents(
+            owner_user_id=owner,
+            dataset_id=dataset,
+            payload=payload,
+            conn=conn,
+        )
+        tool_name, policy_mode, approval_id = self._sync_activity_legacy_context(payload)
+        now = self._db._get_current_utc_timestamp_iso()
+        self._execute(
+            conn,
+            """
+            INSERT INTO task_events (
+                owner_user_id, dataset_id, id, task_id, note_id, event_type, actor_type,
+                actor_id, tool_name, policy_mode, approval_id, old_value_json, new_value_json,
+                created_at, client_id, sync_revision, sync_object_hash, sync_server_cursor,
+                source_device_id, client_occurred_at, source_kind, corrects_activity_id,
+                deleted, deleted_at, delete_reason, source_diagnostic_code,
+                source_diagnostic_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL)
+            """,
+            (
+                owner,
+                dataset,
+                payload.activity_id,
+                payload.task_id,
+                payload.note_id,
+                payload.event_type,
+                payload.actor_type,
+                payload.actor_id,
+                tool_name,
+                policy_mode,
+                approval_id,
+                json.dumps(payload.old_value, sort_keys=True) if payload.old_value is not None else None,
+                json.dumps(payload.new_value, sort_keys=True) if payload.new_value is not None else None,
+                now,
+                self._db.client_id,
+                sync_object_hash,
+                sync_server_cursor,
+                payload.source_device_id,
+                payload.client_occurred_at,
+                payload.source_kind,
+                payload.corrects_activity_id,
+                self._deleted_value(False),
+            ),
+        )
+        self._sync_task_activity_materialization_checkpoint("create")
+        if not self.verify_sync_task_activity_postcondition(
+            owner_user_id=owner,
+            dataset_id=dataset,
+            payload=payload,
+            sync_revision=1,
+            sync_object_hash=sync_object_hash,
+            sync_server_cursor=sync_server_cursor,
+            conn=conn,
+        ):
+            raise CharactersRAGDBError("Sync task activity create postcondition failed.")  # noqa: TRY003
+        created = self.get_sync_task_activity(
+            owner_user_id=owner,
+            dataset_id=dataset,
+            activity_id=payload.activity_id,
+            conn=conn,
+        )
+        if created is None:
+            raise CharactersRAGDBError("Sync task activity create readback failed.")  # noqa: TRY003
+        return created
+
+    def tombstone_sync_task_activity(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        activity_id: str,
+        payload: NotesTaskActivityTombstoneV1,
+        original_payload: NotesTaskActivityV1,
+        base_server_cursor: int,
+        base_hash: str,
+        sync_object_hash: str,
+        sync_server_cursor: int,
+        conn: TaskConnection,
+    ) -> dict[str, Any]:
+        """Apply the exact one-way revision-2 activity tombstone CAS."""
+
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        expected_hash = notes_task_activity_object_hash(
+            payload,
+            revision=2,
+            deleted=True,
+            activity_id=activity_id,
+            original_create_hash=base_hash,
+        )
+        if (
+            activity_id != original_payload.activity_id
+            or sync_object_hash != expected_hash
+            or isinstance(sync_server_cursor, bool)
+            or sync_server_cursor < 1
+        ):
+            raise ConflictError(
+                "Sync task activity tombstone lineage is invalid.",
+                entity="task_activity",
+                entity_id=activity_id,
+            )  # noqa: TRY003
+        self._require_authorized_write_scope(conn, owner_user_id=owner, dataset_id=dataset)
+        current = self.get_sync_task_activity(
+            owner_user_id=owner,
+            dataset_id=dataset,
+            activity_id=activity_id,
+            conn=conn,
+        )
+        if (
+            current is None
+            or bool(current["deleted"])
+            or int(current["sync_revision"]) != 1
+            or current["sync_server_cursor"] != base_server_cursor
+            or current["sync_object_hash"] != base_hash
+            or not self._sync_activity_create_row_matches(current, original_payload)
+        ):
+            raise ConflictError(
+                "Sync task activity base state does not match.",
+                entity="task_activity",
+                entity_id=activity_id,
+            )  # noqa: TRY003
+        cursor = self._execute(
+            conn,
+            """
+            UPDATE task_events
+               SET sync_revision = 2, sync_object_hash = ?, sync_server_cursor = ?,
+                   deleted = ?, deleted_at = ?, delete_reason = ?,
+                   source_diagnostic_code = NULL, source_diagnostic_hash = NULL
+             WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+               AND sync_revision = 1 AND sync_object_hash = ? AND deleted = ?
+            """,
+            (
+                sync_object_hash,
+                sync_server_cursor,
+                self._deleted_value(True),
+                payload.deleted_at,
+                payload.delete_reason,
+                owner,
+                dataset,
+                activity_id,
+                base_hash,
+                self._deleted_value(False),
+            ),
+        )
+        if cursor.rowcount != 1:
+            raise ConflictError(
+                "Sync task activity tombstone compare-and-swap failed.",
+                entity="task_activity",
+                entity_id=activity_id,
+            )  # noqa: TRY003
+        self._sync_task_activity_materialization_checkpoint("tombstone")
+        if not self.verify_sync_task_activity_postcondition(
+            owner_user_id=owner,
+            dataset_id=dataset,
+            payload=payload,
+            original_payload=original_payload,
+            sync_revision=2,
+            sync_object_hash=sync_object_hash,
+            sync_server_cursor=sync_server_cursor,
+            conn=conn,
+        ):
+            raise CharactersRAGDBError("Sync task activity tombstone postcondition failed.")  # noqa: TRY003
+        tombstoned = self.get_sync_task_activity(
+            owner_user_id=owner,
+            dataset_id=dataset,
+            activity_id=activity_id,
+            conn=conn,
+        )
+        if tombstoned is None:
+            raise CharactersRAGDBError("Sync task activity tombstone readback failed.")  # noqa: TRY003
+        return tombstoned
+
+    def get_sync_task_activity(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        activity_id: str,
+        conn: TaskConnection | None = None,
+    ) -> dict[str, Any] | None:
+        """Read one activity through its exact canonical scope."""
+
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+
+        def _get(read_conn: TaskConnection | None) -> dict[str, Any] | None:
+            row = self._read(
+                """
+                SELECT e.* FROM task_events e
+                JOIN notes n ON n.client_id = e.owner_user_id AND n.id = e.note_id
+                LEFT JOIN note_tasks t
+                  ON t.owner_user_id = e.owner_user_id AND t.dataset_id = e.dataset_id
+                 AND t.id = e.task_id AND t.note_id = e.note_id
+                WHERE e.owner_user_id = ? AND e.dataset_id = ? AND e.id = ?
+                  AND (e.task_id IS NULL OR t.id IS NOT NULL)
+                """,
+                (owner, dataset, activity_id),
+                conn=read_conn,
+            ).fetchone()
+            return self._decode_event_row(row)
+
+        return self._with_scoped_read(dataset_id=dataset, conn=conn, fn=_get)
+
+    def page_sync_task_activity(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        after_server_cursor: int | None = None,
+        after_activity_id: str | None = None,
+        limit: int = 100,
+        conn: TaskConnection | None = None,
+    ) -> list[dict[str, Any]]:
+        """Keyset-page canonical activity by server cursor and activity ID."""
+
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        if (after_server_cursor is None) != (after_activity_id is None):
+            raise InputError("Activity keyset cursor fields must be provided together.")  # noqa: TRY003
+        if after_server_cursor is not None and (
+            isinstance(after_server_cursor, bool)
+            or not isinstance(after_server_cursor, int)
+            or after_server_cursor < 1
+            or not isinstance(after_activity_id, str)
+            or not after_activity_id
+        ):
+            raise InputError("Activity keyset cursor is invalid.")  # noqa: TRY003
+        try:
+            bounded_limit = min(max(int(limit), 1), 1_000)
+        except (TypeError, ValueError) as exc:
+            raise InputError("limit must be an integer.") from exc  # noqa: TRY003
+        clauses = [
+            "e.owner_user_id = ?",
+            "e.dataset_id = ?",
+            "e.sync_server_cursor IS NOT NULL",
+            "(e.task_id IS NULL OR t.id IS NOT NULL)",
+        ]
+        params: list[Any] = [owner, dataset]
+        if after_server_cursor is not None:
+            clauses.append(
+                "(e.sync_server_cursor > ? OR "
+                "(e.sync_server_cursor = ? AND e.id > ?))"
+            )
+            params.extend((after_server_cursor, after_server_cursor, after_activity_id))
+        params.append(bounded_limit)
+        query = (
+            "SELECT e.* FROM task_events e "
+            "JOIN notes n ON n.client_id = e.owner_user_id AND n.id = e.note_id "
+            "LEFT JOIN note_tasks t ON t.owner_user_id = e.owner_user_id "
+            "AND t.dataset_id = e.dataset_id AND t.id = e.task_id AND t.note_id = e.note_id "
+            "WHERE "
+            + " AND ".join(clauses)
+            + " ORDER BY e.sync_server_cursor ASC, e.id ASC LIMIT ?"
+        )
+
+        def _page(read_conn: TaskConnection | None) -> list[dict[str, Any]]:
+            rows = self._read(query, tuple(params), conn=read_conn).fetchall()
+            return [self._decode_event_row(row) for row in rows]
+
+        return self._with_scoped_read(dataset_id=dataset, conn=conn, fn=_page)
 
     def record_task_event(
         self,

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -21,6 +21,7 @@ from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
     NotesTaskActivityTombstoneV1,
     NotesTaskActivityV1,
     NotesTaskV1Payload,
+    convert_legacy_task_event,
     notes_task_activity_object_hash,
     notes_task_object_hash,
     parse_notes_task_v1,
@@ -1290,6 +1291,66 @@ class TaskStore:
         decoded["sync_payload"] = payload.model_dump(mode="json")
         return decoded
 
+    def page_legacy_events_for_sync_bootstrap(
+        self,
+        *,
+        owner_user_id: str,
+        dataset_id: str,
+        after_created_at: str | None = None,
+        after_activity_id: str | None = None,
+        limit: int = 1_000,
+        conn: TaskConnection | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return one exact legacy/adopted activity source page."""
+
+        if isinstance(limit, bool) or not 1 <= limit <= 1_000:
+            raise ValueError("Notes task activity bootstrap page limit must be 1..1000")
+        if (after_created_at is None) != (after_activity_id is None):
+            raise ValueError("Notes task activity bootstrap cursor fields must be paired")
+        normalized_after = normalize_sync_timestamp(after_created_at)
+        if after_created_at is not None and (
+            normalized_after != after_created_at
+            or not isinstance(after_activity_id, str)
+            or not after_activity_id
+        ):
+            raise ValueError("Notes task activity bootstrap cursor is invalid")
+        owner, dataset = self._scope(owner_user_id, dataset_id)
+        clauses = [
+            "e.owner_user_id = ?",
+            "e.dataset_id = ?",
+            "((e.sync_server_cursor IS NULL "
+            "AND e.source_diagnostic_code = 'legacy_task_activity_unverified') "
+            "OR (e.sync_server_cursor IS NOT NULL "
+            "AND e.source_kind = 'trusted_bootstrap_v1'))",
+            "(e.task_id IS NULL OR t.id IS NOT NULL)",
+        ]
+        params: list[Any] = [owner, dataset]
+        if normalized_after is not None:
+            clauses.append("(e.created_at > ? OR (e.created_at = ? AND e.id > ?))")
+            params.extend((normalized_after, normalized_after, after_activity_id))
+        params.append(limit)
+        query = (
+            "SELECT e.*, t.note_id AS resolved_task_note_id FROM task_events e "
+            "LEFT JOIN note_tasks t ON t.owner_user_id = e.owner_user_id "
+            "AND t.dataset_id = e.dataset_id AND t.id = e.task_id "
+            "WHERE "
+            + " AND ".join(clauses)
+            + " ORDER BY e.created_at ASC, e.id ASC LIMIT ?"
+        )
+
+        def _page(read_conn: TaskConnection | None) -> list[dict[str, Any]]:
+            rows = self._read(query, tuple(params), conn=read_conn).fetchall()
+            result: list[dict[str, Any]] = []
+            for raw in rows:
+                row = self._decode_event_row(raw)
+                if row is None:
+                    continue
+                row["created_at"] = normalize_sync_timestamp(row.get("created_at"))
+                result.append(row)
+            return result
+
+        return self._with_scoped_read(dataset_id=dataset, conn=conn, fn=_page)
+
     def update_unlinked_task_metadata_record_only(
         self,
         *,
@@ -2076,17 +2137,12 @@ class TaskStore:
                 entity_id=payload.activity_id,
             )  # noqa: TRY003
         self._require_authorized_write_scope(conn, owner_user_id=owner, dataset_id=dataset)
-        if self.get_sync_task_activity(
+        existing = self.get_sync_task_activity(
             owner_user_id=owner,
             dataset_id=dataset,
             activity_id=payload.activity_id,
             conn=conn,
-        ) is not None:
-            raise ConflictError(
-                "Sync task activity identity already exists.",
-                entity="task_activity",
-                entity_id=payload.activity_id,
-            )  # noqa: TRY003
+        )
         self._require_sync_activity_parents(
             owner_user_id=owner,
             dataset_id=dataset,
@@ -2094,6 +2150,85 @@ class TaskStore:
             conn=conn,
         )
         tool_name, policy_mode, approval_id = self._sync_activity_legacy_context(payload)
+        if existing is not None:
+            if not self._legacy_sync_activity_matches(
+                existing,
+                payload=payload,
+                owner_user_id=owner,
+                dataset_id=dataset,
+                conn=conn,
+            ):
+                raise ConflictError(
+                    "Sync task activity identity already exists.",
+                    entity="task_activity",
+                    entity_id=payload.activity_id,
+                )  # noqa: TRY003
+            cursor = self._execute(
+                conn,
+                """
+                UPDATE task_events
+                   SET event_type = ?, actor_type = ?, actor_id = ?, tool_name = ?,
+                       policy_mode = ?, approval_id = ?, old_value_json = ?,
+                       new_value_json = ?, sync_revision = 1, sync_object_hash = ?,
+                       sync_server_cursor = ?, source_device_id = ?, client_occurred_at = ?,
+                       source_kind = ?, corrects_activity_id = ?, deleted = ?,
+                       deleted_at = NULL, delete_reason = NULL,
+                       source_diagnostic_code = NULL, source_diagnostic_hash = NULL
+                 WHERE owner_user_id = ? AND dataset_id = ? AND id = ?
+                   AND sync_server_cursor IS NULL
+                   AND source_diagnostic_code = 'legacy_task_activity_unverified'
+                """,
+                (
+                    payload.event_type,
+                    payload.actor_type,
+                    payload.actor_id,
+                    tool_name,
+                    policy_mode,
+                    approval_id,
+                    json.dumps(payload.old_value, sort_keys=True)
+                    if payload.old_value is not None
+                    else None,
+                    json.dumps(payload.new_value, sort_keys=True)
+                    if payload.new_value is not None
+                    else None,
+                    sync_object_hash,
+                    sync_server_cursor,
+                    payload.source_device_id,
+                    payload.client_occurred_at,
+                    payload.source_kind,
+                    payload.corrects_activity_id,
+                    self._deleted_value(False),
+                    owner,
+                    dataset,
+                    payload.activity_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise ConflictError(
+                    "Sync task activity legacy adoption compare-and-swap failed.",
+                    entity="task_activity",
+                    entity_id=payload.activity_id,
+                )  # noqa: TRY003
+            self._sync_task_activity_materialization_checkpoint("adopt")
+            if not self.verify_sync_task_activity_postcondition(
+                owner_user_id=owner,
+                dataset_id=dataset,
+                payload=payload,
+                sync_revision=1,
+                sync_object_hash=sync_object_hash,
+                sync_server_cursor=sync_server_cursor,
+                conn=conn,
+            ):
+                raise CharactersRAGDBError("Sync task activity adoption postcondition failed.")  # noqa: TRY003
+            adopted = self.get_sync_task_activity(
+                owner_user_id=owner,
+                dataset_id=dataset,
+                activity_id=payload.activity_id,
+                conn=conn,
+            )
+            if adopted is None:
+                raise CharactersRAGDBError("Sync task activity adoption readback failed.")  # noqa: TRY003
+            return adopted
         now = self._db._get_current_utc_timestamp_iso()
         self._execute(
             conn,
@@ -2152,6 +2287,65 @@ class TaskStore:
         if created is None:
             raise CharactersRAGDBError("Sync task activity create readback failed.")  # noqa: TRY003
         return created
+
+    def _legacy_sync_activity_matches(
+        self,
+        row: Mapping[str, Any],
+        *,
+        payload: NotesTaskActivityV1,
+        owner_user_id: str,
+        dataset_id: str,
+        conn: TaskConnection,
+    ) -> bool:
+        """Verify that an unmaterialized legacy row converts to the payload."""
+
+        if (
+            row.get("sync_server_cursor") is not None
+            or row.get("source_diagnostic_code") != "legacy_task_activity_unverified"
+            or bool(row.get("deleted"))
+        ):
+            return False
+        resolved_note_id: str | None = None
+        if row.get("task_id") is not None:
+            task = self._fetch_task(
+                str(row["task_id"]),
+                owner_user_id=owner_user_id,
+                dataset_id=dataset_id,
+                include_deleted=True,
+                conn=conn,
+            )
+            if task is None:
+                return False
+            resolved_note_id = str(task["note_id"])
+        source = {
+            key: row.get(key)
+            for key in (
+                "id",
+                "task_id",
+                "note_id",
+                "event_type",
+                "actor_type",
+                "actor_id",
+                "tool_name",
+                "policy_mode",
+                "approval_id",
+                "old_value",
+                "new_value",
+                "created_at",
+                "client_id",
+            )
+        }
+        source["old_value"] = row.get("old_value_json")
+        source["new_value"] = row.get("new_value_json")
+        try:
+            converted = convert_legacy_task_event(
+                source,
+                owner_user_id=owner_user_id,
+                resolved_task_note_id=resolved_note_id,
+            )
+        except Exception:  # noqa: BLE001 - mismatch is a closed boolean result.
+            return False
+        return converted.model_dump(mode="json") == payload.model_dump(mode="json")
 
     def tombstone_sync_task_activity(
         self,

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -1329,8 +1329,9 @@ class TaskStore:
             clauses.append("(e.created_at > ? OR (e.created_at = ? AND e.id > ?))")
             params.extend((normalized_after, normalized_after, after_activity_id))
         params.append(limit)
+        # Predicate fragments are fixed above; every value remains parameterized.
         query = (
-            "SELECT e.*, t.note_id AS resolved_task_note_id FROM task_events e "
+            "SELECT e.*, t.note_id AS resolved_task_note_id FROM task_events e "  # nosec B608
             "LEFT JOIN note_tasks t ON t.owner_user_id = e.owner_user_id "
             "AND t.dataset_id = e.dataset_id AND t.id = e.task_id "
             "WHERE "
@@ -2524,8 +2525,9 @@ class TaskStore:
             )
             params.extend((after_server_cursor, after_server_cursor, after_activity_id))
         params.append(bounded_limit)
+        # Predicate fragments are fixed above; every value remains parameterized.
         query = (
-            "SELECT e.* FROM task_events e "
+            "SELECT e.* FROM task_events e "  # nosec B608
             "JOIN notes n ON n.client_id = e.owner_user_id AND n.id = e.note_id "
             "LEFT JOIN note_tasks t ON t.owner_user_id = e.owner_user_id "
             "AND t.dataset_id = e.dataset_id AND t.id = e.task_id AND t.note_id = e.note_id "

--- a/tldw_Server_API/app/core/Notes_Tasks/service.py
+++ b/tldw_Server_API/app/core/Notes_Tasks/service.py
@@ -8,6 +8,7 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import date
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
+from uuid import UUID
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import ConflictError, InputError
 from tldw_Server_API.app.core.Notes.organization_capture import (
@@ -17,7 +18,12 @@ from tldw_Server_API.app.core.Notes.organization_capture import (
 from tldw_Server_API.app.core.Notes_Tasks.markdown_parser import parse_note_checklists
 from tldw_Server_API.app.core.Notes_Tasks.models import ParsedChecklistItem, ReconciliationResult, TaskActor
 from tldw_Server_API.app.core.Notes_Tasks.reconciler import NotesTaskReconciler
-from tldw_Server_API.app.core.Sync.v2.models import SyncOperation
+from tldw_Server_API.app.core.Sync.v2.models import SyncOperation, normalize_sync_timestamp
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    NotesTaskActivityV1,
+    TaskActivitySource,
+    parse_notes_task_activity_v1,
+)
 from tldw_Server_API.app.core.Sync.v2.server_origin_batch import ServerOriginMutationStep
 
 if TYPE_CHECKING:
@@ -178,6 +184,14 @@ class TaskStoreScope:
 
 
 @dataclass(frozen=True, slots=True)
+class NotesTaskActivityCapture:
+    """One deterministic dormant activity derived from a task transition."""
+
+    payload: NotesTaskActivityV1
+    step: ServerOriginMutationStep
+
+
+@dataclass(frozen=True, slots=True)
 class NotesTaskCaptureMutation:
     """Canonical dormant capture input for one committed product task mutation."""
 
@@ -192,6 +206,13 @@ class NotesTaskCaptureMutation:
     restore_intent: bool
     idempotency_key: str
     step: ServerOriginMutationStep
+    activity: NotesTaskActivityCapture
+
+    @property
+    def steps(self) -> tuple[ServerOriginMutationStep, ServerOriginMutationStep]:
+        """Return the future atomic task/activity plan in dependency order."""
+
+        return self.step, self.activity.step
 
 
 class NotesTaskCaptureCallback(Protocol):
@@ -203,6 +224,196 @@ class NotesTaskCaptureCallback(Protocol):
         *,
         conn: TaskConnection | None,
     ) -> None: ...
+
+
+def _task_activity_metadata(row: dict[str, Any]) -> dict[str, object]:
+    payload = row["sync_payload"]
+    return {
+        key: payload[key]
+        for key in (
+            "description",
+            "priority",
+            "due_date",
+            "estimate",
+            "recurrence",
+            "assignee_id",
+            "tags",
+            "custom",
+        )
+    }
+
+
+def _task_activity_values(
+    before: dict[str, Any] | None,
+    after: dict[str, Any],
+) -> tuple[str, dict[str, object] | None, dict[str, object]]:
+    """Derive the sole canonical activity shape for one accepted transition."""
+
+    after_payload = after["sync_payload"]
+    if before is None:
+        return (
+            "created",
+            None,
+            {
+                "title": after_payload["title"],
+                "status": after_payload["status"],
+                "completed_at": after_payload["completed_at"],
+                "metadata": _task_activity_metadata(after),
+            },
+        )
+    before_payload = before["sync_payload"]
+    if not bool(before.get("deleted")) and bool(after.get("deleted")):
+        return (
+            "deleted",
+            {
+                "deleted": False,
+                "projection_status": str(before["projection_status"]),
+            },
+            {"deleted": True, "projection_status": "deleted"},
+        )
+    if bool(before.get("deleted")) and not bool(after.get("deleted")):
+        return (
+            "restored",
+            {"deleted": True, "projection_status": "deleted"},
+            {
+                "deleted": False,
+                "projection_status": str(after["projection_status"]),
+            },
+        )
+    before_status = str(before_payload["status"])
+    after_status = str(after_payload["status"])
+    if (before_status, after_status) == ("open", "done"):
+        return "completed", {"status": "open"}, {"status": "done"}
+    if (before_status, after_status) == ("done", "open"):
+        return "reopened", {"status": "done"}, {"status": "open"}
+    before_projection = str(before["projection_status"])
+    after_projection = str(after["projection_status"])
+    if before_projection == "live" and after_projection == "unlinked":
+        return (
+            "projection_unlinked",
+            {"projection_status": "live"},
+            {"projection_status": "unlinked"},
+        )
+    if before_projection in {"unlinked", "ambiguous"} and after_projection == "live":
+        return (
+            "projection_linked",
+            {"projection_status": before_projection},
+            {"projection_status": "live"},
+        )
+    before_metadata = _task_activity_metadata(before)
+    after_metadata = _task_activity_metadata(after)
+    if before_payload["title"] != after_payload["title"]:
+        return (
+            "updated",
+            {"title": before_payload["title"], "metadata": before_metadata},
+            {"title": after_payload["title"], "metadata": after_metadata},
+        )
+    if before_metadata != after_metadata:
+        return "updated", {"metadata": before_metadata}, {"metadata": after_metadata}
+    raise ConflictError(
+        "Task transition has no portable activity.",
+        entity="tasks",
+        entity_id=str(after.get("id") or ""),
+    )
+
+
+def build_task_activity_capture(
+    *,
+    db: CharactersRAGDB,
+    owner_user_id: str,
+    dataset_id: str,
+    actor: TaskActor,
+    before: dict[str, Any] | None,
+    after: dict[str, Any],
+    source_kind: TaskActivitySource = "rest",
+) -> NotesTaskActivityCapture:
+    """Build one strict, stable activity from canonical product task rows."""
+
+    owner = str(owner_user_id)
+    dataset = str(dataset_id)
+    after_row = db.task_store._sync_bootstrap_task_row(after, owner)
+    before_row = (
+        db.task_store._sync_bootstrap_task_row(before, owner)
+        if before is not None
+        else None
+    )
+    if (
+        after_row.get("owner_user_id") != owner
+        or after_row.get("dataset_id") != dataset
+        or (
+            before_row is not None
+            and (
+                before_row.get("owner_user_id") != owner
+                or before_row.get("dataset_id") != dataset
+                or before_row.get("id") != after_row.get("id")
+                or before_row.get("note_id") != after_row.get("note_id")
+            )
+        )
+    ):
+        raise ConflictError(
+            "Task activity capture scope is invalid.",
+            entity="tasks",
+            entity_id=str(after_row.get("id") or ""),
+        )
+    event_type, old_value, new_value = _task_activity_values(before_row, after_row)
+    occurred_at = normalize_sync_timestamp(after_row.get("updated_at"))
+    if occurred_at is None:
+        raise ConflictError(
+            "Task activity capture timestamp is invalid.",
+            entity="tasks",
+            entity_id=str(after_row.get("id") or ""),
+        )
+    identity_hash = hashlib.sha256(
+        json.dumps(
+            [
+                owner,
+                dataset,
+                after_row["id"],
+                int(after_row.get("version") or 0),
+                int(after_row["canonical_revision"]),
+                after_row["canonical_hash"],
+                event_type,
+                old_value,
+                new_value,
+            ],
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    activity_id = str(UUID(bytes=bytes.fromhex(identity_hash[:32]), version=4))
+    payload = parse_notes_task_activity_v1(
+        {
+            "activity_id": activity_id,
+            "note_id": str(after_row["note_id"]),
+            "task_id": str(after_row["id"]),
+            "event_type": event_type,
+            "actor_type": actor.actor_type,
+            "actor_id": actor.actor_id,
+            "source_device_id": None,
+            "client_occurred_at": occurred_at,
+            "source_kind": source_kind,
+            "corrects_activity_id": None,
+            "old_value": old_value,
+            "new_value": new_value,
+            "metadata": {},
+        },
+        owner_user_id=owner,
+        bound_actor_type=actor.actor_type,
+        bound_actor_id=actor.actor_id,
+        authenticated_device_id=None,
+        trusted_server_origin=True,
+    )
+    step = ServerOriginMutationStep(
+        domain="notes.task_activity",
+        operation="upsert",
+        object_id=activity_id,
+        parent_id=str(after_row["note_id"]),
+        payload=payload.model_dump(mode="json"),
+        created_at_client=occurred_at,
+        client_envelope_id=f"notes-task-activity-server-{identity_hash[:32]}",
+        object_revision=1,
+    )
+    return NotesTaskActivityCapture(payload=payload, step=step)
 
 
 def build_task_capture_mutation(
@@ -289,6 +500,14 @@ def build_task_capture_mutation(
         client_envelope_id=f"notes-task-server-{identity_hash[:32]}",
         object_revision=revision,
     )
+    activity = build_task_activity_capture(
+        db=db,
+        owner_user_id=owner,
+        dataset_id=dataset,
+        actor=actor,
+        before=before,
+        after=after,
+    )
     return NotesTaskCaptureMutation(
         owner_user_id=owner,
         dataset_id=dataset,
@@ -301,6 +520,7 @@ def build_task_capture_mutation(
         restore_intent=restore_intent,
         idempotency_key=f"notes-task-capture-{identity_hash}",
         step=step,
+        activity=activity,
     )
 
 

--- a/tldw_Server_API/app/core/Notes_Tasks/service.py
+++ b/tldw_Server_API/app/core/Notes_Tasks/service.py
@@ -227,6 +227,8 @@ class NotesTaskCaptureCallback(Protocol):
 
 
 def _task_activity_metadata(row: dict[str, Any]) -> dict[str, object]:
+    """Return the portable metadata subset used by task activity events."""
+
     payload = row["sync_payload"]
     return {
         key: payload[key]

--- a/tldw_Server_API/app/core/Sync/v2/adapters.py
+++ b/tldw_Server_API/app/core/Sync/v2/adapters.py
@@ -95,6 +95,7 @@ SyncAdapterOutcome = AdapterAccepted | AdapterRejected | AdapterConflict | Adapt
 SyncHead = SyncEnvelope | SyncEnvelopeCreate
 SyncHeadLookup = Callable[[SyncDomain, str], SyncHead | None]
 AuthorizedNoteLookup = Callable[[str], SyncHead | None]
+AuthorizedTaskLookup = Callable[[str], SyncHead | None]
 SyncDomainHeadLoader = Callable[[SyncDomain], Sequence[SyncHead]]
 BootstrapRelationshipVerifier = Callable[
     [SyncDomain, str, Mapping[str, object]], bool
@@ -129,8 +130,12 @@ class SyncAdapterContext:
     prior_envelopes: Sequence[SyncHead] = field(default_factory=tuple)
     get_head: SyncHeadLookup | None = None
     get_authorized_note: AuthorizedNoteLookup | None = None
+    get_authorized_task: AuthorizedTaskLookup | None = None
     list_heads: SyncDomainHeadLoader | None = None
     trusted_server_origin: bool = False
+    authenticated_actor_type: str | None = None
+    authenticated_actor_id: object = None
+    authenticated_device_id: str | None = None
     organization_group_state: str | None = None
     organization_bootstrap_id: str | None = None
     notes_link_bootstrap_id: str | None = None
@@ -485,6 +490,7 @@ __all__ = [
     "StaticSyncAdapter",
     "SyncAdapterContext",
     "SyncDomainHeadLoader",
+    "AuthorizedTaskLookup",
     "SyncHead",
     "SyncHeadLookup",
     "SyncAdapterOutcome",

--- a/tldw_Server_API/app/core/Sync/v2/adapters.py
+++ b/tldw_Server_API/app/core/Sync/v2/adapters.py
@@ -141,6 +141,7 @@ class SyncAdapterContext:
     notes_link_bootstrap_id: str | None = None
     attachment_ref_bootstrap_id: str | None = None
     notes_task_bootstrap_id: str | None = None
+    notes_task_activity_bootstrap_id: str | None = None
     bootstrap_relationship_verifier: BootstrapRelationshipVerifier | None = None
     bootstrap_relationship_absence_verifier: BootstrapRelationshipVerifier | None = None
     supports_attachments: bool = False

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/__init__.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/__init__.py
@@ -8,6 +8,7 @@ from .notes import NotesDomainAdapter
 from .notes_link import NotesLinkDomainAdapter
 from .notes_organization import NotesOrganizationDomainAdapter
 from .notes_task import NotesTaskDomainAdapter
+from .notes_task_activity import NotesTaskActivityDomainAdapter
 from .source_cache import SourceCacheAdapter
 from .workspaces import WorkspacesDomainAdapter
 
@@ -18,6 +19,7 @@ __all__ = [
     "NotesDomainAdapter",
     "NotesLinkDomainAdapter",
     "NotesTaskDomainAdapter",
+    "NotesTaskActivityDomainAdapter",
     "NotesOrganizationDomainAdapter",
     "SourceCacheAdapter",
     "WorkspacesDomainAdapter",

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task_activity.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task_activity.py
@@ -46,8 +46,22 @@ class NotesTaskActivityDomainAdapter:
             or envelope.operation not in {"upsert", "tombstone"}
             or envelope.adapter_version != 1
             or envelope.schema_version != 1
-            or envelope.routing_metadata
         ):
+            return _rejected(envelope, "notes_task_activity_payload_invalid")
+        trusted_bootstrap = _trusted_activity_bootstrap(envelope, context)
+        allowed_routing = (
+            {
+                "bootstrap_capture",
+                "bootstrap_id",
+                "source",
+                "origin",
+                "server_device_id",
+                "server_owner_user_id",
+            }
+            if trusted_bootstrap
+            else set()
+        )
+        if set(envelope.routing_metadata) != allowed_routing:
             return _rejected(envelope, "notes_task_activity_payload_invalid")
 
         head = _get_head(envelope, context)
@@ -65,7 +79,7 @@ class NotesTaskActivityDomainAdapter:
                 task_id is None or isinstance(task_id, str)
             ):
                 return _rejected(envelope, "notes_task_activity_payload_invalid")
-            parent_outcome = _authorize_parents(
+            parent_outcome = None if trusted_bootstrap else _authorize_parents(
                 envelope,
                 dataset=dataset,
                 context=context,
@@ -124,7 +138,7 @@ class NotesTaskActivityDomainAdapter:
         if envelope.object_id != activity_id or envelope.parent_id != note_id:
             return _conflict(envelope, "notes_task_activity_identity_conflict")
 
-        parent_outcome = _authorize_parents(
+        parent_outcome = None if trusted_bootstrap else _authorize_parents(
             envelope,
             dataset=dataset,
             context=context,
@@ -247,6 +261,31 @@ def _same_activity_scope(
         return False
     payload = head.payload
     return payload.get("note_id") == note_id and payload.get("task_id") == task_id
+
+
+def _trusted_activity_bootstrap(
+    envelope: SyncEnvelopeCreate,
+    context: SyncAdapterContext | None,
+) -> bool:
+    """Return whether context and routing authorize legacy activity capture."""
+
+    bootstrap_id = envelope.routing_metadata.get("bootstrap_id")
+    metadata = envelope.payload.get("metadata")
+    return bool(
+        context is not None
+        and context.trusted_server_origin
+        and isinstance(bootstrap_id, str)
+        and bootstrap_id
+        and context.notes_task_activity_bootstrap_id == bootstrap_id
+        and envelope.operation == "upsert"
+        and envelope.payload.get("source_kind") == "trusted_bootstrap_v1"
+        and isinstance(metadata, dict)
+        and metadata.get("legacy_source_verified") is True
+        and envelope.routing_metadata.get("bootstrap_capture") is True
+        and envelope.routing_metadata.get("source")
+        == "notes-task-activity-bootstrap"
+        and envelope.routing_metadata.get("origin") == "server"
+    )
 
 
 def _exact_semantic_replay(head: SyncHead, envelope: SyncEnvelopeCreate) -> bool:

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task_activity.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes_task_activity.py
@@ -1,0 +1,318 @@
+"""Strict dormant Sync v1 adapter for immutable Notes task activity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from tldw_Server_API.app.core.exceptions import NotesTaskContractError
+
+from ..adapters import (
+    AdapterAccepted,
+    AdapterConflict,
+    AdapterDeferred,
+    AdapterRejected,
+    SyncAdapterContext,
+    SyncAdapterOutcome,
+    SyncHead,
+)
+from ..models import SyncDataset, SyncEnvelopeCreate
+from ..notes_task_contract import (
+    NotesTaskActivityV1,
+    notes_task_activity_object_hash,
+    parse_notes_task_activity_tombstone_v1,
+    parse_notes_task_activity_v1,
+)
+from ._lineage import incoming_references_exact_head
+
+
+@dataclass(slots=True)
+class NotesTaskActivityDomainAdapter:
+    """Validate immutable activity lineage without public domain activation."""
+
+    domain: str = "notes.task_activity"
+    supported_adapter_versions: set[int] = field(default_factory=lambda: {1})
+
+    def evaluate_envelope(
+        self,
+        envelope: SyncEnvelopeCreate,
+        *,
+        dataset: SyncDataset,
+        context: SyncAdapterContext | None = None,
+    ) -> SyncAdapterOutcome:
+        """Return a stable authorization, lineage, or acceptance outcome."""
+
+        if (
+            envelope.domain != self.domain
+            or envelope.operation not in {"upsert", "tombstone"}
+            or envelope.adapter_version != 1
+            or envelope.schema_version != 1
+            or envelope.routing_metadata
+        ):
+            return _rejected(envelope, "notes_task_activity_payload_invalid")
+
+        head = _get_head(envelope, context)
+        exact_replay = head is not None and _exact_semantic_replay(head, envelope)
+        if head is not None and _is_deleted(head) and not exact_replay:
+            return _conflict(envelope, "notes_task_activity_immutable")
+
+        if context is None or context.authenticated_actor_type is None:
+            return _rejected(envelope, "notes_task_activity_authorization_unavailable")
+
+        if exact_replay and envelope.operation == "tombstone":
+            note_id = envelope.payload.get("note_id")
+            task_id = envelope.payload.get("task_id")
+            if not isinstance(note_id, str) or not (
+                task_id is None or isinstance(task_id, str)
+            ):
+                return _rejected(envelope, "notes_task_activity_payload_invalid")
+            parent_outcome = _authorize_parents(
+                envelope,
+                dataset=dataset,
+                context=context,
+                note_id=note_id,
+                task_id=task_id,
+            )
+            return parent_outcome or AdapterAccepted(
+                client_envelope_id=envelope.client_envelope_id
+            )
+
+        original: NotesTaskActivityV1 | None = None
+        try:
+            if envelope.operation == "upsert":
+                payload = parse_notes_task_activity_v1(
+                    envelope.payload,
+                    owner_user_id=dataset.owner_user_id,
+                    bound_actor_type=context.authenticated_actor_type,
+                    bound_actor_id=context.authenticated_actor_id,
+                    authenticated_device_id=context.authenticated_device_id,
+                    trusted_server_origin=context.trusted_server_origin,
+                )
+                expected_hash = notes_task_activity_object_hash(
+                    payload,
+                    revision=1,
+                    deleted=False,
+                )
+            else:
+                if head is None:
+                    return _conflict(envelope, "notes_task_activity_base_conflict")
+                original = _parse_stored_create(head, dataset.owner_user_id)
+                payload = parse_notes_task_activity_tombstone_v1(
+                    envelope.payload,
+                    envelope_created_at_client=envelope.created_at_client or "",
+                    original_activity=original,
+                )
+                expected_hash = notes_task_activity_object_hash(
+                    payload,
+                    revision=2,
+                    deleted=True,
+                    activity_id=envelope.object_id,
+                    original_create_hash=head.payload_hash,
+                )
+            expected_revision = 1 if envelope.operation == "upsert" else 2
+            if (
+                envelope.object_revision != expected_revision
+                or envelope.entity_version != expected_revision
+                or envelope.payload_hash != expected_hash
+            ):
+                raise NotesTaskContractError("activity lineage is invalid")
+        except NotesTaskContractError:
+            return _rejected(envelope, "notes_task_activity_payload_invalid")
+
+        note_id = payload.note_id
+        task_id = payload.task_id
+        activity_id = payload.activity_id if isinstance(payload, NotesTaskActivityV1) else envelope.object_id
+        if envelope.object_id != activity_id or envelope.parent_id != note_id:
+            return _conflict(envelope, "notes_task_activity_identity_conflict")
+
+        parent_outcome = _authorize_parents(
+            envelope,
+            dataset=dataset,
+            context=context,
+            note_id=note_id,
+            task_id=task_id,
+        )
+        if parent_outcome is not None:
+            return parent_outcome
+
+        if isinstance(payload, NotesTaskActivityV1):
+            if not context.trusted_server_origin and payload.event_type != "corrected":
+                return _rejected(envelope, "notes_task_activity_origin_invalid")
+            if payload.corrects_activity_id is not None:
+                target = _lookup_head(context, payload.corrects_activity_id)
+                if not _same_activity_scope(target, dataset.dataset_id, note_id, task_id):
+                    return _parent_deferred(envelope)
+
+        if exact_replay:
+            return AdapterAccepted(client_envelope_id=envelope.client_envelope_id)
+
+        if head is None:
+            if envelope.operation != "upsert" or _has_base(envelope):
+                return _conflict(envelope, "notes_task_activity_base_conflict")
+            return AdapterAccepted(client_envelope_id=envelope.client_envelope_id)
+
+        if envelope.operation == "upsert":
+            return _conflict(envelope, "notes_task_activity_identity_reused")
+        if not _same_activity_scope(head, dataset.dataset_id, note_id, task_id):
+            return _conflict(envelope, "notes_task_activity_identity_conflict")
+        if not incoming_references_exact_head(envelope, head):
+            return _conflict(envelope, "notes_task_activity_base_conflict")
+        return AdapterAccepted(client_envelope_id=envelope.client_envelope_id)
+
+
+def _get_head(
+    envelope: SyncEnvelopeCreate,
+    context: SyncAdapterContext | None,
+) -> SyncHead | None:
+    """Load the current activity head when a lookup is available."""
+
+    return _lookup_head(context, envelope.object_id)
+
+
+def _lookup_head(context: SyncAdapterContext | None, object_id: str) -> SyncHead | None:
+    """Load one activity head without exposing other scopes."""
+
+    if context is None:
+        return None
+    if context.get_head is not None:
+        return context.get_head("notes.task_activity", object_id)
+    return next(
+        (
+            item
+            for item in reversed(tuple(context.prior_envelopes))
+            if item.domain == "notes.task_activity" and item.object_id == object_id
+        ),
+        None,
+    )
+
+
+def _parse_stored_create(head: SyncHead, owner_user_id: str) -> NotesTaskActivityV1:
+    """Re-validate one accepted live create using its stored provenance."""
+
+    payload = head.payload
+    source_kind = payload.get("source_kind")
+    trusted = source_kind != "client"
+    return parse_notes_task_activity_v1(
+        payload,
+        owner_user_id=owner_user_id,
+        bound_actor_type=str(payload.get("actor_type")),
+        bound_actor_id=payload.get("actor_id"),
+        authenticated_device_id=(None if trusted else head.device_id),
+        trusted_server_origin=trusted,
+    )
+
+
+def _authorize_parents(
+    envelope: SyncEnvelopeCreate,
+    *,
+    dataset: SyncDataset,
+    context: SyncAdapterContext,
+    note_id: str,
+    task_id: str | None,
+) -> SyncAdapterOutcome | None:
+    """Authorize the required note and optional same-note live task."""
+
+    if context.get_authorized_note is None:
+        return _rejected(envelope, "notes_task_activity_authorization_unavailable")
+    note = context.get_authorized_note(note_id)
+    if note is None or note.dataset_id != dataset.dataset_id:
+        return _parent_deferred(envelope)
+    if _is_deleted(note):
+        return _conflict(envelope, "notes_task_activity_parent_conflict")
+    if task_id is None:
+        return None
+    if context.get_authorized_task is None:
+        return _rejected(envelope, "notes_task_activity_authorization_unavailable")
+    task = context.get_authorized_task(task_id)
+    if (
+        task is None
+        or task.dataset_id != dataset.dataset_id
+        or task.parent_id != note_id
+        or task.payload.get("note_id") != note_id
+    ):
+        return _parent_deferred(envelope)
+    if _is_deleted(task):
+        return _conflict(envelope, "notes_task_activity_parent_conflict")
+    return None
+
+
+def _same_activity_scope(
+    head: SyncHead | None,
+    dataset_id: str,
+    note_id: str,
+    task_id: str | None,
+) -> bool:
+    """Return whether one activity head has the exact authorized parents."""
+
+    if head is None or head.dataset_id != dataset_id or head.parent_id != note_id:
+        return False
+    payload = head.payload
+    return payload.get("note_id") == note_id and payload.get("task_id") == task_id
+
+
+def _exact_semantic_replay(head: SyncHead, envelope: SyncEnvelopeCreate) -> bool:
+    """Return whether an immutable ID and canonical fingerprint are unchanged."""
+
+    return bool(
+        head.dataset_id == envelope.dataset_id
+        and head.operation == envelope.operation
+        and head.object_id == envelope.object_id
+        and head.parent_id == envelope.parent_id
+        and head.object_revision == envelope.object_revision
+        and head.entity_version == envelope.entity_version
+        and head.payload_hash == envelope.payload_hash
+        and head.payload == envelope.payload
+        and head.deleted == envelope.deleted
+    )
+
+
+def _has_base(envelope: SyncEnvelopeCreate) -> bool:
+    """Return whether any optimistic lineage token was supplied."""
+
+    return any(
+        value is not None
+        for value in (
+            envelope.base_server_cursor,
+            envelope.base_object_revision,
+            envelope.base_object_hash,
+        )
+    )
+
+
+def _is_deleted(head: SyncHead) -> bool:
+    """Return whether an activity or parent head is tombstoned."""
+
+    return head.operation == "tombstone" or head.deleted
+
+
+def _parent_deferred(envelope: SyncEnvelopeCreate) -> AdapterDeferred:
+    """Return a sanitized parent/target dependency outcome."""
+
+    return AdapterDeferred(
+        client_envelope_id=envelope.client_envelope_id,
+        message="The authorized activity parent is not available yet",
+    )
+
+
+def _rejected(envelope: SyncEnvelopeCreate, error_code: str) -> AdapterRejected:
+    """Build a bounded activity validation rejection."""
+
+    return AdapterRejected(
+        client_envelope_id=envelope.client_envelope_id,
+        error_code=error_code,
+        message="notes.task_activity envelope validation failed",
+    )
+
+
+def _conflict(envelope: SyncEnvelopeCreate, conflict_type: str) -> AdapterConflict:
+    """Build a bounded immutable activity conflict."""
+
+    return AdapterConflict(
+        client_envelope_id=envelope.client_envelope_id,
+        domain=envelope.domain,
+        entity_id=envelope.object_id,
+        conflict_type=conflict_type,
+        message="notes.task_activity immutable lineage conflicted",
+    )
+
+
+__all__ = ["NotesTaskActivityDomainAdapter"]

--- a/tldw_Server_API/app/core/Sync/v2/factory.py
+++ b/tldw_Server_API/app/core/Sync/v2/factory.py
@@ -24,6 +24,7 @@ from .domain_adapters.notes import NotesDomainAdapter
 from .domain_adapters.notes_link import NotesLinkDomainAdapter
 from .domain_adapters.notes_organization import NotesOrganizationDomainAdapter
 from .domain_adapters.notes_task import NotesTaskDomainAdapter
+from .domain_adapters.notes_task_activity import NotesTaskActivityDomainAdapter
 from .domain_adapters.source_cache import SourceCacheAdapter
 from .domain_adapters.workspaces import WorkspacesDomainAdapter
 from .materializers import (
@@ -34,6 +35,7 @@ from .materializers import (
     NotesLinkMaterializer,
     NotesMaterializer,
     NotesOrganizationMaterializer,
+    NotesTaskActivityMaterializer,
     NotesTaskMaterializer,
     SourceCacheMaterializer,
     SyncMaterializer,
@@ -49,6 +51,7 @@ from .models import (
 from .notes_attachment_bootstrap import NotesAttachmentBootstrapper
 from .notes_link_bootstrap import NotesLinkBootstrapper
 from .notes_organization_bootstrap import NotesOrganizationBootstrapper
+from .notes_task_activity_bootstrap import NotesTaskActivityBootstrapper
 from .notes_task_bootstrap import NotesTaskBootstrapper
 from .security import server_trusted_encryption_status_from_env
 from .service import SyncV2Service, SyncV2Settings
@@ -81,6 +84,7 @@ def default_sync_v2_registry() -> SyncAdapterRegistry:
         + [NotesOrganizationDomainAdapter(domain=domain) for domain in NOTES_ORGANIZATION_DOMAINS]
         + [NotesLinkDomainAdapter()]
         + [NotesTaskDomainAdapter()]
+        + [NotesTaskActivityDomainAdapter()]
     )
 
 
@@ -102,6 +106,7 @@ def sync_v2_service_for_user(user_id: str) -> SyncV2Service:
         "notes.note": NotesMaterializer(note_db),
         "notes.link": NotesLinkMaterializer(note_db),
         "notes.task": NotesTaskMaterializer(note_db),
+        "notes.task_activity": NotesTaskActivityMaterializer(note_db),
         "source_cache.entry": SourceCacheMaterializer(),
         "media.item": MediaMetadataMaterializer(domain="media.item"),
         "media.keyword": MediaMetadataMaterializer(domain="media.keyword"),
@@ -136,6 +141,7 @@ def sync_v2_service_for_user(user_id: str) -> SyncV2Service:
         notes_link_bootstrapper=NotesLinkBootstrapper(note_db),
         notes_attachment_bootstrapper=NotesAttachmentBootstrapper(note_db),
         notes_task_bootstrapper=NotesTaskBootstrapper(note_db),
+        notes_task_activity_bootstrapper=NotesTaskActivityBootstrapper(note_db),
     )
 
 
@@ -191,6 +197,18 @@ def _validate_notes_task_components(
     if not isinstance(materializers.get("notes.task"), NotesTaskMaterializer):
         raise RuntimeError(
             "Private Sync domain has no user-bound materializer: notes.task"
+        )
+    if not isinstance(
+        adapters.get("notes.task_activity"), NotesTaskActivityDomainAdapter
+    ):
+        raise RuntimeError(
+            "Private Sync domain has no strict adapter: notes.task_activity"
+        )
+    if not isinstance(
+        materializers.get("notes.task_activity"), NotesTaskActivityMaterializer
+    ):
+        raise RuntimeError(
+            "Private Sync domain has no user-bound materializer: notes.task_activity"
         )
 
 

--- a/tldw_Server_API/app/core/Sync/v2/materializers/__init__.py
+++ b/tldw_Server_API/app/core/Sync/v2/materializers/__init__.py
@@ -10,6 +10,7 @@ from .notes import NotesMaterializer
 from .notes_link import NotesLinkMaterializer
 from .notes_organization import NotesOrganizationMaterializer
 from .notes_task import NotesTaskMaterializer
+from .notes_task_activity import NotesTaskActivityMaterializer
 from .source_cache import SourceCacheMaterializer
 
 __all__ = [
@@ -22,6 +23,7 @@ __all__ = [
     "NotesLinkMaterializer",
     "NotesOrganizationMaterializer",
     "NotesTaskMaterializer",
+    "NotesTaskActivityMaterializer",
     "SourceCacheMaterializer",
     "SyncMaterializer",
 ]

--- a/tldw_Server_API/app/core/Sync/v2/materializers/notes_task_activity.py
+++ b/tldw_Server_API/app/core/Sync/v2/materializers/notes_task_activity.py
@@ -1,0 +1,347 @@
+"""Materialize immutable ``notes.task_activity`` envelopes into task events."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from loguru import logger
+
+from tldw_Server_API.app.core.DB_Management.backends.base import (
+    DatabaseError as BackendDatabaseError,
+)
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    CharactersRAGDBError,
+    ConflictError,
+    InputError,
+)
+from tldw_Server_API.app.core.exceptions import NotesTaskContractError
+
+from ..models import SyncEnvelope, SyncObjectState
+from ..notes_task_contract import (
+    NotesTaskActivityTombstoneV1,
+    NotesTaskActivityV1,
+    notes_task_activity_object_hash,
+    parse_notes_task_activity_tombstone_v1,
+    parse_notes_task_activity_v1,
+)
+from ..store import SyncV2Store
+from .base import MaterializationResult
+
+_ERROR_CODE = "notes_task_activity_projection_failed"
+_CONFLICT_TYPE = "notes_task_activity_product_conflict"
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedActivityEnvelope:
+    payload: NotesTaskActivityV1 | NotesTaskActivityTombstoneV1
+    original: NotesTaskActivityV1
+
+
+@dataclass(slots=True)
+class NotesTaskActivityMaterializer:
+    """Apply accepted dormant activity envelopes with immutable replay checks."""
+
+    note_db: CharactersRAGDB
+    domain: str = "notes.task_activity"
+
+    def apply(
+        self,
+        envelope: SyncEnvelope,
+        *,
+        store: SyncV2Store,
+    ) -> MaterializationResult:
+        """Commit one product event, then repair Sync projection bookkeeping."""
+
+        if envelope.domain != self.domain:
+            return MaterializationResult(status="skipped")
+        if envelope.server_cursor is None:
+            return MaterializationResult(
+                status="failed",
+                error_code=_ERROR_CODE,
+                message="Stored notes.task_activity envelope is missing a server cursor",
+            )
+        try:
+            parsed = _parse_envelope(
+                envelope,
+                store=store,
+                owner_user_id=str(self.note_db.client_id),
+            )
+        except NotesTaskContractError:
+            return _mark_failed(
+                envelope,
+                store,
+                "notes.task_activity envelope validation failed",
+            )
+
+        task_store = self.note_db.task_store
+        if task_store.verify_sync_task_activity_postcondition(
+            owner_user_id=str(self.note_db.client_id),
+            dataset_id=envelope.dataset_id,
+            payload=parsed.payload,
+            original_payload=parsed.original,
+            sync_revision=int(envelope.object_revision or 0),
+            sync_object_hash=envelope.payload_hash or "",
+            sync_server_cursor=envelope.server_cursor,
+        ):
+            return _record_applied(envelope, store)
+
+        current_state = store.get_object_state(
+            envelope.dataset_id,
+            envelope.domain,
+            envelope.object_id,
+        )
+        conflict = _state_conflict(envelope, current_state)
+        if conflict is not None:
+            return _mark_conflict(envelope, store, conflict)
+
+        try:
+            with self.note_db.transaction() as conn:
+                common = {
+                    "owner_user_id": str(self.note_db.client_id),
+                    "dataset_id": envelope.dataset_id,
+                    "sync_object_hash": envelope.payload_hash or "",
+                    "sync_server_cursor": envelope.server_cursor,
+                    "conn": conn,
+                }
+                if isinstance(parsed.payload, NotesTaskActivityV1):
+                    task_store.create_sync_task_activity(
+                        payload=parsed.payload,
+                        **common,
+                    )
+                else:
+                    task_store.tombstone_sync_task_activity(
+                        activity_id=envelope.object_id,
+                        payload=parsed.payload,
+                        original_payload=parsed.original,
+                        base_server_cursor=envelope.base_server_cursor or 0,
+                        base_hash=envelope.base_object_hash or "",
+                        **common,
+                    )
+            return _record_applied(envelope, store)
+        except ConflictError:
+            return _mark_conflict(
+                envelope,
+                store,
+                _conflict_result("product_state_conflict"),
+            )
+        except Exception as exc:  # noqa: BLE001 - product commit must remain replayable.
+            logger.warning(
+                "Failed to materialize notes.task_activity envelope {} for object {}: {}",
+                envelope.client_envelope_id,
+                envelope.object_id,
+                type(exc).__name__,
+            )
+            return _mark_failed(envelope, store, _safe_error_message(exc))
+
+
+def _parse_create(envelope: SyncEnvelope, owner_user_id: str) -> NotesTaskActivityV1:
+    """Parse and verify one immutable activity create envelope."""
+
+    source_kind = envelope.payload.get("source_kind")
+    trusted = source_kind != "client"
+    payload = parse_notes_task_activity_v1(
+        envelope.payload,
+        owner_user_id=owner_user_id,
+        bound_actor_type=str(envelope.payload.get("actor_type")),
+        bound_actor_id=envelope.payload.get("actor_id"),
+        authenticated_device_id=None if trusted else envelope.device_id,
+        trusted_server_origin=trusted,
+    )
+    if (
+        envelope.operation != "upsert"
+        or envelope.object_revision != 1
+        or envelope.entity_version != 1
+        or envelope.object_id != payload.activity_id
+        or envelope.parent_id != payload.note_id
+        or envelope.payload_hash
+        != notes_task_activity_object_hash(payload, revision=1, deleted=False)
+    ):
+        raise NotesTaskContractError("notes.task_activity create lineage is invalid")
+    return payload
+
+
+def _parse_envelope(
+    envelope: SyncEnvelope,
+    *,
+    store: SyncV2Store,
+    owner_user_id: str,
+) -> _ParsedActivityEnvelope:
+    """Parse and verify one canonical activity envelope and its original create."""
+
+    if (
+        envelope.adapter_version != 1
+        or envelope.schema_version != 1
+        or envelope.operation not in {"upsert", "tombstone"}
+        or envelope.routing_metadata
+    ):
+        raise NotesTaskContractError("notes.task_activity envelope lineage is invalid")
+    if envelope.operation == "upsert":
+        payload = _parse_create(envelope, owner_user_id)
+        return _ParsedActivityEnvelope(payload=payload, original=payload)
+    if (
+        envelope.object_revision != 2
+        or envelope.entity_version != 2
+        or envelope.base_server_cursor is None
+        or envelope.base_object_revision != 1
+        or envelope.base_object_hash is None
+    ):
+        raise NotesTaskContractError("notes.task_activity tombstone lineage is invalid")
+    original_envelope = store.get_envelope_by_server_cursor(envelope.base_server_cursor)
+    if (
+        original_envelope is None
+        or original_envelope.dataset_id != envelope.dataset_id
+        or original_envelope.domain != envelope.domain
+        or original_envelope.object_id != envelope.object_id
+        or original_envelope.payload_hash != envelope.base_object_hash
+    ):
+        raise NotesTaskContractError("notes.task_activity original create is unavailable")
+    original = _parse_create(original_envelope, owner_user_id)
+    payload = parse_notes_task_activity_tombstone_v1(
+        envelope.payload,
+        envelope_created_at_client=envelope.created_at_client or "",
+        original_activity=original,
+    )
+    expected_hash = notes_task_activity_object_hash(
+        payload,
+        revision=2,
+        deleted=True,
+        activity_id=envelope.object_id,
+        original_create_hash=envelope.base_object_hash,
+    )
+    if (
+        envelope.object_id != original.activity_id
+        or envelope.parent_id != payload.note_id
+        or envelope.payload_hash != expected_hash
+    ):
+        raise NotesTaskContractError("notes.task_activity tombstone identity is invalid")
+    return _ParsedActivityEnvelope(payload=payload, original=original)
+
+
+def _state_conflict(
+    envelope: SyncEnvelope,
+    current: SyncObjectState | None,
+) -> MaterializationResult | None:
+    """Return a deterministic conflict unless the immutable transition is current."""
+
+    if current is None:
+        if envelope.operation == "upsert" and all(
+            value is None
+            for value in (
+                envelope.base_server_cursor,
+                envelope.base_object_revision,
+                envelope.base_object_hash,
+            )
+        ):
+            return None
+        return _conflict_result("missing_server_object")
+    if (
+        current.latest_server_cursor == envelope.server_cursor
+        and current.object_revision == envelope.object_revision
+        and current.object_hash == envelope.payload_hash
+        and current.deleted == (envelope.operation == "tombstone")
+    ):
+        return _conflict_result("divergent_product_replay")
+    if envelope.operation != "tombstone" or current.deleted:
+        return _conflict_result("immutable_activity")
+    if (
+        envelope.base_server_cursor != current.latest_server_cursor
+        or envelope.base_object_revision != current.object_revision
+        or envelope.base_object_hash != current.object_hash
+    ):
+        return _conflict_result("stale_base_state")
+    return None
+
+
+def _record_applied(envelope: SyncEnvelope, store: SyncV2Store) -> MaterializationResult:
+    """Record the immutable activity head and applied envelope status."""
+
+    try:
+        store.upsert_object_state(
+            SyncObjectState(
+                dataset_id=envelope.dataset_id,
+                domain=envelope.domain,
+                object_id=envelope.object_id,
+                object_revision=int(envelope.object_revision or 0),
+                object_hash=envelope.payload_hash or "",
+                latest_server_cursor=envelope.server_cursor,
+                deleted=envelope.operation == "tombstone",
+            )
+        )
+        store.mark_envelope_apply_status(envelope.server_cursor, apply_status="applied")
+        return MaterializationResult(status="applied")
+    except Exception as exc:  # noqa: BLE001 - split commits must remain replayable.
+        return _mark_failed(envelope, store, _safe_error_message(exc))
+
+
+def _mark_conflict(
+    envelope: SyncEnvelope,
+    store: SyncV2Store,
+    result: MaterializationResult,
+) -> MaterializationResult:
+    """Persist one deterministic immutable-product conflict."""
+
+    try:
+        store.mark_envelope_apply_status(
+            envelope.server_cursor,
+            apply_status="conflict",
+            apply_error_code=_CONFLICT_TYPE,
+            apply_error_message=result.message,
+        )
+    except Exception as exc:  # noqa: BLE001 - preserve the deterministic conflict.
+        logger.warning(
+            "Could not persist notes.task_activity conflict for cursor {}: {}",
+            envelope.server_cursor,
+            type(exc).__name__,
+        )
+    return result
+
+
+def _mark_failed(
+    envelope: SyncEnvelope,
+    store: SyncV2Store,
+    message: str,
+) -> MaterializationResult:
+    """Persist and return a bounded replayable activity projection failure."""
+
+    try:
+        store.mark_envelope_apply_status(
+            envelope.server_cursor,
+            apply_status="failed",
+            apply_error_code=_ERROR_CODE,
+            apply_error_message=message,
+        )
+    except Exception as exc:  # noqa: BLE001 - preserve a replayable failed result.
+        logger.warning(
+            "Could not persist failed notes.task_activity status for cursor {}: {}",
+            envelope.server_cursor,
+            type(exc).__name__,
+        )
+    return MaterializationResult(status="failed", error_code=_ERROR_CODE, message=message)
+
+
+def _conflict_result(reason: str) -> MaterializationResult:
+    """Build the stable immutable product conflict result."""
+
+    return MaterializationResult(
+        status="conflict",
+        conflict_type=_CONFLICT_TYPE,
+        message="notes.task_activity product state does not match its immutable lineage",
+        metadata={"reason": reason},
+    )
+
+
+def _safe_error_message(exc: Exception) -> str:
+    """Map internal activity projection failures to bounded public messages."""
+
+    if isinstance(exc, NotesTaskContractError):
+        return "notes.task_activity envelope validation failed"
+    if isinstance(exc, InputError):
+        return "notes.task_activity dependency validation failed"
+    if isinstance(exc, (CharactersRAGDBError, BackendDatabaseError, sqlite3.DatabaseError)):
+        return "notes.task_activity product database operation failed"
+    return "notes.task_activity projection failed"
+
+
+__all__ = ["NotesTaskActivityMaterializer"]

--- a/tldw_Server_API/app/core/Sync/v2/materializers/notes_task_activity.py
+++ b/tldw_Server_API/app/core/Sync/v2/materializers/notes_task_activity.py
@@ -170,11 +170,29 @@ def _parse_envelope(
 ) -> _ParsedActivityEnvelope:
     """Parse and verify one canonical activity envelope and its original create."""
 
+    routing = envelope.routing_metadata
+    trusted_bootstrap_routing = bool(
+        set(routing)
+        == {
+            "bootstrap_capture",
+            "bootstrap_id",
+            "source",
+            "origin",
+            "server_device_id",
+            "server_owner_user_id",
+        }
+        and routing.get("bootstrap_capture") is True
+        and isinstance(routing.get("bootstrap_id"), str)
+        and routing.get("bootstrap_id")
+        and routing.get("source") == "notes-task-activity-bootstrap"
+        and routing.get("origin") == "server"
+        and envelope.payload.get("source_kind") == "trusted_bootstrap_v1"
+    )
     if (
         envelope.adapter_version != 1
         or envelope.schema_version != 1
         or envelope.operation not in {"upsert", "tombstone"}
-        or envelope.routing_metadata
+        or (routing and not trusted_bootstrap_routing)
     ):
         raise NotesTaskContractError("notes.task_activity envelope lineage is invalid")
     if envelope.operation == "upsert":

--- a/tldw_Server_API/app/core/Sync/v2/notes_task_activity_bootstrap.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_task_activity_bootstrap.py
@@ -1,0 +1,671 @@
+"""Bounded, resumable bootstrap for legacy Notes task activity."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.exceptions import (
+    NotesTaskBootstrapInterrupted,
+    NotesTaskContractError,
+)
+
+from .errors import SyncStoreError
+from .models import SyncDataset, SyncEnvelope
+from .notes_task_contract import (
+    NotesTaskActivityV1,
+    convert_legacy_task_event,
+    notes_task_activity_object_hash,
+    parse_notes_task_activity_v1,
+)
+from .server_origin_batch import (
+    ServerOriginMutationStep,
+    capture_server_origin_mutation_batch,
+)
+from .service import SyncV2Service
+
+_SOURCE = "notes-task-activity-bootstrap"
+_EMPTY_FINGERPRINT = hashlib.sha256(b"notes.task_activity.bootstrap.v1").hexdigest()
+
+
+class _SourceInvalid(RuntimeError):
+    """Internal marker for malformed legacy activity source data."""
+
+
+class _SourceChanged(RuntimeError):
+    """Internal marker for changed verified source history."""
+
+
+class NotesTaskActivityBootstrapper:
+    """Capture at most one owner-scoped legacy activity page per invocation."""
+
+    PAGE_LIMIT = 1_000
+
+    def __init__(
+        self,
+        note_db: CharactersRAGDB,
+        *,
+        page_limit: int = PAGE_LIMIT,
+        after_page: Callable[[int], None] | None = None,
+    ) -> None:
+        if isinstance(page_limit, bool) or not 1 <= page_limit <= self.PAGE_LIMIT:
+            raise ValueError("Notes task activity bootstrap page limit must be 1..1000")
+        self._db = note_db
+        self._tasks = note_db.task_store
+        self._page_limit = page_limit
+        self._after_page = after_page
+
+    def bootstrap(
+        self,
+        *,
+        service: SyncV2Service,
+        dataset: SyncDataset,
+    ) -> SyncDataset:
+        """Resume one bounded source page and return durable activity readiness."""
+
+        owner = dataset.owner_user_id
+        current = service.store.get_dataset(dataset.dataset_id, owner_user_id=owner)
+        if current is None:
+            raise SyncStoreError("Sync dataset was not found or is not accessible")
+        if self._tasks.resolve_task_compatibility_dataset_id(
+            owner_user_id=owner
+        ) != current.dataset_id:
+            raise SyncStoreError("notes_task_activity_readiness_source_scope_invalid")
+        task_state = current.metadata.get("notes_task_v1")
+        if not isinstance(task_state, Mapping) or task_state.get("state") != "ready":
+            raise SyncStoreError("notes_task_sync_not_ready")
+        if current.metadata.get("task_activity_capture_enabled") is not True:
+            raise SyncStoreError("notes_task_activity_sync_not_ready")
+
+        current = self._ensure_bootstrapping(service, current)
+        state = _readiness(current)
+        if state["state"] == "ready":
+            return current
+        if state["state"] != "bootstrapping":
+            raise SyncStoreError("notes_task_activity_sync_not_ready")
+
+        bootstrap_id = _bootstrap_id(owner, current.dataset_id)
+        try:
+            source = self._source_summary(
+                service=service,
+                owner=owner,
+                dataset_id=current.dataset_id,
+                bootstrap_id=bootstrap_id,
+            )
+            _verify_stored_progress(state, source)
+            after_created_at, after_activity_id = _split_cursor(
+                _optional_string(state.get("source_cursor"))
+            )
+            page = self._tasks.page_legacy_events_for_sync_bootstrap(
+                owner_user_id=owner,
+                dataset_id=current.dataset_id,
+                after_created_at=after_created_at,
+                after_activity_id=after_activity_id,
+                limit=self._page_limit,
+            )
+            running_count = int(state["source_count"])
+            running_fingerprint = str(
+                state.get("source_fingerprint") or _EMPTY_FINGERPRINT
+            )
+            for row in page:
+                source_row = self._source_row(
+                    service=service,
+                    owner=owner,
+                    dataset_id=current.dataset_id,
+                    bootstrap_id=bootstrap_id,
+                    row=row,
+                )
+                self._capture_row(
+                    service=service,
+                    dataset=current,
+                    bootstrap_id=bootstrap_id,
+                    source=source_row,
+                )
+                running_count += 1
+                running_fingerprint = _activity_bootstrap_fingerprint(
+                    running_fingerprint,
+                    source_row.cursor,
+                    source_row.canonical_hash,
+                )
+
+            if page and self._after_page is not None:
+                self._after_page(1)
+            if page:
+                current = service.store.transition_notes_task_activity_readiness(
+                    current.dataset_id,
+                    owner_user_id=owner,
+                    expected_state="bootstrapping",
+                    state="bootstrapping",
+                    source_dataset_id=current.dataset_id,
+                    source_cursor=_row_cursor(page[-1]),
+                    source_count=running_count,
+                    source_fingerprint=running_fingerprint,
+                )
+            if running_count < source.count:
+                return current
+            verified = self._source_summary(
+                service=service,
+                owner=owner,
+                dataset_id=current.dataset_id,
+                bootstrap_id=bootstrap_id,
+            )
+            if verified != source:
+                raise _SourceChanged
+            if (
+                running_count != source.count
+                or running_fingerprint != source.fingerprint
+                or not _sync_bootstrap_matches_source(
+                    service,
+                    current.dataset_id,
+                    bootstrap_id=bootstrap_id,
+                    source=source,
+                )
+            ):
+                raise _SourceChanged
+            current = service.store.transition_notes_task_activity_readiness(
+                current.dataset_id,
+                owner_user_id=owner,
+                expected_state="bootstrapping",
+                state="verifying",
+                source_dataset_id=current.dataset_id,
+                source_cursor=source.cursor,
+                source_count=source.count,
+                source_fingerprint=source.fingerprint,
+            )
+            return service.store.transition_notes_task_activity_readiness(
+                current.dataset_id,
+                owner_user_id=owner,
+                expected_state="verifying",
+                state="ready",
+                source_dataset_id=current.dataset_id,
+                source_cursor=source.cursor,
+                source_count=source.count,
+                source_fingerprint=source.fingerprint,
+            )
+        except NotesTaskBootstrapInterrupted:
+            raise
+        except _SourceChanged:
+            return _block(service, current, reason="notes_task_activity_source_changed")
+        except Exception as exc:  # noqa: BLE001 - details become bounded readiness.
+            if isinstance(exc, SyncStoreError) and str(exc) not in {
+                "notes_task_activity_source_invalid",
+                "notes_task_activity_source_changed",
+            }:
+                raise
+            return _block(service, current, reason="notes_task_activity_source_invalid")
+
+    def _ensure_bootstrapping(
+        self,
+        service: SyncV2Service,
+        dataset: SyncDataset,
+    ) -> SyncDataset:
+        """Enter or resume activity bootstrapping without enrolling the domain."""
+
+        state = _readiness(dataset)
+        if state.get("state") in {"bootstrapping", "ready"}:
+            return dataset
+        if state.get("state") == "blocked" and state.get("resume_phase") == "bootstrapping":
+            return service.store.transition_notes_task_activity_readiness(
+                dataset.dataset_id,
+                owner_user_id=dataset.owner_user_id,
+                expected_state="blocked",
+                state="bootstrapping",
+                source_dataset_id=dataset.dataset_id,
+                source_cursor=_optional_string(state.get("source_cursor")),
+                source_count=int(state["source_count"]),
+                source_fingerprint=(
+                    str(state["source_fingerprint"])
+                    if state.get("source_fingerprint") is not None
+                    else None
+                ),
+            )
+        if state.get("state") != "enrolling":
+            raise SyncStoreError("notes_task_activity_sync_not_ready")
+        return service.store.transition_notes_task_activity_readiness(
+            dataset.dataset_id,
+            owner_user_id=dataset.owner_user_id,
+            expected_state="enrolling",
+            state="bootstrapping",
+            source_dataset_id=dataset.dataset_id,
+            source_cursor=None,
+            source_count=0,
+            source_fingerprint=_EMPTY_FINGERPRINT,
+        )
+
+    def _source_summary(
+        self,
+        *,
+        service: SyncV2Service,
+        owner: str,
+        dataset_id: str,
+        bootstrap_id: str,
+    ) -> _SourceSummary:
+        """Read and validate the complete ordered legacy/adopted source identity."""
+
+        rows: list[_SourceRow] = []
+        after_created_at: str | None = None
+        after_activity_id: str | None = None
+        fingerprint = _EMPTY_FINGERPRINT
+        while True:
+            try:
+                page = self._tasks.page_legacy_events_for_sync_bootstrap(
+                    owner_user_id=owner,
+                    dataset_id=dataset_id,
+                    after_created_at=after_created_at,
+                    after_activity_id=after_activity_id,
+                    limit=self.PAGE_LIMIT,
+                )
+                for row in page:
+                    item = self._source_row(
+                        service=service,
+                        owner=owner,
+                        dataset_id=dataset_id,
+                        bootstrap_id=bootstrap_id,
+                        row=row,
+                    )
+                    rows.append(item)
+                    fingerprint = _activity_bootstrap_fingerprint(
+                        fingerprint,
+                        item.cursor,
+                        item.canonical_hash,
+                    )
+                    after_created_at, after_activity_id = _split_cursor(item.cursor)
+            except _SourceChanged:
+                raise
+            except Exception as exc:  # noqa: BLE001 - source details remain private.
+                raise _SourceInvalid from exc
+            if len(page) < self.PAGE_LIMIT:
+                break
+        cursor = rows[-1].cursor if rows else None
+        return _SourceSummary(tuple(rows), cursor, len(rows), fingerprint)
+
+    def _source_row(
+        self,
+        *,
+        service: SyncV2Service,
+        owner: str,
+        dataset_id: str,
+        bootstrap_id: str,
+        row: Mapping[str, object],
+    ) -> _SourceRow:
+        """Return one verified pending or already-adopted source row."""
+
+        cursor = _row_cursor(row)
+        if row.get("sync_server_cursor") is None:
+            payload = legacy_task_event_to_activity(row, owner_user_id=owner)
+            canonical_hash = notes_task_activity_object_hash(
+                payload,
+                revision=1,
+                deleted=False,
+            )
+        else:
+            envelope = service.store.get_envelope_by_server_cursor(
+                int(row["sync_server_cursor"])
+            )
+            if (
+                envelope is None
+                or envelope.dataset_id != dataset_id
+                or envelope.domain != "notes.task_activity"
+                or envelope.object_id != row.get("id")
+                or envelope.parent_id != row.get("note_id")
+                or envelope.operation != "upsert"
+                or envelope.object_revision != 1
+                or envelope.routing_metadata.get("bootstrap_id") != bootstrap_id
+                or envelope.apply_status != "applied"
+            ):
+                raise _SourceChanged
+            payload = _parse_bootstrap_payload(envelope, owner)
+            canonical_hash = notes_task_activity_object_hash(
+                payload,
+                revision=1,
+                deleted=False,
+            )
+            if (
+                envelope.payload_hash != canonical_hash
+                or row.get("sync_object_hash") != canonical_hash
+                or envelope.created_at_client != row.get("created_at")
+                or not self._tasks.verify_sync_task_activity_postcondition(
+                    owner_user_id=owner,
+                    dataset_id=dataset_id,
+                    payload=payload,
+                    sync_revision=1,
+                    sync_object_hash=canonical_hash,
+                    sync_server_cursor=int(row["sync_server_cursor"]),
+                )
+            ):
+                raise _SourceChanged
+        return _SourceRow(
+            activity_id=payload.activity_id,
+            note_id=payload.note_id,
+            cursor=cursor,
+            canonical_hash=canonical_hash,
+            payload=payload,
+        )
+
+    def _capture_row(
+        self,
+        *,
+        service: SyncV2Service,
+        dataset: SyncDataset,
+        bootstrap_id: str,
+        source: _SourceRow,
+    ) -> None:
+        """Capture and adopt one source-verified legacy event."""
+
+        step = ServerOriginMutationStep(
+            domain="notes.task_activity",
+            operation="upsert",
+            object_id=source.activity_id,
+            parent_id=source.note_id,
+            payload=source.payload.model_dump(mode="json"),
+            routing_metadata=_activity_bootstrap_routing(bootstrap_id),
+            client_envelope_id=_activity_bootstrap_envelope_id(
+                bootstrap_id,
+                source.activity_id,
+                source.canonical_hash,
+            ),
+            object_revision=1,
+            created_at_client=source.payload.client_occurred_at,
+        )
+
+        def source_matches(envelope: SyncEnvelope) -> bool:
+            """Verify source identity immediately before product adoption."""
+
+            current = self._tasks.get_sync_task_activity(
+                owner_user_id=dataset.owner_user_id,
+                dataset_id=dataset.dataset_id,
+                activity_id=source.activity_id,
+            )
+            if current is None:
+                return False
+            if current.get("sync_server_cursor") is not None:
+                return self._tasks.verify_sync_task_activity_postcondition(
+                    owner_user_id=dataset.owner_user_id,
+                    dataset_id=dataset.dataset_id,
+                    payload=source.payload,
+                    sync_revision=1,
+                    sync_object_hash=source.canonical_hash,
+                    sync_server_cursor=int(current["sync_server_cursor"]),
+                )
+            try:
+                converted = legacy_task_event_to_activity(
+                    current,
+                    owner_user_id=dataset.owner_user_id,
+                    resolved_task_note_id=(
+                        source.note_id if current.get("task_id") is not None else None
+                    ),
+                )
+            except NotesTaskContractError:
+                return False
+            return bool(
+                envelope.client_envelope_id == step.client_envelope_id
+                and envelope.object_id == source.activity_id
+                and envelope.parent_id == source.note_id
+                and envelope.payload_hash == source.canonical_hash
+                and dict(envelope.payload) == converted.model_dump(mode="json")
+            )
+
+        capture_server_origin_mutation_batch(
+            service=service,
+            user_id=dataset.owner_user_id,
+            steps=[step],
+            source=_SOURCE,
+            idempotency_key=(
+                f"{bootstrap_id}:{source.activity_id}:{source.canonical_hash}"
+            ),
+            trusted_notes_task_activity_bootstrap_id=bootstrap_id,
+            bootstrap_step_verifier=source_matches,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceRow:
+    activity_id: str
+    note_id: str
+    cursor: str
+    canonical_hash: str
+    payload: NotesTaskActivityV1
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceSummary:
+    rows: tuple[_SourceRow, ...]
+    cursor: str | None
+    count: int
+    fingerprint: str
+
+
+def legacy_task_event_to_activity(
+    row: Mapping[str, object],
+    *,
+    owner_user_id: str,
+    resolved_task_note_id: str | None = None,
+) -> NotesTaskActivityV1:
+    """Convert one exact decoded task-event row through the strict contract."""
+
+    resolved = (
+        resolved_task_note_id
+        if resolved_task_note_id is not None
+        else (
+            str(row["resolved_task_note_id"])
+            if row.get("resolved_task_note_id") is not None
+            else None
+        )
+    )
+    source = {
+        "id": row.get("id"),
+        "task_id": row.get("task_id"),
+        "note_id": row.get("note_id"),
+        "event_type": row.get("event_type"),
+        "actor_type": row.get("actor_type"),
+        "actor_id": row.get("actor_id"),
+        "tool_name": row.get("tool_name"),
+        "policy_mode": row.get("policy_mode"),
+        "approval_id": row.get("approval_id"),
+        "old_value": row.get("old_value_json", row.get("old_value")),
+        "new_value": row.get("new_value_json", row.get("new_value")),
+        "created_at": row.get("created_at"),
+        "client_id": row.get("client_id"),
+    }
+    return convert_legacy_task_event(
+        source,
+        owner_user_id=owner_user_id,
+        resolved_task_note_id=resolved,
+    )
+
+
+def _parse_bootstrap_payload(envelope: SyncEnvelope, owner: str) -> NotesTaskActivityV1:
+    """Re-validate one stored trusted-bootstrap activity payload."""
+
+    return parse_notes_task_activity_v1(
+        envelope.payload,
+        owner_user_id=owner,
+        bound_actor_type=str(envelope.payload.get("actor_type")),
+        bound_actor_id=envelope.payload.get("actor_id"),
+        authenticated_device_id=None,
+        trusted_server_origin=True,
+    )
+
+
+def _verify_stored_progress(state: Mapping[str, object], source: _SourceSummary) -> None:
+    """Reject readiness progress that is not an exact source prefix."""
+
+    count = int(state["source_count"])
+    cursor = _optional_string(state.get("source_cursor"))
+    fingerprint = str(state.get("source_fingerprint") or _EMPTY_FINGERPRINT)
+    if count == 0:
+        if cursor is not None or fingerprint != _EMPTY_FINGERPRINT:
+            raise _SourceChanged
+        return
+    if count > len(source.rows) or source.rows[count - 1].cursor != cursor:
+        raise _SourceChanged
+    expected = _EMPTY_FINGERPRINT
+    for row in source.rows[:count]:
+        expected = _activity_bootstrap_fingerprint(
+            expected,
+            row.cursor,
+            row.canonical_hash,
+        )
+    if expected != fingerprint:
+        raise _SourceChanged
+
+
+def _sync_bootstrap_matches_source(
+    service: SyncV2Service,
+    dataset_id: str,
+    *,
+    bootstrap_id: str,
+    source: _SourceSummary,
+) -> bool:
+    """Return whether applied bootstrap envelopes exactly cover the source."""
+
+    found: dict[str, tuple[str, str | None, str | None, str | None]] = {}
+    cursor = 0
+    while True:
+        page = service.store.list_envelopes_after(
+            dataset_id,
+            cursor,
+            limit=500,
+            domains=["notes.task_activity"],
+            status="accepted",
+        )
+        for envelope in page:
+            if envelope.server_cursor is None:
+                return False
+            cursor = envelope.server_cursor
+            if (
+                envelope.routing_metadata.get("bootstrap_id") != bootstrap_id
+                or envelope.apply_status != "applied"
+                or envelope.operation != "upsert"
+                or envelope.object_revision != 1
+                or envelope.object_id in found
+            ):
+                return False
+            found[envelope.object_id] = (
+                envelope.payload_hash or "",
+                envelope.parent_id,
+                envelope.created_at_client,
+                envelope.client_envelope_id,
+            )
+        if len(page) < 500:
+            break
+    if len(found) != source.count:
+        return False
+    return all(
+        found.get(row.activity_id)
+        == (
+            row.canonical_hash,
+            row.note_id,
+            row.payload.client_occurred_at,
+            _activity_bootstrap_envelope_id(
+                bootstrap_id,
+                row.activity_id,
+                row.canonical_hash,
+            ),
+        )
+        for row in source.rows
+    )
+
+
+def _block(
+    service: SyncV2Service,
+    dataset: SyncDataset,
+    *,
+    reason: str,
+) -> SyncDataset:
+    """Persist bounded blocked activity readiness while retaining progress."""
+
+    state = _readiness(dataset)
+    return service.store.transition_notes_task_activity_readiness(
+        dataset.dataset_id,
+        owner_user_id=dataset.owner_user_id,
+        expected_state="bootstrapping",
+        state="blocked",
+        source_dataset_id=dataset.dataset_id,
+        source_cursor=_optional_string(state.get("source_cursor")),
+        source_count=int(state["source_count"]),
+        source_fingerprint=(
+            str(state["source_fingerprint"])
+            if state.get("source_fingerprint") is not None
+            else None
+        ),
+        reason_code=reason,
+    )
+
+
+def _readiness(dataset: SyncDataset) -> Mapping[str, object]:
+    state = dataset.metadata.get("notes_task_activity_v1")
+    if not isinstance(state, Mapping):
+        raise SyncStoreError("notes_task_activity_readiness_state_invalid")
+    return state
+
+
+def _row_cursor(row: Mapping[str, object]) -> str:
+    created_at = row.get("created_at")
+    activity_id = row.get("id")
+    if not isinstance(created_at, str) or not isinstance(activity_id, str):
+        raise _SourceInvalid
+    return f"{created_at}|{activity_id}"
+
+
+def _split_cursor(value: str | None) -> tuple[str | None, str | None]:
+    if value is None:
+        return None, None
+    try:
+        created_at, activity_id = value.rsplit("|", 1)
+    except ValueError as exc:
+        raise _SourceChanged from exc
+    return created_at, activity_id
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _bootstrap_id(owner_user_id: str, dataset_id: str) -> str:
+    digest = hashlib.sha256(
+        f"notes.task_activity.bootstrap.v1:{owner_user_id}:{dataset_id}".encode()
+    ).hexdigest()
+    return f"notes-task-activity-bootstrap-{digest[:32]}"
+
+
+def _activity_bootstrap_envelope_id(
+    bootstrap_id: str,
+    activity_id: str,
+    canonical_hash: str,
+) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            [bootstrap_id, activity_id, canonical_hash],
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    return f"notes-task-activity-bootstrap-{digest[:32]}"
+
+
+def _activity_bootstrap_routing(bootstrap_id: str) -> dict[str, object]:
+    return {"bootstrap_capture": True, "bootstrap_id": bootstrap_id}
+
+
+def _activity_bootstrap_fingerprint(
+    previous_fingerprint: str | None,
+    source_cursor: str,
+    canonical_hash: str,
+) -> str:
+    seed = previous_fingerprint or _EMPTY_FINGERPRINT
+    return hashlib.sha256(
+        json.dumps(
+            [seed, source_cursor, canonical_hash],
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+
+
+__all__ = [
+    "NotesTaskActivityBootstrapper",
+    "NotesTaskBootstrapInterrupted",
+    "legacy_task_event_to_activity",
+]

--- a/tldw_Server_API/app/core/Sync/v2/notes_task_activity_bootstrap.py
+++ b/tldw_Server_API/app/core/Sync/v2/notes_task_activity_bootstrap.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.exceptions import (
+    NotesTaskActivitySourceChanged,
+    NotesTaskActivitySourceInvalid,
     NotesTaskBootstrapInterrupted,
     NotesTaskContractError,
 )
@@ -29,14 +31,6 @@ from .service import SyncV2Service
 
 _SOURCE = "notes-task-activity-bootstrap"
 _EMPTY_FINGERPRINT = hashlib.sha256(b"notes.task_activity.bootstrap.v1").hexdigest()
-
-
-class _SourceInvalid(RuntimeError):
-    """Internal marker for malformed legacy activity source data."""
-
-
-class _SourceChanged(RuntimeError):
-    """Internal marker for changed verified source history."""
 
 
 class NotesTaskActivityBootstrapper:
@@ -89,13 +83,13 @@ class NotesTaskActivityBootstrapper:
 
         bootstrap_id = _bootstrap_id(owner, current.dataset_id)
         try:
-            source = self._source_summary(
+            self._verify_resume_boundary(
                 service=service,
                 owner=owner,
                 dataset_id=current.dataset_id,
                 bootstrap_id=bootstrap_id,
+                state=state,
             )
-            _verify_stored_progress(state, source)
             after_created_at, after_activity_id = _split_cursor(
                 _optional_string(state.get("source_cursor"))
             )
@@ -144,27 +138,33 @@ class NotesTaskActivityBootstrapper:
                     source_count=running_count,
                     source_fingerprint=running_fingerprint,
                 )
-            if running_count < source.count:
+            if len(page) == self._page_limit and not all(
+                row.get("sync_server_cursor") is not None for row in page
+            ):
                 return current
-            verified = self._source_summary(
+            source = self._source_summary(
                 service=service,
                 owner=owner,
                 dataset_id=current.dataset_id,
                 bootstrap_id=bootstrap_id,
             )
-            if verified != source:
-                raise _SourceChanged
+            if running_count < source.count:
+                return current
             if (
                 running_count != source.count
                 or running_fingerprint != source.fingerprint
+                or _optional_string(
+                    _readiness(current).get("source_cursor")
+                ) != source.cursor
                 or not _sync_bootstrap_matches_source(
                     service,
                     current.dataset_id,
+                    owner=owner,
                     bootstrap_id=bootstrap_id,
                     source=source,
                 )
             ):
-                raise _SourceChanged
+                raise NotesTaskActivitySourceChanged
             current = service.store.transition_notes_task_activity_readiness(
                 current.dataset_id,
                 owner_user_id=owner,
@@ -187,7 +187,7 @@ class NotesTaskActivityBootstrapper:
             )
         except NotesTaskBootstrapInterrupted:
             raise
-        except _SourceChanged:
+        except NotesTaskActivitySourceChanged:
             return _block(service, current, reason="notes_task_activity_source_changed")
         except Exception as exc:  # noqa: BLE001 - details become bounded readiness.
             if isinstance(exc, SyncStoreError) and str(exc) not in {
@@ -235,6 +235,49 @@ class NotesTaskActivityBootstrapper:
             source_fingerprint=_EMPTY_FINGERPRINT,
         )
 
+    def _verify_resume_boundary(
+        self,
+        *,
+        service: SyncV2Service,
+        owner: str,
+        dataset_id: str,
+        bootstrap_id: str,
+        state: Mapping[str, object],
+    ) -> None:
+        """Verify the durable progress boundary without rescanning its prefix."""
+
+        count = int(state["source_count"])
+        cursor = _optional_string(state.get("source_cursor"))
+        fingerprint = str(state.get("source_fingerprint") or _EMPTY_FINGERPRINT)
+        if count == 0:
+            if cursor is not None or fingerprint != _EMPTY_FINGERPRINT:
+                raise NotesTaskActivitySourceChanged
+            return
+        if cursor is None or fingerprint == _EMPTY_FINGERPRINT:
+            raise NotesTaskActivitySourceChanged
+        _created_at, activity_id = _split_cursor(cursor)
+        if activity_id is None:
+            raise NotesTaskActivitySourceChanged
+        row = self._tasks.get_sync_task_activity(
+            owner_user_id=owner,
+            dataset_id=dataset_id,
+            activity_id=activity_id,
+        )
+        if row is None or _row_cursor(row) != cursor:
+            raise NotesTaskActivitySourceChanged
+        try:
+            boundary = self._source_row(
+                service=service,
+                owner=owner,
+                dataset_id=dataset_id,
+                bootstrap_id=bootstrap_id,
+                row=row,
+            )
+        except NotesTaskActivitySourceInvalid as exc:
+            raise NotesTaskActivitySourceChanged from exc
+        if boundary.cursor != cursor:
+            raise NotesTaskActivitySourceChanged
+
     def _source_summary(
         self,
         *,
@@ -243,11 +286,12 @@ class NotesTaskActivityBootstrapper:
         dataset_id: str,
         bootstrap_id: str,
     ) -> _SourceSummary:
-        """Read and validate the complete ordered legacy/adopted source identity."""
+        """Stream the complete source identity with page-bounded memory."""
 
-        rows: list[_SourceRow] = []
         after_created_at: str | None = None
         after_activity_id: str | None = None
+        cursor: str | None = None
+        count = 0
         fingerprint = _EMPTY_FINGERPRINT
         while True:
             try:
@@ -266,21 +310,21 @@ class NotesTaskActivityBootstrapper:
                         bootstrap_id=bootstrap_id,
                         row=row,
                     )
-                    rows.append(item)
+                    count += 1
+                    cursor = item.cursor
                     fingerprint = _activity_bootstrap_fingerprint(
                         fingerprint,
                         item.cursor,
                         item.canonical_hash,
                     )
                     after_created_at, after_activity_id = _split_cursor(item.cursor)
-            except _SourceChanged:
+            except NotesTaskActivitySourceChanged:
                 raise
             except Exception as exc:  # noqa: BLE001 - source details remain private.
-                raise _SourceInvalid from exc
+                raise NotesTaskActivitySourceInvalid from exc
             if len(page) < self.PAGE_LIMIT:
                 break
-        cursor = rows[-1].cursor if rows else None
-        return _SourceSummary(tuple(rows), cursor, len(rows), fingerprint)
+        return _SourceSummary(cursor, count, fingerprint)
 
     def _source_row(
         self,
@@ -316,7 +360,7 @@ class NotesTaskActivityBootstrapper:
                 or envelope.routing_metadata.get("bootstrap_id") != bootstrap_id
                 or envelope.apply_status != "applied"
             ):
-                raise _SourceChanged
+                raise NotesTaskActivitySourceChanged
             payload = _parse_bootstrap_payload(envelope, owner)
             canonical_hash = notes_task_activity_object_hash(
                 payload,
@@ -336,7 +380,7 @@ class NotesTaskActivityBootstrapper:
                     sync_server_cursor=int(row["sync_server_cursor"]),
                 )
             ):
-                raise _SourceChanged
+                raise NotesTaskActivitySourceChanged
         return _SourceRow(
             activity_id=payload.activity_id,
             note_id=payload.note_id,
@@ -423,6 +467,8 @@ class NotesTaskActivityBootstrapper:
 
 @dataclass(frozen=True, slots=True)
 class _SourceRow:
+    """One canonical legacy/adopted activity source row."""
+
     activity_id: str
     note_id: str
     cursor: str
@@ -432,7 +478,8 @@ class _SourceRow:
 
 @dataclass(frozen=True, slots=True)
 class _SourceSummary:
-    rows: tuple[_SourceRow, ...]
+    """Constant-memory identity summary of the complete ordered source."""
+
     cursor: str | None
     count: int
     fingerprint: str
@@ -490,40 +537,20 @@ def _parse_bootstrap_payload(envelope: SyncEnvelope, owner: str) -> NotesTaskAct
     )
 
 
-def _verify_stored_progress(state: Mapping[str, object], source: _SourceSummary) -> None:
-    """Reject readiness progress that is not an exact source prefix."""
-
-    count = int(state["source_count"])
-    cursor = _optional_string(state.get("source_cursor"))
-    fingerprint = str(state.get("source_fingerprint") or _EMPTY_FINGERPRINT)
-    if count == 0:
-        if cursor is not None or fingerprint != _EMPTY_FINGERPRINT:
-            raise _SourceChanged
-        return
-    if count > len(source.rows) or source.rows[count - 1].cursor != cursor:
-        raise _SourceChanged
-    expected = _EMPTY_FINGERPRINT
-    for row in source.rows[:count]:
-        expected = _activity_bootstrap_fingerprint(
-            expected,
-            row.cursor,
-            row.canonical_hash,
-        )
-    if expected != fingerprint:
-        raise _SourceChanged
-
-
 def _sync_bootstrap_matches_source(
     service: SyncV2Service,
     dataset_id: str,
     *,
+    owner: str,
     bootstrap_id: str,
     source: _SourceSummary,
 ) -> bool:
-    """Return whether applied bootstrap envelopes exactly cover the source."""
+    """Stream-verify exact ordered envelope identity against the source summary."""
 
-    found: dict[str, tuple[str, str | None, str | None, str | None]] = {}
     cursor = 0
+    found_count = 0
+    found_cursor: str | None = None
+    found_fingerprint = _EMPTY_FINGERPRINT
     while True:
         page = service.store.list_envelopes_after(
             dataset_id,
@@ -541,32 +568,44 @@ def _sync_bootstrap_matches_source(
                 or envelope.apply_status != "applied"
                 or envelope.operation != "upsert"
                 or envelope.object_revision != 1
-                or envelope.object_id in found
+                or envelope.deleted
             ):
                 return False
-            found[envelope.object_id] = (
-                envelope.payload_hash or "",
-                envelope.parent_id,
-                envelope.created_at_client,
-                envelope.client_envelope_id,
+            try:
+                payload = _parse_bootstrap_payload(envelope, owner)
+                canonical_hash = notes_task_activity_object_hash(
+                    payload,
+                    revision=1,
+                    deleted=False,
+                )
+            except Exception:  # noqa: BLE001 - verification is total and fail-closed.
+                return False
+            found_cursor = f"{payload.client_occurred_at}|{payload.activity_id}"
+            if (
+                envelope.object_id != payload.activity_id
+                or envelope.parent_id != payload.note_id
+                or envelope.created_at_client != payload.client_occurred_at
+                or envelope.payload_hash != canonical_hash
+                or envelope.client_envelope_id
+                != _activity_bootstrap_envelope_id(
+                    bootstrap_id,
+                    payload.activity_id,
+                    canonical_hash,
+                )
+            ):
+                return False
+            found_count += 1
+            found_fingerprint = _activity_bootstrap_fingerprint(
+                found_fingerprint,
+                found_cursor,
+                canonical_hash,
             )
         if len(page) < 500:
             break
-    if len(found) != source.count:
-        return False
-    return all(
-        found.get(row.activity_id)
-        == (
-            row.canonical_hash,
-            row.note_id,
-            row.payload.client_occurred_at,
-            _activity_bootstrap_envelope_id(
-                bootstrap_id,
-                row.activity_id,
-                row.canonical_hash,
-            ),
-        )
-        for row in source.rows
+    return (
+        found_count == source.count
+        and found_cursor == source.cursor
+        and found_fingerprint == source.fingerprint
     )
 
 
@@ -597,6 +636,8 @@ def _block(
 
 
 def _readiness(dataset: SyncDataset) -> Mapping[str, object]:
+    """Return the strict internal activity readiness mapping."""
+
     state = dataset.metadata.get("notes_task_activity_v1")
     if not isinstance(state, Mapping):
         raise SyncStoreError("notes_task_activity_readiness_state_invalid")
@@ -604,28 +645,36 @@ def _readiness(dataset: SyncDataset) -> Mapping[str, object]:
 
 
 def _row_cursor(row: Mapping[str, object]) -> str:
+    """Return the canonical created-at/activity-id keyset cursor."""
+
     created_at = row.get("created_at")
     activity_id = row.get("id")
     if not isinstance(created_at, str) or not isinstance(activity_id, str):
-        raise _SourceInvalid
+        raise NotesTaskActivitySourceInvalid
     return f"{created_at}|{activity_id}"
 
 
 def _split_cursor(value: str | None) -> tuple[str | None, str | None]:
+    """Split one canonical activity cursor into its keyset components."""
+
     if value is None:
         return None, None
     try:
         created_at, activity_id = value.rsplit("|", 1)
     except ValueError as exc:
-        raise _SourceChanged from exc
+        raise NotesTaskActivitySourceChanged from exc
     return created_at, activity_id
 
 
 def _optional_string(value: object) -> str | None:
+    """Return a string value or None without coercion."""
+
     return value if isinstance(value, str) else None
 
 
 def _bootstrap_id(owner_user_id: str, dataset_id: str) -> str:
+    """Return the deterministic trusted-bootstrap identifier for a dataset."""
+
     digest = hashlib.sha256(
         f"notes.task_activity.bootstrap.v1:{owner_user_id}:{dataset_id}".encode()
     ).hexdigest()
@@ -637,6 +686,8 @@ def _activity_bootstrap_envelope_id(
     activity_id: str,
     canonical_hash: str,
 ) -> str:
+    """Return the deterministic envelope identity for one source activity."""
+
     digest = hashlib.sha256(
         json.dumps(
             [bootstrap_id, activity_id, canonical_hash],
@@ -647,6 +698,8 @@ def _activity_bootstrap_envelope_id(
 
 
 def _activity_bootstrap_routing(bootstrap_id: str) -> dict[str, object]:
+    """Return trusted routing metadata for one activity bootstrap."""
+
     return {"bootstrap_capture": True, "bootstrap_id": bootstrap_id}
 
 
@@ -655,6 +708,8 @@ def _activity_bootstrap_fingerprint(
     source_cursor: str,
     canonical_hash: str,
 ) -> str:
+    """Extend the ordered activity source fingerprint by one row."""
+
     seed = previous_fingerprint or _EMPTY_FINGERPRINT
     return hashlib.sha256(
         json.dumps(

--- a/tldw_Server_API/app/core/Sync/v2/server_origin_batch.py
+++ b/tldw_Server_API/app/core/Sync/v2/server_origin_batch.py
@@ -37,7 +37,12 @@ from .mutation_group_validation import (
     mutation_group_plan_hash,
     validate_stored_mutation_group,
 )
-from .notes_task_contract import notes_task_object_hash, parse_notes_task_v1
+from .notes_task_contract import (
+    notes_task_activity_object_hash,
+    notes_task_object_hash,
+    parse_notes_task_activity_v1,
+    parse_notes_task_v1,
+)
 from .server_origin import (
     SERVER_ORIGIN_DEVICE_ID,
     SyncServerOriginMutationNotSupportedError,
@@ -116,6 +121,7 @@ def capture_server_origin_mutation_batch(
     trusted_notes_link_bootstrap_id: str | None = None,
     trusted_notes_attachment_bootstrap_id: str | None = None,
     trusted_notes_task_bootstrap_id: str | None = None,
+    trusted_notes_task_activity_bootstrap_id: str | None = None,
     bootstrap_relationship_verifier: Callable[[SyncDomain, str, Mapping[str, object]], bool]
     | None = None,
     bootstrap_relationship_absence_verifier: Callable[
@@ -139,6 +145,7 @@ def capture_server_origin_mutation_batch(
             trusted_notes_link_bootstrap_id,
             trusted_notes_attachment_bootstrap_id,
             trusted_notes_task_bootstrap_id,
+            trusted_notes_task_activity_bootstrap_id,
         )
         if item is not None
     )
@@ -149,6 +156,7 @@ def capture_server_origin_mutation_batch(
         or trusted_notes_link_bootstrap_id
         or trusted_notes_attachment_bootstrap_id
         or trusted_notes_task_bootstrap_id
+        or trusted_notes_task_activity_bootstrap_id
     )
     if trusted_bootstrap_id is not None and bootstrap_step_verifier is None:
         raise SyncStoreError("Sync bootstrap capture requires a source-step verifier")
@@ -159,6 +167,9 @@ def capture_server_origin_mutation_batch(
         {step.domain for step in plan},
         trusted_bootstrap_id=trusted_bootstrap_id,
         notes_task_bootstrap=trusted_notes_task_bootstrap_id is not None,
+        notes_task_activity_bootstrap=(
+            trusted_notes_task_activity_bootstrap_id is not None
+        ),
     )
     if not server_frontend_mutation_enabled_for_policy(dataset.encryption_policy):
         raise SyncServerOriginMutationNotSupportedError(dataset, plan[0].domain)
@@ -192,8 +203,12 @@ def capture_server_origin_mutation_batch(
             bootstrap_step_verifier=bootstrap_step_verifier,
             materialize_verified_bootstrap=(
                 trusted_notes_attachment_bootstrap_id is not None
+                or trusted_notes_task_activity_bootstrap_id is not None
             ),
             notes_task_bootstrap=trusted_notes_task_bootstrap_id is not None,
+            notes_task_activity_bootstrap=(
+                trusted_notes_task_activity_bootstrap_id is not None
+            ),
         )
 
     envelopes = _evaluate_plan(
@@ -208,6 +223,9 @@ def capture_server_origin_mutation_batch(
             trusted_notes_attachment_bootstrap_id is not None
         ),
         notes_task_bootstrap=trusted_notes_task_bootstrap_id is not None,
+        notes_task_activity_bootstrap=(
+            trusted_notes_task_activity_bootstrap_id is not None
+        ),
         bootstrap_relationship_verifier=bootstrap_relationship_verifier,
         bootstrap_relationship_absence_verifier=(
             bootstrap_relationship_absence_verifier
@@ -220,7 +238,10 @@ def capture_server_origin_mutation_batch(
             inserted = service.store.insert_envelopes_atomic(
                 envelopes,
                 trusted_notes_organization_bootstrap_id=trusted_bootstrap_id,
-                trusted_notes_task_bootstrap_id=trusted_notes_task_bootstrap_id,
+                trusted_notes_task_bootstrap_id=(
+                    trusted_notes_task_bootstrap_id
+                    or trusted_notes_task_activity_bootstrap_id
+                ),
             )
     except SyncIdempotencyConflictError as exc:
         raise SyncServerOriginBatchIdempotencyConflictError(mutation_group_id) from exc
@@ -234,8 +255,12 @@ def capture_server_origin_mutation_batch(
         bootstrap_step_verifier=bootstrap_step_verifier,
         materialize_verified_bootstrap=(
             trusted_notes_attachment_bootstrap_id is not None
+            or trusted_notes_task_activity_bootstrap_id is not None
         ),
         notes_task_bootstrap=trusted_notes_task_bootstrap_id is not None,
+        notes_task_activity_bootstrap=(
+            trusted_notes_task_activity_bootstrap_id is not None
+        ),
     )
 
 
@@ -319,6 +344,7 @@ def _evaluate_plan(
     notes_link_bootstrap: bool = False,
     notes_attachment_bootstrap: bool = False,
     notes_task_bootstrap: bool = False,
+    notes_task_activity_bootstrap: bool = False,
     bootstrap_relationship_verifier: Callable[[SyncDomain, str, Mapping[str, object]], bool]
     | None = None,
     bootstrap_relationship_absence_verifier: Callable[
@@ -380,6 +406,22 @@ def _evaluate_plan(
                 revision=object_revision,
                 deleted=step.operation == "tombstone",
             )
+        if notes_task_activity_bootstrap and step.domain == "notes.task_activity":
+            if step.operation != "upsert" or object_revision != 1:
+                raise SyncStoreError("notes_task_activity_bootstrap_lineage_invalid")
+            activity_payload = parse_notes_task_activity_v1(
+                step.payload,
+                owner_user_id=dataset.owner_user_id,
+                bound_actor_type=str(step.payload.get("actor_type")),
+                bound_actor_id=step.payload.get("actor_id"),
+                authenticated_device_id=None,
+                trusted_server_origin=True,
+            )
+            payload_hash = notes_task_activity_object_hash(
+                activity_payload,
+                revision=1,
+                deleted=False,
+            )
         base_server_cursor = prior_head.server_cursor if prior_head is not None else None
         if isinstance(prior_head, SyncEnvelopeCreate) and base_server_cursor is None:
             # Cursor zero is outside stored history and marks an in-plan virtual head;
@@ -411,7 +453,7 @@ def _evaluate_plan(
             object_revision=object_revision,
             entity_version=(
                 object_revision
-                if step.domain in {"notes.link", "notes.task"}
+                if step.domain in {"notes.link", "notes.task", "notes.task_activity"}
                 else None
             ),
             parent_id=step.parent_id,
@@ -456,6 +498,19 @@ def _evaluate_plan(
                 bootstrap_id if notes_attachment_bootstrap else None
             ),
             notes_task_bootstrap_id=(bootstrap_id if notes_task_bootstrap else None),
+            notes_task_activity_bootstrap_id=(
+                bootstrap_id if notes_task_activity_bootstrap else None
+            ),
+            authenticated_actor_type=(
+                str(step.payload.get("actor_type"))
+                if step.domain == "notes.task_activity"
+                else None
+            ),
+            authenticated_actor_id=(
+                step.payload.get("actor_id")
+                if step.domain == "notes.task_activity"
+                else None
+            ),
             bootstrap_relationship_verifier=bootstrap_relationship_verifier,
             bootstrap_relationship_absence_verifier=(
                 bootstrap_relationship_absence_verifier
@@ -483,6 +538,7 @@ def _materialize_group(
     bootstrap_step_verifier: Callable[[SyncEnvelope], bool] | None = None,
     materialize_verified_bootstrap: bool = False,
     notes_task_bootstrap: bool = False,
+    notes_task_activity_bootstrap: bool = False,
 ) -> ServerOriginBatchResult:
     group = list(envelopes)
     _validate_stored_group(
@@ -495,7 +551,9 @@ def _materialize_group(
             group,
             require_predecessors=bootstrap_id is None,
             trusted_notes_task_bootstrap_id=(
-                bootstrap_id if notes_task_bootstrap else None
+                bootstrap_id
+                if notes_task_bootstrap or notes_task_activity_bootstrap
+                else None
             ),
         ) as guarded_store:
             group = guarded_store.list_mutation_group(
@@ -832,10 +890,13 @@ def _require_batch_write_ready(
     *,
     trusted_bootstrap_id: str | None = None,
     notes_task_bootstrap: bool = False,
+    notes_task_activity_bootstrap: bool = False,
 ) -> None:
     missing_domains = domains.difference(dataset.domains)
     if notes_task_bootstrap:
         missing_domains = missing_domains.difference({"notes.task"})
+    if notes_task_activity_bootstrap:
+        missing_domains = missing_domains.difference({"notes.task_activity"})
     missing = sorted(missing_domains)
     if missing:
         raise SyncStoreError(
@@ -846,6 +907,15 @@ def _require_batch_write_ready(
         state = metadata.get("state") if isinstance(metadata, Mapping) else None
         if not notes_task_bootstrap or trusted_bootstrap_id is None or state != "bootstrapping":
             raise SyncStoreError("notes_task_sync_not_ready")
+    if "notes.task_activity" in domains:
+        metadata = dataset.metadata.get("notes_task_activity_v1")
+        state = metadata.get("state") if isinstance(metadata, Mapping) else None
+        if (
+            not notes_task_activity_bootstrap
+            or trusted_bootstrap_id is None
+            or state != "bootstrapping"
+        ):
+            raise SyncStoreError("notes_task_activity_sync_not_ready")
     if "notes.link" in domains:
         metadata = dataset.metadata.get("notes_link_v1")
         state = metadata.get("state") if isinstance(metadata, Mapping) else None

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -896,6 +896,7 @@ class SyncV2Service:
         notes_link_bootstrapper: object | None = None,
         notes_attachment_bootstrapper: object | None = None,
         notes_task_bootstrapper: object | None = None,
+        notes_task_activity_bootstrapper: object | None = None,
     ) -> None:
         self.store = store
         self.adapters = adapters
@@ -909,6 +910,7 @@ class SyncV2Service:
         self.notes_link_bootstrapper = notes_link_bootstrapper
         self.notes_attachment_bootstrapper = notes_attachment_bootstrapper
         self.notes_task_bootstrapper = notes_task_bootstrapper
+        self.notes_task_activity_bootstrapper = notes_task_activity_bootstrapper
 
     def capabilities(
         self,

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -66,6 +66,7 @@ class SyncV2Store:
     def __init__(self, db: SyncDatabase, *, connection: Any | None = None) -> None:
         self.db = db
         self._connection = connection
+        self._trusted_notes_task_bootstrap_id: str | None = None
 
     @contextmanager
     def materialization_guard(
@@ -87,6 +88,9 @@ class SyncV2Store:
         ) as connection:
             guarded = copy(self)
             guarded._connection = connection
+            guarded._trusted_notes_task_bootstrap_id = (
+                trusted_notes_task_bootstrap_id
+            )
             if require_predecessors:
                 self.db.require_materialization_predecessors_applied(
                     envelopes,
@@ -773,7 +777,13 @@ class SyncV2Store:
         )
 
     def upsert_object_state(self, state: SyncObjectState) -> SyncObjectState:
-        return self.db.upsert_object_state(state, connection=self._connection)
+        return self.db.upsert_object_state(
+            state,
+            connection=self._connection,
+            trusted_notes_task_bootstrap_id=(
+                self._trusted_notes_task_bootstrap_id
+            ),
+        )
 
     def mark_envelope_apply_status(
         self,

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -112,6 +112,14 @@ class NotesTaskBootstrapInterrupted(RuntimeError):
     """Testable interruption that leaves durable task bootstrap progress resumable."""
 
 
+class NotesTaskActivitySourceInvalid(RuntimeError):
+    """Malformed legacy task activity encountered during trusted bootstrap."""
+
+
+class NotesTaskActivitySourceChanged(RuntimeError):
+    """Previously observed task activity changed during trusted bootstrap."""
+
+
 class NotesAttachmentMutationError(RuntimeError):
     """Stable failure for a coordinated Notes attachment mutation."""
 

--- a/tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+++ b/tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
@@ -10,7 +10,11 @@ import pytest
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
 from tldw_Server_API.app.core.Notes_Tasks.models import TaskActor
-from tldw_Server_API.app.core.Notes_Tasks.service import NotesTaskService, _parse_checklist_line
+from tldw_Server_API.app.core.Notes_Tasks.service import (
+    NotesTaskCaptureMutation,
+    NotesTaskService,
+    _parse_checklist_line,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -67,6 +71,33 @@ def test_create_task_for_note_rejects_invalid_status_without_rewriting_note(db: 
         owner_user_id=db.client_id,
         dataset_id="local-unbound",
     ) == []
+
+
+def test_optional_capture_callback_receives_one_task_activity_plan(
+    db: CharactersRAGDB,
+) -> None:
+    captured: list[NotesTaskCaptureMutation] = []
+    service = NotesTaskService(
+        task_capture_callback=lambda mutation, *, conn: captured.append(mutation)
+    )
+    note = _add_note(db, title="Tasks", content="Intro\n")
+
+    service.create_task_for_note(
+        db=db,
+        note_id=str(note["id"]),
+        text="Alpha",
+        status="open",
+        metadata={},
+        expected_note_version=int(note["version"]),
+        actor=TaskActor(actor_type="user", actor_id=db.client_id),
+    )
+
+    assert len(captured) == 1
+    assert [step.domain for step in captured[0].steps] == [
+        "notes.task",
+        "notes.task_activity",
+    ]
+    assert captured[0].activity.payload.event_type == "created"
 
 
 @pytest.mark.parametrize(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_adapter.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_adapter.py
@@ -1,0 +1,572 @@
+"""Contracts for immutable dormant ``notes.task_activity`` lineage."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from tldw_Server_API.app.core.Sync.v2 import domain_adapters
+from tldw_Server_API.app.core.Sync.v2.adapters import (
+    AdapterAccepted,
+    AdapterConflict,
+    AdapterDeferred,
+    AdapterRejected,
+    SyncAdapterContext,
+)
+from tldw_Server_API.app.core.Sync.v2.models import (
+    DEFAULT_M1_ENCRYPTION_POLICY,
+    SyncDataset,
+    SyncEnvelope,
+    SyncEnvelopeCreate,
+)
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    NotesTaskActivityV1,
+    notes_task_activity_object_hash,
+    parse_notes_task_activity_tombstone_v1,
+    parse_notes_task_activity_v1,
+)
+
+pytestmark = pytest.mark.unit
+
+OWNER_ID = "owner-user-1"
+DATASET_ID = "dataset-1"
+ACTIVITY_ID = "11111111-1111-4111-8111-111111111111"
+TARGET_ACTIVITY_ID = "22222222-2222-4222-8222-222222222222"
+NOTE_ID = "33333333-3333-4333-8333-333333333333"
+TASK_ID = "44444444-4444-4444-8444-444444444444"
+OTHER_NOTE_ID = "55555555-5555-4555-8555-555555555555"
+OTHER_TASK_ID = "66666666-6666-4666-8666-666666666666"
+DEVICE_ID = "77777777-7777-4777-8777-777777777777"
+NOW = "2026-08-13T10:00:00+00:00"
+
+
+def _adapter() -> domain_adapters.NotesTaskActivityDomainAdapter:
+    adapter_type = getattr(domain_adapters, "NotesTaskActivityDomainAdapter", None)
+    assert adapter_type is not None, "NotesTaskActivityDomainAdapter is not implemented"
+    return adapter_type()
+
+
+def _dataset() -> SyncDataset:
+    return SyncDataset(
+        dataset_id=DATASET_ID,
+        owner_user_id=OWNER_ID,
+        scope_type="personal",
+        encryption_policy=DEFAULT_M1_ENCRYPTION_POLICY,
+        domains=["notes.note"],
+        workspace_id=None,
+        metadata={},
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _values(event_type: str) -> tuple[dict[str, object] | None, dict[str, object] | None]:
+    if event_type in {"completed", "corrected"}:
+        return {"status": "open"}, {"status": "done"}
+    if event_type == "created":
+        return None, {
+            "title": "Prepare launch notes",
+            "status": "open",
+            "completed_at": None,
+            "metadata": {
+                "description": None,
+                "priority": None,
+                "due_date": None,
+                "estimate": None,
+                "recurrence": None,
+                "assignee_id": None,
+                "tags": [],
+                "custom": {},
+            },
+        }
+    raise AssertionError(f"unsupported test event type: {event_type}")
+
+
+def _payload(
+    *,
+    activity_id: str = ACTIVITY_ID,
+    note_id: str = NOTE_ID,
+    task_id: str | None = TASK_ID,
+    event_type: str = "corrected",
+    trusted: bool = False,
+    actor_id: str | None = OWNER_ID,
+) -> dict[str, object]:
+    old_value, new_value = _values(event_type)
+    return {
+        "activity_id": activity_id,
+        "note_id": note_id,
+        "task_id": task_id,
+        "event_type": event_type,
+        "actor_type": "user",
+        "actor_id": actor_id,
+        "source_device_id": None if trusted else DEVICE_ID,
+        "client_occurred_at": NOW,
+        "source_kind": "rest" if trusted else "client",
+        "corrects_activity_id": TARGET_ACTIVITY_ID if event_type == "corrected" else None,
+        "old_value": old_value,
+        "new_value": new_value,
+        "metadata": {},
+    }
+
+
+def _parse_create(payload: dict[str, object], *, trusted: bool) -> NotesTaskActivityV1:
+    return parse_notes_task_activity_v1(
+        payload,
+        owner_user_id=OWNER_ID,
+        bound_actor_type="user",
+        bound_actor_id=OWNER_ID,
+        authenticated_device_id=None if trusted else DEVICE_ID,
+        trusted_server_origin=trusted,
+    )
+
+
+def _incoming_create(
+    *,
+    activity_id: str = ACTIVITY_ID,
+    note_id: str = NOTE_ID,
+    task_id: str | None = TASK_ID,
+    event_type: str = "corrected",
+    trusted: bool = False,
+    suffix: str = "create",
+) -> SyncEnvelopeCreate:
+    parsed = _parse_create(
+        _payload(
+            activity_id=activity_id,
+            note_id=note_id,
+            task_id=task_id,
+            event_type=event_type,
+            trusted=trusted,
+        ),
+        trusted=trusted,
+    )
+    return SyncEnvelopeCreate(
+        dataset_id=DATASET_ID,
+        client_envelope_id=f"env-{suffix}",
+        domain="notes.task_activity",
+        operation="upsert",
+        object_id=activity_id,
+        parent_id=note_id,
+        device_id=None if trusted else DEVICE_ID,
+        object_revision=1,
+        entity_version=1,
+        adapter_version=1,
+        schema_version=1,
+        payload=parsed.model_dump(mode="json"),
+        payload_hash=notes_task_activity_object_hash(parsed, revision=1, deleted=False),
+        created_at_client=NOW,
+        routing_metadata={},
+    )
+
+
+def _stored(incoming: SyncEnvelopeCreate, *, cursor: int = 10) -> SyncEnvelope:
+    excluded = {"server_cursor", "server_sequence"}
+    return SyncEnvelope(
+        **{
+            field_name: getattr(incoming, field_name)
+            for field_name in incoming.__dataclass_fields__
+            if field_name not in excluded
+        },
+        server_cursor=cursor,
+    )
+
+
+def _incoming_tombstone(
+    head: SyncEnvelope,
+    *,
+    suffix: str = "tombstone",
+    reason: str = "user_request",
+) -> SyncEnvelopeCreate:
+    original = _parse_create(dict(head.payload), trusted=head.device_id is None)
+    raw = {
+        "note_id": original.note_id,
+        "task_id": original.task_id,
+        "deleted_at": NOW,
+        "delete_reason": reason,
+    }
+    parsed = parse_notes_task_activity_tombstone_v1(
+        raw,
+        envelope_created_at_client=NOW,
+        original_activity=original,
+    )
+    return SyncEnvelopeCreate(
+        dataset_id=DATASET_ID,
+        client_envelope_id=f"env-{suffix}",
+        domain="notes.task_activity",
+        operation="tombstone",
+        object_id=head.object_id,
+        parent_id=head.parent_id,
+        device_id=DEVICE_ID,
+        base_server_cursor=head.server_cursor,
+        base_object_revision=head.object_revision,
+        base_object_hash=head.payload_hash,
+        object_revision=2,
+        entity_version=2,
+        adapter_version=1,
+        schema_version=1,
+        payload=parsed.model_dump(mode="json"),
+        payload_hash=notes_task_activity_object_hash(
+            parsed,
+            revision=2,
+            deleted=True,
+            activity_id=str(head.object_id),
+            original_create_hash=head.payload_hash,
+        ),
+        created_at_client=NOW,
+        deleted=True,
+        routing_metadata={},
+    )
+
+
+def _note_head(
+    *,
+    note_id: str = NOTE_ID,
+    dataset_id: str = DATASET_ID,
+    deleted: bool = False,
+) -> SyncEnvelope:
+    return SyncEnvelope(
+        dataset_id=dataset_id,
+        client_envelope_id=f"note-{note_id}",
+        domain="notes.note",
+        operation="tombstone" if deleted else "upsert",
+        server_cursor=1,
+        object_id=note_id,
+        object_revision=1,
+        entity_version=1,
+        payload={"title": "Parent", "content": "body"},
+        payload_hash="sha256:" + "1" * 64,
+        created_at_client=NOW,
+        deleted=deleted,
+    )
+
+
+def _task_head(
+    *,
+    task_id: str = TASK_ID,
+    note_id: str = NOTE_ID,
+    dataset_id: str = DATASET_ID,
+    deleted: bool = False,
+) -> SyncEnvelope:
+    return SyncEnvelope(
+        dataset_id=dataset_id,
+        client_envelope_id=f"task-{task_id}",
+        domain="notes.task",
+        operation="tombstone" if deleted else "upsert",
+        server_cursor=2,
+        object_id=task_id,
+        parent_id=note_id,
+        object_revision=1,
+        entity_version=1,
+        payload={"task_id": task_id, "note_id": note_id},
+        payload_hash="sha256:" + "2" * 64,
+        created_at_client=NOW,
+        deleted=deleted,
+    )
+
+
+def _correction_target(
+    *,
+    note_id: str = NOTE_ID,
+    task_id: str | None = TASK_ID,
+    dataset_id: str = DATASET_ID,
+) -> SyncEnvelope:
+    incoming = _incoming_create(
+        activity_id=TARGET_ACTIVITY_ID,
+        note_id=note_id,
+        task_id=task_id,
+        event_type="completed",
+        trusted=True,
+        suffix="target",
+    )
+    return replace(_stored(incoming, cursor=3), dataset_id=dataset_id)
+
+
+def _context(
+    activity_head: SyncEnvelope | None = None,
+    *,
+    trusted: bool = False,
+    note: SyncEnvelope | None = None,
+    task: SyncEnvelope | None = None,
+    target: SyncEnvelope | None = None,
+    note_available: bool = True,
+    task_available: bool = True,
+) -> SyncAdapterContext:
+    authorized_note = _note_head() if note is None else note
+    authorized_task = _task_head() if task is None else task
+    correction = _correction_target() if target is None else target
+
+    def get_head(domain: str, object_id: str):
+        if domain != "notes.task_activity":
+            return None
+        if activity_head is not None and object_id == activity_head.object_id:
+            return activity_head
+        if object_id == correction.object_id:
+            return correction
+        return None
+
+    def get_authorized_note(note_id: str):
+        if not note_available or note_id != authorized_note.object_id:
+            return None
+        return authorized_note
+
+    def get_authorized_task(task_id: str):
+        if not task_available or task_id != authorized_task.object_id:
+            return None
+        return authorized_task
+
+    return SyncAdapterContext(
+        get_head=get_head,
+        get_authorized_note=get_authorized_note,
+        get_authorized_task=get_authorized_task,
+        trusted_server_origin=trusted,
+        authenticated_actor_type="user",
+        authenticated_actor_id=OWNER_ID,
+        authenticated_device_id=None if trusted else DEVICE_ID,
+    )
+
+
+@pytest.mark.parametrize("task_id", [TASK_ID, None])
+def test_activity_adapter_accepts_trusted_lifecycle_create_with_optional_task(
+    task_id: str | None,
+) -> None:
+    incoming = _incoming_create(
+        task_id=task_id,
+        event_type="created",
+        trusted=True,
+    )
+
+    outcome = _adapter().evaluate_envelope(
+        incoming,
+        dataset=_dataset(),
+        context=_context(trusted=True),
+    )
+
+    assert outcome == AdapterAccepted(client_envelope_id=incoming.client_envelope_id)
+
+
+def test_activity_adapter_allows_only_authorized_direct_corrections() -> None:
+    correction = _incoming_create()
+    accepted = _adapter().evaluate_envelope(
+        correction,
+        dataset=_dataset(),
+        context=_context(),
+    )
+    assert isinstance(accepted, AdapterAccepted)
+
+    lifecycle = _incoming_create(event_type="completed", trusted=True)
+    lifecycle = replace(
+        lifecycle,
+        device_id=DEVICE_ID,
+        payload=_payload(event_type="completed", trusted=False),
+    )
+    parsed = _parse_create(dict(lifecycle.payload), trusted=False)
+    lifecycle = replace(
+        lifecycle,
+        payload_hash=notes_task_activity_object_hash(
+            parsed, revision=1, deleted=False
+        ),
+    )
+    rejected = _adapter().evaluate_envelope(
+        lifecycle,
+        dataset=_dataset(),
+        context=_context(),
+    )
+    assert isinstance(rejected, AdapterRejected)
+    assert rejected.error_code == "notes_task_activity_origin_invalid"
+
+
+def test_activity_adapter_accepts_exact_fingerprint_replay_without_duplication() -> None:
+    incoming = _incoming_create(event_type="created", trusted=True)
+    stored = _stored(incoming)
+    replay = replace(incoming, client_envelope_id="env-replay")
+
+    outcome = _adapter().evaluate_envelope(
+        replay,
+        dataset=_dataset(),
+        context=_context(stored, trusted=True),
+    )
+
+    assert outcome == AdapterAccepted(client_envelope_id="env-replay")
+
+
+def test_activity_adapter_replay_still_requires_authorized_scope() -> None:
+    incoming = _incoming_create(event_type="created", trusted=True)
+    stored = _stored(incoming)
+    replay = replace(incoming, client_envelope_id="env-replay")
+
+    unavailable = _adapter().evaluate_envelope(
+        replay,
+        dataset=_dataset(),
+        context=None,
+    )
+    foreign = _adapter().evaluate_envelope(
+        replay,
+        dataset=_dataset(),
+        context=_context(
+            stored,
+            trusted=True,
+            note=_note_head(dataset_id="other-dataset"),
+        ),
+    )
+
+    assert isinstance(unavailable, AdapterRejected)
+    assert unavailable.error_code == "notes_task_activity_authorization_unavailable"
+    assert isinstance(foreign, AdapterDeferred)
+
+
+def test_activity_adapter_conflicts_changed_stable_id_reuse() -> None:
+    stored = _stored(_incoming_create(event_type="created", trusted=True))
+    changed = _incoming_create(
+        event_type="completed",
+        trusted=True,
+        suffix="changed",
+    )
+
+    outcome = _adapter().evaluate_envelope(
+        changed,
+        dataset=_dataset(),
+        context=_context(stored, trusted=True),
+    )
+
+    assert isinstance(outcome, AdapterConflict)
+    assert outcome.conflict_type == "notes_task_activity_identity_reused"
+
+
+def test_activity_adapter_defers_missing_or_foreign_note_without_disclosure() -> None:
+    incoming = _incoming_create(event_type="created", trusted=True)
+    missing = _adapter().evaluate_envelope(
+        incoming,
+        dataset=_dataset(),
+        context=_context(trusted=True, note_available=False),
+    )
+    foreign = _adapter().evaluate_envelope(
+        incoming,
+        dataset=_dataset(),
+        context=_context(
+            trusted=True,
+            note=_note_head(dataset_id="other-dataset"),
+        ),
+    )
+
+    assert isinstance(missing, AdapterDeferred)
+    assert isinstance(foreign, AdapterDeferred)
+    assert missing.message == foreign.message
+    assert NOTE_ID not in missing.message
+
+
+def test_activity_adapter_requires_same_note_live_task() -> None:
+    incoming = _incoming_create(event_type="created", trusted=True)
+    missing = _adapter().evaluate_envelope(
+        incoming,
+        dataset=_dataset(),
+        context=_context(trusted=True, task_available=False),
+    )
+    wrong_note = _adapter().evaluate_envelope(
+        incoming,
+        dataset=_dataset(),
+        context=_context(
+            trusted=True,
+            task=_task_head(note_id=OTHER_NOTE_ID),
+        ),
+    )
+    deleted = _adapter().evaluate_envelope(
+        incoming,
+        dataset=_dataset(),
+        context=_context(trusted=True, task=_task_head(deleted=True)),
+    )
+
+    assert isinstance(missing, AdapterDeferred)
+    assert isinstance(wrong_note, AdapterDeferred)
+    assert missing.message == wrong_note.message
+    assert isinstance(deleted, AdapterConflict)
+    assert deleted.conflict_type == "notes_task_activity_parent_conflict"
+
+
+def test_activity_adapter_accepts_exact_one_way_tombstone_and_replay() -> None:
+    live = _stored(_incoming_create(event_type="created", trusted=True))
+    tombstone = _incoming_tombstone(live)
+    accepted = _adapter().evaluate_envelope(
+        tombstone,
+        dataset=_dataset(),
+        context=_context(live),
+    )
+    assert isinstance(accepted, AdapterAccepted)
+
+    deleted = _stored(tombstone, cursor=11)
+    replay = replace(tombstone, client_envelope_id="env-delete-replay")
+    replayed = _adapter().evaluate_envelope(
+        replay,
+        dataset=_dataset(),
+        context=_context(deleted),
+    )
+    assert isinstance(replayed, AdapterAccepted)
+
+
+def test_activity_adapter_rejects_restore_update_and_second_tombstone() -> None:
+    live = _stored(_incoming_create(event_type="created", trusted=True))
+    deleted = _stored(_incoming_tombstone(live), cursor=11)
+
+    recreate = _incoming_create(event_type="created", trusted=True, suffix="recreate")
+    recreate_outcome = _adapter().evaluate_envelope(
+        recreate,
+        dataset=_dataset(),
+        context=_context(deleted, trusted=True),
+    )
+    changed_delete = _incoming_tombstone(live, reason="correction")
+    changed_delete = replace(
+        changed_delete,
+        base_server_cursor=deleted.server_cursor,
+        base_object_revision=deleted.object_revision,
+        base_object_hash=deleted.payload_hash,
+    )
+    delete_outcome = _adapter().evaluate_envelope(
+        changed_delete,
+        dataset=_dataset(),
+        context=_context(deleted),
+    )
+
+    for outcome in (recreate_outcome, delete_outcome):
+        assert isinstance(outcome, AdapterConflict)
+        assert outcome.conflict_type == "notes_task_activity_immutable"
+
+
+def test_activity_adapter_rejects_invalid_lineage_and_contract() -> None:
+    incoming = _incoming_create(event_type="created", trusted=True)
+    invalid = (
+        replace(incoming, object_revision=2, entity_version=2),
+        replace(incoming, payload_hash="sha256:" + "0" * 64),
+        replace(incoming, parent_id=OTHER_NOTE_ID),
+        replace(incoming, adapter_version=2),
+    )
+
+    outcomes = [
+        _adapter().evaluate_envelope(
+            envelope,
+            dataset=_dataset(),
+            context=_context(trusted=True),
+        )
+        for envelope in invalid
+    ]
+
+    assert isinstance(outcomes[0], AdapterRejected)
+    assert isinstance(outcomes[1], AdapterRejected)
+    assert isinstance(outcomes[2], AdapterConflict)
+    assert isinstance(outcomes[3], AdapterRejected)
+
+
+def test_activity_adapter_requires_correction_target_in_exact_scope() -> None:
+    incoming = _incoming_create()
+    missing = _adapter().evaluate_envelope(
+        incoming,
+        dataset=_dataset(),
+        context=_context(target=replace(_correction_target(), object_id=OTHER_TASK_ID)),
+    )
+    wrong_note = _adapter().evaluate_envelope(
+        incoming,
+        dataset=_dataset(),
+        context=_context(target=_correction_target(note_id=OTHER_NOTE_ID)),
+    )
+
+    assert isinstance(missing, AdapterDeferred)
+    assert isinstance(wrong_note, AdapterDeferred)
+    assert missing.message == wrong_note.message

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py
@@ -201,6 +201,43 @@ def test_activity_bootstrap_captures_pages_adopts_rows_and_ignores_read_state(
     assert len(envelopes) == 3
 
 
+def test_activity_bootstrap_nonfinal_resume_scans_only_one_page(
+    bootstrap_stack,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep each non-final resume proportional to its configured page."""
+
+    note_db, _sync_store, service, dataset = bootstrap_stack
+    _record_events(note_db, dataset.dataset_id)
+    page_limits: list[int] = []
+    original_page = note_db.task_store.page_legacy_events_for_sync_bootstrap
+
+    def tracked_page(**kwargs):
+        """Record source-page limits without changing storage behavior."""
+
+        page_limits.append(kwargs["limit"])
+        return original_page(**kwargs)
+
+    monkeypatch.setattr(
+        note_db.task_store,
+        "page_legacy_events_for_sync_bootstrap",
+        tracked_page,
+    )
+    bootstrapper = _bootstrap_module().NotesTaskActivityBootstrapper(
+        note_db,
+        page_limit=1,
+    )
+
+    first = bootstrapper.bootstrap(service=service, dataset=dataset)
+    assert first.metadata["notes_task_activity_v1"]["state"] == "bootstrapping"
+    assert page_limits == [1]
+
+    page_limits.clear()
+    second = bootstrapper.bootstrap(service=service, dataset=first)
+    assert second.metadata["notes_task_activity_v1"]["state"] == "bootstrapping"
+    assert page_limits == [1]
+
+
 def test_activity_bootstrap_resumes_after_append_before_progress_split(
     bootstrap_stack,
 ) -> None:

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py
@@ -304,4 +304,3 @@ def test_factory_wires_private_activity_components_without_advertising_domain() 
     assert isinstance(registry.get("notes.task_activity"), NotesTaskActivityDomainAdapter)
     assert "notes.task_activity" not in factory._sync_v2_settings_from_env().supported_domains
     assert hasattr(factory, "_validate_notes_task_components")
-

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_bootstrap.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Sync.v2.adapters import SyncAdapterRegistry
+from tldw_Server_API.app.core.Sync.v2.domain_adapters import (
+    NotesTaskActivityDomainAdapter,
+    NotesTaskDomainAdapter,
+)
+from tldw_Server_API.app.core.Sync.v2.materializers import (
+    NotesTaskActivityMaterializer,
+    NotesTaskMaterializer,
+)
+from tldw_Server_API.app.core.Sync.v2.models import SYNC_V2_SUPPORTED_DOMAINS
+from tldw_Server_API.app.core.Sync.v2.notes_task_bootstrap import NotesTaskBootstrapper
+from tldw_Server_API.app.core.Sync.v2.service import SyncV2Service
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
+
+pytestmark = pytest.mark.unit
+
+OWNER_ID = "owner-user-1"
+NOTE_ID = "20000000-0000-4000-8000-000000000001"
+TASK_ID = "10000000-0000-4000-8000-000000000001"
+EVENT_IDS = (
+    "30000000-0000-4000-8000-000000000001",
+    "30000000-0000-4000-8000-000000000002",
+    "30000000-0000-4000-8000-000000000003",
+)
+OCCURRED_AT = "2026-08-13T10:00:00+00:00"
+
+
+def _bootstrap_module():
+    return importlib.import_module(
+        "tldw_Server_API.app.core.Sync.v2.notes_task_activity_bootstrap"
+    )
+
+
+@pytest.fixture()
+def bootstrap_stack(tmp_path: Path):
+    note_db = CharactersRAGDB(tmp_path / "activity.db", client_id=OWNER_ID)
+    sync_store = SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "sync.db"))
+    dataset = sync_store.get_or_create_default_personal_dataset(OWNER_ID)
+    note_db.note_store.add_note(NOTE_ID, "Activity source", note_id=NOTE_ID)
+    note_db.bind_local_task_graph_to_dataset(
+        owner_user_id=OWNER_ID,
+        target_dataset_id=dataset.dataset_id,
+    )
+    note_db.task_store.create_task(
+        owner_user_id=OWNER_ID,
+        dataset_id=dataset.dataset_id,
+        note_id=NOTE_ID,
+        text="Source task",
+        task_id=TASK_ID,
+        projection_status="unlinked",
+    )
+    service = SyncV2Service(
+        store=sync_store,
+        adapters=SyncAdapterRegistry(
+            [NotesTaskDomainAdapter(), NotesTaskActivityDomainAdapter()]
+        ),
+        materializers={
+            "notes.task": NotesTaskMaterializer(note_db),
+            "notes.task_activity": NotesTaskActivityMaterializer(note_db),
+        },
+    )
+    dataset = NotesTaskBootstrapper(note_db).bootstrap(
+        service=service,
+        dataset=dataset,
+    )
+    assert dataset.metadata["notes_task_v1"]["state"] == "ready"
+    assert dataset.metadata["notes_task_activity_v1"]["state"] == "enrolling"
+    try:
+        yield note_db, sync_store, service, dataset
+    finally:
+        note_db.close_connection()
+
+
+def _record_events(
+    note_db: CharactersRAGDB,
+    dataset_id: str,
+    event_ids: tuple[str, ...] = EVENT_IDS,
+) -> None:
+    for event_id in reversed(event_ids):
+        note_db.task_store.record_task_event(
+            owner_user_id=OWNER_ID,
+            dataset_id=dataset_id,
+            event_id=event_id,
+            task_id=TASK_ID,
+            note_id=NOTE_ID,
+            event_type="status_changed",
+            actor_type="user",
+            actor_id=OWNER_ID,
+            old_value={"status": "open"},
+            new_value={"status": "done"},
+        )
+    note_db.execute_query(
+        "UPDATE task_events SET created_at = ?, client_occurred_at = ? "
+        "WHERE owner_user_id = ? AND dataset_id = ?",
+        (OCCURRED_AT, OCCURRED_AT, OWNER_ID, dataset_id),
+        commit=True,
+    )
+
+
+def _activity_envelopes(sync_store: SyncV2Store, dataset_id: str):
+    return [
+        item
+        for item in sync_store.list_envelopes_after(dataset_id, 0, limit=100)
+        if item.domain == "notes.task_activity"
+    ]
+
+
+def test_legacy_activity_source_page_is_scoped_bounded_and_keyset_ordered(
+    bootstrap_stack,
+) -> None:
+    note_db, _sync_store, _service, dataset = bootstrap_stack
+    _record_events(note_db, dataset.dataset_id)
+
+    first = note_db.task_store.page_legacy_events_for_sync_bootstrap(
+        owner_user_id=OWNER_ID,
+        dataset_id=dataset.dataset_id,
+        limit=2,
+    )
+    second = note_db.task_store.page_legacy_events_for_sync_bootstrap(
+        owner_user_id=OWNER_ID,
+        dataset_id=dataset.dataset_id,
+        after_created_at=first[-1]["created_at"],
+        after_activity_id=first[-1]["id"],
+        limit=10,
+    )
+
+    assert [row["id"] for row in first] == list(EVENT_IDS[:2])
+    assert [row["id"] for row in second] == [EVENT_IDS[2]]
+    assert first[0]["resolved_task_note_id"] == NOTE_ID
+    assert note_db.task_store.page_legacy_events_for_sync_bootstrap(
+        owner_user_id="other-owner",
+        dataset_id=dataset.dataset_id,
+    ) == []
+    with pytest.raises(ValueError, match="1..1000"):
+        note_db.task_store.page_legacy_events_for_sync_bootstrap(
+            owner_user_id=OWNER_ID,
+            dataset_id=dataset.dataset_id,
+            limit=1_001,
+        )
+
+
+def test_activity_bootstrap_captures_pages_adopts_rows_and_ignores_read_state(
+    bootstrap_stack,
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _record_events(note_db, dataset.dataset_id)
+    note_db.task_store.mark_task_activity_read(
+        owner_user_id=OWNER_ID,
+        dataset_id=dataset.dataset_id,
+        event_id=EVENT_IDS[0],
+        user_id=OWNER_ID,
+    )
+    module = _bootstrap_module()
+    bootstrapper = module.NotesTaskActivityBootstrapper(note_db, page_limit=2)
+
+    partial = bootstrapper.bootstrap(service=service, dataset=dataset)
+    state = partial.metadata["notes_task_activity_v1"]
+    assert state["state"] == "bootstrapping"
+    assert state["source_count"] == 2
+    assert state["source_cursor"] == f"{OCCURRED_AT}|{EVENT_IDS[1]}"
+
+    ready = bootstrapper.bootstrap(service=service, dataset=partial)
+    state = ready.metadata["notes_task_activity_v1"]
+    assert state["state"] == "ready"
+    assert state["source_count"] == 3
+    assert "notes.task" not in ready.domains
+    assert "notes.task_activity" not in ready.domains
+    assert "notes.task_activity" not in SYNC_V2_SUPPORTED_DOMAINS
+
+    envelopes = _activity_envelopes(sync_store, dataset.dataset_id)
+    assert [item.object_id for item in envelopes] == list(EVENT_IDS)
+    assert [item.created_at_client for item in envelopes] == [OCCURRED_AT] * 3
+    assert all(item.apply_status == "applied" for item in envelopes)
+    bootstrap_id = module._bootstrap_id(OWNER_ID, dataset.dataset_id)
+    assert [item.client_envelope_id for item in envelopes] == [
+        module._activity_bootstrap_envelope_id(
+            bootstrap_id,
+            item.object_id,
+            item.payload_hash,
+        )
+        for item in envelopes
+    ]
+    rows = note_db.task_store.page_sync_task_activity(
+        owner_user_id=OWNER_ID,
+        dataset_id=dataset.dataset_id,
+        limit=10,
+    )
+    assert [row["id"] for row in rows] == list(EVENT_IDS)
+    assert all(row["event_type"] == "completed" for row in rows)
+    assert all(row["source_kind"] == "trusted_bootstrap_v1" for row in rows)
+    assert all(row["sync_server_cursor"] is not None for row in rows)
+    assert len(envelopes) == 3
+
+
+def test_activity_bootstrap_resumes_after_append_before_progress_split(
+    bootstrap_stack,
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _record_events(note_db, dataset.dataset_id, EVENT_IDS[:2])
+    module = _bootstrap_module()
+
+    def interrupt(_page_number: int) -> None:
+        raise module.NotesTaskBootstrapInterrupted
+
+    with pytest.raises(module.NotesTaskBootstrapInterrupted):
+        module.NotesTaskActivityBootstrapper(
+            note_db,
+            page_limit=2,
+            after_page=interrupt,
+        ).bootstrap(service=service, dataset=dataset)
+    interrupted = sync_store.get_dataset(
+        dataset.dataset_id,
+        owner_user_id=OWNER_ID,
+    )
+    assert interrupted is not None
+    assert interrupted.metadata["notes_task_activity_v1"]["source_count"] == 0
+    before = _activity_envelopes(sync_store, dataset.dataset_id)
+
+    ready = module.NotesTaskActivityBootstrapper(note_db, page_limit=2).bootstrap(
+        service=service,
+        dataset=interrupted,
+    )
+    after = _activity_envelopes(sync_store, dataset.dataset_id)
+    assert ready.metadata["notes_task_activity_v1"]["state"] == "ready"
+    assert [item.client_envelope_id for item in after] == [
+        item.client_envelope_id for item in before
+    ]
+
+
+def test_activity_bootstrap_source_drift_blocks_without_deleting_history(
+    bootstrap_stack,
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _record_events(note_db, dataset.dataset_id, EVENT_IDS[:2])
+    module = _bootstrap_module()
+    bootstrapper = module.NotesTaskActivityBootstrapper(note_db, page_limit=1)
+    partial = bootstrapper.bootstrap(service=service, dataset=dataset)
+    note_db.execute_query(
+        "UPDATE task_events SET sync_object_hash = ? "
+        "WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+        ("sha256:" + "f" * 64, OWNER_ID, dataset.dataset_id, EVENT_IDS[0]),
+        commit=True,
+    )
+
+    blocked = bootstrapper.bootstrap(service=service, dataset=partial)
+
+    state = blocked.metadata["notes_task_activity_v1"]
+    assert state["state"] == "blocked"
+    assert state["reason_code"] == "notes_task_activity_source_changed"
+    assert len(_activity_envelopes(sync_store, dataset.dataset_id)) == 1
+
+
+def test_activity_bootstrap_malformed_legacy_row_blocks_before_append(
+    bootstrap_stack,
+) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+    _record_events(note_db, dataset.dataset_id, EVENT_IDS[:1])
+    note_db.execute_query(
+        "UPDATE task_events SET event_type = ? "
+        "WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+        ("unknown", OWNER_ID, dataset.dataset_id, EVENT_IDS[0]),
+        commit=True,
+    )
+
+    blocked = _bootstrap_module().NotesTaskActivityBootstrapper(note_db).bootstrap(
+        service=service,
+        dataset=dataset,
+    )
+
+    state = blocked.metadata["notes_task_activity_v1"]
+    assert state["state"] == "blocked"
+    assert state["reason_code"] == "notes_task_activity_source_invalid"
+    assert not _activity_envelopes(sync_store, dataset.dataset_id)
+
+
+def test_activity_bootstrap_empty_source_becomes_ready(bootstrap_stack) -> None:
+    note_db, sync_store, service, dataset = bootstrap_stack
+
+    ready = _bootstrap_module().NotesTaskActivityBootstrapper(note_db).bootstrap(
+        service=service,
+        dataset=dataset,
+    )
+
+    state = ready.metadata["notes_task_activity_v1"]
+    assert state["state"] == "ready"
+    assert state["source_count"] == 0
+    assert state["source_cursor"] is None
+    assert not _activity_envelopes(sync_store, dataset.dataset_id)
+
+
+def test_factory_wires_private_activity_components_without_advertising_domain() -> None:
+    from tldw_Server_API.app.core.Sync.v2 import factory
+
+    registry = factory.default_sync_v2_registry()
+    assert isinstance(registry.get("notes.task_activity"), NotesTaskActivityDomainAdapter)
+    assert "notes.task_activity" not in factory._sync_v2_settings_from_env().supported_domains
+    assert hasattr(factory, "_validate_notes_task_components")
+

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_capture.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_capture.py
@@ -1,0 +1,335 @@
+"""Dormant capture contracts for canonical Notes task activity."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.Notes_Tasks.models import TaskActor
+from tldw_Server_API.app.core.Notes_Tasks.service import (
+    build_task_activity_capture,
+    build_task_capture_mutation,
+)
+from tldw_Server_API.app.core.Sync.v2.models import SYNC_V2_SUPPORTED_DOMAINS
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    notes_task_object_hash,
+    parse_notes_task_v1,
+)
+
+pytestmark = pytest.mark.unit
+
+OWNER_ID = "activity-capture-owner"
+DATASET_ID = "local-unbound"
+NOTE_ID = "11111111-1111-4111-8111-111111111111"
+TASK_ID = "22222222-2222-4222-8222-222222222222"
+BEFORE_TIME = "2026-08-23T10:00:00+00:00"
+AFTER_TIME = "2026-08-23T10:01:00+00:00"
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CharactersRAGDB:
+    database = CharactersRAGDB(tmp_path / "activity-capture.db", client_id=OWNER_ID)
+    try:
+        yield database
+    finally:
+        database.close_connection()
+
+
+def _metadata(**changes: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "description": None,
+        "priority": None,
+        "due_date": None,
+        "estimate": None,
+        "recurrence": None,
+        "assignee_id": None,
+        "tags": [],
+        "custom": {},
+    }
+    value.update(changes)
+    return value
+
+
+def _task_row(
+    *,
+    title: str = "Prepare launch",
+    status: str = "open",
+    completed_at: str | None = None,
+    metadata: dict[str, object] | None = None,
+    projection_status: str = "live",
+    deleted: bool = False,
+    version: int = 1,
+    canonical_revision: int = 1,
+    updated_at: str = BEFORE_TIME,
+) -> dict[str, Any]:
+    canonical_metadata = deepcopy(metadata or _metadata())
+    payload = parse_notes_task_v1(
+        {
+            "task_id": TASK_ID,
+            "note_id": NOTE_ID,
+            "title": title,
+            "status": status,
+            "completed_at": completed_at,
+            **canonical_metadata,
+        },
+        owner_user_id=OWNER_ID,
+    )
+    return {
+        "owner_user_id": OWNER_ID,
+        "dataset_id": DATASET_ID,
+        "id": TASK_ID,
+        "note_id": NOTE_ID,
+        "text": title,
+        "status": status,
+        "completed_at": completed_at,
+        "metadata_json": canonical_metadata,
+        "projection_status": projection_status,
+        "deleted": deleted,
+        "version": version,
+        "canonical_revision": canonical_revision,
+        "canonical_hash": notes_task_object_hash(
+            payload,
+            revision=canonical_revision,
+            deleted=deleted,
+        ),
+        "updated_at": updated_at,
+        "source_diagnostic_code": None,
+    }
+
+
+def _actor() -> TaskActor:
+    return TaskActor(
+        actor_type="user",
+        actor_id=OWNER_ID,
+        idempotency_key="activity-request-1",
+    )
+
+
+def _capture(
+    db: CharactersRAGDB,
+    before: dict[str, Any] | None,
+    after: dict[str, Any],
+):
+    return build_task_activity_capture(
+        db=db,
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        actor=_actor(),
+        before=before,
+        after=after,
+        source_kind="rest",
+    )
+
+
+def test_create_capture_uses_exact_snapshot_and_stable_step(db: CharactersRAGDB) -> None:
+    after = _task_row(metadata=_metadata(description="Ship safely", priority="high"))
+
+    first = _capture(db, None, after)
+    replay = _capture(db, None, after)
+
+    assert first == replay
+    assert UUID(first.payload.activity_id).version == 4
+    assert first.payload.event_type == "created"
+    assert first.payload.old_value is None
+    assert first.payload.new_value == {
+        "title": "Prepare launch",
+        "status": "open",
+        "completed_at": None,
+        "metadata": _metadata(description="Ship safely", priority="high"),
+    }
+    assert first.payload.client_occurred_at == BEFORE_TIME
+    assert first.payload.source_kind == "rest"
+    assert first.payload.source_device_id is None
+    assert first.step.domain == "notes.task_activity"
+    assert first.step.object_id == first.payload.activity_id
+    assert first.step.parent_id == NOTE_ID
+    assert first.step.object_revision == 1
+    assert first.step.payload == first.payload.model_dump(mode="json")
+    assert first.step.created_at_client == BEFORE_TIME
+    assert first.step.client_envelope_id == replay.step.client_envelope_id
+
+
+@pytest.mark.parametrize(
+    ("before", "after", "event_type", "old_value", "new_value"),
+    [
+        (
+            _task_row(),
+            _task_row(
+                title="Prepare launch notes",
+                metadata=_metadata(description="Detailed"),
+                version=2,
+                canonical_revision=2,
+                updated_at=AFTER_TIME,
+            ),
+            "updated",
+            {"title": "Prepare launch", "metadata": _metadata()},
+            {
+                "title": "Prepare launch notes",
+                "metadata": _metadata(description="Detailed"),
+            },
+        ),
+        (
+            _task_row(),
+            _task_row(
+                metadata=_metadata(
+                    recurrence={
+                        "frequency": "weekly",
+                        "interval": 1,
+                        "by_weekday": ["mo"],
+                        "until": None,
+                        "state": "active",
+                        "occurrence_index": 0,
+                    }
+                ),
+                version=2,
+                canonical_revision=2,
+                updated_at=AFTER_TIME,
+            ),
+            "updated",
+            {"metadata": _metadata()},
+            {
+                "metadata": _metadata(
+                    recurrence={
+                        "frequency": "weekly",
+                        "interval": 1,
+                        "by_weekday": ["mo"],
+                        "until": None,
+                        "state": "active",
+                        "occurrence_index": 0,
+                    }
+                )
+            },
+        ),
+        (
+            _task_row(),
+            _task_row(
+                status="done",
+                completed_at=AFTER_TIME,
+                version=2,
+                canonical_revision=2,
+                updated_at=AFTER_TIME,
+            ),
+            "completed",
+            {"status": "open"},
+            {"status": "done"},
+        ),
+        (
+            _task_row(status="done", completed_at=BEFORE_TIME),
+            _task_row(
+                status="open",
+                completed_at=None,
+                version=2,
+                canonical_revision=2,
+                updated_at=AFTER_TIME,
+            ),
+            "reopened",
+            {"status": "done"},
+            {"status": "open"},
+        ),
+        (
+            _task_row(),
+            _task_row(
+                projection_status="unlinked",
+                version=2,
+                canonical_revision=1,
+                updated_at=AFTER_TIME,
+            ),
+            "projection_unlinked",
+            {"projection_status": "live"},
+            {"projection_status": "unlinked"},
+        ),
+        (
+            _task_row(projection_status="unlinked"),
+            _task_row(
+                projection_status="deleted",
+                deleted=True,
+                version=2,
+                canonical_revision=2,
+                updated_at=AFTER_TIME,
+            ),
+            "deleted",
+            {"deleted": False, "projection_status": "unlinked"},
+            {"deleted": True, "projection_status": "deleted"},
+        ),
+        (
+            _task_row(projection_status="deleted", deleted=True),
+            _task_row(
+                projection_status="unlinked",
+                deleted=False,
+                version=2,
+                canonical_revision=2,
+                updated_at=AFTER_TIME,
+            ),
+            "restored",
+            {"deleted": True, "projection_status": "deleted"},
+            {"deleted": False, "projection_status": "unlinked"},
+        ),
+    ],
+)
+def test_capture_derives_each_portable_transition_shape(
+    db: CharactersRAGDB,
+    before: dict[str, Any],
+    after: dict[str, Any],
+    event_type: str,
+    old_value: dict[str, object],
+    new_value: dict[str, object],
+) -> None:
+    capture = _capture(db, before, after)
+
+    assert capture.payload.event_type == event_type
+    assert capture.payload.old_value == old_value
+    assert capture.payload.new_value == new_value
+    assert capture.payload.note_id == NOTE_ID
+    assert capture.payload.task_id == TASK_ID
+
+
+def test_task_capture_returns_stable_ordered_task_and_activity_plan(
+    db: CharactersRAGDB,
+) -> None:
+    before = _task_row()
+    after = _task_row(
+        status="done",
+        completed_at=AFTER_TIME,
+        version=2,
+        canonical_revision=2,
+        updated_at=AFTER_TIME,
+    )
+
+    first = build_task_capture_mutation(
+        db=db,
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        actor=_actor(),
+        before=before,
+        after=after,
+    )
+    repair = build_task_capture_mutation(
+        db=db,
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        actor=_actor(),
+        before=before,
+        after=after,
+    )
+
+    assert first == repair
+    assert first.steps == (first.step, first.activity.step)
+    assert [step.domain for step in first.steps] == [
+        "notes.task",
+        "notes.task_activity",
+    ]
+    assert first.activity.payload.event_type == "completed"
+    assert first.activity.payload.activity_id == repair.activity.payload.activity_id
+    assert first.activity.step.client_envelope_id == repair.activity.step.client_envelope_id
+    assert len({step.object_id for step in repair.steps}) == 2
+
+
+def test_capture_does_not_activate_public_task_domains() -> None:
+    dormant = {"notes.task", "notes.task_activity"}
+
+    assert dormant.isdisjoint(SYNC_V2_SUPPORTED_DOMAINS)

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_materializer.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_materializer.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    ConflictError,
+)
+from tldw_Server_API.app.core.DB_Management.Sync_DB import SyncDatabase
+from tldw_Server_API.app.core.Sync.v2 import materializers
+from tldw_Server_API.app.core.Sync.v2.models import (
+    SyncDatasetCreate,
+    SyncEnvelope,
+    SyncEnvelopeCreate,
+)
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    NotesTaskActivityV1,
+    notes_task_activity_object_hash,
+    parse_notes_task_activity_tombstone_v1,
+    parse_notes_task_activity_v1,
+)
+from tldw_Server_API.app.core.Sync.v2.store import SyncV2Store
+
+pytestmark = pytest.mark.unit
+
+OWNER_ID = "owner-user-1"
+DATASET_ID = "dataset-1"
+NOTE_ID = "22222222-2222-4222-8222-222222222222"
+OTHER_NOTE_ID = "33333333-3333-4333-8333-333333333333"
+TASK_ID = "11111111-1111-4111-8111-111111111111"
+ACTIVITY_ID = "55555555-5555-4555-8555-555555555555"
+NOW = "2026-08-13T10:00:00+00:00"
+DELETED_AT = "2026-08-13T11:00:00+00:00"
+
+
+def _materializer(note_db: CharactersRAGDB):
+    materializer_type = getattr(materializers, "NotesTaskActivityMaterializer", None)
+    assert materializer_type is not None, "NotesTaskActivityMaterializer is not implemented"
+    return materializer_type(note_db)
+
+
+def _activity(**overrides: object) -> NotesTaskActivityV1:
+    raw: dict[str, object] = {
+        "activity_id": ACTIVITY_ID,
+        "note_id": NOTE_ID,
+        "task_id": None,
+        "event_type": "projection_drift",
+        "actor_type": "system",
+        "actor_id": None,
+        "source_device_id": None,
+        "client_occurred_at": NOW,
+        "source_kind": "repair",
+        "corrects_activity_id": None,
+        "old_value": None,
+        "new_value": {"reason_code": "missing_marker_base"},
+        "metadata": {"repair_generation": 7},
+    }
+    raw.update(overrides)
+    return parse_notes_task_activity_v1(
+        raw,
+        owner_user_id=OWNER_ID,
+        bound_actor_type=str(raw["actor_type"]),
+        bound_actor_id=raw["actor_id"],
+        authenticated_device_id=None,
+        trusted_server_origin=True,
+    )
+
+
+def _create(payload: NotesTaskActivityV1, *, suffix: str) -> SyncEnvelopeCreate:
+    return SyncEnvelopeCreate(
+        dataset_id=DATASET_ID,
+        client_envelope_id=f"activity-{suffix}",
+        domain="notes.task_activity",
+        operation="upsert",
+        object_id=payload.activity_id,
+        parent_id=payload.note_id,
+        device_id="44444444-4444-4444-8444-444444444444",
+        object_revision=1,
+        entity_version=1,
+        adapter_version=1,
+        schema_version=1,
+        payload=payload.model_dump(mode="json"),
+        payload_hash=notes_task_activity_object_hash(
+            payload,
+            revision=1,
+            deleted=False,
+        ),
+        created_at_client=NOW,
+        routing_metadata={},
+        status="accepted",
+    )
+
+
+def _tombstone(
+    created: SyncEnvelope,
+    original: NotesTaskActivityV1,
+) -> SyncEnvelopeCreate:
+    payload = parse_notes_task_activity_tombstone_v1(
+        {
+            "note_id": original.note_id,
+            "task_id": original.task_id,
+            "deleted_at": DELETED_AT,
+            "delete_reason": "correction",
+        },
+        envelope_created_at_client=DELETED_AT,
+        original_activity=original,
+    )
+    return SyncEnvelopeCreate(
+        dataset_id=DATASET_ID,
+        client_envelope_id="activity-tombstone",
+        domain="notes.task_activity",
+        operation="tombstone",
+        object_id=original.activity_id,
+        parent_id=original.note_id,
+        device_id="44444444-4444-4444-8444-444444444444",
+        base_server_cursor=created.server_cursor,
+        base_object_revision=created.object_revision,
+        base_object_hash=created.payload_hash,
+        object_revision=2,
+        entity_version=2,
+        adapter_version=1,
+        schema_version=1,
+        payload=payload.model_dump(mode="json"),
+        payload_hash=notes_task_activity_object_hash(
+            payload,
+            revision=2,
+            deleted=True,
+            activity_id=original.activity_id,
+            original_create_hash=created.payload_hash,
+        ),
+        created_at_client=DELETED_AT,
+        routing_metadata={},
+        status="accepted",
+    )
+
+
+def _insert_internal(store: SyncV2Store, create: SyncEnvelopeCreate) -> SyncEnvelope:
+    with store.db.backend.transaction() as conn:
+        return store.db._insert_envelope_in_transaction(create, connection=conn)
+
+
+@pytest.fixture()
+def materialization_stack(tmp_path: Path):
+    note_db = CharactersRAGDB(tmp_path / "notes-task-activity-product.db", client_id=OWNER_ID)
+    note_db.note_store.add_note(NOTE_ID, "body", note_id=NOTE_ID)
+    note_db.note_store.add_note(OTHER_NOTE_ID, "other", note_id=OTHER_NOTE_ID)
+    note_db.bind_local_task_graph_to_dataset(
+        owner_user_id=OWNER_ID,
+        target_dataset_id=DATASET_ID,
+    )
+    sync_store = SyncV2Store(SyncDatabase(sqlite_path=tmp_path / "notes-task-activity-sync.db"))
+    sync_store.enroll_dataset(
+        SyncDatasetCreate(
+            dataset_id=DATASET_ID,
+            owner_user_id=OWNER_ID,
+            domains=["notes.note"],
+        )
+    )
+    sync_store.db.execute(
+        "UPDATE sync_datasets SET domain_set_json = ? WHERE dataset_id = ?",
+        (json.dumps(["notes.note", "notes.task_activity"]), DATASET_ID),
+    )
+    try:
+        yield note_db, sync_store
+    finally:
+        note_db.close_connection()
+
+
+def _get(note_db: CharactersRAGDB, activity_id: str = ACTIVITY_ID):
+    return note_db.task_store.get_sync_task_activity(
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        activity_id=activity_id,
+    )
+
+
+def _count(note_db: CharactersRAGDB) -> int:
+    return int(
+        note_db.execute_query(
+            "SELECT COUNT(*) AS count FROM task_events "
+            "WHERE owner_user_id = ? AND dataset_id = ?",
+            (OWNER_ID, DATASET_ID),
+        ).fetchone()["count"]
+    )
+
+
+def test_materializer_inserts_exact_activity_once_and_repairs_split_commit(
+    materialization_stack,
+) -> None:
+    note_db, sync_store = materialization_stack
+    payload = _activity()
+    incoming = _insert_internal(sync_store, _create(payload, suffix="create"))
+
+    class _FailObjectStateOnce:
+        def __init__(self, wrapped: SyncV2Store) -> None:
+            self.wrapped = wrapped
+            self.failed = False
+
+        def upsert_object_state(self, *_args, **_kwargs) -> None:
+            if not self.failed:
+                self.failed = True
+                raise RuntimeError("injected Sync status failure")
+            self.wrapped.upsert_object_state(*_args, **_kwargs)
+
+        def __getattr__(self, name: str):
+            return getattr(self.wrapped, name)
+
+    assert _materializer(note_db).apply(incoming, store=_FailObjectStateOnce(sync_store)).status == "failed"
+    row = _get(note_db)
+    assert row is not None
+    assert row["note_id"] == NOTE_ID
+    assert row["task_id"] is None
+    assert row["event_type"] == "projection_drift"
+    assert row["actor_type"] == "system"
+    assert row["source_kind"] == "repair"
+    assert row["client_occurred_at"] == NOW
+    assert row["old_value_json"] is None
+    assert row["new_value_json"] == {"reason_code": "missing_marker_base"}
+    assert row["sync_revision"] == 1
+    assert row["sync_object_hash"] == incoming.payload_hash
+    assert row["sync_server_cursor"] == incoming.server_cursor
+    assert not bool(row["deleted"])
+
+    assert _materializer(note_db).apply(incoming, store=sync_store).status == "applied"
+    assert _count(note_db) == 1
+    state = sync_store.get_object_state(DATASET_ID, "notes.task_activity", ACTIVITY_ID)
+    assert state is not None and state.latest_server_cursor == incoming.server_cursor
+
+
+def test_materializer_rejects_changed_product_replay(materialization_stack) -> None:
+    note_db, sync_store = materialization_stack
+    incoming = _insert_internal(sync_store, _create(_activity(), suffix="changed"))
+    assert _materializer(note_db).apply(incoming, store=sync_store).status == "applied"
+    note_db.execute_query(
+        "UPDATE task_events SET event_type = ? "
+        "WHERE owner_user_id = ? AND dataset_id = ? AND id = ?",
+        ("projection_linked", OWNER_ID, DATASET_ID, ACTIVITY_ID),
+        commit=True,
+    )
+
+    result = _materializer(note_db).apply(incoming, store=sync_store)
+
+    assert result.status == "conflict"
+    assert result.conflict_type == "notes_task_activity_product_conflict"
+    assert _count(note_db) == 1
+
+
+def test_materializer_applies_one_way_revision_two_tombstone(
+    materialization_stack,
+) -> None:
+    note_db, sync_store = materialization_stack
+    original = _activity()
+    created = _insert_internal(sync_store, _create(original, suffix="before-delete"))
+    assert _materializer(note_db).apply(created, store=sync_store).status == "applied"
+    deleted = _insert_internal(sync_store, _tombstone(created, original))
+
+    assert _materializer(note_db).apply(deleted, store=sync_store).status == "applied"
+    row = _get(note_db)
+    assert row is not None and bool(row["deleted"])
+    assert row["sync_revision"] == 2
+    assert row["sync_object_hash"] == deleted.payload_hash
+    assert row["sync_server_cursor"] == deleted.server_cursor
+    assert row["deleted_at"] == DELETED_AT
+    assert row["delete_reason"] == "correction"
+    assert _materializer(note_db).apply(deleted, store=sync_store).status == "applied"
+    assert _materializer(note_db).apply(created, store=sync_store).status == "conflict"
+    assert _count(note_db) == 1
+
+
+def test_activity_store_enforces_exact_note_task_and_dataset_scope(
+    materialization_stack,
+) -> None:
+    note_db, _sync_store = materialization_stack
+    task = note_db.task_store.create_task(
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        note_id=NOTE_ID,
+        text="Scoped task",
+        task_id=TASK_ID,
+        projection_status="unlinked",
+    )
+    payload = _activity(task_id=TASK_ID)
+    canonical_hash = notes_task_activity_object_hash(payload, revision=1, deleted=False)
+
+    with note_db.transaction() as conn:
+        created = note_db.task_store.create_sync_task_activity(
+            owner_user_id=OWNER_ID,
+            dataset_id=DATASET_ID,
+            payload=payload,
+            sync_object_hash=canonical_hash,
+            sync_server_cursor=41,
+            conn=conn,
+        )
+    assert created["task_id"] == task["id"]
+    assert note_db.task_store.get_sync_task_activity(
+        owner_user_id=OWNER_ID,
+        dataset_id="other-dataset",
+        activity_id=ACTIVITY_ID,
+    ) is None
+
+    wrong_parent = _activity(
+        activity_id="66666666-6666-4666-8666-666666666666",
+        note_id=OTHER_NOTE_ID,
+        task_id=TASK_ID,
+    )
+    with pytest.raises(ConflictError):
+        with note_db.transaction() as conn:
+            note_db.task_store.create_sync_task_activity(
+                owner_user_id=OWNER_ID,
+                dataset_id=DATASET_ID,
+                payload=wrong_parent,
+                sync_object_hash=notes_task_activity_object_hash(
+                    wrong_parent,
+                    revision=1,
+                    deleted=False,
+                ),
+                sync_server_cursor=42,
+                conn=conn,
+            )
+
+
+def test_activity_page_uses_cursor_id_keyset_and_caps_at_one_thousand(
+    materialization_stack,
+) -> None:
+    note_db, _sync_store = materialization_stack
+    with note_db.transaction() as conn:
+        for ordinal in range(1, 1_003):
+            activity_id = str(UUID(int=ordinal, version=4))
+            payload = _activity(activity_id=activity_id)
+            note_db.task_store.create_sync_task_activity(
+                owner_user_id=OWNER_ID,
+                dataset_id=DATASET_ID,
+                payload=payload,
+                sync_object_hash=notes_task_activity_object_hash(
+                    payload,
+                    revision=1,
+                    deleted=False,
+                ),
+                sync_server_cursor=50 if ordinal <= 2 else 50 + ordinal,
+                conn=conn,
+            )
+
+    first = note_db.task_store.page_sync_task_activity(
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        limit=5_000,
+    )
+    assert len(first) == 1_000
+    assert [(row["sync_server_cursor"], row["id"]) for row in first[:3]] == [
+        (50, str(UUID(int=1, version=4))),
+        (50, str(UUID(int=2, version=4))),
+        (53, str(UUID(int=3, version=4))),
+    ]
+    after = first[-1]
+    second = note_db.task_store.page_sync_task_activity(
+        owner_user_id=OWNER_ID,
+        dataset_id=DATASET_ID,
+        after_server_cursor=after["sync_server_cursor"],
+        after_activity_id=after["id"],
+        limit=10,
+    )
+    assert len(second) == 2
+
+
+def test_materializer_product_failure_rolls_back_insert(
+    materialization_stack,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    note_db, sync_store = materialization_stack
+    incoming = _insert_internal(sync_store, _create(_activity(), suffix="rollback"))
+
+    def fail_after_write(_stage: str) -> None:
+        raise RuntimeError("injected product failure")
+
+    monkeypatch.setattr(
+        type(note_db.task_store),
+        "_sync_task_activity_materialization_checkpoint",
+        staticmethod(fail_after_write),
+    )
+
+    result = _materializer(note_db).apply(incoming, store=sync_store)
+
+    assert result.status == "failed"
+    assert _get(note_db) is None

--- a/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_postgres_contract.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_notes_task_activity_postgres_contract.py
@@ -1,0 +1,277 @@
+"""PostgreSQL contracts for dormant ``notes.task_activity`` storage."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from psycopg import sql as psycopg_sql
+
+from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseConfig
+from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBackendFactory
+from tldw_Server_API.app.core.DB_Management.chacha.task_store import TaskStore
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    ConflictError,
+)
+from tldw_Server_API.app.core.Sync.v2.notes_task_contract import (
+    NotesTaskActivityV1,
+    notes_task_activity_object_hash,
+    parse_notes_task_activity_v1,
+)
+
+pytestmark = pytest.mark.integration
+
+DATASET_ID = "local-unbound"
+NOW = "2026-08-23T10:00:00+00:00"
+
+
+def _execute_role_statement(connection: Any, statement: str, role_name: str) -> None:
+    raw_connection = getattr(connection, "_connection", connection)
+    with raw_connection.cursor() as cursor:
+        cursor.execute(psycopg_sql.SQL(statement).format(psycopg_sql.Identifier(role_name)))
+
+
+def _activity(
+    *,
+    owner: str,
+    activity_id: str,
+    note_id: str,
+    task_id: str | None,
+) -> NotesTaskActivityV1:
+    return parse_notes_task_activity_v1(
+        {
+            "activity_id": activity_id,
+            "note_id": note_id,
+            "task_id": task_id,
+            "event_type": "created",
+            "actor_type": "user",
+            "actor_id": owner,
+            "source_device_id": None,
+            "client_occurred_at": NOW,
+            "source_kind": "rest",
+            "corrects_activity_id": None,
+            "old_value": None,
+            "new_value": {
+                "title": "PostgreSQL activity",
+                "status": "open",
+                "completed_at": None,
+                "metadata": {
+                    "description": None,
+                    "priority": None,
+                    "due_date": None,
+                    "estimate": None,
+                    "recurrence": None,
+                    "assignee_id": None,
+                    "tags": [],
+                    "custom": {},
+                },
+            },
+            "metadata": {},
+        },
+        owner_user_id=owner,
+        bound_actor_type="user",
+        bound_actor_id=owner,
+        authenticated_device_id=None,
+        trusted_server_origin=True,
+    )
+
+
+def _seed_task(db: CharactersRAGDB, *, owner: str) -> tuple[str, str]:
+    note_id = str(uuid4())
+    task_id = str(uuid4())
+    db.add_note("PostgreSQL activity", "Body\n", note_id=note_id)
+    db.task_store.create_task(
+        owner_user_id=owner,
+        dataset_id=DATASET_ID,
+        note_id=note_id,
+        text="PostgreSQL activity",
+        task_id=task_id,
+        projection_status="unlinked",
+    )
+    return note_id, task_id
+
+
+def _insert_activity(
+    db: CharactersRAGDB,
+    *,
+    owner: str,
+    role_name: str,
+    payload: NotesTaskActivityV1,
+    cursor: int,
+) -> dict[str, Any]:
+    object_hash = notes_task_activity_object_hash(payload, revision=1, deleted=False)
+    with db.transaction() as conn:
+        _execute_role_statement(conn, "SET LOCAL ROLE {}", role_name)
+        conn.execute("SELECT set_config('app.current_user_id', ?, true)", (owner,))
+        return db.task_store.create_sync_task_activity(
+            owner_user_id=owner,
+            dataset_id=DATASET_ID,
+            payload=payload,
+            sync_object_hash=object_hash,
+            sync_server_cursor=cursor,
+            conn=conn,
+        )
+
+
+def test_activity_sql_binds_scope_parent_and_cursor_id_ordering() -> None:
+    get_source = inspect.getsource(TaskStore.get_sync_task_activity)
+    page_source = inspect.getsource(TaskStore.page_sync_task_activity)
+    parent_source = inspect.getsource(TaskStore._require_sync_activity_parents)
+    indexes = " ".join(CharactersRAGDB._note_task_v60_postgres_indexes())
+    policy = CharactersRAGDB._note_task_v60_policy_predicates()["task_events"]
+
+    assert "e.owner_user_id = ? AND e.dataset_id = ? AND e.id = ?" in get_source
+    assert "t.id = e.task_id AND t.note_id = e.note_id" in get_source
+    assert "e.sync_server_cursor > ?" in page_source
+    assert "e.sync_server_cursor = ? AND e.id > ?" in page_source
+    assert "ORDER BY e.sync_server_cursor ASC, e.id ASC" in page_source
+    assert 'task["note_id"] != payload.note_id' in parent_source
+    assert "idx_task_events_scope_cursor" in indexes
+    assert "task.id=task_events.task_id" in policy
+    assert "task.note_id=task_events.note_id" in policy
+
+
+def test_postgres_activity_rls_parent_paging_replay_and_rollback(
+    pg_database_config: DatabaseConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner_a = "980001"
+    owner_b = "980002"
+    backend_a = DatabaseBackendFactory.create_backend(pg_database_config)
+    backend_b = DatabaseBackendFactory.create_backend(pg_database_config)
+    db_a = CharactersRAGDB(":memory:", client_id=owner_a, backend=backend_a)
+    db_b = CharactersRAGDB(":memory:", client_id=owner_b, backend=backend_b)
+    role_name = f"notes_task_activity_{uuid4().hex[:8]}"
+    role_created = False
+
+    try:
+        with backend_a.transaction() as conn:
+            _execute_role_statement(conn, "CREATE ROLE {} NOLOGIN NOSUPERUSER NOBYPASSRLS", role_name)
+            _execute_role_statement(conn, "GRANT USAGE ON SCHEMA public TO {}", role_name)
+            for table in ("notes", "note_tasks"):
+                _execute_role_statement(conn, f"GRANT SELECT ON {table} TO {{}}", role_name)
+            _execute_role_statement(
+                conn,
+                "GRANT SELECT, UPDATE ON note_task_scope_authority TO {}",
+                role_name,
+            )
+            _execute_role_statement(conn, "GRANT SELECT, INSERT, UPDATE ON task_events TO {}", role_name)
+            _execute_role_statement(conn, "GRANT {} TO CURRENT_USER", role_name)
+        role_created = True
+
+        note_a, task_a = _seed_task(db_a, owner=owner_a)
+        note_b, task_b = _seed_task(db_b, owner=owner_b)
+        wrong_note_a = str(uuid4())
+        db_a.add_note("Wrong activity parent", "Body\n", note_id=wrong_note_a)
+        activity_ids = [str(UUID(int=index, version=4)) for index in (1, 2, 3)]
+        payloads = [
+            _activity(
+                owner=owner_a,
+                activity_id=activity_id,
+                note_id=note_a,
+                task_id=task_a,
+            )
+            for activity_id in activity_ids
+        ]
+        _insert_activity(db_a, owner=owner_a, role_name=role_name, payload=payloads[1], cursor=50)
+        _insert_activity(db_a, owner=owner_a, role_name=role_name, payload=payloads[0], cursor=50)
+        inserted = _insert_activity(
+            db_a,
+            owner=owner_a,
+            role_name=role_name,
+            payload=payloads[2],
+            cursor=51,
+        )
+        foreign = _activity(
+            owner=owner_b,
+            activity_id=str(uuid4()),
+            note_id=note_b,
+            task_id=task_b,
+        )
+        _insert_activity(db_b, owner=owner_b, role_name=role_name, payload=foreign, cursor=60)
+
+        page = db_a.task_store.page_sync_task_activity(
+            owner_user_id=owner_a,
+            dataset_id=DATASET_ID,
+            limit=2,
+        )
+        next_page = db_a.task_store.page_sync_task_activity(
+            owner_user_id=owner_a,
+            dataset_id=DATASET_ID,
+            after_server_cursor=int(page[-1]["sync_server_cursor"]),
+            after_activity_id=str(page[-1]["id"]),
+            limit=2,
+        )
+        assert [(row["sync_server_cursor"], row["id"]) for row in [*page, *next_page]] == [
+            (50, activity_ids[0]),
+            (50, activity_ids[1]),
+            (51, activity_ids[2]),
+        ]
+        assert db_a.task_store.verify_sync_task_activity_postcondition(
+            owner_user_id=owner_a,
+            dataset_id=DATASET_ID,
+            payload=payloads[2],
+            sync_revision=1,
+            sync_object_hash=inserted["sync_object_hash"],
+            sync_server_cursor=51,
+        )
+
+        with db_a.transaction() as conn:
+            _execute_role_statement(conn, "SET LOCAL ROLE {}", role_name)
+            conn.execute("SELECT set_config('app.current_user_id', ?, true)", (owner_a,))
+            conn.execute("SELECT set_config('app.current_dataset_id', ?, true)", (DATASET_ID,))
+            visible = conn.execute("SELECT id FROM task_events ORDER BY id").fetchall()
+        assert {str(row["id"]) for row in visible} == set(activity_ids)
+
+        wrong_parent = _activity(
+            owner=owner_a,
+            activity_id=str(uuid4()),
+            note_id=wrong_note_a,
+            task_id=task_a,
+        )
+        with pytest.raises(ConflictError, match="scope does not match its note"):
+            _insert_activity(
+                db_a,
+                owner=owner_a,
+                role_name=role_name,
+                payload=wrong_parent,
+                cursor=70,
+            )
+
+        rolled_back = _activity(
+            owner=owner_a,
+            activity_id=str(uuid4()),
+            note_id=note_a,
+            task_id=task_a,
+        )
+        monkeypatch.setattr(
+            db_a.task_store,
+            "_sync_task_activity_materialization_checkpoint",
+            lambda _phase: (_ for _ in ()).throw(RuntimeError("forced activity rollback")),
+        )
+        with pytest.raises(RuntimeError, match="forced activity rollback"):
+            _insert_activity(
+                db_a,
+                owner=owner_a,
+                role_name=role_name,
+                payload=rolled_back,
+                cursor=71,
+            )
+        assert db_a.task_store.get_sync_task_activity(
+            owner_user_id=owner_a,
+            dataset_id=DATASET_ID,
+            activity_id=rolled_back.activity_id,
+        ) is None
+    finally:
+        if role_created:
+            with backend_a.transaction() as conn:
+                _execute_role_statement(conn, "REVOKE {} FROM CURRENT_USER", role_name)
+                _execute_role_statement(conn, "DROP OWNED BY {}", role_name)
+                _execute_role_statement(conn, "DROP ROLE {}", role_name)
+        db_b.close_all_connections()
+        db_a.close_all_connections()
+        backend_b.get_pool().close_all()
+        backend_a.get_pool().close_all()


### PR DESCRIPTION
## Summary

This PR lays the groundwork for securely syncing note tasks and task activity across SQLite and PostgreSQL. It adds tenant-scoped storage, migrations, RLS enforcement, dataset binding, readiness tracking, bootstrap/materialization, and transactional capture while keeping the new sync domains disabled from public capabilities until they are ready for activation. It also hardens catalog validation, rollback behavior, compatibility APIs, and malformed-state handling with extensive SQLite and live PostgreSQL coverage.

For TASK-13006.3 specifically, this change:

- adds the immutable notes.task_activity adapter and materializer, including correction supersession and replay-safe identity handling;
- bootstraps legacy SQLite task activity into tenant-bound PostgreSQL datasets with readiness and rollback guarantees;
- derives exact task lifecycle events and captures task plus activity mutations in one server-origin transaction;
- preserves the dormant rollout boundary: neither task sync domain is publicly advertised or publicly writable.

## Architecture

- Implements canonical ADR-039; no new architecture decision is introduced.
- Backlog item: TASK-13006.3.

## Verification

- Required task gate with live PostgreSQL: 281 passed, 0 skipped.
- Adjacent task/activity regression gate: 30 passed.
- Ruff, Bandit, py_compile, and git diff --check passed.
- The canonical 54,346-test local run was started but could not provide valid results because the managed sandbox denied FastAPI startup access to the worktree database; GitHub CI runs outside that restriction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dormant immutable `notes.task_activity` Sync v1 lifecycle (adapter, materializer, bootstrap, and capture) to enable exact task lifecycle synchronization from SQLite to tenant Postgres. The domain remains disabled; public capabilities and existing write paths do not change. Satisfies TASK-13006.3.

- Validates immutable activity lineage (create and one-way tombstone v1) with correction supersession and dormant enforcement; adapter context now carries optional authenticated actor/device fields and an authorized task lookup.
- Materializes envelopes into task events with rollback checkpoints, typed conflicts, idempotency, and strict contract errors.
- Bootstraps legacy activity in deterministic created_at/ID order with provenance stamping; resumable with domain readiness tracked as `notes_task_activity_v1` and explicit interruption/error types.
- Extends server-origin capture to co-commit task and activity; accepts `trusted_notes_task_activity_bootstrap_id` and uses domain-specific readiness keys.
- Updates `NotesTaskService` to optionally emit task-activity capture plans (actor/device/time); behavior is unchanged when the callback is unset.
- Plumbs registration and trusted bootstrap IDs across `SyncV2Service`, `SyncV2Store`, DB seams, and materialization guards; RLS remains enforced.
- Review fixes: selects readiness key per domain in materialization, threads trusted bootstrap ID through store upserts, enriches adapter context, and expands unit/integration tests.

<sup>Written for commit 920e6578520e017550c7d44e44742469e4e181e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

