### PR TITLE
feat(service-prompts): customize image prompt refinement

### DIFF
--- a/apps/packages/ui/src/assets/locale/en/settings.json
+++ b/apps/packages/ui/src/assets/locale/en/settings.json
@@ -39,6 +39,10 @@
         "label": "Conversation title",
         "description": "Controls the instruction used to generate automatic conversation titles."
       },
+      "imagePromptRefinement": {
+        "label": "Image prompt refinement",
+        "description": "Controls the semantic instructions used to refine image-generation prompt drafts."
+      },
       "mediaTextTranslation": {
         "label": "Text translation",
         "description": "Controls the visible instructions used by synchronous text translation."
@@ -56,6 +60,7 @@
       "mainChatWebSearch": "Main chat web search",
       "compareWebSearch": "Compare web search",
       "automaticConversationTitles": "Automatic conversation titles",
+      "imagePromptRefinement": "Image prompt refinement",
       "textTranslation": "Text translation",
       "automaticNotesTitles": "Automatic Notes titles"
     },
@@ -66,6 +71,8 @@
     "parts": {
       "template": "Template",
       "system": "System instructions",
+      "systemSemantics": "Refinement guidance",
+      "rewriteSemantics": "Rewrite guidance",
       "titleInstruction": "Title instruction",
       "userTemplate": "User template"
     },

--- a/apps/packages/ui/src/components/Option/Playground/hooks/__tests__/usePlaygroundImageGen.service-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/hooks/__tests__/usePlaygroundImageGen.service-prompts.test.tsx
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { usePlaygroundImageGen } from "../usePlaygroundImageGen"
+
+const mocks = vi.hoisted(() => ({
+  createChatCompletion: vi.fn(),
+  initialize: vi.fn(),
+  loadServicePromptSnapshot: vi.fn(),
+  releaseSnapshot: vi.fn(),
+  notificationError: vi.fn(),
+  scopeController: new AbortController(),
+  scopeInvalidatedController: new AbortController(),
+  requestScope: {
+    config: { serverUrl: "https://captured.example" },
+    userId: null
+  }
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [], isLoading: false })
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: (...args: unknown[]) => mocks.initialize(...args),
+    createChatCompletion: (...args: unknown[]) =>
+      mocks.createChatCompletion(...args)
+  }
+}))
+
+vi.mock("@/services/service-prompts", () => ({
+  loadServicePromptSnapshot: (...args: unknown[]) =>
+    mocks.loadServicePromptSnapshot(...args)
+}))
+
+vi.mock("@/utils/resolve-api-provider", () => ({
+  resolveApiProviderForModel: vi.fn(async () => "custom")
+}))
+
+const completionResponse = (content: string) => ({
+  json: async () => ({ choices: [{ message: { content } }] })
+})
+
+const servicePromptSnapshot = (includeDefinition = true) => ({
+  scopeKey: "captured-scope",
+  requestScope: mocks.requestScope,
+  capability: "supported",
+  definitions: includeDefinition
+    ? {
+        "image.prompt.refinement": {
+          definition: {
+            id: "image.prompt.refinement",
+            parts: [
+              {
+                key: "system_semantics",
+                mode: "literal",
+                required_variables: []
+              },
+              {
+                key: "rewrite_semantics",
+                mode: "literal",
+                required_variables: []
+              }
+            ]
+          },
+          parts: {
+            system_semantics:
+              "Preserve the subject and favor painterly detail.",
+            rewrite_semantics: "Return a vivid, compact production prompt."
+          },
+          source: "user",
+          revision: "11111111-1111-4111-8111-111111111111"
+        }
+      }
+    : {},
+  scopeSignal: mocks.scopeController.signal,
+  scopeInvalidatedSignal: mocks.scopeInvalidatedController.signal,
+  release: mocks.releaseSnapshot
+})
+
+const baseDeps = () => ({
+  imageBackendDefaultTrimmed: "local-sd",
+  imageBackendOptions: [{ value: "local-sd", label: "Local SD" }],
+  imageEventSyncChatMode: "off" as const,
+  imageEventSyncGlobalDefault: "off" as const,
+  updateChatSettings: vi.fn(),
+  setImageEventSyncGlobalDefault: vi.fn(),
+  messages: [
+    {
+      isBot: true,
+      message: "Lana stands by the rainy neon alley.",
+      moodLabel: "focused"
+    }
+  ],
+  selectedCharacterName: "Lana",
+  selectedModel: "deepseek-chat",
+  currentApiProvider: "custom",
+  formMessage: "",
+  sendMessage: vi.fn(async () => undefined),
+  textAreaFocus: vi.fn(),
+  notificationApi: { error: mocks.notificationError },
+  t: (_key: string, fallback?: string | { defaultValue?: string }) =>
+    typeof fallback === "string" ? fallback : fallback?.defaultValue ?? _key,
+  setToolsPopoverOpen: vi.fn()
+})
+
+const prepareHook = () => {
+  const rendered = renderHook(() => usePlaygroundImageGen(baseDeps()))
+  act(() => {
+    rendered.result.current.setImageGenerateBackend("local-sd")
+    rendered.result.current.setImageGeneratePrompt(
+      "Portrait of Lana in neon rain."
+    )
+  })
+  return rendered
+}
+
+describe("usePlaygroundImageGen Service Prompts", () => {
+  beforeEach(() => {
+    mocks.scopeController = new AbortController()
+    mocks.scopeInvalidatedController = new AbortController()
+    mocks.initialize.mockReset()
+    mocks.initialize.mockResolvedValue(undefined)
+    mocks.createChatCompletion.mockReset()
+    mocks.createChatCompletion.mockResolvedValue(
+      completionResponse("Prompt: cinematic painterly portrait of Lana")
+    )
+    mocks.releaseSnapshot.mockReset()
+    mocks.notificationError.mockReset()
+    mocks.loadServicePromptSnapshot.mockReset()
+    mocks.loadServicePromptSnapshot.mockResolvedValue(servicePromptSnapshot())
+  })
+
+  it("binds one scoped snapshot and its custom semantics to each refinement", async () => {
+    const { result } = prepareHook()
+
+    await act(async () => {
+      await result.current.handleRefineImagePromptDraft()
+    })
+
+    expect(mocks.loadServicePromptSnapshot).toHaveBeenCalledOnce()
+    expect(mocks.loadServicePromptSnapshot).toHaveBeenCalledWith([
+      "image.prompt.refinement"
+    ])
+    const [requestBody, requestOptions] =
+      mocks.createChatCompletion.mock.calls[0] ?? []
+    expect(requestBody.messages[0].content).toContain(
+      "Preserve the subject and favor painterly detail."
+    )
+    expect(requestBody.messages[1].content).toContain(
+      "Return a vivid, compact production prompt."
+    )
+    expect(requestOptions).toEqual({
+      signal: mocks.scopeController.signal,
+      requestScope: mocks.requestScope
+    })
+    expect(result.current.imagePromptRefineCandidate).toBe(
+      "cinematic painterly portrait of Lana"
+    )
+    expect(mocks.releaseSnapshot).toHaveBeenCalledOnce()
+  })
+
+  it("does not commit a candidate after the captured scope is invalidated", async () => {
+    mocks.createChatCompletion.mockImplementationOnce(async () => {
+      mocks.scopeInvalidatedController.abort()
+      mocks.scopeController.abort()
+      return completionResponse("Prompt: stale account result")
+    })
+    const { result } = prepareHook()
+
+    await act(async () => {
+      await result.current.handleRefineImagePromptDraft()
+    })
+
+    expect(result.current.imagePromptRefineCandidate).toBe("")
+    expect(mocks.releaseSnapshot).toHaveBeenCalledOnce()
+  })
+
+  it("does not dispatch after the captured scope is already invalidated", async () => {
+    mocks.scopeInvalidatedController.abort()
+    const { result } = prepareHook()
+
+    await act(async () => {
+      await result.current.handleRefineImagePromptDraft()
+    })
+
+    expect(mocks.createChatCompletion).not.toHaveBeenCalled()
+    expect(result.current.imagePromptRefineCandidate).toBe("")
+    expect(mocks.releaseSnapshot).toHaveBeenCalledOnce()
+  })
+
+  it("fails closed when a supported snapshot omits the requested definition", async () => {
+    mocks.loadServicePromptSnapshot.mockResolvedValueOnce(
+      servicePromptSnapshot(false)
+    )
+    const { result } = prepareHook()
+
+    await act(async () => {
+      await result.current.handleRefineImagePromptDraft()
+    })
+
+    expect(mocks.createChatCompletion).not.toHaveBeenCalled()
+    expect(result.current.imagePromptRefineCandidate).toBe("")
+    expect(mocks.releaseSnapshot).toHaveBeenCalledOnce()
+  })
+
+  it("preserves empty-result reporting without committing a candidate", async () => {
+    mocks.createChatCompletion.mockResolvedValueOnce(completionResponse(""))
+    const { result } = prepareHook()
+
+    await act(async () => {
+      await result.current.handleRefineImagePromptDraft()
+    })
+
+    expect(result.current.imagePromptRefineCandidate).toBe("")
+    expect(mocks.notificationError).toHaveBeenCalledWith({
+      message: "Prompt refinement failed",
+      description: "Refiner returned an empty prompt. Try again."
+    })
+    expect(mocks.releaseSnapshot).toHaveBeenCalledOnce()
+  })
+
+  it("preserves ordinary provider error reporting without committing a candidate", async () => {
+    mocks.createChatCompletion.mockRejectedValueOnce(
+      new Error("Provider unavailable")
+    )
+    const { result } = prepareHook()
+
+    await act(async () => {
+      await result.current.handleRefineImagePromptDraft()
+    })
+
+    expect(result.current.imagePromptRefineCandidate).toBe("")
+    expect(mocks.notificationError).toHaveBeenCalledWith({
+      message: "Prompt refinement failed",
+      description: "Provider unavailable"
+    })
+    expect(mocks.releaseSnapshot).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundImageGen.ts
+++ b/apps/packages/ui/src/components/Option/Playground/hooks/usePlaygroundImageGen.ts
@@ -33,6 +33,11 @@ import {
 } from "../compare-response-diff"
 import { resolveApiProviderForModel } from "@/utils/resolve-api-provider"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
+import {
+  loadServicePromptSnapshot,
+  type ServicePromptSnapshot
+} from "@/services/service-prompts"
+import { createServicePromptScopeChangedError } from "@/services/tldw/service-prompt-scope-error"
 import { parseJsonObject } from "./utils"
 
 // ---------------------------------------------------------------------------
@@ -338,27 +343,50 @@ export function usePlaygroundImageGen(deps: UsePlaygroundImageGenDeps) {
 
     setImagePromptRefineSubmitting(true)
     setImageGenerateRefineMetadata(undefined)
+    let servicePromptSnapshot: ServicePromptSnapshot | null = null
     try {
       const startedAt =
         typeof performance !== "undefined" ? performance.now() : Date.now()
       await tldwClient.initialize().catch(() => null)
+      servicePromptSnapshot = await loadServicePromptSnapshot([
+        "image.prompt.refinement"
+      ])
+      const refinementPrompt =
+        servicePromptSnapshot.definitions["image.prompt.refinement"]
+      if (!refinementPrompt) {
+        throw new Error("Image prompt refinement settings are unavailable.")
+      }
       const provider = await resolveApiProviderForModel({
         modelId: normalizedModel,
         explicitProvider: currentApiProvider
       })
-      const completionResponse = await tldwClient.createChatCompletion({
-        model: normalizedModel,
-        api_provider: provider || undefined,
-        temperature: 0.1,
-        max_tokens: 320,
-        messages: buildImagePromptRefineMessages({
-          originalPrompt: prompt,
-          strategyLabel,
-          backend: imageGenerateBackend,
-          contextEntries
-        })
-      })
+      if (servicePromptSnapshot.scopeInvalidatedSignal.aborted) {
+        throw createServicePromptScopeChangedError()
+      }
+      const completionResponse = await tldwClient.createChatCompletion(
+        {
+          model: normalizedModel,
+          api_provider: provider || undefined,
+          temperature: 0.1,
+          max_tokens: 320,
+          messages: buildImagePromptRefineMessages({
+            originalPrompt: prompt,
+            strategyLabel,
+            backend: imageGenerateBackend,
+            contextEntries,
+            systemSemantics: refinementPrompt.parts.system_semantics,
+            rewriteSemantics: refinementPrompt.parts.rewrite_semantics
+          })
+        },
+        {
+          signal: servicePromptSnapshot.scopeSignal,
+          requestScope: servicePromptSnapshot.requestScope
+        }
+      )
       const completionPayload = await completionResponse.json().catch(() => null)
+      if (servicePromptSnapshot.scopeInvalidatedSignal.aborted) {
+        throw createServicePromptScopeChangedError()
+      }
       const candidate = extractImagePromptRefineCandidate(completionPayload)
       if (!candidate) {
         throw new Error(
@@ -395,6 +423,7 @@ export function usePlaygroundImageGen(deps: UsePlaygroundImageGenDeps) {
           )
       })
     } finally {
+      servicePromptSnapshot?.release()
       setImagePromptRefineSubmitting(false)
     }
   }, [

--- a/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/ServicePromptsSettings.tsx
@@ -132,6 +132,12 @@ const KNOWN_DEFINITIONS = {
     description:
       "Controls the instruction used to generate automatic conversation titles."
   },
+  "image.prompt.refinement": {
+    key: "imagePromptRefinement",
+    label: "Image prompt refinement",
+    description:
+      "Controls the semantic instructions used to refine image-generation prompt drafts."
+  },
   "media.text.translation": {
     key: "mediaTextTranslation",
     label: "Text translation",
@@ -166,6 +172,10 @@ const KNOWN_WORKFLOWS: Record<string, { key: string; label: string }> = {
     key: "automaticConversationTitles",
     label: "Automatic conversation titles"
   },
+  "image.prompt.refinement": {
+    key: "imagePromptRefinement",
+    label: "Image prompt refinement"
+  },
   "media.text.translation": {
     key: "textTranslation",
     label: "Text translation"
@@ -179,6 +189,14 @@ const KNOWN_WORKFLOWS: Record<string, { key: string; label: string }> = {
 const KNOWN_PARTS: Record<string, { key: string; label: string }> = {
   template: { key: "template", label: "Template" },
   system: { key: "system", label: "System instructions" },
+  system_semantics: {
+    key: "systemSemantics",
+    label: "Refinement guidance"
+  },
+  rewrite_semantics: {
+    key: "rewriteSemantics",
+    label: "Rewrite guidance"
+  },
   title_instruction: { key: "titleInstruction", label: "Title instruction" },
   user_template: { key: "userTemplate", label: "User template" }
 }

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/ServicePromptsSettings.test.tsx
@@ -199,6 +199,28 @@ const catalog: ServicePromptCatalogItem[] = [
     ]
   },
   {
+    id: "image.prompt.refinement",
+    label: "Server image refinement prompt",
+    description: "Server image refinement prompt description",
+    parts: [
+      {
+        key: "system_semantics",
+        label: "Server refinement guidance",
+        mode: "literal",
+        required_variables: []
+      },
+      {
+        key: "rewrite_semantics",
+        label: "Server rewrite guidance",
+        mode: "literal",
+        required_variables: []
+      }
+    ],
+    affected_workflows: [
+      { id: "image.prompt.refinement", label: "Server image workflow" }
+    ]
+  },
+  {
     id: "notes.title.generate",
     label: "Server Notes title prompt",
     description: "Server Notes title prompt description",
@@ -241,12 +263,18 @@ const detailFor = (
       ? { template: "History: {chat_history}\nQuestion: {question}" }
       : definition.id === "chat.title.generation"
         ? { user_template: "Create a short title for {query}" }
-      : definition.id === "notes.title.generate"
-        ? {
-            system: "Write concise document titles.",
-            title_instruction: "Write a descriptive title"
-          }
-        : { template: "At {current_date_time}:\n{search_results}" }
+        : definition.id === "image.prompt.refinement"
+          ? {
+              system_semantics:
+                "You refine image-generation prompts. Preserve intent.",
+              rewrite_semantics: "Return a generation-ready prompt."
+            }
+          : definition.id === "notes.title.generate"
+            ? {
+                system: "Write concise document titles.",
+                title_instruction: "Write a descriptive title"
+              }
+            : { template: "At {current_date_time}:\n{search_results}" }
   const effective = options.parts ?? defaults
   const source = options.source ?? "packaged"
   return {
@@ -472,7 +500,7 @@ describe("ServicePromptsSettings", () => {
     expect(document.querySelector("h1")).toBeNull()
   })
 
-  it("renders the six localized definitions, query selection, status, workflows, and exact scope", async () => {
+  it("renders the seven localized definitions, query selection, status, workflows, and exact scope", async () => {
     window.history.replaceState(
       {},
       "",
@@ -481,7 +509,7 @@ describe("ServicePromptsSettings", () => {
     renderSettings()
 
     expect(await screen.findAllByTestId("service-prompt-list-item"))
-      .toHaveLength(6)
+      .toHaveLength(7)
     expect(await screen.findByRole("heading", { name: "Text translation" }))
       .toBeInTheDocument()
     expect(screen.getByText("Server default")).toBeInTheDocument()
@@ -520,6 +548,25 @@ describe("ServicePromptsSettings", () => {
     )
     expect(screen.getByText("Automatic Notes titles")).toBeVisible()
     expect(screen.queryByText("Server Notes title prompt")).not.toBeInTheDocument()
+  })
+
+  it("localizes and edits the image prompt refinement semantics", async () => {
+    renderSettings()
+
+    await openPrompt("Image prompt refinement")
+
+    expect(screen.getByRole("heading", { name: "Image prompt refinement" }))
+      .toBeVisible()
+    expect(screen.getByLabelText("Refinement guidance")).toHaveValue(
+      "You refine image-generation prompts. Preserve intent."
+    )
+    expect(screen.getByLabelText("Rewrite guidance")).toHaveValue(
+      "Return a generation-ready prompt."
+    )
+    expect(screen.getByText("Image prompt refinement", { selector: "li" }))
+      .toBeVisible()
+    expect(screen.queryByText("Server image refinement prompt"))
+      .not.toBeInTheDocument()
   })
 
   it("uses the Prompts Link and reverses dirty HashRouter Back and Forward", async () => {

--- a/apps/packages/ui/src/public/_locales/en/settings.json
+++ b/apps/packages/ui/src/public/_locales/en/settings.json
@@ -6296,6 +6296,12 @@
   "servicePrompts_definitions_chatTitleGeneration_description": {
     "message": "Controls the instruction used to generate automatic conversation titles."
   },
+  "servicePrompts_definitions_imagePromptRefinement_label": {
+    "message": "Image prompt refinement"
+  },
+  "servicePrompts_definitions_imagePromptRefinement_description": {
+    "message": "Controls the semantic instructions used to refine image-generation prompt drafts."
+  },
   "servicePrompts_definitions_notesTitleGenerate_label": {
     "message": "Notes title"
   },
@@ -6305,11 +6311,20 @@
   "servicePrompts_workflows_automaticConversationTitles": {
     "message": "Automatic conversation titles"
   },
+  "servicePrompts_workflows_imagePromptRefinement": {
+    "message": "Image prompt refinement"
+  },
   "servicePrompts_workflows_automaticNotesTitles": {
     "message": "Automatic Notes titles"
   },
   "servicePrompts_parts_titleInstruction": {
     "message": "Title instruction"
+  },
+  "servicePrompts_parts_systemSemantics": {
+    "message": "Refinement guidance"
+  },
+  "servicePrompts_parts_rewriteSemantics": {
+    "message": "Rewrite guidance"
   },
   "servicePrompts_titleGeneration_note": {
     "message": "Automatic title generation is enabled or disabled in Chat settings."

--- a/apps/packages/ui/src/services/__tests__/service-prompts.test.ts
+++ b/apps/packages/ui/src/services/__tests__/service-prompts.test.ts
@@ -130,6 +130,20 @@ const definitions: Record<KnownServicePromptId, ServicePromptCatalogItem> = {
     mode: "template",
     required_variables: ["query"]
   }]),
+  "image.prompt.refinement": definition("image.prompt.refinement", [
+    {
+      key: "system_semantics",
+      label: "Refinement guidance",
+      mode: "literal",
+      required_variables: []
+    },
+    {
+      key: "rewrite_semantics",
+      label: "Rewrite guidance",
+      mode: "literal",
+      required_variables: []
+    }
+  ]),
   "media.text.translation": definition("media.text.translation", [
     {
       key: "system",
@@ -161,12 +175,13 @@ const definitions: Record<KnownServicePromptId, ServicePromptCatalogItem> = {
 }
 
 describe("Service Prompt validation and rendering", () => {
-  it("keeps old-server Chat defaults byte-equivalent to the shared fixture", () => {
+  it("keeps old-server defaults byte-equivalent to the shared fixture", () => {
     expect(LEGACY_SERVICE_PROMPT_DEFAULTS).toEqual({
       "chat.rag.answer": fixture.defaults["chat.rag.answer"],
       "chat.rag.question_rewrite": fixture.defaults["chat.rag.question_rewrite"],
       "chat.web_search.answer": fixture.defaults["chat.web_search.answer"],
-      "chat.title.generation": fixture.defaults["chat.title.generation"]
+      "chat.title.generation": fixture.defaults["chat.title.generation"],
+      "image.prompt.refinement": fixture.defaults["image.prompt.refinement"]
     })
   })
 
@@ -718,6 +733,73 @@ describe("Service Prompt migration and runtime snapshots", () => {
     })
     expect(mocks.promptForRag).not.toHaveBeenCalled()
     expect(mocks.getWebSearchPrompt).not.toHaveBeenCalled()
+    expect(mocks.localGet).not.toHaveBeenCalled()
+    expect(mocks.syncGet).not.toHaveBeenCalled()
+    snapshot.release()
+  })
+
+  it("uses packaged image-refinement semantics on old servers without reading legacy storage", async () => {
+    mocks.listServicePrompts.mockRejectedValue(
+      new ServicePromptApiError("Not found", { status: 404 })
+    )
+
+    const snapshot = await loadServicePromptSnapshot([
+      "image.prompt.refinement"
+    ])
+
+    expect(snapshot).toMatchObject({
+      capability: "legacy-404",
+      definitions: {
+        "image.prompt.refinement": {
+          definition: {
+            id: "image.prompt.refinement",
+            parts: [
+              {
+                key: "system_semantics",
+                mode: "literal",
+                required_variables: []
+              },
+              {
+                key: "rewrite_semantics",
+                mode: "literal",
+                required_variables: []
+              }
+            ]
+          },
+          parts: fixture.defaults["image.prompt.refinement"],
+          source: "packaged",
+          revision: null
+        }
+      }
+    })
+    expect(mocks.promptForRag).not.toHaveBeenCalled()
+    expect(mocks.getWebSearchPrompt).not.toHaveBeenCalled()
+    expect(mocks.localGet).not.toHaveBeenCalled()
+    expect(mocks.syncGet).not.toHaveBeenCalled()
+    snapshot.release()
+  })
+
+  it("uses packaged image-refinement semantics when a supported older catalog omits the definition", async () => {
+    mocks.listServicePrompts.mockResolvedValue(
+      catalog.filter((item) => item.id !== "image.prompt.refinement")
+    )
+
+    const snapshot = await loadServicePromptSnapshot([
+      "image.prompt.refinement"
+    ])
+
+    expect(snapshot).toMatchObject({
+      capability: "supported",
+      definitions: {
+        "image.prompt.refinement": {
+          definition: renderDefinitionFor("image.prompt.refinement"),
+          parts: fixture.defaults["image.prompt.refinement"],
+          source: "packaged",
+          revision: null
+        }
+      }
+    })
+    expect(mocks.getServicePrompt).not.toHaveBeenCalled()
     expect(mocks.localGet).not.toHaveBeenCalled()
     expect(mocks.syncGet).not.toHaveBeenCalled()
     snapshot.release()

--- a/apps/packages/ui/src/services/__tests__/service-prompts.test.ts
+++ b/apps/packages/ui/src/services/__tests__/service-prompts.test.ts
@@ -805,6 +805,47 @@ describe("Service Prompt migration and runtime snapshots", () => {
     snapshot.release()
   })
 
+  it("uses packaged image-refinement semantics when an advertised detail returns 404", async () => {
+    mocks.getServicePrompt.mockRejectedValueOnce(
+      new ServicePromptApiError("Not found", { status: 404 })
+    )
+
+    const snapshot = await loadServicePromptSnapshot([
+      "image.prompt.refinement"
+    ])
+
+    expect(snapshot).toMatchObject({
+      capability: "supported",
+      definitions: {
+        "image.prompt.refinement": {
+          definition: renderDefinitionFor("image.prompt.refinement"),
+          parts: fixture.defaults["image.prompt.refinement"],
+          source: "packaged",
+          revision: null
+        }
+      }
+    })
+    expect(mocks.getServicePrompt).toHaveBeenCalledWith(
+      "image.prompt.refinement",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+    expect(mocks.promptForRag).not.toHaveBeenCalled()
+    expect(mocks.getWebSearchPrompt).not.toHaveBeenCalled()
+    snapshot.release()
+  })
+
+  it.each([412, 500])(
+    "does not fallback when an advertised image-refinement detail returns %s",
+    async (status) => {
+      const error = new ServicePromptApiError("Detail failed", { status })
+      mocks.getServicePrompt.mockRejectedValueOnce(error)
+
+      await expect(
+        loadServicePromptSnapshot(["image.prompt.refinement"])
+      ).rejects.toBe(error)
+    }
+  )
+
   it("rejects a mismatched authenticated user after resolving the matching multi-user target", async () => {
     const multiUserConfig = {
       ...config,

--- a/apps/packages/ui/src/services/service-prompts.ts
+++ b/apps/packages/ui/src/services/service-prompts.ts
@@ -776,11 +776,11 @@ export const loadServicePromptSnapshot = async (
     }
 
     const advertisedIds = new Set(catalog.map((definition) => definition.id))
-    const usePackagedImageRefinement =
+    const catalogOmitsImageRefinement =
       requested.includes("image.prompt.refinement") &&
       !advertisedIds.has("image.prompt.refinement")
     const requestedFromServer = requested.filter(
-      (id) => id !== "image.prompt.refinement" || !usePackagedImageRefinement
+      (id) => id !== "image.prompt.refinement" || !catalogOmitsImageRefinement
     )
     const candidates = requestedFromServer.length > 0
       ? await readLegacyServicePromptCandidates({ signal: lease.signal })
@@ -799,15 +799,29 @@ export const loadServicePromptSnapshot = async (
       throw error
     }
 
-    const details = await Promise.all(requestedFromServer.map((id) =>
-      tldwClient.getServicePrompt(id, {
-        signal: lease.signal,
-        requestScope: scope
-      })
-    ))
+    const details = await Promise.all(requestedFromServer.map(async (id) => {
+      try {
+        return await tldwClient.getServicePrompt(id, {
+          signal: lease.signal,
+          requestScope: scope
+        })
+      } catch (error) {
+        if (
+          id === "image.prompt.refinement" &&
+          error instanceof ServicePromptApiError &&
+          error.status === 404
+        ) {
+          return null
+        }
+        throw error
+      }
+    }))
     throwIfAborted(lease.signal)
+    const usePackagedImageRefinement =
+      catalogOmitsImageRefinement || details.some((detail) => detail === null)
     const definitions: Partial<Record<KnownServicePromptId, SnapshotDefinition>> = {}
     for (const detail of details) {
+      if (!detail) continue
       definitions[detail.id as KnownServicePromptId] = {
         definition: detail,
         parts: { ...detail.effective_parts },

--- a/apps/packages/ui/src/services/service-prompts.ts
+++ b/apps/packages/ui/src/services/service-prompts.ts
@@ -10,6 +10,7 @@ import {
 import { ServicePromptApiError } from "@/services/tldw/domains/service-prompts"
 import type {
   KnownServicePromptId,
+  ServicePromptCatalogItem,
   ServicePromptDetail,
   ServicePromptRequestScope,
   ServicePromptSource
@@ -320,6 +321,21 @@ const LEGACY_RENDER_DEFINITIONS = Object.freeze({
       mode: "template",
       required_variables: ["query"]
     }]
+  }),
+  "image.prompt.refinement": freezeRenderDefinition({
+    id: "image.prompt.refinement",
+    parts: [
+      {
+        key: "system_semantics",
+        mode: "literal",
+        required_variables: []
+      },
+      {
+        key: "rewrite_semantics",
+        mode: "literal",
+        required_variables: []
+      }
+    ]
   })
 })
 
@@ -690,6 +706,22 @@ const legacySnapshot = async (
     }
   }
 
+  if (requested.has("image.prompt.refinement")) {
+    definitions["image.prompt.refinement"] = {
+      definition: LEGACY_RENDER_DEFINITIONS["image.prompt.refinement"],
+      parts: {
+        system_semantics:
+          LEGACY_SERVICE_PROMPT_DEFAULTS["image.prompt.refinement"]
+            .system_semantics,
+        rewrite_semantics:
+          LEGACY_SERVICE_PROMPT_DEFAULTS["image.prompt.refinement"]
+            .rewrite_semantics
+      },
+      source: "packaged",
+      revision: null
+    }
+  }
+
   throwIfAborted(lease.signal)
   return freezeSnapshot(scope, "legacy-404", definitions, lease)
 }
@@ -703,6 +735,7 @@ export const loadServicePromptSnapshot = async (
 ): Promise<ServicePromptSnapshot> => {
   const lease = createServicePromptScopeLease(options.signal)
   try {
+    const requested = [...new Set(ids)]
     throwIfAborted(lease.signal)
     const scope = await resolveServicePromptScope({ signal: lease.signal })
     const expectedRequestScope = options.requestScope
@@ -721,8 +754,9 @@ export const loadServicePromptSnapshot = async (
     }
     lease.bind(scope)
     throwIfAborted(lease.signal)
+    let catalog: ServicePromptCatalogItem[]
     try {
-      await tldwClient.listServicePrompts({
+      catalog = await tldwClient.listServicePrompts({
         signal: lease.signal,
         requestScope: scope
       })
@@ -741,13 +775,19 @@ export const loadServicePromptSnapshot = async (
       throw error
     }
 
-    const requested = [...new Set(ids)]
-    const candidates = await readLegacyServicePromptCandidates({
-      signal: lease.signal
-    })
+    const advertisedIds = new Set(catalog.map((definition) => definition.id))
+    const usePackagedImageRefinement =
+      requested.includes("image.prompt.refinement") &&
+      !advertisedIds.has("image.prompt.refinement")
+    const requestedFromServer = requested.filter(
+      (id) => id !== "image.prompt.refinement" || !usePackagedImageRefinement
+    )
+    const candidates = requestedFromServer.length > 0
+      ? await readLegacyServicePromptCandidates({ signal: lease.signal })
+      : []
     throwIfAborted(lease.signal)
     const unresolved = candidates.filter((candidate) =>
-      requested.includes(candidate.definitionId)
+      requestedFromServer.includes(candidate.definitionId)
     )
     if (unresolved.length > 0) {
       const error = new Error(
@@ -759,7 +799,7 @@ export const loadServicePromptSnapshot = async (
       throw error
     }
 
-    const details = await Promise.all(requested.map((id) =>
+    const details = await Promise.all(requestedFromServer.map((id) =>
       tldwClient.getServicePrompt(id, {
         signal: lease.signal,
         requestScope: scope
@@ -773,6 +813,21 @@ export const loadServicePromptSnapshot = async (
         parts: { ...detail.effective_parts },
         source: detail.source,
         revision: detail.revision
+      }
+    }
+    if (usePackagedImageRefinement) {
+      definitions["image.prompt.refinement"] = {
+        definition: LEGACY_RENDER_DEFINITIONS["image.prompt.refinement"],
+        parts: {
+          system_semantics:
+            LEGACY_SERVICE_PROMPT_DEFAULTS["image.prompt.refinement"]
+              .system_semantics,
+          rewrite_semantics:
+            LEGACY_SERVICE_PROMPT_DEFAULTS["image.prompt.refinement"]
+              .rewrite_semantics
+        },
+        source: "packaged",
+        revision: null
       }
     }
     return freezeSnapshot(scope, "supported", definitions, lease)

--- a/apps/packages/ui/src/services/tldw-server.ts
+++ b/apps/packages/ui/src/services/tldw-server.ts
@@ -513,6 +513,12 @@ Shakespeare Analyse Literarische
 Древнегреческая Философия Обзор
 
 Response:`
+  }),
+  "image.prompt.refinement": Object.freeze({
+    system_semantics:
+      "You refine image-generation prompts. Preserve intent while improving clarity, visual specificity, and composition.",
+    rewrite_semantics:
+      "Rewrite the prompt to be concise, concrete, and generation-ready."
   })
 })
 

--- a/apps/packages/ui/src/services/tldw/domains/service-prompts.ts
+++ b/apps/packages/ui/src/services/tldw/domains/service-prompts.ts
@@ -9,6 +9,7 @@ export type KnownServicePromptId =
   | "chat.rag.question_rewrite"
   | "chat.web_search.answer"
   | "chat.title.generation"
+  | "image.prompt.refinement"
   | "media.text.translation"
   | "notes.title.generate"
 

--- a/apps/packages/ui/src/utils/__fixtures__/service-prompt-rendering.json
+++ b/apps/packages/ui/src/utils/__fixtures__/service-prompt-rendering.json
@@ -12,6 +12,10 @@
     "chat.title.generation": {
       "user_template": "Here is the query:\n\n--------------\n\n{query}\n\n--------------\n\nCreate a concise, 3-5 word phrase as a title for the previous query. Avoid quotation marks or special formatting. RESPOND ONLY WITH THE TITLE TEXT. ANSWER USING THE SAME LANGUAGE AS THE QUERY.\n\n\nExamples of titles:\n\nStellar Achievement Celebration\nFamily Bonding Activities\n🇫🇷 Voyage à Paris\n🍜 Receta de Ramen Casero\nShakespeare Analyse Literarische\n日本の春祭り体験\nДревнегреческая Философия Обзор\n\nResponse:"
     },
+    "image.prompt.refinement": {
+      "system_semantics": "You refine image-generation prompts. Preserve intent while improving clarity, visual specificity, and composition.",
+      "rewrite_semantics": "Rewrite the prompt to be concise, concrete, and generation-ready."
+    },
     "media.text.translation": {
       "system": "You are an expert translator. Your task is to provide accurate,\nnatural-sounding translations that preserve the original meaning, tone, and formatting.\nDo not add explanations or notes - only provide the translation.",
       "user_template": "Translate the following text to {target_language}.\nPreserve the original formatting, meaning, and tone.\nOnly output the translation, no explanations, notes, or additional text.\n\nText to translate:\n{text}"

--- a/apps/packages/ui/src/utils/__tests__/image-prompt-refinement.test.ts
+++ b/apps/packages/ui/src/utils/__tests__/image-prompt-refinement.test.ts
@@ -40,6 +40,39 @@ describe("image prompt refinement utilities", () => {
     expect(userContent).toContain("Mood (16%): focused and intense")
   })
 
+  it("replaces only the editable semantics while preserving locked request carriers", () => {
+    const messages = buildImagePromptRefineMessages({
+      originalPrompt: "Portrait of Lana in neon rain.",
+      strategyLabel: "Expression",
+      backend: "local-sd",
+      contextEntries: [
+        {
+          id: "character",
+          label: "Character",
+          text: "Lana Reed",
+          weight: 0.3,
+          quality: 0.9,
+          score: 0.27
+        }
+      ],
+      systemSemantics: "Custom refinement guidance.",
+      rewriteSemantics: "Custom rewrite guidance."
+    })
+
+    expect(messages[0].content).toBe(
+      "Custom refinement guidance. Output only the final refined prompt as plain text. Do not include markdown, labels, bullets, or commentary."
+    )
+    expect(messages[1].content).toBe(
+      "Prompt mode: Expression\n\nBackend: local-sd\n\nOriginal prompt:\nPortrait of Lana in neon rain.\n\n\n\nContext blend cues:\nCharacter (27%): Lana Reed\n\nCustom rewrite guidance."
+    )
+    expect(messages[0].content).not.toContain(
+      "Preserve intent while improving clarity"
+    )
+    expect(messages[1].content).not.toContain(
+      "Rewrite the prompt to be concise"
+    )
+  })
+
   it("extracts refined prompt text from fenced completion payloads", () => {
     const candidate = extractImagePromptRefineCandidate({
       choices: [

--- a/apps/packages/ui/src/utils/image-prompt-refinement.ts
+++ b/apps/packages/ui/src/utils/image-prompt-refinement.ts
@@ -1,6 +1,13 @@
 import type { ChatMessage } from "@/services/tldw/TldwApiClient"
 import type { WeightedImagePromptContextEntry } from "@/utils/image-prompt-strategies"
 
+const DEFAULT_SYSTEM_SEMANTICS =
+  "You refine image-generation prompts. Preserve intent while improving clarity, visual specificity, and composition."
+const DEFAULT_REWRITE_SEMANTICS =
+  "Rewrite the prompt to be concise, concrete, and generation-ready."
+const LOCKED_OUTPUT_CONTRACT =
+  "Output only the final refined prompt as plain text. Do not include markdown, labels, bullets, or commentary."
+
 const normalizeWhitespace = (value: string): string =>
   value.replace(/\s+/g, " ").trim()
 
@@ -47,6 +54,8 @@ export const buildImagePromptRefineMessages = (args: {
   strategyLabel?: string | null
   backend?: string | null
   contextEntries?: WeightedImagePromptContextEntry[]
+  systemSemantics?: string
+  rewriteSemantics?: string
 }): ChatMessage[] => {
   const normalizedPrompt = normalizeWhitespace(args.originalPrompt || "")
   const strategyLabel = normalizeWhitespace(args.strategyLabel || "Scene")
@@ -59,9 +68,7 @@ export const buildImagePromptRefineMessages = (args: {
   return [
     {
       role: "system",
-      content:
-        "You refine image-generation prompts. Preserve intent while improving clarity, visual specificity, and composition. " +
-        "Output only the final refined prompt as plain text. Do not include markdown, labels, bullets, or commentary."
+      content: `${args.systemSemantics ?? DEFAULT_SYSTEM_SEMANTICS} ${LOCKED_OUTPUT_CONTRACT}`
     },
     {
       role: "user",
@@ -70,7 +77,7 @@ export const buildImagePromptRefineMessages = (args: {
         `Backend: ${backend}`,
         `Original prompt:\n${truncate(normalizedPrompt, 1200)}`,
         contextBlock,
-        "Rewrite the prompt to be concise, concrete, and generation-ready."
+        args.rewriteSemantics ?? DEFAULT_REWRITE_SEMANTICS
       ]
         .filter(Boolean)
         .join("\n\n")

--- a/backlog/tasks/task-13117 - Expose-image-prompt-refinement-in-Service-Prompts.md
+++ b/backlog/tasks/task-13117 - Expose-image-prompt-refinement-in-Service-Prompts.md
@@ -1,0 +1,62 @@
+---
+id: TASK-13117
+title: Expose image prompt refinement in Service Prompts
+status: Done
+assignee: []
+created_date: '2026-08-24 16:51'
+updated_date: '2026-08-24 17:38'
+labels:
+  - service-prompts
+  - image-generation
+  - settings
+dependencies: []
+references:
+  - Docs/Design/service-prompt-inventory.md
+  - >-
+    Docs/superpowers/specs/2026-07-12-user-customizable-service-prompts-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the existing Playground image-prompt refinement instructions as one bounded Service Prompts definition while keeping prompt carriers, output contract, provider settings, normalization, and user review behavior code-owned.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The registry exposes image.prompt.refinement with editable literal system_semantics and rewrite_semantics parts whose packaged defaults preserve the current provider messages.
+- [x] #2 Each Refine action consumes one immutable account/server-scoped snapshot and binds the chat request to its request scope and invalidation signal.
+- [x] #3 Prompt mode, backend, original prompt, context cues, output-only contract, truncation, provider/model settings, response normalization, and user review remain locked and unchanged.
+- [x] #4 Scope changes and cancellation fail closed without applying a candidate; ordinary provider and empty-result errors preserve current safe notification behavior.
+- [x] #5 The catalog-driven WebUI and extension Settings page exposes localized metadata through the existing generic save and reset flow, with older-server packaged fallback.
+- [x] #6 Focused registry, rendering, consumer, Settings, locale, compile, lint, diff, and security verification pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implement test-first in three bounded stages: register defaults and metadata; consume one immutable snapshot in the existing Refine action; run focused regression, scope, compatibility, security, and extension verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented test-first: registered image.prompt.refinement with two literal semantic parts; kept prompt carriers and output contract code-owned; bound each Refine request to one immutable Service Prompt scope; added current-server, catalog-404, and catalog-200-with-missing-definition compatibility; exposed generic localized Settings metadata. Verification: UI focused matrix 200/200; backend registry/API 79/79; extension compile passed; Ruff passed; ESLint 0 errors with 18 pre-existing warnings in large shared files; Bandit 0 findings and 0 errors; locale/fixture JSON valid; git diff --check clean. Independent review found the rolling-upgrade catalog gap, which was reproduced RED, fixed narrowly, and re-reviewed with no remaining findings. Known unrelated baseline: apps/tldw-frontend bun run typecheck still fails only in unchanged settings-nav-config.ts and skills-certification test files; no changed file appears in the errors. No standalone user documentation change was needed because the existing catalog-driven Settings UI exposes the new definition.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Exposed Playground image-prompt refinement through the existing Service Prompts registry and Settings UI. Users can customize only refinement and rewrite semantics; scope-bound dispatch, locked request carriers, safe fallback behavior, and older-server compatibility are preserved without adding storage, endpoints, or a new settings system.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-13117 - Expose-image-prompt-refinement-in-Service-Prompts.md
+++ b/backlog/tasks/task-13117 - Expose-image-prompt-refinement-in-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose image prompt refinement in Service Prompts
 status: Done
 assignee: []
 created_date: '2026-08-24 16:51'
-updated_date: '2026-08-24 19:49'
+updated_date: '2026-08-24 20:01'
 labels:
   - service-prompts
   - image-generation
@@ -45,6 +45,10 @@ Implement test-first in three bounded stages: register defaults and metadata; co
 Implemented test-first: registered image.prompt.refinement with two literal semantic parts; kept prompt carriers and output contract code-owned; bound each Refine request to one immutable Service Prompt scope; added current-server, catalog-404, and catalog-200-with-missing-definition compatibility; exposed generic localized Settings metadata. Verification: UI focused matrix 200/200; backend registry/API 79/79; extension compile passed; Ruff passed; ESLint 0 errors with 18 pre-existing warnings in large shared files; Bandit 0 findings and 0 errors; locale/fixture JSON valid; git diff --check clean. Independent review found the rolling-upgrade catalog gap, which was reproduced RED, fixed narrowly, and re-reviewed with no remaining findings. Known unrelated baseline: apps/tldw-frontend bun run typecheck still fails only in unchanged settings-nav-config.ts and skills-certification test files; no changed file appears in the errors. No standalone user documentation change was needed because the existing catalog-driven Settings UI exposes the new definition.
 
 Pull request: https://github.com/rmusser01/tldw_server/pull/2815
+
+Qodo review on PR #2815 identified catalog/detail rolling-upgrade skew: an advertised image.prompt.refinement detail can 404 from an older instance. Reopened to add a narrowly scoped compatibility fallback and regression while preserving abort, scope-change, 500, and unrelated-definition failures.
+
+Qodo rolling-upgrade finding reproduced RED and fixed narrowly: only an advertised image.prompt.refinement detail 404 uses packaged semantics; 412 scope changes, aborts, 500s, and unrelated definition failures still propagate. Verification after the fix: focused service-prompts 80/80; affected shared-UI matrix 203/203; browser extension compile passed; focused ESLint passed; git diff --check clean. Independent re-review found no actionable issues and marked the fix ready.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-13117 - Expose-image-prompt-refinement-in-Service-Prompts.md
+++ b/backlog/tasks/task-13117 - Expose-image-prompt-refinement-in-Service-Prompts.md
@@ -4,7 +4,7 @@ title: Expose image prompt refinement in Service Prompts
 status: Done
 assignee: []
 created_date: '2026-08-24 16:51'
-updated_date: '2026-08-24 17:38'
+updated_date: '2026-08-24 19:49'
 labels:
   - service-prompts
   - image-generation
@@ -43,6 +43,8 @@ Implement test-first in three bounded stages: register defaults and metadata; co
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented test-first: registered image.prompt.refinement with two literal semantic parts; kept prompt carriers and output contract code-owned; bound each Refine request to one immutable Service Prompt scope; added current-server, catalog-404, and catalog-200-with-missing-definition compatibility; exposed generic localized Settings metadata. Verification: UI focused matrix 200/200; backend registry/API 79/79; extension compile passed; Ruff passed; ESLint 0 errors with 18 pre-existing warnings in large shared files; Bandit 0 findings and 0 errors; locale/fixture JSON valid; git diff --check clean. Independent review found the rolling-upgrade catalog gap, which was reproduced RED, fixed narrowly, and re-reviewed with no remaining findings. Known unrelated baseline: apps/tldw-frontend bun run typecheck still fails only in unchanged settings-nav-config.ts and skills-certification test files; no changed file appears in the errors. No standalone user documentation change was needed because the existing catalog-driven Settings UI exposes the new definition.
+
+Pull request: https://github.com/rmusser01/tldw_server/pull/2815
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
+++ b/tldw_Server_API/app/core/Prompt_Management/service_prompts.py
@@ -98,6 +98,13 @@ _TITLE_GENERATION_USER_TEMPLATE_DEFAULT = (
     "Response:"
 )
 
+_IMAGE_PROMPT_REFINEMENT_SYSTEM_DEFAULT = (
+    "You refine image-generation prompts. Preserve intent while improving clarity, visual specificity, and composition."
+)
+_IMAGE_PROMPT_REFINEMENT_REWRITE_DEFAULT = (
+    "Rewrite the prompt to be concise, concrete, and generation-ready."
+)
+
 _TRANSLATION_SYSTEM_DEFAULT = """You are an expert translator. Your task is to provide accurate,
 natural-sounding translations that preserve the original meaning, tone, and formatting.
 Do not add explanations or notes - only provide the translation."""
@@ -189,6 +196,37 @@ _DEFINITION_SEQUENCE = (
             ServicePromptWorkflow(
                 id="chat.title.generation",
                 label="Automatic conversation titles",
+            ),
+        ),
+    ),
+    ServicePromptDefinition(
+        id="image.prompt.refinement",
+        label="Image prompt refinement",
+        description="Controls the semantic instructions used to refine image-generation prompt drafts.",
+        parts=(
+            ServicePromptPart(
+                key="system_semantics",
+                label="Refinement guidance",
+                mode="literal",
+                required_variables=(),
+            ),
+            ServicePromptPart(
+                key="rewrite_semantics",
+                label="Rewrite guidance",
+                mode="literal",
+                required_variables=(),
+            ),
+        ),
+        default_parts=MappingProxyType(
+            {
+                "system_semantics": _IMAGE_PROMPT_REFINEMENT_SYSTEM_DEFAULT,
+                "rewrite_semantics": _IMAGE_PROMPT_REFINEMENT_REWRITE_DEFAULT,
+            }
+        ),
+        affected_workflows=(
+            ServicePromptWorkflow(
+                id="image.prompt.refinement",
+                label="Image prompt refinement",
             ),
         ),
     ),

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts.py
@@ -65,6 +65,15 @@ EXPECTED_REGISTRY = {
         "parts": (("user_template", "User template", "template", ("query",)),),
         "workflows": (("chat.title.generation", "Automatic conversation titles"),),
     },
+    "image.prompt.refinement": {
+        "label": "Image prompt refinement",
+        "description": "Controls the semantic instructions used to refine image-generation prompt drafts.",
+        "parts": (
+            ("system_semantics", "Refinement guidance", "literal", ()),
+            ("rewrite_semantics", "Rewrite guidance", "literal", ()),
+        ),
+        "workflows": (("image.prompt.refinement", "Image prompt refinement"),),
+    },
     "media.text.translation": {
         "label": "Text translation",
         "description": "Controls the visible instructions used by synchronous text translation.",

--- a/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_service_prompts_api.py
@@ -168,6 +168,30 @@ def test_service_prompt_catalog_returns_exact_metadata_without_prompt_bodies(
             ],
         },
         {
+            "id": "image.prompt.refinement",
+            "label": "Image prompt refinement",
+            "description": (
+                "Controls the semantic instructions used to refine image-generation prompt drafts."
+            ),
+            "parts": [
+                {
+                    "key": "system_semantics",
+                    "label": "Refinement guidance",
+                    "mode": "literal",
+                    "required_variables": [],
+                },
+                {
+                    "key": "rewrite_semantics",
+                    "label": "Rewrite guidance",
+                    "mode": "literal",
+                    "required_variables": [],
+                },
+            ],
+            "affected_workflows": [
+                {"id": "image.prompt.refinement", "label": "Image prompt refinement"}
+            ],
+        },
+        {
             "id": "media.text.translation",
             "label": "Text translation",
             "description": (


### PR DESCRIPTION
## Summary

- What changed:
  - Registered `image.prompt.refinement` with editable `system_semantics` and `rewrite_semantics` literal parts.
  - Bound each Playground Refine request to one immutable Service Prompt account/server scope.
  - Added localized generic Settings support and packaged fallback for legacy and rolling-upgrade servers.
- Why:
  - Let users tailor image-prompt refinement while keeping the output contract, original prompt, backend, mode, context assembly, provider settings, and result review code-owned.
  - Reuse existing Service Prompts storage, API, Settings UI, and scoped transport instead of creating a parallel prompt system.

## Change summary

This PR makes image-prompt refinement customizable through the existing Service Prompts settings in the WebUI and browser extension. It reuses the current storage and Settings interface while preserving provider settings, the output format, and compatibility with older servers. Each refinement request stays bound to the account and server it started with, preventing configuration changes mid-request from mixing scopes.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Task documentation and localized Settings metadata updated; no separate route or configuration guide is required

Validation evidence:
- Shared UI focused matrix: 203/203 passed
- Backend registry/API: 79/79 passed
- Browser extension TypeScript compile: passed
- ESLint: 0 errors; 18 pre-existing warnings in unchanged portions of large shared files
- Ruff: passed
- Bandit: 0 findings, 0 errors
- Locale and fixture JSON validation: passed
- Independent code review and focused re-review: no remaining actionable findings
- WebUI-wide typecheck retains known failures only in unchanged `settings-nav-config.ts` and skills-certification test files

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented)
- [ ] No listed AntD deprecations in console output
- [ ] No `Maximum update depth exceeded` warnings on audited routes
- [ ] No unresolved `{{...}}` placeholders on audited routes
- [x] WebUI/extension parity validated for shared UI fixes

Full Stage 5 route smoke was not run; focused Settings, prompt runtime, scope, compatibility, and extension compile gates were run instead. Flashcards and Watchlists behavior are unchanged.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

Not applicable: Watchlists UI behavior is unchanged.

## Watchlists Scale Checklist (Group 10 Stage 5)

Not applicable: Watchlists polling, notifications, activity, and batch behavior are unchanged.

## Risk & Rollback

- Risk level: Medium
- Rollback plan: Revert this PR to restore the prior fixed image-refinement prompt behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes image prompt refinement configurable via Service Prompts while preserving default results and the output-only contract. Previously semantics were hardcoded; now `image.prompt.refinement` provides editable `system_semantics` and `rewrite_semantics` with scoped dispatch and safe fallbacks, including a fix for rolling catalog/detail skew.

- Binds each Playground Refine action to one Service Prompt snapshot; injects its semantics; uses the snapshot's `requestScope` and `signal`; aborts on scope invalidation; releases the snapshot.
- Registers `image.prompt.refinement` in the server registry and Settings UI with localized labels; updates locales, fixtures, and known IDs; keeps carriers (original prompt, backend, mode, context) and the output-only contract locked.
- Compatibility: uses packaged semantics on legacy servers (404), when a supported catalog omits the definition, and when an advertised detail returns 404 during rolling upgrades; does not fallback on 412 scope changes, 500s, or unrelated prompt failures; no new storage, endpoints, or migrations.
- Tests cover snapshot binding, fallbacks (catalog omission and 404 detail), empty-result/provider errors, and server catalog metadata. Addresses TASK-13117.

<sup>Written for commit dca673af269a8e911781b2bd0a32ad3a48651892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


