### PR TITLE
feat(scheduled-tasks): add Phase 4D execution feasibility gate

### DIFF
--- a/Docs/ADR/041-scheduled-agent-execution-feasibility.md
+++ b/Docs/ADR/041-scheduled-agent-execution-feasibility.md
@@ -1,0 +1,60 @@
+# ADR-041: Scheduled Agent execution feasibility
+
+**Status:** Accepted
+**Date:** 2026-08-26
+**Backfilled from:** not backfilled
+**Decision owner:** tldw_server maintainers
+**Related task:** TASK-13129
+**Related spec/plan:** `Docs/superpowers/specs/2026-08-24-scheduled-tasks-phase4d-agent-task-execution-design.md`, `Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md`
+
+## Decision
+
+No current deployment class is certified for Scheduled Tasks Agent automation execution. Statically eligible isolation runtimes remain `draft_only` until all seven server-verified evidence domains pass for an exact deployment class; host-local and current non-eligible runtimes are `unsupported`. Existing ordinary ACP, Sandbox, and MCP primitives remain dependencies, but they are not proof.
+
+Certification is necessary but not sufficient. The existing capabilities API, manual Run Now admission, scheduler arming and firing, and worker admission all require both a `certified` deployment result and a separately implemented execution stack. The production stack-readiness function is source-defined as false in TASK-13129.
+
+## Context
+
+Scheduled Agent execution combines delayed authority, untrusted model output, credentials, tools, durable recovery, and cross-process cancellation. Static runtime metadata or successful interactive-agent behavior cannot demonstrate those properties. A credible decision must bind evidence to one opaque deployment class containing host, architecture, AuthNZ mode, runtime, adapter version, server build, and isolation-policy identities.
+
+The current repository has reusable pieces, but each required proof remains incomplete:
+
+- ordinary ACP records and forks can retain prompt content;
+- generic Sandbox idempotency is not an ACP dispatch-token recovery contract;
+- cancellation and terminal state lack one ordered per-attempt evidence journal;
+- MCP credential brokering and governance are not Scheduled Tasks grants or per-action mediation;
+- no authoritative verifier signs and validates the exact seven-domain evidence bundle.
+
+The baseline at `Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json` therefore records `draft_only` for the observed Docker candidate class. Its corresponding Markdown artifact includes repository-static eligibility for all supported runtime values. Neither artifact grants execution authority.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Trust Docker or container isolation alone | Container selection does not prove exact mounts, deny-all egress, tenant binding, credential handling, mediation, recovery, or operational fail-closed behavior. |
+| Reuse ordinary ACP transcripts for scheduled prompts | Ordinary storage and fork behavior can retain prompt content and do not provide the required scheduled-mode non-disclosure boundary. |
+| Treat Sandbox idempotency as ACP dispatch recovery | Generic session/run idempotency is not bound to a stable adapter dispatch token and cannot recover the exact ACP attempt after process loss. |
+| Treat generic MCP credentials and governance as scheduled grants | Existing policy is not bound to the Scheduled Tasks subject, definition revision, credential version, exact action arguments, or live per-action revocation. |
+| Hide Agent automation until execution is complete | Hiding the family removes API discoverability and prevents clients from distinguishing draft-only work from a deployment that is structurally unsupported. |
+| Allow an operator flag or edited evidence file to enable execution | Mutable local inputs would bypass the server trust boundary and make capability claims unverifiable. |
+
+## Consequences
+
+- `/api/v1/scheduled-tasks/capabilities` exposes a sanitized, versioned `execution_certification` object for `agent_task`.
+- `execute` and `run_now` remain disabled for every production state in this slice.
+- `draft_only` permits Agent definition drafting and ordinary management but not execution.
+- `unsupported` keeps the family visible while refusing preview creation, definition creation, and duplication; existing definitions remain inspectable, pausable, resumable, and archivable.
+- Manual Run Now returns a typed conflict before idempotency, Job creation, or audit creation.
+- The scheduler refuses Agent arming, firing, and rearming. The worker independently records already-queued Agent Jobs as blocked skips before executor lookup.
+- Recurring Questions, Watchlists, and standalone interactive Agent Tasks retain their existing contracts.
+- Evidence expires and becomes invalid when its subject, build, runtime, image, policy, adapter, AuthNZ mode, signer, or validity window changes.
+- The accepted tradeoff is visible draft functionality without background execution until dependency work supplies authoritative proof.
+
+## Follow-up
+
+- `TASK-13130`: isolation attestation and hostile runtime proof.
+- `TASK-13131`: scheduled-mode secure ACP transcripts and leakage gates.
+- `TASK-13132`: ACP dispatch recovery and monotonic execution evidence.
+- `TASK-13133`: scheduled identity, credentials, revocation, and pre-action mediation.
+- `operational_fail_closed` remains a cross-cutting exit criterion for all four tasks.
+- Phase 4D.1B may change the source-defined execution-stack readiness only after its complete vertical slice passes independently.

--- a/Docs/ADR/README.md
+++ b/Docs/ADR/README.md
@@ -72,3 +72,4 @@ Small bug fixes, local implementation details, product copy, temporary experimen
 | [ADR-038](038-canonical-notes-attachment-registry-and-blob-lifecycle.md) | Accepted | Give Notes attachments stable product identity while reusing the shared Sync blob lifecycle. |
 | [ADR-039](039-canonical-notes-task-sync-and-derived-checklist-projections.md) | Accepted | Synchronize mutable Notes tasks and immutable activity while keeping Markdown checklists and read state derived. |
 | [ADR-040](040-synchronized-moodboards-and-studio-authority.md) | Proposed | Synchronize moodboards, explicit placements, and accepted Studio sidecars while retaining existing product authority and derived smart matches. |
+| [ADR-041](041-scheduled-agent-execution-feasibility.md) | Accepted | Keep Scheduled Agent execution fail-closed until exact deployment certification and the separate execution stack are both ready. |

--- a/Docs/Development/Scheduled_Agent_Execution_Certification.md
+++ b/Docs/Development/Scheduled_Agent_Execution_Certification.md
@@ -1,0 +1,191 @@
+# Scheduled Agent Execution Certification
+
+This guide defines the operator and API contract for Scheduled Tasks Agent execution feasibility. It does not enable Agent execution.
+
+## Current decision
+
+ADR-041 records that no current deployment class is certified.
+
+- Candidate runtimes with untrusted isolation and strict deny-all metadata are `draft_only` while required proof is incomplete.
+- Host-local or otherwise ineligible runtimes are `unsupported`.
+- Agent execution requires both `certified` evidence and the separately delivered execution stack.
+- The production execution-stack readiness function remains source-defined as false.
+
+The reviewed baseline is:
+
+- JSON: `Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json`
+- Markdown: `Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md`
+- Evidence ID: `sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874`
+- Deployment class: `sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337`
+- Outcome: `draft_only`
+
+This baseline is repository characterization. It is not an attestation or execution grant.
+
+## Outcome contract
+
+| Outcome | Meaning | Agent definition behavior | Execution behavior |
+| --- | --- | --- | --- |
+| `certified` | Every domain passed with fresh, exact-subject, server-verified evidence covered by an authoritative bundle receipt | Available, subject to ordinary permissions | Still disabled until the independent execution stack is ready |
+| `draft_only` | The runtime is a static candidate, but proof is missing, partial, stale, unverified, or receipt-less | Preview, create, edit, duplicate, pause, resume, archive, and inspect remain available | Run Now, scheduled dispatch, and worker execution are blocked |
+| `unsupported` | The runtime is ineligible or a verified safety boundary failed | Family remains discoverable; new preview, definition, update-preview, and duplicate operations are unavailable; existing resources remain manageable | Blocked at API, scheduler, and worker |
+
+## Deployment-class identity
+
+Certification is bound to one canonical digest derived from:
+
+- host OS family and architecture;
+- AuthNZ mode;
+- sandbox runtime;
+- adapter ID and version;
+- server build SHA;
+- runtime image identity;
+- mount, egress, credential, tenant-boundary, and mediation policy identities;
+- isolation-profile version.
+
+The capabilities API exposes only the deployment-class digest. It does not expose the raw host or policy tuple.
+
+`TLDW_BUILD_SHA` is the only production source for server build identity. It must contain a 40- or 64-character hexadecimal digest. Missing or malformed values become `unverified` and prevent certification. The API process never invokes Git to infer this value.
+
+## Required evidence
+
+| Requirement | Passing proof |
+| --- | --- |
+| `isolation_attestation` | The server verifies a signed, fresh binding for tenant, workspace, runtime, image, mounts, egress, credentials, signer, and exact deployment class against a live trust root |
+| `hostile_boundary` | Attested probes deny controlled host-file access, denied and public network access, subprocess bypass, direct MCP/tool access, inherited environment data, and ambient credentials |
+| `scheduled_transcript_non_disclosure` | Prompt sentinels are absent from ordinary ACP detail, events, artifacts, fork, export, bootstrap, search, logs, errors, audit, and backup surfaces |
+| `adapter_dispatch_recovery` | Adapter session creation is idempotent by stable dispatch token and process-loss recovery finds the exact attempt |
+| `monotonic_execution_evidence` | Terminal, timeout, pre-action approval, effect, and cancellation evidence is durable and ordered per attempt |
+| `brokered_credentials_and_mediation` | Scheduled identity and grants bind exact actions; credentials are issued per action with live revocation and no ambient channel |
+| `operational_fail_closed` | Installation, upgrade invalidation, health, evidence freshness, outages, and policy changes fail closed for the exact deployment |
+
+All seven requirements must pass. Partial primitives remain `missing`; they are not promoted to passing evidence.
+
+## Trust levels
+
+| Verification | Authority |
+| --- | --- |
+| `server_verified` | Eligible only when subject-bound, fresh, complete, and covered by the internal authoritative receipt |
+| `host_gated_unverified` | Diagnostic evidence only |
+| `repository_characterization` | Documents current code and metadata; cannot certify |
+| `self_asserted` | Cannot certify |
+| `mock` | Test-only; cannot certify |
+
+The authoritative receipt type is internal to the server trust boundary. The API, helper JSON, and operators cannot construct it.
+
+## Evidence artifacts
+
+The schema is `scheduled-agent-execution-certification.v1`. A JSON manifest contains:
+
+- `schema_version`, `evidence_id`, and `deployment_class_id`;
+- source commit and validity timestamps;
+- outcome and bounded reason codes;
+- exactly seven sanitized requirement records;
+- exactly seven value-free command templates.
+
+Requirement records contain state, verification level, subject digest, timestamps, reason codes, evidence digest, and the safety-boundary flag. They do not contain probe output.
+
+Committed artifacts must not contain prompt or transcript content, credentials, environment values, raw action arguments, local paths, hostnames, user-controlled names, or raw stdout/stderr. Host-gated raw artifacts remain outside the repository under operator-controlled retention. Only sanitized digests and bounded results may be committed.
+
+Editing the JSON cannot certify a deployment. Canonical identity validation rejects changed content with a stale `evidence_id`, and a recomputed manifest still has no authoritative server receipt. Markdown must exactly render the paired JSON, including the typed runtime eligibility appendix.
+
+## Generate a characterization baseline
+
+Run from the repository root with the project virtual environment active. Replace every identity with the exact deployment value. Use `unverified` only when the value is genuinely unavailable; doing so prevents certification.
+
+```bash
+source .venv/bin/activate
+BUILD_SHA="$(git rev-parse HEAD)"
+python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py \
+  --host-os darwin \
+  --host-arch arm64 \
+  --runtime docker \
+  --auth-mode single_user \
+  --adapter-id acp \
+  --adapter-version 1 \
+  --source-commit "$BUILD_SHA" \
+  --server-build-sha "$BUILD_SHA" \
+  --image-digest unverified \
+  --mount-policy-hash unverified \
+  --egress-policy-hash unverified \
+  --credential-policy-hash unverified \
+  --tenant-boundary-policy-hash unverified \
+  --mediation-policy-hash unverified \
+  --isolation-profile-version phase4d0f-baseline \
+  --output-json Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json \
+  --output-markdown Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md
+```
+
+Without `--repository-characterization-only`, the helper rejects a claimed host OS or architecture that differs from the observed host. That override permits a non-host repository characterization; it does not create host evidence.
+
+## Validate a pair
+
+```bash
+source .venv/bin/activate
+python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py \
+  --validate-artifacts \
+  Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json \
+  Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md
+```
+
+Validation checks the exact schema, canonical evidence identity, allowed reason vocabulary, seven-domain order, subject binding, non-certified current outcome, exact Markdown rendering, and runtime appendix derived from typed runtime metadata.
+
+## Hostile-probe admission
+
+`--run-hostile` is opt-in. It requires:
+
+- a real, non-symlinked evidence directory;
+- a loopback server URL;
+- the name of an environment variable containing the API credential;
+- a server-verified attestation reference for the exact deployment class.
+
+TASK-13129 intentionally has no server-side attestation verifier. Even with all inputs present, admission exits nonzero with `hostile_probe_blocked_server_attestation_verifier_unimplemented`. It does not launch a subprocess, call the server, or write a passing artifact.
+
+## API projection
+
+`GET /api/v1/scheduled-tasks/capabilities` returns `execution_certification` only for the `agent_task` family:
+
+```json
+{
+  "schema_version": "scheduled_task_execution_certification.v1",
+  "outcome": "draft_only",
+  "deployment_class_id": "sha256:<opaque>",
+  "evidence_id": null,
+  "evidence_source": "repository_characterization",
+  "observed_at": "<timestamp>",
+  "expires_at": "<timestamp>",
+  "reason_codes": ["isolation_attestation_missing"],
+  "recovery_action": "Complete server-verified Scheduled Agent execution certification for this deployment class."
+}
+```
+
+Agent `execute` and `run_now` actions repeat bounded evidence source, freshness, reason, and recovery metadata. Clients must consume this server response. They must not infer capability from browser environment, deployment mode, visible controls, or local configuration.
+
+Manual Run Now returns HTTP 409 with `scheduled_task_agent_execution_unavailable`. Unsupported creation and duplication return HTTP 409 with `scheduled_task_agent_automation_unsupported`. The error envelope includes the same stable readiness reason and recovery action shown by capability discovery.
+
+## Freshness and rerun rules
+
+Repository characterization uses a 24-hour validity window. Authoritative evidence must define and enforce its own reviewed validity window.
+
+Rerun and review evidence after any change to:
+
+- server build or adapter version;
+- host OS or architecture;
+- AuthNZ mode;
+- sandbox runtime or image;
+- mount, egress, credential, tenant, or mediation policy;
+- trust root, signer, or revocation state;
+- transcript storage, dispatch recovery, journal, credential, or governance implementation.
+
+A subject change creates a new deployment-class digest. Expired, wrong-subject, partial, failed, unsigned, or receipt-less evidence cannot retain `certified`.
+
+## Release gate
+
+An execution-capable release requires all of the following:
+
+1. Every exact deployment class has seven fresh `server_verified` passing records.
+2. The server verifier issues a matching authoritative bundle receipt.
+3. Hostile probes pass under the attested profile without leaking raw evidence.
+4. TASK-13130 through TASK-13133 satisfy their domain and cross-cutting operational criteria.
+5. The later Phase 4D execution slice independently changes stack readiness through reviewed source code and passes API, scheduler, worker, recovery, and security tests.
+
+Until then, `draft_only` and `unsupported` are successful honest outcomes of the feasibility gate, and Agent execution remains unavailable.

--- a/Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json
+++ b/Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json
@@ -1,0 +1,298 @@
+{
+  "commands": [
+    {
+      "description": "Characterize static runtime isolation metadata; no attestation is issued.",
+      "id": "isolation_attestation",
+      "invocation_template": "python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py --host-os --host-arch --runtime --auth-mode --adapter-id --adapter-version --source-commit --server-build-sha --image-digest --mount-policy-hash --egress-policy-hash --credential-policy-hash --tenant-boundary-policy-hash --mediation-policy-hash --isolation-profile-version",
+      "parameter_names": [
+        "host-os",
+        "host-arch",
+        "runtime",
+        "auth-mode",
+        "adapter-id",
+        "adapter-version",
+        "source-commit",
+        "server-build-sha",
+        "image-digest",
+        "mount-policy-hash",
+        "egress-policy-hash",
+        "credential-policy-hash",
+        "tenant-boundary-policy-hash",
+        "mediation-policy-hash",
+        "isolation-profile-version"
+      ],
+      "required_environment_names": [],
+      "safe_to_run_by_default": true
+    },
+    {
+      "description": "Enumerate the hostile boundary vector; launch remains attestation-gated.",
+      "id": "hostile_boundary",
+      "invocation_template": "python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py --host-os --host-arch --runtime --auth-mode --adapter-id --adapter-version --source-commit --server-build-sha --image-digest --mount-policy-hash --egress-policy-hash --credential-policy-hash --tenant-boundary-policy-hash --mediation-policy-hash --isolation-profile-version --run-hostile",
+      "parameter_names": [
+        "host-os",
+        "host-arch",
+        "runtime",
+        "auth-mode",
+        "adapter-id",
+        "adapter-version",
+        "source-commit",
+        "server-build-sha",
+        "image-digest",
+        "mount-policy-hash",
+        "egress-policy-hash",
+        "credential-policy-hash",
+        "tenant-boundary-policy-hash",
+        "mediation-policy-hash",
+        "isolation-profile-version",
+        "run-hostile",
+        "evidence-dir",
+        "server-url",
+        "api-key-env-name",
+        "attestation-reference"
+      ],
+      "required_environment_names": [
+        "configured_credential_environment"
+      ],
+      "safe_to_run_by_default": false
+    },
+    {
+      "description": "Characterize ordinary ACP prompt persistence and fork behavior.",
+      "id": "scheduled_transcript_non_disclosure",
+      "invocation_template": "python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py --host-os --host-arch --runtime --auth-mode --adapter-id --adapter-version --source-commit --server-build-sha --image-digest --mount-policy-hash --egress-policy-hash --credential-policy-hash --tenant-boundary-policy-hash --mediation-policy-hash --isolation-profile-version",
+      "parameter_names": [
+        "host-os",
+        "host-arch",
+        "runtime",
+        "auth-mode",
+        "adapter-id",
+        "adapter-version",
+        "source-commit",
+        "server-build-sha",
+        "image-digest",
+        "mount-policy-hash",
+        "egress-policy-hash",
+        "credential-policy-hash",
+        "tenant-boundary-policy-hash",
+        "mediation-policy-hash",
+        "isolation-profile-version"
+      ],
+      "required_environment_names": [],
+      "safe_to_run_by_default": true
+    },
+    {
+      "description": "Characterize generic idempotency and missing ACP dispatch bindings.",
+      "id": "adapter_dispatch_recovery",
+      "invocation_template": "python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py --host-os --host-arch --runtime --auth-mode --adapter-id --adapter-version --source-commit --server-build-sha --image-digest --mount-policy-hash --egress-policy-hash --credential-policy-hash --tenant-boundary-policy-hash --mediation-policy-hash --isolation-profile-version",
+      "parameter_names": [
+        "host-os",
+        "host-arch",
+        "runtime",
+        "auth-mode",
+        "adapter-id",
+        "adapter-version",
+        "source-commit",
+        "server-build-sha",
+        "image-digest",
+        "mount-policy-hash",
+        "egress-policy-hash",
+        "credential-policy-hash",
+        "tenant-boundary-policy-hash",
+        "mediation-policy-hash",
+        "isolation-profile-version"
+      ],
+      "required_environment_names": [],
+      "safe_to_run_by_default": true
+    },
+    {
+      "description": "Characterize cancellation primitives and the missing ordered journal.",
+      "id": "monotonic_execution_evidence",
+      "invocation_template": "python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py --host-os --host-arch --runtime --auth-mode --adapter-id --adapter-version --source-commit --server-build-sha --image-digest --mount-policy-hash --egress-policy-hash --credential-policy-hash --tenant-boundary-policy-hash --mediation-policy-hash --isolation-profile-version",
+      "parameter_names": [
+        "host-os",
+        "host-arch",
+        "runtime",
+        "auth-mode",
+        "adapter-id",
+        "adapter-version",
+        "source-commit",
+        "server-build-sha",
+        "image-digest",
+        "mount-policy-hash",
+        "egress-policy-hash",
+        "credential-policy-hash",
+        "tenant-boundary-policy-hash",
+        "mediation-policy-hash",
+        "isolation-profile-version"
+      ],
+      "required_environment_names": [],
+      "safe_to_run_by_default": true
+    },
+    {
+      "description": "Characterize managed credentials, session environment, and grant gaps.",
+      "id": "brokered_credentials_and_mediation",
+      "invocation_template": "python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py --host-os --host-arch --runtime --auth-mode --adapter-id --adapter-version --source-commit --server-build-sha --image-digest --mount-policy-hash --egress-policy-hash --credential-policy-hash --tenant-boundary-policy-hash --mediation-policy-hash --isolation-profile-version",
+      "parameter_names": [
+        "host-os",
+        "host-arch",
+        "runtime",
+        "auth-mode",
+        "adapter-id",
+        "adapter-version",
+        "source-commit",
+        "server-build-sha",
+        "image-digest",
+        "mount-policy-hash",
+        "egress-policy-hash",
+        "credential-policy-hash",
+        "tenant-boundary-policy-hash",
+        "mediation-policy-hash",
+        "isolation-profile-version"
+      ],
+      "required_environment_names": [],
+      "safe_to_run_by_default": true
+    },
+    {
+      "description": "Evaluate the current fail-closed outcome for the exact deployment class.",
+      "id": "operational_fail_closed",
+      "invocation_template": "python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py --host-os --host-arch --runtime --auth-mode --adapter-id --adapter-version --source-commit --server-build-sha --image-digest --mount-policy-hash --egress-policy-hash --credential-policy-hash --tenant-boundary-policy-hash --mediation-policy-hash --isolation-profile-version",
+      "parameter_names": [
+        "host-os",
+        "host-arch",
+        "runtime",
+        "auth-mode",
+        "adapter-id",
+        "adapter-version",
+        "source-commit",
+        "server-build-sha",
+        "image-digest",
+        "mount-policy-hash",
+        "egress-policy-hash",
+        "credential-policy-hash",
+        "tenant-boundary-policy-hash",
+        "mediation-policy-hash",
+        "isolation-profile-version"
+      ],
+      "required_environment_names": [],
+      "safe_to_run_by_default": true
+    }
+  ],
+  "created_at": "2026-08-27T03:13:27.817481+00:00",
+  "deployment_class_id": "sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337",
+  "evidence_id": "sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874",
+  "outcome": "draft_only",
+  "reason_codes": [
+    "adapter_dispatch_recovery_missing",
+    "adapter_dispatch_recovery_unverified",
+    "authoritative_receipt_missing",
+    "brokered_credentials_and_mediation_missing",
+    "brokered_credentials_and_mediation_unverified",
+    "deployment_identity_unverified",
+    "hostile_boundary_missing",
+    "hostile_boundary_unverified",
+    "isolation_attestation_missing",
+    "isolation_attestation_unverified",
+    "isolation_profile_identity_unverified",
+    "monotonic_execution_evidence_missing",
+    "monotonic_execution_evidence_unverified",
+    "operational_fail_closed_missing",
+    "operational_fail_closed_unverified",
+    "scheduled_transcript_non_disclosure_missing",
+    "scheduled_transcript_non_disclosure_unverified"
+  ],
+  "requirements": [
+    {
+      "evidence_sha256": "sha256:7a5b003949395c6c2ef2a6496dceea781b8f6389a0705eaaea8289df0d2cf481",
+      "observed_at": "2026-08-27T03:13:27.817481+00:00",
+      "reason_codes": [
+        "isolation_attestation_missing"
+      ],
+      "requirement_id": "isolation_attestation",
+      "safety_boundary_breached": false,
+      "state": "missing",
+      "subject_id": "sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337",
+      "valid_until": "2026-08-28T03:13:27.817481+00:00",
+      "verification": "repository_characterization"
+    },
+    {
+      "evidence_sha256": "sha256:cc184783ba5a2d774f6d05a1bbab7ab869e100652764ae5d5be18a2cdc87bfdc",
+      "observed_at": "2026-08-27T03:13:27.817481+00:00",
+      "reason_codes": [
+        "hostile_boundary_missing"
+      ],
+      "requirement_id": "hostile_boundary",
+      "safety_boundary_breached": false,
+      "state": "missing",
+      "subject_id": "sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337",
+      "valid_until": "2026-08-28T03:13:27.817481+00:00",
+      "verification": "repository_characterization"
+    },
+    {
+      "evidence_sha256": "sha256:46ecbb64e917dbf6d692daaaf0956f2337b45dd522375c65e17b99904f23dbd4",
+      "observed_at": "2026-08-27T03:13:27.817481+00:00",
+      "reason_codes": [
+        "scheduled_transcript_non_disclosure_missing"
+      ],
+      "requirement_id": "scheduled_transcript_non_disclosure",
+      "safety_boundary_breached": false,
+      "state": "missing",
+      "subject_id": "sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337",
+      "valid_until": "2026-08-28T03:13:27.817481+00:00",
+      "verification": "repository_characterization"
+    },
+    {
+      "evidence_sha256": "sha256:d53e28686dd45800f19b68fab3a7e05645ddf12367a20a0ae0d28665a7fdbbd8",
+      "observed_at": "2026-08-27T03:13:27.817481+00:00",
+      "reason_codes": [
+        "adapter_dispatch_recovery_missing"
+      ],
+      "requirement_id": "adapter_dispatch_recovery",
+      "safety_boundary_breached": false,
+      "state": "missing",
+      "subject_id": "sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337",
+      "valid_until": "2026-08-28T03:13:27.817481+00:00",
+      "verification": "repository_characterization"
+    },
+    {
+      "evidence_sha256": "sha256:12c4b0382054cc98b45f4e3c00df5925be7332a591e16c493dfa0ae0ed83eacd",
+      "observed_at": "2026-08-27T03:13:27.817481+00:00",
+      "reason_codes": [
+        "monotonic_execution_evidence_missing"
+      ],
+      "requirement_id": "monotonic_execution_evidence",
+      "safety_boundary_breached": false,
+      "state": "missing",
+      "subject_id": "sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337",
+      "valid_until": "2026-08-28T03:13:27.817481+00:00",
+      "verification": "repository_characterization"
+    },
+    {
+      "evidence_sha256": "sha256:cbc36034e35fb166ea862630fa0af90a1235d91be684c48eadb1c87f9ed39aae",
+      "observed_at": "2026-08-27T03:13:27.817481+00:00",
+      "reason_codes": [
+        "brokered_credentials_and_mediation_missing"
+      ],
+      "requirement_id": "brokered_credentials_and_mediation",
+      "safety_boundary_breached": false,
+      "state": "missing",
+      "subject_id": "sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337",
+      "valid_until": "2026-08-28T03:13:27.817481+00:00",
+      "verification": "repository_characterization"
+    },
+    {
+      "evidence_sha256": "sha256:f775c9a7bc1e5f803764eb1f19cbc29100270bd8703916a146333241a2cade2f",
+      "observed_at": "2026-08-27T03:13:27.817481+00:00",
+      "reason_codes": [
+        "operational_fail_closed_missing"
+      ],
+      "requirement_id": "operational_fail_closed",
+      "safety_boundary_breached": false,
+      "state": "missing",
+      "subject_id": "sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337",
+      "valid_until": "2026-08-28T03:13:27.817481+00:00",
+      "verification": "repository_characterization"
+    }
+  ],
+  "schema_version": "scheduled-agent-execution-certification.v1",
+  "source_commit": "a43949d4b06a5a633619c0c8227ecb9771ddde28",
+  "valid_until": "2026-08-28T03:13:27.817481+00:00"
+}

--- a/Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md
+++ b/Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md
@@ -1,0 +1,58 @@
+# Scheduled Agent Execution Feasibility Evidence
+
+| Field | Value |
+| --- | --- |
+| Evidence ID | `sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874` |
+| Deployment class | `sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337` |
+| Source commit | `a43949d4b06a5a633619c0c8227ecb9771ddde28` |
+| Created | `2026-08-27T03:13:27.817481+00:00` |
+| Valid until | `2026-08-28T03:13:27.817481+00:00` |
+| Outcome | `draft_only` |
+
+## Reasons
+
+- `adapter_dispatch_recovery_missing`
+- `adapter_dispatch_recovery_unverified`
+- `authoritative_receipt_missing`
+- `brokered_credentials_and_mediation_missing`
+- `brokered_credentials_and_mediation_unverified`
+- `deployment_identity_unverified`
+- `hostile_boundary_missing`
+- `hostile_boundary_unverified`
+- `isolation_attestation_missing`
+- `isolation_attestation_unverified`
+- `isolation_profile_identity_unverified`
+- `monotonic_execution_evidence_missing`
+- `monotonic_execution_evidence_unverified`
+- `operational_fail_closed_missing`
+- `operational_fail_closed_unverified`
+- `scheduled_transcript_non_disclosure_missing`
+- `scheduled_transcript_non_disclosure_unverified`
+
+## Requirements
+
+| Requirement | State | Verification | Evidence |
+| --- | --- | --- | --- |
+| `isolation_attestation` | `missing` | `repository_characterization` | `sha256:7a5b003949395c6c2ef2a6496dceea781b8f6389a0705eaaea8289df0d2cf481` |
+| `hostile_boundary` | `missing` | `repository_characterization` | `sha256:cc184783ba5a2d774f6d05a1bbab7ab869e100652764ae5d5be18a2cdc87bfdc` |
+| `scheduled_transcript_non_disclosure` | `missing` | `repository_characterization` | `sha256:46ecbb64e917dbf6d692daaaf0956f2337b45dd522375c65e17b99904f23dbd4` |
+| `adapter_dispatch_recovery` | `missing` | `repository_characterization` | `sha256:d53e28686dd45800f19b68fab3a7e05645ddf12367a20a0ae0d28665a7fdbbd8` |
+| `monotonic_execution_evidence` | `missing` | `repository_characterization` | `sha256:12c4b0382054cc98b45f4e3c00df5925be7332a591e16c493dfa0ae0ed83eacd` |
+| `brokered_credentials_and_mediation` | `missing` | `repository_characterization` | `sha256:cbc36034e35fb166ea862630fa0af90a1235d91be684c48eadb1c87f9ed39aae` |
+| `operational_fail_closed` | `missing` | `repository_characterization` | `sha256:f775c9a7bc1e5f803764eb1f19cbc29100270bd8703916a146333241a2cade2f` |
+
+## Repository-Static Runtime Eligibility
+
+This appendix is derived from typed runtime metadata. It is not deployment certification evidence.
+
+| Runtime | Default outcome | Primary reason |
+| --- | --- | --- |
+| `docker` | `draft_only` | `required_server_verified_evidence_incomplete` |
+| `firecracker` | `draft_only` | `required_server_verified_evidence_incomplete` |
+| `lima` | `draft_only` | `required_server_verified_evidence_incomplete` |
+| `vz_linux` | `draft_only` | `required_server_verified_evidence_incomplete` |
+| `vz_macos` | `unsupported` | `runtime_not_untrusted_eligible, runtime_strict_deny_all_unavailable` |
+| `seatbelt` | `unsupported` | `runtime_not_untrusted_eligible, runtime_strict_deny_all_unavailable` |
+| `worktree` | `unsupported` | `runtime_not_untrusted_eligible, runtime_strict_deny_all_unavailable` |
+
+Repository characterization is not deployment certification. Host-gated raw evidence is retained outside the repository.

--- a/Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
@@ -54,8 +54,8 @@
 | --- | --- | --- | --- | --- |
 | 1 | Freeze the certification vocabulary and fail-closed evaluator | All outcome and freshness rules are deterministic and mock evidence cannot certify | Pure unit tests | Complete |
 | 2 | Produce reproducible current-state evidence | Seven requirement records and a sanitized manifest are generated for an exact deployment class | Helper and characterization tests | Complete |
-| 3 | Publish and enforce the API-first readiness gate | Versioned capability metadata, typed Run Now refusal, no Agent scheduler enqueue, and worker defense-in-depth agree | Schema/service/API/OpenAPI/feed/consumer tests | In Progress |
-| 4 | Publish the decision and current baseline | ADR, operator guide, JSON/Markdown evidence, and dependency tasks agree | Artifact validator and docs checks | Not Started |
+| 3 | Publish and enforce the API-first readiness gate | Versioned capability metadata, typed Run Now refusal, no Agent scheduler enqueue, and worker defense-in-depth agree | Schema/service/API/OpenAPI/feed/consumer tests | Complete |
+| 4 | Publish the decision and current baseline | ADR, operator guide, JSON/Markdown evidence, and dependency tasks agree | Artifact validator and docs checks | In Progress |
 | 5 | Complete regression and security gates | Focused cross-module tests, compile, lint, Bandit, diff review, and Backlog evidence pass | Verification matrix | Not Started |
 
 ## File Map
@@ -362,7 +362,7 @@ Expected: one commit containing the reusable sanitized harness and its tests, wi
 - Consumes: `ExecutionCertification` from an injectable resolver and an independently injected `execution_stack_ready` input that is false in this task.
 - Produces: additive versioned `execution_certification` metadata, honest execution-action status, a typed manual refusal, no Agent scheduler enqueue, and worker-side refusal of already-queued Agent Jobs.
 
-- [ ] **Step 1: Write failing schema and service tests**
+- [x] **Step 1: Write failing schema and service tests**
 
 Add `ScheduledTaskExecutionCertificationCapability` with exactly:
 
@@ -392,7 +392,7 @@ Add API tests that Run Now on an `agent_task` returns HTTP 409 with code `schedu
 
 Add scheduler tests that an `agent_task` definition is not armed during load/reconcile/rescan, an already-armed race is refused again in `_fire()`, and no Job is created. Recurring-question definitions continue to arm and enqueue normally. Add a consumer test that an already-queued `agent_task` Job creates no adapter call even when a test executor is registered; it completes with a typed skipped result and a valid blocked run/audit record when the definition exists.
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 source "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.venv/bin/activate"
@@ -405,7 +405,7 @@ python -m pytest -q --tb=short \
 
 Expected: FAIL because the response lacks `execution_certification`, currently advertises Agent `run_now` as available, Run Now enqueues an Agent Job, and the scheduler has no Agent readiness gate.
 
-- [ ] **Step 3: Implement the projection and gate**
+- [x] **Step 3: Implement the projection and gate**
 
 Add optional certification and execution-stack readiness resolvers to `ScheduledTaskAutomationService.__init__`; default them to `resolve_current_agent_execution_certification` and a source-defined function that returns false. The certification resolver must be side-effect-free and must not perform host probes on an API request. The production stack-readiness function must not read environment or configuration; only a later reviewed code slice may replace it. Reuse the same pure readiness helper in the service, scheduler, and consumer instead of duplicating outcome logic.
 
@@ -413,7 +413,7 @@ Add optional certification and execution-stack readiness resolvers to `Scheduled
 
 Map `draft_only` and `unsupported` to disabled execution actions with stable reasons `execution_certification_draft_only` or `execution_certification_unsupported`. Map `certified` plus the current false stack input to disabled with `agent_execution_stack_unimplemented`. Run Now raises the same typed reason before idempotency or Job creation. For `unsupported`, preview-create, definition-create, and duplicate raise `agent_automation_unsupported` before persistence; retain ordinary management of existing definitions. The scheduler refuses Agent arming and rechecks at fire time. The consumer rechecks after the TASK-13127 owner-scoped definition preflight and records a skipped blocked run without calling an executor. Do not change recurring-question scheduling/execution or draft-only definition mutation.
 
-- [ ] **Step 4: Run GREEN and API regressions**
+- [x] **Step 4: Run GREEN and API regressions**
 
 ```bash
 source "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.venv/bin/activate"
@@ -426,7 +426,9 @@ python -m pytest -q --tb=short \
 
 Expected: PASS. Capability discovery remains additive, owner-independent, and protected by `TASKS_READ`; direct API, scheduler, and stale-Job paths all fail closed for Agent execution while Recurring Questions are unchanged.
 
-- [ ] **Step 5: Commit the API gate**
+Recorded result: eight focused RED cases failed at the absent schema, unsupported-admission, Run Now, scheduler, and worker gates. The focused GREEN rerun passed all eight. The final four-file regression matrix passed 102 tests with 11 warnings in 89.61 seconds. Ruff and compileall passed. Bandit report `/tmp/bandit_task_13129_stage3.json` contains zero findings and zero errors across 4,359 production lines.
+
+- [x] **Step 5: Commit the API gate**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
@@ -53,8 +53,8 @@
 | Stage | Goal | Success Criteria | Tests | Status |
 | --- | --- | --- | --- | --- |
 | 1 | Freeze the certification vocabulary and fail-closed evaluator | All outcome and freshness rules are deterministic and mock evidence cannot certify | Pure unit tests | Complete |
-| 2 | Produce reproducible current-state evidence | Seven requirement records and a sanitized manifest are generated for an exact deployment class | Helper and characterization tests | In Progress |
-| 3 | Publish and enforce the API-first readiness gate | Versioned capability metadata, typed Run Now refusal, no Agent scheduler enqueue, and worker defense-in-depth agree | Schema/service/API/OpenAPI/feed/consumer tests | Not Started |
+| 2 | Produce reproducible current-state evidence | Seven requirement records and a sanitized manifest are generated for an exact deployment class | Helper and characterization tests | Complete |
+| 3 | Publish and enforce the API-first readiness gate | Versioned capability metadata, typed Run Now refusal, no Agent scheduler enqueue, and worker defense-in-depth agree | Schema/service/API/OpenAPI/feed/consumer tests | In Progress |
 | 4 | Publish the decision and current baseline | ADR, operator guide, JSON/Markdown evidence, and dependency tasks agree | Artifact validator and docs checks | Not Started |
 | 5 | Complete regression and security gates | Focused cross-module tests, compile, lint, Bandit, diff review, and Backlog evidence pass | Verification matrix | Not Started |
 
@@ -234,7 +234,7 @@ Expected: pure tests pass and the first commit cannot activate execution.
 - Consumes: explicit `--host-os`, `--host-arch`, `--runtime`, `--auth-mode`, `--adapter-id`, `--adapter-version`, `--source-commit`, `--server-build-sha`, `--image-digest`, `--mount-policy-hash`, `--egress-policy-hash`, `--credential-policy-hash`, `--tenant-boundary-policy-hash`, `--mediation-policy-hash`, `--isolation-profile-version`, output format/destination, and optional host-gated run flag.
 - Produces: schema `scheduled-agent-execution-certification.v1`, one exact deployment-class digest, seven sanitized requirement records, the derived outcome, and a command manifest.
 
-- [ ] **Step 1: Write failing manifest and sanitization tests**
+- [x] **Step 1: Write failing manifest and sanitization tests**
 
 The default invocation emits a manifest and repository characterization without launching a sandbox. Test exact top-level keys:
 
@@ -255,7 +255,7 @@ Each requirement contains only `requirement_id`, `state`, `verification`, `subje
 
 Seed tests with prompt, credential, path, hostname, tool-argument, and environment sentinels and assert none appears anywhere in JSON or Markdown output. Test that absolute paths and all argument values are removed before serialization. Recompute `evidence_id` from canonical sanitized content and reject a mismatched digest during artifact validation.
 
-- [ ] **Step 2: Define all seven evidence commands**
+- [x] **Step 2: Define all seven evidence commands**
 
 Use these stable command IDs:
 
@@ -273,13 +273,13 @@ For transcript characterization, write a random sentinel to a temporary ordinary
 
 For adapter recovery, verify generic Sandbox session/run idempotency exists but ACP sandbox `create_session()` has no dispatch-token parameter and its durable control record has no dispatch token. For monotonic evidence, verify current cancel/terminal primitives exist but no per-attempt ordered journal contract is available. For credentials, verify the managed external broker exists while current ACP session env remains a possible ambient channel. Partial primitives remain `missing`, not `passed`.
 
-- [ ] **Step 3: Make hostile execution opt-in and fail closed**
+- [x] **Step 3: Make hostile execution opt-in and fail closed**
 
 `--run-hostile` requires `--evidence-dir`, a local server URL, an API key environment-variable name, and a pre-existing server-verified attestation reference for the exact deployment class. Missing any prerequisite exits non-zero before launch and records `hostile_probe_blocked_by_missing_attestation` in the in-memory result only; it must not write a misleading pass artifact.
 
 The generated hostile test vector must enumerate attempts against a controlled host-file sentinel, a controlled denied network listener, public egress, subprocess launch, direct MCP/tool access, inherited environment sentinel, and ambient credential sentinel. The harness records pass only when every attempt is denied and the server verifies the exact attestation. In this task's baseline, the hostile command is expected to refuse because the attestation dependency is absent.
 
-- [ ] **Step 4: Run RED, implement, then run GREEN**
+- [x] **Step 4: Run RED, implement, then run GREEN**
 
 ```bash
 source "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.venv/bin/activate"
@@ -289,7 +289,7 @@ python -m pytest -q --tb=short \
 
 Expected RED: collection fails because the helper is absent. Expected GREEN after implementation: all helper tests pass; eligible current profiles emit `draft_only`; ineligible profiles emit `unsupported`; no fixture can emit `certified` without seven server-verified records.
 
-- [ ] **Step 5: Verify the CLI behavior**
+- [x] **Step 5: Verify the CLI behavior**
 
 ```bash
 source "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.venv/bin/activate"
@@ -331,7 +331,9 @@ python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py
 
 Expected: Docker reports `draft_only`; worktree reports `unsupported`; neither output contains an absolute local path, raw prompt, credential value, or raw environment value.
 
-- [ ] **Step 6: Commit the evidence harness**
+Recorded result: RED produced 21 expected failures while the helper was absent. GREEN produced 21 passes and 2 warnings. Docker JSON contained seven requirements and seven commands with `draft_only`; worktree Markdown reported `unsupported`. A same-run JSON/Markdown pair validated successfully. Fully populated hostile prerequisites exited 2 with `hostile_probe_blocked_server_attestation_verifier_unimplemented` and launched nothing. Ruff and compileall passed; Bandit reported zero findings after replacing optimization-sensitive assertions with explicit validation.
+
+- [x] **Step 6: Commit the evidence harness**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
@@ -55,8 +55,8 @@
 | 1 | Freeze the certification vocabulary and fail-closed evaluator | All outcome and freshness rules are deterministic and mock evidence cannot certify | Pure unit tests | Complete |
 | 2 | Produce reproducible current-state evidence | Seven requirement records and a sanitized manifest are generated for an exact deployment class | Helper and characterization tests | Complete |
 | 3 | Publish and enforce the API-first readiness gate | Versioned capability metadata, typed Run Now refusal, no Agent scheduler enqueue, and worker defense-in-depth agree | Schema/service/API/OpenAPI/feed/consumer tests | Complete |
-| 4 | Publish the decision and current baseline | ADR, operator guide, JSON/Markdown evidence, and dependency tasks agree | Artifact validator and docs checks | In Progress |
-| 5 | Complete regression and security gates | Focused cross-module tests, compile, lint, Bandit, diff review, and Backlog evidence pass | Verification matrix | Not Started |
+| 4 | Publish the decision and current baseline | ADR, operator guide, JSON/Markdown evidence, and dependency tasks agree | Artifact validator and docs checks | Complete |
+| 5 | Complete regression and security gates | Focused cross-module tests, compile, lint, Bandit, diff review, and Backlog evidence pass | Verification matrix | Complete |
 
 ## File Map
 
@@ -461,7 +461,7 @@ Expected: one API-first commit with no frontend, Watchlists, standalone Agent Ta
 - Consumes: the helper at the two preceding commits and current runtime metadata.
 - Produces: a reproducible reviewed decision that no deployment class is certified yet, plus bounded follow-on dependency tasks.
 
-- [ ] **Step 1: Generate the exact current baseline artifacts**
+- [x] **Step 1: Generate the exact current baseline artifacts**
 
 Run the helper for the implementation host's observed OS/architecture/AuthNZ/runtime/adapter tuple and use the current implementation commit SHA as both `source_commit` and the baseline build identity. The values below are examples for the current worktree host and must be replaced if observation differs; the helper must refuse a claimed host OS/architecture that disagrees with its local observation unless `--repository-characterization-only` is explicit. The JSON artifact is evidence for that one exact, unverified deployment class. The Markdown artifact renders the same record and adds a clearly labeled repository-static eligibility appendix for all runtime values; neither the appendix nor a repository-characterization baseline is deployment certification evidence.
 
@@ -503,7 +503,7 @@ The static appendix applies these expected default outcomes when all non-runtime
 
 The generator must validate that the JSON record and corresponding Markdown deployment-class section have identical outcome/reason codes before writing. It must also validate the static appendix directly from `runtime_capabilities.py`. Any unexpected `certified` result is a release-blocking failure.
 
-- [ ] **Step 2: Write ADR-041**
+- [x] **Step 2: Write ADR-041**
 
 Use the repository ADR template and add ADR-041 to `Docs/ADR/README.md` with its final status and one-sentence decision. The decision is:
 
@@ -511,11 +511,11 @@ Use the repository ADR template and add ADR-041 to `Docs/ADR/README.md` with its
 
 Alternatives rejected must include: trusting Docker/container isolation alone; reusing ordinary ACP transcripts; treating Sandbox idempotency as adapter dispatch recovery; treating generic MCP credentials/governance as scheduled grants; and hiding Agent automation entirely instead of retaining an explicit draft-only API state.
 
-- [ ] **Step 3: Write the operator guide**
+- [x] **Step 3: Write the operator guide**
 
 Document the exact CLI invocations, evidence schema, seven requirement definitions, trust levels, freshness/subject invalidation, safe refusal behavior, artifact redaction, API projection, and rerun procedure. State that changing evidence JSON manually cannot certify a deployment. Document that host-gated raw artifacts remain outside the repository and only sanitized digests/results are committed.
 
-- [ ] **Step 4: Attach confirmed evidence to the pre-created dependency tasks**
+- [x] **Step 4: Attach confirmed evidence to the pre-created dependency tasks**
 
 Use Backlog.md MCP to add ADR-041 and both baseline artifacts to these existing tasks:
 
@@ -526,7 +526,7 @@ Use Backlog.md MCP to add ADR-041 and both baseline artifacts to these existing 
 
 Record `operational_fail_closed` as a cross-cutting exit criterion on TASK-13129 and all four dependency tasks rather than creating a fifth implementation silo. Do not begin any dependency task in this branch.
 
-- [ ] **Step 5: Validate documentation and artifact consistency**
+- [x] **Step 5: Validate documentation and artifact consistency**
 
 ```bash
 source "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.venv/bin/activate"
@@ -545,7 +545,15 @@ python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py
 
 Expected: artifact validation passes; both negated scans exit 0 because no match exists; no document claims a certified current deployment. Review operator-guide prose separately because it intentionally names prohibited data categories without including values.
 
-- [ ] **Step 6: Commit the evidence decision**
+Recorded result: the regenerated artifact pair validates exactly. Evidence
+`sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874`
+reports `draft_only` for deployment class
+`sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337`.
+Both prohibited-content scans returned no matches after the command-manifest
+placeholder was narrowed from an API-key-shaped name to a generic credential
+environment name. The focused helper suite passed 22 tests with 2 warnings.
+
+- [x] **Step 6: Commit the evidence decision**
 
 ```bash
 git add \
@@ -575,7 +583,7 @@ Expected: only the ADR and index, guide, validated evidence, TASK-13129, and the
 - Consumes: all four implementation units and generated evidence.
 - Produces: a reviewed, test-backed gate with no execution capability enabled.
 
-- [ ] **Step 1: Run focused and adjacent tests**
+- [x] **Step 1: Run focused and adjacent tests**
 
 ```bash
 source "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.venv/bin/activate"
@@ -596,7 +604,10 @@ python -m pytest -q --tb=short \
 
 Expected: PASS except explicitly recorded host-gated skips. A skipped host probe cannot count as passing evidence.
 
-- [ ] **Step 2: Run syntax, lint, and Bandit gates**
+Recorded result: 275 passed, 0 failed, 0 skipped, and 19 warnings in
+93.04 seconds. No host-gated skip was counted as evidence.
+
+- [x] **Step 2: Run syntax, lint, and Bandit gates**
 
 ```bash
 source "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.venv/bin/activate"
@@ -628,7 +639,11 @@ python -m bandit -r \
 
 Expected: compile and lint exit 0; Bandit reports no new findings in touched Python.
 
-- [ ] **Step 3: Perform the security self-review**
+Recorded result: compileall and Ruff exited 0. Bandit report
+`/tmp/bandit_task_13129.json` contains zero findings and zero errors across
+4,965 production lines.
+
+- [x] **Step 3: Perform the security self-review**
 
 Verify all of the following:
 
@@ -642,7 +657,14 @@ Verify all of the following:
 - recurring questions, Watchlists, and standalone Agent Tasks are unchanged;
 - there is no frontend inference or execution implementation in the diff.
 
-- [ ] **Step 4: Finalize TASK-13129 and amend the evidence commit**
+Recorded result: all checks passed. The current resolver can emit only
+repository characterization; the production stack gate is source-defined
+false; exact-subject, freshness, receipt, hostile-admission, redaction, and
+cross-layer API/scheduler/worker invariants remain fail closed. Recurring
+Questions are unchanged, and the branch contains no frontend, Watchlists, or
+standalone Agent Tasks changes.
+
+- [x] **Step 4: Finalize TASK-13129 and amend the evidence commit**
 
 Use Backlog.md MCP to record exact test counts, host-gated skips, artifact evidence IDs, Bandit result, API/admission behavior, ADR decision, and TASK-13130 through TASK-13133. Check acceptance criteria and definition-of-done only after verification. Mark Done when the gate and documentation are complete even though the outcome is `draft_only`/`unsupported`; the task's objective is an honest feasibility decision, not forced certification.
 
@@ -654,7 +676,7 @@ git commit --amend --no-edit
 
 Expected: the final Backlog evidence is included in the existing evidence/ADR commit, retaining four implementation commits.
 
-- [ ] **Step 5: Review the complete branch diff after finalization**
+- [x] **Step 5: Review the complete branch diff after finalization**
 
 ```bash
 git diff --check origin/dev...HEAD

--- a/Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
@@ -34,7 +34,7 @@
 - Certification is necessary but not sufficient for execution. In this slice, `execute` and `run_now` for the `agent_task` family are always `disabled`: non-certified deployments report the certification blocker, while a synthetic certified fixture reports `agent_execution_stack_unimplemented`. No state maps to `available` until the later 4D.1B execution stack adds an independently tested readiness input.
 - Manual Run Now, scheduler arming/fire, and worker admission apply the same conjunction. They reject or skip `agent_task` before adapter execution in this slice, including a synthetically certified deployment, while recurring-question execution remains unchanged.
 - Preserve standalone Agent Tasks. Its ordinary interactive ACP lifecycle and UX are a separate job/persona and are not gated or renamed by this work.
-- ADR number 040 is current at plan time. Recheck `Docs/ADR/README.md` and the directory immediately before edits; if 040 has been claimed on current dev, update this plan and TASK-13129 to the next free number before creating the ADR.
+- ADR-040 is occupied by synchronized moodboards on the implementation baseline. ADR-041 is reserved for this feasibility decision; recheck `Docs/ADR/README.md` immediately before creating the ADR and advance again if current `dev` claims it first.
 
 ## Evidence Domains And Current Gaps
 
@@ -52,8 +52,8 @@
 
 | Stage | Goal | Success Criteria | Tests | Status |
 | --- | --- | --- | --- | --- |
-| 1 | Freeze the certification vocabulary and fail-closed evaluator | All outcome and freshness rules are deterministic and mock evidence cannot certify | Pure unit tests | Not Started |
-| 2 | Produce reproducible current-state evidence | Seven requirement records and a sanitized manifest are generated for an exact deployment class | Helper and characterization tests | Not Started |
+| 1 | Freeze the certification vocabulary and fail-closed evaluator | All outcome and freshness rules are deterministic and mock evidence cannot certify | Pure unit tests | Complete |
+| 2 | Produce reproducible current-state evidence | Seven requirement records and a sanitized manifest are generated for an exact deployment class | Helper and characterization tests | In Progress |
 | 3 | Publish and enforce the API-first readiness gate | Versioned capability metadata, typed Run Now refusal, no Agent scheduler enqueue, and worker defense-in-depth agree | Schema/service/API/OpenAPI/feed/consumer tests | Not Started |
 | 4 | Publish the decision and current baseline | ADR, operator guide, JSON/Markdown evidence, and dependency tasks agree | Artifact validator and docs checks | Not Started |
 | 5 | Complete regression and security gates | Focused cross-module tests, compile, lint, Bandit, diff review, and Backlog evidence pass | Verification matrix | Not Started |
@@ -66,7 +66,7 @@
 - `tldw_Server_API/tests/Notifications/test_scheduled_task_execution_certification.py` - pure outcome, subject-binding, freshness, and runtime-eligibility tests in the existing Scheduled Tasks test area.
 - `Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py` - sanitized manifest/evidence generator and explicit host-gated refusal/run controls.
 - `tldw_Server_API/tests/Helper_Scripts/test_scheduled_agent_execution_certification.py` - helper CLI, evidence schema, sentinel exclusion, and no-false-certification tests.
-- `Docs/ADR/040-scheduled-agent-execution-feasibility.md` - accepted/rejected deployment-class decision and consequences.
+- `Docs/ADR/041-scheduled-agent-execution-feasibility.md` - accepted/rejected deployment-class decision and consequences.
 - `Docs/Development/Scheduled_Agent_Execution_Certification.md` - operator commands, trust/evidence contract, outcome interpretation, and rerun rules.
 - `Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json` - machine-readable current repository result.
 - `Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md` - bounded human-readable result and gaps.
@@ -74,7 +74,7 @@
 **Modify**
 
 - `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py` - additive typed certification capability.
-- `Docs/ADR/README.md` - register ADR-040 in the canonical ADR index.
+- `Docs/ADR/README.md` - register ADR-041 in the canonical ADR index.
 - `tldw_Server_API/app/services/scheduled_task_automation_service.py` - inject/resolve certification and gate Agent capability projection and Run Now admission.
 - `tldw_Server_API/app/services/scheduled_task_automation_scheduler.py` - prevent Agent definitions from arming or enqueueing before the complete execution stack is ready.
 - `tldw_Server_API/app/core/Scheduled_Tasks/agent_task_jobs.py` - worker-side defense in depth for already-queued Agent Jobs.
@@ -109,7 +109,7 @@
 - Consumes: completed TASK-13127, current `origin/dev`, the approved Phase 4D spec, and existing Sandbox/ACP/MCP evidence contracts.
 - Produces: one clean implementation worktree and an explicit record of every evidence source and known limitation.
 
-- [ ] **Step 1: Start only after TASK-13127 is merged**
+- [x] **Step 1: Start only after TASK-13127 is merged**
 
 ```bash
 git fetch origin dev
@@ -122,20 +122,20 @@ backlog task TASK-13127 --plain
 
 Expected: clean worktree on current dev and TASK-13127 Done. If TASK-13127 is not merged, stop; do not combine the prerequisite and security gate.
 
-- [ ] **Step 2: Confirm ADR 040 is free**
+- [x] **Step 2: Reserve the next free ADR after finding ADR-040 occupied**
 
 ```bash
 ls Docs/ADR
-rg -n '^# ADR-040:' Docs/ADR
+rg -n '^# ADR-04[01]:' Docs/ADR
 ```
 
-Expected: no existing ADR-040. If it exists, update this plan and TASK-13129 to the next free number before any ADR file is created.
+Observed: ADR-040 is occupied by synchronized moodboards. ADR-041 is the next free number and is reserved in this plan and TASK-13129 before any ADR file is created.
 
-- [ ] **Step 3: Mark TASK-13129 In Progress and record the evidence inventory**
+- [x] **Step 3: Mark TASK-13129 In Progress and record the evidence inventory**
 
 Use Backlog.md MCP to record the dev SHA and the exact reusable sources from the evidence table. Record these baseline facts: ordinary ACP stores raw prompts; ACP sandbox creation has no dispatch token/idempotency key; current cancellation lacks the required event journal; MCP credential brokering is partial; no deployment class is currently certified.
 
-- [ ] **Step 4: Run the focused pre-change baseline**
+- [x] **Step 4: Run the focused pre-change baseline**
 
 ```bash
 source "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.venv/bin/activate"
@@ -149,7 +149,7 @@ python -m pytest -q --tb=short \
   tldw_Server_API/tests/MCP_Hub/test_mcp_slot_status.py
 ```
 
-Expected: record exact counts and pre-existing skips/failures in TASK-13129. These tests establish reusable primitives; they do not count as Phase 4D.0F certification.
+Observed on baseline SHA `2306c1939f3b460f9c62da8ae83a1aa47c02ee0d`: 171 passed, 0 failed, 0 skipped, and 19 warnings in 78.28 seconds. These tests establish reusable primitives; they do not count as Phase 4D.0F certification.
 
 ### Task 1: Define Deployment Identity And Fail-Closed Outcome Rules
 
@@ -161,7 +161,7 @@ Expected: record exact counts and pre-existing skips/failures in TASK-13129. The
 - Consumes: a normalized `DeploymentClass`, seven `RequirementEvidence` records, runtime isolation/network metadata, and an injected UTC clock.
 - Produces: immutable `ExecutionCertification` with outcome, opaque deployment-class ID, optional evidence ID, validity timestamps, and bounded stable reason codes.
 
-- [ ] **Step 1: Write failing type and identity tests**
+- [x] **Step 1: Write failing type and identity tests**
 
 Cover the exact public vocabulary:
 
@@ -176,7 +176,7 @@ EvidenceVerification = Literal[
 
 Define these seven closed requirement IDs in the order shown in the evidence table. Test that `DeploymentClass.canonical_payload()` sorts fields and that `deployment_class_id` is `sha256:` plus 64 lowercase hex characters. Changing any identity field must change the digest; insertion order must not.
 
-- [ ] **Step 2: Write failing evaluator tests**
+- [x] **Step 2: Write failing evaluator tests**
 
 Test all rules independently:
 
@@ -190,7 +190,7 @@ Test all rules independently:
 - ordinary missing dependencies, including the absent scheduled transcript mode, produce `draft_only`, not a false claim that the runtime itself was breached;
 - reason codes are sorted, deduplicated, bounded, and contain no free text.
 
-- [ ] **Step 3: Run RED**
+- [x] **Step 3: Run RED**
 
 ```bash
 source "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.venv/bin/activate"
@@ -200,7 +200,7 @@ python -m pytest -q --tb=short \
 
 Expected: FAIL during collection because `execution_certification.py` does not exist.
 
-- [ ] **Step 4: Implement the minimal pure domain**
+- [x] **Step 4: Implement the minimal pure domain**
 
 Use frozen dataclasses and pure helpers. `evaluate_execution_certification(subject, evidence, verification_receipt, *, now)` must never read environment, files, databases, or network. Validate all requirement IDs, subject digests, timestamps, verification levels, evidence IDs, and the already-verified receipt's bundle digest before applying the outcome rules. The receipt type is an internal trust-boundary input, is never accepted from the API or evidence JSON, and has no production constructor in this task. Unit tests may construct it only through a test helper to prove the outcome table; that does not create a production certification path.
 
@@ -208,7 +208,7 @@ Add `resolve_current_agent_execution_certification()` as a separate fail-closed 
 
 Add a separate pure `agent_execution_dispatch_readiness(certification, *, execution_stack_ready)` decision. It returns ready only when certification is `certified` **and** the later stack input is true. The production call sites in this task always pass a source-defined false constant; no environment variable, config file, API parameter, or evidence artifact can change it. Tests prove a certified fixture remains blocked with `agent_execution_stack_unimplemented`.
 
-- [ ] **Step 5: Run GREEN and commit the domain unit**
+- [x] **Step 5: Run GREEN and commit the domain unit**
 
 ```bash
 source "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.venv/bin/activate"
@@ -446,7 +446,7 @@ Expected: one API-first commit with no frontend, Watchlists, standalone Agent Ta
 ### Task 4: Generate The Baseline, ADR, Operator Guide, And Dependencies
 
 **Files:**
-- Create: `Docs/ADR/040-scheduled-agent-execution-feasibility.md`
+- Create: `Docs/ADR/041-scheduled-agent-execution-feasibility.md`
 - Modify: `Docs/ADR/README.md`
 - Create: `Docs/Development/Scheduled_Agent_Execution_Certification.md`
 - Create: `Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json`
@@ -499,9 +499,9 @@ The static appendix applies these expected default outcomes when all non-runtime
 
 The generator must validate that the JSON record and corresponding Markdown deployment-class section have identical outcome/reason codes before writing. It must also validate the static appendix directly from `runtime_capabilities.py`. Any unexpected `certified` result is a release-blocking failure.
 
-- [ ] **Step 2: Write ADR-040**
+- [ ] **Step 2: Write ADR-041**
 
-Use the repository ADR template and add ADR-040 to `Docs/ADR/README.md` with its final status and one-sentence decision. The decision is:
+Use the repository ADR template and add ADR-041 to `Docs/ADR/README.md` with its final status and one-sentence decision. The decision is:
 
 > No current deployment class is certified for Scheduled Tasks Agent automation execution. Statically eligible isolation runtimes remain draft-only until all seven server-verified evidence domains pass for an exact deployment class; host-local and current non-eligible runtimes are unsupported. Existing ordinary ACP, Sandbox, and MCP primitives are retained as dependencies but are not treated as proof.
 
@@ -513,7 +513,7 @@ Document the exact CLI invocations, evidence schema, seven requirement definitio
 
 - [ ] **Step 4: Attach confirmed evidence to the pre-created dependency tasks**
 
-Use Backlog.md MCP to add ADR-040 and both baseline artifacts to these existing tasks:
+Use Backlog.md MCP to add ADR-041 and both baseline artifacts to these existing tasks:
 
 1. `TASK-13130`: `isolation_attestation` and `hostile_boundary`.
 2. `TASK-13131`: `scheduled_transcript_non_disclosure`.
@@ -531,7 +531,7 @@ python Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py
   Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json \
   Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md
 ! rg -n '[T]ODO|[T]BD|[F]IXME|certified.*true' \
-  Docs/ADR/040-scheduled-agent-execution-feasibility.md \
+  Docs/ADR/041-scheduled-agent-execution-feasibility.md \
   Docs/ADR/README.md \
   Docs/Development/Scheduled_Agent_Execution_Certification.md \
   Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.*
@@ -545,7 +545,7 @@ Expected: artifact validation passes; both negated scans exit 0 because no match
 
 ```bash
 git add \
-  Docs/ADR/040-scheduled-agent-execution-feasibility.md \
+  Docs/ADR/041-scheduled-agent-execution-feasibility.md \
   Docs/ADR/README.md \
   Docs/Development/Scheduled_Agent_Execution_Certification.md \
   Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json \

--- a/Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py
+++ b/Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py
@@ -1,0 +1,922 @@
+#!/usr/bin/env python3
+"""Generate sanitized Scheduled Agent execution feasibility evidence.
+
+This helper characterizes current repository behavior. It cannot construct the
+authoritative receipt required for certification and cannot launch hostile
+probes until a later server-side attestation verifier exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import inspect
+import json
+import os
+import platform
+import re
+import secrets
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import urlsplit
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (  # noqa: E402
+    runtime_isolation_metadata,
+    runtime_network_policy_metadata,
+)
+from tldw_Server_API.app.core.Scheduled_Tasks.execution_certification import (  # noqa: E402
+    CERTIFICATION_REASON_CODES,
+    REQUIRED_EVIDENCE_DOMAINS,
+    DeploymentClass,
+    IsolationProfile,
+    RequirementEvidence,
+    RuntimeEligibility,
+    evaluate_execution_certification,
+)
+
+SCHEMA_VERSION = "scheduled-agent-execution-certification.v1"
+VALIDITY_WINDOW = timedelta(hours=24)
+HELPER_PATH = (
+    "Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py"
+)
+_SHA256_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+_COMMIT_PATTERN = re.compile(r"^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
+_SLUG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_ENVIRONMENT_NAME_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
+_MANIFEST_KEYS = {
+    "schema_version",
+    "evidence_id",
+    "deployment_class_id",
+    "source_commit",
+    "created_at",
+    "valid_until",
+    "outcome",
+    "reason_codes",
+    "requirements",
+    "commands",
+}
+_REQUIREMENT_KEYS = {
+    "requirement_id",
+    "state",
+    "verification",
+    "subject_id",
+    "observed_at",
+    "valid_until",
+    "reason_codes",
+    "evidence_sha256",
+    "safety_boundary_breached",
+}
+_COMMAND_KEYS = {
+    "id",
+    "description",
+    "invocation_template",
+    "parameter_names",
+    "safe_to_run_by_default",
+    "required_environment_names",
+}
+_COMMON_PARAMETER_NAMES = [
+    "host-os",
+    "host-arch",
+    "runtime",
+    "auth-mode",
+    "adapter-id",
+    "adapter-version",
+    "source-commit",
+    "server-build-sha",
+    "image-digest",
+    "mount-policy-hash",
+    "egress-policy-hash",
+    "credential-policy-hash",
+    "tenant-boundary-policy-hash",
+    "mediation-policy-hash",
+    "isolation-profile-version",
+]
+_INVOCATION_TEMPLATE = " ".join(
+    ["python", HELPER_PATH, *[f"--{name}" for name in _COMMON_PARAMETER_NAMES]]
+)
+_COMMAND_DESCRIPTIONS = {
+    "isolation_attestation": (
+        "Characterize static runtime isolation metadata; no attestation is issued."
+    ),
+    "hostile_boundary": (
+        "Enumerate the hostile boundary vector; launch remains attestation-gated."
+    ),
+    "scheduled_transcript_non_disclosure": (
+        "Characterize ordinary ACP prompt persistence and fork behavior."
+    ),
+    "adapter_dispatch_recovery": (
+        "Characterize generic idempotency and missing ACP dispatch bindings."
+    ),
+    "monotonic_execution_evidence": (
+        "Characterize cancellation primitives and the missing ordered journal."
+    ),
+    "brokered_credentials_and_mediation": (
+        "Characterize managed credentials, session environment, and grant gaps."
+    ),
+    "operational_fail_closed": (
+        "Evaluate the current fail-closed outcome for the exact deployment class."
+    ),
+}
+
+
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("evidence timestamps must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def sha256_text(value: str) -> str:
+    """Return a bounded one-way identity for sensitive characterization text."""
+
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _require_slug(name: str, value: str) -> str:
+    normalized = str(value or "").strip()
+    if not _SLUG_PATTERN.fullmatch(normalized):
+        raise ValueError(f"{name} must be a bounded identifier")
+    return normalized
+
+
+def _require_commit(name: str, value: str) -> str:
+    normalized = str(value or "").strip()
+    if not _COMMIT_PATTERN.fullmatch(normalized):
+        raise ValueError(f"{name} must be a 40- or 64-character commit digest")
+    return normalized.lower()
+
+
+def _require_hash_or_unverified(name: str, value: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized != "unverified" and not _SHA256_PATTERN.fullmatch(normalized):
+        raise ValueError(f"{name} must be unverified or a sha256 identity")
+    return normalized
+
+
+@dataclass(frozen=True)
+class CertificationInputs:
+    """Explicit private inputs used only to derive opaque evidence subjects."""
+
+    host_os: str
+    host_arch: str
+    runtime: str
+    auth_mode: str
+    adapter_id: str
+    adapter_version: str
+    source_commit: str
+    server_build_sha: str
+    image_digest: str
+    mount_policy_hash: str
+    egress_policy_hash: str
+    credential_policy_hash: str
+    tenant_boundary_policy_hash: str
+    mediation_policy_hash: str
+    isolation_profile_version: str
+
+    def __post_init__(self) -> None:
+        normalized = {
+            "host_os": _require_slug("host_os", self.host_os).lower(),
+            "host_arch": _require_slug("host_arch", self.host_arch).lower(),
+            "runtime": _require_slug("runtime", self.runtime).lower(),
+            "auth_mode": _require_slug("auth_mode", self.auth_mode).lower(),
+            "adapter_id": _require_slug("adapter_id", self.adapter_id).lower(),
+            "adapter_version": _require_slug(
+                "adapter_version", self.adapter_version
+            ),
+            "source_commit": _require_commit("source_commit", self.source_commit),
+            "server_build_sha": _require_commit(
+                "server_build_sha", self.server_build_sha
+            ),
+            "image_digest": _require_hash_or_unverified(
+                "image_digest", self.image_digest
+            ),
+            "mount_policy_hash": _require_hash_or_unverified(
+                "mount_policy_hash", self.mount_policy_hash
+            ),
+            "egress_policy_hash": _require_hash_or_unverified(
+                "egress_policy_hash", self.egress_policy_hash
+            ),
+            "credential_policy_hash": _require_hash_or_unverified(
+                "credential_policy_hash", self.credential_policy_hash
+            ),
+            "tenant_boundary_policy_hash": _require_hash_or_unverified(
+                "tenant_boundary_policy_hash", self.tenant_boundary_policy_hash
+            ),
+            "mediation_policy_hash": _require_hash_or_unverified(
+                "mediation_policy_hash", self.mediation_policy_hash
+            ),
+            "isolation_profile_version": _require_slug(
+                "isolation_profile_version", self.isolation_profile_version
+            ),
+        }
+        for field_name, value in normalized.items():
+            object.__setattr__(self, field_name, value)
+
+    def deployment_class(self) -> DeploymentClass:
+        """Build the exact private subject whose digest is published."""
+
+        profile = IsolationProfile(
+            runtime_image_digest=self.image_digest,
+            mount_policy_hash=self.mount_policy_hash,
+            egress_policy_hash=self.egress_policy_hash,
+            credential_policy_hash=self.credential_policy_hash,
+            tenant_boundary_policy_hash=self.tenant_boundary_policy_hash,
+            mediation_policy_hash=self.mediation_policy_hash,
+            isolation_profile_version=self.isolation_profile_version,
+        )
+        return DeploymentClass(
+            host_os_family=self.host_os,
+            host_architecture=self.host_arch,
+            auth_mode=self.auth_mode,
+            sandbox_runtime=self.runtime,
+            adapter_id=self.adapter_id,
+            adapter_version=self.adapter_version,
+            server_build_sha=self.server_build_sha,
+            isolation_profile=profile,
+        )
+
+
+@dataclass(frozen=True)
+class CharacterizationSentinels:
+    """Values exercised by probes but replaced with hashes before serialization."""
+
+    prompt: str
+    credential: str
+    host_path: str
+    hostname: str
+    tool_argument: str
+    environment_value: str
+
+
+def _random_sentinels() -> CharacterizationSentinels:
+    return CharacterizationSentinels(
+        prompt="prompt-" + secrets.token_hex(16),
+        credential="credential-" + secrets.token_hex(16),
+        host_path="/private/characterization/" + secrets.token_hex(16),
+        hostname="host-" + secrets.token_hex(16) + ".invalid",
+        tool_argument="--characterization=" + secrets.token_hex(16),
+        environment_value="environment-" + secrets.token_hex(16),
+    )
+
+
+def characterize_ordinary_acp_transcript(
+    *,
+    database_path: Path,
+    prompt_sentinel: str,
+) -> dict[str, object]:
+    """Use ordinary ACP storage to prove current prompt and fork disclosure."""
+
+    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+    database = ACPSessionsDB(str(database_path))
+    run_identity = secrets.token_hex(8)
+    source_session_id = f"phase4d0f-source-{run_identity}"
+    fork_session_id = f"phase4d0f-fork-{run_identity}"
+    try:
+        database.register_session(
+            session_id=source_session_id,
+            user_id=1,
+            agent_type="custom",
+        )
+        database.record_prompt(
+            source_session_id,
+            [{"role": "user", "content": prompt_sentinel}],
+            {"content": "characterization response"},
+        )
+        source_messages = database.get_messages(source_session_id)
+        database.fork_session(
+            source_session_id,
+            fork_session_id,
+            message_index=0,
+            user_id=1,
+        )
+        fork_messages = database.get_messages(fork_session_id)
+        source_retrievable = any(
+            prompt_sentinel in str(message.get("content") or "")
+            for message in source_messages
+        )
+        fork_copies_prompt = any(
+            prompt_sentinel in str(message.get("content") or "")
+            for message in fork_messages
+        )
+    finally:
+        database.close()
+    return {
+        "ordinary_prompt_retrievable": source_retrievable,
+        "ordinary_fork_copies_prompt": fork_copies_prompt,
+        "prompt_sha256": sha256_text(prompt_sentinel),
+        "reason_code": "scheduled_transcript_mode_unimplemented",
+    }
+
+
+def characterize_current_primitives(
+    *,
+    database_path: Path,
+    prompt_sentinel: str,
+) -> dict[str, dict[str, object]]:
+    """Characterize existing typed APIs without treating partials as proof."""
+
+    from tldw_Server_API.app.core.Agent_Client_Protocol.sandbox_runner_client import (
+        ACPSandboxRunnerManager,
+    )
+    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+    from tldw_Server_API.app.core.Sandbox.service import SandboxService
+    from tldw_Server_API.app.services.mcp_credential_broker_service import (
+        McpCredentialBrokerService,
+    )
+
+    acp_create_parameters = inspect.signature(
+        ACPSandboxRunnerManager.create_session
+    ).parameters
+    sandbox_create_parameters = inspect.signature(SandboxService.create_session).parameters
+    persisted_session_parameters = inspect.signature(
+        ACPSessionsDB.register_session
+    ).parameters
+    transcript = characterize_ordinary_acp_transcript(
+        database_path=database_path,
+        prompt_sentinel=prompt_sentinel,
+    )
+    return {
+        "isolation_attestation": {
+            "server_attestation_verifier": False,
+        },
+        "hostile_boundary": {
+            "hostile_probe_launch_allowed": False,
+        },
+        "scheduled_transcript_non_disclosure": transcript,
+        "adapter_dispatch_recovery": {
+            "sandbox_idempotency_available": "idem_key" in sandbox_create_parameters,
+            "acp_dispatch_token_parameter": "dispatch_token" in acp_create_parameters,
+            "acp_dispatch_token_persisted": (
+                "dispatch_token" in persisted_session_parameters
+            ),
+        },
+        "monotonic_execution_evidence": {
+            "cancellation_primitive_available": hasattr(
+                ACPSandboxRunnerManager,
+                "cancel",
+            ),
+            "terminal_state_primitive_available": hasattr(
+                ACPSessionsDB,
+                "set_session_status",
+            ),
+            "ordered_attempt_journal": hasattr(
+                ACPSessionsDB,
+                "append_execution_event",
+            ),
+        },
+        "brokered_credentials_and_mediation": {
+            "managed_credential_broker_available": hasattr(
+                McpCredentialBrokerService,
+                "get_slot_status",
+            ),
+            "acp_session_env_channel_present": "session_env" in acp_create_parameters,
+            "scheduled_grant_action_binding": False,
+        },
+        "operational_fail_closed": {
+            "unified_certification_gate_available": True,
+            "authoritative_evidence_ingestion_available": False,
+        },
+    }
+
+
+def _runtime_eligibility(runtime: str) -> RuntimeEligibility:
+    try:
+        isolation = runtime_isolation_metadata(runtime)
+        deny_all = runtime_network_policy_metadata(runtime).deny_all
+    except ValueError:
+        return RuntimeEligibility(untrusted_eligible=False, strict_deny_all=False)
+    return RuntimeEligibility(
+        untrusted_eligible=isolation.untrusted_eligible,
+        strict_deny_all=(
+            deny_all.strict_enforcement
+            and deny_all.support_state in {"supported", "host_gated"}
+        ),
+    )
+
+
+def _requirement_record(
+    *,
+    requirement_id: str,
+    subject_id: str,
+    observed_at: datetime,
+    valid_until: datetime,
+    facts: Mapping[str, object],
+    sentinel_hashes: Mapping[str, str],
+) -> dict[str, object]:
+    evidence_sha256 = sha256_text(
+        _canonical_json(
+            {
+                "facts": dict(facts),
+                "requirement_id": requirement_id,
+                "sentinel_hashes": dict(sentinel_hashes),
+                "subject_id": subject_id,
+            }
+        )
+    )
+    return {
+        "requirement_id": requirement_id,
+        "state": "missing",
+        "verification": "repository_characterization",
+        "subject_id": subject_id,
+        "observed_at": observed_at.isoformat(),
+        "valid_until": valid_until.isoformat(),
+        "reason_codes": [f"{requirement_id}_missing"],
+        "evidence_sha256": evidence_sha256,
+        "safety_boundary_breached": False,
+    }
+
+
+def _command_manifest() -> list[dict[str, object]]:
+    commands: list[dict[str, object]] = []
+    for requirement_id in REQUIRED_EVIDENCE_DOMAINS:
+        parameter_names = list(_COMMON_PARAMETER_NAMES)
+        safe_to_run = requirement_id != "hostile_boundary"
+        if requirement_id == "hostile_boundary":
+            parameter_names.extend(
+                [
+                    "run-hostile",
+                    "evidence-dir",
+                    "server-url",
+                    "api-key-env-name",
+                    "attestation-reference",
+                ]
+            )
+        commands.append(
+            {
+                "id": requirement_id,
+                "description": _COMMAND_DESCRIPTIONS[requirement_id],
+                "invocation_template": (
+                    _INVOCATION_TEMPLATE
+                    + (" --run-hostile" if not safe_to_run else "")
+                ),
+                "parameter_names": parameter_names,
+                "safe_to_run_by_default": safe_to_run,
+                "required_environment_names": (
+                    ["configured_api_key_environment"] if not safe_to_run else []
+                ),
+            }
+        )
+    return commands
+
+
+def compute_manifest_evidence_id(manifest: Mapping[str, object]) -> str:
+    """Hash canonical sanitized content while excluding its identity field."""
+
+    payload = dict(manifest)
+    payload.pop("evidence_id", None)
+    return sha256_text(_canonical_json(payload))
+
+
+def validate_manifest(manifest: Mapping[str, object]) -> None:
+    """Validate the closed characterization schema and integrity digest."""
+
+    if set(manifest) != _MANIFEST_KEYS:
+        raise ValueError("manifest fields do not match the v1 schema")
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unsupported evidence schema_version")
+    if manifest.get("evidence_id") != compute_manifest_evidence_id(manifest):
+        raise ValueError("manifest evidence_id does not match sanitized content")
+    if manifest.get("outcome") not in {"draft_only", "unsupported"}:
+        raise ValueError("repository characterization cannot be certified")
+    if not _COMMIT_PATTERN.fullmatch(str(manifest.get("source_commit") or "")):
+        raise ValueError("manifest source_commit is invalid")
+    if not _SHA256_PATTERN.fullmatch(
+        str(manifest.get("deployment_class_id") or "")
+    ):
+        raise ValueError("manifest deployment_class_id is invalid")
+
+    reasons = manifest.get("reason_codes")
+    if not isinstance(reasons, list) or any(
+        not isinstance(reason, str) or reason not in CERTIFICATION_REASON_CODES
+        for reason in reasons
+    ):
+        raise ValueError("manifest reason_codes are invalid")
+
+    requirements = manifest.get("requirements")
+    if not isinstance(requirements, list):
+        raise ValueError("manifest requirements must be a list")
+    if [item.get("requirement_id") for item in requirements] != list(
+        REQUIRED_EVIDENCE_DOMAINS
+    ):
+        raise ValueError("manifest requirements are incomplete or out of order")
+    for item in requirements:
+        if not isinstance(item, dict) or set(item) != _REQUIREMENT_KEYS:
+            raise ValueError("manifest requirement fields are invalid")
+        if item.get("verification") != "repository_characterization":
+            raise ValueError("manifest requirement is not repository characterization")
+        if item.get("state") != "missing":
+            raise ValueError("current characterization requirement must remain missing")
+        if item.get("subject_id") != manifest.get("deployment_class_id"):
+            raise ValueError("manifest requirement subject mismatch")
+        if not _SHA256_PATTERN.fullmatch(str(item.get("evidence_sha256") or "")):
+            raise ValueError("manifest requirement evidence digest is invalid")
+
+    commands = manifest.get("commands")
+    if not isinstance(commands, list):
+        raise ValueError("manifest commands must be a list")
+    if [item.get("id") for item in commands] != list(REQUIRED_EVIDENCE_DOMAINS):
+        raise ValueError("manifest commands are incomplete or out of order")
+    if any(not isinstance(item, dict) or set(item) != _COMMAND_KEYS for item in commands):
+        raise ValueError("manifest command fields are invalid")
+
+
+def build_evidence_manifest(
+    inputs: CertificationInputs,
+    *,
+    now: datetime,
+    temporary_directory: Path,
+    sentinels: CharacterizationSentinels | None = None,
+) -> dict[str, object]:
+    """Build one exact, sanitized repository-characterization manifest."""
+
+    observed_at = _aware_utc(now)
+    valid_until = observed_at + VALIDITY_WINDOW
+    subject = inputs.deployment_class()
+    active_sentinels = sentinels or _random_sentinels()
+    temporary_directory.mkdir(parents=True, exist_ok=True)
+    facts = characterize_current_primitives(
+        database_path=temporary_directory / "scheduled-agent-characterization.db",
+        prompt_sentinel=active_sentinels.prompt,
+    )
+    sentinel_hashes = {
+        name: sha256_text(value)
+        for name, value in vars(active_sentinels).items()
+    }
+    requirements = [
+        _requirement_record(
+            requirement_id=requirement_id,
+            subject_id=subject.deployment_class_id,
+            observed_at=observed_at,
+            valid_until=valid_until,
+            facts=facts[requirement_id],
+            sentinel_hashes=sentinel_hashes,
+        )
+        for requirement_id in REQUIRED_EVIDENCE_DOMAINS
+    ]
+    domain_evidence = tuple(
+        RequirementEvidence(
+            requirement_id=str(item["requirement_id"]),
+            state="missing",
+            verification="repository_characterization",
+            subject_id=str(item["subject_id"]),
+            observed_at=observed_at,
+            valid_until=valid_until,
+            evidence_sha256=str(item["evidence_sha256"]),
+        )
+        for item in requirements
+    )
+    certification = evaluate_execution_certification(
+        subject,
+        domain_evidence,
+        None,
+        runtime_eligibility=_runtime_eligibility(inputs.runtime),
+        now=observed_at,
+    )
+    manifest: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "evidence_id": "",
+        "deployment_class_id": subject.deployment_class_id,
+        "source_commit": inputs.source_commit,
+        "created_at": observed_at.isoformat(),
+        "valid_until": valid_until.isoformat(),
+        "outcome": certification.outcome,
+        "reason_codes": list(certification.reason_codes),
+        "requirements": requirements,
+        "commands": _command_manifest(),
+    }
+    manifest["evidence_id"] = compute_manifest_evidence_id(manifest)
+    validate_manifest(manifest)
+    return manifest
+
+
+def render_manifest_json(manifest: Mapping[str, object]) -> str:
+    """Render stable, human-diffable JSON."""
+
+    validate_manifest(manifest)
+    return json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+
+
+def render_manifest_markdown(manifest: Mapping[str, object]) -> str:
+    """Render a bounded Markdown summary of the same manifest."""
+
+    validate_manifest(manifest)
+    reasons = manifest["reason_codes"]
+    requirements = manifest["requirements"]
+    if not isinstance(reasons, list) or not isinstance(requirements, list):
+        raise ValueError("validated manifest collections are invalid")
+    lines = [
+        "# Scheduled Agent Execution Feasibility Evidence",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Evidence ID | `{manifest['evidence_id']}` |",
+        f"| Deployment class | `{manifest['deployment_class_id']}` |",
+        f"| Source commit | `{manifest['source_commit']}` |",
+        f"| Created | `{manifest['created_at']}` |",
+        f"| Valid until | `{manifest['valid_until']}` |",
+        f"| Outcome | `{manifest['outcome']}` |",
+        "",
+        "## Reasons",
+        "",
+    ]
+    lines.extend(f"- `{reason}`" for reason in reasons)
+    lines.extend(
+        [
+            "",
+            "## Requirements",
+            "",
+            "| Requirement | State | Verification | Evidence |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(
+        "| `{requirement_id}` | `{state}` | `{verification}` | "
+        "`{evidence_sha256}` |".format(**item)
+        for item in requirements
+    )
+    lines.extend(
+        [
+            "",
+            "Repository characterization is not deployment certification. Host-gated "
+            "raw evidence is retained outside the repository.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary_path = Path(handle.name)
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def write_artifacts(
+    manifest: Mapping[str, object],
+    *,
+    json_path: Path | None,
+    markdown_path: Path | None,
+) -> None:
+    """Validate then atomically replace each requested sanitized artifact."""
+
+    validate_manifest(manifest)
+    json_content = render_manifest_json(manifest)
+    markdown_content = render_manifest_markdown(manifest)
+    if json_path is not None:
+        _atomic_write(json_path, json_content)
+    if markdown_path is not None:
+        _atomic_write(markdown_path, markdown_content)
+
+
+def validate_artifact_pair(json_path: Path, markdown_path: Path) -> None:
+    """Verify integrity and identity parity across JSON and Markdown artifacts."""
+
+    manifest = json.loads(json_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise ValueError("JSON evidence must contain one manifest object")
+    validate_manifest(manifest)
+    markdown = markdown_path.read_text(encoding="utf-8")
+    expected_values = (
+        str(manifest["evidence_id"]),
+        str(manifest["deployment_class_id"]),
+        f"| Outcome | `{manifest['outcome']}` |",
+    )
+    if any(value not in markdown for value in expected_values):
+        raise ValueError("Markdown artifact does not match JSON evidence")
+
+
+@dataclass(frozen=True)
+class HostileProbeRequest:
+    """Prerequisites for a future attested hostile boundary run."""
+
+    deployment_class_id: str
+    evidence_dir: Path | None
+    server_url: str | None
+    api_key_environment_name: str | None
+    attestation_reference: str | None
+
+
+@dataclass(frozen=True)
+class HostileProbeAdmission:
+    """Bounded fail-closed admission result without launch details."""
+
+    allowed: bool
+    reason_code: str
+
+
+def _local_server_url(value: str) -> bool:
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+    return (
+        parsed.scheme in {"http", "https"}
+        and parsed.hostname in {"127.0.0.1", "::1", "localhost"}
+        and parsed.username is None
+        and parsed.password is None
+    )
+
+
+def evaluate_hostile_probe_admission(
+    request: HostileProbeRequest,
+    *,
+    environment: Mapping[str, str],
+) -> HostileProbeAdmission:
+    """Refuse hostile launch until every prerequisite is server-verified."""
+
+    if request.evidence_dir is None:
+        return HostileProbeAdmission(False, "hostile_probe_blocked_evidence_dir_missing")
+    if not request.evidence_dir.is_dir() or request.evidence_dir.is_symlink():
+        return HostileProbeAdmission(
+            False,
+            "hostile_probe_blocked_evidence_dir_unavailable",
+        )
+    if not request.server_url:
+        return HostileProbeAdmission(False, "hostile_probe_blocked_server_url_missing")
+    if not _local_server_url(request.server_url):
+        return HostileProbeAdmission(False, "hostile_probe_blocked_nonlocal_server")
+    environment_name = str(request.api_key_environment_name or "")
+    if not environment_name:
+        return HostileProbeAdmission(
+            False,
+            "hostile_probe_blocked_api_key_environment_missing",
+        )
+    if not _ENVIRONMENT_NAME_PATTERN.fullmatch(environment_name):
+        return HostileProbeAdmission(
+            False,
+            "hostile_probe_blocked_api_key_environment_invalid",
+        )
+    if not str(environment.get(environment_name) or ""):
+        return HostileProbeAdmission(
+            False,
+            "hostile_probe_blocked_api_key_unavailable",
+        )
+    if not request.attestation_reference:
+        return HostileProbeAdmission(
+            False,
+            "hostile_probe_blocked_attestation_reference_missing",
+        )
+    if not _SHA256_PATTERN.fullmatch(request.attestation_reference):
+        return HostileProbeAdmission(
+            False,
+            "hostile_probe_blocked_attestation_reference_invalid",
+        )
+    if not _SHA256_PATTERN.fullmatch(request.deployment_class_id):
+        return HostileProbeAdmission(
+            False,
+            "hostile_probe_blocked_deployment_class_invalid",
+        )
+    return HostileProbeAdmission(
+        False,
+        "hostile_probe_blocked_server_attestation_verifier_unimplemented",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for option in _COMMON_PARAMETER_NAMES:
+        parser.add_argument(f"--{option}")
+    parser.add_argument("--format", choices=("json", "markdown"))
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--output-markdown", type=Path)
+    parser.add_argument("--repository-characterization-only", action="store_true")
+    parser.add_argument("--run-hostile", action="store_true")
+    parser.add_argument("--evidence-dir", type=Path)
+    parser.add_argument("--server-url")
+    parser.add_argument("--api-key-env-name")
+    parser.add_argument("--attestation-reference")
+    parser.add_argument(
+        "--validate-artifacts",
+        nargs=2,
+        type=Path,
+        metavar=("JSON", "MARKDOWN"),
+    )
+    return parser
+
+
+def _inputs_from_args(args: argparse.Namespace) -> CertificationInputs:
+    missing = [
+        name
+        for name in _COMMON_PARAMETER_NAMES
+        if not getattr(args, name.replace("-", "_"), None)
+    ]
+    if missing:
+        raise ValueError("missing required parameters: " + ", ".join(missing))
+    return CertificationInputs(
+        host_os=args.host_os,
+        host_arch=args.host_arch,
+        runtime=args.runtime,
+        auth_mode=args.auth_mode,
+        adapter_id=args.adapter_id,
+        adapter_version=args.adapter_version,
+        source_commit=args.source_commit,
+        server_build_sha=args.server_build_sha,
+        image_digest=args.image_digest,
+        mount_policy_hash=args.mount_policy_hash,
+        egress_policy_hash=args.egress_policy_hash,
+        credential_policy_hash=args.credential_policy_hash,
+        tenant_boundary_policy_hash=args.tenant_boundary_policy_hash,
+        mediation_policy_hash=args.mediation_policy_hash,
+        isolation_profile_version=args.isolation_profile_version,
+    )
+
+
+def _validate_observed_host(inputs: CertificationInputs) -> None:
+    observed_os = platform.system().lower()
+    observed_arch = platform.machine().lower()
+    if inputs.host_os != observed_os or inputs.host_arch != observed_arch:
+        raise ValueError(
+            "claimed host does not match the observed host; use "
+            "--repository-characterization-only for a non-host claim"
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run characterization, validation, or fail-closed hostile admission."""
+
+    parser = _parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        if args.validate_artifacts:
+            validate_artifact_pair(*args.validate_artifacts)
+            print("Artifacts valid.")
+            return 0
+
+        inputs = _inputs_from_args(args)
+        if not args.repository_characterization_only:
+            _validate_observed_host(inputs)
+        with tempfile.TemporaryDirectory(prefix="scheduled-agent-certification-") as temp:
+            manifest = build_evidence_manifest(
+                inputs,
+                now=datetime.now(timezone.utc),
+                temporary_directory=Path(temp),
+            )
+
+        if args.run_hostile:
+            admission = evaluate_hostile_probe_admission(
+                HostileProbeRequest(
+                    deployment_class_id=str(manifest["deployment_class_id"]),
+                    evidence_dir=args.evidence_dir,
+                    server_url=args.server_url,
+                    api_key_environment_name=args.api_key_env_name,
+                    attestation_reference=args.attestation_reference,
+                ),
+                environment=os.environ,
+            )
+            if not admission.allowed:
+                print(admission.reason_code, file=sys.stderr)
+                return 2
+
+        write_artifacts(
+            manifest,
+            json_path=args.output_json,
+            markdown_path=args.output_markdown,
+        )
+        output_format = args.format
+        if output_format is None and not args.output_json and not args.output_markdown:
+            output_format = "json"
+        if output_format == "json":
+            print(render_manifest_json(manifest), end="")
+        elif output_format == "markdown":
+            print(render_manifest_markdown(manifest), end="")
+        return 0
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py
+++ b/Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py
@@ -24,6 +24,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urlsplit
 
+from loguru import logger
+
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -137,12 +139,16 @@ _COMMAND_DESCRIPTIONS = {
 
 
 def _aware_utc(value: datetime) -> datetime:
+    """Normalize one aware evidence timestamp to UTC."""
+
     if value.tzinfo is None or value.utcoffset() is None:
         raise ValueError("evidence timestamps must be timezone-aware")
     return value.astimezone(timezone.utc)
 
 
 def _canonical_json(value: object) -> str:
+    """Serialize sanitized evidence into canonical JSON."""
+
     return json.dumps(
         value,
         sort_keys=True,
@@ -158,6 +164,8 @@ def sha256_text(value: str) -> str:
 
 
 def _require_slug(name: str, value: str) -> str:
+    """Validate one bounded non-secret identifier."""
+
     normalized = str(value or "").strip()
     if not _SLUG_PATTERN.fullmatch(normalized):
         raise ValueError(f"{name} must be a bounded identifier")
@@ -165,6 +173,8 @@ def _require_slug(name: str, value: str) -> str:
 
 
 def _require_commit(name: str, value: str) -> str:
+    """Validate and normalize one source/build commit digest."""
+
     normalized = str(value or "").strip()
     if not _COMMIT_PATTERN.fullmatch(normalized):
         raise ValueError(f"{name} must be a 40- or 64-character commit digest")
@@ -172,6 +182,8 @@ def _require_commit(name: str, value: str) -> str:
 
 
 def _require_hash_or_unverified(name: str, value: str) -> str:
+    """Validate an opaque SHA-256 identity or explicit unverified marker."""
+
     normalized = str(value or "").strip().lower()
     if normalized != "unverified" and not _SHA256_PATTERN.fullmatch(normalized):
         raise ValueError(f"{name} must be unverified or a sha256 identity")
@@ -199,6 +211,8 @@ class CertificationInputs:
     isolation_profile_version: str
 
     def __post_init__(self) -> None:
+        """Normalize and validate all explicit private input identities."""
+
         normalized = {
             "host_os": _require_slug("host_os", self.host_os).lower(),
             "host_arch": _require_slug("host_arch", self.host_arch).lower(),
@@ -274,6 +288,8 @@ class CharacterizationSentinels:
 
 
 def _random_sentinels() -> CharacterizationSentinels:
+    """Generate per-run sensitive values that must never be serialized."""
+
     return CharacterizationSentinels(
         prompt="prompt-" + secrets.token_hex(16),
         credential="credential-" + secrets.token_hex(16),
@@ -406,6 +422,8 @@ def characterize_current_primitives(
 
 
 def _runtime_eligibility(runtime: str) -> RuntimeEligibility:
+    """Map typed Sandbox runtime metadata to certification eligibility."""
+
     try:
         isolation = runtime_isolation_metadata(runtime)
         deny_all = runtime_network_policy_metadata(runtime).deny_all
@@ -429,6 +447,8 @@ def _requirement_record(
     facts: Mapping[str, object],
     sentinel_hashes: Mapping[str, str],
 ) -> dict[str, object]:
+    """Build one sanitized missing-evidence requirement record."""
+
     evidence_sha256 = sha256_text(
         _canonical_json(
             {
@@ -453,6 +473,8 @@ def _requirement_record(
 
 
 def _command_manifest() -> list[dict[str, object]]:
+    """Return the closed deterministic command metadata manifest."""
+
     commands: list[dict[str, object]] = []
     for requirement_id in REQUIRED_EVIDENCE_DOMAINS:
         parameter_names = list(_COMMON_PARAMETER_NAMES)
@@ -544,6 +566,8 @@ def validate_manifest(manifest: Mapping[str, object]) -> None:
         raise ValueError("manifest commands are incomplete or out of order")
     if any(not isinstance(item, dict) or set(item) != _COMMAND_KEYS for item in commands):
         raise ValueError("manifest command fields are invalid")
+    if commands != _command_manifest():
+        raise ValueError("manifest command metadata does not match the v1 schema")
 
 
 def build_evidence_manifest(
@@ -623,6 +647,8 @@ def render_manifest_json(manifest: Mapping[str, object]) -> str:
 
 
 def _static_runtime_eligibility_rows() -> list[tuple[str, str, str]]:
+    """Derive the appendix rows from typed runtime metadata."""
+
     rows: list[tuple[str, str, str]] = []
     for runtime in STATIC_RUNTIME_VALUES:
         eligibility = _runtime_eligibility(runtime)
@@ -710,6 +736,8 @@ def render_manifest_markdown(manifest: Mapping[str, object]) -> str:
 
 
 def _atomic_write(path: Path, content: str) -> None:
+    """Write one validated artifact atomically."""
+
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary_path: Path | None = None
     try:
@@ -780,6 +808,8 @@ class HostileProbeAdmission:
 
 
 def _local_server_url(value: str) -> bool:
+    """Return whether a URL targets an explicit loopback HTTP server."""
+
     try:
         parsed = urlsplit(value)
     except ValueError:
@@ -848,6 +878,8 @@ def evaluate_hostile_probe_admission(
 
 
 def _parser() -> argparse.ArgumentParser:
+    """Build the command-line parser for generation and validation modes."""
+
     parser = argparse.ArgumentParser(description=__doc__)
     for option in _COMMON_PARAMETER_NAMES:
         parser.add_argument(f"--{option}")
@@ -870,6 +902,8 @@ def _parser() -> argparse.ArgumentParser:
 
 
 def _inputs_from_args(args: argparse.Namespace) -> CertificationInputs:
+    """Build validated certification inputs from parsed CLI arguments."""
+
     missing = [
         name
         for name in _COMMON_PARAMETER_NAMES
@@ -897,6 +931,8 @@ def _inputs_from_args(args: argparse.Namespace) -> CertificationInputs:
 
 
 def _validate_observed_host(inputs: CertificationInputs) -> None:
+    """Reject host identity claims that differ from local observation."""
+
     observed_os = platform.system().lower()
     observed_arch = platform.machine().lower()
     if inputs.host_os != observed_os or inputs.host_arch != observed_arch:
@@ -956,7 +992,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(render_manifest_markdown(manifest), end="")
         return 0
     except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
-        print(f"Error: {exc}", file=sys.stderr)
+        logger.error("Scheduled Agent characterization failed: {}", exc)
         return 2
 
 

--- a/Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py
+++ b/Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py
@@ -44,6 +44,15 @@ from tldw_Server_API.app.core.Scheduled_Tasks.execution_certification import (  
 
 SCHEMA_VERSION = "scheduled-agent-execution-certification.v1"
 VALIDITY_WINDOW = timedelta(hours=24)
+STATIC_RUNTIME_VALUES = (
+    "docker",
+    "firecracker",
+    "lima",
+    "vz_linux",
+    "vz_macos",
+    "seatbelt",
+    "worktree",
+)
 HELPER_PATH = (
     "Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py"
 )
@@ -469,7 +478,7 @@ def _command_manifest() -> list[dict[str, object]]:
                 "parameter_names": parameter_names,
                 "safe_to_run_by_default": safe_to_run,
                 "required_environment_names": (
-                    ["configured_api_key_environment"] if not safe_to_run else []
+                    ["configured_credential_environment"] if not safe_to_run else []
                 ),
             }
         )
@@ -613,6 +622,28 @@ def render_manifest_json(manifest: Mapping[str, object]) -> str:
     return json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
 
 
+def _static_runtime_eligibility_rows() -> list[tuple[str, str, str]]:
+    rows: list[tuple[str, str, str]] = []
+    for runtime in STATIC_RUNTIME_VALUES:
+        eligibility = _runtime_eligibility(runtime)
+        if eligibility.untrusted_eligible and eligibility.strict_deny_all:
+            rows.append(
+                (
+                    runtime,
+                    "draft_only",
+                    "required_server_verified_evidence_incomplete",
+                )
+            )
+            continue
+        reasons: list[str] = []
+        if not eligibility.untrusted_eligible:
+            reasons.append("runtime_not_untrusted_eligible")
+        if not eligibility.strict_deny_all:
+            reasons.append("runtime_strict_deny_all_unavailable")
+        rows.append((runtime, "unsupported", ", ".join(reasons)))
+    return rows
+
+
 def render_manifest_markdown(manifest: Mapping[str, object]) -> str:
     """Render a bounded Markdown summary of the same manifest."""
 
@@ -650,6 +681,22 @@ def render_manifest_markdown(manifest: Mapping[str, object]) -> str:
         "| `{requirement_id}` | `{state}` | `{verification}` | "
         "`{evidence_sha256}` |".format(**item)
         for item in requirements
+    )
+    lines.extend(
+        [
+            "",
+            "## Repository-Static Runtime Eligibility",
+            "",
+            "This appendix is derived from typed runtime metadata. It is not "
+            "deployment certification evidence.",
+            "",
+            "| Runtime | Default outcome | Primary reason |",
+            "| --- | --- | --- |",
+        ]
+    )
+    lines.extend(
+        f"| `{runtime}` | `{outcome}` | `{reason}` |"
+        for runtime, outcome, reason in _static_runtime_eligibility_rows()
     )
     lines.extend(
         [
@@ -709,12 +756,7 @@ def validate_artifact_pair(json_path: Path, markdown_path: Path) -> None:
         raise ValueError("JSON evidence must contain one manifest object")
     validate_manifest(manifest)
     markdown = markdown_path.read_text(encoding="utf-8")
-    expected_values = (
-        str(manifest["evidence_id"]),
-        str(manifest["deployment_class_id"]),
-        f"| Outcome | `{manifest['outcome']}` |",
-    )
-    if any(value not in markdown for value in expected_values):
+    if markdown != render_manifest_markdown(manifest):
         raise ValueError("Markdown artifact does not match JSON evidence")
 
 

--- a/backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
+++ b/backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-13129
 title: Implement Scheduled Tasks Phase 4D.0F execution feasibility gate
-status: In Progress
+status: Done
 created_date: 2026-08-24 17:33
 dependencies:
 - TASK-13127
@@ -25,7 +25,31 @@ documentation:
 - Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
 - Docs/ADR/041-scheduled-agent-execution-feasibility.md
 - Docs/Development/Scheduled_Agent_Execution_Certification.md
-updated_date: 2026-08-27 02:19
+updated_date: 2026-08-27 03:22
+modified_files:
+- Docs/ADR/041-scheduled-agent-execution-feasibility.md
+- Docs/ADR/README.md
+- Docs/Development/Scheduled_Agent_Execution_Certification.md
+- Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json
+- Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md
+- Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
+- Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py
+- backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
+- backlog/tasks/task-13130 - Add-scheduled-execution-isolation-attestation-and-hostile-runtime-proof.md
+- backlog/tasks/task-13131 - Add-ACP-scheduled-mode-secure-transcripts-and-leakage-gates.md
+- backlog/tasks/task-13132 - Add-ACP-dispatch-recovery-and-monotonic-execution-evidence.md
+- backlog/tasks/task-13133 - Add-scheduled-execution-identity-credentials-and-pre-action-mediation.md
+- tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
+- tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py
+- tldw_Server_API/app/core/Scheduled_Tasks/agent_task_jobs.py
+- tldw_Server_API/app/core/Scheduled_Tasks/execution_certification.py
+- tldw_Server_API/app/services/scheduled_task_automation_scheduler.py
+- tldw_Server_API/app/services/scheduled_task_automation_service.py
+- tldw_Server_API/tests/Helper_Scripts/test_scheduled_agent_execution_certification.py
+- tldw_Server_API/tests/Notifications/test_agent_task_jobs_consumer.py
+- tldw_Server_API/tests/Notifications/test_automation_definition_feed.py
+- tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+- tldw_Server_API/tests/Notifications/test_scheduled_task_execution_certification.py
 ---
 
 ## Description
@@ -35,15 +59,15 @@ Implement the Phase 4D.0F proof and fail-closed API/admission gate. Produce repr
 <!-- SECTION:DESCRIPTION:END -->
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A typed certification model defines deployment-class identity, the seven required evidence domains, freshness, stable reason codes, and the exact certified, draft_only, and unsupported outcome rules.
-- [ ] #2 Reproducible manifests and probes cover isolation attestation, hostile boundary attempts, scheduled transcript leakage, exact dispatch-token recovery, monotonic terminal/approval/effect/cancellation evidence, brokered credentials and pre-action mediation, and operational installation/upgrade/health/fail-closed behavior.
-- [ ] #3 The current repository baseline is evaluated honestly: statically ineligible runtimes are unsupported, eligible runtimes with missing or failed proof are draft_only, and no production resolver or artifact path can certify mocked, self-asserted, unsigned, stale, or wrong-subject evidence.
-- [ ] #4 The Scheduled Tasks capabilities API reports a versioned Agent automation certification outcome, evidence identity/source/freshness, bounded reasons, and recovery without exposing raw evidence, paths, prompts, credentials, host details, or argument values.
-- [ ] #5 Certification is necessary but not sufficient: Agent execute/run_now remain disabled, direct Run Now refuses, the scheduler does not arm or enqueue Agent definitions, and already-queued Agent Jobs cannot reach an executor until the later execution stack is independently ready; no environment flag can bypass this gate.
-- [ ] #6 Unsupported deployments visibly refuse Agent preview-create, definition-create, and duplicate through the same typed API contract while existing definitions remain inspectable and safely manageable.
-- [ ] #7 The ADR and operator guide document the evidence commands, trust boundary, retention/freshness, current outcomes, and the exact follow-on dependency tasks required before any deployment class can become certified.
-- [ ] #8 No Scheduled Tasks Agent execution implementation, automatic migration activation, Watchlists behavior, standalone Agent Tasks behavior, or frontend execution control is added by this task.
-- [ ] #9 Focused Scheduled Tasks, ACP, Sandbox, capability API, admission, helper, static-analysis, and Bandit gates pass, with host-gated skips and evidence limitations recorded explicitly.
+- [x] #1 A typed certification model defines deployment-class identity, the seven required evidence domains, freshness, stable reason codes, and the exact certified, draft_only, and unsupported outcome rules.
+- [x] #2 Reproducible manifests and probes cover isolation attestation, hostile boundary attempts, scheduled transcript leakage, exact dispatch-token recovery, monotonic terminal/approval/effect/cancellation evidence, brokered credentials and pre-action mediation, and operational installation/upgrade/health/fail-closed behavior.
+- [x] #3 The current repository baseline is evaluated honestly: statically ineligible runtimes are unsupported, eligible runtimes with missing or failed proof are draft_only, and no production resolver or artifact path can certify mocked, self-asserted, unsigned, stale, or wrong-subject evidence.
+- [x] #4 The Scheduled Tasks capabilities API reports a versioned Agent automation certification outcome, evidence identity/source/freshness, bounded reasons, and recovery without exposing raw evidence, paths, prompts, credentials, host details, or argument values.
+- [x] #5 Certification is necessary but not sufficient: Agent execute/run_now remain disabled, direct Run Now refuses, the scheduler does not arm or enqueue Agent definitions, and already-queued Agent Jobs cannot reach an executor until the later execution stack is independently ready; no environment flag can bypass this gate.
+- [x] #6 Unsupported deployments visibly refuse Agent preview-create, definition-create, and duplicate through the same typed API contract while existing definitions remain inspectable and safely manageable.
+- [x] #7 The ADR and operator guide document the evidence commands, trust boundary, retention/freshness, current outcomes, and the exact follow-on dependency tasks required before any deployment class can become certified.
+- [x] #8 No Scheduled Tasks Agent execution implementation, automatic migration activation, Watchlists behavior, standalone Agent Tasks behavior, or frontend execution control is added by this task.
+- [x] #9 Focused Scheduled Tasks, ACP, Sandbox, capability API, admission, helper, static-analysis, and Bandit gates pass, with host-gated skips and evidence limitations recorded explicitly.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -60,19 +84,22 @@ Baseline dev SHA: 2306c1939f3b460f9c62da8ae83a1aa47c02ee0d. ADR-040 is occupied 
 Focused pre-change baseline on the recorded SHA: 171 passed, 0 failed, 0 skipped, and 19 warnings in 78.28 seconds across Scheduled Tasks automation API, ACP sandbox/session/runner, Sandbox runtime capabilities/operator evidence, and MCP slot-status tests. This validates reusable primitives only and is not Phase 4D.0F certification evidence. Two unrelated untracked Watchlists templates appeared in the isolated worktree and are intentionally excluded from this task.
 
 Stage 1 TDD evidence: the new pure-domain suite first failed during collection because execution_certification.py did not exist. The implemented immutable domain now covers canonical deployment/profile identity, the seven closed requirements, exact subject/freshness/verification checks, authoritative bundle receipt matching, unsupported boundary outcomes, bounded reason codes, a repository-characterization-only current resolver, and the independent execution-stack conjunction. GREEN rerun: 31 passed, 0 failed, 2 warnings in 7.97 seconds. Ruff and compileall passed. Bandit report /tmp/bandit_task_13129_stage1.json contains 0 findings and 0 errors across 510 lines. git diff --check passed.
+Stage 2/3 evidence: the sanitized helper now has 22 passing tests and exact JSON/Markdown pair validation, including a typed runtime-eligibility appendix. The API-first gate regression matrix passed 102 tests with 11 warnings; Ruff, compileall, and Bandit passed with zero findings. Agent execution remains disabled at capability discovery, direct Run Now, scheduler arm/fire/rearm, and queued-job worker admission; Recurring Questions remain unchanged.
+
+Stage 4 decision evidence: ADR-041 accepts that no current deployment class is certified. Baseline evidence `sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874` for deployment class `sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337` is `draft_only`, contains exactly seven missing repository-characterization domains and seven value-free command templates, and passes exact pair/prohibited-content validation. TASK-13130 through TASK-13133 now own the four bounded domain slices; `operational_fail_closed` is a cross-cutting exit criterion for this gate and all four dependencies.
+Final verification: the 12-file cross-module matrix passed 275 tests with 0 failures, 0 skips, and 19 warnings in 93.04 seconds. Compileall and Ruff passed. Bandit `/tmp/bandit_task_13129.json` reports 0 findings and 0 errors across 4,965 production lines. Artifact-pair validation and both prohibited-content scans passed. Branch-wide diff review found no frontend, Watchlists, standalone Agent Tasks, migration activation, or execution-stack implementation.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented the API-first Phase 4D.0F Scheduled Agent execution feasibility gate. Added the immutable seven-domain certification model, sanitized evidence generator and baseline, versioned capability projection, and consistent fail-closed Run Now, scheduler, and worker admission. ADR-041 records that no current deployment class is certified: eligible runtimes remain `draft_only`, ineligible runtimes are `unsupported`, and execution remains unavailable until a separate reviewed stack is ready. Attached the accepted decision and baseline to TASK-13130 through TASK-13133 without starting those dependency slices. Verification completed with 275 passing tests, compileall, Ruff, zero Bandit findings, artifact validation, redaction scans, and branch-scope review.
 <!-- SECTION:FINAL_SUMMARY:END -->
-
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
+++ b/backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
@@ -26,7 +26,7 @@ documentation:
 - Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
 - Docs/ADR/041-scheduled-agent-execution-feasibility.md
 - Docs/Development/Scheduled_Agent_Execution_Certification.md
-updated_date: 2026-08-27 03:30
+updated_date: 2026-08-27 03:38
 modified_files:
 - Docs/ADR/041-scheduled-agent-execution-feasibility.md
 - Docs/ADR/README.md
@@ -90,6 +90,7 @@ Stage 2/3 evidence: the sanitized helper now has 22 passing tests and exact JSON
 Stage 4 decision evidence: ADR-041 accepts that no current deployment class is certified. Baseline evidence `sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874` for deployment class `sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337` is `draft_only`, contains exactly seven missing repository-characterization domains and seven value-free command templates, and passes exact pair/prohibited-content validation. TASK-13130 through TASK-13133 now own the four bounded domain slices; `operational_fail_closed` is a cross-cutting exit criterion for this gate and all four dependencies.
 Final verification: the 12-file cross-module matrix passed 275 tests with 0 failures, 0 skips, and 19 warnings in 93.04 seconds. Compileall and Ruff passed. Bandit `/tmp/bandit_task_13129.json` reports 0 findings and 0 errors across 4,965 production lines. Artifact-pair validation and both prohibited-content scans passed. Branch-wide diff review found no frontend, Watchlists, standalone Agent Tasks, migration activation, or execution-stack implementation.
 Pull request opened: https://github.com/rmusser01/tldw_server/pull/2827. Merge remains blocked by the repository policy until the human requester supplies a Change summary explaining both what changed and why these implementation choices were made.
+Human-authored Change summary supplied by the requester and added verbatim to PR #2827 on 2026-08-26. The AI-generated PR change-summary merge gate is satisfied; CI and review requirements remain independent merge gates.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 

--- a/backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
+++ b/backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
@@ -26,7 +26,7 @@ documentation:
 - Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
 - Docs/ADR/041-scheduled-agent-execution-feasibility.md
 - Docs/Development/Scheduled_Agent_Execution_Certification.md
-updated_date: 2026-08-27 03:38
+updated_date: 2026-08-27 05:32
 modified_files:
 - Docs/ADR/041-scheduled-agent-execution-feasibility.md
 - Docs/ADR/README.md
@@ -47,6 +47,7 @@ modified_files:
 - tldw_Server_API/app/services/scheduled_task_automation_scheduler.py
 - tldw_Server_API/app/services/scheduled_task_automation_service.py
 - tldw_Server_API/tests/Helper_Scripts/test_scheduled_agent_execution_certification.py
+- tldw_Server_API/tests/Notifications/_scheduled_agent_execution_certification_fixtures.py
 - tldw_Server_API/tests/Notifications/test_agent_task_jobs_consumer.py
 - tldw_Server_API/tests/Notifications/test_automation_definition_feed.py
 - tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
@@ -91,11 +92,16 @@ Stage 4 decision evidence: ADR-041 accepts that no current deployment class is c
 Final verification: the 12-file cross-module matrix passed 275 tests with 0 failures, 0 skips, and 19 warnings in 93.04 seconds. Compileall and Ruff passed. Bandit `/tmp/bandit_task_13129.json` reports 0 findings and 0 errors across 4,965 production lines. Artifact-pair validation and both prohibited-content scans passed. Branch-wide diff review found no frontend, Watchlists, standalone Agent Tasks, migration activation, or execution-stack implementation.
 Pull request opened: https://github.com/rmusser01/tldw_server/pull/2827. Merge remains blocked by the repository policy until the human requester supplies a Change summary explaining both what changed and why these implementation choices were made.
 Human-authored Change summary supplied by the requester and added verbatim to PR #2827 on 2026-08-26. The AI-generated PR change-summary merge gate is satisfied; CI and review requirements remain independent merge gates.
+PR #2827 review remediation started. Qodo posted 10 open threads: core-boundary delegation, constructor return annotations, callable docstrings, helper-test markers, supported verifier test boundary, integration-test isolation, Loguru CLI errors, unsupported update admission, scheduler health consistency, and complete command-metadata validation. All findings will be verified against repository behavior before changes.
+PR #2827 review remediation implemented for all 10 Qodo findings. Core now owns Agent authoring admission and recovery decisions; unsupported updates are gated both before idempotency and inside the transaction; readiness-blocked scheduler jobs are removed and definitions transition to audited execution_unavailable health; command metadata validation is exact and deterministic. Quality remediation adds explicit constructor/helper annotations, callable docstrings, the helper-test unit marker, focused endpoint tests, Loguru operational errors, and a test-only receipt fixture boundary that preserves private production authority.
+
+Review-remediation TDD evidence: the unsupported update, blocked scheduler health, and digest-recomputed command-tampering tests first failed against the prior implementation. Focused GREEN rerun passed 6 tests. Full 12-module matrix passed 285 tests with 0 failures, 0 skips, 19 warnings in 104.41 seconds. Compileall and Ruff passed; artifact-pair validation and both prohibited-content scans passed; Bandit /tmp/bandit_task_13129_review.json reports 0 findings and 0 errors across 5,105 production lines. Two unrelated untracked Watchlists templates remain intentionally excluded.
+Final independent re-review found no actionable findings after two additional fail-closed capability corrections: malformed internal certification outcomes now normalize through core to unsupported across the capability outcome, family availability, family reason, and action reasons. The family-level reason regression was RED before the final projection fix and GREEN afterward. Definitive post-review matrix: 289 passed, 0 failed, 0 skipped, 19 warnings in 103.92 seconds. Final compileall and Ruff passed; Bandit /tmp/bandit_task_13129_review_final.json reports 0 findings and 0 errors across 5,130 production lines; git diff --check passed. The earlier artifact-pair and prohibited-content validations remain valid because the helper/artifacts were unchanged by the final core/service-only correction.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the API-first Phase 4D.0F Scheduled Agent execution feasibility gate. Added the immutable seven-domain certification model, sanitized evidence generator and baseline, versioned capability projection, and consistent fail-closed Run Now, scheduler, and worker admission. ADR-041 records that no current deployment class is certified: eligible runtimes remain `draft_only`, ineligible runtimes are `unsupported`, and execution remains unavailable until a separate reviewed stack is ready. Attached the accepted decision and baseline to TASK-13130 through TASK-13133 without starting those dependency slices. Verification completed with 275 passing tests, compileall, Ruff, zero Bandit findings, artifact validation, redaction scans, and branch-scope review.
+Implemented and review-hardened the API-first Phase 4D.0F Scheduled Agent execution feasibility gate. The immutable seven-domain certification model, sanitized evidence generator and baseline, versioned capability projection, and fail-closed Run Now, scheduler, worker, and definition-authoring admission remain intact. PR review remediation moved admission/recovery policy into core, normalized malformed internal outcomes to unsupported, enforced unsupported update admission, made blocked scheduler health honest, closed command-metadata validation, and improved test isolation, typing, documentation, markers, logging, and receipt-fixture boundaries. ADR-041 still records that no current deployment class is certified and no execution stack is enabled. Final review found no actionable issues; 289 tests passed, compileall and Ruff passed, artifact/redaction validation passed, Bandit reported zero findings, and unrelated Watchlists files remained excluded.
 <!-- SECTION:FINAL_SUMMARY:END -->
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
+++ b/backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
@@ -21,11 +21,12 @@ references:
 - TASK-13131
 - TASK-13132
 - TASK-13133
+- https://github.com/rmusser01/tldw_server/pull/2827
 documentation:
 - Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
 - Docs/ADR/041-scheduled-agent-execution-feasibility.md
 - Docs/Development/Scheduled_Agent_Execution_Certification.md
-updated_date: 2026-08-27 03:22
+updated_date: 2026-08-27 03:30
 modified_files:
 - Docs/ADR/041-scheduled-agent-execution-feasibility.md
 - Docs/ADR/README.md
@@ -88,6 +89,7 @@ Stage 2/3 evidence: the sanitized helper now has 22 passing tests and exact JSON
 
 Stage 4 decision evidence: ADR-041 accepts that no current deployment class is certified. Baseline evidence `sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874` for deployment class `sha256:76a1074c303c74cd6db3f6823f391133e44437a0da019f99f5b02b95b2cb3337` is `draft_only`, contains exactly seven missing repository-characterization domains and seven value-free command templates, and passes exact pair/prohibited-content validation. TASK-13130 through TASK-13133 now own the four bounded domain slices; `operational_fail_closed` is a cross-cutting exit criterion for this gate and all four dependencies.
 Final verification: the 12-file cross-module matrix passed 275 tests with 0 failures, 0 skips, and 19 warnings in 93.04 seconds. Compileall and Ruff passed. Bandit `/tmp/bandit_task_13129.json` reports 0 findings and 0 errors across 4,965 production lines. Artifact-pair validation and both prohibited-content scans passed. Branch-wide diff review found no frontend, Watchlists, standalone Agent Tasks, migration activation, or execution-stack implementation.
+Pull request opened: https://github.com/rmusser01/tldw_server/pull/2827. Merge remains blocked by the repository policy until the human requester supplies a Change summary explaining both what changed and why these implementation choices were made.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 ## Final Summary
 

--- a/backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
+++ b/backlog/tasks/task-13129 - Implement-Scheduled-Tasks-Phase-4D.0F-execution-feasibility-gate.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-13129
 title: Implement Scheduled Tasks Phase 4D.0F execution feasibility gate
-status: To Do
+status: In Progress
 created_date: 2026-08-24 17:33
 dependencies:
 - TASK-13127
@@ -23,9 +23,9 @@ references:
 - TASK-13133
 documentation:
 - Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
-- Docs/ADR/040-scheduled-agent-execution-feasibility.md
+- Docs/ADR/041-scheduled-agent-execution-feasibility.md
 - Docs/Development/Scheduled_Agent_Execution_Certification.md
-updated_date: 2026-08-24 17:58
+updated_date: 2026-08-27 02:19
 ---
 
 ## Description
@@ -55,9 +55,12 @@ Execute Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-ga
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Baseline dev SHA: 2306c1939f3b460f9c62da8ae83a1aa47c02ee0d. ADR-040 is occupied by synchronized moodboards; ADR-041 is reserved for this task. Reusable evidence sources: Sandbox runtime capabilities/operator evidence/operator status; ACP sandbox bridge/runner and session persistence/admin service; MCP managed credential broker; existing ACP certification smoke helper. Confirmed limitations: ordinary ACP stores raw prompts; ACP sandbox creation has no stable dispatch token/idempotency binding; cancellation lacks the required ordered per-attempt evidence journal; MCP credential brokering is partial and not Scheduled Tasks grant/action-token binding; no deployment class is currently certified. Statically eligible runtimes must remain draft_only until all seven server-verified domains pass; ineligible runtimes are unsupported.
 
+Focused pre-change baseline on the recorded SHA: 171 passed, 0 failed, 0 skipped, and 19 warnings in 78.28 seconds across Scheduled Tasks automation API, ACP sandbox/session/runner, Sandbox runtime capabilities/operator evidence, and MCP slot-status tests. This validates reusable primitives only and is not Phase 4D.0F certification evidence. Two unrelated untracked Watchlists templates appeared in the isolated worktree and are intentionally excluded from this task.
+
+Stage 1 TDD evidence: the new pure-domain suite first failed during collection because execution_certification.py did not exist. The implemented immutable domain now covers canonical deployment/profile identity, the seven closed requirements, exact subject/freshness/verification checks, authoritative bundle receipt matching, unsupported boundary outcomes, bounded reason codes, a repository-characterization-only current resolver, and the independent execution-stack conjunction. GREEN rerun: 31 passed, 0 failed, 2 warnings in 7.97 seconds. Ruff and compileall passed. Bandit report /tmp/bandit_task_13129_stage1.json contains 0 findings and 0 errors across 510 lines. git diff --check passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-13130 - Add-scheduled-execution-isolation-attestation-and-hostile-runtime-proof.md
+++ b/backlog/tasks/task-13130 - Add-scheduled-execution-isolation-attestation-and-hostile-runtime-proof.md
@@ -15,7 +15,11 @@ priority: High
 references:
 - Docs/superpowers/specs/2026-08-24-scheduled-tasks-phase4d-agent-task-execution-design.md
 - Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
-updated_date: 2026-08-24 17:54
+updated_date: 2026-08-27 03:14
+documentation:
+- Docs/ADR/041-scheduled-agent-execution-feasibility.md
+- Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json
+- Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md
 ---
 
 ## Description
@@ -37,9 +41,8 @@ Implement the server-verified isolation attestation and hostile-agent proof requ
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Phase 4D.0F evidence handoff: this task owns `isolation_attestation` and `hostile_boundary`. Baseline evidence `sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874` records both as missing repository characterization and grants no execution authority. `operational_fail_closed` is a cross-cutting exit criterion: installation, upgrade invalidation, health, freshness, signer revocation, policy changes, and verifier outages must fail closed for the exact deployment class.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-13131 - Add-ACP-scheduled-mode-secure-transcripts-and-leakage-gates.md
+++ b/backlog/tasks/task-13131 - Add-ACP-scheduled-mode-secure-transcripts-and-leakage-gates.md
@@ -15,7 +15,11 @@ priority: High
 references:
 - Docs/superpowers/specs/2026-08-24-scheduled-tasks-phase4d-agent-task-execution-design.md
 - Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
-updated_date: 2026-08-24 17:55
+updated_date: 2026-08-27 03:14
+documentation:
+- Docs/ADR/041-scheduled-agent-execution-feasibility.md
+- Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json
+- Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md
 ---
 
 ## Description
@@ -37,9 +41,8 @@ Add an ACP scheduled execution mode whose prompt and secure output storage is te
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Phase 4D.0F evidence handoff: this task owns `scheduled_transcript_non_disclosure`. Baseline evidence `sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874` records scheduled transcript protection as missing repository characterization; ordinary ACP prompt persistence and fork behavior are dependencies, not proof. `operational_fail_closed` is a cross-cutting exit criterion: installation, upgrades, health, freshness, storage/export changes, and dependency outages must preserve non-disclosure or disable scheduled execution.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-13132 - Add-ACP-dispatch-recovery-and-monotonic-execution-evidence.md
+++ b/backlog/tasks/task-13132 - Add-ACP-dispatch-recovery-and-monotonic-execution-evidence.md
@@ -16,7 +16,11 @@ priority: High
 references:
 - Docs/superpowers/specs/2026-08-24-scheduled-tasks-phase4d-agent-task-execution-design.md
 - Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
-updated_date: 2026-08-24 17:55
+updated_date: 2026-08-27 03:14
+documentation:
+- Docs/ADR/041-scheduled-agent-execution-feasibility.md
+- Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json
+- Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md
 ---
 
 ## Description
@@ -38,9 +42,8 @@ Add ACP adapter session creation idempotent by stable dispatch token, exact look
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Phase 4D.0F evidence handoff: this task owns `adapter_dispatch_recovery` and `monotonic_execution_evidence`. Baseline evidence `sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874` records both as missing repository characterization; generic Sandbox idempotency and current cancellation primitives are dependencies, not the required dispatch-token and ordered per-attempt contracts. `operational_fail_closed` is a cross-cutting exit criterion: restarts, lease loss, timeout, cancellation, upgrades, and persistence outages must preserve exact recovery and monotonic evidence or disable execution.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-13133 - Add-scheduled-execution-identity-credentials-and-pre-action-mediation.md
+++ b/backlog/tasks/task-13133 - Add-scheduled-execution-identity-credentials-and-pre-action-mediation.md
@@ -16,7 +16,11 @@ priority: High
 references:
 - Docs/superpowers/specs/2026-08-24-scheduled-tasks-phase4d-agent-task-execution-design.md
 - Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md
-updated_date: 2026-08-24 17:55
+updated_date: 2026-08-27 03:15
+documentation:
+- Docs/ADR/041-scheduled-agent-execution-feasibility.md
+- Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json
+- Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.md
 ---
 
 ## Description
@@ -38,9 +42,8 @@ Implement scheduled execution identity, version-bound act-as and credential-use 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Phase 4D.0F evidence handoff: this task owns `brokered_credentials_and_mediation`. Baseline evidence `sha256:1df8024b73472ea0a02a323fbad0d2f864d8b5f604611cb01bf49478f60a5874` records it as missing repository characterization; the managed MCP credential broker is a dependency, not a Scheduled Tasks grant/action-token binding. `operational_fail_closed` is a cross-cutting exit criterion: revocation, policy/version changes, broker or governance outages, installation, upgrades, and health failures must deny issuance/action or disable scheduled execution.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
@@ -4,8 +4,8 @@ from datetime import datetime, timezone
 from typing import Any, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
 
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, User, get_request_user, rbac_rate_limit
 from tldw_Server_API.app.api.v1.schemas.reminders_schemas import (
     ReminderTaskCreateRequest,
     ReminderTaskUpdateRequest,
@@ -22,7 +22,6 @@ from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas impor
     ScheduledTaskDefinitionUpdateRequest,
     ScheduledTaskDuplicateRequest,
     ScheduledTaskMarkSolvedRequest,
-    ScheduledTaskRunNowResponse,
     ScheduledTaskPreviewCreateRequest,
     ScheduledTaskPreviewListResponse,
     ScheduledTaskPreviewMode,
@@ -34,6 +33,7 @@ from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas impor
     ScheduledTaskResultReviewRequest,
     ScheduledTaskReviewState,
     ScheduledTaskRunListResponse,
+    ScheduledTaskRunNowResponse,
     ScheduledTaskRunResponse,
     ScheduledTaskRunStatus,
 )
@@ -92,6 +92,16 @@ def _scheduled_task_error(
 
 
 _AUTOMATION_ERROR_MAP: dict[str, tuple[int, str, str]] = {
+    "agent_execution_unavailable": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_agent_execution_unavailable",
+        "Scheduled Agent execution is unavailable for this deployment.",
+    ),
+    "agent_automation_unsupported": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_agent_automation_unsupported",
+        "Scheduled Agent automation is unsupported for this deployment.",
+    ),
     "scheduled_task_family_unavailable": (
         status.HTTP_409_CONFLICT,
         "scheduled_task_family_unavailable",
@@ -315,12 +325,15 @@ def _raise_automation_error(request: Request, exc: ScheduledTaskAutomationError)
             "Scheduled task automation request could not be completed.",
         ),
     )
+    details = {"reason": exc.reason or raw_code}
+    if exc.recovery_action:
+        details["recovery_action"] = exc.recovery_action
     raise _scheduled_task_error(
         request=request,
         status_code=status_code,
         code=code,
         message=message,
-        details={"reason": raw_code},
+        details=details,
     ) from exc
 
 

--- a/tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py
@@ -34,6 +34,34 @@ class ScheduledTaskActionCapability(BaseModel):
     status: ScheduledTaskAutomationActionStatus
     reason: str | None = None
     required_permissions: list[str] = Field(default_factory=list)
+    evidence_source: Literal[
+        "server_verified",
+        "repository_characterization",
+        "none",
+    ] | None = None
+    recovery_action: str | None = None
+    observed_at: datetime | None = None
+    expires_at: datetime | None = None
+
+
+class ScheduledTaskExecutionCertificationCapability(BaseModel):
+    """Sanitized Agent execution feasibility for one deployment class."""
+
+    schema_version: Literal[
+        "scheduled_task_execution_certification.v1"
+    ] = "scheduled_task_execution_certification.v1"
+    outcome: Literal["certified", "draft_only", "unsupported"]
+    deployment_class_id: str
+    evidence_id: str | None = None
+    evidence_source: Literal[
+        "server_verified",
+        "repository_characterization",
+        "none",
+    ]
+    observed_at: datetime | None = None
+    expires_at: datetime | None = None
+    reason_codes: list[str] = Field(default_factory=list)
+    recovery_action: str | None = None
 
 
 class ScheduledTaskAutomationCapability(BaseModel):
@@ -45,7 +73,10 @@ class ScheduledTaskAutomationCapability(BaseModel):
     missing_dependencies: list[str] = Field(default_factory=list)
     related_capabilities: dict[str, Any] = Field(default_factory=dict)
     reason: str | None = None
-    schema_version: str = "2026-06-09"
+    execution_certification: (
+        ScheduledTaskExecutionCertificationCapability | None
+    ) = None
+    schema_version: str = "2026-08-24"
 
 
 class ScheduledTaskAutomationCapabilitiesResponse(BaseModel):

--- a/tldw_Server_API/app/core/Scheduled_Tasks/agent_task_jobs.py
+++ b/tldw_Server_API/app/core/Scheduled_Tasks/agent_task_jobs.py
@@ -7,12 +7,12 @@ time, and delivery of the outcome as a user notification through the same
 channel reminders use.
 
 Phase-1 boundary (tldw_chatbook ADR-077, decision 4, owner-accepted):
-execution is **side-effect-free only**. ``recurring_question`` runs
-generate their answer through the registered executor; ``agent_task``
-runs execute in generation-only mode; tool-using configurations are NOT
-executed — they resolve to an explicit ``skipped`` run with an actionable
-reason until the approval-escalation design exists. The boundary is
-enforced HERE, by the consumer, not assumed from the definition.
+``recurring_question`` runs generate their answer through the registered
+executor. ``agent_task`` runs fail closed before executor lookup unless
+both deployment certification and the separately delivered execution stack
+are ready. Tool-using configurations are also rejected independently. These
+boundaries are enforced HERE, by the consumer, not assumed from the
+definition or scheduler.
 
 Timeout semantics (ADR-077 decision 5): a run cancelled at its execution
 deadline records the distinct ``timed_out`` status — the client displays
@@ -41,6 +41,12 @@ from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
     ScheduledTasksDatabase,
 )
 from tldw_Server_API.app.core.exceptions import BadRequestError
+from tldw_Server_API.app.core.Scheduled_Tasks.execution_certification import (
+    ExecutionCertification,
+    agent_execution_dispatch_readiness,
+    current_agent_execution_stack_ready,
+    resolve_current_agent_execution_certification,
+)
 
 AUTOMATION_DOMAIN = "scheduled_tasks"
 AUTOMATION_JOB_TYPE = "agent_task_run"
@@ -92,9 +98,7 @@ def _phase1_tools_requested(definition: DefinitionRow) -> bool:
         return True
     if isinstance(tools, str) and tools.strip().lower() not in ("", "false", "none", "0"):
         return True
-    if isinstance(tools, bool) and tools:
-        return True
-    return False
+    return bool(isinstance(tools, bool) and tools)
 
 
 def _normalize_slot_utc(value: Any) -> str:
@@ -143,6 +147,12 @@ async def handle_agent_task_job(
     scheduled_db: ScheduledTasksDatabase | None = None,
     collections_db: CollectionsDatabase | None = None,
     execution_timeout_seconds: float = RUN_EXECUTION_TIMEOUT_SECONDS,
+    execution_certification_resolver: Callable[
+        [], ExecutionCertification
+    ] = resolve_current_agent_execution_certification,
+    execution_stack_ready_resolver: Callable[
+        [], bool
+    ] = current_agent_execution_stack_ready,
 ) -> dict[str, Any]:
     """Consume one ``agent_task_run`` Job: run row, execute, notify, audit.
 
@@ -238,6 +248,38 @@ async def handle_agent_task_job(
             execution_timeout_seconds=execution_timeout_seconds,
         )
         return {"status": "skipped", "definition_id": definition_id, "run_id": run["id"]}
+
+    if definition.family == "agent_task":
+        readiness = agent_execution_dispatch_readiness(
+            execution_certification_resolver(),
+            execution_stack_ready=execution_stack_ready_resolver(),
+        )
+        if not readiness.ready:
+            reason = readiness.reason or "agent_execution_unavailable"
+            _finish(
+                sdb,
+                cdb,
+                definition=definition,
+                run_id=run["id"],
+                status="skipped",
+                error=reason,
+                summary=(
+                    "Scheduled Agent execution is blocked by the deployment "
+                    f"readiness gate ({reason})."
+                ),
+                jobs_job_id=(
+                    str(job.get("id"))
+                    if job.get("id") is not None
+                    else None
+                ),
+                execution_timeout_seconds=execution_timeout_seconds,
+            )
+            return {
+                "status": "skipped",
+                "definition_id": definition_id,
+                "run_id": run["id"],
+                "reason": reason,
+            }
 
     # Phase-1 boundary, enforced by the consumer (not assumed): tools are
     # out of bounds until the approval-escalation design exists.

--- a/tldw_Server_API/app/core/Scheduled_Tasks/execution_certification.py
+++ b/tldw_Server_API/app/core/Scheduled_Tasks/execution_certification.py
@@ -500,6 +500,12 @@ def agent_execution_dispatch_readiness(
     return AgentExecutionDispatchReadiness(ready=True, reason=None)
 
 
+def current_agent_execution_stack_ready() -> bool:
+    """Return the source-defined Phase 4D execution-stack readiness state."""
+
+    return False
+
+
 def _normalize_build_sha(value: str | None) -> str:
     normalized = str(value or "").strip()
     if not _BUILD_SHA_PATTERN.fullmatch(normalized):

--- a/tldw_Server_API/app/core/Scheduled_Tasks/execution_certification.py
+++ b/tldw_Server_API/app/core/Scheduled_Tasks/execution_certification.py
@@ -1,0 +1,607 @@
+"""Fail-closed feasibility certification for Scheduled Tasks Agent execution.
+
+Certification is a prerequisite, not execution authority. The current resolver
+only emits repository characterization and therefore cannot certify a runtime.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+CertificationOutcome = Literal["certified", "draft_only", "unsupported"]
+EvidenceState = Literal["passed", "failed", "missing", "stale"]
+EvidenceVerification = Literal[
+    "server_verified",
+    "host_gated_unverified",
+    "repository_characterization",
+    "mock",
+    "self_asserted",
+]
+EvidenceSource = Literal["server_verified", "repository_characterization", "none"]
+RequirementId = Literal[
+    "isolation_attestation",
+    "hostile_boundary",
+    "scheduled_transcript_non_disclosure",
+    "adapter_dispatch_recovery",
+    "monotonic_execution_evidence",
+    "brokered_credentials_and_mediation",
+    "operational_fail_closed",
+]
+
+REQUIRED_EVIDENCE_DOMAINS: tuple[RequirementId, ...] = (
+    "isolation_attestation",
+    "hostile_boundary",
+    "scheduled_transcript_non_disclosure",
+    "adapter_dispatch_recovery",
+    "monotonic_execution_evidence",
+    "brokered_credentials_and_mediation",
+    "operational_fail_closed",
+)
+
+MAX_REASON_CODES = 32
+_EVIDENCE_VALIDITY = timedelta(hours=24)
+_SHA256_ID_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+_BUILD_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
+
+_BASE_REASON_CODES = {
+    "agent_execution_stack_unimplemented",
+    "authoritative_receipt_mismatch",
+    "authoritative_receipt_missing",
+    "authoritative_receipt_stale",
+    "deployment_identity_unverified",
+    "isolation_profile_identity_unverified",
+    "runtime_not_untrusted_eligible",
+    "runtime_strict_deny_all_unavailable",
+    "safety_boundary_breached",
+    "server_build_identity_unverified",
+}
+_REQUIREMENT_REASON_CODES = {
+    f"{requirement_id}_{suffix}"
+    for requirement_id in REQUIRED_EVIDENCE_DOMAINS
+    for suffix in ("failed", "missing", "stale", "subject_mismatch", "unverified")
+}
+CERTIFICATION_REASON_CODES = frozenset(
+    _BASE_REASON_CODES | _REQUIREMENT_REASON_CODES
+)
+
+
+def _canonical_digest(payload: object) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("ascii")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _normalized_identity(value: object, *, lowercase: bool = True) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        return "unverified"
+    return normalized.lower() if lowercase else normalized
+
+
+def _aware_utc(value: datetime | None) -> datetime | None:
+    if value is None or value.tzinfo is None or value.utcoffset() is None:
+        return None
+    return value.astimezone(timezone.utc)
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    normalized = _aware_utc(value)
+    return normalized.isoformat() if normalized is not None else None
+
+
+def _valid_sha256_id(value: str | None) -> bool:
+    return bool(value and _SHA256_ID_PATTERN.fullmatch(value))
+
+
+@dataclass(frozen=True)
+class IsolationProfile:
+    """Exact isolation inputs collapsed into one opaque profile fingerprint."""
+
+    runtime_image_digest: str
+    mount_policy_hash: str
+    egress_policy_hash: str
+    credential_policy_hash: str
+    tenant_boundary_policy_hash: str
+    mediation_policy_hash: str
+    isolation_profile_version: str
+
+    def canonical_payload(self) -> dict[str, str]:
+        """Return deterministic private identity inputs for hashing."""
+
+        values = {
+            "credential_policy_hash": _normalized_identity(
+                self.credential_policy_hash
+            ),
+            "egress_policy_hash": _normalized_identity(self.egress_policy_hash),
+            "isolation_profile_version": _normalized_identity(
+                self.isolation_profile_version,
+                lowercase=False,
+            ),
+            "mediation_policy_hash": _normalized_identity(
+                self.mediation_policy_hash
+            ),
+            "mount_policy_hash": _normalized_identity(self.mount_policy_hash),
+            "runtime_image_digest": _normalized_identity(
+                self.runtime_image_digest
+            ),
+            "tenant_boundary_policy_hash": _normalized_identity(
+                self.tenant_boundary_policy_hash
+            ),
+        }
+        return dict(sorted(values.items()))
+
+    @property
+    def isolation_profile_id(self) -> str:
+        """Return the opaque digest exposed through deployment identity."""
+
+        return _canonical_digest(self.canonical_payload())
+
+    @property
+    def is_verified_identity(self) -> bool:
+        """Return whether every profile component has an explicit identity."""
+
+        return all(value != "unverified" for value in self.canonical_payload().values())
+
+
+@dataclass(frozen=True)
+class DeploymentClass:
+    """Exact subject to which Scheduled Tasks execution evidence is bound."""
+
+    host_os_family: str
+    host_architecture: str
+    auth_mode: str
+    sandbox_runtime: str
+    adapter_id: str
+    adapter_version: str
+    server_build_sha: str
+    isolation_profile: IsolationProfile
+
+    def canonical_payload(self) -> dict[str, str]:
+        """Return stable subject fields without exposing raw profile inputs."""
+
+        values = {
+            "adapter_id": _normalized_identity(self.adapter_id),
+            "adapter_version": _normalized_identity(
+                self.adapter_version,
+                lowercase=False,
+            ),
+            "auth_mode": _normalized_identity(self.auth_mode),
+            "host_architecture": _normalized_identity(self.host_architecture),
+            "host_os_family": _normalized_identity(self.host_os_family),
+            "isolation_profile_id": self.isolation_profile.isolation_profile_id,
+            "sandbox_runtime": _normalized_identity(self.sandbox_runtime),
+            "server_build_sha": _normalized_identity(self.server_build_sha),
+        }
+        return dict(sorted(values.items()))
+
+    @property
+    def deployment_class_id(self) -> str:
+        """Return an opaque digest for the exact deployment class."""
+
+        return _canonical_digest(self.canonical_payload())
+
+    @property
+    def has_verified_identity(self) -> bool:
+        """Return whether all top-level and isolation identities are explicit."""
+
+        return (
+            all(value != "unverified" for value in self.canonical_payload().values())
+            and self.isolation_profile.is_verified_identity
+        )
+
+
+@dataclass(frozen=True)
+class RuntimeEligibility:
+    """Static isolation and deny-all eligibility used before evidence."""
+
+    untrusted_eligible: bool
+    strict_deny_all: bool
+
+
+@dataclass(frozen=True)
+class RequirementEvidence:
+    """One bounded evidence-domain result for an exact deployment class."""
+
+    requirement_id: str
+    state: EvidenceState
+    verification: EvidenceVerification
+    subject_id: str
+    observed_at: datetime | None
+    valid_until: datetime | None
+    evidence_sha256: str | None
+    safety_boundary_breached: bool = False
+
+    def canonical_payload(self) -> dict[str, object]:
+        """Return the sanitized fields covered by the bundle receipt."""
+
+        values: dict[str, object] = {
+            "evidence_sha256": self.evidence_sha256,
+            "observed_at": _isoformat(self.observed_at),
+            "requirement_id": self.requirement_id,
+            "safety_boundary_breached": self.safety_boundary_breached,
+            "state": self.state,
+            "subject_id": self.subject_id,
+            "valid_until": _isoformat(self.valid_until),
+            "verification": self.verification,
+        }
+        return dict(sorted(values.items()))
+
+
+def canonical_evidence_bundle_digest(
+    evidence: Sequence[RequirementEvidence],
+) -> str:
+    """Return the digest an authoritative verifier must cover."""
+
+    payload = [
+        item.canonical_payload()
+        for item in sorted(evidence, key=lambda candidate: candidate.requirement_id)
+    ]
+    return _canonical_digest(payload)
+
+
+class _ServerVerifierAuthority:
+    """Unserializable constructor authority reserved for a later verifier."""
+
+
+_SERVER_VERIFIER_AUTHORITY = _ServerVerifierAuthority()
+
+
+@dataclass(frozen=True)
+class _AuthoritativeBundleReceipt:
+    """Internal receipt proving that the server verified one exact bundle."""
+
+    deployment_class_id: str
+    evidence_id: str
+    bundle_digest: str
+    observed_at: datetime | None
+    valid_until: datetime | None
+    _authority: object = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._authority is not _SERVER_VERIFIER_AUTHORITY:
+            raise ValueError("authoritative receipt requires server verifier authority")
+
+
+@dataclass(frozen=True)
+class ExecutionCertification:
+    """Immutable feasibility outcome projected to capability and admission gates."""
+
+    outcome: CertificationOutcome
+    deployment_class_id: str
+    evidence_id: str | None
+    evidence_source: EvidenceSource
+    observed_at: datetime | None
+    expires_at: datetime | None
+    reason_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AgentExecutionDispatchReadiness:
+    """Conjunction of certification and the independently delivered stack."""
+
+    ready: bool
+    reason: str | None
+
+
+def _validate_requirement_set(evidence: Sequence[RequirementEvidence]) -> None:
+    seen: set[str] = set()
+    allowed = set(REQUIRED_EVIDENCE_DOMAINS)
+    for item in evidence:
+        if item.requirement_id not in allowed:
+            raise ValueError(f"unknown certification requirement: {item.requirement_id!r}")
+        if item.requirement_id in seen:
+            raise ValueError(
+                f"duplicate certification requirement: {item.requirement_id!r}"
+            )
+        seen.add(item.requirement_id)
+
+
+def _record_reason_codes(
+    item: RequirementEvidence,
+    *,
+    subject_id: str,
+    now: datetime,
+) -> set[str]:
+    prefix = item.requirement_id
+    reasons: set[str] = set()
+    if item.state == "missing":
+        reasons.add(f"{prefix}_missing")
+    elif item.state == "failed":
+        reasons.add(f"{prefix}_failed")
+    elif item.state == "stale":
+        reasons.add(f"{prefix}_stale")
+    if item.subject_id != subject_id:
+        reasons.add(f"{prefix}_subject_mismatch")
+    if item.verification != "server_verified":
+        reasons.add(f"{prefix}_unverified")
+
+    observed_at = _aware_utc(item.observed_at)
+    valid_until = _aware_utc(item.valid_until)
+    if (
+        observed_at is None
+        or valid_until is None
+        or observed_at > now
+        or valid_until <= now
+        or valid_until <= observed_at
+    ):
+        reasons.add(f"{prefix}_stale")
+    if not _valid_sha256_id(item.evidence_sha256):
+        reasons.add(f"{prefix}_unverified")
+    return reasons
+
+
+def _receipt_reason_codes(
+    receipt: _AuthoritativeBundleReceipt | None,
+    *,
+    subject_id: str,
+    evidence: Sequence[RequirementEvidence],
+    now: datetime,
+) -> set[str]:
+    if receipt is None:
+        return {"authoritative_receipt_missing"}
+
+    reasons: set[str] = set()
+    if (
+        receipt.deployment_class_id != subject_id
+        or receipt.bundle_digest != canonical_evidence_bundle_digest(evidence)
+        or not _valid_sha256_id(receipt.evidence_id)
+        or not _valid_sha256_id(receipt.bundle_digest)
+    ):
+        reasons.add("authoritative_receipt_mismatch")
+
+    observed_at = _aware_utc(receipt.observed_at)
+    valid_until = _aware_utc(receipt.valid_until)
+    if (
+        observed_at is None
+        or valid_until is None
+        or observed_at > now
+        or valid_until <= now
+        or valid_until <= observed_at
+    ):
+        reasons.add("authoritative_receipt_stale")
+    return reasons
+
+
+def _bounded_reason_codes(reasons: set[str]) -> tuple[str, ...]:
+    unknown = reasons - CERTIFICATION_REASON_CODES
+    if unknown:
+        raise ValueError("unregistered certification reason code")
+    return tuple(sorted(reasons)[:MAX_REASON_CODES])
+
+
+def evaluate_execution_certification(
+    subject: DeploymentClass,
+    evidence: Sequence[RequirementEvidence],
+    verification_receipt: _AuthoritativeBundleReceipt | None,
+    *,
+    runtime_eligibility: RuntimeEligibility,
+    now: datetime,
+) -> ExecutionCertification:
+    """Evaluate an exact evidence bundle without I/O or mutable configuration."""
+
+    evaluated_at = _aware_utc(now)
+    if evaluated_at is None:
+        raise ValueError("certification evaluation requires an aware UTC clock")
+    _validate_requirement_set(evidence)
+
+    reasons: set[str] = set()
+    if not runtime_eligibility.untrusted_eligible:
+        reasons.add("runtime_not_untrusted_eligible")
+    if not runtime_eligibility.strict_deny_all:
+        reasons.add("runtime_strict_deny_all_unavailable")
+    if not subject.has_verified_identity:
+        reasons.add("deployment_identity_unverified")
+    if subject.server_build_sha == "unverified":
+        reasons.add("server_build_identity_unverified")
+    if not subject.isolation_profile.is_verified_identity:
+        reasons.add("isolation_profile_identity_unverified")
+
+    by_requirement = {item.requirement_id: item for item in evidence}
+    for requirement_id in REQUIRED_EVIDENCE_DOMAINS:
+        item = by_requirement.get(requirement_id)
+        if item is None:
+            reasons.add(f"{requirement_id}_missing")
+            continue
+        reasons.update(
+            _record_reason_codes(
+                item,
+                subject_id=subject.deployment_class_id,
+                now=evaluated_at,
+            )
+        )
+        if item.safety_boundary_breached:
+            reasons.add("safety_boundary_breached")
+
+    reasons.update(
+        _receipt_reason_codes(
+            verification_receipt,
+            subject_id=subject.deployment_class_id,
+            evidence=evidence,
+            now=evaluated_at,
+        )
+    )
+
+    unsupported = (
+        not runtime_eligibility.untrusted_eligible
+        or not runtime_eligibility.strict_deny_all
+        or "safety_boundary_breached" in reasons
+    )
+    if unsupported:
+        outcome: CertificationOutcome = "unsupported"
+    elif reasons:
+        outcome = "draft_only"
+    else:
+        outcome = "certified"
+
+    repository_characterization = any(
+        item.verification == "repository_characterization" for item in evidence
+    )
+    if outcome == "certified":
+        evidence_source: EvidenceSource = "server_verified"
+    elif repository_characterization:
+        evidence_source = "repository_characterization"
+    else:
+        evidence_source = "none"
+
+    observed_values = [
+        value
+        for value in (_aware_utc(item.observed_at) for item in evidence)
+        if value is not None
+    ]
+    expiry_values = [
+        value
+        for value in (_aware_utc(item.valid_until) for item in evidence)
+        if value is not None
+    ]
+    return ExecutionCertification(
+        outcome=outcome,
+        deployment_class_id=subject.deployment_class_id,
+        evidence_id=(
+            verification_receipt.evidence_id
+            if outcome == "certified" and verification_receipt is not None
+            else None
+        ),
+        evidence_source=evidence_source,
+        observed_at=max(observed_values) if observed_values else None,
+        expires_at=min(expiry_values) if expiry_values else None,
+        reason_codes=_bounded_reason_codes(reasons),
+    )
+
+
+def agent_execution_dispatch_readiness(
+    certification: ExecutionCertification,
+    *,
+    execution_stack_ready: bool,
+) -> AgentExecutionDispatchReadiness:
+    """Require both certified evidence and a separately implemented stack."""
+
+    if certification.outcome != "certified":
+        return AgentExecutionDispatchReadiness(
+            ready=False,
+            reason=f"execution_certification_{certification.outcome}",
+        )
+    if not execution_stack_ready:
+        return AgentExecutionDispatchReadiness(
+            ready=False,
+            reason="agent_execution_stack_unimplemented",
+        )
+    return AgentExecutionDispatchReadiness(ready=True, reason=None)
+
+
+def _normalize_build_sha(value: str | None) -> str:
+    normalized = str(value or "").strip()
+    if not _BUILD_SHA_PATTERN.fullmatch(normalized):
+        return "unverified"
+    return normalized.lower()
+
+
+def _default_isolation_profile() -> IsolationProfile:
+    return IsolationProfile(
+        runtime_image_digest="unverified",
+        mount_policy_hash="unverified",
+        egress_policy_hash="unverified",
+        credential_policy_hash="unverified",
+        tenant_boundary_policy_hash="unverified",
+        mediation_policy_hash="unverified",
+        isolation_profile_version="phase4d0f-current",
+    )
+
+
+def _runtime_eligibility(runtime: str) -> RuntimeEligibility:
+    from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
+        runtime_isolation_metadata,
+        runtime_network_policy_metadata,
+    )
+
+    try:
+        isolation = runtime_isolation_metadata(runtime)
+        deny_all = runtime_network_policy_metadata(runtime).deny_all
+    except ValueError:
+        return RuntimeEligibility(untrusted_eligible=False, strict_deny_all=False)
+    return RuntimeEligibility(
+        untrusted_eligible=isolation.untrusted_eligible,
+        strict_deny_all=(
+            deny_all.strict_enforcement
+            and deny_all.support_state in {"supported", "host_gated"}
+        ),
+    )
+
+
+def _current_identity_defaults() -> tuple[str, str]:
+    from tldw_Server_API.app.core.Agent_Client_Protocol.config import (
+        load_acp_sandbox_config,
+    )
+    from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+
+    return load_acp_sandbox_config().runtime, get_settings().AUTH_MODE
+
+
+def resolve_current_agent_execution_certification(
+    *,
+    now: datetime | None = None,
+    host_os_family: str | None = None,
+    host_architecture: str | None = None,
+    auth_mode: str | None = None,
+    sandbox_runtime: str | None = None,
+    adapter_id: str = "acp",
+    adapter_version: str = "1",
+    isolation_profile: IsolationProfile | None = None,
+) -> ExecutionCertification:
+    """Project current static metadata without granting certification authority."""
+
+    if sandbox_runtime is None or auth_mode is None:
+        default_runtime, default_auth_mode = _current_identity_defaults()
+        sandbox_runtime = sandbox_runtime or default_runtime
+        auth_mode = auth_mode or default_auth_mode
+    evaluated_at = _aware_utc(now or datetime.now(timezone.utc))
+    if evaluated_at is None:
+        raise ValueError("certification resolution requires an aware UTC clock")
+
+    subject = DeploymentClass(
+        host_os_family=host_os_family or platform.system(),
+        host_architecture=host_architecture or platform.machine(),
+        auth_mode=auth_mode,
+        sandbox_runtime=sandbox_runtime,
+        adapter_id=adapter_id,
+        adapter_version=adapter_version,
+        server_build_sha=_normalize_build_sha(os.getenv("TLDW_BUILD_SHA")),
+        isolation_profile=isolation_profile or _default_isolation_profile(),
+    )
+    valid_until = evaluated_at + _EVIDENCE_VALIDITY
+    evidence = tuple(
+        RequirementEvidence(
+            requirement_id=requirement_id,
+            state="missing",
+            verification="repository_characterization",
+            subject_id=subject.deployment_class_id,
+            observed_at=evaluated_at,
+            valid_until=valid_until,
+            evidence_sha256=_canonical_digest(
+                {
+                    "requirement_id": requirement_id,
+                    "source": "repository_characterization",
+                    "subject_id": subject.deployment_class_id,
+                }
+            ),
+        )
+        for requirement_id in REQUIRED_EVIDENCE_DOMAINS
+    )
+    return evaluate_execution_certification(
+        subject,
+        evidence,
+        None,
+        runtime_eligibility=_runtime_eligibility(sandbox_runtime),
+        now=evaluated_at,
+    )

--- a/tldw_Server_API/app/core/Scheduled_Tasks/execution_certification.py
+++ b/tldw_Server_API/app/core/Scheduled_Tasks/execution_certification.py
@@ -51,6 +51,18 @@ _EVIDENCE_VALIDITY = timedelta(hours=24)
 _SHA256_ID_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 _BUILD_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
 
+_DRAFT_CERTIFICATION_RECOVERY = (
+    "Complete server-verified Scheduled Agent execution certification "
+    "for this deployment class."
+)
+_UNSUPPORTED_CERTIFICATION_RECOVERY = (
+    "Use an untrusted-eligible runtime with strict deny-all networking, "
+    "then rerun Scheduled Agent execution certification."
+)
+_EXECUTION_STACK_RECOVERY = (
+    "Install the reviewed Scheduled Agent execution stack before enabling execution."
+)
+
 _BASE_REASON_CODES = {
     "agent_execution_stack_unimplemented",
     "authoritative_receipt_mismatch",
@@ -74,6 +86,8 @@ CERTIFICATION_REASON_CODES = frozenset(
 
 
 def _canonical_digest(payload: object) -> str:
+    """Return the stable SHA-256 identity for canonical JSON content."""
+
     encoded = json.dumps(
         payload,
         sort_keys=True,
@@ -84,6 +98,8 @@ def _canonical_digest(payload: object) -> str:
 
 
 def _normalized_identity(value: object, *, lowercase: bool = True) -> str:
+    """Normalize one identity component without inventing missing values."""
+
     normalized = str(value or "").strip()
     if not normalized:
         return "unverified"
@@ -91,17 +107,23 @@ def _normalized_identity(value: object, *, lowercase: bool = True) -> str:
 
 
 def _aware_utc(value: datetime | None) -> datetime | None:
+    """Normalize an aware timestamp to UTC or return ``None``."""
+
     if value is None or value.tzinfo is None or value.utcoffset() is None:
         return None
     return value.astimezone(timezone.utc)
 
 
 def _isoformat(value: datetime | None) -> str | None:
+    """Serialize one valid aware timestamp in canonical UTC form."""
+
     normalized = _aware_utc(value)
     return normalized.isoformat() if normalized is not None else None
 
 
 def _valid_sha256_id(value: str | None) -> bool:
+    """Return whether a value is a canonical SHA-256 identifier."""
+
     return bool(value and _SHA256_ID_PATTERN.fullmatch(value))
 
 
@@ -270,6 +292,8 @@ class _AuthoritativeBundleReceipt:
     _authority: object = field(repr=False, compare=False)
 
     def __post_init__(self) -> None:
+        """Reject receipts not issued inside the server verifier boundary."""
+
         if self._authority is not _SERVER_VERIFIER_AUTHORITY:
             raise ValueError("authoritative receipt requires server verifier authority")
 
@@ -295,7 +319,19 @@ class AgentExecutionDispatchReadiness:
     reason: str | None
 
 
+@dataclass(frozen=True)
+class AgentAutomationAdmission:
+    """Core decision for definition-authoring operations on Agent automation."""
+
+    allowed: bool
+    effective_outcome: CertificationOutcome
+    reason: str | None
+    recovery_action: str | None
+
+
 def _validate_requirement_set(evidence: Sequence[RequirementEvidence]) -> None:
+    """Reject unknown or duplicate evidence-domain records."""
+
     seen: set[str] = set()
     allowed = set(REQUIRED_EVIDENCE_DOMAINS)
     for item in evidence:
@@ -314,6 +350,8 @@ def _record_reason_codes(
     subject_id: str,
     now: datetime,
 ) -> set[str]:
+    """Derive bounded failure reasons for one requirement record."""
+
     prefix = item.requirement_id
     reasons: set[str] = set()
     if item.state == "missing":
@@ -349,6 +387,8 @@ def _receipt_reason_codes(
     evidence: Sequence[RequirementEvidence],
     now: datetime,
 ) -> set[str]:
+    """Derive verifier-receipt reasons for one exact evidence bundle."""
+
     if receipt is None:
         return {"authoritative_receipt_missing"}
 
@@ -375,6 +415,8 @@ def _receipt_reason_codes(
 
 
 def _bounded_reason_codes(reasons: set[str]) -> tuple[str, ...]:
+    """Validate, sort, and bound public certification reason codes."""
+
     unknown = reasons - CERTIFICATION_REASON_CODES
     if unknown:
         raise ValueError("unregistered certification reason code")
@@ -487,10 +529,15 @@ def agent_execution_dispatch_readiness(
 ) -> AgentExecutionDispatchReadiness:
     """Require both certified evidence and a separately implemented stack."""
 
+    if certification.outcome == "draft_only":
+        return AgentExecutionDispatchReadiness(
+            ready=False,
+            reason="execution_certification_draft_only",
+        )
     if certification.outcome != "certified":
         return AgentExecutionDispatchReadiness(
             ready=False,
-            reason=f"execution_certification_{certification.outcome}",
+            reason="execution_certification_unsupported",
         )
     if not execution_stack_ready:
         return AgentExecutionDispatchReadiness(
@@ -500,6 +547,72 @@ def agent_execution_dispatch_readiness(
     return AgentExecutionDispatchReadiness(ready=True, reason=None)
 
 
+def certification_recovery_action(outcome: CertificationOutcome) -> str | None:
+    """Return the bounded operator action for a certification outcome.
+
+    Args:
+        outcome: Closed certification state to explain.
+
+    Returns:
+        A sanitized recovery instruction when action is required, otherwise
+        ``None``.
+    """
+
+    if outcome == "unsupported":
+        return _UNSUPPORTED_CERTIFICATION_RECOVERY
+    if outcome == "draft_only":
+        return _DRAFT_CERTIFICATION_RECOVERY
+    return None
+
+
+def readiness_recovery_action(reason: str | None) -> str | None:
+    """Return the bounded operator action for an execution blocker.
+
+    Args:
+        reason: Closed readiness reason code, if execution is blocked.
+
+    Returns:
+        A sanitized recovery instruction for a known blocker, otherwise
+        ``None``.
+    """
+
+    if reason == "agent_execution_stack_unimplemented":
+        return _EXECUTION_STACK_RECOVERY
+    if reason == "execution_certification_unsupported":
+        return _UNSUPPORTED_CERTIFICATION_RECOVERY
+    if reason == "execution_certification_draft_only":
+        return _DRAFT_CERTIFICATION_RECOVERY
+    return None
+
+
+def agent_automation_admission(
+    certification: ExecutionCertification,
+) -> AgentAutomationAdmission:
+    """Decide whether Agent definitions may be authored on this deployment.
+
+    Args:
+        certification: Current server-resolved deployment certification.
+
+    Returns:
+        A core admission decision with bounded reason and recovery metadata.
+    """
+
+    if certification.outcome in {"certified", "draft_only"}:
+        return AgentAutomationAdmission(
+            allowed=True,
+            effective_outcome=certification.outcome,
+            reason=None,
+            recovery_action=None,
+        )
+    reason = "execution_certification_unsupported"
+    return AgentAutomationAdmission(
+        allowed=False,
+        effective_outcome="unsupported",
+        reason=reason,
+        recovery_action=readiness_recovery_action(reason),
+    )
+
+
 def current_agent_execution_stack_ready() -> bool:
     """Return the source-defined Phase 4D execution-stack readiness state."""
 
@@ -507,6 +620,8 @@ def current_agent_execution_stack_ready() -> bool:
 
 
 def _normalize_build_sha(value: str | None) -> str:
+    """Normalize an accepted Git build digest or fail closed to unverified."""
+
     normalized = str(value or "").strip()
     if not _BUILD_SHA_PATTERN.fullmatch(normalized):
         return "unverified"
@@ -514,6 +629,8 @@ def _normalize_build_sha(value: str | None) -> str:
 
 
 def _default_isolation_profile() -> IsolationProfile:
+    """Return the current deliberately unverified isolation profile."""
+
     return IsolationProfile(
         runtime_image_digest="unverified",
         mount_policy_hash="unverified",
@@ -526,6 +643,8 @@ def _default_isolation_profile() -> IsolationProfile:
 
 
 def _runtime_eligibility(runtime: str) -> RuntimeEligibility:
+    """Map typed Sandbox metadata to certification eligibility."""
+
     from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
         runtime_isolation_metadata,
         runtime_network_policy_metadata,
@@ -546,6 +665,8 @@ def _runtime_eligibility(runtime: str) -> RuntimeEligibility:
 
 
 def _current_identity_defaults() -> tuple[str, str]:
+    """Load current runtime and AuthNZ identity defaults."""
+
     from tldw_Server_API.app.core.Agent_Client_Protocol.config import (
         load_acp_sandbox_config,
     )

--- a/tldw_Server_API/app/services/scheduled_task_automation_scheduler.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_scheduler.py
@@ -38,9 +38,10 @@ Env:
   SCHEDULED_TASKS_AUTOMATION_RESCAN_SEC         -> rescan interval (>= 30)
   AUTOMATION_JOBS_QUEUE                         -> queue name (default: default)
 
-The gate ships OFF: arming before the ``agent_task_run`` consumer
-(TASK-13021) is deployed only queues jobs nobody executes, so enable it
-together with the consumer.
+The service gate ships OFF. Even when the generic scheduler is enabled,
+``agent_task`` definitions are not armed or enqueued until deployment
+certification and the separately delivered Agent execution stack are both
+ready. Recurring Question scheduling is unchanged.
 """
 
 from __future__ import annotations
@@ -48,6 +49,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -57,13 +59,19 @@ from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 from loguru import logger
 
+from tldw_Server_API.app.core.config import settings as core_settings
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
     DefinitionRow,
     ScheduledTasksDatabase,
 )
-from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Jobs.manager import JobManager
-from tldw_Server_API.app.core.config import settings as core_settings
+from tldw_Server_API.app.core.Scheduled_Tasks.execution_certification import (
+    ExecutionCertification,
+    agent_execution_dispatch_readiness,
+    current_agent_execution_stack_ready,
+    resolve_current_agent_execution_certification,
+)
 from tldw_Server_API.app.core.testing import env_flag_enabled
 from tldw_Server_API.app.services.reminders_scheduler import (
     _NONCRITICAL_EXCEPTIONS,
@@ -190,13 +198,41 @@ class _AutomationScheduler:
     callback still enqueues the occurrence it was armed for).
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        execution_certification_resolver: Callable[
+            [], ExecutionCertification
+        ] = resolve_current_agent_execution_certification,
+        execution_stack_ready_resolver: Callable[
+            [], bool
+        ] = current_agent_execution_stack_ready,
+    ) -> None:
         self._aps: AsyncIOScheduler | None = None
         self._db_cache: dict[int, ScheduledTasksDatabase] = {}
         self._lock = asyncio.Lock()
         self._started = False
         self._rescan_task: asyncio.Task | None = None
         self._jobs = JobManager()
+        self._execution_certification_resolver = (
+            execution_certification_resolver
+        )
+        self._execution_stack_ready_resolver = execution_stack_ready_resolver
+
+    def _agent_execution_ready(self, definition: DefinitionRow) -> bool:
+        if definition.family != "agent_task":
+            return True
+        readiness = agent_execution_dispatch_readiness(
+            self._execution_certification_resolver(),
+            execution_stack_ready=self._execution_stack_ready_resolver(),
+        )
+        if not readiness.ready:
+            logger.warning(
+                "Automation scheduler blocked Agent definition {}: {}",
+                definition.id,
+                readiness.reason,
+            )
+        return readiness.ready
 
     async def start(self) -> None:
         """Start the scheduler: initial arm pass plus the periodic rescan loop."""
@@ -355,6 +391,8 @@ class _AutomationScheduler:
         """
         if not self._aps:
             return False
+        if not self._agent_execution_ready(definition):
+            return False
         trigger, reason = build_trigger(definition.schedule)
         if trigger is None:
             logger.warning(
@@ -450,6 +488,8 @@ class _AutomationScheduler:
             return
         if definition is None or definition.lifecycle != "configured":
             return
+        if not self._agent_execution_ready(definition):
+            return
 
         # The schedule may have become unusable between arming and this
         # fire (an edit raced the reconcile): a callback whose definition
@@ -515,6 +555,8 @@ class _AutomationScheduler:
         except _NONCRITICAL_EXCEPTIONS:
             return
         if definition is None or definition.lifecycle != "configured":
+            return
+        if not self._agent_execution_ready(definition):
             return
         trigger, _reason = build_trigger(definition.schedule)
         if trigger is None:

--- a/tldw_Server_API/app/services/scheduled_task_automation_scheduler.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_scheduler.py
@@ -82,6 +82,7 @@ from tldw_Server_API.app.services.reminders_scheduler import (
 AUTOMATION_DOMAIN = "scheduled_tasks"
 AUTOMATION_JOB_TYPE = "agent_task_run"
 ARMED_HEALTH = "ready"
+UNAVAILABLE_HEALTH = "execution_unavailable"
 SCHEDULER_ACTOR = "automation-scheduler"
 _MIN_RESCAN_SECONDS = 30
 
@@ -208,6 +209,8 @@ class _AutomationScheduler:
             [], bool
         ] = current_agent_execution_stack_ready,
     ) -> None:
+        """Initialize scheduler state and injectable Agent readiness inputs."""
+
         self._aps: AsyncIOScheduler | None = None
         self._db_cache: dict[int, ScheduledTasksDatabase] = {}
         self._lock = asyncio.Lock()
@@ -219,7 +222,13 @@ class _AutomationScheduler:
         )
         self._execution_stack_ready_resolver = execution_stack_ready_resolver
 
-    def _agent_execution_ready(self, definition: DefinitionRow) -> bool:
+    def _agent_execution_ready(
+        self,
+        definition: DefinitionRow,
+        user_id: int,
+    ) -> bool:
+        """Apply core readiness and persist honest blocked scheduler state."""
+
         if definition.family != "agent_task":
             return True
         readiness = agent_execution_dispatch_readiness(
@@ -231,6 +240,14 @@ class _AutomationScheduler:
                 "Automation scheduler blocked Agent definition {}: {}",
                 definition.id,
                 readiness.reason,
+            )
+            if self._aps is not None:
+                with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+                    self._aps.remove_job(_job_id(definition.id))
+            self._mark_unavailable(
+                definition,
+                user_id,
+                reason=readiness.reason or "agent_execution_unavailable",
             )
         return readiness.ready
 
@@ -391,7 +408,7 @@ class _AutomationScheduler:
         """
         if not self._aps:
             return False
-        if not self._agent_execution_ready(definition):
+        if not self._agent_execution_ready(definition, user_id):
             return False
         trigger, reason = build_trigger(definition.schedule)
         if trigger is None:
@@ -430,20 +447,25 @@ class _AutomationScheduler:
         self._mark_ready(definition, user_id)
         return True
 
-    def _mark_ready(self, definition: DefinitionRow, user_id: int) -> None:
-        """Health honesty (TASK-13020 AC#4): armed definitions read ``ready``.
+    def _mark_health(
+        self,
+        definition: DefinitionRow,
+        user_id: int,
+        *,
+        health: str,
+        event_type: str,
+        summary: str,
+    ) -> None:
+        """Persist and audit one scheduler-owned health transition on change."""
 
-        Written only on change so rescans do not churn the definition's
-        version column; audited through the standard trail.
-        """
-        if definition.health == ARMED_HEALTH:
+        if definition.health == health:
             return
         db = self._get_db(user_id)
         try:
             updated = db.update_definition(
                 owner_id=user_id,
                 definition_id=definition.id,
-                patch={"health": ARMED_HEALTH, "updated_by": SCHEDULER_ACTOR},
+                patch={"health": health, "updated_by": SCHEDULER_ACTOR},
             )
         except _NONCRITICAL_EXCEPTIONS as exc:
             logger.warning(
@@ -454,15 +476,49 @@ class _AutomationScheduler:
             db.create_audit_event(
                 owner_id=user_id,
                 definition_id=definition.id,
-                event_type="scheduler_armed",
+                event_type=event_type,
                 actor=SCHEDULER_ACTOR,
-                summary=(
-                    f"Definition armed by scheduler (schedule kind "
-                    f"'{definition.schedule.get('kind')}'); health -> ready."
-                ),
+                summary=summary,
                 before={"health": definition.health},
                 after={"health": updated.health},
             )
+
+    def _mark_ready(self, definition: DefinitionRow, user_id: int) -> None:
+        """Health honesty (TASK-13020 AC#4): armed definitions read ``ready``.
+
+        Written only on change so rescans do not churn the definition's
+        version column; audited through the standard trail.
+        """
+        self._mark_health(
+            definition,
+            user_id,
+            health=ARMED_HEALTH,
+            event_type="scheduler_armed",
+            summary=(
+                f"Definition armed by scheduler (schedule kind "
+                f"'{definition.schedule.get('kind')}'); health -> ready."
+            ),
+        )
+
+    def _mark_unavailable(
+        self,
+        definition: DefinitionRow,
+        user_id: int,
+        *,
+        reason: str,
+    ) -> None:
+        """Persist the unavailable health state for a readiness-blocked Agent."""
+
+        self._mark_health(
+            definition,
+            user_id,
+            health=UNAVAILABLE_HEALTH,
+            event_type="scheduler_blocked",
+            summary=(
+                "Definition blocked by Scheduled Agent readiness gate "
+                f"({reason}); health -> execution_unavailable."
+            ),
+        )
 
     async def _run_definition_schedule(
         self, definition_id: str, user_id: int, slot_iso: str
@@ -488,7 +544,7 @@ class _AutomationScheduler:
             return
         if definition is None or definition.lifecycle != "configured":
             return
-        if not self._agent_execution_ready(definition):
+        if not self._agent_execution_ready(definition, user_id):
             return
 
         # The schedule may have become unusable between arming and this
@@ -556,7 +612,7 @@ class _AutomationScheduler:
             return
         if definition is None or definition.lifecycle != "configured":
             return
-        if not self._agent_execution_ready(definition):
+        if not self._agent_execution_ready(definition, user_id):
             return
         trigger, _reason = build_trigger(definition.schedule)
         if trigger is None:

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -38,10 +38,14 @@ from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
     ScheduledTasksTransaction,
 )
 from tldw_Server_API.app.core.Scheduled_Tasks.execution_certification import (
+    AgentAutomationAdmission,
     AgentExecutionDispatchReadiness,
     ExecutionCertification,
+    agent_automation_admission,
     agent_execution_dispatch_readiness,
+    certification_recovery_action,
     current_agent_execution_stack_ready,
+    readiness_recovery_action,
     resolve_current_agent_execution_certification,
 )
 from tldw_Server_API.app.core.Scheduled_Tasks.recurring_question_models import (
@@ -56,19 +60,6 @@ PREVIEW_TTL = timedelta(hours=24)
 IDEMPOTENCY_TTL = timedelta(hours=24)
 DEFAULT_DEFINITION_HEALTH = "execution_unavailable"
 _SUPPORTED_SCHEDULE_KINDS = {"one_time", "interval", "daily", "weekly", "cron"}
-_DRAFT_CERTIFICATION_RECOVERY = (
-    "Complete server-verified Scheduled Agent execution certification "
-    "for this deployment class."
-)
-_UNSUPPORTED_CERTIFICATION_RECOVERY = (
-    "Use an untrusted-eligible runtime with strict deny-all networking, "
-    "then rerun Scheduled Agent execution certification."
-)
-_EXECUTION_STACK_RECOVERY = (
-    "Install the reviewed Scheduled Agent execution stack before enabling execution."
-)
-
-
 class ScheduledTaskAutomationError(Exception):
     """Expected, user-actionable scheduled task automation failure."""
 
@@ -78,7 +69,9 @@ class ScheduledTaskAutomationError(Exception):
         *,
         reason: str | None = None,
         recovery_action: str | None = None,
-    ):
+    ) -> None:
+        """Initialize a bounded service error for endpoint translation."""
+
         super().__init__(code)
         self.code = code
         self.reason = reason
@@ -249,24 +242,6 @@ def _normalize_visibility_policy(family: str, value: Any) -> str:
     return "metadata_only" if family == "agent_task" else "findings_only"
 
 
-def _certification_recovery_action(outcome: str) -> str | None:
-    if outcome == "unsupported":
-        return _UNSUPPORTED_CERTIFICATION_RECOVERY
-    if outcome == "draft_only":
-        return _DRAFT_CERTIFICATION_RECOVERY
-    return None
-
-
-def _readiness_recovery_action(reason: str | None) -> str | None:
-    if reason == "agent_execution_stack_unimplemented":
-        return _EXECUTION_STACK_RECOVERY
-    if reason == "execution_certification_unsupported":
-        return _UNSUPPORTED_CERTIFICATION_RECOVERY
-    if reason == "execution_certification_draft_only":
-        return _DRAFT_CERTIFICATION_RECOVERY
-    return None
-
-
 class ScheduledTaskAutomationService:
     """Business service for Scheduled Tasks-owned automation definitions."""
 
@@ -280,7 +255,9 @@ class ScheduledTaskAutomationService:
         execution_stack_ready_resolver: Callable[
             [], bool
         ] = current_agent_execution_stack_ready,
-    ):
+    ) -> None:
+        """Initialize repository access and injectable readiness resolvers."""
+
         self._repository = repository
         self._schema_ready_keys: set[tuple[int, str]] = set()
         self._execution_certification_resolver = (
@@ -291,6 +268,8 @@ class ScheduledTaskAutomationService:
     def _agent_execution_readiness(
         self,
     ) -> tuple[ExecutionCertification, AgentExecutionDispatchReadiness]:
+        """Resolve certification and core dispatch readiness together."""
+
         certification = self._execution_certification_resolver()
         readiness = agent_execution_dispatch_readiness(
             certification,
@@ -301,17 +280,20 @@ class ScheduledTaskAutomationService:
     @staticmethod
     def _certification_capability(
         certification: ExecutionCertification,
+        admission: AgentAutomationAdmission,
     ) -> ScheduledTaskExecutionCertificationCapability:
+        """Project one sanitized core certification into the API schema."""
+
         return ScheduledTaskExecutionCertificationCapability(
-            outcome=certification.outcome,
+            outcome=admission.effective_outcome,
             deployment_class_id=certification.deployment_class_id,
             evidence_id=certification.evidence_id,
             evidence_source=certification.evidence_source,
             observed_at=certification.observed_at,
             expires_at=certification.expires_at,
             reason_codes=list(certification.reason_codes),
-            recovery_action=_certification_recovery_action(
-                certification.outcome
+            recovery_action=certification_recovery_action(
+                admission.effective_outcome
             ),
         )
 
@@ -322,17 +304,21 @@ class ScheduledTaskAutomationService:
         readiness: AgentExecutionDispatchReadiness,
         status: str = "disabled",
     ) -> ScheduledTaskActionCapability:
+        """Project one core readiness blocker into an action capability."""
+
         return ScheduledTaskActionCapability(
             status=status,
             reason=readiness.reason,
             required_permissions=[TASKS_CONTROL],
             evidence_source=certification.evidence_source,
-            recovery_action=_readiness_recovery_action(readiness.reason),
+            recovery_action=readiness_recovery_action(readiness.reason),
             observed_at=certification.observed_at,
             expires_at=certification.expires_at,
         )
 
     def _require_agent_execution_available(self, family: str) -> None:
+        """Raise the service error when core execution admission is blocked."""
+
         if family != "agent_task":
             return
         _certification, readiness = self._agent_execution_readiness()
@@ -341,19 +327,23 @@ class ScheduledTaskAutomationService:
         raise ScheduledTaskAutomationError(
             "agent_execution_unavailable",
             reason=readiness.reason,
-            recovery_action=_readiness_recovery_action(readiness.reason),
+            recovery_action=readiness_recovery_action(readiness.reason),
         )
 
     def _require_agent_automation_supported(self, family: str) -> None:
+        """Raise the service error when core authoring admission is blocked."""
+
         if family != "agent_task":
             return
-        certification, readiness = self._agent_execution_readiness()
-        if certification.outcome != "unsupported":
+        admission = agent_automation_admission(
+            self._execution_certification_resolver()
+        )
+        if admission.allowed:
             return
         raise ScheduledTaskAutomationError(
             "agent_automation_unsupported",
-            reason=readiness.reason,
-            recovery_action=_readiness_recovery_action(readiness.reason),
+            reason=admission.reason,
+            recovery_action=admission.recovery_action,
         )
 
     def get_capabilities(self) -> ScheduledTaskAutomationCapabilitiesResponse:
@@ -362,6 +352,8 @@ class ScheduledTaskAutomationService:
         def _execution_actions(
             tools_reason: str,
         ) -> dict[str, ScheduledTaskActionCapability]:
+            """Build the common action map for executable task families."""
+
             actions = self._definition_actions()
             actions["run_now"] = ScheduledTaskActionCapability(
                 status="available",
@@ -386,6 +378,7 @@ class ScheduledTaskAutomationService:
             )
         )
         certification, readiness = self._agent_execution_readiness()
+        admission = agent_automation_admission(certification)
         agent_actions = self._definition_actions()
         agent_actions["execute"] = self._agent_gated_action(
             certification=certification,
@@ -400,7 +393,7 @@ class ScheduledTaskAutomationService:
             reason="agent_tool_execution_requires_reviewed_approval_mediation",
             required_permissions=[TASKS_CONTROL],
         )
-        if certification.outcome == "unsupported":
+        if not admission.allowed:
             for action_name in (
                 "preview",
                 "create_definition",
@@ -435,19 +428,14 @@ class ScheduledTaskAutomationService:
                 ScheduledTaskAutomationCapability(
                     family="agent_task",
                     family_availability=(
-                        "unavailable"
-                        if certification.outcome == "unsupported"
-                        else "available"
+                        "available" if admission.allowed else "unavailable"
                     ),
                     actions=agent_actions,
                     related_capabilities={"acp": {"status": "not_checked"}},
-                    reason=(
-                        readiness.reason
-                        if certification.outcome == "unsupported"
-                        else None
-                    ),
+                    reason=admission.reason,
                     execution_certification=self._certification_capability(
-                        certification
+                        certification,
+                        admission,
                     ),
                 ),
             ]
@@ -564,11 +552,34 @@ class ScheduledTaskAutomationService:
         idempotency_key: str | None = None,
         request_id: str | None = None,
     ) -> ScheduledTaskDefinitionResponse:
+        """Update a definition from a valid preview under current admission.
+
+        Args:
+            owner_id: Authenticated definition owner.
+            actor: Sanitized audit actor identity.
+            definition_id: Existing definition identifier.
+            payload: Typed update request or equivalent mapping.
+            idempotency_key: Optional replay key for this exact request.
+            request_id: Optional request correlation identifier.
+
+        Returns:
+            The updated definition projection.
+
+        Raises:
+            ScheduledTaskAutomationError: If the definition, preview,
+                lifecycle, version, or Agent admission state is invalid.
+        """
+
         request = (
             payload
             if isinstance(payload, ScheduledTaskDefinitionUpdateRequest)
             else ScheduledTaskDefinitionUpdateRequest(**payload)
         )
+        current = self._get_definition_row(
+            owner_id=owner_id,
+            definition_id=definition_id,
+        )
+        self._require_agent_automation_supported(current.family)
         payload_hash = _canonical_hash({"definition_id": definition_id, **request.model_dump(mode="json")})
         return self._with_idempotency(
             owner_id=owner_id,
@@ -1086,10 +1097,14 @@ class ScheduledTaskAutomationService:
         idempotency_key: str | None,
         request_id: str | None,
     ) -> ScheduledTaskDefinitionResponse:
+        """Apply one previewed update after transactional admission checks."""
+
         current = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
+        self._require_agent_automation_supported(current.family)
         if current.lifecycle == "archived":
             raise ScheduledTaskAutomationError("definition_archived")
         preview = self._require_valid_preview(tx=tx, owner_id=owner_id, preview_id=request.preview_id)
+        self._require_agent_automation_supported(preview.family)
         if preview.mode != "update" or preview.definition_id != definition_id:
             raise ScheduledTaskAutomationError("preview_definition_mismatch")
         if preview.definition_version != current.version:

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 from pydantic import BaseModel
 
 from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas import (
-    ScheduledTaskRunNowResponse,
     ScheduledTaskActionCapability,
     ScheduledTaskAuditEventResponse,
     ScheduledTaskAuditListResponse,
@@ -22,10 +21,12 @@ from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas impor
     ScheduledTaskDefinitionResponse,
     ScheduledTaskDefinitionUpdateRequest,
     ScheduledTaskDuplicateRequest,
+    ScheduledTaskExecutionCertificationCapability,
     ScheduledTaskPreviewCreateRequest,
     ScheduledTaskPreviewListResponse,
     ScheduledTaskPreviewResponse,
     ScheduledTaskResultResponse,
+    ScheduledTaskRunNowResponse,
     ScheduledTaskRunResponse,
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL
@@ -33,8 +34,15 @@ from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
     AuditEventRow,
     DefinitionRow,
     PreviewRow,
-    ScheduledTasksTransaction,
     ScheduledTasksDatabase,
+    ScheduledTasksTransaction,
+)
+from tldw_Server_API.app.core.Scheduled_Tasks.execution_certification import (
+    AgentExecutionDispatchReadiness,
+    ExecutionCertification,
+    agent_execution_dispatch_readiness,
+    current_agent_execution_stack_ready,
+    resolve_current_agent_execution_certification,
 )
 from tldw_Server_API.app.core.Scheduled_Tasks.recurring_question_models import (
     FINDING_POLICY_PRESETS,
@@ -48,14 +56,33 @@ PREVIEW_TTL = timedelta(hours=24)
 IDEMPOTENCY_TTL = timedelta(hours=24)
 DEFAULT_DEFINITION_HEALTH = "execution_unavailable"
 _SUPPORTED_SCHEDULE_KINDS = {"one_time", "interval", "daily", "weekly", "cron"}
+_DRAFT_CERTIFICATION_RECOVERY = (
+    "Complete server-verified Scheduled Agent execution certification "
+    "for this deployment class."
+)
+_UNSUPPORTED_CERTIFICATION_RECOVERY = (
+    "Use an untrusted-eligible runtime with strict deny-all networking, "
+    "then rerun Scheduled Agent execution certification."
+)
+_EXECUTION_STACK_RECOVERY = (
+    "Install the reviewed Scheduled Agent execution stack before enabling execution."
+)
 
 
 class ScheduledTaskAutomationError(Exception):
     """Expected, user-actionable scheduled task automation failure."""
 
-    def __init__(self, code: str):
+    def __init__(
+        self,
+        code: str,
+        *,
+        reason: str | None = None,
+        recovery_action: str | None = None,
+    ):
         super().__init__(code)
         self.code = code
+        self.reason = reason
+        self.recovery_action = recovery_action
 
 
 def _utcnow() -> datetime:
@@ -222,25 +249,118 @@ def _normalize_visibility_policy(family: str, value: Any) -> str:
     return "metadata_only" if family == "agent_task" else "findings_only"
 
 
+def _certification_recovery_action(outcome: str) -> str | None:
+    if outcome == "unsupported":
+        return _UNSUPPORTED_CERTIFICATION_RECOVERY
+    if outcome == "draft_only":
+        return _DRAFT_CERTIFICATION_RECOVERY
+    return None
+
+
+def _readiness_recovery_action(reason: str | None) -> str | None:
+    if reason == "agent_execution_stack_unimplemented":
+        return _EXECUTION_STACK_RECOVERY
+    if reason == "execution_certification_unsupported":
+        return _UNSUPPORTED_CERTIFICATION_RECOVERY
+    if reason == "execution_certification_draft_only":
+        return _DRAFT_CERTIFICATION_RECOVERY
+    return None
+
+
 class ScheduledTaskAutomationService:
     """Business service for Scheduled Tasks-owned automation definitions."""
 
-    def __init__(self, repository: ScheduledTasksDatabase | None = None):
+    def __init__(
+        self,
+        repository: ScheduledTasksDatabase | None = None,
+        *,
+        execution_certification_resolver: Callable[
+            [], ExecutionCertification
+        ] = resolve_current_agent_execution_certification,
+        execution_stack_ready_resolver: Callable[
+            [], bool
+        ] = current_agent_execution_stack_ready,
+    ):
         self._repository = repository
         self._schema_ready_keys: set[tuple[int, str]] = set()
+        self._execution_certification_resolver = (
+            execution_certification_resolver
+        )
+        self._execution_stack_ready_resolver = execution_stack_ready_resolver
+
+    def _agent_execution_readiness(
+        self,
+    ) -> tuple[ExecutionCertification, AgentExecutionDispatchReadiness]:
+        certification = self._execution_certification_resolver()
+        readiness = agent_execution_dispatch_readiness(
+            certification,
+            execution_stack_ready=self._execution_stack_ready_resolver(),
+        )
+        return certification, readiness
+
+    @staticmethod
+    def _certification_capability(
+        certification: ExecutionCertification,
+    ) -> ScheduledTaskExecutionCertificationCapability:
+        return ScheduledTaskExecutionCertificationCapability(
+            outcome=certification.outcome,
+            deployment_class_id=certification.deployment_class_id,
+            evidence_id=certification.evidence_id,
+            evidence_source=certification.evidence_source,
+            observed_at=certification.observed_at,
+            expires_at=certification.expires_at,
+            reason_codes=list(certification.reason_codes),
+            recovery_action=_certification_recovery_action(
+                certification.outcome
+            ),
+        )
+
+    @staticmethod
+    def _agent_gated_action(
+        *,
+        certification: ExecutionCertification,
+        readiness: AgentExecutionDispatchReadiness,
+        status: str = "disabled",
+    ) -> ScheduledTaskActionCapability:
+        return ScheduledTaskActionCapability(
+            status=status,
+            reason=readiness.reason,
+            required_permissions=[TASKS_CONTROL],
+            evidence_source=certification.evidence_source,
+            recovery_action=_readiness_recovery_action(readiness.reason),
+            observed_at=certification.observed_at,
+            expires_at=certification.expires_at,
+        )
+
+    def _require_agent_execution_available(self, family: str) -> None:
+        if family != "agent_task":
+            return
+        _certification, readiness = self._agent_execution_readiness()
+        if readiness.ready:
+            return
+        raise ScheduledTaskAutomationError(
+            "agent_execution_unavailable",
+            reason=readiness.reason,
+            recovery_action=_readiness_recovery_action(readiness.reason),
+        )
+
+    def _require_agent_automation_supported(self, family: str) -> None:
+        if family != "agent_task":
+            return
+        certification, readiness = self._agent_execution_readiness()
+        if certification.outcome != "unsupported":
+            return
+        raise ScheduledTaskAutomationError(
+            "agent_automation_unsupported",
+            reason=readiness.reason,
+            recovery_action=_readiness_recovery_action(readiness.reason),
+        )
 
     def get_capabilities(self) -> ScheduledTaskAutomationCapabilitiesResponse:
-        """Return capabilities with honest per-family execution truth.
+        """Return additive per-family capability and feasibility truth."""
 
-        Since TASK-13020/13021, definitions execute server-side through
-        the Jobs pipeline (scheduler feed + agent_task consumer) in
-        generation-only phase 1: recurring_question runs execute; agent_task
-        runs execute generation-only; tools are explicitly NOT executable
-        pending the approval-escalation design. The ``run_now`` action is
-        available on both families (TASK-13022).
-        """
         def _execution_actions(
-            tools_reason: str, execute_status: str = "available"
+            tools_reason: str,
         ) -> dict[str, ScheduledTaskActionCapability]:
             actions = self._definition_actions()
             actions["run_now"] = ScheduledTaskActionCapability(
@@ -248,10 +368,8 @@ class ScheduledTaskAutomationService:
                 required_permissions=[TASKS_CONTROL],
             )
             actions["execute"] = ScheduledTaskActionCapability(
-                status=execute_status,
-                reason="phase1_generation_only"
-                if execute_status == "available"
-                else tools_reason,
+                status="available",
+                reason="phase1_generation_only",
                 required_permissions=[TASKS_CONTROL],
             )
             actions["execute_tools"] = ScheduledTaskActionCapability(
@@ -267,6 +385,33 @@ class ScheduledTaskAutomationService:
                 "recurring_question has no tool surface; tools are not applicable"
             )
         )
+        certification, readiness = self._agent_execution_readiness()
+        agent_actions = self._definition_actions()
+        agent_actions["execute"] = self._agent_gated_action(
+            certification=certification,
+            readiness=readiness,
+        )
+        agent_actions["run_now"] = self._agent_gated_action(
+            certification=certification,
+            readiness=readiness,
+        )
+        agent_actions["execute_tools"] = ScheduledTaskActionCapability(
+            status="planned",
+            reason="agent_tool_execution_requires_reviewed_approval_mediation",
+            required_permissions=[TASKS_CONTROL],
+        )
+        if certification.outcome == "unsupported":
+            for action_name in (
+                "preview",
+                "create_definition",
+                "update_definition",
+                "duplicate",
+            ):
+                agent_actions[action_name] = self._agent_gated_action(
+                    certification=certification,
+                    readiness=readiness,
+                    status="unavailable",
+                )
         return ScheduledTaskAutomationCapabilitiesResponse(
             items=[
                 ScheduledTaskAutomationCapability(
@@ -289,14 +434,21 @@ class ScheduledTaskAutomationService:
                 ),
                 ScheduledTaskAutomationCapability(
                     family="agent_task",
-                    family_availability="available",
-                    actions=_execution_actions(
-                        "agent_task is not executable in phase 1: its message "
-                        "is redacted at rest (metadata_only policy) and "
-                        "tool use awaits the approval-escalation design",
-                        execute_status="planned",
+                    family_availability=(
+                        "unavailable"
+                        if certification.outcome == "unsupported"
+                        else "available"
                     ),
+                    actions=agent_actions,
                     related_capabilities={"acp": {"status": "not_checked"}},
+                    reason=(
+                        readiness.reason
+                        if certification.outcome == "unsupported"
+                        else None
+                    ),
+                    execution_certification=self._certification_capability(
+                        certification
+                    ),
                 ),
             ]
         )
@@ -310,6 +462,7 @@ class ScheduledTaskAutomationService:
         idempotency_key: str | None = None,
     ) -> ScheduledTaskPreviewResponse:
         request = payload if isinstance(payload, ScheduledTaskPreviewCreateRequest) else ScheduledTaskPreviewCreateRequest(**payload)
+        self._require_agent_automation_supported(request.family)
         payload_hash = _canonical_hash(self._preview_hash_payload(request))
         return self._with_idempotency(
             owner_id=owner_id,
@@ -379,6 +532,12 @@ class ScheduledTaskAutomationService:
             if isinstance(payload, ScheduledTaskDefinitionCreateRequest)
             else ScheduledTaskDefinitionCreateRequest(**payload)
         )
+        preview = self._repo(owner_id).get_preview(
+            owner_id=owner_id,
+            preview_id=request.preview_id,
+        )
+        if preview is not None:
+            self._require_agent_automation_supported(preview.family)
         payload_hash = _canonical_hash(request.model_dump(mode="json"))
         return self._with_idempotency(
             owner_id=owner_id,
@@ -588,7 +747,8 @@ class ScheduledTaskAutomationService:
         ``definition_disabled`` (a manual trigger must not silently
         resurrect a definition the owner paused).
         """
-        from datetime import datetime, timezone as _tz
+        from datetime import datetime
+        from datetime import timezone as _tz
 
         from tldw_Server_API.app.core.Jobs.manager import JobManager
         from tldw_Server_API.app.services.scheduled_task_automation_scheduler import (
@@ -599,6 +759,7 @@ class ScheduledTaskAutomationService:
         definition = repo.get_definition(owner_id=owner_id, definition_id=definition_id)
         if definition is None:
             raise ScheduledTaskAutomationError("definition_not_found")
+        self._require_agent_execution_available(definition.family)
         if definition.lifecycle == "archived":
             raise ScheduledTaskAutomationError("definition_archived")
         if definition.lifecycle == "disabled" and definition.disabled_lock_kind in {
@@ -764,6 +925,11 @@ class ScheduledTaskAutomationService:
         request_id: str | None = None,
     ) -> ScheduledTaskDefinitionResponse:
         request = payload if isinstance(payload, ScheduledTaskDuplicateRequest) else ScheduledTaskDuplicateRequest(**payload)
+        source = self._get_definition_row(
+            owner_id=owner_id,
+            definition_id=definition_id,
+        )
+        self._require_agent_automation_supported(source.family)
         payload_hash = _canonical_hash({"definition_id": definition_id, **request.model_dump(mode="json")})
         return self._with_idempotency(
             owner_id=owner_id,
@@ -837,6 +1003,7 @@ class ScheduledTaskAutomationService:
         request: ScheduledTaskPreviewCreateRequest,
         payload_hash: str,
     ) -> ScheduledTaskPreviewResponse:
+        self._require_agent_automation_supported(request.family)
         normalized, validation_errors, warnings = self._normalize_preview(request)
         status = "invalid" if validation_errors else "valid"
         row = tx.create_preview(
@@ -870,6 +1037,7 @@ class ScheduledTaskAutomationService:
         request_id: str | None,
     ) -> ScheduledTaskDefinitionResponse:
         preview = self._require_valid_preview(tx=tx, owner_id=owner_id, preview_id=request.preview_id)
+        self._require_agent_automation_supported(preview.family)
         if preview.mode != "create" or preview.definition_id is not None:
             raise ScheduledTaskAutomationError("preview_mode_mismatch")
         normalized = preview.normalized_config
@@ -1152,6 +1320,7 @@ class ScheduledTaskAutomationService:
         request_id: str | None,
     ) -> ScheduledTaskDefinitionResponse:
         source = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
+        self._require_agent_automation_supported(source.family)
         if source.lifecycle == "archived":
             raise ScheduledTaskAutomationError("definition_archived")
         if source.lifecycle == "disabled" and source.disabled_lock_kind in {"admin", "security"}:

--- a/tldw_Server_API/tests/Helper_Scripts/test_scheduled_agent_execution_certification.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_scheduled_agent_execution_certification.py
@@ -248,6 +248,7 @@ def test_command_manifest_contains_names_but_no_values_or_urls(
     assert "single_user" not in serialized
     assert "docker" not in serialized
     assert "b" * 40 not in serialized
+    assert "api_key" not in serialized
 
 
 def test_evidence_id_covers_canonical_sanitized_content(tmp_path: Path) -> None:
@@ -334,6 +335,48 @@ def test_write_and_validate_artifact_pair(tmp_path: Path) -> None:
     module.validate_artifact_pair(json_path, markdown_path)
     assert json.loads(json_path.read_text(encoding="utf-8")) == manifest
     assert manifest["evidence_id"] in markdown_path.read_text(encoding="utf-8")
+
+
+def test_markdown_runtime_appendix_is_derived_and_pair_validated(
+    tmp_path: Path,
+) -> None:
+    """Static runtime eligibility is complete and covered by pair validation."""
+
+    module = _load_module()
+    manifest = module.build_evidence_manifest(
+        _inputs(module),
+        now=NOW,
+        temporary_directory=tmp_path,
+    )
+    markdown = module.render_manifest_markdown(manifest)
+    expected = {
+        "docker": "draft_only",
+        "firecracker": "draft_only",
+        "lima": "draft_only",
+        "vz_linux": "draft_only",
+        "vz_macos": "unsupported",
+        "seatbelt": "unsupported",
+        "worktree": "unsupported",
+    }
+
+    assert "## Repository-Static Runtime Eligibility" in markdown
+    for runtime, outcome in expected.items():
+        assert f"| `{runtime}` | `{outcome}` |" in markdown
+
+    json_path = tmp_path / "baseline.json"
+    markdown_path = tmp_path / "baseline.md"
+    json_path.write_text(module.render_manifest_json(manifest), encoding="utf-8")
+    markdown_path.write_text(
+        markdown.replace(
+            "| `docker` | `draft_only` |",
+            "| `docker` | `certified` |",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Markdown"):
+        module.validate_artifact_pair(json_path, markdown_path)
 
 
 def test_artifact_pair_rejects_markdown_from_another_manifest(

--- a/tldw_Server_API/tests/Helper_Scripts/test_scheduled_agent_execution_certification.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_scheduled_agent_execution_certification.py
@@ -9,8 +9,11 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 import pytest
+
+pytestmark = pytest.mark.unit
 
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[3]
@@ -62,6 +65,8 @@ COMMAND_KEYS = {
 
 
 def _load_module() -> ModuleType:
+    """Load the standalone characterization script as an isolated module."""
+
     spec = importlib.util.spec_from_file_location(
         "scheduled_agent_execution_certification",
         SCRIPT_PATH,
@@ -74,7 +79,9 @@ def _load_module() -> ModuleType:
     return module
 
 
-def _inputs(module: ModuleType, *, runtime: str = "docker"):
+def _inputs(module: ModuleType, *, runtime: str = "docker") -> Any:
+    """Build typed characterization inputs from the dynamically loaded module."""
+
     return module.CertificationInputs(
         host_os=platform.system().lower(),
         host_arch=platform.machine().lower(),
@@ -94,7 +101,9 @@ def _inputs(module: ModuleType, *, runtime: str = "docker"):
     )
 
 
-def _sentinels(module: ModuleType):
+def _sentinels(module: ModuleType) -> Any:
+    """Build non-secret sentinels for output-disclosure assertions."""
+
     return module.CharacterizationSentinels(
         prompt="PROMPT-SENTINEL-9ca92c",
         credential="CREDENTIAL-SENTINEL-8e448f",
@@ -106,6 +115,8 @@ def _sentinels(module: ModuleType):
 
 
 def _base_cli_args(runtime: str = "docker") -> list[str]:
+    """Return the minimum stable command-line arguments for harness tests."""
+
     return [
         "--host-os",
         platform.system().lower(),
@@ -266,6 +277,31 @@ def test_evidence_id_covers_canonical_sanitized_content(tmp_path: Path) -> None:
     tampered = json.loads(json.dumps(manifest))
     tampered["outcome"] = "certified"
     with pytest.raises(ValueError, match="evidence_id"):
+        module.validate_manifest(tampered)
+
+
+def test_manifest_rejects_digest_recomputed_command_metadata_tampering(
+    tmp_path: Path,
+) -> None:
+    """Security-sensitive command metadata must match the closed manifest."""
+
+    module = _load_module()
+    manifest = module.build_evidence_manifest(
+        _inputs(module),
+        now=NOW,
+        temporary_directory=tmp_path,
+    )
+    tampered = json.loads(json.dumps(manifest))
+    hostile = next(
+        command
+        for command in tampered["commands"]
+        if command["id"] == "hostile_boundary"
+    )
+    hostile["safe_to_run_by_default"] = True
+    hostile["invocation_template"] += " --credential secret-value"
+    tampered["evidence_id"] = module.compute_manifest_evidence_id(tampered)
+
+    with pytest.raises(ValueError, match="command"):
         module.validate_manifest(tampered)
 
 
@@ -528,13 +564,22 @@ def test_cli_rejects_claimed_host_without_characterization_override(
     args = _base_cli_args()
     host_index = args.index("--host-os") + 1
     args[host_index] = "windows" if platform.system().lower() != "windows" else "linux"
+    errors: list[str] = []
+    sink_id = module.logger.add(
+        lambda message: errors.append(str(message)),
+        level="ERROR",
+        format="{message}",
+    )
 
-    result = module.main([*args, "--format", "json"])
+    try:
+        result = module.main([*args, "--format", "json"])
+    finally:
+        module.logger.remove(sink_id)
     captured = capsys.readouterr()
 
     assert result == 2
     assert captured.out == ""
-    assert "does not match the observed host" in captured.err
+    assert any("does not match the observed host" in error for error in errors)
 
 
 def test_cli_hostile_refusal_does_not_write_artifacts(

--- a/tldw_Server_API/tests/Helper_Scripts/test_scheduled_agent_execution_certification.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_scheduled_agent_execution_certification.py
@@ -1,0 +1,561 @@
+"""Scheduled Agent execution evidence harness tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import platform
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "Helper_Scripts"
+    / "Testing-related"
+    / "scheduled_agent_execution_certification.py"
+)
+NOW = datetime(2026, 8, 26, 20, 0, tzinfo=timezone.utc)
+REQUIREMENT_IDS = (
+    "isolation_attestation",
+    "hostile_boundary",
+    "scheduled_transcript_non_disclosure",
+    "adapter_dispatch_recovery",
+    "monotonic_execution_evidence",
+    "brokered_credentials_and_mediation",
+    "operational_fail_closed",
+)
+MANIFEST_KEYS = {
+    "schema_version",
+    "evidence_id",
+    "deployment_class_id",
+    "source_commit",
+    "created_at",
+    "valid_until",
+    "outcome",
+    "reason_codes",
+    "requirements",
+    "commands",
+}
+REQUIREMENT_KEYS = {
+    "requirement_id",
+    "state",
+    "verification",
+    "subject_id",
+    "observed_at",
+    "valid_until",
+    "reason_codes",
+    "evidence_sha256",
+    "safety_boundary_breached",
+}
+COMMAND_KEYS = {
+    "id",
+    "description",
+    "invocation_template",
+    "parameter_names",
+    "safe_to_run_by_default",
+    "required_environment_names",
+}
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "scheduled_agent_execution_certification",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _inputs(module: ModuleType, *, runtime: str = "docker"):
+    return module.CertificationInputs(
+        host_os=platform.system().lower(),
+        host_arch=platform.machine().lower(),
+        runtime=runtime,
+        auth_mode="single_user",
+        adapter_id="acp",
+        adapter_version="1",
+        source_commit="a" * 40,
+        server_build_sha="b" * 40,
+        image_digest="unverified",
+        mount_policy_hash="unverified",
+        egress_policy_hash="unverified",
+        credential_policy_hash="unverified",
+        tenant_boundary_policy_hash="unverified",
+        mediation_policy_hash="unverified",
+        isolation_profile_version="phase4d0f-baseline",
+    )
+
+
+def _sentinels(module: ModuleType):
+    return module.CharacterizationSentinels(
+        prompt="PROMPT-SENTINEL-9ca92c",
+        credential="CREDENTIAL-SENTINEL-8e448f",
+        host_path="/private/sensitive/path/SENTINEL-51db",
+        hostname="internal-host-SENTINEL-71c3.example",
+        tool_argument="--secret-argument=SENTINEL-3df2",
+        environment_value="ENVIRONMENT-SENTINEL-88a1",
+    )
+
+
+def _base_cli_args(runtime: str = "docker") -> list[str]:
+    return [
+        "--host-os",
+        platform.system().lower(),
+        "--host-arch",
+        platform.machine().lower(),
+        "--runtime",
+        runtime,
+        "--auth-mode",
+        "single_user",
+        "--adapter-id",
+        "acp",
+        "--adapter-version",
+        "1",
+        "--source-commit",
+        "a" * 40,
+        "--server-build-sha",
+        "b" * 40,
+        "--image-digest",
+        "unverified",
+        "--mount-policy-hash",
+        "unverified",
+        "--egress-policy-hash",
+        "unverified",
+        "--credential-policy-hash",
+        "unverified",
+        "--tenant-boundary-policy-hash",
+        "unverified",
+        "--mediation-policy-hash",
+        "unverified",
+        "--isolation-profile-version",
+        "phase4d0f-baseline",
+    ]
+
+
+def test_manifest_has_exact_sanitized_schema_and_all_seven_domains(
+    tmp_path: Path,
+) -> None:
+    """A missing or extra public field must not silently change the evidence API."""
+
+    module = _load_module()
+
+    manifest = module.build_evidence_manifest(
+        _inputs(module),
+        now=NOW,
+        temporary_directory=tmp_path,
+        sentinels=_sentinels(module),
+    )
+
+    assert set(manifest) == MANIFEST_KEYS
+    assert manifest["schema_version"] == (
+        "scheduled-agent-execution-certification.v1"
+    )
+    assert manifest["outcome"] == "draft_only"
+    assert [item["requirement_id"] for item in manifest["requirements"]] == list(
+        REQUIREMENT_IDS
+    )
+    assert all(set(item) == REQUIREMENT_KEYS for item in manifest["requirements"])
+    assert [command["id"] for command in manifest["commands"]] == list(
+        REQUIREMENT_IDS
+    )
+    assert all(set(command) == COMMAND_KEYS for command in manifest["commands"])
+
+
+def test_repository_characterization_never_emits_certified(
+    tmp_path: Path,
+) -> None:
+    """Static and temporary local characterization must not become authority."""
+
+    module = _load_module()
+
+    manifest = module.build_evidence_manifest(
+        _inputs(module),
+        now=NOW,
+        temporary_directory=tmp_path,
+    )
+
+    assert manifest["outcome"] != "certified"
+    assert all(
+        item["verification"] == "repository_characterization"
+        for item in manifest["requirements"]
+    )
+    assert all(item["state"] == "missing" for item in manifest["requirements"])
+
+
+def test_ineligible_worktree_runtime_is_unsupported(tmp_path: Path) -> None:
+    """Host-local repository worktrees must not be reported as draft-ready."""
+
+    module = _load_module()
+
+    manifest = module.build_evidence_manifest(
+        _inputs(module, runtime="worktree"),
+        now=NOW,
+        temporary_directory=tmp_path,
+    )
+
+    assert manifest["outcome"] == "unsupported"
+    assert "runtime_not_untrusted_eligible" in manifest["reason_codes"]
+    assert "runtime_strict_deny_all_unavailable" in manifest["reason_codes"]
+
+
+def test_prompt_and_other_sensitive_values_never_serialize(tmp_path: Path) -> None:
+    """Characterization values must be reduced to bounded hashes and reason codes."""
+
+    module = _load_module()
+    sentinels = _sentinels(module)
+    manifest = module.build_evidence_manifest(
+        _inputs(module),
+        now=NOW,
+        temporary_directory=tmp_path,
+        sentinels=sentinels,
+    )
+
+    rendered = module.render_manifest_json(manifest) + module.render_manifest_markdown(
+        manifest
+    )
+
+    for sentinel in vars(sentinels).values():
+        assert sentinel not in rendered
+    assert str(tmp_path) not in rendered
+
+
+def test_command_manifest_contains_names_but_no_values_or_urls(
+    tmp_path: Path,
+) -> None:
+    """A runnable manifest must not publish local arguments or environment values."""
+
+    module = _load_module()
+    manifest = module.build_evidence_manifest(
+        _inputs(module),
+        now=NOW,
+        temporary_directory=tmp_path,
+    )
+    serialized = json.dumps(manifest["commands"], sort_keys=True)
+
+    assert "Helper_Scripts/Testing-related/scheduled_agent_execution_certification.py" in serialized
+    assert "--runtime" in serialized
+    assert "http://" not in serialized
+    assert "https://" not in serialized
+    assert str(tmp_path) not in serialized
+    assert "single_user" not in serialized
+    assert "docker" not in serialized
+    assert "b" * 40 not in serialized
+
+
+def test_evidence_id_covers_canonical_sanitized_content(tmp_path: Path) -> None:
+    """Changing an artifact after generation must invalidate its evidence identity."""
+
+    module = _load_module()
+    manifest = module.build_evidence_manifest(
+        _inputs(module),
+        now=NOW,
+        temporary_directory=tmp_path,
+    )
+
+    assert manifest["evidence_id"] == module.compute_manifest_evidence_id(manifest)
+
+    tampered = json.loads(json.dumps(manifest))
+    tampered["outcome"] = "certified"
+    with pytest.raises(ValueError, match="evidence_id"):
+        module.validate_manifest(tampered)
+
+
+def test_transcript_characterization_uses_real_store_and_fork_without_leaking(
+    tmp_path: Path,
+) -> None:
+    """The ordinary ACP leakage finding must come from persisted behavior."""
+
+    module = _load_module()
+    sentinel = "PROMPT-STORE-SENTINEL-4dc6"
+
+    result = module.characterize_ordinary_acp_transcript(
+        database_path=tmp_path / "acp.db",
+        prompt_sentinel=sentinel,
+    )
+
+    assert result == {
+        "ordinary_prompt_retrievable": True,
+        "ordinary_fork_copies_prompt": True,
+        "prompt_sha256": module.sha256_text(sentinel),
+        "reason_code": "scheduled_transcript_mode_unimplemented",
+    }
+    assert sentinel not in json.dumps(result, sort_keys=True)
+
+
+def test_characterization_records_current_partial_primitives(tmp_path: Path) -> None:
+    """Generic primitives must remain gaps when scheduled bindings are absent."""
+
+    module = _load_module()
+
+    facts = module.characterize_current_primitives(
+        database_path=tmp_path / "acp.db",
+        prompt_sentinel="PROMPT-PARTIAL-SENTINEL-1d2f",
+    )
+
+    assert facts["adapter_dispatch_recovery"] == {
+        "sandbox_idempotency_available": True,
+        "acp_dispatch_token_parameter": False,
+        "acp_dispatch_token_persisted": False,
+    }
+    assert facts["monotonic_execution_evidence"]["ordered_attempt_journal"] is False
+    assert facts["brokered_credentials_and_mediation"] == {
+        "managed_credential_broker_available": True,
+        "acp_session_env_channel_present": True,
+        "scheduled_grant_action_binding": False,
+    }
+
+
+def test_write_and_validate_artifact_pair(tmp_path: Path) -> None:
+    """JSON and Markdown outputs must describe the same immutable result."""
+
+    module = _load_module()
+    manifest = module.build_evidence_manifest(
+        _inputs(module),
+        now=NOW,
+        temporary_directory=tmp_path,
+    )
+    json_path = tmp_path / "baseline.json"
+    markdown_path = tmp_path / "baseline.md"
+
+    module.write_artifacts(
+        manifest,
+        json_path=json_path,
+        markdown_path=markdown_path,
+    )
+
+    module.validate_artifact_pair(json_path, markdown_path)
+    assert json.loads(json_path.read_text(encoding="utf-8")) == manifest
+    assert manifest["evidence_id"] in markdown_path.read_text(encoding="utf-8")
+
+
+def test_artifact_pair_rejects_markdown_from_another_manifest(
+    tmp_path: Path,
+) -> None:
+    """A stale Markdown summary must not validate beside newer JSON evidence."""
+
+    module = _load_module()
+    docker = module.build_evidence_manifest(
+        _inputs(module),
+        now=NOW,
+        temporary_directory=tmp_path,
+    )
+    worktree = module.build_evidence_manifest(
+        _inputs(module, runtime="worktree"),
+        now=NOW,
+        temporary_directory=tmp_path,
+    )
+    json_path = tmp_path / "baseline.json"
+    markdown_path = tmp_path / "baseline.md"
+    json_path.write_text(module.render_manifest_json(docker), encoding="utf-8")
+    markdown_path.write_text(
+        module.render_manifest_markdown(worktree),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Markdown"):
+        module.validate_artifact_pair(json_path, markdown_path)
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    [
+        "evidence_dir",
+        "server_url",
+        "api_key_environment_name",
+        "attestation_reference",
+    ],
+)
+def test_hostile_probe_refuses_before_launch_when_prerequisite_is_missing(
+    tmp_path: Path,
+    missing_field: str,
+) -> None:
+    """Hostile execution must fail closed before any adapter or network call."""
+
+    module = _load_module()
+    values = {
+        "evidence_dir": tmp_path,
+        "server_url": "http://127.0.0.1:8000",
+        "api_key_environment_name": "TLDW_TEST_API_KEY",
+        "attestation_reference": "sha256:" + "c" * 64,
+    }
+    values[missing_field] = None
+    request = module.HostileProbeRequest(
+        deployment_class_id="sha256:" + "d" * 64,
+        **values,
+    )
+
+    result = module.evaluate_hostile_probe_admission(
+        request,
+        environment={"TLDW_TEST_API_KEY": "secret-value"},
+    )
+
+    assert result.allowed is False
+    assert result.reason_code.startswith("hostile_probe_blocked_")
+
+
+def test_hostile_probe_refuses_nonlocal_server_url(tmp_path: Path) -> None:
+    """A hostile vector must never target a remote or user-controlled host."""
+
+    module = _load_module()
+    request = module.HostileProbeRequest(
+        deployment_class_id="sha256:" + "d" * 64,
+        evidence_dir=tmp_path,
+        server_url="https://example.com",
+        api_key_environment_name="TLDW_TEST_API_KEY",
+        attestation_reference="sha256:" + "c" * 64,
+    )
+
+    result = module.evaluate_hostile_probe_admission(
+        request,
+        environment={"TLDW_TEST_API_KEY": "secret-value"},
+    )
+
+    assert result.allowed is False
+    assert result.reason_code == "hostile_probe_blocked_nonlocal_server"
+
+
+def test_hostile_probe_remains_blocked_without_server_verifier(tmp_path: Path) -> None:
+    """Supplying every CLI value must not substitute for attestation verification."""
+
+    module = _load_module()
+    request = module.HostileProbeRequest(
+        deployment_class_id="sha256:" + "d" * 64,
+        evidence_dir=tmp_path,
+        server_url="http://127.0.0.1:8000",
+        api_key_environment_name="TLDW_TEST_API_KEY",
+        attestation_reference="sha256:" + "c" * 64,
+    )
+
+    result = module.evaluate_hostile_probe_admission(
+        request,
+        environment={"TLDW_TEST_API_KEY": "secret-value"},
+    )
+
+    assert result.allowed is False
+    assert result.reason_code == (
+        "hostile_probe_blocked_server_attestation_verifier_unimplemented"
+    )
+
+
+def test_cli_emits_draft_json_for_eligible_runtime(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The default CLI path must produce machine-readable draft evidence."""
+
+    module = _load_module()
+
+    result = module.main([*_base_cli_args(), "--format", "json"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert result == 0
+    assert payload["outcome"] == "draft_only"
+    assert captured.err == ""
+
+
+def test_cli_emits_unsupported_markdown_for_worktree(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The human-readable CLI path must preserve the unsupported outcome."""
+
+    module = _load_module()
+
+    result = module.main([*_base_cli_args("worktree"), "--format", "markdown"])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Outcome | `unsupported`" in captured.out
+    assert captured.err == ""
+
+
+def test_cli_rejects_claimed_host_without_characterization_override(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An operator typo must not mint evidence for a different host subject."""
+
+    module = _load_module()
+    args = _base_cli_args()
+    host_index = args.index("--host-os") + 1
+    args[host_index] = "windows" if platform.system().lower() != "windows" else "linux"
+
+    result = module.main([*args, "--format", "json"])
+    captured = capsys.readouterr()
+
+    assert result == 2
+    assert captured.out == ""
+    assert "does not match the observed host" in captured.err
+
+
+def test_cli_hostile_refusal_does_not_write_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A blocked hostile probe must not leave an artifact that resembles a pass."""
+
+    module = _load_module()
+    monkeypatch.setenv("TLDW_TEST_API_KEY", "secret-value")
+    json_path = tmp_path / "must-not-exist.json"
+    markdown_path = tmp_path / "must-not-exist.md"
+    args = [
+        *_base_cli_args(),
+        "--run-hostile",
+        "--evidence-dir",
+        str(tmp_path),
+        "--server-url",
+        "http://127.0.0.1:8000",
+        "--api-key-env-name",
+        "TLDW_TEST_API_KEY",
+        "--attestation-reference",
+        "sha256:" + "c" * 64,
+        "--output-json",
+        str(json_path),
+        "--output-markdown",
+        str(markdown_path),
+    ]
+
+    result = module.main(args)
+    captured = capsys.readouterr()
+
+    assert result == 2
+    assert "server_attestation_verifier_unimplemented" in captured.err
+    assert not json_path.exists()
+    assert not markdown_path.exists()
+
+
+def test_cli_validates_existing_artifacts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Operators need a deterministic success code for unchanged evidence pairs."""
+
+    module = _load_module()
+    manifest = module.build_evidence_manifest(
+        _inputs(module),
+        now=NOW,
+        temporary_directory=tmp_path,
+    )
+    json_path = tmp_path / "baseline.json"
+    markdown_path = tmp_path / "baseline.md"
+    module.write_artifacts(
+        manifest,
+        json_path=json_path,
+        markdown_path=markdown_path,
+    )
+
+    result = module.main(
+        ["--validate-artifacts", str(json_path), str(markdown_path)]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.out == "Artifacts valid.\n"
+    assert captured.err == ""

--- a/tldw_Server_API/tests/Notifications/_scheduled_agent_execution_certification_fixtures.py
+++ b/tldw_Server_API/tests/Notifications/_scheduled_agent_execution_certification_fixtures.py
@@ -1,0 +1,34 @@
+"""Test-only authority boundary for Scheduled Agent certification fixtures.
+
+Production code intentionally exposes no receipt-minting API. Pure evaluator tests
+use this module as the single explicit boundary for constructing authoritative
+receipts without spreading private verifier authority through the test suite.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from tldw_Server_API.app.core.Scheduled_Tasks import execution_certification as cert
+
+
+def issue_test_authoritative_receipt(
+    subject: cert.DeploymentClass,
+    evidence: tuple[cert.RequirementEvidence, ...],
+    *,
+    observed_at: datetime,
+    valid_until: datetime,
+    evidence_id: str,
+    bundle_digest: str | None = None,
+) -> Any:
+    """Issue a verifier receipt exclusively for isolated rule-evaluator tests."""
+
+    return cert._AuthoritativeBundleReceipt(
+        deployment_class_id=subject.deployment_class_id,
+        evidence_id=evidence_id,
+        bundle_digest=bundle_digest or cert.canonical_evidence_bundle_digest(evidence),
+        observed_at=observed_at,
+        valid_until=valid_until,
+        _authority=cert._SERVER_VERIFIER_AUTHORITY,
+    )

--- a/tldw_Server_API/tests/Notifications/test_agent_task_jobs_consumer.py
+++ b/tldw_Server_API/tests/Notifications/test_agent_task_jobs_consumer.py
@@ -26,10 +26,26 @@ from tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs import (
     handle_agent_task_job,
     register_executor,
 )
+from tldw_Server_API.app.core.Scheduled_Tasks.execution_certification import (
+    ExecutionCertification,
+)
 
 pytestmark = pytest.mark.unit
 
 SLOT = "2026-08-21T09:00:00+00:00"
+
+
+def _certified_execution() -> ExecutionCertification:
+    observed_at = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+    return ExecutionCertification(
+        outcome="certified",
+        deployment_class_id="sha256:" + ("1" * 64),
+        evidence_id="sha256:" + ("2" * 64),
+        evidence_source="server_verified",
+        observed_at=observed_at,
+        expires_at=observed_at + timedelta(hours=24),
+        reason_codes=(),
+    )
 
 
 @pytest.fixture()
@@ -40,21 +56,13 @@ def consumer_env(monkeypatch, tmp_path):
     settings.USER_DB_BASE_DIR = str(base_dir)
     monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
     monkeypatch.setenv("JOBS_DB_PATH", str(base_dir / "jobs.db"))
-    _orig_executors = dict(getattr(__import__(
-        "tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs", fromlist=["_EXECUTORS"]
-    ), "_EXECUTORS"))
-    __import__(
-        "tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs", fromlist=["_EXECUTORS"]
-    )._EXECUTORS.clear()
+    _orig_executors = dict(agent_task_jobs._EXECUTORS)
+    agent_task_jobs._EXECUTORS.clear()
     try:
         yield
     finally:
-        module = __import__(
-            "tldw_Server_API.app.core.Scheduled_Tasks.agent_task_jobs",
-            fromlist=["_EXECUTORS"],
-        )
-        module._EXECUTORS.clear()
-        module._EXECUTORS.update(_orig_executors)
+        agent_task_jobs._EXECUTORS.clear()
+        agent_task_jobs._EXECUTORS.update(_orig_executors)
         if prev_base_dir is not None:
             settings.USER_DB_BASE_DIR = prev_base_dir
         else:
@@ -365,6 +373,48 @@ async def test_cross_owner_definition_is_treated_as_missing(
 # ---------------------------------------------------------------------------
 # Phase-1 boundary (enforced by the consumer)
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_queued_agent_job_is_blocked_before_registered_executor(
+    consumer_env,
+) -> None:
+    user_id = 1025
+    definition = _create_definition(
+        user_id,
+        family="agent_task",
+        input_config={
+            "agent_ref": "agent:triage",
+            "message_ref": "redacted:example",
+        },
+    )
+    executor = AsyncMock(return_value="must not execute")
+    register_executor("agent_task", executor)
+
+    result = await handle_agent_task_job(
+        _job(definition, user_id),
+        execution_certification_resolver=_certified_execution,
+        execution_stack_ready_resolver=lambda: False,
+    )
+
+    assert result["status"] == "skipped"  # nosec B101
+    assert result["definition_id"] == definition.id  # nosec B101
+    assert result["run_id"] is not None  # nosec B101
+    assert result["reason"] == "agent_execution_stack_unimplemented"  # nosec B101
+    executor.assert_not_awaited()
+    sdb = ScheduledTasksDatabase.for_user(user_id=user_id)
+    run = sdb.get_scheduled_task_run_by_slot(
+        definition_id=definition.id,
+        run_slot_key=SLOT,
+    )
+    assert run is not None  # nosec B101
+    assert run["status"] == "skipped"  # nosec B101
+    assert run["error"] == "agent_execution_stack_unimplemented"  # nosec B101
+    audits, _total = sdb.list_audit_events(
+        owner_id=user_id,
+        definition_id=definition.id,
+    )
+    assert any(event.event_type == "run_skipped" for event in audits)  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Notifications/test_automation_definition_feed.py
+++ b/tldw_Server_API/tests/Notifications/test_automation_definition_feed.py
@@ -18,11 +18,14 @@ from typing import Any
 import pytest
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
+from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
     DefinitionRow,
     ScheduledTasksDatabase,
 )
-from tldw_Server_API.app.core.config import settings
+from tldw_Server_API.app.core.Scheduled_Tasks.execution_certification import (
+    ExecutionCertification,
+)
 from tldw_Server_API.app.services.reminders_scheduler import _normalize_slot_to_utc_iso
 from tldw_Server_API.app.services.scheduled_task_automation_scheduler import (
     ARMED_HEALTH,
@@ -34,6 +37,19 @@ from tldw_Server_API.app.services.scheduled_task_automation_scheduler import (
 )
 
 pytestmark = pytest.mark.unit
+
+
+def _certified_execution() -> ExecutionCertification:
+    observed_at = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+    return ExecutionCertification(
+        outcome="certified",
+        deployment_class_id="sha256:" + ("1" * 64),
+        evidence_id="sha256:" + ("2" * 64),
+        evidence_source="server_verified",
+        observed_at=observed_at,
+        expires_at=observed_at + timedelta(hours=24),
+        reason_codes=(),
+    )
 
 
 @pytest.fixture()
@@ -374,6 +390,66 @@ async def test_arms_next_occurrence_with_slot_bound_in_args(automation_scheduler
     finally:
         scheduler._aps.shutdown(wait=False)
         scheduler._aps = None
+
+
+@pytest.mark.asyncio
+async def test_agent_definition_never_arms_during_load_rescan_or_reconcile(
+    automation_scheduler_env,
+    monkeypatch,
+) -> None:
+    user_id = 998
+    definition = _create_definition(
+        user_id,
+        family="agent_task",
+        schedule={"kind": "daily", "at": "23:59"},
+    )
+    scheduler = _AutomationScheduler()
+    scheduler._execution_certification_resolver = _certified_execution
+    scheduler._execution_stack_ready_resolver = lambda: False
+    scheduler._aps = AsyncIOScheduler(timezone="UTC")
+    scheduler._aps.start()
+    monkeypatch.setattr(scheduler, "_enumerate_user_ids", lambda: {user_id})
+    try:
+        await scheduler._load_all()
+        assert scheduler._aps.get_jobs() == []  # nosec B101
+
+        await scheduler._rescan_once()
+        assert scheduler._aps.get_jobs() == []  # nosec B101
+
+        scheduler._started = True
+        await scheduler.reconcile_definition(
+            definition_id=definition.id,
+            user_id=user_id,
+        )
+        assert scheduler._aps.get_jobs() == []  # nosec B101
+    finally:
+        scheduler._aps.shutdown(wait=False)
+        scheduler._aps = None
+
+
+@pytest.mark.asyncio
+async def test_agent_definition_race_refuses_again_at_fire(
+    automation_scheduler_env,
+) -> None:
+    user_id = 999
+    definition = _create_definition(
+        user_id,
+        family="agent_task",
+        schedule={"kind": "cron", "cron": "* * * * *"},
+    )
+    scheduler = _bare_scheduler(user_id)
+    scheduler._execution_certification_resolver = _certified_execution
+    scheduler._execution_stack_ready_resolver = lambda: False
+    created = _capture_jobs(scheduler)
+    slot = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+
+    await scheduler._fire(
+        definition.id,
+        user_id,
+        _normalize_slot_to_utc_iso(slot),
+    )
+
+    assert created == []  # nosec B101
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/tests/Notifications/test_automation_definition_feed.py
+++ b/tldw_Server_API/tests/Notifications/test_automation_definition_feed.py
@@ -428,6 +428,58 @@ async def test_agent_definition_never_arms_during_load_rescan_or_reconcile(
 
 
 @pytest.mark.asyncio
+async def test_reconcile_blocked_agent_removes_job_and_marks_unavailable(
+    automation_scheduler_env,
+) -> None:
+    """A newly blocked Agent must not retain an armed job or ready health."""
+
+    user_id = 996
+    definition = _create_definition(
+        user_id,
+        family="agent_task",
+        schedule={"kind": "daily", "at": "23:59"},
+    )
+    scheduler = _AutomationScheduler(
+        execution_certification_resolver=_certified_execution,
+        execution_stack_ready_resolver=lambda: True,
+    )
+    scheduler._aps = AsyncIOScheduler(timezone="UTC")
+    scheduler._aps.start()
+    scheduler._started = True
+    try:
+        assert scheduler._arm(definition, user_id) is True
+        ready = scheduler._get_db(user_id).get_definition(
+            owner_id=user_id,
+            definition_id=definition.id,
+        )
+        assert ready is not None
+        assert ready.health == ARMED_HEALTH
+        assert scheduler._aps.get_job(f"automation:{definition.id}") is not None
+
+        scheduler._execution_stack_ready_resolver = lambda: False
+        await scheduler.reconcile_definition(
+            definition_id=definition.id,
+            user_id=user_id,
+        )
+
+        blocked = scheduler._get_db(user_id).get_definition(
+            owner_id=user_id,
+            definition_id=definition.id,
+        )
+        assert blocked is not None
+        assert blocked.health == "execution_unavailable"
+        assert scheduler._aps.get_job(f"automation:{definition.id}") is None
+        audits, _total = scheduler._get_db(user_id).list_audit_events(
+            owner_id=user_id,
+            definition_id=definition.id,
+        )
+        assert any(audit.event_type == "scheduler_blocked" for audit in audits)
+    finally:
+        scheduler._aps.shutdown(wait=False)
+        scheduler._aps = None
+
+
+@pytest.mark.asyncio
 async def test_agent_definition_race_refuses_again_at_fire(
     automation_scheduler_env,
 ) -> None:

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
@@ -8,20 +8,51 @@ from typing import Any
 import pytest
 from fastapi import Request
 
-from tldw_Server_API.app.api.v1.endpoints import scheduled_tasks_control_plane
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.endpoints import scheduled_tasks_control_plane
 from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL, TASKS_READ
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import ScheduledTasksDatabase
+from tldw_Server_API.app.core.Scheduled_Tasks.execution_certification import (
+    ExecutionCertification,
+)
 from tldw_Server_API.app.services.scheduled_task_automation_service import (
     ScheduledTaskAutomationError,
+    ScheduledTaskAutomationService,
 )
 from tldw_Server_API.app.services.scheduled_task_recurring_question_service import (
     ScheduledTaskRecurringQuestionService,
 )
 
 RAW_SENTINEL = "RAW_AGENT_SECRET_DO_NOT_LEAK_ENDPOINT_4B"
+CERTIFICATION_NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def _execution_certification(
+    outcome: str = "draft_only",
+) -> ExecutionCertification:
+    return ExecutionCertification(
+        outcome=outcome,
+        deployment_class_id="sha256:" + ("1" * 64),
+        evidence_id="sha256:" + ("2" * 64) if outcome == "certified" else None,
+        evidence_source=(
+            "server_verified"
+            if outcome == "certified"
+            else "repository_characterization"
+        ),
+        observed_at=CERTIFICATION_NOW,
+        expires_at=CERTIFICATION_NOW + timedelta(hours=24),
+        reason_codes=(
+            ()
+            if outcome == "certified"
+            else (
+                ("runtime_not_untrusted_eligible",)
+                if outcome == "unsupported"
+                else ("isolation_attestation_missing",)
+            )
+        ),
+    )
 
 
 class _FakeJobManager:
@@ -83,6 +114,8 @@ def scheduled_tasks_client(client_user_only, tmp_path):
     repo.ensure_schema()
     job_manager = _FakeJobManager()
     service = ScheduledTaskRecurringQuestionService(repository=repo, job_manager=job_manager)
+    service._execution_certification_resolver = _execution_certification
+    service._execution_stack_ready_resolver = lambda: False
     _override_auth(client_user_only)
     client_user_only.app.dependency_overrides[
         scheduled_tasks_control_plane.get_scheduled_task_automation_service
@@ -192,23 +225,46 @@ def test_capabilities_report_definition_and_execution_actions(scheduled_tasks_cl
     body = response.json()
     families = {item["family"]: item for item in body["items"]}
     assert {"recurring_question", "agent_task"} <= set(families)  # nosec B101
-    for family in ("recurring_question", "agent_task"):
-        actions = families[family]["actions"]
-        assert actions["preview"]["status"] == "available"  # nosec B101
-        assert actions["create_definition"]["status"] == "available"  # nosec B101
-        # TASK-13022/13110: execution truth -- recurring_question runs are
-        # executable (phase-1 generation-only); agent_task is planned (its
-        # message is redacted at rest); run_now is available on both.
-        if family == "recurring_question":
-            assert actions["execute"]["status"] == "available"  # nosec B101
-            assert actions["execute"]["reason"] == "phase1_generation_only"  # nosec B101
-        else:
-            assert actions["execute"]["status"] == "planned"  # nosec B101
-            assert "redacted at rest" in actions["execute"]["reason"]  # nosec B101
-        assert actions["run_now"]["status"] == "available"  # nosec B101
-        assert actions["execute_tools"]["status"] == "planned"  # nosec B101
-
     recurring_actions = families["recurring_question"]["actions"]
+    assert recurring_actions["preview"]["status"] == "available"  # nosec B101
+    assert recurring_actions["create_definition"]["status"] == "available"  # nosec B101
+    assert recurring_actions["execute"]["status"] == "available"  # nosec B101
+    assert recurring_actions["execute"]["reason"] == "phase1_generation_only"  # nosec B101
+    assert recurring_actions["run_now"]["status"] == "available"  # nosec B101
+    assert recurring_actions["execute_tools"]["status"] == "planned"  # nosec B101
+
+    agent = families["agent_task"]
+    agent_actions = agent["actions"]
+    assert agent["schema_version"] == "2026-08-24"  # nosec B101
+    assert agent["family_availability"] == "available"  # nosec B101
+    assert agent["execution_certification"] == {  # nosec B101
+        "schema_version": "scheduled_task_execution_certification.v1",
+        "outcome": "draft_only",
+        "deployment_class_id": "sha256:" + ("1" * 64),
+        "evidence_id": None,
+        "evidence_source": "repository_characterization",
+        "observed_at": CERTIFICATION_NOW.isoformat().replace("+00:00", "Z"),
+        "expires_at": (
+            CERTIFICATION_NOW + timedelta(hours=24)
+        ).isoformat().replace("+00:00", "Z"),
+        "reason_codes": ["isolation_attestation_missing"],
+        "recovery_action": (
+            "Complete server-verified Scheduled Agent execution certification "
+            "for this deployment class."
+        ),
+    }
+    for action_name in ("execute", "run_now"):
+        action = agent_actions[action_name]
+        assert action["status"] == "disabled"  # nosec B101
+        assert action["reason"] == "execution_certification_draft_only"  # nosec B101
+        assert action["evidence_source"] == "repository_characterization"  # nosec B101
+        assert action["observed_at"] is not None  # nosec B101
+        assert action["expires_at"] is not None  # nosec B101
+        assert action["recovery_action"]  # nosec B101
+    assert agent_actions["preview"]["status"] == "available"  # nosec B101
+    assert agent_actions["create_definition"]["status"] == "available"  # nosec B101
+    assert agent_actions["execute_tools"]["status"] == "planned"  # nosec B101
+
     for action in (
         "preview",
         "create_definition",
@@ -232,6 +288,69 @@ def test_capabilities_report_definition_and_execution_actions(scheduled_tasks_cl
         "disabled",
     }
     assert "degraded" not in {action["status"] for action in recurring_actions.values()}  # nosec B101
+
+
+def test_default_current_agent_capability_fails_closed(monkeypatch):
+    monkeypatch.delenv("TLDW_BUILD_SHA", raising=False)
+
+    items = {
+        item.family: item
+        for item in ScheduledTaskAutomationService().get_capabilities().items
+    }
+    agent = items["agent_task"]
+
+    assert agent.execution_certification is not None  # nosec B101
+    assert agent.execution_certification.outcome in {  # nosec B101
+        "draft_only",
+        "unsupported",
+    }
+    assert agent.actions["execute"].status == "disabled"  # nosec B101
+    assert agent.actions["run_now"].status == "disabled"  # nosec B101
+    assert agent.actions["execute"].recovery_action  # nosec B101
+    assert agent.actions["execute"].observed_at is not None  # nosec B101
+
+
+def test_certification_alone_does_not_advertise_agent_execution():
+    service = ScheduledTaskAutomationService(
+        execution_certification_resolver=lambda: _execution_certification(
+            "certified"
+        ),
+        execution_stack_ready_resolver=lambda: False,
+    )
+
+    agent = {
+        item.family: item for item in service.get_capabilities().items
+    }["agent_task"]
+
+    assert agent.execution_certification is not None  # nosec B101
+    assert agent.execution_certification.outcome == "certified"  # nosec B101
+    assert agent.actions["execute"].status == "disabled"  # nosec B101
+    assert agent.actions["run_now"].status == "disabled"  # nosec B101
+    assert agent.actions["execute"].reason == "agent_execution_stack_unimplemented"  # nosec B101
+    assert agent.actions["run_now"].reason == "agent_execution_stack_unimplemented"  # nosec B101
+
+
+def test_openapi_exposes_execution_certification_without_new_execution_route(
+    scheduled_tasks_client,
+):
+    scheduled_tasks_client.app.openapi_schema = None
+    response = scheduled_tasks_client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text  # nosec B101
+    document = response.json()
+    schemas = document["components"]["schemas"]
+    capability = schemas["ScheduledTaskAutomationCapability"]["properties"]
+    assert "execution_certification" in capability  # nosec B101
+    assert "ScheduledTaskExecutionCertificationCapability" in json.dumps(  # nosec B101
+        capability["execution_certification"]
+    )
+    assert (  # nosec B101
+        "/api/v1/scheduled-tasks/capabilities" in document["paths"]
+    )
+    assert (  # nosec B101
+        "/api/v1/scheduled-tasks/definitions/{definition_id}/execute"
+        not in document["paths"]
+    )
 
 
 def test_preview_create_list_and_detail_return_valid_and_invalid_statuses(scheduled_tasks_client, auth_headers):
@@ -895,6 +1014,158 @@ def test_run_now_triggers_real_dispatch_and_returns_run_reference(
         f"definition:{definition['id']}:{body['run_slot_utc']}"
     )  # nosec B101
     assert created[0]["payload"]["manual"] is True  # nosec B101
+
+
+@pytest.mark.integration
+def test_agent_run_now_refuses_before_job_or_audit(
+    scheduled_tasks_client, auth_headers, monkeypatch
+):
+    definition = _create_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Blocked agent run",
+    )
+    repo = scheduled_tasks_client.scheduled_task_automation_repo
+    before_audits, before_total = repo.list_audit_events(
+        owner_id=880,
+        definition_id=definition["id"],
+    )
+    assert before_audits  # nosec B101
+
+    def _fail_if_called(_self=None, **_kwargs):
+        raise AssertionError("Agent Run Now must not enqueue")
+
+    from tldw_Server_API.app.core.Jobs import manager as jobs_manager_module
+
+    monkeypatch.setattr(
+        jobs_manager_module.JobManager,
+        "create_job",
+        _fail_if_called,
+    )
+    response = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/run",
+        headers=auth_headers,
+    )
+
+    _assert_error_envelope(
+        response,
+        code="scheduled_task_agent_execution_unavailable",
+        status_code=409,
+    )
+    detail = response.json()["detail"]
+    assert detail["details"]["reason"] == "execution_certification_draft_only"  # nosec B101
+    assert detail["details"]["recovery_action"]  # nosec B101
+    _after_audits, after_total = repo.list_audit_events(
+        owner_id=880,
+        definition_id=definition["id"],
+    )
+    assert after_total == before_total  # nosec B101
+
+
+@pytest.mark.integration
+def test_unsupported_agent_creation_and_duplicate_refuse_without_persistence(
+    scheduled_tasks_client,
+    auth_headers,
+):
+    source = _create_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Existing unsupported agent",
+    )
+    pending_preview = _create_preview(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Pending unsupported agent",
+    )
+    service = scheduled_tasks_client.scheduled_task_automation_service
+    service._execution_certification_resolver = lambda: _execution_certification(
+        "unsupported"
+    )
+    capabilities = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/capabilities",
+        headers=auth_headers,
+    ).json()
+    agent_capability = {
+        item["family"]: item for item in capabilities["items"]
+    }["agent_task"]
+    assert agent_capability["family_availability"] == "unavailable"  # nosec B101
+    assert agent_capability["execution_certification"]["outcome"] == "unsupported"  # nosec B101
+    for action_name in ("preview", "create_definition", "duplicate"):
+        assert agent_capability["actions"][action_name]["status"] == "unavailable"  # nosec B101
+    for action_name in ("execute", "run_now"):
+        assert agent_capability["actions"][action_name]["status"] == "disabled"  # nosec B101
+    before_definitions = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/definitions?family=agent_task",
+        headers=auth_headers,
+    ).json()["total"]
+    before_previews = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/previews?family=agent_task",
+        headers=auth_headers,
+    ).json()["total"]
+
+    preview_response = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/previews",
+        headers=auth_headers,
+        json=_payload(family="agent_task", name="Must not persist"),
+    )
+    create_response = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=auth_headers,
+        json={"preview_id": pending_preview["id"]},
+    )
+    duplicate_response = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{source['id']}/duplicate",
+        headers=auth_headers,
+        json={"name": "Must not duplicate"},
+    )
+
+    for response in (preview_response, create_response, duplicate_response):
+        _assert_error_envelope(
+            response,
+            code="scheduled_task_agent_automation_unsupported",
+            status_code=409,
+        )
+        details = response.json()["detail"]["details"]
+        assert details["reason"] == "execution_certification_unsupported"  # nosec B101
+        assert details["recovery_action"]  # nosec B101
+
+    listed = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/definitions?family=agent_task",
+        headers=auth_headers,
+    )
+    detail = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{source['id']}",
+        headers=auth_headers,
+    )
+    paused = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{source['id']}/pause",
+        headers=auth_headers,
+    )
+    archived = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{source['id']}/archive",
+        headers=auth_headers,
+    )
+
+    assert listed.status_code == 200, listed.text  # nosec B101
+    assert listed.json()["total"] == before_definitions  # nosec B101
+    assert detail.status_code == 200, detail.text  # nosec B101
+    assert paused.status_code == 200, paused.text  # nosec B101
+    assert archived.status_code == 200, archived.text  # nosec B101
+    preview_detail = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/previews/{pending_preview['id']}",
+        headers=auth_headers,
+    )
+    assert preview_detail.status_code == 200, preview_detail.text  # nosec B101
+    assert preview_detail.json()["status"] == "valid"  # nosec B101
+    after_previews = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/previews?family=agent_task",
+        headers=auth_headers,
+    )
+    assert after_previews.status_code == 200, after_previews.text  # nosec B101
+    assert after_previews.json()["total"] == before_previews  # nosec B101
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
@@ -207,6 +207,28 @@ def _assert_error_envelope(response, *, code: str, status_code: int) -> None:
     assert "correlation_id" in detail  # nosec B101
 
 
+def _set_unsupported_agent_certification(client: Any) -> None:
+    """Switch the injected certification resolver to an unsupported deployment."""
+
+    service = client.scheduled_task_automation_service
+    service._execution_certification_resolver = lambda: _execution_certification(
+        "unsupported"
+    )
+
+
+def _assert_unsupported_agent_refusal(response: Any) -> None:
+    """Assert the stable API contract for unsupported Agent authoring."""
+
+    _assert_error_envelope(
+        response,
+        code="scheduled_task_agent_automation_unsupported",
+        status_code=409,
+    )
+    details = response.json()["detail"]["details"]
+    assert details["reason"] == "execution_certification_unsupported"  # nosec B101
+    assert details["recovery_action"]  # nosec B101
+
+
 def test_scheduled_task_static_child_routes_do_not_resolve_as_task_ids(scheduled_tasks_client, auth_headers):
     for path in (
         "/api/v1/scheduled-tasks/capabilities",
@@ -1064,26 +1086,14 @@ def test_agent_run_now_refuses_before_job_or_audit(
 
 
 @pytest.mark.integration
-def test_unsupported_agent_creation_and_duplicate_refuse_without_persistence(
+def test_unsupported_agent_capabilities_explain_disabled_authoring(
     scheduled_tasks_client,
     auth_headers,
-):
-    source = _create_definition(
-        scheduled_tasks_client,
-        auth_headers,
-        family="agent_task",
-        name="Existing unsupported agent",
-    )
-    pending_preview = _create_preview(
-        scheduled_tasks_client,
-        auth_headers,
-        family="agent_task",
-        name="Pending unsupported agent",
-    )
-    service = scheduled_tasks_client.scheduled_task_automation_service
-    service._execution_certification_resolver = lambda: _execution_certification(
-        "unsupported"
-    )
+) -> None:
+    """Capabilities must distinguish unavailable authoring from execution."""
+
+    _set_unsupported_agent_certification(scheduled_tasks_client)
+
     capabilities = scheduled_tasks_client.get(
         "/api/v1/scheduled-tasks/capabilities",
         headers=auth_headers,
@@ -1092,11 +1102,52 @@ def test_unsupported_agent_creation_and_duplicate_refuse_without_persistence(
         item["family"]: item for item in capabilities["items"]
     }["agent_task"]
     assert agent_capability["family_availability"] == "unavailable"  # nosec B101
+    assert agent_capability["reason"] == "execution_certification_unsupported"  # nosec B101
     assert agent_capability["execution_certification"]["outcome"] == "unsupported"  # nosec B101
     for action_name in ("preview", "create_definition", "duplicate"):
         assert agent_capability["actions"][action_name]["status"] == "unavailable"  # nosec B101
     for action_name in ("execute", "run_now"):
         assert agent_capability["actions"][action_name]["status"] == "disabled"  # nosec B101
+
+
+@pytest.mark.integration
+def test_malformed_agent_certification_capabilities_fail_closed(
+    scheduled_tasks_client,
+    auth_headers,
+) -> None:
+    """Capability discovery must normalize an invalid internal outcome."""
+
+    service = scheduled_tasks_client.scheduled_task_automation_service
+    service._execution_certification_resolver = lambda: _execution_certification(
+        "unexpected_state"
+    )
+
+    response = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/capabilities",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text  # nosec B101
+    agent_capability = {
+        item["family"]: item for item in response.json()["items"]
+    }["agent_task"]
+    assert agent_capability["family_availability"] == "unavailable"  # nosec B101
+    assert agent_capability["reason"] == "execution_certification_unsupported"  # nosec B101
+    assert agent_capability["execution_certification"]["outcome"] == "unsupported"  # nosec B101
+    assert agent_capability["actions"]["preview"]["status"] == "unavailable"  # nosec B101
+    assert agent_capability["actions"]["preview"]["reason"] == (  # nosec B101
+        "execution_certification_unsupported"
+    )
+
+
+@pytest.mark.integration
+def test_unsupported_agent_preview_refuses_without_persistence(
+    scheduled_tasks_client,
+    auth_headers,
+) -> None:
+    """Unsupported deployments must not persist new Agent previews."""
+
+    _set_unsupported_agent_certification(scheduled_tasks_client)
     before_definitions = scheduled_tasks_client.get(
         "/api/v1/scheduled-tasks/definitions?family=agent_task",
         headers=auth_headers,
@@ -1111,26 +1162,107 @@ def test_unsupported_agent_creation_and_duplicate_refuse_without_persistence(
         headers=auth_headers,
         json=_payload(family="agent_task", name="Must not persist"),
     )
+
+    _assert_unsupported_agent_refusal(preview_response)
+    after_previews = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/previews?family=agent_task",
+        headers=auth_headers,
+    )
+    after_definitions = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/definitions?family=agent_task",
+        headers=auth_headers,
+    )
+    assert after_previews.status_code == 200, after_previews.text  # nosec B101
+    assert after_previews.json()["total"] == before_previews  # nosec B101
+    assert after_definitions.json()["total"] == before_definitions  # nosec B101
+
+
+@pytest.mark.integration
+def test_unsupported_agent_create_refuses_stale_valid_preview(
+    scheduled_tasks_client,
+    auth_headers,
+) -> None:
+    """A previously valid preview must not bypass current authoring admission."""
+
+    pending_preview = _create_preview(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Pending unsupported agent",
+    )
+    before_definitions = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/definitions?family=agent_task",
+        headers=auth_headers,
+    ).json()["total"]
+    _set_unsupported_agent_certification(scheduled_tasks_client)
+
     create_response = scheduled_tasks_client.post(
         "/api/v1/scheduled-tasks/definitions",
         headers=auth_headers,
         json={"preview_id": pending_preview["id"]},
     )
+
+    _assert_unsupported_agent_refusal(create_response)
+    preview_detail = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/previews/{pending_preview['id']}",
+        headers=auth_headers,
+    )
+    after_definitions = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/definitions?family=agent_task",
+        headers=auth_headers,
+    )
+    assert preview_detail.status_code == 200, preview_detail.text  # nosec B101
+    assert preview_detail.json()["status"] == "valid"  # nosec B101
+    assert after_definitions.json()["total"] == before_definitions  # nosec B101
+
+
+@pytest.mark.integration
+def test_unsupported_agent_duplicate_refuses_without_persistence(
+    scheduled_tasks_client,
+    auth_headers,
+) -> None:
+    """Duplicating an existing Agent must respect current authoring admission."""
+
+    source = _create_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Existing unsupported agent",
+    )
+    before_definitions = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/definitions?family=agent_task",
+        headers=auth_headers,
+    ).json()["total"]
+    _set_unsupported_agent_certification(scheduled_tasks_client)
+
     duplicate_response = scheduled_tasks_client.post(
         f"/api/v1/scheduled-tasks/definitions/{source['id']}/duplicate",
         headers=auth_headers,
         json={"name": "Must not duplicate"},
     )
 
-    for response in (preview_response, create_response, duplicate_response):
-        _assert_error_envelope(
-            response,
-            code="scheduled_task_agent_automation_unsupported",
-            status_code=409,
-        )
-        details = response.json()["detail"]["details"]
-        assert details["reason"] == "execution_certification_unsupported"  # nosec B101
-        assert details["recovery_action"]  # nosec B101
+    _assert_unsupported_agent_refusal(duplicate_response)
+    after_definitions = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/definitions?family=agent_task",
+        headers=auth_headers,
+    )
+    assert after_definitions.json()["total"] == before_definitions  # nosec B101
+
+
+@pytest.mark.integration
+def test_unsupported_agent_definition_reads_remain_available(
+    scheduled_tasks_client,
+    auth_headers,
+) -> None:
+    """Unsupported execution must not hide existing Agent definitions."""
+
+    source = _create_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Existing unsupported agent",
+    )
+    _set_unsupported_agent_certification(scheduled_tasks_client)
 
     listed = scheduled_tasks_client.get(
         "/api/v1/scheduled-tasks/definitions?family=agent_task",
@@ -1140,32 +1272,101 @@ def test_unsupported_agent_creation_and_duplicate_refuse_without_persistence(
         f"/api/v1/scheduled-tasks/definitions/{source['id']}",
         headers=auth_headers,
     )
+    assert listed.status_code == 200, listed.text  # nosec B101
+    assert listed.json()["total"] == 1  # nosec B101
+    assert detail.status_code == 200, detail.text  # nosec B101
+
+
+@pytest.mark.integration
+def test_unsupported_agent_definition_can_be_paused(
+    scheduled_tasks_client,
+    auth_headers,
+) -> None:
+    """Unsupported execution must still allow the safe pause action."""
+
+    source = _create_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Agent to pause",
+    )
+    _set_unsupported_agent_certification(scheduled_tasks_client)
+
     paused = scheduled_tasks_client.post(
         f"/api/v1/scheduled-tasks/definitions/{source['id']}/pause",
         headers=auth_headers,
     )
+
+    assert paused.status_code == 200, paused.text  # nosec B101
+
+
+@pytest.mark.integration
+def test_unsupported_agent_definition_can_be_archived(
+    scheduled_tasks_client,
+    auth_headers,
+) -> None:
+    """Unsupported execution must still allow the safe archive action."""
+
+    source = _create_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Agent to archive",
+    )
+    _set_unsupported_agent_certification(scheduled_tasks_client)
+
     archived = scheduled_tasks_client.post(
         f"/api/v1/scheduled-tasks/definitions/{source['id']}/archive",
         headers=auth_headers,
     )
 
-    assert listed.status_code == 200, listed.text  # nosec B101
-    assert listed.json()["total"] == before_definitions  # nosec B101
-    assert detail.status_code == 200, detail.text  # nosec B101
-    assert paused.status_code == 200, paused.text  # nosec B101
     assert archived.status_code == 200, archived.text  # nosec B101
-    preview_detail = scheduled_tasks_client.get(
-        f"/api/v1/scheduled-tasks/previews/{pending_preview['id']}",
-        headers=auth_headers,
+
+
+@pytest.mark.integration
+def test_unsupported_agent_update_refuses_stale_valid_preview(
+    scheduled_tasks_client,
+    auth_headers,
+) -> None:
+    """A preview minted before support changes must not bypass update admission."""
+
+    definition = _create_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Existing agent to update",
     )
-    assert preview_detail.status_code == 200, preview_detail.text  # nosec B101
-    assert preview_detail.json()["status"] == "valid"  # nosec B101
-    after_previews = scheduled_tasks_client.get(
-        "/api/v1/scheduled-tasks/previews?family=agent_task",
-        headers=auth_headers,
+    update_preview = _create_preview(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        mode="update",
+        definition_id=definition["id"],
+        definition_version=definition["version"],
+        name="Blocked update",
     )
-    assert after_previews.status_code == 200, after_previews.text  # nosec B101
-    assert after_previews.json()["total"] == before_previews  # nosec B101
+    service = scheduled_tasks_client.scheduled_task_automation_service
+    service._execution_certification_resolver = lambda: _execution_certification(
+        "unsupported"
+    )
+
+    response = scheduled_tasks_client.patch(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}",
+        headers=auth_headers,
+        json={"preview_id": update_preview["id"]},
+    )
+
+    _assert_unsupported_agent_refusal(response)
+    unchanged = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}",
+        headers=auth_headers,
+    ).json()
+    assert unchanged["name"] == definition["name"]
+    preview = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/previews/{update_preview['id']}",
+        headers=auth_headers,
+    ).json()
+    assert preview["status"] == "valid"
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_execution_certification.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_execution_certification.py
@@ -1,0 +1,467 @@
+"""Fail-closed Scheduled Tasks Agent execution certification tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tldw_Server_API.app.core.Scheduled_Tasks import execution_certification as cert
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime(2026, 8, 26, 19, 30, tzinfo=timezone.utc)
+BUILD_SHA = "a" * 40
+REQUIREMENT_IDS = (
+    "isolation_attestation",
+    "hostile_boundary",
+    "scheduled_transcript_non_disclosure",
+    "adapter_dispatch_recovery",
+    "monotonic_execution_evidence",
+    "brokered_credentials_and_mediation",
+    "operational_fail_closed",
+)
+
+
+def _profile() -> cert.IsolationProfile:
+    return cert.IsolationProfile(
+        runtime_image_digest="sha256:" + "1" * 64,
+        mount_policy_hash="sha256:" + "2" * 64,
+        egress_policy_hash="sha256:" + "3" * 64,
+        credential_policy_hash="sha256:" + "4" * 64,
+        tenant_boundary_policy_hash="sha256:" + "5" * 64,
+        mediation_policy_hash="sha256:" + "6" * 64,
+        isolation_profile_version="phase4d0f-v1",
+    )
+
+
+def _deployment(**changes: object) -> cert.DeploymentClass:
+    values: dict[str, object] = {
+        "host_os_family": "darwin",
+        "host_architecture": "arm64",
+        "auth_mode": "single_user",
+        "sandbox_runtime": "docker",
+        "adapter_id": "acp",
+        "adapter_version": "1",
+        "server_build_sha": BUILD_SHA,
+        "isolation_profile": _profile(),
+    }
+    values.update(changes)
+    return cert.DeploymentClass(**values)
+
+
+def _evidence(
+    subject: cert.DeploymentClass,
+    *,
+    verification: cert.EvidenceVerification = "server_verified",
+    state: cert.EvidenceState = "passed",
+) -> tuple[cert.RequirementEvidence, ...]:
+    return tuple(
+        cert.RequirementEvidence(
+            requirement_id=requirement_id,
+            state=state,
+            verification=verification,
+            subject_id=subject.deployment_class_id,
+            observed_at=NOW - timedelta(minutes=5),
+            valid_until=NOW + timedelta(hours=1),
+            evidence_sha256="sha256:" + f"{index:x}" * 64,
+        )
+        for index, requirement_id in enumerate(REQUIREMENT_IDS, start=1)
+    )
+
+
+def _authoritative_receipt(
+    subject: cert.DeploymentClass,
+    evidence: tuple[cert.RequirementEvidence, ...],
+    *,
+    valid_until: datetime | None = None,
+    bundle_digest: str | None = None,
+) -> cert._AuthoritativeBundleReceipt:
+    """Construct the otherwise unavailable verifier receipt for pure rule tests."""
+
+    return cert._AuthoritativeBundleReceipt(
+        deployment_class_id=subject.deployment_class_id,
+        evidence_id="sha256:" + "e" * 64,
+        bundle_digest=bundle_digest or cert.canonical_evidence_bundle_digest(evidence),
+        observed_at=NOW - timedelta(minutes=1),
+        valid_until=valid_until or NOW + timedelta(minutes=30),
+        _authority=cert._SERVER_VERIFIER_AUTHORITY,
+    )
+
+
+def _evaluate(
+    subject: cert.DeploymentClass,
+    evidence: tuple[cert.RequirementEvidence, ...],
+    receipt: cert._AuthoritativeBundleReceipt | None,
+    *,
+    untrusted_eligible: bool = True,
+    strict_deny_all: bool = True,
+) -> cert.ExecutionCertification:
+    return cert.evaluate_execution_certification(
+        subject,
+        evidence,
+        receipt,
+        runtime_eligibility=cert.RuntimeEligibility(
+            untrusted_eligible=untrusted_eligible,
+            strict_deny_all=strict_deny_all,
+        ),
+        now=NOW,
+    )
+
+
+def test_deployment_identity_is_canonical_and_opaque() -> None:
+    """A field-order change must not alter an exact deployment-class identity."""
+
+    deployment = _deployment()
+    payload = deployment.canonical_payload()
+    expected = "sha256:" + hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("ascii")
+    ).hexdigest()
+
+    assert list(payload) == sorted(payload)
+    assert deployment.deployment_class_id == expected
+    assert len(deployment.deployment_class_id) == 71
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("host_os_family", "linux"),
+        ("host_architecture", "x86_64"),
+        ("auth_mode", "multi_user"),
+        ("sandbox_runtime", "lima"),
+        ("adapter_id", "acp-v2"),
+        ("adapter_version", "2"),
+        ("server_build_sha", "b" * 40),
+        (
+            "isolation_profile",
+            replace(_profile(), egress_policy_hash="sha256:" + "7" * 64),
+        ),
+    ],
+)
+def test_every_deployment_identity_field_changes_the_digest(
+    field: str,
+    replacement: object,
+) -> None:
+    """Changing any exact subject binding must invalidate its evidence identity."""
+
+    baseline = _deployment()
+    changed = replace(baseline, **{field: replacement})
+
+    assert changed.deployment_class_id != baseline.deployment_class_id
+
+
+def test_all_exact_server_verified_requirements_can_certify() -> None:
+    """The closed outcome remains reachable only behind an authoritative receipt."""
+
+    subject = _deployment()
+    evidence = _evidence(subject)
+
+    result = _evaluate(subject, evidence, _authoritative_receipt(subject, evidence))
+
+    assert result.outcome == "certified"
+    assert result.evidence_id == "sha256:" + "e" * 64
+    assert result.evidence_source == "server_verified"
+    assert result.reason_codes == ()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_reason"),
+    [
+        ("missing", "operational_fail_closed_missing"),
+        ("stale_state", "operational_fail_closed_stale"),
+        ("expired", "operational_fail_closed_stale"),
+        ("wrong_subject", "operational_fail_closed_subject_mismatch"),
+        ("self_asserted", "operational_fail_closed_unverified"),
+        ("host_gated_unverified", "operational_fail_closed_unverified"),
+        ("mock", "operational_fail_closed_unverified"),
+        ("no_validity", "operational_fail_closed_stale"),
+        ("no_digest", "operational_fail_closed_unverified"),
+    ],
+)
+def test_one_untrusted_or_incomplete_requirement_stays_draft_only(
+    mutation: str,
+    expected_reason: str,
+) -> None:
+    """One bad domain must prevent a partial bundle from becoming certified."""
+
+    subject = _deployment()
+    evidence = list(_evidence(subject))
+    target = evidence[-1]
+    if mutation == "missing":
+        target = replace(target, state="missing")
+    elif mutation == "stale_state":
+        target = replace(target, state="stale")
+    elif mutation == "expired":
+        target = replace(target, valid_until=NOW - timedelta(seconds=1))
+    elif mutation == "wrong_subject":
+        target = replace(target, subject_id="sha256:" + "f" * 64)
+    elif mutation in {"self_asserted", "host_gated_unverified", "mock"}:
+        target = replace(target, verification=mutation)
+    elif mutation == "no_validity":
+        target = replace(target, valid_until=None)
+    elif mutation == "no_digest":
+        target = replace(target, evidence_sha256=None)
+    evidence[-1] = target
+    evidence_tuple = tuple(evidence)
+
+    result = _evaluate(
+        subject,
+        evidence_tuple,
+        _authoritative_receipt(subject, evidence_tuple),
+    )
+
+    assert result.outcome == "draft_only"
+    assert expected_reason in result.reason_codes
+    assert result.evidence_source != "server_verified"
+
+
+def test_receipt_is_required_and_must_match_the_exact_bundle() -> None:
+    """Self-labeled records or a receipt for other bytes must never certify."""
+
+    subject = _deployment()
+    evidence = _evidence(subject)
+
+    without_receipt = _evaluate(subject, evidence, None)
+    mismatched_receipt = _evaluate(
+        subject,
+        evidence,
+        _authoritative_receipt(
+            subject,
+            evidence,
+            bundle_digest="sha256:" + "0" * 64,
+        ),
+    )
+
+    assert without_receipt.outcome == "draft_only"
+    assert "authoritative_receipt_missing" in without_receipt.reason_codes
+    assert mismatched_receipt.outcome == "draft_only"
+    assert "authoritative_receipt_mismatch" in mismatched_receipt.reason_codes
+
+
+def test_expired_receipt_cannot_certify_fresh_records() -> None:
+    """Bundle authority must expire even when every domain record is still fresh."""
+
+    subject = _deployment()
+    evidence = _evidence(subject)
+
+    result = _evaluate(
+        subject,
+        evidence,
+        _authoritative_receipt(
+            subject,
+            evidence,
+            valid_until=NOW - timedelta(seconds=1),
+        ),
+    )
+
+    assert result.outcome == "draft_only"
+    assert "authoritative_receipt_stale" in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    ("untrusted_eligible", "strict_deny_all", "expected_reason"),
+    [
+        (False, True, "runtime_not_untrusted_eligible"),
+        (True, False, "runtime_strict_deny_all_unavailable"),
+    ],
+)
+def test_static_runtime_ineligibility_is_unsupported(
+    untrusted_eligible: bool,
+    strict_deny_all: bool,
+    expected_reason: str,
+) -> None:
+    """Host-local or weak-network runtimes must not be described as draft-ready."""
+
+    subject = _deployment()
+    evidence = _evidence(subject)
+
+    result = _evaluate(
+        subject,
+        evidence,
+        _authoritative_receipt(subject, evidence),
+        untrusted_eligible=untrusted_eligible,
+        strict_deny_all=strict_deny_all,
+    )
+
+    assert result.outcome == "unsupported"
+    assert expected_reason in result.reason_codes
+
+
+def test_boundary_breach_is_unsupported_but_missing_feature_is_not() -> None:
+    """A demonstrated escape and an absent dependency must remain distinguishable."""
+
+    subject = _deployment()
+    evidence = list(_evidence(subject))
+    evidence[1] = replace(
+        evidence[1],
+        state="failed",
+        safety_boundary_breached=True,
+    )
+    breached = tuple(evidence)
+    missing = tuple(
+        replace(item, state="missing")
+        if item.requirement_id == "scheduled_transcript_non_disclosure"
+        else item
+        for item in _evidence(subject)
+    )
+
+    breached_result = _evaluate(
+        subject,
+        breached,
+        _authoritative_receipt(subject, breached),
+    )
+    missing_result = _evaluate(
+        subject,
+        missing,
+        _authoritative_receipt(subject, missing),
+    )
+
+    assert breached_result.outcome == "unsupported"
+    assert "safety_boundary_breached" in breached_result.reason_codes
+    assert missing_result.outcome == "draft_only"
+    assert "safety_boundary_breached" not in missing_result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "invalid_ids",
+    [
+        ("unknown_requirement",),
+        ("isolation_attestation", "isolation_attestation"),
+    ],
+)
+def test_unknown_or_duplicate_requirements_are_rejected(
+    invalid_ids: tuple[str, ...],
+) -> None:
+    """Malformed requirement sets must fail instead of being silently ignored."""
+
+    subject = _deployment()
+    evidence = list(_evidence(subject))
+    for index, requirement_id in enumerate(invalid_ids):
+        evidence[index] = replace(evidence[index], requirement_id=requirement_id)
+
+    with pytest.raises(ValueError, match="requirement"):
+        _evaluate(subject, tuple(evidence), None)
+
+
+def test_reason_codes_are_closed_sorted_and_bounded() -> None:
+    """Evidence-controlled text must never leak into public diagnostic reasons."""
+
+    subject = _deployment()
+    evidence = tuple(
+        replace(
+            item,
+            state="missing",
+            verification="self_asserted",
+            subject_id="attacker-controlled free text",
+            valid_until=None,
+            evidence_sha256=None,
+        )
+        for item in _evidence(subject)
+    )
+
+    result = _evaluate(subject, evidence, None)
+
+    assert result.reason_codes == tuple(sorted(set(result.reason_codes)))
+    assert len(result.reason_codes) <= cert.MAX_REASON_CODES
+    assert all(reason in cert.CERTIFICATION_REASON_CODES for reason in result.reason_codes)
+    assert "attacker-controlled free text" not in " ".join(result.reason_codes)
+
+
+def test_certification_is_not_sufficient_for_dispatch() -> None:
+    """A certified fixture must remain blocked until the execution stack exists."""
+
+    subject = _deployment()
+    evidence = _evidence(subject)
+    certification = _evaluate(
+        subject,
+        evidence,
+        _authoritative_receipt(subject, evidence),
+    )
+
+    blocked = cert.agent_execution_dispatch_readiness(
+        certification,
+        execution_stack_ready=False,
+    )
+    ready = cert.agent_execution_dispatch_readiness(
+        certification,
+        execution_stack_ready=True,
+    )
+
+    assert blocked.ready is False
+    assert blocked.reason == "agent_execution_stack_unimplemented"
+    assert ready.ready is True
+    assert ready.reason is None
+
+
+def test_current_resolver_cannot_certify_repository_characterization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Current local metadata must remain a draft even with a verified build SHA."""
+
+    monkeypatch.setenv("TLDW_BUILD_SHA", BUILD_SHA.upper())
+
+    result = cert.resolve_current_agent_execution_certification(
+        now=NOW,
+        host_os_family="darwin",
+        host_architecture="arm64",
+        auth_mode="single_user",
+        sandbox_runtime="docker",
+        adapter_id="acp",
+        adapter_version="1",
+        isolation_profile=_profile(),
+    )
+
+    assert result.outcome == "draft_only"
+    assert result.evidence_id is None
+    assert result.evidence_source == "repository_characterization"
+    assert "authoritative_receipt_missing" in result.reason_codes
+
+
+def test_current_resolver_fails_closed_on_unverified_build_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing or malformed configured build SHA must never become an identity claim."""
+
+    monkeypatch.setenv("TLDW_BUILD_SHA", "not-a-commit")
+
+    result = cert.resolve_current_agent_execution_certification(
+        now=NOW,
+        host_os_family="darwin",
+        host_architecture="arm64",
+        auth_mode="single_user",
+        sandbox_runtime="docker",
+        adapter_id="acp",
+        adapter_version="1",
+        isolation_profile=_profile(),
+    )
+
+    assert result.outcome == "draft_only"
+    assert "server_build_identity_unverified" in result.reason_codes
+
+
+def test_current_ineligible_runtime_is_unsupported() -> None:
+    """The production resolver must project host-local worktrees as unsupported."""
+
+    result = cert.resolve_current_agent_execution_certification(
+        now=NOW,
+        host_os_family="darwin",
+        host_architecture="arm64",
+        auth_mode="single_user",
+        sandbox_runtime="worktree",
+        adapter_id="acp",
+        adapter_version="1",
+        isolation_profile=_profile(),
+    )
+
+    assert result.outcome == "unsupported"
+    assert "runtime_not_untrusted_eligible" in result.reason_codes
+    assert "runtime_strict_deny_all_unavailable" in result.reason_codes

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_execution_certification.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_execution_certification.py
@@ -6,10 +6,14 @@ import hashlib
 import json
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
+from typing import Any, cast
 
 import pytest
 
 from tldw_Server_API.app.core.Scheduled_Tasks import execution_certification as cert
+from tldw_Server_API.tests.Notifications._scheduled_agent_execution_certification_fixtures import (
+    issue_test_authoritative_receipt,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -27,6 +31,8 @@ REQUIREMENT_IDS = (
 
 
 def _profile() -> cert.IsolationProfile:
+    """Return a complete immutable isolation-profile fixture."""
+
     return cert.IsolationProfile(
         runtime_image_digest="sha256:" + "1" * 64,
         mount_policy_hash="sha256:" + "2" * 64,
@@ -39,6 +45,8 @@ def _profile() -> cert.IsolationProfile:
 
 
 def _deployment(**changes: object) -> cert.DeploymentClass:
+    """Return a deployment fixture with optional identity-field overrides."""
+
     values: dict[str, object] = {
         "host_os_family": "darwin",
         "host_architecture": "arm64",
@@ -59,6 +67,8 @@ def _evidence(
     verification: cert.EvidenceVerification = "server_verified",
     state: cert.EvidenceState = "passed",
 ) -> tuple[cert.RequirementEvidence, ...]:
+    """Return one evidence record for every closed certification domain."""
+
     return tuple(
         cert.RequirementEvidence(
             requirement_id=requirement_id,
@@ -73,33 +83,35 @@ def _evidence(
     )
 
 
-def _authoritative_receipt(
+def _receipt(
     subject: cert.DeploymentClass,
     evidence: tuple[cert.RequirementEvidence, ...],
     *,
     valid_until: datetime | None = None,
     bundle_digest: str | None = None,
-) -> cert._AuthoritativeBundleReceipt:
-    """Construct the otherwise unavailable verifier receipt for pure rule tests."""
+) -> Any:
+    """Request an authoritative receipt from the test-only fixture boundary."""
 
-    return cert._AuthoritativeBundleReceipt(
-        deployment_class_id=subject.deployment_class_id,
-        evidence_id="sha256:" + "e" * 64,
-        bundle_digest=bundle_digest or cert.canonical_evidence_bundle_digest(evidence),
+    return issue_test_authoritative_receipt(
+        subject,
+        evidence,
         observed_at=NOW - timedelta(minutes=1),
         valid_until=valid_until or NOW + timedelta(minutes=30),
-        _authority=cert._SERVER_VERIFIER_AUTHORITY,
+        evidence_id="sha256:" + "e" * 64,
+        bundle_digest=bundle_digest,
     )
 
 
 def _evaluate(
     subject: cert.DeploymentClass,
     evidence: tuple[cert.RequirementEvidence, ...],
-    receipt: cert._AuthoritativeBundleReceipt | None,
+    receipt: Any | None,
     *,
     untrusted_eligible: bool = True,
     strict_deny_all: bool = True,
 ) -> cert.ExecutionCertification:
+    """Evaluate a fixture bundle with explicit runtime eligibility."""
+
     return cert.evaluate_execution_certification(
         subject,
         evidence,
@@ -165,7 +177,7 @@ def test_all_exact_server_verified_requirements_can_certify() -> None:
     subject = _deployment()
     evidence = _evidence(subject)
 
-    result = _evaluate(subject, evidence, _authoritative_receipt(subject, evidence))
+    result = _evaluate(subject, evidence, _receipt(subject, evidence))
 
     assert result.outcome == "certified"
     assert result.evidence_id == "sha256:" + "e" * 64
@@ -216,7 +228,7 @@ def test_one_untrusted_or_incomplete_requirement_stays_draft_only(
     result = _evaluate(
         subject,
         evidence_tuple,
-        _authoritative_receipt(subject, evidence_tuple),
+        _receipt(subject, evidence_tuple),
     )
 
     assert result.outcome == "draft_only"
@@ -234,7 +246,7 @@ def test_receipt_is_required_and_must_match_the_exact_bundle() -> None:
     mismatched_receipt = _evaluate(
         subject,
         evidence,
-        _authoritative_receipt(
+        _receipt(
             subject,
             evidence,
             bundle_digest="sha256:" + "0" * 64,
@@ -256,7 +268,7 @@ def test_expired_receipt_cannot_certify_fresh_records() -> None:
     result = _evaluate(
         subject,
         evidence,
-        _authoritative_receipt(
+        _receipt(
             subject,
             evidence,
             valid_until=NOW - timedelta(seconds=1),
@@ -287,7 +299,7 @@ def test_static_runtime_ineligibility_is_unsupported(
     result = _evaluate(
         subject,
         evidence,
-        _authoritative_receipt(subject, evidence),
+        _receipt(subject, evidence),
         untrusted_eligible=untrusted_eligible,
         strict_deny_all=strict_deny_all,
     )
@@ -317,12 +329,12 @@ def test_boundary_breach_is_unsupported_but_missing_feature_is_not() -> None:
     breached_result = _evaluate(
         subject,
         breached,
-        _authoritative_receipt(subject, breached),
+        _receipt(subject, breached),
     )
     missing_result = _evaluate(
         subject,
         missing,
-        _authoritative_receipt(subject, missing),
+        _receipt(subject, missing),
     )
 
     assert breached_result.outcome == "unsupported"
@@ -384,7 +396,7 @@ def test_certification_is_not_sufficient_for_dispatch() -> None:
     certification = _evaluate(
         subject,
         evidence,
-        _authoritative_receipt(subject, evidence),
+        _receipt(subject, evidence),
     )
 
     blocked = cert.agent_execution_dispatch_readiness(
@@ -400,6 +412,65 @@ def test_certification_is_not_sufficient_for_dispatch() -> None:
     assert blocked.reason == "agent_execution_stack_unimplemented"
     assert ready.ready is True
     assert ready.reason is None
+
+
+@pytest.mark.parametrize(
+    ("outcome", "allowed"),
+    [
+        ("certified", True),
+        ("draft_only", True),
+        ("unsupported", False),
+    ],
+)
+def test_core_agent_automation_admission_is_closed_and_stable(
+    outcome: cert.CertificationOutcome,
+    allowed: bool,
+) -> None:
+    """The core boundary must own Agent authoring support decisions."""
+
+    certification = cert.ExecutionCertification(
+        outcome=outcome,
+        deployment_class_id="sha256:" + "1" * 64,
+        evidence_id="sha256:" + "2" * 64 if outcome == "certified" else None,
+        evidence_source=(
+            "server_verified" if outcome == "certified" else "repository_characterization"
+        ),
+        observed_at=NOW,
+        expires_at=NOW + timedelta(hours=1),
+        reason_codes=(),
+    )
+
+    admission = cert.agent_automation_admission(certification)
+
+    assert admission.allowed is allowed
+    assert admission.effective_outcome == outcome
+    if allowed:
+        assert admission.reason is None
+        assert admission.recovery_action is None
+    else:
+        assert admission.reason == "execution_certification_unsupported"
+        assert admission.recovery_action
+
+
+def test_core_agent_automation_admission_rejects_unknown_runtime_state() -> None:
+    """A resolver contract violation must fail closed at the core boundary."""
+
+    certification = cert.ExecutionCertification(
+        outcome=cast(Any, "unexpected_state"),
+        deployment_class_id="sha256:" + "1" * 64,
+        evidence_id=None,
+        evidence_source="repository_characterization",
+        observed_at=NOW,
+        expires_at=NOW + timedelta(hours=1),
+        reason_codes=(),
+    )
+
+    admission = cert.agent_automation_admission(certification)
+
+    assert admission.allowed is False
+    assert admission.effective_outcome == "unsupported"
+    assert admission.reason == "execution_certification_unsupported"
+    assert admission.recovery_action
 
 
 def test_current_resolver_cannot_certify_repository_characterization(


### PR DESCRIPTION
## Summary

- What changed:
  - Added an immutable seven-domain Scheduled Agent execution certification model and sanitized evidence generator.
  - Added versioned capability metadata plus consistent fail-closed gates for Run Now, scheduler arming/firing, and queued-job worker admission.
  - Published ADR-041, the operator guide, a validated draft-only baseline, and dependency handoffs for TASK-13130 through TASK-13133.
- Why:
  - Scheduled Agent automation combines delayed authority, untrusted output, credentials, tools, recovery, and cancellation. Current Sandbox, ACP, and MCP primitives do not yet prove those properties for an exact deployment class.
  - The API must report honest draft-only or unsupported states and prevent execution until both authoritative certification and the separate execution stack are ready.

## Change summary

PR #2827 adds an API-first, fail-closed feasibility gate for Scheduled Agent tasks. It introduces a seven-domain certification model, sanitized evidence tooling, capability metadata, and consistent safeguards across Run Now, scheduler, and worker execution paths. It documents that no deployment is currently certified, keeping eligible environments draft-only and unsupported environments blocked until the required security evidence and execution stack are complete, without changing Watchlists, the WebUI, or standalone Agent Tasks.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)
- 275 passed, 0 failed, 0 skipped, 19 warnings
- compileall passed
- Ruff passed
- Bandit: 0 findings across 4,965 production lines
- Evidence JSON/Markdown pair and prohibited-content scans passed

## UX Audit Checklist (v2 Stage 5)

- [ ] Not applicable: this PR does not change the WebUI or extension.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] Not applicable: this PR does not change Watchlists.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] Not applicable: this PR does not change Watchlists.

## Risk & Rollback

- Risk level: Medium
- Rollback plan: Revert this PR. No schema migration or data migration is introduced.