### PR TITLE
fix(ci): restore required gate baseline

### DIFF
--- a/.github/workflows/coverage-required.yml
+++ b/.github/workflows/coverage-required.yml
@@ -89,6 +89,9 @@ jobs:
     name: coverage-required
     runs-on: ubuntu-latest
     needs: [changes]
+    if: >-
+      always() && !cancelled() &&
+      needs.changes.result == 'success'
     timeout-minutes: 30
     steps:
       - name: No-op pass (coverage not required)

--- a/.github/workflows/e2e-required.yml
+++ b/.github/workflows/e2e-required.yml
@@ -89,6 +89,9 @@ jobs:
     name: e2e-required
     runs-on: ubuntu-latest
     needs: [changes]
+    if: >-
+      always() && !cancelled() &&
+      needs.changes.result == 'success'
     timeout-minutes: 40
     services:
       redis:

--- a/Docs/Published/ADR/041-scheduled-agent-execution-feasibility.md
+++ b/Docs/Published/ADR/041-scheduled-agent-execution-feasibility.md
@@ -1,0 +1,60 @@
+# ADR-041: Scheduled Agent execution feasibility
+
+**Status:** Accepted
+**Date:** 2026-08-26
+**Backfilled from:** not backfilled
+**Decision owner:** tldw_server maintainers
+**Related task:** TASK-13129
+**Related spec/plan:** `Docs/superpowers/specs/2026-08-24-scheduled-tasks-phase4d-agent-task-execution-design.md`, `Docs/superpowers/plans/2026-08-24-scheduled-tasks-phase4d-feasibility-gate-implementation-plan.md`
+
+## Decision
+
+No current deployment class is certified for Scheduled Tasks Agent automation execution. Statically eligible isolation runtimes remain `draft_only` until all seven server-verified evidence domains pass for an exact deployment class; host-local and current non-eligible runtimes are `unsupported`. Existing ordinary ACP, Sandbox, and MCP primitives remain dependencies, but they are not proof.
+
+Certification is necessary but not sufficient. The existing capabilities API, manual Run Now admission, scheduler arming and firing, and worker admission all require both a `certified` deployment result and a separately implemented execution stack. The production stack-readiness function is source-defined as false in TASK-13129.
+
+## Context
+
+Scheduled Agent execution combines delayed authority, untrusted model output, credentials, tools, durable recovery, and cross-process cancellation. Static runtime metadata or successful interactive-agent behavior cannot demonstrate those properties. A credible decision must bind evidence to one opaque deployment class containing host, architecture, AuthNZ mode, runtime, adapter version, server build, and isolation-policy identities.
+
+The current repository has reusable pieces, but each required proof remains incomplete:
+
+- ordinary ACP records and forks can retain prompt content;
+- generic Sandbox idempotency is not an ACP dispatch-token recovery contract;
+- cancellation and terminal state lack one ordered per-attempt evidence journal;
+- MCP credential brokering and governance are not Scheduled Tasks grants or per-action mediation;
+- no authoritative verifier signs and validates the exact seven-domain evidence bundle.
+
+The baseline at `Docs/Evidence/Scheduled_Agent_Execution/2026-08-24-phase4d0f-baseline.json` therefore records `draft_only` for the observed Docker candidate class. Its corresponding Markdown artifact includes repository-static eligibility for all supported runtime values. Neither artifact grants execution authority.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Trust Docker or container isolation alone | Container selection does not prove exact mounts, deny-all egress, tenant binding, credential handling, mediation, recovery, or operational fail-closed behavior. |
+| Reuse ordinary ACP transcripts for scheduled prompts | Ordinary storage and fork behavior can retain prompt content and do not provide the required scheduled-mode non-disclosure boundary. |
+| Treat Sandbox idempotency as ACP dispatch recovery | Generic session/run idempotency is not bound to a stable adapter dispatch token and cannot recover the exact ACP attempt after process loss. |
+| Treat generic MCP credentials and governance as scheduled grants | Existing policy is not bound to the Scheduled Tasks subject, definition revision, credential version, exact action arguments, or live per-action revocation. |
+| Hide Agent automation until execution is complete | Hiding the family removes API discoverability and prevents clients from distinguishing draft-only work from a deployment that is structurally unsupported. |
+| Allow an operator flag or edited evidence file to enable execution | Mutable local inputs would bypass the server trust boundary and make capability claims unverifiable. |
+
+## Consequences
+
+- `/api/v1/scheduled-tasks/capabilities` exposes a sanitized, versioned `execution_certification` object for `agent_task`.
+- `execute` and `run_now` remain disabled for every production state in this slice.
+- `draft_only` permits Agent definition drafting and ordinary management but not execution.
+- `unsupported` keeps the family visible while refusing preview creation, definition creation, and duplication; existing definitions remain inspectable, pausable, resumable, and archivable.
+- Manual Run Now returns a typed conflict before idempotency, Job creation, or audit creation.
+- The scheduler refuses Agent arming, firing, and rearming. The worker independently records already-queued Agent Jobs as blocked skips before executor lookup.
+- Recurring Questions, Watchlists, and standalone interactive Agent Tasks retain their existing contracts.
+- Evidence expires and becomes invalid when its subject, build, runtime, image, policy, adapter, AuthNZ mode, signer, or validity window changes.
+- The accepted tradeoff is visible draft functionality without background execution until dependency work supplies authoritative proof.
+
+## Follow-up
+
+- `TASK-13130`: isolation attestation and hostile runtime proof.
+- `TASK-13131`: scheduled-mode secure ACP transcripts and leakage gates.
+- `TASK-13132`: ACP dispatch recovery and monotonic execution evidence.
+- `TASK-13133`: scheduled identity, credentials, revocation, and pre-action mediation.
+- `operational_fail_closed` remains a cross-cutting exit criterion for all four tasks.
+- Phase 4D.1B may change the source-defined execution-stack readiness only after its complete vertical slice passes independently.

--- a/Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md
+++ b/Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md
@@ -157,7 +157,7 @@ Run the focused and full CI contract tests from Task 1, the OpenAPI check, the p
 
 Confirm the implementation is limited to two job conditions, one contract test, one fingerprint refresh, one published ADR mirror, this plan, and the TASK-13013.1 record. Confirm no runtime API, admission, classifier, dependency, or system-tool change.
 
-- [ ] **Step 3: Record evidence and create the implementation commit**
+- [x] **Step 3: Record evidence and create the implementation commit**
 
 Update TASK-13013.1 with local verification commands/results, stage only the
 bounded paths, and commit without bypassing hooks. Immediately append the exact

--- a/Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md
+++ b/Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md
@@ -1,0 +1,172 @@
+# TASK-13013.1 Required CI Baseline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore every documented required CI lane to a deterministic, green result on one exact `dev`-based candidate.
+
+**Architecture:** Repair only the four proven baseline defects: downstream required jobs skipped after successful change detection, a stale committed OpenAPI fingerprint, and a missing published ADR mirror. Preserve the existing admission, path-classification, schema-export, and documentation-publication mechanisms rather than adding new CI machinery.
+
+**Tech Stack:** GitHub Actions YAML, Python 3.11/pytest/PyYAML, existing OpenAPI exporter, existing published-doc refresh script, Backlog.md CLI.
+
+**Spec:** `Docs/superpowers/specs/2026-08-21-core-release-readiness-program-design.md`
+
+## Global Constraints
+
+- Work from exact merged `dev` commit `1ad2f1e5b30c49ea75396e4b713496b73e875fec` on `codex/task-13013-1-ci-baseline`.
+- Keep TASK-13013.1 current through the Backlog CLI and commit its record with the implementation.
+- Do not install dependencies, alter system tools, redesign admission, or change live branch rulesets.
+- Preserve deterministic no-op success for required lanes when classified paths are irrelevant.
+- Use the existing repository virtual environment and generation scripts only.
+- Require a human-written change summary before making an AI-authored pull request ready for merge.
+
+---
+
+### Task 1: Make Conditional Required Jobs Report Deterministically
+
+**Files:**
+- Modify: `tldw_Server_API/tests/CI/test_required_workflow_contracts.py`
+- Modify: `tldw_Server_API/tests/CI/test_license_first_workflow_contracts.py`
+- Modify: `.github/workflows/coverage-required.yml`
+- Modify: `.github/workflows/e2e-required.yml`
+
+**Interfaces:**
+- Consumes: the existing `changes` job and its `coverage_required` / `e2e_changed` outputs.
+- Produces: required jobs that run after successful change detection even when the reusable admission job is intentionally skipped for a direct pull request.
+
+- [x] **Step 1: Add the failing contract test**
+
+```python
+def test_conditional_required_lanes_run_after_successful_change_detection() -> None:
+    for workflow_path, job_name in (
+        (".github/workflows/coverage-required.yml", "coverage-required"),
+        (".github/workflows/e2e-required.yml", "e2e-required"),
+    ):
+        job = _load(workflow_path)["jobs"][job_name]
+        assert job["needs"] == ["changes"]
+        assert " ".join(job["if"].split()) == (
+            "always() && !cancelled() && needs.changes.result == 'success'"
+        )
+```
+
+This test catches removal of `always()`, which makes GitHub skip the required downstream job when the direct-PR admission job is intentionally skipped.
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider \
+  tldw_Server_API/tests/CI/test_required_workflow_contracts.py::test_conditional_required_lanes_run_after_successful_change_detection
+```
+
+Expected: fail because each required job lacks the job-level `if` condition.
+
+- [x] **Step 3: Add the minimal job-level conditions**
+
+Add this exact condition immediately after `needs: [changes]` in both required jobs:
+
+```yaml
+if: >-
+  always() && !cancelled() &&
+  needs.changes.result == 'success'
+```
+
+Update the existing license-first workflow contract to allow only this same exact
+condition on these two jobs; continue rejecting every other unapproved condition.
+
+- [x] **Step 4: Verify GREEN and the neighboring workflow contracts**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider \
+  tldw_Server_API/tests/CI/test_required_workflow_contracts.py \
+  tldw_Server_API/tests/CI/test_license_first_workflow_contracts.py
+```
+
+Expected: pass with no failures or collection errors; existing baseline warnings
+may remain.
+
+---
+
+### Task 2: Refresh the Two Stale Generated Baselines
+
+**Files:**
+- Modify: `apps/tldw-frontend/lib/api/openapi.fingerprint.json`
+- Create: `Docs/Published/ADR/041-scheduled-agent-execution-feasibility.md`
+
+**Interfaces:**
+- Consumes: the runtime FastAPI schema at the exact candidate and `Docs/ADR/041-scheduled-agent-execution-feasibility.md`.
+- Produces: the committed OpenAPI fingerprint expected by `backend-required` and the published ADR tree expected by `onboarding-docs-gate`.
+
+- [x] **Step 1: Preserve the already-observed OpenAPI RED evidence**
+
+The exact exporter check at base commit `1ad2f1e5b30c49ea75396e4b713496b73e875fec` produced checked-in digest `a4c4b6b24aea9cfbaa4102595c29988e5ed8041e10574ff798773bf0d0ef09b4` (2,040 paths / 3,037 schemas) versus runtime digest `eb829bd8d3a62b55a61add5c595b522646455c55a2c540d2eabaec02da82ad19` (2,040 / 3,038). Preserve that diagnostic in TASK-13013.1.
+
+- [x] **Step 2: Refresh the committed fingerprint with the existing exporter**
+
+Generate in a clean temporary archive using the existing virtual environment, then copy only the resulting fingerprint values into `apps/tldw-frontend/lib/api/openapi.fingerprint.json`. The resulting literal values must be:
+
+```json
+{
+  "note": "Regenerate with `make openapi-fingerprint`. A change here means the backend API contract drifted; regenerate the frontend types (`bun run generate:api-types` in apps/tldw-frontend) and review.",
+  "openapi_version": "3.1.0",
+  "path_count": 2040,
+  "schema_count": 3038,
+  "sha256": "eb829bd8d3a62b55a61add5c595b522646455c55a2c540d2eabaec02da82ad19"
+}
+```
+
+- [x] **Step 3: Refresh the published documentation mirror**
+
+Run:
+
+```bash
+bash Helper_Scripts/refresh_docs_published.sh
+```
+
+Expected tracked documentation change: add `Docs/Published/ADR/041-scheduled-agent-execution-feasibility.md`, byte-equivalent to its source after the repository's normal publication transform. Reject unrelated generated changes.
+
+- [x] **Step 4: Verify both generated baselines**
+
+Run the exact OpenAPI check from a clean temporary archive of the candidate and
+`test_refresh_output_matches_tracked_published_files` from the repository virtual
+environment. Expected: both pass. The refresh also exposed six pre-existing
+tracked-content mirror diffs; preserve them in the named repo-local stash
+`task-13013-1-unrelated-published-docs-refresh` rather than expanding this PR.
+
+---
+
+### Task 3: Verify, Record, and Publish the Exact Candidate
+
+**Files:**
+- Modify: `backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md`
+- Modify: `Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md`
+
+**Interfaces:**
+- Consumes: Tasks 1 and 2 plus the documented required-gate contract.
+- Produces: one reviewable commit and pull request whose exact head reports all six documented required gates.
+
+- [x] **Step 1: Run local verification**
+
+Run the focused and full CI contract tests from Task 1, the OpenAPI check, the published-doc refresh test, YAML parsing for both workflow files, `git diff --check`, and Bandit over the touched Python test (or record why test-only code is out of Bandit's production scope). Do not install anything.
+
+- [x] **Step 2: Review the exact diff**
+
+Confirm the implementation is limited to two job conditions, one contract test, one fingerprint refresh, one published ADR mirror, this plan, and the TASK-13013.1 record. Confirm no runtime API, admission, classifier, dependency, or system-tool change.
+
+- [ ] **Step 3: Record evidence and create the implementation commit**
+
+Update TASK-13013.1 with local verification commands/results, stage only the
+bounded paths, and commit without bypassing hooks. Immediately append the exact
+implementation SHA to the task through the CLI before opening the pull request.
+
+- [ ] **Step 4: Push and create the pull request**
+
+Push `codex/task-13013-1-ci-baseline`, create a pull request targeting `dev`, and request the user's own change-summary wording before marking the AI-authored pull request ready or merging it.
+
+- [ ] **Step 5: Record exact hosted evidence**
+
+Wait for `backend-required`, `security-required`, `coverage-required`, `frontend-required`, `e2e-required`, and `container-build-check` on the exact pull-request head. Record their run links and any policy-valid baseline-only no-op results in TASK-13013.1; do not close the task until all six report success on that same SHA.

--- a/Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md
+++ b/Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md
@@ -163,7 +163,7 @@ Update TASK-13013.1 with local verification commands/results, stage only the
 bounded paths, and commit without bypassing hooks. Immediately append the exact
 implementation SHA to the task through the CLI before opening the pull request.
 
-- [ ] **Step 4: Push and create the pull request**
+- [x] **Step 4: Push and create the pull request**
 
 Push `codex/task-13013-1-ci-baseline`, create a pull request targeting `dev`, and request the user's own change-summary wording before marking the AI-authored pull request ready or merging it.
 

--- a/apps/tldw-frontend/lib/api/openapi.fingerprint.json
+++ b/apps/tldw-frontend/lib/api/openapi.fingerprint.json
@@ -2,6 +2,6 @@
   "note": "Regenerate with `make openapi-fingerprint`. A change here means the backend API contract drifted; regenerate the frontend types (`bun run generate:api-types` in apps/tldw-frontend) and review.",
   "openapi_version": "3.1.0",
   "path_count": 2040,
-  "schema_count": 3037,
-  "sha256": "a4c4b6b24aea9cfbaa4102595c29988e5ed8041e10574ff798773bf0d0ef09b4"
+  "schema_count": 3038,
+  "sha256": "eb829bd8d3a62b55a61add5c595b522646455c55a2c540d2eabaec02da82ad19"
 }

--- a/backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md
+++ b/backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md
@@ -4,7 +4,7 @@ title: Restore all required CI gates to green on the current dev release line
 status: In Progress
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-28 15:39'
+updated_date: '2026-08-28 15:49'
 labels:
   - release-readiness
   - ci
@@ -36,6 +36,8 @@ Diagnose and repair the required-gate failure present at the audited dev head, b
 2026-08-28 implementation plan: Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md. TDD evidence: new downstream-condition contract RED with KeyError if missing, then GREEN; required + license-first workflow contracts 56 passed. Clean-archive OpenAPI exporter generated and checked eb829bd8d3a62b55a61add5c595b522646455c55a2c540d2eabaec02da82ad19 (2040 paths/3038 schemas). ADR-041 published mirror is source-identical and the formerly failing tracked-path docs contract passed. YAML parsing and git diff --check passed. Bandit found no medium/high issues in touched test files; low-only findings are existing pytest asserts/test subprocess literals. Classifier flags: backend_changed=true, frontend_changed=true, tldw_frontend_changed=true, e2e_changed=true, security_relevant_changed=true, coverage_required=true. Known out-of-scope concern: the docs refresh exposed six pre-existing tracked-content mirror diffs; preserved without loss in named stash task-13013-1-unrelated-published-docs-refresh and excluded from this bounded PR.
 
 Implementation commit: ebb67166cee868410e77b286082b60d4c2bfa5df (sole parent 1ad2f1e5b30c49ea75396e4b713496b73e875fec; exact bounded eight-path scope). Repository hooks completed; only pre-existing Git gc/unreachable-object maintenance warnings were emitted, and no repository/system cleanup was attempted.
+
+Draft PR: https://github.com/rmusser01/tldw_server/pull/2831. Branch pushed from reviewed head fdb22fbcaeb42644896332bc049a61fb700fd61f; PR remains draft pending maintainer-authored Change summary. Hosted required-gate evidence will be recorded only from the final exact PR head.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md
+++ b/backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-13013.1
 title: Restore all required CI gates to green on the current dev release line
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-21 19:50'
+updated_date: '2026-08-28 15:38'
 labels:
   - release-readiness
   - ci
@@ -26,6 +27,14 @@ Diagnose and repair the required-gate failure present at the audited dev head, b
 - [ ] #2 Every documented required backend, security, coverage, frontend, end-to-end, and container gate passes on one exact candidate.
 - [ ] #3 The root cause, verification commands, workflow run links, and any baseline-only skips are recorded.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-08-28 diagnostic at exact dev 1ad2f1e5b30c49ea75396e4b713496b73e875fec: backend-required fails OpenAPI drift (checked-in a4c4b6b2, 2040 paths/3037 schemas; runtime eb829bd8, 2040/3038) introduced by merged PR #2827; coverage-required and e2e-required are skipped on direct PR runs because their downstream jobs lack an admission-safe always() condition; onboarding-docs-gate lacks the published ADR-041 mirror. Approved bounded implementation: workflow guards + TDD contract coverage, fingerprint refresh, published ADR refresh, then one exact-candidate PR gate run.
+
+2026-08-28 implementation plan: Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md. TDD evidence: new downstream-condition contract RED with KeyError if missing, then GREEN; required + license-first workflow contracts 56 passed. Clean-archive OpenAPI exporter generated and checked eb829bd8d3a62b55a61add5c595b522646455c55a2c540d2eabaec02da82ad19 (2040 paths/3038 schemas). ADR-041 published mirror is source-identical and the formerly failing tracked-path docs contract passed. YAML parsing and git diff --check passed. Bandit found no medium/high issues in touched test files; low-only findings are existing pytest asserts/test subprocess literals. Classifier flags: backend_changed=true, frontend_changed=true, tldw_frontend_changed=true, e2e_changed=true, security_relevant_changed=true, coverage_required=true. Known out-of-scope concern: the docs refresh exposed six pre-existing tracked-content mirror diffs; preserved without loss in named stash task-13013-1-unrelated-published-docs-refresh and excluded from this bounded PR.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md
+++ b/backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md
@@ -4,7 +4,7 @@ title: Restore all required CI gates to green on the current dev release line
 status: In Progress
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-28 15:38'
+updated_date: '2026-08-28 15:39'
 labels:
   - release-readiness
   - ci
@@ -34,6 +34,8 @@ Diagnose and repair the required-gate failure present at the audited dev head, b
 2026-08-28 diagnostic at exact dev 1ad2f1e5b30c49ea75396e4b713496b73e875fec: backend-required fails OpenAPI drift (checked-in a4c4b6b2, 2040 paths/3037 schemas; runtime eb829bd8, 2040/3038) introduced by merged PR #2827; coverage-required and e2e-required are skipped on direct PR runs because their downstream jobs lack an admission-safe always() condition; onboarding-docs-gate lacks the published ADR-041 mirror. Approved bounded implementation: workflow guards + TDD contract coverage, fingerprint refresh, published ADR refresh, then one exact-candidate PR gate run.
 
 2026-08-28 implementation plan: Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md. TDD evidence: new downstream-condition contract RED with KeyError if missing, then GREEN; required + license-first workflow contracts 56 passed. Clean-archive OpenAPI exporter generated and checked eb829bd8d3a62b55a61add5c595b522646455c55a2c540d2eabaec02da82ad19 (2040 paths/3038 schemas). ADR-041 published mirror is source-identical and the formerly failing tracked-path docs contract passed. YAML parsing and git diff --check passed. Bandit found no medium/high issues in touched test files; low-only findings are existing pytest asserts/test subprocess literals. Classifier flags: backend_changed=true, frontend_changed=true, tldw_frontend_changed=true, e2e_changed=true, security_relevant_changed=true, coverage_required=true. Known out-of-scope concern: the docs refresh exposed six pre-existing tracked-content mirror diffs; preserved without loss in named stash task-13013-1-unrelated-published-docs-refresh and excluded from this bounded PR.
+
+Implementation commit: ebb67166cee868410e77b286082b60d4c2bfa5df (sole parent 1ad2f1e5b30c49ea75396e4b713496b73e875fec; exact bounded eight-path scope). Repository hooks completed; only pre-existing Git gc/unreachable-object maintenance warnings were emitted, and no repository/system cleanup was attempted.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md
+++ b/backlog/tasks/task-13013.1 - Restore-all-required-CI-gates-to-green-on-the-current-dev-release-line.md
@@ -4,7 +4,7 @@ title: Restore all required CI gates to green on the current dev release line
 status: In Progress
 assignee: []
 created_date: '2026-08-21 19:50'
-updated_date: '2026-08-28 15:49'
+updated_date: '2026-08-29 03:28'
 labels:
   - release-readiness
   - ci
@@ -38,6 +38,12 @@ Diagnose and repair the required-gate failure present at the audited dev head, b
 Implementation commit: ebb67166cee868410e77b286082b60d4c2bfa5df (sole parent 1ad2f1e5b30c49ea75396e4b713496b73e875fec; exact bounded eight-path scope). Repository hooks completed; only pre-existing Git gc/unreachable-object maintenance warnings were emitted, and no repository/system cleanup was attempted.
 
 Draft PR: https://github.com/rmusser01/tldw_server/pull/2831. Branch pushed from reviewed head fdb22fbcaeb42644896332bc049a61fb700fd61f; PR remains draft pending maintainer-authored Change summary. Hosted required-gate evidence will be recorded only from the final exact PR head.
+
+2026-08-28 hosted coverage-required run 33187044639 exposed the current dev AuthNZ baseline: coverage itself passed at 39.41% (floor 35%), but 42 tests failed and 173 passed. Root cause evidence: stale AuthNZ_SQLite setup performs raw profile-visible users writes now rejected by profile_user_write_guard; TransactionError and DatabaseError wrappers hide many ProfileUserWriteRejected causes, with one separate BYOK credential-fixture failure. User approved a bounded TDD correction limited to test setup/fixtures, followed by the exact coverage command and complete required-gate rerun; no production AuthNZ relaxation or branch-protection bypass is authorized.
+
+2026-08-28 hosted coverage correction: migrated stale AuthNZ_SQLite user setup to the production guarded/versioned write path, bound the SQLite API-key repository tests to SQLite instead of the PostgreSQL fixture, modeled BYOK absence with a physical fixture delete, and updated guard-boundary expectations. Production AuthNZ code is unchanged. Exact hosted-equivalent coverage command is GREEN: 215 passed in 267.64s, total coverage 40.93% against 35% floor. Required/license-first workflow contracts: 56 passed. Ruff: new helper fully clean; all touched tests clean for E9/F63/F7/F82. Bandit medium/high: none. git diff --check: clean. No installs or system-file changes.
+
+Final-byte verification before commit: hosted-equivalent AuthNZ coverage gate passed 215/215 in 263.95s with 40.87% coverage (35% floor). The earlier 40.93% figure was the preceding successful run; both exceeded the gate. Final git diff --check clean and production app diff empty.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/tests/AuthNZ_SQLite/_user_fixtures.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/_user_fixtures.py
@@ -1,0 +1,62 @@
+"""Authorized user-record setup helpers for SQLite AuthNZ tests."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.profile_version import VersionedUserWriteGateway
+
+
+async def create_authnz_test_user(
+    pool: Any,
+    *,
+    username: str,
+    email: str,
+    password_hash: str = "x",
+    role: str = "user",
+    is_active: bool = True,
+    is_verified: bool = False,
+    is_superuser: bool = False,
+    user_id: int | None = None,
+    ignore_conflict: bool = False,
+) -> int:
+    """Create a test user through the production versioned-write gateway."""
+
+    backend = "postgres" if getattr(pool, "pool", None) is not None else "sqlite"
+    values: dict[str, Any] = {
+        "uuid": str(uuid.uuid4()),
+        "username": username,
+        "email": email.lower(),
+        "password_hash": password_hash,
+        "role": role,
+        "is_active": is_active if backend == "postgres" else int(is_active),
+        "is_verified": is_verified if backend == "postgres" else int(is_verified),
+        "is_superuser": is_superuser if backend == "postgres" else int(is_superuser),
+        "storage_quota_mb": 5120,
+    }
+    if user_id is not None:
+        values["id"] = user_id
+
+    async with pool.transaction() as conn:
+        result = await VersionedUserWriteGateway(backend).insert_user(
+            conn,
+            values=values,
+            ignore_conflict=ignore_conflict,
+        )
+
+    if result.affected_user_ids:
+        return int(result.affected_user_ids[0])
+    if ignore_conflict and user_id is not None:
+        return user_id
+    raise AssertionError("authorized test-user insert did not return a user id")
+
+
+async def set_authnz_test_user_active(pool: Any, user_id: int, active: bool) -> None:
+    """Update test-user activity through the production user abstraction."""
+
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+
+    users_db = UsersDB(pool)
+    await users_db.initialize(ensure_schema=False)
+    await users_db.update_user(user_id, is_active=active)

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_endpoints_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_endpoints_sqlite.py
@@ -6,6 +6,8 @@ import pytest
 from fastapi.testclient import TestClient
 from loguru import logger
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 @pytest.mark.asyncio
 async def test_admin_endpoints_basic_sqlite(tmp_path):
@@ -28,13 +30,10 @@ async def test_admin_endpoints_basic_sqlite(tmp_path):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Create a user to satisfy FK and for membership
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("adminuser", "admin@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "adminuser")
+    # Create a user to satisfy FK and for membership.
+    user_id = await create_authnz_test_user(
+        pool, username="adminuser", email="admin@example.com"
+    )
 
     # Create TestClient and override admin/principal dependencies to bypass auth
     from tldw_Server_API.app.main import app
@@ -207,13 +206,10 @@ async def test_org_member_list_pagination_filters_sqlite(tmp_path):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Seed an admin user for auth overrides
-    async with pool.transaction() as conn:
-        cursor = await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("rootadmin", "rootadmin@example.com", "x"),
-        )
-        admin_id = cursor.lastrowid
+    # Seed an admin user for auth overrides.
+    admin_id = await create_authnz_test_user(
+        pool, username="rootadmin", email="rootadmin@example.com"
+    )
 
     from tldw_Server_API.app.main import app
     from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
@@ -255,16 +251,15 @@ async def test_org_member_list_pagination_filters_sqlite(tmp_path):
     suspended_ids: set[int] = set()
     lead_invited_ids: set[int] = set()
 
-    async with pool.transaction() as conn:
-        for idx in range(total_members):
-            username = f"member{idx}"
-            cursor = await conn.execute(
-                "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-                (username, f"{username}@example.com", "x"),
+    for idx in range(total_members):
+        username = f"member{idx}"
+        user_ids.append(
+            await create_authnz_test_user(
+                pool, username=username, email=f"{username}@example.com"
             )
-            user_id = cursor.lastrowid
-            user_ids.append(user_id)
+        )
 
+    async with pool.transaction() as conn:
         org_cursor = await conn.execute(
             "INSERT INTO organizations (name, slug, owner_user_id) VALUES (?, ?, ?)",
             ("Paginated Org", "paginated-org", admin_id),

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_membership_audit_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_membership_audit_sqlite.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.tests.helpers.audit_helpers import await_audit_action, flush_audit_events
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
 
 
 @pytest.mark.real_audit
@@ -29,18 +30,13 @@ async def test_admin_org_membership_audit_events_sqlite(tmp_path, real_audit_ser
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Create admin user (id should be 1 by default) and a target user
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("single_user", "single@example.com", "x"),
-        )
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("victim", "victim@example.com", "x"),
-        )
-    admin_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "single_user")
-    target_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "victim")
+    # Create admin user (id should be 1 by default) and a target user.
+    admin_id = await create_authnz_test_user(
+        pool, username="single_user", email="single@example.com"
+    )
+    target_id = await create_authnz_test_user(
+        pool, username="victim", email="victim@example.com"
+    )
 
     # Prepare app
     from tldw_Server_API.app.main import app

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_membership_audit_team_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_membership_audit_team_sqlite.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.tests.helpers.audit_helpers import await_audit_action, flush_audit_events
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
 
 
 @pytest.mark.real_audit
@@ -28,18 +29,13 @@ async def test_team_membership_audit_events_sqlite(tmp_path, real_audit_service)
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Create admin user (should be id=1) and a target user
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("single_user", "single@example.com", "x"),
-        )
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("victim", "victim@example.com", "x"),
-        )
-    admin_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "single_user")
-    target_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "victim")
+    # Create admin user (should be id=1) and a target user.
+    admin_id = await create_authnz_test_user(
+        pool, username="single_user", email="single@example.com"
+    )
+    target_id = await create_authnz_test_user(
+        pool, username="victim", email="victim@example.com"
+    )
 
     # Prepare app
     from tldw_Server_API.app.main import app

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_org_members_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_org_members_sqlite.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 @pytest.mark.asyncio
 async def test_admin_org_members_endpoints_sqlite(tmp_path):
@@ -22,23 +24,16 @@ async def test_admin_org_members_endpoints_sqlite(tmp_path):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Create users
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("admin", "admin@example.com", "x"),
-        )
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("bob", "bob@example.com", "x"),
-        )
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("charlie", "charlie@example.com", "x"),
-        )
-    admin_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "admin")
-    bob_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "bob")
-    charlie_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "charlie")
+    # Create users through the guarded write path.
+    admin_id = await create_authnz_test_user(
+        pool, username="admin", email="admin@example.com"
+    )
+    bob_id = await create_authnz_test_user(
+        pool, username="bob", email="bob@example.com"
+    )
+    charlie_id = await create_authnz_test_user(
+        pool, username="charlie", email="charlie@example.com"
+    )
 
     # Prepare app client and override principal to simulate admin claims
     from tldw_Server_API.app.main import app

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_allowlists_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_allowlists_sqlite.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 @pytest.mark.asyncio
 async def test_provider_model_allowlists_sqlite(tmp_path):
@@ -23,13 +25,10 @@ async def test_provider_model_allowlists_sqlite(tmp_path):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Create a user
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("vkuser", "vkuser@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "vkuser")
+    # Create a user through the guarded write path.
+    user_id = await create_authnz_test_user(
+        pool, username="vkuser", email="vkuser@example.com"
+    )
 
     # Create a virtual key with allowlists
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
@@ -88,13 +87,10 @@ async def test_missing_provider_header_allows_when_allowlist_present_sqlite(tmp_
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Create a user
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("vkuser2", "vkuser2@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "vkuser2")
+    # Create a user through the guarded write path.
+    user_id = await create_authnz_test_user(
+        pool, username="vkuser2", email="vkuser2@example.com"
+    )
 
     # Create a virtual key with provider/model allowlists
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
@@ -141,12 +137,9 @@ async def test_non_json_body_skips_model_enforcement_sqlite(tmp_path):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("vkuser3", "vkuser3@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "vkuser3")
+    user_id = await create_authnz_test_user(
+        pool, username="vkuser3", email="vkuser3@example.com"
+    )
 
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
     mgr = APIKeyManager()
@@ -196,12 +189,9 @@ async def test_invalid_json_body_skips_model_enforcement_sqlite(tmp_path):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("vkuser4", "vkuser4@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "vkuser4")
+    user_id = await create_authnz_test_user(
+        pool, username="vkuser4", email="vkuser4@example.com"
+    )
 
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
     mgr = APIKeyManager()

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_api_key_rotation_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_api_key_rotation_sqlite.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 @pytest.mark.asyncio
 async def test_api_key_rotation_marks_old_key_and_links():
@@ -34,17 +36,12 @@ async def test_api_key_rotation_marks_old_key_and_links():
         pool = await get_db_pool()
         ensure_authnz_tables(Path(pool.db_path))
 
-        # Create test user
-        async with pool.transaction() as conn:
-            await conn.execute(
-                """
-                INSERT INTO users (username, email, password_hash, is_active)
-                VALUES (?, ?, ?, 1)
-                """,
-                ("rotate_user", "rotate@example.com", "hash"),
-            )
-        user_id = await pool.fetchval(
-            "SELECT id FROM users WHERE username = ?", "rotate_user"
+        # Create test user through the guarded write path.
+        user_id = await create_authnz_test_user(
+            pool,
+            username="rotate_user",
+            email="rotate@example.com",
+            password_hash="hash",
         )
 
         mgr = APIKeyManager(pool)

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_api_keys_repo_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_api_keys_repo_sqlite.py
@@ -1,19 +1,39 @@
 import json
 import uuid
+from pathlib import Path
 
 import pytest
 
-pytest_plugins = ("tldw_Server_API.tests._plugins.authnz_full_fixtures",)
+
+@pytest.fixture
+async def sqlite_test_environment(tmp_path, monkeypatch):
+    """Bind these SQLite-specific repository tests to an actual SQLite pool."""
+
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("JWT_SECRET_KEY", "sqlite-api-keys-test-secret-32-chars-minimum")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'users.db'}")
+    reset_settings()
+    await reset_db_pool()
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(pool.db_path))
+    try:
+        yield
+    finally:
+        await reset_db_pool()
+        reset_settings()
 
 
 @pytest.mark.asyncio
-async def test_authnz_api_keys_repo_fetch_key_limits_sqlite(isolated_test_environment):
+async def test_authnz_api_keys_repo_fetch_key_limits_sqlite(sqlite_test_environment):
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
     from tldw_Server_API.app.core.AuthNZ.repos.api_keys_repo import AuthnzApiKeysRepo
     from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
 
-    _client, _db_name = isolated_test_environment
     pool = await get_db_pool()
 
     # Ensure core AuthNZ tables exist via UsersDB and APIKeyManager so we
@@ -53,12 +73,11 @@ async def test_authnz_api_keys_repo_fetch_key_limits_sqlite(isolated_test_enviro
 
 
 @pytest.mark.asyncio
-async def test_authnz_api_keys_repo_virtual_key_scope_alignment_sqlite(isolated_test_environment):
+async def test_authnz_api_keys_repo_virtual_key_scope_alignment_sqlite(sqlite_test_environment):
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
     from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
 
-    _client, _db_name = isolated_test_environment
     pool = await get_db_pool()
 
     users_db = UsersDB(pool)
@@ -97,12 +116,11 @@ async def test_authnz_api_keys_repo_virtual_key_scope_alignment_sqlite(isolated_
 
 
 @pytest.mark.asyncio
-async def test_api_key_scope_list_serializes_and_normalizes_sqlite(isolated_test_environment):
+async def test_api_key_scope_list_serializes_and_normalizes_sqlite(sqlite_test_environment):
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
     from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager, normalize_scope
 
-    _client, _db_name = isolated_test_environment
     pool = await get_db_pool()
 
     users_db = UsersDB(pool)
@@ -144,7 +162,7 @@ async def test_api_key_scope_list_serializes_and_normalizes_sqlite(isolated_test
 
 
 @pytest.mark.asyncio
-async def test_authnz_api_keys_repo_rotation_and_revoke_sqlite(isolated_test_environment):
+async def test_authnz_api_keys_repo_rotation_and_revoke_sqlite(sqlite_test_environment):
     """AuthnzApiKeysRepo mark_rotated / revoke_api_key_for_user should work on SQLite."""
     from datetime import datetime
 
@@ -153,7 +171,6 @@ async def test_authnz_api_keys_repo_rotation_and_revoke_sqlite(isolated_test_env
     from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager, APIKeyStatus
 
-    _client, _db_name = isolated_test_environment
     pool = await get_db_pool()
 
     # Ensure user and tables exist
@@ -228,14 +245,13 @@ async def test_authnz_api_keys_repo_rotation_and_revoke_sqlite(isolated_test_env
 
 
 @pytest.mark.asyncio
-async def test_authnz_api_keys_repo_usage_and_audit_sqlite(isolated_test_environment):
+async def test_authnz_api_keys_repo_usage_and_audit_sqlite(sqlite_test_environment):
     """AuthnzApiKeysRepo.increment_usage and insert_audit_log work on SQLite."""
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
     from tldw_Server_API.app.core.AuthNZ.repos.api_keys_repo import AuthnzApiKeysRepo
     from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
 
-    _client, _db_name = isolated_test_environment
     pool = await get_db_pool()
 
     users_db = UsersDB(pool)

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_org_provider_secrets_repo_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_org_provider_secrets_repo_sqlite.py
@@ -10,6 +10,8 @@ from sqlite3 import IntegrityError
 
 import pytest
 
+from tldw_Server_API.app.core.AuthNZ.profile_user_write_guard import ProfileUserWriteRejected
+
 pytest_plugins = ("tldw_Server_API.tests._plugins.authnz_full_fixtures",)
 
 
@@ -289,9 +291,9 @@ async def test_authorized_shared_fetch_rejects_null_activity_boundaries_sqlite(
     ) is not None
 
     if null_boundary in {"team_user", "org_user"}:
-        # Current SQLite schemas reject this legacy state at the storage
-        # boundary; PostgreSQL coverage below exercises the nullable-row join.
-        with pytest.raises(IntegrityError):
+        # The managed write boundary rejects this legacy state before SQLite;
+        # PostgreSQL coverage below exercises the nullable-row join directly.
+        with pytest.raises(ProfileUserWriteRejected):
             await state["pool"].execute(
                 "UPDATE users SET is_active = NULL WHERE id = ?",
                 (user_id,),

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_orgs_teams_repo_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_orgs_teams_repo_sqlite.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 @pytest.mark.integration
 @pytest.mark.asyncio
@@ -28,28 +30,12 @@ async def test_authnz_orgs_teams_repo_membership_sqlite(tmp_path, monkeypatch):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Create two users for org/team membership
-    async with pool.transaction() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (username, email, password_hash, is_active)
-            VALUES (?, ?, ?, 1)
-            """,
-            ("owner", "owner@example.com", "x"),
-        )
-        await conn.execute(
-            """
-            INSERT INTO users (username, email, password_hash, is_active)
-            VALUES (?, ?, ?, 1)
-            """,
-            ("member", "member@example.com", "x"),
-        )
-
-    owner_id = await pool.fetchval(
-        "SELECT id FROM users WHERE username = ?", ("owner",)
+    # Create two users for org/team membership through the guarded write path.
+    owner_id = await create_authnz_test_user(
+        pool, username="owner", email="owner@example.com"
     )
-    member_id = await pool.fetchval(
-        "SELECT id FROM users WHERE username = ?", ("member",)
+    member_id = await create_authnz_test_user(
+        pool, username="member", email="member@example.com"
     )
 
     repo = AuthnzOrgsTeamsRepo(pool)

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_token_blacklist_repo_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_token_blacklist_repo_sqlite.py
@@ -11,6 +11,7 @@ from tldw_Server_API.app.core.AuthNZ.repos.token_blacklist_repo import (
     AuthnzTokenBlacklistRepo,
 )
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
 
 
 @pytest.mark.asyncio
@@ -29,19 +30,14 @@ async def test_authnz_token_blacklist_repo_sqlite(tmp_path, monkeypatch):
     now = datetime.now(timezone.utc).replace(microsecond=0)
     future = now + timedelta(hours=1)
 
-    # Seed a simple user row for FK safety
-    async with pool.transaction() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (username, email, password_hash, is_active, is_verified, role)
-            VALUES (?, ?, ?, 1, 1, 'user')
-            """,
-            ("blacklist-sqlite-user", "blacklist-sqlite@example.com", "hash"),
-        )
-    user_id = await pool.fetchval(
-        "SELECT id FROM users WHERE username = ?", "blacklist-sqlite-user"
+    # Seed a simple user row for FK safety through the guarded write path.
+    user_id = await create_authnz_test_user(
+        pool,
+        username="blacklist-sqlite-user",
+        email="blacklist-sqlite@example.com",
+        password_hash="hash",
+        is_verified=True,
     )
-    assert user_id is not None
 
     repo = AuthnzTokenBlacklistRepo(pool)
 

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_user_provider_secrets_repo_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_user_provider_secrets_repo_sqlite.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 
 import pytest
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import set_authnz_test_user_active
+
 pytest_plugins = ("tldw_Server_API.tests._plugins.authnz_full_fixtures",)
 
 
@@ -192,13 +194,13 @@ async def test_user_provider_secrets_repo_sqlite(tmp_path, monkeypatch) -> None:
         include_revoked=True,
     )
     assert active_owner_row is not None
-    await pool.execute("UPDATE users SET is_active = 0 WHERE id = ?", (user_id,))
+    await set_authnz_test_user_active(pool, user_id, False)
     assert await repo.fetch_secret_for_active_user(
         user_id,
         "openai",
         include_revoked=True,
     ) is None
-    await pool.execute("UPDATE users SET is_active = 1 WHERE id = ?", (user_id,))
+    await set_authnz_test_user_active(pool, user_id, True)
 
     items = await repo.list_secrets_for_user(user_id)
     assert len(items) == 1

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_byok_runtime_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_byok_runtime_sqlite.py
@@ -28,6 +28,7 @@ from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
     loads_envelope,
 )
 from tldw_Server_API.app.core.Metrics.metrics_manager import get_metrics_registry
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import set_authnz_test_user_active
 from tldw_Server_API.tests.AuthNZ_SQLite.test_byok_endpoints_sqlite import (
     _insert_raw_shared_key,
     _setup_byok_sqlite,
@@ -292,7 +293,10 @@ async def test_byok_resolution_precedence(tmp_path, monkeypatch):
 
     # Remove the final BYOK key to prove the complete precedence chain reaches
     # the server-secret boundary without manufacturing a repository fallback.
-    await org_repo.delete_secret("org", org_id, "openai")
+    await pool.execute(
+        "DELETE FROM org_provider_secrets WHERE scope_type = ? AND scope_id = ? AND provider = ?",
+        ("org", org_id, "openai"),
+    )
     resolved = await resolve_byok_credentials(
         "openai",
         user_id=user_id,
@@ -1183,10 +1187,7 @@ async def test_inactive_user_blocks_overlapping_oauth_refresh_before_openai_adap
         await asyncio.wait_for(initial_reads_ready.wait(), timeout=5)
         await asyncio.sleep(0)
         assert not second_task.done()
-        await pool.execute(
-            "UPDATE users SET is_active = 0 WHERE id = ?",
-            (user_id,),
-        )
+        await set_authnz_test_user_active(pool, user_id, False)
     finally:
         release_refresh.set()
 
@@ -1228,10 +1229,7 @@ async def test_inactive_user_static_openai_key_fails_before_adapter_sqlite(
         "openai",
         "sk-inactive-owner-must-not-dispatch",
     )
-    await pool.execute(
-        "UPDATE users SET is_active = 0 WHERE id = ?",
-        (user_id,),
-    )
+    await set_authnz_test_user_active(pool, user_id, False)
     adapter, captured_headers = _capture_real_openai_adapter_headers(monkeypatch)
     adapter_calls = 0
 

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_claims_rbac_overlaps_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_claims_rbac_overlaps_sqlite.py
@@ -10,6 +10,7 @@ from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
 from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
 
 
 def _base_env(tmp_path: Path, monkeypatch) -> None:
@@ -32,15 +33,12 @@ def _make_request(api_key: str) -> Request:
 
 
 async def _seed_user(pool, username: str) -> int:
-    async with pool.transaction() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (username, email, password_hash, is_active, is_verified, role)
-            VALUES (?, ?, ?, 1, 1, 'user')
-            """,
-            (username, f"{username}@example.com", "x"),
-        )
-    return int(await pool.fetchval("SELECT id FROM users WHERE username = ?", username))
+    return await create_authnz_test_user(
+        pool,
+        username=username,
+        email=f"{username}@example.com",
+        is_verified=True,
+    )
 
 
 async def _ensure_role(pool, role_name: str) -> int:

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_llm_budget_402_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_llm_budget_402_sqlite.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 def _chat_stub_response():
     return {
@@ -63,13 +65,10 @@ async def test_llm_budget_middleware_returns_402_on_overage(tmp_path):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Create a user
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("budgetuser", "budgetuser@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "budgetuser")
+    # Create a user through the guarded write path.
+    user_id = await create_authnz_test_user(
+        pool, username="budgetuser", email="budgetuser@example.com"
+    )
 
     # Create a virtual key with small daily token budget and allow chat.completions
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
@@ -138,12 +137,9 @@ async def test_llm_budget_allows_under_budget_chat_sqlite(tmp_path, monkeypatch)
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("budget_ok_user", "budget_ok@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "budget_ok_user")
+    user_id = await create_authnz_test_user(
+        pool, username="budget_ok_user", email="budget_ok@example.com"
+    )
 
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
     mgr = APIKeyManager()
@@ -192,12 +188,9 @@ async def test_llm_budget_middleware_blocks_disallowed_endpoint_sqlite(tmp_path)
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("endpointuser", "endpointuser@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "endpointuser")
+    user_id = await create_authnz_test_user(
+        pool, username="endpointuser", email="endpointuser@example.com"
+    )
 
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
     mgr = APIKeyManager()
@@ -240,13 +233,10 @@ async def test_llm_budget_middleware_enforces_usd_budgets_sqlite(tmp_path):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Create a user
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("usduser", "usduser@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "usduser")
+    # Create a user through the guarded write path.
+    user_id = await create_authnz_test_user(
+        pool, username="usduser", email="usduser@example.com"
+    )
 
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
     mgr = APIKeyManager()
@@ -344,12 +334,9 @@ async def test_llm_budget_middleware_enforces_month_tokens_sqlite(tmp_path):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("monthtok_user", "monthtok@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "monthtok_user")
+    user_id = await create_authnz_test_user(
+        pool, username="monthtok_user", email="monthtok@example.com"
+    )
 
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
     mgr = APIKeyManager()
@@ -410,12 +397,9 @@ async def test_llm_budget_middleware_returns_402_on_embeddings_overage(tmp_path)
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("embeduser", "embeduser@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "embeduser")
+    user_id = await create_authnz_test_user(
+        pool, username="embeduser", email="embeduser@example.com"
+    )
 
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
     mgr = APIKeyManager()

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_org_rbac_scoped_permissions_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_org_rbac_scoped_permissions_sqlite.py
@@ -4,6 +4,8 @@ import pytest
 from fastapi import Depends, FastAPI, Request
 from httpx import ASGITransport, AsyncClient
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 async def _issue_access_token(
     user_row: dict,
@@ -57,16 +59,9 @@ async def test_org_rbac_scoped_permissions_require_active_sqlite(tmp_path, monke
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (username, email, password_hash, is_active)
-            VALUES (?, ?, ?, 1)
-            """,
-            ("alice", "alice@example.com", "x"),
-        )
-
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", ("alice",))
+    user_id = await create_authnz_test_user(
+        pool, username="alice", email="alice@example.com"
+    )
 
     repo = AuthnzOrgsTeamsRepo(pool)
     org = await repo.create_organization(name="Acme", owner_user_id=user_id)
@@ -135,17 +130,11 @@ async def test_org_rbac_scoped_permissions_endpoint_allows_media_read(tmp_path, 
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (username, email, password_hash, is_active, role)
-            VALUES (?, ?, ?, 1, ?)
-            """,
-            ("scoped-user", "scoped@example.com", "x", "guest"),
-        )
-
-    user_id = await pool.fetchval(
-        "SELECT id FROM users WHERE username = ?", ("scoped-user",)
+    user_id = await create_authnz_test_user(
+        pool,
+        username="scoped-user",
+        email="scoped@example.com",
+        role="guest",
     )
 
     repo = AuthnzOrgsTeamsRepo(pool)
@@ -197,17 +186,8 @@ async def test_org_rbac_scoped_permissions_denylist_blocks_admin(tmp_path, monke
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (username, email, password_hash, is_active, role)
-            VALUES (?, ?, ?, 1, ?)
-            """,
-            ("deny-user", "deny@example.com", "x", "guest"),
-        )
-
-    user_id = await pool.fetchval(
-        "SELECT id FROM users WHERE username = ?", ("deny-user",)
+    user_id = await create_authnz_test_user(
+        pool, username="deny-user", email="deny@example.com", role="guest"
     )
 
     repo = AuthnzOrgsTeamsRepo(pool)
@@ -279,17 +259,11 @@ async def test_org_rbac_scoped_permissions_team_denylist_blocks_admin(tmp_path, 
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (username, email, password_hash, is_active, role)
-            VALUES (?, ?, ?, 1, ?)
-            """,
-            ("deny-team-user", "deny-team@example.com", "x", "guest"),
-        )
-
-    user_id = await pool.fetchval(
-        "SELECT id FROM users WHERE username = ?", ("deny-team-user",)
+    user_id = await create_authnz_test_user(
+        pool,
+        username="deny-team-user",
+        email="deny-team@example.com",
+        role="guest",
     )
 
     repo = AuthnzOrgsTeamsRepo(pool)
@@ -365,17 +339,11 @@ async def test_org_rbac_scoped_permissions_allows_tools_execute(tmp_path, monkey
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    async with pool.transaction() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (username, email, password_hash, is_active, role)
-            VALUES (?, ?, ?, 1, ?)
-            """,
-            ("tool-user", "tool-user@example.com", "x", "guest"),
-        )
-
-    user_id = await pool.fetchval(
-        "SELECT id FROM users WHERE username = ?", ("tool-user",)
+    user_id = await create_authnz_test_user(
+        pool,
+        username="tool-user",
+        email="tool-user@example.com",
+        role="guest",
     )
 
     repo = AuthnzOrgsTeamsRepo(pool)

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_orgs_teams_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_orgs_teams_sqlite.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 @pytest.mark.asyncio
 async def test_orgs_teams_crud_sqlite(tmp_path, authnz_schema_ready):
@@ -20,16 +22,10 @@ async def test_orgs_teams_crud_sqlite(tmp_path, authnz_schema_ready):
     # Schema ensured by authnz_schema_ready; acquire pool for ops
     pool = await get_db_pool()
 
-    # Create a dummy user for membership FKs
-    async with pool.transaction() as conn:
-        await conn.execute(
-            """
-            INSERT INTO users (username, email, password_hash, is_active)
-            VALUES (?, ?, ?, 1)
-            """,
-            ("alice", "alice@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "alice")
+    # Create a dummy user for membership FKs through the guarded write path.
+    user_id = await create_authnz_test_user(
+        pool, username="alice", email="alice@example.com"
+    )
 
     # Use service helpers
     from tldw_Server_API.app.core.AuthNZ.orgs_teams import (

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_quota_enforcement_http_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_quota_enforcement_http_sqlite.py
@@ -5,6 +5,8 @@ from typing import Any, Callable
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 def _jwt_service():
     from tldw_Server_API.app.core.AuthNZ.jwt_service import get_jwt_service
@@ -92,13 +94,10 @@ async def test_jwt_quota_enforced_for_chat_and_rag_sqlite(monkeypatch, tmp_path)
         pool = await get_db_pool()
         ensure_authnz_tables(Path(pool.db_path))
 
-        # Create a user for JWT auth
-        async with pool.transaction() as conn:
-            await conn.execute(
-                "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-                ("su", "su@example.com", "x"),
-            )
-        user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "su")
+        # Create a user for JWT auth through the guarded write path.
+        user_id = await create_authnz_test_user(
+            pool, username="su", email="su@example.com"
+        )
         from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
 
         await AuthnzUsersRepo(db_pool=pool).assign_role_if_missing(
@@ -215,13 +214,10 @@ async def test_api_key_quota_enforced_for_rag_and_chat_sqlite(monkeypatch, tmp_p
         pool = await get_db_pool()
         ensure_authnz_tables(Path(pool.db_path))
 
-        # Create a user
-        async with pool.transaction() as conn:
-            await conn.execute(
-                "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-                ("alice", "alice@example.com", "x"),
-            )
-        user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "alice")
+        # Create a user through the guarded write path.
+        user_id = await create_authnz_test_user(
+            pool, username="alice", email="alice@example.com"
+        )
         from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
 
         await AuthnzUsersRepo(db_pool=pool).assign_role_if_missing(

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_rag_media_permissions_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_rag_media_permissions_sqlite.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 def _base_env(tmp_path: Path):
     os.environ["AUTH_MODE"] = "multi_user"
@@ -14,12 +16,9 @@ def _base_env(tmp_path: Path):
 
 
 async def _seed_user(pool, username: str):
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            (username, f"{username}@example.com", "x"),
-        )
-    return await pool.fetchval("SELECT id FROM users WHERE username = ?", username)
+    return await create_authnz_test_user(
+        pool, username=username, email=f"{username}@example.com"
+    )
 
 
 async def _ensure_permission(pool, code: str) -> int:

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_single_user_bootstrap_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_single_user_bootstrap_sqlite.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import pytest
 from loguru import logger
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 @pytest.mark.asyncio
 async def test_single_user_bootstrap_creates_admin_user_and_primary_key(tmp_path, monkeypatch):
@@ -150,15 +152,18 @@ async def test_single_user_bootstrap_reuses_preseeded_primary_key(tmp_path, monk
     key_hash = manager.hash_api_key(key_value)
     key_prefix = (key_value[:10] + "...") if len(key_value) > 10 else key_value
 
-    # Pre-seed a primary key row for SINGLE_USER_API_KEY to simulate an existing deployment
+    # Pre-seed a primary key row for SINGLE_USER_API_KEY to simulate an existing deployment.
+    await create_authnz_test_user(
+        pool,
+        user_id=single_user_id,
+        username="single_user",
+        email="single_user@example.local",
+        password_hash="",
+        role="admin",
+        is_verified=True,
+        ignore_conflict=True,
+    )
     async with pool.transaction() as conn:  # type: ignore[attr-defined]
-        await conn.execute(
-            """
-            INSERT OR IGNORE INTO users (id, username, email, password_hash, is_active, is_verified, role)
-            VALUES (?, ?, ?, ?, 1, 1, 'admin')
-            """,
-            (single_user_id, "single_user", "single_user@example.local", ""),
-        )
         await conn.execute(
             """
             INSERT INTO api_keys (
@@ -230,15 +235,13 @@ async def test_single_user_bootstrap_fails_with_extra_active_user_sqlite(tmp_pat
     ensure_authnz_tables(Path(pool.db_path))
 
     # Pre-seed an additional active user to trigger bootstrap failure.
-    await pool.execute(
-        """
-        INSERT INTO users (id, username, email, password_hash, is_active, is_verified, role)
-        VALUES (?, ?, ?, ?, 1, 1, 'user')
-        """,
-        999,
-        "extra_user",
-        "extra@example.local",
-        "",
+    await create_authnz_test_user(
+        pool,
+        user_id=999,
+        username="extra_user",
+        email="extra@example.local",
+        password_hash="",
+        is_verified=True,
     )
 
     from tldw_Server_API.app.core.AuthNZ.initialize import bootstrap_single_user_profile
@@ -269,15 +272,15 @@ async def test_single_user_bootstrap_fails_with_multiple_primary_keys_sqlite(tmp
     single_user_id = settings.SINGLE_USER_FIXED_ID
 
     # Ensure the single-user row exists for FK constraints.
-    await pool.execute(
-        """
-        INSERT OR IGNORE INTO users (id, username, email, password_hash, is_active, is_verified, role)
-        VALUES (?, ?, ?, ?, 1, 1, 'admin')
-        """,
-        single_user_id,
-        "single_user",
-        "single_user@example.local",
-        "",
+    await create_authnz_test_user(
+        pool,
+        user_id=single_user_id,
+        username="single_user",
+        email="single_user@example.local",
+        password_hash="",
+        role="admin",
+        is_verified=True,
+        ignore_conflict=True,
     )
 
     manager = APIKeyManager()

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_virtual_keys_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_virtual_keys_sqlite.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from tldw_Server_API.tests.AuthNZ_SQLite._user_fixtures import create_authnz_test_user
+
 
 @pytest.mark.asyncio
 async def test_create_virtual_key_and_budget_checks(tmp_path):
@@ -21,13 +23,10 @@ async def test_create_virtual_key_and_budget_checks(tmp_path):
     pool = await get_db_pool()
     ensure_authnz_tables(Path(pool.db_path))
 
-    # Create a dummy user for FK
-    async with pool.transaction() as conn:
-        await conn.execute(
-            "INSERT INTO users (username, email, password_hash, is_active) VALUES (?, ?, ?, 1)",
-            ("bob", "bob@example.com", "x"),
-        )
-    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", "bob")
+    # Create a dummy user for FK through the guarded write path.
+    user_id = await create_authnz_test_user(
+        pool, username="bob", email="bob@example.com"
+    )
 
     # Create a virtual key
     from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager

--- a/tldw_Server_API/tests/CI/test_license_first_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_license_first_workflow_contracts.py
@@ -445,6 +445,13 @@ def test_runner_roots_cannot_bypass_admission_and_checkouts_are_immutable() -> N
                         "github.event_name != 'pull_request' && "
                         "github.event_name != 'workflow_run'"
                     )
+                elif (name, job_name) in {
+                    ("coverage-required.yml", "coverage-required"),
+                    ("e2e-required.yml", "e2e-required"),
+                }:
+                    assert _normalized(job.get("if")) == _normalized(
+                        "always() && !cancelled() && needs.changes.result == 'success'"
+                    )
                 else:
                     assert job.get("if") is None, (name, job_name)
 

--- a/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
@@ -138,6 +138,18 @@ def test_coverage_required_is_path_conditional() -> None:
     assert "coverage-required" in jobs
 
 
+def test_conditional_required_lanes_run_after_successful_change_detection() -> None:
+    for workflow_path, job_name in (
+        (".github/workflows/coverage-required.yml", "coverage-required"),
+        (".github/workflows/e2e-required.yml", "e2e-required"),
+    ):
+        job = _load(workflow_path)["jobs"][job_name]
+        assert job["needs"] == ["changes"]
+        assert " ".join(job["if"].split()) == (
+            "always() && !cancelled() && needs.changes.result == 'success'"
+        )
+
+
 def test_coverage_required_installs_portaudio_for_pyaudio_builds() -> None:
     workflow = _load(".github/workflows/coverage-required.yml")
     steps = workflow["jobs"]["coverage-required"]["steps"]


### PR DESCRIPTION
## Change summary

This PR restores the required CI baseline for the current dev release line. It fixes coverage and end-to-end gate admission so direct pull requests are no longer incorrectly skipped, refreshes the OpenAPI fingerprint, publishes the missing ADR-041 documentation, and adds regression tests to prevent these failures from returning.

## Technical changes

- make `coverage-required` and `e2e-required` survive direct-PR admission skip propagation while still failing closed for unadmitted `workflow_run` events
- refresh the exact runtime OpenAPI fingerprint to 2,040 paths and 3,038 schemas
- track the missing published ADR-041 mirror
- add focused workflow contract coverage and TASK-13013.1 evidence

## Local verification

- required and license-first workflow contracts: 56 passed
- formerly failing published-path contract: 1 passed
- clean-archive OpenAPI fingerprint check: PASS (`eb829bd8d3a62b55a61add5c595b522646455c55a2c540d2eabaec02da82ad19`)
- YAML parsing, medium/high Bandit, and `git diff --check`: PASS
- independent review: no Critical, Important, or Minor findings

## Tracking

- TASK-13013.1
- plan: `Docs/superpowers/plans/2026-08-28-task-13013-1-ci-baseline.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the required CI baseline by fixing skipped coverage/e2e gates, refreshing stale generated baselines, and aligning AuthNZ SQLite test fixtures with the production guarded write path so the coverage gate passes.

- The coverage gate was failing because test setup wrote users directly, bypassing `profile_user_write_guard`; tests now use the versioned write gateway and production abstractions, with SQLite-specific bindings for API-key repo tests. Production code is unchanged.
- `coverage-required` and `e2e-required` now use `always() && !cancelled() && needs.changes.result == 'success'` instead of being skipped when the admission job is skipped on direct PR runs.
- Refreshes `openapi.fingerprint.json` to the runtime digest (2,040 paths / 3,038 schemas).
- Adds the published `Docs/Published/ADR/041-scheduled-agent-execution-feasibility.md` mirror.
- Adds contract tests enforcing the new job conditions and tracks TASK-13013.1 evidence.

<sup>Written for commit c336469210016866a9bb877d5ac473916180c47e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

